### PR TITLE
Add telemetry

### DIFF
--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Net;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
+using System.Text.RegularExpressions;
 
 namespace Build
 {
@@ -36,6 +37,22 @@ namespace Build
             .Aggregate(string.Empty, (a, b) => $"{a} --source {b}");
 
             Shell.Run("dotnet", $"restore {Settings.ProjectFile} {feeds}");
+        }
+
+        public static void ReplaceTelemetryInstrumentationKey()
+        {
+            var instrumentationKey = Settings.TelemetryInstrumentationKey;
+            if (!string.IsNullOrEmpty(instrumentationKey))
+            {
+                // Given the small size of the file, it should be ok to load it in the memory
+                var constantsFileText = File.ReadAllText(Settings.ConstantsFile);
+                if (Regex.Matches(constantsFileText, Settings.TelemetryKeyToReplace).Count != 1)
+                {
+                    throw new Exception($"Could not find exactly one {Settings.TelemetryKeyToReplace} in {Settings.ConstantsFile} to replace.");
+                }
+                constantsFileText = constantsFileText.Replace(Settings.TelemetryKeyToReplace, instrumentationKey);
+                File.WriteAllText(Settings.ConstantsFile, constantsFileText);
+            }
         }
 
         public static void DotnetPublish()

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -13,6 +13,7 @@ namespace Build
                 .CreateForTarget(args)
                 .Then(Clean)
                 .Then(RestorePackages)
+                .Then(ReplaceTelemetryInstrumentationKey)
                 .Then(DotnetPublish)
                 .Then(AddDistLib)
                 .Then(AddPythonWorker)

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -32,6 +32,8 @@ namespace Build
 
         public static readonly string DurableFolder = Path.Combine(TestProjectPath, "Resources", "DurableTestFolder");
 
+        public static readonly string ConstantsFile = Path.Combine(SrcProjectPath, "Common", "Constants.cs");
+
         public static readonly string[] TargetRuntimes = new[] { "win-x86", "win-x64", "linux-x64", "osx-x64", "no-runtime" };
 
         public const string DistLibVersion = "distlib-15dba58a827f56195b0fa0afe80a8925a92e8bf5";
@@ -48,9 +50,13 @@ namespace Build
 
         public static readonly string ProjectTemplates = $"https://www.nuget.org/api/v2/package/Microsoft.Azure.WebJobs.ProjectTemplates/{ProjectTemplatesVersion}";
 
+        public static readonly string TelemetryKeyToReplace = "00000000-0000-0000-0000-000000000000";
+
         public static string BuildNumber => config(null, "Build.BuildId") ?? config("9999", "APPVEYOR_BUILD_NUMBER");
 
         public static string CommitId => config(null, "Build.SourceVersion") ?? config("N /A", "APPVEYOR_REPO_COMMIT");
+
+        public static string TelemetryInstrumentationKey => config(null, "TELEMETRY_INSTRUMENTATION_KEY");
 
         public static string BuildArtifactsStorage => config(null);
     }

--- a/src/Azure.Functions.Cli/Actions/BaseAction.cs
+++ b/src/Azure.Functions.Cli/Actions/BaseAction.cs
@@ -1,12 +1,18 @@
 ﻿using System.Threading.Tasks;
 using Fclp;
 using Azure.Functions.Cli.Interfaces;
