### PR TITLE
[E2E Test] Add features to deploy Azure resources for testing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,12 +23,22 @@ variables:
 steps:
 - pwsh: |
     Write-Host "Target branch: '$(APPVEYOR_REPO_BRANCH)'"
-- task: NodeTool@0 
+- task: NodeTool@0
   inputs:
     versionSpec: '10.x'
 - task: NuGetToolInstaller@1
   inputs:
-    versionSpec: 
+    versionSpec:
+- task: AzureCLI@2
+  displayName: Login via Azure CLI to acquire access token
+  inputs:
+    azureSubscription: $(E2ETestServiceConnectionName)
+    scriptType: ps
+    scriptLocation: inlineScript
+    inlineScript: |
+      # acquire access token from Azure CLI and export it to AZURE_MANAGEMENT_ACCESS_TOKEN
+      $accessToken = (az account get-access-token --query "accessToken" | % { $_.Trim('"') })
+      echo "##vso[task.setvariable variable=azure_management_access_token]$accessToken"
 - pwsh: |
     .\build.ps1
   env:

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -41,6 +41,8 @@ namespace Azure.Functions.Cli.Common
         public const string WebsiteContentAzureFileConnectionString = "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING";
         public const string WebsiteContentShared = "WEBSITE_CONTENTSHARE";
         public const string TelemetrySentinelFile = "telemetryDefaultOn.sentinel";
+        public const string DefaultManagementURL = "https://management.azure.com/";
+        public const string AzureManagementAccessToken = "AZURE_MANAGEMENT_ACCESS_TOKEN";
 
         public static string CliVersion => typeof(Constants).GetTypeInfo().Assembly.GetName().Version.ToString(3);
 

