### PR TITLE
Less verbose logs on func start

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -6,27 +6,19 @@ using System.Linq;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
-using Azure.Functions.Cli.Actions.HostActions.WebHost.Security;
 using Azure.Functions.Cli.Common;
-using Azure.Functions.Cli.Diagnostics;
-using Azure.Functions.Cli.ExtensionBundle;
 using Azure.Functions.Cli.Extensions;
 using Azure.Functions.Cli.Helpers;
 using Azure.Functions.Cli.Interfaces;
 using Azure.Functions.Cli.NativeMethods;
 using Colors.Net;
 using Fclp;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.WebHost;
-using Microsoft.Azure.WebJobs.Script.WebHost.Authentication;
-using Microsoft.Azure.WebJobs.Script.WebHost.Controllers;
-using Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection;
-using Microsoft.Azure.WebJobs.Script.WebHost.Security;
-using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -45,6 +37,8 @@ namespace Azure.Functions.Cli.Actions.HostActions
         private const int DefaultPort = 7071;
         private const int DefaultTimeout = 20;
         private readonly ISecretsManager _secretsManager;
+        private LoggingFilterHelper _loggingFilterHelper;
+        private IConfigurationRoot _hostJsonConfig;
 
         public int Port { get; set; }
 
@@ -65,6 +59,9 @@ namespace Azure.Functions.Cli.Actions.HostActions
         public bool NoBuild { get; set; }
 
         public bool EnableAuth { get; set; }
+
+        public bool? VerboseLogging { get; set; }
+
         public List<string> EnabledFunctions { get; private set; }
 
         public StartHostAction(ISecretsManager secretsManager)
@@ -75,7 +72,6 @@ namespace Azure.Functions.Cli.Actions.HostActions
         public override ICommandLineParserResult ParseArgs(string[] args)
         {
             var hostSettings = _secretsManager.GetHostStartSettings();
-
             Parser
                 .Setup<int>('p', "port")
                 .WithDescription($"Local port to listen on. Default: {DefaultPort}")
@@ -138,17 +134,34 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 .WithDescription("A space seperated list of functions to load.")
                 .Callback(f => EnabledFunctions = f);
 
-            return base.ParseArgs(args);
+            Parser
+                .Setup<bool>("verbose")
+                .WithDescription("When false, hides system logs other than warnings and errors.")
+                .SetDefault(false)
+                .Callback(v => VerboseLogging = v);
+
+            var parserResult = base.ParseArgs(args);
+            bool verboseLoggingArgExists = parserResult.UnMatchedOptions.Where(o => o.LongName.Equals("verbose", StringComparison.OrdinalIgnoreCase)).Any();
+            // Input args do not contain --verbose flag
+            if (!VerboseLogging.Value && verboseLoggingArgExists)
+            {
+                VerboseLogging = null;
+            }
+            return parserResult;
         }
 
         private async Task<IWebHost> BuildWebHost(ScriptApplicationHostOptions hostOptions, Uri listenAddress, Uri baseAddress, X509Certificate2 certificate)
         {
             IDictionary<string, string> settings = await GetConfigurationSettings(hostOptions.ScriptPath, baseAddress);
+           
             settings.AddRange(LanguageWorkerHelper.GetWorkerConfiguration(LanguageWorkerSetting));
             UpdateEnvironmentVariables(settings);
 
-            var defaultBuilder = Microsoft.AspNetCore.WebHost.CreateDefaultBuilder(Array.Empty<string>());
+            _hostJsonConfig = Utilities.BuildHostJsonConfigutation(hostOptions);
+            _loggingFilterHelper = new LoggingFilterHelper(_hostJsonConfig, VerboseLogging);
 
+            var defaultBuilder = Microsoft.AspNetCore.WebHost.CreateDefaultBuilder(Array.Empty<string>());
+            
             if (UseHttps)
             {
                 defaultBuilder
@@ -160,7 +173,6 @@ namespace Azure.Functions.Cli.Actions.HostActions
                     });
                 });
             }
-
             return defaultBuilder
                 .UseSetting(WebHostDefaults.ApplicationKey, typeof(Startup).Assembly.GetName().Name)
                 .UseUrls(listenAddress.ToString())
@@ -171,12 +183,13 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 .ConfigureLogging(loggingBuilder =>
                 {
                     loggingBuilder.ClearProviders();
-                    loggingBuilder.AddDefaultWebJobsFilters();
-                    loggingBuilder.AddProvider(new ColoredConsoleLoggerProvider((cat, level) => level >= LogLevel.Information));
+                    _loggingFilterHelper.AddConsoleLoggingProvider(loggingBuilder);
                 })
-                .ConfigureServices((context, services) => services.AddSingleton<IStartup>(new Startup(context, hostOptions, CorsOrigins, CorsCredentials, EnableAuth)))
+                .ConfigureServices((context, services) => services.AddSingleton<IStartup>(new Startup(context, hostOptions, CorsOrigins, CorsCredentials, EnableAuth, _loggingFilterHelper)))
                 .Build();
         }
+
+       
 
         private async Task<IDictionary<string, string>> GetConfigurationSettings(string scriptPath, Uri uri)
         {
@@ -234,15 +247,19 @@ namespace Azure.Functions.Cli.Actions.HostActions
         public override async Task RunAsync()
         {
             await PreRunConditions();
-            Utilities.PrintLogo();
+            if (VerboseLogging.HasValue && VerboseLogging.Value)
+            {
+                Utilities.PrintLogo();
+            }
             Utilities.PrintVersion();
-            ValidateHostJsonConfiguration();
 
-            var settings = SelfHostWebHostSettingsFactory.Create(Environment.CurrentDirectory);
+            ScriptApplicationHostOptions hostOptions = SelfHostWebHostSettingsFactory.Create(Environment.CurrentDirectory);
+            _hostJsonConfig = Utilities.BuildHostJsonConfigutation(hostOptions);
+            ValidateHostJsonConfiguration();
 
             (var listenUri, var baseUri, var certificate) = await Setup();
 
-            IWebHost host = await BuildWebHost(settings, listenUri, baseUri, certificate);
+            IWebHost host = await BuildWebHost(hostOptions, listenUri, baseUri, certificate);
             var runTask = host.RunAsync();
 
             var hostService = host.Services.GetRequiredService<WebJobsScriptHostService>();
@@ -251,9 +268,14 @@ namespace Azure.Functions.Cli.Actions.HostActions
 
             var scriptHost = hostService.Services.GetRequiredService<IScriptJobHost>();
             var httpOptions = hostService.Services.GetRequiredService<IOptions<HttpOptions>>();
-            DisplayHttpFunctionsInfo(scriptHost, httpOptions.Value, baseUri);
-            DisplayDisabledFunctions(scriptHost);
-
+            if (scriptHost != null && scriptHost.Functions.Any())
+            {
+                DisplayFunctionsInfoUtilities.DisplayFunctionsInfo(scriptHost.Functions, httpOptions.Value, baseUri);
+            }
+            if (VerboseLogging == null || !VerboseLogging.Value)
+            {
+                ColoredConsole.WriteLine(AdditionalInfoColor("For detailed output, run func with --verbose flag."));
+            }
             await runTask;
         }
 
@@ -266,7 +288,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 throw new CliException($"Host.json file in missing. Please make sure host.json file is preset at {Environment.CurrentDirectory}");
             }
 
