### PR TITLE
Skip local setting with empty key

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -309,7 +309,10 @@ namespace Azure.Functions.Cli.Actions.HostActions
         {
             foreach (var secret in secrets)
             {
-                if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(secret.Key)))
+                if (string.IsNullOrEmpty(secret.Key)) {
+                    ColoredConsole.WriteLine(WarningColor($"Skipping local setting with empty key."));
+                }
+                else if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(secret.Key)))
                 {
                     ColoredConsole.WriteLine(WarningColor($"Skipping '{secret.Key}' from local settings as it's already defined in current environment variables."));
                 }


### PR DESCRIPTION
resolves #1732.

## Current behavior

If you have `"": ""` in `local.settings.json` (only repros for me on windows, not mac)

> Error: Insufficient memory to continue the execution of the program.

If you have `"": "non-empty-value"` in `local.settings.json` (repros on both windows and mac)

> Error: String cannot be of zero length. (Parameter 'variable')

## New behavior (warning)

> Warning: Skipping local setting with empty key.

NOTE: The issue was fixed on the dev branch by https://github.com/Azure/azure-functions-core-tools/pull/1735, but never ported to v3.x or v4.x branches. That PR did not address the second error case mentioned above and did not show a warning, so I created this PR with a new fix.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [x] Otherwise: https://github.com/Azure/azure-functions-core-tools/pull/2983
* [x] I have added all required tests (Unit tests, E2E tests)