### PR TITLE
Changing CopyItems to a Move in azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -194,14 +194,9 @@ steps:
     testResultsFiles: '**/*.trx'
     failTaskOnFailedTests: true
   condition: succeededOrFailed()
-- task: CopyFiles@2
-  inputs:
-    SourceFolder: '$(Build.Repository.LocalPath)\artifacts'
-    Contents: |
-      Azure.Functions.Cli.*
-      func-cli*.msi
-    TargetFolder: '$(Build.ArtifactStagingDirectory)'
-    CleanTargetFolder: true
+- pwsh: |
+    Move-Item -Path '$(Build.Repository.LocalPath)\artifacts\Azure.Functions.Cli.*' -Destination '$(Build.ArtifactStagingDirectory)'
+    Move-Item -Path '$(Build.Repository.LocalPath)\artifacts\func-cli*.msi' -Destination '$(Build.ArtifactStagingDirectory)'
 - task: PublishBuildArtifacts@1
   inputs:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -197,6 +197,7 @@ steps:
 - pwsh: |
     Move-Item -Path '$(Build.Repository.LocalPath)\artifacts\Azure.Functions.Cli.*' -Destination '$(Build.ArtifactStagingDirectory)'
     Move-Item -Path '$(Build.Repository.LocalPath)\artifacts\func-cli*.msi' -Destination '$(Build.ArtifactStagingDirectory)'
+  displayName: 'Move artifacts'
 - task: PublishBuildArtifacts@1
   inputs:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)'


### PR DESCRIPTION
In official builds we were running out of space on VM. Trying to use a Move instead of a Copy to save space.