### PR TITLE
Core Tools - Update Java Worker to Java1.1.0-beta2-10014

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Colors.Net" Version="1.1.0" />
     <PackageReference Include="AccentedCommandLineParser" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.0-beta2-10009" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.0-beta2-10014" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta1-10026" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="2.0.0-beta2-11478" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />


### PR DESCRIPTION
Support change to load dependencies from /lib in functionapp root corresponding to @christopheranderson azure-functions-host PR [#2459](https://github.com/Azure/azure-functions-host/pull/2459)

\+ @christopheranderson @ahmelsayed @fabiocav 