### PR TITLE
Show inner exception when there is an issue with connecting to a blob storage account

### DIFF
--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -759,8 +759,8 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                     if (StaticSettings.IsDebug)
                     {
                         ColoredConsole.Error.WriteLine(ErrorColor(ex.ToString()));
-                    }
-                    throw new CliException($"Error creating a Blob container reference. Please make sure your connection string in \"AzureWebJobsStorage\" is valid");
+                    }                    
+                    throw new CliException($"Error creating a Blob container reference. {ex.Message}. Please make sure your connection string in \"AzureWebJobsStorage\" is valid");
                 }
 
                 var blob = blobContainer.GetBlockBlobReference(blobName);

--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -760,7 +760,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                     {
                         ColoredConsole.Error.WriteLine(ErrorColor(ex.ToString()));
                     }                    
-                    throw new CliException($"Error creating a Blob container reference. {ex.Message}. Please make sure your connection string in \"AzureWebJobsStorage\" is valid");
+                    throw new CliException($"Error creating a Blob container reference. {ex.Message} Please make sure your connection string in \"AzureWebJobsStorage\" is valid");
                 }
 
                 var blob = blobContainer.GetBlockBlobReference(blobName);


### PR DESCRIPTION
# Show inner exception when there is an issue with connecting to a blob storage account

## Context

Recently I hit an issue where the cli was telling me the generic error of "Please make sure your connection string in "AzureWebJobsStorage" is valid.

After to much time to debug I came across the environment variable "CLI_DEBUG" and could then see the auth token was not valid, due to WSL datetime being out of sync.

To help ease debugging efforts in the future I think it would be great to show the inner exception as part of the exception that we bubble up to the surface.

## New error messages

New messages take the format of: "Error creating a Blob container reference. {**inner exception for Blob SDK**}.Please make sure your connection string in "AzureWebJobsStorage" is valid"

### Wrong connection string

Error creating a Blob container reference. Settings must be of the form "name=value". Please make sure your connection string in "AzureWebJobsStorage" is valid

### Wrong key

Error creating a Blob container reference. No valid combination of account information found. Please make sure your connection string in "AzureWebJobsStorage" is valid

### Wrong endpoint

Error creating a Blob container reference. No such device or address. Please make sure your connection string in "AzureWebJobsStorage" is valid

### Failed auth

Error creating a Blob container reference. Server failed to authenticate the request. Make sure the value of Authorization header is formed correctly including the signature. Please make sure your connection string in "AzureWebJobsStorage" is valid

