### PR TITLE
Initial PR for the changes to manages function keys in Kubernetes

### DIFF
--- a/src/Azure.Functions.Cli/Actions/KubernetesActions/KubernetesDeployAction.cs
+++ b/src/Azure.Functions.Cli/Actions/KubernetesActions/KubernetesDeployAction.cs
@@ -65,8 +65,8 @@ namespace Azure.Functions.Cli.Actions.KubernetesActions
             SetFlag<string>("funcappkeys-secret-name", "The name of a kubernetes secret collection to use for the function app keys (host keys, function keys etc.)", ksn => FunAppKeysSecretsCollectionName = ksn);
             SetFlag<string>("funcappkeys-config-map-name", "The name of a kubernetes config map to use for the function app keys (host keys, function keys etc.)", kcm => FunAppKeysConfigMapName = kcm);
             SetFlag<bool>("mount-funcappkeys-as-containervolume", "The flag indicating to mount the func app keys as container volume", kmv => MountFuncAppKeysAsContainerVolume = kmv);
-            SetFlag<string>("appsettings-secret-name", "The name of a kubernetes secret collection to use in the deployment instead of generating one based on local.settings.json", sn => AppSettingsSecretsCollectionName = sn);
-            SetFlag<string>("appsettings-config-map-name", "The name of a config map to use in the deployment", cm => AppSettingsConfigMapName = cm);
+            SetFlag<string>("appsettings-secret-name", "The name of a existing func app settings kubernetes secret collection to use in the deployment instead of generating one based on local.settings.json", sn => AppSettingsSecretsCollectionName = sn);
+            SetFlag<string>("appsettings-config-map-name", "The name of an existing config map with func app settings to use in the deployment", cm => AppSettingsConfigMapName = cm);
             SetFlag<string>("service-type", "Kubernetes Service Type. Default LoadBalancer  Valid options: " + string.Join(",", ServiceTypes), s =>
             {
                 if (!string.IsNullOrEmpty(s) && !ServiceTypes.Contains(s))

--- a/src/Azure.Functions.Cli/Actions/KubernetesActions/KubernetesDeployAction.cs
+++ b/src/Azure.Functions.Cli/Actions/KubernetesActions/KubernetesDeployAction.cs
@@ -26,14 +26,13 @@ namespace Azure.Functions.Cli.Actions.KubernetesActions
         public string Namespace { get; set; } = "default";
         public string PullSecret { get; set; } = string.Empty;
         public bool NoDocker { get; set; }
-        public bool UseConfigMapForAppSettings { get; set; }
+        public bool UseConfigMap { get; set; }
         public bool DryRun { get; private set; }
         public string ImageName { get; private set; }
-        public string AppSettingsConfigMapName { get; private set; }
-        public string AppSettingsSecretsCollectionName { get; private set; }
-        public string FunAppKeysConfigMapName { get; private set; }
-        public string FunAppKeysSecretsCollectionName { get; private set; }
-        public bool MountFuncAppKeysAsContainerVolume { get; private set; }
+        public string ConfigMapName { get; private set; }
+        public string SecretsCollectionName { get; private set; }
+        public string KeysSecretCollectionName { get; private set; }
+        public bool MountFuncKeysAsContainerVolume { get; private set; }
         public int? PollingInterval { get; private set; }
         public int? CooldownPeriod { get; private set; }
         public string ServiceType { get; set; } = "LoadBalancer";
@@ -62,11 +61,10 @@ namespace Azure.Functions.Cli.Actions.KubernetesActions
             SetFlag<int>("cooldown-period", "The cooldown period for the deployment before scaling back to 0 after all triggers are no longer active. Default: 300 (seconds)", p => CooldownPeriod = p);
             SetFlag<int>("min-replicas", "Minimum replica count", m => MinReplicaCount = m);
             SetFlag<int>("max-replicas", "Maximum replica count to scale to by HPA", m => MaxReplicaCount = m);
-            SetFlag<string>("funcappkeys-secret-name", "The name of a kubernetes secret collection to use for the function app keys (host keys, function keys etc.)", ksn => FunAppKeysSecretsCollectionName = ksn);
-            SetFlag<string>("funcappkeys-config-map-name", "The name of a kubernetes config map to use for the function app keys (host keys, function keys etc.)", kcm => FunAppKeysConfigMapName = kcm);
-            SetFlag<bool>("mount-funcappkeys-as-containervolume", "The flag indicating to mount the func app keys as container volume", kmv => MountFuncAppKeysAsContainerVolume = kmv);
-            SetFlag<string>("appsettings-secret-name", "The name of a existing func app settings kubernetes secret collection to use in the deployment instead of generating one based on local.settings.json", sn => AppSettingsSecretsCollectionName = sn);
-            SetFlag<string>("appsettings-config-map-name", "The name of an existing config map with func app settings to use in the deployment", cm => AppSettingsConfigMapName = cm);
+            SetFlag<string>("keys-secret-name", "The name of a kubernetes secret collection to use for the function app keys (host keys, function keys etc.)", ksn => KeysSecretCollectionName = ksn);    
+            SetFlag<bool>("mount-funckeys-as-containervolume", "The flag indicating to mount the func app keys as container volume", kmv => MountFuncKeysAsContainerVolume = kmv);
+            SetFlag<string>("secret-name", "The name of an existing kubernetes secret collection, containing func app settings, to use in the deployment instead of creating new a new one based upon local.settings.json", sn => SecretsCollectionName = sn);
+            SetFlag<string>("config-map-name", "The name of an existing config map with func app settings to use in the deployment", cm => ConfigMapName = cm);
             SetFlag<string>("service-type", "Kubernetes Service Type. Default LoadBalancer  Valid options: " + string.Join(",", ServiceTypes), s =>
             {
                 if (!string.IsNullOrEmpty(s) && !ServiceTypes.Contains(s))
@@ -76,7 +74,7 @@ namespace Azure.Functions.Cli.Actions.KubernetesActions
                 ServiceType = s;
             });
             SetFlag<bool>("no-docker", "With --image-name, the core-tools will inspect the functions inside the image. This will require mounting the image filesystem. Passing --no-docker uses current directory for functions.", nd => NoDocker = nd);
-            SetFlag<bool>("use-config-map-for-appsettings", "Use a ConfigMap/V1 instead of a Secret/V1 object for function app settings configurations", c => UseConfigMapForAppSettings = c);
+            SetFlag<bool>("use-config-map", "Use a ConfigMap/V1 instead of a Secret/V1 object for function app settings configurations", c => UseConfigMap = c);
             SetFlag<bool>("dry-run", "Show the deployment template", f => DryRun = f);
             SetFlag<bool>("ignore-errors", "Proceed with the deployment if a resource returns an error. Default: false", f => IgnoreErrors = f);
             return base.ParseArgs(args);
@@ -108,28 +106,24 @@ namespace Azure.Functions.Cli.Actions.KubernetesActions
                 }
                 triggers = await DockerHelpers.GetTriggersFromDockerImage(resolvedImageName);
             }
-
-            var functionNames = triggers.FunctionsJson.Select(f => f.Key);
-            var funcAppKeys = FuncAppKeysHelper.CreateKeys(functionNames);
+           
             var resources = await KubernetesHelper.GetFunctionsDeploymentResources(
                 Name,
                 resolvedImageName,
                 Namespace,
                 triggers,
                 _secretsManager.GetSecrets(),
-                funcAppKeys,
                 PullSecret,
-                AppSettingsSecretsCollectionName,
-                AppSettingsConfigMapName,
-                UseConfigMapForAppSettings,
+                SecretsCollectionName,
+                ConfigMapName,
+                UseConfigMap,
                 PollingInterval,
                 CooldownPeriod,
                 ServiceType,
                 MinReplicaCount,
                 MaxReplicaCount,
-                FunAppKeysSecretsCollectionName,
-                FunAppKeysConfigMapName,
-                MountFuncAppKeysAsContainerVolume);
+                KeysSecretCollectionName,
+                MountFuncKeysAsContainerVolume);
 
             if (DryRun)
             {

--- a/src/Azure.Functions.Cli/Actions/KubernetesActions/KubernetesDeployAction.cs
+++ b/src/Azure.Functions.Cli/Actions/KubernetesActions/KubernetesDeployAction.cs
@@ -29,7 +29,7 @@ namespace Azure.Functions.Cli.Actions.KubernetesActions
         public string Namespace { get; set; } = "default";
         public string PullSecret { get; set; } = string.Empty;
         public bool NoDocker { get; set; }
-        public bool UseConfigMap { get; set; }
+        public bool UseConfigMapForAppSettings { get; set; }
         public bool DryRun { get; private set; }
         public string ImageName { get; private set; }
         public string ConfigMapName { get; private set; }
@@ -109,17 +109,18 @@ namespace Azure.Functions.Cli.Actions.KubernetesActions
                 }
                 triggers = await DockerHelpers.GetTriggersFromDockerImage(resolvedImageName);
             }
