### PR TITLE
Update PowerShellWorker to 0.1.159-preview

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -112,7 +112,7 @@
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage.Internal" Version="1.4.0" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.5.10246" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.3" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.152-preview" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.159-preview" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="2.0.12641" />
     <PackageReference Include="Microsoft.Azure.Functions.PythonWorkerRunEnvironments" Version="1.0.0-beta20190816.7" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />


### PR DESCRIPTION
Changes in this release:

- Fixed cold start time regression when using Managed Dependencies.
- Fixed a problem with installing some modules from the PowerShell Gallery when using the `<MajorVersion>.*` pattern.

For more information, please see https://github.com/Azure/azure-functions-powershell-worker/releases