### PR TITLE
Add Durable triggers to TriggersWithoutStorage

### DIFF
--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -71,7 +71,16 @@ namespace Azure.Functions.Cli.Common
             { WorkerRuntime.powershell, new [] { "mcr.microsoft.com/azure-functions/powershell", "microsoft/azure-functions-powershell" } }
         };
 
-        public static readonly string[] TriggersWithoutStorage = new[] { "httptrigger", "kafkatrigger" };
+        public static readonly string[] TriggersWithoutStorage = new[]
+        {
+            "httptrigger",
+            "kafkatrigger",
+
+            // Durable Functions triggers can also support non-Azure Storage backends
+            "orchestrationTrigger",
+            "activityTrigger",
+            "entityTrigger",
+        };
 
         public static class Errors
         {


### PR DESCRIPTION
This is to support running Durable Functions with the new SQL backend that's currently under development.