### PR TITLE
Fixes #1141 : Remove extra platform runtimes powershell

### DIFF
--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -75,6 +75,43 @@ namespace Build
             }
         }
 
+        public static void FilterPowershellRuntimes()
+        {
+            var minifiedRuntimes = Settings.TargetRuntimes.Where(r => r.StartsWith(Settings.MinifiedVersionPrefix));
+            foreach (var runtime in Settings.TargetRuntimes.Except(minifiedRuntimes))
+            {
+                var powershellRuntimePath = Path.Combine(Settings.OutputDir, runtime, "workers", "powershell", "runtimes");
+
+                var allKnownPowershellRuntimes = Settings.ToolsRuntimeToPowershellRuntimes.Values.SelectMany(x => x).Distinct().ToList();
+                var allFoundPowershellRuntimes = Directory.GetDirectories(powershellRuntimePath).Select(Path.GetFileName).ToList();
+
+                // Check to make sure any new runtime is categorizied properly and all the expected runtimes are available
+                if (allFoundPowershellRuntimes.Count != allKnownPowershellRuntimes.Count || !allKnownPowershellRuntimes.All(allFoundPowershellRuntimes.Contains))
+                {
+                    throw new Exception($"Mismatch between classified Powershell runtimes and Powershell runtimes found. Classified runtimes are ${string.Join(", ", allKnownPowershellRuntimes)}." +
+                        $"{Environment.NewLine}Found runtimes are ${string.Join(", ", allFoundPowershellRuntimes)}");
+                }
+
+                // Delete all the runtimes that should not belong to the current runtime
+                var powershellForCurrentRuntime = Settings.ToolsRuntimeToPowershellRuntimes[runtime];
+                allFoundPowershellRuntimes.Except(powershellForCurrentRuntime).ToList().ForEach(r => Directory.Delete(Path.Combine(powershellRuntimePath, r), recursive: true));
+            }
+
+            // Small test to ensure we have all the right runtimes at the right places
+            foreach (var runtime in Settings.TargetRuntimes.Except(minifiedRuntimes))
+            {
+                var powershellRuntimePath = Path.Combine(Settings.OutputDir, runtime, "workers", "powershell", "runtimes");
+                var currentPowershellRuntimes = Directory.GetDirectories(powershellRuntimePath).Select(Path.GetFileName).ToList();
+                var requiredPowershellRuntimes = Settings.ToolsRuntimeToPowershellRuntimes[runtime].Distinct().ToList();
+
+                if (currentPowershellRuntimes.Count != requiredPowershellRuntimes.Count() || !requiredPowershellRuntimes.All(currentPowershellRuntimes.Contains))
+                {
+                    throw new Exception($"Mismatch between Expected Powershell runtimes ({string.Join(", ", requiredPowershellRuntimes)}) and Found Powershell runtimes " +
+                        $"({string.Join(", ", currentPowershellRuntimes)}) in the path {powershellRuntimePath}");
+                }
+            }
+        }
+
         private static void RemoveLanguageWorkers(string outputPath)
         {
             foreach (var languageWorker in Settings.LanguageWorkers)

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -16,6 +16,7 @@ namespace Build
                 .Then(LogIntoAzure)
                 .Then(RestorePackages)
                 .Then(DotnetPublish)
+                .Then(FilterPowershellRuntimes)
                 .Then(AddDistLib)
                 .Then(AddPythonWorker)
                 .Then(AddTemplatesNupkgs)

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -46,6 +46,20 @@ namespace Build
             { "min.win-x64", "Windows" },
         };
 
+        public static readonly Dictionary<string, string[]> ToolsRuntimeToPowershellRuntimes = new Dictionary<string, string[]>
+        {
+            { "win-x86", new [] { "win-x86", "win", "win10-x86", "win8-x86", "win81-x86", "win7-x86" } },
+            { "win-x64", new [] { "win-x64", "win", "win10-x64", "win8-x64", "win81-x64", "win7-x64" } },
+            { "linux-x64", new [] { "linux", "linux-x64", "unix", "linux-musl-x64" } },
+            { "osx-x64", new [] { "osx", "unix" } },
+            { "no-runtime", new [] {
+                "win-x86", "win", "win10-x86", "win8-x86", "win81-x86", "win7-x86",
+                "win-x64", "win10-x64", "win8-x64", "win81-x64", "win7-x64", "linux",
+                "linux-x64", "unix", "linux-musl-x64",
+                "osx", "win-arm64", "win-arm", "linux-arm", "linux-arm64"
+            } }
+        };
+
         public static readonly string[] LanguageWorkers = new[] { "java", "powershell", "node", "python" };
 
         public static string MinifiedVersionPrefix = "min.";


### PR DESCRIPTION
## Size of Artifacts

**Before:**
```
206M    Azure.Functions.Cli.linux-x64.2.4.9999.zip
56M     Azure.Functions.Cli.min.win-x64.2.4.9999.zip
53M     Azure.Functions.Cli.min.win-x86.2.4.9999.zip
186M    Azure.Functions.Cli.no-runtime.2.4.9999.zip
170M    Azure.Functions.Cli.osx-x64.2.4.9999.zip
170M    Azure.Functions.Cli.win-x64.2.4.9999.zip
168M    Azure.Functions.Cli.win-x86.2.4.9999.zip
```

**After:**
```
156M    Azure.Functions.Cli.linux-x64.2.4.9999.zip
56M     Azure.Functions.Cli.min.win-x64.2.4.9999.zip
53M     Azure.Functions.Cli.min.win-x86.2.4.9999.zip
186M    Azure.Functions.Cli.no-runtime.2.4.9999.zip
119M    Azure.Functions.Cli.osx-x64.2.4.9999.zip
120M    Azure.Functions.Cli.win-x64.2.4.9999.zip
116M    Azure.Functions.Cli.win-x86.2.4.9999.zip
```

I kept all the platform runtimes in `.no-runtime` version.