### PR TITLE
Add azure-functions to requirements

### DIFF
--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -30,6 +30,7 @@ namespace Azure.Functions.Cli.Common
         public const string PythonDockerImageVersionSetting = "FUNCTIONS_PYTHON_DOCKER_IMAGE";
         public const string PythonDockerImageSkipPull = "FUNCTIONS_PYTHON_DOCKER_SKIP_PULL";
         public const string PythonDockerRunCommand = "FUNCTIONS_PYTHON_DOCKER_RUN_COMMAND";
+        public const string PythonFunctionsLibrary = "azure-functions";
         public const string FunctionsCoreToolsEnvironment = "FUNCTIONS_CORETOOLS_ENVIRONMENT";
 
         public static string CliVersion => typeof(Constants).GetTypeInfo().Assembly.GetName().Version.ToString(3);

--- a/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
@@ -66,7 +66,7 @@ namespace Azure.Functions.Cli.Helpers
         {
             if (!FileSystemHelpers.FileExists(Constants.RequirementsTxt))
             {
-                FileSystemHelpers.CreateFile(Constants.RequirementsTxt);
+                FileSystemHelpers.WriteAllTextToFile(Constants.RequirementsTxt, Constants.PythonFunctionsLibrary);
             }
             else
             {


### PR DESCRIPTION
Fixes Azure/azure-functions-python-worker#511
Fixes https://github.com/Azure/azure-functions-core-tools/issues/1194

An important extension of the work already done in https://github.com/Azure/azure-functions-python-worker/pull/506 and https://github.com/Azure/azure-functions-python-worker/pull/409. With the separation of the worker and the library, the users should now have control over the `azure-functions` library in their `requirements.txt`. This should be included in the startup experience so users publishing to Azure have the knowledge that they are in control of this dependency. 