### PR TITLE
[DONT SYNC] Fix remote build support for old function app

### DIFF
--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -35,6 +35,7 @@ namespace Azure.Functions.Cli.Common
         public const string EnablePersistenceChannelDebugSetting = "FUNCTIONS_CORE_TOOLS_ENABLE_PERSISTENCE_CHANNEL_DEBUG_OUTPUT";
         public const string TelemetryOptOutVariable = "FUNCTIONS_CORE_TOOLS_TELEMETRY_OPTOUT";
         public const string TelemetryInstrumentationKey = "00000000-0000-0000-0000-000000000000";
+        public const string ScmRunFromPackage = "SCM_RUN_FROM_PACKAGE";
 
         public static string CliVersion => typeof(Constants).GetTypeInfo().Assembly.GetName().Version.ToString(3);
 
@@ -83,6 +84,9 @@ namespace Azure.Functions.Cli.Common
         {
             public const int ArmTokenExpiryMinutes = 4;
             public const int StatusRefreshSeconds = 3;
+            public const int ScmRunFromPackageBlobExpiryInDays = 3650;
+            public const string ScmRunFromPackageContainerName = "scm-releases";
+            public const string ScmRunFromPackageBlobFormat = "scm-latest-{0}-{1}.squashfs";
 
             public static readonly IDictionary<string, string> LinuxDedicatedBuildSettings = new Dictionary<string, string>
             {

--- a/src/Azure.Functions.Cli/Helpers/StorageBlobHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/StorageBlobHelper.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+
+namespace Azure.Functions.Cli.Helpers
+{
+    public static class StorageBlobHelper
+    {
+        public static async Task<string> PrepareScmRunFromPackageBlob(string connectionString, string containerName, string blobName, int expiryInDays)
+        {
+            containerName = containerName.ToLower();
+
+            var storageAccount = CloudStorageAccount.Parse(connectionString);
+            CloudBlobClient blobClient = storageAccount.CreateCloudBlobClient();
+
+            var container = blobClient.GetContainerReference(containerName);
+            await container.CreateIfNotExistsAsync();
+            CloudBlockBlob blockBlob = container.GetBlockBlobReference(blobName);
+
+            SharedAccessBlobPolicy sasConstraints = new SharedAccessBlobPolicy()
+            {
+                SharedAccessExpiryTime = DateTimeOffset.Now.AddDays(expiryInDays),
+                Permissions = SharedAccessBlobPermissions.Write | SharedAccessBlobPermissions.Read
+            };
+
+            var blobSas = blockBlob.GetSharedAccessSignature(sasConstraints);
+            return blockBlob.Uri + blobSas;
+        }
+    }
+}


### PR DESCRIPTION
### Background
Function apps created before 8/1/2019 does not have SCM site, thus remote build are disabled. Since recently we allow the user to update their site in ARM endpoint to acquire a new SCM site for their function app, the SCM_RUN_FROM_PACKAGE app setting is not properly configured.

This lead to a remote build issue where KuduLite failed to find the destination for blob uploading.

### Solution
In core tool, we perform the following steps to enable remote build for these old function apps.
1. Use **StorageBlobHelper** to create a placeholder blob in function app's **AzureWebJobsStorage**.
2. Use **POST api/settings** endpoint to set **SCM_RUN_FROM_PACKAGE** in KuduLite (This will not change the ARM app settings. It only affects the KuduLite container.)
3. Perform the **remote build**.
4. Set **WEBSITE_RUN_FROM_PACKAGE** app setting via ARM and point to the new package.
5. Finally, **remove** the **SCM_RUN_FROM_PACKAGE** from KuduLite container.