### PR TITLE
Fixes #887 - Add preview flag to python

### DIFF
--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -105,7 +105,9 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             else if (string.IsNullOrEmpty(WorkerRuntime))
             {
                 ColoredConsole.Write("Select a worker runtime: ");
-                workerRuntime = SelectionMenuHelper.DisplaySelectionWizard(WorkerRuntimeLanguageHelper.AvailableWorkersList);
+                IDictionary<WorkerRuntime, string> workerRuntimeToDisplayString = WorkerRuntimeLanguageHelper.GetWorkerToDisplayStrings();
+                var workerRuntimeString = SelectionMenuHelper.DisplaySelectionWizard(workerRuntimeToDisplayString.Values);
+                workerRuntime = workerRuntimeToDisplayString.FirstOrDefault(wr => wr.Value.Equals(workerRuntimeString)).Key;
                 ColoredConsole.WriteLine(TitleColor(workerRuntime.ToString()));
             }
             else

--- a/src/Azure.Functions.Cli/Helpers/WorkerRuntimeLanguageHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/WorkerRuntimeLanguageHelper.cs
@@ -52,6 +52,24 @@ namespace Azure.Functions.Cli.Helpers
             .Where(k => k != WorkerRuntime.java)
             .Where(k => k != WorkerRuntime.powershell);
 
+        public static IDictionary<WorkerRuntime, string> GetWorkerToDisplayStrings()
+        {
+            IDictionary<WorkerRuntime, string> workerToDisplayStrings = new Dictionary<WorkerRuntime, string>();
+            foreach (WorkerRuntime wr in availableWorkersRuntime.Keys)
+            {
+                switch (wr)
+                {
+                    case WorkerRuntime.python:
+                        workerToDisplayStrings[wr] = "python (preview)";
+                        break;
+                    default:
+                        workerToDisplayStrings[wr] = wr.ToString();
+                        break;
+                }
+            }
+            return workerToDisplayStrings;
+        }
+
         public static WorkerRuntime NormalizeWorkerRuntime(string workerRuntime)
         {
             if (string.IsNullOrWhiteSpace(workerRuntime))


### PR DESCRIPTION
Adding `(preview)` while displaying the selection wizard on `func init` without affecting the parameter `--worker-runtime`. `func init --worker-runtime python` should still be valid.