### PR TITLE
Remove WEBSITE_RUN_FROM_PACKAGE app setting (v2)

### DIFF
--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -455,8 +455,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             if (PublishBuildOption == BuildOption.Remote)
             {
                 await EnsureRemoteBuildIsSupported(functionApp);
-                // We don't need to remove WEBSITE_RUN_FROM_PACKAGE since Linux Consumption will set the app setting pointing to the latest package
-                await RemoveFunctionAppAppSetting(functionApp, Constants.WebsiteContentAzureFileConnectionString, Constants.WebsiteContentShared);
+                await RemoveFunctionAppAppSetting(functionApp, Constants.WebsiteRunFromPackage, Constants.WebsiteContentAzureFileConnectionString, Constants.WebsiteContentShared);
                 Task<DeployStatus> pollConsumptionBuild(HttpClient client) => KuduLiteDeploymentHelpers.WaitForRemoteBuild(client, functionApp);
                 var deployStatus = await PerformServerSideBuild(functionApp, zipFileFactory, pollConsumptionBuild);
                 return deployStatus == DeployStatus.Success;
@@ -704,7 +703,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             using (var handler = new ProgressMessageHandler(new HttpClientHandler()))
             using (var client = GetRemoteZipClient(new Uri($"https://{functionApp.ScmUri}"), handler))
             using (var request = new HttpRequestMessage(HttpMethod.Post, new Uri(
-                $"api/zipdeploy?isAsync=true&author={Environment.MachineName}&forceremotebuild=true", UriKind.Relative)))
+                $"api/zipdeploy?isAsync=true&author={Environment.MachineName}", UriKind.Relative)))
             {
                 ColoredConsole.WriteLine("Creating archive for current directory...");
 


### PR DESCRIPTION
Since we disable setting WEBSITE_RUN_FROM_PACKAGE in **kudu-2.11a**, we should remove WEBSITE_RUN_FROM_PACKAGE app setting in core tools.