### PR TITLE
Minor changes to logging and add variable to display ascii logo

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -253,9 +253,9 @@ namespace Azure.Functions.Cli.Actions.HostActions
         public override async Task RunAsync()
         {
             await PreRunConditions();
-            var displayLogo = Environment.GetEnvironmentVariable(Constants.DisplayLogoVariable) == "1";
+
             var isVerbose = VerboseLogging.HasValue && VerboseLogging.Value;
-            if (isVerbose || displayLogo)
+            if (isVerbose || Utilities.ShouldPrintLogo())
             {
                 Utilities.PrintLogo();
             }

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -255,16 +255,13 @@ namespace Azure.Functions.Cli.Actions.HostActions
             await PreRunConditions();
 
             var isVerbose = VerboseLogging.HasValue && VerboseLogging.Value;
-            if (isVerbose || Utilities.ShouldPrintLogo())
+            if (isVerbose || EnvironmentHelper.GetEnvironmentVariableAsBool(Constants.DisplayLogo))
             {
                 Utilities.PrintLogo();
             }
 
-            var aspnetVerbosityAlreadySet = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(Constants.AspNetCoreSuppressStatusMessagesVariable));
-            if (!isVerbose && !aspnetVerbosityAlreadySet)
-            {
-                Environment.SetEnvironmentVariable(Constants.AspNetCoreSuppressStatusMessagesVariable, "true");
-            }
+            // Suppress AspNetCoreSupressStatusMessages
+            EnvironmentHelper.SetEnvironmentVariableAsBoolIfNotExists(Constants.AspNetCoreSupressStatusMessages);
 
             Utilities.PrintVersion();
 

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -257,6 +257,10 @@ namespace Azure.Functions.Cli.Actions.HostActions
             {
                 Utilities.PrintLogo();
             }
+            else
+            {
+                Environment.SetEnvironmentVariable("ASPNETCORE_SUPPRESSSTATUSMESSAGES", "true");
+            }
             Utilities.PrintVersion();
 
             ScriptApplicationHostOptions hostOptions = SelfHostWebHostSettingsFactory.Create(Environment.CurrentDirectory);

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -253,14 +253,18 @@ namespace Azure.Functions.Cli.Actions.HostActions
         public override async Task RunAsync()
         {
             await PreRunConditions();
-            if (VerboseLogging.HasValue && VerboseLogging.Value)
+            var displayLogo = Environment.GetEnvironmentVariable(Constants.DisplayLogoVariable) == "1";
+            var isVerbose = VerboseLogging.HasValue && VerboseLogging.Value;
+            if (isVerbose || displayLogo)
             {
                 Utilities.PrintLogo();
             }
-            else
+
+            if (!isVerbose)
             {
                 Environment.SetEnvironmentVariable("ASPNETCORE_SUPPRESSSTATUSMESSAGES", "true");
             }
+
             Utilities.PrintVersion();
 
             ScriptApplicationHostOptions hostOptions = SelfHostWebHostSettingsFactory.Create(Environment.CurrentDirectory);

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -260,9 +260,10 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 Utilities.PrintLogo();
             }
 
-            if (!isVerbose)
+            var aspnetVerbosityAlreadySet = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(Constants.AspNetCoreSuppressStatusMessagesVariable));
+            if (!isVerbose && !aspnetVerbosityAlreadySet)
             {
-                Environment.SetEnvironmentVariable("ASPNETCORE_SUPPRESSSTATUSMESSAGES", "true");
+                Environment.SetEnvironmentVariable(Constants.AspNetCoreSuppressStatusMessagesVariable, "true");
             }
 
             Utilities.PrintVersion();

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -52,6 +52,7 @@ namespace Azure.Functions.Cli.Common
         public const string HttpTriggerTemplateName = "HttpTrigger";
         public const string PowerShellWorkerDefaultVersion = "~7";
         public const string UserSecretsIdElementName = "UserSecretsId";
+        public const string DisplayLogoVariable = "FUNCTIONS_CORE_TOOLS_DISPLAY_LOGO";
 
         public static string CliVersion => typeof(Constants).GetTypeInfo().Assembly.GetName().Version.ToString(3);
 

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -53,6 +53,7 @@ namespace Azure.Functions.Cli.Common
         public const string PowerShellWorkerDefaultVersion = "~7";
         public const string UserSecretsIdElementName = "UserSecretsId";
         public const string DisplayLogoVariable = "FUNCTIONS_CORE_TOOLS_DISPLAY_LOGO";
+        public const string AspNetCoreSuppressStatusMessagesVariable = "ASPNETCORE_SUPPRESSSTATUSMESSAGES";
 
         public static string CliVersion => typeof(Constants).GetTypeInfo().Assembly.GetName().Version.ToString(3);
 

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -52,8 +52,8 @@ namespace Azure.Functions.Cli.Common
         public const string HttpTriggerTemplateName = "HttpTrigger";
         public const string PowerShellWorkerDefaultVersion = "~7";
         public const string UserSecretsIdElementName = "UserSecretsId";
-        public const string DisplayLogoVariable = "FUNCTIONS_CORE_TOOLS_DISPLAY_LOGO";
-        public const string AspNetCoreSuppressStatusMessagesVariable = "ASPNETCORE_SUPPRESSSTATUSMESSAGES";
+        public const string DisplayLogo = "FUNCTIONS_CORE_TOOLS_DISPLAY_LOGO";
+        public const string AspNetCoreSupressStatusMessages = "ASPNETCORE_SUPPRESSSTATUSMESSAGES";
 
         public static string CliVersion => typeof(Constants).GetTypeInfo().Assembly.GetName().Version.ToString(3);
 

