### PR TITLE
Reverting reference to pre-release Powershell version

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -163,7 +163,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.10.0-SNAPSHOT" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.1.2" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS6" Version="3.0.630" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7" Version="3.0.1450" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7" Version="3.0.1272" />
     <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="3.1.2.6" />
   </ItemGroup>
 


### PR DESCRIPTION
[This PR](https://github.com/Azure/azure-functions-core-tools/pull/2908) as part of the 3.4.2 release process incorrectly added a pre-release version of the powershell worker. I have updated the instructions for the release process to rectify this moving forward; this PR will fix the issue before we start the current core tools release.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)