### PR TITLE
Revert "changing the default bundle download path for osx"

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -540,7 +540,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 var bundleId = ExtensionBundleHelper.GetExtensionBundleOptions(_hostOptions).Id;
                 if (!string.IsNullOrEmpty(bundleId))
                 {
-                    Environment.SetEnvironmentVariable("AzureFunctionsJobHost__extensionBundle__downloadPath", ExtensionBundleHelper.GetDownloadPath(bundleId));
+                    Environment.SetEnvironmentVariable("AzureFunctionsJobHost__extensionBundle__downloadPath", Path.Combine(Path.GetTempPath(), "Functions", ScriptConstants.ExtensionBundleDirectory, bundleId));
                     Environment.SetEnvironmentVariable("AzureFunctionsJobHost__extensionBundle__ensureLatest", "true");
                 }
             }

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -46,8 +46,6 @@ namespace Azure.Functions.Cli.Common
         public const string DefaultManagementURL = "https://management.azure.com/";
         public const string AzureManagementAccessToken = "AZURE_MANAGEMENT_ACCESS_TOKEN";
         public const string ExtensionBundleConfigPropertyName = "extensionBundle";
-        public const string OSXCoreToolsTempDirectoryName = ".azure-functions-core-tools";
-        public const string OSXRootPath = "~/";
         public const string ManagedDependencyConfigPropertyName = "managedDependency";
         public const string CustomHandlerPropertyName = "customHandler";
         public const string PowerShellWorkerDefaultVersion = "~7";

--- a/src/Azure.Functions.Cli/ExtensionBundle/ExtensionBundleConfigurationBuilder.cs
+++ b/src/Azure.Functions.Cli/ExtensionBundle/ExtensionBundleConfigurationBuilder.cs
@@ -1,6 +1,12 @@
 ﻿using System.Collections.Generic;
+using System.IO;
+using Azure.Functions.Cli.Common;
 using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Azure.Functions.Cli.ExtensionBundle
 {
@@ -20,7 +26,7 @@ namespace Azure.Functions.Cli.ExtensionBundle
             {
                 builder.AddInMemoryCollection(new Dictionary<string, string>
                 {
-                    { "AzureFunctionsJobHost:extensionBundle:downloadPath", ExtensionBundleHelper.GetDownloadPath(bundleId) },
+                    { "AzureFunctionsJobHost:extensionBundle:downloadPath", Path.Combine(Path.GetTempPath(), "Functions", ScriptConstants.ExtensionBundleDirectory, bundleId)},
                     { "AzureFunctionsJobHost:extensionBundle:ensureLatest", "true"}
                 });
             }

--- a/src/Azure.Functions.Cli/ExtensionBundle/ExtensionBundleHelper.cs
+++ b/src/Azure.Functions.Cli/ExtensionBundle/ExtensionBundleHelper.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Text;
 
 namespace Azure.Functions.Cli.ExtensionBundle
@@ -42,12 +41,6 @@ namespace Azure.Functions.Cli.ExtensionBundle
         public static ExtensionBundleContentProvider GetExtensionBundleContentProvider()
         {
             return new ExtensionBundleContentProvider(GetExtensionBundleManager(), NullLogger<ExtensionBundleContentProvider>.Instance);
-        }
-
-        public static string GetDownloadPath(string bundleId)
-        {
-            string rootDirectoryPath = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? Path.Combine(Constants.OSXRootPath, Constants.OSXCoreToolsTempDirectoryName) : Path.GetTempPath();
-            return Path.Combine(rootDirectoryPath, "Functions", ScriptConstants.ExtensionBundleDirectory, bundleId);
         }
     }
 }


### PR DESCRIPTION
This reverts commit b0455000f9001d7c6b531997097becb0ebd1aa48.

This is to fix the issue outlined here - https://github.com/Azure/azure-functions-core-tools/issues/2154
The actual I think is to not use `~` and instead use an expanded path to home directory. In my machine this just creates a directory `~`. But, to fix users right away and avoid any unwanted consequences, we should revert this change and fix this change / commit for the next release.

cc: @soninaren