### PR TITLE
Alter Chocolatey package name

### DIFF
--- a/publish-scripts/shared/constants.py
+++ b/publish-scripts/shared/constants.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 
 # same for all different OSes
-PACKAGENAME = "azure-functions-core-tools-4"
+PACKAGENAME = "azure-functions-core-tools"
 CMD = "func"
 ARTIFACTFOLDER = "artifact"
 BUILDFOLDER = "build"


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Alters the Chocolatey package name to `azure-functions-core-tools`, as all future releases to Chocolatey will be done under that name. Same changes as done in #2950 . These changes will require documentation changes as described in #2954 
### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [x] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)