### PR TITLE
Add PowerShell Worker 7.2, update PowerShell Worker 7.0, and remove PowerShell Worker 6

### DIFF
--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -59,17 +59,17 @@ namespace Build
         public static readonly Dictionary<string, Dictionary<string, string[]>> ToolsRuntimeToPowershellRuntimes = new Dictionary<string, Dictionary<string, string[]>>
         {
             {
-                "6",
+                "7",
                 new Dictionary<string, string[]>
                 {
                     { "win-x86", _winPowershellRuntimes },
                     { "win-x64", _winPowershellRuntimes },
                     { "linux-x64", new [] { "linux", "linux-x64", "unix", "linux-musl-x64" } },
-                    { "osx-x64", new [] { "osx", "unix" } }
+                    { "osx-x64", new [] { "osx", "osx-x64", "unix" } }
                 }
             },
             {
-                "7",
+                "7.2",
                 new Dictionary<string, string[]>
                 {
                     { "win-x86", _winPowershellRuntimes },

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -158,7 +158,7 @@
   <ItemGroup Condition="'$(NoWorkers)' != 'true'">
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.8.2-SNAPSHOT" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.1.2" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7" Version="3.0.833" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" Version="4.0.1049" />
     <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="3.1.2.5" />
   </ItemGroup>
 

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -159,6 +159,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.8.2-SNAPSHOT" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.1.2" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" Version="4.0.1049" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.2" Version="4.0.988" />
     <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="3.1.2.5" />
   </ItemGroup>
 

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -158,7 +158,6 @@
   <ItemGroup Condition="'$(NoWorkers)' != 'true'">
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.8.2-SNAPSHOT" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.1.2" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS6" Version="3.0.630" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7" Version="3.0.833" />
     <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="3.1.2.5" />
   </ItemGroup>


### PR DESCRIPTION
This PR contains the following changes:
* Add PowerShell Worker 7.2 (package version `4.0.988`)
* Update PowerShell Worker 7.0 (package version `4.0.1049`)
* Remove PowerShell Worker 6