### PR TITLE
Fix how we run pip to accomodate pip not in path

### DIFF
--- a/tools/python/packapp/__main__.py
+++ b/tools/python/packapp/__main__.py
@@ -75,7 +75,7 @@ def find_and_build_deps(args):
     # for that.
     with tempfile.TemporaryDirectory(prefix='azureworker') as td:
         run_or_die([
-            'pip', 'download', '-r', str(req_txt), '--dest', td
+           sys.executable, '-m', 'pip', 'download', '-r', str(req_txt), '--dest', td
         ], verbose=args.verbose)
 
         files = os.listdir(td)


### PR DESCRIPTION
We should do `python -m pip download` instead of `pip download` to avoid issues where `pip` is not in path or points to a different pip version than the one expected.

Fixes https://github.com/Azure/azure-functions-core-tools/issues/1649