-
+			
             (var resources, var existingKeysSecret, var newKeysSecret) = await KubernetesHelper.GetFunctionsDeploymentResources(
                 Name,
                 resolvedImageName,
                 Namespace,
                 triggers,
                 _secretsManager.GetSecrets(),
+                funcAppKeys,
                 PullSecret,
-                SecretsCollectionName,
-                ConfigMapName,
-                UseConfigMap,
+                AppSettingsSecretsCollectionName,
+                AppSettingsConfigMapName,
+                UseConfigMapForAppSettings,
                 PollingInterval,
                 CooldownPeriod,
                 ServiceType,

--- a/src/Azure.Functions.Cli/Actions/KubernetesActions/KubernetesDeployAction.cs
+++ b/src/Azure.Functions.Cli/Actions/KubernetesActions/KubernetesDeployAction.cs
@@ -29,7 +29,7 @@ namespace Azure.Functions.Cli.Actions.KubernetesActions
         public string Namespace { get; set; } = "default";
         public string PullSecret { get; set; } = string.Empty;
         public bool NoDocker { get; set; }
-        public bool UseConfigMapForAppSettings { get; set; }
+        public bool UseConfigMap { get; set; }
         public bool DryRun { get; private set; }
         public string ImageName { get; private set; }
         public string ConfigMapName { get; private set; }
@@ -116,11 +116,10 @@ namespace Azure.Functions.Cli.Actions.KubernetesActions
                 Namespace,
                 triggers,
                 _secretsManager.GetSecrets(),
-                funcAppKeys,
                 PullSecret,
-                AppSettingsSecretsCollectionName,
-                AppSettingsConfigMapName,
-                UseConfigMapForAppSettings,
+                SecretsCollectionName,
+                ConfigMapName,
+                UseConfigMap,
                 PollingInterval,
                 CooldownPeriod,
                 ServiceType,

--- a/src/Azure.Functions.Cli/Actions/KubernetesActions/KubernetesDeployAction.cs
+++ b/src/Azure.Functions.Cli/Actions/KubernetesActions/KubernetesDeployAction.cs
@@ -150,7 +150,7 @@ namespace Azure.Functions.Cli.Actions.KubernetesActions
                 }
 
                 //Print the function keys message to the console
-                FuncAppKeysHelper.FunKeysMessage(funcKeys);
+                await KubernetesHelper.PrintFunctionsInfo($"{Name}-http", Namespace, funcKeys, triggers);
             }
         }
 

--- a/src/Azure.Functions.Cli/Actions/KubernetesActions/KubernetesDeployAction.cs
+++ b/src/Azure.Functions.Cli/Actions/KubernetesActions/KubernetesDeployAction.cs
@@ -150,7 +150,7 @@ namespace Azure.Functions.Cli.Actions.KubernetesActions
                 }
 
                 //Print the function keys message to the console
-                FuncAppKeysHelper.FunKeysMessage(existingKeysSecret, newKeysSecret);
+                FuncAppKeysHelper.FunKeysMessage(unchangedFuncKeys, newFuncKeys);
             }
         }
 

--- a/src/Azure.Functions.Cli/Actions/KubernetesActions/KubernetesDeployAction.cs
+++ b/src/Azure.Functions.Cli/Actions/KubernetesActions/KubernetesDeployAction.cs
@@ -150,7 +150,7 @@ namespace Azure.Functions.Cli.Actions.KubernetesActions
                 }
 
                 //Print the function keys message to the console
-                FuncAppKeysHelper.FunKeysMessage(unchangedFuncKeys, newFuncKeys);
+                FuncAppKeysHelper.FunKeysMessage(funcKeys);
             }
         }
 

--- a/src/Azure.Functions.Cli/Actions/KubernetesActions/KubernetesDeployAction.cs
+++ b/src/Azure.Functions.Cli/Actions/KubernetesActions/KubernetesDeployAction.cs
@@ -110,7 +110,7 @@ namespace Azure.Functions.Cli.Actions.KubernetesActions
                 triggers = await DockerHelpers.GetTriggersFromDockerImage(resolvedImageName);
             }
 			
