### PR TITLE
Adding support for Python 3.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ nCrunchTemp*
 artifacts/
 /src/Azure.Functions.Cli/Properties/launchSettings.json
 launchSettings.json
+
+# MacOS related
+.DS_Store

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -58,7 +58,7 @@
     <EmbeddedResource Include="StaticResources\Dockerfile.python38">
       <LogicalName>$(AssemblyName).Dockerfile.python38</LogicalName>
     </EmbeddedResource>
-        <EmbeddedResource Include="StaticResources\Dockerfile.python39">
+      <EmbeddedResource Include="StaticResources\Dockerfile.python39">
       <LogicalName>$(AssemblyName).Dockerfile.python39</LogicalName>
     </EmbeddedResource>
     <EmbeddedResource Include="StaticResources\Dockerfile.powershell">

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -58,6 +58,9 @@
     <EmbeddedResource Include="StaticResources\Dockerfile.python38">
       <LogicalName>$(AssemblyName).Dockerfile.python38</LogicalName>
     </EmbeddedResource>
+        <EmbeddedResource Include="StaticResources\Dockerfile.python39">
+      <LogicalName>$(AssemblyName).Dockerfile.python39</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="StaticResources\Dockerfile.powershell">
       <LogicalName>$(AssemblyName).Dockerfile.powershell</LogicalName>
     </EmbeddedResource>

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -119,9 +119,10 @@ namespace Azure.Functions.Cli.Common
 
         public static class DockerImages
         {
-            public const string LinuxPython36ImageAmd64 = "mcr.microsoft.com/azure-functions/python:2.0.12493-python3.6-buildenv";
-            public const string LinuxPython37ImageAmd64 = "mcr.microsoft.com/azure-functions/python:2.0.12763-python3.7-buildenv";
-            public const string LinuxPython38ImageAmd64 = "mcr.microsoft.com/azure-functions/python:3.0.13106-python3.8-buildenv";
+            public const string LinuxPython36ImageAmd64 = "mcr.microsoft.com/azure-functions/python:2.0.14786-python3.6-buildenv";
+            public const string LinuxPython37ImageAmd64 = "mcr.microsoft.com/azure-functions/python:2.0.14786-python3.7-buildenv";
+            public const string LinuxPython38ImageAmd64 = "mcr.microsoft.com/azure-functions/python:3.0.15066-python3.8-buildenv";
+            public const string LinuxPython39ImageAmd64 = "mcr.microsoft.com/azure-functions/python:3.0.15066-python3.9-buildenv";
         }
 
         public static class StaticResourcesNames

