### PR TITLE
Moving to WebHost version 11820

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -324,13 +324,13 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.3.0-beta1-11332\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Script, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.1.0.0-beta3-11818\lib\net451\Microsoft.Azure.WebJobs.Script.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.1.0.0-beta3-11820\lib\net451\Microsoft.Azure.WebJobs.Script.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Script.Extensibility, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.Extensibility.1.0.0-beta3-10955\lib\net45\Microsoft.Azure.WebJobs.Script.Extensibility.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Script.WebHost, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.WebHost.1.0.0-beta3-11818\lib\net451\Microsoft.Azure.WebJobs.Script.WebHost.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.WebHost.1.0.0-beta3-11820\lib\net451\Microsoft.Azure.WebJobs.Script.WebHost.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.3.0-beta1-11332\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>

--- a/src/Azure.Functions.Cli/packages.config
+++ b/src/Azure.Functions.Cli/packages.config
@@ -71,9 +71,9 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.3.0-beta1-10623" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Logging" version="2.3.0-beta1-11332" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.3.0-beta1-11332" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Script" version="1.0.0-beta3-11818" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Script" version="1.0.0-beta3-11820" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-beta3-10955" targetFramework="net461" />
-  <package id="Microsoft.Azure.WebJobs.Script.WebHost" version="1.0.0-beta3-11818" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Script.WebHost" version="1.0.0-beta3-11820" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.3.0-beta1-11332" targetFramework="net471" />
   <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.81-alpha" targetFramework="net461" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net461" />

--- a/test/Azure.Functions.Cli.Tests/Azure.Functions.Cli.Tests.csproj
+++ b/test/Azure.Functions.Cli.Tests/Azure.Functions.Cli.Tests.csproj
@@ -254,7 +254,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.3.0-beta1-11327\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.3.0-beta1-11332\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.3.0-beta1-10623\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -287,25 +287,25 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Twilio.1.3.0-beta1-10623\lib\net45\Microsoft.Azure.WebJobs.Extensions.Twilio.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.3.0-beta1-11327\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.3.0-beta1-11332\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.2.3.0-beta1-11284\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.3.0-beta1-11327\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.3.0-beta1-11332\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Script, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.1.0.0-beta3-11818\lib\net451\Microsoft.Azure.WebJobs.Script.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.1.0.0-beta3-11820\lib\net451\Microsoft.Azure.WebJobs.Script.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Script.Extensibility, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.Extensibility.1.0.0-beta3-10955\lib\net45\Microsoft.Azure.WebJobs.Script.Extensibility.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Script.WebHost, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.WebHost.1.0.0-beta3-11818\lib\net451\Microsoft.Azure.WebJobs.Script.WebHost.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.WebHost.1.0.0-beta3-11820\lib\net451\Microsoft.Azure.WebJobs.Script.WebHost.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.3.0-beta1-11327\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.3.0-beta1-11332\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebSites.DataProtection, Version=0.1.6.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.81-alpha\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>

--- a/test/Azure.Functions.Cli.Tests/packages.config
+++ b/test/Azure.Functions.Cli.Tests/packages.config
@@ -54,8 +54,8 @@
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net461" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net461" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net461" />
-  <package id="Microsoft.Azure.WebJobs" version="2.3.0-beta1-11327" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.3.0-beta1-11327" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs" version="2.3.0-beta1-11332" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.3.0-beta1-11332" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.3.0-beta1-10623" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta9-10623" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" targetFramework="net461" />
@@ -67,11 +67,11 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.3.0-beta1-10623" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.3.0-beta1-10623" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Logging" version="2.3.0-beta1-11284" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.3.0-beta1-11327" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Script" version="1.0.0-beta3-11818" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.3.0-beta1-11332" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Script" version="1.0.0-beta3-11820" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-beta3-10955" targetFramework="net461" />
-  <package id="Microsoft.Azure.WebJobs.Script.WebHost" version="1.0.0-beta3-11818" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.3.0-beta1-11327" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Script.WebHost" version="1.0.0-beta3-11820" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.3.0-beta1-11332" targetFramework="net471" />
   <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.81-alpha" targetFramework="net471" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net461" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net461" />


### PR DESCRIPTION
I didn't update to the right host version in the last update. This is the correct version, matching the release https://github.com/Azure/azure-functions-host/releases/tag/v1.0.11820