### PR TITLE
HOTFIX: Rollback PowerShell Worker

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -95,7 +95,7 @@
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage.Internal" Version="1.4.0" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.3.1-SNAPSHOT" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.97-preview" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.95-preview" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="2.0.12427" />
     <PackageReference Include="Microsoft.Azure.Functions.PythonWorkerRunEnvironments" Version="1.0.0-beta20190304.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />


### PR DESCRIPTION
In 0.1.97-preview, local debugging (both in VSCode and console debugging) stopped working entirely.

We've root caused the issue, but we don't have a fix yet. This rolls back the PowerShell Worker for now to get us back in a good state.

Since PowerShell support in Azure FUnctions is in Public Preview starting today.... and PowerShell Summit NA started today (and the Keynote included a PowerShell in Azure Functions demo) this should be hotfixed as soon as possible.

NOTE: only a Core Tools release is needed. The host is fine with the change that caused the regression.

cc @anirudhgarg @daxian-dbw @joeyaiello @eamonoreilly @SatishRanjan 