### PR TITLE
Improve githash calculation by adding an implementation that matches github actions.

### DIFF
--- a/src/Azure.Functions.Cli/Actions/KubernetesActions/KubernetesDeployAction.cs
+++ b/src/Azure.Functions.Cli/Actions/KubernetesActions/KubernetesDeployAction.cs
@@ -12,6 +12,7 @@ using Azure.Functions.Cli.Kubernetes.Models;
 using Azure.Functions.Cli.Kubernetes.Models.Kubernetes;
 using Colors.Net;
 using Fclp;
+using Microsoft.Extensions.FileSystemGlobbing;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -45,6 +46,8 @@ namespace Azure.Functions.Cli.Actions.KubernetesActions
         public bool ShowServiceFqdn { get; set; } = false;
 
         public bool UseGitHashAsImageVersion { get; set; } = false;
+
+        public string HashFilesPattern { get; set; } = "";
 
         public KubernetesDeployAction(ISecretsManager secretsManager)
         {
@@ -85,6 +88,7 @@ namespace Azure.Functions.Cli.Actions.KubernetesActions
             SetFlag<bool>("ignore-errors", "Proceed with the deployment if a resource returns an error. Default: false", f => IgnoreErrors = f);
             SetFlag<bool>("show-service-fqdn", "display Http Trigger URL with kubernetes FQDN rather than IP. Default: false", f => ShowServiceFqdn = f);
             SetFlag<bool>("use-git-hash-version", "Use the githash as the version for the image", f => UseGitHashAsImageVersion = f);
+            SetFlag<string>("hash-files", "Files to hash to determine the image version", f => HashFilesPattern = f);
             return base.ParseArgs(args);
         }
 
@@ -228,11 +232,21 @@ namespace Azure.Functions.Cli.Actions.KubernetesActions
         {
             var version = "latest";
             if (UseGitHashAsImageVersion) {
-                (var stdout, var err, var exit) = await GitHelpers.GitHash();
-                if (exit != 0) {
-                    throw new CliException("Git describe failed: " + err);
+                if (HashFilesPattern.Length > 0)
+                {
+                    var matcher = new Matcher();
+                    matcher.AddInclude(HashFilesPattern);
+                    var matches = MatcherExtensions.GetResultsInFullPath(matcher, "./");
+                    version = GitHelpers.ActionsHashFiles(matches);
                 }
-                version = stdout;
+                else
+                {
+                    (var stdout, var err, var exit) = await GitHelpers.GitHash();
+                    if (exit != 0) {
+                        throw new CliException("Git describe failed: " + err);
+                    }
+                    version = stdout;
+                }
             }
             if (!string.IsNullOrEmpty(Registry))
             {

--- a/src/Azure.Functions.Cli/Helpers/GitHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/GitHelpers.cs
@@ -1,17 +1,52 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 using Azure.Functions.Cli.Common;
-using Azure.Functions.Cli.Kubernetes.Models;
-using Colors.Net;
-using Newtonsoft.Json;
-using static Azure.Functions.Cli.Common.OutputTheme;
 
 namespace Azure.Functions.Cli.Helpers
 {
     public static class GitHelpers
     {
+        public static string ActionsHashFiles(IEnumerable<string> files)
+        {
+            var digests = new MemoryStream();
+            foreach (var file in files)
+            {
+                using (var sha = SHA256.Create())
+                {
+                    try
+                    {
+                        using (var stream = File.Open(file, FileMode.Open))
+                        {
+                            stream.Position = 0;
+                            digests.Write(sha.ComputeHash(stream));
+                        }
+                    }
+                    catch (IOException e)
+                    {
+                        Console.WriteLine($"I/O Exception: {e.Message}");
+                    }
+                    catch (UnauthorizedAccessException e)
+                    {
+                        Console.WriteLine($"Access Exception: {e.Message}");
+                    }
+                }
+            }
+            using (var sha = SHA256.Create())
+            {
+                var hash = sha.ComputeHash(digests.ToArray());
+                var str = "";
+                for (int i = 0; i < hash.Length; i++)
+                {
+                    str += $"{hash[i]:x2}";
+                }
+                return str;
+            }
+        }
+
         public static async Task<(string output, string error, int exit)> GitHash(bool ignoreError = false)
         {
             var git = new Executable("git", "describe --always --dirty");


### PR DESCRIPTION
See https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#hashfiles

and

https://github.com/actions/runner/blob/master/src/Misc/expressionFunc/hashFiles/src/hashFiles.ts