### PR TITLE
Add default webjobs loglevel filter and treat logs with category ILogger<T> as user logs

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -181,6 +181,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 .ConfigureLogging(loggingBuilder =>
                 {
                     loggingBuilder.ClearProviders();
+                    loggingBuilder.AddDefaultWebJobsFilters();
                     loggingFilterHelper.AddConsoleLoggingProvider(loggingBuilder);
                 })
                 .ConfigureServices((context, services) => services.AddSingleton<IStartup>(new Startup(context, hostOptions, CorsOrigins, CorsCredentials, EnableAuth, loggingFilterHelper)))

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Diagnostics;
 using Azure.Functions.Cli.Extensions;
 using Azure.Functions.Cli.Helpers;
 using Azure.Functions.Cli.Interfaces;
@@ -181,8 +182,8 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 .ConfigureLogging(loggingBuilder =>
                 {
                     loggingBuilder.ClearProviders();
-                    loggingBuilder.AddDefaultWebJobsFilters();
-                    loggingFilterHelper.AddConsoleLoggingProvider(loggingBuilder);
+                    // This is needed to filter system logs only for known categories
+                    loggingBuilder.AddFilter<ColoredConsoleLoggerProvider>((category, level) => Utilities.SystemLoggingFilter(category, level, LogLevel.Trace)).AddProvider(new ColoredConsoleLoggerProvider(loggingFilterHelper));
                 })
                 .ConfigureServices((context, services) => services.AddSingleton<IStartup>(new Startup(context, hostOptions, CorsOrigins, CorsCredentials, EnableAuth, loggingFilterHelper)))
                 .Build();

--- a/src/Azure.Functions.Cli/Common/Utilities.cs
+++ b/src/Azure.Functions.Cli/Common/Utilities.cs
@@ -250,7 +250,7 @@ namespace Azure.Functions.Cli
             {
                 return actualLevel >= userLogMinLevel;
             }
