### PR TITLE
Fix durable function test

### DIFF
--- a/src/Azure.Functions.Cli/Common/DurableManager.cs
+++ b/src/Azure.Functions.Cli/Common/DurableManager.cs
@@ -33,7 +33,7 @@ namespace Azure.Functions.Cli.Common
 
         public const string DefaultTaskHubName = "DurableFunctionsHub";
 
-        public const string DurableAzureStorageExtensionName = "DurableTask.AzureStorage.dll";
+        public const string DurableAzureStorageExtensionName = "DurableTask.AzureStorage*.dll";
 
         public const string MinimumDurableAzureStorageExtensionVersion = "1.4.0";
 


### PR DESCRIPTION
Durable functions test often fails because it's missing a dll -- `DurableTask.AzureStorage.dll`. Looking at the [references](https://github.com/Azure/azure-functions-core-tools/blob/e91b3c96ad8646c27b462ff01bdd483de2442747/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj#L118) and artifacts, it looks to me that it should be `DurableTask.AzureStorage.Internal.dll`.

Trying to see if this fixes the flaky test. I think our build passes often because these tests do not run everytime.