### PR TITLE
Update Python Worker to 1.1.9 (v2)

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -122,7 +122,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.2.2" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="2.0.554" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="2.0.14786" />
-    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="2.0.14494" />
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="2.1.1.7" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="YamlDotNet" Version="6.0.0" />
   </ItemGroup>

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -122,7 +122,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.2.2" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="2.0.554" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="2.0.14786" />
-    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="2.1.1.8" />
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="2.1.1.9" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="YamlDotNet" Version="6.0.0" />
   </ItemGroup>

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -122,7 +122,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.2.2" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="2.0.554" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="2.0.14786" />
-    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="2.1.1.7" />
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="2.1.1.8" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="YamlDotNet" Version="6.0.0" />
   </ItemGroup>


### PR DESCRIPTION
- Update Python Worker to 1.1.8 [Release Note](https://github.com/Azure/azure-functions-python-worker/releases/tag/1.1.8)
- Update Python Worker to 1.1.9 [Release Note](https://github.com/Azure/azure-functions-python-worker/releases/tag/1.1.9)
- Update Python Library to 1.5.0 [Release Note](https://github.com/Azure/azure-functions-python-library/releases/tag/1.5.0)

Python Worker 1.1.9 only reduces the worker size by using manylinux2010 wheel. No CX facing changes.