### PR TITLE
Enable managed dependencies for PowerShell function apps.

### DIFF
--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -337,25 +337,25 @@ namespace Azure.Functions.Cli.Actions.LocalActions
 
         private static bool ResolveManagedDependencies(WorkerRuntime workerRuntime, bool? managedDependenciesOption)
         {
-            if (managedDependenciesOption.HasValue)
+            if (workerRuntime != Helpers.WorkerRuntime.powershell)
             {
-                if (workerRuntime != Helpers.WorkerRuntime.powershell)
+                if (managedDependenciesOption.HasValue)
                 {
                     throw new CliException("Managed dependencies is only supported for PowerShell.");
                 }
 
+                return false;
+            }
+
+            if (managedDependenciesOption.HasValue)
+            {
                 return managedDependenciesOption.Value;
             }
 
-            bool result = false;
             ColoredConsole.Write("Would you like to install the Azure modules and have these automatically managed in Azure? ");
-            var answer = SelectionMenuHelper.DisplaySelectionWizard(WorkerRuntimeLanguageHelper.ManagedDependenciesInstallationOptions());
-            ColoredConsole.WriteLine(TitleColor(answer.ToString()));
-            if (answer.ToString().Equals(InstallManagedDependencies.Yes.ToString(), StringComparison.OrdinalIgnoreCase))
-            {
-                result = true;
-            }
-            return result;
+            var answer = SelectionMenuHelper.DisplaySelectionWizard(WorkerRuntimeLanguageHelper.ManagedDependenciesInstallationOptions()).ToString();
+            ColoredConsole.WriteLine(TitleColor(answer));
+            return (answer.Equals(InstallManagedDependencies.Yes.ToString(), StringComparison.OrdinalIgnoreCase));
         }
 
         private static async Task WriteHostJson(WorkerRuntime workerRuntime, bool managedDependenciesOption)

--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -352,10 +352,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 return managedDependenciesOption.Value;
             }
 
-            ColoredConsole.Write("Would you like to install the Azure modules and have these automatically managed in Azure? ");
-            var answer = SelectionMenuHelper.DisplaySelectionWizard(WorkerRuntimeLanguageHelper.ManagedDependenciesInstallationOptions()).ToString();
-            ColoredConsole.WriteLine(TitleColor(answer));
-            return (answer.Equals(InstallManagedDependencies.Yes.ToString(), StringComparison.OrdinalIgnoreCase));
+            return SelectionMenuHelper.Confirm("Would you like to install the Azure modules and have these automatically managed in Azure?");
         }
 
         private static async Task WriteHostJson(WorkerRuntime workerRuntime, bool managedDependenciesOption)

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -39,6 +39,9 @@
     <EmbeddedResource Include="StaticResources\gitignore">
       <LogicalName>$(AssemblyName).gitignore</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="StaticResources\powershell.host.json">
+      <LogicalName>$(AssemblyName).powershell.host.json</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="StaticResources\host.json">
       <LogicalName>$(AssemblyName).host.json</LogicalName>
     </EmbeddedResource>
@@ -65,6 +68,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="StaticResources\funcignore">
       <LogicalName>$(AssemblyName).funcignore</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="StaticResources\requirements.psd1">
+      <LogicalName>$(AssemblyName).requirements.psd1</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/src/Azure.Functions.Cli/Helpers/PowerShellHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/PowerShellHelper.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Threading.Tasks;
+using Azure.Functions.Cli.Common;
+using System.Net.Http;
+using System.Xml;
+
+namespace Azure.Functions.Cli.Helpers
+{
+    public static class PowerShellHelper
+    {
+        // The module name for the Azure Resource Manager.
+        private const string AzModuleName = "Az";
+
+        // The PowerShellGallery uri to query for the latest module version.
+        private const string PowerShellGalleryFindPackagesByIdUri = "https://www.powershellgallery.com/api/v2/FindPackagesById()?id=";
+        
+        /// <summary>
+        /// Gets the latest supported major version of the Az module from the PSGallery.
+        /// </summary>
+        public static async Task<string> GetLatestAzModuleMajorVersion()
+        {
+            Uri address = new Uri($"{PowerShellGalleryFindPackagesByIdUri}'{AzModuleName}'");
+            int numberOfRetries = 3;
+
+            string latestMajorVersion = null;
+            string errorMessage = $@"Fail to get module version for {AzModuleName}";
+
+            HttpResponseMessage response = null;
+            using (HttpClient client = new HttpClient())
+            {
+                bool successfulRequest = false;
+                do
+                {
+                    response = await client.GetAsync(address);
+                    successfulRequest = response.IsSuccessStatusCode;
+                    numberOfRetries--;
+                } while (!successfulRequest && numberOfRetries <= 0);
+            }
+
+            if (response == null)
+            {
+                throw new CliException(errorMessage);
+            }
+
+            var stream = response.Content.ReadAsStreamAsync().Result;
+            if (stream != null)
+            {
+                // Load up the XML response
+                XmlDocument doc = new XmlDocument();
+                using (XmlReader reader = XmlReader.Create(stream))
+                {
+                    doc.Load(reader);
+                }
+
+                // Add the namespaces for the gallery xml content
+                XmlNamespaceManager nsmgr = new XmlNamespaceManager(doc.NameTable);
+                nsmgr.AddNamespace("ps", "http://www.w3.org/2005/Atom");
+                nsmgr.AddNamespace("d", "http://schemas.microsoft.com/ado/2007/08/dataservices");
+                nsmgr.AddNamespace("m", "http://schemas.microsoft.com/ado/2007/08/dataservices/metadata");
+
+                // Find the version information
+                XmlNode root = doc.DocumentElement;
+                var props = root.SelectNodes("//m:properties/d:Version", nsmgr);
+                var latestVersion = new Version("0.0");
+
+                if (props != null && props.Count > 0)
+                {
+                    for (int i = 0; i < props.Count; i++)
+                    {
+                        var currentVersion = new Version(props[i].FirstChild.Value);
+
+                        var result = currentVersion.CompareTo(latestVersion);
+                        if (result > 0)
+                        {
+                            latestVersion = currentVersion;
+                        }
+                    }
+                }
+
+                latestMajorVersion = latestVersion.ToString().Split(".")[0];
+            }
+
+            if (string.IsNullOrEmpty(latestMajorVersion))
+            {
+                throw new CliException(errorMessage);
+            }
+
+            return latestMajorVersion;
+        }
+    }
+}

