### PR TITLE
Support secretless extensions 

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -377,10 +377,11 @@ namespace Azure.Functions.Cli.Actions.HostActions
                        
         internal static async Task CheckNonOptionalSettings(IEnumerable<KeyValuePair<string, string>> secrets, string scriptPath, bool skipAzureWebJobsStorageCheck = false)
         {
+            string storageConnectionKey = "AzureWebJobsStorage";
             try
             {
                 // FirstOrDefault returns a KeyValuePair<string, string> which is a struct so it can't be null.
-                var azureWebJobsStorage = secrets.FirstOrDefault(pair => pair.Key.Equals("AzureWebJobsStorage", StringComparison.OrdinalIgnoreCase)).Value;
+                var azureWebJobsStorage = secrets.FirstOrDefault(pair => pair.Key.Equals(storageConnectionKey, StringComparison.OrdinalIgnoreCase)).Value;
                 var functionJsonFiles = await FileSystemHelpers
                     .GetDirectories(scriptPath)
                     .Select(d => Path.Combine(d, "function.json"))
@@ -400,7 +401,8 @@ namespace Azure.Functions.Cli.Actions.HostActions
                     .Where(b => b.IndexOf("Trigger", StringComparison.OrdinalIgnoreCase) != -1)
                     .All(t => Constants.TriggersWithoutStorage.Any(tws => tws.Equals(t, StringComparison.OrdinalIgnoreCase)));
 
-                if (!skipAzureWebJobsStorageCheck && string.IsNullOrWhiteSpace(azureWebJobsStorage) && !allNonStorageTriggers)
+                if (!skipAzureWebJobsStorageCheck && string.IsNullOrWhiteSpace(azureWebJobsStorage) && 
+                    !StorageConnectionExists(secrets, storageConnectionKey) && !allNonStorageTriggers) 
                 {
                     throw new CliException($"Missing value for AzureWebJobsStorage in {SecretsManager.AppSettingsFileName}. " +
                         $"This is required for all triggers other than {string.Join(", ", Constants.TriggersWithoutStorage)}. "
@@ -439,6 +441,28 @@ namespace Azure.Functions.Cli.Actions.HostActions
                     ColoredConsole.WriteLine(e);
                 }
             }
+        }
+
+        internal static bool StorageConnectionExists(IEnumerable<KeyValuePair<string, string>> secrets, string connectionStringKey)
+        {
+            // convert secrets into IConfiguration object, check for storage connection in config section
+            var convertedEnv = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var kvp in secrets)
+            {
+                var convertedKey = kvp.Key.Replace("__", ":");
+                if (!convertedEnv.ContainsKey(convertedKey))
+                {
+                    convertedEnv.Add(convertedKey, kvp.Value);
+                }
+            }
+
+            var configuration = new ConfigurationBuilder().AddInMemoryCollection(convertedEnv).Build();
+            var connectionStringSection = configuration?.GetSection("ConnectionStrings").GetSection(connectionStringKey);
+            if (!connectionStringSection.Exists())
+            {
+                connectionStringSection = configuration?.GetSection(connectionStringKey);
+            }
+            return connectionStringSection.Exists();
         }
 
         private async Task<(Uri listenUri, Uri baseUri, X509Certificate2 cert)> Setup()

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -406,7 +406,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 {
                     throw new CliException($"Missing value for AzureWebJobsStorage in {SecretsManager.AppSettingsFileName}. " +
                         $"This is required for all triggers other than {string.Join(", ", Constants.TriggersWithoutStorage)}. "
-                        + $"You can run 'func azure functionapp fetch-app-settings <functionAppName>' or specify a connection string in {SecretsManager.AppSettingsFileName}.");
+                        + $"You can run 'func azure functionapp fetch-app-settings <functionAppName>', specify a connection string in {SecretsManager.AppSettingsFileName}, or use managed identity to authenticate.");
                 }
 
                 foreach ((var filePath, var functionJson) in functionsJsons)

--- a/test/Azure.Functions.Cli.Tests/ActionsTests/StartHostActionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/ActionsTests/StartHostActionTests.cs
@@ -79,8 +79,6 @@ namespace Azure.Functions.Cli.Tests.ActionsTests
             exception.Should().BeNull();
         }
 
