### PR TITLE
Update v3 Python Worker Version to 1.1.10

### DIFF
--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -215,9 +215,7 @@ namespace Build
                         }
                     }
 
-                    // Bypass atLeastOne check for Windows Python 3.9 since we don't have it yet.
-                    bool isPython39 = pyVersionPath.EndsWith("3.9");
-                    if (!atLeastOne && !isPython39)
+                    if (!atLeastOne)
                     {
                         throw new Exception($"No Python worker matched the OS '{Settings.RuntimesToOS[runtime]}' for runtime '{runtime}'. " +
                             $"Something went wrong.");

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" InitialTargets="ExcludeWorkersFromReadyToRun">
+<Project Sdk="Microsoft.NET.Sdk" InitialTargets="ExcludeWorkersFromReadyToRun">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -18,7 +18,7 @@
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
     <Title>Azure Functions Cli</Title>
-    <Copyright>© .NET Foundation.  All rights reserved.</Copyright>
+    <Copyright>� .NET Foundation.  All rights reserved.</Copyright>
     <PackageLicenseUrl>http://www.microsoft.com/web/webpi/eula/aspnetcomponent_rtw_enu.htm</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/Azure/azure-functions-cli</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -137,7 +137,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS6" Version="3.0.552" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7" Version="3.0.549" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="3.0.14916" />
-    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="3.1.1.9" />
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="3.1.1.10" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="YamlDotNet" Version="6.0.0" />
   </ItemGroup>

--- a/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
@@ -508,11 +508,14 @@ namespace Azure.Functions.Cli.Helpers
         {
             if (info?.Major == 3)
             {
-                return (info?.Minor) switch
+                switch (info?.Minor)
                 {
-                    9 or 8 or 7 or 6 => true,
-                    _ => false,
-                };
+                    case 9:
+                    case 8:	
+                    case 7:	
+                    case 6:  return true;	
+                    default: return false;
+                }
             } else return false;
         }
     }

--- a/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/PythonHelpers.cs
@@ -102,34 +102,23 @@ namespace Azure.Functions.Cli.Helpers
 
             ColoredConsole.WriteLine(AdditionalInfoColor($"Found Python version {pythonVersion.Version} ({pythonVersion.ExecutablePath})."));
 
-            // Python 3.6 | 3.7 | 3.8 | 3.9 (on macOS and Linux) (supported)
+            // Python 3.[6|7|8|9] (supported)
             if (IsVersionSupported(pythonVersion))
             {
                 return;
             }
 
-            // Python 3.x (but not 3.6 | 3.7 | 3.8 | 3.9 (on macOS and Linux)), not recommended, may fail
+            // Python 3.x (but not 3.[6|7|8|9]), not recommended, may fail. E.g.: 3.4, 3.5.
             if (pythonVersion.Major == 3)
             {
-                if (pythonVersion.Major == 3 && pythonVersion.Minor == 9 && PlatformHelper.IsWindows)
-                {
-                    string errorMessage = "Python 3.9.x is currently not supported on Windows and will be coming soon.";
-
-                    if (errorIfNotSupported)
-                        throw new CliException(errorMessage);
-                    ColoredConsole.WriteLine(WarningColor(errorMessage + " We recommend you install Python 3.6, 3.7 or 3.8, and " +
-                            $"use a virtual environment to switch to Python 3.6, 3.7 or 3.8."));
-                }
-
                 if (errorIfNotSupported)
-                    throw new CliException($"Python 3.6.x, 3.7.x, 3.8.x, 3.9.x is required for this operation. " +
-                        $"Please install Python 3.6, 3.7, 3.8, or 3.9 and use a virtual environment to switch to Python 3.6, 3.7 or 3.8.");
+                    throw new CliException($"Python 3.6.x to 3.9.x is required for this operation. " +
+                        $"Please install Python 3.6, 3.7, 3.8, or 3.9 and use a virtual environment to switch to Python 3.6, 3.7, 3.8, or 3.9.");
                 ColoredConsole.WriteLine(WarningColor("Python 3.6.x, 3.7.x, 3.8.x, or 3.9.x is recommended, and used in Azure Functions."));
             }
 
             // No Python 3
-            var error = "Python 3.x (recommended version 3.6, 3.7, 3.8 or 3.9) is required. " +
-                "Python 3.9.x is currently not supported on Windows and will be coming soon.";
+            var error = "Python 3.x (recommended version 3.[6|7|8|9]) is required.";
             if (errorIfNoVersion) throw new CliException(error);
             ColoredConsole.WriteLine(WarningColor(error));
         }
@@ -519,17 +508,11 @@ namespace Azure.Functions.Cli.Helpers
         {
             if (info?.Major == 3)
             {
-                switch (info?.Minor)
+                return (info?.Minor) switch
                 {
-                    case 9:
-                        // We currently do not support Python 3.9 on Windows.
-                        if (PlatformHelper.IsWindows) { return false; }
-                        else return true;
-                    case 8:
-                    case 7:
-                    case 6: return true;
-                    default: return false;
-                }
+                    9 or 8 or 7 or 6 => true,
+                    _ => false,
+                };
             } else return false;
         }
     }

--- a/src/Azure.Functions.Cli/StaticResources/Dockerfile.python39
+++ b/src/Azure.Functions.Cli/StaticResources/Dockerfile.python39
@@ -1,6 +1,6 @@
 ﻿# To enable ssh & remote debugging on app service change the base image to the one below
-# FROM mcr.microsoft.com/azure-functions/python:3.0.15066-python3.9-appservice
-FROM mcr.microsoft.com/azure-functions/python:3.0.15066-python3.9
+# FROM mcr.microsoft.com/azure-functions/python:3.0.15149-python3.9-appservice
+FROM mcr.microsoft.com/azure-functions/python:3.0.15149-python3.9
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true

--- a/src/Azure.Functions.Cli/StaticResources/Dockerfile.python39
+++ b/src/Azure.Functions.Cli/StaticResources/Dockerfile.python39
@@ -1,6 +1,6 @@
 ﻿# To enable ssh & remote debugging on app service change the base image to the one below
-# FROM mcr.microsoft.com/azure-functions/python:3.0.15149-python3.9-appservice
-FROM mcr.microsoft.com/azure-functions/python:3.0.15149-python3.9
+# FROM mcr.microsoft.com/azure-functions/python:3.0-python3.9-appservice
+FROM mcr.microsoft.com/azure-functions/python:3.0-python3.9
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true

--- a/test/Azure.Functions.Cli.Tests/PythonHelperTests.cs
+++ b/test/Azure.Functions.Cli.Tests/PythonHelperTests.cs
@@ -47,7 +47,7 @@ namespace Azure.Functions.Cli.Tests
         [InlineData("3.6.8b", false)]
         [InlineData("3.7.2", false)]
         [InlineData("3.8.0", false)]
-        [InlineData("3.9.0", true)] // Only supported in Mac/Linux.
+        [InlineData("3.9.0", false)]
         public void AssertPythonVersion(string pythonVersion, bool expectException)
         {
             WorkerLanguageVersionInfo worker = new WorkerLanguageVersionInfo(WorkerRuntime.python, pythonVersion, "python");


### PR DESCRIPTION
Python Worker Release note [1.1.10](https://github.com/Azure/azure-functions-python-worker/releases/tag/1.1.10)

Miscellaneous:
Converting CRLF => LF to make the newline character consistent. 