### PR TITLE
Update CLI Version tag (for runtime 1.0.11913)

### DIFF
--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -6,7 +6,7 @@ namespace Azure.Functions.Cli.Common
         public const string FunctionsStorageAccountNamePrefix = "AzureFunctions";
         public const string StorageAccountArmType = "Microsoft.Storage/storageAccounts";
         public const string FunctionAppArmKind = "functionapp";
-        public const string CliVersion = "1.0.13";
+        public const string CliVersion = "1.0.14";
         public const string CliDebug = "CLI_DEBUG";
         public const string DefaultSqlProviderName = "System.Data.SqlClient";
         public const string WebsiteHostname = "WEBSITE_HOSTNAME";


### PR DESCRIPTION
Looks like commit https://github.com/Azure/azure-functions-core-tools/commit/4c6db1c00884b0c5aae9d24adb01292f01e1fec8 missed updating the CLI version number.. @soninaren FYI