-            if (IsPreCompiledApp && BundleConfigurationExists(hostJsonPath))
+            if (IsPreCompiledApp && Utilities.JobHostConfigSectionExists(_hostJsonConfig, ConfigurationSectionNames.ExtensionBundle))
             {
                 throw new CliException($"Extension bundle configuration should not be present for the function app with pre-compiled functions. Please remove extension bundle configuration from host.json: {Path.Combine(Environment.CurrentDirectory, "host.json")}");
             }
@@ -304,13 +326,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 throw new CliException($"Port {Port} is unavailable. Close the process using that port, or specify another port using --port [-p].");
             }
         }
-
-        private bool BundleConfigurationExists(string hostJsonPath)
-        {
-            var hostJson = FileSystemHelpers.ReadAllTextFromFile(hostJsonPath);
-            return hostJson.Contains(Constants.ExtensionBundleConfigPropertyName, StringComparison.OrdinalIgnoreCase);
-        }
-
+       
         private bool IsPreCompiledFunctionApp()
         {
             bool isPrecompiled = false;
@@ -332,67 +348,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
             return isPrecompiled;
         }
 
-        private void DisplayDisabledFunctions(IScriptJobHost scriptHost)
-        {
-            if (scriptHost != null)
-            {
-                foreach (var function in scriptHost.Functions.Where(f => f.Metadata.IsDisabled()))
-                {
-                    ColoredConsole.WriteLine(WarningColor($"Function {function.Name} is disabled."));
-                }
-            }
-        }
-
-        private void DisplayHttpFunctionsInfo(IScriptJobHost scriptHost, HttpOptions httpOptions, Uri baseUri)
-        {
-            if (scriptHost != null)
-            {
-                var httpFunctions = scriptHost.Functions.Where(f => f.Metadata.IsHttpFunction() && !f.Metadata.IsDisabled());
-                if (httpFunctions.Any())
-                {
-                    ColoredConsole
-                        .WriteLine()
-                        .WriteLine(DarkYellow("Http Functions:"))
-                        .WriteLine();
-                }
-
-                foreach (var function in httpFunctions)
-                {
-                    var binding = function.Metadata.Bindings.FirstOrDefault(b => b.Type != null && b.Type.Equals("httpTrigger", StringComparison.OrdinalIgnoreCase));
-                    var httpRoute = binding?.Raw?.GetValue("route", StringComparison.OrdinalIgnoreCase)?.ToString();
-                    httpRoute = httpRoute ?? function.Name;
-
-                    string[] methods = null;
-                    var methodsRaw = binding?.Raw?.GetValue("methods", StringComparison.OrdinalIgnoreCase)?.ToString();
-                    if (string.IsNullOrEmpty(methodsRaw) == false)
-                    {
-                        methods = methodsRaw.Split(',');
-                    }
-
-                    string hostRoutePrefix = "";
-                    if (!function.Metadata.IsProxy())
-                    {
-                        hostRoutePrefix = httpOptions.RoutePrefix ?? "api/";
-                        hostRoutePrefix = string.IsNullOrEmpty(hostRoutePrefix) || hostRoutePrefix.EndsWith("/")
-                            ? hostRoutePrefix
-                            : $"{hostRoutePrefix}/";
-                    }
-
-                    var functionMethods = methods != null ? $"{CleanAndFormatHttpMethods(string.Join(",", methods))}" : null;
-                    var url = $"{baseUri.ToString().Replace("0.0.0.0", "localhost")}{hostRoutePrefix}{httpRoute}";
-                    ColoredConsole
-                        .WriteLine($"\t{HttpFunctionNameColor($"{function.Name}:")} {HttpFunctionUrlColor(functionMethods)} {HttpFunctionUrlColor(url)}")
-                        .WriteLine();
-                }
-            }
-        }
-
-        private string CleanAndFormatHttpMethods(string httpMethods)
-        {
-            return httpMethods.Replace(Environment.NewLine, string.Empty).Replace(" ", string.Empty)
-                .Replace("\"", string.Empty).ToUpperInvariant();
-        }
-
+                       
         internal static async Task CheckNonOptionalSettings(IEnumerable<KeyValuePair<string, string>> secrets, string scriptPath)
         {
             try
@@ -466,127 +422,6 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 ? await SecurityHelpers.GetOrCreateCertificate(CertPath, CertPassword)
                 : null;
             return (new Uri($"{protocol}://0.0.0.0:{Port}"), new Uri($"{protocol}://localhost:{Port}"), cert);
-        }
-
-        public class Startup : IStartup
-        {
-            private readonly WebHostBuilderContext _builderContext;
-            private readonly ScriptApplicationHostOptions _hostOptions;
-            private readonly string[] _corsOrigins;
-            private readonly bool _corsCredentials;
-            private readonly bool _enableAuth;
-
-            public Startup(WebHostBuilderContext builderContext, ScriptApplicationHostOptions hostOptions, string corsOrigins, bool corsCredentials, bool enableAuth)
-            {
-                _builderContext = builderContext;
-                _hostOptions = hostOptions;
-                _enableAuth = enableAuth;
-
-                if (!string.IsNullOrEmpty(corsOrigins))
-                {
-                    _corsOrigins = corsOrigins.Split(',', StringSplitOptions.RemoveEmptyEntries);
-                    _corsCredentials = corsCredentials;
-                }
-            }
-
-            public IServiceProvider ConfigureServices(IServiceCollection services)
-            {
-                if (_corsOrigins != null)
-                {
-                    services.AddCors();
-                }
-
-                if (_enableAuth)
-                {
-                    services.AddWebJobsScriptHostAuthentication();
-                }
-                else
-                {
-                    services.AddAuthentication()
-                        .AddScriptJwtBearer()
-                        .AddScheme<AuthenticationLevelOptions, CliAuthenticationHandler<AuthenticationLevelOptions>>(AuthLevelAuthenticationDefaults.AuthenticationScheme, configureOptions: _ => { })
-                        .AddScheme<ArmAuthenticationOptions, CliAuthenticationHandler<ArmAuthenticationOptions>>(ArmAuthenticationDefaults.AuthenticationScheme, _ => { });
-                }
-
-                services.AddWebJobsScriptHostAuthorization();
-
-                services.AddMvc()
-                    .AddApplicationPart(typeof(HostController).Assembly);
-
-                // workaround for https://github.com/Azure/azure-functions-core-tools/issues/2097
-                SetBundlesEnvironmentVariables();
-
-                services.AddWebJobsScriptHost(_builderContext.Configuration);
-
-                services.Configure<ScriptApplicationHostOptions>(o =>
-                {
-                    o.ScriptPath = _hostOptions.ScriptPath;
-                    o.LogPath = _hostOptions.LogPath;
-                    o.IsSelfHost = _hostOptions.IsSelfHost;
-                    o.SecretsPath = _hostOptions.SecretsPath;
-                });
-
-                services.AddSingleton<IConfigureBuilder<IConfigurationBuilder>>(_ => new ExtensionBundleConfigurationBuilder(_hostOptions));
-                services.AddSingleton<IConfigureBuilder<IConfigurationBuilder>, DisableConsoleConfigurationBuilder>();
-                services.AddSingleton<IConfigureBuilder<ILoggingBuilder>, LoggingBuilder>();
-                if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.dotnet)
-                {
-                    services.AddSingleton<IConfigureBuilder<IConfigurationBuilder>>(_ => new UserSecretsConfigurationBuilder(_hostOptions.ScriptPath));
-                }
-
-                services.AddSingleton<IDependencyValidator, ThrowingDependencyValidator>();
-
-                return services.BuildServiceProvider();
-            }
-
-            private void SetBundlesEnvironmentVariables()
-            {
-                var bundleId = ExtensionBundleHelper.GetExtensionBundleOptions(_hostOptions).Id;
-                if (!string.IsNullOrEmpty(bundleId))
-                {
-                    Environment.SetEnvironmentVariable("AzureFunctionsJobHost__extensionBundle__downloadPath", ExtensionBundleHelper.GetBundleDownloadPath(bundleId));
-                    Environment.SetEnvironmentVariable("AzureFunctionsJobHost__extensionBundle__ensureLatest", "true");
-                }
-            }
-
-            public void Configure(IApplicationBuilder app)
-            {
-                if (_corsOrigins != null)
-                {
-                    app.UseCors(builder =>
-                    {
-                        var origins = builder.WithOrigins(_corsOrigins)
-                            .AllowAnyHeader()
-                            .AllowAnyMethod();
-                        if (_corsCredentials)
-                        {
-                            origins.AllowCredentials();
-                        }
-                    });
-                }
-
-                IApplicationLifetime applicationLifetime = app.ApplicationServices
-                    .GetRequiredService<IApplicationLifetime>();
-
-                app.UseWebJobsScriptHost(applicationLifetime);
-            }
-
-            private class ThrowingDependencyValidator : DependencyValidator
-            {
-                public override void Validate(IServiceCollection services)
-                {
-                    try
-                    {
-                        base.Validate(services);
-                    }
-                    catch (InvalidHostServicesException ex)
-                    {
-                        // Rethrow this as an InvalidOperationException to bypass the handling
-                        // in the host. This will stop invalid services in the CLI only.
-                        throw new InvalidOperationException("Invalid host services.", ex);
-                    }
-                }
-            }
         }
     }
 }

