### PR TITLE
Updating, "func extensions install", "func new", "func init ." and "func host start" actions

### DIFF
--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -143,7 +143,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             if (workerRuntime != WorkerRuntime.dotnet || Csx)
             {
                 // Restore all valid extensions
-                var installExtensionAction = new InstallExtensionAction(_secretsManager);
+                var installExtensionAction = new InstallExtensionAction(_secretsManager, false);
                 await installExtensionAction.RunAsync();
             }
 

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Azure.Functions.Cli.Actions.HostActions.WebHost.Security;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Diagnostics;
+using Azure.Functions.Cli.ExtensionBundle;
 using Azure.Functions.Cli.Extensions;
 using Azure.Functions.Cli.Helpers;
 using Azure.Functions.Cli.Interfaces;
@@ -456,7 +457,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
                         .AddScheme<AuthenticationLevelOptions, CliAuthenticationHandler<AuthenticationLevelOptions>>(AuthLevelAuthenticationDefaults.AuthenticationScheme, configureOptions: _ => { })
                         .AddScheme<ArmAuthenticationOptions, CliAuthenticationHandler<ArmAuthenticationOptions>>(ArmAuthenticationDefaults.AuthenticationScheme, _ => { });
                 }
-                
+
                 services.AddWebJobsScriptHostAuthorization();
 
                 services.AddMvc()
@@ -472,6 +473,8 @@ namespace Azure.Functions.Cli.Actions.HostActions
                     o.SecretsPath = _hostOptions.SecretsPath;
                 });
 
+
+                services.AddSingleton<IConfigureBuilder<IConfigurationBuilder>>(_ => new ExtensionBundleConfigurationBuilder(_hostOptions.ScriptPath));
                 services.AddSingleton<IConfigureBuilder<IConfigurationBuilder>, DisableConsoleConfigurationBuilder>();
                 services.AddSingleton<IConfigureBuilder<ILoggingBuilder>, LoggingBuilder>();
 

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -474,7 +474,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 });
 
 
-                services.AddSingleton<IConfigureBuilder<IConfigurationBuilder>>(_ => new ExtensionBundleConfigurationBuilder(_hostOptions.ScriptPath));
+                services.AddSingleton<IConfigureBuilder<IConfigurationBuilder>>(_ => new ExtensionBundleConfigurationBuilder(_hostOptions));
                 services.AddSingleton<IConfigureBuilder<IConfigurationBuilder>, DisableConsoleConfigurationBuilder>();
                 services.AddSingleton<IConfigureBuilder<ILoggingBuilder>, LoggingBuilder>();
 

