### PR TITLE
Inherit file permissions for a Linux package

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -111,6 +111,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.152-preview" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="2.0.12625" />
     <PackageReference Include="Microsoft.Azure.Functions.PythonWorkerRunEnvironments" Version="1.0.0-beta20190801.11" />
+    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="YamlDotNet" Version="6.0.0" />
   </ItemGroup>

--- a/src/Azure.Functions.Cli/Extensions/ZipArchiveExtensions.cs
+++ b/src/Azure.Functions.Cli/Extensions/ZipArchiveExtensions.cs
@@ -1,5 +1,8 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.IO.Compression;
+using Azure.Functions.Cli.Helpers;
+using Mono.Unix;
 
 namespace Azure.Functions.Cli.Extensions
 {
@@ -13,9 +16,38 @@ namespace Azure.Functions.Cli.Extensions
             }
         }
 
+        public static bool TryGetLinuxFileAttributes(string fileName, out int fileAttribs)
+        {
+            try
+            {
+                var unixFileInfo = new UnixFileInfo(fileName);
+                fileAttribs = (int) unixFileInfo.FileAccessPermissions | (int) unixFileInfo.FileSpecialAttributes;
+                fileAttribs = fileAttribs << 16;
+                return true;
+            }
+            catch (Exception)
+            {
+                // If any error occur, we go back to not updating attributes
+                // This is a safety net to make sure this temporary solution does not set people up for failure
+                fileAttribs = 0;
+                return false;
+            }
+        }
+
         public static void AddFile(this ZipArchive archive, string fileName, string zipRoot, Stream contentStream)
         {
             var entry = archive.CreateEntry(fileName.FixFileNameForZip(zipRoot), CompressionLevel.Fastest);
+
+            // If not Windows, we can assume it's a Unix environment
+            // For Unix environments, we need to explicity add file attributes in the Zipfile
+            if (!PlatformHelper.IsWindows)
+            {
+                if (TryGetLinuxFileAttributes(fileName, out int fileAttributes))
+                {
+                    entry.ExternalAttributes = fileAttributes;
+                }
+            }
+
             using (var zipStream = entry.Open())
             {
                 contentStream.CopyTo(zipStream);


### PR DESCRIPTION
Fixes #1484 

@jeffhollan @alexkarcher-msft, once the build completes, I can give you artifacts to verify.
I did quick tests and this should work fine. 

@ahmelsayed, this should likely also solve issues with fuse mounting a zip package. I wanted to write tests for that. But, I would need a bit of additional work and don't want to block the P0 issue for it.

I tried a couple of different scenarios that this may have affected (building from unix deploying to Windows, vice-versa), but all looks file. Let me know if you can think of additional tests you would want me to perform.