### PR TITLE
Fixes #919 - Create a new func up command

### DIFF
--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -49,6 +49,14 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             _secretsManager = secretsManager;
         }
 
+        public PublishFunctionAppAction(ISettings settings, ISecretsManager secretsManager, string functionAppName, string accessToken)
+        {
+            _settings = settings;
+            _secretsManager = secretsManager;
+            AccessToken = accessToken;
+            FunctionAppName = functionAppName;
+        }
+
         public override ICommandLineParserResult ParseArgs(string[] args)
         {
             Parser

--- a/src/Azure.Functions.Cli/Actions/AzureActions/UpAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/UpAction.cs
@@ -1,0 +1,227 @@
+﻿using Azure.Functions.Cli.Actions.LocalActions;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Helpers;
+using Azure.Functions.Cli.Interfaces;
+using Colors.Net;
+using Fclp;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using static Colors.Net.StringStaticMethods;
+
+namespace Azure.Functions.Cli.Actions.AzureActions
+{
+    [Action(Name = "up", HelpText = "Create a new Function App in the current folder.")]
+    internal class UpAction : BaseAzureAction
+    {
+        private readonly ITemplatesManager _templatesManager;
+        private readonly ISecretsManager _secretsManager;
+        private readonly ISettings _settings;
+
+        public string WorkerRuntime { get; set; }
+
+        public bool Force { get; set; }
+
+        public string Location { get; set; }
+
+        public UpAction(ISettings settings, ITemplatesManager templatesManager, ISecretsManager secretsManager)
+        {
+            _settings = settings;
+            _templatesManager = templatesManager;
+            _secretsManager = secretsManager;
+        }
+
+        public override ICommandLineParserResult ParseArgs(string[] args)
+        {
+            Parser
+            .Setup<string>("worker-runtime")
+            .SetDefault(null)
+            .WithDescription($"Runtime framework for the functions. Options are: {WorkerRuntimeLanguageHelper.AvailableWorkersRuntimeString}")
+            .Callback(w => WorkerRuntime = w);
+
+            Parser
+            .Setup<bool>("force")
+            .WithDescription("Force initializing")
+            .Callback(f => Force = f);
+
+            Parser
+            .Setup<string>("location")
+            .WithDescription("Location or Region of your new functionapp.")
+            .Callback(f => Location = f);
+
+            return base.ParseArgs(args);
+        }
+
+        public override async Task RunAsync()
+        {
+            if (NeedNewLocalProject(out string functionProject))
+            {
+                functionProject = await CreateNewLocalProject();
+                await CreateNewFunction();
+            }
+            Environment.CurrentDirectory = functionProject;
+            var functionAppName = await GetFunctionAppName();
+            await PublishLocalProject(functionAppName);
+        }
+
+        private bool NeedNewLocalProject(out string functionProject)
+        {
+            try
+            {
+                functionProject = ScriptHostHelpers.GetFunctionAppRootDirectory(Environment.CurrentDirectory);
+                return false;
+            }
+            catch (Exception)
+            {
+                functionProject = default(string);
+                return true;
+            }
+        }
+
+        private bool TryGetStorageAndFunctionAppNames(out string functionAppName)
+        {
+            var publishConfigFileName = Path.Combine(Environment.CurrentDirectory, Constants.PublishConfigurationFileName);
+            if (FileSystemHelpers.FileExists(publishConfigFileName))
+            {
+                try
+                {
+                    var publishConfig = FileSystemHelpers.ReadAllTextFromFile(publishConfigFileName);
+                    functionAppName = JsonConvert.DeserializeObject<JObject>(publishConfig)[Constants.FunctionAppKeyPublish].ToString();
+                    return true;
+                }
+                catch (Exception)
+                {
+                    ColoredConsole.WriteLine(Yellow($"Could not parse {Constants.PublishConfigurationFileName} file. Continuing without it..."));
+                }
+            }
+            functionAppName = default(string);
+            return false;
+        }
+
+        private async Task<string> GetFunctionAppName()
+        {
+            if (TryGetStorageAndFunctionAppNames(out string functionAppName))
+            {
+                ColoredConsole.WriteLine($"Using functionapp {functionAppName} from {Constants.PublishConfigurationFileName}");
+                return functionAppName;
+            }
+            if (string.IsNullOrEmpty(Location))
+            {
+                throw new CliException("Must specify --location in order to create a new function app");
+            }
+            var resourceGroup = await CreateAzureResourceGroup();
+            var storageAccount = await CreateAzureStorage(resourceGroup);
+            var functionApp = await CreateAzureFunctionApp(resourceGroup, storageAccount);
+            SavePublishConfiguration(functionApp);
+            return functionApp;
+        }
+
+        private string GetPossibleResourceName(Random random, string baseName)
+        {
+            const int extraRandom = 6;
+            const string chars = "acdefghijklmnopqrstuvwxyz";
+
+            var randomElement = new string(Enumerable.Repeat(chars, extraRandom)
+              .Select(s => s[random.Next(s.Length)]).ToArray());
+            return baseName + randomElement;
+        }
+
+        private void SavePublishConfiguration(string functionApp)
+        {
+            IDictionary<string, string> publishConfig = new Dictionary<string, string>
+            {
+                { Constants.FunctionAppKeyPublish, functionApp }
+            };
+            FileSystemHelpers.WriteAllTextToFile(Constants.PublishConfigurationFileName, JsonConvert.SerializeObject(publishConfig));
+            // TODO: Write it to .funcignore and .gitignore
+        }
+
+        private async Task<string> FindValidNameAndCreatAzureResource(Func<string, Task<bool>> isResourceTakenFunc, Func<string, Task> createResourceFunc, string resourceName)
+        {
+            var localFunctionName = new DirectoryInfo(Environment.CurrentDirectory).Name;
+            // Could probably be less restrictive here, but for now only limiting names to characters and numbers
+            var validNameRegex = new Regex("[^a-zA-Z0-9]");
+            var localFunctionValidName = validNameRegex.Replace(localFunctionName, "");
+            Random random = new Random();
+            ColoredConsole.WriteLine($"Looking for a valid name to create a new Azure {resourceName}...");
+            while (localFunctionValidName.Length < 2 || await isResourceTakenFunc(localFunctionValidName))
+            {
+                localFunctionValidName = GetPossibleResourceName(random, validNameRegex.Replace(localFunctionName, ""));
+            }
+            ColoredConsole.WriteLine($"Creating an Azure {resourceName} with name \'{localFunctionValidName}\'...{Environment.NewLine}");
+            await createResourceFunc(localFunctionValidName);
+            return localFunctionValidName;
+        }
+
+        private async Task<string> CreateAzureResourceGroup()
+        {
+            async Task<bool> isResourceTakenFunc(string name) {
+                return await AzureHelper.CheckIfResourceGroupAlreadyExists(name);
+            }
+            async Task createResourceFunc(string name)
+            {
+                await AzureHelper.CreateResourceGroup(Location, name);
+            }
+            return await FindValidNameAndCreatAzureResource(isResourceTakenFunc, createResourceFunc, "Resource Group");
+        }
+
+        private async Task<string> CreateAzureStorage(string resourceGroup)
+        {
+            async Task<bool> isResourceTakenFunc(string name)
+            {
+                return await AzureHelper.IsStorageAccountNameTaken(name);
+            }
+            async Task createResourceFunc(string name)
+            {
+                await AzureHelper.CreateAzureStorage(name, resourceGroup);
+            }
+            return await FindValidNameAndCreatAzureResource(isResourceTakenFunc, createResourceFunc, "Storage Account");
+        }
+
+        private async Task<string> CreateAzureFunctionApp(string resourceGroup, string storageAccount)
+        {
+            async Task<bool> isResourceTakenFunc(string name)
+            {
+                return await AzureHelper.CheckIfFunctionAppAlreadyExists(name, AccessToken);
+            }
+            async Task createResourceFunc(string name)
+            {
+                var workerRuntime = string.IsNullOrEmpty(WorkerRuntime)
+                    ? WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(_secretsManager)
+                    : WorkerRuntimeLanguageHelper.NormalizeWorkerRuntime(WorkerRuntime);
+
+                var os = workerRuntime == Helpers.WorkerRuntime.python ? "linux" : "windows";
+                await AzureHelper.CreateAzureFunction(resourceGroup, storageAccount, name, os, workerRuntime.ToString(), Location);
+            }
+            return await FindValidNameAndCreatAzureResource(isResourceTakenFunc, createResourceFunc, "Function App");
+        }
+
+        private async Task<string> CreateNewLocalProject()
+        {
+            ColoredConsole.WriteLine("Creating a new local Functions project...");
+            InitAction initAction = new InitAction(_templatesManager, SourceControl.Git, WorkerRuntime, Force, initDocker: false, csx: false);
+            await initAction.RunAsync();
+            ColoredConsole.WriteLine("Project created.");
+            return Environment.CurrentDirectory;
+        }
+
+        private async Task CreateNewFunction()
+        {
+            ColoredConsole.WriteLine("Creating a new local Function...");
+            CreateFunctionAction createAction = new CreateFunctionAction(_templatesManager, _secretsManager, language: null, templateName: null, functionName: null, csx: false);
+            await createAction.RunAsync();
+        }
+
+        private async Task PublishLocalProject(string functionApp)
+        {
+            ColoredConsole.WriteLine("Publishing your local Function...");
+            PublishFunctionAppAction publishFunctionAppAction = new PublishFunctionAppAction(_settings, _secretsManager, functionApp, AccessToken);
+            await publishFunctionAppAction.RunAsync();
+        }
+    }
+}

--- a/src/Azure.Functions.Cli/Actions/LocalActions/CreateFunctionAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/CreateFunctionAction.cs
@@ -31,6 +31,16 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             _secretsManager = secretsManager;
         }
 
