### PR TITLE
Removed V4 from package ID so that versions are not redundant

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.nuspec
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.nuspec
@@ -5,7 +5,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 -->
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <id>Microsoft.Azure.Functions.CoreTools.V4</id>
+    <id>Microsoft.Azure.Functions.CoreTools</id>
     <!-- Needed to specify the version here for the nuspec to be valid -->
     <version>$version$</version>
     <title>Azure Functions Core Tools</title>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Removes V4 from the ID of the nupkg file generated so that major versions are not redundant.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [x] Otherwise: Backport tracked by issue/PR #2918 
* [x] I have added all required tests (Unit tests, E2E tests)