### PR TITLE
Fix chmod in post install logic

### DIFF
--- a/src/Azure.Functions.Cli/npm/lib/install.js
+++ b/src/Azure.Functions.Cli/npm/lib/install.js
@@ -46,7 +46,7 @@ https.get(url, response => {
             const unzipStream = unzipper.Extract({ path: installPath })
                 .on('close', () => {
                     if (os.platform() === 'linux' || os.platform() === 'darwin') {
-                        fs.chmodSync(`${installPath}/func`, 755);
+                        fs.chmodSync(`${installPath}/func`, 0o755);
                     }
                 });
             response.pipe(unzipStream);


### PR DESCRIPTION
Octal notation required, otherwise results in bad permissions, no error is thrown -- https://nodejs.org/api/fs.html#fs_file_modes