-            if (AllowedCategoryPrefixes.Where(p => category.StartsWith(p)).Any())
+            if (IsSystemLogCategory(category))
             {
                 // System logs
                 return actualLevel >= systemLogMinLevel;
@@ -275,7 +275,12 @@ namespace Azure.Functions.Cli
 
         internal static bool SystemLoggingFilter(string category, LogLevel actualLevel, LogLevel minLevel)
         {
-            return actualLevel >= minLevel && AllowedCategoryPrefixes.Where(p => category.StartsWith(p)).Any();
+            return actualLevel >= minLevel && IsSystemLogCategory(category);
+        }
+
+        internal static bool IsSystemLogCategory(string category)
+        {
+            return SystemCategoryPrefixes.Where(p => category.StartsWith(p)).Any();
         }
 
         internal static IConfigurationRoot BuildHostJsonConfigutation(ScriptApplicationHostOptions hostOptions)

--- a/src/Azure.Functions.Cli/Common/Utilities.cs
+++ b/src/Azure.Functions.Cli/Common/Utilities.cs
@@ -23,7 +23,7 @@ namespace Azure.Functions.Cli
     {
         public const string LogLevelSection = "loglevel";
         public const string LogLevelDefaultSection = "Default";
-        internal static readonly string[] AllowedCategoryPrefixes = new[]
+        internal static readonly string[] SystemCategoryPrefixes = new[]
         {
             "Microsoft.Azure.WebJobs.",
             "Function.",

--- a/src/Azure.Functions.Cli/Common/Utilities.cs
+++ b/src/Azure.Functions.Cli/Common/Utilities.cs
@@ -16,8 +16,6 @@ using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Azure.Functions.Cli
 {
@@ -25,6 +23,13 @@ namespace Azure.Functions.Cli
     {
         public const string LogLevelSection = "loglevel";
         public const string LogLevelDefaultSection = "Default";
+        internal static readonly string[] AllowedCategoryPrefixes = new[]
+        {
+            "Microsoft.Azure.WebJobs.",
+            "Function.",
+            "Worker.",
+            "Host."
+        };
 
         internal static void PrintLogo()
         {
@@ -245,7 +250,13 @@ namespace Azure.Functions.Cli
             {
                 return actualLevel >= userLogMinLevel;
             }
-            return actualLevel >= systemLogMinLevel;
+            if (AllowedCategoryPrefixes.Where(p => category.StartsWith(p)).Any())
+            {
+                // System logs
+                return actualLevel >= systemLogMinLevel;
+            }
+            // consider any other category as user log
+            return actualLevel >= userLogMinLevel;
         }
 
         /// <summary>
@@ -260,6 +271,11 @@ namespace Azure.Functions.Cli
                 return false;
             }
             return actualLevel >= LogLevel.Trace;
+        }
+
+        internal static bool SystemLoggingFilter(string category, LogLevel actualLevel, LogLevel minLevel)
+        {
+            return actualLevel >= minLevel && AllowedCategoryPrefixes.Where(p => category.StartsWith(p)).Any();
         }
 
         internal static IConfigurationRoot BuildHostJsonConfigutation(ScriptApplicationHostOptions hostOptions)

--- a/src/Azure.Functions.Cli/Diagnostics/LoggingFilterHelper.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/LoggingFilterHelper.cs
@@ -14,14 +14,6 @@ namespace Azure.Functions.Cli
         private const string DefaultLogLevelKey = "default";
         private IConfigurationRoot _hostJsonConfig = null;
 
-        internal static readonly string[] AllowedCategoryPrefixes = new[]
-        {
-            "Microsoft.Azure.WebJobs",
-            "Function",
-            "Worker",
-            "Host"
-        };
-
         // CI EnvironmentSettings
         // https://github.com/watson/ci-info/blob/master/index.js#L52-L59
         public const string Ci = "CI"; // Travis CI, CircleCI, Cirrus CI, Gitlab CI, Appveyor, CodeShip, dsari
@@ -73,13 +65,8 @@ namespace Azure.Functions.Cli
 
         internal void AddConsoleLoggingProvider(ILoggingBuilder loggingBuilder)
         {
-            // Filter is needed to force all the logs.
-            loggingBuilder.AddFilter<ColoredConsoleLoggerProvider>((category, level) => Filter(category, level, LogLevel.Trace)).AddProvider(new ColoredConsoleLoggerProvider(this));
-        }
-
-        private static bool Filter(string category, LogLevel actualLevel, LogLevel minLevel)
-        {
-            return actualLevel >= minLevel && AllowedCategoryPrefixes.Where(p => category.StartsWith(p)).Any();
+            // Filter is needed to force all the logs at jobhost level
+            loggingBuilder.AddFilter<ColoredConsoleLoggerProvider>((category, level) => true).AddProvider(new ColoredConsoleLoggerProvider(this));
         }
 
         internal bool IsEnabled(string category, LogLevel logLevel)

--- a/src/Azure.Functions.Cli/Helpers/ProjectHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/ProjectHelpers.cs
@@ -24,7 +24,7 @@ namespace Azure.Functions.Cli.Helpers
                     foreach (FileInfo file in projectFiles)
                     {
                         if (string.Equals(projectFiles[0].Name, Constants.ExtenstionsCsProjFile, StringComparison.OrdinalIgnoreCase)) continue;
-                        logger.LogInformation($"Found {file.FullName}. Using for user secrets file configuration.");
+                        logger.LogDebug($"Found {file.FullName}. Using for user secrets file configuration.");
                         return file.FullName;
                     }
                 }
@@ -32,7 +32,7 @@ namespace Azure.Functions.Cli.Helpers
             }
             while (filePath.FullName != filePath.Root.FullName);
 
-            logger.LogInformation($"Csproj not found in {path} directory tree. Skipping user secrets file configuration.");
+            logger.LogDebug($"Csproj not found in {path} directory tree. Skipping user secrets file configuration.");
             return null;
         }
 

--- a/test/Azure.Functions.Cli.Tests/UtilitiesTests.cs
+++ b/test/Azure.Functions.Cli.Tests/UtilitiesTests.cs
@@ -119,6 +119,17 @@ namespace Azure.Functions.Cli.Tests
             Assert.Equal(expected, Utilities.DefaultLoggingFilter(inputCategory, inputLogLevel, LogLevel.Information, LogLevel.Warning));
         }
 
+        [Theory]
+        [InlineData("Function.Function1", true)]
+        [InlineData("Random", false)]
+        [InlineData("Host.Startup", true)]
+        [InlineData("Microsoft.Azure.WebJobs.TestLogger", true)]
+        [InlineData("Microsoft.Azure.TestLogger", false)]
+        public void IsSystemLogCategory_Test(string inputCategory, bool expected)
+        {
+            Assert.Equal(expected, Utilities.IsSystemLogCategory(inputCategory));
+        }
+
         private void DeleteIfExists(string filePath)
         {
             try


### PR DESCRIPTION
cc @anthonychu 

Fixes #2189 Fixes #2184 

- Added missing Webjobs logging filters defined here: https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script/Extensions/ScriptLoggingBuilderExtensions.cs#L28

 For  now this is a copy of the code until issue https://github.com/Azure/azure-functions-host/issues/6588 is fixed.

- Fixed user category filter to ensure logs with category ILogger<T> are treated as user logs

