### PR TITLE
Fixes #876 - Ensure dotnet for functions with extensions

### DIFF
--- a/src/Azure.Functions.Cli/Actions/LocalActions/CreateFunctionAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/CreateFunctionAction.cs
@@ -136,10 +136,11 @@ namespace Azure.Functions.Cli.Actions.LocalActions
 
                 if (template == null)
                 {
-                    ColoredConsole.Error.WriteLine(ErrorColor($"Can't find template \"{TemplateName}\" in \"{Language}\""));
+                    throw new CliException($"Can't find template \"{TemplateName}\" in \"{Language}\"");
                 }
                 else
                 {
+                    ExtensionsHelper.EnsureDotNetForExtensions(template);
                     ColoredConsole.Write($"Function name: [{template.Metadata.DefaultFunctionName}] ");
                     FunctionName = FunctionName ?? Console.ReadLine();
                     FunctionName = string.IsNullOrEmpty(FunctionName) ? template.Metadata.DefaultFunctionName : FunctionName;

--- a/src/Azure.Functions.Cli/Helpers/ExtensionsHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/ExtensionsHelper.cs
@@ -67,5 +67,14 @@ namespace Azure.Functions.Cli.Helpers
 
             return packages.Values;
         }
+
+        public static void EnsureDotNetForExtensions(Template template)
+        {
+            if (template.Metadata.Extensions != null && !CommandChecker.CommandExists("dotnet"))
+            {
+                throw new CliException($"The {template.Metadata.Name} template has extensions which require dotnet on your path. " +
+                    $"Please make sure to install dotnet for your system from https://www.microsoft.com/net/download");
+            }
+        }
     }
 }


### PR DESCRIPTION
I am not doing the check for when worker-runtime is dotnet. Currently, it should fail as expected because cli runs the `dotnet` command.