### PR TITLE
Add worker references directly to csproj temporarily

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -107,6 +107,9 @@
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage.Internal" Version="1.4.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="2.0.12590" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.5.10246" />
+    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.3" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.120-preview" />
     <PackageReference Include="Microsoft.Azure.Functions.PythonWorkerRunEnvironments" Version="1.0.0-beta20190710.5" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="YamlDotNet" Version="6.0.0" />


### PR DESCRIPTION
Reverting this in a way -- https://github.com/Azure/azure-functions-core-tools/pull/1464

Also making Node.js worker to match the host version.

As discussed offline with @fabiocav, while we should try and remove the explicit dependencies from the csproj to make releases and version management easier, we are experiencing build issues, and can't delay the release. We may need to visit Nuget packaging logic of the language workers to see if we are able to get them as transient dependency later.


 @pragnagopa 