### PR TITLE
Updated WebHost.Script references to 1.0.13154

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -325,14 +325,14 @@
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Script">
       <Private>True</Private>
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.1.0.0-beta3-13150\lib\net451\Microsoft.Azure.WebJobs.Script.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.1.0.0-beta3-13154\lib\net451\Microsoft.Azure.WebJobs.Script.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Script.Extensibility, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.Extensibility.1.0.0-beta3-10955\lib\net45\Microsoft.Azure.WebJobs.Script.Extensibility.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Script.WebHost">
       <Private>True</Private>
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.WebHost.1.0.0-beta3-13150\lib\net451\Microsoft.Azure.WebJobs.Script.WebHost.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.WebHost.1.0.0-beta3-13154\lib\net451\Microsoft.Azure.WebJobs.Script.WebHost.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>

--- a/src/Azure.Functions.Cli/packages.config
+++ b/src/Azure.Functions.Cli/packages.config
@@ -71,9 +71,9 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.3.0-beta1-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Logging" version="2.4.0-beta1-11780" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.4.0-beta1-11780" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Script" version="1.0.0-beta3-13146" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Script" version="1.0.0-beta3-13154" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-beta3-10955" targetFramework="net461" />
-  <package id="Microsoft.Azure.WebJobs.Script.WebHost" version="1.0.0-beta3-13146" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Script.WebHost" version="1.0.0-beta3-13154" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.4.0-beta1-11780" targetFramework="net471" />
   <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.81-alpha" targetFramework="net461" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net461" />


### PR DESCRIPTION
NuGet tried to remote the `<Private>True</Private>` tag from the webhost references, but I put them back in because they're in the branch now. Please let me know if these shouldn't be there.