### PR TITLE
Update profile.ps1 template to set Disable-AzContextAutosave scope to process instead of current user.

### DIFF
--- a/src/Azure.Functions.Cli/StaticResources/profile.ps1
+++ b/src/Azure.Functions.Cli/StaticResources/profile.ps1
@@ -12,7 +12,7 @@
 # Authenticate with Azure PowerShell using MSI.
 # Remove this if you are not planning on using MSI or Azure PowerShell.
 if ($env:MSI_SECRET) {
-    Disable-AzContextAutosave
+    Disable-AzContextAutosave -Scope Process | Out-Null
     Connect-AzAccount -Identity
 }
 

--- a/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
@@ -412,7 +412,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                         ContentContains = new []
                         {
                             "env:MSI_SECRET",
-                            "Disable-AzContextAutosave",
+                            "Disable-AzContextAutosave -Scope Process | Out-Null",
                             "Connect-AzAccount -Identity"
                         }
                     },


### PR DESCRIPTION
Back port fix to V2.

Fixes https://github.com/Azure/azure-functions-core-tools/issues/2206

By default, `Disable-AzContextAutosave` cmdlet call in the profile.ps1 defaults to scope user. We need to set this option for the process, so adding `-Scope Process`. Also, adding Out-Null to omit the cmdlet output. 