### PR TITLE
Allow Knative service to be backed by a hostname and don't fail eagerly.

### DIFF
--- a/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/KnativePlatform.cs
+++ b/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/KnativePlatform.cs
@@ -66,18 +66,19 @@ namespace Azure.Functions.Cli.Actions.DeployActions.Platforms
             File.Delete("deployment.json");
 
             var endpoint = await GetIstioClusterIngressEndpoint();
-            if (string.IsNullOrEmpty(endpoint))
-            {
-                ColoredConsole.WriteLine("Couldn't find Istio Cluster Ingress External IP");
-                return;
-            }
-
             var host = GetFunctionHost(name, nameSpace);
 
             ColoredConsole.WriteLine();
             ColoredConsole.WriteLine("Function deployed successfully!");
             ColoredConsole.WriteLine();
-            ColoredConsole.WriteLine($"Function URL: http://{endpoint}");
+            if (string.IsNullOrEmpty(endpoint))
+            {
+                ColoredConsole.WriteLine($"Function URL: http://{endpoint}");
+            }
+            else
+            {
+                ColoredConsole.WriteLine("Couldn't identify Function URL: Couldn't find Istio Cluster Ingress endpoint");
+            }
             ColoredConsole.WriteLine($"Function Host: {host}");
             ColoredConsole.WriteLine();
             ColoredConsole.WriteLine("Plese note: it may take a few minutes for the knative service to be reachable");


### PR DESCRIPTION
Related to: #866 

A Loadbalancer can actually have an IP or a Hostname (or both I think). Both should be fair game for the purposes of printing them out here.

Also added a bit more lenient error handling so the whole command doesn't fail if this cannot be determined by the CLI.