### PR TITLE
Enable compilation of F# projects.

### DIFF
--- a/src/Azure.Functions.Cli/Helpers/DotnetHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/DotnetHelpers.cs
@@ -74,16 +74,18 @@ namespace Azure.Functions.Cli.Helpers
         {
             EnsureDotnet();
             var csProjFiles = FileSystemHelpers.GetFiles(Environment.CurrentDirectory, searchPattern: "*.csproj").ToList();
+            var fsProjFiles = FileSystemHelpers.GetFiles(Environment.CurrentDirectory, searchPattern: "*.fsproj").ToList();
             // If the project name is extensions only then is extensions.csproj a valid csproj file
             if (!Path.GetFileName(Environment.CurrentDirectory).Equals("extensions"))
             {
                 csProjFiles.Remove("extensions.csproj");
+                fsProjFiles.Remove("extensions.fsproj");
             }
-            if (csProjFiles.Count > 1)
+            if (csProjFiles.Count + fsProjFiles.Count > 1)
             {
-                throw new CliException($"Can't determine Project to build. Expected 1 .csproj but found {csProjFiles.Count}");
+                throw new CliException($"Can't determine Project to build. Expected 1 .csproj or .fsproj but found {csProjFiles.Count + fsProjFiles.Count}");
             }
-            return csProjFiles.Count == 1;
+            return csProjFiles.Count + fsProjFiles.Count == 1;
         }
 
         public static async Task<bool> BuildDotnetProject(string outputPath, string dotnetCliParams, bool showOutput = true)
@@ -104,7 +106,7 @@ namespace Azure.Functions.Cli.Helpers
             return true;
         }
 
-        public static string GetCsproj()
+        public static string GetCsprojOrFsproj()
         {
             EnsureDotnet();
             var csProjFiles = FileSystemHelpers.GetFiles(Environment.CurrentDirectory, searchPattern: "*.csproj").ToList();
@@ -114,7 +116,15 @@ namespace Azure.Functions.Cli.Helpers
             }
             else
             {
-                throw new CliException($"Can't determine Project to build. Expected 1 .csproj but found {csProjFiles.Count}");
+                var fsProjFiles = FileSystemHelpers.GetFiles(Environment.CurrentDirectory, searchPattern: "*.fsproj").ToList();
+                if (fsProjFiles.Count == 1)
+                {
+                    return fsProjFiles.First();
+                }
+                else
+                {
+                    throw new CliException($"Can't determine Project to build. Expected 1 .csproj or .fsproj but found {csProjFiles.Count + fsProjFiles.Count}");
+                }
             }
         }
 

--- a/src/Azure.Functions.Cli/Helpers/ExtensionsHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/ExtensionsHelper.cs
@@ -19,7 +19,7 @@ namespace Azure.Functions.Cli.Helpers
             var workerRuntime = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(secretsManager);
             if (workerRuntime == WorkerRuntime.dotnet && !csx)
             {
-                return DotnetHelpers.GetCsproj();
+                return DotnetHelpers.GetCsprojOrFsproj();
             }
 
             if (String.IsNullOrEmpty(extensionsDir))


### PR DESCRIPTION
This PR enables the compilation of F# function projects.

> Simply searches for the existence of *.fsproj files additionally to *.csproj files.
> The dotnet build system then builds the project before the function host starts.

Previously:
```
[22.06.2019 07:21:30] Starting JobHost
[22.06.2019 07:21:30] Starting Host (HostId=desktopahhb6e1-383811222, InstanceId=bcf09484-1474-4e67-a381-25c295b34816, Version=2.0.12507.0, ProcessId=15216, AppDomainId=1, InDebugMode=False, InDiagnosticMode=False, FunctionsExtensionVersion=)
[22.06.2019 07:21:30] Loading functions metadata
[22.06.2019 07:21:30] 0 functions loaded
[22.06.2019 07:21:30] Generating 0 job function(s)
[22.06.2019 07:21:30] No job functions found. Try making your job classes and methods public. If you're using binding extensions (e.g. Azure Storage, ServiceBus, Timers, etc.) make sure you've called the registration method for the extension(s) in your startup code (e.g. builder.AddAzureStorage(), builder.AddServiceBus(), builder.AddTimers(), etc.).
[22.06.2019 07:21:30] Host initialized (67ms)
[22.06.2019 07:21:30] Host started (81ms)
[22.06.2019 07:21:30] Job host started
```

Now:
```
[22.06.2019 07:23:21] Starting JobHost
[22.06.2019 07:23:21] Starting Host (HostId=desktopahhb6e1-243951228, InstanceId=4d628fb3-f432-4c3a-b772-61f7ce7cd631, Version=2.0.12543.0, ProcessId=10856, AppDomainId=1, InDebugMode=False, InDiagnosticMode=False, FunctionsExtensionVersion=)
[22.06.2019 07:23:21] Loading functions metadata
[22.06.2019 07:23:21] 1 functions loaded
[22.06.2019 07:23:21] Generating 1 job function(s)
[22.06.2019 07:23:21] Found the following functions:
[22.06.2019 07:23:21] AzureFuncFsprojSupport.HttpTrigger.Run
[22.06.2019 07:23:21]
[22.06.2019 07:23:21] Host initialized (270ms)
[22.06.2019 07:23:21] Host started (297ms)
[22.06.2019 07:23:21] Job host started
```

Sample repository: https://github.com/toburger/AzureFuncFsprojSupport