### PR TITLE
Update PowerShellWorker version to 0.1.120-preview

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -108,7 +108,7 @@
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage.Internal" Version="1.4.0" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.4.1" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.111-preview" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.120-preview" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="2.0.12555" />
     <PackageReference Include="Microsoft.Azure.Functions.PythonWorkerRunEnvironments" Version="1.0.0-beta20190710.5" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />


### PR DESCRIPTION
The major changes for this release are:
- Ignore function load requests with duplicate FunctionId values

Release details: https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v0.1.120-preview