### PR TITLE
Improve python function remote build help text

### DIFF
--- a/tools/python/packapp/__main__.py
+++ b/tools/python/packapp/__main__.py
@@ -201,9 +201,9 @@ def build_independent_wheel(name, version, args, dest):
 
 
 def build_binary_wheel(name, version, args, dest):
-    die(f'cannot install {name}-{version} dependency: binary dependencies '
-        f'without wheels are not supported.  Use the "--build remote" or "--build-native-deps" option '
-        f'to automatically build and configure the dependencies using a Docker container. '
+    die(f'cannot install {name}-{version} dependency: binary dependencies without wheels are not supported when building locally. '
+        f'Use the "--build remote" option to build dependencies on the Azure Functions build server, '
+        f'or "--build-native-deps" option to automatically build and configure the dependencies using a Docker container. '
         f'More information at https://aka.ms/func-python-publish', ExitCode.native_deps_error)
 
 


### PR DESCRIPTION
Suggest by Dan Taylor, we may want to change the error message into

ERROR: cannot install cryptography-2.7 dependency: binary dependencies without wheels are not supported **when building locally**.  Use the "--build remote" **option to build dependencies using the Azure Functions build server**, or "--build-native-deps" option to automatically build and configure the dependencies using a Docker container **on your local machine**. More information at https://aka.ms/func-python-publish