### PR TITLE
Update Java Worker to 1.8.1

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -118,7 +118,7 @@
     <PackageReference Include="AccentedCommandLineParser" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage.Internal" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.8.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.8.1" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.2.2" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="2.0.554" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="2.0.14786" />


### PR DESCRIPTION
Change to support Distributed Tracing Scenario for Linux Consumption Plan. We update `%AZURE_FUNCTIONS_MESH_JAVA_OPTS%` argument in the `worker.config.json` That is internal argument that is not allowed to modify by users. We are going to inject Java Application Insights Agent using this argument. 

### Issue describing the changes in this PR

No issue. Related for supporting Distributed Tracing for Java Consumption plan.

* [Release: Azure Functions Java Worker 1.8.1](https://github.com/Azure/azure-functions-java-worker/releases/tag/1.8.1)