### PR TITLE
update tenantid after login, #408

### DIFF
--- a/src/Azure.Functions.Cli/Arm/ArmClient.cs
+++ b/src/Azure.Functions.Cli/Arm/ArmClient.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading.Tasks;
+using Azure.Functions.Cli.Interfaces;
 using Newtonsoft.Json;
 
 namespace Azure.Functions.Cli.Arm
@@ -11,14 +12,14 @@ namespace Azure.Functions.Cli.Arm
     {
         private readonly int _retryCount;
         private readonly IArmTokenManager _tokenManager;
-        private readonly string _currentTenant;
+        private readonly ISettings _settings;
         private readonly Random _random;
 
-        public ArmClient(IArmTokenManager tokenManager, string currentTenant, int retryCount)
+        public ArmClient(IArmTokenManager tokenManager, ISettings settings, int retryCount)
         {
             _retryCount = retryCount;
             _tokenManager = tokenManager;
-            _currentTenant = currentTenant;
+            _settings = settings;
             _random = new Random();
         }
 
@@ -74,7 +75,7 @@ namespace Azure.Functions.Cli.Arm
             using (var client = new HttpClient(new HttpClientHandler()))
             {
                 const string jsonContentType = "application/json";
-                client.DefaultRequestHeaders.Add("Authorization", $"Bearer {await _tokenManager.GetToken(_currentTenant)}");
+                client.DefaultRequestHeaders.Add("Authorization", $"Bearer {await _tokenManager.GetToken(_settings.CurrentTenant)}");
                 client.DefaultRequestHeaders.Add("User-Agent", "functions-cli/2.0");
                 client.DefaultRequestHeaders.Add("Accept", jsonContentType);
                 client.DefaultRequestHeaders.Add("x-ms-request-id", Guid.NewGuid().ToString());

--- a/src/Azure.Functions.Cli/Arm/ArmManager.cs
+++ b/src/Azure.Functions.Cli/Arm/ArmManager.cs
@@ -23,7 +23,7 @@ namespace Azure.Functions.Cli.Arm
         {
             _settings = settings;
             _tokenManager = tokenManager;
-            _client = new ArmClient(tokenManager, settings.CurrentTenant, retryCount: 3);
+            _client = new ArmClient(tokenManager, settings, retryCount: 3);
         }
 
         public async Task<IEnumerable<Site>> GetFunctionAppsAsync()

--- a/src/Azure.Functions.Cli/Arm/ArmTokenManager.cs
+++ b/src/Azure.Functions.Cli/Arm/ArmTokenManager.cs
@@ -56,7 +56,7 @@ namespace Azure.Functions.Cli.Arm
                 if (catchException)
                 {
                     await Login();
-                    return await GetToken(tenantId, false);
+                    return await GetToken(_settings.CurrentTenant, false);
                 }
                 throw;
             }


### PR DESCRIPTION
this is a bandage fix, will take time to refactor before merge

1. when making arm request for the first time, there's no persistent setting, hence tenant id will be empty, so constructing `authenticationcontext` will error out with `'authority' Uri should have at least one segment in the path (i.e. https://<host>/<path>/...) Parameter name: authority`
2. in these scenarios we will perform user login to try get tenantid, however there's a small bug where we retry with the cached tenantid instead of the one acquired from login:
https://github.com/Azure/azure-functions-core-tools/blob/4d8cc0a639b1ecac6bcd14b149bc1d582430c1a7/src/Azure.Functions.Cli/Arm/ArmTokenManager.cs#L46-L59
3. hence 4 repetitive retries are performed and only when you rerun the command (now the tenantid is presented in the persistent setting) it will work