### PR TITLE
Update PowerShell worker to 1.0.194

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -115,7 +115,7 @@
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage.Internal" Version="1.4.0" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.5.2-SNAPSHOT" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="1.0.188" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="1.0.194" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="2.0.12763" />
     <PackageReference Include="Microsoft.Azure.Functions.PythonWorkerRunEnvironments" Version="1.0.0-beta20190910.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />


### PR DESCRIPTION
Changes in this release:

- Resolved an issue that was sometimes making automatically installed modules intermittently unavailable until the first app reboot (issue https://github.com/Azure/azure-functions-powershell-worker/pull/351).
- Improved system log messages related to dependency management.

For more information, please see https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v1.0.194.