+using Fclp.Internals;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Azure.Functions.Cli.Actions
 {
     abstract class BaseAction : IAction
     {
         protected FluentCommandLineParser Parser { get; private set; }
+
+        public IEnumerable<ICommandLineOption> MatchedOptions { get; private set; }
+
         public BaseAction()
         {
             Parser = new FluentCommandLineParser();
@@ -14,7 +20,9 @@ namespace Azure.Functions.Cli.Actions
 
         public virtual ICommandLineParserResult ParseArgs(string[] args)
         {
-            return Parser.Parse(args);
+            var parserResult = Parser.Parse(args);
+            MatchedOptions = Parser.Options.Except(parserResult.UnMatchedOptions);
+            return parserResult;
         }
 
         public abstract Task RunAsync();

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -122,7 +122,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 .SetDefault(false)
                 .Callback(b => NoBuild = b);
 
-            return Parser.Parse(args);
+            return base.ParseArgs(args);
         }
 
         private async Task<IWebHost> BuildWebHost(ScriptApplicationHostOptions hostOptions, WorkerRuntime workerRuntime, Uri baseAddress, X509Certificate2 certificate)

--- a/src/Azure.Functions.Cli/Actions/InternalUseAction.cs
+++ b/src/Azure.Functions.Cli/Actions/InternalUseAction.cs
@@ -33,7 +33,7 @@ namespace Azure.Functions.Cli.Actions
                 .WithDescription(nameof(Protocol))
                 .Callback(p => Protocol = p);
 
-            return Parser.Parse(args);
+            return base.ParseArgs(args);
         }
 
         public override Task RunAsync()

--- a/src/Azure.Functions.Cli/Actions/LocalActions/CreateFunctionAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/CreateFunctionAction.cs
@@ -9,13 +9,14 @@ using Azure.Functions.Cli.Interfaces;
 using Colors.Net;
 using Fclp;
 using static Azure.Functions.Cli.Common.OutputTheme;
+using static Azure.Functions.Cli.Helpers.TelemetryHelpers;
 
 namespace Azure.Functions.Cli.Actions.LocalActions
 {
     [Action(Name = "new", Context = Context.Function, HelpText = "Create a new function from a template.")]
     [Action(Name = "new", HelpText = "Create a new function from a template.")]
     [Action(Name = "create", Context = Context.Function, HelpText = "Create a new function from a template.")]
-    internal class CreateFunctionAction : BaseAction
+    internal class CreateFunctionAction : BaseAction, ITelemetryEventAction
     {
         private readonly ITemplatesManager _templatesManager;
         private readonly ISecretsManager _secretsManager;
@@ -148,6 +149,15 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 }
             }
             ColoredConsole.WriteLine($"The function \"{FunctionName}\" was created successfully from the \"{TemplateName}\" template.");
+        }
+
+        public void UpdateTelemetryLogEvent(ConsoleAppLogEvent consoleEvent)
+        {
+            consoleEvent.CommandEvents = new Dictionary<string, string>
+            {
+                { "language", Language },
+                { "trigger", TemplateName }
+            };
         }
     }
 }

--- a/src/Azure.Functions.Cli/Actions/LocalActions/CreateFunctionAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/CreateFunctionAction.cs
@@ -52,7 +52,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 .Setup<bool>("csx")
                 .WithDescription("use old style csx dotnet functions")
                 .Callback(csx => Csx = csx);
-            return Parser.Parse(args);
+            return base.ParseArgs(args);
         }
 
         public async override Task RunAsync()

--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -11,12 +11,13 @@ using Colors.Net;
 using Fclp;
 using Microsoft.Azure.WebJobs.Script;
 using static Azure.Functions.Cli.Common.OutputTheme;
+using static Azure.Functions.Cli.Helpers.TelemetryHelpers;
 using static Colors.Net.StringStaticMethods;
 
 namespace Azure.Functions.Cli.Actions.LocalActions
 {
     [Action(Name = "init", HelpText = "Create a new Function App in the current folder. Initializes git repo.")]
-    internal class InitAction : BaseAction
+    internal class InitAction : BaseAction, ITelemetryEventAction
     {
         public SourceControl SourceControl { get; set; } = SourceControl.Git;
 
@@ -101,12 +102,14 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             if (Csx)
             {
                 workerRuntime = Helpers.WorkerRuntime.dotnet;
+                WorkerRuntime = workerRuntime.ToString();
             }
             else if (string.IsNullOrEmpty(WorkerRuntime))
             {
                 ColoredConsole.Write("Select a worker runtime: ");
                 workerRuntime = SelectionMenuHelper.DisplaySelectionWizard(WorkerRuntimeLanguageHelper.AvailableWorkersList);
-                ColoredConsole.WriteLine(TitleColor(workerRuntime.ToString()));
+                WorkerRuntime = workerRuntime.ToString();
+                ColoredConsole.WriteLine(TitleColor(WorkerRuntime));
             }
             else
             {
@@ -228,6 +231,14 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             {
                 ColoredConsole.WriteLine($"{fileName} already exists. Skipped!");
             }
+        }
+
+        public void UpdateTelemetryLogEvent(ConsoleAppLogEvent consoleEvent)
+        {
+            consoleEvent.CommandEvents = new Dictionary<string, string>
+            {
+                { "worker-runtime", WorkerRuntime }
+            };
         }
     }
 }

