### PR TITLE
Update parsing logic for the output of nuget list command

### DIFF
--- a/build/PackageInfo.cs
+++ b/build/PackageInfo.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Build
+{
+    internal class PackageInfo
+    {
+        public PackageInfo(string Name, string Version)
+        {
+            this.Name = Name;
+            this.Version = Version;
+        }
+
+        public string Name { get; set; }
+        public string Version { get; set; }
+    }
+}


### PR DESCRIPTION
Update parsing logic for the output of nuget list command

When trying to retrieve the available versions for a single package, `nuget list` returns multiple versions. See example below:

```powershell
nuget list "Microsoft.Azure.Functions.PowerShellWorker.PS7" -source "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsPreRelease/nuget/v3/index.json"
Microsoft.Azure.Functions.PowerShellWorker.PS7 3.0.1008
Microsoft.Azure.Functions.PowerShellWorker.PS7.2 4.0.1127
```
I am updating the parse logic to account for this case and match the exact package name. 