### PR TITLE
Add SBOM generation task to V2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,17 +3,16 @@ name: $(Build.SourceBranchName)_$(Build.Reason)
 pr:
   branches:
     include:
-    - master
     - dev
 
 trigger:
   branches:
     include:
     - dev
-    - master
 
 pool:
-  vmImage: 'vs2017-win2016'
+  name: '1ES-Hosted-AzFunc'
+  vmImage: 'MMS2022TLS'
 
 variables:
   devops_buildNumber: $[counter(format(''), 1500)]
@@ -22,11 +21,33 @@ variables:
 
 steps:
 - pwsh: |
+      $isReleaseBuild = $false
+      if ($env:BuildSourceBranchName -like "release_2.0*")
+      {
+          $isReleaseBuild = $true
+      }
+      Write-Host "##vso[task.setvariable variable=IsReleaseBuild]$isReleaseBuild"
+      Write-Host "IsReleaseBuild: $isReleaseBuild"
+    displayName: 'Set IsReleaseBuild variable'
+    env:
+      BuildSourceBranchName: $(Build.SourceBranchName)
+- pwsh: |
     Write-Host "Target branch: '$(APPVEYOR_REPO_BRANCH)'"
   displayName: Set up environment variables
 - task: NodeTool@0
   inputs:
     versionSpec: '10.x'
+- pwsh: |
+      Import-Module ".\pipelineUtilities.psm1" -Force
+      Install-Dotnet
+    displayName: 'Install .NET 2.2'
+- pwsh: |
+    Import-Module ".\pipelineUtilities.psm1" -Force
+    Install-SBOMUtil -SBOMUtilSASUrl $env:SBOMUtilSASUrl
+  env:
+    SBOMUtilSASUrl: $(SBOMUtilSASUrl)
+  condition: or(eq(variables['IsReleaseBuild'], 'true'), eq(variables['SimulateReleaseBuild'], 'true'))
+  displayName: 'Install SBOM ManifestTool'
 - task: NuGetToolInstaller@1
   inputs:
     versionSpec:
@@ -42,22 +63,12 @@ steps:
       $accessToken = (az account get-access-token --query "accessToken" | % { $_.Trim('"') })
       echo "##vso[task.setvariable variable=azure_management_access_token]$accessToken"
 - pwsh: |
-    # Set DotNetPath
-    $sdkBasePath = dotnet --info | Where-Object {$_ -match "Base Path"} | ForEach-Object {($_ -replace '\s+Base Path:','').trim()}
-    $dotnetPath = Split-Path (Split-Path $sdkBasePath)
-    Write-Host "dotnet path: $dotnetPath"
-    Write-Host "##vso[task.setvariable variable=DotNetPath]$dotnetPath"
-  displayName: 'Set DotNetPath'
-- task: UseDotNet@2
-  inputs:
-    packageType: 'sdk'
-    version: '2.2.207'
-    installationPath: $(DotNetPath)
-- pwsh: |
     .\build.ps1
   env:
     AzureBlobSigningConnectionString: $(AzureBlobSigningConnectionString)
     BuildArtifactsStorage: $(BuildArtifactsStorage)
+    IsReleaseBuild: $(IsReleaseBuild)
+    SimulateReleaseBuild: $(SimulateReleaseBuild)
     DURABLE_STORAGE_CONNECTION: $(DURABLE_STORAGE_CONNECTION)
     TELEMETRY_INSTRUMENTATION_KEY: $(TELEMETRY_INSTRUMENTATION_KEY)
   displayName: 'Executing build script'
@@ -94,7 +105,7 @@ steps:
     SessionTimeout: '60'
     MaxConcurrency: '50'
     MaxRetryAttempts: '5'
-  condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['Build.SourceBranch'], 'refs/heads/release/3.0')))
+  condition: and(succeeded(), or(eq(variables['IsReleaseBuild'], 'true'), eq(variables['SimulateReleaseBuild'], 'true')))
 - task: EsrpCodeSigning@1
   displayName: 'Third party signing'
   inputs:
