### PR TITLE
Update references for Functions 1.0.13154

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -282,7 +282,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.3.0-beta1-10663\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -315,13 +315,13 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Twilio.1.3.0-beta1-10663\lib\net45\Microsoft.Azure.WebJobs.Extensions.Twilio.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Script">
       <Private>True</Private>
@@ -335,7 +335,7 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.WebHost.1.0.0-beta3-13150\lib\net451\Microsoft.Azure.WebJobs.Script.WebHost.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebSites.DataProtection, Version=0.1.6.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.81-alpha\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -6,7 +6,7 @@ namespace Azure.Functions.Cli.Common
         public const string FunctionsStorageAccountNamePrefix = "AzureFunctions";
         public const string StorageAccountArmType = "Microsoft.Storage/storageAccounts";
         public const string FunctionAppArmKind = "functionapp";
-        public const string CliVersion = "1.0.26";
+        public const string CliVersion = "1.0.28";
         public const string CliDebug = "CLI_DEBUG";
         public const string DefaultSqlProviderName = "System.Data.SqlClient";
         public const string WebsiteHostname = "WEBSITE_HOSTNAME";

--- a/src/Azure.Functions.Cli/npm/package.json
+++ b/src/Azure.Functions.Cli/npm/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-functions-core-tools",
-    "version": "1.0.27",
+    "version": "1.0.28",
     "description": "Azure Functions Core Tools",
     "scripts": {
         "postinstall": "node lib/install.js"

--- a/src/Azure.Functions.Cli/packages.config
+++ b/src/Azure.Functions.Cli/packages.config
@@ -57,8 +57,8 @@
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net461" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net461" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net461" />
-  <package id="Microsoft.Azure.WebJobs" version="2.4.0-beta1-11751" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.4.0-beta1-11751" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs" version="2.4.0-beta1-11780" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.4.0-beta1-11780" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.3.0-beta1-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta9-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" targetFramework="net461" />
@@ -69,12 +69,12 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.3.0-beta1-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.3.0-beta1-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.3.0-beta1-10663" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Logging" version="2.4.0-beta1-11751" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.4.0-beta1-11751" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Logging" version="2.4.0-beta1-11780" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.4.0-beta1-11780" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Script" version="1.0.0-beta3-13146" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-beta3-10955" targetFramework="net461" />
   <package id="Microsoft.Azure.WebJobs.Script.WebHost" version="1.0.0-beta3-13146" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.4.0-beta1-11751" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.4.0-beta1-11780" targetFramework="net471" />
   <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.81-alpha" targetFramework="net461" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net461" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net461" />

--- a/test/Azure.Functions.Cli.Tests/Azure.Functions.Cli.Tests.csproj
+++ b/test/Azure.Functions.Cli.Tests/Azure.Functions.Cli.Tests.csproj
@@ -253,8 +253,8 @@
       <HintPath>..\..\packages\Microsoft.Azure.NotificationHubs.1.0.7\lib\net45-full\Microsoft.Azure.NotificationHubs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-	<Reference Include="Microsoft.Azure.WebJobs, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.3.0-beta1-10663\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -286,14 +286,14 @@
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.Twilio, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Twilio.1.3.0-beta1-10663\lib\net45\Microsoft.Azure.WebJobs.Extensions.Twilio.dll</HintPath>
     </Reference>
-	<Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Script">
       <Private>True</Private>
@@ -307,7 +307,7 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.WebHost.1.0.0-beta3-13150\lib\net451\Microsoft.Azure.WebJobs.Script.WebHost.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebSites.DataProtection, Version=0.1.6.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.81-alpha\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>

--- a/test/Azure.Functions.Cli.Tests/packages.config
+++ b/test/Azure.Functions.Cli.Tests/packages.config
@@ -54,8 +54,8 @@
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net461" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net461" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net461" />
-  <package id="Microsoft.Azure.WebJobs" version="2.4.0-beta1-11751" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.4.0-beta1-11751" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs" version="2.4.0-beta1-11780" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.4.0-beta1-11780" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.3.0-beta1-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta9-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" targetFramework="net461" />
@@ -66,12 +66,12 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.3.0-beta1-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.3.0-beta1-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.3.0-beta1-10663" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Logging" version="2.4.0-beta1-11751" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.4.0-beta1-11751" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Logging" version="2.4.0-beta1-11780" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.4.0-beta1-11780" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Script" version="1.0.0-beta3-13150" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-beta3-10955" targetFramework="net461" />
   <package id="Microsoft.Azure.WebJobs.Script.WebHost" version="1.0.0-beta3-13150" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.4.0-beta1-11751" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.4.0-beta1-11780" targetFramework="net471" />
   <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.81-alpha" targetFramework="net471" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net461" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net461" />


### PR DESCRIPTION
I changed both Constants.cs and package.json to `1.0.28` because they were at `1.0.26` and `1.0.27` respectively. I assumed that two different releases with `1.0.27` in their package.json would cause issue.