--- a/src/Azure.Functions.Cli/Common/Utilities.cs
+++ b/src/Azure.Functions.Cli/Common/Utilities.cs
@@ -46,8 +46,9 @@ namespace Azure.Functions.Cli
         internal static void PrintVersion()
         {
             ColoredConsole
-                .WriteLine($"Azure Functions Core Tools ({Constants.CliDetailedVersion})")
-                .WriteLine($"Function Runtime Version: {ScriptHost.Version}");
+                .WriteLine($"\n\x1b[1m<⚡️>".DarkCyan() + " Azure Functions Core Tools\x1b[0m")
+                .WriteLine($"Core Tools Version:       {Constants.CliDetailedVersion}".DarkGray())
+                .WriteLine($"Function Runtime Version: {ScriptHost.Version}\n".DarkGray());
         }
 
         private static RichString AlternateLogoColor(string str, int firstColorCount = -1)

--- a/src/Azure.Functions.Cli/Common/Utilities.cs
+++ b/src/Azure.Functions.Cli/Common/Utilities.cs
@@ -252,5 +252,11 @@ namespace Azure.Functions.Cli
             var configuration = builder.Build();
             return configuration;
         }
+
+        internal static bool ShouldPrintLogo()
+        {
+            var displayLogoVariable = Environment.GetEnvironmentVariable(Constants.DisplayLogoVariable);
+            return displayLogoVariable == "1" || displayLogoVariable == "true";
+        }
     }
 }

--- a/src/Azure.Functions.Cli/Common/Utilities.cs
+++ b/src/Azure.Functions.Cli/Common/Utilities.cs
@@ -46,7 +46,7 @@ namespace Azure.Functions.Cli
         internal static void PrintVersion()
         {
             ColoredConsole
-                .WriteLine($"\n\x1b[1m{"<".DarkCyan()}{"\u26A1".DarkYellow()}{">".DarkCyan()} Azure Functions Core Tools\x1b[0m")
+                .WriteLine($"\nAzure Functions Core Tools")
                 .WriteLine($"Core Tools Version:       {Constants.CliDetailedVersion}".DarkGray())
                 .WriteLine($"Function Runtime Version: {ScriptHost.Version}\n".DarkGray());
         }

--- a/src/Azure.Functions.Cli/Common/Utilities.cs
+++ b/src/Azure.Functions.Cli/Common/Utilities.cs
@@ -252,11 +252,5 @@ namespace Azure.Functions.Cli
             var configuration = builder.Build();
             return configuration;
         }
-
-        internal static bool ShouldPrintLogo()
-        {
-            var displayLogoVariable = Environment.GetEnvironmentVariable(Constants.DisplayLogoVariable);
-            return displayLogoVariable == "1" || displayLogoVariable == "true";
-        }
     }
 }

--- a/src/Azure.Functions.Cli/Common/Utilities.cs
+++ b/src/Azure.Functions.Cli/Common/Utilities.cs
@@ -46,7 +46,7 @@ namespace Azure.Functions.Cli
         internal static void PrintVersion()
         {
             ColoredConsole
-                .WriteLine($"\n\x1b[1m<⚡️>".DarkCyan() + " Azure Functions Core Tools\x1b[0m")
+                .WriteLine($"\n\x1b[1m{"<".DarkCyan()}{"\u26A1".DarkYellow()}{">".DarkCyan()} Azure Functions Core Tools\x1b[0m")
                 .WriteLine($"Core Tools Version:       {Constants.CliDetailedVersion}".DarkGray())
                 .WriteLine($"Function Runtime Version: {ScriptHost.Version}\n".DarkGray());
         }

--- a/src/Azure.Functions.Cli/Diagnostics/ColoredConsoleLogger.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/ColoredConsoleLogger.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using Azure.Functions.Cli.Common;
 using static Azure.Functions.Cli.Common.OutputTheme;
 using System.Linq;
+using Colors.Net.StringColorExtensions;
 
 namespace Azure.Functions.Cli.Diagnostics
 {
@@ -90,7 +91,7 @@ namespace Azure.Functions.Cli.Diagnostics
         {
             foreach (var line in GetMessageString(logLevel, formattedMessage, exception))
             {
-                ColoredConsole.WriteLine($"[{DateTime.UtcNow.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff")}] {line}");
+                ColoredConsole.WriteLine($"[{DateTime.UtcNow.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff")}] ".DarkGray() + line);
             }
         }
 

--- a/src/Azure.Functions.Cli/Helpers/EnvironmentHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/EnvironmentHelper.cs
@@ -17,5 +17,13 @@ namespace Azure.Functions.Cli.Helpers
 
             return val.Equals("1") || val.Equals("true", StringComparison.OrdinalIgnoreCase);
         }
+
+        public static void SetEnvironmentVariableAsBoolIfNotExists(string keyName)
+        {
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(keyName)))
+            {
+                Environment.SetEnvironmentVariable(keyName, "true");
+            }
+        }
     }
 }

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -38,7 +38,8 @@ namespace Azure.Functions.Cli.Tests.E2E
                 },
                 OutputDoesntContain = new string[]
                 {
-                        "Initializing function HTTP routes"
+                        "Initializing function HTTP routes",
+                        "Content root path:" // ASPNETCORE_SUPPRESSSTATUSMESSAGES is set to true by default
                 },
                 Test = async (workingDir, p) =>
                 {


### PR DESCRIPTION
Some small changes while investigating options for #2222. @pragnagopa let me know what you think.

* Remove ASP.NET Core startup logs if not verbose
* Change formatting to make the beginning of the command stand out a bit more
* Change timestamps to gray to make them less prominent
* Add `FUNCTIONS_CORE_TOOLS_DISPLAY_LOGO` to force ASCII art if set to `1`

![image](https://user-images.githubusercontent.com/3982077/93723965-f0dd8f80-fb57-11ea-9714-51aac2764e8f.png)
