### PR TITLE
Copy into src folder directly to match path of pdb

### DIFF
--- a/src/Azure.Functions.Cli/StaticResources/Dockerfile.dotnet
+++ b/src/Azure.Functions.Cli/StaticResources/Dockerfile.dotnet
@@ -1,7 +1,7 @@
 FROM microsoft/dotnet:2.2-sdk AS installer-env
 
-COPY . /src/dotnet-function-app
-RUN cd /src/dotnet-function-app && \
+COPY . /src
+RUN cd /src && \
     mkdir -p /home/site/wwwroot && \
     dotnet publish *.csproj --output /home/site/wwwroot
 


### PR DESCRIPTION
### PDB symbol path don't add up when debugging (attaching) Azure Functions inside a container
It looks like the paths don't match when you attach to a running container hosting Azure Functions.
resolves #2784

### Pull request checklist

* [X] My changes **do not** require documentation changes
* [X] My changes **should not** be added to the release notes for the next release
* [X] My changes **do not** need to be backported to a previous version
* [ ] I have added all required tests (Unit tests, E2E tests)
