### PR TITLE
Add x64 notice installing tools for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ choco install azure-functions-core-tools
 ```
 #### Notice: To debug functions under vscode, x64 bitness is required
 ```bash
-choco install azure-functions-core-tools --params "'/x64:true'"
+choco install azure-functions-core-tools --params "'/x64'"
 ```
 ### Mac
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ To install with chocolatey:
 ```bash
 choco install azure-functions-core-tools
 ```
-
+#### Notice: To debug functions under vscode, x64 bitness is required
+```bash
+choco install azure-functions-core-tools --params "'/x64:true'"
+```
 ### Mac
 
 **Homebrew**:


### PR DESCRIPTION
For debugging under vscode, x64 installer is required.
After issue #693 x64 install option is available.
Comment in https://github.com/Azure/azure-functions-core-tools/issues/693#issuecomment-573294750 says that clarification in README file is needed for installing x64 bitness from choco.

This PR adds a notice in README.md file on how specify x64 bitness when installing from choco package manager.