### PR TITLE
Adds KEDA support for default connection fields for some Azure triggers

### DIFF
--- a/src/Azure.Functions.Cli/Kubernetes/KEDA/V2/KedaV2Resource.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/KEDA/V2/KedaV2Resource.cs
@@ -64,9 +64,15 @@ namespace Azure.Functions.Cli.Kubernetes.KEDA.V2
             switch (triggerType)
             {
                 case TriggerTypes.AzureBlobStorage:
-                case TriggerTypes.AzureEventHubs:
-                case TriggerTypes.AzureServiceBus:
                 case TriggerTypes.AzureStorageQueue:
+                    metadata[ConnectionFromEnvField] = metadata[ConnectionField] ?? "AzureWebJobsStorage";
+                    metadata.Remove(ConnectionField);
+                    break;
+                case TriggerTypes.AzureServiceBus:
+                    metadata[ConnectionFromEnvField] = metadata[ConnectionField] ?? "AzureWebJobsServiceBus";
+                    metadata.Remove(ConnectionField);
+                    break;
+                case TriggerTypes.AzureEventHubs:
                     metadata[ConnectionFromEnvField] = metadata[ConnectionField];
                     metadata.Remove(ConnectionField);
                     break;


### PR DESCRIPTION
Adds Keda support for default connection variable names for Azure Service Bus, Azure Queue Storage, and Azure Blob Storage triggers.

This change will cause the PopulateMetadataDictionary method of KedaV2Resource to default to AzureWebJobsStorage for Azure Queue Storage, and Azure Blob Storage triggers, and AzureWebJobsServiceBus in the case of Azure Service Bus triggers.

This will allow users to not have to specify their connection variable name if they intend to use supported defaults.

Resolves Azure/azure-functions-core-tools#2404