### PR TITLE
Displaying HTTP methods for functions triggered with [HttpTrigger]

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -287,6 +287,13 @@ namespace Azure.Functions.Cli.Actions.HostActions
                     var httpRoute = binding?.Raw?.GetValue("route", StringComparison.OrdinalIgnoreCase)?.ToString();
                     httpRoute = httpRoute ?? function.Name;
 
+                    string[] methods = null;
+                    var methodsRaw = binding?.Raw?.GetValue("methods", StringComparison.OrdinalIgnoreCase)?.ToString();
+                    if (string.IsNullOrEmpty(methodsRaw) == false)
+                    {
+                        methods = methodsRaw.Split(',');
+                    }
+
                     string hostRoutePrefix = "";
                     if (!function.Metadata.IsProxy)
                     {
@@ -295,12 +302,20 @@ namespace Azure.Functions.Cli.Actions.HostActions
                             ? hostRoutePrefix
                             : $"{hostRoutePrefix}/";
                     }
+
+                    var functionMethods = methods != null ? $"{CleanAndFormatHttpMethods(string.Join(",", methods))}" : null;
                     var url = $"{baseUri.ToString().Replace("0.0.0.0", "localhost")}{hostRoutePrefix}{httpRoute}";
                     ColoredConsole
-                        .WriteLine($"\t{Yellow($"{function.Name}:")} {Green(url)}")
+                        .WriteLine($"\t{Yellow($"{function.Name}:")} {Green(functionMethods)} {Green(url)}")
                         .WriteLine();
                 }
             }
+        }
+
+        private string CleanAndFormatHttpMethods(string httpMethods)
+        {
+            return httpMethods.Replace(Environment.NewLine, string.Empty).Replace(" ", string.Empty)
+                .Replace("\"", string.Empty).ToUpperInvariant();
         }
 
         private async Task SetupDebuggerAsync(Uri baseUri)


### PR DESCRIPTION
Hi,

While working with Azure Functions CLI and localhost, I often find it difficult to immediately know, how a function triggered via HTTP request should be called(which HTTP method should I use). This PR proposes a simple solution by prepending e.g. [POST, GET] to the displayed function URL when a host runs.

Regards,
Kamil