### PR TITLE
Removing ManagedDependencies folder from gitignore since the app dependencies will not be installed under the function app root.

### DIFF
--- a/src/Azure.Functions.Cli/StaticResources/gitignore
+++ b/src/Azure.Functions.Cli/StaticResources/gitignore
@@ -41,6 +41,3 @@ venv.bak/
 __pycache__/
 *.py[cod]
 *$py.class
-
-# Managed dependencies folder
-ManagedDependencies/


### PR DESCRIPTION
Removing ManagedDependencies folder from gitignore since the app dependencies will not be installed under the function app root.