### PR TITLE
Add support for server side build

### DIFF
--- a/src/Azure.Functions.Cli/Actions/LocalActions/PackAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/PackAction.cs
@@ -105,7 +105,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             // Restore all valid extensions
             var installExtensionAction = new InstallExtensionAction(_secretsManager, false);
             await installExtensionAction.RunAsync();
-            var stream = await ZipHelper.GetAppZipFile(workerRuntime, functionAppRoot, BuildNativeDeps, noBuild: false, additionalPackages: AdditionalPackages);
+            var stream = await ZipHelper.GetAppZipFile(workerRuntime, functionAppRoot, BuildNativeDeps, noBuild: false, buildOption: BuildOption.Default, additionalPackages: AdditionalPackages);
 
             if (Squashfs)
             {

--- a/src/Azure.Functions.Cli/Common/BuildOption.cs
+++ b/src/Azure.Functions.Cli/Common/BuildOption.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.Functions.Cli.Common
+{
+    [Flags]
+    public enum BuildOption
+    {
+        None, // will act as "func azure functionapp publish <appname> --no-build"
+        Local, // will act as "func azure functionapp publish <appname>"
+        Remote, // will act as "func azure functionapp publish <appname> --server-side-build"
+        Container, // will act as "func azure functionapp publish <appname> --build-native-deps"
+        Default // will trigger remote build if requirements.txt has content
+    }
+}

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -74,6 +74,12 @@ namespace Azure.Functions.Cli.Common
             public const string AADClientId = "1950a258-227b-4e31-a9cf-717495945fc2";
         }
 
+        public static class KuduLiteDeploymentConstants
+        {
+            public const int ArmTokenExpiryMinutes = 4;
+            public const int StatusRefreshSeconds = 3;
+        }
+
         public static class DockerImages
         {
             public const string LinuxPythonImageAmd64 = "mcr.microsoft.com/azure-functions/python:2.0.12493-python3.6-buildenv";

--- a/src/Azure.Functions.Cli/Common/DeploymentStatus.cs
+++ b/src/Azure.Functions.Cli/Common/DeploymentStatus.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.Functions.Cli.Common
+{
+    public enum DeployStatus
+    {
+        Pending = 0,
+        Building = 1,
+        Deploying = 2,
+        Failed = 3,
+        Success = 4
+    }
+}

--- a/src/Azure.Functions.Cli/Helpers/AzureHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/AzureHelper.cs
@@ -140,6 +140,12 @@ namespace Azure.Functions.Cli.Helpers
             return ArmHttpAsync<IEnumerable<FunctionInfo>>(HttpMethod.Get, url, accessToken);
         }
 
