### PR TITLE
Warn users to stop using azure-functions-worker in requirements.txt (v2)

### DIFF
--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -271,6 +271,12 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 }
             }
 
+            // Check if azure-functions-worker exists in requirements.txt for Python function app
+            if (workerRuntime == WorkerRuntime.python)
+            {
+                await PythonHelpers.WarnIfAzureFunctionsWorkerInRequirementsTxt();
+            }
+
             return result;
         }
 

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -84,6 +84,9 @@
     <EmbeddedResource Include="StaticResources\requirements.psd1">
       <LogicalName>$(AssemblyName).requirements.psd1</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="StaticResources\requirements.txt">
+      <LogicalName>$(AssemblyName).requirements.txt</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="StaticResources\dockerignore">
       <LogicalName>$(AssemblyName).dockerignore</LogicalName>
     </EmbeddedResource>

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -33,7 +33,6 @@ namespace Azure.Functions.Cli.Common
         public const string PythonDockerImageVersionSetting = "FUNCTIONS_PYTHON_DOCKER_IMAGE";
         public const string PythonDockerImageSkipPull = "FUNCTIONS_PYTHON_DOCKER_SKIP_PULL";
         public const string PythonDockerRunCommand = "FUNCTIONS_PYTHON_DOCKER_RUN_COMMAND";
-        public const string PythonFunctionsLibrary = "azure-functions";
         public const string FunctionsCoreToolsEnvironment = "FUNCTIONS_CORETOOLS_ENVIRONMENT";
         public const string EnablePersistenceChannelDebugSetting = "FUNCTIONS_CORE_TOOLS_ENABLE_PERSISTENCE_CHANNEL_DEBUG_OUTPUT";
         public const string TelemetryOptOutVariable = "FUNCTIONS_CORE_TOOLS_TELEMETRY_OPTOUT";

--- a/src/Azure.Functions.Cli/Common/PythonPackage.cs
+++ b/src/Azure.Functions.Cli/Common/PythonPackage.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.Functions.Cli.Common
+{
+    public class PythonPackage
+    {
+        // azure-functions-worker
+        public string Name { get; set; }
+
+        // >=1.0.0,<1.0.3
+        public string Specification { get; set; }
+
+        // python_version < '2.8' or python_version == '2.7'
+        public string EnvironmentMarkers { get; set; }
+
+        // @ file:///somewhere
+        public string DirectReference { get; set; }
+    }
+}

--- a/src/Azure.Functions.Cli/Common/RequirementsTxtParser.cs
+++ b/src/Azure.Functions.Cli/Common/RequirementsTxtParser.cs
@@ -37,17 +37,17 @@ namespace Azure.Functions.Cli.Common
                 {
                     GroupCollection groups = match.Groups;
 
-                    groups.TryGetValue("name", out Group packageName);
-                    groups.TryGetValue("spec", out Group packageSpec);
-                    groups.TryGetValue("envmarker", out Group packageEnvMarker);
-                    groups.TryGetValue("directref", out Group packageDirectRef);
+                    Group packageName = groups["name"];
+                    Group packageSpec = groups["spec"];
+                    Group packageEnvMarker = groups["envmarker"];
+                    Group packageDirectRef = groups["directref"];
 
                     packages.Add(new PythonPackage()
                     {
-                        Name = packageName.Value.ToLower().Replace('_', '-').Replace('.', '-').Trim(),
-                        Specification = packageSpec?.Value?.Trim() ?? string.Empty,
-                        EnvironmentMarkers = packageEnvMarker?.Value?.Trim() ?? string.Empty,
-                        DirectReference = packageDirectRef?.Value?.Trim() ?? string.Empty
+                        Name = packageName.Success ? packageName.Value.ToLower().Replace('_', '-').Replace('.', '-').Trim() : string.Empty,
+                        Specification = packageSpec.Success ? packageSpec.Value.Trim() : string.Empty,
+                        EnvironmentMarkers = packageEnvMarker.Success ? packageEnvMarker.Value.Trim() : string.Empty,
+                        DirectReference = packageDirectRef.Success ? packageDirectRef.Value.Trim() : string.Empty
                     });
                 }
             });

