### PR TITLE
Fixes #1133 - AzureWebJobsStorage is not required for kafka trigger

### DIFF
--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -42,6 +42,8 @@ namespace Azure.Functions.Cli.Common
             { WorkerRuntime.powershell, new [] { "mcr.microsoft.com/azure-functions/powershell", "microsoft/azure-functions-powershell" } }
         };
 
+        public static readonly string[] TriggersWithoutStorage = new[] { "httptrigger", "kafkatrigger" };
+
         public static class Errors
         {
             public const string NoRunningInstances = "No running instances";

--- a/test/Azure.Functions.Cli.Tests/ActionsTests/StartHostActionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/ActionsTests/StartHostActionTests.cs
@@ -22,7 +22,7 @@ namespace Azure.Functions.Cli.Tests.ActionsTests
         public async Task CheckNonOptionalSettingsThrowsOnMissingAzureWebJobsStorage()
         {
             Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
-                reason: "Environment.CurrentDirectory throws in linux in test cases for some reason. Revisit this once we figure out why it's failling");
+                reason: "Environment.CurrentDirectory throws in linux in test cases for some reason. Revisit this once we figure out why it's failing");
 
             var fileSystem = GetFakeFileSystem(new[]
             {
@@ -44,7 +44,8 @@ namespace Azure.Functions.Cli.Tests.ActionsTests
 
             exception.Should().NotBeNull();
             exception.Should().BeOfType<CliException>();
-            exception.Message.Should().Contain("Missing value for AzureWebJobsStorage in local.settings.json. This is required for all triggers other than HTTP.");
+            exception.Message.Should().Contain($"Missing value for AzureWebJobsStorage in local.settings.json. " +
+                $"This is required for all triggers other than {string.Join(", ", Constants.TriggersWithoutStorage)}.");
         }
 
         [Fact]


### PR DESCRIPTION
Note that, even after this change, kafka dotnet functions will still see the warning `Missing value for AzureWebJobsStorage in local.settings.json. This is required for all triggers other than HTTP.` because of https://github.com/Azure/azure-functions-vs-build-sdk/blob/87d3faf121b1b443f6288b4b1d54c5b72f22ee39/src/Microsoft.NET.Sdk.Functions.Generator/FunctionJsonConverter.cs#L206.

@jeffhollan, fyi.

I will make a PR to that repo as well and post an update here.
Update:
https://github.com/Azure/azure-functions-vs-build-sdk/pull/303