@@ -129,7 +140,7 @@ steps:
     SessionTimeout: '60'
     MaxConcurrency: '50'
     MaxRetryAttempts: '5'
-  condition: and(succeeded(),or (eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['Build.SourceBranch'], 'refs/heads/release/3.0')))
+  condition: and(succeeded(), or(eq(variables['IsReleaseBuild'], 'true'), eq(variables['SimulateReleaseBuild'], 'true')))
 - pwsh: |
     .\repackageBinaries.ps1
   displayName: Repackage signed binaries
@@ -138,14 +149,14 @@ steps:
     BuildArtifactsStorage: $(BuildArtifactsStorage)
     DURABLE_STORAGE_CONNECTION: $(DURABLE_STORAGE_CONNECTION)
     TELEMETRY_INSTRUMENTATION_KEY: $(TELEMETRY_INSTRUMENTATION_KEY)
-  condition: and(succeeded(),or (eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['Build.SourceBranch'], 'refs/heads/release/3.0')))
+  condition: and(succeeded(), or(eq(variables['IsReleaseBuild'], 'true'), eq(variables['SimulateReleaseBuild'], 'true')))
 - task: DotNetCoreCLI@2
   inputs:
     command: 'run'
     workingDirectory: '.\build'
     arguments: 'TestSignedArtifacts --signTest'
   displayName: 'Verify signed binaries'
-  condition: and(succeeded(),or (eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['Build.SourceBranch'], 'refs/heads/release/3.0')))
+  condition: and(succeeded(), or(eq(variables['IsReleaseBuild'], 'true'), eq(variables['SimulateReleaseBuild'], 'true')))
 - pwsh: |
     .\generateSha.ps1
   displayName: 'Generate sha files'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,9 +38,9 @@ steps:
   inputs:
     versionSpec: '10.x'
 - pwsh: |
-      Import-Module ".\pipelineUtilities.psm1" -Force
-      Install-Dotnet
-    displayName: 'Install .NET 2.2'
+    Import-Module ".\pipelineUtilities.psm1" -Force
+    Install-Dotnet
+  displayName: 'Install .NET 2.2'
 - pwsh: |
     Import-Module ".\pipelineUtilities.psm1" -Force
     Install-SBOMUtil -SBOMUtilSASUrl $env:SBOMUtilSASUrl

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,16 +21,16 @@ variables:
 
 steps:
 - pwsh: |
-      $isReleaseBuild = $false
-      if ($env:BuildSourceBranchName -like "release_2.0*")
-      {
-          $isReleaseBuild = $true
-      }
-      Write-Host "##vso[task.setvariable variable=IsReleaseBuild]$isReleaseBuild"
-      Write-Host "IsReleaseBuild: $isReleaseBuild"
-    displayName: 'Set IsReleaseBuild variable'
-    env:
-      BuildSourceBranchName: $(Build.SourceBranchName)
+    $isReleaseBuild = $false
+    if ($env:BuildSourceBranchName -like "release_2.0*")
+    {
+        $isReleaseBuild = $true
+    }
+    Write-Host "##vso[task.setvariable variable=IsReleaseBuild]$isReleaseBuild"
+    Write-Host "IsReleaseBuild: $isReleaseBuild"
+  displayName: 'Set IsReleaseBuild variable'
+  env:
+    BuildSourceBranchName: $(Build.SourceBranchName)
 - pwsh: |
     Write-Host "Target branch: '$(APPVEYOR_REPO_BRANCH)'"
   displayName: Set up environment variables