--- a/src/Azure.Functions.Cli/Actions/LocalActions/InstallExtensionAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InstallExtensionAction.cs
@@ -74,12 +74,10 @@ namespace Azure.Functions.Cli.Actions.LocalActions
 
         public async override Task RunAsync()
         {
-            var hostOptions = SelfHostWebHostSettingsFactory.Create(Environment.CurrentDirectory);
-            var extensionBundleOption = ExtensionBundleHelper.GetExtensionBundleOptions(hostOptions);
-            var extensionBundleManager = new ExtensionBundleManager(extensionBundleOption, SystemEnvironment.Instance, NullLoggerFactory.Instance);
+            var extensionBundleManager = ExtensionBundleHelper.GetExtensionBundleManager();
             if (extensionBundleManager.IsExtensionBundleConfigured())
             {
-                var hostFilePath = Path.Combine(hostOptions.ScriptPath, ScriptConstants.HostMetadataFileName);
+                var hostFilePath = Path.Combine(Environment.CurrentDirectory, ScriptConstants.HostMetadataFileName);
                 ColoredConsole.WriteLine(WarningColor($"No action performed. Extension bundle is configured in {hostFilePath}"));
                 return;
             }

--- a/src/Azure.Functions.Cli/Actions/LocalActions/InstallExtensionAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InstallExtensionAction.cs
@@ -8,8 +8,6 @@ using Azure.Functions.Cli.Interfaces;
 using Colors.Net;
 using Fclp;
 using Microsoft.Azure.WebJobs.Script;
-using Microsoft.Azure.WebJobs.Script.ExtensionBundle;
-using Microsoft.Extensions.Logging.Abstractions;
 using static Azure.Functions.Cli.Common.OutputTheme;
 
 namespace Azure.Functions.Cli.Actions.LocalActions

--- a/src/Azure.Functions.Cli/Actions/LocalActions/InstallExtensionAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InstallExtensionAction.cs
@@ -16,6 +16,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
     internal class InstallExtensionAction : BaseAction
     {
         private readonly ISecretsManager _secretsManager;
+        private readonly bool _showExtensionBundleWarning;
 
         public string Package { get; set; } = string.Empty;
         public string Version { get; set; } = string.Empty;
@@ -25,9 +26,10 @@ namespace Azure.Functions.Cli.Actions.LocalActions
         public bool Csx { get; set; }
         public bool Force { get; set; } = false;
 
-        public InstallExtensionAction(ISecretsManager secretsManager)
+        public InstallExtensionAction(ISecretsManager secretsManager, bool showExtensionBundleWarning = true)
         {
             _secretsManager = secretsManager;
+            _showExtensionBundleWarning = showExtensionBundleWarning;
         }
 
         public override ICommandLineParserResult ParseArgs(string[] args)
@@ -76,7 +78,10 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             if (extensionBundleManager.IsExtensionBundleConfigured())
             {
                 var hostFilePath = Path.Combine(Environment.CurrentDirectory, ScriptConstants.HostMetadataFileName);
-                ColoredConsole.WriteLine(WarningColor($"No action performed. Extension bundle is configured in {hostFilePath}"));
+                if (_showExtensionBundleWarning)
+                {
+                    ColoredConsole.WriteLine(WarningColor($"No action performed. Extension bundle is configured in {hostFilePath}"));
+                }
                 return;
             }
 
@@ -113,7 +118,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                     );
                 }
 
-                var syncAction = new SyncExtensionsAction(_secretsManager)
+                var syncAction = new SyncExtensionsAction(_secretsManager, false)
                 {
                     OutputPath = OutputPath,
                     ConfigPath = ConfigPath

--- a/src/Azure.Functions.Cli/Actions/LocalActions/PackAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/PackAction.cs
@@ -98,7 +98,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             }
 
             // Restore all valid extensions
-            var installExtensionAction = new InstallExtensionAction(_secretsManager);
+            var installExtensionAction = new InstallExtensionAction(_secretsManager, false);
             await installExtensionAction.RunAsync();
             var zipStream = await ZipHelper.GetAppZipFile(workerRuntime, functionAppRoot, BuildNativeDeps, noBuild: false, additionalPackages: AdditionalPackages);
             ColoredConsole.WriteLine($"Creating a new package {outputPath}");

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -24,6 +24,9 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
   </PropertyGroup>
   <ItemGroup>
+    <EmbeddedResource Include="StaticResources\bundleConfig.json">
+      <LogicalName>$(AssemblyName).bundleConfig.json</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="StaticResources\ExtensionsProj.csproj.template">
       <LogicalName>$(AssemblyName).ExtensionsProj.csproj</LogicalName>
     </EmbeddedResource>

