### PR TITLE
Enable AppSettings update before deployment happens in case of Kubernetes Environment

### DIFF
--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -382,10 +382,11 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 NoBuild, ignoreParser, AdditionalPackages, ignoreDotNetCheck: true);
 
             bool shouldSyncTriggers = true;
+            bool shouldDeferPublishZipDeploy = false;
             if (functionApp.IsKubeApp)
             {
                 shouldSyncTriggers = false;
-                await PublishZipDeploy(functionApp, zipStreamFactory);
+                shouldDeferPublishZipDeploy = true;
             }
             else if (functionApp.IsLinux && functionApp.IsDynamic)
             {
@@ -425,6 +426,11 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             else if (additionalAppSettings.Any())
             {
                 await PublishAppSettings(functionApp, new Dictionary<string, string>(), additionalAppSettings);
+            }
+
+            if (shouldDeferPublishZipDeploy)
+            { 
+                await PublishZipDeploy(functionApp, zipStreamFactory);
             }
 
             if (shouldSyncTriggers)


### PR DESCRIPTION
In case of the Kubernetes Environment, we need to update AppSettings before the deployment happens for the binding expression update. 

cc @pragnagopa 

# Fix
https://github.com/Azure/azure-functions-core-tools/issues/2579