### PR TITLE
Fixes #1230 - add options to override Docker run

### DIFF
--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -27,6 +27,8 @@ namespace Azure.Functions.Cli.Common
         public const string PackageReferenceElementName = "PackageReference";
         public const string LinuxFxVersion = "linuxFxVersion";
         public const string PythonDockerImageVersionSetting = "FUNCTIONS_PYTHON_DOCKER_IMAGE";
+        public const string PythonDockerImageSkipPull = "FUNCTIONS_PYTHON_DOCKER_SKIP_PULL";
+        public const string PythonDockerRunCommand = "FUNCTIONS_PYTHON_DOCKER_RUN_COMMAND";
         public const string FunctionsCoreToolsEnvironment = "FUNCTIONS_CORETOOLS_ENVIRONMENT";
 
         public static string CliVersion => typeof(Constants).GetTypeInfo().Assembly.GetName().Version.ToString(3);

--- a/src/Azure.Functions.Cli/Helpers/DockerHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/DockerHelpers.cs
@@ -92,7 +92,7 @@ namespace Azure.Functions.Cli.Helpers
             string trim(string str) => str.Trim(new[] { ' ', '\n' });
         }
 
-        private static async Task<(string output, string error, int exitCode)> RunDockerCommand(string args, string containerId = null, bool ignoreError = false, bool showProgress = true)
+        internal static async Task<(string output, string error, int exitCode)> RunDockerCommand(string args, string containerId = null, bool ignoreError = false, bool showProgress = true)
         {
             var printArgs = string.IsNullOrWhiteSpace(containerId)
                 ? args


### PR DESCRIPTION
NEED TO TEST THIS. (Will do once build completes)

Now we will have 3 configurable choices:

1. If you want CLI to pull and build on a different image, use `FUNCTIONS_PYTHON_DOCKER_IMAGE`
2. If you want CLI to avoid pulling in case you are using 1 for a local image, set `FUNCTIONS_PYTHON_DOCKER_SKIP_PULL` to `true` or `1`.
3. If you want to customize the run command, pass any envs or other flags, use `FUNCTIONS_PYTHON_DOCKER_RUN_COMMAND` + `FUNCTIONS_PYTHON_DOCKER_SKIP_PULL` (ideally).

@ahmelsayed, would you recommend making `FUNCTIONS_PYTHON_DOCKER_SKIP_PULL` to be assumed when setting `FUNCTIONS_PYTHON_DOCKER_RUN_COMMAND`?