### PR TITLE
K8s deployment for MSSQL-based Durable Functions

### DIFF
--- a/src/Azure.Functions.Cli/Kubernetes/KEDA/V2/KedaV2Resource.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/KEDA/V2/KedaV2Resource.cs
@@ -41,20 +41,56 @@ namespace Azure.Functions.Cli.Kubernetes.KEDA.V2
                         .Where(b => b?["type"] != null)
                         .Where(b => b["type"].ToString().IndexOf("Trigger", StringComparison.OrdinalIgnoreCase) != -1)
                         .Where(b => b["type"].ToString().IndexOf("httpTrigger", StringComparison.OrdinalIgnoreCase) == -1)
-                        .Select(t => new ScaledObjectTriggerV1Alpha1
-                        {
-                            Type = GetKedaTriggerType(t["type"]?.ToString()),
-                            Metadata = PopulateMetadataDictionary(t)
-                        })
+                        .GroupBy(b => IsDurable(b)) // Multiple durable triggers map to a single scaler
+                        .SelectMany(group => group.Key ? GetDurableScalar(triggers.HostJson) : group.Select(GetStandardScalar))
                 }
             };
         }
 
-        private const string ConnectionField = "connection";
-        private const string ConnectionFromEnvField = "connectionFromEnv";
+        private static bool IsDurable(JToken trigger) => 
+            trigger["type"].ToString().Equals("orchestrationTrigger", StringComparison.OrdinalIgnoreCase) ||
+            trigger["type"].ToString().Equals("activityTrigger", StringComparison.OrdinalIgnoreCase) ||
+            trigger["type"].ToString().Equals("entityTrigger", StringComparison.OrdinalIgnoreCase);
+
+        private static IEnumerable<ScaledObjectTriggerV1Alpha1> GetDurableScalar(JObject hostJson)
+        {
+            // Reference: https://docs.microsoft.com/azure/azure-functions/durable/durable-functions-bindings#durable-functions-2-0-host-json
+            JObject storageProviderConfig = hostJson.SelectToken("extensions.durableTask.storageProvider") as JObject;
+            string storageType = storageProviderConfig?["type"]?.ToString();
+
+            // Custom storage types are supported starting in Durable Functions v2.4.2
+            if (string.Equals(storageType, "MicrosoftSQL", StringComparison.OrdinalIgnoreCase))
+            {
+                yield return new ScaledObjectTriggerV1Alpha1
+                {
+                    // MSSQL scaler reference: https://keda.sh/docs/2.2/scalers/mssql/
+                    Type = "mssql",
+                    Metadata = new Dictionary<string, string>
+                    {
+                        ["connectionStringFromEnv"] = storageProviderConfig?["connectionStringName"]?.ToString(),
+                    }
+                };
+            }
+            else
+            {
+                // TODO: Support for the Azure Storage and Netherite backends
+            }
+        }
+
+        private ScaledObjectTriggerV1Alpha1 GetStandardScalar(JToken binding)
+        {
+            return new ScaledObjectTriggerV1Alpha1
+            {
+                Type = GetKedaTriggerType(binding["type"]?.ToString()),
+                Metadata = PopulateMetadataDictionary(binding)
+            };
+        }
 
         public override IDictionary<string, string> PopulateMetadataDictionary(JToken t)
         {
+            const string ConnectionField = "connection";
+            const string ConnectionFromEnvField = "connectionFromEnv";
+
             IDictionary<string, string> metadata = t.ToObject<Dictionary<string, JToken>>()
                 .Where(i => i.Value.Type == JTokenType.String)
                 .ToDictionary(k => k.Key, v => v.Value.ToString());

--- a/src/Azure.Functions.Cli/Kubernetes/KEDA/V2/KedaV2Resource.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/KEDA/V2/KedaV2Resource.cs
@@ -67,6 +67,8 @@ namespace Azure.Functions.Cli.Kubernetes.KEDA.V2
                     Type = "mssql",
                     Metadata = new Dictionary<string, string>
                     {
+                        ["query"] = "SELECT dt.GetScaleMetric()",
+                        ["targetValue"] = "1", // super-conservative default
                         ["connectionStringFromEnv"] = storageProviderConfig?["connectionStringName"]?.ToString(),
                     }
                 };


### PR DESCRIPTION
### Context for this PR
This PR adds support for deploying a Durable Functions app to Kubernetes using the `func kubernetes deploy` command. It's specifically designed to use the new [MSSQL backend for Durable Functions](https://microsoft.github.io/durabletask-mssql) and relies on the [MSSQL KEDA scaler](https://keda.sh/docs/2.2/scalers/mssql/) that is part of KEDA v2.2.  Support for other backends, like the default Azure Storage backend or the new [Netherite backend](https://microsoft.github.io/durabletask-netherite) will come at another time.

### The changes
I had to refactor some of the existing code because unlike all other trigger types, Durable Functions triggers are _not_ 1:1 with respect to scalers. Rather, all Durable triggers in a function app are powered by a single scaler.

### Testing
I tested this using a Durable Functions app named **durabletask-mssql-app** that I'm working on. Prior to this PR, the `func kubernetes deploy` command resulted in the following yaml for the ScaledObject:

```yaml
---
apiVersion: keda.sh/v1alpha1
kind: ScaledObject
metadata:
  name: durabletask-mssql-app
  namespace: default
  labels: {}
spec:
  scaleTargetRef:
    name: durabletask-mssql-app
  triggers:
  - type: orchestrationtrigger
    metadata: {}
  - type: entitytrigger
    metadata: {}
  - type: orchestrationtrigger
    metadata: {}
  - type: orchestrationtrigger
    metadata: {}
  - type: activitytrigger
    metadata: {}
  - type: activitytrigger
    metadata: {}
  - type: activitytrigger
    metadata: {}
```

The tool doesn't know anything about Durable, so it creates a bogus set of KEDA triggers, one for each of my orchestration, activity, and entity triggers. However, after my changes, the same command now correctly generates a single scaler that covers all the Durable triggers:

```yaml
---
apiVersion: keda.sh/v1alpha1
kind: ScaledObject
metadata:
  name: durabletask-mssql-app
  labels: {}
spec:
  scaleTargetRef:
    name: durabletask-mssql-app
  triggers:
  - type: mssql
    metadata:
      connectionStringFromEnv: SQLDB_Connection
```