### PR TITLE
Fix app insights sampling setting excludedTypes in template host.json

### DIFF
--- a/src/Azure.Functions.Cli/StaticResources/host.json
+++ b/src/Azure.Functions.Cli/StaticResources/host.json
@@ -2,9 +2,9 @@
   "version": "2.0",
   "logging": {
     "applicationInsights": {
-      "samplingExcludedTypes": "Request",
       "samplingSettings": {
-        "isEnabled": true
+        "isEnabled": true,
+        "excludedTypes": "Request"
       }
     }
   }

--- a/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
@@ -430,7 +430,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                         ContentContains = new []
                         {
                             "applicationInsights",
-                            "samplingExcludedTypes",
+                            "excludedTypes",
                             "Request",
                             "logging"
                         }


### PR DESCRIPTION
Seems like the `samplingExcludedTypes` is actually under `samplingSettings` and is simply `excludedTypes` itself as seen in [this line](https://github.com/Azure/azure-functions-host/blob/123813c244919360c4fbd54f01ee52986989562b/src/WebJobs.Script/Config/ApplicationInsightsLoggerOptionsSetup.cs#L58).

This was brought up on a [docs issue](https://github.com/MicrosoftDocs/azure-docs/issues/50233) since this file is used for new projects.