### PR TITLE
Fix default logging filters - rely on LoggerFilterOptions

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -182,8 +182,16 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 .ConfigureLogging(loggingBuilder =>
                 {
                     loggingBuilder.ClearProviders();
+                    loggingBuilder.Services.AddSingleton<ILoggerProvider>(p =>
+                    {
+                        //Cache LoggerFilterOptions to be used by the logger to filter logs based on content
+                        var filterOptions = p.GetService<IOptions<LoggerFilterOptions>>().Value;
+                        // Set min level to SystemLogDefaultLogLevel.
+                        filterOptions.MinLevel = loggingFilterHelper.SystemLogDefaultLogLevel;
+                        return new ColoredConsoleLoggerProvider(loggingFilterHelper, filterOptions);
+                    });
                     // This is needed to filter system logs only for known categories
-                    loggingBuilder.AddFilter<ColoredConsoleLoggerProvider>((category, level) => Utilities.SystemLoggingFilter(category, level, LogLevel.Trace)).AddProvider(new ColoredConsoleLoggerProvider(loggingFilterHelper));
+                    loggingBuilder.AddDefaultWebJobsFilters<ColoredConsoleLoggerProvider>(LogLevel.Trace);
                 })
                 .ConfigureServices((context, services) => services.AddSingleton<IStartup>(new Startup(context, hostOptions, CorsOrigins, CorsCredentials, EnableAuth, loggingFilterHelper)))
                 .Build();

--- a/src/Azure.Functions.Cli/Actions/HostActions/Startup.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/Startup.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using Azure.Functions.Cli.Actions.HostActions.WebHost.Security;
 using Azure.Functions.Cli.Diagnostics;
 using Azure.Functions.Cli.ExtensionBundle;
@@ -16,6 +15,7 @@ using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Azure.Functions.Cli.Actions.HostActions
 {
@@ -78,13 +78,13 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 o.IsSelfHost = _hostOptions.IsSelfHost;
                 o.SecretsPath = _hostOptions.SecretsPath;
             });
-
+            
             services.AddSingleton<IConfigureBuilder<IConfigurationBuilder>>(_ => new ExtensionBundleConfigurationBuilder(_hostOptions));
             services.AddSingleton<IConfigureBuilder<IConfigurationBuilder>, DisableConsoleConfigurationBuilder>();
             services.AddSingleton<IConfigureBuilder<ILoggingBuilder>>(_ => new LoggingBuilder(_loggingFilterHelper));
             if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.dotnet)
             {
-                services.AddSingleton<IConfigureBuilder<IConfigurationBuilder>>(_ => new UserSecretsConfigurationBuilder(_hostOptions.ScriptPath, _loggingFilterHelper));
+                services.AddSingleton<IConfigureBuilder<IConfigurationBuilder>>((provider) => new UserSecretsConfigurationBuilder(_hostOptions.ScriptPath, _loggingFilterHelper, provider.GetService<IOptions<LoggerFilterOptions>>().Value));
             }
 
             services.AddSingleton<IDependencyValidator, ThrowingDependencyValidator>();

--- a/src/Azure.Functions.Cli/Diagnostics/ColoredConsoleLogger.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/ColoredConsoleLogger.cs
@@ -55,7 +55,7 @@ namespace Azure.Functions.Cli.Diagnostics
             {
                 return Utilities.DefaultLoggingFilter(category, logLevel, filterRule.LogLevel.Value, filterRule.LogLevel.Value);
             }
-            return Utilities.DefaultLoggingFilter(category, logLevel, filterRule.LogLevel.Value, filterRule.LogLevel.Value);
+            return Utilities.DefaultLoggingFilter(category, logLevel, _loggingFilterHelper.UserLogDefaultLogLevel, _loggingFilterHelper.SystemLogDefaultLogLevel);
         }
 
         public bool IsEnabled(LogLevel logLevel)

--- a/src/Azure.Functions.Cli/Diagnostics/ColoredConsoleLogger.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/ColoredConsoleLogger.cs
@@ -90,7 +90,7 @@ namespace Azure.Functions.Cli.Diagnostics
         {
             foreach (var line in GetMessageString(logLevel, formattedMessage, exception))
             {
-                ColoredConsole.WriteLine($"[{DateTime.UtcNow.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss")}] {line}");
+                ColoredConsole.WriteLine($"[{DateTime.UtcNow.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff")}] {line}");
             }
         }
 

