### PR TITLE
PowerShell function apps. Ignore prerelease versions of the Az module.

### DIFF
--- a/src/Azure.Functions.Cli/Helpers/PowerShellHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/PowerShellHelper.cs
@@ -67,17 +67,16 @@ namespace Azure.Functions.Cli.Helpers
 
                 // Find the version information
                 XmlNode root = doc.DocumentElement;
-                var props = root.SelectNodes("//m:properties/d:Version", nsmgr);
+                var props = root.SelectNodes("//m:properties[d:IsPrerelease = \"false\"]/d:Version", nsmgr);
                 var latestVersion = new Version("0.0");
 
                 if (props != null && props.Count > 0)
                 {
                     foreach (XmlNode prop in props)
                     {
-                        var currentVersion = new Version(prop.FirstChild.Value);
+                        Version.TryParse(prop.FirstChild.Value, out var currentVersion);
 
-                        var result = currentVersion.CompareTo(latestVersion);
-                        if (result > 0)
+                        if (currentVersion != null && currentVersion > latestVersion)
                         {
                             latestVersion = currentVersion;
                         }


### PR DESCRIPTION
The PowerShell gallery contains both prerelease and regular versions of the Az module. 
Updating logic in the ```PowerShellHelper.cs``` to skip prerelease versions. 