### PR TITLE
Add architecture (32 or 64 bit) note to start up message

### DIFF
--- a/src/Azure.Functions.Cli/Common/Utilities.cs
+++ b/src/Azure.Functions.Cli/Common/Utilities.cs
@@ -49,7 +49,7 @@ namespace Azure.Functions.Cli
         {
             ColoredConsole
                 .WriteLine($"\nAzure Functions Core Tools")
-                .WriteLine($"Core Tools Version:       {Constants.CliDetailedVersion + (Environment.Is64BitProcess ? " (64-bit)" : " (32-bit)")}".DarkGray())
+                .WriteLine($"Core Tools Version:       {Constants.CliDetailedVersion}".DarkGray())
                 .WriteLine($"Function Runtime Version: {ScriptHost.Version}\n".DarkGray());
         }
 

--- a/src/Azure.Functions.Cli/Common/Utilities.cs
+++ b/src/Azure.Functions.Cli/Common/Utilities.cs
@@ -49,7 +49,7 @@ namespace Azure.Functions.Cli
         {
             ColoredConsole
                 .WriteLine($"\nAzure Functions Core Tools")
-                .WriteLine($"Core Tools Version:       {Constants.CliDetailedVersion}".DarkGray())
+                .WriteLine($"Core Tools Version:       {Constants.CliDetailedVersion + (Environment.Is64BitProcess ? " (64-bit)" : " (32-bit)")}".DarkGray())
                 .WriteLine($"Function Runtime Version: {ScriptHost.Version}\n".DarkGray());
         }
 


### PR DESCRIPTION
Adds architecture "32-bit" or "64-bit" note to the version information displayed on func startup. Makes it easy to confirm which one is running.