### PR TITLE
Remove old myget references

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -6,7 +6,6 @@
     <add key="azure_app_service_staging" value="https://www.myget.org/F/azure-appservice-staging/api/v2" />
     <add key="fuse_labs" value="https://www.myget.org/F/fusemandistfeed/api/v2" />
     <add key="buildTools" value="https://www.myget.org/F/30de4ee06dd54956a82013fa17a3accb/" />
-    <add key="AspNetVNext" value="https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json" />
     <add key="Microsoft.Azure.Functions.PowerShellWorker" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/Microsoft.Azure.Functions.PowerShellWorker/nuget/v3/index.json" />
     <add key="AzureFunctionsPreRelease" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsPreRelease/nuget/v3/index.json" />
   </packageSources>

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -31,7 +31,6 @@ namespace Build
                 "https://www.myget.org/F/fusemandistfeed/api/v2",
                 "https://www.myget.org/F/30de4ee06dd54956a82013fa17a3accb/",
                 "https://www.myget.org/F/xunit/api/v3/index.json",
-                "https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json",
                 "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/Microsoft.Azure.Functions.PowerShellWorker/nuget/v3/index.json",
                 "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsPreRelease/nuget/v3/index.json"
             }


### PR DESCRIPTION
Looks like this feed was removed -- https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json
I am not sure why we had a reference to this feed. Assuming that it's an outdated reference as the build seems to work fine without it.