### PR TITLE
Update PowerShell Worker (PS7) to 3.0.833

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -154,7 +154,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.8.2-SNAPSHOT" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.1.1" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS6" Version="3.0.630" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7" Version="3.0.738" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7" Version="3.0.833" />
     <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="3.1.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Update PowerShell Worker (PS7) to 3.0.833 ([Release Notes](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v3.0.833))