-            (var resources, var existingKeysSecret, var newKeysSecret) = await KubernetesHelper.GetFunctionsDeploymentResources(
+            (var resources, var funcKeys) = await KubernetesHelper.GetFunctionsDeploymentResources(
                 Name,
                 resolvedImageName,
                 Namespace,

--- a/src/Azure.Functions.Cli/Extensions/HttpExtension.cs
+++ b/src/Azure.Functions.Cli/Extensions/HttpExtension.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+
+namespace Azure.Functions.Cli.Extensions
+{
+    public static class HttpExtension
+    {
+        /// <summary>
+        /// Clones HttpRequestMessage
+        /// </summary>
+        /// <param name="request">The HttpRequestMessage to be cloned</param>
+        /// <returns></returns>
+        public static HttpRequestMessage Clone(this HttpRequestMessage request)
+        {
+            if (request == null)
+            {
+                return null;
+            }
+
+            var clone = new HttpRequestMessage(request.Method, request.RequestUri)
+            {
+                Content = request.Content.Clone(),
+                Version = request.Version
+            };
+            foreach (KeyValuePair<string, object> prop in request.Properties)
+            {
+                clone.Properties.Add(prop);
+            }
+            foreach (KeyValuePair<string, IEnumerable<string>> header in request.Headers)
+            {
+                clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+
+            return clone;
+        }
+
+        /// <summary>
+        /// Clones HttpContent object
+        /// </summary>
+        /// <param name="content">HttpContent to be cloned</param>
+        /// <returns>The cloned HttpContent object</returns>
+        public static HttpContent Clone(this HttpContent content)
+        {
+            if (content == null)
+            {
+                return null;
+            }
+
+            var ms = new MemoryStream();
+            content.CopyToAsync(ms).Wait();
+            ms.Position = 0;
+
+            var clone = new StreamContent(ms);
+            foreach (KeyValuePair<string, IEnumerable<string>> header in content.Headers)
+            {
+                clone.Headers.Add(header.Key, header.Value);
+            }
+            return clone;
+        }
+    }
+}

--- a/src/Azure.Functions.Cli/Kubernetes/FuncKeys/FuncAppKeysHelper.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/FuncKeys/FuncAppKeysHelper.cs
@@ -1,0 +1,125 @@
+﻿using Azure.Functions.Cli.Kubernetes.Models.Kubernetes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Functions.Cli.Kubernetes.FuncKeys
+{
+    public class FuncAppKeysHelper
+    {
+        private const string FuncAppKeysVolumeName = "functions-keys-volume";
+        private const string KubernetesSecretsMountPath = "/run/secrets/functions-keys";
+        private const string AzureWebJobsSecretStorageTypeEnvVariableName = "AzureWebJobsSecretStorageType";
+        private const string AzureWebJobsKubernetesSecretNameEnvVariableName = "AzureWebJobsKubernetesSecretName";
+        private const string MasterKey = "host.master";
+        private const string HostFunctionKey = "host.function.default";
+        private const string HostSystemKey = "host.systemKey.default";
+        private const string FunctionKeyPrefix = "functions.";
+        private const string FunctionDefaultKeyName = "default";
+        /// <summary>
+        /// Implementation of this method creates the Host and Function Keys
+        /// </summary>
+        /// <param name="functionNames">The <see cref="IEnumerable{string}"></see> of function names </param>
+        /// <returns>The <see cref="IDictionary{string, string}"/> of function app's host and function keys</returns>
+        public static IDictionary<string, string> CreateKeys(IEnumerable<string> functionNames)
+        {
+            var funcAppKeys = new Dictionary<string, string>
+            {
+                { MasterKey, GenerateKey() },
+                { HostFunctionKey, GenerateKey() },
+                { HostSystemKey, GenerateKey() }
+            };
+
+            if (functionNames?.Any() == true)
+            {
+                foreach (var funcName in functionNames)
+                {
+                    funcAppKeys[$"{FunctionKeyPrefix}{funcName}.{FunctionDefaultKeyName}"] = GenerateKey();
+                }
+            }
+
+            return funcAppKeys;
+        }
+
+        public static void AddAppKeysEnvironVariableNames(IDictionary<string, string> envVariables,
+            string funcAppKeysSecretsCollectionName,
+            string funcAppKeysConfigMapName,
+            bool mountFuncKeysAsContainerVolume)
+        {
+            if (envVariables == null)
+            {
+                envVariables = new Dictionary<string, string>();
+            }
+
+            if (!envVariables.ContainsKey(AzureWebJobsSecretStorageTypeEnvVariableName))
+            {
+                envVariables.Add(AzureWebJobsSecretStorageTypeEnvVariableName, "kubernetes");
+            }
+
+            if (!envVariables.ContainsKey(AzureWebJobsKubernetesSecretNameEnvVariableName) && !mountFuncKeysAsContainerVolume)
+            {
+                if (!string.IsNullOrWhiteSpace(funcAppKeysSecretsCollectionName))
+                {
+                    envVariables.Add(AzureWebJobsKubernetesSecretNameEnvVariableName, $"secrets/{funcAppKeysSecretsCollectionName}");
+                }
+                else if (!string.IsNullOrWhiteSpace(funcAppKeysConfigMapName))
+                {
+                    envVariables.Add(AzureWebJobsKubernetesSecretNameEnvVariableName, $"configmaps/{funcAppKeysConfigMapName}");
+                }
+            }
+        }
+
+        public static void CreateFuncAppKeysVolumeMountDeploymentResource(IEnumerable<DeploymentV1Apps> deployments,
+            string funcAppKeysSecretsCollectionName,
+            string funcAppKeysConfigMapName)
+        {
+            if (deployments?.Any() == false)
+            {
+                return;
+            }
+
+            var volume = new VolumeV1
+            {
+                Name = FuncAppKeysVolumeName
+            };
+
+            if (!string.IsNullOrWhiteSpace(funcAppKeysSecretsCollectionName))
+            {
+                volume.VolumeSecret = new VolumeSecretV1 { SecretName = funcAppKeysSecretsCollectionName };
+            }
+            else if (!string.IsNullOrWhiteSpace(funcAppKeysConfigMapName))
+            {
+                volume.VolumeConfigMap = new VolumeConfigMapV1 { Name = funcAppKeysSecretsCollectionName };
+            }
+
+            foreach (var deployment in deployments)
+            {
+                deployment.Spec.Template.Spec.Volumes = new VolumeV1[] { volume };
+                deployment.Spec.Template.Spec.Containers.First().VolumeMounts = new ContainerVolumeMountV1[]
+                {
+                        new ContainerVolumeMountV1
+                        {
+                            Name = FuncAppKeysVolumeName,
+                            MountPath = KubernetesSecretsMountPath
+                        }
+                };
+            }
+        }
+
+        private static string GenerateKey()
+        {
+            using (var rng = RandomNumberGenerator.Create())
+            {
+                byte[] data = new byte[40];
+                rng.GetBytes(data);
+                string secret = Convert.ToBase64String(data);
+
+                // Replace pluses as they are problematic as URL values
+                return secret.Replace('+', 'a');
+            }
+        }
+    }
+}

--- a/src/Azure.Functions.Cli/Kubernetes/FuncKeys/FuncAppKeysHelper.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/FuncKeys/FuncAppKeysHelper.cs
@@ -59,7 +59,8 @@ namespace Azure.Functions.Cli.Kubernetes.FuncKeys
                 envVariables.Add(AzureWebJobsSecretStorageTypeEnvVariableName, "kubernetes");
             }
 
-            if (!envVariables.ContainsKey(AzureWebJobsKubernetesSecretNameEnvVariableName) && !mountFuncKeysAsContainerVolume)
+            if (!envVariables.ContainsKey(AzureWebJobsKubernetesSecretNameEnvVariableName) 
+                && !mountFuncKeysAsContainerVolume)
             {
                 if (!string.IsNullOrWhiteSpace(funcAppKeysSecretsCollectionName))
                 {

--- a/src/Azure.Functions.Cli/Kubernetes/FuncKeys/FuncAppKeysHelper.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/FuncKeys/FuncAppKeysHelper.cs
@@ -54,12 +54,14 @@ namespace Azure.Functions.Cli.Kubernetes.FuncKeys
                 envVariables = new Dictionary<string, string>();
             }
 
-            if (!envVariables.ContainsKey(AzureWebJobsSecretStorageTypeEnvVariableName))
+            //if funcAppKeysSecretsCollectionName, funcAppKeysConfigMapName or mountFuncKeysAsContainerVolume has been assigned then that means the func app keys needs to be managed as kubernetes secret/configMap
+            if ((!string.IsNullOrWhiteSpace(funcAppKeysSecretsCollectionName) || !string.IsNullOrWhiteSpace(funcAppKeysConfigMapName) || mountFuncKeysAsContainerVolume)
+                && !envVariables.ContainsKey(AzureWebJobsSecretStorageTypeEnvVariableName))
             {
                 envVariables.Add(AzureWebJobsSecretStorageTypeEnvVariableName, "kubernetes");
             }
 
-            if (!envVariables.ContainsKey(AzureWebJobsKubernetesSecretNameEnvVariableName) 
+            if (!envVariables.ContainsKey(AzureWebJobsKubernetesSecretNameEnvVariableName)
                 && !mountFuncKeysAsContainerVolume)
             {
                 if (!string.IsNullOrWhiteSpace(funcAppKeysSecretsCollectionName))

--- a/src/Azure.Functions.Cli/Kubernetes/FuncKeys/FuncAppKeysHelper.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/FuncKeys/FuncAppKeysHelper.cs
@@ -81,12 +81,14 @@ namespace Azure.Functions.Cli.Kubernetes.FuncKeys
                 envVariables = new Dictionary<string, string>();
             }
 
-            if (!envVariables.ContainsKey(AzureWebJobsSecretStorageTypeEnvVariableName))
+            //if funcAppKeysSecretsCollectionName, funcAppKeysConfigMapName or mountFuncKeysAsContainerVolume has been assigned then that means the func app keys needs to be managed as kubernetes secret/configMap
+            if ((!string.IsNullOrWhiteSpace(funcAppKeysSecretsCollectionName) || !string.IsNullOrWhiteSpace(funcAppKeysConfigMapName) || mountFuncKeysAsContainerVolume)
+                && !envVariables.ContainsKey(AzureWebJobsSecretStorageTypeEnvVariableName))
             {
                 envVariables.Add(AzureWebJobsSecretStorageTypeEnvVariableName, "kubernetes");
             }
 
-            if (!envVariables.ContainsKey(AzureWebJobsKubernetesSecretNameEnvVariableName) 
+            if (!envVariables.ContainsKey(AzureWebJobsKubernetesSecretNameEnvVariableName)
                 && !mountFuncKeysAsContainerVolume)
             {
                 if (!string.IsNullOrWhiteSpace(funcAppKeysSecretsCollectionName))

--- a/src/Azure.Functions.Cli/Kubernetes/FuncKeys/FuncAppKeysHelper.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/FuncKeys/FuncAppKeysHelper.cs
@@ -94,22 +94,16 @@ namespace Azure.Functions.Cli.Kubernetes.FuncKeys
             }
         }
 
-        public static void FunKeysMessage(IDictionary<string, string> unchangedFuncKeys, IDictionary<string, string> newFuncKeys)
+        public static void FunKeysMessage(IDictionary<string, string> funcKeys)
         {
-            if (unchangedFuncKeys?.Any() == true || newFuncKeys?.Any() == true)
+            if (funcKeys?.Any() == true)
             {
                 ColoredConsole.WriteLine("Http Functions:");
             }
 
-            if (unchangedFuncKeys?.Any() == true)
+            if (funcKeys?.Any() == true)
             {
-                var existingFunctionKeys = unchangedFuncKeys.Where(item => item.Key.StartsWith("functions"));
-                PrintKeyOutputMessage(existingFunctionKeys, " # this didn't change");
-            }
-
-            if (newFuncKeys?.Any() == true)
-            {
-                var newFunctionKeys = newFuncKeys.Where(item => item.Key.StartsWith("functions"));
+                var newFunctionKeys = funcKeys.Where(item => item.Key.StartsWith("functions"));
                 PrintKeyOutputMessage(newFunctionKeys, " # this was added");
             }
         }
@@ -119,9 +113,8 @@ namespace Azure.Functions.Cli.Kubernetes.FuncKeys
             var keyOutputMsgTemplate = "http://[ip]/api/{0}?code={1}";
             foreach (var funcKey in functionKeys)
             {
-                var functionName = funcKey.Key.Split('.')[1];
-                var functionKey = Encoding.UTF8.GetString(Convert.FromBase64String(funcKey.Value));
-                ColoredConsole.WriteLine(string.Concat("\t", string.Format(keyOutputMsgTemplate, functionName, functionKey), keyMsg));
+                var functionName = funcKey.Key.Split('.')[1];          
+                ColoredConsole.WriteLine(string.Concat("\t", string.Format(keyOutputMsgTemplate, functionName, funcKey.Value), keyMsg));
             }
         }
 

--- a/src/Azure.Functions.Cli/Kubernetes/FuncKeys/FuncAppKeysHelper.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/FuncKeys/FuncAppKeysHelper.cs
@@ -94,30 +94,6 @@ namespace Azure.Functions.Cli.Kubernetes.FuncKeys
             }
         }
 
-        public static void FunKeysMessage(IDictionary<string, string> funcKeys)
-        {
-            if (funcKeys?.Any() == true)
-            {
-                ColoredConsole.WriteLine("Http Functions:");
-            }
-
-            if (funcKeys?.Any() == true)
-            {
-                var newFunctionKeys = funcKeys.Where(item => item.Key.StartsWith("functions"));
-                PrintKeyOutputMessage(newFunctionKeys, " # this was added");
-            }
-        }
-
-        private static void PrintKeyOutputMessage(IEnumerable<KeyValuePair<string, string>> functionKeys, string keyMsg)
-        {
-            var keyOutputMsgTemplate = "http://[ip]/api/{0}?code={1}";
-            foreach (var funcKey in functionKeys)
-            {
-                var functionName = funcKey.Key.Split('.')[1];          
-                ColoredConsole.WriteLine(string.Concat("\t", string.Format(keyOutputMsgTemplate, functionName, funcKey.Value), keyMsg));
-            }
-        }
-
         private static string GenerateKey()
         {
             using (var rng = RandomNumberGenerator.Create())

--- a/src/Azure.Functions.Cli/Kubernetes/FuncKeys/FuncAppKeysHelper.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/FuncKeys/FuncAppKeysHelper.cs
@@ -1,15 +1,9 @@
-﻿using Azure.Functions.Cli.Kubernetes.Models.Kubernetes;
-<<<<<<< HEAD
+﻿﻿using Azure.Functions.Cli.Kubernetes.Models.Kubernetes;
 using Colors.Net;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
-=======
-using System;
-using System.Collections.Generic;
-using System.Linq;
->>>>>>> Function keys in Kubernetes
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
@@ -45,14 +39,13 @@ namespace Azure.Functions.Cli.Kubernetes.FuncKeys
             {
                 foreach (var funcName in functionNames)
                 {
-                    funcAppKeys[$"{FunctionKeyPrefix}{funcName}.{FunctionDefaultKeyName}"] = GenerateKey();
+                    funcAppKeys[$"{FunctionKeyPrefix}{funcName.ToLower()}.{FunctionDefaultKeyName}"] = GenerateKey();
                 }
             }
 
             return funcAppKeys;
         }
 
-<<<<<<< HEAD
         public static IDictionary<string, string> FuncKeysKubernetesEnvironVariables(string keysSecretCollectionName, bool mountKeysAsContainerVolume)
         {
             var funcKeysKubernetesEnvironVariables = new Dictionary<string, string>
@@ -70,42 +63,6 @@ namespace Azure.Functions.Cli.Kubernetes.FuncKeys
         }
 
         public static void CreateFuncAppKeysVolumeMountDeploymentResource(IEnumerable<DeploymentV1Apps> deployments, string funcAppKeysSecretsCollectionName)
-=======
-        public static void AddAppKeysEnvironVariableNames(IDictionary<string, string> envVariables,
-            string funcAppKeysSecretsCollectionName,
-            string funcAppKeysConfigMapName,
-            bool mountFuncKeysAsContainerVolume)
-        {
-            if (envVariables == null)
-            {
-                envVariables = new Dictionary<string, string>();
-            }
-
-            //if funcAppKeysSecretsCollectionName, funcAppKeysConfigMapName or mountFuncKeysAsContainerVolume has been assigned then that means the func app keys needs to be managed as kubernetes secret/configMap
-            if ((!string.IsNullOrWhiteSpace(funcAppKeysSecretsCollectionName) || !string.IsNullOrWhiteSpace(funcAppKeysConfigMapName) || mountFuncKeysAsContainerVolume)
-                && !envVariables.ContainsKey(AzureWebJobsSecretStorageTypeEnvVariableName))
-            {
-                envVariables.Add(AzureWebJobsSecretStorageTypeEnvVariableName, "kubernetes");
-            }
-
-            if (!envVariables.ContainsKey(AzureWebJobsKubernetesSecretNameEnvVariableName)
-                && !mountFuncKeysAsContainerVolume)
-            {
-                if (!string.IsNullOrWhiteSpace(funcAppKeysSecretsCollectionName))
-                {
-                    envVariables.Add(AzureWebJobsKubernetesSecretNameEnvVariableName, $"secrets/{funcAppKeysSecretsCollectionName}");
-                }
-                else if (!string.IsNullOrWhiteSpace(funcAppKeysConfigMapName))
-                {
-                    envVariables.Add(AzureWebJobsKubernetesSecretNameEnvVariableName, $"configmaps/{funcAppKeysConfigMapName}");
-                }
-            }
-        }
-
-        public static void CreateFuncAppKeysVolumeMountDeploymentResource(IEnumerable<DeploymentV1Apps> deployments,
-            string funcAppKeysSecretsCollectionName,
-            string funcAppKeysConfigMapName)
->>>>>>> Function keys in Kubernetes
         {
             if (deployments?.Any() == false)
             {
@@ -121,16 +78,8 @@ namespace Azure.Functions.Cli.Kubernetes.FuncKeys
             {
                 volume.VolumeSecret = new VolumeSecretV1 { SecretName = funcAppKeysSecretsCollectionName };
             }
-<<<<<<< HEAD
 
             //Mount the app keys as volume mount to the container at the path "/run/secrets/functions-keys"
-=======
-            else if (!string.IsNullOrWhiteSpace(funcAppKeysConfigMapName))
-            {
-                volume.VolumeConfigMap = new VolumeConfigMapV1 { Name = funcAppKeysSecretsCollectionName };
-            }
-
->>>>>>> Function keys in Kubernetes
             foreach (var deployment in deployments)
             {
                 deployment.Spec.Template.Spec.Volumes = new VolumeV1[] { volume };
@@ -145,40 +94,6 @@ namespace Azure.Functions.Cli.Kubernetes.FuncKeys
             }
         }
 
-<<<<<<< HEAD
-        public static void FunKeysMessage(SecretsV1 existingKeysSecret, SecretsV1 newKeysSecret)
-        {
-            if (existingKeysSecret?.Data?.Any() == true || newKeysSecret?.Data?.Any() == true)
-            {
-                ColoredConsole.WriteLine("Http Functions:");
-            }
-
-            if (existingKeysSecret?.Data?.Any() == true)
-            {
-                var existingFunctionKeys = existingKeysSecret.Data.Where(item => item.Key.StartsWith("functions"));
-                PrintKeyOutputMessage(existingFunctionKeys, " # this didn't change");
-            }
-
-            if (newKeysSecret?.Data?.Any() == true)
-            {
-                var newFunctionKeys = newKeysSecret.Data.Where(item => item.Key.StartsWith("functions"));
-                PrintKeyOutputMessage(newFunctionKeys, " # this was added");
-            }
-        }
-
-        private static void PrintKeyOutputMessage(IEnumerable<KeyValuePair<string, string>> functionKeys, string keyMsg)
-        {
-            var keyOutputMsgTemplate = "http://[ip]/api/{0}?code={1}";
-            foreach (var funcKey in functionKeys)
-            {
-                var functionName = funcKey.Key.Split('.')[1];
-                var functionKey = Encoding.UTF8.GetString(Convert.FromBase64String(funcKey.Value));
-                ColoredConsole.WriteLine(string.Concat("\t", string.Format(keyOutputMsgTemplate, functionName, functionKey), keyMsg));
-            }
-        }
-
-=======
->>>>>>> Function keys in Kubernetes
         private static string GenerateKey()
         {
             using (var rng = RandomNumberGenerator.Create())

--- a/src/Azure.Functions.Cli/Kubernetes/FuncKeys/FuncAppKeysHelper.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/FuncKeys/FuncAppKeysHelper.cs
@@ -1,9 +1,15 @@
 ﻿using Azure.Functions.Cli.Kubernetes.Models.Kubernetes;
+<<<<<<< HEAD
 using Colors.Net;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
+=======
+using System;
+using System.Collections.Generic;
+using System.Linq;
+>>>>>>> Function keys in Kubernetes
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
@@ -46,6 +52,7 @@ namespace Azure.Functions.Cli.Kubernetes.FuncKeys
             return funcAppKeys;
         }
 
+<<<<<<< HEAD
         public static IDictionary<string, string> FuncKeysKubernetesEnvironVariables(string keysSecretCollectionName, bool mountKeysAsContainerVolume)
         {
             var funcKeysKubernetesEnvironVariables = new Dictionary<string, string>
@@ -63,6 +70,39 @@ namespace Azure.Functions.Cli.Kubernetes.FuncKeys
         }
 
         public static void CreateFuncAppKeysVolumeMountDeploymentResource(IEnumerable<DeploymentV1Apps> deployments, string funcAppKeysSecretsCollectionName)
+=======
+        public static void AddAppKeysEnvironVariableNames(IDictionary<string, string> envVariables,
+            string funcAppKeysSecretsCollectionName,
+            string funcAppKeysConfigMapName,
+            bool mountFuncKeysAsContainerVolume)
+        {
+            if (envVariables == null)
+            {
+                envVariables = new Dictionary<string, string>();
+            }
+
+            if (!envVariables.ContainsKey(AzureWebJobsSecretStorageTypeEnvVariableName))
+            {
+                envVariables.Add(AzureWebJobsSecretStorageTypeEnvVariableName, "kubernetes");
+            }
+
+            if (!envVariables.ContainsKey(AzureWebJobsKubernetesSecretNameEnvVariableName) && !mountFuncKeysAsContainerVolume)
+            {
+                if (!string.IsNullOrWhiteSpace(funcAppKeysSecretsCollectionName))
+                {
+                    envVariables.Add(AzureWebJobsKubernetesSecretNameEnvVariableName, $"secrets/{funcAppKeysSecretsCollectionName}");
+                }
+                else if (!string.IsNullOrWhiteSpace(funcAppKeysConfigMapName))
+                {
+                    envVariables.Add(AzureWebJobsKubernetesSecretNameEnvVariableName, $"configmaps/{funcAppKeysConfigMapName}");
+                }
+            }
+        }
+
+        public static void CreateFuncAppKeysVolumeMountDeploymentResource(IEnumerable<DeploymentV1Apps> deployments,
+            string funcAppKeysSecretsCollectionName,
+            string funcAppKeysConfigMapName)
+>>>>>>> Function keys in Kubernetes
         {
             if (deployments?.Any() == false)
             {
@@ -78,8 +118,16 @@ namespace Azure.Functions.Cli.Kubernetes.FuncKeys
             {
                 volume.VolumeSecret = new VolumeSecretV1 { SecretName = funcAppKeysSecretsCollectionName };
             }
+<<<<<<< HEAD
 
             //Mount the app keys as volume mount to the container at the path "/run/secrets/functions-keys"
+=======
+            else if (!string.IsNullOrWhiteSpace(funcAppKeysConfigMapName))
+            {
+                volume.VolumeConfigMap = new VolumeConfigMapV1 { Name = funcAppKeysSecretsCollectionName };
+            }
+
+>>>>>>> Function keys in Kubernetes
             foreach (var deployment in deployments)
             {
                 deployment.Spec.Template.Spec.Volumes = new VolumeV1[] { volume };
@@ -94,6 +142,7 @@ namespace Azure.Functions.Cli.Kubernetes.FuncKeys
             }
         }
 
+<<<<<<< HEAD
         public static void FunKeysMessage(SecretsV1 existingKeysSecret, SecretsV1 newKeysSecret)
         {
             if (existingKeysSecret?.Data?.Any() == true || newKeysSecret?.Data?.Any() == true)
@@ -125,6 +174,8 @@ namespace Azure.Functions.Cli.Kubernetes.FuncKeys
             }
         }
 
+=======
+>>>>>>> Function keys in Kubernetes
         private static string GenerateKey()
         {
             using (var rng = RandomNumberGenerator.Create())

--- a/src/Azure.Functions.Cli/Kubernetes/FuncKeys/FuncAppKeysHelper.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/FuncKeys/FuncAppKeysHelper.cs
@@ -94,22 +94,22 @@ namespace Azure.Functions.Cli.Kubernetes.FuncKeys
             }
         }
 
-        public static void FunKeysMessage(SecretsV1 existingKeysSecret, SecretsV1 newKeysSecret)
+        public static void FunKeysMessage(IDictionary<string, string> unchangedFuncKeys, IDictionary<string, string> newFuncKeys)
         {
-            if (existingKeysSecret?.Data?.Any() == true || newKeysSecret?.Data?.Any() == true)
+            if (unchangedFuncKeys?.Any() == true || newFuncKeys?.Any() == true)
             {
                 ColoredConsole.WriteLine("Http Functions:");
             }
 
-            if (existingKeysSecret?.Data?.Any() == true)
+            if (unchangedFuncKeys?.Any() == true)
             {
-                var existingFunctionKeys = existingKeysSecret.Data.Where(item => item.Key.StartsWith("functions"));
+                var existingFunctionKeys = unchangedFuncKeys.Where(item => item.Key.StartsWith("functions"));
                 PrintKeyOutputMessage(existingFunctionKeys, " # this didn't change");
             }
 
-            if (newKeysSecret?.Data?.Any() == true)
+            if (newFuncKeys?.Any() == true)
             {
-                var newFunctionKeys = newKeysSecret.Data.Where(item => item.Key.StartsWith("functions"));
+                var newFunctionKeys = newFuncKeys.Where(item => item.Key.StartsWith("functions"));
                 PrintKeyOutputMessage(newFunctionKeys, " # this was added");
             }
         }

--- a/src/Azure.Functions.Cli/Kubernetes/FuncKeys/FuncAppKeysHelper.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/FuncKeys/FuncAppKeysHelper.cs
@@ -86,7 +86,8 @@ namespace Azure.Functions.Cli.Kubernetes.FuncKeys
                 envVariables.Add(AzureWebJobsSecretStorageTypeEnvVariableName, "kubernetes");
             }
 
