### PR TITLE
fix: fetching old value of function information after deployment for Kubernetes Environment

### DIFF
--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -44,7 +44,6 @@ namespace Azure.Functions.Cli.Actions.AzureActions
         public bool NoBuild { get; set; }
         public string DotnetCliParameters { get; set; }
         public string DotnetFrameworkVersion { get; set; }
-        public bool DeployOnly { get; set; }
 
         public PublishFunctionAppAction(ISettings settings, ISecretsManager secretsManager)
         {
@@ -117,10 +116,6 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 .Setup<string>("dotnet-framework-version")
                 .WithDescription("Only applies to dotnet-isolated applications. Specifies the .NET Framework version for the function app. For example, set to '5.0' when publishing a .NET 5 app.")
                 .Callback(s => DotnetFrameworkVersion = s);
-            Parser
-                .Setup<bool>("deploy-only")
-                .WithDescription("Skip showing function trigger info after the deployment.")
-                .Callback(f => DeployOnly = f);
             return base.ParseArgs(args);
         }
 
@@ -492,8 +487,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             // So, we only show the info, if Function App is not Linux Elastic Premium
             // or a Linux Dedicated Function App with remote build
             if (!(functionApp.IsLinux && functionApp.IsElasticPremium)
-                && !(isFunctionAppDedicatedLinux && PublishBuildOption == BuildOption.Remote)
-                && !DeployOnly)
+                && !(isFunctionAppDedicatedLinux && PublishBuildOption == BuildOption.Remote))
             {
                 await AzureHelper.PrintFunctionsInfo(functionApp, AccessToken, ManagementURL, showKeys: true);
             }

--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -44,6 +44,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
         public bool NoBuild { get; set; }
         public string DotnetCliParameters { get; set; }
         public string DotnetFrameworkVersion { get; set; }
+        public bool DeployOnly { get; set; }
 
         public PublishFunctionAppAction(ISettings settings, ISecretsManager secretsManager)
         {
@@ -116,7 +117,10 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 .Setup<string>("dotnet-framework-version")
                 .WithDescription("Only applies to dotnet-isolated applications. Specifies the .NET Framework version for the function app. For example, set to '5.0' when publishing a .NET 5 app.")
                 .Callback(s => DotnetFrameworkVersion = s);
-
+            Parser
+                .Setup<bool>("deploy-only")
+                .WithDescription("Skip showing function trigger info after the deployment.")
+                .Callback(f => DeployOnly = f);
             return base.ParseArgs(args);
         }
 
@@ -488,7 +492,8 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             // So, we only show the info, if Function App is not Linux Elastic Premium
             // or a Linux Dedicated Function App with remote build
             if (!(functionApp.IsLinux && functionApp.IsElasticPremium)
-                && !(isFunctionAppDedicatedLinux && PublishBuildOption == BuildOption.Remote))
+                && !(isFunctionAppDedicatedLinux && PublishBuildOption == BuildOption.Remote)
+                && !DeployOnly)
             {
                 await AzureHelper.PrintFunctionsInfo(functionApp, AccessToken, ManagementURL, showKeys: true);
             }

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -57,7 +57,8 @@ namespace Azure.Functions.Cli.Common
         public const string AspNetCoreSupressStatusMessages = "ASPNETCORE_SUPPRESSSTATUSMESSAGES";
         public const string SequentialJobHostRestart = "AzureFunctionsJobHost__SequentialRestart";
         public const long DefaultMaxRequestBodySize = 104857600;
-        public const int DefaultWorkerProcessUptimeReadiness = 60000;
+        public const int DefaultGetFunctionReadinessTime = 30000;
+        public const int DefaultRestartedWorkerProcessUptimeWithin = 45000;
 
         public static string CliVersion => typeof(Constants).GetTypeInfo().Assembly.GetName().Version.ToString(3);
 

