### PR TITLE
Added instructions for installing from winget

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,20 @@ npm i -g azure-functions-core-tools@3 --unsafe-perm true
 
 To install with chocolatey:
 
-"**v2**"
+**v2**
 ```bash
 choco install azure-functions-core-tools
 ```
-"**v3**"
+**v3**
 ```bash
 choco install azure-functions-core-tools-3
+```
+
+To install with winget:
+
+**v3**
+```bash
+winget install Microsoft.AzureFunctionsCoreTools -v 3.0.2534
 ```
 
 #### Notice: To debug functions under vscode, x64 bitness is required


### PR DESCRIPTION
Added a link to winget, which now have support for installing v3.x of the core tools. 
Adding a separate PR in the core tools repo with instructions for usage.