### PR TITLE
adding 3.1 to build in dotnet-isolated dockerfile

### DIFF
--- a/src/Azure.Functions.Cli/StaticResources/Dockerfile.dotnetIsolated
+++ b/src/Azure.Functions.Cli/StaticResources/Dockerfile.dotnetIsolated
@@ -1,5 +1,8 @@
 FROM mcr.microsoft.com/dotnet/sdk:5.0 AS installer-env
 
+# Build requires 3.1 SDK
+COPY --from=mcr.microsoft.com/dotnet/core/sdk:3.1 /usr/share/dotnet /usr/share/dotnet
+
 COPY . /src/dotnet-function-app
 RUN cd /src/dotnet-function-app && \
     mkdir -p /home/site/wwwroot && \


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-dotnet-worker/issues/519