### PR TITLE
Update Dotnet Static Template to 3.1.1788

### DIFF
--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -24,7 +24,7 @@ namespace Build
         public const string DotnetIsolatedProjectTemplatesVersion = "3.1.1733";
         public const string DotnetItemTemplatesVersion = "3.1.1788";
         public const string DotnetProjectTemplatesVersion = "3.1.1788";
-        public const string TemplateJsonVersion = "3.1.1788";
+        public const string TemplateJsonVersion = "3.1.1648";
 
         public static readonly string SrcProjectPath = Path.GetFullPath("../src/Azure.Functions.Cli/");
 

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -22,9 +22,9 @@ namespace Build
 
         public const string DotnetIsolatedItemTemplatesVersion = "3.1.1733";
         public const string DotnetIsolatedProjectTemplatesVersion = "3.1.1733";
-        public const string DotnetItemTemplatesVersion = "3.1.1648";
-        public const string DotnetProjectTemplatesVersion = "3.1.1648";
-        public const string TemplateJsonVersion = "3.1.1648";
+        public const string DotnetItemTemplatesVersion = "3.1.1788";
+        public const string DotnetProjectTemplatesVersion = "3.1.1788";
+        public const string TemplateJsonVersion = "3.1.1788";
 
         public static readonly string SrcProjectPath = Path.GetFullPath("../src/Azure.Functions.Cli/");
 


### PR DESCRIPTION
The current template doesn't include 

The latest version 3.1.1788 includes RabbitMQ and Kafka Extension

Commit:
https://github.com/Azure/azure-functions-templates/tree/31a837d9ec5759205b71b0a083fc4165cdb87d45 
https://azfunc.visualstudio.com/Azure%20Functions/_build/results?buildId=12411&view=results

