### PR TITLE
Update Node.js package.json templates for `func init`

### DIFF
--- a/src/Azure.Functions.Cli/StaticResources/javascriptPackage.json
+++ b/src/Azure.Functions.Cli/StaticResources/javascriptPackage.json
@@ -1,9 +1,11 @@
 {
   "name": "",
-  "version": "",
+  "version": "1.0.0",
   "description": "",
-  "scripts" : {
+  "scripts": {
+    "start": "func start",
     "test": "echo \"No tests yet...\""
   },
-  "author": ""
+  "dependencies": {},
+  "devDependencies": {}
 }

--- a/src/Azure.Functions.Cli/StaticResources/package.json
+++ b/src/Azure.Functions.Cli/StaticResources/package.json
@@ -1,19 +1,17 @@
 {
   "name": "",
-  "version": "",
-  "scripts" : {
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
     "build": "tsc",
-    "build:production": "npm run prestart && npm prune --production",
-    "watch": "tsc --w",
-    "prestart": "npm run build && func extensions install",
-    "start:host": "func start",
-    "start": "npm-run-all --parallel start:host watch",
+    "watch": "tsc -w",
+    "prestart": "npm run build",
+    "start": "func start",
     "test": "echo \"No tests yet...\""
   },
-  "description": "",
+  "dependencies": {},
   "devDependencies": {
-    "@azure/functions": "^1.0.1-beta1",
-    "npm-run-all": "^4.1.5",
-    "typescript": "^3.3.3"
+    "@azure/functions": "^3.0.0",
+    "typescript": "^4.0.0"
   }
 }


### PR DESCRIPTION
- Updated the version of `@azure/functions` to v3 (see [here](https://github.com/Azure/azure-functions-nodejs-worker/issues/428) for versioning info). This was the main motivation for the PR
- Simplified the scripts. For example, `func extensions install` is no longer necessary. Also I chose to get rid of `npm-run-all`. This [package](https://www.npmjs.com/package/npm-run-all) has not been updated in 3 years and has 9 of its own dependencies, both things I avoid when adding npm packages. IMO its better for the template to be clean & simple
- Made it so that it exactly matches the templates users get in VS Code

I will make a similar PR to the v3.x branch.