### PR TITLE
Sequential JobHost restart

### DIFF
--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -54,7 +54,7 @@ namespace Azure.Functions.Cli.Common
         public const string UserSecretsIdElementName = "UserSecretsId";
         public const string DisplayLogo = "FUNCTIONS_CORE_TOOLS_DISPLAY_LOGO";
         public const string AspNetCoreSupressStatusMessages = "ASPNETCORE_SUPPRESSSTATUSMESSAGES";
-        public const string SequentialJobHostRestart = "AzureFunctionsJobHost__SequentialRestart"
+        public const string SequentialJobHostRestart = "AzureFunctionsJobHost__SequentialRestart";
 
         public static string CliVersion => typeof(Constants).GetTypeInfo().Assembly.GetName().Version.ToString(3);
 

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -54,6 +54,7 @@ namespace Azure.Functions.Cli.Common
         public const string UserSecretsIdElementName = "UserSecretsId";
         public const string DisplayLogo = "FUNCTIONS_CORE_TOOLS_DISPLAY_LOGO";
         public const string AspNetCoreSupressStatusMessages = "ASPNETCORE_SUPPRESSSTATUSMESSAGES";
+        public const string SequentialJobHostRestart = "AzureFunctionsJobHost__SequentialRestart"
 
         public static string CliVersion => typeof(Constants).GetTypeInfo().Assembly.GetName().Version.ToString(3);
 

--- a/src/Azure.Functions.Cli/Program.cs
+++ b/src/Azure.Functions.Cli/Program.cs
@@ -48,6 +48,11 @@ namespace Azure.Functions.Cli
             {
                 Environment.SetEnvironmentVariable(Constants.FunctionsCoreToolsEnvironment, "True");
             }
+
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(Constants.SequentialJobHostRestart)))
+            {
+                Environment.SetEnvironmentVariable(Constants.SequentialJobHostRestart, "True");
+            }
         }
 
         internal static IContainer InitializeAutofacContainer()

--- a/src/Azure.Functions.Cli/Program.cs
+++ b/src/Azure.Functions.Cli/Program.cs
@@ -3,6 +3,7 @@ using Autofac;
 using Colors.Net;
 using Azure.Functions.Cli.Arm;
 using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Helpers;
 using Azure.Functions.Cli.Interfaces;
 using static Azure.Functions.Cli.Common.OutputTheme;
 

--- a/src/Azure.Functions.Cli/Program.cs
+++ b/src/Azure.Functions.Cli/Program.cs
@@ -44,8 +44,8 @@ namespace Azure.Functions.Cli
 
         private static void SetCoreToolsEnvironmentVaraibles()
         {
-            EnvironmentHelpers.SetEnvironmentVariableAsBoolIfNotExists(Constants.FunctionsCoreToolsEnvironment);
-            EnvironmentHelpers.SetEnvironmentVariableAsBoolIfNotExists(Constants.SequentialJobHostRestart);
+            EnvironmentHelper.SetEnvironmentVariableAsBoolIfNotExists(Constants.FunctionsCoreToolsEnvironment);
+            EnvironmentHelper.SetEnvironmentVariableAsBoolIfNotExists(Constants.SequentialJobHostRestart);
         }
 
         internal static IContainer InitializeAutofacContainer()

--- a/src/Azure.Functions.Cli/Program.cs
+++ b/src/Azure.Functions.Cli/Program.cs
@@ -44,15 +44,8 @@ namespace Azure.Functions.Cli
 
         private static void SetCoreToolsEnvironmentVaraibles()
         {
-            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(Constants.FunctionsCoreToolsEnvironment)))
-            {
-                Environment.SetEnvironmentVariable(Constants.FunctionsCoreToolsEnvironment, "True");
-            }
-
-            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(Constants.SequentialJobHostRestart)))
-            {
-                Environment.SetEnvironmentVariable(Constants.SequentialJobHostRestart, "True");
-            }
+            EnvironmentHelpers.SetEnvironmentVariableAsBoolIfNotExists(Constants.FunctionsCoreToolsEnvironment);
+            EnvironmentHelpers.SetEnvironmentVariableAsBoolIfNotExists(Constants.SequentialJobHostRestart);
         }
 
         internal static IContainer InitializeAutofacContainer()


### PR DESCRIPTION
Commit https://github.com/Azure/azure-functions-host/commit/12fff582f5880ee120e3ccd0ed1ea7753e705469 added support for non-overlapping worker recycle 

This PR consumes the host change 

Resolves https://github.com/Azure/azure-functions-core-tools/issues/2317

Note that to get the continuous debug experience, there is still more work required on the VS Code side, but this unblocks those changes.

