### PR TITLE
Add slot support, and use ARG for function app

### DIFF
--- a/src/Azure.Functions.Cli/Actions/AzureActions/BaseAzureAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/BaseAzureAction.cs
@@ -91,23 +91,6 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             {
                 ManagementURL = await GetManagementURL();
             }
-
-            if (string.IsNullOrEmpty(Subscription))
-            {
-                Subscription = await GetDefaultSubscription();
-            }
-        }
-
-        private async Task<string> GetDefaultSubscription()
-        {
-            try
-            {
-                return await RunAzCLICommand("account show --query \"id\" --output json");
-            }
-            catch (Exception)
-            {
-                return null;
-            }
         }
 
         private async Task<string> GetManagementURL()

--- a/src/Azure.Functions.Cli/Actions/AzureActions/BaseFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/BaseFunctionAppAction.cs
@@ -9,6 +9,8 @@ namespace Azure.Functions.Cli.Actions.AzureActions
     {
         public string FunctionAppName { get; set; }
 
+        public string Slot { get; set; }
+
         public override ICommandLineParserResult ParseArgs(string[] args)
         {
             if (args.Any() && !args.First().StartsWith("-"))
@@ -20,6 +22,12 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 throw new CliArgumentsException("Must specify functionApp name.", Parser.Parse(args),
                     new CliArgument { Name = nameof(FunctionAppName), Description = "Function App name" });
             }
+
+            Parser
+                .Setup<string>("slot")
+                .WithDescription("The deployment slot in the function app to use (if configured)")
+                .SetDefault(null)
+                .Callback(t => Slot = t);
 
             return base.ParseArgs(args);
         }

--- a/src/Azure.Functions.Cli/Actions/AzureActions/FetchAppSettingsAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/FetchAppSettingsAction.cs
@@ -21,7 +21,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
 
         public override async Task RunAsync()
         {
-            var functionApp = await AzureHelper.GetFunctionApp(FunctionAppName, AccessToken, ManagementURL);
+            var functionApp = await AzureHelper.GetFunctionApp(FunctionAppName, AccessToken, ManagementURL, Slot);
             if (functionApp != null)
             {
                 ColoredConsole.WriteLine(TitleColor("App Settings:"));

--- a/src/Azure.Functions.Cli/Actions/AzureActions/ListFunctionsActions.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/ListFunctionsActions.cs
@@ -33,7 +33,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
 
         public override async Task RunAsync()
         {
-            var functionApp = await AzureHelper.GetFunctionApp(FunctionAppName, AccessToken, ManagementURL);
+            var functionApp = await AzureHelper.GetFunctionApp(FunctionAppName, AccessToken, ManagementURL, Slot);
             if (functionApp != null)
             {
                 await AzureHelper.PrintFunctionsInfo(functionApp, AccessToken, ManagementURL, ShowKeys);

--- a/src/Azure.Functions.Cli/Actions/AzureActions/LogStreamAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/LogStreamAction.cs
@@ -38,7 +38,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
         {
             var subscriptions = await AzureHelper.GetSubscriptions(AccessToken, ManagementURL);
             ColoredConsole.WriteLine("Retrieving Function App...");
-            var functionApp = await AzureHelper.GetFunctionApp(FunctionAppName, AccessToken, ManagementURL, allSubs: subscriptions);
+            var functionApp = await AzureHelper.GetFunctionApp(FunctionAppName, AccessToken, ManagementURL, Slot, allSubs: subscriptions);
             if (UseBrowser)
             {
                 await OpenLiveStreamInBrowser(functionApp, subscriptions);

--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -116,7 +116,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
         public override async Task RunAsync()
         {
             // Get function app
-            var functionApp = await AzureHelper.GetFunctionApp(FunctionAppName, AccessToken, ManagementURL, Subscription);
+            var functionApp = await AzureHelper.GetFunctionApp(FunctionAppName, AccessToken, ManagementURL, Slot, Subscription);
 
             // Get the GitIgnoreParser from the functionApp root
             var functionAppRoot = ScriptHostHelpers.GetFunctionAppRootDirectory(Environment.CurrentDirectory);


### PR DESCRIPTION
Closes #1381, #1423 

- Using ARG is a lot faster as we don't need to go through subscription(s) page by page to find a Function App. It also saves an `az` call.
- Slot support for all azure commands.
 