### PR TITLE
Fixes #889 - Do not show query param if anonymous

### DIFF
--- a/src/Azure.Functions.Cli/Actions/AzureActions/ListFunctionsActions.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/ListFunctionsActions.cs
@@ -39,7 +39,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 await AzureHelper.PrintFunctionsInfo(functionApp, AccessToken, ShowKeys);
                 if (!ShowKeys)
                 {
-                    ColoredConsole.WriteLine("Use --show-keys to retrieve the Http-triggered URLs with appropriate keys in them");
+                    ColoredConsole.WriteLine("Use --show-keys to retrieve the Http-triggered URLs with appropriate keys in them (if enabled)");
                 }
             }
             else

--- a/src/Azure.Functions.Cli/Helpers/AzureHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/AzureHelper.cs
@@ -281,12 +281,23 @@ namespace Azure.Functions.Cli.Helpers
                     ?["type"];
 
                 trigger = trigger ?? "No Trigger Found";
+                var showFunctionKey = showKeys;
+
+                var authLevel = function
+                    .Config?["bindings"]
+                    ?.FirstOrDefault(o => !string.IsNullOrEmpty(o["authLevel"]?.ToString()))
+                    ?["authLevel"];
+
+                if (authLevel != null && authLevel.ToString().Equals("anonymous", StringComparison.OrdinalIgnoreCase))
+                {
+                    showFunctionKey = false;
+                }
 
                 ColoredConsole.WriteLine($"    {function.Name} - [{VerboseColor(trigger.ToString())}]");
                 if (!string.IsNullOrEmpty(function.InvokeUrlTemplate))
                 {
                     // If there's a key available and the key is requested, add it to the url
-                    var key = showKeys? await GetFunctionKey(function.Name, functionApp.SiteId, accessToken) : null;
+                    var key = showFunctionKey? await GetFunctionKey(function.Name, functionApp.SiteId, accessToken) : null;
                     if (!string.IsNullOrEmpty(key))
                     {
                         ColoredConsole.WriteLine($"        Invoke url: {VerboseColor($"{function.InvokeUrlTemplate}?code={key}")}");


### PR DESCRIPTION
- This also mean if a user does `func azure functionapp list-functions --show-keys`, we won't show keys if their functions are anonymous, which make sense because there's really no keys to show.