### PR TITLE
Set `PowerShellWorkerDefaultVersion` to `'~7'`

### DIFF
--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -292,6 +292,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 : string.Empty;
 
             localSettingsJsonContent = localSettingsJsonContent.Replace($"{{{Constants.AzureWebJobsStorage}}}", storageConnectionStringValue);
+
             await WriteFiles("local.settings.json", localSettingsJsonContent);
         }
 
@@ -409,9 +410,12 @@ namespace Azure.Functions.Cli.Actions.LocalActions
 
         private static async Task WriteHostJson(WorkerRuntime workerRuntime, bool managedDependenciesOption, bool extensionBundle = true)
         {
-            var hostJsonContent = (workerRuntime == Helpers.WorkerRuntime.powershell && managedDependenciesOption)
-                ? await StaticResources.PowerShellHostJson
-                : await StaticResources.HostJson;
+            var hostJsonContent = await StaticResources.HostJson;
+
+            if (workerRuntime == Helpers.WorkerRuntime.powershell && managedDependenciesOption)
+            {
+                hostJsonContent = await AddManagedDependencyConfig(hostJsonContent);
+            }
 
             if (extensionBundle)
             {
@@ -426,7 +430,16 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             var hostJsonObj = JsonConvert.DeserializeObject<JObject>(hostJsonContent);
             var bundleConfigContent = await StaticResources.BundleConfig;
             var bundleConfig = JsonConvert.DeserializeObject<JToken>(bundleConfigContent);
-            hostJsonObj.Add("extensionBundle", bundleConfig);
+            hostJsonObj.Add(Constants.ExtensionBundleConfigPropertyName, bundleConfig);
+            return JsonConvert.SerializeObject(hostJsonObj, Formatting.Indented);
+        }
+
+        private static async Task<string> AddManagedDependencyConfig(string hostJsonContent)
+        {
+            var hostJsonObj = JsonConvert.DeserializeObject<JObject>(hostJsonContent);
+            var managedDependenciesConfigContent = await StaticResources.ManagedDependenciesConfig;
+            var managedDependenciesConfig = JsonConvert.DeserializeObject<JToken>(managedDependenciesConfigContent);
+            hostJsonObj.Add(Constants.ManagedDependencyConfigPropertyName, managedDependenciesConfig);
             return JsonConvert.SerializeObject(hostJsonObj, Formatting.Indented);
         }
     }

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -60,8 +60,8 @@
     <EmbeddedResource Include="StaticResources\gitignore">
       <LogicalName>$(AssemblyName).gitignore</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="StaticResources\powershell.host.json">
-      <LogicalName>$(AssemblyName).powershell.host.json</LogicalName>
+    <EmbeddedResource Include="StaticResources\managedDependenciesConfig.json">
+      <LogicalName>$(AssemblyName).managedDependenciesConfig.json</LogicalName>
     </EmbeddedResource>
     <EmbeddedResource Include="StaticResources\host.json">
       <LogicalName>$(AssemblyName).host.json</LogicalName>

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -46,6 +46,7 @@ namespace Azure.Functions.Cli.Common
         public const string DefaultManagementURL = "https://management.azure.com/";
         public const string AzureManagementAccessToken = "AZURE_MANAGEMENT_ACCESS_TOKEN";
         public const string ExtensionBundleConfigPropertyName = "extensionBundle";
+        public const string ManagedDependencyConfigPropertyName = "managedDependency";
 
         public static string CliVersion => typeof(Constants).GetTypeInfo().Assembly.GetName().Version.ToString(3);
 

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -47,7 +47,7 @@ namespace Azure.Functions.Cli.Common
         public const string AzureManagementAccessToken = "AZURE_MANAGEMENT_ACCESS_TOKEN";
         public const string ExtensionBundleConfigPropertyName = "extensionBundle";
         public const string ManagedDependencyConfigPropertyName = "managedDependency";
-        public const string PowerShellWorkerDefaultVersion = "~6";
+        public const string PowerShellWorkerDefaultVersion = "~7";
 
         public static string CliVersion => typeof(Constants).GetTypeInfo().Assembly.GetName().Version.ToString(3);
 

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -47,6 +47,7 @@ namespace Azure.Functions.Cli.Common
         public const string AzureManagementAccessToken = "AZURE_MANAGEMENT_ACCESS_TOKEN";
         public const string ExtensionBundleConfigPropertyName = "extensionBundle";
         public const string ManagedDependencyConfigPropertyName = "managedDependency";
+        public const string PowerShellWorkerDefaultVersion = "~6";
 
         public static string CliVersion => typeof(Constants).GetTypeInfo().Assembly.GetName().Version.ToString(3);
 