-
-
         [Fact]
         public async Task CheckNonOptionalSettingsDoesntThrowOnMissingAzureWebJobsStorage()
         {

--- a/test/Azure.Functions.Cli.Tests/ActionsTests/StartHostActionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/ActionsTests/StartHostActionTests.cs
@@ -19,7 +19,7 @@ namespace Azure.Functions.Cli.Tests.ActionsTests
     public class StartHostActionTests : IDisposable
     {
         [SkippableFact]
-        public async Task CheckNonOptionalSettingsThrowsOnMissingAzureWebJobsStorage()
+        public async Task CheckNonOptionalSettingsThrowsOnMissingAzureWebJobsStorageAndManagedIdentity()
         {
             Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
                 reason: "Environment.CurrentDirectory throws in linux in test cases for some reason. Revisit this once we figure out why it's failing");
@@ -47,6 +47,41 @@ namespace Azure.Functions.Cli.Tests.ActionsTests
             exception.Message.Should().Contain($"Missing value for AzureWebJobsStorage in local.settings.json. " +
                 $"This is required for all triggers other than {string.Join(", ", Constants.TriggersWithoutStorage)}.");
         }
+
+        [Fact]
+        public async Task CheckNonOptionalSettingsDoesntThrowMissingStorageUsingManagedIdentity()
+        {
+
+            Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+                reason: "Environment.CurrentDirectory throws in linux in test cases for some reason. Revisit this once we figure out why it's failing");
+            var fileSystem = GetFakeFileSystem(new[]
+                {
+                ("x:\\folder1", "{'bindings': [{'type': 'blobTrigger'}]}"),
+                ("x:\\folder2", "{'bindings': [{'type': 'httpTrigger'}]}")
+            });
+
+            var secrets = new Dictionary<string, string>()
+            {
+                { "AzureWebJobsStorage:blobServiceUri", "myuri" },
+                { "AzureWebJobsStorage:queueServiceUri", "queueuri" }
+            };
+
+            FileSystemHelpers.Instance = fileSystem;
+
+            Exception exception = null;
+            try
+            {
+                await StartHostAction.CheckNonOptionalSettings(secrets, "x:\\");
+            }
+            catch (Exception e)
+            {
+                exception = e;
+            }
+
+            exception.Should().BeNull();
+        }
+
+
 
         [Fact]
         public async Task CheckNonOptionalSettingsDoesntThrowOnMissingAzureWebJobsStorage()

--- a/test/Azure.Functions.Cli.Tests/ActionsTests/StartHostActionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/ActionsTests/StartHostActionTests.cs
@@ -99,7 +99,7 @@ namespace Azure.Functions.Cli.Tests.ActionsTests
         public async Task CheckNonOptionalSettingsPrintsWarningForMissingSettings()
         {
             Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
-                reason: "Environment.CurrentDirectory throws in linux in test cases for some reason. Revisit this once we figure out why it's failling");
+                reason: "Environment.CurrentDirectory throws in linux in test cases for some reason. Revisit this once we figure out why it's failing");
 
             var fileSystem = GetFakeFileSystem(new[]
             {

--- a/test/Azure.Functions.Cli.Tests/ActionsTests/StartHostActionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/ActionsTests/StartHostActionTests.cs
@@ -51,7 +51,6 @@ namespace Azure.Functions.Cli.Tests.ActionsTests
         [Fact]
         public async Task CheckNonOptionalSettingsDoesntThrowMissingStorageUsingManagedIdentity()
         {
-
             Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
                 reason: "Environment.CurrentDirectory throws in linux in test cases for some reason. Revisit this once we figure out why it's failing");
             var fileSystem = GetFakeFileSystem(new[]
@@ -63,7 +62,7 @@ namespace Azure.Functions.Cli.Tests.ActionsTests
             var secrets = new Dictionary<string, string>()
             {
                 { "AzureWebJobsStorage:blobServiceUri", "myuri" },
-                { "AzureWebJobsStorage:queueServiceUri", "queueuri" }
+                { "AzureWebJobsStorage__queueServiceUri", "queueuri" }
             };
 
             FileSystemHelpers.Instance = fileSystem;
@@ -77,7 +76,6 @@ namespace Azure.Functions.Cli.Tests.ActionsTests
             {
                 exception = e;
             }
-
             exception.Should().BeNull();
         }
 


### PR DESCRIPTION
No longer throw warning when customer uses managed identity (rather than a connection string) to connect to service.

Fixes #2552 