### PR TITLE
Potential fix #718 - move distlib install to buildtime

### DIFF
--- a/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
@@ -138,7 +138,6 @@ namespace Azure.Functions.Cli.Helpers
             var requirementsTxt = Path.Combine(functionAppRoot, Constants.RequirementsTxt);
 
             var packApp = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "tools", "python", "packapp");
-            await InstallDislib(packApp);
 
             var exe = new Executable("python", $"{packApp} --platform linux --python-version 36 --packages-dir-name {Constants.ExternalPythonPackages} {functionAppRoot}");
             var sbErrors = new StringBuilder();
@@ -150,18 +149,6 @@ namespace Azure.Functions.Cli.Helpers
             }
 
             return packagesLocation;
-        }
-
-        private static async Task InstallDislib(string packApp)
-        {
-            var exe = new Executable("pip", $"install --target={packApp} git+https://github.com/vsajip/distlib.git@15dba58a827f56195b0fa0afe80a8925a92e8bf5");
-            var sbErrors = new StringBuilder();
-            var exitCode = await exe.RunAsync(o => ColoredConsole.WriteLine(o), e => sbErrors.AppendLine(e));
-
-            if (exitCode != 0)
-            {
-                throw new CliException("There was an error installing distlib." + sbErrors.ToString());
-            }
         }
 
         private static async Task<Stream> InternalPreparePythonDeploymentInDocker(IEnumerable<string> files, string functionAppRoot, string additionalPackages)


### PR DESCRIPTION
I made the change to move distlib install to build script. I noticed that some files are involved in the zip signing. Please let me know if that's something the downloaded library will have to contribute to.
