### PR TITLE
Use next available port when the default port is already used

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -91,7 +91,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
             Parser
                 .Setup<int>('p', "port")
                 .WithDescription($"Local port to listen on. Default: {DefaultPort}")
-                .SetDefault(hostSettings.LocalHttpPort == default(int) ? DefaultPort : hostSettings.LocalHttpPort)
+                .SetDefault(hostSettings.LocalHttpPort == default(int) ? NetworkHelpers.GetNextAvailablePort(DefaultPort) : hostSettings.LocalHttpPort)
                 .Callback(p => Port = p);
 
             Parser

--- a/test/Azure.Functions.Cli.Tests/NetworkHelpersTests.cs
+++ b/test/Azure.Functions.Cli.Tests/NetworkHelpersTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Net.Sockets;
+using Xunit;
+using Azure.Functions.Cli.Helpers;
+using Xunit.Abstractions;
+
+namespace Azure.Functions.Cli.Tests.E2E
+{
+  public class NetworkHelpersTests : BaseE2ETest
+  {
+    public NetworkHelpersTests(ITestOutputHelper output) : base(output) { }
+
+    [Fact]
+    public void IsPortAvailable_PortIsAvailable_ReturnsTrue()
+    {
+      int port = NetworkHelpers.GetAvailablePort();
+      bool result = NetworkHelpers.IsPortAvailable(port);
+      Assert.True(result);
+    }
+
+    [Fact]
+    public void IsPortAvailable_PortIsNotAvailable_ReturnsFalse()
+    {
+      int port = NetworkHelpers.GetAvailablePort();
+      var listener = new TcpListener(System.Net.IPAddress.Any, port);
+      listener.Start();
+
+      bool result = NetworkHelpers.IsPortAvailable(port);
+      listener.Stop();
+
+      Assert.False(result);
+    }
+
+    [Fact]
+    public void GetAvailablePort_ReturnsValidPort()
+    {
+      int port = NetworkHelpers.GetAvailablePort();
+      Assert.InRange(port, 1024, 65535);
+    }
+
+    [Fact]
+    public void GetNextAvailablePort_ValidStartPort_ReturnsNextAvailablePort()
+    {
+      int startPort = 5000;
+      int port = NetworkHelpers.GetNextAvailablePort(startPort);
+      Assert.InRange(port, startPort, 65535);
+    }
+
+    [Fact]
+    public void GetNextAvailablePort_InvalidStartPort_ThrowsArgumentOutOfRangeException()
+    {
+      Assert.Throws<ArgumentOutOfRangeException>(() => NetworkHelpers.GetNextAvailablePort(1023));
+      Assert.Throws<ArgumentOutOfRangeException>(() => NetworkHelpers.GetNextAvailablePort(65536));
+    }
+  }
+}


### PR DESCRIPTION
When working with multiple function apps locally, every function host apart from the first needs to have a different port manually set either via the command line argument `--port` or the `Host.LocalHttpPort` property in `local.settings.json`. Also, in some cases the default port might be blocked with another process (sometimes an older `func` itself that didn't terminate).

This PR adds support to pick up the next available port (7072, 7073, ...) when none is provided. If a port is defined in either place mentioned above, this would not do anything.

One known issue is that multiple function apps run at the exact same time might end up picking the same port, causing one of them to error out. This is present even today with the static default port, primarily because the validation is done before the host starts up.