### PR TITLE
Removing explicit language worker dependencies

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -106,9 +106,6 @@
     <PackageReference Include="AccentedCommandLineParser" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage.Internal" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.5.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.120-preview" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="2.0.12575" />
     <PackageReference Include="Microsoft.Azure.Functions.PythonWorkerRunEnvironments" Version="1.0.0-beta20190710.5" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />


### PR DESCRIPTION
**BEFORE MERGING THIS:** This is synchronizing the Node worker with the runtime version, but it causes a downgrade. We can combine this with an update to the host, but this change is important to make sure we don't get out of sync here.