### PR TITLE
Added host and trigger name mapping for rabbitmq

### DIFF
--- a/src/Azure.Functions.Cli/Kubernetes/KubernetesHelpers.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/KubernetesHelpers.cs
@@ -442,7 +442,7 @@ namespace Azure.Functions.Cli.Kubernetes
                                     .Where(i => i.Value.Type == JTokenType.String)
                                     .ToDictionary(k => k.Key, v => v.Value.ToString());
 
-            if (t["type"].ToString().ToLower() == "rabbitmqtrigger")
+            if (t["type"].ToString() == "rabbitMQTrigger")
             {
                 metadata["host"] = metadata["connectionStringSetting"];
                 metadata.Remove("connectionStringSetting");

--- a/src/Azure.Functions.Cli/Kubernetes/KubernetesHelpers.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/KubernetesHelpers.cs
@@ -442,7 +442,7 @@ namespace Azure.Functions.Cli.Kubernetes
                                     .Where(i => i.Value.Type == JTokenType.String)
                                     .ToDictionary(k => k.Key, v => v.Value.ToString());
 
-            if (t["type"].ToString() == "rabbitMQTrigger")
+            if (t["type"].ToString().Equals("rabbitMQTrigger", StringComparison.InvariantCultureIgnoreCase))
             {
                 metadata["host"] = metadata["connectionStringSetting"];
                 metadata.Remove("connectionStringSetting");

--- a/src/Azure.Functions.Cli/Kubernetes/KubernetesHelpers.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/KubernetesHelpers.cs
@@ -436,7 +436,7 @@ namespace Azure.Functions.Cli.Kubernetes
             };
         }
 
-        private static IDictionary<string, string> PopulateMetadataDictionary(JToken t)
+        internal static IDictionary<string, string> PopulateMetadataDictionary(JToken t)
         {
             IDictionary<string, string> metadata = t.ToObject<Dictionary<string, JToken>>()
                                     .Where(i => i.Value.Type == JTokenType.String)

--- a/test/Azure.Functions.Cli.Tests/KubernetesHelperUnitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/KubernetesHelperUnitTests.cs
@@ -1,6 +1,9 @@
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Kubernetes;
 using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Azure.Functions.Cli.Tests
@@ -27,6 +30,32 @@ namespace Azure.Functions.Cli.Tests
                     throw;
                 }
             }
+        }
+
+        [Fact]
+        public void PopulateMetadataDictionary_CorrectlyPopulatesRabbitMQMetadata()
+        {
+            string jsonText = @"
+            {
+                ""type"": ""rabbitMQTrigger"",
+                ""connectionStringSetting"": ""RabbitMQConnection"",
+                ""queueName"": ""myQueue"",
+                ""name"": ""message""
+            }";
+
+            JToken jsonObj = JToken.Parse(jsonText);
+
+            IDictionary<string, string> metadata = KubernetesHelper.PopulateMetadataDictionary(jsonObj);
+
+            Assert.Equal(4, metadata.Count);
+            Assert.True(metadata.ContainsKey("type"));
+            Assert.True(metadata.ContainsKey("host"));
+            Assert.True(metadata.ContainsKey("name"));
+            Assert.True(metadata.ContainsKey("queueName"));
+            Assert.Equal("rabbitMQTrigger", metadata["type"]);
+            Assert.Equal("RabbitMQConnection", metadata["host"]);
+            Assert.Equal("message", metadata["name"]);
+            Assert.Equal("myQueue", metadata["queueName"]);
         }
     }
 }


### PR DESCRIPTION
Maps the string "rabbitmqtrigger" to "rabbitmq" for Kubernetes. Also populates "host" in metadata with the RabbitMQ connection string.

Details: https://github.com/Azure/azure-functions-rabbitmq-extension/issues/55

@pragnagopa @ahmelsayed @jeffhollan 