### PR TITLE
Update PowerShellWorker to 0.1.152-preview

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -108,7 +108,7 @@
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage.Internal" Version="1.4.0" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.5.10246" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.3" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.120-preview" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.152-preview" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="2.0.12612" />
     <PackageReference Include="Microsoft.Azure.Functions.PythonWorkerRunEnvironments" Version="1.0.0-beta20190801.11" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />


### PR DESCRIPTION
Changes in this release:

- Major Managed Dependencies update:
  - Allowed specifying any (not just `Az`) module from PowerShell Gallery in `requirements.psd1` (up to 10 entries).
  - Allowed specifying exact module versions in `requirements.psd1` (as opposed to just `<MajorVersion>.*` 
 pattern), including pre-release versions.
  - More reliable implementation of module upgrades (fixing [#247](https://github.com/Azure/azure-functions-powershell-worker/issues/247), [#248](https://github.com/Azure/azure-functions-powershell-worker/issues/248), [#252](https://github.com/Azure/azure-functions-powershell-worker/issues/252), and other intermittent issues).
  - Improved cold start performance.
  - Added a warning when `managedDependencies` is enabled in `host.json` but no dependencies are specified in `requirements.psd1`.
- Fixed issue [#281](https://github.com/Azure/azure-functions-powershell-worker/issues/281) (Clear pushed output binding values on exceptions).
- System logging fixes and improvements.

For more information, please see https://github.com/Azure/azure-functions-powershell-worker/releases