### PR TITLE
Add initial support for Conda environments

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -45,6 +45,9 @@
     <EmbeddedResource Include="StaticResources\local.settings.json.template">
       <LogicalName>$(AssemblyName).local.settings.json</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="StaticResources\python_docker_build_conda.sh">
+      <LogicalName>$(AssemblyName).python_docker_build_conda.sh</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="StaticResources\python_docker_build_no_bundler.sh">
       <LogicalName>$(AssemblyName).python_docker_build_no_bundler.sh</LogicalName>
     </EmbeddedResource>

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -18,6 +18,7 @@ namespace Azure.Functions.Cli.Common
         public const string FuncIgnoreFile = ".funcignore";
         public const string FunctionsWorkerRuntime = "FUNCTIONS_WORKER_RUNTIME";
         public const string RequirementsTxt = "requirements.txt";
+        public const string EnvironmentYml = "environment.yml";
         public const string FunctionJsonFileName = "function.json";
         public const string DefaultVEnvName = "worker_env";
         public const string ExternalPythonPackages = ".python_packages";
@@ -85,6 +86,7 @@ namespace Azure.Functions.Cli.Common
         {
             public const string PythonDockerBuild = "python_docker_build.sh";
             public const string PythonDockerBuildNoBundler = "python_docker_build_no_bundler.sh";
+            public const string PythonDockerBuildConda = "python_docker_build_conda.sh";
             public const string PythonBundleScript = "python_bundle_script.py";
         }
 

--- a/src/Azure.Functions.Cli/StaticResources/StaticResources.cs
+++ b/src/Azure.Functions.Cli/StaticResources/StaticResources.cs
@@ -47,6 +47,8 @@ namespace Azure.Functions.Cli
 
         public static Task<string> PythonDockerBuildNoBundler => GetValue(Constants.StaticResourcesNames.PythonDockerBuildNoBundler);
 
+        public static Task<string> PythonDockerBuildConda => GetValue(Constants.StaticResourcesNames.PythonDockerBuildConda);
+
         public static Task<string> PowerShellProfilePs1 => GetValue("profile.ps1");
 
         public static Task<string> TemplatesJson => GetValue("templates.json");

--- a/src/Azure.Functions.Cli/StaticResources/python_docker_build_conda.sh
+++ b/src/Azure.Functions.Cli/StaticResources/python_docker_build_conda.sh
@@ -1,0 +1,14 @@
+﻿#! /bin/bash
+
+# Exit on errors
+set -e
+
+cd /home/site/wwwroot
+if [ -d worker_venv ]; then
+    rm -rf worker_venv
+fi
+conda config --set allow_softlinks False
+conda env create -f environment.yml -p worker_venv
+apt-get update
+apt-get install zip -y
+zip --symlinks -r /app.zip .


### PR DESCRIPTION
This adds the necessary bits to enable the publishing of conda-based
function apps.  This support is incomplete without the corresponding
server-side changes.

Conda environments are fundamentally different from regular Python
virtual environments.  Every environment contains a complete set of
binaries and shared libraries, including Python itself, required to 
run the application.  As such, the generated function package is
substantial: ~800MiB for a minimal environment.  

The difference in organization also necessiates a different launch
protocol, as a Conda environment is a mini-buildroot, "activating" 
it is a lot more involved.

Issue: #1031