### PR TITLE
Fix template issue for VS Mac

### DIFF
--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -262,21 +262,26 @@ namespace Build
         public static void AddTemplatesNupkgs()
         {
             var templatesPath = Path.Combine(Settings.OutputDir, "nupkg-templates");
+            var isolatedTemplatesPath = Path.Combine(templatesPath, "net5-isolated");
+
             Directory.CreateDirectory(templatesPath);
+            Directory.CreateDirectory(isolatedTemplatesPath);
 
             using (var client = new WebClient())
             {
+                // If any of these names / paths change, we need to make sure our tooling partners (in particular VS and VS Mac) are notified
+                // and we are sure it doesn't break them.
                 client.DownloadFile(Settings.DotnetIsolatedItemTemplates,
-                    Path.Combine(templatesPath, $"isolated.itemTemplates.{Settings.DotnetIsolatedItemTemplatesVersion}.nupkg"));
+                    Path.Combine(isolatedTemplatesPath, $"itemTemplates.{Settings.DotnetIsolatedItemTemplatesVersion}.nupkg"));
 
                 client.DownloadFile(Settings.DotnetIsolatedProjectTemplates,
-                    Path.Combine(templatesPath, $"isolated.projectTemplates.{Settings.DotnetIsolatedProjectTemplatesVersion}.nupkg"));
+                    Path.Combine(isolatedTemplatesPath, $"projectTemplates.{Settings.DotnetIsolatedProjectTemplatesVersion}.nupkg"));
 
                 client.DownloadFile(Settings.DotnetItemTemplates,
-                    Path.Combine(templatesPath, $"webjobs.itemTemplates.{Settings.DotnetItemTemplatesVersion}.nupkg"));
+                    Path.Combine(templatesPath, $"itemTemplates.{Settings.DotnetItemTemplatesVersion}.nupkg"));
 
                 client.DownloadFile(Settings.DotnetProjectTemplates,
-                    Path.Combine(templatesPath, $"webjobs.projectTemplates.{Settings.DotnetProjectTemplatesVersion}.nupkg"));
+                    Path.Combine(templatesPath, $"projectTemplates.{Settings.DotnetProjectTemplatesVersion}.nupkg"));
             }
 
             foreach (var runtime in Settings.TargetRuntimes)

--- a/src/Azure.Functions.Cli/Helpers/DotnetHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/DotnetHelpers.cs
@@ -240,19 +240,19 @@ namespace Azure.Functions.Cli.Helpers
             await exe.RunAsync();
         }
 
-        private static Task InstallWebJobsTemplates() => DotnetTemplatesAction("install", "webjobs.*.nupkg");
+        private static Task InstallWebJobsTemplates() => DotnetTemplatesAction("install", "templates");
 
-        private static Task InstallIsolatedTemplates() => DotnetTemplatesAction("install", "isolated.*.nupkg");
+        private static Task InstallIsolatedTemplates() => DotnetTemplatesAction("install", Path.Combine("templates", "net5-isolated"));
 
-        private static async Task DotnetTemplatesAction(string action, string pattern)
+        private static async Task DotnetTemplatesAction(string action, string templateDirectory)
         {
-            var templatesLocation = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "templates");
+            var templatesLocation = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), templateDirectory);
             if (!FileSystemHelpers.DirectoryExists(templatesLocation))
             {
                 throw new CliException($"Can't find templates location. Looked under '{templatesLocation}'");
             }
 
-            foreach (var nupkg in FileSystemHelpers.GetFiles(templatesLocation, null, null, pattern))
+            foreach (var nupkg in Directory.GetFiles(templatesLocation, "*.nupkg", SearchOption.TopDirectoryOnly))
             {
                 var exe = new Executable("dotnet", $"new --{action} \"{nupkg}\"");
                 await exe.RunAsync();


### PR DESCRIPTION
VS Mac relies on our templates. I had changed the name of the templates and added multiple templates for dotnet isolated, but this breaks VS Mac experience (as they rely on a certain structure). To fix this, I am putting these files in the nested directory, as requested by the VS team.