### PR TITLE
Catch exception thrown checking free TCP ports, when running on WSL

### DIFF
--- a/src/Azure.Functions.Cli/Helpers/NetworkHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/NetworkHelpers.cs
@@ -9,17 +9,25 @@ namespace Azure.Functions.Cli.Helpers
         // If the race condition does occur, it'll fail later on in the binding step
         public static bool IsPortAvailable(int port)
         {
-            var ipGlobalProperties = IPGlobalProperties.GetIPGlobalProperties();
-            var tcpConnInfoArray = ipGlobalProperties.GetActiveTcpConnections();
+            try {
+                var ipGlobalProperties = IPGlobalProperties.GetIPGlobalProperties();
+                var tcpConnInfoArray = ipGlobalProperties.GetActiveTcpConnections();
 
-            foreach (var tcpi in tcpConnInfoArray)
-            {
-                if (tcpi.LocalEndPoint.Port == port)
+                foreach (var tcpi in tcpConnInfoArray)
                 {
-                    return false;
+                    if (tcpi.LocalEndPoint.Port == port)
+                    {
+                        return false;
+                    }
                 }
+                return true;
+            } catch (System.Exception exp) {
+                // There are a number of reasons we can end up here...
+                // The main one being running under WSL and this bug https://github.com/dotnet/corefx/issues/30909
+
+                // Only realistic option is to assume port is free
+                return true;
             }
-            return true;
         }
     }
 }


### PR DESCRIPTION
This PR is a fix for WSL users
As discussed in this issue https://github.com/Azure/azure-functions-core-tools/issues/704

The fix is a simple exception try/catch wrap around the TCP port free check. The root cause is poor handling of WSL by System.Net.NetworkInformation.IPGlobalProperties, see this issue https://github.com/dotnet/corefx/issues/30909

I don't see any option but to return true and assume the port is free, if we can't get hold of the information from the OS or the network stack