--- a/src/Azure.Functions.Cli/Helpers/SelectionMenuHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/SelectionMenuHelper.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Azure.Functions.Cli.Common;
 using Colors.Net;
 using static Azure.Functions.Cli.Common.OutputTheme;
 using static Colors.Net.StringStaticMethods;
@@ -25,6 +26,21 @@ namespace Azure.Functions.Cli.Helpers
                 }
             }
             return DisplaySelectionWizardUnix(options);
+        }
+
+        public static bool Confirm(string question)
+        {
+            if (string.IsNullOrEmpty(question))
+            {
+                throw new CliException("Question cannot be null or empty.");
+            }
+
+            List<string> options = new List<string>() { "Yes", "No" };
+            ColoredConsole.Write(question);
+            var answer = DisplaySelectionWizard(options);
+            ColoredConsole.WriteLine(TitleColor(answer));
+
+            return answer.Equals("Yes", StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool IsEnvironmentCursorTopFriendly()

--- a/src/Azure.Functions.Cli/Helpers/WorkerRuntimeLanguageHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/WorkerRuntimeLanguageHelper.cs
@@ -65,13 +65,11 @@ namespace Azure.Functions.Cli.Helpers
 
         public static string AvailableWorkersRuntimeString =>
             string.Join(", ", availableWorkersRuntime.Keys
-                .Where(k => k != WorkerRuntime.powershell)
                 .Where(k => k != WorkerRuntime.java)
                 .Select(s => s.ToString()));
 
         public static IEnumerable<WorkerRuntime> AvailableWorkersList => availableWorkersRuntime.Keys
-            .Where(k => k != WorkerRuntime.java)
-            .Where(k => k != WorkerRuntime.powershell);
+            .Where(k => k != WorkerRuntime.java);
 
         public static IDictionary<WorkerRuntime, string> GetWorkerToDisplayStrings()
         {
@@ -80,6 +78,9 @@ namespace Azure.Functions.Cli.Helpers
             {
                 switch (wr)
                 {
+                    case WorkerRuntime.powershell:
+                        workerToDisplayStrings[wr] = "powershell (preview)";
+                        break;
                     case WorkerRuntime.python:
                         workerToDisplayStrings[wr] = "python (preview)";
                         break;
@@ -161,5 +162,16 @@ namespace Azure.Functions.Cli.Helpers
             }
             return workerToDefaultLanguageMap[worker];
         }
+
+        public static IEnumerable<InstallManagedDependencies> ManagedDependenciesInstallationOptions()
+        {
+            return Enum.GetValues(typeof(InstallManagedDependencies)).Cast<InstallManagedDependencies>();
+        }
+    }
+
+    public enum InstallManagedDependencies
+    {
+        Yes,
+        No
     }
 }

--- a/src/Azure.Functions.Cli/StaticResources/StaticResources.cs
+++ b/src/Azure.Functions.Cli/StaticResources/StaticResources.cs
@@ -41,6 +41,8 @@ namespace Azure.Functions.Cli
 
         public static Task<string> HostJson => GetValue("host.json");
 
+        public static Task<string> PowerShellHostJson => GetValue("powershell.host.json");
+
         public static Task<string> PythonDockerBuildScript => GetValue(Constants.StaticResourcesNames.PythonDockerBuild);
 
         public static Task<string> PowerShellProfilePs1 => GetValue("profile.ps1");
@@ -52,5 +54,7 @@ namespace Azure.Functions.Cli
         public static Task<string> PackageJson => GetValue("package.json");
 
         public static Task<string> TsConfig => GetValue("tsconfig.json");
+
+        public static Task<string> PowerShellRequirementsPsd1 => GetValue("requirements.psd1");
     }
 }

