### PR TITLE
Force logs only when Default LogLevel is None

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -6,27 +6,19 @@ using System.Linq;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
-using Azure.Functions.Cli.Actions.HostActions.WebHost.Security;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Diagnostics;
-using Azure.Functions.Cli.ExtensionBundle;
 using Azure.Functions.Cli.Extensions;
 using Azure.Functions.Cli.Helpers;
 using Azure.Functions.Cli.Interfaces;
 using Azure.Functions.Cli.NativeMethods;
 using Colors.Net;
 using Fclp;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Script;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.WebHost;
-using Microsoft.Azure.WebJobs.Script.WebHost.Authentication;
-using Microsoft.Azure.WebJobs.Script.WebHost.Controllers;
-using Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection;
-using Microsoft.Azure.WebJobs.Script.WebHost.Security;
-using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -45,6 +37,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
         private const int DefaultPort = 7071;
         private const int DefaultTimeout = 20;
         private readonly ISecretsManager _secretsManager;
+        private readonly LogLevel _hostJsonDefaultLogLevel = LogLevel.Information;
 
         public int Port { get; set; }
 
@@ -70,6 +63,13 @@ namespace Azure.Functions.Cli.Actions.HostActions
         public StartHostAction(ISecretsManager secretsManager)
         {
             _secretsManager = secretsManager;
+            try
+            {
+                _hostJsonDefaultLogLevel = Utilities.GetHostJsonDefaultLogLevel(FileSystemHelpers.ReadAllTextFromFile("host.json"));
+            }
+            catch
+            {
+            }
         }
 
         public override ICommandLineParserResult ParseArgs(string[] args)
@@ -171,10 +171,13 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 .ConfigureLogging(loggingBuilder =>
                 {
                     loggingBuilder.ClearProviders();
-                    loggingBuilder.AddDefaultWebJobsFilters();
-                    loggingBuilder.AddProvider(new ColoredConsoleLoggerProvider((cat, level) => level >= LogLevel.Information));
+                    if (_hostJsonDefaultLogLevel != LogLevel.None)
+                    {
+                        loggingBuilder.AddDefaultWebJobsFilters();
+                        loggingBuilder.AddProvider(new ColoredConsoleLoggerProvider((cat, level) => level >= LogLevel.Information));
+                    }
                 })
-                .ConfigureServices((context, services) => services.AddSingleton<IStartup>(new Startup(context, hostOptions, CorsOrigins, CorsCredentials, EnableAuth)))
+                .ConfigureServices((context, services) => services.AddSingleton<IStartup>(new Startup(context, hostOptions, CorsOrigins, CorsCredentials, EnableAuth, _hostJsonDefaultLogLevel)))
                 .Build();
         }
 
@@ -466,123 +469,6 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 ? await SecurityHelpers.GetOrCreateCertificate(CertPath, CertPassword)
                 : null;
             return (new Uri($"{protocol}://0.0.0.0:{Port}"), new Uri($"{protocol}://localhost:{Port}"), cert);