--- a/src/Azure.Functions.Cli/StaticResources/StaticResources.cs
+++ b/src/Azure.Functions.Cli/StaticResources/StaticResources.cs
@@ -53,7 +53,7 @@ namespace Azure.Functions.Cli
 
         public static Task<string> BundleConfig => GetValue("bundleConfig.json");
 
-        public static Task<string> PowerShellHostJson => GetValue("powershell.host.json");
+        public static Task<string> ManagedDependenciesConfig => GetValue("managedDependenciesConfig.json");
 
         public static Task<string> PythonDockerBuildScript => GetValue(Constants.StaticResourcesNames.PythonDockerBuild);
 

--- a/src/Azure.Functions.Cli/StaticResources/managedDependenciesConfig.json
+++ b/src/Azure.Functions.Cli/StaticResources/managedDependenciesConfig.json
@@ -1,0 +1,3 @@
+{
+  "enabled": true
+}

--- a/src/Azure.Functions.Cli/StaticResources/powershell.host.json
+++ b/src/Azure.Functions.Cli/StaticResources/powershell.host.json
@@ -1,6 +1,0 @@
-{
-  "version": "2.0",
-  "managedDependency": {
-    "enabled": true
-  }
-}

--- a/src/Azure.Functions.Cli/StaticResources/profile.ps1
+++ b/src/Azure.Functions.Cli/StaticResources/profile.ps1
@@ -11,7 +11,8 @@
 
 # Authenticate with Azure PowerShell using MSI.
 # Remove this if you are not planning on using MSI or Azure PowerShell.
-if ($env:MSI_SECRET -and (Get-Module -ListAvailable Az.Accounts)) {
+if ($env:MSI_SECRET) {
+    Disable-AzContextAutosave
     Connect-AzAccount -Identity
 }
 

--- a/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
@@ -424,7 +424,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                             "FUNCTIONS_WORKER_RUNTIME",
                             "powershell",
                             "FUNCTIONS_WORKER_RUNTIME_VERSION",
-                            "~6"
+                            "~7"
                         }
                     }
                 },

--- a/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
@@ -378,7 +378,7 @@ namespace Azure.Functions.Cli.Tests.E2E
         }
 
         [Fact]
-        public Task init_function_app_powershell_and_enable_managed_dependencies()
+        public Task init_function_app_powershell_enable_managed_dependencies_and_set_default_version()
         {
             return CliTester.Run(new RunConfiguration
             {
@@ -422,7 +422,9 @@ namespace Azure.Functions.Cli.Tests.E2E
                         ContentContains = new []
                         {
                             "FUNCTIONS_WORKER_RUNTIME",
-                            "powershell"
+                            "powershell",
+                            "FUNCTIONS_WORKER_RUNTIME_VERSION",
+                            "~6"
                         }
                     }
                 },

--- a/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
@@ -252,7 +252,7 @@ namespace Azure.Functions.Cli.Tests.E2E
             }, _output);
         }
 
-                [Fact]
+        [Fact]
         public Task javascript_adds_packagejson()
         {
             return CliTester.Run(new RunConfiguration
@@ -378,7 +378,7 @@ namespace Azure.Functions.Cli.Tests.E2E
         }
 
         [Fact]
-        public Task init_function_app_powershell_supports_managed_dependencies()
+        public Task init_function_app_powershell_and_enable_managed_dependencies()
         {
             return CliTester.Run(new RunConfiguration
             {
@@ -390,6 +390,9 @@ namespace Azure.Functions.Cli.Tests.E2E
                         Name = "host.json",
                         ContentContains = new []
                         {
+                            "logging",
+                            "applicationInsights",
+                            "extensionBundle",
                             "managedDependency",
                             "enabled",
                             "true"
@@ -401,6 +404,25 @@ namespace Azure.Functions.Cli.Tests.E2E
                         ContentContains = new []
                         {
                             "Az",
+                        }
+                    },
+                    new FileResult
+                    {
+                        Name = "profile.ps1",
+                        ContentContains = new []
+                        {
+                            "env:MSI_SECRET",
+                            "Disable-AzContextAutosave",
+                            "Connect-AzAccount -Identity"
+                        }
+                    },
+                    new FileResult
+                    {
+                        Name = "local.settings.json",
+                        ContentContains = new []
+                        {
+                            "FUNCTIONS_WORKER_RUNTIME",
+                            "powershell"
                         }
                     }
                 },


### PR DESCRIPTION
Set `PowerShellWorkerDefaultVersion` to `'~7'`

Fixes https://github.com/Azure/azure-functions-core-tools/issues/2084

This PR is cherry picking two commits from 2 PRs merged from the dev branch:
* Update profile.ps1 template and update generation of host.json for PowerShell function apps -- https://github.com/Azure/azure-functions-core-tools/pull/2004
* Add worker version for PowerShell function apps -- https://github.com/Azure/azure-functions-core-tools/pull/2045
