### PR TITLE
Add script to validate host/worker versions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,6 +85,9 @@ jobs:
         $accessToken = (az account get-access-token --query "accessToken" | % { $_.Trim('"') })
         echo "##vso[task.setvariable variable=azure_management_access_token]$accessToken"
   - pwsh: |
+      .\validateWorkerVersions.ps1
+    displayName: 'Validate worker versions'
+  - pwsh: |
       .\build.ps1
     env:
       AzureBlobSigningConnectionString: $(AzureBlobSigningConnectionString)

--- a/validateWorkerVersions.ps1
+++ b/validateWorkerVersions.ps1
@@ -1,0 +1,87 @@
+<#
+    .SYNOPSIS
+        Used to validate and/or update worker package versions
+    .EXAMPLE
+        ./validateWorkerVersions.ps1
+
+        Validates the workers match the existing host version and throws an error if they don't
+    .EXAMPLE
+        ./validateWorkerVersions.ps1 -Update -HostVersion 4.0.0
+
+        Updates the host reference to 4.0.0 and the workers to their matching versions
+#>
+param (
+    [Switch]$Update,
+    
+    # An explicit host version, otherwise the host version from Azure.Functions.Cli.csproj will be used
+    [string]$hostVersion
+)
+
+# the xml will fail to parse if the data is encoded with a bom character
+function removeBomIfExists([string]$data)
+{
+    if ($data.StartsWith(0xFEFF)) {
+        $data = $data.substring(1)
+    }
+    return $data
+}
+
+$cliCsprojPath = "./src/Azure.Functions.Cli/Azure.Functions.Cli.csproj"
+$cliCsprojContent = removeBomIfExists(Get-Content $cliCsprojPath)
+$cliCsprojXml = [xml]$cliCsprojContent
+
+function getPackageVersion([string]$packageName, [string]$csprojContent)
+{
+    $version = (Select-Xml -Content $csprojContent -XPath "/Project//PackageReference[@Include='$packageName']/@Version").ToString()
+    if (-Not $version) {
+        throw "Failed to find version for package $packageName"
+    }
+    return $version
+}
+
+function setCliPackageVersion([string]$packageName, [string]$version)
+{
+    $node = $cliCsprojXml.SelectSingleNode("/Project//PackageReference[@Include='$packageName']")
+    $node.Version = $version
+}
+
+$hostPackageName = "Microsoft.Azure.WebJobs.Script.WebHost"
+if (-Not $hostVersion) {
+    $hostVersion = getPackageVersion $hostPackageName $cliCsprojContent
+} elseif ($Update) {
+    setCliPackageVersion $hostPackageName $hostVersion
+}
+
+$hostRepoUrlBase = "https://raw.githubusercontent.com/Azure/azure-functions-host/v$hostVersion"
+$hostCsprojContent = removeBomIfExists((Invoke-WebRequest -Uri "$hostRepoUrlBase/src/WebJobs.Script/WebJobs.Script.csproj").Content)
+$pythonPropsContent = removeBomIfExists((Invoke-WebRequest -Uri "$hostRepoUrlBase/build/python.props").Content)
+
+$workers = "JavaWorker", "NodeJsWorker", "PowerShellWorker.PS7.0", "PowerShellWorker.PS7.2", "PythonWorker"
+
+$failedValidation = $false
+foreach($worker in $workers) {
+    $packageName = "Microsoft.Azure.Functions.$worker"
+    if ($worker -eq "PythonWorker") {
+        $hostWorkerVersion = getPackageVersion $packageName $pythonPropsContent
+    } else {
+        $hostWorkerVersion = getPackageVersion $packageName $hostCsprojContent
+    }
+    $cliWorkerVersion = getPackageVersion $packageName $cliCsprojContent
+
+    if ($Update) {
+        setCliPackageVersion $packageName $hostWorkerVersion
+    } elseif ($hostWorkerVersion -ne $cliWorkerVersion) {
+        Write-Output "Reference to $worker in the host ($hostWorkerVersion) does not match version in the cli ($cliWorkerVersion)"
+        $failedValidation = $true
+    }
+}
+
+if ($Update) {
+    $cliCsprojXml.Save($cliCsprojPath)
+    Write-Output "Updated worker versions! 🚀"
+} elseif ($failedValidation) {
+    Write-Output "You can run './validateWorkerVersions.ps1 -Update' locally to fix worker versions."
+    throw "Not all worker versions matched. 😢 See output for more info"
+} else {
+    Write-Output "Worker versions match! 🥳"
+}


### PR DESCRIPTION
Currently, the process for updating workers in this repo is very disjointed and could easily lead to a situation where core tools ships a host/worker combination that is not possible in Azure. I've added a script to ensure that the worker versions match what was shipped with the respective version of the host. The script can be used to either validate the versions (as a part of the dev ops build) or update the versions (run manually before submitting a PR). Here is the criteria used to determine if a worker version matches:
1. Check the version of "Microsoft.Azure.WebJobs.Script.WebHost" in `Azure.Functions.Cli.csproj`
2. Find the matching github tag on the host repo (i.e. https://github.com/Azure/azure-functions-host/tree/v4.1.3)
3. Make sure the worker versions on that tag match what's in `Azure.Functions.Cli.csproj`

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [x] Otherwise: Just trust me I'll backport it :P
* [x] I have added all required tests (Unit tests, E2E tests)