### PR TITLE
Add ability to override the docker image used to package

### DIFF
--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -26,6 +26,7 @@ namespace Azure.Functions.Cli.Common
         public const string AzureWebJobsStorage = "AzureWebJobsStorage";
         public const string PackageReferenceElementName = "PackageReference";
         public const string LinuxFxVersion = "linuxFxVersion";
+        public const string PythonDockerImageVersionSetting = "FUNCTIONS_PYTHON_DOCKER_IMAGE";
 
         public static string CliVersion => typeof(Constants).GetTypeInfo().Assembly.GetName().Version.ToString(3);
 

--- a/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
@@ -202,12 +202,15 @@ namespace Azure.Functions.Cli.Helpers
         private static async Task<Stream> InternalPreparePythonDeploymentInDocker(IEnumerable<string> files, string functionAppRoot, string additionalPackages, bool noBundler)
         {
             var appContentPath = CopyToTemp(files, functionAppRoot);
+            var dockerImage = string.IsNullOrEmpty(Environment.GetEnvironmentVariable(Constants.PythonDockerImageVersionSetting))
+                ? Constants.DockerImages.LinuxPythonImageAmd64
+                : Environment.GetEnvironmentVariable(Constants.PythonDockerImageVersionSetting);
 
-            await DockerHelpers.DockerPull(Constants.DockerImages.LinuxPythonImageAmd64);
+            await DockerHelpers.DockerPull(dockerImage);
             var containerId = string.Empty;
             try
             {
-                containerId = await DockerHelpers.DockerRun(Constants.DockerImages.LinuxPythonImageAmd64);
+                containerId = await DockerHelpers.DockerRun(dockerImage);
                 await DockerHelpers.ExecInContainer(containerId, "mkdir -p /home/site/wwwroot/");
                 await DockerHelpers.CopyToContainer(containerId, $"{appContentPath}/.", "/home/site/wwwroot");
 


### PR DESCRIPTION
This will help us a ton when creating end to end tests for packaging using the development version of Docker images.