### PR TITLE
Reduce size of build

### DIFF
--- a/build/Program.cs
+++ b/build/Program.cs
@@ -20,6 +20,7 @@ namespace Build
                 .Then(ReplaceTelemetryInstrumentationKey, skip: !args.Contains("--ci"))
                 .Then(DotnetPublish)
                 .Then(FilterPowershellRuntimes)
+                .Then(FilterPythonRuntimes)
                 .Then(AddDistLib)
                 .Then(AddTemplatesNupkgs)
                 .Then(AddTemplatesJson)

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -36,17 +36,17 @@ namespace Build
 
         public static readonly string DurableFolder = Path.Combine(TestProjectPath, "Resources", "DurableTestFolder");
 
-        public static readonly string[] TargetRuntimes = new[] {"linux-x64", "osx-x64", "no-runtime", "win-x86", "win-x64", "min.win-x86", "min.win-x64" };
+        public static readonly string[] TargetRuntimes = new[] {"min.win-x86", "min.win-x64", "linux-x64", "osx-x64", "no-runtime", "win-x86", "win-x64" };
 
         public static readonly Dictionary<string, string> RuntimesToOS = new Dictionary<string, string>
         {
-            { "win-x86", "Windows" },
-            { "win-x64", "Windows" },
-            { "linux-x64", "Linux" },
-            { "osx-x64", "Mac" },
-            { "no-runtime", "Linux" },
-            { "min.win-x86", "Windows" },
-            { "min.win-x64", "Windows" },
+            { "win-x86", "WINDOWS" },
+            { "win-x64", "WINDOWS" },
+            { "linux-x64", "LINUX" },
+            { "osx-x64", "OSX" },
+            { "no-runtime", "LINUX" },
+            { "min.win-x86", "WINDOWS" },
+            { "min.win-x64", "WINDOWS" },
         };
 
         private static readonly string[] _winPowershellRuntimes = new[] { "win-x86", "win", "win10-x86", "win8-x86", "win81-x86", "win7-x86", "win-x64", "win10-x64", "win8-x64", "win81-x64", "win7-x64" };


### PR DESCRIPTION
The build has been running out of space for V3. I noticed that we ship all Python workers for all runtimes. For example, with `win-x64`, it includes, python worker for 3.6, 3.7 and 3.8 all of which have binaries for Windows, Linux and OSx. In this example, I would remove Linux and OSX as they will never be used for `win-x64` core tools.

Added other minor improvements. Hoping that this fixes the space issue. Long term, we may need a better solution such as self-hosted agents. Or I think that we should do builds separately -- Linux builds in Ubuntu, Windows in Windows. This may also speed up our builds, and solve other issues that we face such as -- `func.exe` missing executable bit in Linux, and needs to be manually added after extracting.