-            if (!envVariables.ContainsKey(AzureWebJobsKubernetesSecretNameEnvVariableName) && !mountFuncKeysAsContainerVolume)
+            if (!envVariables.ContainsKey(AzureWebJobsKubernetesSecretNameEnvVariableName) 
+                && !mountFuncKeysAsContainerVolume)
             {
                 if (!string.IsNullOrWhiteSpace(funcAppKeysSecretsCollectionName))
                 {

--- a/src/Azure.Functions.Cli/Kubernetes/FuncKeys/KeyBasedDictionaryComparer.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/FuncKeys/KeyBasedDictionaryComparer.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+
+namespace Azure.Functions.Cli.Kubernetes.FuncKeys
+{
+    public class KeyBasedDictionaryComparer : IEqualityComparer<KeyValuePair<string, string>>
+    {
+        public bool Equals(KeyValuePair<string, string> x, KeyValuePair<string, string> y)
+        {
+            //If the compared objects reference the same data.
+            if (ReferenceEquals(x, y))
+            {
+                return true;
+            }
+
+            //If any of the compared objects is null.
+            if (ReferenceEquals(x, null) || ReferenceEquals(y, null))
+            {
+                return false;
+            }
+
+            return x.Key == y.Key;
+        }
+
+        public int GetHashCode(KeyValuePair<string, string> keyValPair)
+        {
+            //If the keyValPair is null
+            if (ReferenceEquals(keyValPair, null)) return 0;
+
+            //Get hash code for the Key field.
+            int hashKey = keyValPair.Key == null ? 0 : keyValPair.Key.GetHashCode();
+
+            return hashKey;
+        }
+    }
+}

--- a/src/Azure.Functions.Cli/Kubernetes/KubernetesHelpers.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/KubernetesHelpers.cs
@@ -146,7 +146,6 @@ namespace Azure.Functions.Cli.Kubernetes
         }
 
         internal async static Task<(IEnumerable<IKubernetesResource>, SecretsV1, SecretsV1)> GetFunctionsDeploymentResources(
-
             string name,
             string imageName,
             string @namespace,
@@ -281,7 +280,7 @@ namespace Azure.Functions.Cli.Kubernetes
                     };
                 }
             }
