### PR TITLE
[V2]Add default webjobs loglevel filter and treat logs with category ILogger<T> as user logs

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Diagnostics;
 using Azure.Functions.Cli.Extensions;
 using Azure.Functions.Cli.Helpers;
 using Azure.Functions.Cli.Interfaces;
@@ -188,7 +189,8 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 .ConfigureLogging(loggingBuilder =>
                 {
                     loggingBuilder.ClearProviders();
-                    loggingFilterHelper.AddConsoleLoggingProvider(loggingBuilder);
+                    // This is needed to filter system logs only for known categories
+                    loggingBuilder.AddFilter<ColoredConsoleLoggerProvider>((category, level) => Utilities.SystemLoggingFilter(category, level, LogLevel.Trace)).AddProvider(new ColoredConsoleLoggerProvider(loggingFilterHelper));
                 })
                 .ConfigureServices((context, services) => services.AddSingleton<IStartup>(new Startup(context, hostOptions, CorsOrigins, CorsCredentials, EnableAuth, loggingFilterHelper)))
                 .Build();

--- a/src/Azure.Functions.Cli/Diagnostics/LoggingFilterHelper.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/LoggingFilterHelper.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Azure.Functions.Cli
 {
@@ -64,7 +65,7 @@ namespace Azure.Functions.Cli
 
         internal void AddConsoleLoggingProvider(ILoggingBuilder loggingBuilder)
         {
-            // Filter is needed to force all the logs.
+            // Filter is needed to force all the logs at jobhost level
             loggingBuilder.AddFilter<ColoredConsoleLoggerProvider>((category, level) => true).AddProvider(new ColoredConsoleLoggerProvider(this));
         }
 

--- a/test/Azure.Functions.Cli.Tests/ColoredConsoleLoggerTests.cs
+++ b/test/Azure.Functions.Cli.Tests/ColoredConsoleLoggerTests.cs
@@ -10,7 +10,7 @@ namespace Azure.Functions.Cli.Tests
 {
     public class ColoredConsoleLoggerTests
     {
-        [Theory]
+        [Theory(Skip = "https://github.com/Azure/azure-functions-core-tools/issues/2174")]
         [InlineData("somelog", false)]
         [InlineData("Worker process started and initialized.", true)]
         [InlineData("Worker PROCESS started and initialized.", true)]
@@ -27,7 +27,7 @@ namespace Azure.Functions.Cli.Tests
             Assert.Equal(expected, coloredConsoleLogger.DoesMessageStartsWithAllowedLogsPrefix(formattedMessage));
         }
 
-        [Theory]
+        [Theory(Skip = "https://github.com/Azure/azure-functions-core-tools/issues/2174")]
         [InlineData("somelog", false)]
         [InlineData("Worker process started and initialized.", true)]
         [InlineData("Worker PROCESS started and initialized.", true)]

--- a/test/Azure.Functions.Cli.Tests/UtilitiesTests.cs
+++ b/test/Azure.Functions.Cli.Tests/UtilitiesTests.cs
@@ -119,6 +119,17 @@ namespace Azure.Functions.Cli.Tests
             Assert.Equal(expected, Utilities.DefaultLoggingFilter(inputCategory, inputLogLevel, LogLevel.Information, LogLevel.Warning));
         }
 
+        [Theory]
+        [InlineData("Function.Function1", true)]
+        [InlineData("Random", false)]
+        [InlineData("Host.Startup", true)]
+        [InlineData("Microsoft.Azure.WebJobs.TestLogger", true)]
+        [InlineData("Microsoft.Azure.TestLogger", false)]
+        public void IsSystemLogCategory_Test(string inputCategory, bool expected)
+        {
+            Assert.Equal(expected, Utilities.IsSystemLogCategory(inputCategory));
+        }
+
         private void DeleteIfExists(string filePath)
         {
             try


### PR DESCRIPTION
Porting PR https://github.com/Azure/azure-functions-core-tools/pull/2191 to V2