### PR TITLE
Port func init and new for custom handlers (#2093)

### DIFF
--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -20,9 +20,9 @@ namespace Build
                 : value;
         }
 
-        public const string ItemTemplatesVersion = "3.1.1518";
-        public const string ProjectTemplatesVersion = "3.1.1518";
-        public const string TemplateJsonVersion = "3.1.1518";
+        public const string ItemTemplatesVersion = "3.1.1582";
+        public const string ProjectTemplatesVersion = "3.1.1582";
+        public const string TemplateJsonVersion = "3.1.1582";
 
         public static readonly string SrcProjectPath = Path.GetFullPath("../src/Azure.Functions.Cli/");
 

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -33,11 +33,17 @@
     <EmbeddedResource Include="StaticResources\bundleConfig.json">
       <LogicalName>$(AssemblyName).bundleConfig.json</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="StaticResources\customHandlerConfig.json">
+      <LogicalName>$(AssemblyName).customHandlerConfig.json</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="StaticResources\ExtensionsProj.csproj.template">
       <LogicalName>$(AssemblyName).ExtensionsProj.csproj</LogicalName>
     </EmbeddedResource>
     <EmbeddedResource Include="StaticResources\Dockerfile.csx.dotnet">
       <LogicalName>$(AssemblyName).Dockerfile.csx.dotnet</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="StaticResources\Dockerfile.custom">
+      <LogicalName>$(AssemblyName).Dockerfile.custom</LogicalName>
     </EmbeddedResource>
     <EmbeddedResource Include="StaticResources\Dockerfile.dotnet">
       <LogicalName>$(AssemblyName).Dockerfile.dotnet</LogicalName>

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -49,6 +49,7 @@ namespace Azure.Functions.Cli.Common
         public const string OSXCoreToolsTempDirectoryName = ".azure-functions-core-tools";
         public const string OSXRootPath = "~/";
         public const string ManagedDependencyConfigPropertyName = "managedDependency";
+        public const string CustomHandlerPropertyName = "customHandler";
         public const string PowerShellWorkerDefaultVersion = "~7";
 
         public static string CliVersion => typeof(Constants).GetTypeInfo().Assembly.GetName().Version.ToString(3);
@@ -84,6 +85,7 @@ namespace Azure.Functions.Cli.Common
             public const string CSharp = "c#";
             public const string Powershell = "powershell";
             public const string Java = "java";
+            public const string Custom = "custom";
         }
 
         public static class ArmConstants

--- a/src/Azure.Functions.Cli/Common/TemplatesManager.cs
+++ b/src/Azure.Functions.Cli/Common/TemplatesManager.cs
@@ -1,12 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Colors.Net;
 using Newtonsoft.Json;
 using Azure.Functions.Cli.Interfaces;
-using Newtonsoft.Json.Linq;
 using Azure.Functions.Cli.Actions.LocalActions;
 using Azure.Functions.Cli.ExtensionBundle;
 using System.Linq;
@@ -34,9 +32,9 @@ namespace Azure.Functions.Cli.Common
         private static async Task<IEnumerable<Template>> GetTemplates()
         {
             var extensionBundleManager = ExtensionBundleHelper.GetExtensionBundleManager();
+            string templatesJson; 
 
-            string templatesJson;
-            if (extensionBundleManager.IsExtensionBundleConfigured())
+            if(extensionBundleManager.IsExtensionBundleConfigured())
             {
                 var contentProvider = ExtensionBundleHelper.GetExtensionBundleContentProvider();
                 templatesJson = await contentProvider.GetTemplates();
@@ -45,6 +43,7 @@ namespace Azure.Functions.Cli.Common
             {
                 templatesJson = GetTemplatesJson();
             }
+
             return JsonConvert.DeserializeObject<IEnumerable<Template>>(templatesJson);
         }
 

--- a/src/Azure.Functions.Cli/Extensions/StringExtensions.cs
+++ b/src/Azure.Functions.Cli/Extensions/StringExtensions.cs
@@ -1,7 +1,9 @@
 ﻿using Azure.Functions.Cli.Exceptions;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 
 namespace Azure.Functions.Cli.Extensions
 {
@@ -40,6 +42,15 @@ namespace Azure.Functions.Cli.Extensions
             }
 
             return cleanImageName.ToLowerInvariant().Substring(0, Math.Min(cleanImageName.Length, 128)).Trim();
+        }
+
+        public static async Task<string> AppendContent(this string hostJsonContent, string contentPropertyName, Task<string> contentSource)
+        {
+            var hostJsonObj = JsonConvert.DeserializeObject<JObject>(hostJsonContent);
+            var additionalContent = await contentSource;
+            var additionalConfig = JsonConvert.DeserializeObject<JToken>(additionalContent);
+            hostJsonObj.Add(contentPropertyName, additionalConfig);
+            return JsonConvert.SerializeObject(hostJsonObj, Formatting.Indented);
         }
     }
 }

