### PR TITLE
Use force remote build for Linux Consumption deployment v3

### DIFF
--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -454,7 +454,8 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             if (PublishBuildOption == BuildOption.Remote)
             {
                 await EnsureRemoteBuildIsSupported(functionApp);
-                await RemoveFunctionAppAppSetting(functionApp, Constants.WebsiteRunFromPackage, Constants.WebsiteContentAzureFileConnectionString, Constants.WebsiteContentShared);
+                // We don't need to remove WEBSITE_RUN_FROM_PACKAGE since Linux Consumption will set the app setting pointing to the latest package
+                await RemoveFunctionAppAppSetting(functionApp, Constants.WebsiteContentAzureFileConnectionString, Constants.WebsiteContentShared);
                 Task<DeployStatus> pollConsumptionBuild(HttpClient client) => KuduLiteDeploymentHelpers.WaitForRemoteBuild(client, functionApp);
                 var deployStatus = await PerformServerSideBuild(functionApp, zipFileFactory, pollConsumptionBuild);
                 return deployStatus == DeployStatus.Success;
@@ -702,7 +703,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             using (var handler = new ProgressMessageHandler(new HttpClientHandler()))
             using (var client = GetRemoteZipClient(new Uri($"https://{functionApp.ScmUri}"), handler))
             using (var request = new HttpRequestMessage(HttpMethod.Post, new Uri(
-                $"api/zipdeploy?isAsync=true&author={Environment.MachineName}", UriKind.Relative)))
+                $"api/zipdeploy?isAsync=true&author={Environment.MachineName}&forceremotebuild=true", UriKind.Relative)))
             {
                 ColoredConsole.WriteLine("Creating archive for current directory...");
 

--- a/src/Azure.Functions.Cli/Helpers/KuduLiteDeploymentHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/KuduLiteDeploymentHelpers.cs
@@ -36,15 +36,9 @@ namespace Azure.Functions.Cli.Helpers
                 try
                 {
                     statusCode = await GetDeploymentStatusById(client, functionApp, id);
-                } catch (HttpRequestException)
-                {
-                    return DeployStatus.Unknown;
-                }
-
-                try
-                {
                     logLastUpdate = await DisplayDeploymentLog(client, functionApp, id, logLastUpdate);
-                } catch (HttpRequestException)
+                }
+                catch (HttpRequestException)
                 {
                     return DeployStatus.Unknown;
                 }

--- a/src/Azure.Functions.Cli/Helpers/KuduLiteDeploymentHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/KuduLiteDeploymentHelpers.cs
@@ -1,7 +1,6 @@
 ﻿using Azure.Functions.Cli.Arm.Models;
 using Azure.Functions.Cli.Common;
 using Colors.Net;
-using static Colors.Net.StringStaticMethods;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -34,8 +33,22 @@ namespace Azure.Functions.Cli.Helpers
 
             while (statusCode != DeployStatus.Success && statusCode != DeployStatus.Failed && statusCode != DeployStatus.Unknown)
             {
-                statusCode = await GetDeploymentStatusById(client, functionApp, id);
-                logLastUpdate = await DisplayDeploymentLog(client, functionApp, id, logLastUpdate);
+                try
+                {
+                    statusCode = await GetDeploymentStatusById(client, functionApp, id);
+                } catch (HttpRequestException)
+                {
+                    return DeployStatus.Unknown;
+                }
+
+                try
+                {
+                    logLastUpdate = await DisplayDeploymentLog(client, functionApp, id, logLastUpdate);
+                } catch (HttpRequestException)
+                {
+                    return DeployStatus.Unknown;
+                }
+
                 await Task.Delay(TimeSpan.FromSeconds(Constants.KuduLiteDeploymentConstants.StatusRefreshSeconds));
             }
 
@@ -62,15 +75,7 @@ namespace Azure.Functions.Cli.Helpers
 
         private static async Task<DeployStatus> GetDeploymentStatusById(HttpClient client, Site functionApp, string id)
         {
-            Dictionary<string, string> json;
-            try
-            {
-                json = await InvokeRequest<Dictionary<string, string>>(client, HttpMethod.Get, $"/deployments/{id}");
-            } catch (HttpRequestException)
-            {
-                return DeployStatus.Unknown;
-            }
-
+            Dictionary<string, string> json = await InvokeRequest<Dictionary<string, string>>(client, HttpMethod.Get, $"/deployments/{id}");
             if (!json.TryGetValue("status", out string statusString))
             {
                 return DeployStatus.Unknown;


### PR DESCRIPTION
### Description

Use &forceremotebuild=true to perform remote build in Linux Consumption deployment. This allow KuduLite overwrite WEBSITE_RUN_FROM_PACKAGE app setting once the deployment is finished, eliminating the ambiguity of the hidden app setting SCM_RUN_FROM_PACKAGE