### PR TITLE
func kubernetes deploy should deploy to the current namespace, not the default

### DIFF
--- a/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/KnativePlatform.cs
+++ b/src/Azure.Functions.Cli/Actions/DeployActions/Platforms/KnativePlatform.cs
@@ -13,9 +13,6 @@ namespace Azure.Functions.Cli.Actions.DeployActions.Platforms
 {
     public class KnativePlatform : IHostingPlatform
     {
-        private string configFile = string.Empty;
-        private const string FUNCTIONS_NAMESPACE = "azure-functions";
-
         public async Task DeployContainerizedFunction(string functionName, string image, string nameSpace, int min, int max, double cpu = 0.1, int memory = 128, string port = "80", string pullSecret = "")
         {
             await Deploy(functionName, image, nameSpace, min, max);

--- a/src/Azure.Functions.Cli/Actions/KubernetesActions/InstallKedaAction.cs
+++ b/src/Azure.Functions.Cli/Actions/KubernetesActions/InstallKedaAction.cs
@@ -9,13 +9,13 @@ namespace Azure.Functions.Cli.Actions.KubernetesActions
     [Action(Name = "install", Context = Context.Kubernetes, HelpText = "Install KEDA (non-http scale to zero) in the kubernetes cluster from kubectl config")]
     internal class DeployKedaAction : BaseAction
     {
-        public string Namespace { get; private set; } = "default";
+        public string Namespace { get; private set; }
         public KedaVersion KedaVersion { get; private set; } = KedaVersion.v2;
         public bool DryRun { get; private set; }
 
         public override ICommandLineParserResult ParseArgs(string[] args)
         {
-            SetFlag<string>("namespace", "Kubernetes namespace to deploy to. Default: default", s => Namespace = s);
+            SetFlag<string>("namespace", "Kubernetes namespace to deploy to. Default: Current namespace in Kubernetes config.", ns => Namespace = ns);
             SetFlag<KedaVersion>("keda-version", $"Defines the version of KEDA to install. Default: {KedaVersion.v2}. Options are: {KedaVersion.v1} or {KedaVersion.v2}", f => KedaVersion = f);
             SetFlag<bool>("dry-run", "Show the deployment template", f => DryRun = f);
 

--- a/src/Azure.Functions.Cli/Actions/KubernetesActions/KubernetesDeployAction.cs
+++ b/src/Azure.Functions.Cli/Actions/KubernetesActions/KubernetesDeployAction.cs
@@ -24,7 +24,7 @@ namespace Azure.Functions.Cli.Actions.KubernetesActions
 
         public string Registry { get; set; }
         public string Name { get; set; } = string.Empty;
-        public string Namespace { get; set; } = "default";
+        public string Namespace { get; set; }
         public string PullSecret { get; set; } = string.Empty;
         public bool NoDocker { get; set; }
         public bool UseConfigMap { get; set; }
@@ -59,7 +59,7 @@ namespace Azure.Functions.Cli.Actions.KubernetesActions
             SetFlag<string>("image-name", "Image to use for the pod deployment and to read functions from", n => ImageName = n);
             SetFlag<KedaVersion>("keda-version", $"Defines the version of KEDA to use. Default: {Kubernetes.KEDA.KedaVersion.v2}. Options are: {Kubernetes.KEDA.KedaVersion.v1} or {Kubernetes.KEDA.KedaVersion.v2}", n => KedaVersion = n);
             SetFlag<string>("registry", "When set, a docker build is run and the image is pushed to that registry/name. This is mutually exclusive with --image-name. For docker hub, use username.", r => Registry = r);
-            SetFlag<string>("namespace", "Kubernetes namespace to deploy to. Default: default", ns => Namespace = ns);
+            SetFlag<string>("namespace", "Kubernetes namespace to deploy to. Default: Current namespace in Kubernetes config.", ns => Namespace = ns);
             SetFlag<string>("pull-secret", "The secret holding a private registry credentials", s => PullSecret = s);
             SetFlag<int>("polling-interval", "The polling interval for checking non-http triggers. Default: 30 (seconds)", p => PollingInterval = p);
             SetFlag<int>("cooldown-period", "The cooldown period for the deployment before scaling back to 0 after all triggers are no longer active. Default: 300 (seconds)", p => CooldownPeriod = p);

--- a/src/Azure.Functions.Cli/Kubernetes/Models/Kubernetes/ObjectMetadataV1.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/Models/Kubernetes/ObjectMetadataV1.cs
@@ -9,7 +9,7 @@ namespace Azure.Functions.Cli.Kubernetes.Models.Kubernetes
         [JsonProperty("name")]
         public string Name { get; set; }
 
-        [JsonProperty("namespace", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("namespace")]
         public string Namespace { get; set; }
 
         [JsonProperty("labels")]

--- a/src/Azure.Functions.Cli/Kubernetes/Models/Kubernetes/ObjectMetadataV1.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/Models/Kubernetes/ObjectMetadataV1.cs
@@ -9,7 +9,7 @@ namespace Azure.Functions.Cli.Kubernetes.Models.Kubernetes
         [JsonProperty("name")]
         public string Name { get; set; }
 
-        [JsonProperty("namespace")]
+        [JsonProperty("namespace", NullValueHandling = NullValueHandling.Ignore)]
         public string Namespace { get; set; }
 
         [JsonProperty("labels")]


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

Open work:
- [x] Check if look-ups specify namespace

### Example: Specifying namespace

```yaml
data:
  AzureWebJobsStorage: VXNlRGV2ZWxvcG1lbnRTdG9yYWdlPXRydWU=
  FUNCTIONS_WORKER_RUNTIME: ZG90bmV0
apiVersion: v1
kind: Secret
metadata:
  name: foo
  namespace: example
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: foo
  namespace: example
  labels:
    app: foo
spec:
  selector:
    matchLabels:
      app: foo
  template:
    metadata:
      labels:
        app: foo
    spec:
      containers:
      - name: foo
        image: bar.io/foo
        env:
        - name: AzureFunctionsJobHost__functions__0
          value: test
        envFrom:
        - secretRef:
            name: foo
        readinessProbe:
          failureThreshold: 3
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 240
          httpGet:
            path: /
            port: 80
            scheme: HTTP
        startupProbe:
          failureThreshold: 3
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 240
          httpGet:
            path: /
            port: 80
            scheme: HTTP
---
apiVersion: keda.sh/v1alpha1
kind: ScaledObject
metadata:
  name: foo
  namespace: example
  labels: {}
spec:
  scaleTargetRef:
    name: foo
  triggers:
  - type: azure-queue
    metadata:
      queueName: myqueue-items
      connectionFromEnv: ''
---


```

### Example: No namespace specified

```yaml
data:
  AzureWebJobsStorage: VXNlRGV2ZWxvcG1lbnRTdG9yYWdlPXRydWU=
  FUNCTIONS_WORKER_RUNTIME: ZG90bmV0
apiVersion: v1
kind: Secret
metadata:
  name: foo
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: foo
  labels:
    app: foo
spec:
  selector:
    matchLabels:
      app: foo
  template:
    metadata:
      labels:
        app: foo
    spec:
      containers:
      - name: foo
        image: bar.io/foo
        env:
        - name: AzureFunctionsJobHost__functions__0
          value: test
        envFrom:
        - secretRef:
            name: foo
        readinessProbe:
          failureThreshold: 3
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 240
          httpGet:
            path: /
            port: 80
            scheme: HTTP
        startupProbe:
          failureThreshold: 3
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 240
          httpGet:
            path: /
            port: 80
            scheme: HTTP
---
apiVersion: keda.sh/v1alpha1
kind: ScaledObject
metadata:
  name: foo
  labels: {}
spec:
  scaleTargetRef:
    name: foo
  triggers:
  - type: azure-queue
    metadata:
      queueName: myqueue-items
      connectionFromEnv: ''
---


```

Fixes #2407