### PR TITLE
Fix Connection Strings Logic

### DIFF
--- a/src/Azure.Functions.Cli/Actions/AzureActions/FetchAppSettingsAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/FetchAppSettingsAction.cs
@@ -39,7 +39,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 foreach (var connectionString in connectionStrings)
                 {
                     ColoredConsole.WriteLine($"Loading {connectionString.Key} = *****");
-                    _secretsManager.SetConnectionString(connectionString.Key, connectionString.Value.Value);
+                    _secretsManager.SetConnectionString(connectionString.Key, connectionString.Value.Value, connectionString.Value.Type);
                 }
 
             }

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -166,7 +166,15 @@ namespace Azure.Functions.Cli.Actions.HostActions
             secrets.Add(Constants.WebsiteHostname, uri.Authority);
 
             // Add our connection strings
-            secrets.AddRange(connectionStrings.ToDictionary(c => $"ConnectionStrings:{c.Name}", c => c.Value));
+            if (c.ProviderName == Constants.DefaultSqlProviderName)
+            {
+                secrets.AddRange(connectionStrings.ToDictionary(c => $"ConnectionStrings:{c.Name}", c => c.Value));
+            }
+            else
+            {
+                secrets.AddRange(connectionStrings.ToDictionary(c => $"{c.ProviderName}CONNSTR_{c.Name}", c => c.Value));
+            }
+
             secrets.Add(EnvironmentSettingNames.AzureWebJobsScriptRoot, scriptPath);
 
             await CheckNonOptionalSettings(secrets, scriptPath);

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -166,15 +166,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
             secrets.Add(Constants.WebsiteHostname, uri.Authority);
 
             // Add our connection strings
-            if (c.ProviderName == Constants.DefaultSqlProviderName)
-            {
-                secrets.AddRange(connectionStrings.ToDictionary(c => $"ConnectionStrings:{c.Name}", c => c.Value));
-            }
-            else
-            {
-                secrets.AddRange(connectionStrings.ToDictionary(c => $"{c.ProviderName}CONNSTR_{c.Name}", c => c.Value));
-            }
-
+            secrets.AddRange(connectionStrings.ToDictionary(c => (c.ProviderName == Constants.DefaultSqlProviderName) ? $"ConnectionStrings:{c.Name}" : $"{c.ProviderName}CONNSTR_{c.Name}", c => c.Value));
             secrets.Add(EnvironmentSettingNames.AzureWebJobsScriptRoot, scriptPath);
 
             await CheckNonOptionalSettings(secrets, scriptPath);

--- a/src/Azure.Functions.Cli/Actions/LocalActions/AddSettingAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/AddSettingAction.cs
@@ -54,7 +54,8 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             }
             if (IsConnectionString)
             {
-                _secretsManager.SetConnectionString(Name, Value);
+                // TODO: Make provider name configurable
+                _secretsManager.SetConnectionString(Name, Value, Constants.DefaultSqlProviderName);
             }
             else
             {

--- a/src/Azure.Functions.Cli/Arm/Models/AppServiceConnectionString.cs
+++ b/src/Azure.Functions.Cli/Arm/Models/AppServiceConnectionString.cs
@@ -8,6 +8,6 @@ namespace Azure.Functions.Cli.Arm.Models
         public string Value { get; set; }
 
         [JsonProperty("type")]
-        public int Type { get; set; }
+        public string Type { get; set; }
     }
 }

--- a/src/Azure.Functions.Cli/Common/SecretsManager.cs
+++ b/src/Azure.Functions.Cli/Common/SecretsManager.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Newtonsoft.Json;
+using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Interfaces;
 using Azure.Functions.Cli.Helpers;
 using Newtonsoft.Json.Linq;
@@ -57,10 +58,10 @@ namespace Azure.Functions.Cli.Common
             appSettingsFile.Commit();
         }
 
-        public void SetConnectionString(string name, string value)
+        public void SetConnectionString(string name, string value, string ProviderName = Constants.DefaultSqlProviderName)
         {
             var appSettingsFile = new AppSettingsFile(AppSettingsFilePath);
-            appSettingsFile.SetConnectionString(name, value, Constants.DefaultSqlProviderName);
+            appSettingsFile.SetConnectionString(name, value, ProviderName);
             appSettingsFile.Commit();
         }
 
@@ -174,7 +175,7 @@ namespace Azure.Functions.Cli.Common
                 };
             }
 
-            public void SetConnectionString(string name, string value, string providerName)
+            public void SetConnectionString(string name, string value, string providerName = Constants.DefaultSqlProviderName)
             {
                 value = IsEncrypted
                     ? Convert.ToBase64String(ProtectedData.Protect(Encoding.Default.GetBytes(value), reason))

--- a/src/Azure.Functions.Cli/Common/SecretsManager.cs
+++ b/src/Azure.Functions.Cli/Common/SecretsManager.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Newtonsoft.Json;
-using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Interfaces;
 using Azure.Functions.Cli.Helpers;
 using Newtonsoft.Json.Linq;

--- a/src/Azure.Functions.Cli/Interfaces/ISecretsManager.cs
+++ b/src/Azure.Functions.Cli/Interfaces/ISecretsManager.cs
@@ -8,7 +8,7 @@ namespace Azure.Functions.Cli.Interfaces
         IDictionary<string, string> GetSecrets();
         IEnumerable<ConnectionString> GetConnectionStrings();
         void SetSecret(string name, string value);
-        void SetConnectionString(string name, string value);
+        void SetConnectionString(string name, string value, string ProviderName);
         void DecryptSettings();
         void EncryptSettings();
         void DeleteSecret(string name);


### PR DESCRIPTION
Some sort of attempted fix for #348 and #214 (basically connection strings are not imported with the same environment variable names as the Azure Function Apps)

This naming convention seems to be derived from the one described in the following blog post: https://blogs.msdn.microsoft.com/silverlining/2012/10/23/getting-database-connection-information-in-windows-azure-web-sites/

I've never seriously coded in csharp so this is slightly speculative coding - but I've tested it and in itself it works :)

I'm very confident the Type of connection is a string rather than integer. But wasn't very sure if the provider name should map to this property or something else.

```
$ az webapp config connection-string list --name <func_name> --resource-group <rs_group>
[
  {
    "name": "ConnectionStringName",
    "slotSetting": false,
    "value": {
      "type": "SQLAzure",
      "value": "<connectionString>;"
    }
  }
]
```

This was a redo of #359 in an attempt to force appveyor to run tests on it