--- a/src/Azure.Functions.Cli/Common/RequirementsTxtParser.cs
+++ b/src/Azure.Functions.Cli/Common/RequirementsTxtParser.cs
@@ -1,0 +1,58 @@
+﻿using Azure.Functions.Cli.Common;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Text.RegularExpressions;
+using System.Collections.Concurrent;
+
+namespace Azure.Functions.Cli.Common
+{
+    // Requirements.txt PEP https://www.python.org/dev/peps/pep-0440/
+    public static class RequirementsTxtParser
+    {
+        public static async Task<List<PythonPackage>> ParseRequirementsTxtFile(string functionAppRoot)
+        {
+            // Check if requirements.txt exist
+            string requirementsTxtPath = $"{functionAppRoot}/{Constants.RequirementsTxt}";
+            if (!FileSystemHelpers.FileExists(requirementsTxtPath))
+            {
+                return new List<PythonPackage>();
+            }
+
+            // Parse requirements.txt line by line
+            string fileContent = await FileSystemHelpers.ReadAllTextFromFileAsync(requirementsTxtPath);
+            return ParseRequirementsTxtContent(fileContent);
+        }
+
+        public static List<PythonPackage> ParseRequirementsTxtContent(string fileContent)
+        {
+            string pattern = @"^(?<name>(\w|\-|_|\.)+\s*)((?<spec>(===|==|<=|>=|!=|~=|>|<)[(\d|\w\d)\.]*[^;@])?)((;(?<envmarker>[^@]+))?)((@(?<directref>[^$]+))?)$";
+            Regex rx = new Regex(pattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            var packages = new ConcurrentBag<PythonPackage>();
+
+            fileContent.Split('\r', '\n').Where(l => !string.IsNullOrWhiteSpace(l)).AsParallel().ForAll(line => {
+                Match match = rx.Match(line);
+
+                if (match.Success)
+                {
+                    GroupCollection groups = match.Groups;
+
+                    groups.TryGetValue("name", out Group packageName);
+                    groups.TryGetValue("spec", out Group packageSpec);
+                    groups.TryGetValue("envmarker", out Group packageEnvMarker);
+                    groups.TryGetValue("directref", out Group packageDirectRef);
+
+                    packages.Add(new PythonPackage()
+                    {
+                        Name = packageName.Value.ToLower().Replace('_', '-').Replace('.', '-').Trim(),
+                        Specification = packageSpec?.Value?.Trim() ?? string.Empty,
+                        EnvironmentMarkers = packageEnvMarker?.Value?.Trim() ?? string.Empty,
+                        DirectReference = packageDirectRef?.Value?.Trim() ?? string.Empty
+                    });
+                }
+            });
+
+            return packages.ToList();
+        }
+    }
+}

--- a/src/Azure.Functions.Cli/Common/RequirementsTxtParser.cs
+++ b/src/Azure.Functions.Cli/Common/RequirementsTxtParser.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Text.RegularExpressions;
 using System.Collections.Concurrent;
+using System.IO;
 
 namespace Azure.Functions.Cli.Common
 {
@@ -13,7 +14,7 @@ namespace Azure.Functions.Cli.Common
         public static async Task<List<PythonPackage>> ParseRequirementsTxtFile(string functionAppRoot)
         {
             // Check if requirements.txt exist
-            string requirementsTxtPath = $"{functionAppRoot}/{Constants.RequirementsTxt}";
+            string requirementsTxtPath = Path.Join(functionAppRoot, Constants.RequirementsTxt);
             if (!FileSystemHelpers.FileExists(requirementsTxtPath))
             {
                 return new List<PythonPackage>();

--- a/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
@@ -24,8 +24,20 @@ namespace Azure.Functions.Cli.Helpers
             var pyVersion = await GetEnvironmentPythonVersion();
             AssertPythonVersion(pyVersion, errorIfNoVersion: false);
 
-            CreateRequirements();
+            await CreateRequirements();
             await EnsureVirtualEnvrionmentIgnored();
+        }
+
+        public static async Task WarnIfAzureFunctionsWorkerInRequirementsTxt()
+        {
+            if (FileSystemHelpers.FileExists(Path.Join(Environment.CurrentDirectory, Constants.RequirementsTxt))) {
+                List<PythonPackage> packages = await RequirementsTxtParser.ParseRequirementsTxtFile(Environment.CurrentDirectory);
+                PythonPackage workerPackage = packages.FirstOrDefault(p => p.Name == "azure-functions-worker");
+                if (workerPackage != null)
+                {
+                    ColoredConsole.WriteLine(WarningColor($"Please remove '{workerPackage.Name}{workerPackage.Specification}' from requirements.txt as it may conflict with the Azure Functions platform."));
+                }
+            }
         }
 
         public static async Task EnsureVirtualEnvrionmentIgnored()
@@ -64,11 +76,13 @@ namespace Azure.Functions.Cli.Helpers
             }
         }
 
-        private static void CreateRequirements()
+        private async static Task CreateRequirements()
         {
             if (!FileSystemHelpers.FileExists(Constants.RequirementsTxt))
             {
-                FileSystemHelpers.WriteAllTextToFile(Constants.RequirementsTxt, Constants.PythonFunctionsLibrary);
+                ColoredConsole.WriteLine($"Writing {Constants.RequirementsTxt}");
+                string requirementsTxtContent = await StaticResources.PythonRequirementsTxt;
+                await FileSystemHelpers.WriteAllTextToFileAsync(Constants.RequirementsTxt, requirementsTxtContent);
             }
             else
             {

--- a/src/Azure.Functions.Cli/StaticResources/StaticResources.cs
+++ b/src/Azure.Functions.Cli/StaticResources/StaticResources.cs
@@ -67,6 +67,8 @@ namespace Azure.Functions.Cli
 
         public static Task<string> PowerShellRequirementsPsd1 => GetValue("requirements.psd1");
 
+        public static Task<string> PythonRequirementsTxt => GetValue("requirements.txt");
+
         public static Task<string> PrintFunctionJson => GetValue("print-functions.sh");
 
 

--- a/src/Azure.Functions.Cli/StaticResources/requirements.txt
+++ b/src/Azure.Functions.Cli/StaticResources/requirements.txt
@@ -1,0 +1,3 @@
+﻿# Do not include azure-functions-worker as it may conflict with the Azure Functions platform
+
+azure-functions

--- a/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
@@ -508,5 +508,33 @@ namespace Azure.Functions.Cli.Tests.E2E
                 }
             }, _output);
         }
