### PR TITLE
Update publish function app to do run from package = 1

### DIFF
--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -271,7 +271,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             ColoredConsole.WriteLine("Getting site publishing info...");
             var functionAppRoot = ScriptHostHelpers.GetFunctionAppRootDirectory(Environment.CurrentDirectory);
 
-            // For dedicated linux apps, we do not support Run from zip right now
+            // For dedicated linux apps, we do not support run from package right now
             if (functionApp.IsLinux && !functionApp.IsDynamic && RunFromPackageDeploy)
             {
                 ColoredConsole.WriteLine("Assuming --nozip (do not run from package) for publishing to Linux dedicated plan.");


### PR DESCRIPTION
Updated logic:
````
if (Consumption Linux):
    publish run from package = sas
else if (Dedicated Linux OR "--no-zip"): 
    publish zip deploy
else:
    publish run from package = 1 and zip deploy
````
Resolves https://github.com/Azure/azure-functions-core-tools/issues/1086