### PR TITLE
Adding dapr triggers to not require storage in core-tools

### DIFF
--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -70,7 +70,7 @@ namespace Azure.Functions.Cli.Common
             { WorkerRuntime.powershell, new [] { "mcr.microsoft.com/azure-functions/powershell", "microsoft/azure-functions-powershell" } }
         };
 
-        public static readonly string[] TriggersWithoutStorage = new[] { "httptrigger", "kafkatrigger", "rabbitmqtrigger" };
+        public static readonly string[] TriggersWithoutStorage = new[] { "httptrigger", "kafkatrigger", "rabbitmqtrigger", "daprBindingTrigger", "daprServiceInvocationTrigger", "daprTopicTrigger" };
 
         public static class Errors
         {


### PR DESCRIPTION
We launched 3 new triggers that don't require a storage account that are blocked in core tools today. This PR should unblock them. 


Fixes #2065 