--- a/src/Azure.Functions.Cli/Helpers/GlobalCoreToolsSettings.cs
+++ b/src/Azure.Functions.Cli/Helpers/GlobalCoreToolsSettings.cs
@@ -70,6 +70,10 @@ namespace Azure.Functions.Cli.Helpers
                 {
                     _currentWorkerRuntime = WorkerRuntime.powershell;
                 }
+                else if(args.Contains("--custom"))
+                {
+                    _currentWorkerRuntime = WorkerRuntime.custom;
+                }
                 else
                 {
                     _currentWorkerRuntime = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(secretsManager);

--- a/src/Azure.Functions.Cli/Helpers/LanguageWorkerHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/LanguageWorkerHelper.cs
@@ -13,6 +13,7 @@ namespace Azure.Functions.Cli.Helpers
             { WorkerRuntime.java, "languageWorkers:java:arguments" },
             { WorkerRuntime.powershell, "languageWorkers:powershell:arguments" },
             { WorkerRuntime.dotnet, string.Empty },
+            { WorkerRuntime.custom, string.Empty },
             { WorkerRuntime.None, string.Empty }
         }
         .Select(p => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)

--- a/src/Azure.Functions.Cli/Helpers/WorkerRuntimeLanguageHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/WorkerRuntimeLanguageHelper.cs
@@ -15,7 +15,8 @@ namespace Azure.Functions.Cli.Helpers
         node,
         python,
         java,
-        powershell
+        powershell,
+        custom
     }
 
     public static class WorkerRuntimeLanguageHelper
@@ -26,7 +27,8 @@ namespace Azure.Functions.Cli.Helpers
             { WorkerRuntime.node, new [] { "js", "javascript", "typescript", "ts" } },
             { WorkerRuntime.python, new []  { "py" } },
             { WorkerRuntime.java, new string[] { } },
-            { WorkerRuntime.powershell, new [] { "pwsh" } }
+            { WorkerRuntime.powershell, new [] { "pwsh" } },
+            { WorkerRuntime.custom, new string[] { } }
         };
 
         private static readonly IDictionary<string, WorkerRuntime> normalizeMap = availableWorkersRuntime
@@ -39,7 +41,8 @@ namespace Azure.Functions.Cli.Helpers
             { WorkerRuntime.dotnet, Constants.Languages.CSharp },
             { WorkerRuntime.node, Constants.Languages.JavaScript },
             { WorkerRuntime.python, Constants.Languages.Python },
-            { WorkerRuntime.powershell, Constants.Languages.Powershell }
+            { WorkerRuntime.powershell, Constants.Languages.Powershell },
+            { WorkerRuntime.custom, Constants.Languages.Custom },
         };
 
         private static readonly IDictionary<string, IEnumerable<string>> languageToAlias = new Dictionary<string, IEnumerable<string>>
@@ -50,7 +53,8 @@ namespace Azure.Functions.Cli.Helpers
             { Constants.Languages.Python, new [] { "py" } },
             { Constants.Languages.Powershell, new [] { "pwsh" } },
             { Constants.Languages.CSharp, new [] { "csharp", "dotnet" } },
