### PR TITLE
Enable Kubernetes deployment using a private registry, namespace support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,10 +150,22 @@ func init --docker
 func deploy --platform kubernetes --name myfunction --registry <docker-hub-id or registry-server>
 ```
 
+### Deploy using a private registry
+
+```bash
+func deploy --platform kubernetes --name myfunction --registry <docker-hub-id or registry-server> --pull-secret <registry auth secret>
+```
+
 ### Deploy a function with a minimum of 3 instances and a maximum of 10
 
 ```bash
 func deploy --platform kubernetes --name myfunction --registry <docker-hub-id or registry-server> --min 3 --max 10
+```
+
+### Deploy a function to a custom namespace
+
+```bash
+func deploy --platform kubernetes --name myfunction --registry <docker-hub-id or registry-server> --namespace <namespace-name>
 ```
 
 #### Scaling out Http Trigger

--- a/src/Azure.Functions.Cli/Actions/DeployActions/DeployFunctionAction.cs
+++ b/src/Azure.Functions.Cli/Actions/DeployActions/DeployFunctionAction.cs
@@ -24,8 +24,13 @@ namespace Azure.Functions.Cli.Actions.LocalActions
         public string Platform { get; set; } = string.Empty;
         public int MinInstances { get; set; } = 1;
         public int MaxInstances { get; set; } = 1000;
+        public double CPU { get; set; } = 0.1;
+        public int Memory { get; set; } = 128;
+        public string Port { get; set; } = "80";
+        public string Namespace { get; set; } = "azure-functions";
         public string FolderName { get; set; } = string.Empty;
         public string ConfigPath { get; set; } = string.Empty;
+        public string PullSecret  { get; set; } = string.Empty;
 
         public List<string> Platforms { get; set; } = new List<string>() { "kubernetes", "knative" };
         private readonly ITemplatesManager _templatesManager;
@@ -61,6 +66,16 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 .Setup<int>("max")
                 .WithDescription("[Optional] Maximum number of function instances")
                 .Callback(t => MaxInstances = t);
+
+            Parser
+                .Setup<string>("pull-secret")
+                .WithDescription("[Optional] The secret holding a private registry credentials")
+                .Callback(t => PullSecret = t);
+
+            Parser
+                .Setup<string>("namespace")
+                .WithDescription("[Optional] The namespace to deploy the function to")
+                .Callback(t => Namespace = t);
 
             Parser
                 .Setup<string>("config")
@@ -120,7 +135,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 return;
             }
 
-            await platform.DeployContainerizedFunction(Name, image, MinInstances, MaxInstances);
+            await platform.DeployContainerizedFunction(Name, image, Namespace, MinInstances, MaxInstances, CPU, Memory, Port, PullSecret);
         }
     }
 }

--- a/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/KnativePlatform.cs
+++ b/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/KnativePlatform.cs
@@ -21,7 +21,7 @@ namespace Azure.Functions.Cli.Actions.DeployActions.Platforms
         private const string FUNCTIONS_NAMESPACE = "azure-functions";
         private static KubeApiClient client;
 
-        public async Task DeployContainerizedFunction(string functionName, string image, int min, int max)
+        public async Task DeployContainerizedFunction(string functionName, string image, string nameSpace, int min, int max, double cpu = 0.1, int memory = 128, string port = "80", string pullSecret = "")
         {
             await Deploy(functionName, image, FUNCTIONS_NAMESPACE, min, max);
         }

--- a/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/KubernetesPlatform.cs
+++ b/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/KubernetesPlatform.cs
@@ -66,7 +66,7 @@ namespace Azure.Functions.Cli.Actions.DeployActions.Platforms
                             });
 
             File.WriteAllText("deployment.json", json);
-            KubernetesHelper.RunKubectl($"apply -f deployment.json");
+            await KubernetesHelper.RunKubectl($"apply -f deployment.json");
 
             ColoredConsole.WriteLine("Deployment successful");
 

--- a/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/KubernetesPlatform.cs
+++ b/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/KubernetesPlatform.cs
@@ -19,9 +19,9 @@ namespace Azure.Functions.Cli.Actions.DeployActions.Platforms
         private const string FUNCTIONS_NAMESPACE = "azure-functions";
         private static KubeApiClient client;
 
-        public async Task DeployContainerizedFunction(string functionName, string image, int min, int max)
+        public async Task DeployContainerizedFunction(string functionName, string image, string nameSpace, int min, int max, double cpu = 0.1, int memory = 128, string port = "80", string pullSecret = "")
         {
-            await Deploy(functionName, image, FUNCTIONS_NAMESPACE, min, max);
+            await Deploy(functionName, image, nameSpace, min, max, cpu,  memory, port, pullSecret);
         }
 
         public KubernetesPlatform(string configFile)
@@ -46,7 +46,7 @@ namespace Azure.Functions.Cli.Actions.DeployActions.Platforms
             await client.DeploymentsV1Beta1().Delete(name, nameSpace);
         }
 
-        private async Task Deploy(string name, string image, string nameSpace, int min, int max, double cpu = 0.1, int memory = 128, string port = "80")
+        private async Task Deploy(string name, string image, string nameSpace, int min, int max, double cpu, int memory, string port, string pullSecret)
         {
             await CreateNamespace(nameSpace);
             client.DefaultNamespace = nameSpace;
@@ -57,7 +57,7 @@ namespace Azure.Functions.Cli.Actions.DeployActions.Platforms
 
             ColoredConsole.WriteLine("Deploying function to Kubernetes...");
 
-            var deployment = GetDeployment(deploymentName, image, cpu, memory, port, nameSpace, min);
+            var deployment = GetDeployment(deploymentName, image, cpu, memory, port, nameSpace, min, pullSecret);
             var json = Newtonsoft.Json.JsonConvert.SerializeObject(deployment,
                             Newtonsoft.Json.Formatting.None,
                             new Newtonsoft.Json.JsonSerializerSettings
@@ -152,7 +152,7 @@ namespace Azure.Functions.Cli.Actions.DeployActions.Platforms
             };
         }
 
-        private Deployment GetDeployment(string name, string image, double cpu, int memory, string port, string nameSpace, int min)
+        private Deployment GetDeployment(string name, string image, double cpu, int memory, string port, string nameSpace, int min, string pullSecret)
         {
             var deployment = new Deployment();
             deployment.apiVersion = "apps/v1beta1";
@@ -212,6 +212,17 @@ namespace Azure.Functions.Cli.Actions.DeployActions.Platforms
                     effect = "NoSchedule"
                 }
             };
+
+            if (!string.IsNullOrEmpty(pullSecret))
+            {
+                deployment.spec.template.spec.imagePullSecrets = new List<ImagePullSecret>()
+                {
+                    new ImagePullSecret
+                    {
+                        name = pullSecret
+                    }
+                };
+            }
 
             return deployment;
         }

--- a/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/Models/Kubernetes.cs
+++ b/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/Models/Kubernetes.cs
@@ -61,6 +61,7 @@ namespace Azure.Functions.Cli.Actions.DeployActions.Platforms.Models
         public List<Container> containers { get; set; }
         public string dnsPolicy { get; set; }
         public List<Toleration> tolerations { get; set; }
+        public List<ImagePullSecret> imagePullSecrets { get; set; }
     }
 
     public class Template
@@ -74,6 +75,11 @@ namespace Azure.Functions.Cli.Actions.DeployActions.Platforms.Models
         public int replicas { get; set; }
         public Selector selector { get; set; }
         public Template template { get; set; }
+    }
+
+    public class ImagePullSecret
+    {
+        public string name { get; set; }
     }
 
     public class Deployment

--- a/src/Azure.Functions.Cli/Interfaces/IHostingPlatform.cs
+++ b/src/Azure.Functions.Cli/Interfaces/IHostingPlatform.cs
@@ -4,6 +4,6 @@ namespace Azure.Functions.Cli.Interfaces
 {
     public interface IHostingPlatform
     {
-        Task DeployContainerizedFunction(string functionName, string image, int min, int max);
+        Task DeployContainerizedFunction(string functionName, string image, string nameSpace, int min, int max, double cpu, int memory, string port, string pullSecret);
     }
 }


### PR DESCRIPTION
This PR enables the following use cases for deploying to Kubernetes:

* using a private docker registry by specifying a pull secret
* deploying to a namespace of choice,  (default today is  ```azure-functions```)

Minor semantic fixes along the way.
Knative implementation should follow shortly.