### PR TITLE
Fix logging filters-rely on LoggerFilterOptions

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -189,8 +189,16 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 .ConfigureLogging(loggingBuilder =>
                 {
                     loggingBuilder.ClearProviders();
+                    loggingBuilder.Services.AddSingleton<ILoggerProvider>(p =>
+                    {
+                        //Cache LoggerFilterOptions to be used by the logger to filter logs based on content
+                        var filterOptions = p.GetService<IOptions<LoggerFilterOptions>>().Value;
+                        // Set min level to SystemLogDefaultLogLevel.
+                        filterOptions.MinLevel = loggingFilterHelper.SystemLogDefaultLogLevel;
+                        return new ColoredConsoleLoggerProvider(loggingFilterHelper, filterOptions);
+                    });
                     // This is needed to filter system logs only for known categories
-                    loggingBuilder.AddFilter<ColoredConsoleLoggerProvider>((category, level) => Utilities.SystemLoggingFilter(category, level, LogLevel.Trace)).AddProvider(new ColoredConsoleLoggerProvider(loggingFilterHelper));
+                    loggingBuilder.AddDefaultWebJobsFilters<ColoredConsoleLoggerProvider>(LogLevel.Trace);
                 })
                 .ConfigureServices((context, services) => services.AddSingleton<IStartup>(new Startup(context, hostOptions, CorsOrigins, CorsCredentials, EnableAuth, loggingFilterHelper)))
                 .Build();

