### PR TITLE
Update PowerShell worker to v0.1.111-preview.

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -108,7 +108,7 @@
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage.Internal" Version="1.4.0" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.4.1" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.102-preview" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.111-preview" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="2.0.12543" />
     <PackageReference Include="Microsoft.Azure.Functions.PythonWorkerRunEnvironments" Version="1.0.0-beta20190617.3" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />


### PR DESCRIPTION
The major changes for this release are:
* Proxies fix
* Updated proto files used by PowerShell worker
* Set response Content-Type to 'application/json' when an object is provided to Body
* Managed Dependencies (MDs) enhancements:
    -    Added retry logic for module installation with a maximum of 3 retries
    -    If unable to reach the PSGallery during installation:
         * If this is the first time we are installing MDs, we error out and stop execution
         * If there is a previous installation of MDs, log that we could not connect to the PSGallery and continue with the function app execution
* Enhancements to throughput performance