### PR TITLE
Fix func new creating host.json

### DIFF
--- a/src/Azure.Functions.Cli/Actions/LocalActions/CreateFunctionAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/CreateFunctionAction.cs
@@ -73,8 +73,8 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 }
             }
 
-            var templates = await _templatesManager.Templates;
             var workerRuntime = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(_secretsManager);
+            var templates = await _templatesManager.Templates;
 
             if (workerRuntime != WorkerRuntime.None && !string.IsNullOrWhiteSpace(Language))
             {


### PR DESCRIPTION
On an empty directory, `_templatesManager` seems to create a `host.json` when there isn't one. This causes `WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage` to believe that there is a function app in the current directory. This messes up our logic for function app creation.

Running the template manager after trying to get the worker runtime fixes this scenario, as now `GetCurrentWorkerRuntimeLanguage` can throw an error when `host.json` is not present. 