--- a/src/Azure.Functions.Cli/Diagnostics/ColoredConsoleLogger.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/ColoredConsoleLogger.cs
@@ -14,18 +14,53 @@ namespace Azure.Functions.Cli.Diagnostics
         private readonly bool _verboseErrors;
         private readonly string _category;
         private readonly LoggingFilterHelper _loggingFilterHelper;
+        private readonly LoggerFilterOptions _loggerFilterOptions;
         private readonly string[] allowedLogsPrefixes = new string[] { "Worker process started and initialized.", "Host lock lease acquired by instance ID" };
+        private static readonly LoggerRuleSelector RuleSelector = new LoggerRuleSelector();
+        private static readonly Type ProviderType = typeof(ColoredConsoleLoggerProvider);
 
-        public ColoredConsoleLogger(string category, LoggingFilterHelper loggingFilterHelper)
+        public ColoredConsoleLogger(string category, LoggingFilterHelper loggingFilterHelper, LoggerFilterOptions loggerFilterOptions)
         {
             _category = category;
-            _loggingFilterHelper = loggingFilterHelper;
+            _loggerFilterOptions = loggerFilterOptions ?? throw new ArgumentNullException(nameof(loggerFilterOptions));
+            _loggingFilterHelper = loggingFilterHelper ?? throw new ArgumentNullException(nameof(loggingFilterHelper));
             _verboseErrors = StaticSettings.IsDebug;
+        }
+
+        internal LoggerFilterRule SelectRule(string categoryName, LoggerFilterOptions loggerFilterOptions)
+        {
+            RuleSelector.Select(loggerFilterOptions, ProviderType, categoryName,
+                out LogLevel? minLevel, out Func<string, string, LogLevel, bool> filter);
+
+            return new LoggerFilterRule(ProviderType.FullName, categoryName, minLevel, filter);
+        }
+
+        internal bool IsEnabled(string category, LogLevel logLevel)
+        {
+            LoggerFilterRule filterRule = SelectRule(category, _loggerFilterOptions);
+
+            if (filterRule.LogLevel != null && logLevel < filterRule.LogLevel)
+            {
+                return false;
+            }
+            if (filterRule.Filter != null)
+            {
+                bool enabled = filterRule.Filter(ProviderType.FullName, category, logLevel);
+                if (!enabled)
+                {
+                    return false;
+                }
+            }
+            if (filterRule.LogLevel != null)
+            {
+                return Utilities.DefaultLoggingFilter(category, logLevel, filterRule.LogLevel.Value, filterRule.LogLevel.Value);
+            }
+            return Utilities.DefaultLoggingFilter(category, logLevel, filterRule.LogLevel.Value, filterRule.LogLevel.Value);
         }
 
         public bool IsEnabled(LogLevel logLevel)
         {
-            return _loggingFilterHelper.IsEnabled(_category, logLevel);
+            return IsEnabled(_category, logLevel);
         }
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
@@ -55,12 +90,7 @@ namespace Azure.Functions.Cli.Diagnostics
         {
             foreach (var line in GetMessageString(logLevel, formattedMessage, exception))
             {
-                var outputline = $"{line}";
-                if (_loggingFilterHelper.VerboseLogging)
-                {
-                    outputline = $"[{DateTime.UtcNow}] {outputline}";
-                }
-                ColoredConsole.WriteLine($"{outputline}");
+                ColoredConsole.WriteLine($"[{DateTime.UtcNow.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss")}] {line}");
             }
         }
 

