### PR TITLE
Fix typo in RunAsync() V3

### DIFF
--- a/src/Azure.Functions.Cli/ConsoleApp.cs
+++ b/src/Azure.Functions.Cli/ConsoleApp.cs
@@ -81,7 +81,7 @@ namespace Azure.Functions.Cli
 
                 if (args.Any(a => a.Equals("--pause-on-error", StringComparison.OrdinalIgnoreCase)))
                 {
-                    ColoredConsole.Write("Press any to continue....");
+                    ColoredConsole.Write("Press any key to continue....");
                     Console.ReadKey(true);
                 }
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Cherry-pick of the changes from #2623, fixing a typo in the documentation of a command.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)