### PR TITLE
Add ability to bundle python modules with worker

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -51,6 +51,9 @@
     <EmbeddedResource Include="StaticResources\python_docker_build.sh.template">
       <LogicalName>$(AssemblyName).python_docker_build.sh</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="StaticResources\python_bundle_script.py.template">
+      <LogicalName>$(AssemblyName).python_bundle_script.py</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="StaticResources\templates.json.template">
       <LogicalName>$(AssemblyName).templates.json</LogicalName>
     </EmbeddedResource>

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -55,6 +55,7 @@ namespace Azure.Functions.Cli.Common
         public static class StaticResourcesNames
         {
             public const string PythonDockerBuild = "python_docker_build.sh";
+            public const string PythonBundleScript = "python_bundle_script.py";
         }
 
         public static ExtensionPackage ExtensionsMetadataGeneratorPackage => new ExtensionPackage { Name = "Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator", Version = "1.0.1" };

--- a/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
@@ -165,6 +165,10 @@ namespace Azure.Functions.Cli.Helpers
 
                 var scriptFilePath = Path.GetTempFileName();
                 await FileSystemHelpers.WriteAllTextToFileAsync(scriptFilePath, (await StaticResources.PythonDockerBuildScript).Replace("\r\n", "\n"));
+
+                var bundleScriptFilePath = Path.GetTempFileName();
+                await FileSystemHelpers.WriteAllTextToFileAsync(bundleScriptFilePath, (await StaticResources.PythonBundleScript).Replace("\r\n", "\n"));
+
                 if (!string.IsNullOrWhiteSpace(additionalPackages))
                 {
                     // Give the container time to start up
@@ -173,7 +177,9 @@ namespace Azure.Functions.Cli.Helpers
                     await DockerHelpers.ExecInContainer(containerId, $"apt-get install -y {additionalPackages}");
                 }
                 await DockerHelpers.CopyToContainer(containerId, scriptFilePath, Constants.StaticResourcesNames.PythonDockerBuild);
+                await DockerHelpers.CopyToContainer(containerId, bundleScriptFilePath, Constants.StaticResourcesNames.PythonBundleScript);
                 await DockerHelpers.ExecInContainer(containerId, $"chmod +x /{Constants.StaticResourcesNames.PythonDockerBuild}");
+                await DockerHelpers.ExecInContainer(containerId, $"chmod +x /{Constants.StaticResourcesNames.PythonBundleScript}");
                 await DockerHelpers.ExecInContainer(containerId, $"/{Constants.StaticResourcesNames.PythonDockerBuild}");
 
                 var tempDir = Path.Combine(Path.GetTempPath(), Path.GetTempFileName().Replace(".", ""));

--- a/src/Azure.Functions.Cli/StaticResources/StaticResources.cs
+++ b/src/Azure.Functions.Cli/StaticResources/StaticResources.cs
@@ -43,6 +43,8 @@ namespace Azure.Functions.Cli
 
         public static Task<string> PythonDockerBuildScript => GetValue(Constants.StaticResourcesNames.PythonDockerBuild);
 
+        public static Task<string> PythonBundleScript => GetValue(Constants.StaticResourcesNames.PythonBundleScript);
+
         public static Task<string> TemplatesJson => GetValue("templates.json");
     }
 }

--- a/src/Azure.Functions.Cli/StaticResources/python_bundle_script.py.template
+++ b/src/Azure.Functions.Cli/StaticResources/python_bundle_script.py.template
@@ -1,0 +1,56 @@
+from PyInstaller.__main__ import run
+import os
+import sys
+
+not_allowed = ["__pycache__"]
+
+# Gets the list of all the possible modules from a directory
+def get_possible_modules(location):
+    all_modules = []
+    dirs, files = get_dirs_files(location)
+    for a_file in files:
+        if is_python_file(a_file):
+            all_modules.append(os.path.splitext(a_file)[0])
+    for a_dir in dirs:
+        if a_dir in not_allowed:
+            continue
+        if dir_has_python_files(os.path.join(location, a_dir)):
+            all_modules.append(a_dir)
+    return all_modules
+
+# Gets the files and directories from a location
+def get_dirs_files(location):
+    dir_entries = os.listdir(location)
+    files = [entry for entry in dir_entries if os.path.isfile(os.path.join(location, entry))]
+    dirs = [entry for entry in dir_entries if os.path.isdir(os.path.join(location, entry))]
+    return dirs, files
+
+# Checks if the directory has any python files in it
+def dir_has_python_files(a_dir):
+    dirs, files = get_dirs_files(a_dir)
+    for a_file in files:
+        if is_python_file(a_file):
+            return True
+    for a_sub_dir in dirs:
+        if a_sub_dir in not_allowed:
+            continue
+        if dir_has_python_files(os.path.join(a_dir, a_sub_dir)):
+            return True
+    return False
+
+def is_python_file(a_file):
+    return a_file.endswith('.so') or a_file.endswith('.py') or a_file.endswith('.pyd') or a_file.endswith('.pyo') or a_file.endswith('.pyc')
+
+def __main__():
+    if len(sys.argv) < 3:
+        print("Need more arguments: Usage: python_build_template.py [starter_script] [python_packages_path]")
+        return 
+    packages_location = sys.argv[2]
+    all_modules = get_possible_modules(packages_location)
+    entry_file = sys.argv[1]
+    # Creates a list of hidden imports arguments for pyinstaller in the format - "--hidden-import=<module>"
+    hidden_modules_commands = ["--hidden-import=" + module_name for module_name in all_modules]
+    run(["--paths=" + packages_location, "--distpath=.", *hidden_modules_commands, "--name=worker-bundle", entry_file])
+
+if __name__ == '__main__':
+    __main__()

--- a/src/Azure.Functions.Cli/StaticResources/python_docker_build.sh.template
+++ b/src/Azure.Functions.Cli/StaticResources/python_docker_build.sh.template
@@ -7,9 +7,15 @@ cd /home/site/wwwroot
 if [ -d worker_venv ]; then
     rm -rf worker_venv
 fi
-python -m venv --copies worker_venv
-source worker_venv/bin/activate
-pip install -r requirements.txt
+
+pip install --target=./site_packages -r requirements.txt
+
+# Bundle using pyinstaller
+pip install pyinstaller==3.4
+python /python_bundle_script.py /azure-functions-host/workers/python/worker.py  ./site_packages
+rm -r ./site_packages ./build
+rm worker-bundle.spec
+
 apt-get update
 apt-get install zip -y
 zip --symlinks -r /app.zip .


### PR DESCRIPTION
**Note: Please do not merge yet, still working on testing different scenarios.**

Add ability to bundle the python worker with the modules from `requirements.txt` using pyinstaller.
In addition, please review- https://github.com/Azure/azure-functions-docker/pull/34

Additional work to be done (in case we take this path):
1) Make sure venv is not included in the zip created by pack
2) Make `--build-native-deps` the default, as we will need to take the docker path if we use pyinstaller.