### PR TITLE
Add error messages to Python failures

### DIFF
--- a/src/Azure.Functions.Cli/Helpers/DockerHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/DockerHelpers.cs
@@ -39,9 +39,15 @@ namespace Azure.Functions.Cli.Helpers
             var docker = new Executable("docker", "ps");
             var sb = new StringBuilder();
             var exitCode = await docker.RunAsync(l => sb.AppendLine(l), e => sb.AppendLine(e));
-            if (exitCode != 0 && sb.ToString().IndexOf("permission denied", StringComparison.OrdinalIgnoreCase) != 0)
+
+            if (exitCode != 0)
             {
-                throw new CliException("Got permission denied trying to run docker. Make sure the user you are running the cli from is in docker group or is root");
+                var errorStr = sb.ToString();
+                if (errorStr.IndexOf("permission denied", StringComparison.OrdinalIgnoreCase) != -1)
+                {
+                    throw new CliException("Got permission denied trying to run docker. Make sure the user you are running the cli from is in docker group or is root");
+                }
+                throw new CliException($"Could not connect to Docker.{Environment.NewLine}Error: {errorStr}");
             }
             return true;
         }

--- a/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
@@ -290,13 +290,13 @@ namespace Azure.Functions.Cli.Helpers
             var packApp = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "tools", "python", "packapp");
 
             var pythonExe = await ValidatePythonVersion(errorOutIfOld: true);
-            var exe = new Executable(pythonExe, $"\"{packApp}\" --platform linux --python-version 36 --packages-dir-name {Constants.ExternalPythonPackages} \"{functionAppRoot}\"");
+            var exe = new Executable(pythonExe, $"\"{packApp}\" --platform linux --python-version 36 --packages-dir-name {Constants.ExternalPythonPackages} \"{functionAppRoot}\" --verbose");
             var sbErrors = new StringBuilder();
             var exitCode = await exe.RunAsync(o => ColoredConsole.WriteLine(o), e => sbErrors.AppendLine(e));
 
             if (exitCode != 0)
             {
-                var errorMessage = "There was an error restoring dependencies." + sbErrors.ToString();
+                var errorMessage = "There was an error restoring dependencies. " + sbErrors.ToString();
                 // If --build-native-deps if required, we exit with this specific code to notify other toolings
                 // If this exit code changes, partner tools must be updated
                 if (exitCode == ExitCodes.BuildNativeDepsRequired)


### PR DESCRIPTION
Fixes #1372 

Made `packapp` to always run on `--verbose`. I think this helps with the actual error and showing the actual download progress is clearer too.

Docker was initially logging permission error for all `docker ps` failures.