+        internal static Task<string> GetSiteRestrictedToken(Site functionApp, string accessToken, string managementURL)
+        {
+            var url = new Uri($"{managementURL}{functionApp.SiteId}/hostruntime/admin/host/token?api-version={ArmUriTemplates.WebsitesApiVersion}");
+            return ArmHttpAsync<string>(HttpMethod.Get, url, accessToken);
+        }
+
         internal static async Task<string> GetFunctionKey(string functionName, string appId, string accessToken, string managementURL)
         {
             // If anything goes wrong anywhere, simply return null and let the caller take care of it.

--- a/src/Azure.Functions.Cli/Helpers/KuduLiteDeploymentHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/KuduLiteDeploymentHelpers.cs
@@ -1,0 +1,136 @@
+﻿using Azure.Functions.Cli.Arm.Models;
+using Azure.Functions.Cli.Common;
+using Colors.Net;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Azure.Functions.Cli.Helpers
+{
+    internal class KuduLiteDeploymentHelpers
+    {
+        private static string CachedARMRestrictedToken = string.Empty;
+        private static DateTime TokenLastUpdate = DateTime.MinValue;
+
+        public static async Task<string> GetRestrictedToken(Site functionApp, string accessToken, string managementUrl)
+        {
+            DateTime expiry = TokenLastUpdate + TimeSpan.FromMinutes(Constants.KuduLiteDeploymentConstants.ArmTokenExpiryMinutes);
+            if (DateTime.UtcNow > expiry || string.IsNullOrEmpty(CachedARMRestrictedToken))
+            {
+                try
+                {
+                    CachedARMRestrictedToken = await AzureHelper.GetSiteRestrictedToken(functionApp, accessToken, managementUrl);
+                    TokenLastUpdate = DateTime.UtcNow;
+                }
+                catch
+                {
+                    // When host is restarting, we will suppress the error and use the old ARM token (still valid for 1 minute)
+                }
+            }
+            return CachedARMRestrictedToken;
+        }
+
+        public static async Task<DeployStatus> WaitForServerSideBuild(HttpClient client, Site functionApp, string accessToken, string managementUrl)
+        {
+            ColoredConsole.WriteLine("Server side build in progress, please wait");
+            DeployStatus statusCode = DeployStatus.Pending;
+            DateTime logLastUpdate = DateTime.MinValue;
+            string id = null;
+
+            while (string.IsNullOrEmpty(id))
+            {
+                string restrictedToken = await GetRestrictedToken(functionApp, accessToken, managementUrl);
+                id = await GetLatestDeploymentId(client, functionApp, restrictedToken);
+                await Task.Delay(TimeSpan.FromSeconds(Constants.KuduLiteDeploymentConstants.StatusRefreshSeconds));
+            }
+
+            while (statusCode != DeployStatus.Success && statusCode != DeployStatus.Failed)
+            {
+                string restrictedToken = await GetRestrictedToken(functionApp, accessToken, managementUrl);
+                statusCode = await GetDeploymentStatusById(client, functionApp, restrictedToken, id);
+                logLastUpdate = await DisplayDeploymentLog(client, functionApp, restrictedToken, id, logLastUpdate);
+                await Task.Delay(TimeSpan.FromSeconds(Constants.KuduLiteDeploymentConstants.StatusRefreshSeconds));
+            }
+
+            return statusCode;
+        }
+
+        private static async Task<string> GetLatestDeploymentId(HttpClient client, Site functionApp, string restrictedToken)
+        {
+            var json = await InvokeRequest<List<Dictionary<string, string>>>(client,
+                HttpMethod.Get, "/deployments", restrictedToken);
+
+            // Automatically ordered by received time
+            var latestDeployment = json.First();
+            if (latestDeployment.TryGetValue("status", out string statusString))
+            {
+                DeployStatus status = ConvertToDeployementStatus(statusString);
+                if (status != DeployStatus.Pending)
+                {
+                    return latestDeployment["id"];
+                }
+            }
+            return null;
+        }
+
+        private static async Task<DeployStatus> GetDeploymentStatusById(HttpClient client, Site functionApp, string restrictedToken, string id)
+        {
+            var json = await InvokeRequest<Dictionary<string, string>>(client,
+                HttpMethod.Get, $"/deployments/{id}", restrictedToken);
+
+            if (json.TryGetValue("status", out string statusString))
+            {
+                return ConvertToDeployementStatus(json["status"]);
+            }
+            return DeployStatus.Failed;
+        }
+
+        private static async Task<DateTime> DisplayDeploymentLog(HttpClient client, Site functionApp, string restrictedToken, string id, DateTime lastUpdate)
+        {
+            var json = await InvokeRequest<List<Dictionary<string, string>>>(client,
+                HttpMethod.Get, $"/deployments/{id}/log", restrictedToken);
+
+            var logs = json.Where(dict => DateTime.Parse(dict["log_time"]) > lastUpdate);
+            foreach (var log in logs)
+            {
+                ColoredConsole.WriteLine(log["message"]);
+            }
+            return logs.LastOrDefault() != null ? DateTime.Parse(logs.Last()["log_time"]) : lastUpdate;
+        }
+
+        private static async Task<T> InvokeRequest<T>(HttpClient client, HttpMethod method, string url, string restrictedToken)
+        {
+            using (var request = new HttpRequestMessage(method, new Uri(url, UriKind.Relative)))
+            {
+                if (!string.IsNullOrEmpty(restrictedToken))
+                {
+                    request.Headers.Add("x-ms-site-restricted-token", restrictedToken);
+                }
+
+                HttpResponseMessage response = null;
+                await RetryHelper.Retry(async () =>
+                {
+                    response = await client.SendAsync(request);
+                    response.EnsureSuccessStatusCode();
+                }, 3);
+
+                if (response != null)
+                {
+                    string jsonString = await response.Content.ReadAsStringAsync();
+                    return JsonConvert.DeserializeObject<T>(jsonString);
+                } else
+                {
+                    return default(T);
+                }
+            }
+        }
+
+        private static DeployStatus ConvertToDeployementStatus(string statusString)
+        {
+            return Enum.Parse<DeployStatus>(statusString);
+        }
+    }
+}

--- a/src/Azure.Functions.Cli/Helpers/PublishHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/PublishHelper.cs
@@ -1,4 +1,9 @@
+using System;
 using System.IO;
+using System.Net.Http;
+using System.Net.Http.Handlers;
+using System.Threading.Tasks;
+using Azure.Functions.Cli.Arm.Models;
 using Azure.Functions.Cli.Common;
 
 namespace Azure.Functions.Cli.Helpers
@@ -17,6 +22,58 @@ namespace Azure.Functions.Cli.Helpers
             }
             catch { }
             return null;