-			
+
             SecretsV1 existingFuncKeysSecret = null;
             SecretsV1 newKeysSecret = null;
             if (httpFunctions.Any())
@@ -307,7 +306,7 @@ namespace Azure.Functions.Cli.Kubernetes
                     newKeysSecret = GetSecret(keysSecretCollectionName, @namespace, funcKeys);
                     keysSecret = newKeysSecret;
                 }
-				
+
                 result.Insert(resourceIndex, keysSecret);
                 resourceIndex++;
 

--- a/src/Azure.Functions.Cli/Kubernetes/KubernetesHelpers.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/KubernetesHelpers.cs
@@ -306,12 +306,7 @@ namespace Azure.Functions.Cli.Kubernetes
                 if (newFuncKeys?.Any() == true)
                 {
                     kubernetesKeysSecretResource = GetSecret(keysSecretCollectionName, @namespace, newFuncKeys);
-                    newFuncKeys = new Dictionary<string, string>();
-                    foreach (var item in kubernetesKeysSecretResource.Data)
-                    {
-                        newFuncKeys.Add(item);
-                    }
-
+                    newFuncKeys = new Dictionary<string, string>(kubernetesKeysSecretResource.Data);
                     if (unchangedFuncKeys?.Any() == true)
                     {
                         foreach (var item in unchangedFuncKeys)

--- a/src/Azure.Functions.Cli/Kubernetes/KubernetesHelpers.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/KubernetesHelpers.cs
@@ -122,10 +122,16 @@ namespace Azure.Functions.Cli.Kubernetes
             return exitCode == 0;
         }
 
-        internal static async Task<bool> ResourceExists(string resourceTypeName, string resourceName, string @namespace)
+        internal static async Task<(string, bool)> ResourceExists(string resourceTypeName, string resourceName, string @namespace, bool returnJsonOutput = false)
         {
-            (_, _, var exitCode) = await KubectlHelper.RunKubectl($"get {resourceTypeName} {resourceName} --namespace {@namespace}", ignoreError: true, showOutput: false);
-            return exitCode == 0;
+            string cmd = $"get {resourceTypeName} {resourceName} --namespace {@namespace}";
+            if (returnJsonOutput)
+            {
+                cmd = string.Concat(cmd, " -o json");
+            }
+
+            (string output, _, var exitCode) = await KubectlHelper.RunKubectl(cmd, ignoreError: true, showOutput: false);
+            return (output, exitCode == 0);
         }
 
         internal static Task CreateNamespace(string @namespace)
@@ -139,7 +145,7 @@ namespace Azure.Functions.Cli.Kubernetes
                 .Replace("KEDA_NAMESPACE", @namespace);
         }
 
