### PR TITLE
Fixes #553 - detect if built project available

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -238,17 +238,48 @@ namespace Azure.Functions.Cli.Actions.HostActions
             {
                 PythonHelpers.VerifyVirtualEnvironment();
             }
-            else if (workerRuntime == WorkerRuntime.dotnet && Build)
+            else if (workerRuntime == WorkerRuntime.dotnet)
             {
-                const string outputPath = "bin/output";
-                await DotnetHelpers.BuildDotnetProject(outputPath, string.Empty);
-                Environment.CurrentDirectory = Path.Combine(Environment.CurrentDirectory, outputPath);
+                string outputPath = Path.Join("bin", "output");
+                if (Build)
+                {
+                    await DotnetHelpers.BuildDotnetProject(outputPath, string.Empty);
+                    Environment.CurrentDirectory = Path.Combine(Environment.CurrentDirectory, outputPath);
+                }
+                // If the current directory does not have a built project, but there is a built project in the output path, change the directory to output path
+                else if (!await HasBeenBuilt(".") && await HasBeenBuilt(outputPath))
+                {
+                    Environment.CurrentDirectory = Path.Combine(Environment.CurrentDirectory, outputPath);
+                    ColoredConsole.WriteLine(Yellow($"Using the built project in {Environment.CurrentDirectory}"));
+                }
             }
 
             if (!NetworkHelpers.IsPortAvailable(Port))
             {
                 throw new CliException($"Port {Port} is unavailable. Close the process using that port, or specify another port using --port [-p].");
             }
+        }
+
+        public static async Task<bool> HasBeenBuilt(string path)
+        {
+            try
+            {
+                var directories = FileSystemHelpers.GetDirectories(path);
+                foreach (var directory in directories)
+                {
+                    if (FileSystemHelpers.FileExists(Path.Join(directory, "function.json")))
+                    {
+                        var funcSettings = await FileSystemHelpers.ReadAllTextFromFileAsync(Path.Join(directory, "function.json"));
+                        var values = JsonConvert.DeserializeObject<JObject>(funcSettings);
+                        return FileSystemHelpers.FileExists(Path.Join(directory, values["scriptFile"].ToString()));
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return false;
         }
 
         private void DisplayDisabledFunctions(IScriptJobHost scriptHost)

--- a/test/Azure.Functions.Cli.Tests/ActionsTests/StartHostActionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/ActionsTests/StartHostActionTests.cs
@@ -71,6 +71,23 @@ namespace Azure.Functions.Cli.Tests.ActionsTests
             exception.Should().BeNull();
         }
 
+        [Fact]
+        public async Task CheckIfProjectIsAlreadyBuilt()
+        {
+            var fileSystem = GetFakeFileSystem(new[]
+            {
+                (Path.Combine("x:", "folder1"), "{'scriptFile': '../bin/blah.dll'}"),
+                (Path.Combine("x:", "folder2"), "{'bindings': [{'type': 'httpTrigger'}]}")
+            });
+            fileSystem.File.Exists(Arg.Is(Path.Combine("x:", "folder1", "../bin/blah.dll"))).Returns(true);
+            FileSystemHelpers.Instance = fileSystem;
+            bool test = await StartHostAction.HasBeenBuilt(".");
+            Assert.True(test);
+
+            fileSystem.File.Exists(Arg.Is(Path.Combine("x:", "folder1", "../bin/blah.dll"))).Returns(false);
+            Assert.False(await StartHostAction.HasBeenBuilt("."));
+        }
+
         [SkippableFact]
         public async Task CheckNonOptionalSettingsPrintsWarningForMissingSettings()
         {


### PR DESCRIPTION
Added a small logic to check if there is a pre-built project available in `bin/output`

Note- I am currently checking if the current directory does not have a build AND there is one available in `bin/output`, only then would it use the `bin/output` directory. Just so, if the user actually just wants to run the command from the built project directory. 

Ideally (if we don't have one already), I think it would be nice to have a flag (--build-path or something), that can also provide the path we want to use the project from. 