### PR TITLE
Update PowerShell Worker to v3.0.216

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -6,10 +6,10 @@ if ($env:APPVEYOR_REPO_BRANCH -eq "disabled") {
     Write-host "Adding Microsoft.Azure.Functions.JavaWorker $javaWorkerVersion to project" -ForegroundColor Green
     Invoke-Expression -Command "dotnet add package Microsoft.Azure.Functions.JavaWorker -v $javaWorkerVersion -s  https://ci.appveyor.com/NuGet/azure-functions-java-worker-fejnnsvmrkqg"
     
-    $result = Invoke-Expression -Command "NuGet list Microsoft.Azure.Functions.PowerShellWorker -Source https://ci.appveyor.com/nuget/azure-functions-powershell-wor-0842fakagqy6 -PreRelease"
+    $result = Invoke-Expression -Command "NuGet list Microsoft.Azure.Functions.PowerShellWorker.PS6 -Source https://ci.appveyor.com/nuget/azure-functions-powershell-wor-0842fakagqy6 -PreRelease"
     $powerShellWorkerVersion = $result.Split()[1]
-    Write-host "Adding Microsoft.Azure.Functions.PowerShellWorker $powerShellWorkerVersion to project" -ForegroundColor Green
-    Invoke-Expression -Command "dotnet add package Microsoft.Azure.Functions.PowerShellWorker -v $powerShellWorkerVersion -s https://ci.appveyor.com/nuget/azure-functions-powershell-wor-0842fakagqy6"
+    Write-host "Adding Microsoft.Azure.Functions.PowerShellWorker.PS6 $powerShellWorkerVersion to project" -ForegroundColor Green
+    Invoke-Expression -Command "dotnet add package Microsoft.Azure.Functions.PowerShellWorker.PS6 -v $powerShellWorkerVersion -s https://ci.appveyor.com/nuget/azure-functions-powershell-wor-0842fakagqy6"
 
     $result = Invoke-Expression -Command "NuGet list Microsoft.Azure.Functions.NodeJsWorker -Source https://ci.appveyor.com/nuget/azure-functions-nodejs-worker-0fcvx371y52p -PreRelease"
     $nodeJsWorkerVersion = $result.Split()[1]

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -124,7 +124,7 @@
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage.Internal" Version="1.4.0" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.5.2-SNAPSHOT" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.0.2" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="1.0.201" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS6" Version="3.0.216" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="3.0.13107" />
     <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="1.1.202001106" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />


### PR DESCRIPTION
Changes in this release:

- Upgraded to PowerShell [6.2.4](https://github.com/PowerShell/PowerShell/releases/tag/v6.2.4).
- Minor internal improvements.

For more information, please see https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v3.0.216.