-        }
-
-        public class Startup : IStartup
-        {
-            private readonly WebHostBuilderContext _builderContext;
-            private readonly ScriptApplicationHostOptions _hostOptions;
-            private readonly string[] _corsOrigins;
-            private readonly bool _corsCredentials;
-            private readonly bool _enableAuth;
-
-            public Startup(WebHostBuilderContext builderContext, ScriptApplicationHostOptions hostOptions, string corsOrigins, bool corsCredentials, bool enableAuth)
-            {
-                _builderContext = builderContext;
-                _hostOptions = hostOptions;
-                _enableAuth = enableAuth;
-
-                if (!string.IsNullOrEmpty(corsOrigins))
-                {
-                    _corsOrigins = corsOrigins.Split(',', StringSplitOptions.RemoveEmptyEntries);
-                    _corsCredentials = corsCredentials;
-                }
-            }
-
-            public IServiceProvider ConfigureServices(IServiceCollection services)
-            {
-                if (_corsOrigins != null)
-                {
-                    services.AddCors();
-                }
-
-                if (_enableAuth)
-                {
-                    services.AddWebJobsScriptHostAuthentication();
-                }
-                else
-                {
-                    services.AddAuthentication()
-                        .AddScriptJwtBearer()
-                        .AddScheme<AuthenticationLevelOptions, CliAuthenticationHandler<AuthenticationLevelOptions>>(AuthLevelAuthenticationDefaults.AuthenticationScheme, configureOptions: _ => { })
-                        .AddScheme<ArmAuthenticationOptions, CliAuthenticationHandler<ArmAuthenticationOptions>>(ArmAuthenticationDefaults.AuthenticationScheme, _ => { });
-                }
-
-                services.AddWebJobsScriptHostAuthorization();
-
-                services.AddMvc()
-                    .AddApplicationPart(typeof(HostController).Assembly);
-
-                // workaround for https://github.com/Azure/azure-functions-core-tools/issues/2097
-                SetBundlesEnvironmentVariables();
-
-                services.AddWebJobsScriptHost(_builderContext.Configuration);
-
-                services.Configure<ScriptApplicationHostOptions>(o =>
-                {
-                    o.ScriptPath = _hostOptions.ScriptPath;
-                    o.LogPath = _hostOptions.LogPath;
-                    o.IsSelfHost = _hostOptions.IsSelfHost;
-                    o.SecretsPath = _hostOptions.SecretsPath;
-                });
-
-                services.AddSingleton<IConfigureBuilder<IConfigurationBuilder>>(_ => new ExtensionBundleConfigurationBuilder(_hostOptions));
-                services.AddSingleton<IConfigureBuilder<IConfigurationBuilder>, DisableConsoleConfigurationBuilder>();
-                services.AddSingleton<IConfigureBuilder<ILoggingBuilder>, LoggingBuilder>();
-
-                services.AddSingleton<IDependencyValidator, ThrowingDependencyValidator>();
-
-                return services.BuildServiceProvider();
-            }
-
-            private void SetBundlesEnvironmentVariables()
-            {
-                var bundleId = ExtensionBundleHelper.GetExtensionBundleOptions(_hostOptions).Id;
-                if (!string.IsNullOrEmpty(bundleId))
-                {
-                    Environment.SetEnvironmentVariable("AzureFunctionsJobHost__extensionBundle__downloadPath", ExtensionBundleHelper.GetDownloadPath(bundleId));
-                    Environment.SetEnvironmentVariable("AzureFunctionsJobHost__extensionBundle__ensureLatest", "true");
-                }
-            }
-
-            public void Configure(IApplicationBuilder app)
-            {
-                if (_corsOrigins != null)
-                {
-                    app.UseCors(builder =>
-                    {
-                        var origins = builder.WithOrigins(_corsOrigins)
-                            .AllowAnyHeader()
-                            .AllowAnyMethod();
-                        if (_corsCredentials)
-                        {
-                            origins.AllowCredentials();
-                        }
-                    });
-                }
-
-                IApplicationLifetime applicationLifetime = app.ApplicationServices
-                    .GetRequiredService<IApplicationLifetime>();
-
-                app.UseWebJobsScriptHost(applicationLifetime);
-            }
-
-            private class ThrowingDependencyValidator : DependencyValidator
-            {
-                public override void Validate(IServiceCollection services)
-                {
-                    try
-                    {
-                        base.Validate(services);
-                    }
-                    catch (InvalidHostServicesException ex)
-                    {
-                        // Rethrow this as an InvalidOperationException to bypass the handling
-                        // in the host. This will stop invalid services in the CLI only.
-                        throw new InvalidOperationException("Invalid host services.", ex);
-                    }
-                }
-            }
         }
     }
 }

