### PR TITLE
Display size and progress bar for uploads file uploads.

### DIFF
--- a/src/Azure.Functions.Cli/Common/SimpleProgressBar.cs
+++ b/src/Azure.Functions.Cli/Common/SimpleProgressBar.cs
@@ -1,0 +1,80 @@
+﻿using Colors.Net;
+using Microsoft.WindowsAzure.Storage.Core.Util;
+using System;
+
+namespace Azure.Functions.Cli.Common
+{
+    // Simplified https://gist.github.com/DanielSWolf/0ab6a96899cc5377bf54
+    class SimpleProgressBar : IDisposable
+    {
+        private bool isCompleted = false;
+        private readonly int width;
+        private int completed;
+
+        public SimpleProgressBar(string title)
+        {
+            var bufferWidth = Console.BufferWidth;
+            bufferWidth = bufferWidth > 100 ? 100 : bufferWidth;
+            this.width = bufferWidth - (title.Length + 4);
+
+            ColoredConsole.Write(title);
+
+            ColoredConsole.Write(" [");
+
+            for (var i = 0; i < width; i++)
+            {
+                ColoredConsole.Write('-');
+            }
+
+            ColoredConsole.Write("]");
+
+            for (var i = 0; i < width + 1; i++)
+            {
+                ColoredConsole.Write('\b');
+            }
+        }
+
+        public void Report(int progressPercentage)
+        {
+            if (isCompleted || Console.IsOutputRedirected)
+            {
+                return;
+            }
+
+            var tick = this.width * progressPercentage / 100;
+            var diff = tick - completed;
+            completed = tick;
+            for (var i = 0; i < diff; i++)
+            {
+                ColoredConsole.Write('#');
+            }
+
+            if (tick == width)
+            {
+                ColoredConsole.WriteLine(']');
+                isCompleted = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Report(100);
+            isCompleted = true;
+        }
+    }
+
+    class StorageProgressBar : SimpleProgressBar, IProgress<StorageProgress>
+    {
+        private readonly long size;
+
+        public StorageProgressBar(string title, long size) : base(title)
+        {
+            this.size = size;
+        }
+
+        public void Report(StorageProgress value)
+        {
+            Report((int)(value.BytesTransferred * 100 / size));
+        }
+    }
+}

--- a/src/Azure.Functions.Cli/Common/Utilities.cs
+++ b/src/Azure.Functions.Cli/Common/Utilities.cs
@@ -88,5 +88,21 @@ namespace Azure.Functions.Cli
         {
             return str.Replace(" ", string.Empty).Equals(another.Replace(" ", string.Empty), StringComparison.OrdinalIgnoreCase);
         }
+
+        // https://stackoverflow.com/a/281679
+        internal static string BytesToHumanReadable(double length)
+        {
+            string[] sizes = { "B", "KB", "MB", "GB", "TB" };
+            int order = 0;
+            while (length >= 1024 && order < sizes.Length - 1)
+            {
+                order++;
+                length = length / 1024;
+            }
+
+            // Adjust the format string to your preferences. For example "{0:0.#}{1}" would
+            // show a single decimal place, and no space.
+            return string.Format("{0:0.##} {1}", length, sizes[order]);
+        }
     }
 }

--- a/src/Azure.Functions.Cli/Helpers/ZipHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/ZipHelper.cs
@@ -34,16 +34,19 @@ namespace Azure.Functions.Cli.Helpers
 
         public static Stream CreateZip(IEnumerable<string> files, string rootPath)
         {
-            var memoryStream = new MemoryStream();
-            using (var zip = new ZipArchive(memoryStream, ZipArchiveMode.Create, leaveOpen: true))
+            const int defaultBufferSize = 4096;
+            var fileStream = new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, defaultBufferSize, FileOptions.DeleteOnClose);
+
+            using (var zip = new ZipArchive(fileStream, ZipArchiveMode.Create, leaveOpen: true))
             {
                 foreach (var fileName in files)
                 {
                     zip.AddFile(fileName, fileName, rootPath);
                 }
             }
-            memoryStream.Seek(0, SeekOrigin.Begin);
-            return memoryStream;
+
+            fileStream.Seek(0, SeekOrigin.Begin);
+            return fileStream;
         }
     }
 }


### PR DESCRIPTION
Closes #696 
Closes #513
Closes #681

I still have to test it on a linux console though 

it should work for both /zipdeploy and uploading to storage. 
![2018-11-09_15-01-31](https://user-images.githubusercontent.com/645740/48292747-7ce8e100-e430-11e8-9693-9d8797674a78.gif)