-        internal async static Task<IEnumerable<IKubernetesResource>> GetFunctionsDeploymentResources(
+        internal async static Task<(IEnumerable<IKubernetesResource>, SecretsV1, SecretsV1)> GetFunctionsDeploymentResources(
             string name,
             string imageName,
             string @namespace,
@@ -154,7 +160,7 @@ namespace Azure.Functions.Cli.Kubernetes
             string serviceType = "LoadBalancer",
             int? minReplicas = null,
             int? maxReplicas = null,
-            string keysSecretCollectionName = null,
+            string keysSecretCollectionName = "func-keys-secret",
             bool mountKeysAsContainerVolume = false)
         {
             ScaledObjectV1Alpha1 scaledobject = null;
@@ -167,8 +173,13 @@ namespace Azure.Functions.Cli.Kubernetes
             {
                 int position = 0;
                 var enabledFunctions = httpFunctions.ToDictionary(k => $"AzureFunctionsJobHost__functions__{position++}", v => v.Key);
-                //Add environment variables for the func app keys
-                FuncAppKeysHelper.AddAppKeysEnvironVariableNames(enabledFunctions, keysSecretCollectionName, mountKeysAsContainerVolume);
+                //Environment variables for the func app keys
+                var funcKeyEnvironmentVariables = FuncAppKeysHelper.FuncKeysKubernetesEnvironVariables(keysSecretCollectionName, mountKeysAsContainerVolume);
+                foreach (var environmentVar in funcKeyEnvironmentVariables)
+                {
+                    enabledFunctions.TryAdd(environmentVar.Key, environmentVar.Value);
+                }
+
                 var deployment = GetDeployment(name + "-http", @namespace, imageName, pullSecret, 1, enabledFunctions, new Dictionary<string, string>
                 {
                     { "osiris.deislabs.io/enabled", "true" },
@@ -270,19 +281,34 @@ namespace Azure.Functions.Cli.Kubernetes
                 }
             }
 
+            SecretsV1 existingFuncKeysSecret = null;
+            SecretsV1 newKeysSecret = null;
             if (httpFunctions.Any())
             {
-                var funcKeys = FuncAppKeysHelper.CreateKeys(triggers.FunctionsJson.Select(f => f.Key));
-                if (!string.IsNullOrWhiteSpace(keysSecretCollectionName))
+                var funcKeys = FuncAppKeysHelper.CreateKeys(httpFunctions.Select(f => f.Key));
+                SecretsV1 keysSecret = null;
+                (string output, bool keysSecretExist) = await ResourceExists("secret", keysSecretCollectionName, @namespace, true);
+                if (keysSecretExist)
                 {
-                    var appKeysSecret = GetSecret(keysSecretCollectionName, @namespace, funcKeys);
-
-                    if (!await ResourceExists("secret", keysSecretCollectionName, @namespace))
+                    existingFuncKeysSecret = TryParse<SecretsV1>(output);
+                    if (existingFuncKeysSecret?.Data?.Any() == true)
                     {
-                        result.Insert(resourceIndex, appKeysSecret);
-                        resourceIndex++;
+                        funcKeys = funcKeys.Where(item => !existingFuncKeysSecret.Data.ContainsKey(item.Key)).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+                        if (!funcKeys.Any())
+                        {
+                            keysSecret = existingFuncKeysSecret;
+                        }
                     }
                 }
+
+                if (funcKeys.Any())
+                {
+                    newKeysSecret = GetSecret(keysSecretCollectionName, @namespace, funcKeys);
+                    keysSecret = newKeysSecret;
+                }
+
+                result.Insert(resourceIndex, keysSecret);
+                resourceIndex++;
 
                 //if function keys Secrets needs to be mounted as volume in the function runtime container
                 if (mountKeysAsContainerVolume)
@@ -299,11 +325,8 @@ namespace Azure.Functions.Cli.Kubernetes
 
                     var funcKeysManagerRoleName = "functions-keys-manager-role";
                     var secretManagerRole = GetSecretManagerRole(funcKeysManagerRoleName, @namespace);
-                    if (!await ResourceExists("Role", funcKeysManagerRoleName, @namespace))
-                    {
-                        result.Insert(resourceIndex, secretManagerRole);
-                        resourceIndex++;
-                    }
+                    result.Insert(resourceIndex, secretManagerRole);
+                    resourceIndex++;
 
                     var roleBindingName = $"{svcActName}-functions-keys-manager-rolebinding";
                     var funcKeysRoleBindingDeploymentResource = GetRoleBinding(roleBindingName, @namespace, funcKeysManagerRoleName, svcActName);
@@ -319,10 +342,7 @@ namespace Azure.Functions.Cli.Kubernetes
             }
 
             result = result.Concat(deployments).ToList();
-
-            return scaledobject != null
-                ? result.Append(scaledobject)
-                : result;
+            return (scaledobject != null ? result.Append(scaledobject) : result, existingFuncKeysSecret, newKeysSecret);
         }
 
         internal static async Task RemoveKeda(string @namespace)
@@ -655,12 +675,23 @@ namespace Azure.Functions.Cli.Kubernetes
                 {
                     new RoleSubjectV1
                     {
-                        ApiGroup = "rbac.authorization.k8s.io",
                         Kind = "ServiceAccount",
                         Name = subjectName
                     }
                 }
             };
+        }
+
+        private static T TryParse<T>(string jsonData)
+        {
+            try
+            {
+                return JsonConvert.DeserializeObject<T>(jsonData);
+            }
+            catch
+            {
+                return default;
+            }
         }
     }
 }

--- a/src/Azure.Functions.Cli/Kubernetes/KubernetesHelpers.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/KubernetesHelpers.cs
@@ -184,8 +184,8 @@ namespace Azure.Functions.Cli.Kubernetes
                 var enabledFunctions = httpFunctions.ToDictionary(k => $"AzureFunctionsJobHost__functions__{position++}", v => v.Key);
                 //Environment variables for the func app keys kubernetes secret
                 var kubernetesSecretEnvironmentVariable = FuncAppKeysHelper.FuncKeysKubernetesEnvironVariables(keysSecretCollectionName, mountKeysAsContainerVolume);
