### PR TITLE
fix the issue of rabbitmq trigger w/o stroage account

### DIFF
--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -70,7 +70,7 @@ namespace Azure.Functions.Cli.Common
             { WorkerRuntime.powershell, new [] { "mcr.microsoft.com/azure-functions/powershell", "microsoft/azure-functions-powershell" } }
         };
 
-        public static readonly string[] TriggersWithoutStorage = new[] { "httptrigger", "kafkatrigger" };
+        public static readonly string[] TriggersWithoutStorage = new[] { "httptrigger", "kafkatrigger", "rabbitmqtrigger" };
 
         public static class Errors
         {


### PR DESCRIPTION
Fix: https://github.com/Azure/azure-functions-core-tools/issues/2530

RabbitMQ Trigger doesn't required Storage account, however, It block run locally since it is not registered as non-storage account trigger. 

@yojagad Could you have a look if I am wrong? 
CC: @pragnagopa 
