### PR TITLE
Updating extension command and csproj template to install latest metadata generator package

### DIFF
--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -55,6 +55,8 @@ namespace Azure.Functions.Cli.Common
             public const string PythonDockerBuild = "python_docker_build.sh";
         }
 
+        public static ExtensionPackage ExtensionsMetadataGeneratorPackage => new ExtensionPackage { Name = "Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator", Version = "1.0.0-beta7" };
+
         public static IDictionary<string, ExtensionPackage> BindingPackageMap { get; } = new ReadOnlyDictionary<string, ExtensionPackage>(
                 new Dictionary<string, ExtensionPackage> {
                     { "servicebustrigger",

--- a/src/Azure.Functions.Cli/Helpers/ExtensionsHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/ExtensionsHelper.cs
@@ -62,6 +62,9 @@ namespace Azure.Functions.Cli.Helpers
                     packages.TryAdd(package.Name, package);
                 }
             }
+
+            packages.Add("ExtensionsMetadataGeneratorPackage", Constants.ExtensionsMetadataGeneratorPackage);
+
             return packages.Values;
         }
     }

--- a/src/Azure.Functions.Cli/StaticResources/ExtensionsProj.csproj.template
+++ b/src/Azure.Functions.Cli/StaticResources/ExtensionsProj.csproj.template
@@ -5,6 +5,6 @@
 	<DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.0.0-beta3" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.0.0-beta7" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updating CLI to use latest metadata generator package for `func extension install` command and default extension csproj