### PR TITLE
Add DotNetZip.dll in the list to be signed

### DIFF
--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -123,6 +123,7 @@ namespace Build
                 "Autofac.dll",
                 "BouncyCastle.Crypto.dll",
                 "Colors.Net.dll",
+                "DotNetZip.dll",
                 "Dynamitey.dll",
                 "Google.Protobuf.dll",
                 "Grpc.Core.dll",


### PR DESCRIPTION
I am still not 100% sure why `sigcheck.exe` test did not report this to us. When I ran it locally, the sign build failed as expected. Not sure why it went through in our pipeline.

I will look more into this later. But did not want to block on unsigned dlls.