### PR TITLE
Perform sync trigger when server side build succeeds

### DIFF
--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -520,6 +520,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 {
                     throw new CliException($"Error remove {appSettingName}: {result.ErrorResult}.");
                 }
+                await Task.Delay(TimeSpan.FromSeconds(5));
             }
         }
 

--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -403,8 +403,8 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 if (buildOption == BuildOption.Remote)
                 {
                     await RemoveFunctionAppAppSetting(functionApp, "WEBSITE_RUN_FROM_PACKAGE");
-                    await PerformServerSideBuild(functionApp, zipFileStreamTask);
-                    return false;
+                    var deployStatus = await PerformServerSideBuild(functionApp, zipFileStreamTask);
+                    return deployStatus == DeployStatus.Success;
                 }
             }
             else
@@ -545,7 +545,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             }, 2);
         }
 
-        public async Task PerformServerSideBuild(Site functionApp, Func<Task<Stream>> zipFileFactory)
+        public async Task<DeployStatus> PerformServerSideBuild(Site functionApp, Func<Task<Stream>> zipFileFactory)
         {
             using (var handler = new ProgressMessageHandler(new HttpClientHandler()))
             using (var client = GetRemoteZipClient(new Uri($"https://{functionApp.ScmUri}"), handler))
@@ -576,6 +576,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 {
                     ColoredConsole.WriteLine(Red("Server side build failed!"));
                 }
+                return status;
             }
         }
 

--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -513,7 +513,8 @@ namespace Azure.Functions.Cli.Actions.AzureActions
         {
             if (functionApp.AzureAppSettings.ContainsKey(appSettingName))
             {
-                ColoredConsole.WriteLine(Yellow($"Removing {appSettingName} App Setting"));
+                var appSettingValue = functionApp.AzureAppSettings[appSettingName];
+                ColoredConsole.WriteLine(Yellow($"Removing {appSettingName} app setting ({appSettingValue})"));
                 functionApp.AzureAppSettings.Remove(appSettingName);
                 var result = await AzureHelper.UpdateFunctionAppAppSettings(functionApp, AccessToken, ManagementURL);
                 if (!result.IsSuccessful)


### PR DESCRIPTION
Previously, we run into an issue where the list function has the old content before the server side build.
To address this issue, after each server side build succeeds, we should perform a sync trigger before listing the functions information.