### PR TITLE
changing the default bundle download path for osx

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -553,7 +553,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 var bundleId = ExtensionBundleHelper.GetExtensionBundleOptions(_hostOptions).Id;
                 if (!string.IsNullOrEmpty(bundleId))
                 {
-                    Environment.SetEnvironmentVariable("AzureFunctionsJobHost__extensionBundle__downloadPath", Path.Combine(Path.GetTempPath(), "Functions", ScriptConstants.ExtensionBundleDirectory, bundleId));
+                    Environment.SetEnvironmentVariable("AzureFunctionsJobHost__extensionBundle__downloadPath", ExtensionBundleHelper.GetDownloadPath(bundleId));
                     Environment.SetEnvironmentVariable("AzureFunctionsJobHost__extensionBundle__ensureLatest", "true");
                 }
             }

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -48,6 +48,8 @@ namespace Azure.Functions.Cli.Common
         public const string AzureFunctionsEnvorinmentEnvironmentVariable = "AZURE_FUNCTIONS_ENVIRONMENT";
         public const string ExtensionBundleConfigPropertyName = "extensionBundle";
         public const string AspNetCoreEnvironmentEnvironmentVariable = "ASPNETCORE_ENVIRONMENT";
+        public const string OSXCoreToolsTempDirectoryName = ".azure-functions-core-tools";
+        public const string OSXRootPath = "~/";
         public const string ManagedDependencyConfigPropertyName = "managedDependency";
         public const string PowerShellWorkerDefaultVersion = "~6";
 

--- a/src/Azure.Functions.Cli/ExtensionBundle/ExtensionBundleConfigurationBuilder.cs
+++ b/src/Azure.Functions.Cli/ExtensionBundle/ExtensionBundleConfigurationBuilder.cs
@@ -1,12 +1,6 @@
 ﻿using System.Collections.Generic;
-using System.IO;
-using Azure.Functions.Cli.Common;
 using Microsoft.Azure.WebJobs.Script;
-using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Azure.Functions.Cli.ExtensionBundle
 {
@@ -26,7 +20,7 @@ namespace Azure.Functions.Cli.ExtensionBundle
             {
                 builder.AddInMemoryCollection(new Dictionary<string, string>
                 {
-                    { "AzureFunctionsJobHost:extensionBundle:downloadPath", Path.Combine(Path.GetTempPath(), "Functions", ScriptConstants.ExtensionBundleDirectory, bundleId)},
+                    { "AzureFunctionsJobHost:extensionBundle:downloadPath", ExtensionBundleHelper.GetDownloadPath(bundleId) },
                     { "AzureFunctionsJobHost:extensionBundle:ensureLatest", "true"}
                 });
             }

--- a/src/Azure.Functions.Cli/ExtensionBundle/ExtensionBundleHelper.cs
+++ b/src/Azure.Functions.Cli/ExtensionBundle/ExtensionBundleHelper.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace Azure.Functions.Cli.ExtensionBundle
@@ -41,6 +42,12 @@ namespace Azure.Functions.Cli.ExtensionBundle
         public static ExtensionBundleContentProvider GetExtensionBundleContentProvider()
         {
             return new ExtensionBundleContentProvider(GetExtensionBundleManager(), NullLogger<ExtensionBundleContentProvider>.Instance);
+        }
+
+        public static string GetDownloadPath(string bundleId)
+        {
+            string rootDirectoryPath = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? Path.Combine(Constants.OSXRootPath, Constants.OSXCoreToolsTempDirectoryName) : Path.GetTempPath();
+            return Path.Combine(rootDirectoryPath, "Functions", ScriptConstants.ExtensionBundleDirectory, bundleId);
         }
     }
 }


### PR DESCRIPTION
Porting fix for https://github.com/Azure/azure-functions-core-tools/pull/2107
fixes #1999 