### PR TITLE
First step in migrating to FAKE 5

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,6 +1,6 @@
 source https://nuget.org/api/v2
 
-nuget FAKE
+nuget FAKE prerelease
 nuget xunit.runner.console = 2.3.0-beta4-build3742
 nuget WindowsAzure.Storage = 7.2.1
 nuget FSharp.Data

--- a/paket.lock
+++ b/paket.lock
@@ -1,6 +1,6 @@
 NUGET
   remote: https://www.nuget.org/api/v2
-    FAKE (4.63)
+    FAKE (5.3)
     FSharp.Core (4.5) - restriction: && (< net40) (< portable-net45+win8+wp8+wpa81)
     FSharp.Data (2.4.6)
       FSharp.Core (>= 4.0.0.1) - restriction: && (< net40) (< portable-net45+win8+wp8+wpa81)


### PR DESCRIPTION
In this PR I migrated build script to FAKE 5 legacy (https://fake.build/fake-migrate-to-fake-5.html#Migration-Guide).

Next step is to fully migrate to FAKE 5 by installing FAKE 5 as dependency on your build infrastructure (https://fake.build/fake-gettingstarted.html#Install-FAKE).