### PR TITLE
Added knative support

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,18 @@ func logs --name myfunction --platform kubernetes
 ```bash
 func deploy --platform kubernetes --name myfunction --registry <docker-hub-id or registry-server> --config /mypath/config
 ```
+### Deploy a function to Knative
+
+#### Prerequisites
+
+* [Knative](https://github.com/knative/docs/tree/master/install/)
+
+Deploying Azure Functions to knative is supported with the ```--platform knative``` flag.
+The Core Tools CLI identifies non HTTP trigger functions and annotates the knative manifest with the the ```minScale``` annotation to opt out of scale-to-zero.
+
+```bash
+func deploy --platform knative --name myfunction --registry <docker-hub-id or registry-server>
+```
 
 ### Deploying a function to AKS using ACR
 Using the configuration options an Azure Function app can also be deployed to a [AKS](https://azure.microsoft.com/en-us/services/kubernetes-service/) (Azure Kubernetes Service) Kubernetes cluster and use [ACR](https://azure.microsoft.com/en-us/services/container-registry/) as the registry server. Do all of the following *before* you run the deployment command.

--- a/src/Azure.Functions.Cli/Actions/DeployActions/DeployFunctionAction.cs
+++ b/src/Azure.Functions.Cli/Actions/DeployActions/DeployFunctionAction.cs
@@ -110,7 +110,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             await DockerHelpers.DockerBuild(image, Environment.CurrentDirectory);
 
             ColoredConsole.WriteLine("Pushing function image to registry...");
-           // await DockerHelpers.DockerPush(image);
+            await DockerHelpers.DockerPush(image);
 
             var platform = PlatformFactory.CreatePlatform(Platform, ConfigPath);
 

--- a/src/Azure.Functions.Cli/Actions/DeployActions/DeployFunctionAction.cs
+++ b/src/Azure.Functions.Cli/Actions/DeployActions/DeployFunctionAction.cs
@@ -27,7 +27,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
         public string FolderName { get; set; } = string.Empty;
         public string ConfigPath { get; set; } = string.Empty;
 
-        public List<string> Platforms { get; set; } = new List<string>() { "kubernetes" };
+        public List<string> Platforms { get; set; } = new List<string>() { "kubernetes", "knative" };
         private readonly ITemplatesManager _templatesManager;
 
         public DeployAction(ITemplatesManager templatesManager)
@@ -92,7 +92,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
 
             if (!CommandChecker.CommandExists("kubectl"))
             {
-                ColoredConsole.Error.WriteLine(ErrorColor($"kubectl is required for deploying to kubernetes. Please make sure to install kubectl and try again."));
+                ColoredConsole.Error.WriteLine(ErrorColor($"kubectl is required for deploying to kubernetes and knative. Please make sure to install kubectl and try again."));
                 return;
             }
 
@@ -110,7 +110,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             await DockerHelpers.DockerBuild(image, Environment.CurrentDirectory);
 
             ColoredConsole.WriteLine("Pushing function image to registry...");
-            await DockerHelpers.DockerPush(image);
+           // await DockerHelpers.DockerPush(image);
 
             var platform = PlatformFactory.CreatePlatform(Platform, ConfigPath);
 

--- a/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/KnativePlatform.cs
+++ b/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/KnativePlatform.cs
@@ -80,7 +80,7 @@ namespace Azure.Functions.Cli.Actions.DeployActions.Platforms
             ColoredConsole.WriteLine();
             ColoredConsole.WriteLine($"Function URL: http://{externalIP}");
             ColoredConsole.WriteLine($"Function Host: {host}");
-            ColoredConsole.WriteLine("");
+            ColoredConsole.WriteLine();
             ColoredConsole.WriteLine("Plese note: it may take a few minutes for the knative service to be reachable");
         }
 

--- a/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/KnativePlatform.cs
+++ b/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/KnativePlatform.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Linq;
+using System.IO;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Helpers;
+using Azure.Functions.Cli.Interfaces;
+using Colors.Net;
+using KubeClient;
+using KubeClient.Models;
+using Azure.Functions.Cli.Actions.DeployActions.Platforms.Models;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json;
+
+namespace Azure.Functions.Cli.Actions.DeployActions.Platforms
+{
+    public class KnativePlatform : IHostingPlatform
+    {
+        private string configFile = string.Empty;
+        private const string FUNCTIONS_NAMESPACE = "azure-functions";
+        private static KubeApiClient client;
+
+        public async Task DeployContainerizedFunction(string functionName, string image, int min, int max)
+        {
+            await Deploy(functionName, image, FUNCTIONS_NAMESPACE, min, max);
+        }
+
+        public KnativePlatform(string configFile)
+        {
+            this.configFile = configFile;
+            KubeClientOptions options;
+
+            if (!string.IsNullOrEmpty(configFile))
+            {
+                options = K8sConfig.Load(configFile).ToKubeClientOptions(defaultKubeNamespace: FUNCTIONS_NAMESPACE);
+            }
+            else
+            {
+                options = K8sConfig.Load().ToKubeClientOptions(defaultKubeNamespace: FUNCTIONS_NAMESPACE);
+            }
+
+            client = KubeApiClient.Create(options);
+        }
+
+        private async Task Deploy(string name, string image, string nameSpace, int min, int max)
+        {
+            var isHTTP = IsHTTPTrigger(name);
+
+            await CreateNamespace(nameSpace);
+            client.DefaultNamespace = nameSpace;
+
+            ColoredConsole.WriteLine();
+            ColoredConsole.WriteLine("Deploying function to Knative...");
+
+            var knativeService = GetKnativeService(name, image, nameSpace, min, max, isHTTP);
+            var json = Newtonsoft.Json.JsonConvert.SerializeObject(knativeService,
+                            Newtonsoft.Json.Formatting.None,
+                            new Newtonsoft.Json.JsonSerializerSettings
+                            {
+                                NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore
+                            });
+
+            File.WriteAllText("deployment.json", json);
+            await KubernetesHelper.RunKubectl($"apply -f deployment.json");
+            File.Delete("deployment.json");
+
+            var externalIP = await GetIstioClusterIngressIP();
+            if (externalIP == "")
+            {
+                ColoredConsole.WriteLine("Couldn't find Istio Cluster Ingress External IP");
+                return;
+            }
+
+            var host = GetFunctionHost(name, nameSpace);
+
+            ColoredConsole.WriteLine("");
+
+            ColoredConsole.WriteLine("Function deployed successfully!");
+            ColoredConsole.WriteLine();
+            ColoredConsole.WriteLine($"Function URL: http://{externalIP}");
+            ColoredConsole.WriteLine($"Function Host: {host}");
+            ColoredConsole.WriteLine("");
+            ColoredConsole.WriteLine("Plese note: it may take a few minutes for the knative service to be reachable");
+        }
+
+        private string GetFunctionHost(string functionName, string nameSpace) {
+            return string.Format("{0}.{1}.example.com", functionName, nameSpace);
+        }
+
+        private bool IsHTTPTrigger(string functionName)
+        {
+            var str = File.ReadAllText(string.Format("{0}/function.json", functionName));
+            var jObj = JsonConvert.DeserializeObject<FunctionJson>(str);
+            return jObj.bindings.Any(d=> d.type == "http");
+        }
+
+        private KnativeService GetKnativeService(string name, string image, string nameSpace, int min, int max, bool isHTTP)
+        {
+            var knativeService = new KnativeService();
+            knativeService.kind = "Service";
+            knativeService.apiVersion = "serving.knative.dev/v1alpha1";
+            knativeService.metadata = new Metadata();
+            knativeService.metadata.name = name;
+            knativeService.metadata.@namespace = nameSpace;
+
+            knativeService.spec = new KnativeSpec();
+            knativeService.spec.runLatest = new RunLatest();
+            knativeService.spec.runLatest.configuration = new Configuration();
+            knativeService.spec.runLatest.configuration.revisionTemplate = new RevisionTemplate();
+            knativeService.spec.runLatest.configuration.revisionTemplate.spec = new RevisionTemplateSpec();
+            knativeService.spec.runLatest.configuration.revisionTemplate.spec.container = new KnativeContainer();
+            knativeService.spec.runLatest.configuration.revisionTemplate.spec.container.image = image;
+
+            knativeService.spec.runLatest.configuration.revisionTemplate.metadata = new RevisionTemplateMetadata();
+            knativeService.spec.runLatest.configuration.revisionTemplate.metadata.annotations = new Dictionary<string, string>();
+
+            // opt out of knative scale-to-zero for non-http triggers
+            if (!isHTTP) {
+                knativeService.spec.runLatest.configuration.revisionTemplate.metadata.annotations.Add("autoscaling.knative.dev/minScale", min.ToString());
+            }
+
+            if (max > 0) {
+                knativeService.spec.runLatest.configuration.revisionTemplate.metadata.annotations.Add("autoscaling.knative.dev/maxScale", max.ToString());
+            }
+
+            return knativeService;
+        }
+
+        private async Task<string> GetIstioClusterIngressIP()
+        {
+            var gateway = await client.ServicesV1().Get("istio-ingressgateway", "istio-system");
+            if (gateway == null)
+            {
+                return "";
+            }
+
+            return gateway.Status.LoadBalancer.Ingress[0].Ip;
+        }
+
+        private async Task CreateNamespace(string name)
+        {
+            await KubernetesHelper.RunKubectl($"create ns {name}");
+        }
+    }
+}
+

--- a/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/KnativePlatform.cs
+++ b/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/KnativePlatform.cs
@@ -74,8 +74,7 @@ namespace Azure.Functions.Cli.Actions.DeployActions.Platforms
 
             var host = GetFunctionHost(name, nameSpace);
 
-            ColoredConsole.WriteLine("");
-
+            ColoredConsole.WriteLine();
             ColoredConsole.WriteLine("Function deployed successfully!");
             ColoredConsole.WriteLine();
             ColoredConsole.WriteLine($"Function URL: http://{externalIP}");

--- a/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/KnativePlatform.cs
+++ b/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/KnativePlatform.cs
@@ -66,7 +66,7 @@ namespace Azure.Functions.Cli.Actions.DeployActions.Platforms
             File.Delete("deployment.json");
 
             var externalIP = await GetIstioClusterIngressIP();
-            if (externalIP == "")
+            if (string.IsNullOrEmpty(externalIP))
             {
                 ColoredConsole.WriteLine("Couldn't find Istio Cluster Ingress External IP");
                 return;

--- a/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/KnativePlatform.cs
+++ b/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/KnativePlatform.cs
@@ -83,7 +83,8 @@ namespace Azure.Functions.Cli.Actions.DeployActions.Platforms
             ColoredConsole.WriteLine("Plese note: it may take a few minutes for the knative service to be reachable");
         }
 
-        private string GetFunctionHost(string functionName, string nameSpace) {
+        private string GetFunctionHost(string functionName, string nameSpace) 
+        {
             return string.Format("{0}.{1}.example.com", functionName, nameSpace);
         }
 
@@ -115,11 +116,13 @@ namespace Azure.Functions.Cli.Actions.DeployActions.Platforms
             knativeService.spec.runLatest.configuration.revisionTemplate.metadata.annotations = new Dictionary<string, string>();
 
             // opt out of knative scale-to-zero for non-http triggers
-            if (!isHTTP) {
+            if (!isHTTP) 
+            {
                 knativeService.spec.runLatest.configuration.revisionTemplate.metadata.annotations.Add("autoscaling.knative.dev/minScale", min.ToString());
             }
 
-            if (max > 0) {
+            if (max > 0) 
+            {
                 knativeService.spec.runLatest.configuration.revisionTemplate.metadata.annotations.Add("autoscaling.knative.dev/maxScale", max.ToString());
             }
 

--- a/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/KnativePlatform.cs
+++ b/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/KnativePlatform.cs
@@ -92,7 +92,7 @@ namespace Azure.Functions.Cli.Actions.DeployActions.Platforms
         {
             var str = File.ReadAllText(string.Format("{0}/function.json", functionName));
             var jObj = JsonConvert.DeserializeObject<FunctionJson>(str);
-            return jObj.bindings.Any(d=> d.type == "http");
+            return jObj.bindings.Any(d=> d.type == "httpTrigger");
         }
 
         private KnativeService GetKnativeService(string name, string image, string nameSpace, int min, int max, bool isHTTP)

--- a/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/Models/FunctionJson.cs
+++ b/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/Models/FunctionJson.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace Azure.Functions.Cli.Actions.DeployActions.Platforms.Models
+{
+    public class Binding
+    {
+        public string authLevel { get; set; }
+        public string type { get; set; }
+        public string direction { get; set; }
+        public string name { get; set; }
+        public List<string> methods { get; set; }
+    }
+
+    public class FunctionJson
+    {
+        public bool disabled { get; set; }
+        public List<Binding> bindings { get; set; }
+    }
+}

--- a/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/Models/KnativeService.cs
+++ b/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/Models/KnativeService.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Azure.Functions.Cli.Actions.DeployActions.Platforms.Models
+{
+
+    public class Env
+    {
+        public string name { get; set; }
+        public string value { get; set; }
+    }
+
+    public class KnativeContainer
+    {
+        public string image { get; set; }
+        public List<Env> env { get; set; }
+    }
+
+    public class RevisionTemplateSpec
+    {
+        public KnativeContainer container { get; set; }
+    }
+
+    public class RevisionTemplateMetadata
+    {
+        public Dictionary<string,string> annotations { get; set; }
+    }
+
+    public class RevisionTemplate
+    {
+        public RevisionTemplateSpec spec { get; set; }
+        public RevisionTemplateMetadata metadata { get; set; }
+
+    }
+
+    public class Configuration
+    {
+        public RevisionTemplate revisionTemplate { get; set; }
+    }
+
+    public class RunLatest
+    {
+        public Configuration configuration { get; set; }
+    }
+
+    public class KnativeSpec
+    {
+        public RunLatest runLatest { get; set; }
+    }
+
+    public class KnativeService
+    {
+        public string apiVersion { get; set; }
+        public string kind { get; set; }
+        public Metadata metadata { get; set; }
+        public KnativeSpec spec { get; set; }
+    }
+}

--- a/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/PlatformFactory.cs
+++ b/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/PlatformFactory.cs
@@ -12,6 +12,8 @@ namespace Azure.Functions.Cli.Actions.DeployActions.Platforms
             {
                 case "kubernetes":
                     return new KubernetesPlatform(configFile);
+                case "knative":
+                    return new KnativePlatform(configFile);
                 default:
                     return null;
             }


### PR DESCRIPTION
This PR adds knative as a target platform to the 'func deploy' command.

Non-HTTP trigger workloads are supported - the minScale annotation is added to non-HTTP trigger functions in order to avoid scale-to-zero.

