### PR TITLE
Leverage Docker build cache

### DIFF
--- a/src/Azure.Functions.Cli/StaticResources/Dockerfile.python
+++ b/src/Azure.Functions.Cli/StaticResources/Dockerfile.python
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/azure-functions/python:2.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 
-COPY . /home/site/wwwroot
+COPY requirements.txt /
+RUN pip install -r /requirements.txt
 
-RUN cd /home/site/wwwroot && \
-    pip install -r requirements.txt
+COPY . /home/site/wwwroot


### PR DESCRIPTION
If we are adding any additional dependencies in `requirements.txt` for `pip install`, it takes a long time to install them again and again for any minor code change. Moving the steps to copy `requirements.txt` then `pip install` before copying the code takes advantage of the docker cache and drastically reduces build time.

Same would be applicable for other languages as well, e.g. node.