### PR TITLE
Fix AddDistLib url for CI

### DIFF
--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -67,9 +67,9 @@ namespace Build
 
         public static string MinifiedVersionPrefix = "min.";
 
-        public const string DistLibVersion = "distlib-15dba58a827f56195b0fa0afe80a8925a92e8bf5";
+        public const string DistLibVersion = "distlib-0.3.0";
 
-        public const string DistLibUrl = "https://github.com/vsajip/distlib/archive/15dba58a827f56195b0fa0afe80a8925a92e8bf5.zip";
+        public const string DistLibUrl = "https://github.com/vsajip/distlib/archive/0.3.0.zip";
 
         public static readonly string OutputDir = Path.Combine(Path.GetFullPath(".."), "artifacts");
 


### PR DESCRIPTION
### Background
https://github.com/Azure/azure-functions-core-tools/issues/718
This bug is introduced by distlib when the 0.2.8 version is released to publish. At that time, we need to get a specific commit with the fix for our packapp tool.

### Issue
The old commit `15dba58a827f56195b0fa0afe80a8925a92e8bf5` in distlib is removed. Hence, the AddDistLib build step is failing.

### Solution
Upgrade the distlib version to 0.3.0