--- a/src/Azure.Functions.Cli/Actions/HostActions/Startup.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/Startup.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.Collections.Generic;
+using Azure.Functions.Cli.Actions.HostActions.WebHost.Security;
+using Azure.Functions.Cli.Diagnostics;
+using Azure.Functions.Cli.ExtensionBundle;
+using Azure.Functions.Cli.Helpers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Authentication;
+using Microsoft.Azure.WebJobs.Script.WebHost.Controllers;
+using Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Functions.Cli.Actions.HostActions
+{
+    public class Startup : IStartup
+    {
+        private readonly WebHostBuilderContext _builderContext;
+        private readonly ScriptApplicationHostOptions _hostOptions;
+        private readonly string[] _corsOrigins;
+        private readonly bool _corsCredentials;
+        private readonly bool _enableAuth;
+        private readonly LoggingFilterHelper _loggingFilterHelper;
+
+        public Startup(WebHostBuilderContext builderContext, ScriptApplicationHostOptions hostOptions, string corsOrigins, bool corsCredentials, bool enableAuth, LoggingFilterHelper loggingFilterHelper)
+        {
+            _builderContext = builderContext;
+            _hostOptions = hostOptions;
+            _enableAuth = enableAuth;
+            _loggingFilterHelper = loggingFilterHelper;
+
+            if (!string.IsNullOrEmpty(corsOrigins))
+            {
+                _corsOrigins = corsOrigins.Split(',', StringSplitOptions.RemoveEmptyEntries);
+                _corsCredentials = corsCredentials;
+            }
+        }
+
+        public IServiceProvider ConfigureServices(IServiceCollection services)
+        {
+            if (_corsOrigins != null)
+            {
+                services.AddCors();
+            }
+
+            if (_enableAuth)
+            {
+                services.AddWebJobsScriptHostAuthentication();
+            }
+            else
+            {
+                services.AddAuthentication()
+                    .AddScriptJwtBearer()
+                    .AddScheme<AuthenticationLevelOptions, CliAuthenticationHandler<AuthenticationLevelOptions>>(AuthLevelAuthenticationDefaults.AuthenticationScheme, configureOptions: _ => { })
+                    .AddScheme<ArmAuthenticationOptions, CliAuthenticationHandler<ArmAuthenticationOptions>>(ArmAuthenticationDefaults.AuthenticationScheme, _ => { });
+            }
+
+            services.AddWebJobsScriptHostAuthorization();
+
+            services.AddMvc()
+                .AddApplicationPart(typeof(HostController).Assembly);
+
+            // workaround for https://github.com/Azure/azure-functions-core-tools/issues/2097
+            SetBundlesEnvironmentVariables();
+
+            services.AddWebJobsScriptHost(_builderContext.Configuration);
+
+            services.Configure<ScriptApplicationHostOptions>(o =>
+            {
+                o.ScriptPath = _hostOptions.ScriptPath;
+                o.LogPath = _hostOptions.LogPath;
+                o.IsSelfHost = _hostOptions.IsSelfHost;
+                o.SecretsPath = _hostOptions.SecretsPath;
+            });
+
+            services.AddSingleton<IConfigureBuilder<IConfigurationBuilder>>(_ => new ExtensionBundleConfigurationBuilder(_hostOptions));
+            services.AddSingleton<IConfigureBuilder<IConfigurationBuilder>, DisableConsoleConfigurationBuilder>();
+            services.AddSingleton<IConfigureBuilder<ILoggingBuilder>>(_ => new LoggingBuilder(_loggingFilterHelper));
+            if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.dotnet)
+            {
+                services.AddSingleton<IConfigureBuilder<IConfigurationBuilder>>(_ => new UserSecretsConfigurationBuilder(_hostOptions.ScriptPath, _loggingFilterHelper));
+            }
+
+            services.AddSingleton<IDependencyValidator, ThrowingDependencyValidator>();
+
+            return services.BuildServiceProvider();
+        }
+
+        private void SetBundlesEnvironmentVariables()
+        {
+            var bundleId = ExtensionBundleHelper.GetExtensionBundleOptions(_hostOptions).Id;
+            if (!string.IsNullOrEmpty(bundleId))
+            {
+                Environment.SetEnvironmentVariable("AzureFunctionsJobHost__extensionBundle__downloadPath", ExtensionBundleHelper.GetBundleDownloadPath(bundleId));
+                Environment.SetEnvironmentVariable("AzureFunctionsJobHost__extensionBundle__ensureLatest", "true");
+            }
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            if (_corsOrigins != null)
+            {
+                app.UseCors(builder =>
+                {
+                    var origins = builder.WithOrigins(_corsOrigins)
+                        .AllowAnyHeader()
+                        .AllowAnyMethod();
+                    if (_corsCredentials)
+                    {
+                        origins.AllowCredentials();
+                    }
+                });
+            }
+
+            IApplicationLifetime applicationLifetime = app.ApplicationServices
+                .GetRequiredService<IApplicationLifetime>();
+
+            app.UseWebJobsScriptHost(applicationLifetime);
+        }
+
+        private class ThrowingDependencyValidator : DependencyValidator
+        {
+            public override void Validate(IServiceCollection services)
+            {
+                try
+                {
+                    base.Validate(services);
+                }
+                catch (InvalidHostServicesException ex)
+                {
+                    // Rethrow this as an InvalidOperationException to bypass the handling
+                    // in the host. This will stop invalid services in the CLI only.
+                    throw new InvalidOperationException("Invalid host services.", ex);
+                }
+            }
+        }
+    }
+}

