### PR TITLE
Add filter to suppress shared mem warnings locally

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -224,6 +224,13 @@ namespace Azure.Functions.Cli.Actions.HostActions
                     });
                     // This is needed to filter system logs only for known categories
                     loggingBuilder.AddDefaultWebJobsFilters<ColoredConsoleLoggerProvider>(LogLevel.Trace);
+
+                    // temporarily suppress shared memory warnings
+                    loggingBuilder.AddFilter((category, logLevel) => {
+                        var isSharedMemoryWarning = logLevel == LogLevel.Warning
+                            && string.Equals(category, "Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer.MemoryMappedFileAccessor");
+                        return !isSharedMemoryWarning;
+                    });
                 })
                 .ConfigureServices((context, services) =>
                 {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Temporary workaround for:

#2600 
#2758 

Suppresses these `LogWarning` messages when running locally:
- https://github.com/Azure/azure-functions-host/blob/12618ff4c0147ab68c30065ce49e865af6d36e51/src/WebJobs.Script/Workers/SharedMemoryDataTransfer/MemoryMappedFileAccessorUnix.cs#L135
- https://github.com/Azure/azure-functions-host/blob/12618ff4c0147ab68c30065ce49e865af6d36e51/src/WebJobs.Script/Workers/SharedMemoryDataTransfer/MemoryMappedFileAccessorUnix.cs#L180
- https://github.com/Azure/azure-functions-host/blob/12618ff4c0147ab68c30065ce49e865af6d36e51/src/WebJobs.Script/Workers/SharedMemoryDataTransfer/MemoryMappedFileAccessorUnix.cs#L194
- https://github.com/Azure/azure-functions-host/blob/12618ff4c0147ab68c30065ce49e865af6d36e51/src/WebJobs.Script/Workers/SharedMemoryDataTransfer/MemoryMappedFileAccessorUnix.cs#L199
- https://github.com/Azure/azure-functions-host/blob/12618ff4c0147ab68c30065ce49e865af6d36e51/src/WebJobs.Script/Workers/SharedMemoryDataTransfer/MemoryMappedFileAccessorUnix.cs#L276

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [x] Otherwise: Backport tracked by issue #2803
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
