### PR TITLE
Update Python Worker to 1.1.9 (v3)

### DIFF
--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -218,7 +218,9 @@ namespace Build
                         }
                     }
 
-                    if (!atLeastOne)
+                    // Bypass atLeastOne check for Windows Python 3.9 since we don't have it yet.
+                    bool isPython39 = pyVersionPath.EndsWith("3.9");
+                    if (!atLeastOne && !isPython39)
                     {
                         throw new Exception($"No Python worker matched the OS '{Settings.RuntimesToOS[runtime]}' for runtime '{runtime}'. " +
                             $"Something went wrong.");

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -134,7 +134,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS6" Version="3.0.552" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7" Version="3.0.549" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="3.0.14916" />
-    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="3.0.14492" />
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="3.1.1.7" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="YamlDotNet" Version="6.0.0" />
   </ItemGroup>

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -134,7 +134,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS6" Version="3.0.552" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7" Version="3.0.549" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="3.0.14916" />
-    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="3.1.1.8" />
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="3.1.1.9" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="YamlDotNet" Version="6.0.0" />
   </ItemGroup>

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -134,7 +134,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS6" Version="3.0.552" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7" Version="3.0.549" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="3.0.14916" />
-    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="3.1.1.7" />
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="3.1.1.8" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="YamlDotNet" Version="6.0.0" />
   </ItemGroup>


### PR DESCRIPTION
- Update Python Worker to 1.1.8 [Release Note](https://github.com/Azure/azure-functions-python-worker/releases/tag/1.1.8)
- Update Python Worker to 1.1.9 [Release Note](https://github.com/Azure/azure-functions-python-worker/releases/tag/1.1.9)
- Update Python Library to 1.5.0 [Release Note](https://github.com/Azure/azure-functions-python-library/releases/tag/1.5.0)

Python Worker 1.1.9 only reduces the worker size by using manylinux2010 wheel. No CX facing changes.

### Ongoing Python 3.9 Release
This version of the core tool does not have 3.9 enable, since the Python docker images are not yet ready.
We need to have these docker images for:
1. Linux Consumption/Dedicated/Premium runtime
2. To support `func azure functionapp publish <> --build-native-dependencies`
3. To support `func init --python --docker`