--- a/src/Azure.Functions.Cli/Actions/LocalActions/InstallExtensionAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InstallExtensionAction.cs
@@ -65,7 +65,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 .WithDescription("update extensions version when running 'func extensions install'")
                 .Callback(force => Force = force);
 
-            return Parser.Parse(args);
+            return base.ParseArgs(args);
         }
 
         public async override Task RunAsync()

--- a/src/Azure.Functions.Cli/Actions/LocalActions/ListSettingsAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/ListSettingsAction.cs
@@ -24,7 +24,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 .Setup<bool>('a', "showValue")
                 .Callback(a => ShowValues = a)
                 .WithDescription("Specifying this shows decrypted settings."); 
-            return Parser.Parse(args);
+            return base.ParseArgs(args);
         }
 
         public override Task RunAsync()

--- a/src/Azure.Functions.Cli/Actions/LocalActions/SyncExtensionsAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/SyncExtensionsAction.cs
@@ -42,7 +42,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 .WithDescription("use old style csx dotnet functions")
                 .Callback(csx => Csx = csx);
 
-            return Parser.Parse(args);
+            return base.ParseArgs(args);
         }
 
         public async override Task RunAsync()

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -26,6 +26,9 @@ namespace Azure.Functions.Cli.Common
         public const string AzureWebJobsStorage = "AzureWebJobsStorage";
         public const string PackageReferenceElementName = "PackageReference";
         public const string LinuxFxVersion = "linuxFxVersion";
+        public const string TelemtryOptOutVariable = "FUNCTIONS_CLI_TELEMETRY_OPTOUT";
+        // This should be injected during build
+        public const string TelemetryInstrumentationKey = "00000000-0000-0000-0000-000000000000";
 
         public static string CliVersion => typeof(Constants).GetTypeInfo().Assembly.GetName().Version.ToString(3);
 

--- a/src/Azure.Functions.Cli/ConsoleApp.cs
+++ b/src/Azure.Functions.Cli/ConsoleApp.cs
@@ -53,7 +53,13 @@ namespace Azure.Functions.Cli
                     }
                     // All Actions are async. No return value is expected from any action.
                     await action.RunAsync();
+
                     // If we are here, we succeeded
+                    if (action is ITelemetryEventAction)
+                    {
+                        var telemetryEvent = action as ITelemetryEventAction;
+                        telemetryEvent.UpdateTelemetryLogEvent(app._consoleEvent);
+                    }
                     app._consoleEvent.IsSuccessful = true;
                 }
                 stopWatch.Stop();

