### PR TITLE
Add support for dotnet user secrets files

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -529,6 +529,10 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 services.AddSingleton<IConfigureBuilder<IConfigurationBuilder>>(_ => new ExtensionBundleConfigurationBuilder(_hostOptions));
                 services.AddSingleton<IConfigureBuilder<IConfigurationBuilder>, DisableConsoleConfigurationBuilder>();
                 services.AddSingleton<IConfigureBuilder<ILoggingBuilder>, LoggingBuilder>();
+                if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.dotnet)
+                {
+                    services.AddSingleton<IConfigureBuilder<IConfigurationBuilder>>(_ => new UserSecretsConfigurationBuilder(_hostOptions.ScriptPath));
+                }
 
                 services.AddSingleton<IDependencyValidator, ThrowingDependencyValidator>();
 

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -49,6 +49,7 @@ namespace Azure.Functions.Cli.Common
         public const string ManagedDependencyConfigPropertyName = "managedDependency";
         public const string CustomHandlerPropertyName = "customHandler";
         public const string PowerShellWorkerDefaultVersion = "~7";
+        public const string UserSecretsIdElementName = "UserSecretsId";
 
         public static string CliVersion => typeof(Constants).GetTypeInfo().Assembly.GetName().Version.ToString(3);
 

--- a/src/Azure.Functions.Cli/Helpers/ProjectHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/ProjectHelpers.cs
@@ -4,16 +4,37 @@ using Azure.Functions.Cli.Common;
 using System.Threading.Tasks;
 using System.IO;
 using System.Xml;
+using System;
+using Azure.Functions.Cli.Diagnostics;
+using Microsoft.Extensions.Logging;
 
 namespace Azure.Functions.Cli.Helpers
 {
     internal static class ProjectHelpers
     {
-        public static bool PackageReferenceExists(this ProjectRootElement project, string packageId)
+        public static string FindProjectFile(string path)
         {
-            ProjectItemElement existingPackageReference = project.Items
-                .FirstOrDefault(item => item.ItemType == Constants.PackageReferenceElementName && item.Include.ToLowerInvariant() == packageId.ToLowerInvariant());
-            return existingPackageReference != null;
+            ColoredConsoleLogger logger = new ColoredConsoleLogger("ProjectHelpers");
+            DirectoryInfo filePath = new DirectoryInfo(path);
+
+            do
+            {
+                var projectFiles = filePath.GetFiles("*.csproj");
+                if (projectFiles.Any())
+                {
+                    foreach (FileInfo file in projectFiles)
+                    {
+                        if (string.Equals(projectFiles[0].Name, Constants.ExtenstionsCsProjFile, StringComparison.OrdinalIgnoreCase)) continue;
+                        logger.LogInformation($"Found {file.FullName}. Using for user secrets file configuration.");
+                        return file.FullName;
+                    }
+                }
+                filePath = filePath.Parent;
+            }
+            while (filePath.FullName != filePath.Root.FullName);
+
+            logger.LogInformation($"Csproj not found in {path} directory tree. Skipping user secrets file configuration.");
+            return null;
         }
 
         public static ProjectRootElement GetProject(string path)
@@ -28,5 +49,22 @@ namespace Azure.Functions.Cli.Helpers
 
             return root;
         }
+
+        public static bool PackageReferenceExists(this ProjectRootElement project, string packageId)
+        {
+            ProjectItemElement existingPackageReference = project.Items
+                .FirstOrDefault(item => item.ItemType == Constants.PackageReferenceElementName && item.Include.ToLowerInvariant() == packageId.ToLowerInvariant());
+            return existingPackageReference != null;
+        }
+
+        public static string GetPropertyValue(this ProjectRootElement project, string propertyName)
+        {
+            var property = project.Properties
+                .FirstOrDefault(item => string.Equals(item.Name, propertyName, StringComparison.OrdinalIgnoreCase));
+
+            return property == null ? null : property.Value;
+        }
+
+
     }
 }

--- a/src/Azure.Functions.Cli/Secrets/UserSecretsConfigurationBuilder.cs
+++ b/src/Azure.Functions.Cli/Secrets/UserSecretsConfigurationBuilder.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Helpers;
+using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Extensions.Configuration;
+
+namespace Azure.Functions.Cli.Diagnostics
+{
+    internal class UserSecretsConfigurationBuilder : IConfigureBuilder<IConfigurationBuilder>
+    {
+        private readonly string _scriptPath;
+
+        public UserSecretsConfigurationBuilder(string scriptPath)
+        {
+            if (string.IsNullOrEmpty(scriptPath))
+            {
+                _scriptPath = Environment.CurrentDirectory;
+            }
+            else
+            {
+                _scriptPath = scriptPath;
+            }
+        }
+
+        public void Configure(IConfigurationBuilder builder)
+        {
+            string userSecretsId = GetUserSecretsId(_scriptPath);
+            if (userSecretsId == null) return;
+
+            builder.AddUserSecrets(userSecretsId);
+        }
+
+        private string GetUserSecretsId(string scriptPath)
+        {
+            if (string.IsNullOrEmpty(scriptPath)) return null;
+
+            string projectFilePath = ProjectHelpers.FindProjectFile(scriptPath);
+            if (projectFilePath == null) return null;
+
+            var projectRoot = ProjectHelpers.GetProject(projectFilePath);
+            var userSecretsId = ProjectHelpers.GetPropertyValue(projectRoot, Constants.UserSecretsIdElementName);
+
+            return userSecretsId;
+        }
+    }
+}


### PR DESCRIPTION
Resolves #1970

This will allow a user to make use of dotnet user secrets files detailed [here](https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-3.1&tabs=windows). The user would also have to implement dependency injection in their function ([more info](https://docs.microsoft.com/en-us/azure/azure-functions/functions-dotnet-dependency-injection)), and access their development secrets through an `IConfiguration` object.

One thing I'm unsure of is the logging I added. If that's the right way to do it, but also if those logs are clear and helpful. I want to give the user insight into the decision making process/where we looked so they are empowered to fix any issues, but I didn't want to bombard them with a bunch of "checking this folder... checking this folder..."