### PR TITLE
Add Python 3.8 support in core tools

### DIFF
--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -328,14 +328,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
         private static async Task WritePythonDockerFile()
         {
             WorkerLanguageVersionInfo worker = await PythonHelpers.GetEnvironmentPythonVersion();
-            if (worker?.Major == 3 && worker?.Minor == 7)
-            {
-                await WriteFiles("Dockerfile", await StaticResources.DockerfilePython37);
-            }
-            else
-            {
-                await WriteFiles("Dockerfile", await StaticResources.DockerfilePython36);
-            }
+            await WriteFiles("Dockerfile", await worker.DockerInitFileContent);
         }
 
         private static async Task WriteExtensionsJson()

--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -328,7 +328,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
         private static async Task WritePythonDockerFile()
         {
             WorkerLanguageVersionInfo worker = await PythonHelpers.GetEnvironmentPythonVersion();
-            await WriteFiles("Dockerfile", await worker.DockerInitFileContent);
+            await WriteFiles("Dockerfile", await PythonHelpers.GetDockerInitFileContent(worker));
         }
 
         private static async Task WriteExtensionsJson()

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -126,7 +126,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.0.1" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="1.0.201" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="3.0.12930" />
-    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="1.0.201911015" />
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="1.1.202001106" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="YamlDotNet" Version="6.0.0" />
   </ItemGroup>

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -48,6 +48,9 @@
     <EmbeddedResource Include="StaticResources\Dockerfile.python37">
       <LogicalName>$(AssemblyName).Dockerfile.python37</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="StaticResources\Dockerfile.python38">
+      <LogicalName>$(AssemblyName).Dockerfile.python38</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="StaticResources\Dockerfile.powershell">
       <LogicalName>$(AssemblyName).Dockerfile.powershell</LogicalName>
     </EmbeddedResource>

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -106,6 +106,7 @@ namespace Azure.Functions.Cli.Common
         {
             public const string LinuxPython36ImageAmd64 = "mcr.microsoft.com/azure-functions/python:2.0.12493-python3.6-buildenv";
             public const string LinuxPython37ImageAmd64 = "mcr.microsoft.com/azure-functions/python:2.0.12763-python3.7-buildenv";
+            public const string LinuxPython38ImageAmd64 = "mcr.microsoft.com/azure-functions/python:3.0.13106-python3.8-buildenv";
         }
 
         public static class StaticResourcesNames

--- a/src/Azure.Functions.Cli/Common/WorkerLanguageVersionInfo.cs
+++ b/src/Azure.Functions.Cli/Common/WorkerLanguageVersionInfo.cs
@@ -88,6 +88,14 @@ namespace Azure.Functions.Cli.Common
             }
         }
 
+        public bool IsVersionSupported
+        {
+            get
+            {
+                return (Major == 3 && Minor == 6) || (Major == 3 && Minor == 7) || (Major == 3 && Minor == 8);
+            }
+        }
+
         /// <summary>
         /// Construct the basic information of a worker runtime
         /// </summary>

--- a/src/Azure.Functions.Cli/Common/WorkerLanguageVersionInfo.cs
+++ b/src/Azure.Functions.Cli/Common/WorkerLanguageVersionInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading.Tasks;
 using Azure.Functions.Cli.Helpers;
 
 namespace Azure.Functions.Cli.Common

--- a/src/Azure.Functions.Cli/Common/WorkerLanguageVersionInfo.cs
+++ b/src/Azure.Functions.Cli/Common/WorkerLanguageVersionInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Azure.Functions.Cli.Helpers;
 
 namespace Azure.Functions.Cli.Common
@@ -44,6 +45,46 @@ namespace Azure.Functions.Cli.Common
                     return Version.Split('.')[2];
                 }
                 return null;
+            }
+        }
+
+        public Task<string> DockerInitFileContent
+        {
+            get
+            {
+                if (Major == 3)
+                {
+                    switch (Minor)
+                    {
+                        case 6:
+                            return StaticResources.DockerfilePython36;
+                        case 7:
+                            return StaticResources.DockerfilePython37;
+                        case 8:
+                            return StaticResources.DockerfilePython38;
+                    }
+                }
+                return StaticResources.DockerfilePython36;
+            }
+        }
+
+        public string BuildNativeDepsEnvironmentImage
+        {
+            get
+            {
+                if (Major == 3)
+                {
+                    switch (Minor)
+                    {
+                        case 6:
+                            return Constants.DockerImages.LinuxPython36ImageAmd64;
+                        case 7:
+                            return Constants.DockerImages.LinuxPython37ImageAmd64;
+                        case 8:
+                            return Constants.DockerImages.LinuxPython38ImageAmd64;
+                    }
+                }
+                return Constants.DockerImages.LinuxPython36ImageAmd64;
             }
         }
 

