### PR TITLE
Adding Rabbit MQ as non-Azure Storage backend for v3

### DIFF
--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -75,6 +75,7 @@ namespace Azure.Functions.Cli.Common
         {
             "httptrigger",
             "kafkatrigger",
+            "rabbitmqtrigger",
 
             // Durable Functions triggers can also support non-Azure Storage backends
             "orchestrationTrigger",


### PR DESCRIPTION
Fix: https://github.com/Azure/azure-functions-core-tools/issues/2530

RabbitMQ Trigger doesn't required Storage account, however, It block run locally since it is not registered as non-storage account trigger. 
v3x version of this PR. 
https://github.com/Azure/azure-functions-core-tools/pull/2531

CC: @pragnagopa 