--- a/src/Azure.Functions.Cli/Actions/HostActions/Startup.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/Startup.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using Azure.Functions.Cli.Actions.HostActions.WebHost.Security;
+using Azure.Functions.Cli.Diagnostics;
+using Azure.Functions.Cli.ExtensionBundle;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Authentication;
+using Microsoft.Azure.WebJobs.Script.WebHost.Controllers;
+using Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Functions.Cli.Actions.HostActions
+{
+    public class Startup : IStartup
+    {
+        private readonly WebHostBuilderContext _builderContext;
+        private readonly ScriptApplicationHostOptions _hostOptions;
+        private readonly string[] _corsOrigins;
+        private readonly bool _corsCredentials;
+        private readonly bool _enableAuth;
+        private readonly LogLevel _defaultLogLevel;
+
+        public Startup(WebHostBuilderContext builderContext, ScriptApplicationHostOptions hostOptions, string corsOrigins, bool corsCredentials, bool enableAuth, LogLevel defaultLogLevel)
+        {
+            _builderContext = builderContext;
+            _hostOptions = hostOptions;
+            _enableAuth = enableAuth;
+            _defaultLogLevel = defaultLogLevel;
+
+            if (!string.IsNullOrEmpty(corsOrigins))
+            {
+                _corsOrigins = corsOrigins.Split(',', StringSplitOptions.RemoveEmptyEntries);
+                _corsCredentials = corsCredentials;
+            }
+        }
+
+        public IServiceProvider ConfigureServices(IServiceCollection services)
+        {
+            if (_corsOrigins != null)
+            {
+                services.AddCors();
+            }
+
+            if (_enableAuth)
+            {
+                services.AddWebJobsScriptHostAuthentication();
+            }
+            else
+            {
+                services.AddAuthentication()
+                    .AddScriptJwtBearer()
+                    .AddScheme<AuthenticationLevelOptions, CliAuthenticationHandler<AuthenticationLevelOptions>>(AuthLevelAuthenticationDefaults.AuthenticationScheme, configureOptions: _ => { })
+                    .AddScheme<ArmAuthenticationOptions, CliAuthenticationHandler<ArmAuthenticationOptions>>(ArmAuthenticationDefaults.AuthenticationScheme, _ => { });
+            }
+
+            services.AddWebJobsScriptHostAuthorization();
+
+            services.AddMvc()
+                .AddApplicationPart(typeof(HostController).Assembly);
+
+            // workaround for https://github.com/Azure/azure-functions-core-tools/issues/2097
+            SetBundlesEnvironmentVariables();
+
+            services.AddWebJobsScriptHost(_builderContext.Configuration);
+
+            services.Configure<ScriptApplicationHostOptions>(o =>
+            {
+                o.ScriptPath = _hostOptions.ScriptPath;
+                o.LogPath = _hostOptions.LogPath;
+                o.IsSelfHost = _hostOptions.IsSelfHost;
+                o.SecretsPath = _hostOptions.SecretsPath;
+            });
+
+            services.AddSingleton<IConfigureBuilder<IConfigurationBuilder>>(_ => new ExtensionBundleConfigurationBuilder(_hostOptions));
+            services.AddSingleton<IConfigureBuilder<IConfigurationBuilder>, DisableConsoleConfigurationBuilder>();
+            services.AddSingleton<IConfigureBuilder<ILoggingBuilder>>(_ => new LoggingBuilder(_defaultLogLevel));
+
+            services.AddSingleton<IDependencyValidator, ThrowingDependencyValidator>();
+
+            return services.BuildServiceProvider();
+        }
+
+        private void SetBundlesEnvironmentVariables()
+        {
+            var bundleId = ExtensionBundleHelper.GetExtensionBundleOptions(_hostOptions).Id;
+            if (!string.IsNullOrEmpty(bundleId))
+            {
+                Environment.SetEnvironmentVariable("AzureFunctionsJobHost__extensionBundle__downloadPath", ExtensionBundleHelper.GetDownloadPath(bundleId));
+                Environment.SetEnvironmentVariable("AzureFunctionsJobHost__extensionBundle__ensureLatest", "true");
+            }
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            if (_corsOrigins != null)
+            {
+                app.UseCors(builder =>
+                {
+                    var origins = builder.WithOrigins(_corsOrigins)
+                        .AllowAnyHeader()
+                        .AllowAnyMethod();
+                    if (_corsCredentials)
+                    {
+                        origins.AllowCredentials();
+                    }
+                });
+            }
+
+            IApplicationLifetime applicationLifetime = app.ApplicationServices
+                .GetRequiredService<IApplicationLifetime>();
+
+            app.UseWebJobsScriptHost(applicationLifetime);
+        }
+
+        private class ThrowingDependencyValidator : DependencyValidator
+        {
+            public override void Validate(IServiceCollection services)
+            {
+                try
+                {
+                    base.Validate(services);
+                }
+                catch (InvalidHostServicesException ex)
+                {
+                    // Rethrow this as an InvalidOperationException to bypass the handling
+                    // in the host. This will stop invalid services in the CLI only.
+                    throw new InvalidOperationException("Invalid host services.", ex);
+                }
+            }
+        }
+    }
+}

