### PR TITLE
Enable --build-native-deps and --build local for python 3.7

### DIFF
--- a/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
@@ -312,7 +312,8 @@ namespace Azure.Functions.Cli.Helpers
             var packApp = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "tools", "python", "packapp");
             var pythonWorkerInfo = await ValidatePythonVersion(errorOutIfOld: true);
             var pythonExe = pythonWorkerInfo.ExecutablePath;
-            var exe = new Executable(pythonExe, $"\"{packApp}\" --platform linux --python-version 36 --packages-dir-name {Constants.ExternalPythonPackages} \"{functionAppRoot}\" --verbose");
+            var pythonVersion = $"{pythonWorkerInfo.Major}{pythonWorkerInfo.Minor}";
+            var exe = new Executable(pythonExe, $"\"{packApp}\" --platform linux --python-version {pythonVersion} --packages-dir-name {Constants.ExternalPythonPackages} \"{functionAppRoot}\" --verbose");
             var sbErrors = new StringBuilder();
             var exitCode = await exe.RunAsync(o => ColoredConsole.WriteLine(o), e => sbErrors.AppendLine(e));
 

--- a/src/Azure.Functions.Cli/StaticResources/python_docker_build.sh
+++ b/src/Azure.Functions.Cli/StaticResources/python_docker_build.sh
@@ -3,4 +3,9 @@
 # Exit on errors
 set -e
 
-pip install --target="/.python_packages/lib/python3.6/site-packages" -r /requirements.txt
+PYTHON_PACKAGE_PATH="/.python_packages/lib/site-packages"
+if [[ "$PYTHON_VERSION" == "3.6"* ]]; then
+    PYTHON_PACKAGE_PATH="/.python_packages/lib/python3.6/site-packages"
+fi;
+
+pip install --target="$PYTHON_PACKAGE_PATH" -r /requirements.txt

--- a/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
@@ -145,12 +145,6 @@ namespace Azure.Functions.Cli.Tests.E2E
             WorkerLanguageVersionInfo worker = await PythonHelpers.ValidatePythonVersion();
             Skip.If(worker == null);
 
-            string expectedDockerImage = "FROM mcr.microsoft.com/azure-functions/python:2.0";
-            if (worker.Major == 3 && worker.Minor == 7)
-            {
-                expectedDockerImage = "FROM mcr.microsoft.com/azure-functions/python:2.0-python3.7";
-            }
-
             await CliTester.Run(new RunConfiguration
             {
                 Commands = new[] { $"init . --worker-runtime python --docker" },
@@ -159,7 +153,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     new FileResult
                     {
                         Name = "Dockerfile",
-                        ContentContains = new[] { expectedDockerImage }
+                        ContentContains = new[] { $"FROM mcr.microsoft.com/azure-functions/python:2.0-python{worker.Major}.{worker.Minor}" }
                     }
                 },
                 OutputContains = new[] { "Dockerfile" }

--- a/tools/python/packapp/__main__.py
+++ b/tools/python/packapp/__main__.py
@@ -110,8 +110,13 @@ def find_and_build_deps(args):
                 headers = venv / 'Include'
                 scripts = venv / 'Scripts'
                 data = venv
-            elif args.platform == 'linux':
+            elif args.platform == 'linux' and python == "python3.6":
                 sp = venv / 'lib' / python / 'site-packages'
+                headers = venv / 'include' / 'site' / python
+                scripts = venv / 'bin'
+                data = venv
+            elif args.platform == 'linux':
+                sp = venv / 'lib' / 'site-packages'
                 headers = venv / 'include' / 'site' / python
                 scripts = venv / 'bin'
                 data = venv


### PR DESCRIPTION
### --build-native-deps
- Change **python_docker_build.sh** to use the new python package path `/.python_packages/lib/site-packages`

### --build local
- Change **packapp/__main__.py** to use the new python package path `/.python_packages/lib/site-packages`
- Change **PythonHelpers.cs** to automatically pick the right python-version

### --build remote
- The build remote will automatically choose the oryx build version, no code change is required