### PR TITLE
Support dotnet and node remote build

### DIFF
--- a/src/Azure.Functions.Cli/Common/FileSystemHelpers.cs
+++ b/src/Azure.Functions.Cli/Common/FileSystemHelpers.cs
@@ -119,9 +119,14 @@ namespace Azure.Functions.Cli.Common
             DeleteFileSystemInfo(Instance.DirectoryInfo.FromDirectoryName(path), ignoreErrors);
         }
 
-        public static IEnumerable<string> GetLocalFiles(string path, GitIgnoreParser ignoreParser = null, bool returnIgnored = false)
+        public static IEnumerable<string> GetLocalFiles(string path, GitIgnoreParser ignoreParser = null, bool returnIgnored = false,
+            IEnumerable<string> additionalIgnoredDirectories = null)
         {
-            var ignoredDirectories = new[] { ".git", ".vscode" };
+            List<string> ignoredDirectories = new List<string>{ ".git", ".vscode" };
+            if (additionalIgnoredDirectories != null)
+            {
+                ignoredDirectories.AddRange(additionalIgnoredDirectories);
+            }
             var ignoredFiles = new[] { ".funcignore", ".gitignore", "local.settings.json", "project.lock.json" };
 
             foreach (var file in FileSystemHelpers.GetFiles(path, ignoredDirectories, ignoredFiles))

--- a/src/Azure.Functions.Cli/Helpers/ZipHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/ZipHelper.cs
@@ -34,9 +34,13 @@ namespace Azure.Functions.Cli.Helpers
             {
                 throw new CliException("Pack command doesn't work for dotnet functions");
             }
-            else
+            else if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.dotnet && buildOption == BuildOption.Remote)
             {
-                return CreateZip(FileSystemHelpers.GetLocalFiles(functionAppRoot, ignoreParser), functionAppRoot);
+                // Remote build for dotnet does not require bin and obj folders. They will be generated during the oryx build
+                return CreateZip(FileSystemHelpers.GetLocalFiles(functionAppRoot, ignoreParser, false, new string[] { "bin", "obj" }), functionAppRoot);
+            } else
+            {
+                return CreateZip(FileSystemHelpers.GetLocalFiles(functionAppRoot, ignoreParser, false), functionAppRoot);
             }
         }
 

--- a/src/Azure.Functions.Cli/StaticResources/funcignore
+++ b/src/Azure.Functions.Cli/StaticResources/funcignore
@@ -4,4 +4,3 @@
 .vscode
 local.settings.json
 test
-tsconfig.json


### PR DESCRIPTION
### Supporting Node server side build
1. tsconfig.json must be included
2. currently, if the user want to use the extensions
  - without extension bundling, it will still upload the extension binaries to remote build
  - with extension bundling, it will only upload the source code and settings to remote build

### Supporting Dotnet server side build
1. dotnet server side build should not have "bin" or "obj" while oryx build will run "dotnet build"
2. expose "additionalIgnoredDirectories" in "GetLocalFiles" for ignoring additional directories when packaging the source folder.
