### PR TITLE
add profile.ps1 creation for PowerShell Function Apps

### DIFF
--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -137,6 +137,10 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             {
                 await PythonHelpers.InstallPackage();
             }
+            else if (workerRuntime == Helpers.WorkerRuntime.powershell)
+            {
+                await WriteFiles("profile.ps1", await StaticResources.PowerShellProfilePs1);
+            }
         }
 
         private async Task WriteLocalSettingsJson(WorkerRuntime workerRuntime)

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -57,6 +57,9 @@
     <EmbeddedResource Include="StaticResources\python_bundle_script.py.template">
       <LogicalName>$(AssemblyName).python_bundle_script.py</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="StaticResources\profile.ps1.template">
+      <LogicalName>$(AssemblyName).profile.ps1</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="StaticResources\templates.json.template">
       <LogicalName>$(AssemblyName).templates.json</LogicalName>
     </EmbeddedResource>

--- a/src/Azure.Functions.Cli/StaticResources/StaticResources.cs
+++ b/src/Azure.Functions.Cli/StaticResources/StaticResources.cs
@@ -47,6 +47,8 @@ namespace Azure.Functions.Cli
 
         public static Task<string> PythonDockerBuildNoBundler => GetValue(Constants.StaticResourcesNames.PythonDockerBuildNoBundler);
 
+        public static Task<string> PowerShellProfilePs1 => GetValue("profile.ps1");
+
         public static Task<string> TemplatesJson => GetValue("templates.json");
     }
 }

--- a/src/Azure.Functions.Cli/StaticResources/profile.ps1.template
+++ b/src/Azure.Functions.Cli/StaticResources/profile.ps1.template
@@ -1,0 +1,23 @@
+# Azure Functions profile.ps1
+#
+# This profile.ps1 will get executed every "cold start" of your Function App.
+# "cold start" occurs when:
+#
+# * A Function App starts up for the very first time
+# * A Function App starts up after being de-allocated due to inactivity
+#
+# You can define helper functions, run commands, or specify environment variables
+# NOTE: any variables defined that are not environment variables will get reset after the first execution
+
+# Authenticate with Azure PowerShell using MSI.
+# Remove this if you are not planning on using MSI or Azure PowerShell.
+if ($env:MSI_SECRET -and (Get-Module -ListAvailable Az.Accounts)) {
+    $tokenAuthURI = $env:MSI_ENDPOINT + "?resource=https://management.azure.com&api-version=2017-09-01"
+    $tokenResponse = Invoke-RestMethod -Method Get -Headers @{"Secret"="$env:MSI_SECRET"} -Uri $tokenAuthURI
+    Connect-AzAccount -AccessToken $tokenResponse.access_token -AccountId $env:WEBSITE_SITE_NAME
+}
+
+# Enable legacy AzureRm alias in Azure PowerShell.
+# Enable-AzureRmAlias
+
+# You can also define functions or aliases that can be referenced in any of your PowerShell functions.

--- a/src/Azure.Functions.Cli/StaticResources/profile.ps1.template
+++ b/src/Azure.Functions.Cli/StaticResources/profile.ps1.template
@@ -17,7 +17,7 @@ if ($env:MSI_SECRET -and (Get-Module -ListAvailable Az.Accounts)) {
     Connect-AzAccount -AccessToken $tokenResponse.access_token -AccountId $env:WEBSITE_SITE_NAME
 }
 
-# Enable legacy AzureRm alias in Azure PowerShell.
+# Uncomment the next line to enable legacy AzureRm alias in Azure PowerShell.
 # Enable-AzureRmAlias
 
 # You can also define functions or aliases that can be referenced in any of your PowerShell functions.

--- a/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
@@ -17,23 +17,36 @@ namespace Azure.Functions.Cli.Tests.E2E
         [Theory]
         [InlineData("node")]
         [InlineData("java")]
+        [InlineData("powershell")]
         public Task init_with_worker_runtime(string workerRuntime)
         {
+            var files = new List<FileResult>
+            {
+                new FileResult
+                {
+                    Name = "local.settings.json",
+                    ContentContains = new []
+                    {
+                        "FUNCTIONS_WORKER_RUNTIME",
+                        workerRuntime
+                    }
+                },
+                
+            };
+            
+            if (workerRuntime == "powershell")
+            {
+                files.Add(new FileResult
+                {
+                    Name = "profile.ps1",
+                    ContentContains = new [] { "# Azure Functions profile.ps1" }
+                });
+            }
+
             return CliTester.Run(new RunConfiguration
             {
                 Commands = new[] { $"init . --worker-runtime {workerRuntime}" },
-                CheckFiles = new FileResult[]
-                {
-                    new FileResult
-                    {
-                        Name = "local.settings.json",
-                        ContentContains = new []
-                        {
-                            "FUNCTIONS_WORKER_RUNTIME",
-                            workerRuntime
-                        }
-                    }
-                },
+                CheckFiles = files.ToArray(),
                 OutputContains = new[]
                 {
                     "Writing .gitignore",


### PR DESCRIPTION
When a PowerShell Function App is created, it will also be created with a profile.ps1 which is a script that will be executed at "cold start".

Initially, this profile.ps1 will automatically authenticate you to Azure if you have the Az.Accounts module available and also have setup MSI. The profile also has an example on how to enable the old AzureRm alias.

I didn't see any tests for the InitAction but if they are hiding somewhere, please let me know and I will gladly add tests.

cc @daxian-dbw @SteveL-MSFT @joeyaiello @anirudhgarg @paulbatum @ahmelsayed @pragnagopa 