--- a/src/Azure.Functions.Cli/Helpers/AzureHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/AzureHelper.cs
@@ -468,7 +468,7 @@ namespace Azure.Functions.Cli.Helpers
             if (functionApp.IsKubeApp && !functions.value.Any())
             {
                 ColoredConsole.WriteLine(WarningColor(
-                    $"The deployment success. Wait for {Constants.DefaultRestartedWorkerProcessUptimeWithin / 1000} sec to fetch the trigger info after the function app provisioning has been finished."));
+                    $"The deployment succeeded. Waiting for {Constants.DefaultRestartedWorkerProcessUptimeWithin / 1000} sec to fetch the list of functions deployed in the function app."));
             }
             foreach (var function in functions.value.Select(v => v.properties))
             {

--- a/src/Azure.Functions.Cli/Helpers/AzureHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/AzureHelper.cs
@@ -429,9 +429,10 @@ namespace Azure.Functions.Cli.Helpers
                       {
                           var json = await response.Content.ReadAsAsync<JToken>();
                           var processUpTime = json["processUptime"]?.ToObject<int>() ?? 0;
-
-                          // Wait 60sec for the readiness of the worker process rebooting by deployment.
-                          if (processUpTime >= Constants.DefaultWorkerProcessUptimeReadiness)  
+                          // Wait for 30 sec after Restart is happening.
+                          // We assume that we need to wait until the restart happens if the ProcessUpTime is greater than 45sec.
+                          if (processUpTime >= Constants.DefaultGetFunctionReadinessTime &&
+                              processUpTime < Constants.DefaultRestartedWorkerProcessUptimeWithin)
                           {
                               ColoredConsole.WriteLine(" done");
                               return;
@@ -445,7 +446,7 @@ namespace Azure.Functions.Cli.Helpers
                       {
                           throw new Exception($"Status check returns unsuccessful status. Hostname: {functionApp.HostName}");
                       }
-                  }, 6, TimeSpan.FromSeconds(10)
+                  }, 18, TimeSpan.FromSeconds(3)
             );
         }
 
@@ -464,6 +465,11 @@ namespace Azure.Functions.Cli.Helpers
             functions = await GetFunctions(functionApp, accessToken, managementURL);
 
             ColoredConsole.WriteLine(TitleColor($"Functions in {functionApp.SiteName}:"));
+            if (functionApp.IsKubeApp && !functions.value.Any())
+            {
+                ColoredConsole.WriteLine(WarningColor(
+                    $"The deployment success. Wait for {Constants.DefaultRestartedWorkerProcessUptimeWithin / 1000} sec to fetch the trigger info after the function app provisioning has been finished."));
+            }
             foreach (var function in functions.value.Select(v => v.properties))
             {
                 var trigger = function


### PR DESCRIPTION
When we use Kubernetes Environment, when we deploy the app, it returns immediately, and returns old information of the Azure Functions App. The problem is, the current version is just watch the `/host/admin/status` 's body `processUptime` is exceed `60 sec`. 

I observe when the new Function App information is available. It is on average 15 sec around. 
New Logic will be `processUptime` should be between 30 sec and 45 sec includes some slack by the experiment.  The polling was 5sec, I make it 3 sec for now.  Through the experiment, I experience some customer's pains, so that I improve that points as well.

This PR is the fix and provide additional feature for improving the customer experience of the deployment.  We need to assume several state for this sub command. 
Move from https://github.com/Azure/azure-functions-core-tools/pull/2592

CC: @pragnagopa @ahmelsayed 

## 1.  Just after the Function App deployment, publish your app. 
The deployment is not ready. We will see following error. 

```
$ func.exe azure functionapp publish tsushiqueue1906
Can't find app with name "tsushiqueue1906"
```
## 2.  Function App is ready however, the pod processUptime is less than 45 sec. 
The deployment is ready and ok, however, it is too fast, so that fetching Function App info wont' available. There is no way to identify if it is the first deployment or not.  I show the warning message for it.  Deployment itself is fine.

```
$ func.exe azure functionapp publish tsushiqueue1906
Getting site publishing info...
Creating archive for current directory...
Could not find gozip for packaging. Using DotNetZip to package. This may cause problems preserving file permissions when using in a Linux based environment.
Uploading 2.3 KB [################################################################################]
Upload completed successfully.
Waiting for the functions host up and running . done
Functions in tsushiqueue1906:
The deployment happens soon after the Function App deployment. Wait for 40 sec to fetch the trigger info after the function app provisioning has been finished.
```

## 3. Function App lives more than 45 sec 

```
$ func.exe azure functionapp publish tsushiqueue1907
Getting site publishing info...
Creating archive for current directory...
Could not find gozip for packaging. Using DotNetZip to package. This may cause problems preserving file permissions when using in a Linux based environment.
Uploading 2.3 KB [################################################################################]
Upload completed successfully.
Waiting for the functions host up and running ........... done
Functions in tsushiqueue1907:
    QueueTrigger12 - [queueTrigger]
```

##  4. The case customers don't want to wait 30 sec
Customers need to wait until the new Function App available. For the new change, it will be 30 sec. 
So that customer might want to skip fetching information especially CI scenario. 

I introduce a new flag `--deploy-only` it skip to fetch the function info. Just Deploy the app. 

```
$ func.exe azure functionapp publish tsushiqueue1908 --deploy-only
Getting site publishing info...
Creating archive for current directory...
Could not find gozip for packaging. Using DotNetZip to package. This may cause problems preserving file permissions when using in a Linux based environment.
Uploading 2.3 KB [################################################################################]
Upload completed successfully.
```


