### PR TITLE
Add all powershell runtimes for windows

### DIFF
--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -48,8 +48,8 @@ namespace Build
 
         public static readonly Dictionary<string, string[]> ToolsRuntimeToPowershellRuntimes = new Dictionary<string, string[]>
         {
-            { "win-x86", new [] { "win-x86", "win", "win10-x86", "win8-x86", "win81-x86", "win7-x86" } },
-            { "win-x64", new [] { "win-x64", "win", "win10-x64", "win8-x64", "win81-x64", "win7-x64" } },
+            { "win-x86", new [] { "win-x86", "win", "win10-x86", "win8-x86", "win81-x86", "win7-x86", "win-x64", "win", "win10-x64", "win8-x64", "win81-x64", "win7-x64" } },
+            { "win-x64", new [] { "win-x86", "win", "win10-x86", "win8-x86", "win81-x86", "win7-x86", "win-x64", "win", "win10-x64", "win8-x64", "win81-x64", "win7-x64" } },
             { "linux-x64", new [] { "linux", "linux-x64", "unix", "linux-musl-x64" } },
             { "osx-x64", new [] { "osx", "unix" } },
             { "no-runtime", new [] {
@@ -92,7 +92,7 @@ namespace Build
             public static readonly string SignedDir = "signed";
             public static readonly string Authenticode = "SignAuthenticode";
             public static readonly string ThirdParty = "Sign3rdParty";
-            public static readonly string[] RuntimesToSign = new[] {"min.win-x86"};
+            public static readonly string[] RuntimesToSign = new[] { "min.win-x86" };
             public static readonly string[] FilterExtenstionsSign = new[] { ".json", ".spec", ".cfg", ".pdb", ".config", ".nupkg", ".py" };
             public static readonly string SigcheckDownloadURL = "https://functionsbay.blob.core.windows.net/public/tools/sigcheck64.exe";
 

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -46,10 +46,11 @@ namespace Build
             { "min.win-x64", "Windows" },
         };
 
+        private static readonly string[] _winPowershellRuntimes = new [] { "win-x86", "win", "win10-x86", "win8-x86", "win81-x86", "win7-x86", "win-x64", "win10-x64", "win8-x64", "win81-x64", "win7-x64" };
         public static readonly Dictionary<string, string[]> ToolsRuntimeToPowershellRuntimes = new Dictionary<string, string[]>
         {
-            { "win-x86", new [] { "win-x86", "win", "win10-x86", "win8-x86", "win81-x86", "win7-x86", "win-x64", "win", "win10-x64", "win8-x64", "win81-x64", "win7-x64" } },
-            { "win-x64", new [] { "win-x86", "win", "win10-x86", "win8-x86", "win81-x86", "win7-x86", "win-x64", "win", "win10-x64", "win8-x64", "win81-x64", "win7-x64" } },
+            { "win-x86", _winPowershellRuntimes },
+            { "win-x64", _winPowershellRuntimes },
             { "linux-x64", new [] { "linux", "linux-x64", "unix", "linux-musl-x64" } },
             { "osx-x64", new [] { "osx", "unix" } },
             { "no-runtime", new [] {


### PR DESCRIPTION
It looks like Powershell launches `dotnet` process which then will load the right `runtime`. The bitness of `dotnet` will depend on what the user has installed, not the bitness of `func`. So we need to include both bitness runtimes in the both cli packages for Windows. 