--- a/src/Azure.Functions.Cli/Common/WorkerLanguageVersionInfo.cs
+++ b/src/Azure.Functions.Cli/Common/WorkerLanguageVersionInfo.cs
@@ -48,54 +48,6 @@ namespace Azure.Functions.Cli.Common
             }
         }
 
-        public Task<string> DockerInitFileContent
-        {
-            get
-            {
-                if (Major == 3)
-                {
-                    switch (Minor)
-                    {
-                        case 6:
-                            return StaticResources.DockerfilePython36;
-                        case 7:
-                            return StaticResources.DockerfilePython37;
-                        case 8:
-                            return StaticResources.DockerfilePython38;
-                    }
-                }
-                return StaticResources.DockerfilePython36;
-            }
-        }
-
-        public string BuildNativeDepsEnvironmentImage
-        {
-            get
-            {
-                if (Major == 3)
-                {
-                    switch (Minor)
-                    {
-                        case 6:
-                            return Constants.DockerImages.LinuxPython36ImageAmd64;
-                        case 7:
-                            return Constants.DockerImages.LinuxPython37ImageAmd64;
-                        case 8:
-                            return Constants.DockerImages.LinuxPython38ImageAmd64;
-                    }
-                }
-                return Constants.DockerImages.LinuxPython36ImageAmd64;
-            }
-        }
-
-        public bool IsVersionSupported
-        {
-            get
-            {
-                return (Major == 3 && Minor == 6) || (Major == 3 && Minor == 7) || (Major == 3 && Minor == 8);
-            }
-        }
-
         /// <summary>
         /// Construct the basic information of a worker runtime
         /// </summary>

--- a/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
@@ -129,20 +129,26 @@ namespace Azure.Functions.Cli.Helpers
             var python3GetVersionTask = GetVersion("python3");
             var python36GetVersionTask = GetVersion("python3.6");
             var python37GetVersionTask = GetVersion("python3.7");
+            var python38GetVersionTask = GetVersion("python3.8");
 
             var versions = new List<WorkerLanguageVersionInfo>
             {
                 await pythonGetVersionTask,
                 await python3GetVersionTask,
                 await python36GetVersionTask,
-                await python37GetVersionTask
+                await python37GetVersionTask,
+                await python38GetVersionTask
             };
 
             // Highest preference -- Go through the list, if we find the first python 3.6 or python 3.7 worker, we prioritize that.
-            WorkerLanguageVersionInfo python36_37worker = versions.FirstOrDefault(w => (w?.Major == 3 && w?.Minor == 6) || (w?.Major == 3 && w?.Minor == 7));
-            if (python36_37worker != null)
+            WorkerLanguageVersionInfo recommendedPythonWorker = versions.FirstOrDefault(w =>
+                (w?.Major == 3 && w?.Minor == 6) ||
+                (w?.Major == 3 && w?.Minor == 7) ||
+                (w?.Major == 3 && w?.Minor == 8)
+            );
+            if (recommendedPythonWorker != null)
             {
-                _pythonVersionCache = python36_37worker;
+                _pythonVersionCache = recommendedPythonWorker;
                 return _pythonVersionCache;
             }
 

--- a/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
@@ -89,7 +89,7 @@ namespace Azure.Functions.Cli.Helpers
             ColoredConsole.WriteLine(AdditionalInfoColor($"Found Python version {pythonVersion.Version} ({pythonVersion.ExecutablePath})."));
 
             // Python 3.6 | 3.7 | 3.8 (supported)
-            if (pythonVersion.IsVersionSupported)
+            if (IsVersionSupported(pythonVersion))
             {
                 return;
             }
@@ -431,7 +431,7 @@ namespace Azure.Functions.Cli.Helpers
         private static async Task<string> ChoosePythonBuildEnvImage()
         {
             WorkerLanguageVersionInfo workerInfo = await GetEnvironmentPythonVersion();
-            return workerInfo.BuildNativeDepsEnvironmentImage;
+            return GetBuildNativeDepsEnvironmentImage(workerInfo);
         }
 
         private static string CopyToTemp(IEnumerable<string> files, string rootPath)
@@ -448,6 +448,45 @@ namespace Azure.Functions.Cli.Helpers
                 FileSystemHelpers.Copy(file, Path.Combine(tmp, relativeFileName));
             }
             return tmp;
