### PR TITLE
Fixed issue where AzureWebJobsStorage wasn't being properly set in local.settings.json

### DIFF
--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -289,7 +289,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 ? Constants.StorageEmulatorConnectionString
                 : string.Empty;
 
-            localSettingsJsonContent = localSettingsJsonContent.Replace($"{{{Constants.StorageEmulatorConnectionString}}}", storageConnectionStringValue);
+            localSettingsJsonContent = localSettingsJsonContent.Replace($"{{{Constants.AzureWebJobsStorage}}}", storageConnectionStringValue);
             await WriteFiles("local.settings.json", localSettingsJsonContent);
         }
 


### PR DESCRIPTION
Resolves #1927 

This looks like this is a bug that was introduced during a revert 2 years ago. Although I might be missing something since it's been around for so long unless it's pretty low impact. The code has been trying to set the value of AzureWebJobsStorage in local.settings.json, but it's been using the value it's trying to set as the value it's trying to replace (Setting y to a value of x by searching/replacing x).