### PR TITLE
Update integration tests build logic to account for multiple package versions

### DIFF
--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -677,6 +677,8 @@ namespace Build
                         return package;
                     }
                 }
+
+                throw new Exception($"Failed to find {name} package for major version {majorVersion}.");
             }
 
             return packageInfo;

--- a/build/Package.cs
+++ b/build/Package.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Build
+{
+    internal class Package
+    {
+        public string Name { get; set; }
+        public string MajorVersion { get; set; }
+    }
+}


### PR DESCRIPTION
Update integration tests build logic to account for multiple package versions.

This is the old package list format:
```
[
    "Microsoft.Azure.WebJobs.Script",
    "Microsoft.Azure.WebJobs.Script.Grpc",
    "Microsoft.Azure.WebJobs.Script.WebHost",
    "Microsoft.Azure.Functions.NodeJsWorker",
    "Microsoft.Azure.Functions.JavaWorker",
    "Microsoft.Azure.Functions.PowerShellWorker.PS7",
    "Microsoft.Azure.Functions.PythonWorker"
]
```

This is the new list format with key value pairs for the name and version: 
```
[
  {
    "Name": "Microsoft.Azure.WebJobs.Script",
    "MajorVersion": "3"
  },
  {
    "Name": "Microsoft.Azure.WebJobs.Script.Grpc",
    "MajorVersion": "3"
  },
  {
    "Name": "Microsoft.Azure.WebJobs.Script.WebHost",
    "MajorVersion": "3"
  },
  {
    "Name": "Microsoft.Azure.Functions.NodeJsWorker",
    "MajorVersion": "2"
  },
  {
    "Name": "Microsoft.Azure.Functions.JavaWorker",
    "MajorVersion": null
  },
  {
    "Name": "Microsoft.Azure.Functions.PowerShellWorker.PS7",
    "MajorVersion": null
  },
  {
    "Name": "Microsoft.Azure.Functions.PythonWorker",
    "MajorVersion": null
  }
]
```
