### PR TITLE
Add build logic for -2 packages

### DIFF
--- a/publish-scripts/chocolatey/buildNUPKG.py
+++ b/publish-scripts/chocolatey/buildNUPKG.py
@@ -27,7 +27,7 @@ def getChocoVersion(version):
 # assume buildFolder is clean
 # output a deb nupkg
 # depends on chocolatey
-def preparePackage():
+def preparePackage(packageName):
     fileName_x86 = f"Azure.Functions.Cli.win-x86.{constants.VERSION}.zip"
     fileName_x64 = f"Azure.Functions.Cli.win-x64.{constants.VERSION}.zip"
     url_x86 = f'https://functionscdn.azureedge.net/public/{constants.VERSION}/{fileName_x86}'
@@ -63,17 +63,17 @@ def preparePackage():
     t = Template(stringData)
     with open(os.path.join(tools, "chocolateyinstall.ps1"), "w") as f:
         print("writing install powershell script")
-        f.write(t.safe_substitute(ZIPURL_X86=url_x86, ZIPURL_X64=url_x64, PACKAGENAME=constants.PACKAGENAME,
+        f.write(t.safe_substitute(ZIPURL_X86=url_x86, ZIPURL_X64=url_x64, PACKAGENAME=packageName,
                                   CHECKSUM_X86=fileHash_x86, CHECKSUM_X64=fileHash_x64, HASHALG=HASH))
 
     # write nuspec package metadata
     with open(os.path.join(scriptDir,"nuspec_template")) as f:
         stringData = f.read()
     t = Template(stringData)
-    nuspecFile = os.path.join(constants.BUILDFOLDER, constants.PACKAGENAME+".nuspec")
+    nuspecFile = os.path.join(constants.BUILDFOLDER, packageName+".nuspec")
     with open(nuspecFile,'w') as f:
         print("writing nuspec")
-        f.write(t.safe_substitute(PACKAGENAME=constants.PACKAGENAME, CHOCOVERSION=chocoVersion))
+        f.write(t.safe_substitute(PACKAGENAME=packageName, CHOCOVERSION=chocoVersion))
 
     # run choco pack, stdout is merged into python interpreter stdout
     output = printReturnOutput(["choco", "pack", nuspecFile, "--outputdirectory", constants.ARTIFACTFOLDER])

--- a/publish-scripts/driver.py
+++ b/publish-scripts/driver.py
@@ -25,13 +25,22 @@ def main(*args):
         print(f"Does not support platform {platformSystem} yet.")
         return
 
-    # at root
+    # Build packages
+    # we create two packages 'azure-functions-core-tools-2' and 'azure-functions-core-tools'
+
+    # Build 'azure-functions-core-tools'
     initWorkingDir(constants.BUILDFOLDER, True)
     initWorkingDir(constants.ARTIFACTFOLDER)
 
-    # build package
-    print("Building package...")
-    dist.preparePackage()
+    print(f"Building package {constants.PACKAGENAME_BASE}...")
+    dist.preparePackage(constants.PACKAGENAME_BASE)
+
+    # Build 'azure-functions-core-tools-2'
+    initWorkingDir(constants.BUILDFOLDER, True)
+    initWorkingDir(constants.ARTIFACTFOLDER)
+
+    print(f"Building package {constants.PACKAGENAME_BASE}-2...")
+    dist.preparePackage(f"{constants.PACKAGENAME_BASE}-2")
 
 def initWorkingDir(dirName, clean = False):
     if clean:

--- a/publish-scripts/shared/helper.py
+++ b/publish-scripts/shared/helper.py
@@ -53,7 +53,7 @@ def produceHashForfile(filePath, hashType, Upper = True):
         return hashobj.hexdigest().lower()
 
 @restoreDirectory
-def linuxOutput(buildFolder):
+def linuxOutput(buildFolder, packageName):
     os.chdir(constants.DRIVERROOTDIR)
 
     # ubuntu dropped 64, fedora supports both
@@ -69,7 +69,7 @@ def linuxOutput(buildFolder):
 
     usr = os.path.join(buildFolder, "usr")
     usrlib = os.path.join(usr, "lib")
-    usrlibFunc = os.path.join(usrlib, constants.PACKAGENAME)
+    usrlibFunc = os.path.join(usrlib, packageName)
     os.makedirs(usrlibFunc)
     # unzip here
     import zipfile
@@ -83,7 +83,7 @@ def linuxOutput(buildFolder):
     # cd into usr/bin, create relative symlink
     os.chdir(usrbin)
     print("create symlink for func")
-    os.symlink(f"../lib/{constants.PACKAGENAME}/func", "func")
+    os.symlink(f"../lib/{packageName}/func", "func")
     # executable to be returned
     exeFullPath = os.path.abspath("func")
 

--- a/publish-scripts/ubuntu/bulidDEB.py
+++ b/publish-scripts/ubuntu/bulidDEB.py
@@ -24,16 +24,16 @@ def returnDebVersion(version):
 # output a deb package
 # depends on gzip, dpkg-deb, strip
 @helper.restoreDirectory
-def preparePackage():
+def preparePackage(packageName):
     os.chdir(constants.DRIVERROOTDIR)
 
     debianVersion = returnDebVersion(constants.VERSION)
-    packageFolder = f"{constants.PACKAGENAME}_{debianVersion}"
+    packageFolder = f"{packageName}_{debianVersion}"
     buildFolder = os.path.join(os.getcwd(), constants.BUILDFOLDER, packageFolder)
-    helper.linuxOutput(buildFolder)
+    helper.linuxOutput(buildFolder, packageName)
 
     os.chdir(buildFolder)
-    document = os.path.join("usr", "share", "doc", constants.PACKAGENAME)
+    document = os.path.join("usr", "share", "doc", packageName)
     os.makedirs(document)
     # write copywrite
     print("include MIT copyright")
@@ -47,7 +47,7 @@ def preparePackage():
     time = datetime.datetime.utcnow().strftime("%a, %d %b %Y %X")
     with open(os.path.join(document, "changelog.Debian"), "w") as f:
         print(f"writing changelog with date utc: {time}")
-        f.write(t.safe_substitute(DEBIANVERSION=debianVersion, DATETIME=time, VERSION=constants.VERSION, PACKAGENAME=constants.PACKAGENAME))
+        f.write(t.safe_substitute(DEBIANVERSION=debianVersion, DATETIME=time, VERSION=constants.VERSION, PACKAGENAME=packageName))
     # by default gzip compress file in place
     output = helper.printReturnOutput(["gzip", "-9", "-n", os.path.join(document, "changelog.Debian")])
     helper.chmodFolderAndFiles(os.path.join("usr", "share"))
@@ -77,7 +77,7 @@ def preparePackage():
     t = Template(stringData)
     with open(os.path.join(debian, "control"), "w") as f:
         print("trying to write control file")
-        f.write(t.safe_substitute(DEBIANVERSION=debianVersion, PACKAGENAME=constants.PACKAGENAME, DEPENDENCY=deps))
+        f.write(t.safe_substitute(DEBIANVERSION=debianVersion, PACKAGENAME=packageName, DEPENDENCY=deps))
     helper.chmodFolderAndFiles(debian)
 
     postinst = ''
@@ -93,4 +93,4 @@ def preparePackage():
     os.chdir(constants.DRIVERROOTDIR)
     output = helper.printReturnOutput(["fakeroot", "dpkg-deb", "--build",
                    os.path.join(constants.BUILDFOLDER, packageFolder), os.path.join(constants.ARTIFACTFOLDER, packageFolder+".deb")])
-    assert(f"building package '{constants.PACKAGENAME}'" in output)
+    assert(f"building package '{packageName}'" in output)

--- a/publish-scripts/ubuntu/control_template
+++ b/publish-scripts/ubuntu/control_template
@@ -7,5 +7,7 @@ Vcs-Git: https://github.com/Azure/azure-functions-core-tools.git
 Package: $PACKAGENAME
 Architecture: amd64
 Depends: $DEPENDENCY
+Conflicts: azure-functions-core-tools, azure-functions-core-tools-2
+Replaces: azure-functions-core-tools, azure-functions-core-tools-2
 Description: Azure Function Core Tools v2
  The Azure Functions Core Tools provide a local development experience for creating, developing, testing, running, and debugging Azure Functions.


### PR DESCRIPTION
This fixes a small bug, and now starts creating two release artifacts `azure-functions-core-tools` and `azure-functions-core-tools`.