### PR TITLE
Multi-stage docker builds for python

### DIFF
--- a/src/Azure.Functions.Cli/StaticResources/Dockerfile.python36
+++ b/src/Azure.Functions.Cli/StaticResources/Dockerfile.python36
@@ -1,11 +1,16 @@
-# To enable ssh & remote debugging on app service change the base image to the one below
-# FROM mcr.microsoft.com/azure-functions/python:3.0-python3.6-appservice
-FROM mcr.microsoft.com/azure-functions/python:3.0-python3.6
+FROM mcr.microsoft.com/azure-functions/python:3.0-python3.6-buildenv AS installer-env
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 
 COPY requirements.txt /
-RUN pip install -r /requirements.txt
+RUN pip install --user -r /requirements.txt
 
 COPY . /home/site/wwwroot
+
+# To enable ssh & remote debugging on app service change the base image to the one below
+# FROM mcr.microsoft.com/azure-functions/python:3.0-python3.6-appservice
+FROM mcr.microsoft.com/azure-functions/python:3.0-python3.6
+
+COPY --from=installer-env /home/.local /home/.local
+ENV PATH=/home/.local/bin:$PATH

--- a/src/Azure.Functions.Cli/StaticResources/Dockerfile.python37
+++ b/src/Azure.Functions.Cli/StaticResources/Dockerfile.python37
@@ -1,11 +1,16 @@
-﻿# To enable ssh & remote debugging on app service change the base image to the one below
-# FROM mcr.microsoft.com/azure-functions/python:3.0-python3.7-appservice
-FROM mcr.microsoft.com/azure-functions/python:3.0-python3.7
+﻿FROM mcr.microsoft.com/azure-functions/python:3.0-python3.7-buildenv AS installer-env
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 
 COPY requirements.txt /
-RUN pip install -r /requirements.txt
+RUN pip install --user -r /requirements.txt
 
 COPY . /home/site/wwwroot
+
+# To enable ssh & remote debugging on app service change the base image to the one below
+# FROM mcr.microsoft.com/azure-functions/python:3.0-python3.7-appservice
+FROM mcr.microsoft.com/azure-functions/python:3.0-python3.7
+
+COPY --from=installer-env /home/.local /home/.local
+ENV PATH=/home/.local/bin:$PATH

--- a/src/Azure.Functions.Cli/StaticResources/Dockerfile.python38
+++ b/src/Azure.Functions.Cli/StaticResources/Dockerfile.python38
@@ -1,11 +1,16 @@
-﻿# To enable ssh & remote debugging on app service change the base image to the one below
-# FROM mcr.microsoft.com/azure-functions/python:3.0-python3.8-appservice
-FROM mcr.microsoft.com/azure-functions/python:3.0-python3.8
+﻿FROM mcr.microsoft.com/azure-functions/python:3.0-python3.8-buildenv AS installer-env
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 
 COPY requirements.txt /
-RUN pip install -r /requirements.txt
+RUN pip install --user -r /requirements.txt
 
 COPY . /home/site/wwwroot
+
+# To enable ssh & remote debugging on app service change the base image to the one below
+# FROM mcr.microsoft.com/azure-functions/python:3.0-python3.8-appservice
+FROM mcr.microsoft.com/azure-functions/python:3.0-python3.8
+
+COPY --from=installer-env /home/.local /home/.local
+ENV PATH=/home/.local/bin:$PATH

--- a/src/Azure.Functions.Cli/StaticResources/Dockerfile.python39
+++ b/src/Azure.Functions.Cli/StaticResources/Dockerfile.python39
@@ -1,11 +1,16 @@
-﻿# To enable ssh & remote debugging on app service change the base image to the one below
-# FROM mcr.microsoft.com/azure-functions/python:3.0-python3.9-appservice
-FROM mcr.microsoft.com/azure-functions/python:3.0-python3.9
+﻿FROM mcr.microsoft.com/azure-functions/python:3.0-python3.9-buildenv AS installer-env
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 
 COPY requirements.txt /
-RUN pip install -r /requirements.txt
+RUN pip install --user -r /requirements.txt
 
 COPY . /home/site/wwwroot
+
+# To enable ssh & remote debugging on app service change the base image to the one below
+# FROM mcr.microsoft.com/azure-functions/python:3.0-python3.9-appservice
+FROM mcr.microsoft.com/azure-functions/python:3.0-python3.9
+
+COPY --from=installer-env /home/.local /home/.local
+ENV PATH=/home/.local/bin:$PATH


### PR DESCRIPTION
More closely match what happens when publishing a python function app.

Using the `-buildenv` image for doing pip installs. Without this packages like `pyodbc` fail to install as there is no gcc installed in function rumtime image.