### PR TITLE
Fixes #738 - show functionapp if it's in the next page

### DIFF
--- a/src/Azure.Functions.Cli/Arm/Models/ArmArrayWrapper.cs
+++ b/src/Azure.Functions.Cli/Arm/Models/ArmArrayWrapper.cs
@@ -5,5 +5,7 @@ namespace Azure.Functions.Cli.Arm.Models
     internal class ArmArrayWrapper<T>
     {
         public IEnumerable<ArmWrapper<T>> value { get; set; }
+
+        public string nextLink { get; set; }
     }
 }

--- a/src/Azure.Functions.Cli/Helpers/AzureHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/AzureHelper.cs
@@ -33,6 +33,20 @@ namespace Azure.Functions.Cli.Helpers
                 }),
                 accessToken);
 
+                // If we haven't found the functionapp, and there is a next page, keep going
+                while (!functionApps.value.Any() && !string.IsNullOrEmpty(functionApps.nextLink))
+                {
+                    try
+                    {
+                        functionApps = await ArmHttpAsync<ArmArrayWrapper<ArmGenericResource>>(HttpMethod.Get, new Uri(functionApps.nextLink), accessToken);
+                    }
+                    catch (Exception)
+                    {
+                        // If we can't go to the next page for some reason, just move on for now
+                        break;
+                    }
+                }
+
                 if (functionApps.value.Any())
                 {
                     var app = new Site(functionApps.value.First().id);


### PR DESCRIPTION
I made the change to go to retrieve all the functionapps.

I didn't add the suggested `resource-group` flag yet. I was unable to make a successful request to the ARM with a resource group that would give me my functionapp using the link suggested in the issue. It there's a specific format of the link and if we want this flag, please let me know, I will update the PR.