### PR TITLE
Update Sprint 79/80 Functions Host references to 2.0.14248

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -118,10 +118,10 @@
     <PackageReference Include="AccentedCommandLineParser" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage.Internal" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.6.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.7.3-SNAPSHOT" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.2.2" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="2.0.292" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="2.0.14192" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="2.0.14248" />
     <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="2.0.14118" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="YamlDotNet" Version="6.0.0" />


### PR DESCRIPTION
Moving WebJobs.Script.WebHost to 2.0.14248 and Java Worker to
1.7.3-SNAPSHOT