--- a/src/Azure.Functions.Cli/Diagnostics/ColoredConsoleLoggerProvider.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/ColoredConsoleLoggerProvider.cs
@@ -6,15 +6,17 @@ namespace Azure.Functions.Cli.Diagnostics
     public class ColoredConsoleLoggerProvider : ILoggerProvider
     {
         private readonly LoggingFilterHelper _loggingFilterHelper;
+        private readonly LoggerFilterOptions _loggerFilterOptions;
 
-        public ColoredConsoleLoggerProvider(LoggingFilterHelper loggingFilterHelper)
+        public ColoredConsoleLoggerProvider(LoggingFilterHelper loggingFilterHelper, LoggerFilterOptions loggerFilterOptions)
         {
-            _loggingFilterHelper = loggingFilterHelper;
+            _loggerFilterOptions = loggerFilterOptions ?? throw new ArgumentNullException(nameof(loggerFilterOptions));
+            _loggingFilterHelper = loggingFilterHelper ?? throw new ArgumentNullException(nameof(loggingFilterHelper));
         }
 
         public ILogger CreateLogger(string categoryName)
         {
-            return new ColoredConsoleLogger(categoryName, _loggingFilterHelper);
+            return new ColoredConsoleLogger(categoryName, _loggingFilterHelper, _loggerFilterOptions);
         }
 
         public void Dispose()

--- a/src/Azure.Functions.Cli/Diagnostics/LoggerRuleSelector.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/LoggerRuleSelector.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+// This file is modified copy of: 
+// https://github.com/aspnet/Logging/blob/cc350d7ef616ef292c1b4ae7130b8c2b45fc1164/src/Microsoft.Extensions.Logging/LoggerRuleSelector.cs.
+
+using System;
+
+namespace Microsoft.Extensions.Logging
+{
+    internal class LoggerRuleSelector
+    {
+        public void Select(LoggerFilterOptions options, Type providerType, string category, out LogLevel? minLevel, out Func<string, string, LogLevel, bool> filter)
+        {
+            filter = null;
+            minLevel = options.MinLevel;
+
+            // Filter rule selection:
+            // 1. Select rules for current logger type, if there is none, select ones without logger type specified
+            // 2. Select rules with longest matching categories
+            // 3. If there nothing matched by category take all rules without category
+            // 3. If there is only one rule use it's level and filter
+            // 4. If there are multiple rules use last
+            // 5. If there are no applicable rules use global minimal level
+
+            LoggerFilterRule current = null;
+            foreach (var rule in options.Rules)
+            {
+                if (IsBetter(rule, current, null, category))
+                {
+                    current = rule;
+                }
+            }
+
+            if (current != null)
+            {
+                filter = current.Filter;
+                minLevel = current.LogLevel;
+            }
+        }
+
+        private static bool IsBetter(LoggerFilterRule rule, LoggerFilterRule current, string logger, string category)
+        {
+            // Skip rules with inapplicable type or category
+            if (rule.ProviderName != null && rule.ProviderName != logger)
+            {
+                return false;
+            }
+
+            if (rule.CategoryName != null && !category.StartsWith(rule.CategoryName, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (current?.ProviderName != null)
+            {
+                if (rule.ProviderName == null)
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                // We want to skip category check when going from no provider to having provider
+                if (rule.ProviderName != null)
+                {
+                    return true;
+                }
+            }
+
+            if (current?.CategoryName != null)
+            {
+                if (rule.CategoryName == null)
+                {
+                    return false;
+                }
+
+                if (current.CategoryName.Length > rule.CategoryName.Length)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Azure.Functions.Cli/Diagnostics/LoggingFilterHelper.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/LoggingFilterHelper.cs
@@ -1,5 +1,6 @@
 ﻿using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Diagnostics;
+using Dynamitey;
 using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -11,9 +12,6 @@ namespace Azure.Functions.Cli
 {
     public class LoggingFilterHelper
     {
-        private const string DefaultLogLevelKey = "default";
-        private IConfigurationRoot _hostJsonConfig = null;
-
         // CI EnvironmentSettings
         // https://github.com/watson/ci-info/blob/master/index.js#L52-L59
         public const string Ci = "CI"; // Travis CI, CircleCI, Cirrus CI, Gitlab CI, Appveyor, CodeShip, dsari
@@ -23,7 +21,6 @@ namespace Azure.Functions.Cli
 
         public LoggingFilterHelper(IConfigurationRoot hostJsonConfig, bool? verboseLogging)
         {
-            _hostJsonConfig = hostJsonConfig;
             VerboseLogging = verboseLogging.HasValue && verboseLogging.Value;
 
             if (IsCiEnvironment(verboseLogging.HasValue))
@@ -34,12 +31,10 @@ namespace Azure.Functions.Cli
             {
                 SystemLogDefaultLogLevel = LogLevel.Information;
             }
-            bool defaultLogLevelExists = Utilities.LogLevelExists(hostJsonConfig, DefaultLogLevelKey);
-            if (defaultLogLevelExists)
+            if (Utilities.LogLevelExists(hostJsonConfig, Utilities.LogLevelDefaultSection, out LogLevel logLevel))
             {
-                DefaultLogLevel = Utilities.GetHostJsonDefaultLogLevel(hostJsonConfig);
-                SystemLogDefaultLogLevel = DefaultLogLevel;
-                UserLogDefaultLogLevel = DefaultLogLevel;
+                SystemLogDefaultLogLevel = logLevel;
+                UserLogDefaultLogLevel = logLevel;
             }
         }
 
@@ -62,26 +57,6 @@ namespace Azure.Functions.Cli
         /// Is set to true if `func start` is started with `--verbose` flag. If set, SystemLogDefaultLogLevel is set to Information
         /// </summary>
         public bool VerboseLogging { get; private set; }
-
-        internal void AddConsoleLoggingProvider(ILoggingBuilder loggingBuilder)
-        {
-            // Filter is needed to force all the logs at jobhost level
-            loggingBuilder.AddFilter<ColoredConsoleLoggerProvider>((category, level) => true).AddProvider(new ColoredConsoleLoggerProvider(this));
-        }
-
-        internal bool IsEnabled(string category, LogLevel logLevel)
-        {
-            if (_hostJsonConfig != null && Utilities.LogLevelExists(_hostJsonConfig, category))
-            {
-                // If category exists in `loglevel` section, ensure defaults do not apply.
-                return Utilities.UserLoggingFilter(logLevel);
-            }
-            if (DefaultLogLevel == LogLevel.None)
-            {
-                return false;
-            }
-            return Utilities.DefaultLoggingFilter(category, logLevel, UserLogDefaultLogLevel, SystemLogDefaultLogLevel);
-        }
 
         internal bool IsCiEnvironment(bool verboseLoggingArgExists)
         {

--- a/src/Azure.Functions.Cli/Diagnostics/ProviderAliasUtilities.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/ProviderAliasUtilities.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Microsoft.Extensions.Logging
+{
+    internal static class ProviderAliasUtilities
+    {
+        internal static string GetAlias(Type providerType)
+        {
+            var attribute = providerType.GetCustomAttributes<ProviderAliasAttribute>(inherit: false).FirstOrDefault();
+            return attribute?.Alias;
+        }
+    }
+}

--- a/test/Azure.Functions.Cli.Tests/ColoredConsoleLoggerTests.cs
+++ b/test/Azure.Functions.Cli.Tests/ColoredConsoleLoggerTests.cs
@@ -1,10 +1,14 @@
 ﻿using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Diagnostics;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
+using System;
+using System.Collections.Generic;
 
 namespace Azure.Functions.Cli.Tests
 {
@@ -23,7 +27,7 @@ namespace Azure.Functions.Cli.Tests
             string defaultJson = "{\"version\": \"2.0\",\"Logging\": {\"LogLevel\": {\"Host.Startup\": \"Debug\"}}}";
             await FileSystemHelpers.WriteToFile("host.json", new MemoryStream(Encoding.ASCII.GetBytes(defaultJson)));
             var testConfiguration = new ConfigurationBuilder().AddJsonFile("host.json").Build();
-            ColoredConsoleLogger coloredConsoleLogger = new ColoredConsoleLogger("test", new LoggingFilterHelper(testConfiguration, true));
+            ColoredConsoleLogger coloredConsoleLogger = new ColoredConsoleLogger("test", new LoggingFilterHelper(testConfiguration, true), new LoggerFilterOptions());
             Assert.Equal(expected, coloredConsoleLogger.DoesMessageStartsWithAllowedLogsPrefix(formattedMessage));
         }
 
@@ -40,8 +44,60 @@ namespace Azure.Functions.Cli.Tests
             string defaultJson = "{\"version\": \"2.0\",\"Logging\": {\"LogLevel\": {\"Host.Startup\": \"Debug\"}}}";
             await FileSystemHelpers.WriteToFile("host.json", new MemoryStream(Encoding.ASCII.GetBytes(defaultJson)));
             var testConfiguration = new ConfigurationBuilder().AddJsonFile("host.json").Build();
-            ColoredConsoleLogger coloredConsoleLogger = new ColoredConsoleLogger("test", new LoggingFilterHelper(testConfiguration, true));
+            ColoredConsoleLogger coloredConsoleLogger = new ColoredConsoleLogger("test", new LoggingFilterHelper(testConfiguration, true), new LoggerFilterOptions());
             Assert.Equal(expected, coloredConsoleLogger.DoesMessageStartsWithAllowedLogsPrefix(formattedMessage));
+        }
+
+        [Theory]
+        [InlineData("Random", LogLevel.Information, true)]
+        [InlineData("Random", LogLevel.Debug, false)]
+        [InlineData("Host.Startup", LogLevel.Information, true)]
+        [InlineData("Host.Startup", LogLevel.Trace, false)]
+        [InlineData("Host.General", LogLevel.Trace, false)]
+        [InlineData("Host.General", LogLevel.Debug, false)]
+        [InlineData("Host.General", LogLevel.Information, false)]
+        public async Task IsEnabled_LoggerFilterTests_Tests(string inputCategory, LogLevel inputLogLevel, bool expected)
+        {
+            string defaultJson = "{\"version\": \"2.0\",\"Logging\": {\"LogLevel\": {\"Host.Startup\": \"Debug\"}}}";
+            await FileSystemHelpers.WriteToFile("host.json", new MemoryStream(Encoding.ASCII.GetBytes(defaultJson)));
+            var testConfiguration = new ConfigurationBuilder().AddJsonFile("host.json").Build();
+
+            LoggerFilterRule loggerFilterRule1 = new LoggerFilterRule(null, "Host.", LogLevel.None, null);
+            LoggerFilterRule loggerFilterRule2 = new LoggerFilterRule(null, "Host.Startup", LogLevel.Debug, null);
+
+            LoggerFilterOptions customFilterOptions = new LoggerFilterOptions();
+            customFilterOptions.MinLevel = LogLevel.Information;
+            customFilterOptions.Rules.Add(loggerFilterRule1);
+            customFilterOptions.Rules.Add(loggerFilterRule2);
+
+            ColoredConsoleLogger coloredConsoleLogger = new ColoredConsoleLogger(inputCategory, new LoggingFilterHelper(testConfiguration, true), customFilterOptions);
+            bool result = coloredConsoleLogger.IsEnabled(inputCategory, inputLogLevel);
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public async Task SelectRule_Tests()
+        {
+            string defaultJson = "{\"version\": \"2.0\",\"Logging\": {\"LogLevel\": {\"Host.Startup\": \"Debug\"}}}";
+            await FileSystemHelpers.WriteToFile("host.json", new MemoryStream(Encoding.ASCII.GetBytes(defaultJson)));
+            var testConfiguration = new ConfigurationBuilder().AddJsonFile("host.json").Build();
+
+            List<LoggerFilterRule> loggerFilterRules = new List<LoggerFilterRule>();
+            LoggerFilterRule loggerFilterRule = new LoggerFilterRule(null, "Host.", LogLevel.Trace, null);
+            loggerFilterRules.Add(loggerFilterRule);
+
+            LoggerFilterOptions customFilterOptions = new LoggerFilterOptions();
+            customFilterOptions.MinLevel = LogLevel.Information;
+            customFilterOptions.Rules.Add(loggerFilterRule);
+
+            ColoredConsoleLogger coloredConsoleLogger = new ColoredConsoleLogger("test", new LoggingFilterHelper(testConfiguration, true), customFilterOptions);
+            var startupLogsRule = coloredConsoleLogger.SelectRule("Host.Startup", customFilterOptions);
+            Assert.NotNull(startupLogsRule.LogLevel);
+            Assert.Equal(LogLevel.Trace, startupLogsRule.LogLevel);
+
+            var functionLogsRule = coloredConsoleLogger.SelectRule("Function.TestFunction", customFilterOptions);
+            Assert.NotNull(functionLogsRule.LogLevel);
+            Assert.Equal(LogLevel.Information, functionLogsRule.LogLevel);
         }
     }
 }

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -49,7 +49,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                         var result = await response.Content.ReadAsStringAsync();
                         p.Kill();
                         result.Should().Be("Hello, Test. This HTTP triggered function executed successfully.", because: "response from default function should be 'Hello, {name}. This HTTP triggered function executed successfully.'");
-                    }   
+                    }
                 },
             }, _output);
         }
@@ -184,9 +184,16 @@ namespace Azure.Functions.Cli.Tests.E2E
                     },
                     Test = async (_, p) =>
                     {
-                        // give the host time to load functions and print any errors
-                        await Task.Delay(TimeSpan.FromSeconds(10));
-                        p.Kill();
+                        try
+                        {
+                            // give the host time to load functions and print any errors
+                            await Task.Delay(TimeSpan.FromSeconds(15));
+                            p.Kill();
+                        }
+                        catch
+                        {
+                            //ignore
+                        }
                     }
                 },
             }, _output, startHost: true);

