### PR TITLE
Upgrade pipeline task PublishBuildArtifacts to PublishPipelineArtifacts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,7 +78,7 @@ jobs:
       Pattern: '*.dll, *.exe'
       signConfigType: 'inlineSignParams'
       inlineOperation: |
-        [    
+        [
             {
               "KeyCode": "CP-230012",
               "OperationCode": "SigntoolSign",
@@ -220,11 +220,11 @@ jobs:
     env:
       IntegrationBuildNumber: $(INTEGRATIONBUILDNUMBER)
     displayName: 'Move artifacts'
-  - task: PublishBuildArtifacts@1
+  - task: PublishPipelineArtifact@1
     inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-      ArtifactName: 'drop'
-      publishLocation: 'Container'
+      targetPath: '$(Build.ArtifactStagingDirectory)'
+      artifactName: 'drop'
+      artifactType: 'pipeline'
   - pwsh: |
       .\uploadContentToStorageAccount.ps1 -StorageAccountName $env:IntegrationTestsStorageAccountName -StorageAccountKey $env:IntegrationTestsStorageAccountKey -SourcePath '$(Build.ArtifactStagingDirectory)'
     env:


### PR DESCRIPTION
As per https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/build-artifacts?view=azure-devops&tabs=yaml.
We should use PublishPipelineArtifacts instead of PublishBuildArtifacts to yield more uploading speed.