--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,3 @@
-
 if ($env:APPVEYOR_REPO_BRANCH -eq "disabled") {
     Set-Location ".\src\Azure.Functions.Cli"
     $result = Invoke-Expression -Command "NuGet list Microsoft.Azure.Functions.JavaWorker -Source  https://ci.appveyor.com/NuGet/azure-functions-java-worker-fejnnsvmrkqg -PreRelease"
@@ -26,5 +25,25 @@ else {
     Set-Location ".\build"
 }
 
-Invoke-Expression -Command  "dotnet run --ci"
+$buildCommand = $null
+
+$isReleaseBuild = $null
+$simulateReleaseBuild = $null
+if (-not([bool]::TryParse($env:IsReleaseBuild, [ref] $isReleaseBuild) -and
+    [bool]::TryParse($env:SimulateReleaseBuild, [ref] $simulateReleaseBuild)))
+{
+    throw "IsReleaseBuild and GenerateSBOM can only be set to true or false."
+}
+
+if ($isReleaseBuild -or $simulateReleaseBuild)
+{
+    $buildCommand = "dotnet run --ci --generateSBOM"
+}
+else
+{
+    $buildCommand = "dotnet run --ci"
+}
+
+Write-Host "Running $buildCommand"
+Invoke-Expression -Command $buildCommand
 if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)  }

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -574,36 +574,6 @@ namespace Build
             }
         }
 
-        public static void DotnetPublishForNupkg()
-        {
-            // By default, this publishes to the /bin/Release/$targetFramework$/publish
-            Shell.Run("dotnet", $"publish {Settings.ProjectFile} " +
-                                $"/p:BuildNumber=\"{Settings.BuildNumber}\" " +
-                                $"/p:NoWorkers=\"true\" " +
-                                $"/p:CommitHash=\"{Settings.CommitId}\" " +
-                                (string.IsNullOrEmpty(Settings.IntegrationBuildNumber) ? string.Empty : $"/p:IntegrationBuildNumber=\"{Settings.IntegrationBuildNumber}\" ") +
-                                $"-c Release");
-        }
-
-        public static void GenerateSBOMManifestForNupkg()
-        {
-            Directory.CreateDirectory(Settings.SBOMManifestTelemetryDir);
-            var packageName = $"Microsoft.Azure.Functions.CoreTools";
-            var buildPath = Settings.NupkgPublishDir;
-            var manifestFolderPath = Path.Combine(buildPath, "_manifest");
-            var telemetryFilePath = Path.Combine(Settings.SBOMManifestTelemetryDir, Guid.NewGuid().ToString() + ".json");
-
-            // Delete the manifest folder if it exists
-            if (Directory.Exists(manifestFolderPath))
-            {
-                Directory.Delete(manifestFolderPath, recursive: true);
-            }
-
-            Shell.Run("dotnet",
-                    $"{Settings.SBOMManifestToolPath} generate -PackageName {packageName} -BuildDropPath {buildPath}"
-                    + $" -BuildComponentPath {buildPath} -Verbosity Information -t {telemetryFilePath}");
-        }
-
         public static void DeleteSBOMTelemetryFolder()
         {
             Directory.Delete(Settings.SBOMManifestTelemetryDir, recursive: true);

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -18,7 +18,7 @@ namespace Build
                 .Then(LogIntoAzure, skip: !args.Contains("--ci"))
                 .Then(RestorePackages)
                 .Then(ReplaceTelemetryInstrumentationKey, skip: !args.Contains("--ci"))
-                .Then(DotnetPublish)
+                .Then(DotnetPublishForZips)
                 .Then(FilterPowershellRuntimes)
                 .Then(AddDistLib)
                 .Then(AddTemplatesNupkgs)
@@ -27,7 +27,9 @@ namespace Build
                 .Then(TestPreSignedArtifacts, skip: !args.Contains("--ci"))
                 .Then(CopyBinariesToSign, skip: !args.Contains("--ci"))
                 .Then(Test)
+                .Then(GenerateSBOMManifestForZips, skip: !args.Contains("--generateSBOM"))
                 .Then(Zip)
+                .Then(DeleteSBOMTelemetryFolder, skip: !args.Contains("--generateSBOM"))
                 .Then(UploadToStorage, skip: !args.Contains("--ci"))
                 .Run();
         }

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -18,7 +18,7 @@ namespace Build
                 .Then(LogIntoAzure, skip: !args.Contains("--ci"))
                 .Then(RestorePackages)
                 .Then(ReplaceTelemetryInstrumentationKey, skip: !args.Contains("--ci"))
