### PR TITLE
logging exception for all LogLevels

### DIFF
--- a/src/Azure.Functions.Cli/Diagnostics/ColoredConsoleLogger.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/ColoredConsoleLogger.cs
@@ -50,16 +50,15 @@ namespace Azure.Functions.Cli.Diagnostics
 
         private static IEnumerable<RichString> GetMessageString(LogLevel level, string formattedMessage, Exception exception)
         {
+            if (exception != null)
+            {
+                formattedMessage += Environment.NewLine + Utility.FlattenException(exception);
+            }
+
             switch (level)
             {
                 case LogLevel.Error:
-                    string errorMessage = formattedMessage +
-                        Environment.NewLine +
-                        (exception == null
-                        ? string.Empty
-                        : Utility.FlattenException(exception));
-
-                    return SplitAndApply(errorMessage, ErrorColor);
+                    return SplitAndApply(formattedMessage, ErrorColor);
                 case LogLevel.Warning:
                     return SplitAndApply(formattedMessage, WarningColor);
                 case LogLevel.Information:


### PR DESCRIPTION
We were ignoring exceptions in the console unless they were logged with `LogLevel.Error`. Did a quick test with this code:

```
 [FunctionName("LogSomething")]
 public static async Task<IActionResult> Run(
     [HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)] HttpRequest req,
     ILogger log)
 {
     try
     {
         throw new InvalidOperationException("Boom!");
     }
     catch (Exception ex)
     {
         log.Log(LogLevel.Information, ex, "Something happened. But it's okay.");
     }

     return new OkObjectResult($"Hello");
 }
```

Before:
![image](https://user-images.githubusercontent.com/1089915/47458006-6a627c80-d78d-11e8-9f87-99d709ff61ff.png)

After:
![image](https://user-images.githubusercontent.com/1089915/47458036-7b12f280-d78d-11e8-97f2-a595a9af39cd.png)