-                enabledFunctions = enabledFunctions.Concat(kubernetesSecretEnvironmentVariable).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
-                var deployment = GetDeployment(name + "-http", @namespace, imageName, pullSecret, 1, enabledFunctions, new Dictionary<string, string>
+                var additionalEnvVars = enabledFunctions.Concat(kubernetesSecretEnvironmentVariable).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+                var deployment = GetDeployment(name + "-http", @namespace, imageName, pullSecret, 1, additionalEnvVars, new Dictionary<string, string>
                 {
                     { "osiris.deislabs.io/enabled", "true" },
                     { "osiris.deislabs.io/minReplicas", "1" }

--- a/src/Azure.Functions.Cli/Kubernetes/KubernetesHelpers.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/KubernetesHelpers.cs
@@ -308,7 +308,7 @@ namespace Azure.Functions.Cli.Kubernetes
                     newKeysSecret = GetSecret(keysSecretCollectionName, @namespace, funcKeys);
                     keysSecret = newKeysSecret;
                 }
-
+				
                 result.Insert(resourceIndex, keysSecret);
                 resourceIndex++;
 

--- a/src/Azure.Functions.Cli/Kubernetes/KubernetesHelpers.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/KubernetesHelpers.cs
@@ -176,14 +176,15 @@ namespace Azure.Functions.Cli.Kubernetes
                 .Where(b => b.Value["bindings"]?.Any(e => e?["type"].ToString().IndexOf("httpTrigger", StringComparison.OrdinalIgnoreCase) != -1) == true);
             var nonHttpFunctions = triggers.FunctionsJson.Where(f => httpFunctions.All(h => h.Key != f.Key));
             keysSecretCollectionName = string.IsNullOrEmpty(keysSecretCollectionName)
-                ? string.Concat($"func-keys-kube-secret-{name}")
+                ? $"func-keys-kube-secret-{name}"
                 : keysSecretCollectionName;
             if (httpFunctions.Any())
             {
                 int position = 0;
                 var enabledFunctions = httpFunctions.ToDictionary(k => $"AzureFunctionsJobHost__functions__{position++}", v => v.Key);
-                //Environment variables for the func app keys kubernetes secret              
-                enabledFunctions = enabledFunctions.Concat(FuncAppKeysHelper.FuncKeysKubernetesEnvironVariables(keysSecretCollectionName, mountKeysAsContainerVolume)).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+                //Environment variables for the func app keys kubernetes secret
+                var kubernetesSecretEnvironmentVariable = FuncAppKeysHelper.FuncKeysKubernetesEnvironVariables(keysSecretCollectionName, mountKeysAsContainerVolume);
+                enabledFunctions = enabledFunctions.Concat(kubernetesSecretEnvironmentVariable).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
                 var deployment = GetDeployment(name + "-http", @namespace, imageName, pullSecret, 1, enabledFunctions, new Dictionary<string, string>
                 {
                     { "osiris.deislabs.io/enabled", "true" },

--- a/src/Azure.Functions.Cli/Kubernetes/KubernetesHelpers.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/KubernetesHelpers.cs
@@ -664,7 +664,7 @@ namespace Azure.Functions.Cli.Kubernetes
                     new RuleV1
                     {
                         ApiGroups = new string[]{""},
-                        Resources = new string[]{"secrets"},
+                        Resources = new string[]{"secrets", "configMaps"},
                         Verbs = new string[]{ "get", "list", "watch", "create", "update", "patch", "delete" }
                     }
                 }

--- a/src/Azure.Functions.Cli/Kubernetes/KubernetesHelpers.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/KubernetesHelpers.cs
@@ -197,11 +197,13 @@ namespace Azure.Functions.Cli.Kubernetes
             {
                 appSettingsSecrets[Constants.FunctionsWorkerRuntime] = GlobalCoreToolsSettings.CurrentWorkerRuntime.ToString();
             }
-          
+
+            int resourceIndex = 0;
             if (useConfigMapForAppSettings)
             {
                 var configMap = GetConfigMap(name, @namespace, appSettingsSecrets);
-                result.Insert(0, configMap);
+                result.Insert(resourceIndex, configMap);
+                resourceIndex++;
                 foreach (var deployment in deployments)
                 {
                     deployment.Spec.Template.Spec.Containers.First().EnvFrom = new ContainerEnvironmentFromV1[]
@@ -251,7 +253,8 @@ namespace Azure.Functions.Cli.Kubernetes
             else
             {
                 var secret = GetSecret(name, @namespace, appSettingsSecrets);
-                result.Insert(0, secret);
+                result.Insert(resourceIndex, secret);
+                resourceIndex++;
                 foreach (var deployment in deployments)
                 {
                     deployment.Spec.Template.Spec.Containers.First().EnvFrom = new ContainerEnvironmentFromV1[]
@@ -267,15 +270,14 @@ namespace Azure.Functions.Cli.Kubernetes
                 }
             }
 
-            int resourceIndex = 0;
             if (!string.IsNullOrWhiteSpace(funcAppKeysSecretsCollectionName))
             {
                 var appKeysSecret = GetSecret(funcAppKeysSecretsCollectionName, @namespace, funcAppKeys);
-              
+
                 if (!await ResourceExists("secret", funcAppKeysSecretsCollectionName, @namespace))
                 {
-                    resourceIndex++;
                     result.Insert(resourceIndex, appKeysSecret);
+                    resourceIndex++;
                 }
 
                 foreach (var deployment in deployments)
@@ -294,10 +296,10 @@ namespace Azure.Functions.Cli.Kubernetes
             {
                 var appKeysConfigMap = GetConfigMap(funcAppKeysConfigMapName, @namespace, funcAppKeys);
 
-                resourceIndex++;
                 if (!await ResourceExists("configMap", funcAppKeysConfigMapName, @namespace))
                 {
                     result.Insert(resourceIndex, appKeysConfigMap);
+                    resourceIndex++;
                 }
 
                 foreach (var deployment in deployments)
@@ -324,24 +326,24 @@ namespace Azure.Functions.Cli.Kubernetes
                 var svcAct = GetServiceAccount(svcActName, @namespace);
                 if (!await ResourceExists("ServiceAccount", svcActName, @namespace))
                 {
-                    resourceIndex++;
                     result.Insert(resourceIndex, svcAct);
+                    resourceIndex++;
                 }
 
                 var secretManagerRoleName = "secrets-manager-role";
                 var secretManagerRole = GetRole(secretManagerRoleName, @namespace);
                 if (!await ResourceExists("Role", secretManagerRoleName, @namespace))
                 {
-                    resourceIndex++;
                     result.Insert(resourceIndex, svcAct);
+                    resourceIndex++;
                 }
 
                 var roleBindingName = "function-identity-svcact-to-secret-manager-rolebinding";
                 var secretRoleBinding = GetRoleBinding(roleBindingName, @namespace, secretManagerRoleName, svcActName);
                 if (!await ResourceExists("RoleBinding", secretManagerRoleName, @namespace))
                 {
-                    resourceIndex++;
                     result.Insert(resourceIndex, svcAct);
+                    resourceIndex++;
                 }
 
                 foreach (var deployment in deployments)

--- a/src/Azure.Functions.Cli/Kubernetes/Models/Kubernetes/ContainerV1.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/Models/Kubernetes/ContainerV1.cs
@@ -26,6 +26,18 @@ namespace Azure.Functions.Cli.Kubernetes.Models.Kubernetes
 
         [JsonProperty("imagePullPolicy")]
         public string ImagePullPolicy { get; internal set; }
+
+        [JsonProperty("volumeMounts")]
+        public IEnumerable<ContainerVolumeMountV1> VolumeMounts { get; internal set; }
+    }
+
+    public class ContainerVolumeMountV1
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("mountPath")]
+        public string MountPath { get; set; }
     }
 
     public class ContainerResourceRequestsV1
@@ -93,5 +105,17 @@ namespace Azure.Functions.Cli.Kubernetes.Models.Kubernetes
     {
         [JsonProperty("name")]
         public string Name { get; set; }
+    }
+
+    public class VolumeMountV1
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("mountPath")]
+        public string MountPath { get; set; }
+
+        [JsonProperty("readOnly")]
+        public bool ReadOnly { get; set; }
     }
 }

--- a/src/Azure.Functions.Cli/Kubernetes/Models/Kubernetes/PodV1.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/Models/Kubernetes/PodV1.cs
@@ -25,6 +25,32 @@ namespace Azure.Functions.Cli.Kubernetes.Models.Kubernetes
 
         [JsonProperty("serviceAccountName")]
         public string ServiceAccountName { get; internal set; }
+
+        [JsonProperty("volumes")]
+        public IEnumerable<VolumeV1> Volumes { get; set; }
+    }
+    public class VolumeV1
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("configMap")]
+        public VolumeConfigMapV1 VolumeConfigMap { get; set; }
+
+        [JsonProperty("secret")]
+        public VolumeSecretV1 VolumeSecret { get; set; }
+    }
+
+    public class VolumeConfigMapV1
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+
+    public class VolumeSecretV1
+    {
+        [JsonProperty("secretName")]
+        public string SecretName { get; set; }
     }
 
     public class PodTolerationV1

