### PR TITLE
Bump app insights package to fix build

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -153,7 +153,7 @@
     <PackageReference Include="Colors.Net" Version="1.1.0" />
     <PackageReference Include="AccentedCommandLineParser" Version="2.0.0" />
     <PackageReference Include="DotNetZip" Version="1.13.3" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.18.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.20.0" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage.Internal" Version="1.4.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="4.1.3" />


### PR DESCRIPTION
Remote builds are currently failing with this:

> /Users/erijiz/Repos/func-cli/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj : error NU1605: Detected package downgrade: Microsoft.ApplicationInsights from 2.20.0 to 2.18.0. Reference the package directly from the project to select a different version. 
> /Users/erijiz/Repos/func-cli/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj : error NU1605:  Microsoft.Azure.Functions.CoreTools -> Microsoft.Azure.WebJobs.Script.WebHost 4.1.3 -> Microsoft.Azure.WebJobs.Script 4.1.3 -> Microsoft.Azure.WebJobs.Script.Abstractions 1.0.3-preview -> Microsoft.ApplicationInsights (>= 2.20.0) 
> /Users/erijiz/Repos/func-cli/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj : error NU1605:  Microsoft.Azure.Functions.CoreTools -> Microsoft.ApplicationInsights (>= 2.18.0)

Depending on the state of your repo and dotnet cache, the error may not repro locally.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)