### PR TITLE
Change python docker init based image

### DIFF
--- a/src/Azure.Functions.Cli/StaticResources/Dockerfile.python36
+++ b/src/Azure.Functions.Cli/StaticResources/Dockerfile.python36
@@ -1,6 +1,6 @@
 # To enable ssh & remote debugging on app service change the base image to the one below
-# FROM mcr.microsoft.com/azure-functions/python:2.0-appservice
-FROM mcr.microsoft.com/azure-functions/python:2.0
+# FROM mcr.microsoft.com/azure-functions/python:2.0-python3.6-appservice
+FROM mcr.microsoft.com/azure-functions/python:2.0-python3.6
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true


### PR DESCRIPTION
The python 3.7 docker file base image already has the correct name.
Changing the python 3.6 docker file to **2.0-python3.6** and **2.0-python3.6-appservice**