### PR TITLE
[v2] Only show upgrade warning when an action is invoked

### DIFF
--- a/src/Azure.Functions.Cli/ConsoleApp.cs
+++ b/src/Azure.Functions.Cli/ConsoleApp.cs
@@ -55,6 +55,9 @@ namespace Azure.Functions.Cli
                 var action = app.Parse();
                 if (action != null)
                 {
+                    Utilities.PrintUpgradeWarning();
+                    await Task.Delay(TimeSpan.FromSeconds(1));
+
                     if (action is IInitializableAction)
                     {
                         var initializableAction = action as IInitializableAction;

--- a/src/Azure.Functions.Cli/Program.cs
+++ b/src/Azure.Functions.Cli/Program.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading;
 using Autofac;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Interfaces;
@@ -13,8 +12,6 @@ namespace Azure.Functions.Cli
             FirstTimeCliExperience();
             SetupGlobalExceptionHandler();
             SetCoreToolsEnvironmentVaraibles();
-            Utilities.PrintUpgradeWarning();
-            Thread.Sleep(1000);
             ConsoleApp.Run<Program>(args, InitializeAutofacContainer());
         }
 

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -470,7 +470,7 @@ namespace Azure.Functions.Cli.Tests.E2E
             }, _output);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/Azure/azure-functions-core-tools/issues/2320")]
         public async Task start_powershell()
         {
             await CliTester.Run(new RunConfiguration


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-core-tools/issues/2307

Doing it this way ensures that we don't show the v2 upgrade warning when `func --version` is invoked. This change makes it so we show the warning if any action was found. So any command that does something other than `func --version` should show the warning.