### PR TITLE
Update to Az.Accounts

### DIFF
--- a/src/Azure.Functions.Cli/Actions/AzureActions/BaseAzureAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/BaseAzureAction.cs
@@ -17,7 +17,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
     abstract class BaseAzureAction : BaseAction, IInitializableAction
     {
         // Az is the Azure PowerShell module that works in both PowerShell Core and Windows PowerShell
-        private const string _azProfileModuleName = "Az.Profile";
+        private const string _azProfileModuleName = "Az.Accounts";
 
         // AzureRm is the Azure PowerShell module that only works on Windows PowerShell
         private const string _azureRmProfileModuleName = "AzureRM.Profile";
@@ -86,7 +86,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             (bool powershellSucceeded, string psToken) = await TryGetAzPowerShellToken();
             if (powershellSucceeded) return psToken;
             
-            throw new CliException("Unable to connect to Azure. Make sure you have the `az` CLI or Azure PowerShell installed and logged in and try again");
+            throw new CliException($"Unable to connect to Azure. Make sure you have the `az` CLI or `{_azProfileModuleName}` PowerShell installed and logged in and try again");
         }
 
         private async Task<(bool succeeded, string token)> TryGetAzCliToken()

--- a/src/Azure.Functions.Cli/Actions/AzureActions/BaseAzureAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/BaseAzureAction.cs
@@ -86,7 +86,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             (bool powershellSucceeded, string psToken) = await TryGetAzPowerShellToken();
             if (powershellSucceeded) return psToken;
             
-            throw new CliException($"Unable to connect to Azure. Make sure you have the `az` CLI or `{_azProfileModuleName}` PowerShell installed and logged in and try again");
+            throw new CliException($"Unable to connect to Azure. Make sure you have the `az` CLI or `{_azProfileModuleName}` PowerShell module installed and logged in and try again");
         }
 
         private async Task<(bool succeeded, string token)> TryGetAzCliToken()


### PR DESCRIPTION
In the official 1.0 release of `Az` they renamed `Az.Profile` to `Az.Accounts`. This change reflects that.

I _think_ since `Az` wasn't at 1.0 we don't have to be backward compatible here - I updated the error text to specify the Az.Accounts module that needs to be installed. If you think I should be backwards compatible with Az.Profile, let me know and I can update this PR.

AzureRm will still work... but no new features are going into it so I'm not calling it out in the error text.

thoughts on this design? @joeyaiello @stevel-msft @anirudhgarg @Francisco-Gamino 