--- a/src/Azure.Functions.Cli/Common/DisplayFunctionsInfoUtilities.cs
+++ b/src/Azure.Functions.Cli/Common/DisplayFunctionsInfoUtilities.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Linq;
+using Azure.Functions.Cli.Extensions;
+using Colors.Net;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Script;
+using static Colors.Net.StringStaticMethods;
+using static Azure.Functions.Cli.Common.OutputTheme;
+using Microsoft.Azure.WebJobs.Script.Description;
+using System.Collections.Generic;
+
+namespace Azure.Functions.Cli
+{
+    public static class DisplayFunctionsInfoUtilities
+    {
+        internal static void DisplayFunctionsInfo(ICollection<FunctionDescriptor> functions, HttpOptions httpOptions, Uri baseUri)
+        {
+                var allValidFunctions = functions.Where(f => !f.Metadata.IsDisabled());
+                if (allValidFunctions.Any())
+                {
+                    ColoredConsole
+                        .WriteLine()
+                        .WriteLine(DarkYellow("Functions:"))
+                        .WriteLine();
+                }
+                DisplayHttpFunctions(functions, httpOptions, baseUri);
+                DisplayNonHttpFunctionsInfo(functions);
+                DisplayDisabledFunctions(functions);
+        }
+
+        private static void DisplayHttpFunctions(ICollection<FunctionDescriptor> functions, HttpOptions httpOptions, Uri baseUri)
+        {
+            var httpFunctions = functions.Where(f => f.Metadata.IsHttpFunction() && !f.Metadata.IsDisabled());
+            foreach (var function in httpFunctions)
+            {
+                var binding = function.Metadata.Bindings.FirstOrDefault(b => b.Type != null && b.Type.Equals("httpTrigger", StringComparison.OrdinalIgnoreCase));
+                var httpRoute = binding?.Raw?.GetValue("route", StringComparison.OrdinalIgnoreCase)?.ToString();
+                httpRoute = httpRoute ?? function.Name;
+
+                string[] methods = null;
+                var methodsRaw = binding?.Raw?.GetValue("methods", StringComparison.OrdinalIgnoreCase)?.ToString();
+                if (string.IsNullOrEmpty(methodsRaw) == false)
+                {
+                    methods = methodsRaw.Split(',');
+                }
+
+                string hostRoutePrefix = "";
+                if (!function.Metadata.IsProxy())
+                {
+                    hostRoutePrefix = httpOptions.RoutePrefix ?? "api/";
+                    hostRoutePrefix = string.IsNullOrEmpty(hostRoutePrefix) || hostRoutePrefix.EndsWith("/")
+                        ? hostRoutePrefix
+                        : $"{hostRoutePrefix}/";
+                }
+
+                var functionMethods = methods != null ? $"{CleanAndFormatHttpMethods(string.Join(",", methods))}" : null;
+                var url = $"{baseUri.ToString().Replace("0.0.0.0", "localhost")}{hostRoutePrefix}{httpRoute}";
+                ColoredConsole
+                    .WriteLine($"\t{HttpFunctionNameColor($"{function.Name}:")} {HttpFunctionUrlColor(functionMethods)} {HttpFunctionUrlColor(url)}")
+                    .WriteLine();
+            }
+        }
+
+        private static string CleanAndFormatHttpMethods(string httpMethods)
+        {
+            return httpMethods.Replace(Environment.NewLine, string.Empty).Replace(" ", string.Empty)
+                .Replace("\"", string.Empty).ToUpperInvariant();
+        }
+
+        private static void DisplayNonHttpFunctionsInfo(ICollection<FunctionDescriptor> functions)
+        {
+                var nonHttpFunctions = functions.Where(f => !f.Metadata.IsHttpFunction() && !f.Metadata.IsDisabled());
+                foreach (var function in nonHttpFunctions)
+                {
+                    var trigger = function.Metadata.Bindings.FirstOrDefault(b => b.Type != null && b.Type.EndsWith("Trigger", ignoreCase: true, null));
+                    ColoredConsole
+                        .WriteLine($"\t{Yellow($"{function.Name}:")} {trigger?.Type}")
+                        .WriteLine();
+                }
+        }
+
+        private static void DisplayDisabledFunctions(ICollection<FunctionDescriptor> functions)
+        {
+                foreach (var function in functions.Where(f => f.Metadata.IsDisabled()))
+                {
+                    ColoredConsole.WriteLine(WarningColor($"Function {function.Name} is disabled."));
+                }
+        }
+    }
+}