--- a/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
@@ -94,7 +94,7 @@ namespace Azure.Functions.Cli.Helpers
         {
             if (pythonVersion?.Version == null)
             {
-                var message = "Could not find a Python version. Python 3.6.x, 3.7.x or 3.8.x is recommended, and used in Azure Functions.";
+                var message = "Could not find a Python version. Python 3.6.x, 3.7.x, 3.8.x or 3.9.x is recommended, and used in Azure Functions.";
                 if (errorIfNoVersion) throw new CliException(message);
                 ColoredConsole.WriteLine(WarningColor(message));
                 return;
@@ -102,22 +102,33 @@ namespace Azure.Functions.Cli.Helpers
 
             ColoredConsole.WriteLine(AdditionalInfoColor($"Found Python version {pythonVersion.Version} ({pythonVersion.ExecutablePath})."));
 
-            // Python 3.6 | 3.7 | 3.8 (supported)
+            // Python 3.6 | 3.7 | 3.8 | 3.9 (on macOS and Linux) (supported)
             if (IsVersionSupported(pythonVersion))
             {
                 return;
             }
 
-            // Python 3.x (but not 3.6 | 3.7 | 3.8), not recommended, may fail
+            // Python 3.x (but not 3.6 | 3.7 | 3.8 | 3.9 (on macOS and Linux)), not recommended, may fail
             if (pythonVersion.Major == 3)
             {
-                if (errorIfNotSupported) throw new CliException($"Python 3.6.x, 3.7.x, 3.8.x is required for this operation. "
-                + "Please install Python 3.6, 3.7 or 3.8, and use a virtual environment to switch to Python 3.6, 3.7 or 3.8.");
-                ColoredConsole.WriteLine(WarningColor("Python 3.6.x, 3.7.x or 3.8.x is recommended, and used in Azure Functions."));
+                if (pythonVersion.Major == 3 && pythonVersion.Minor == 9 && PlatformHelper.IsWindows)
+                {
+                    string errorMessage = $"Python 3.9.x is currently not supported on Windows and will be coming soon.";
+
+                    if (errorIfNotSupported)
+                        throw new CliException(errorMessage);
+                    ColoredConsole.WriteLine(WarningColor(errorMessage + " We recommend you install Python 3.6, 3.7 or 3.8, and " +
+                            $"use a virtual environment to switch to Python 3.6, 3.7 or 3.8."));
+                }
+
+                if (errorIfNotSupported)
+                    throw new CliException($"Python 3.6.x, 3.7.x, 3.8.x, 3.9.x is required for this operation. " +
+                        $"Please install Python 3.6, 3.7, 3.8, or 3.9 and use a virtual environment to switch to Python 3.6, 3.7 or 3.8.");
+                ColoredConsole.WriteLine(WarningColor("Python 3.6.x, 3.7.x, 3.8.x, or 3.9.x is recommended, and used in Azure Functions."));
             }
 
             // No Python 3
-            var error = "Python 3.x (recommended version 3.6, 3.7 or 3.8) is required.";
+            var error = "Python 3.x (recommended version 3.6, 3.7, 3.8 or 3.9) is required.";
             if (errorIfNoVersion) throw new CliException(error);
             ColoredConsole.WriteLine(WarningColor(error));
         }
@@ -148,6 +159,7 @@ namespace Azure.Functions.Cli.Helpers
             var python36GetVersionTask = GetVersion("python3.6");
             var python37GetVersionTask = GetVersion("python3.7");
             var python38GetVersionTask = GetVersion("python3.8");
+            var python39GetVersionTask = GetVersion("python3.9");
 
             var versions = new List<WorkerLanguageVersionInfo>
             {
@@ -156,7 +168,8 @@ namespace Azure.Functions.Cli.Helpers
                 await pythonGetVersionTask,
                 await python36GetVersionTask,
                 await python37GetVersionTask,
-                await python38GetVersionTask
+                await python38GetVersionTask,
+                await python39GetVersionTask
             };
 
             // Highest preference -- Go through the list, if we find the first python 3.6 or python 3.7 worker, we prioritize that.
@@ -475,6 +488,8 @@ namespace Azure.Functions.Cli.Helpers
                         return StaticResources.DockerfilePython37;
                     case 8:
                         return StaticResources.DockerfilePython38;
+                    case 9:
+                        return StaticResources.DockerfilePython39;
                 }
             }
             return StaticResources.DockerfilePython36;
@@ -492,6 +507,8 @@ namespace Azure.Functions.Cli.Helpers
                         return Constants.DockerImages.LinuxPython37ImageAmd64;
                     case 8:
                         return Constants.DockerImages.LinuxPython38ImageAmd64;
+                    case 9:
+                        return Constants.DockerImages.LinuxPython39ImageAmd64;
                 }
             }
             return Constants.DockerImages.LinuxPython36ImageAmd64;
@@ -499,7 +516,20 @@ namespace Azure.Functions.Cli.Helpers
 
         private static bool IsVersionSupported(WorkerLanguageVersionInfo info)
         {
-            return (info?.Major == 3 && info?.Minor == 6) || (info?.Major == 3 && info?.Minor == 7) || (info?.Major == 3 && info?.Minor == 8);
+            if (info?.Major == 3)
+            {
+                switch (info?.Minor)
+                {
+                    case 9:
+                        // We currently do not support Python 3.9 on Windows.
+                        if (PlatformHelper.IsWindows) { return false; }
+                        else return true;
+                    case 8:
+                    case 7:
+                    case 6: return true;
+                    default: return false;
+                }
+            } else return false;
         }
     }
 }