+        }
+
+        public static BuildOption UpdateLinuxConsumptionBuildOption(BuildOption currentBuildOption, WorkerRuntime workerRuntime)
+        {
+            return currentBuildOption;
+        }
+
+        public static async Task<HttpResponseMessage> InvokeLongRunningRequest(HttpClient client,
+            ProgressMessageHandler handler, HttpRequestMessage request, long requestSize=0, string prompt=null)
+        {
+            if (prompt == null)
+            {
+                prompt = string.Empty;
+            }
+
+            string message = string.Empty;
+            if (requestSize > 0)
+            {
+                message = Utilities.BytesToHumanReadable(requestSize);
+            }
+
+            using (var pb = new SimpleProgressBar($"{prompt} {message}"))
+            {
+                handler.HttpSendProgress += (s, e) => pb.Report(e.ProgressPercentage);
+                return await client.SendAsync(request);
+            }
+        }
+
+        public static async Task CheckResponseStatusAsync(HttpResponseMessage response, string message=null)
+        {
+            if (message == null)
+            {
+                message = string.Empty;
+            }
+
+            if (response == null)
+            {
+                throw new ArgumentNullException("Response must not be null");
+            }
+
+            if (response == null || !response.IsSuccessStatusCode)
+            {
+                var responseContent = await response.Content.ReadAsStringAsync();
+                var errorMessage = $"Error {message} ({response.StatusCode}).";
+
+                if (!string.IsNullOrEmpty(responseContent))
+                {
+                    errorMessage += $"{Environment.NewLine}Server Response: {responseContent}";
+                }
+
+                throw new CliException(errorMessage);
+            }
         }
     }
 }

--- a/src/Azure.Functions.Cli/Helpers/ZipHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/ZipHelper.cs
@@ -12,7 +12,7 @@ namespace Azure.Functions.Cli.Helpers
 {
     public static class ZipHelper
     {
-        public static async Task<Stream> GetAppZipFile(WorkerRuntime workerRuntime, string functionAppRoot, bool buildNativeDeps, bool noBuild, GitIgnoreParser ignoreParser = null, string additionalPackages = null, bool ignoreDotNetCheck = false)
+        public static async Task<Stream> GetAppZipFile(WorkerRuntime workerRuntime, string functionAppRoot, bool buildNativeDeps, BuildOption buildOption, bool noBuild, GitIgnoreParser ignoreParser = null, string additionalPackages = null, bool ignoreDotNetCheck = false)
         {
             var gitIgnorePath = Path.Combine(functionAppRoot, Constants.FuncIgnoreFile);
             if (ignoreParser == null && FileSystemHelpers.FileExists(gitIgnorePath))
@@ -23,13 +23,16 @@ namespace Azure.Functions.Cli.Helpers
             if (noBuild)
             {
                 ColoredConsole.WriteLine(Yellow("Skipping build event for functions project (--no-build)."));
+            } else if (buildOption == BuildOption.Remote)
+            {
+                ColoredConsole.WriteLine(Yellow("Perform remote build for functions project (--build remote)."));
             }
 
-            if (workerRuntime == WorkerRuntime.python && !noBuild)
+            if (workerRuntime == WorkerRuntime.python && !noBuild && buildOption != BuildOption.Remote)
             {
-                return await PythonHelpers.GetPythonDeploymentPackage(FileSystemHelpers.GetLocalFiles(functionAppRoot, ignoreParser), functionAppRoot, buildNativeDeps, additionalPackages);
+                return await PythonHelpers.GetPythonDeploymentPackage(FileSystemHelpers.GetLocalFiles(functionAppRoot, ignoreParser), functionAppRoot, buildNativeDeps, buildOption, additionalPackages);
             }
-            else if (workerRuntime == WorkerRuntime.dotnet && !ignoreDotNetCheck && !noBuild)
+            else if (workerRuntime == WorkerRuntime.dotnet && !ignoreDotNetCheck && !noBuild && buildOption != BuildOption.Remote)
             {
                 throw new CliException("Pack command doesn't work for dotnet functions");
             }


### PR DESCRIPTION
### Dependency
https://github.com/Azure/azure-functions-host/pull/4585

### Background
Allow user to use --server-side-build flag in core tools and enable 
The expected behaviors:
1. User use `func azure functionapp publish <function site name> --server-side-build` to trigger a new build.
2. The core tools will initiate a web request to `https://management.azure.com/subscriptions/<subscription>/resourceGroups/<resource group>/providers/Microsoft.Web/sites/<function site name>/hostruntime/**admin/getsitetoken**` to get an **x-ms-site-restricted-token**. This **x-ms-site-restricted-token** will be used as authentication token in scmsite endpoints.
3. Core tools packs the files in user's local source directory into a zip file.
4. Core tools upload the zip file to `scmsite/api/zipdeploy?isAsync=true`.
4. Core tools will pull the build status from `scmsite/deployments/<id>`.
5. Core tools will emit the server side build log from `scmsite/deployments/<id>/log`.
6. Core tools will finish the execution once it receives Deployment Success or Deployment Failure status.

### Notice
1. The --server-side-build flag is only available to Linux Consumption Python.
2. Every 3 seconds, the core tool checks the build status.
3. Every 3 seconds, the core tool pulls down the full server side build log, and concatenate the logs to console. The size of the log can go up to a few hundreds KBs. Since we have a 30MB response content limitation. I don't think this is an issue.

### CR Request
@ahmelsayed @ankitkumarr 