### PR TITLE
Fixes #762 - Add verification for linuxFxVersion while publishing

### DIFF
--- a/src/Azure.Functions.Cli/Arm/Models/ArmWebsiteConfig.cs
+++ b/src/Azure.Functions.Cli/Arm/Models/ArmWebsiteConfig.cs
@@ -3,5 +3,6 @@
     internal class ArmWebsiteConfig
     {
         public string scmType { get; set; }
+        public string linuxFxVersion { get; set; }
     }
 }

--- a/src/Azure.Functions.Cli/Arm/Models/Site.cs
+++ b/src/Azure.Functions.Cli/Arm/Models/Site.cs
@@ -26,6 +26,8 @@ namespace Azure.Functions.Cli.Arm.Models
 
         public string Sku { get; set; }
 
+        public string LinuxFxVersion { get; set; }
+
         public IDictionary<string, string> AzureAppSettings { get; set; }
 
         public IDictionary<string, AppServiceConnectionString> ConnectionStrings { get; set; }

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -1,3 +1,4 @@
+using Azure.Functions.Cli.Helpers;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Reflection;
@@ -24,10 +25,19 @@ namespace Azure.Functions.Cli.Common
         public const string StorageEmulatorConnectionString = "UseDevelopmentStorage=true";
         public const string AzureWebJobsStorage = "AzureWebJobsStorage";
         public const string PackageReferenceElementName = "PackageReference";
+        public const string LinuxFxVersion = "linuxFxVersion";
 
         public static string CliVersion => typeof(Constants).GetTypeInfo().Assembly.GetName().Version.ToString(3);
 
         public static string CliDetailedVersion = typeof(Constants).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty;
+
+        public static readonly Dictionary<WorkerRuntime, IEnumerable<string>> WorkerRuntimeImages = new Dictionary<WorkerRuntime, IEnumerable<string>>
+        {
+            { WorkerRuntime.dotnet, new [] { "mcr.microsoft.com/azure-functions/dotnet", "microsoft/azure-functions-dotnet2.0", "mcr.microsoft.com/azure-functions/base", "microsoft/azure-functions-base" } },
+            { WorkerRuntime.node, new [] { "mcr.microsoft.com/azure-functions/node", "microsoft/azure-functions-node8" } },
+            { WorkerRuntime.python, new [] { "mcr.microsoft.com/azure-functions/python", "microsoft/azure-functions-python3.6"  } },
+            { WorkerRuntime.powershell, new [] { "mcr.microsoft.com/azure-functions/powershell", "microsoft/azure-functions-powershell" } }
+        };
 
         public static class Errors
         {


### PR DESCRIPTION
The check will only fail if they have a linuxFxVersion set to something in the portal. Let me know, if I should also fail if they don't have a version configured on linux dedicated.