### PR TITLE
fixing dotnet-version updates during publish

### DIFF
--- a/test/Azure.Functions.Cli.Tests/E2E/Helpers/RunConfiguration.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/Helpers/RunConfiguration.cs
@@ -18,7 +18,7 @@ namespace Azure.Functions.Cli.Tests.E2E.Helpers
         public string[] ErrorDoesntContain { get; set; } = Array.Empty<string>();
         public Action<string> PreTest { get; set; }
         public Func<string, Process, Task> Test { get; set; }
-        public TimeSpan CommandTimeout { get; set; } = TimeSpan.FromSeconds(20);
+        public TimeSpan CommandTimeout { get; set; } = TimeSpan.FromSeconds(40);
         public string CommandsStr => $"{string.Join(", ", Commands)}";
     }
 }

--- a/test/Azure.Functions.Cli.Tests/PublishActionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/PublishActionTests.cs
@@ -94,20 +94,50 @@ namespace Azure.Functions.Cli.Tests
 
             var setting = _helperService.UpdatedSettings.Single();
             Assert.Equal(Constants.LinuxFxVersion, setting.Key);
-            Assert.Equal("DOTNET-ISOLATED|5.0", setting.Value);
+            Assert.Equal("DOTNET-ISOLATED|6.0", setting.Value);
         }
 
         [Fact]
         public async Task NetFrameworkVersion_DotnetIsolated_Windows_Null()
         {
-            // If not specified, assume 5.0
+            // If not specified, assume 6.0
             var site = new Site("test");
 
             await PublishFunctionAppAction.UpdateFrameworkVersions(site, WorkerRuntime.dotnetIsolated, null, false, _helperService);
 
             var setting = _helperService.UpdatedSettings.Single();
             Assert.Equal(Constants.DotnetFrameworkVersion, setting.Key);
-            Assert.Equal("v5.0", setting.Value);
+            Assert.Equal("v6.0", setting.Value);
+        }
+
+        [Fact]
+        public async Task NetFrameworkVersion_Dotnet_Windows_Null()
+        {
+            var site = new Site("test")
+            {
+                NetFrameworkVersion = "v4.0"
+            };
+
+            // If not specified, assume 6.0
+            await PublishFunctionAppAction.UpdateFrameworkVersions(site, WorkerRuntime.dotnet, null, false, _helperService);
+
+            var setting = _helperService.UpdatedSettings.Single();
+            Assert.Equal(Constants.DotnetFrameworkVersion, setting.Key);
+            Assert.Equal("v6.0", setting.Value);
+        }
+
+        [Fact]
+        public async Task NetFrameworkVersion_Dotnet_Windows_NoOp()
+        {
+            var site = new Site("test")
+            {
+                NetFrameworkVersion = "v6.0"
+            };
+
+            await PublishFunctionAppAction.UpdateFrameworkVersions(site, WorkerRuntime.dotnet, null, false, _helperService);
+
+            // Should be a no-op as site is already v6.0
+            Assert.Null(_helperService.UpdatedSettings);
         }
 
         [Theory]


### PR DESCRIPTION
Fixes two issues related to dotnet-isolated publishing:
1. We would evaluate the `dotnet-version` twice.
2. If `dotnet-version` wasn't specified, it was rolling back to 5.0.

/cc @anthonychu that ran into this