--- a/src/Azure.Functions.Cli/StaticResources/gitignore
+++ b/src/Azure.Functions.Cli/StaticResources/gitignore
@@ -41,3 +41,6 @@ venv.bak/
 __pycache__/
 *.py[cod]
 *$py.class
+
+# Managed dependencies folder
+ManagedDependencies/

--- a/src/Azure.Functions.Cli/StaticResources/powershell.host.json
+++ b/src/Azure.Functions.Cli/StaticResources/powershell.host.json
@@ -1,0 +1,6 @@
+{
+  "version": "2.0",
+  "managedDependency": {
+    "enabled": true
+  }
+}

--- a/src/Azure.Functions.Cli/StaticResources/requirements.psd1
+++ b/src/Azure.Functions.Cli/StaticResources/requirements.psd1
@@ -1,0 +1,7 @@
+﻿# This file enables modules to be automatically managed by the Functions service.
+# Only the Azure Az module is supported in preview.
+# See https://aka.ms/functionsmanageddependency for additional information.
+#
+@{
+    'Az' = 'MAJOR_VERSION.*'
+}

--- a/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
@@ -279,5 +279,61 @@ namespace Azure.Functions.Cli.Tests.E2E
                 }
             }, _output);
         }
+
+        [Fact]
+        public Task init_function_app_powershell_supports_managed_dependencies()
+        {
+            return CliTester.Run(new RunConfiguration
+            {
+                Commands = new[] { "init . --worker-runtime powershell --managed-dependencies" },
+                CheckFiles = new FileResult[]
+                {
+                    new FileResult
+                    {
+                        Name = "host.json",
+                        ContentContains = new []
+                        {
+                            "managedDependency",
+                            "enabled",
+                            "true"
+                        }
+                    },
+                    new FileResult
+                    {
+                        Name = "requirements.psd1",
+                        ContentContains = new []
+                        {
+                            "Az",
+                        }
+                    }
+                },
+                OutputContains = new[]
+                {
+                    "Writing profile.ps1",
+                    "Writing requirements.psd1",
+                    "Writing .gitignore",
+                    "Writing host.json",
+                    "Writing local.settings.json",
+                    $".vscode{Path.DirectorySeparatorChar}extensions.json",
+                }
+            }, _output);
+        }
+
+        [Fact]
+        public Task init_managed_dependencies_is_only_supported_in_powershell()
+        {
+            return CliTester.Run(new RunConfiguration
+            {
+                Commands = new[]
+                {
+                    $"init . --worker-runtime python --managed-dependencies "
+                },
+                HasStandardError = true,
+                ErrorContains = new[]
+                {
+                    $"Managed dependencies is only supported for PowerShell"
+                }
+            }, _output);
+        }
     }
 }


### PR DESCRIPTION


This PR contains the following changes:
*  Adding support in func init to enable managed dependencies for PowerShell.
* Unit test for 'init --worker-runtime powershell --managed-dependencies'
* Adding PowerShell (preview) to drop down list of available runtime workers.

**Installation flow**
At function app creation, the user has the option to opt into Managed Dependencies for PowerShell function apps using the --managed-dependencies switch. Managed dependencies enables modules to be automatically managed by the Functions service. Currently, only the Azure Az module is supported. 

If the user opts in, we add an entry to host.json and create a requirements.psd1.

Scenario 1: User opts into managed dependencies for PowerShell
```
init --worker-runtime powershell --managed-dependencies
Writing profile.ps1
Writing requirements.psd1
Writing .gitignore
Writing host.json
Writing local.settings.json
Writing E:\MyFunctions\MyFuncApp\.vscode\extensions.json
```
Running this command adds a managedDependency entry in host.json and generates a requirements.psd1 file.

```
# Contents of host.json
{
  "version": "2.0",
  "managedDependency": {
    "enabled": true
  }
}

# Contents of requirements.psd1

# This file enables modules to be automatically managed by the Functions service.
# Only the Azure Az module is supported in preview.
# See https://aka.ms/functionsmanageddependency for additional information.
#
@{
    'Az' = '1.*'
}
```

Scenario 2: User creates a PowerShell function app. If the –managed-dependencies switch is not specified, the user will get prompted. 
```
init --worker-runtime powershell
Would you like to install the Azure modules and have these automatically managed in Azure?
Yes
No
```
If the customer selects ‘yes’, we do the same as in Scenario 1.

Scenario 3: User creates a PowerShell function app and opts out of managed dependencies. This means that no requirements.psd1 file is generated and no managedDependency entry is added to host.json.
```
init --worker-runtime powershell
Would you like to install the Azure modules and have these automatically managed in Azure?
Yes
No
# Select no, or
init --worker-runtime powershell --managed-dependencies=false
```