### PR TITLE
Port "Update Node.js package.json templates for func init" to v3.x

### DIFF
--- a/src/Azure.Functions.Cli/StaticResources/javascriptPackage.json
+++ b/src/Azure.Functions.Cli/StaticResources/javascriptPackage.json
@@ -1,9 +1,11 @@
 {
   "name": "",
-  "version": "",
+  "version": "1.0.0",
   "description": "",
-  "scripts" : {
+  "scripts": {
+    "start": "func start",
     "test": "echo \"No tests yet...\""
   },
-  "author": ""
+  "dependencies": {},
+  "devDependencies": {}
 }

--- a/src/Azure.Functions.Cli/StaticResources/package.json
+++ b/src/Azure.Functions.Cli/StaticResources/package.json
@@ -1,19 +1,17 @@
 {
   "name": "",
-  "version": "",
-  "scripts" : {
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
     "build": "tsc",
-    "build:production": "npm run prestart && npm prune --production",
-    "watch": "tsc --w",
-    "prestart": "npm run build && func extensions install",
-    "start:host": "func start",
-    "start": "npm-run-all --parallel start:host watch",
+    "watch": "tsc -w",
+    "prestart": "npm run build",
+    "start": "func start",
     "test": "echo \"No tests yet...\""
   },
-  "description": "",
+  "dependencies": {},
   "devDependencies": {
-    "@azure/functions": "^1.0.1-beta1",
-    "npm-run-all": "^4.1.5",
-    "typescript": "^3.3.3"
+    "@azure/functions": "^3.0.0",
+    "typescript": "^4.0.0"
   }
 }

--- a/src/Azure.Functions.Cli/StaticResources/package.json
+++ b/src/Azure.Functions.Cli/StaticResources/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@azure/functions": "^3.0.0",
+    "@azure/functions": "^2.0.0",
     "typescript": "^4.0.0"
   }
 }


### PR DESCRIPTION
Only difference is `@azure/functions` version should be 2 instead of 3 (see [here](https://github.com/Azure/azure-functions-nodejs-worker/issues/428) for versioning info)

Original PR: https://github.com/Azure/azure-functions-core-tools/pull/2852