### PR TITLE
Fix: add Dockerfile for powershell worker runtime

### DIFF
--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -322,6 +322,10 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             {
                 await WriteFiles("Dockerfile", await StaticResources.DockerfilePython);
             }
+            else if (workerRuntime == Helpers.WorkerRuntime.powershell)
+            {
+                await WriteFiles("Dockerfile", await StaticResources.DockerfilePowershell);
+            }
             else if (workerRuntime == Helpers.WorkerRuntime.None)
             {
                 throw new CliException("Can't find WorkerRuntime None");

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -39,6 +39,9 @@
     <EmbeddedResource Include="StaticResources\Dockerfile.python">
       <LogicalName>$(AssemblyName).Dockerfile.python</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="StaticResources\Dockerfile.powershell">
+      <LogicalName>$(AssemblyName).Dockerfile.powershell</LogicalName>
+    </EmbeddedResource>    
     <EmbeddedResource Include="StaticResources\Dockerfile.node">
       <LogicalName>$(AssemblyName).Dockerfile.node</LogicalName>
     </EmbeddedResource>

--- a/src/Azure.Functions.Cli/StaticResources/Dockerfile.powershell
+++ b/src/Azure.Functions.Cli/StaticResources/Dockerfile.powershell
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/azure-functions/powershell:2.0
+ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
+    AzureFunctionsJobHost__Logging__Console__IsEnabled=true
+
+COPY . /home/site/wwwroot

--- a/src/Azure.Functions.Cli/StaticResources/StaticResources.cs
+++ b/src/Azure.Functions.Cli/StaticResources/StaticResources.cs
@@ -35,6 +35,8 @@ namespace Azure.Functions.Cli
 
         public static Task<string> DockerfilePython => GetValue("Dockerfile.python");
 
+        public static Task<string> DockerfilePowershell => GetValue("Dockerfile.powershell");
+
         public static Task<string> DockerfileNode => GetValue("Dockerfile.node");
 
         public static Task<string> DockerIgnoreFile => GetValue("dockerignore");

--- a/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
@@ -119,6 +119,7 @@ namespace Azure.Functions.Cli.Tests.E2E
         [Theory]
         [InlineData("dotnet")]
         [InlineData("node")]
+        [InlineData("powershell")]
         public Task init_with_Dockerfile(string workerRuntime)
         {
             return CliTester.Run(new RunConfiguration
@@ -291,6 +292,7 @@ namespace Azure.Functions.Cli.Tests.E2E
         [Theory]
         [InlineData("dotnet")]
         [InlineData("node")]
+        [InlineData("powershell")]
         public Task init_docker_only_for_existing_project(string workerRuntime)
         {
             return CliTester.Run(new RunConfiguration


### PR DESCRIPTION
The current cli is missing the Dockerfile when the worker runtime is powershell.

Please see: DockerFile PowerShell #1389

Regards,
Jian