### PR TITLE
Fixes an issue with a false exception and AzureWebJobsStorage config.…

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -341,8 +341,8 @@ namespace Azure.Functions.Cli.Actions.HostActions
 
                 if (string.IsNullOrWhiteSpace(azureWebJobsStorage) && !allHttpTrigger)
                 {
-                    throw new CliException($"Missing value for AzureWebJobsStorage in {SecretsManager.AppSettingsFileName}. This is required for all triggers other than HTTP. "
-                        + $"You can run 'func azure functionapp fetch-app-settings <functionAppName>' or specify a connection string in {SecretsManager.AppSettingsFileName}.");
+                    ColoredConsole.WriteLine(WarningColor($"Missing value for AzureWebJobsStorage in {SecretsManager.AppSettingsFileName}. This is required for most triggers other than HTTP. "
+                        + $"You can run 'func azure functionapp fetch-app-settings <functionAppName>' or specify a connection string in {SecretsManager.AppSettingsFileName}."));
                 }
 
                 foreach ((var filePath, var functionJson) in functionsJsons)


### PR DESCRIPTION
Throwing an error when a Trigger is not HTTP and AzureWebJobsStorage is not configured is not correct. You can run other triggers without AzureWebJobsStorage for example: [TimerTrigger("0 */5 * * * *", UseMonitor=false)] or custom triggers. 
I replaced the exception with a warning.
Thanks and regards
Christian