### PR TITLE
Update requirements.psd1 for PowerShell function apps and disable downloading the Az module by default.

### DIFF
--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -244,25 +244,30 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 {
                     var requirementsContent = await StaticResources.PowerShellRequirementsPsd1;
 
-                    string majorVersion = null;
-
+                    bool majorVersionRetrievedSuccessfully = false;
                     string guidance = null;
+
                     try
                     {
-                        majorVersion = await PowerShellHelper.GetLatestAzModuleMajorVersion();
-
-                        requirementsContent = Regex.Replace(requirementsContent, @"#(\s?)'Az'", "'Az'");
+                        var majorVersion = await PowerShellHelper.GetLatestAzModuleMajorVersion();
                         requirementsContent = Regex.Replace(requirementsContent, "MAJOR_VERSION", majorVersion);
+
+                        majorVersionRetrievedSuccessfully = true;
                     }
                     catch
                     {
-                        guidance = "Uncomment the next line and replace the MAJOR_VERSION, e.g., 'Az' = '2.*'";
+                        guidance = "Uncomment the next line and replace the MAJOR_VERSION, e.g., 'Az' = '5.*'";
 
                         var warningMsg = "Failed to get Az module version. Edit the requirements.psd1 file when the powershellgallery.com is accessible.";
                         ColoredConsole.WriteLine(WarningColor(warningMsg));
                     }
 
-                    requirementsContent = Regex.Replace(requirementsContent, "GUIDANCE", guidance ?? string.Empty);
+                    if (majorVersionRetrievedSuccessfully)
+                    {
+                        guidance = Environment.NewLine + "    # To use the Az module in your function app, please uncomment the line below.";
+                    }
+
+                    requirementsContent = Regex.Replace(requirementsContent, "GUIDANCE", guidance);
                     await WriteFiles("requirements.psd1", requirementsContent);
                 }
             }

--- a/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
@@ -403,6 +403,8 @@ namespace Azure.Functions.Cli.Tests.E2E
                         Name = "requirements.psd1",
                         ContentContains = new []
                         {
+                            "For latest supported version, go to 'https://www.powershellgallery.com/packages/Az'.",
+                            "To use the Az module in your function app, please uncomment the line below.",
                             "Az",
                         }
                     },


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-functions-core-tools/issues/2377 

**Summary of the changes**
The `requirements.psd1` file gets created at `func init` as follows:

**Scenario 1**: A Functions user creates a PowerShell function app via the Core Tools. In this case, the customer has internet connection and the tooling is able to reach the PowerShell Gallery.

Note: For this scenario, we connect to the PowerShellGallery.com and get the latest major version of the Az module that is currently supported. After that, we replace 'MAJOR_VERSION.*' with this major version value, e.g., '5.*'. Lastly, we leave the Az module entry commented out, so the module is not downloaded when the first function invocation takes place. However, if the user would like to enable downloading/installing the Az module for their function app, they just need to uncomment the Az line (just like the guidance in the template advices).

Here is how requirements.psd1 file will look like:

```powershell
# This file enables modules to be automatically managed by the Functions service.
# See https://aka.ms/functionsmanageddependency for additional information.
#
@{    
    # For latest supported version, go to 'https://www.powershellgallery.com/packages/Az'.
    # To use the Az module in your function app, please uncomment the line below. 
    # 'Az' = '5.*'
}
```

**Scenario 2**: A Functions user creates a PowerShell function app via the Core Tools. In this case, the customer does not have internet connection and the tooling cannot reach the PowerShell Gallery.

Here is how requirements.psd1 file will look like:

```powershell
# This file enables modules to be automatically managed by the Functions service.
# See https://aka.ms/functionsmanageddependency for additional information.
#
@{
    # For latest supported version, go to 'https://www.powershellgallery.com/packages/Az'. Uncomment the next line and replace the MAJOR_VERSION, e.g., 'Az' = '2.*'
    # 'Az' = 'MAJOR_VERSION.*'
}
```
