### PR TITLE
Fixed warning for missing settings when they're set in user secrets file

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/Startup.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/Startup.cs
@@ -13,6 +13,7 @@ using Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.UserSecrets;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -26,13 +27,22 @@ namespace Azure.Functions.Cli.Actions.HostActions
         private readonly string[] _corsOrigins;
         private readonly bool _corsCredentials;
         private readonly bool _enableAuth;
+        private readonly string _userSecretsId;
         private readonly LoggingFilterHelper _loggingFilterHelper;
 
-        public Startup(WebHostBuilderContext builderContext, ScriptApplicationHostOptions hostOptions, string corsOrigins, bool corsCredentials, bool enableAuth, LoggingFilterHelper loggingFilterHelper)
+        public Startup(
+            WebHostBuilderContext builderContext,
+            ScriptApplicationHostOptions hostOptions,
+            string corsOrigins,
+            bool corsCredentials,
+            bool enableAuth,
+            string userSecretsId,
+            LoggingFilterHelper loggingFilterHelper)
         {
             _builderContext = builderContext;
             _hostOptions = hostOptions;
             _enableAuth = enableAuth;
+            _userSecretsId = userSecretsId;
             _loggingFilterHelper = loggingFilterHelper;
 
             if (!string.IsNullOrEmpty(corsOrigins))
@@ -82,9 +92,9 @@ namespace Azure.Functions.Cli.Actions.HostActions
             services.AddSingleton<IConfigureBuilder<IConfigurationBuilder>>(_ => new ExtensionBundleConfigurationBuilder(_hostOptions));
             services.AddSingleton<IConfigureBuilder<IConfigurationBuilder>, DisableConsoleConfigurationBuilder>();
             services.AddSingleton<IConfigureBuilder<ILoggingBuilder>>(_ => new LoggingBuilder(_loggingFilterHelper));
-            if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.dotnet)
+            if (!string.IsNullOrEmpty(_userSecretsId))
             {
-                services.AddSingleton<IConfigureBuilder<IConfigurationBuilder>>((provider) => new UserSecretsConfigurationBuilder(_hostOptions.ScriptPath, _loggingFilterHelper, provider.GetService<IOptions<LoggerFilterOptions>>().Value));
+                services.AddSingleton<IConfigureBuilder<IConfigurationBuilder>>((provider) => new UserSecretsConfigurationBuilder(_userSecretsId, _loggingFilterHelper, provider.GetService<IOptions<LoggerFilterOptions>>().Value));
             }
 
             services.AddSingleton<IDependencyValidator, ThrowingDependencyValidator>();

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -78,6 +78,10 @@ namespace Azure.Functions.Cli.Common
             public const string EitherPidOrAllMustBeSpecified = "Must specify either -a/--all or -p/--processId <Pid>";
             public const string ExtensionsNeedDotnet = "Extensions command requires dotnet on your path. Please make sure to install dotnet (.NET Core SDK) for your system from https://www.microsoft.com/net/download";
             public const string UnableToUpdateAppSettings = "Error updating Application Settings for the Function App for deployment.";
+            public const string WebJobsStorageNotFound = "Missing value for AzureWebJobsStorage in {0}. This is required for all triggers other than {1}. You can run 'func azure functionapp fetch-app-settings <functionAppName>' or specify a connection string in {2}.";
+            public const string WebJobsStorageNotFoundWithUserSecrets = "Missing value for AzureWebJobsStorage in {0} and User Secrets. This is required for all triggers other than {1}. You can run 'func azure functionapp fetch-app-settings <functionAppName>' or specify a connection string in {2} or User Secrets.";
+            public const string AppSettingNotFound = "Warning: Cannot find value named '{0}' in {1} that matches '{2}' property set on '{3}' in '{4}'. You can run 'func azure functionapp fetch-app-settings <functionAppName>' or specify a connection string in {5}.";
+            public const string AppSettingNotFoundWithUserSecrets = "Warning: Cannot find value named '{0}' in {1} or User Secrets that matches '{2}' property set on '{3}' in '{4}'. You can run 'func azure functionapp fetch-app-settings <functionAppName>' or specify a connection string in {5} or User Secrets.";
         }
 
         public static class Languages

