### PR TITLE
Fixes #481 - Support language alias when creating templates

### DIFF
--- a/src/Azure.Functions.Cli/Actions/LocalActions/CreateFunctionAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/CreateFunctionAction.cs
@@ -128,10 +128,11 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             else
             {
                 ColoredConsole.Write("Select a template: ");
-                TemplateName = TemplateName ?? SelectionMenuHelper.DisplaySelectionWizard(templates.Where(t => t.Metadata.Language.Equals(Language, StringComparison.OrdinalIgnoreCase)).Select(t => t.Metadata.Name).Distinct());
+                var templateLanguage = WorkerRuntimeLanguageHelper.GetTemplateLanguageFromWorker(workerRuntime);
+                TemplateName = TemplateName ?? SelectionMenuHelper.DisplaySelectionWizard(templates.Where(t => t.Metadata.Language.Equals(templateLanguage, StringComparison.OrdinalIgnoreCase)).Select(t => t.Metadata.Name).Distinct());
                 ColoredConsole.WriteLine(TitleColor(TemplateName));
 
-                var template = templates.FirstOrDefault(t => t.Metadata.Name.Equals(TemplateName, StringComparison.OrdinalIgnoreCase) && t.Metadata.Language.Equals(Language, StringComparison.OrdinalIgnoreCase));
+                var template = templates.FirstOrDefault(t => t.Metadata.Name.Equals(TemplateName, StringComparison.OrdinalIgnoreCase) && t.Metadata.Language.Equals(templateLanguage, StringComparison.OrdinalIgnoreCase));
 
                 if (template == null)
                 {

--- a/src/Azure.Functions.Cli/Helpers/WorkerRuntimeLanguageHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/WorkerRuntimeLanguageHelper.cs
@@ -32,6 +32,13 @@ namespace Azure.Functions.Cli.Helpers
             .SelectMany(i => i)
             .ToDictionary(k => k.key, v => v.value, StringComparer.OrdinalIgnoreCase);
 
+        private static readonly IDictionary<WorkerRuntime, string> workerToLanguageMap = new Dictionary<WorkerRuntime, string>
+        {
+            { WorkerRuntime.dotnet, "c#" },
+            { WorkerRuntime.node, "javascript" },
+            { WorkerRuntime.python, "python" }
+        };
+
         public static string AvailableWorkersRuntimeString =>
             string.Join(", ", availableWorkersRuntime.Keys.Where(k => k != WorkerRuntime.python).Select(s => s.ToString()));
 
@@ -81,6 +88,15 @@ namespace Azure.Functions.Cli.Helpers
                 .WriteLine(WarningColor($"'{worker}' has been set in your local.settings.json"));
 
             return worker;
+        }
+
+        public static string GetTemplateLanguageFromWorker(WorkerRuntime worker)
+        {
+            if (!workerToLanguageMap.ContainsKey(worker))
+            {
+                throw new ArgumentException($"Worker runtime '{worker}' is not a valid worker for a template.");
+            }
+            return workerToLanguageMap[worker];
         }
     }
 }

--- a/test/Azure.Functions.Cli.Tests/E2E/CreateFunctionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/CreateFunctionTests.cs
@@ -50,5 +50,22 @@ namespace Azure.Functions.Cli.Tests.E2E
                 }
             }, _output);
         }
+
+        [Fact]
+        public async Task create_template_function_using_alias()
+        {
+            await CliTester.Run(new RunConfiguration
+            {
+                Commands = new[]
+                {
+                    "init . --worker-runtime node",
+                    "new --language js --template \"http trigger\" --name testfunc"
+                },
+                OutputContains = new[]
+                {
+                    "The function \"testfunc\" was created successfully from the \"http trigger\" template."
+                }
+            }, _output);
+        }
     }
 }


### PR DESCRIPTION
Created a mapping for getting the template names from the worker, for now, assuming each worker supports only one language for the template. Let me know if I should change the implementation to not rely on the worker runtime. Thanks! 