### PR TITLE
Revert Powershell worker to match prod

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -108,7 +108,7 @@
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage.Internal" Version="1.4.0" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.5.10246" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.3" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.152-preview" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.120-preview" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="2.0.12625" />
     <PackageReference Include="Microsoft.Azure.Functions.PythonWorkerRunEnvironments" Version="1.0.0-beta20190801.11" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />


### PR DESCRIPTION
We need to release core-tools before this Powershell Worker version is available in Azure. So, we have to revert this for now.