### PR TITLE
Fixes #553, #765 - dotnet build by default

### DIFF
--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -121,9 +121,16 @@ namespace Azure.Functions.Cli.Actions.AzureActions
 
             if (workerRuntime == WorkerRuntime.dotnet && !Csx && !NoBuild)
             {
-                const string outputPath = "bin/publish";
-                await DotnetHelpers.BuildDotnetProject(outputPath, DotnetCliParameters);
-                Environment.CurrentDirectory = Path.Combine(Environment.CurrentDirectory, outputPath);
+                if (DotnetHelpers.CanDotnetBuild())
+                {
+                    var outputPath = Path.Combine("bin", "publish");
+                    await DotnetHelpers.BuildDotnetProject(outputPath, DotnetCliParameters);
+                    Environment.CurrentDirectory = Path.Combine(Environment.CurrentDirectory, outputPath);
+                }
+                else if (StaticSettings.IsDebug)
+                {
+                    ColoredConsole.WriteLine("Could not find a valid .csproj file. Skipping the build.");
+                }
             }
 
             if (ListIncludedFiles)

--- a/src/Azure.Functions.Cli/Helpers/DotnetHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/DotnetHelpers.cs
@@ -70,28 +70,35 @@ namespace Azure.Functions.Cli.Helpers
             };
         }
 
-        public static async Task BuildDotnetProject(string outputPath, string dotnetCliParams)
+        public static bool CanDotnetBuild()
         {
             EnsureDotnet();
             var csProjFiles = FileSystemHelpers.GetFiles(Environment.CurrentDirectory, searchPattern: "*.csproj").ToList();
-            if (csProjFiles.Count == 1)
+            // If the project name is extensions only then is extensions.csproj a valid csproj file
+            if (!Path.GetFileName(Environment.CurrentDirectory).Equals("extensions"))
             {
-                if (FileSystemHelpers.DirectoryExists(outputPath))
-                {
-                    FileSystemHelpers.DeleteDirectorySafe(outputPath);
-                }
-
-                var exe = new Executable("dotnet", $"build --output {outputPath} {dotnetCliParams}");
-                var exitCode = await exe.RunAsync(o => ColoredConsole.WriteLine(o), e => ColoredConsole.Error.WriteLine(e));
-                if (exitCode != 0)
-                {
-                    throw new CliException("Error building project");
-                }
+                csProjFiles.Remove("extensions.csproj");
             }
-            else
+            if (csProjFiles.Count > 1)
             {
                 throw new CliException($"Can't determin Project to build. Expected 1 .csproj but found {csProjFiles.Count}");
             }
+            return csProjFiles.Count == 1;
+        }
+
+        public static async Task<bool> BuildDotnetProject(string outputPath, string dotnetCliParams)
+        {
+            if (FileSystemHelpers.DirectoryExists(outputPath))
+            {
+                FileSystemHelpers.DeleteDirectorySafe(outputPath);
+            }
+            var exe = new Executable("dotnet", $"build --output {outputPath} {dotnetCliParams}");
+            var exitCode = await exe.RunAsync(o => ColoredConsole.WriteLine(o), e => ColoredConsole.Error.WriteLine(e));
+            if (exitCode != 0)
+            {
+                throw new CliException("Error building project");
+            }
+            return true;
         }
 
         public static string GetCsproj()


### PR DESCRIPTION
One additional thing to note is:

Before this change, if you were to try and do `azure functionapp publish <name>` on a dotnet runtime project without a `.csproj`, it would error out complaining that it couldn't build as 0 `.csproj` was found. 
But, after this, it would still continue informing the user that the build step was skipped. I think it makes sense to keep it this way if someone wants to just publish their built project directly. I can't imagine a case where this would be a breaking change.

Let me know if you prefer me to keep the publishing the original way, I can update the PR.