### PR TITLE
WEBSITE_MOUNT_ENABLED =  1 for linux consumption

### DIFF
--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -523,7 +523,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             ColoredConsole.WriteLine("Upload completed successfully.");
 
             // Set app setting
-            await SetRunFromPackageAppSetting(functionApp, sas, enableMount: fileName.EndsWith("squashfs"));
+            await SetRunFromPackageAppSetting(functionApp, sas);
             ColoredConsole.WriteLine("Deployment completed successfully.");
         }
 
@@ -612,7 +612,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             throw new CliException("Timed out waiting for SCM to update the Environment Settings");
         }
 
-        private async Task SetRunFromPackageAppSetting(Site functionApp, string runFromPackageValue, bool enableMount = false)
+        private async Task SetRunFromPackageAppSetting(Site functionApp, string runFromPackageValue)
         {
             // Set app setting
             functionApp.AzureAppSettings["WEBSITE_RUN_FROM_PACKAGE"] = runFromPackageValue;
@@ -627,7 +627,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 }
             }
 
-            if (functionApp.IsDynamic && functionApp.IsLinux && enableMount && !functionApp.AzureAppSettings.ContainsKey("WEBSITE_MOUNT_ENABLED"))
+            if (functionApp.IsDynamic && functionApp.IsLinux && !functionApp.AzureAppSettings.ContainsKey("WEBSITE_MOUNT_ENABLED"))
             {
                 functionApp.AzureAppSettings["WEBSITE_MOUNT_ENABLED"] = "1";
             }


### PR DESCRIPTION
This reverts commit cd9bfca26f9c7fe06ce245f5bf69bc6486a685dd.

This allows persisting the permissions of binaries being deployed in linux consumption (Which is needed in case of custom handlers)