### PR TITLE
added func logs functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ func deploy --platform kubernetes --name myfunction --registry <docker-hub-id or
 func deploy --platform kubernetes --name myfunction --registry <docker-hub-id or registry-server> --min 3 --max 10
 ```
 
+### Get function logs
+
+```
+func logs --name myfunction --platform kubernetes
+```
+
 ### Provide a kubeconfig file
 
 ```bash

--- a/src/Azure.Functions.Cli/Actions/LogsActions/GetLogsAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LogsActions/GetLogsAction.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Azure.Functions.Cli.Actions.DeployActions.Platforms;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Helpers;
+using Azure.Functions.Cli.Interfaces;
+using Colors.Net;
+using Fclp;
+using Microsoft.Azure.WebJobs.Script;
+using static Azure.Functions.Cli.Common.OutputTheme;
+using static Colors.Net.StringStaticMethods;
+
+namespace Azure.Functions.Cli.Actions.LocalActions
+{
+    [Action(Name = "logs", HelpText = "Gets logs of Functions running on custom backends")]
+    internal class GetLogsAction : BaseAction
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Platform { get; set; } = string.Empty;
+        public string ConfigPath { get; set; } = string.Empty;
+        private Dictionary<string, Func<string, Task>> logsHandlersMap = new Dictionary<string, Func<string, Task>>();
+        private const string KUBERNETES_DEFAULT_NAMESPACE = "azure-functions";
+
+        private readonly ITemplatesManager _templatesManager;
+
+        public GetLogsAction(ITemplatesManager templatesManager)
+        {
+            _templatesManager = templatesManager;
+            LoadLogHandlers();
+        }
+
+        private void LoadLogHandlers()
+        {
+            logsHandlersMap.Add("kubernetes", this.GetKubernetesFunctionLogs);
+        }
+
+        public override ICommandLineParserResult ParseArgs(string[] args)
+        {
+            Parser
+                .Setup<string>("platform")
+                .WithDescription("Hosting platform for the function app. Valid options: " + String.Join(",", logsHandlersMap.Keys))
+                .Callback(t => Platform = t).Required();
+
+            Parser
+                .Setup<string>("name")
+                .WithDescription("Function name")
+                .Callback(t => Name = t).Required();
+
+            Parser
+                .Setup<string>("config")
+                .WithDescription("[Optional] Config file")
+                .Callback(t => ConfigPath = t);
+
+            return base.ParseArgs(args);
+        }
+
+        public async Task GetKubernetesFunctionLogs(string functionName)
+        {
+            string nameSpace = KUBERNETES_DEFAULT_NAMESPACE;
+            await KubernetesHelper.RunKubectl($"logs -l app={functionName}-deployment -n {nameSpace}", true);
+        }
+
+        public override async Task RunAsync()
+        {
+            if (!logsHandlersMap.ContainsKey(Platform))
+            {
+                ColoredConsole.Error.WriteLine(ErrorColor($"platform {Platform} is not supported. Valid options are: {String.Join(",", logsHandlersMap.Keys)}"));
+                return;
+            }            
+
+            var logsHandler = logsHandlersMap[Platform];
+            ColoredConsole.WriteLine("Function logs:");
+            await logsHandler(Name);
+            
+        }
+    }
+}

--- a/src/Azure.Functions.Cli/Actions/LogsActions/GetLogsAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LogsActions/GetLogsAction.cs
@@ -24,11 +24,8 @@ namespace Azure.Functions.Cli.Actions.LocalActions
         private Dictionary<string, Func<string, Task>> logsHandlersMap = new Dictionary<string, Func<string, Task>>();
         private const string KUBERNETES_DEFAULT_NAMESPACE = "azure-functions";
 
-        private readonly ITemplatesManager _templatesManager;
-
-        public GetLogsAction(ITemplatesManager templatesManager)
+        public GetLogsAction()
         {
-            _templatesManager = templatesManager;
             LoadLogHandlers();
         }
 

--- a/src/Azure.Functions.Cli/Helpers/KubernetesHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/KubernetesHelper.cs
@@ -9,10 +9,15 @@ namespace Azure.Functions.Cli.Helpers
 {
     public static class KubernetesHelper
     {
-        public static async Task RunKubectl(string cmd)
+        public static async Task RunKubectl(string cmd, bool showOutput = false)
         {
             var kubectl = new Executable("kubectl", cmd);
-            await kubectl.RunAsync();
+
+            if (!showOutput)
+                await kubectl.RunAsync();
+            else {
+                await kubectl.RunAsync(l => ColoredConsole.WriteLine(l), e => ColoredConsole.Error.WriteLine(ErrorColor(e)));
+            }
         }
     }
 }


### PR DESCRIPTION
Allows for func logs --name <function-name> --platform <platform> to get the logs of functions running on custom backends such as Kubernetes