### PR TITLE
Ignore Azurite Files in Function App (CLI v4)

### DIFF
--- a/src/Azure.Functions.Cli/StaticResources/gitignore
+++ b/src/Azure.Functions.Cli/StaticResources/gitignore
@@ -41,3 +41,8 @@ venv.bak/
 __pycache__/
 *.py[cod]
 *$py.class
+
+# Azurite artifacts
+__blobstorage__
+__queuestorage__
+__azurite_db*__.json


### PR DESCRIPTION
### Issue describing the changes in this PR

When initializing an Azure Functions via the CLI and switching to VSCode for development the Azurite Extension in Visual Studio Code (<https://marketplace.visualstudio.com/items?itemName=Azurite.azurite>) often gets used for storage emulation in local development. The extension creates several files in the Azure Functions project directory that are only relevant for local development. In analogy to e.g. `local.settings.json` they should be ignored by git by default.
It would be very comfortable if this would also be the case for the CLI.

This pull request contains the required enhancement `.gitignore` file as a proposal to cover the scenario described above.

### Pull request checklist

* [X] My changes **do not** require documentation changes
* [X ] My changes **should not** be added to the release notes for the next release
* [X] My changes **do not** need to be backported to a previous version