### PR TITLE
Enabling managed dependencies by default for PowerShell function apps.

### DIFF
--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -352,7 +352,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 return managedDependenciesOption.Value;
             }
 
-            return SelectionMenuHelper.Confirm("Would you like to install the Azure modules and have these automatically managed in Azure?");
+            return true;
         }
 
         private static async Task WriteHostJson(WorkerRuntime workerRuntime, bool managedDependenciesOption)

--- a/src/Azure.Functions.Cli/Helpers/SelectionMenuHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/SelectionMenuHelper.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
-using Azure.Functions.Cli.Common;
 using Colors.Net;
 using static Azure.Functions.Cli.Common.OutputTheme;
 using static Colors.Net.StringStaticMethods;
@@ -26,21 +25,6 @@ namespace Azure.Functions.Cli.Helpers
                 }
             }
             return DisplaySelectionWizardUnix(options);
-        }
-
-        public static bool Confirm(string question)
-        {
-            if (string.IsNullOrEmpty(question))
-            {
-                throw new CliException("Question cannot be null or empty.");
-            }
-
-            List<string> options = new List<string>() { "Yes", "No" };
-            ColoredConsole.Write(question);
-            var answer = DisplaySelectionWizard(options);
-            ColoredConsole.WriteLine(TitleColor(answer));
-
-            return answer.Equals("Yes", StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool IsEnvironmentCursorTopFriendly()


### PR DESCRIPTION
Enabling Managed Dependencies (MDs) by default for PowerShell function apps.

Scenario 1: User creates a PowerShell function app and enables MDs using the --managed-dependencies switch. 
```
PS E:\MyFunctions\MyFuncApp> E:\CLI\func.exe init --worker-runtime powershell  --managed-dependencies
Writing profile.ps1
Writing requirements.psd1
Writing .gitignore
Writing host.json
Writing local.settings.json
Writing E:\MyFunctions\MyFuncApp\.vscode\extensions.json

# Contents of host.json
PS E:\MyFunctions\MyFuncApp> gc .\host.json
{
  "version": "2.0",
  "managedDependency": {
    "enabled": true
  }
}

# Contents of requirements.psd1
PS E:\MyFunctions\MyFuncApp> gc .\requirements.psd1
# This file enables modules to be automatically managed by the Functions service.
# Only the Azure Az module is supported in preview.
# See https://aka.ms/functionsmanageddependency for additional information.
#
@{
    'Az' = '1.*'
}
PS E:\MyFunctions\MyFuncApp>
```

Scenario 2: User creates a PowerShell function app. By default MDs is enabled. This generates the same output as scenario 1.
```
PS E:\MyFunctions\MyFuncApp> E:\CLI\func.exe init --worker-runtime powershell 
Writing profile.ps1
Writing requirements.psd1
Writing .gitignore
Writing host.json
Writing local.settings.json
Writing E:\MyFunctions\MyFuncApp\.vscode\extensions.json
```

Scenario 3: User creates a PowerShell function app and opts out of managed dependencies. This means that no requirements.psd1 file is generated and no managedDependency entry is added to host.json.

```
PS E:\MyFunctions\MyFuncApp> E:\CLI\func.exe init --worker-runtime powershell --managed-dependencies=false
Writing profile.ps1
Writing .gitignore
Writing host.json
Writing local.settings.json
Writing E:\MyFunctions\MyFuncApp\.vscode\extensions.json
PS E:\MyFunctions\MyFuncApp>
```