--- a/src/Azure.Functions.Cli/Helpers/TelemetryHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/TelemetryHelpers.cs
@@ -1,0 +1,91 @@
+﻿using Azure.Functions.Cli.Common;
+using Fclp.Internals;
+using Microsoft.ApplicationInsights;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Azure.Functions.Cli.Helpers
+{
+    internal static class TelemetryHelpers
+    {
+        internal class ConsoleAppLogEvent
+        {
+            public string CommandName { get; set; }
+            public string IActionName { get; set; }
+            public IEnumerable<string> Parameters { get; set; }
+            public bool PrefixOrScriptRoot { get; set; }
+            public bool IsSuccessful { get; set; }
+            public bool ParseError { get; set; }
+            public long TimeTaken { get; set; }
+        }
+
+        public static IEnumerable<string> GetCommandsFromCommandLineOptions(IEnumerable<ICommandLineOption> options)
+        {
+            return options.Select(option => option.HasLongName ? option.LongName : option.ShortName);
+        }
+
+        private static string GetTelemetryUserID()
+        {
+            MD5 md5 = MD5.Create();
+            byte[] userIDBytes = Encoding.Unicode.GetBytes($"{Environment.MachineName}:{Environment.UserName}");
+            byte[] hashedID = md5.ComputeHash(userIDBytes);
+
+            StringBuilder sb = new StringBuilder();
+            // Append the bytes in hexadecimal form to the string builder
+            hashedID.ToList().ForEach(bt => sb.Append(bt.ToString("x2")));
+            return sb.ToString();
+        }
+
+        public static void LogEventIfAllowed(ConsoleAppLogEvent consoleEvent)
+        {
+            var instrumentationKey = Guid.Parse(Constants.TelemetryInstrumentationKey);
+            var telemetryOptOut = Environment.GetEnvironmentVariable(Constants.TelemtryOptOutVariable);
+            // Make sure that the user did not opt out
+            // and an instrumentation key is available
+            if ((string.IsNullOrEmpty(telemetryOptOut) || (!telemetryOptOut.Equals("true") && !telemetryOptOut.Equals("1")))
+                && !instrumentationKey.Equals(Guid.Empty))
+            {
+                try
+                {
+                    var tc = new TelemetryClient()
+                    {
+                        InstrumentationKey = instrumentationKey.ToString()
+                    };
+                    tc.Context.User.Id = GetTelemetryUserID();
+                    tc.Context.Device.OperatingSystem = Environment.OSVersion.ToString();
+                    LogEvent(tc, consoleEvent);
+                }
+                catch
+                {
+                    // If we can't log this event for some reason, it's ok.
+                }
+            }
+        }
+
+        private static void LogEvent(TelemetryClient tc, ConsoleAppLogEvent consoleEvent)
+        {
+            // If we didn't set the parameters, make it an empty list to avoid failure
+            consoleEvent.Parameters = consoleEvent.Parameters ?? new List<string>();
+            var properties = new Dictionary<string, string>
+            {
+                { "commandName" , consoleEvent.CommandName },
+                { "iActionName" , consoleEvent.IActionName },
+                { "parameters" , string.Join(",", consoleEvent.Parameters) },
+                { "prefixOrScriptRoot" , consoleEvent.PrefixOrScriptRoot.ToString() },
+                { "parseError" , consoleEvent.ParseError.ToString() },
+                { "isSuccessful" , consoleEvent.IsSuccessful.ToString() }
+            };
+
+            var metrics = new Dictionary<string, double>
+            {
+                { "timeTaken" , consoleEvent.TimeTaken }
+            };
+
+            tc.TrackEvent(consoleEvent.CommandName, properties, metrics);
+            tc.Flush();
+        }
+    }
+}

--- a/src/Azure.Functions.Cli/Helpers/TelemetryHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/TelemetryHelpers.cs
@@ -20,6 +20,7 @@ namespace Azure.Functions.Cli.Helpers
             public bool IsSuccessful { get; set; }
             public bool ParseError { get; set; }
             public long TimeTaken { get; set; }
+            public IDictionary<string, string> CommandEvents { get; set; }
         }
 
         public static IEnumerable<string> GetCommandsFromCommandLineOptions(IEnumerable<ICommandLineOption> options)
@@ -78,6 +79,12 @@ namespace Azure.Functions.Cli.Helpers
                 { "parseError" , consoleEvent.ParseError.ToString() },
                 { "isSuccessful" , consoleEvent.IsSuccessful.ToString() }
             };
