### PR TITLE
adding console output for ILogger

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -739,6 +739,9 @@
     <Compile Include="Common\Utilities.cs" />
     <Compile Include="ConsoleApp.cs" />
     <Compile Include="Context.cs" />
+    <Compile Include="Diagnostics\CliLoggerFactoryBuilder.cs" />
+    <Compile Include="Diagnostics\ColoredConsoleLogger.cs" />
+    <Compile Include="Diagnostics\ColoredConsoleLoggerProvider.cs" />
     <Compile Include="Diagnostics\ConsoleTraceWriter.cs" />
     <Compile Include="Extensions\DictionaryExtensions.cs" />
     <Compile Include="Extensions\FunctionMetadataExtensions.cs" />

--- a/src/Azure.Functions.Cli/Common/SelfHostWebHostSettingsFactory.cs
+++ b/src/Azure.Functions.Cli/Common/SelfHostWebHostSettingsFactory.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
-using Microsoft.Azure.WebJobs.Script.WebHost;
 using Azure.Functions.Cli.Diagnostics;
-using Azure.Functions.Cli.Helpers;
+using Colors.Net;
+using Microsoft.Azure.WebJobs.Script.WebHost;
 
 namespace Azure.Functions.Cli.Common
 {
@@ -11,6 +11,12 @@ namespace Azure.Functions.Cli.Common
     {
         public static WebHostSettings Create(TraceLevel consoleTraceLevel, string scriptPath)
         {
+            // We want to prevent any Console writers added by the core WebJobs SDK
+            // from writing to console, so we set our output to the original console TextWriter
+            // and replace it with a Null TextWriter
+            ColoredConsole.Out = new ColoredConsoleWriter(Console.Out);
+            Console.SetOut(TextWriter.Null);
+
             return new WebHostSettings
             {
                 IsSelfHost = true,
@@ -18,6 +24,7 @@ namespace Azure.Functions.Cli.Common
                 LogPath = Path.Combine(Path.GetTempPath(), @"LogFiles\Application\Functions"),
                 SecretsPath = Path.Combine(Path.GetTempPath(), "secrets", "functions", "secrets"),
                 TraceWriter = new ConsoleTraceWriter(consoleTraceLevel),
+                LoggerFactoryBuilder = new CliLoggerFactoryBuilder(),
                 IsAuthDisabled = true
             };
         }

--- a/src/Azure.Functions.Cli/Diagnostics/CliLoggerFactoryBuilder.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/CliLoggerFactoryBuilder.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Functions.Cli.Diagnostics
+{
+    internal class CliLoggerFactoryBuilder : DefaultLoggerFactoryBuilder
+    {
+        public override void AddLoggerProviders(ILoggerFactory factory, ScriptHostConfiguration scriptConfig, ScriptSettingsManager settingsManager)
+        {
+            base.AddLoggerProviders(factory, scriptConfig, settingsManager);
+
+            factory.AddProvider(new ColoredConsoleLoggerProvider(scriptConfig.LogFilter.Filter));
+        }
+    }
+}

--- a/src/Azure.Functions.Cli/Diagnostics/ColoredConsoleLogger.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/ColoredConsoleLogger.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Functions.Cli.Diagnostics
+{
+    public class ColoredConsoleLogger : ILogger
+    {
+        private readonly Func<string, LogLevel, bool> _filter;
+        private readonly string _category;
+        private readonly TraceWriter _consoleTraceWriter;
+
+        public ColoredConsoleLogger(string category, Func<string, LogLevel, bool> filter)
+        {
+            _category = category;
+            _filter = filter;
+
+            // Use a ConsoleTraceWriter to handle all formatting
+            _consoleTraceWriter = new ConsoleTraceWriter(TraceLevel.Verbose);
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            if (_filter == null)
+            {
+                return true;
+            }
+
+            return _filter(_category, logLevel);
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            if (!IsEnabled(logLevel))
+            {
+                return;
+            }
+
+            // TraceWriter traces are forwarded to ILoggers. Ignore them to prevent duplicate logging.
+            if (IsFromTraceWriter(state as IEnumerable<KeyValuePair<string, object>>))
+            {
+                return;
+            }
+
+            string formattedMessage = formatter(state, exception);
+
+            TraceEvent trace = new TraceEvent(GetTraceLevel(logLevel), formattedMessage, exception: exception);
+            _consoleTraceWriter.Trace(trace);
+        }
+
+        private static TraceLevel GetTraceLevel(LogLevel level)
+        {
+            switch (level)
+            {
+                case LogLevel.Error:
+                    return TraceLevel.Error;
+                case LogLevel.Warning:
+                    return TraceLevel.Warning;
+                case LogLevel.Information:
+                    return TraceLevel.Info;
+                case LogLevel.Debug:
+                case LogLevel.Trace:
+                    return TraceLevel.Verbose;
+                default:
+                    return TraceLevel.Off;
+            }
+        }
+
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            return null;
+        }
+
+        private static bool IsFromTraceWriter(IEnumerable<KeyValuePair<string, object>> properties)
+        {
+            if (properties == null)
+            {
+                return false;
+            }
+            else
+            {
+                return properties.Any(kvp => string.Equals(kvp.Key, ScriptConstants.TracePropertyIsUserTraceKey, StringComparison.OrdinalIgnoreCase));
+            }
+        }
+    }
+}

--- a/src/Azure.Functions.Cli/Diagnostics/ColoredConsoleLoggerProvider.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/ColoredConsoleLoggerProvider.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Azure.Functions.Cli.Diagnostics
+{
+    public class ColoredConsoleLoggerProvider : ILoggerProvider
+    {
+        private readonly Func<string, LogLevel, bool> _filter;
+
+        public ColoredConsoleLoggerProvider(Func<string, LogLevel, bool> filter)
+        {
+            _filter = filter;
+        }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            // Restrict any console logging from the ILogger to only the "Function" category, which are logs
+            // coming directly from a function. This removes duplicate host logging.
+            if (categoryName == LogCategories.Function)
+            {
+                return new ColoredConsoleLogger(categoryName, _filter);
+            }
+            else
+            {
+                return NullLogger.Instance;
+            }
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Azure.Functions.Cli/Diagnostics/ConsoleTraceWriter.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/ConsoleTraceWriter.cs
@@ -1,12 +1,10 @@
 ﻿using System;
-using System.Diagnostics;
-using System.IO;
-using Colors.Net;
-using Colors.Net.StringColorExtensions;
-using Microsoft.Azure.WebJobs.Host;
-using static Azure.Functions.Cli.Common.OutputTheme;
-using Microsoft.Azure.WebJobs.Script;
 using System.Collections.Generic;
+using System.Diagnostics;
+using Colors.Net;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Script;
+using static Azure.Functions.Cli.Common.OutputTheme;
 
 namespace Azure.Functions.Cli.Diagnostics
 {
@@ -14,11 +12,6 @@ namespace Azure.Functions.Cli.Diagnostics
     {
         public ConsoleTraceWriter(TraceLevel level) : base(level)
         {
-            // We want to prevent any Console writers added by the core WebJobs SDK
-            // from writing to console, so we set our output to the original console TextWriter
-            // and replace it with a Null TextWriter
-            ColoredConsole.Out = new ColoredConsoleWriter(Console.Out);
-            Console.SetOut(TextWriter.Null);
         }
 
         public override void Trace(TraceEvent traceEvent)


### PR DESCRIPTION
Fixes #130.

Had to handle some special cases as simply adding a ConsoleLoggerProvider wouldn't work:
1. Since we set `Console.Out` to null, no console output could come from elsewhere.
2. The standard console logger doesn't look anything like our existing logging, so I wanted to use ConsoleTraceWriter internally so everything looked nice.
3. TraceWriter traces are forwarded to ILoggers to make App Insights work as expected, but this can cause duplicate logs. Making sure this doesn't happen.
4. We log to both TraceWriter and ILogger everywhere in the host, so I've restricted this output to be strictly for function logs.
