### PR TITLE
Updating dotnet templates to 3.1.1812.

### DIFF
--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -22,8 +22,8 @@ namespace Build
 
         public const string DotnetIsolatedItemTemplatesVersion = "3.1.1733";
         public const string DotnetIsolatedProjectTemplatesVersion = "3.1.1733";
-        public const string DotnetItemTemplatesVersion = "3.1.1648";
-        public const string DotnetProjectTemplatesVersion = "3.1.1648";
+        public const string DotnetItemTemplatesVersion = "3.1.1812";
+        public const string DotnetProjectTemplatesVersion = "3.1.1812";
         public const string TemplateJsonVersion = "3.1.1648";
 
         public static readonly string SrcProjectPath = Path.GetFullPath("../src/Azure.Functions.Cli/");


### PR DESCRIPTION
This update will pull in references to Microsoft.NET.Sdk.Functions 3.0.13.