### PR TITLE
Add a typescript specific Dockerfile

### DIFF
--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -148,7 +148,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
 
         private async Task InitDockerFileOnly()
         {
-            await WriteDockerfile(GlobalCoreToolsSettings.CurrentWorkerRuntime, Csx);
+            await WriteDockerfile(GlobalCoreToolsSettings.CurrentWorkerRuntime, Language, Csx);
         }
 
         private async Task InitFunctionAppProject()
@@ -185,7 +185,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             }
             if (InitDocker)
             {
-                await WriteDockerfile(ResolvedWorkerRuntime, Csx);
+                await WriteDockerfile(ResolvedWorkerRuntime, Language, Csx);
             }
         }
 
@@ -305,7 +305,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             await WriteFiles("local.settings.json", localSettingsJsonContent);
         }
 
-        private static async Task WriteDockerfile(WorkerRuntime workerRuntime, bool csx)
+        private static async Task WriteDockerfile(WorkerRuntime workerRuntime, string language, bool csx)
         {
             if (workerRuntime == Helpers.WorkerRuntime.dotnet)
             {
@@ -320,7 +320,14 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             }
             else if (workerRuntime == Helpers.WorkerRuntime.node)
             {
-                await WriteFiles("Dockerfile", await StaticResources.DockerfileNode);
+                if (language == Constants.Languages.TypeScript)
+                {
+                    await WriteFiles("Dockerfile", await StaticResources.DockerfileTypescript);
+                }
+                else
+                {
+                    await WriteFiles("Dockerfile", await StaticResources.DockerfileNode);
+                }
             }
             else if (workerRuntime == Helpers.WorkerRuntime.python)
             {

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -72,6 +72,9 @@
     <EmbeddedResource Include="StaticResources\Dockerfile.node">
       <LogicalName>$(AssemblyName).Dockerfile.node</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="StaticResources\Dockerfile.typescript">
+      <LogicalName>$(AssemblyName).Dockerfile.typescript</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="StaticResources\gitignore">
       <LogicalName>$(AssemblyName).gitignore</LogicalName>
     </EmbeddedResource>

--- a/src/Azure.Functions.Cli/StaticResources/Dockerfile.typescript
+++ b/src/Azure.Functions.Cli/StaticResources/Dockerfile.typescript
@@ -1,0 +1,12 @@
+# To enable ssh & remote debugging on app service change the base image to the one below
+# FROM mcr.microsoft.com/azure-functions/node:3.0-appservice
+FROM mcr.microsoft.com/azure-functions/node:3.0
+
+ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
+    AzureFunctionsJobHost__Logging__Console__IsEnabled=true
+
+COPY . /home/site/wwwroot
+
+RUN cd /home/site/wwwroot && \
+    npm install && \
+    npm run build

--- a/src/Azure.Functions.Cli/StaticResources/StaticResources.cs
+++ b/src/Azure.Functions.Cli/StaticResources/StaticResources.cs
@@ -47,6 +47,8 @@ namespace Azure.Functions.Cli
 
         public static Task<string> DockerfileNode => GetValue("Dockerfile.node");
 
+        public static Task<string> DockerfileTypescript => GetValue("Dockerfile.typescript");
+
         public static Task<string> DockerIgnoreFile => GetValue("dockerignore");
 
         public static Task<string> VsCodeExtensionsJson => GetValue("vscode.extensions.json");


### PR DESCRIPTION
The old node dockerfile didn't have a build step, and thus on a clean function (e.g. git clone) it didn't work right.