### PR TITLE
Fix --build-native-deps validation

### DIFF
--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -131,7 +131,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             var additionalAppSettings = await ValidateFunctionAppPublish(functionApp, workerRuntime);
 
             // Update build option
-            PublishBuildOption = PublishHelper.UpdateBuildOption(PublishBuildOption, workerRuntime, functionApp);
+            PublishBuildOption = PublishHelper.ResolveBuildOption(PublishBuildOption, workerRuntime, functionApp, BuildNativeDeps, NoBuild);
 
             if (workerRuntime == WorkerRuntime.dotnet && !Csx && !NoBuild && PublishBuildOption != BuildOption.Remote)
             {
@@ -282,16 +282,6 @@ namespace Azure.Functions.Cli.Actions.AzureActions
 
             // For dedicated linux apps, we do not support run from package right now
             var isFunctionAppDedicatedLinux = functionApp.IsLinux && !functionApp.IsDynamic && !functionApp.IsElasticPremium;
-
-            // For Python linux apps, we do not support --build remote with --build-native-deps flag
-            if (PublishBuildOption != BuildOption.Default && BuildNativeDeps)
-            {
-                throw new CliException("Cannot use '--build-native-deps' along with '--build' flag");
-            }
-            else if (PublishBuildOption == BuildOption.Container || PublishBuildOption == BuildOption.None)
-            {
-                throw new CliException("The --build flag only supports '--build remote' or '--build local'");
-            }
 
             if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.python && !functionApp.IsLinux)
             {

--- a/src/Azure.Functions.Cli/Helpers/PublishHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/PublishHelper.cs
@@ -24,8 +24,19 @@ namespace Azure.Functions.Cli.Helpers
             return null;
         }
 
-        public static BuildOption UpdateBuildOption(BuildOption currentBuildOption, WorkerRuntime runtime, Site site)
+        public static BuildOption ResolveBuildOption(BuildOption currentBuildOption, WorkerRuntime runtime, Site site, bool buildNativeDeps, bool noBuild)
         {
+            // --no-build and --build-native-deps will take precedence over --build local and --build remote
+            if (noBuild)
+            {
+                return BuildOption.None;
+            }
+
+            if (buildNativeDeps)
+            {
+                return BuildOption.Container;
+            }
+
             if (currentBuildOption == BuildOption.Default)
             {
                 // Change to remote build if, python app, has requirements.txt, requirements.txt has content

--- a/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
@@ -276,11 +276,6 @@ namespace Azure.Functions.Cli.Helpers
             FileSystemHelpers.EnsureDirectory(packagesLocation);
 
             // Only one of the remote build or build-native-deps flag can be chosen
-            if (buildNativeDeps && buildOption == BuildOption.Remote)
-            {
-                throw new CliException("Cannot perform '--build-native-deps' along with '--build remote'");
-            }
-
             if (buildNativeDeps)
             {
                 if (CommandChecker.CommandExists("docker") && await DockerHelpers.VerifyDockerAccess())


### PR DESCRIPTION
Previously, due to the change on remote build default, a validation of not consistent build options will always block the --build-native-deps.

This issue is addressed in this PR. Now --no-build and --build-native-deps will have higher precedence over --build flag