--- a/src/Azure.Functions.Cli/Kubernetes/Models/Kubernetes/RoleBindingV1.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/Models/Kubernetes/RoleBindingV1.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.Functions.Cli.Kubernetes.Models.Kubernetes
+{
+    public class RoleBindingV1 : BaseKubernetesResource<IKubernetesSpec>
+    {
+        [JsonProperty("roleRef")]
+        public RoleSubjectV1 RoleRef { get; set; }
+
+        [JsonProperty("subjects")]
+        public IEnumerable<RoleSubjectV1> Subjects { get; set; }
+    }
+
+    public class RoleSubjectV1
+    {
+        [JsonProperty("apiGroup")]
+        public string ApiGroup { get; set; }
+
+        [JsonProperty("kind")]
+        public string Kind { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+}

--- a/src/Azure.Functions.Cli/Kubernetes/Models/Kubernetes/RoleV1.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/Models/Kubernetes/RoleV1.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.Functions.Cli.Kubernetes.Models.Kubernetes
+{
+    public class RoleV1 : BaseKubernetesResource<IKubernetesSpec>
+    {
+        [JsonProperty("rules")]
+        public IEnumerable<RuleV1> Rules { get; set; }
+    }
+
+    public class RuleV1
+    {
+        [JsonProperty("apiGroups")]
+        public IEnumerable<string> ApiGroups { get; set; }
+
+        [JsonProperty("resources")]
+        public IEnumerable<string> Resources { get; set; }
+
+        [JsonProperty("resourceNames")]
+        public IEnumerable<string> ResourceNames { get; set; }
+
+        [JsonProperty("verbs")]
+        public IEnumerable<string> Verbs { get; set; }
+    }
+}

--- a/src/Azure.Functions.Cli/Kubernetes/Models/Kubernetes/ServiceAccountV1.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/Models/Kubernetes/ServiceAccountV1.cs
@@ -2,6 +2,5 @@ namespace Azure.Functions.Cli.Kubernetes.Models.Kubernetes
 {
     public class ServiceAccountV1 : BaseKubernetesResource<IKubernetesSpec>
     {
-        
     }
 }

--- a/src/Azure.Functions.Cli/Kubernetes/Models/Kubernetes/ServiceV1.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/Models/Kubernetes/ServiceV1.cs
@@ -4,7 +4,10 @@ using Newtonsoft.Json;
 namespace Azure.Functions.Cli.Kubernetes.Models.Kubernetes
 {
     public class ServiceV1 : BaseKubernetesResource<ServiceSpecV1>
-    { }
+    {
+        [JsonProperty("status")]
+        public ServiceStatus Status { get; set; }
+    }
 
     public class ServiceSpecV1 : IKubernetesSpec
     {
@@ -31,5 +34,23 @@ namespace Azure.Functions.Cli.Kubernetes.Models.Kubernetes
 
         [JsonProperty("targetPort")]
         public int TargetPort { get; set; }
+    }
+
+    public class ServiceStatus
+    {
+        [JsonProperty("loadBalancer")]
+        public ServiceLoadBalancer LoadBalancer { get; set; }
+    }
+
+    public class ServiceLoadBalancer
+    {
+        [JsonProperty("ingress")]
+        public IEnumerable<ServiceIp> Ingress { get; set; }
+    }
+
+    public class ServiceIp
+    {
+        [JsonProperty("ip")]
+        public string Ip { get; set; }
     }
 }

--- a/test/Azure.Functions.Cli.Tests/KubernetesHelperUnitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/KubernetesHelperUnitTests.cs
@@ -1,7 +1,9 @@
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Kubernetes;
 using FluentAssertions;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using NuGet.ContentModel;
 using System;
 using System.Collections.Generic;
 using Xunit;
@@ -56,6 +58,53 @@ namespace Azure.Functions.Cli.Tests
             Assert.Equal("RabbitMQConnection", metadata["host"]);
             Assert.Equal("message", metadata["name"]);
             Assert.Equal("myQueue", metadata["queueName"]);
+        }
+
+        [Fact]
+        public void GetServiceAccountTest()
+        {
+            var svcActName = "function-identity-svc-act";
+            var @namespace = "funcappkeys-test-ns0";
+            var resource = KubernetesHelper.GetServiceAccount(svcActName, @namespace);
+            var payload = JsonConvert.SerializeObject(resource, Formatting.Indented,
+               new JsonSerializerSettings
+               {
+                   NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore
+               });
+
+            Assert.True(JToken.Parse(payload) is JToken);
+        }
+
+        [Fact]
+        public void GetRoleTest()
+        {
+            var roleName = "secrets-manager-role";
+            var @namespace = "funcappkeys-test-ns0";
+            var resource = KubernetesHelper.GetRole(roleName, @namespace);
+            var payload = JsonConvert.SerializeObject(resource, Formatting.Indented,
+               new JsonSerializerSettings
+               {
+                   NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore
+               });
+
+            Assert.True(JToken.Parse(payload) is JToken);
+        }
+
+        [Fact]
+        public void GetRoleBindingTest()
+        {
+            var roleBindingName = "function-identity-svcact-to-secret-manager-rolebinding";
+            var roleName = "secrets-manager-role";
+            var svcActName = "function-identity-svc-act";
+            var @namespace = "funcappkeys-test-ns0";
+            var resource = KubernetesHelper.GetRoleBinding(roleBindingName, @namespace, roleName, svcActName);
+            var payload = JsonConvert.SerializeObject(resource, Formatting.Indented,
+               new JsonSerializerSettings
+               {
+                   NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore
+               });
+
+            Assert.True(JToken.Parse(payload) is JToken);
         }
     }
 }

--- a/test/Azure.Functions.Cli.Tests/KubernetesHelperUnitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/KubernetesHelperUnitTests.cs
@@ -80,7 +80,7 @@ namespace Azure.Functions.Cli.Tests
         {
             var roleName = "secrets-manager-role";
             var @namespace = "funcappkeys-test-ns0";
-            var resource = KubernetesHelper.GetRole(roleName, @namespace);
+            var resource = KubernetesHelper.GetSecretManagerRole(roleName, @namespace);
             var payload = JsonConvert.SerializeObject(resource, Formatting.Indented,
                new JsonSerializerSettings
                {

--- a/test/Azure.Functions.Cli.Tests/KubernetesHelperUnitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/KubernetesHelperUnitTests.cs
@@ -1,10 +1,5 @@
-using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Kubernetes;
-using FluentAssertions;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using NuGet.ContentModel;
-using System;
 using System.Collections.Generic;
 using Xunit;
 
@@ -58,53 +53,6 @@ namespace Azure.Functions.Cli.Tests
             Assert.Equal("RabbitMQConnection", metadata["host"]);
             Assert.Equal("message", metadata["name"]);
             Assert.Equal("myQueue", metadata["queueName"]);
-        }
-
-        [Fact]
-        public void GetServiceAccountTest()
-        {
-            var svcActName = "function-identity-svc-act";
-            var @namespace = "funcappkeys-test-ns0";
-            var resource = KubernetesHelper.GetServiceAccount(svcActName, @namespace);
-            var payload = JsonConvert.SerializeObject(resource, Formatting.Indented,
-               new JsonSerializerSettings
-               {
-                   NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore
-               });
-
-            Assert.True(JToken.Parse(payload) is JToken);
-        }
-
-        [Fact]
-        public void GetRoleTest()
-        {
-            var roleName = "secrets-manager-role";
-            var @namespace = "funcappkeys-test-ns0";
-            var resource = KubernetesHelper.GetSecretManagerRole(roleName, @namespace);
-            var payload = JsonConvert.SerializeObject(resource, Formatting.Indented,
-               new JsonSerializerSettings
-               {
-                   NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore
-               });
-
-            Assert.True(JToken.Parse(payload) is JToken);
-        }
-
-        [Fact]
-        public void GetRoleBindingTest()
-        {
-            var roleBindingName = "function-identity-svcact-to-secret-manager-rolebinding";
-            var roleName = "secrets-manager-role";
-            var svcActName = "function-identity-svc-act";
-            var @namespace = "funcappkeys-test-ns0";
-            var resource = KubernetesHelper.GetRoleBinding(roleBindingName, @namespace, roleName, svcActName);
-            var payload = JsonConvert.SerializeObject(resource, Formatting.Indented,
-               new JsonSerializerSettings
-               {
-                   NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore
-               });
-
-            Assert.True(JToken.Parse(payload) is JToken);
         }
     }
 }


### PR DESCRIPTION
The changes include creation of below three flags in core tools to manages function keys in Kubernetes

- funcappkeys-secret-name: Kubernetes secret name where default function keys (host, system and function keys) will be created and can be used from the function run time container using secretRef
- funcappkeys-config-map-name: The Kubernetes configMap name where default function keys (host, system and function keys) will be created and can be used from the function run time container using configMapRef
- mount-funcappkeys-as-containervolume: A flag indicating if function keys needs to be mounted in the function run-time container as volume mount at the path "/run/secrets/functions-keys" from either from Kubernetes secret or configMap

Also, service account, role, and role-binding is created and Pod identity of service account is assigned with the correct permissions to add/modify the Kubernetes secrets and config maps