### PR TITLE
adding support for dotnet-framework-version during publishing

### DIFF
--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -254,8 +254,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 await UpdateDotNetIsolatedFrameworkVersion(functionApp, DotnetFrameworkVersion,
                     (settings) => AzureHelper.UpdateWebSettings(functionApp, settings, AccessToken, ManagementURL));
             }
-
-            if (workerRuntime != WorkerRuntime.dotnetIsolated && functionApp.IsLinux && !functionApp.IsDynamic && !string.IsNullOrEmpty(functionApp.LinuxFxVersion))
+            else if (functionApp.IsLinux && !functionApp.IsDynamic && !string.IsNullOrEmpty(functionApp.LinuxFxVersion))
             {
                 // If linuxFxVersion does not match any of our images
                 if (PublishHelper.IsLinuxFxVersionUsingCustomImage(functionApp.LinuxFxVersion))

--- a/test/Azure.Functions.Cli.Tests/PublishActionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/PublishActionTests.cs
@@ -1,0 +1,130 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Azure.Functions.Cli.Actions.AzureActions;
+using Azure.Functions.Cli.Arm.Models;
+using Azure.Functions.Cli.Common;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests
+{
+    public class PublishActionTests
+    {
+        private Dictionary<string, string> _settings;
+
+        [Fact]
+        public async Task NetFrameworkVersion_DotnetIsolated_Linux_Consumption_AlreadyEmpty()
+        {
+            var site = new Site("test")
+            {
+                Kind = "linux",
+                Sku = "dynamic",
+                LinuxFxVersion = null
+            };
+
+            await PublishFunctionAppAction.UpdateDotNetIsolatedFrameworkVersion(site, "6.0", UpdateWebSettings);
+
+            // no-op if already null or empty
+            Assert.Null(_settings);
+        }
+
+        [Fact]
+        public async Task NetFrameworkVersion_DotnetIsolated_Linux_Consumption_Updated()
+        {
+            var site = new Site("test")
+            {
+                Kind = "linux",
+                Sku = "dynamic",
+                LinuxFxVersion = "something"
+            };
+
+            await PublishFunctionAppAction.UpdateDotNetIsolatedFrameworkVersion(site, "6.0", UpdateWebSettings);
+
+            // update it to empty
+            var setting = _settings.Single();
+            Assert.Equal(Constants.LinuxFxVersion, setting.Key);
+            Assert.Equal(string.Empty, setting.Value);
+        }
+
+        [Theory]
+        [InlineData("v6.0")]
+        [InlineData("6.0")]
+        [InlineData("6.0.1")]
+        public async Task NetFrameworkVersion_DotnetIsolated_Linux_Dedicated(string specifiedVersion)
+        {
+            var site = new Site("test")
+            {
+                Kind = "linux"
+            };
+
+            await PublishFunctionAppAction.UpdateDotNetIsolatedFrameworkVersion(site, specifiedVersion, UpdateWebSettings);
+
+            var setting = _settings.Single();
+            Assert.Equal(Constants.LinuxFxVersion, setting.Key);
+            Assert.Equal("DOTNET-ISOLATED|6.0", setting.Value);
+        }
+
+        [Theory]
+        [InlineData("v6.0")]
+        [InlineData("6.0")]
+        [InlineData("6.0.1")]
+        public async Task NetFrameworkVersion_DotnetIsolated_Windows(string specifiedVersion)
+        {
+            var site = new Site("test");
+
+            await PublishFunctionAppAction.UpdateDotNetIsolatedFrameworkVersion(site, specifiedVersion, UpdateWebSettings);
+
+            var setting = _settings.Single();
+            Assert.Equal(Constants.DotnetFrameworkVersion, setting.Key);
+            Assert.Equal("v6.0", setting.Value);
+        }
+
+        [Fact]
+        public async Task NetFrameworkVersion_DotnetIsolated_Linux_Null()
+        {
+            // If not specified, assume 5.0
+            var site = new Site("test")
+            {
+                Kind = "linux"
+            };
+
+            await PublishFunctionAppAction.UpdateDotNetIsolatedFrameworkVersion(site, null, UpdateWebSettings);
+
+            var setting = _settings.Single();
+            Assert.Equal(Constants.LinuxFxVersion, setting.Key);
+            Assert.Equal("DOTNET-ISOLATED|5.0", setting.Value);
+        }
+
+        [Fact]
+        public async Task NetFrameworkVersion_DotnetIsolated_Windows_Null()
+        {
+            // If not specified, assume 5.0
+            var site = new Site("test");
+
+            await PublishFunctionAppAction.UpdateDotNetIsolatedFrameworkVersion(site, null, UpdateWebSettings);
+
+            var setting = _settings.Single();
+            Assert.Equal(Constants.DotnetFrameworkVersion, setting.Key);
+            Assert.Equal("v5.0", setting.Value);
+        }
+
+        [Theory]
+        [InlineData("abc")]
+        [InlineData("6.0.a.b")]
+        public async Task NetFrameworkVersion_Invalid(string specifiedVersion)
+        {
+            var site = new Site("test");
+
+            var exception = await Assert.ThrowsAsync<CliException>(() =>
+                PublishFunctionAppAction.UpdateDotNetIsolatedFrameworkVersion(site, specifiedVersion, UpdateWebSettings));
+
+            Assert.StartsWith($"The dotnet-framework-version value of '{specifiedVersion}' is invalid.", exception.Message);
+        }
+
+        private Task<HttpResult<string, string>> UpdateWebSettings(Dictionary<string, string> settings)
+        {
+            _settings = settings;
+            return Task.FromResult(new HttpResult<string, string>(string.Empty));
+        }
+    }
+}


### PR DESCRIPTION
fixes #2573 

In dotnet-isolated scenarios, we need to allow the customer to specify what version of .NET they want running in their Function app. Today we assume .NET 5, but with .NET 6 coming, we need to allow this to be specified.

Ideally, we'll be able to auto-detect, but we'll still want this to allow for overrides.