### PR TITLE
Add node_modules to .gitignore

### DIFF
--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -53,6 +53,8 @@ project.lock.json
 .secrets
 appsettings.json
 local.settings.json
+
+node_modules
 "},
             { new Lazy<string>(() => ScriptConstants.HostMetadataFileName), "{ }" },
             { new Lazy<string>(() => SecretsManager.AppSettingsFileName), @"{


### PR DESCRIPTION
It looks like our .gitignore files are not project specific (i.e. C# vs JavaScript), but we can add `node_modules` to the generated .gitignore to make sure that it's there no matter what.