### PR TITLE
Fixes #650 - Ensure template names to be consistent

### DIFF
--- a/src/Azure.Functions.Cli/Actions/LocalActions/CreateFunctionAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/CreateFunctionAction.cs
@@ -123,7 +123,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 FunctionName = FunctionName ?? Console.ReadLine();
                 ColoredConsole.WriteLine(FunctionName);
                 var namespaceStr = Path.GetFileName(Environment.CurrentDirectory);
-                await DotnetHelpers.DeployDotnetFunction(TemplateName, Utilities.SanitizeClassName(FunctionName), Utilities.SanitizeNameSpace(namespaceStr));
+                await DotnetHelpers.DeployDotnetFunction(TemplateName.Replace(" ", string.Empty), Utilities.SanitizeClassName(FunctionName), Utilities.SanitizeNameSpace(namespaceStr));
             }
             else
             {
@@ -132,7 +132,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 TemplateName = TemplateName ?? SelectionMenuHelper.DisplaySelectionWizard(templates.Where(t => t.Metadata.Language.Equals(templateLanguage, StringComparison.OrdinalIgnoreCase)).Select(t => t.Metadata.Name).Distinct());
                 ColoredConsole.WriteLine(TitleColor(TemplateName));
 
-                var template = templates.FirstOrDefault(t => t.Metadata.Name.Equals(TemplateName, StringComparison.OrdinalIgnoreCase) && t.Metadata.Language.Equals(templateLanguage, StringComparison.OrdinalIgnoreCase));
+                var template = templates.FirstOrDefault(t => Utilities.EqualsIgnoreCaseAndSpace(t.Metadata.Name, TemplateName) && t.Metadata.Language.Equals(templateLanguage, StringComparison.OrdinalIgnoreCase));
 
                 if (template == null)
                 {

--- a/src/Azure.Functions.Cli/Common/Utilities.cs
+++ b/src/Azure.Functions.Cli/Common/Utilities.cs
@@ -83,5 +83,10 @@ namespace Azure.Functions.Cli
             }
             return sanitized.ToString();
         }
+
+        internal static bool EqualsIgnoreCaseAndSpace(string str, string another)
+        {
+            return str.Replace(" ", string.Empty).Equals(another.Replace(" ", string.Empty), StringComparison.OrdinalIgnoreCase);
+        }
     }
 }

--- a/test/Azure.Functions.Cli.Tests/E2E/CreateFunctionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/CreateFunctionTests.cs
@@ -67,5 +67,39 @@ namespace Azure.Functions.Cli.Tests.E2E
                 }
             }, _output);
         }
+
+        [Fact]
+        public async Task create_template_function_js_no_space_name()
+        {
+            await CliTester.Run(new RunConfiguration
+            {
+                Commands = new[]
+                {
+                    "init . --worker-runtime node",
+                    "new --language js --template httptrigger --name testfunc"
+                },
+                OutputContains = new[]
+                {
+                    "The function \"testfunc\" was created successfully from the \"httptrigger\" template."
+                }
+            }, _output);
+        }
+
+        [Fact]
+        public async Task create_template_function_dotnet_space_name()
+        {
+            await CliTester.Run(new RunConfiguration
+            {
+                Commands = new[]
+                {
+                    "init . --worker-runtime dotnet",
+                    "new --template \"http trigger\" --name testfunc2"
+                },
+                OutputContains = new[]
+                {
+                    "The function \"testfunc2\" was created successfully from the \"http trigger\" template."
+                }
+            }, _output);
+        }
     }
 }


### PR DESCRIPTION
Any template names should work across all languages (Http Trigger, httptrigger, etc).