### PR TITLE
Add architecture (32 or 64bit) to start up print version message

### DIFF
--- a/src/Azure.Functions.Cli/Common/Utilities.cs
+++ b/src/Azure.Functions.Cli/Common/Utilities.cs
@@ -47,7 +47,7 @@ namespace Azure.Functions.Cli
         {
             ColoredConsole
                 .WriteLine($"\nAzure Functions Core Tools")
-                .WriteLine($"Core Tools Version:       {Constants.CliDetailedVersion}".DarkGray())
+                .WriteLine($"Core Tools Version:       {Constants.CliDetailedVersion + (Environment.Is64BitProcess ? " (64-bit)" : " (32-bit)")}".DarkGray())
                 .WriteLine($"Function Runtime Version: {ScriptHost.Version}\n".DarkGray());
         }
 


### PR DESCRIPTION
Adds 32-bit or 64-bit message to the version number information displayed on startup.