### PR TITLE
Enable building func cli as a dotnet global tool

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>func</AssemblyName>
     <RuntimeIdentifiers>win-x64;win-x86;linux-x64;osx-x64</RuntimeIdentifiers>
     <PackAsTool>true</PackAsTool>
-    <ToolCommandName>azurefunc</ToolCommandName>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">1</BuildNumber>
     <MajorMinorProductVersion>2.3</MajorMinorProductVersion>
     <Version>$(MajorMinorProductVersion).$(BuildNumber)</Version>

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -4,7 +4,8 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyName>func</AssemblyName>
     <RuntimeIdentifiers>win-x64;win-x86;linux-x64;osx-x64</RuntimeIdentifiers>
-
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>azurefunc</ToolCommandName>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">1</BuildNumber>
     <MajorMinorProductVersion>2.3</MajorMinorProductVersion>
     <Version>$(MajorMinorProductVersion).$(BuildNumber)</Version>


### PR DESCRIPTION
@joeyaiello mentioned there was a discussion about func cli as a dotnet global tool. 

I did a quick change and tested this on my fork. To build and use the global tool:

1. `dotnet pack` under `src\Azure.Functions.Cli`
2. `dotnet tool install -g --add-source <path to nupkg> func`
3. `func`

`dotnet pack` produces a `.nupkg` which needs to be released to `nuget.org`.