--- a/src/Azure.Functions.Cli/Common/Utilities.cs
+++ b/src/Azure.Functions.Cli/Common/Utilities.cs
@@ -2,6 +2,9 @@
 using Colors.Net;
 using Colors.Net.StringColorExtensions;
 using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -99,7 +102,7 @@ namespace Azure.Functions.Cli
                 Match match = Regex.Match(sanitizedString, removeRegex);
                 string matchString;
                 // Keep removing the matching regex until no more match is found
-                while(!string.IsNullOrEmpty(matchString = match.Value))
+                while (!string.IsNullOrEmpty(matchString = match.Value))
                 {
                     sanitizedString = sanitizedString.Replace(matchString, new string(fillerChar, matchString.Length));
                     match = Regex.Match(sanitizedString, removeRegex);
@@ -170,6 +173,23 @@ namespace Azure.Functions.Cli
             var localPath = Path.Combine(appDataDir, "azure-functions-core-tools");
             FileSystemHelpers.EnsureDirectory(localPath);
             return localPath;
+        }
+
+        internal static LogLevel GetHostJsonDefaultLogLevel(string hostJsonFileContent)
+        {
+            var hostJson = JsonConvert.DeserializeObject<JObject>(hostJsonFileContent.ToLower());
+            try
+            {
+                if (Enum.TryParse(typeof(LogLevel), hostJson["logging"]["loglevel"]["default"].ToString(), true, out object outLevel))
+                {
+                    return (LogLevel)outLevel;
+                }
+            }
+            catch
+            {
+            }
+            // Default log level
+            return LogLevel.Information;
         }
     }
 }

--- a/src/Azure.Functions.Cli/Diagnostics/ColoredConsoleLogger.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/ColoredConsoleLogger.cs
@@ -5,6 +5,7 @@ using Microsoft.Azure.WebJobs.Script;
 using Microsoft.Extensions.Logging;
 using Azure.Functions.Cli.Common;
 using static Azure.Functions.Cli.Common.OutputTheme;
+using System.Linq;
 
 namespace Azure.Functions.Cli.Diagnostics
 {
@@ -13,12 +14,15 @@ namespace Azure.Functions.Cli.Diagnostics
         private readonly Func<string, LogLevel, bool> _filter;
         private readonly bool _verboseErrors;
         private readonly string _category;
+        private readonly LogLevel _defaultLogLevel = LogLevel.Information;
+        private readonly string[] whitelistedLogsPrefixes = new string[] { "Worker process started and initialized.", "Host lock lease acquired by instance ID" };
 
-        public ColoredConsoleLogger(string category, Func<string, LogLevel, bool> filter = null)
+        public ColoredConsoleLogger(string category, Func<string, LogLevel, bool> filter = null, LogLevel logLevel = LogLevel.Information)
         {
             _category = category;
             _filter = filter;
             _verboseErrors = StaticSettings.IsDebug;
+            _defaultLogLevel = logLevel;
         }
 
         public bool IsEnabled(LogLevel logLevel)
@@ -33,11 +37,6 @@ namespace Azure.Functions.Cli.Diagnostics
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
-            if (!IsEnabled(logLevel))
-            {
-                return;
-            }
-
             string formattedMessage = formatter(state, exception);
 
             if (string.IsNullOrEmpty(formattedMessage))
@@ -45,10 +44,29 @@ namespace Azure.Functions.Cli.Diagnostics
                 return;
             }
 
+            if (!IsEnabled(logLevel))
+            {
+                return;
+            }
+
+            if (_defaultLogLevel == LogLevel.None)
+            {
+                if (!DoesMessageStartsWithWhiteListedPrefix(formattedMessage))
+                {
+                    return;
+                }
+            }
+
             foreach (var line in GetMessageString(logLevel, formattedMessage, exception))
             {
                 ColoredConsole.WriteLine($"[{DateTime.UtcNow}] {line}");
             }