-            { Constants.Languages.Java, new string[] { } }
+            { Constants.Languages.Java, new string[] { } },
+            { Constants.Languages.Custom, new string[] { } }
         };
 
         public static readonly IDictionary<string, string> WorkerRuntimeStringToLanguage = languageToAlias
@@ -65,7 +69,7 @@ namespace Azure.Functions.Cli.Helpers
 
         public static string AvailableWorkersRuntimeString =>
             string.Join(", ", availableWorkersRuntime.Keys
-                .Where(k => k != WorkerRuntime.java)
+                .Where(k => (k != WorkerRuntime.java))
                 .Select(s => s.ToString()));
 
         public static IEnumerable<WorkerRuntime> AvailableWorkersList => availableWorkersRuntime.Keys

--- a/src/Azure.Functions.Cli/StaticResources/Dockerfile.custom
+++ b/src/Azure.Functions.Cli/StaticResources/Dockerfile.custom
@@ -1,0 +1,6 @@
+# To enable ssh & remote debugging on app service change the base image to the one below
+FROM mcr.microsoft.com/azure-functions/dotnet:3.0-appservice 
+ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
+    AzureFunctionsJobHost__Logging__Console__IsEnabled=true
+
+COPY --from=installer-env ["/home/site/wwwroot", "/home/site/wwwroot"]

--- a/src/Azure.Functions.Cli/StaticResources/StaticResources.cs
+++ b/src/Azure.Functions.Cli/StaticResources/StaticResources.cs
@@ -31,6 +31,8 @@ namespace Azure.Functions.Cli
 
         public static Task<string> DockerfileDotNet => GetValue("Dockerfile.dotnet");
 
+        public static Task<string> DockerfileCustom => GetValue("Dockerfile.custom");
+
         public static Task<string> DockerfileCsxDotNet => GetValue("Dockerfile.csx.dotnet");
 
         public static Task<string> DockerfilePython36 => GetValue("Dockerfile.python36");
@@ -52,6 +54,8 @@ namespace Azure.Functions.Cli
         public static Task<string> HostJson => GetValue("host.json");
 
         public static Task<string> BundleConfig => GetValue("bundleConfig.json");
+
+        public static Task<string> CustomHandlerConfig => GetValue("customHandlerConfig.json");
 
         public static Task<string> ManagedDependenciesConfig => GetValue("managedDependenciesConfig.json");
 

--- a/src/Azure.Functions.Cli/StaticResources/customHandlerConfig.json
+++ b/src/Azure.Functions.Cli/StaticResources/customHandlerConfig.json
@@ -1,0 +1,7 @@
+﻿{
+  "description": {
+    "defaultExecutablePath": "",
+    "workingDirectory": "",
+    "arguments": [ ]
+  }
+}

--- a/test/Azure.Functions.Cli.Tests/E2E/CreateFunctionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/CreateFunctionTests.cs
@@ -72,6 +72,23 @@ namespace Azure.Functions.Cli.Tests.E2E
         }
 
         [Fact]
+        public async Task create_function_custom()
+        {
+            await CliTester.Run(new RunConfiguration
+            {
+                Commands = new[]
+                {
+                    "init . --worker-runtime custom --no-bundle",
+                    "new --template \"Http Trigger\" --name testfunc"
+                },
+                OutputContains = new[]
+                {
+                    "The function \"testfunc\" was created successfully from the \"Http Trigger\" template."
+                }
+            }, _output);
+        }
+
+        [Fact]
         public async Task create_template_function_js_no_space_name()
         {
             await CliTester.Run(new RunConfiguration


### PR DESCRIPTION
Port of https://github.com/Azure/azure-functions-core-tools/commit/7dd097e1d7f5ce4d6ef5bd16f425ff0a5b83da4d

This cannot be checked in until https://github.com/Azure/azure-functions-templates/pull/970 is checked in and released due to the dependency here https://github.com/Azure/azure-functions-core-tools/blob/v3.x/build/Settings.cs