+
+        [Fact]
+        public Task init_python_app_generates_requirements_txt()
+        {
+            return CliTester.Run(new RunConfiguration
+            {
+                Commands = new[]
+                {
+                    "init . --worker-runtime python"
+                },
+                OutputContains = new[]
+                {
+                    "Writing requirements.txt"
+                },
+                CheckFiles = new FileResult[]
+                {
+                    new FileResult
+                    {
+                        Name = "requirements.txt",
+                        ContentContains = new []
+                        {
+                            "# Do not include azure-functions-worker as it may conflict with the Azure Functions platform",
+                            "azure-functions"
+                        }
+                    }
+                },
+            }, _output);
+        }
     }
 }

--- a/test/Azure.Functions.Cli.Tests/PublishHelperTests.cs
+++ b/test/Azure.Functions.Cli.Tests/PublishHelperTests.cs
@@ -16,7 +16,7 @@ namespace Azure.Functions.Cli.PublishHelperTests
         [InlineData("", false)]
         public void IsLinuxFxVersionUsingCustomImageTest(string linuxFxVersion, bool expected)
         {
-            Assert.Equal(expected, PublishHelper.IsLinuxFxVersionUsingCustomImage(linuxFxVersion)); 
+            Assert.Equal(expected, PublishHelper.IsLinuxFxVersionUsingCustomImage(linuxFxVersion));
         }
 
         [Theory]