--- a/test/Azure.Functions.Cli.Tests/LoggingFilterHelperTests.cs
+++ b/test/Azure.Functions.Cli.Tests/LoggingFilterHelperTests.cs
@@ -97,26 +97,6 @@ namespace Azure.Functions.Cli.Tests
         }
 
         [Theory(Skip = "https://github.com/Azure/azure-functions-core-tools/issues/2174")]
-        [InlineData("{\"version\": \"2.0\",\"Logging\": {\"LogLevel\": {\"Default\": \"None\"}}}", "test", LogLevel.Information, false)]
-        [InlineData("{\"version\": \"2.0\",\"Logging\": {\"LogLevel\": {\"Host.Startup\": \"Debug\"}}}", "Host.Startup", LogLevel.Information, true)]
-        [InlineData("{\"version\": \"2.0\",\"Logging\": {\"LogLevel\": {\"Host.Startup\": \"Debug\"}}}", "Host.General", LogLevel.Information, false)]
-        [InlineData("{\"version\": \"2.0\",\"Logging\": {\"LogLevel\": {\"Host.Startup\": \"Debug\"}}}", "Host.General", LogLevel.Warning, true)]
-        public void IsEnabled_Tests(string hostJsonContent, string category, LogLevel logLevel, bool expected)
-        {
-            try
-            {
-                FileSystemHelpers.WriteAllTextToFile(_hostJsonFilePath, hostJsonContent);
-                var configuration = Utilities.BuildHostJsonConfigutation(_hostOptions);
-                LoggingFilterHelper loggingFilterHelper = new LoggingFilterHelper(configuration, false);
-                Assert.Equal(expected, loggingFilterHelper.IsEnabled(category, logLevel));
-            }
-            finally
-            {
-                DeleteIfExists(_workerDir);
-            }
-        }
-
-        [Theory(Skip = "https://github.com/Azure/azure-functions-core-tools/issues/2174")]
         [InlineData(false, null, false)]
         [InlineData(true, false, false)]
         [InlineData(true, null, true)]


### PR DESCRIPTION
**Resolves #2216** and **Resolves #2220**
- Use registered `LoggerFilterOptions` to filter logs
    - Default log levels apply only if `LoggingFilterRule` does not have a `logLevel` for a category.

**Resolves #2217**
- Bring back time stamps in the logs
- Print Function Executing and Executed messages.

port commit # d552c6741a37422684f0efab41d541ebad2b2bd2