### PR TITLE
Allow for regional date formats in Durable Test

### DIFF
--- a/src/Azure.Functions.Cli/Actions/DurableActions/DurableGetInstances.cs
+++ b/src/Azure.Functions.Cli/Actions/DurableActions/DurableGetInstances.cs
@@ -32,12 +32,12 @@ namespace Azure.Functions.Cli.Actions.DurableActions
             Parser
                 .Setup<DateTime>("created-after")
                 .WithDescription("(Optional) Retrieve the instances created after this date/time (UTC). All ISO 8601 formatted datetimes accepted.")
-                .SetDefault(DateTime.MinValue)
+                .SetDefault(DurableManager.CreatedAfterDefault)
                 .Callback(n => CreatedTimeFrom = n);
             Parser
                 .Setup<DateTime>("created-before")
                 .WithDescription("(Optional) Retrieve the instances created before this date/time (UTC). All ISO 8601 formatted datetimes accepted.")
-                .SetDefault(DateTime.MaxValue.AddDays(-1)) // subtract one to avoid overflow/timezone error
+                .SetDefault(DurableManager.CreatedBeforeDefault)
                 .Callback(n => CreatedTimeTo = n);
             Parser
                 .Setup<string>("runtime-status")

--- a/src/Azure.Functions.Cli/Actions/DurableActions/DurablePurgeHistory.cs
+++ b/src/Azure.Functions.Cli/Actions/DurableActions/DurablePurgeHistory.cs
@@ -9,6 +9,9 @@ namespace Azure.Functions.Cli.Actions.DurableActions
     [Action(Name = "purge-history", Context = Context.Durable, HelpText = "Purge orchestration instance state, history, and blob storage for orchestrations older than the specified threshold time.")]
     class DurablePurgeHistory : BaseDurableAction
     {
+        public readonly static DateTime CreatedAfterDefault = DateTime.MinValue;
+        public readonly static DateTime CreatedBeforeDefault = DateTime.MaxValue.AddDays(-1); // subtract one to avoid overflow/timezone error
+
         private readonly IDurableManager _durableManager;
 
         private DateTime CreatedTimeFrom { get; set; }
@@ -27,12 +30,12 @@ namespace Azure.Functions.Cli.Actions.DurableActions
             Parser
                 .Setup<DateTime>("created-after")
                 .WithDescription("(Optional) Delete the history of instances created after this date/time (UTC). All ISO 8601 formatted datetimes accepted.")
-                .SetDefault(DateTime.MinValue)
+                .SetDefault(CreatedAfterDefault)
                 .Callback(n => CreatedTimeFrom = n);
             Parser
                 .Setup<DateTime>("created-before")
                 .WithDescription("(Optional) Delete the history of instances created before this date/time (UTC). All ISO 8601 formatted datetimes accepted.")
-                .SetDefault(DateTime.MaxValue.AddDays(-1)) // subtract one to avoid overflow/timezone error
+                .SetDefault(CreatedBeforeDefault)
                 .Callback(n => CreatedTimeTo = n);
             Parser
                 .Setup<string>("runtime-status")

--- a/src/Azure.Functions.Cli/Actions/DurableActions/DurablePurgeHistory.cs
+++ b/src/Azure.Functions.Cli/Actions/DurableActions/DurablePurgeHistory.cs
@@ -9,8 +9,6 @@ namespace Azure.Functions.Cli.Actions.DurableActions
     [Action(Name = "purge-history", Context = Context.Durable, HelpText = "Purge orchestration instance state, history, and blob storage for orchestrations older than the specified threshold time.")]
     class DurablePurgeHistory : BaseDurableAction
     {
-        public readonly static DateTime CreatedAfterDefault = DateTime.MinValue;
-        public readonly static DateTime CreatedBeforeDefault = DateTime.MaxValue.AddDays(-1); // subtract one to avoid overflow/timezone error
 
         private readonly IDurableManager _durableManager;
 
@@ -30,12 +28,12 @@ namespace Azure.Functions.Cli.Actions.DurableActions
             Parser
                 .Setup<DateTime>("created-after")
                 .WithDescription("(Optional) Delete the history of instances created after this date/time (UTC). All ISO 8601 formatted datetimes accepted.")
-                .SetDefault(CreatedAfterDefault)
+                .SetDefault(DurableManager.CreatedAfterDefault)
                 .Callback(n => CreatedTimeFrom = n);
             Parser
                 .Setup<DateTime>("created-before")
                 .WithDescription("(Optional) Delete the history of instances created before this date/time (UTC). All ISO 8601 formatted datetimes accepted.")
-                .SetDefault(CreatedBeforeDefault)
+                .SetDefault(DurableManager.CreatedBeforeDefault)
                 .Callback(n => CreatedTimeTo = n);
             Parser
                 .Setup<string>("runtime-status")

--- a/src/Azure.Functions.Cli/Common/DurableManager.cs
+++ b/src/Azure.Functions.Cli/Common/DurableManager.cs
@@ -37,6 +37,10 @@ namespace Azure.Functions.Cli.Common
 
         public const string MinimumDurableAzureStorageExtensionVersion = "1.4.0";
 
+        public readonly static DateTime CreatedAfterDefault = DateTime.MinValue;
+        public readonly static DateTime CreatedBeforeDefault = DateTime.MaxValue.AddDays(-1); // subtract one to avoid overflow/timezone error
+
+
         public DurableManager(ISecretsManager secretsManager)
         {
             _secretsManager = secretsManager;

--- a/test/Azure.Functions.Cli.Tests/E2E/DurableTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/DurableTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Threading.Tasks;
+using Azure.Functions.Cli.Actions.DurableActions;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Tests.E2E.Helpers;
 using Newtonsoft.Json;
@@ -163,7 +164,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                 },
                 OutputContains = new string[]
                 {
-                    $"Purged orchestration history for all instances created between '{DateTime.MinValue}' and '{DateTime.MaxValue.AddDays(-1)}'"
+                    $"Purged orchestration history for all instances created between '{DurablePurgeHistory.CreatedAfterDefault}' and '{DurablePurgeHistory.CreatedBeforeDefault}'"
                 },
                 CommandTimeout = TimeSpan.FromSeconds(45)
             },

--- a/test/Azure.Functions.Cli.Tests/E2E/DurableTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/DurableTests.cs
@@ -164,7 +164,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                 },
                 OutputContains = new string[]
                 {
-                    $"Purged orchestration history for all instances created between '{DurablePurgeHistory.CreatedAfterDefault}' and '{DurablePurgeHistory.CreatedBeforeDefault}'"
+                    $"Purged orchestration history for all instances created between '{DurableManager.CreatedAfterDefault}' and '{DurableManager.CreatedBeforeDefault}'"
                 },
                 CommandTimeout = TimeSpan.FromSeconds(45)
             },

--- a/test/Azure.Functions.Cli.Tests/E2E/DurableTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/DurableTests.cs
@@ -163,7 +163,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                 },
                 OutputContains = new string[]
                 {
-                    "Purged orchestration history for all instances created between '1/1/0001 12:00:00 AM' and '12/30/9999 11:59:59 PM'"
+                    $"Purged orchestration history for all instances created between '{DateTime.MinValue}' and '{DateTime.MaxValue.AddDays(-1)}'"
                 },
                 CommandTimeout = TimeSpan.FromSeconds(45)
             },


### PR DESCRIPTION
Fixes #944 

I considered forcing the output in the purge command to use the invariant culture so that the test could retain non-computed values for the assertion, but there seems to be a precedent for locale-based date output in [ColoredConsoleLogger](https://github.com/Azure/azure-functions-core-tools/blob/cd919dc1f4e993a631a9fdc43bd0946660a4ca86/src/Azure.Functions.Cli/Diagnostics/ColoredConsoleLogger.cs#L47)