### PR TITLE
Removed reference to release_notes.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,13 +8,6 @@ resolves #issue_for_this_pr
 
 * [ ] My changes **do not** require documentation changes
   * [ ] Otherwise: Documentation issue linked to PR
-* [ ] My changes **should not** be added to the release notes for the next release
-  * [ ] Otherwise: I've added my notes to `release_notes.md`
 * [ ] My changes **do not** need to be backported to a previous version
   * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
 * [ ] I have added all required tests (Unit tests, E2E tests)
-
-<!-- Optional: delete if not applicable  -->
-### Additional information
-
-Additional PR information


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Updates the pull request template, so that there is no reference to `release_notes.md`, as that file does not exist in this repository. Also removes the Additional Information section, as all information is expected to be included at the top. This is to be ported to `v4.x` in preparation for making that the default branch

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)