### PR TITLE
Update PowerShell to 0.1.69-preview

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -89,7 +89,7 @@
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage.Internal" Version="1.4.0" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.3.1-SNAPSHOT" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.63-preview" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.69-preview" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="2.0.12332" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>


### PR DESCRIPTION
Update powershell worker to 0.1.69-preview

this handles all gRPC messages and moves to PowerShell SDK 6.2.0-rc.1 which includes needed feature for F5 debugging experience