-                .Then(DotnetPublishForZips)
+                .Then(DotnetPublish)
                 .Then(FilterPowershellRuntimes)
                 .Then(AddDistLib)
                 .Then(AddTemplatesNupkgs)

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -78,7 +78,7 @@ namespace Build
 
         public static readonly string SBOMManifestTelemetryDir = Path.Combine(OutputDir, "SBOMManifestTelemetry");
         
-        public static string TargetFramework = "netcoreapp3.1";
+        public static string TargetFramework = "netcoreapp2.2";
 
         public static readonly string NupkgPublishDir = Path.GetFullPath($"../src/Azure.Functions.Cli/bin/Release/{TargetFramework}/publish");
         

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -24,6 +24,8 @@ namespace Build
         public const string ProjectTemplatesVersion = "2.1.1579";
         public const string TemplateJsonVersion = "2.1.1579";
 
+        public static readonly string SBOMManifestToolPath = Path.GetFullPath("../ManifestTool/Microsoft.ManifestTool.dll");
+        
         public static readonly string SrcProjectPath = Path.GetFullPath("../src/Azure.Functions.Cli/");
 
         public static readonly string ConstantsFile = Path.Combine(SrcProjectPath, "Common", "Constants.cs");
@@ -74,6 +76,12 @@ namespace Build
 
         public static readonly string OutputDir = Path.Combine(Path.GetFullPath(".."), "artifacts");
 
+        public static readonly string SBOMManifestTelemetryDir = Path.Combine(OutputDir, "SBOMManifestTelemetry");
+        
+        public static string TargetFramework = "netcoreapp3.1";
+
+        public static readonly string NupkgPublishDir = Path.GetFullPath($"../src/Azure.Functions.Cli/bin/Release/{TargetFramework}/publish");
+        
         public static readonly string PreSignTestDir = "PreSignTest";
 
         public static readonly string SignTestDir = "SignTest";