--- a/src/Azure.Functions.Cli/Diagnostics/ColoredConsoleLoggerProvider.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/ColoredConsoleLoggerProvider.cs
@@ -6,15 +6,17 @@ namespace Azure.Functions.Cli.Diagnostics
     public class ColoredConsoleLoggerProvider : ILoggerProvider
     {
         private readonly LoggingFilterHelper _loggingFilterHelper;
+        private readonly LoggerFilterOptions _loggerFilterOptions;
 
-        public ColoredConsoleLoggerProvider(LoggingFilterHelper loggingFilterHelper)
+        public ColoredConsoleLoggerProvider(LoggingFilterHelper loggingFilterHelper, LoggerFilterOptions loggerFilterOptions)
         {
-            _loggingFilterHelper = loggingFilterHelper;
+            _loggerFilterOptions = loggerFilterOptions ?? throw new ArgumentNullException(nameof(loggerFilterOptions));
+            _loggingFilterHelper = loggingFilterHelper ?? throw new ArgumentNullException(nameof(loggingFilterHelper));
         }
 
         public ILogger CreateLogger(string categoryName)
         {
-            return new ColoredConsoleLogger(categoryName, _loggingFilterHelper);
+            return new ColoredConsoleLogger(categoryName, _loggingFilterHelper, _loggerFilterOptions);
         }
 
         public void Dispose()

--- a/src/Azure.Functions.Cli/Diagnostics/LoggerRuleSelector.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/LoggerRuleSelector.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+// This file is modified copy of: 
+// https://github.com/aspnet/Logging/blob/cc350d7ef616ef292c1b4ae7130b8c2b45fc1164/src/Microsoft.Extensions.Logging/LoggerRuleSelector.cs.
+
+using System;
+
+namespace Microsoft.Extensions.Logging
+{
+    internal class LoggerRuleSelector
+    {
+        public void Select(LoggerFilterOptions options, Type providerType, string category, out LogLevel? minLevel, out Func<string, string, LogLevel, bool> filter)
+        {
+            filter = null;
+            minLevel = options.MinLevel;
+
+            // Filter rule selection:
+            // 1. Select rules for current logger type, if there is none, select ones without logger type specified
+            // 2. Select rules with longest matching categories
+            // 3. If there nothing matched by category take all rules without category
+            // 3. If there is only one rule use it's level and filter
+            // 4. If there are multiple rules use last
+            // 5. If there are no applicable rules use global minimal level
+
+            LoggerFilterRule current = null;
+            foreach (var rule in options.Rules)
+            {
+                if (IsBetter(rule, current, null, category))
+                {
+                    current = rule;
+                }
+            }
+
+            if (current != null)
+            {
+                filter = current.Filter;
+                minLevel = current.LogLevel;
+            }
+        }
+
+        private static bool IsBetter(LoggerFilterRule rule, LoggerFilterRule current, string logger, string category)
+        {
+            // Skip rules with inapplicable type or category
+            if (rule.ProviderName != null && rule.ProviderName != logger)
+            {
+                return false;
+            }
+
+            if (rule.CategoryName != null && !category.StartsWith(rule.CategoryName, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (current?.ProviderName != null)
+            {
+                if (rule.ProviderName == null)
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                // We want to skip category check when going from no provider to having provider
+                if (rule.ProviderName != null)
+                {
+                    return true;
+                }
+            }
+
+            if (current?.CategoryName != null)
+            {
+                if (rule.CategoryName == null)
+                {
+                    return false;
+                }
+
+                if (current.CategoryName.Length > rule.CategoryName.Length)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Azure.Functions.Cli/Diagnostics/LoggingFilterHelper.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/LoggingFilterHelper.cs
@@ -1,5 +1,6 @@
 ﻿using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Diagnostics;
+using Dynamitey;
 using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -11,9 +12,6 @@ namespace Azure.Functions.Cli
 {
     public class LoggingFilterHelper
     {
-        private const string DefaultLogLevelKey = "default";
-        private IConfigurationRoot _hostJsonConfig = null;
-
         // CI EnvironmentSettings
         // https://github.com/watson/ci-info/blob/master/index.js#L52-L59
         public const string Ci = "CI"; // Travis CI, CircleCI, Cirrus CI, Gitlab CI, Appveyor, CodeShip, dsari
@@ -23,7 +21,6 @@ namespace Azure.Functions.Cli
 
         public LoggingFilterHelper(IConfigurationRoot hostJsonConfig, bool? verboseLogging)
         {
-            _hostJsonConfig = hostJsonConfig;
             VerboseLogging = verboseLogging.HasValue && verboseLogging.Value;
 
             if (IsCiEnvironment(verboseLogging.HasValue))
@@ -34,12 +31,10 @@ namespace Azure.Functions.Cli
             {
                 SystemLogDefaultLogLevel = LogLevel.Information;
             }
-            bool defaultLogLevelExists = Utilities.LogLevelExists(hostJsonConfig, DefaultLogLevelKey);
-            if (defaultLogLevelExists)
+            if (Utilities.LogLevelExists(hostJsonConfig, Utilities.LogLevelDefaultSection, out LogLevel logLevel))
             {
-                DefaultLogLevel = Utilities.GetHostJsonDefaultLogLevel(hostJsonConfig);
-                SystemLogDefaultLogLevel = DefaultLogLevel;
-                UserLogDefaultLogLevel = DefaultLogLevel;
+                SystemLogDefaultLogLevel = logLevel;
+                UserLogDefaultLogLevel = logLevel;
             }
         }
 
@@ -62,26 +57,6 @@ namespace Azure.Functions.Cli
         /// Is set to true if `func start` is started with `--verbose` flag. If set, SystemLogDefaultLogLevel is set to Information
         /// </summary>
         public bool VerboseLogging { get; private set; }
-
-        internal void AddConsoleLoggingProvider(ILoggingBuilder loggingBuilder)
-        {
-            // Filter is needed to force all the logs at jobhost level
-            loggingBuilder.AddFilter<ColoredConsoleLoggerProvider>((category, level) => true).AddProvider(new ColoredConsoleLoggerProvider(this));
-        }
-
-        internal bool IsEnabled(string category, LogLevel logLevel)
-        {
-            if (_hostJsonConfig != null && Utilities.LogLevelExists(_hostJsonConfig, category))
-            {
-                // If category exists in `loglevel` section, ensure defaults do not apply.
-                return Utilities.UserLoggingFilter(logLevel);
-            }
-            if (DefaultLogLevel == LogLevel.None)
-            {
-                return false;
-            }
-            return Utilities.DefaultLoggingFilter(category, logLevel, UserLogDefaultLogLevel, SystemLogDefaultLogLevel);
-        }
 
         internal bool IsCiEnvironment(bool verboseLoggingArgExists)
         {

--- a/src/Azure.Functions.Cli/Diagnostics/ProviderAliasUtilities.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/ProviderAliasUtilities.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Microsoft.Extensions.Logging
+{
+    internal static class ProviderAliasUtilities
+    {
+        internal static string GetAlias(Type providerType)
+        {
+            var attribute = providerType.GetCustomAttributes<ProviderAliasAttribute>(inherit: false).FirstOrDefault();
+            return attribute?.Alias;
+        }
+    }
+}

--- a/src/Azure.Functions.Cli/Helpers/GlobalCoreToolsSettings.cs
+++ b/src/Azure.Functions.Cli/Helpers/GlobalCoreToolsSettings.cs
@@ -15,7 +15,7 @@ namespace Azure.Functions.Cli.Helpers
             {
                 if (_currentWorkerRuntime == WorkerRuntime.None)
                 {
-                    ColoredConsole.Error.WriteLine(QuietWarningColor("Can't determine project language from files. Please use one of [--csharp, --javascript, --typescript, --java, --python, --powershell], --custom"));
+                    ColoredConsole.Error.WriteLine(QuietWarningColor("Can't determine project language from files. Please use one of [--csharp, --javascript, --typescript, --java, --python, --powershell, --custom]"));
                 }
                 return _currentWorkerRuntime;
             }

--- a/src/Azure.Functions.Cli/Helpers/ProjectHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/ProjectHelpers.cs
@@ -1,7 +1,6 @@
 ﻿using System.Linq;
 using Microsoft.Build.Construction;
 using Azure.Functions.Cli.Common;
-using System.Threading.Tasks;
 using System.IO;
 using System.Xml;
 using System;
@@ -12,9 +11,9 @@ namespace Azure.Functions.Cli.Helpers
 {
     internal static class ProjectHelpers
     {
-        public static string FindProjectFile(string path, LoggingFilterHelper loggingFilterHelper)
+        public static string FindProjectFile(string path, LoggingFilterHelper loggingFilterHelper, LoggerFilterOptions loggerFilterOptions)
         {
-            ColoredConsoleLogger logger = new ColoredConsoleLogger("ProjectHelpers", loggingFilterHelper);
+            ColoredConsoleLogger logger = new ColoredConsoleLogger("ProjectHelpers", loggingFilterHelper, loggerFilterOptions);
             DirectoryInfo filePath = new DirectoryInfo(path);
             do
             {

--- a/src/Azure.Functions.Cli/Secrets/UserSecretsConfigurationBuilder.cs
+++ b/src/Azure.Functions.Cli/Secrets/UserSecretsConfigurationBuilder.cs
@@ -3,6 +3,7 @@ using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Helpers;
 using Microsoft.Azure.WebJobs.Script;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 
 namespace Azure.Functions.Cli.Diagnostics
 {
@@ -10,10 +11,12 @@ namespace Azure.Functions.Cli.Diagnostics
     {
         private readonly string _scriptPath;
         private readonly LoggingFilterHelper _loggingFilterHelper;
+        private readonly LoggerFilterOptions _loggerFilterOptions;
 
-        public UserSecretsConfigurationBuilder(string scriptPath, LoggingFilterHelper loggingFilterHelper)
+        public UserSecretsConfigurationBuilder(string scriptPath, LoggingFilterHelper loggingFilterHelper, LoggerFilterOptions loggerFilterOptions)
         {
             _loggingFilterHelper = loggingFilterHelper;
+            _loggerFilterOptions = loggerFilterOptions;
             if (string.IsNullOrEmpty(scriptPath))
             {
                 _scriptPath = Environment.CurrentDirectory;
@@ -40,7 +43,7 @@ namespace Azure.Functions.Cli.Diagnostics
             {
                 return null;
             }
-            string projectFilePath = ProjectHelpers.FindProjectFile(_scriptPath, _loggingFilterHelper);
+            string projectFilePath = ProjectHelpers.FindProjectFile(_scriptPath, _loggingFilterHelper, _loggerFilterOptions);
             if (projectFilePath == null) return null;
 
             var projectRoot = ProjectHelpers.GetProject(projectFilePath);

--- a/test/Azure.Functions.Cli.Tests/ColoredConsoleLoggerTests.cs
+++ b/test/Azure.Functions.Cli.Tests/ColoredConsoleLoggerTests.cs
@@ -1,10 +1,15 @@
 ﻿using Azure.Functions.Cli.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Extensions.Configuration;
-using System;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.DependencyInjection;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using Xunit;
+using System;
 
 namespace Azure.Functions.Cli.Tests
 {
@@ -28,7 +33,7 @@ namespace Azure.Functions.Cli.Tests
         [InlineData("Host lock lease", false)]
         public void DoesMessageStartsWithWhiteListedPrefix_Tests(string formattedMessage, bool expected)
         {
-            ColoredConsoleLogger coloredConsoleLogger = new ColoredConsoleLogger("test", new LoggingFilterHelper(_testConfiguration, true));
+            ColoredConsoleLogger coloredConsoleLogger = new ColoredConsoleLogger("test", new LoggingFilterHelper(_testConfiguration, true), new LoggerFilterOptions());
             Assert.Equal(expected, coloredConsoleLogger.DoesMessageStartsWithAllowedLogsPrefix(formattedMessage));
         }
 
@@ -40,10 +45,54 @@ namespace Azure.Functions.Cli.Tests
         [InlineData("Host lock lease acquired by instance ID", true)]
         [InlineData("Host lock lease acquired by instance id", true)]
         [InlineData("Host lock lease", false)]
-        public void IsEnabled_Tests(string formattedMessage, bool expected)
+        public void DoesMessageStartsWithAllowedLogsPrefix_Tests(string formattedMessage, bool expected)
         {
-            ColoredConsoleLogger coloredConsoleLogger = new ColoredConsoleLogger("test", new LoggingFilterHelper(_testConfiguration, true));
+            ColoredConsoleLogger coloredConsoleLogger = new ColoredConsoleLogger("test", new LoggingFilterHelper(_testConfiguration, true), new LoggerFilterOptions());
             Assert.Equal(expected, coloredConsoleLogger.DoesMessageStartsWithAllowedLogsPrefix(formattedMessage));
+        }
+
+        [Theory]
+        [InlineData("Random", LogLevel.Information, true)]
+        [InlineData("Random", LogLevel.Debug, false)]
+        [InlineData("Host.Startup", LogLevel.Information, true)]
+        [InlineData("Host.Startup", LogLevel.Trace, false)]
+        [InlineData("Host.General", LogLevel.Trace, false)]
+        [InlineData("Host.General", LogLevel.Debug, false)]
+        [InlineData("Host.General", LogLevel.Information, false)]
+        public void IsEnabled_LoggerFilterTests_Tests(string inputCategory, LogLevel inputLogLevel, bool expected)
+        {
+            LoggerFilterRule loggerFilterRule1 = new LoggerFilterRule(null, "Host.", LogLevel.None, null);
+            LoggerFilterRule loggerFilterRule2 = new LoggerFilterRule(null, "Host.Startup", LogLevel.Debug, null);
+
+            LoggerFilterOptions customFilterOptions = new LoggerFilterOptions();
+            customFilterOptions.MinLevel = LogLevel.Information;
+            customFilterOptions.Rules.Add(loggerFilterRule1);
+            customFilterOptions.Rules.Add(loggerFilterRule2);
+
+            ColoredConsoleLogger coloredConsoleLogger = new ColoredConsoleLogger(inputCategory, new LoggingFilterHelper(_testConfiguration, true), customFilterOptions);
+            bool result = coloredConsoleLogger.IsEnabled(inputCategory, inputLogLevel);
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void SelectRule_Tests()
+        {
+            List<LoggerFilterRule> loggerFilterRules = new List<LoggerFilterRule>();
+            LoggerFilterRule loggerFilterRule = new LoggerFilterRule(null, "Host.", LogLevel.Trace, null);
+            loggerFilterRules.Add(loggerFilterRule);
+
+            LoggerFilterOptions customFilterOptions = new LoggerFilterOptions();
+            customFilterOptions.MinLevel = LogLevel.Information;
+            customFilterOptions.Rules.Add(loggerFilterRule);
+
+            ColoredConsoleLogger coloredConsoleLogger = new ColoredConsoleLogger("test", new LoggingFilterHelper(_testConfiguration, true), customFilterOptions);
+            var startupLogsRule = coloredConsoleLogger.SelectRule("Host.Startup", customFilterOptions);
+            Assert.NotNull(startupLogsRule.LogLevel);
+            Assert.Equal(LogLevel.Trace, startupLogsRule.LogLevel);
+
+            var functionLogsRule = coloredConsoleLogger.SelectRule("Function.TestFunction", customFilterOptions);
+            Assert.NotNull(functionLogsRule.LogLevel);
+            Assert.Equal(LogLevel.Information, functionLogsRule.LogLevel);
         }
     }
 }

--- a/test/Azure.Functions.Cli.Tests/LoggingFilterHelperTests.cs
+++ b/test/Azure.Functions.Cli.Tests/LoggingFilterHelperTests.cs
@@ -89,33 +89,6 @@ namespace Azure.Functions.Cli.Tests
                         Assert.Equal(LogLevel.Warning, loggingFilterHelper.SystemLogDefaultLogLevel);
                     }
                 }
-                var loggerFactory = LoggerFactory.Create(builder =>
-                {
-                    loggingFilterHelper.AddConsoleLoggingProvider(builder);
-                    var serviceProvider = builder.Services.BuildServiceProvider();
-                    var coloredConsoleLoggerProvider = (ColoredConsoleLoggerProvider)serviceProvider.GetService<ILoggerProvider>();
-                    Assert.NotNull(coloredConsoleLoggerProvider);
-                });
-            }
-            finally
-            {
-                DeleteIfExists(_workerDir);
-            }
-        }
-
-        [Theory(Skip = "https://github.com/Azure/azure-functions-core-tools/issues/2174")]
-        [InlineData("{\"version\": \"2.0\",\"Logging\": {\"LogLevel\": {\"Default\": \"None\"}}}", "test", LogLevel.Information, false)]
-        [InlineData("{\"version\": \"2.0\",\"Logging\": {\"LogLevel\": {\"Host.Startup\": \"Debug\"}}}", "Host.Startup", LogLevel.Information, true)]
-        [InlineData("{\"version\": \"2.0\",\"Logging\": {\"LogLevel\": {\"Host.Startup\": \"Debug\"}}}", "Host.General", LogLevel.Information, false)]
-        [InlineData("{\"version\": \"2.0\",\"Logging\": {\"LogLevel\": {\"Host.Startup\": \"Debug\"}}}", "Host.General", LogLevel.Warning, true)]
-        public void IsEnabled_Tests(string hostJsonContent, string category, LogLevel logLevel, bool expected)
-        {
-            try
-            {
-                FileSystemHelpers.WriteAllTextToFile(_hostJsonFilePath, hostJsonContent);
-                var configuration = Utilities.BuildHostJsonConfigutation(_hostOptions);
-                LoggingFilterHelper loggingFilterHelper = new LoggingFilterHelper(configuration, false);
-                Assert.Equal(expected, loggingFilterHelper.IsEnabled(category, logLevel));
             }
             finally
             {


### PR DESCRIPTION
**Resolves #2216** and **Resolves #2220**
- Use registered `LoggerFilterOptions` to filter logs
    - Default log levels apply only if `LoggingFilterRule` does not have a `logLevel` for a category.

**Resolves #2217**
- Bring back time stamps in the logs
- Print Function Executing and Executed messages.