### PR TITLE
Added --debug command line argument

### DIFF
--- a/src/Azure.Functions.Cli/Program.cs
+++ b/src/Azure.Functions.Cli/Program.cs
@@ -16,7 +16,7 @@ namespace Azure.Functions.Cli
         {
             FirstTimeCliExperience();
             SetupGlobalExceptionHandler();
-            SetCoreToolsEnvironmentVaraibles(args);
+            SetCoreToolsEnvironmentVariables(args);
             ConsoleApp.Run<Program>(args, InitializeAutofacContainer());
         }
 
@@ -44,7 +44,7 @@ namespace Azure.Functions.Cli
             }
         }
 
-        private static void SetCoreToolsEnvironmentVaraibles(string[] args)
+        private static void SetCoreToolsEnvironmentVariables(string[] args)
         {
             EnvironmentHelper.SetEnvironmentVariableAsBoolIfNotExists(Constants.FunctionsCoreToolsEnvironment);
             EnvironmentHelper.SetEnvironmentVariableAsBoolIfNotExists(Constants.SequentialJobHostRestart);


### PR DESCRIPTION
Added "--debug" argument so that debug mode could be run without setting environment variable CLI_DEBUG=1. Added command without removing environment variable functionality. 

Resolves #1336 