### PR TITLE
Update PowerShell Worker to v2.0.215

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -118,7 +118,7 @@
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage.Internal" Version="1.4.0" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.5.2-SNAPSHOT" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="1.0.197" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="2.0.215" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="2.0.12961" />
     <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="1.0.201912137" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />


### PR DESCRIPTION
Changes in this release:

- Upgraded to PowerShell [6.2.4](https://github.com/PowerShell/PowerShell/releases/tag/v6.2.4).
- Minor internal improvements.

For more information, please see https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v2.0.215.