--- a/test/Azure.Functions.Cli.Tests/RequirementsTxtParserTests.cs
+++ b/test/Azure.Functions.Cli.Tests/RequirementsTxtParserTests.cs
@@ -1,0 +1,143 @@
+﻿using Azure.Functions.Cli.Common;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests
+{
+    public class RequirementsTxtParserTests
+    {
+        [Fact]
+        public void ShouldReturnEmptyListOnEmptyContent()
+        {
+            List<PythonPackage> result = RequirementsTxtParser.ParseRequirementsTxtContent("");
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void ShouldIgnoreComment()
+        {
+            List<PythonPackage> result = RequirementsTxtParser.ParseRequirementsTxtContent("" +
+                "# This is a comment");
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void ShouldIgnoreExtraIndex()
+        {
+            List<PythonPackage> result = RequirementsTxtParser.ParseRequirementsTxtContent("" +
+                "--extra-index = https://extra.index.org");
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void ShouldIgnoreInvalidPackage()
+        {
+            List<PythonPackage> result = RequirementsTxtParser.ParseRequirementsTxtContent("" +
+                "numpy<>3.5.2");
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void ShouldReturnPackageWithNoSpecification()
+        {
+            List<PythonPackage> result = RequirementsTxtParser.ParseRequirementsTxtContent("" +
+                "numpy");
+            Assert.Single(result);
+
+            PythonPackage numpyPackage = result[0];
+            Assert.Equal("numpy", numpyPackage.Name);
+            Assert.Empty(numpyPackage.Specification);
+            Assert.Empty(numpyPackage.EnvironmentMarkers);
+            Assert.Empty(numpyPackage.DirectReference);
+        }
+
+        [Theory]
+        [InlineData("numpy===1.19.1", "numpy", "===1.19.1")]
+        [InlineData("numpy~=1.19.1", "numpy", "~=1.19.1")]
+        [InlineData("numpy!=1.19.1", "numpy", "!=1.19.1")]
+        [InlineData("numpy>=1.19.1", "numpy", ">=1.19.1")]
+        [InlineData("numpy<=1.19.1", "numpy", "<=1.19.1")]
+        [InlineData("numpy>1.19.1", "numpy", ">1.19.1")]
+        [InlineData("numpy<1.19.1", "numpy", "<1.19.1")]
+        public void ShouldReturnPackageWithSpecification(string content, string expectedName, string expectedSpec)
+        {
+            List<PythonPackage> result = RequirementsTxtParser.ParseRequirementsTxtContent("" +
+                content);
+            Assert.Single(result);
+
+            PythonPackage numpyPackage = result[0];
+            Assert.Equal(expectedName, numpyPackage.Name);
+            Assert.Equal(expectedSpec, numpyPackage.Specification);
+            Assert.Empty(numpyPackage.EnvironmentMarkers);
+            Assert.Empty(numpyPackage.DirectReference);
+        }
+
+        [Fact]
+        public void ShouldReturnPackageWithEnvironmentMarker()
+        {
+            List<PythonPackage> result = RequirementsTxtParser.ParseRequirementsTxtContent("" +
+                "numpy; python_version == '2.7'");
+            Assert.Single(result);
+
+            PythonPackage numpyPackage = result[0];
+            Assert.Equal("numpy", numpyPackage.Name);
+            Assert.Empty(numpyPackage.Specification);
+            Assert.Equal("python_version == '2.7'", numpyPackage.EnvironmentMarkers);
+            Assert.Empty(numpyPackage.DirectReference);
+        }
+
+        [Fact]
+        public void ShouldReturnPackageWithSpecAndEnvironmentMarker()
+        {
+            List<PythonPackage> result = RequirementsTxtParser.ParseRequirementsTxtContent("" +
+                "numpy>=3.5.1; python_version == '2.7'");
+            Assert.Single(result);
+
+            PythonPackage numpyPackage = result[0];
+            Assert.Equal("numpy", numpyPackage.Name);
+            Assert.Equal(">=3.5.1", numpyPackage.Specification);
+            Assert.Equal("python_version == '2.7'", numpyPackage.EnvironmentMarkers);
+            Assert.Empty(numpyPackage.DirectReference);
+        }
+
+        [Fact]
+        public void ShouldReturnPackageDirectReference()
+        {
+            List<PythonPackage> result = RequirementsTxtParser.ParseRequirementsTxtContent("" +
+                "numpy @ https://direct.reference/numpy");
+            Assert.Single(result);
+
+            PythonPackage numpyPackage = result[0];
+            Assert.Equal("numpy", numpyPackage.Name);
+            Assert.Empty(numpyPackage.Specification);
+            Assert.Empty(numpyPackage.EnvironmentMarkers);
+            Assert.Equal("https://direct.reference/numpy", numpyPackage.DirectReference);
+        }
+
+        [Fact]
+        public void PackageSpecWithDirectReference()
+        {
+            List<PythonPackage> result = RequirementsTxtParser.ParseRequirementsTxtContent("" +
+                "numpy==3.5.2 @ https://direct.reference/numpy");
+            Assert.Single(result);
+
+            PythonPackage numpyPackage = result[0];
+            Assert.Equal("numpy", numpyPackage.Name);
+            Assert.Equal("==3.5.2", numpyPackage.Specification);
+            Assert.Empty(numpyPackage.EnvironmentMarkers);
+            Assert.Equal("https://direct.reference/numpy", numpyPackage.DirectReference);
+        }
+
+        [Fact]
+        public void PackageNameShouldBeFormalizedIntoDashes()
+        {
+            List<PythonPackage> result = RequirementsTxtParser.ParseRequirementsTxtContent("" +
+                "Azure-Functions-Worker\r\n" +
+                "azure.functions.worker\n" +
+                "azure_functions_worker");
+
+            Assert.Equal(3, result.Count);
+            Assert.All(result, r => Assert.Equal("azure-functions-worker", r.Name));
+        }
+    }
+}


### PR DESCRIPTION
1. Add a message for warning users to not include azure-functions-worker in requirements.txt.
```
# Do not include azure-functions-worker as it may conflict with the Azure Functions platform

azure-functions
```
2. Add a parser of requirements.txt in RequirementsTxtParser.cs
3. Add a warning message when `func azure functionapp publish` with `azure-functions-worker` in requirements.txt