### PR TITLE
Update PowerShell Worker (PS7) to 3.0.705

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -151,7 +151,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.8.1" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS6" Version="3.0.630" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7" Version="3.0.629" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7" Version="3.0.705" />
     <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="3.1.1.10" />
   </ItemGroup>
 


### PR DESCRIPTION
Update PowerShell Worker (PS7) to 3.0.705 ([Release Notes](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v3.0.705))