+
+            if (consoleEvent.CommandEvents != null)
+            {
+                // This should be ok as long as there's no duplicate keys
+                properties = properties.Union(consoleEvent.CommandEvents).ToDictionary(k => k.Key, v => v.Value);
+            }
 
             var metrics = new Dictionary<string, double>
             {

--- a/src/Azure.Functions.Cli/Interfaces/IAction.cs
+++ b/src/Azure.Functions.Cli/Interfaces/IAction.cs
@@ -1,10 +1,13 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Fclp;
+using Fclp.Internals;
 
 namespace Azure.Functions.Cli.Interfaces
 {
     internal interface IAction
     {
+        IEnumerable<ICommandLineOption> MatchedOptions { get; }
         ICommandLineParserResult ParseArgs(string[] args);
         Task RunAsync();
     }

--- a/src/Azure.Functions.Cli/Interfaces/ITelemetryEventAction.cs
+++ b/src/Azure.Functions.Cli/Interfaces/ITelemetryEventAction.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using static Azure.Functions.Cli.Helpers.TelemetryHelpers;
+
+namespace Azure.Functions.Cli.Interfaces
+{
+    interface ITelemetryEventAction
+    {
+        void UpdateTelemetryLogEvent(ConsoleAppLogEvent consoleEvent);
+    }
+}

--- a/src/Azure.Functions.Cli/npm/lib/install.js
+++ b/src/Azure.Functions.Cli/npm/lib/install.js
@@ -47,6 +47,14 @@ const proxy = process.env.npm_config_https_proxy ||
             process.env.HTTP_PROXY ||
             process.env.http_proxy;
 
+const telemetryInfo = os.EOL
+    + 'Telemetry' + os.EOL
+    + '---------' + os.EOL
+    + 'The Azure Functions Core tools collect usage data in order to help us improve your experience. ' + os.EOL
+    + 'The data is anonymous and doesn\'t include any user specific or personal information. The data is collected by Microsoft.' + os.EOL
+    + os.EOL
+    + 'You can opt-out of telemetry by setting the FUNCTIONS_CLI_TELEMETRY_OPTOUT environment variable to \'1\' or \'true\' using your favorite shell.' + os.EOL
+
 if (proxy) {
     console.log('using proxy server %j', proxy);
     options.agent = new HttpsProxyAgent(proxy);
@@ -64,6 +72,7 @@ https.get(options, response => {
             response.on('data', data => bar.tick(data.length));
             const unzipStream = unzipper.Extract({ path: installPath })
                 .on('close', () => {
+                    console.log(telemetryInfo)
                     if (os.platform() === 'linux' || os.platform() === 'darwin') {
                         fs.chmodSync(`${installPath}/func`, 0o755);
                     }

--- a/test/Azure.Functions.Cli.Tests/HelpersTests/TelemetryHelpersTests.cs
+++ b/test/Azure.Functions.Cli.Tests/HelpersTests/TelemetryHelpersTests.cs
@@ -1,0 +1,61 @@
+﻿using Azure.Functions.Cli.Helpers;
+using Fclp.Internals;
+using Microsoft.ApplicationInsights;
+using Moq;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.HelpersTests
+{
+    public class TelemetryHelpersTests
+    {
+        private static Mock<ICommandLineOption> SetupCommand(string longName, string shortName, bool hasLongName, bool hasShortName)
+        {
+            var mockCommand = new Mock<ICommandLineOption>();
+
+            mockCommand
+                .Setup(m => m.LongName)
+                .Returns(longName);
+
+            mockCommand
+                .Setup(m => m.ShortName)
+                .Returns(shortName);
+
+            mockCommand
+                .Setup(m => m.HasLongName)
+                .Returns(hasLongName);
+
+            mockCommand
+                .Setup(m => m.HasShortName)
+                .Returns(hasShortName);
+
+            return mockCommand;
+        }
+
+        [Fact]
+        public void GetCommandsFromCommandLineOptions()
+        {
+            var mockForce = new Mock<ICommandLineOption>();
+            mockForce
+                .Setup(m => m.HasLongName)
+                .Returns(true);
+                
+            var cliOptions = new List<ICommandLineOption>
+            {
+                SetupCommand(longName : "force", shortName : "f", hasLongName : true, hasShortName : true).Object,
+                SetupCommand(longName : "verbose", shortName : "v", hasLongName : true, hasShortName : true).Object,
+                SetupCommand(longName : null, shortName : "e", hasLongName : false, hasShortName : true).Object,
+                SetupCommand(longName : "port", shortName : "p", hasLongName : false, hasShortName : true).Object
+            };
+
+            var commands = TelemetryHelpers.GetCommandsFromCommandLineOptions(cliOptions);
+
+            Assert.Contains("force", commands);
+            Assert.Contains("verbose", commands);
+            Assert.Contains("e", commands);
+            Assert.Contains("p", commands);
+            Assert.Equal(4, commands.Count());
+        }
+    }
+}


### PR DESCRIPTION
First take at adding basic telemetry to the CLI. 
I will be performing tests to make sure we log most of the scenarios possible and that we don't log any PII.

To test, please add the Instrumentation Key for you App Insights app. 

UPDATE - 
Here's how the Telemetry information looks in a basic command prompt-
![telemetryoptoutlook](https://user-images.githubusercontent.com/16520682/48577977-58c44e80-e8cd-11e8-8ed9-834ee748ec3d.PNG)

UPDATE 2- 
Here's the other PRs for the build systems we have-
https://github.com/Azure/homebrew-functions/pull/15
https://github.com/ahmelsayed/publish-script/pull/1