### PR TITLE
Minor fix in file extensions python

### DIFF
--- a/src/Azure.Functions.Cli/StaticResources/python_bundle_script.py.template
+++ b/src/Azure.Functions.Cli/StaticResources/python_bundle_script.py.template
@@ -9,7 +9,7 @@ def get_possible_modules(location, parent = ''):
     dirs, files = get_dirs_files(location)
     for a_file in files:
         if is_python_file(a_file):
-            all_modules.append(parent + os.path.splitext(a_file)[0])
+            all_modules.append(parent + a_file.split(os.extsep)[0])
     for a_dir in dirs:
         if dir_has_python_files(os.path.join(location, a_dir)):
             all_modules.append(parent + a_dir)


### PR DESCRIPTION
This is a minor fix to change the way we pass hidden-imports to pyinstaller for bundling.

`os.path.splitext("test_approximate.cpython-36.so")`  returns `['test_approximate.cpython-36', 'so']`
while,
`"test_approximate.cpython-36.so".split(os.extsep)` returns `['test_approximate','cpython-36','so']`

We need the latter because `import test_approximate` is the valid syntax while `import test_approximate.cpython-36` is not.