### PR TITLE
Retain Azure Files settings for Linux consumption remote build

### DIFF
--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -466,7 +466,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             if (PublishBuildOption == BuildOption.Remote)
             {
                 await EnsureRemoteBuildIsSupported(functionApp);
-                await RemoveFunctionAppAppSetting(functionApp, Constants.WebsiteRunFromPackage, Constants.WebsiteContentAzureFileConnectionString, Constants.WebsiteContentShared);
+                await RemoveFunctionAppAppSetting(functionApp, Constants.WebsiteRunFromPackage);
                 Task<DeployStatus> pollConsumptionBuild(HttpClient client) => KuduLiteDeploymentHelpers.WaitForRemoteBuild(client, functionApp);
                 var deployStatus = await PerformServerSideBuild(functionApp, zipFileFactory, pollConsumptionBuild);
                 return deployStatus == DeployStatus.Success;


### PR DESCRIPTION
Reverting https://github.com/Azure/azure-functions-core-tools/pull/1437/files which was originally required to workaround a limitation.