### PR TITLE
Release Java worker 2.1.0-SNAPSHOT

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -161,7 +161,7 @@
     <PackageReference Include="YamlDotNet" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(NoWorkers)' != 'true'">
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="2.1.0-SNAPSHOT" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" Version="4.0.1049" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.2" Version="4.0.1128" />


### PR DESCRIPTION
Release Java worker 2.1.0-SNAPSHOT
https://github.com/Azure/azure-functions-java-worker/releases/tag/2.1.0-SNAPSHOT