+        }
+
+        public static Task<string> GetDockerInitFileContent(WorkerLanguageVersionInfo info)
+        {
+            if (info?.Major == 3)
+            {
+                switch (info?.Minor)
+                {
+                    case 6:
+                        return StaticResources.DockerfilePython36;
+                    case 7:
+                        return StaticResources.DockerfilePython37;
+                    case 8:
+                        return StaticResources.DockerfilePython38;
+                }
+            }
+            return StaticResources.DockerfilePython36;
+        }
+
+        private static string GetBuildNativeDepsEnvironmentImage(WorkerLanguageVersionInfo info)
+        {
+            if (info?.Major == 3)
+            {
+                switch (info?.Minor)
+                {
+                    case 6:
+                        return Constants.DockerImages.LinuxPython36ImageAmd64;
+                    case 7:
+                        return Constants.DockerImages.LinuxPython37ImageAmd64;
+                    case 8:
+                        return Constants.DockerImages.LinuxPython38ImageAmd64;
+                }
+            }
+            return Constants.DockerImages.LinuxPython36ImageAmd64;
+        }
+
+        private static bool IsVersionSupported(WorkerLanguageVersionInfo info)
+        {
+            return (info?.Major == 3 && info?.Minor == 6) || (info?.Major == 3 && info?.Minor == 7) || (info?.Major == 3 && info?.Minor == 8);
         }
     }
 }

--- a/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
@@ -143,11 +143,7 @@ namespace Azure.Functions.Cli.Helpers
             };
 
             // Highest preference -- Go through the list, if we find the first python 3.6 or python 3.7 worker, we prioritize that.
-            WorkerLanguageVersionInfo recommendedPythonWorker = versions.FirstOrDefault(w =>
-                (w?.Major == 3 && w?.Minor == 6) ||
-                (w?.Major == 3 && w?.Minor == 7) ||
-                (w?.Major == 3 && w?.Minor == 8)
-            );
+            WorkerLanguageVersionInfo recommendedPythonWorker = versions.FirstOrDefault(w => IsVersionSupported(w));
             if (recommendedPythonWorker != null)
             {
                 _pythonVersionCache = recommendedPythonWorker;

--- a/src/Azure.Functions.Cli/StaticResources/Dockerfile.python38
+++ b/src/Azure.Functions.Cli/StaticResources/Dockerfile.python38
@@ -1,0 +1,11 @@
+﻿# To enable ssh & remote debugging on app service change the base image to the one below
+# FROM mcr.microsoft.com/azure-functions/python:3.0-python3.8-appservice
+FROM mcr.microsoft.com/azure-functions/python:3.0-python3.8
+
+ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
+    AzureFunctionsJobHost__Logging__Console__IsEnabled=true
+
+COPY requirements.txt /
+RUN pip install -r /requirements.txt
+
+COPY . /home/site/wwwroot

--- a/src/Azure.Functions.Cli/StaticResources/StaticResources.cs
+++ b/src/Azure.Functions.Cli/StaticResources/StaticResources.cs
@@ -37,6 +37,8 @@ namespace Azure.Functions.Cli
 
         public static Task<string> DockerfilePython37 => GetValue("Dockerfile.python37");
 
+        public static Task<string> DockerfilePython38 => GetValue("Dockerfile.python38");
+
         public static Task<string> DockerfilePowershell => GetValue("Dockerfile.powershell");
 
         public static Task<string> DockerfileNode => GetValue("Dockerfile.node");

--- a/test/Azure.Functions.Cli.Tests/PythonHelperTests.cs
+++ b/test/Azure.Functions.Cli.Tests/PythonHelperTests.cs
@@ -5,19 +5,11 @@ using System.Runtime.InteropServices;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Helpers;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Azure.Functions.Cli.Tests
 {
     public class PythonHelperTests
     {
-        private readonly ITestOutputHelper _output;
-
-        public PythonHelperTests(ITestOutputHelper output)
-        {
-            _output = output;
-        }
-
         [SkipIfPythonNonExistFact]
         public async void InterpreterShouldHaveExecutablePath()
         {


### PR DESCRIPTION
### Depends On:
✅Host release: 3.0.13113
✅Python BuildEnv image: mcr.microsoft.com/azure-functions/python:3.0.13106-python3.8-buildenv
✅https://mcr.microsoft.com/v2/azure-functions/python/tags/list "3.0-python3.8", "3.0-python3.8-appservice", "3.0-python3.8-buildenv",

### Changes:
1. Add Python 3.8 Dockerfile when using --docker init
2. Allow Python 3.8 to be published with --build local and --build-native-deps 