### PR TITLE
Case insensitive hub name from host.json

### DIFF
--- a/src/Azure.Functions.Cli/Common/DurableManager.cs
+++ b/src/Azure.Functions.Cli/Common/DurableManager.cs
@@ -59,24 +59,26 @@ namespace Azure.Functions.Cli.Common
                 {
                     // Attempt to retrieve Durable override settings from host.json
                     dynamic hostSettings = JObject.Parse(File.ReadAllText(ScriptConstants.HostMetadataFileName));
+                    JObject durableTask = null;
 
                     string version = hostSettings["version"];
                     if (version?.Equals("2.0") == true)
                     {
                         // If the version is (explicitly) 2.0, prepend path to 'durableTask' with 'extensions'
-                        _connectionStringKey = hostSettings?.extensions?.durableTask?.AzureStorageConnectionStringName ?? _connectionStringKey;
-
-                        // Allow uppercase or lowercase hub name in host.json
-                        _taskHubName = hostSettings?.extensions?.durableTask?.HubName ?? _taskHubName;
-                        _taskHubName = hostSettings?.extensions?.durableTask?.hubName ?? _taskHubName;
+                        durableTask = hostSettings?.extensions?.durableTask;
                     }
                     else
                     {
-                        _connectionStringKey = hostSettings?.durableTask?.AzureStorageConnectionStringName ?? _connectionStringKey;
+                        durableTask = hostSettings?.durableTask;
+                    }
 
-                        // Allow uppercase or lowercase hub name in host.json
-                        _taskHubName = hostSettings?.durableTask?.HubName ?? _taskHubName;
-                        _taskHubName = hostSettings?.durableTask?.hubName ?? _taskHubName;
+                    if (durableTask != null)
+                    {
+                        // Override connection string or task hub name if they exist in host.json
+                        _connectionStringKey = durableTask.GetValue("AzureStorageConnectionStringName", StringComparison.OrdinalIgnoreCase)?.ToString()
+                            ?? _connectionStringKey;
+                        _taskHubName = durableTask.GetValue("HubName", StringComparison.OrdinalIgnoreCase)?.ToString()
+                            ?? _taskHubName;
                     }
                 }
                 else

--- a/src/Azure.Functions.Cli/Common/DurableManager.cs
+++ b/src/Azure.Functions.Cli/Common/DurableManager.cs
@@ -65,12 +65,18 @@ namespace Azure.Functions.Cli.Common
                     {
                         // If the version is (explicitly) 2.0, prepend path to 'durableTask' with 'extensions'
                         _connectionStringKey = hostSettings?.extensions?.durableTask?.AzureStorageConnectionStringName ?? _connectionStringKey;
+
+                        // Allow uppercase or lowercase hub name in host.json
                         _taskHubName = hostSettings?.extensions?.durableTask?.HubName ?? _taskHubName;
+                        _taskHubName = hostSettings?.extensions?.durableTask?.hubName ?? _taskHubName;
                     }
                     else
                     {
                         _connectionStringKey = hostSettings?.durableTask?.AzureStorageConnectionStringName ?? _connectionStringKey;
+
+                        // Allow uppercase or lowercase hub name in host.json
                         _taskHubName = hostSettings?.durableTask?.HubName ?? _taskHubName;
+                        _taskHubName = hostSettings?.durableTask?.hubName ?? _taskHubName;
                     }
                 }
                 else


### PR DESCRIPTION
The Durable Functions documentation for [host.json](https://docs.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-bindings#host-json) indicates that `HubName` should be capitalized. As seen in [this issue](https://github.com/Azure/azure-functions-durable-extension/issues/448#issuecomment-454887043), Visual Studio indicates it should be `hubName`. This PR allows for either capitalization.