### PR TITLE
Handle lack of internet connection when creating PowerShell function apps

### DIFF
--- a/src/Azure.Functions.Cli/Helpers/PowerShellHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/PowerShellHelper.cs
@@ -15,6 +15,9 @@ namespace Azure.Functions.Cli.Helpers
         // The PowerShellGallery uri to query for the latest module version.
         private const string PowerShellGalleryFindPackagesByIdUri = "https://www.powershellgallery.com/api/v2/FindPackagesById()?id=";
 
+        // Default timeout in seconds to retrieve the module version.
+        private const int DefaultTimeOutInSeconds = 10;
+
         /// <summary>
         /// Gets the latest supported major version of the Az module from the PSGallery.
         /// </summary>
@@ -30,6 +33,7 @@ namespace Azure.Functions.Cli.Helpers
                 using (var client = new HttpClient())
                 {
                     client.DefaultRequestHeaders.Add("User-Agent", Constants.CliUserAgent);
+                    client.Timeout = TimeSpan.FromSeconds(DefaultTimeOutInSeconds);
 
                     try
                     {

--- a/src/Azure.Functions.Cli/StaticResources/requirements.psd1
+++ b/src/Azure.Functions.Cli/StaticResources/requirements.psd1
@@ -1,7 +1,8 @@
 ﻿# This file enables modules to be automatically managed by the Functions service.
-# Only the Azure Az module is supported in preview.
+# Only the Azure Az module is supported in public preview.
 # See https://aka.ms/functionsmanageddependency for additional information.
 #
 @{
-    'Az' = 'MAJOR_VERSION.*'
+    # For latest supported version, go to 'https://www.powershellgallery.com/packages/Az'. [GUIDANCE]
+    # 'Az' = 'MAJOR_VERSION.*'
 }


### PR DESCRIPTION
For PowerShell function apps, we enable Managed Dependencies (MDs) at creation time via func init. During this process, we connect to the www.powershellgallery.com to retrieve the latest available module version for the Azure Az modules. 

After this code change, if the user does not have internet access during func init, we do the following:

1) Write a warning to the console:
![image](https://user-images.githubusercontent.com/12720858/60994379-4340e080-a305-11e9-947f-19f1d7ba6400.png)

2) Provide instructions in requirements.psd1 on what to do next:

```
Contents of requirements.psd1

# This file enables modules to be automatically managed by the Functions service.
# Only the Azure Az module is supported in public preview.
# See https://aka.ms/functionsmanageddependency for additional information.
#
@{
    # For latest supported version, go to 'https://www.powershellgallery.com/packages/Az'. Uncomment the next line and replace the MAJOR_VERSION, e.g., 'Az' = '2.*'
    # 'Az' = 'MAJOR_VERSION.*'
}
```



```func init``` for a PowerShell function app with internet connection continues to work the same. However, the comments in ```requirements.psd1``` file have been updated. Please see below:

```
PS D:\Functions\MyFuction3> E:\CLI\func init --worker-runtime powershell
Writing profile.ps1
Writing requirements.psd1
Writing .gitignore
Writing host.json
Writing local.settings.json
Writing D:\Functions\MyFuction3\.vscode\extensions.json
```

Contents of requirements.psd1
```
# This file enables modules to be automatically managed by the Functions service.
# Only the Azure Az module is supported in public preview.
# See https://aka.ms/functionsmanageddependency for additional information.
#
@{
    # For latest supported version, go to 'https://www.powershellgallery.com/packages/Az'.
    'Az' = '2.*'
}
```

