### PR TITLE
Error out if remote build runs on a broken SCM site

### DIFF
--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -452,14 +452,11 @@ namespace Azure.Functions.Cli.Actions.AzureActions
         private async Task<bool> HandleLinuxConsumptionPublish(Site functionApp, Func<Task<Stream>> zipFileFactory)
         {
             string fileNameNoExtension = string.Format("{0}-{1}", DateTimeOffset.UtcNow.ToString("yyyyMMddHHmmss"), Guid.NewGuid());
-
             // Consumption Linux, try squashfs as a package format.
             if (PublishBuildOption == BuildOption.Remote)
             {
-                await RemoveFunctionAppAppSetting(functionApp,
-                    "WEBSITE_RUN_FROM_PACKAGE",
-                    "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
-                    "WEBSITE_CONTENTSHARE");
+                await EnsureRemoteBuildIsSupported(functionApp);
+                await RemoveFunctionAppAppSetting(functionApp, Constants.WebsiteRunFromPackage, Constants.WebsiteContentAzureFileConnectionString, Constants.WebsiteContentShared);
                 Task<DeployStatus> pollConsumptionBuild(HttpClient client) => KuduLiteDeploymentHelpers.WaitForConsumptionServerSideBuild(client, functionApp, AccessToken, ManagementURL);
                 var deployStatus = await PerformServerSideBuild(functionApp, zipFileFactory, pollConsumptionBuild);
                 return deployStatus == DeployStatus.Success;
@@ -654,6 +651,32 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             }
         }
 
+        public async Task EnsureRemoteBuildIsSupported(Site functionApp)
+        {
+            string errorMessage = $"Remote build is a new feature added to function apps.{Environment.NewLine}" +
+                $"Your function app {functionApp.SiteName} does not support remote build as it was created before August 1st, 2019.{Environment.NewLine}" +
+                $"Please use '--build local' or '--build-native-deps'.{Environment.NewLine}" +
+                $"For more information, please visit https://aka.ms/remotebuild";
+
+            // Check if SCM site and SCM_RUN_FROM_PACKAGE exist. If not, we know it is an old function app.
+            if (functionApp.IsLinux && functionApp.IsDynamic)
+            {
+                if (string.IsNullOrEmpty(functionApp.ScmUri))
+                {
+                    throw new CliException(errorMessage);
+                }
+
+                using (var client = GetRemoteZipClient(new Uri($"https://{functionApp.ScmUri}")))
+                {
+                    var kuduAppSettings = await KuduLiteDeploymentHelpers.GetAppSettings(client);
+                    if (!kuduAppSettings.ContainsKey(Constants.ScmRunFromPackage))
+                    {
+                        throw new CliException(errorMessage);
+                    }
+                }
+            }
+        }
+
         public async Task PublishZipDeploy(Site functionApp, Func<Task<Stream>> zipFileFactory)
         {
             await RetryHelper.Retry(async () =>
@@ -678,14 +701,6 @@ namespace Azure.Functions.Cli.Actions.AzureActions
 
         public async Task<DeployStatus> PerformServerSideBuild(Site functionApp, Func<Task<Stream>> zipFileFactory, Func<HttpClient, Task<DeployStatus>> deploymentStatusPollTask)
         {
-            if (string.IsNullOrEmpty(functionApp.ScmUri))
-            {
-                throw new CliException($"Remote build is a new feature added to function apps.{Environment.NewLine}" +
-                    $"Your function app {functionApp.SiteName} does not support remote build as it was created before August 1st, 2019.{Environment.NewLine}" +
-                    $"Please use '--build local', '--build-native-deps' or manually enable remote build.{Environment.NewLine}" +
-                    $"For more information, please visit https://aka.ms/remotebuild");
-            }
-
             using (var handler = new ProgressMessageHandler(new HttpClientHandler()))
             using (var client = GetRemoteZipClient(new Uri($"https://{functionApp.ScmUri}"), handler))
             using (var request = new HttpRequestMessage(HttpMethod.Post, new Uri(

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -36,6 +36,10 @@ namespace Azure.Functions.Cli.Common
         public const string EnablePersistenceChannelDebugSetting = "FUNCTIONS_CORE_TOOLS_ENABLE_PERSISTENCE_CHANNEL_DEBUG_OUTPUT";
         public const string TelemetryOptOutVariable = "FUNCTIONS_CORE_TOOLS_TELEMETRY_OPTOUT";
         public const string TelemetryInstrumentationKey = "00000000-0000-0000-0000-000000000000";
+        public const string ScmRunFromPackage = "SCM_RUN_FROM_PACKAGE";
+        public const string WebsiteRunFromPackage = "WEBSITE_RUN_FROM_PACKAGE";
+        public const string WebsiteContentAzureFileConnectionString = "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING";
+        public const string WebsiteContentShared = "WEBSITE_CONTENTSHARE";
 
         public static string CliVersion => typeof(Constants).GetTypeInfo().Assembly.GetName().Version.ToString(3);
 

--- a/src/Azure.Functions.Cli/Helpers/KuduLiteDeploymentHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/KuduLiteDeploymentHelpers.cs
@@ -12,6 +12,11 @@ namespace Azure.Functions.Cli.Helpers
 {
     internal class KuduLiteDeploymentHelpers
     {
+        public static async Task<Dictionary<string, string>> GetAppSettings(HttpClient client)
+        {
+            return await InvokeRequest<Dictionary<string, string>>(client, HttpMethod.Get, "/api/settings");
+        }
+
         public static async Task<DeployStatus> WaitForConsumptionServerSideBuild(HttpClient client, Site functionApp, string accessToken, string managementUrl)
         {
             ColoredConsole.WriteLine("Remote build in progress, please wait...");


### PR DESCRIPTION
### Background
Previously, we allow customer to update their function app with Azure CLI to create a new SCM site. Unfortunately, the SCM site lacks the SCM_RUN_FROM_PACKAGE setting, and thus, the remote build fails to update the artifact to a valid blob url.

This issue affects Linux Consumption function app created before 8/1/2019

### Mitigation
@balag0 suggested a mitigation for current broken SCM sites.
Remove and reset the app setting for AzureWebJobsStorage. However, this method will take the function app offline and it is not recoverable if the core tool fails in the middle of a remote build deployment.

### Proper Solution
Bala may introduce a solution to refresh the SCM_RUN_FROM_PACKAGE setting when the user updates any of the app setting. Before that, we should discourage our user from manually enabling the SCM site.

### Miscellaneous
resolves #1622