--- a/src/Azure.Functions.Cli/Diagnostics/ColoredConsoleLoggerProvider.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/ColoredConsoleLoggerProvider.cs
@@ -5,16 +5,16 @@ namespace Azure.Functions.Cli.Diagnostics
 {
     public class ColoredConsoleLoggerProvider : ILoggerProvider
     {
-        private readonly Func<string, LogLevel, bool> _filter;
+        private readonly LoggingFilterHelper _loggingFilterHelper;
 
-        public ColoredConsoleLoggerProvider(Func<string, LogLevel, bool> filter = null)
+        public ColoredConsoleLoggerProvider(LoggingFilterHelper loggingFilterHelper)
         {
-            _filter = filter;
+            _loggingFilterHelper = loggingFilterHelper;
         }
 
         public ILogger CreateLogger(string categoryName)
         {
-            return new ColoredConsoleLogger(categoryName, _filter);
+            return new ColoredConsoleLogger(categoryName, _loggingFilterHelper);
         }
 
         public void Dispose()

--- a/src/Azure.Functions.Cli/Diagnostics/LoggingBuilder.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/LoggingBuilder.cs
@@ -10,9 +10,16 @@ namespace Azure.Functions.Cli.Diagnostics
 {
     internal class LoggingBuilder : IConfigureBuilder<ILoggingBuilder>
     {
+        private LoggingFilterHelper _loggingFilterHelper;
+
+        public LoggingBuilder(LoggingFilterHelper loggingFilterHelper)
+        {
+            _loggingFilterHelper = loggingFilterHelper;
+        }
+
         public void Configure(ILoggingBuilder builder)
         {
-            builder.AddProvider(new ColoredConsoleLoggerProvider());
+            _loggingFilterHelper.AddConsoleLoggingProvider(builder);
 
             builder.Services.AddSingleton<TelemetryClient>(provider =>
             {

--- a/src/Azure.Functions.Cli/Diagnostics/LoggingFilterHelper.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/LoggingFilterHelper.cs
@@ -58,7 +58,7 @@ namespace Azure.Functions.Cli
         public LogLevel DefaultLogLevel { get; private set; } = LogLevel.Information;
 
         /// <summary>
-        /// Is set to true if `func start` is with `--verbose` flag. If set, SystemLogDefaultLogLevel is set to Information
+        /// Is set to true if `func start` is started with `--verbose` flag. If set, SystemLogDefaultLogLevel is set to Information
         /// </summary>
         public bool VerboseLogging { get; private set; }
 

--- a/src/Azure.Functions.Cli/Diagnostics/LoggingFilterHelper.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/LoggingFilterHelper.cs
@@ -1,0 +1,101 @@
+﻿using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.Eventing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+
+namespace Azure.Functions.Cli
+{
+    public class LoggingFilterHelper
+    {
+        private const string DefaultLogLevelKey = "default";
+        private IConfigurationRoot _hostJsonConfig = null;
+
+        // CI EnvironmentSettings
+        // https://github.com/watson/ci-info/blob/master/index.js#L52-L59
+        public const string Ci = "CI"; // Travis CI, CircleCI, Cirrus CI, Gitlab CI, Appveyor, CodeShip, dsari
+        public const string Ci_Continuous_Integration = "CONTINUOUS_INTEGRATION";  // Travis CI, Cirrus CI
+        public const string Ci_Build_Number = "BUILD_NUMBER";  // Travis CI, Cirrus CI
+        public const string Ci_Run_Id = "RUN_ID"; // TaskCluster, dsari
+
+        public LoggingFilterHelper(IConfigurationRoot hostJsonConfig, bool? verboseLogging)
+        {
+            _hostJsonConfig = hostJsonConfig;
+            VerboseLogging = verboseLogging.HasValue && verboseLogging.Value;
+
+            if (IsCiEnvironment(verboseLogging.HasValue))
+            {
+                VerboseLogging = true;
+            }
+            if (VerboseLogging)
+            {
+                SystemLogDefaultLogLevel = LogLevel.Information;
+            }
+            bool defaultLogLevelExists = Utilities.LogLevelExists(hostJsonConfig, DefaultLogLevelKey);
+            if (defaultLogLevelExists)
+            {
+                DefaultLogLevel = Utilities.GetHostJsonDefaultLogLevel(hostJsonConfig);
+                SystemLogDefaultLogLevel = DefaultLogLevel;
+                UserLogDefaultLogLevel = DefaultLogLevel;
+            }
+        }
+
+        /// <summary>
+        /// Default level for system logs
+        /// </summary>
+        public LogLevel SystemLogDefaultLogLevel { get; } = LogLevel.Warning;
+
+        /// <summary>
+        /// Default level for user logs
+        /// </summary>
+        public LogLevel UserLogDefaultLogLevel { get; } = LogLevel.Information;
+
+        /// <summary>
+        /// Default log level set in host.json. If not present, deafaults to Information
+        /// </summary>
+        public LogLevel DefaultLogLevel { get; private set; } = LogLevel.Information;
+
+        /// <summary>
+        /// Is set to true if `func start` is with `--verbose` flag. If set, SystemLogDefaultLogLevel is set to Information
+        /// </summary>
+        public bool VerboseLogging { get; private set; }
+
+        internal void AddConsoleLoggingProvider(ILoggingBuilder loggingBuilder)
+        {
+            // Filter is needed to force all the logs.
+            loggingBuilder.AddFilter<ColoredConsoleLoggerProvider>((category, level) => true).AddProvider(new ColoredConsoleLoggerProvider(this));
+        }
+
+        internal bool IsEnabled(string category, LogLevel logLevel)
+        {
+            if (_hostJsonConfig != null && Utilities.LogLevelExists(_hostJsonConfig, category))
+            {
+                // If category exists in `loglevel` section, ensure defaults do not apply.
+                return Utilities.UserLoggingFilter(logLevel);
+            }
+            if (DefaultLogLevel == LogLevel.None)
+            {
+                return false;
+            }
+            return Utilities.DefaultLoggingFilter(category, logLevel, UserLogDefaultLogLevel, SystemLogDefaultLogLevel);
+        }
+
+        internal bool IsCiEnvironment(bool verboseLoggingArgExists)
+        {
+            if (verboseLoggingArgExists)
+            {
+                return VerboseLogging;
+            }
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(Ci)) ||
+                !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(Ci_Continuous_Integration)) ||
+                !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(Ci_Build_Number)) ||
+                !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(Ci_Run_Id)))
+            {
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Azure.Functions.Cli/ExtensionBundle/ExtensionBundleHelper.cs
+++ b/src/Azure.Functions.Cli/ExtensionBundle/ExtensionBundleHelper.cs
@@ -15,16 +15,13 @@ namespace Azure.Functions.Cli.ExtensionBundle
         public static ExtensionBundleOptions GetExtensionBundleOptions(ScriptApplicationHostOptions hostOptions = null)
         {
             hostOptions = hostOptions ?? SelfHostWebHostSettingsFactory.Create(Environment.CurrentDirectory);
-            IConfigurationBuilder builder = new ConfigurationBuilder();
-            builder.Add(new HostJsonFileConfigurationSource(hostOptions, SystemEnvironment.Instance, loggerFactory: NullLoggerFactory.Instance, metricsLogger: new MetricsLogger()));
-            var configuration = builder.Build();
-
+            IConfigurationRoot configuration = Utilities.BuildHostJsonConfigutation(hostOptions);
             var configurationHelper = new ExtensionBundleConfigurationHelper(configuration, SystemEnvironment.Instance);
             var options = new ExtensionBundleOptions();
             configurationHelper.Configure(options);
             return options;
         }
-
+        
         public static ExtensionBundleManager GetExtensionBundleManager()
         {
             var extensionBundleOption = GetExtensionBundleOptions();

--- a/src/Azure.Functions.Cli/Helpers/ProjectHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/ProjectHelpers.cs
@@ -12,11 +12,10 @@ namespace Azure.Functions.Cli.Helpers
 {
     internal static class ProjectHelpers
     {
-        public static string FindProjectFile(string path)
+        public static string FindProjectFile(string path, LoggingFilterHelper loggingFilterHelper)
         {
-            ColoredConsoleLogger logger = new ColoredConsoleLogger("ProjectHelpers");
+            ColoredConsoleLogger logger = new ColoredConsoleLogger("ProjectHelpers", loggingFilterHelper);
             DirectoryInfo filePath = new DirectoryInfo(path);
-
             do
             {
                 var projectFiles = filePath.GetFiles("*.csproj");

--- a/src/Azure.Functions.Cli/Secrets/UserSecretsConfigurationBuilder.cs
+++ b/src/Azure.Functions.Cli/Secrets/UserSecretsConfigurationBuilder.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Helpers;
 using Microsoft.Azure.WebJobs.Script;
@@ -10,9 +9,11 @@ namespace Azure.Functions.Cli.Diagnostics
     internal class UserSecretsConfigurationBuilder : IConfigureBuilder<IConfigurationBuilder>
     {
         private readonly string _scriptPath;
+        private readonly LoggingFilterHelper _loggingFilterHelper;
 
-        public UserSecretsConfigurationBuilder(string scriptPath)
+        public UserSecretsConfigurationBuilder(string scriptPath, LoggingFilterHelper loggingFilterHelper)
         {
+            _loggingFilterHelper = loggingFilterHelper;
             if (string.IsNullOrEmpty(scriptPath))
             {
                 _scriptPath = Environment.CurrentDirectory;
@@ -25,17 +26,21 @@ namespace Azure.Functions.Cli.Diagnostics
 
         public void Configure(IConfigurationBuilder builder)
         {
-            string userSecretsId = GetUserSecretsId(_scriptPath);
-            if (userSecretsId == null) return;
-
+            string userSecretsId = GetUserSecretsId();
+            if (userSecretsId == null)
+            {
+                return;
+            }
             builder.AddUserSecrets(userSecretsId);
         }
 
-        private string GetUserSecretsId(string scriptPath)
+        private string GetUserSecretsId()
         {
-            if (string.IsNullOrEmpty(scriptPath)) return null;
-
-            string projectFilePath = ProjectHelpers.FindProjectFile(scriptPath);
+            if (string.IsNullOrEmpty(_scriptPath))
+            {
+                return null;
+            }
+            string projectFilePath = ProjectHelpers.FindProjectFile(_scriptPath, _loggingFilterHelper);
             if (projectFilePath == null) return null;
 
             var projectRoot = ProjectHelpers.GetProject(projectFilePath);

--- a/test/Azure.Functions.Cli.Tests/ColoredConsoleLoggerTests.cs
+++ b/test/Azure.Functions.Cli.Tests/ColoredConsoleLoggerTests.cs
@@ -1,0 +1,49 @@
+﻿using Azure.Functions.Cli.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests
+{
+    public class ColoredConsoleLoggerTests
+    {
+        private IConfigurationRoot _testConfiguration;
+
+        public ColoredConsoleLoggerTests()
+        {
+            string defaultJson = "{\"version\": \"2.0\",\"Logging\": {\"LogLevel\": {\"Host.Startup\": \"Debug\"}}}";
+            _testConfiguration = new ConfigurationBuilder().AddJsonStream(new MemoryStream(Encoding.ASCII.GetBytes(defaultJson))).Build();
+        }
+
+        [Theory]
+        [InlineData("somelog", false)]
+        [InlineData("Worker process started and initialized.", true)]
+        [InlineData("Worker PROCESS started and initialized.", true)]
+        [InlineData("Worker process started.", false)]
+        [InlineData("Host lock lease acquired by instance ID", true)]
+        [InlineData("Host lock lease acquired by instance id", true)]
+        [InlineData("Host lock lease", false)]
+        public void DoesMessageStartsWithWhiteListedPrefix_Tests(string formattedMessage, bool expected)
+        {
+            ColoredConsoleLogger coloredConsoleLogger = new ColoredConsoleLogger("test", new LoggingFilterHelper(_testConfiguration, true));
+            Assert.Equal(expected, coloredConsoleLogger.DoesMessageStartsWithAllowedLogsPrefix(formattedMessage));
+        }
+
+        [Theory]
+        [InlineData("somelog", false)]
+        [InlineData("Worker process started and initialized.", true)]
+        [InlineData("Worker PROCESS started and initialized.", true)]
+        [InlineData("Worker process started.", false)]
+        [InlineData("Host lock lease acquired by instance ID", true)]
+        [InlineData("Host lock lease acquired by instance id", true)]
+        [InlineData("Host lock lease", false)]
+        public void IsEnabled_Tests(string formattedMessage, bool expected)
+        {
+            ColoredConsoleLogger coloredConsoleLogger = new ColoredConsoleLogger("test", new LoggingFilterHelper(_testConfiguration, true));
+            Assert.Equal(expected, coloredConsoleLogger.DoesMessageStartsWithAllowedLogsPrefix(formattedMessage));
+        }
+    }
+}

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -33,7 +33,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                 ExpectExit = false,
                 OutputContains = new[]
                 {
-                    "Http Functions:",
+                    "Functions:",
                     "HttpTrigger: [GET,POST] http://localhost:7071/api/HttpTrigger"
                 },
                 Test = async (workingDir, p) =>
@@ -59,7 +59,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                 {
                     "init . --worker-runtime node",
                     "new --template \"Http trigger\" --name HttpTrigger",
-                    "start --language-worker -- \"--inspect=5050\""
+                    "start --verbose --language-worker -- \"--inspect=5050\""
                 },
                 ExpectExit = false,
                 OutputContains = new[]

--- a/test/Azure.Functions.Cli.Tests/LoggingFilterHelperTests.cs
+++ b/test/Azure.Functions.Cli.Tests/LoggingFilterHelperTests.cs
@@ -1,0 +1,98 @@
+﻿using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Diagnostics;
+using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests
+{
+    public class LoggingFilterHelperTests
+    {
+        private ScriptApplicationHostOptions _hostOptions;
+
+        public LoggingFilterHelperTests()
+        {
+            _hostOptions = new ScriptApplicationHostOptions
+            {
+                ScriptPath = Directory.GetCurrentDirectory()
+            };
+        }
+
+        [Theory]
+        [InlineData("{\"version\": \"2.0\",\"Logging\": {\"LogLevel\": {\"Default\": \"None\"}}}", true, LogLevel.None)]
+        [InlineData("{\"version\": \"2.0\",\"Logging\": {\"LogLevel\": {\"Default\": \"DEBUG\"}}}", true, LogLevel.Debug)]
+        [InlineData("{\"version\": \"2.0\"}", null, LogLevel.Information)]
+        [InlineData("{\"version\": \"2.0\",\"Logging\": {\"LogLevel\": {\"Host.Startup\": \"Debug\"}}}", true, LogLevel.Information)]
+        public void LoggingFilterHelper_Tests(string hostJsonContent, bool? verboseLogging, LogLevel expectedDefaultLogLevel)
+        {
+            FileSystemHelpers.WriteAllTextToFile(Constants.HostJsonFileName, hostJsonContent);
+            var configuration = Utilities.BuildHostJsonConfigutation(_hostOptions);
+            LoggingFilterHelper loggingFilterHelper = new LoggingFilterHelper(configuration, verboseLogging);
+            if (verboseLogging == null)
+            {
+                Assert.False(loggingFilterHelper.VerboseLogging);
+            }
+            Assert.Equal(loggingFilterHelper.DefaultLogLevel, expectedDefaultLogLevel);
+            if (hostJsonContent.Contains("Default"))
+            {
+                Assert.Equal(loggingFilterHelper.DefaultLogLevel, loggingFilterHelper.UserLogDefaultLogLevel);
+                Assert.Equal(loggingFilterHelper.DefaultLogLevel, loggingFilterHelper.SystemLogDefaultLogLevel);
+            }
+            else
+            {
+                Assert.Equal(LogLevel.Information, loggingFilterHelper.UserLogDefaultLogLevel);
+                if (verboseLogging.HasValue && verboseLogging.Value)
+                {
+                    Assert.Equal(LogLevel.Information, loggingFilterHelper.SystemLogDefaultLogLevel);
+                }
+                else
+                {
+                    Assert.Equal(LogLevel.Warning, loggingFilterHelper.SystemLogDefaultLogLevel);
+                }
+            }
+            var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                loggingFilterHelper.AddConsoleLoggingProvider(builder);
+                var serviceProvider = builder.Services.BuildServiceProvider();
+                var coloredConsoleLoggerProvider = (ColoredConsoleLoggerProvider)serviceProvider.GetService<ILoggerProvider>();
+                Assert.NotNull(coloredConsoleLoggerProvider);
+            });
+        }
+
+        [Theory]
+        [InlineData("{\"version\": \"2.0\",\"Logging\": {\"LogLevel\": {\"Default\": \"None\"}}}", "test", LogLevel.Information, false)]
+        [InlineData("{\"version\": \"2.0\",\"Logging\": {\"LogLevel\": {\"Host.Startup\": \"Debug\"}}}", "Host.Startup", LogLevel.Information, true)]
+        [InlineData("{\"version\": \"2.0\",\"Logging\": {\"LogLevel\": {\"Host.Startup\": \"Debug\"}}}", "Host.General", LogLevel.Information, false)]
+        [InlineData("{\"version\": \"2.0\",\"Logging\": {\"LogLevel\": {\"Host.Startup\": \"Debug\"}}}", "Host.General", LogLevel.Warning, true)]
+        public void IsEnabled_Tests(string hostJsonContent, string category, LogLevel logLevel, bool expected)
+        {
+            FileSystemHelpers.WriteAllTextToFile(Constants.HostJsonFileName, hostJsonContent);
+            var configuration = Utilities.BuildHostJsonConfigutation(_hostOptions);
+            LoggingFilterHelper loggingFilterHelper = new LoggingFilterHelper(configuration, false);
+            Assert.Equal(expected, loggingFilterHelper.IsEnabled(category, logLevel));
+        }
+
+        [Theory]
+        [InlineData(false, null, false)]
+        [InlineData(true, false, false)]
+        [InlineData(true, null, true)]
+        public void IsCI_Tests(bool isCiEnv, bool? verboseLogging, bool expected)
+        {
+            if (isCiEnv)
+            {
+                Environment.SetEnvironmentVariable(LoggingFilterHelper.Ci_Build_Number, "90l99");
+            }
+            string defaultJson = "{\"version\": \"2.0\"}";
+            FileSystemHelpers.WriteAllTextToFile(Constants.HostJsonFileName, defaultJson);
+            var configuration = Utilities.BuildHostJsonConfigutation(_hostOptions);
+            LoggingFilterHelper loggingFilterHelper = new LoggingFilterHelper(configuration, verboseLogging);
+            Assert.Equal(expected, loggingFilterHelper.IsCiEnvironment(verboseLogging.HasValue));
+            Environment.SetEnvironmentVariable(LoggingFilterHelper.Ci_Build_Number, "");
+        }
+    }
+}

--- a/test/Azure.Functions.Cli.Tests/UtilitiesTests.cs
+++ b/test/Azure.Functions.Cli.Tests/UtilitiesTests.cs
@@ -1,0 +1,81 @@
+﻿using Azure.Functions.Cli.Common;
+using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests
+{
+    public class UtilitiesTests
+    {
+        [Theory]
+        [InlineData("{\"version\": \"2.0\",\"Logging\": {\"LogLevel\": {\"Default\": \"None\"}}}", LogLevel.None)]
+        [InlineData("{\"version\": \"2.0\",\"logging\": {\"logLevel\": {\"Default\": \"NONE\"}}}", LogLevel.None)]
+        [InlineData("{\"version\": \"2.0\",\"logging\": {\"logLevel\": {\"Default\": \"Debug\"}}}", LogLevel.Debug)]
+        [InlineData("{\"version\": \"2.0\"}", LogLevel.Information)]
+        public void GetHostJsonDefaultLogLevel_Test(string hostJsonContent, LogLevel expectedLogLevel)
+        {
+            FileSystemHelpers.WriteAllTextToFile(Constants.HostJsonFileName, hostJsonContent);
+            ScriptApplicationHostOptions hostOptions = new ScriptApplicationHostOptions
+            {
+                ScriptPath = Directory.GetCurrentDirectory()
+            };
+            var configuration = Utilities.BuildHostJsonConfigutation(hostOptions);
+            LogLevel actualLogLevel = Utilities.GetHostJsonDefaultLogLevel(configuration);
+            Assert.Equal(actualLogLevel, expectedLogLevel);
+        }
+
+        [Theory]
+        [InlineData("{\"version\": \"2.0\",\"Logging\": {\"LogLevel\": {\"Host.General\": \"Debug\"}}}", "Host.General",  true)]
+        [InlineData("{\"version\": \"2.0\",\"Logging\": {\"LogLevel\": {\"Host.Startup\": \"Debug\"}}}", "Host.General", false)]
+        [InlineData("{\"version\": \"2.0\"}", "Function.HttpFunction", false)]
+        public void LogLevelExists_Test(string hostJsonContent, string category, bool expected)
+        {
+            FileSystemHelpers.WriteAllTextToFile(Constants.HostJsonFileName, hostJsonContent);
+            ScriptApplicationHostOptions hostOptions = new ScriptApplicationHostOptions
+            {
+                ScriptPath = Directory.GetCurrentDirectory()
+            };
+            var configuration = Utilities.BuildHostJsonConfigutation(hostOptions); 
+            Assert.Equal(expected, Utilities.LogLevelExists(configuration, category));
+        }
+
+        [Theory]
+        [InlineData("{\"version\": \"2.0\",\"extensionBundle\": { \"id\": \"Microsoft.Azure.Functions.ExtensionBundle\",\"version\": \"[1.*, 2.0.0)\"}}", "extensionBundle", true)]
+        [InlineData("{\"version\": \"2.0\",\"extensionBundle\": { \"id\": \"Microsoft.Azure.Functions.ExtensionBundle\",\"version\": \"[1.*, 2.0.0)\"}}", "ExtensionBundle", true)]
+        [InlineData("{\"version\": \"2.0\"}", "extensionBundle", false)]
+        public void JobHostConfigSectionExists_Test(string hostJsonContent, string section, bool expected)
+        {
+            FileSystemHelpers.WriteAllTextToFile(Constants.HostJsonFileName, hostJsonContent);
+            ScriptApplicationHostOptions hostOptions = new ScriptApplicationHostOptions
+            {
+                ScriptPath = Directory.GetCurrentDirectory()
+            };
+            var configuration = Utilities.BuildHostJsonConfigutation(hostOptions);
+            Assert.Equal(expected, Utilities.JobHostConfigSectionExists(configuration, section));
+        }
+
+        [Theory]
+        [InlineData(LogLevel.None, false)]
+        [InlineData(LogLevel.Debug, true)]
+        [InlineData(LogLevel.Information, true)]
+        public void UserLoggingFilter_Test(LogLevel inputLogLevel, bool expected)
+        {
+            Assert.Equal(expected, Utilities.UserLoggingFilter(inputLogLevel));
+        }
+
+        [Theory]
+        [InlineData("Function.Function1", LogLevel.None, true)]
+        [InlineData("Function.Function1", LogLevel.Warning, true)]
+        [InlineData("Function.Function1.User", LogLevel.Information, true)]
+        [InlineData("Host.General", LogLevel.Information, false)]
+        [InlineData("Host.Startup", LogLevel.Error, true)]
+        [InlineData("Host.General", LogLevel.Warning, true)]
+        public void DefaultLoggingFilter_Test(string inputCategory, LogLevel inputLogLevel, bool expected)
+        {
+            Assert.Equal(expected, Utilities.DefaultLoggingFilter(inputCategory, inputLogLevel, LogLevel.Information, LogLevel.Warning));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2141 Fixes #2143  Fixes #2110

This PR:
- Added `--verbose` flag. Running with `--verbose` flag will give users existing logging behavior
- If running in CI environment - https://github.com/watson/ci-info/blob/master/index.js#L52-L59, `--verbose` flag is set.
- Displays all the functions  (incorporated code from @anthonychu)
- Strips out date from log messages.
- By default `func host start` will have less verbose system logs:
    - Default log level for system logs is `Warning`
    - Deafult log level for user logs is `Information`
- If `Default` log level is specified in `host.json` - both user logs and system logs level is set to the value specified in `host.json`
- If `host.json` has default loglevel set to `None` - Only whitelisted logs that **VS Code** uses will be logged
- If `host.json` lists any category then defaults do not apply

Sample output on func host start with default host.json

```
func.exe host start
Azure Functions Core Tools (3.0.1 Commit hash: N/A)
Function Runtime Version: 3.0.1.0
Hosting environment: Production
Content root path: C:\pgopa\vsCode\jsDebug
Now listening on: http://0.0.0.0:7071
Application started. Press Ctrl+C to shut down.

Functions:

        HttpTrigger: [GET,POST] http://localhost:7071/api/HttpTrigger

For detailed output, run func with --verbose flag.
Worker process started and initialized.
Host lock lease acquired by instance ID '00000000000000000000000022DF9FE8'.
JavaScript HTTP trigger function processed a request.
```

Sample output on func host start with following host.json

```
{
	"version": "2.0",
	"logging": {
		"LogLevel": {
			"Function.HttpTrigger": "Trace",
			"Microsoft.Azure.WebJobs.Script.Description.WorkerFunctionInvoker": "Trace",
			"Microsoft.Azure.WebJobs.Script.WebHost.Middleware.SystemTraceMiddleware": "Information"
		}
	}
}
```

**NOTE: To see middleware tracing user explicitly needs to add that category in host.json**
Output :

```
Azure Functions Core Tools (3.0.1 Commit hash: N/A)
Function Runtime Version: 3.0.1.0
Hosting environment: Production
Content root path: C:\pgopa\vsCode\jsDebug
Now listening on: http://0.0.0.0:7071
Application started. Press Ctrl+C to shut down.

Functions:

        HttpTrigger: [GET,POST] http://localhost:7071/api/HttpTrigger

For detailed output, run func with --verbose flag.
Worker process started and initialized.
Host lock lease acquired by instance ID '00000000000000000000000022DF9FE8'.
Executing HTTP request: {
  requestId: "0b7d77b8-df93-4bb7-be6b-34e3ab2cb0f8",
  method: "GET",
  userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
  uri: "/api/HttpTrigger"
}
Executing 'Functions.HttpTrigger' (Reason='This function was programmatically called via the host APIs.', Id=8c804b69-e49c-4577-8ffb-0210875b4073)
Sending invocation id:8c804b69-e49c-4577-8ffb-0210875b4073
JavaScript HTTP trigger function processed a request.
Executed 'Functions.HttpTrigger' (Succeeded, Id=8c804b69-e49c-4577-8ffb-0210875b4073, Duration=258ms)
Executed HTTP request: {
  requestId: "0b7d77b8-df93-4bb7-be6b-34e3ab2cb0f8",
  identities: "(WebJobsAuthLevel:Admin)",
  status: "200",
  duration: "454"
}
```
