### PR TITLE
Add preliminary support for osx-arm64

### DIFF
--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -70,7 +70,7 @@ namespace Build
                     { "win-x64", _winPowershellRuntimes },
                     { "linux-x64", new [] { "linux", "linux-x64", "unix", "linux-musl-x64" } },
                     { "osx-x64", new [] { "osx", "osx-x64", "unix" } },
-                    // NOTE: arm support wasn't added until PowerShell 7.2
+                    // NOTE: PowerShell 7.0 does not support arm. First version supporting it is 7.2
                     // https://docs.microsoft.com/powershell/scripting/install/installing-powershell-on-macos?view=powershell-7.2#installation-via-direct-download
                     // That being said, we might as well include "osx" and "unix" since it'll hardly affect package size and should lead to more accurate error messages
                     { "osx-arm64", new [] { "osx", "unix" } }

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -71,7 +71,8 @@ namespace Build
                     { "linux-x64", new [] { "linux", "linux-x64", "unix", "linux-musl-x64" } },
                     { "osx-x64", new [] { "osx", "osx-x64", "unix" } },
                     // NOTE: arm support wasn't added until PowerShell 7.2
-                    // https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-macos?view=powershell-7.2#installation-via-direct-download
+                    // https://docs.microsoft.com/powershell/scripting/install/installing-powershell-on-macos?view=powershell-7.2#installation-via-direct-download
+                    // That being said, we might as well include "osx" and "unix" since it'll hardly affect package size and should lead to more accurate error messages
                     { "osx-arm64", new [] { "osx", "unix" } }
                 }
             },

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -44,6 +44,7 @@ namespace Build
             "min.win-x64",
             "linux-x64",
             "osx-x64",
+            "osx-arm64",
             "win-x86",
             "win-x64" };
 
@@ -53,6 +54,7 @@ namespace Build
             { "win-x64", "WINDOWS" },
             { "linux-x64", "LINUX" },
             { "osx-x64", "OSX" },
+            { "osx-arm64", "OSX" },
             { "min.win-x86", "WINDOWS" },
             { "min.win-x64", "WINDOWS" },
         };
@@ -67,7 +69,10 @@ namespace Build
                     { "win-x86", _winPowershellRuntimes },
                     { "win-x64", _winPowershellRuntimes },
                     { "linux-x64", new [] { "linux", "linux-x64", "unix", "linux-musl-x64" } },
-                    { "osx-x64", new [] { "osx", "osx-x64", "unix" } }
+                    { "osx-x64", new [] { "osx", "osx-x64", "unix" } },
+                    // NOTE: arm support wasn't added until PowerShell 7.2
+                    // https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-macos?view=powershell-7.2#installation-via-direct-download
+                    { "osx-arm64", new [] { "osx", "unix" } }
                 }
             },
             {
@@ -77,7 +82,8 @@ namespace Build
                     { "win-x86", _winPowershellRuntimes },
                     { "win-x64", _winPowershellRuntimes },
                     { "linux-x64", new [] { "linux", "linux-x64", "unix", "linux-musl-x64" } },
-                    { "osx-x64", new [] { "osx", "osx-x64", "unix" } }
+                    { "osx-x64", new [] { "osx", "osx-x64", "unix" } },
+                    { "osx-arm64", new [] { "osx", "osx-arm64", "unix" } }
                 }
             }
         };

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>func</AssemblyName>
 
-    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;osx-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers>
 
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">1</BuildNumber>
     <MajorMinorProductVersion>4.0</MajorMinorProductVersion>

--- a/src/Azure.Functions.Cli/npm/lib/install.js
+++ b/src/Azure.Functions.Cli/npm/lib/install.js
@@ -27,7 +27,11 @@ let platform = '';
 if (os.platform() === 'win32') {
     platform = 'win-x64';
 } else if (os.platform() === 'darwin') {
-    platform = 'osx-x64';
+    if (os.arch() === 'arm64') {
+        platform = 'osx-arm64';
+    } else {
+        platform = 'osx-x64';
+    }
 } else if (os.platform() === 'linux') {
     platform = 'linux-x64';
 } else {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Related to https://github.com/Azure/azure-functions-core-tools/issues/2834

I was able to do some basic sanity testing (func init, func new, func start) on an M1 Mac for both JS and C# with a build created from this branch. I think that's good enough to get the PR going, but will continue to do more testing.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)