### PR TITLE
Add worker version for PowerShell function apps.

### DIFF
--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -291,6 +291,11 @@ namespace Azure.Functions.Cli.Actions.LocalActions
 
             localSettingsJsonContent = localSettingsJsonContent.Replace($"{{{Constants.AzureWebJobsStorage}}}", storageConnectionStringValue);
 
+            if (workerRuntime == Helpers.WorkerRuntime.powershell)
+            {
+                localSettingsJsonContent = AddWorkerVersion(localSettingsJsonContent, Constants.PowerShellWorkerDefaultVersion);
+            }
+
             await WriteFiles("local.settings.json", localSettingsJsonContent);
         }
 
@@ -446,6 +451,20 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             var managedDependenciesConfig = JsonConvert.DeserializeObject<JToken>(managedDependenciesConfigContent);
             hostJsonObj.Add(Constants.ManagedDependencyConfigPropertyName, managedDependenciesConfig);
             return JsonConvert.SerializeObject(hostJsonObj, Formatting.Indented);
+        }
+
+        private static string AddWorkerVersion(string localSettingsContent, string workerVersion)
+        {
+            var localSettingsObj = JsonConvert.DeserializeObject<JObject>(localSettingsContent);
+
+            if (localSettingsObj.TryGetValue("Values", StringComparison.OrdinalIgnoreCase, out var valuesContent))
+            {
+                var values = valuesContent as JObject;
+                values.Property(Constants.FunctionsWorkerRuntime).AddAfterSelf(
+                        new JProperty(Constants.FunctionsWorkerRuntimeVersion, workerVersion));
+            }
+
+            return JsonConvert.SerializeObject(localSettingsObj, Formatting.Indented);
         }
     }
 }

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -49,6 +49,7 @@ namespace Azure.Functions.Cli.Common
         public const string ExtensionBundleConfigPropertyName = "extensionBundle";
         public const string AspNetCoreEnvironmentEnvironmentVariable = "ASPNETCORE_ENVIRONMENT";
         public const string ManagedDependencyConfigPropertyName = "managedDependency";
+        public const string PowerShellWorkerDefaultVersion = "~6";
 
         public static string CliVersion => typeof(Constants).GetTypeInfo().Assembly.GetName().Version.ToString(3);
 

--- a/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
@@ -378,7 +378,7 @@ namespace Azure.Functions.Cli.Tests.E2E
         }
 
         [Fact]
-        public Task init_function_app_powershell_and_enable_managed_dependencies()
+        public Task init_function_app_powershell_enable_managed_dependencies_and_set_default_version()
         {
             return CliTester.Run(new RunConfiguration
             {
@@ -422,7 +422,9 @@ namespace Azure.Functions.Cli.Tests.E2E
                         ContentContains = new []
                         {
                             "FUNCTIONS_WORKER_RUNTIME",
-                            "powershell"
+                            "powershell",
+                            "FUNCTIONS_WORKER_RUNTIME_VERSION",
+                            "~6"
                         }
                     }
                 },


### PR DESCRIPTION
This PR addresses https://github.com/Azure/azure-functions-core-tools/issues/1787

Set `"FUNCTIONS_WORKER_RUNTIME_VERSION"` to `"~6"` in `local.settings.json` for PowerShell function apps. 

Here is what the contents of `local.settings.json` will look like: 
```powershell
PS D:\MyFunction> gc .\local.settings.json
{
  "IsEncrypted": false,
  "Values": {
    "FUNCTIONS_WORKER_RUNTIME": "powershell",
    "FUNCTIONS_WORKER_RUNTIME_VERSION": "~6",
    "AzureWebJobsStorage": "UseDevelopmentStorage=true"
  }
}
```