--- a/pipelineUtilities.psm1
+++ b/pipelineUtilities.psm1
@@ -1,0 +1,113 @@
+#
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+#Requires -Version 6.0
+
+using namespace System.Runtime.InteropServices
+
+$DLL_NAME = "Microsoft.ManifestTool.dll"
+$MANIFESTOOLNAME = "ManifestTool"
+$MANIFESTOOL_DIRECTORY = Join-Path $PSScriptRoot $MANIFESTOOLNAME
+$MANIFEST_TOOL_PATH = "$MANIFESTOOL_DIRECTORY/$DLL_NAME"
+
+function Get-ManifestToolPath
+{
+    if (Test-Path $MANIFEST_TOOL_PATH)
+    {
+        return $MANIFEST_TOOL_PATH
+    }
+    throw "The SBOM Manifest Tool is not installed. Please run Install-SBOMUtil -SBOMUtilSASUrl <SASUrl>"
+}
+
+function Install-SBOMUtil
+{
+    param(
+        [string]
+        $SBOMUtilSASUrl
+    )
+    
+    if ([string]::IsNullOrEmpty($SBOMUtilSASUrl))
+    {
+        throw "The `$SBOMUtilSASUrl parameter cannot be null or empty."
+    }
+
+    Write-Host "Installing $MANIFESTOOLNAME..."
+    Remove-Item -Recurse -Force $MANIFESTOOL_DIRECTORY -ErrorAction Ignore
+
+    Invoke-RestMethod -Uri $SBOMUtilSASUrl -OutFile "$MANIFESTOOL_DIRECTORY.zip"
+    Expand-Archive "$MANIFESTOOL_DIRECTORY.zip" -DestinationPath $MANIFESTOOL_DIRECTORY
+    
+    if (-not (Test-Path $MANIFEST_TOOL_PATH))
+    {
+        throw "$MANIFESTOOL_DIRECTORY does not contain '$DLL_NAME'"
+    }
+
+    Write-Host 'Done.'
+
+    return $MANIFEST_TOOL_PATH
+}
+
+$DotnetSDKVersionRequirements = @{
+
+    # .NET SDK 3.1 is required by the Microsoft.ManifestTool.dll tool
+    '2.2' = @{
+        MinimalPatch = '207'
+        DefaultPatch = '207'
+    }
+}
+
+function AddLocalDotnetDirPath {
+    $LocalDotnetDirPath = if ($IsWindows) { "$env:ProgramFiles/dotnet" } else { "/usr/share/dotnet" }
+    if (($env:PATH -split [IO.Path]::PathSeparator) -notcontains $LocalDotnetDirPath) {
+        $env:PATH = $LocalDotnetDirPath + [IO.Path]::PathSeparator + $env:PATH
+    }
+}
+
+function Find-Dotnet
+{
+    AddLocalDotnetDirPath
+    $listSdksOutput = dotnet --list-sdks
+    $installedDotnetSdks = $listSdksOutput | ForEach-Object { $_.Split(" ")[0] }
+    Write-Host "Detected dotnet SDKs: $($installedDotnetSdks -join ', ')"
+    foreach ($majorMinorVersion in $DotnetSDKVersionRequirements.Keys) {
+        $minimalVersion = "$majorMinorVersion.$($DotnetSDKVersionRequirements[$majorMinorVersion].MinimalPatch)"
+        $firstAcceptable = $installedDotnetSdks |
+                                Where-Object { $_.StartsWith("$majorMinorVersion.") } |
+                                Where-Object { [System.Management.Automation.SemanticVersion]::new($_) -ge [System.Management.Automation.SemanticVersion]::new($minimalVersion) } |
+                                Select-Object -First 1
+        if (-not $firstAcceptable) {
+            throw "Cannot find the dotnet SDK for .NET Core $majorMinorVersion. Version $minimalVersion or higher is required. Please specify '-Bootstrap' to install build dependencies."
+        }
+    }
+}
+
+function Install-Dotnet {
+    [CmdletBinding()]
+    param(
+        [string]$Channel = 'release'
+    )
+    try {
+        Find-Dotnet
+        return  # Simply return if we find dotnet SDk with the correct version
+    } catch { }
+    $obtainUrl = "https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain"
+    try {
+        $installScript = if ($IsWindows) { "dotnet-install.ps1" } else { "dotnet-install.sh" }
+        Invoke-WebRequest -Uri $obtainUrl/$installScript -OutFile $installScript
+        foreach ($majorMinorVersion in $DotnetSDKVersionRequirements.Keys) {
+            $version = "$majorMinorVersion.$($DotnetSDKVersionRequirements[$majorMinorVersion].DefaultPatch)"
+            Write-Host "Installing dotnet SDK version $version"
+            if ($IsWindows) {
+                & .\$installScript -InstallDir "$env:ProgramFiles/dotnet" -Channel $Channel -Version $Version
+            } else {
+                bash ./$installScript --install-dir "/usr/share/dotnet" -c $Channel -v $Version
+            }
+        }
+        AddLocalDotnetDirPath
+    }
+    finally {
+        Remove-Item $installScript -Force -ErrorAction SilentlyContinue
+    }
+}


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #2871. Cherry-pick of changes in PR #2879. Small modifications for V2 include:
- removing `master` from the list of branches that trigger the pipeline, as this branch no longer corresponds with V2
- making the sole .NET SDK dependency on .NET 2.2 in `pipelineUtilities.psm1`
- removing everything related to integration builds, as they were not an original part of the V2 build pipeline 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