--- a/src/Azure.Functions.Cli/Common/Utilities.cs
+++ b/src/Azure.Functions.Cli/Common/Utilities.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -7,6 +8,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Diagnostics;
 using Colors.Net;
 using Colors.Net.StringColorExtensions;
 using Microsoft.Azure.WebJobs.Logging;
@@ -212,6 +214,15 @@ namespace Azure.Functions.Cli
             }
             catch { }
             return false;
+        }
+
+        internal static IEnumerable<KeyValuePair<string, string>> BuildUserSecrets(string userSecretsId, IConfigurationRoot hostJsonConfig, bool? verboseLogging)
+        {
+            var configureBuilder = new UserSecretsConfigurationBuilder(userSecretsId, new LoggingFilterHelper(hostJsonConfig, verboseLogging), new LoggerFilterOptions());
+            var configurationBuilder = new ConfigurationBuilder();
+            configureBuilder.Configure(configurationBuilder);
+            var root = configurationBuilder.Build();
+            return root.AsEnumerable();
         }
 
         /// <summary>

--- a/src/Azure.Functions.Cli/Helpers/ProjectHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/ProjectHelpers.cs
@@ -11,6 +11,24 @@ namespace Azure.Functions.Cli.Helpers
 {
     internal static class ProjectHelpers
     {
+        public static string GetUserSecretsId(string scriptPath, LoggingFilterHelper loggingFilterHelper, LoggerFilterOptions loggerFilterOptions)
+        {
+            if (string.IsNullOrEmpty(scriptPath))
+            {
+                return null;
+            }
+            string projectFilePath = ProjectHelpers.FindProjectFile(scriptPath, loggingFilterHelper, loggerFilterOptions);
+            if (projectFilePath == null)
+            {
+                return null;
+            }
+
+            var projectRoot = ProjectHelpers.GetProject(projectFilePath);
+            var userSecretsId = ProjectHelpers.GetPropertyValue(projectRoot, Constants.UserSecretsIdElementName);
+
+            return userSecretsId;
+        }
+
         public static string FindProjectFile(string path, LoggingFilterHelper loggingFilterHelper, LoggerFilterOptions loggerFilterOptions)
         {
             ColoredConsoleLogger logger = new ColoredConsoleLogger("ProjectHelpers", loggingFilterHelper, loggerFilterOptions);

--- a/src/Azure.Functions.Cli/Secrets/UserSecretsConfigurationBuilder.cs
+++ b/src/Azure.Functions.Cli/Secrets/UserSecretsConfigurationBuilder.cs
@@ -9,47 +9,24 @@ namespace Azure.Functions.Cli.Diagnostics
 {
     internal class UserSecretsConfigurationBuilder : IConfigureBuilder<IConfigurationBuilder>
     {
-        private readonly string _scriptPath;
+        private readonly string _userSecretsId;
         private readonly LoggingFilterHelper _loggingFilterHelper;
         private readonly LoggerFilterOptions _loggerFilterOptions;
 
-        public UserSecretsConfigurationBuilder(string scriptPath, LoggingFilterHelper loggingFilterHelper, LoggerFilterOptions loggerFilterOptions)
+        public UserSecretsConfigurationBuilder(string userSecretsId, LoggingFilterHelper loggingFilterHelper, LoggerFilterOptions loggerFilterOptions)
         {
             _loggingFilterHelper = loggingFilterHelper;
             _loggerFilterOptions = loggerFilterOptions;
-            if (string.IsNullOrEmpty(scriptPath))
-            {
-                _scriptPath = Environment.CurrentDirectory;
-            }
-            else
-            {
-                _scriptPath = scriptPath;
-            }
+            _userSecretsId = userSecretsId;
         }
 
         public void Configure(IConfigurationBuilder builder)
         {
-            string userSecretsId = GetUserSecretsId();
-            if (userSecretsId == null)
+            if (_userSecretsId == null)
             {
                 return;
             }
-            builder.AddUserSecrets(userSecretsId);
-        }
-
-        private string GetUserSecretsId()
-        {
-            if (string.IsNullOrEmpty(_scriptPath))
-            {
-                return null;
-            }
-            string projectFilePath = ProjectHelpers.FindProjectFile(_scriptPath, _loggingFilterHelper, _loggerFilterOptions);
-            if (projectFilePath == null) return null;
-
-            var projectRoot = ProjectHelpers.GetProject(projectFilePath);
-            var userSecretsId = ProjectHelpers.GetPropertyValue(projectRoot, Constants.UserSecretsIdElementName);
-
-            return userSecretsId;
+            builder.AddUserSecrets(_userSecretsId);
         }
     }
 }

--- a/test/Azure.Functions.Cli.Tests/ActionsTests/StartHostActionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/ActionsTests/StartHostActionTests.cs
@@ -35,7 +35,7 @@ namespace Azure.Functions.Cli.Tests.ActionsTests
             Exception exception = null;
             try
             {
-                await StartHostAction.CheckNonOptionalSettings(new Dictionary<string, string>(), "x:\\");
+                await StartHostAction.CheckNonOptionalSettings(new Dictionary<string, string>(), "x:\\", false);
             }
             catch (Exception e)
             {
@@ -62,7 +62,7 @@ namespace Azure.Functions.Cli.Tests.ActionsTests
             Exception exception = null;
             try
             {
-                await StartHostAction.CheckNonOptionalSettings(new Dictionary<string, string>(), "x:\\");
+                await StartHostAction.CheckNonOptionalSettings(new Dictionary<string, string>(), "x:\\", false);
             }
             catch (Exception e)
             {
@@ -93,7 +93,7 @@ namespace Azure.Functions.Cli.Tests.ActionsTests
             ColoredConsole.Out = console;
             ColoredConsole.Error = console;
 
-            await StartHostAction.CheckNonOptionalSettings(new Dictionary<string, string>(), "x:\\");
+            await StartHostAction.CheckNonOptionalSettings(new Dictionary<string, string>(), "x:\\", false);
             output.ToString().Should().Contain("Warning: Cannot find value named 'blah'");
             output.ToString().Should().Contain("Warning: 'connection' property in 'x:\\folder2\\function.json' is empty.");
         }


### PR DESCRIPTION
Resolves #2219 

A few design decisions I wanted to explain:

- Because secrets.json is only read after the host has started (during startup), we didn't have access to secrets.json to see if the needed settings were defined. We can't parse the secrets.json ourselves because we don't necessarily know where it is and the format might change. So we create a dummy configuration which parses the secrets.json, and then use that configuration to make sure all necessary settings are defined.
- I changed all the `if (dotnet)`s to `if (userSecretsEnabled)`s because we're doing more (checks, etc...) with user secrets so I thought it would pay off to be more specific
    - As a result, I changed the flow so that we're only traversing folders and parsing the csproj for secrets id once. If I had kept it how it was, we would be doing it 3 times (to see if secrets are enabled, to make sure settings are defined, to actually include them in the config) so I wanted to be more efficient. Especially since I didn't want to come up with a weird fix so it only logs the traversal once.
- I changed the warnings/errors for if settings aren't defined slightly... but in a weird way. If the user is using a secrets.json, I wanted to include that in our list of files we checked and the list of files they could add the setting to in order to fix the problem. However, the exception for if `AzureWebJobsStorage` is not defined is worded in a way that it makes sense to say "local.settings.json AND User Secrets". All the rest are set up to use OR. I know that there are tests that count on this warning to be worded in a specific way and I'm assuming it might cause issues if I changed it, so I decided to accommodate it. If it's not a big deal and I can change that error I think that's the best course of action. This is what the warnings will look like:

If everything is fine:
![specified](https://user-images.githubusercontent.com/41077832/95639616-fe4ab300-0a4d-11eb-93e6-0702fc6e753e.jpg)

If AzureWebJobsStorage is undefined:
![storage_unspecified](https://user-images.githubusercontent.com/41077832/95639658-25a18000-0a4e-11eb-8c13-0b9fd7fbd96f.jpg)

If a different, important setting is undefined:
![trigger_var_unspecified](https://user-images.githubusercontent.com/41077832/95639665-32be6f00-0a4e-11eb-9eb9-fb7e725fc716.jpg)


Note the build warnings are something that needs to be taken care of in azure-functions-vs-build-sdk. [Issue here](https://github.com/Azure/azure-functions-vs-build-sdk/issues/477)