+        }
+
+        private bool DoesMessageStartsWithWhiteListedPrefix(string formattedMessage)
+        {
+            var formattedMessagesWithWhiteListePrefixes = whitelistedLogsPrefixes.Where(s => formattedMessage.StartsWith(s, StringComparison.OrdinalIgnoreCase));
+            return formattedMessagesWithWhiteListePrefixes.Any();
         }
 
         private IEnumerable<RichString> GetMessageString(LogLevel level, string formattedMessage, Exception exception)

--- a/src/Azure.Functions.Cli/Diagnostics/ColoredConsoleLoggerProvider.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/ColoredConsoleLoggerProvider.cs
@@ -6,15 +6,21 @@ namespace Azure.Functions.Cli.Diagnostics
     public class ColoredConsoleLoggerProvider : ILoggerProvider
     {
         private readonly Func<string, LogLevel, bool> _filter;
+        private readonly LogLevel _logLevel = LogLevel.Information;
 
         public ColoredConsoleLoggerProvider(Func<string, LogLevel, bool> filter = null)
         {
             _filter = filter;
         }
 
+        public ColoredConsoleLoggerProvider(LogLevel logLevel)
+        {
+            _logLevel = logLevel;
+        }
+
         public ILogger CreateLogger(string categoryName)
         {
-            return new ColoredConsoleLogger(categoryName, _filter);
+            return new ColoredConsoleLogger(categoryName, _filter, _logLevel);
         }
 
         public void Dispose()

--- a/src/Azure.Functions.Cli/Diagnostics/LoggingBuilder.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/LoggingBuilder.cs
@@ -10,9 +10,23 @@ namespace Azure.Functions.Cli.Diagnostics
 {
     internal class LoggingBuilder : IConfigureBuilder<ILoggingBuilder>
     {
+        private LogLevel _hostJsonDefaultLogLevel = LogLevel.Information;
+
+        public LoggingBuilder(LogLevel logLevel)
+        {
+            _hostJsonDefaultLogLevel = logLevel;
+        }
+
         public void Configure(ILoggingBuilder builder)
         {
-            builder.AddProvider(new ColoredConsoleLoggerProvider());
+            if (_hostJsonDefaultLogLevel == LogLevel.None)
+            {
+                builder.AddProvider(new ColoredConsoleLoggerProvider(_hostJsonDefaultLogLevel)).AddFilter((cat, level) => true);
+            }
+            else
+            {
+                builder.AddProvider(new ColoredConsoleLoggerProvider());
+            }
 
             builder.Services.AddSingleton<TelemetryClient>(provider =>
             {

--- a/test/Azure.Functions.Cli.Tests/UtilitiesTests.cs
+++ b/test/Azure.Functions.Cli.Tests/UtilitiesTests.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests
+{
+    public class UtilitiesTests
+    {
+        [Theory]
+        [InlineData("{\"version\": \"2.0\",\"Logging\": {\"LogLevel\": {\"Default\": \"None\"}}}", LogLevel.None)]
+        [InlineData("{\"version\": \"2.0\",\"logging\": {\"logLevel\": {\"Default\": \"NONE\"}}}", LogLevel.None)]
+        [InlineData("{\"version\": \"2.0\",\"logging\": {\"logLevel\": {\"Default\": \"Debug\"}}}", LogLevel.Debug)]
+        [InlineData("{\"version\": \"2.0\"}", LogLevel.Information)]
+        public void GetHostJsonDefaultLogLevel_Test(string hostJsonContent, LogLevel expectedLogLevel)
+        {
+            LogLevel actualLogLevel = Utilities.GetHostJsonDefaultLogLevel(hostJsonContent);
+            Assert.Equal(actualLogLevel, expectedLogLevel);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2110 

host.json has default loglevel set to `None`

```
{
  "version": "2.0",
   "Logging": {
      "LogLevel": {
		"Default": "None"
        }
   }
}
```

then add filter in JobHost logging builder to ensure all logs flow through and inspect each log. If Log starts with whitelisted prefix then log console otherwise do not log.

This keeps the existing behavior but allows core tools to *Force logs* ignoring the default log level