### PR TITLE
[pack] Python v2 worker release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ nCrunchTemp*
 artifacts/
 /src/Azure.Functions.Cli/Properties/launchSettings.json
 launchSettings.json
+
+# Mac specific files
+.DS_Store

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -122,7 +122,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.2.2" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="2.0.448" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="2.0.14494" />
-    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="2.0.14118" />
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="2.0.14494" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="YamlDotNet" Version="6.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Bumping the Python Worker to 1.1.6 - [Release Notes](https://github.com/Azure/azure-functions-python-worker/releases/tag/1.1.6)