### PR TITLE
Update support for Durable Functions SQL backend

### DIFF
--- a/src/Azure.Functions.Cli/Kubernetes/KEDA/V2/KedaV2Resource.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/KEDA/V2/KedaV2Resource.cs
@@ -59,7 +59,8 @@ namespace Azure.Functions.Cli.Kubernetes.KEDA.V2
             string storageType = storageProviderConfig?["type"]?.ToString();
 
             // Custom storage types are supported starting in Durable Functions v2.4.2
-            if (string.Equals(storageType, "MicrosoftSQL", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(storageType, "MicrosoftSQL", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(storageType, "mssql", StringComparison.OrdinalIgnoreCase))
             {
                 yield return new ScaledObjectTriggerV1Alpha1
                 {
@@ -67,8 +68,9 @@ namespace Azure.Functions.Cli.Kubernetes.KEDA.V2
                     Type = "mssql",
                     Metadata = new Dictionary<string, string>
                     {
-                        ["query"] = "SELECT dt.GetScaleMetric()",
-                        ["targetValue"] = "1", // super-conservative default
+                        // Durable SQL scaling: https://microsoft.github.io/durabletask-mssql/#/scaling?id=worker-auto-scale
+                        ["query"] = "SELECT dt.GetScaleRecommendation(10, 1)", // max 10 orchestrations and 1 activity per replica
+                        ["targetValue"] = "1",
                         ["connectionStringFromEnv"] = storageProviderConfig?["connectionStringName"]?.ToString(),
                     }
                 };


### PR DESCRIPTION
We made some changes in the latest version of the Durable Functions SQL backend that broke Core Tools support. Specifically, we renamed the storage type name from "MicrosoftSQL" to "mssql". This PR now handles both type names.

We also added a new SQL function for getting scale information called `dt.GetScaleRecommendation`. We'd like to use this as the new default expression rather than `dt.GetScaleMetric` (though the latter will still be supported).