--- a/src/Azure.Functions.Cli/Common/TemplatesManager.cs
+++ b/src/Azure.Functions.Cli/Common/TemplatesManager.cs
@@ -36,9 +36,8 @@ namespace Azure.Functions.Cli.Common
             string templatesJson;
             if (extensionBundleManager.IsExtensionBundleConfigured())
             {
-                var bundlePath = await extensionBundleManager.GetExtensionBundlePath();
-                var templatesJsonFilePath = Path.Combine(bundlePath, "StaticContent", "v1", "Templates", "templates.json");
-                templatesJson = await FileSystemHelpers.ReadAllTextFromFileAsync(templatesJsonFilePath);
+                var contentProvider = ExtensionBundleHelper.GetExtensionBundleContentProvider();
+                templatesJson = await contentProvider.GetTemplates();
             }
             else
             {

--- a/src/Azure.Functions.Cli/Common/TemplatesManager.cs
+++ b/src/Azure.Functions.Cli/Common/TemplatesManager.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json;
 using Azure.Functions.Cli.Interfaces;
 using Newtonsoft.Json.Linq;
 using Azure.Functions.Cli.Actions.LocalActions;
+using Azure.Functions.Cli.ExtensionBundle;
 
 namespace Azure.Functions.Cli.Common
 {
@@ -30,7 +31,19 @@ namespace Azure.Functions.Cli.Common
 
         private static async Task<IEnumerable<Template>> GetTemplates()
         {
-            var templatesJson = await StaticResources.TemplatesJson;
+            var extensionBundleManager = ExtensionBundleHelper.GetExtensionBundleManager();
+
+            string templatesJson;
+            if (extensionBundleManager.IsExtensionBundleConfigured())
+            {
+                var bundlePath = await extensionBundleManager.GetExtensionBundlePath();
+                var templatesJsonFilePath = Path.Combine(bundlePath, "StaticContent", "v1", "Templates", "templates.json");
+                templatesJson = await FileSystemHelpers.ReadAllTextFromFileAsync(templatesJsonFilePath);
+            }
+            else
+            {
+                templatesJson = await StaticResources.TemplatesJson;
+            }
             return JsonConvert.DeserializeObject<IEnumerable<Template>>(templatesJson);
         }
 

--- a/src/Azure.Functions.Cli/Common/TemplatesManager.cs
+++ b/src/Azure.Functions.Cli/Common/TemplatesManager.cs
@@ -83,7 +83,7 @@ namespace Azure.Functions.Cli.Common
             {
                 foreach (var extension in template.Metadata.Extensions)
                 {
-                    var installAction = new InstallExtensionAction(_secretsManager)
+                    var installAction = new InstallExtensionAction(_secretsManager, false)
                     {
                         Package = extension.Id,
                         Version = extension.Version

--- a/src/Azure.Functions.Cli/ConsoleApp.cs
+++ b/src/Azure.Functions.Cli/ConsoleApp.cs
@@ -366,7 +366,9 @@ namespace Azure.Functions.Cli
         internal IAction CreateAction(Type type)
         {
             var ctor = type.GetConstructors()?.SingleOrDefault();
-            var args = ctor?.GetParameters()?.Select(p => _container.Resolve(p.ParameterType)).ToArray();
+            var args = ctor?.GetParameters()?.Select(p =>
+                p.Attributes == (ParameterAttributes.HasDefault | ParameterAttributes.Optional) ? p.DefaultValue : _container.Resolve(p.ParameterType)
+            ).ToArray();
             return args == null || args.Length == 0
                 ? (IAction)Activator.CreateInstance(type)
                 : (IAction)Activator.CreateInstance(type, args);

--- a/src/Azure.Functions.Cli/ExtensionBundle/ExtensionBundleConfigurationBuilder.cs
+++ b/src/Azure.Functions.Cli/ExtensionBundle/ExtensionBundleConfigurationBuilder.cs
@@ -10,16 +10,16 @@ namespace Azure.Functions.Cli.ExtensionBundle
 {
     internal class ExtensionBundleConfigurationBuilder : IConfigureBuilder<IConfigurationBuilder>
     {
-        private readonly string _scriptPath;
+        private readonly ScriptApplicationHostOptions _hostOptions;
 
-        public ExtensionBundleConfigurationBuilder(string scriptPath)
+        public ExtensionBundleConfigurationBuilder(ScriptApplicationHostOptions hostOptions)
         {
-            _scriptPath = scriptPath;
+            _hostOptions = hostOptions;
         }
 
         public void Configure(IConfigurationBuilder builder)
         {
-            var bundleId = ExtensionBundleHelper.GetExtensionBundleOptions(_scriptPath).Id;
+            var bundleId = ExtensionBundleHelper.GetExtensionBundleOptions(_hostOptions).Id;
             if (!string.IsNullOrEmpty(bundleId))
             {
                 builder.AddInMemoryCollection(new Dictionary<string, string>

--- a/src/Azure.Functions.Cli/ExtensionBundle/ExtensionBundleConfigurationBuilder.cs
+++ b/src/Azure.Functions.Cli/ExtensionBundle/ExtensionBundleConfigurationBuilder.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using Azure.Functions.Cli.Common;
+using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Azure.Functions.Cli.ExtensionBundle
+{
+    internal class ExtensionBundleConfigurationBuilder : IConfigureBuilder<IConfigurationBuilder>
+    {
+        private readonly string _scriptPath;
+
+        public ExtensionBundleConfigurationBuilder(string scriptPath)
+        {
+            _scriptPath = scriptPath;
+        }
+
+        public void Configure(IConfigurationBuilder builder)
+        {
+            var bundleId = ExtensionBundleHelper.GetExtensionBundleOptions(_scriptPath).Id;
+            if (!string.IsNullOrEmpty(bundleId))
+            {
+                builder.AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "AzureFunctionsJobHost:extensionBundle:downloadPath", Path.Combine(Path.GetTempPath(), "Functions", ScriptConstants.ExtensionBundleDirectory, bundleId)}
+                });
+            }
+
+        }
+    }
+}

--- a/src/Azure.Functions.Cli/ExtensionBundle/ExtensionBundleHelper.cs
+++ b/src/Azure.Functions.Cli/ExtensionBundle/ExtensionBundleHelper.cs
@@ -10,13 +10,8 @@ namespace Azure.Functions.Cli.ExtensionBundle
 {
     class ExtensionBundleHelper
     {
-        public static ExtensionBundleOptions GetExtensionBundleOptions(string scriptPath)
+        public static ExtensionBundleOptions GetExtensionBundleOptions(ScriptApplicationHostOptions hostOptions)
         {
-            var hostOptions = new ScriptApplicationHostOptions()
-            {
-                ScriptPath = scriptPath
-            };
-
             IConfigurationBuilder builder = new ConfigurationBuilder();
             builder.Add(new HostJsonFileConfigurationSource(hostOptions, SystemEnvironment.Instance, loggerFactory: NullLoggerFactory.Instance));
             var configuration = builder.Build();

--- a/src/Azure.Functions.Cli/ExtensionBundle/ExtensionBundleHelper.cs
+++ b/src/Azure.Functions.Cli/ExtensionBundle/ExtensionBundleHelper.cs
@@ -32,5 +32,10 @@ namespace Azure.Functions.Cli.ExtensionBundle
             extensionBundleOption.DownloadPath = Path.Combine(Path.GetTempPath(), "Functions", ScriptConstants.ExtensionBundleDirectory, extensionBundleOption.Id);
             return new ExtensionBundleManager(extensionBundleOption, SystemEnvironment.Instance, NullLoggerFactory.Instance);
         }
+
+        public static ExtensionBundleContentProvider GetExtensionBundleContentProvider()
+        {
+            return new ExtensionBundleContentProvider(GetExtensionBundleManager(), NullLogger<ExtensionBundleContentProvider>.Instance);
+        }
     }
 }

--- a/src/Azure.Functions.Cli/ExtensionBundle/ExtensionBundleHelper.cs
+++ b/src/Azure.Functions.Cli/ExtensionBundle/ExtensionBundleHelper.cs
@@ -1,17 +1,21 @@
-﻿using Microsoft.Azure.WebJobs.Script;
+﻿using Azure.Functions.Cli.Common;
+using Microsoft.Azure.WebJobs.Script;
 using Microsoft.Azure.WebJobs.Script.Configuration;
+using Microsoft.Azure.WebJobs.Script.ExtensionBundle;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 
 namespace Azure.Functions.Cli.ExtensionBundle
 {
     class ExtensionBundleHelper
     {
-        public static ExtensionBundleOptions GetExtensionBundleOptions(ScriptApplicationHostOptions hostOptions)
+        public static ExtensionBundleOptions GetExtensionBundleOptions(ScriptApplicationHostOptions hostOptions = null)
         {
+            hostOptions = hostOptions ?? SelfHostWebHostSettingsFactory.Create(Environment.CurrentDirectory);
             IConfigurationBuilder builder = new ConfigurationBuilder();
             builder.Add(new HostJsonFileConfigurationSource(hostOptions, SystemEnvironment.Instance, loggerFactory: NullLoggerFactory.Instance));
             var configuration = builder.Build();
@@ -20,6 +24,13 @@ namespace Azure.Functions.Cli.ExtensionBundle
             var options = new ExtensionBundleOptions();
             configurationHelper.Configure(options);
             return options;
+        }
+
+        public static ExtensionBundleManager GetExtensionBundleManager()
+        {
+            var extensionBundleOption = GetExtensionBundleOptions();
+            extensionBundleOption.DownloadPath = Path.Combine(Path.GetTempPath(), "Functions", ScriptConstants.ExtensionBundleDirectory, extensionBundleOption.Id);
+            return new ExtensionBundleManager(extensionBundleOption, SystemEnvironment.Instance, NullLoggerFactory.Instance);
         }
     }
 }

--- a/src/Azure.Functions.Cli/ExtensionBundle/ExtensionBundleHelper.cs
+++ b/src/Azure.Functions.Cli/ExtensionBundle/ExtensionBundleHelper.cs
@@ -29,7 +29,10 @@ namespace Azure.Functions.Cli.ExtensionBundle
         public static ExtensionBundleManager GetExtensionBundleManager()
         {
             var extensionBundleOption = GetExtensionBundleOptions();
-            extensionBundleOption.DownloadPath = Path.Combine(Path.GetTempPath(), "Functions", ScriptConstants.ExtensionBundleDirectory, extensionBundleOption.Id);
+            if (!string.IsNullOrEmpty(extensionBundleOption.Id))
+            {
+                extensionBundleOption.DownloadPath = Path.Combine(Path.GetTempPath(), "Functions", ScriptConstants.ExtensionBundleDirectory, extensionBundleOption.Id);
+            }
             return new ExtensionBundleManager(extensionBundleOption, SystemEnvironment.Instance, NullLoggerFactory.Instance);
         }
 

--- a/src/Azure.Functions.Cli/ExtensionBundle/ExtensionBundleHelper.cs
+++ b/src/Azure.Functions.Cli/ExtensionBundle/ExtensionBundleHelper.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Azure.WebJobs.Script.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.Functions.Cli.ExtensionBundle
+{
+    class ExtensionBundleHelper
+    {
+        public static ExtensionBundleOptions GetExtensionBundleOptions(string scriptPath)
+        {
+            var hostOptions = new ScriptApplicationHostOptions()
+            {
+                ScriptPath = scriptPath
+            };
+
+            IConfigurationBuilder builder = new ConfigurationBuilder();
+            builder.Add(new HostJsonFileConfigurationSource(hostOptions, SystemEnvironment.Instance, loggerFactory: NullLoggerFactory.Instance));
+            var configuration = builder.Build();
+
+            var configurationHelper = new ExtensionBundleConfigurationHelper(configuration, SystemEnvironment.Instance);
+            var options = new ExtensionBundleOptions();
+            configurationHelper.Configure(options);
+            return options;
+        }
+    }
+}

--- a/src/Azure.Functions.Cli/StaticResources/StaticResources.cs
+++ b/src/Azure.Functions.Cli/StaticResources/StaticResources.cs
@@ -41,6 +41,8 @@ namespace Azure.Functions.Cli
 
         public static Task<string> HostJson => GetValue("host.json");
 
+        public static Task<string> BundleConfig => GetValue("bundleConfig.json");
+
         public static Task<string> PowerShellHostJson => GetValue("powershell.host.json");
 
         public static Task<string> PythonDockerBuildScript => GetValue(Constants.StaticResourcesNames.PythonDockerBuild);

--- a/src/Azure.Functions.Cli/StaticResources/bundleConfig.json
+++ b/src/Azure.Functions.Cli/StaticResources/bundleConfig.json
@@ -1,0 +1,4 @@
+{
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[1.*, 2.0.0)"
+}


### PR DESCRIPTION
`func host start` will load extensions from extension bundle if it is configured in host.json
closes #1105 

`func init . --extension-bundle` will add default extension bundling config to host.json
closes #1106 

`func extensions install` will be a no-op with a warning if extension bundle is configured in host.json
closes #1109 

`func new` will load the templates from extension bundle if it is configured in host.json
closes #1108 