+        public CreateFunctionAction(ITemplatesManager templatesManager, ISecretsManager secretsManager, string language, string templateName, string functionName, bool csx)
+        {
+            _templatesManager = templatesManager;
+            _secretsManager = secretsManager;
+            Language = language;
+            TemplateName = templateName;
+            FunctionName = functionName;
+            Csx = csx;
+        }
+
         public override ICommandLineParserResult ParseArgs(string[] args)
         {
             Parser

--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -44,6 +44,16 @@ namespace Azure.Functions.Cli.Actions.LocalActions
         {
             _templatesManager = templatesManager;
         }
+        public InitAction(ITemplatesManager templatesManager, SourceControl sourceControl, string workerRuntime, bool force, bool initDocker, bool csx, string folderName = null)
+        {
+            _templatesManager = templatesManager;
+            SourceControl = sourceControl;
+            WorkerRuntime = workerRuntime;
+            Force = force;
+            InitDocker = initDocker;
+            Csx = csx;
+            FolderName = folderName;
+        }
 
         public override ICommandLineParserResult ParseArgs(string[] args)
         {

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -19,6 +19,7 @@ namespace Azure.Functions.Cli.Common
         public const string FunctionsWorkerRuntime = "FUNCTIONS_WORKER_RUNTIME";
         public const string RequirementsTxt = "requirements.txt";
         public const string FunctionJsonFileName = "function.json";
+        public const string PublishConfigurationFileName = "publish_configuration.json";
         public const string DefaultVEnvName = "worker_env";
         public const string ExternalPythonPackages = ".python_packages";
         public const string FunctionsExtensionVersion = "FUNCTIONS_EXTENSION_VERSION";
@@ -26,6 +27,7 @@ namespace Azure.Functions.Cli.Common
         public const string AzureWebJobsStorage = "AzureWebJobsStorage";
         public const string PackageReferenceElementName = "PackageReference";
         public const string LinuxFxVersion = "linuxFxVersion";
+        public const string FunctionAppKeyPublish = "functionapp";
 
         public static string CliVersion => typeof(Constants).GetTypeInfo().Assembly.GetName().Version.ToString(3);
 


### PR DESCRIPTION
I still have to write some tests, improve console messages, make sure everything works properly, minor refactoring etc. Just wanted to get feedback on the approach here and if we need major changes before I wrap this up.

Here's the output video of `func up --location westus` (sorry, a little too big for a gif)
[func_up1.zip](https://github.com/Azure/azure-functions-core-tools/files/2682298/func_up1.zip)

and Here's the output video of any subsequent `func up` commands
[func_up2.zip](https://github.com/Azure/azure-functions-core-tools/files/2682303/func_up2.zip)

Note: I deleted the apps that were created in the above video, so do not try to ping those.

Some consideration and work items-
- (minor) Need to make sure to add `publish_settings.json` to `.funcignore` and `.gitignore`
- `func up` behavior for python like languages which need `--build-native-deps` in certain cases.
- Most of this is done using the az cli
- App insights are not created right now, but once I add the support in az cli, it should be simple to create it from here.
- I made `--location` required for the first command. Although the error shows up after creating the local project, which could be fine.

Please let me know if there are any questions.

/cc @ahmedelnably  
