### PR TITLE
Add ability to allow using cached dependencies for python

### DIFF
--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -41,6 +41,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
         public string AdditionalPackages { get; set; } = string.Empty;
         public bool NoBuild { get; set; }
         public string DotnetCliParameters { get; set; }
+        public bool UseCached { get; set; }
 
         public PublishFunctionAppAction(ISettings settings, ISecretsManager secretsManager)
         {
@@ -101,6 +102,11 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 .Setup<bool>("no-build")
                 .WithDescription("Skip building dotnet functions")
                 .Callback(f => NoBuild = f);
+            Parser
+                .Setup<bool>("use-cached")
+                .SetDefault(false)
+                .WithDescription("Exclude cached python packages while packaging.")
+                .Callback(f => UseCached = f);
             Parser
                 .Setup<string>("dotnet-cli-params")
                 .WithDescription("When publishing dotnet functions, the core tools calls 'dotnet build --output bin/publish'. Any parameters passed to this will be appended to the command line.")
@@ -292,7 +298,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 throw new CliException("Publishing Python functions is only supported for Linux FunctionApps");
             }
 
-            Func<Task<Stream>> zipStreamFactory = () => ZipHelper.GetAppZipFile(workerRuntimeEnum, functionAppRoot, BuildNativeDeps, NoBundler, ignoreParser, AdditionalPackages, ignoreDotNetCheck: true);
+            Func<Task<Stream>> zipStreamFactory = () => ZipHelper.GetAppZipFile(workerRuntimeEnum, functionAppRoot, BuildNativeDeps, NoBundler, UseCached, Force, ignoreParser, AdditionalPackages, ignoreDotNetCheck: true);
 
             // if consumption Linux, or run from zip
             if ((functionApp.IsLinux && functionApp.IsDynamic) || RunFromZipDeploy)

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -18,6 +18,7 @@ namespace Azure.Functions.Cli.Common
         public const string FuncIgnoreFile = ".funcignore";
         public const string FunctionsWorkerRuntime = "FUNCTIONS_WORKER_RUNTIME";
         public const string RequirementsTxt = "requirements.txt";
+        public const string CachedPackagesTxt = "cached_packages.txt";
         public const string FunctionJsonFileName = "function.json";
         public const string DefaultVEnvName = "worker_env";
         public const string ExternalPythonPackages = ".python_packages";
@@ -26,6 +27,7 @@ namespace Azure.Functions.Cli.Common
         public const string AzureWebJobsStorage = "AzureWebJobsStorage";
         public const string PackageReferenceElementName = "PackageReference";
         public const string LinuxFxVersion = "linuxFxVersion";
+        public const string CachedRequirementsUrl = "https://raw.githubusercontent.com/Azure/azure-functions-docker/master/host/2.0/stretch/amd64/python-context/cached_start/cached_requirements.txt";
 
         public static string CliVersion => typeof(Constants).GetTypeInfo().Assembly.GetName().Version.ToString(3);
 

--- a/src/Azure.Functions.Cli/Common/FileSystemHelpers.cs
+++ b/src/Azure.Functions.Cli/Common/FileSystemHelpers.cs
@@ -28,6 +28,11 @@ namespace Azure.Functions.Cli.Common
             return Instance.File.ReadAllBytes(path);
         }
 
+        internal static string[] ReadAllLines(string path)
+        {
+            return Instance.File.ReadAllLines(path);
+        }
+
         public static string ReadAllTextFromFile(string path)
         {
             return Instance.File.ReadAllText(path);

--- a/src/Azure.Functions.Cli/Helpers/ZipHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/ZipHelper.cs
@@ -10,7 +10,7 @@ namespace Azure.Functions.Cli.Helpers
 {
     public static class ZipHelper
     {
-        public static async Task<Stream> GetAppZipFile(WorkerRuntime workerRuntime, string functionAppRoot, bool buildNativeDeps, bool noBundler, GitIgnoreParser ignoreParser = null, string additionalPackages = null, bool ignoreDotNetCheck = false)
+        public static async Task<Stream> GetAppZipFile(WorkerRuntime workerRuntime, string functionAppRoot, bool buildNativeDeps, bool noBundler, bool useCached, bool force, GitIgnoreParser ignoreParser = null, string additionalPackages = null, bool ignoreDotNetCheck = false)
         {
             var gitIgnorePath = Path.Combine(functionAppRoot, Constants.FuncIgnoreFile);
             if (ignoreParser == null && FileSystemHelpers.FileExists(gitIgnorePath))
@@ -20,7 +20,11 @@ namespace Azure.Functions.Cli.Helpers
 
             if (workerRuntime == WorkerRuntime.python)
             {
-                return await PythonHelpers.GetPythonDeploymentPackage(FileSystemHelpers.GetLocalFiles(functionAppRoot, ignoreParser), functionAppRoot, buildNativeDeps, noBundler, additionalPackages);
+                if (useCached && !PythonHelpers.InVirtualEnvironment)
+                {
+                    throw new CliException("For Python function apps using cached packages, you have to be running in a venv with the required packages installed while packaging/publish.");
+                }
+                return await PythonHelpers.GetPythonDeploymentPackage(FileSystemHelpers.GetLocalFiles(functionAppRoot, ignoreParser), functionAppRoot, buildNativeDeps, noBundler, useCached, force, additionalPackages);
             }
             else if (workerRuntime == WorkerRuntime.dotnet && !ignoreDotNetCheck)
             {

--- a/src/Azure.Functions.Cli/StaticResources/python_docker_build_no_bundler.sh.template
+++ b/src/Azure.Functions.Cli/StaticResources/python_docker_build_no_bundler.sh.template
@@ -9,7 +9,7 @@ if [ -d worker_venv ]; then
 fi
 python -m venv --copies worker_venv
 source worker_venv/bin/activate
-pip install -r requirements.txt
+pip install -r /requirements.txt
 apt-get update
 apt-get install zip -y
 zip --symlinks -r /app.zip .

--- a/tools/python/packapp/__main__.py
+++ b/tools/python/packapp/__main__.py
@@ -58,6 +58,9 @@ def find_and_build_deps(args):
     app_path = pathlib.Path(args.path)
     req_txt = app_path / 'requirements.txt'
 
+    if args.requirements:
+        req_txt = pathlib.Path(args.requirements)
+
     if not req_txt.exists():
         die('missing requirements.txt file.  '
             'If you do not have any requirements, please pass --no-deps.')
@@ -205,6 +208,7 @@ def parse_args(argv):
     parser.add_argument('--verbose', default=False, action='store_true')
     parser.add_argument('--platform', type=str)
     parser.add_argument('--python-version', type=str)
+    parser.add_argument('--requirements', type=str)
     parser.add_argument('--no-deps', default=False, action='store_true')
     parser.add_argument('--packages-dir-name', type=str,
                         default='.python_packages',


### PR DESCRIPTION
Do not merge yet as this still needs to be tested thoroughly.

To test this, if you use `--build-native-deps`, be sure to also use `--no-bundler` because we cannot use package caching when bundling the application.

The link to the `cached_requirements.txt` will not work because the file is not published yet. So, I recommend hosting [this](https://github.com/Azure/azure-functions-docker/pull/50/files#diff-8cc79e5d7ae45669e82f7c75401e43e7) elsewhere, changing the code and then testing it.

Reference - https://github.com/Azure/azure-functions-docker/pull/50

Next Steps:
- Add messages to let users know that if they use different versions of certain packages, we can use cached ones and hence save the size.
- Take care of `package` vs `package==<version>` in `requirements.txt`