### PR TITLE
Update path to bash

### DIFF
--- a/src/Azure.Functions.Cli/Common/CommandChecker.cs
+++ b/src/Azure.Functions.Cli/Common/CommandChecker.cs
@@ -13,7 +13,7 @@ namespace Azure.Functions.Cli.Common
         public static bool CommandExists(string command)
             => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
             ? CheckExitCode("where", command)
-            : CheckExitCode("bash", $"-c \"command -v {command}\"");
+            : CheckExitCode("/bin/bash", $"-c \"command -v {command}\"");
 
         public static async Task<bool> PowerShellModuleExistsAsync(string powershellExecutable, string module)
         {


### PR DESCRIPTION
- Fix path to bash so the tools can be used on macOS without throwing "No such file or directory" error.
- Fixes #1403