### PR TITLE
Remove Function key by default when publishing

### DIFF
--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -37,7 +37,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
         public bool ListIgnoredFiles { get; set; }
         public bool ListIncludedFiles { get; set; }
         public bool RunFromPackageDeploy { get; private set; }
-        public bool RemoveFunctionKey { get; set; }
+        public bool ShowKeys { get; set; }
         public bool Force { get; set; }
         public bool Csx { get; set; }
         public bool BuildNativeDeps { get; set; }
@@ -97,9 +97,9 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 .WithDescription("[Deprecated] Skips generating a bundle when publishing python function apps with build-native-deps.")
                 .Callback(nb => ColoredConsole.WriteLine(WarningColor($"Warning: Argument {AdditionalInfoColor("--no-bundler")} is deprecated and a no-op. Python function apps are not bundled anymore.")));
             Parser
-                .Setup<bool>("no-key")
-                .WithDescription("Removes function keys from the URLs displayed in the logs. For functions where the access level is not anonymous, requests must include an API access key in the request.")
-                .Callback(nk => RemoveFunctionKey = nk)
+                .Setup<bool>("show-keys")
+                .WithDescription("Adds function keys to the URLs displayed in the logs.")
+                .Callback(sk => ShowKeys = sk)
                 .SetDefault(false);
             Parser
                 .Setup<string>("additional-packages")
@@ -511,7 +511,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             if (!(functionApp.IsLinux && functionApp.IsElasticPremium)
                 && !(isFunctionAppDedicatedLinux && PublishBuildOption == BuildOption.Remote))
             {
-                await AzureHelper.PrintFunctionsInfo(functionApp, AccessToken, ManagementURL, showKeys: RemoveFunctionKey);
+                await AzureHelper.PrintFunctionsInfo(functionApp, AccessToken, ManagementURL, showKeys: ShowKeys);
             }
         }
 

--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -37,6 +37,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
         public bool ListIgnoredFiles { get; set; }
         public bool ListIncludedFiles { get; set; }
         public bool RunFromPackageDeploy { get; private set; }
+        public bool RemoveFunctionKey { get; set; }
         public bool Force { get; set; }
         public bool Csx { get; set; }
         public bool BuildNativeDeps { get; set; }
@@ -95,6 +96,11 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 .Setup<bool>("no-bundler")
                 .WithDescription("[Deprecated] Skips generating a bundle when publishing python function apps with build-native-deps.")
                 .Callback(nb => ColoredConsole.WriteLine(WarningColor($"Warning: Argument {AdditionalInfoColor("--no-bundler")} is deprecated and a no-op. Python function apps are not bundled anymore.")));
+            Parser
+                .Setup<bool>("no-key")
+                .WithDescription("Removes function keys from the URLs displayed in the logs. For functions where the access level is not anonymous, requests must include an API access key in the request.")
+                .Callback(nk => RemoveFunctionKey = nk)
+                .SetDefault(false);
             Parser
                 .Setup<string>("additional-packages")
                 .WithDescription("List of packages to install when building native dependencies. For example: \"python3-dev libevent-dev\"")
@@ -505,7 +511,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             if (!(functionApp.IsLinux && functionApp.IsElasticPremium)
                 && !(isFunctionAppDedicatedLinux && PublishBuildOption == BuildOption.Remote))
             {
-                await AzureHelper.PrintFunctionsInfo(functionApp, AccessToken, ManagementURL, showKeys: true);
+                await AzureHelper.PrintFunctionsInfo(functionApp, AccessToken, ManagementURL, showKeys: RemoveFunctionKey);
             }
         }
 

--- a/src/Azure.Functions.Cli/Helpers/AzureHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/AzureHelper.cs
@@ -391,7 +391,7 @@ namespace Azure.Functions.Cli.Helpers
         }
 
         internal static async Task WaitUntilFunctionAppReadyAsync(Site functionApp, string accessToken, string managementURL,
-            bool showKeys, HttpMessageHandler messageHandler = null)
+            HttpMessageHandler messageHandler = null)
         {
             var masterKey = await GetMasterKeyAsync(functionApp.SiteId, accessToken, managementURL);
 
@@ -457,7 +457,7 @@ namespace Azure.Functions.Cli.Helpers
             if (functionApp.IsKubeApp)
             {
                 ColoredConsole.Write("Waiting for the functions host up and running ");
-                await WaitUntilFunctionAppReadyAsync(functionApp, accessToken, managementURL, showKeys);
+                await WaitUntilFunctionAppReadyAsync(functionApp, accessToken, managementURL);
             }
 
             ArmArrayWrapper<FunctionInfo> functions = await GetFunctions(functionApp, accessToken, managementURL);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #2813 for Core Tools V4. This is to be ported to `v3.x`.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)
