### PR TITLE
Add back UploadToStorage stage to publish Core Tools builds

### DIFF
--- a/build/Program.cs
+++ b/build/Program.cs
@@ -32,6 +32,7 @@ namespace Build
                 .Then(Zip)
                 .Then(DotnetPack)
                 .Then(CreateIntegrationTestsBuildManifest, skip: !args.Contains("--integrationTests"))
+                .Then(UploadToStorage, skip: !args.Contains("--ci"))
                 .Run();
         }
     }


### PR DESCRIPTION
Add back UploadToStorage stage to publish Core Tools builds. This stage will be removed once we have daily Integration Tests Core Tools builds.

