### PR TITLE
Fixes #1015 - Consistent way to provide user dependencies

### DIFF
--- a/src/Azure.Functions.Cli/StaticResources/python_docker_build.sh
+++ b/src/Azure.Functions.Cli/StaticResources/python_docker_build.sh
@@ -3,13 +3,4 @@
 # Exit on errors
 set -e
 
-cd /home/site/wwwroot
-if [ -d worker_venv ]; then
-    rm -rf worker_venv
-fi
-python -m venv --copies worker_venv
-source worker_venv/bin/activate
-pip install -r requirements.txt
-apt-get update
-apt-get install zip -y
-zip --symlinks -r /app.zip .
+pip install --target="/.python_packages/lib/python3.6/site-packages" -r /requirements.txt


### PR DESCRIPTION
Will run my e2e tests and update with results.

After this change, we can make it very clear to users about our deployment path. They can see `.python_packages` that will be created with or without `--build-native-deps`. In case if they don't want to restore custom dependencies in subsequent publish commands, they will now be able to just do `publish --no-build` and it will work.

@asavaritayal, once merged, we should update our docs as well.