--- a/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/BaseAzureResourceManager.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/BaseAzureResourceManager.cs
@@ -1,0 +1,96 @@
+﻿using Azure.Functions.Cli.Common;
+using System;
+
+namespace Azure.Functions.Cli.Tests.E2E.AzureResourceManagers
+{
+    public abstract class BaseAzureResourceManager: IDisposable
+    {
+        private static string _accessToken;
+        private static string _subscriptionId;
+        private static string _windowsResourceGroup;
+        private static string _linuxResourceGroup;
+
+        public static string ManagementURL => Constants.DefaultManagementURL;
+
+        protected static string AccessToken
+        {
+            get
+            {
+                if (_accessToken == null)
+                {
+                    _accessToken = Environment.GetEnvironmentVariable(Constants.AzureManagementAccessToken);
+                    if (string.IsNullOrEmpty(_accessToken))
+                    {
+                        throw new Exception($"{Constants.AzureManagementAccessToken} is not defined in current environment");
+                    }
+                }
+                return _accessToken;
+            }
+        }
+
+        protected static string SubscriptionId
+        {
+            get
+            {
+                if (_subscriptionId == null)
+                {
+                    _subscriptionId = Environment.GetEnvironmentVariable(E2ETestConstants.TestSubscriptionId);
+                    if (string.IsNullOrEmpty(_subscriptionId))
+                    {
+                        throw new Exception($"{E2ETestConstants.TestSubscriptionId} is not defined in current environment");
+                    }
+                }
+                return _subscriptionId;
+            }
+        }
+
+        protected static string WindowsResourceGroupName
+        {
+            get
+            {
+                if (_windowsResourceGroup == null)
+                {
+                    _windowsResourceGroup = Environment.GetEnvironmentVariable(E2ETestConstants.TestResourceGroupNameWindows);
+                    if (string.IsNullOrEmpty(_windowsResourceGroup))
+                    {
+                        throw new Exception($"{E2ETestConstants.TestResourceGroupNameWindows} is not defined in current environment");
+                    }
+                }
+                return _windowsResourceGroup;
+            }
+        }
+
+        protected static string LinuxResourceGroupName
+        {
+            get
+            {
+                if (_linuxResourceGroup == null)
+                {
+                    _linuxResourceGroup = Environment.GetEnvironmentVariable(E2ETestConstants.TestResourceGroupNameLinux);
+                    if (string.IsNullOrEmpty(_linuxResourceGroup))
+                    {
+                        throw new Exception($"{E2ETestConstants.TestResourceGroupNameLinux} is not defined in current environment");
+                    }
+                }
+                return _linuxResourceGroup;
+            }
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                CleanUp();
+            }
+            catch
+            {
+                // ITestOutputHelper cannot be used by fixture
+            }
+        }
+
+        protected virtual void CleanUp()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/Commons/FunctionApp.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/Commons/FunctionApp.cs
@@ -1,0 +1,16 @@
+﻿using Dynamitey;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.Functions.Cli.Tests.E2E.AzureResourceManagers.Commons
+{
+    public class FunctionApp
+    {
+        public string Name { get; set; }
+        public FunctionAppOs Os { get; set; }
+        public FunctionAppSku Sku { get; set; }
+        public FunctionAppRuntime Runtime { get; set; }
+        public FunctionAppLocation Location { get; set; }
+    }
+}

--- a/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/Commons/FunctionAppLocation.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/Commons/FunctionAppLocation.cs
@@ -1,0 +1,19 @@
+﻿namespace Azure.Functions.Cli.Tests.E2E.AzureResourceManagers.Commons
+{
+    public enum FunctionAppLocation
+    {
+        WestUs,
+        WestUs2,
+        CentralUs,
+        EastUs,
+        EastAsia,
+        SoutheastAsia
+    }
+
+    public static class FunctionAppLocationExtensions
+    {
+        public static string ToRegion(this FunctionAppLocation location) {
+            return location.ToString().ToLower();
+        }
+    }
+}

--- a/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/Commons/FunctionAppOs.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/Commons/FunctionAppOs.cs
@@ -1,0 +1,38 @@
+﻿using Azure.Functions.Cli.Common;
+
+namespace Azure.Functions.Cli.Tests.E2E.AzureResourceManagers.Commons
+{
+    public enum FunctionAppOs
+    {
+        Windows,
+        Linux
+    }
+
+    public static class FunctionAppOsExtensions
+    {
+        public static string GetFunctionAppKindLabel(this FunctionAppOs os)
+        {
+            switch (os)
+            {
+                case FunctionAppOs.Windows:
+                    return "functionapp";
+                case FunctionAppOs.Linux:
+                    return "functionapp,linux";
+                default:
+                    return string.Empty;
+            }
+        }
+        public static string GetServerFarmKindLabel(this FunctionAppOs os)
+        {
+            switch (os)
+            {
+                case FunctionAppOs.Windows:
+                    return "windows";
+                case FunctionAppOs.Linux:
+                    return "linux";
+                default:
+                    return string.Empty;
+            }
+        }
+    }
+}

--- a/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/Commons/FunctionAppRuntime.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/Commons/FunctionAppRuntime.cs
@@ -1,0 +1,19 @@
+﻿namespace Azure.Functions.Cli.Tests.E2E.AzureResourceManagers.Commons
+{
+    public enum FunctionAppRuntime
+    {
+        DotNet,
+        PowerShell,
+        Java,
+        Node,
+        Python
+    }
+
+    public static class FunctionAppRuntimeExtensions
+    {
+        public static string ToFunctionWorkerRuntime(this FunctionAppRuntime runtime)
+        {
+            return runtime.ToString().ToLower();
+        }
+    }
+}

--- a/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/Commons/FunctionAppSku.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/Commons/FunctionAppSku.cs
@@ -1,0 +1,104 @@
+﻿using System;
+
+namespace Azure.Functions.Cli.Tests.E2E.AzureResourceManagers.Commons
+{
+    public enum FunctionAppSku
+    {
+        Consumption,
+        Dedicated,
+        ElasticPremium
+    }
+
+    public static class FunctionAppSkuExtensions
+    {
+        public static ServerFarmSkuObject GetServerFarmSku(this FunctionAppSku sku, FunctionAppOs os)
+        {
+            // Consumption
+            if (sku == FunctionAppSku.Consumption)
+            {
+                return new ServerFarmSkuObject
+                {
+                    Tier = "Dynamic",
+                    Name = "Y1"
+                };
+            }
+            
+            // Dedicated
+            if (sku == FunctionAppSku.Dedicated && os == FunctionAppOs.Windows)
+            {
+                return new ServerFarmSkuObject
+                {
+                    Tier = "Standard",
+                    Name = "S1"
+                };
+            }
+            else if (sku == FunctionAppSku.Dedicated && os == FunctionAppOs.Linux)
+            {
+                return new ServerFarmSkuObject
+                {
+                    Tier = "PremiumV2",
+                    Name = "P1v2"
+                };
+            }
+
+            // ElasticPremium
+            if (sku == FunctionAppSku.ElasticPremium)
+            {
+                return new ServerFarmSkuObject
+                {
+                    Tier = "ElasticPremium",
+                    Name = "EP1"
+                };
+            }
+
+            return null;
+        }
+
+        public static ServerFarmPropertiesObject GetServerFarmProperties(this FunctionAppSku sku, FunctionAppOs os)
+        {
+            // Consumption
+            if (sku == FunctionAppSku.Consumption)
+            {
+                return new ServerFarmPropertiesObject
+                {
+                    workerSize = 0,
+                    workerSizeId = 0,
+                    numberOfWorkers = 1,
+                    maximumElasticWorkerCount = 0,
+                    hostingEnvironment = string.Empty,
+                    reserved = os == FunctionAppOs.Linux
+                };
+            }
+
+            // Dedicated
+            if (sku == FunctionAppSku.Dedicated)
+            {
+                return new ServerFarmPropertiesObject
+                {
+                    workerSize = 0,
+                    workerSizeId = 0,
+                    numberOfWorkers = 1,
+                    maximumElasticWorkerCount = 0,
+                    hostingEnvironment = string.Empty,
+                    reserved = os == FunctionAppOs.Linux
+                };
+            }
+
+            // ElasticPremium
+            if (sku == FunctionAppSku.ElasticPremium)
+            {
+                return new ServerFarmPropertiesObject
+                {
+                    workerSize = 3,
+                    workerSizeId = 3,
+                    numberOfWorkers = 1,
+                    maximumElasticWorkerCount = 20,
+                    hostingEnvironment = string.Empty,
+                    reserved = os == FunctionAppOs.Linux
+                };
+            }
+
+            return null;
+        }
+    }
+}

--- a/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/Commons/ListKeysResponse.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/Commons/ListKeysResponse.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.Functions.Cli.Tests.E2E.AzureResourceManagers.Commons
+{
+    public class ListKeysResponse
+    {
+        public List<StorageAccountKey> keys { get; set; }
+    }
+}

--- a/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/Commons/ServerFarmPropertiesObject.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/Commons/ServerFarmPropertiesObject.cs
@@ -1,0 +1,12 @@
+﻿namespace Azure.Functions.Cli.Tests.E2E.AzureResourceManagers.Commons
+{
+    public class ServerFarmPropertiesObject
+    {
+        public int workerSize { get; set; }
+        public int workerSizeId { get; set; }
+        public int numberOfWorkers { get; set; }
+        public int maximumElasticWorkerCount { get; set; }
+        public bool reserved { get; set; }
+        public string hostingEnvironment { get; set; }
+    }
+}

--- a/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/Commons/ServerFarmSkuObject.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/Commons/ServerFarmSkuObject.cs
@@ -1,0 +1,8 @@
+﻿namespace Azure.Functions.Cli.Tests.E2E.AzureResourceManagers.Commons
+{
+    public class ServerFarmSkuObject
+    {
+        public string Tier { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/Commons/StorageAccountKey.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/Commons/StorageAccountKey.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.Functions.Cli.Tests.E2E.AzureResourceManagers.Commons
+{
+    public class StorageAccountKey
+    {
+        public string keyName { get; set; }
+        public string value { get; set; }
+        public string permissions { get; set; }
+    }
+}

--- a/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/Commons/TestArgResponse.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/Commons/TestArgResponse.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace Azure.Functions.Cli.Tests.E2E.AzureResourceManagers.Commons
+{
+    class TestArgResponse
+    {
+        [JsonProperty(PropertyName = "count")]
+        public int Count { get; set; }
+
+        [JsonProperty(PropertyName = "data")]
+        public object Data { get; set; }
+    }
+}

--- a/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/FunctionAppManager.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/FunctionAppManager.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Azure.Functions.Cli.Arm;
+using Azure.Functions.Cli.Helpers;
+using Azure.Functions.Cli.Tests.E2E.AzureResourceManagers.Commons;
+using Newtonsoft.Json;
+
+namespace Azure.Functions.Cli.Tests.E2E.AzureResourceManagers
+{
+    public class FunctionAppManager : MultiOsResourcesManager<string>
+    {
+        public async Task<HttpResponseMessage> Get(
+            string name)
+        {
+            FunctionAppOs os = GetOsFromResourceLabel(name);
+            string resourceGroup = GetResourceGroupName(os);
+            Uri uri = new Uri($"{ManagementURL}subscriptions/{SubscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Web/sites/{name}?api-version=2018-11-01");
+            return await ArmClient.HttpInvoke("GET", uri, AccessToken);
+        }
+
+        public async Task Create(
+            string name,
+            string storageAccountName,
+            string storageAccountKey,
+            string serverFarmName,
+            FunctionAppLocation location = FunctionAppLocation.WestUs2,
+            FunctionAppSku sku = FunctionAppSku.Consumption,
+            FunctionAppOs os = FunctionAppOs.Windows,
+            FunctionAppRuntime runtime = FunctionAppRuntime.DotNet)
+        {
+            string resourceGroup = GetResourceGroupName(os);
+            Uri uri = new Uri($"{ManagementURL}subscriptions/{SubscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Web/sites/{name}?api-version=2018-11-01");
+
+            string storageAccountConnectionString = $"DefaultEndpointsProtocol=https;AccountName={storageAccountName};AccountKey={storageAccountKey};EndpointSuffix=core.windows.net";
+
+            List<Dictionary<string, string>> appSettings = new List<Dictionary<string, string>>();
+            appSettings.Add(new Dictionary<string, string> { { "name", "FUNCTIONS_WORKER_RUNTIME" }, { "value", runtime.ToFunctionWorkerRuntime() } });
+            appSettings.Add(new Dictionary<string, string> { { "name", "FUNCTIONS_EXTENSION_VERSION" }, { "value", "~2" } });
+            appSettings.Add(new Dictionary<string, string> { { "name", "AzureWebJobsStorage" }, { "value", storageAccountConnectionString } });
+
+            object payload = new
+            {
+                kind = os.GetFunctionAppKindLabel(),
+                location = location.ToRegion(),
+                properties = new
+                {
+                    siteConfig = new
+                    {
+                        appSettings = appSettings
+                    },
+                    serverFarmId = $"/subscriptions/{SubscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Web/serverfarms/{serverFarmName}",
+                    hostingEnvironment = "",
+                    clientAffinityEnable = false
+                }
+            };
+
+            var response = await ArmClient.HttpInvoke("PUT", uri, AccessToken, payload);
+            if (response.IsSuccessStatusCode)
+            {
+                AddToResources(name, os);
+            }
+            else
+            {
+                string statusCode = response.StatusCode.ToString();
+                string message = await response.Content.ReadAsStringAsync();
+                throw new Exception($"Failed to create function app {name}: ({statusCode}) {message}");
+            }
+        }
+
+        public async Task Delete(
+            string name)
+        {
+            FunctionAppOs os = GetOsFromResourceLabel(name);
+            string resourceGroup = GetResourceGroupName(os);
+
+            Uri uri = new Uri($"{ManagementURL}/subscriptions/{SubscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Web/sites/{name}?api-version=2018-11-01");
+            var response = await ArmClient.HttpInvoke("DELETE", uri, AccessToken);
+            if (response.IsSuccessStatusCode)
+            {
+                RemoveFromResources(name, os);
+            }
+            else
+            {
+                string statusCode = response.StatusCode.ToString();
+                string message = await response.Content.ReadAsStringAsync();
+                throw new Exception($"Failed to remove function app {name}: ({statusCode}) {message}");
+            }
+        }
+
+        public async Task<bool> CheckIfSiteExistsFromArg(
+            string name)
+        {
+            var url = new Uri($"{ManagementURL}/{ArmUriTemplates.ArgUri}?api-version={ArmUriTemplates.ArgApiVersion}");
+            var payload = new
+            {
+                subscriptions = new[] { SubscriptionId },
+                query = $"where type =~ \'Microsoft.Web/sites\' and name =~ \'{name}\'"
+            };
+
+            var response = await ArmClient.HttpInvoke(HttpMethod.Post, url, AccessToken, payload);
+            response.EnsureSuccessStatusCode();
+
+            var result = await response.Content.ReadAsStringAsync();
+            var argResponse = JsonConvert.DeserializeObject<TestArgResponse>(result);
+            return argResponse.Count > 0;
+        }
+
+        public bool Contains(
+            string name)
+        {
+            return ContainsResource(name);
+        }
+
+        public async Task WaitUntilCreated(
+            string name,
+            int numOfRetries = 5,
+            int retryIntervalSec = 10)
+        {
+            await RetryHelper.Retry(async () =>
+            {
+                HttpResponseMessage response = await Get(name);
+                response.EnsureSuccessStatusCode();
+            }, retryCount: numOfRetries, retryDelay: TimeSpan.FromSeconds(retryIntervalSec));
+        }
+
+        public async Task WaitUntilSiteAvailable(
+            string name,
+            int numOfRetries = 5,
+            int retryIntervalSec = 10)
+        {
+            await RetryHelper.Retry(async () =>
+            {
+                bool exist = await CheckIfSiteExistsFromArg(name);
+                if (!exist)
+                {
+                    throw new Exception($"Function app {name} does not exist in Azure Graph");
+                }
+            }, retryCount: numOfRetries, retryDelay: TimeSpan.FromSeconds(retryIntervalSec));
+        }
+
+        public async Task WaitUntilScmSiteAvailable(
+            string name,
+            int numOfRetries = 5,
+            int retryIntervalSec = 10)
+        {
+            Uri uri = new Uri($"https://{name}.scm.azurewebsites.net");
+            await RetryHelper.Retry(async () =>
+            {
+                HttpResponseMessage response = await ArmClient.HttpInvoke("GET", uri, AccessToken);
+                response.EnsureSuccessStatusCode();
+            }, retryCount: numOfRetries, retryDelay: TimeSpan.FromSeconds(retryIntervalSec));
+        }
+
+        public async Task WaitUntilDeleted(
+            string name,
+            int numOfRetries = 5,
+            int retryIntervalSec = 10)
+        {
+            await RetryHelper.Retry(async () =>
+            {
+                await Delete(name);
+            }, retryCount: numOfRetries, retryDelay: TimeSpan.FromSeconds(retryIntervalSec));
+        }
+
+        protected override void CleanUp()
+        {
+            List<Task> deletedTasks = new List<Task>();
+            deletedTasks.AddRange(WindowsResources.Select(sa => WaitUntilDeleted(sa)));
+            deletedTasks.AddRange(LinuxResources.Select(sa => WaitUntilDeleted(sa)));
+            Task.WhenAll(deletedTasks).Wait();
+        }
+    }
+}

--- a/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/MultiOsResourcesManager.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/MultiOsResourcesManager.cs
@@ -1,0 +1,95 @@
+﻿using Azure.Functions.Cli.Tests.E2E.AzureResourceManagers.Commons;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.Functions.Cli.Tests.E2E.AzureResourceManagers
+{
+    public class MultiOsResourcesManager<ResourceLabel> : BaseAzureResourceManager
+    {
+        private HashSet<ResourceLabel> _windowsResources;
+        private HashSet<ResourceLabel> _linuxResources;
+
+        public MultiOsResourcesManager()
+        {
+            _windowsResources = new HashSet<ResourceLabel>();
+            _linuxResources = new HashSet<ResourceLabel>();
+        }
+
+        protected IEnumerable<ResourceLabel> WindowsResources
+        {
+            get
+            {
+                return _windowsResources;
+            }
+        }
+
+        protected IEnumerable<ResourceLabel> LinuxResources
+        {
+            get
+            {
+                return _linuxResources;
+            }
+        }
+
+
+        public string GetResourceGroupName(FunctionAppOs os)
+        {
+            switch (os)
+            {
+                case FunctionAppOs.Windows:
+                    return WindowsResourceGroupName;
+                case FunctionAppOs.Linux:
+                    return LinuxResourceGroupName;
+                default:
+                    return string.Empty;
+            }
+        }
+
+        protected FunctionAppOs GetOsFromResourceLabel(ResourceLabel resource)
+        {
+            if (_windowsResources.Contains(resource))
+            {
+                return FunctionAppOs.Windows;
+            }
+
+            if (_linuxResources.Contains(resource))
+            {
+                return FunctionAppOs.Linux;
+            }
+
+            throw new Exception($"Resource {resource.ToString()} does not exist when executing GetOsFromResourceLabel");
+        }
+
+        protected void AddToResources(ResourceLabel resource, FunctionAppOs os)
+        {
+            if (os == FunctionAppOs.Windows)
+            {
+                _windowsResources.Add(resource);
+            }
+
+            if (os == FunctionAppOs.Linux)
+            {
+                _linuxResources.Add(resource);
+            }
+        }
+
+        protected bool ContainsResource(ResourceLabel resource)
+        {
+            return _windowsResources.Contains(resource) || _linuxResources.Contains(resource);
+        }
+
+        protected void RemoveFromResources(ResourceLabel resource, FunctionAppOs os)
+        {
+            if (os == FunctionAppOs.Windows)
+            {
+                _windowsResources.Remove(resource);
+            }
+
+            if (os == FunctionAppOs.Linux)
+            {
+                _linuxResources.Remove(resource);
+            }
+        }
+    }
+}

--- a/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/ServerFarmManager.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/ServerFarmManager.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Azure.Functions.Cli.Arm;
+using Azure.Functions.Cli.Helpers;
+using Azure.Functions.Cli.Tests.E2E.AzureResourceManagers.Commons;
+
+namespace Azure.Functions.Cli.Tests.E2E.AzureResourceManagers
+{
+    public class ServerFarmManager : MultiOsResourcesManager<string>
+    {
+        public async Task<HttpResponseMessage> Get(
+            string name)
+        {
+            FunctionAppOs os = GetOsFromResourceLabel(name);
+            string resourceGroup = GetResourceGroupName(os);
+            Uri uri = new Uri($"{ManagementURL}subscriptions/{SubscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Web/serverfarms/{name}?api-version=2019-08-01");
+            return await ArmClient.HttpInvoke("GET", uri, AccessToken);
+        }
+
+        public async Task Create(
+            string name,
+            FunctionAppLocation location = FunctionAppLocation.WestUs2,
+            FunctionAppSku sku = FunctionAppSku.Consumption,
+            FunctionAppOs os = FunctionAppOs.Windows)
+        {
+            string resourceGroup = GetResourceGroupName(os);
+            Uri uri = new Uri($"{ManagementURL}subscriptions/{SubscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Web/serverfarms/{name}?api-version=2019-08-01");
+            object payload = new
+            {
+                kind = os.GetServerFarmKindLabel(),
+                location = location.ToRegion(),
+                properties = sku.GetServerFarmProperties(os),
+                sku = sku.GetServerFarmSku(os)
+            };
+            var response = await ArmClient.HttpInvoke("PUT", uri, AccessToken, payload);
+            if (response.IsSuccessStatusCode)
+            {
+                AddToResources(name, os);
+            }
+            else
+            {
+                string statusCode = response.StatusCode.ToString();
+                string message = await response.Content.ReadAsStringAsync();
+                throw new Exception($"Failed to create server farm {name}: ({statusCode}) {message}");
+            }
+        }
+
+        public async Task Delete(
+            string name)
+        {
+            FunctionAppOs os = GetOsFromResourceLabel(name);
+            string resourceGroup = GetResourceGroupName(os);
+            Uri uri = new Uri($"{ManagementURL}subscriptions/{SubscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Web/serverfarms/{name}?api-version=2019-08-01");
+
+            var response = await ArmClient.HttpInvoke("DELETE", uri, AccessToken);
+            if (response.IsSuccessStatusCode)
+            {
+                RemoveFromResources(name, os);
+            }
+            else
+            {
+                string statusCode = response.StatusCode.ToString();
+                string message = await response.Content.ReadAsStringAsync();
+                throw new Exception($"Failed to remove server farm {name}: ({statusCode}) {message}");
+            }
+        }
+        public bool Contains(
+            string name)
+        {
+            return ContainsResource(name);
+        }
+
+        public async Task WaitUntilCreated(
+            string name,
+            int numOfRetries = 5,
+            int retryIntervalSec = 10)
+        {
+            await RetryHelper.Retry(async () =>
+            {
+                HttpResponseMessage response = await Get(name);
+                response.EnsureSuccessStatusCode();
+            }, retryCount: numOfRetries, retryDelay: TimeSpan.FromSeconds(retryIntervalSec));
+        }
+
+        public async Task WaitUntilDeleted(
+            string name,
+            int numOfRetries = 5,
+            int retryIntervalSec = 10)
+        {
+            await RetryHelper.Retry(async () =>
+            {
+                await Delete(name);
+            }, retryCount: numOfRetries, retryDelay: TimeSpan.FromSeconds(retryIntervalSec));
+        }
+
+        protected override void CleanUp()
+        {
+            List<Task> deletedTasks = new List<Task>();
+            deletedTasks.AddRange(WindowsResources.Select(sa => WaitUntilDeleted(sa)));
+            deletedTasks.AddRange(LinuxResources.Select(sa => WaitUntilDeleted(sa)));
+            Task.WhenAll(deletedTasks).Wait();
+        }
+    }
+}

--- a/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/StorageAccountManager.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/AzureResourceManagers/StorageAccountManager.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Azure.Functions.Cli.Arm;
+using Azure.Functions.Cli.Helpers;
+using Azure.Functions.Cli.Tests.E2E.AzureResourceManagers.Commons;
+using Newtonsoft.Json;
+
+namespace Azure.Functions.Cli.Tests.E2E.AzureResourceManagers
+{
+    public class StorageAccountManager : MultiOsResourcesManager<string>
+    {
+        private HashSet<string> _storageAccounts;
+
+        public StorageAccountManager() : base()
+        {
+            _storageAccounts = new HashSet<string>();
+        }
+
+        public async Task<HttpResponseMessage> Get(
+            string name)
+        {
+            FunctionAppOs os = GetOsFromResourceLabel(name);
+            string resourceGroup = GetResourceGroupName(os);
+            Uri uri = new Uri($"{ManagementURL}subscriptions/{SubscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Storage/storageAccounts/{name}?api-version=2019-06-01");
+            return await ArmClient.HttpInvoke("GET", uri, AccessToken);
+        }
+
+        public async Task<ListKeysResponse> ListKeys(
+            string name)
+        {
+            FunctionAppOs os = GetOsFromResourceLabel(name);
+            string resourceGroup = GetResourceGroupName(os);
+            Uri uri = new Uri($"{ManagementURL}subscriptions/{SubscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Storage/storageAccounts/{name}/listkeys?api-version=2019-06-01");
+            var response = await ArmClient.HttpInvoke("POST", uri, AccessToken);
+            if (response.IsSuccessStatusCode)
+            {
+                string json = await response.Content.ReadAsStringAsync();
+                return JsonConvert.DeserializeObject<ListKeysResponse>(json);
+            }
+            else
+            {
+                string statusCode = response.StatusCode.ToString();
+                string message = await response.Content.ReadAsStringAsync();
+                throw new Exception($"Failed to list keys for storage account {name}: ({statusCode}) {message}");
+            }
+        }
+
+        public async Task Create(
+            string name,
+            FunctionAppLocation location = FunctionAppLocation.WestUs2,
+            FunctionAppOs os = FunctionAppOs.Windows)
+        {
+            string resourceGroup = GetResourceGroupName(os);
+            Uri uri = new Uri($"{ManagementURL}subscriptions/{SubscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Storage/storageAccounts/{name}?api-version=2019-06-01");
+            object payload = new
+            {
+                kind = "StorageV2",
+                location = location.ToRegion(),
+                sku = new
+                {
+                    name = "Standard_LRS"
+                }
+            };
+            var response = await ArmClient.HttpInvoke("PUT", uri, AccessToken, payload);
+            if (response.IsSuccessStatusCode)
+            {
+                AddToResources(name, os);
+            }
+            else
+            {
+                string statusCode = response.StatusCode.ToString();
+                string message = await response.Content.ReadAsStringAsync();
+                throw new Exception($"Failed to create storage account {name}: ({statusCode}) {message}");
+            }
+        }
+
+        public async Task Delete(
+            string name)
+        {
+            FunctionAppOs os = GetOsFromResourceLabel(name);
+            string resourceGroup = GetResourceGroupName(os);
+            Uri uri = new Uri($"{ManagementURL}subscriptions/{SubscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Storage/storageAccounts/{name}?api-version=2019-06-01");
+            var response = await ArmClient.HttpInvoke("DELETE", uri, AccessToken);
+            if (response.IsSuccessStatusCode)
+            {
+                RemoveFromResources(name, os);
+            }
+            else
+            {
+                string statusCode = response.StatusCode.ToString();
+                string message = await response.Content.ReadAsStringAsync();
+                throw new Exception($"Failed to remove storage account {name}: ({statusCode}) {message}");
+            }
+        }
+
+        public bool Contains(
+            string name)
+        {
+            return ContainsResource(name);
+        }
+
+        public async Task WaitUntilCreated(
+            string name,
+            int numOfRetries = 5,
+            int retryIntervalSec = 10)
+        {
+            await RetryHelper.Retry(async () =>
+            {
+                HttpResponseMessage response = await Get(name);
+                response.EnsureSuccessStatusCode();
+            }, retryCount: numOfRetries, retryDelay: TimeSpan.FromSeconds(retryIntervalSec));
+        }
+
+        public async Task<ListKeysResponse> WaitUntilListKeys(
+            string name,
+            int numOfRetries = 5,
+            int retryIntervalSec = 10)
+        {
+            ListKeysResponse result = null;
+            await RetryHelper.Retry(async () =>
+            {
+                result = await ListKeys(name);
+            }, retryCount: numOfRetries, retryDelay: TimeSpan.FromSeconds(retryIntervalSec));
+            return result;
+        }
+
+        public async Task WaitUntilDeleted(
+            string name,
+            int numOfRetries = 5,
+            int retryIntervalSec = 10)
+        {
+            await RetryHelper.Retry(async () =>
+            {
+                await Delete(name);
+            }, retryCount: numOfRetries, retryDelay: TimeSpan.FromSeconds(retryIntervalSec));
+        }
+
+        protected override void CleanUp()
+        {
+            List<Task> deletedTasks = new List<Task>();
+            deletedTasks.AddRange(WindowsResources.Select(sa => WaitUntilDeleted(sa)));
+            deletedTasks.AddRange(LinuxResources.Select(sa => WaitUntilDeleted(sa)));
+            Task.WhenAll(deletedTasks).Wait();
+        }
+    }
+}

--- a/test/Azure.Functions.Cli.Tests/E2E/DeploymentTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/DeploymentTests.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Azure.Functions.Cli.Tests.E2E.AzureResourceManagers;
+using Azure.Functions.Cli.Tests.E2E.AzureResourceManagers.Commons;
+using Azure.Functions.Cli.Tests.E2E.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Azure.Functions.Cli.Tests.E2E
+{
+    
+    public class DeploymentTests : BaseE2ETest, IClassFixture<StorageAccountManager>, IClassFixture<ServerFarmManager>, IClassFixture<FunctionAppManager>
+    {
+        private readonly StorageAccountManager _storageAccountManager;
+        private readonly ServerFarmManager _serverFarmManager;
+        private readonly FunctionAppManager _functionAppManager;
+
+        private readonly static string id = DateTime.Now.ToString("HHmmss");
+        private readonly static string linuxStorageAccountName = $"lcte2estorage{id}";
+        private readonly static string linuxConsumptionServerFarm = $"lcte2ecserverfarm{id}";
+        private readonly static string linuxConsumptionPythonFunctionApp = $"lcte2ecpython{id}";
+
+        public DeploymentTests(ITestOutputHelper output, StorageAccountManager saManager, ServerFarmManager sfManager, FunctionAppManager faManager) : base(output)
+        {
+            _storageAccountManager = saManager;
+            _serverFarmManager = sfManager;
+            _functionAppManager = faManager;
+            if (!_storageAccountManager.Contains(linuxStorageAccountName) ||
+                !_serverFarmManager.Contains(linuxConsumptionServerFarm) ||
+                !_functionAppManager.Contains(linuxConsumptionPythonFunctionApp))
+            {
+                InitializeLinuxResources().Wait();
+            }
+        }
+
+        private async Task InitializeLinuxResources()
+        {
+            // Create storage account and server farm
+            await Task.WhenAll(
+                _storageAccountManager.Create(linuxStorageAccountName, os: FunctionAppOs.Linux),
+                _serverFarmManager.Create(linuxConsumptionServerFarm, os: FunctionAppOs.Linux)
+            );
+
+            // Check if creation has finished
+            await Task.WhenAll(
+                _storageAccountManager.WaitUntilCreated(linuxStorageAccountName),
+                _serverFarmManager.WaitUntilCreated(linuxConsumptionServerFarm));
+
+            // Acquire storage account key
+            ListKeysResponse listkeys = await _storageAccountManager.WaitUntilListKeys(linuxStorageAccountName);
+            string storageAccountKey = listkeys.keys.FirstOrDefault().value;
+
+            // Create function app
+            await _functionAppManager.Create(linuxConsumptionPythonFunctionApp, linuxStorageAccountName, storageAccountKey, linuxConsumptionServerFarm,
+                os: FunctionAppOs.Linux, runtime: FunctionAppRuntime.Python);
+            await _functionAppManager.WaitUntilSiteAvailable(linuxConsumptionPythonFunctionApp);
+            await _functionAppManager.WaitUntilScmSiteAvailable(linuxConsumptionPythonFunctionApp);
+        }
+
+        [SkippableFact]
+        public async void RemoteBuildPythonFunctionApp()
+        {
+            TestConditions.SkipIfEnableDeploymentTestsNotDefined();
+            await CliTester.Run(new[] {
+                new RunConfiguration
+                {
+                    Commands = new[]
+                    {
+                        "init . --worker-runtime python",
+                        "new -l python -t HttpTrigger -n httptrigger",
+                        $"azure functionapp publish {linuxConsumptionPythonFunctionApp} --build remote"
+                    },
+                    OutputContains = new string[]
+                    {
+                        "Remote build succeeded!"
+                    },
+                    CommandTimeout = TimeSpan.FromMinutes(5)
+                },
+            }, _output);
+        }
+    }
+}

--- a/test/Azure.Functions.Cli.Tests/E2E/E2ETestConstants.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/E2ETestConstants.cs
@@ -1,0 +1,10 @@
+﻿namespace Azure.Functions.Cli.Tests.E2E
+{
+    public static class E2ETestConstants
+    {
+        public const string TestSubscriptionId = "TEST_SUBSCRIPTION_ID";
+        public const string TestResourceGroupNameWindows = "TEST_RESOURCE_GROUP_NAME_WINDOWS";
+        public const string TestResourceGroupNameLinux = "TEST_RESOURCE_GROUP_NAME_LINUX";
+        public const string EnableDeploymentTests = "ENABLE_DEPLOYMENT_TEST";
+    }
+}

--- a/test/Azure.Functions.Cli.Tests/E2E/Helpers/TestConditions.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/Helpers/TestConditions.cs
@@ -1,5 +1,7 @@
 using System;
 using Xunit;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Helpers;
 
 namespace Azure.Functions.Cli.Tests.E2E.Helpers
 {
@@ -15,6 +17,12 @@ namespace Azure.Functions.Cli.Tests.E2E.Helpers
                     string.IsNullOrEmpty(appId) ||
                     string.IsNullOrEmpty(key),
                 reason: "One or more of AZURE_DIRECTORY_ID, AZURE_SERVICE_PRINCIPAL_ID, AZURE_SERVICE_PRINCIPAL_KEY is not defined");
+        }
+
+        public static void SkipIfEnableDeploymentTestsNotDefined()
+        {
+            Skip.If(!EnvironmentHelper.GetEnvironmentVariableAsBool(E2ETestConstants.EnableDeploymentTests),
+                reason: $"{E2ETestConstants.EnableDeploymentTests} is not set to true");
         }
     }
 }


### PR DESCRIPTION
### Background
The deployment helper for Azure Functions Core Tools does not contain tests so far.
This due to a lack of tool-set to change Azure Resource via ARM 

### azure-pipelines.yml
1. Create a test resource group in an Azure Testing Subscription.
2. Generate a service principle to the test resource group.
3. In Azure DevOps pipelines, use **AzureCLI@2** and `az account get-access-token --query "accessToken"` to generate an access token in every build.
4. Pass the access token to **AZCLI_ACCESS_TOKEN**
5. Parse the AZCLI_ACCESS_TOKEN from core tool test helper
6. Use xunit test framework to perform E2E test

### AzureResourceManagers
- **Common**: contains data models and enums for ARM requests and responses
- **BaseAzureResourceManager**: used for providing Bearer AccessToken, Subscription ID, Resource Group name
- **MultiOsResourcesManager**: used for distinguishing Windows / Linux resources in different resource groups
- **FunctionAppManager / ServerFarmManager / StorageAccountManager**: used for creating/querying/deleting function app
- **DeploymentTests**: Basic remote build for Python consumption function app. (will add more tests in separate PRs)

### Pipeline Variables
- **ENABLE_DEPLOYMENT_TEST**: setting this to **true** to enable deployment tests. Set to **false** to opt out deployment tests.
- **TEST_SUBSCRIPTION_ID**: the subscription for creating resources
- **TEST_RESOURCE_GROUP_NAME_WINDOWS**: the name of resource group for creating windows resources
- **TEST_RESOURCE_GROUP_NAME_LINUX**: the name of resource group for creating linux resources