--- a/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
@@ -113,7 +113,7 @@ namespace Azure.Functions.Cli.Helpers
             {
                 if (pythonVersion.Major == 3 && pythonVersion.Minor == 9 && PlatformHelper.IsWindows)
                 {
-                    string errorMessage = $"Python 3.9.x is currently not supported on Windows and will be coming soon.";
+                    string errorMessage = "Python 3.9.x is currently not supported on Windows and will be coming soon.";
 
                     if (errorIfNotSupported)
                         throw new CliException(errorMessage);
@@ -128,7 +128,8 @@ namespace Azure.Functions.Cli.Helpers
             }
 
             // No Python 3
-            var error = "Python 3.x (recommended version 3.6, 3.7, 3.8 or 3.9) is required.";
+            var error = "Python 3.x (recommended version 3.6, 3.7, 3.8 or 3.9) is required. " +
+                "Python 3.9.x is currently not supported on Windows and will be coming soon.";
             if (errorIfNoVersion) throw new CliException(error);
             ColoredConsole.WriteLine(WarningColor(error));
         }

--- a/src/Azure.Functions.Cli/StaticResources/Dockerfile.python39
+++ b/src/Azure.Functions.Cli/StaticResources/Dockerfile.python39
@@ -1,0 +1,11 @@
+﻿# To enable ssh & remote debugging on app service change the base image to the one below
+# FROM mcr.microsoft.com/azure-functions/python:3.0.15066-python3.9-appservice
+FROM mcr.microsoft.com/azure-functions/python:3.0.15066-python3.9
+
+ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
+    AzureFunctionsJobHost__Logging__Console__IsEnabled=true
+
+COPY requirements.txt /
+RUN pip install -r /requirements.txt
+
+COPY . /home/site/wwwroot

--- a/src/Azure.Functions.Cli/StaticResources/StaticResources.cs
+++ b/src/Azure.Functions.Cli/StaticResources/StaticResources.cs
@@ -41,6 +41,8 @@ namespace Azure.Functions.Cli
 
         public static Task<string> DockerfilePython38 => GetValue("Dockerfile.python38");
 
+        public static Task<string> DockerfilePython39 => GetValue("Dockerfile.python39");
+
         public static Task<string> DockerfilePowershell => GetValue("Dockerfile.powershell");
 
         public static Task<string> DockerfileNode => GetValue("Dockerfile.node");

--- a/test/Azure.Functions.Cli.Tests/PythonHelperTests.cs
+++ b/test/Azure.Functions.Cli.Tests/PythonHelperTests.cs
@@ -47,7 +47,7 @@ namespace Azure.Functions.Cli.Tests
         [InlineData("3.6.8b", false)]
         [InlineData("3.7.2", false)]
         [InlineData("3.8.0", false)]
-        [InlineData("3.9.0", false)]
+        [InlineData("3.9.0", true)] // Only supported in Mac/Linux.
         public void AssertPythonVersion(string pythonVersion, bool expectException)
         {
             WorkerLanguageVersionInfo worker = new WorkerLanguageVersionInfo(WorkerRuntime.python, pythonVersion, "python");

--- a/test/Azure.Functions.Cli.Tests/PythonHelperTests.cs
+++ b/test/Azure.Functions.Cli.Tests/PythonHelperTests.cs
@@ -47,6 +47,7 @@ namespace Azure.Functions.Cli.Tests
         [InlineData("3.6.8b", false)]
         [InlineData("3.7.2", false)]
         [InlineData("3.8.0", false)]
+        [InlineData("3.9.0", false)]
         public void AssertPythonVersion(string pythonVersion, bool expectException)
         {
             WorkerLanguageVersionInfo worker = new WorkerLanguageVersionInfo(WorkerRuntime.python, pythonVersion, "python");
@@ -68,11 +69,11 @@ namespace Azure.Functions.Cli.Tests
             string[] pythons;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                pythons = new string[] { "python.exe", "python3.exe", "python36.exe", "python37.exe", "python38.exe", "py.exe" };
+                pythons = new string[] { "python.exe", "python3.exe", "python36.exe", "python37.exe", "python38.exe", "python39.exe", "py.exe" };
             }
             else
             {
-                pythons = new string[] { "python", "python3", "python36", "python37", "python38" };
+                pythons = new string[] { "python", "python3", "python36", "python37", "python38", "python39" };
             }
 
             string pythonExe = pythons.FirstOrDefault(p => CheckIfPythonExist(p));


### PR DESCRIPTION
Adding support for Python 3.9 in CoreTools. It currently only works for macOS and Linux and whenever we would have support for Windows, we'll remove the checks.