### PR TITLE
Make null and unsupported Key Vault reference formats non-blocking

### DIFF
--- a/src/Azure.Functions.Cli/Common/KeyVaultReferencesManager.cs
+++ b/src/Azure.Functions.Cli/Common/KeyVaultReferencesManager.cs
@@ -14,9 +14,9 @@ namespace Azure.Functions.Cli.Common
     class KeyVaultReferencesManager
     {
         private const string vaultUriSuffix = "vault.azure.net";
-        private static readonly Regex KeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\([\S]*\)$", RegexOptions.Compiled);
-        private static readonly Regex PrimaryValidKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\(SecretUri=(?<VaultUri>https://[\S^/]+)/(?<Secrets>[\S^/]+)/(?<SecretName>[\S^/]+)/(?<Version>[\S^/]+)\)$", RegexOptions.Compiled);
-        private static readonly Regex SecondaryValidKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\(VaultName=(?<VaultName>[\S^;]+);SecretName=(?<SecretName>[\S^;]+)\)$", RegexOptions.Compiled); 
+        private static readonly Regex BasicKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\([\S]*\)$", RegexOptions.Compiled);
+        private static readonly Regex PrimaryKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\(SecretUri=(?<VaultUri>https://[\S^/]+)/(?<Secrets>[\S^/]+)/(?<SecretName>[\S^/]+)/(?<Version>[\S^/]+)\)$", RegexOptions.Compiled);
+        private static readonly Regex SecondaryKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\(VaultName=(?<VaultName>[\S^;]+);SecretName=(?<SecretName>[\S^;]+)\)$", RegexOptions.Compiled); 
         private readonly ConcurrentDictionary<string, SecretClient> clients = new ConcurrentDictionary<string, SecretClient>();
         private readonly TokenCredential credential = new DefaultAzureCredential();
 
@@ -58,7 +58,7 @@ namespace Azure.Functions.Cli.Common
             }
 
             // Determine if the secret value is attempting to use a key vault reference
-            if (KeyVaultReferenceRegex.Match(value).Success)
+            if (BasicKeyVaultReferenceRegex.Match(value).Success)
             {
                 var result = ParsePrimaryRegexSecret(value) ?? ParseSecondaryRegexSecret(value);
                 // If we detect that a key vault reference was attempted, but did not match any of
@@ -74,7 +74,7 @@ namespace Azure.Functions.Cli.Common
 
         private ParseSecretResult ParsePrimaryRegexSecret(string value)
         {
-            var match = PrimaryValidKeyVaultReferenceRegex.Match(value);
+            var match = PrimaryKeyVaultReferenceRegex.Match(value);
             if (match.Success)
             {
                 return new ParseSecretResult
@@ -89,7 +89,7 @@ namespace Azure.Functions.Cli.Common
 
         private ParseSecretResult ParseSecondaryRegexSecret(string value)
         {
-            var altMatch = SecondaryValidKeyVaultReferenceRegex.Match(value);
+            var altMatch = SecondaryKeyVaultReferenceRegex.Match(value);
             if (altMatch.Success)
             {
                 return new ParseSecretResult

--- a/src/Azure.Functions.Cli/Common/KeyVaultReferencesManager.cs
+++ b/src/Azure.Functions.Cli/Common/KeyVaultReferencesManager.cs
@@ -14,9 +14,9 @@ namespace Azure.Functions.Cli.Common
     class KeyVaultReferencesManager
     {
         private const string vaultUriSuffix = "vault.azure.net";
-        private static readonly Regex BasicKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\([\S]*\)$", RegexOptions.Compiled);
-        private static readonly Regex PrimaryKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\(SecretUri=(?<VaultUri>https://[\S^/]+)/(?<Secrets>[\S^/]+)/(?<SecretName>[\S^/]+)/(?<Version>[\S^/]+)\)$", RegexOptions.Compiled);
-        private static readonly Regex SecondaryKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\(VaultName=(?<VaultName>[\S^;]+);SecretName=(?<SecretName>[\S^;]+)\)$", RegexOptions.Compiled); 
+        private static readonly Regex BasicKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\(\S*\)$", RegexOptions.Compiled);
+        private static readonly Regex PrimaryKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\(SecretUri=(?<VaultUri>https://[^\s/]+)/(?<Secrets>[^\s/]+)/(?<SecretName>[^\s/]+)/(?<Version>[^\s/]+)\)$", RegexOptions.Compiled);
+        private static readonly Regex SecondaryKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\(VaultName=(?<VaultName>[^\s;]+);SecretName=(?<SecretName>[^\s;]+)\)$", RegexOptions.Compiled); 
         private readonly ConcurrentDictionary<string, SecretClient> clients = new ConcurrentDictionary<string, SecretClient>();
         private readonly TokenCredential credential = new DefaultAzureCredential();
 
@@ -65,7 +65,7 @@ namespace Azure.Functions.Cli.Common
                 // the supported formats, we write a warning to the console.
                 if (result == null)
                 {
-                    ColoredConsole.WriteLine(WarningColor($"Invalid Key Vault reference format: {value}"));
+                    ColoredConsole.WriteLine(WarningColor($"Unable to parse the Key Vault reference: {value}"));
                 }
                 return result;
             }

--- a/src/Azure.Functions.Cli/Common/KeyVaultReferencesManager.cs
+++ b/src/Azure.Functions.Cli/Common/KeyVaultReferencesManager.cs
@@ -14,7 +14,7 @@ namespace Azure.Functions.Cli.Common
     class KeyVaultReferencesManager
     {
         private const string vaultUriSuffix = "vault.azure.net";
-        private static readonly Regex BasicKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\((?<ReferenceString>\S*)\)$", RegexOptions.Compiled);
+        private static readonly Regex BasicKeyVaultReferenceRegex = new Regex(@"^@Microsoft\.KeyVault\((?<ReferenceString>.*)\)$", RegexOptions.Compiled);
         private readonly ConcurrentDictionary<string, SecretClient> clients = new ConcurrentDictionary<string, SecretClient>();
         private readonly TokenCredential credential = new DefaultAzureCredential();
 

--- a/src/Azure.Functions.Cli/Common/KeyVaultReferencesManager.cs
+++ b/src/Azure.Functions.Cli/Common/KeyVaultReferencesManager.cs
@@ -15,7 +15,7 @@ namespace Azure.Functions.Cli.Common
     {
         private const string vaultUriSuffix = "vault.azure.net";
         private static readonly Regex BasicKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\((?<ReferenceString>\S*)\)$", RegexOptions.Compiled);
-        private static readonly Regex PrimaryReferenceStringRegex = new Regex(@"^SecretUri=(?<VaultUri>https://[^\s/]+)/(?<Secrets>[^\s/]+)/(?<SecretName>[^\s/]+)/(?<Version>[^\s/]+)$", RegexOptions.Compiled);
+        private static readonly Regex PrimaryReferenceStringRegex = new Regex(@"^SecretUri=(?<VaultUri>https://[^\s/]+)/secrets/(?<SecretName>[^\s/]+)/(?<Version>[^\s/]+)$", RegexOptions.Compiled);
         private static readonly Regex SecondaryReferenceStringRegex = new Regex(@"^VaultName=(?<VaultName>[^\s;]+);SecretName=(?<SecretName>[^\s;]+)$", RegexOptions.Compiled); 
         private readonly ConcurrentDictionary<string, SecretClient> clients = new ConcurrentDictionary<string, SecretClient>();
         private readonly TokenCredential credential = new DefaultAzureCredential();

--- a/src/Azure.Functions.Cli/Common/KeyVaultReferencesManager.cs
+++ b/src/Azure.Functions.Cli/Common/KeyVaultReferencesManager.cs
@@ -68,7 +68,16 @@ namespace Azure.Functions.Cli.Common
             if (keyVaultReferenceMatch.Success)
             {
                 var referenceString = keyVaultReferenceMatch.Groups["ReferenceString"].Value;
-                var result = ParseVaultReference(referenceString);
+                ParseSecretResult result = null;
+                try
+                {
+                    result = ParseVaultReference(referenceString);
+                }
+                catch
+                {
+                    // ignore and show warning below
+                }
+
                 // If we detect that a key vault reference was attempted, but did not match any of
                 // the supported formats, we write a warning to the console.
                 if (result == null)

--- a/src/Azure.Functions.Cli/Common/KeyVaultReferencesManager.cs
+++ b/src/Azure.Functions.Cli/Common/KeyVaultReferencesManager.cs
@@ -3,17 +3,20 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Colors.Net;
 using Azure.Core;
 using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
+using static Azure.Functions.Cli.Common.OutputTheme;
 
 namespace Azure.Functions.Cli.Common
 {
     class KeyVaultReferencesManager
     {
         private const string vaultUriSuffix = "vault.azure.net";
-        private static readonly Regex PrimaryKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\(SecretUri=(?<VaultUri>[\S^/]+)/(?<Secrets>[\S^/]+)/(?<SecretName>[\S^/]+)/(?<Version>[\S^/]+)\)$", RegexOptions.Compiled);
-        private static readonly Regex SecondaryKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\(VaultName=(?<VaultName>[\S^;]+);SecretName=(?<SecretName>[\S^;]+)\)$", RegexOptions.Compiled); 
+        private static readonly Regex KeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\([\S]*\)$", RegexOptions.Compiled);
+        private static readonly Regex PrimaryValidKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\(SecretUri=(?<VaultUri>https://[\S^/]+)/(?<Secrets>[\S^/]+)/(?<SecretName>[\S^/]+)/(?<Version>[\S^/]+)\)$", RegexOptions.Compiled);
+        private static readonly Regex SecondaryValidKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\(VaultName=(?<VaultName>[\S^;]+);SecretName=(?<SecretName>[\S^;]+)\)$", RegexOptions.Compiled); 
         private readonly ConcurrentDictionary<string, SecretClient> clients = new ConcurrentDictionary<string, SecretClient>();
         private readonly TokenCredential credential = new DefaultAzureCredential();
 
@@ -45,19 +48,33 @@ namespace Azure.Functions.Cli.Common
 
         private ParseSecretResult ParseSecret(string value)
         {
-            try
+            // If the value is null, then we return nothing, as the subsequent call to
+            // UpdateEnvironmentVariables(settings) will log to the user that the setting
+            // is skipped. We check here, because Regex.Match throws when supplied with a
+            // null value.
+            if (value == null)
             {
-                return ParsePrimaryRegexSecret(value) ?? ParseSecondaryRegexSecret(value);
+                return null;
             }
-            catch
+
+            // Determine if the secret value is attempting to use a key vault reference
+            if (KeyVaultReferenceRegex.Match(value).Success)
             {
-                throw new FormatException($"Key Vault Reference format invalid: {value}");
+                var result = ParsePrimaryRegexSecret(value) ?? ParseSecondaryRegexSecret(value);
+                // If we detect that a key vault reference was attempted, but did not match any of
+                // the supported formats, we write a warning to the console.
+                if (result == null)
+                {
+                    ColoredConsole.WriteLine(WarningColor($"Invalid Key Vault Reference format: {value}"));
+                }
+                return result;
             }
+            return null;
         }
 
         private ParseSecretResult ParsePrimaryRegexSecret(string value)
         {
-            var match = PrimaryKeyVaultReferenceRegex.Match(value);
+            var match = PrimaryValidKeyVaultReferenceRegex.Match(value);
             if (match.Success)
             {
                 return new ParseSecretResult
@@ -72,7 +89,7 @@ namespace Azure.Functions.Cli.Common
 
         private ParseSecretResult ParseSecondaryRegexSecret(string value)
         {
-            var altMatch = SecondaryKeyVaultReferenceRegex.Match(value);
+            var altMatch = SecondaryValidKeyVaultReferenceRegex.Match(value);
             if (altMatch.Success)
             {
                 return new ParseSecretResult

--- a/src/Azure.Functions.Cli/Common/KeyVaultReferencesManager.cs
+++ b/src/Azure.Functions.Cli/Common/KeyVaultReferencesManager.cs
@@ -65,7 +65,7 @@ namespace Azure.Functions.Cli.Common
                 // the supported formats, we write a warning to the console.
                 if (result == null)
                 {
-                    ColoredConsole.WriteLine(WarningColor($"Invalid Key Vault Reference format: {value}"));
+                    ColoredConsole.WriteLine(WarningColor($"Invalid Key Vault reference format: {value}"));
                 }
                 return result;
             }

--- a/test/Azure.Functions.Cli.Tests/KeyVaultReferencesManagerTests.cs
+++ b/test/Azure.Functions.Cli.Tests/KeyVaultReferencesManagerTests.cs
@@ -72,27 +72,26 @@ namespace Azure.Functions.Cli.Tests
         // See https://docs.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
         // for more detail on supported key vault reference syntax.
         [Theory]
-        [InlineData("SecretUri=https://sampleURL/secrets/mysecret/version", true)]
-        [InlineData("VaultName=sampleVault;SecretName=mysecret", false)]
-        [InlineData("VaultName=sampleVault;SecretName=mysecret;SecretVersion=secretVersion", false)]
-        // The below syntax is not yet supported in Core Tools
-        [InlineData("SecretUri=https://sampleURL/secrets/mysecret/", false)]
-        public void PrimaryReferenceStringRegexMatchesAppropriately(string value, bool shouldMatch)
+        [InlineData("SecretUri=https://sampleurl/secrets/mysecret/version", true, "https://sampleurl/", "mysecret", "version")]
+        [InlineData("SecretUri=https://sampleurl/secrets/mysecret/", true, "https://sampleurl/", "mysecret", null)]
+        [InlineData("VaultName=sampleVault;SecretName=mysecret", true, "https://samplevault.vault.azure.net/", "mysecret", null)]
+        [InlineData("VaultName=sampleVault;SecretName=mysecret;SecretVersion=secretVersion", true, "https://samplevault.vault.azure.net/", "mysecret", "secretVersion")]
+        public void ParseVaultReferenceMatchesFieldsAppropriately(
+            string vaultReference,
+            bool shouldMatch,
+            string expectedVaultUri = null,
+            string expectedSecretName = null,
+            string expectedVersion = null)
         {
-            var match = _keyVaultReferencesManager.ParsePrimaryRegexSecret(value) != null;
-            Assert.True(!(match ^ shouldMatch));
-        }
+            var matchResult = _keyVaultReferencesManager.ParseVaultReference(vaultReference);
 
-        [Theory]
-        [InlineData("SecretUri=https://sampleURL/secrets/mysecret/", false)]
-        [InlineData("SecretUri=https://sampleURL/secrets/mysecret/version", false)]
-        [InlineData("VaultName=sampleVault;SecretName=mysecret", true)]
-        // The below syntax is not yet supported in Core Tools
-        [InlineData("VaultName=sampleVault;SecretName=mysecret;SecretVersion=secretVersion", false)]
-        public void SecondaryReferenceStringRegexMatchesAppropriately(string value, bool shouldMatch)
-        {
-            var match = _keyVaultReferencesManager.ParseSecondaryRegexSecret(value) != null;
-            Assert.True(!(match ^ shouldMatch));
+            Assert.True(!((matchResult != null) ^ shouldMatch));
+            if (shouldMatch)
+            {
+                Assert.Equal(matchResult.Uri.ToString(), expectedVaultUri);
+                Assert.Equal(matchResult.Name, expectedSecretName);
+                Assert.Equal(matchResult.Version, expectedVersion);
+            }
         }
     }
 }

--- a/test/Azure.Functions.Cli.Tests/KeyVaultReferencesManagerTests.cs
+++ b/test/Azure.Functions.Cli.Tests/KeyVaultReferencesManagerTests.cs
@@ -74,9 +74,12 @@ namespace Azure.Functions.Cli.Tests
         // for more detail on supported key vault reference syntax.
         [Theory]
         [InlineData("SecretUri=https://sampleurl/secrets/mysecret/version", true, "https://sampleurl/", "mysecret", "version")]
+        [InlineData("SecretUri=https://sampleurl/secrets/mysecret/version;", true, "https://sampleurl/", "mysecret", "version")] // with semicolon at the end
         [InlineData("SecretUri=https://sampleurl/secrets/mysecret/", true, "https://sampleurl/", "mysecret", null)]
         [InlineData("VaultName=sampleVault;SecretName=mysecret", true, "https://samplevault.vault.azure.net/", "mysecret", null)]
+        [InlineData("VaultName=sampleVault;SecretName=mysecret;", true, "https://samplevault.vault.azure.net/", "mysecret", null)] // with semicolon at the end
         [InlineData("VaultName=sampleVault;SecretName=mysecret;SecretVersion=secretVersion", true, "https://samplevault.vault.azure.net/", "mysecret", "secretVersion")]
+        [InlineData("SecretName=mysecret;VaultName=sampleVault;SecretVersion=secretVersion", true, "https://samplevault.vault.azure.net/", "mysecret", "secretVersion")] // different order
         public void ParseVaultReferenceMatchesFieldsAppropriately(
             string vaultReference,
             bool shouldMatch,

--- a/test/Azure.Functions.Cli.Tests/KeyVaultReferencesManagerTests.cs
+++ b/test/Azure.Functions.Cli.Tests/KeyVaultReferencesManagerTests.cs
@@ -21,6 +21,7 @@ namespace Azure.Functions.Cli.Tests
         [InlineData("testKey", null)]
         [InlineData("testKey", "")]
         [InlineData("testKey", "testValue")]
+        [InlineData("testKey", "testValue: {\"nestedKey\": \"nestedValue\"}")]
         public void ResolveKeyVaultReferencesDoesNotThrow(string key, string value)
         {
             _settings = new Dictionary<string, string>

--- a/test/Azure.Functions.Cli.Tests/KeyVaultReferencesManagerTests.cs
+++ b/test/Azure.Functions.Cli.Tests/KeyVaultReferencesManagerTests.cs
@@ -45,8 +45,12 @@ namespace Azure.Functions.Cli.Tests
         [InlineData("test", null, false)]
         [InlineData("test", "@Microsoft.KeyVault()", true)]
         [InlineData("test", "@Microsoft.KeyVault(string)", true)]
+        [InlineData("test", "@Microsoft.KeyVault(SecretUri=bad uri)", true)]
+        [InlineData("test", "@Microsoft.KeyVault(VaultName=vault;)", true)] // missing secret name
+        [InlineData("test", "@Microsoft.KeyVault(SecretName=vault;)", true)] // missing vault name
+        [InlineData("test", "@Microsoft-KeyVault()", false)] // hyphen instead of dot
         // Attempted Key Vault references are seen as those matching the regular expression
-        // "^@Microsoft.KeyVault(\S*)$".
+        // "^@Microsoft.KeyVault(.*)$".
         public void ParseSecretEmitsWarningWithUnsuccessullyMatchedKeyVaultReferences(string key, string value, bool attemptedKeyVaultReference)
         {
             var output = new StringBuilder();

--- a/test/Azure.Functions.Cli.Tests/KeyVaultReferencesManagerTests.cs
+++ b/test/Azure.Functions.Cli.Tests/KeyVaultReferencesManagerTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Colors.Net;
+using FluentAssertions;
+using NSubstitute;
+using Xunit;
+
+using Azure.Functions.Cli.Common;
+
+namespace Azure.Functions.Cli.Tests
+{
+    public class KeyVaultReferencesManagerTests
+    {
+        private static IDictionary<string, string> _settings = new Dictionary<string, string>
+        {
+            { Constants.AzureWebJobsStorage, "UseDevelopmentStorage=true" },
+        };
+
+        private readonly KeyVaultReferencesManager _keyVaultReferencesManager = new KeyVaultReferencesManager();
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("", null)]
+        [InlineData(null, "")]
+        [InlineData("testKey", null)]
+        [InlineData("testKey", "")]
+        [InlineData(null, "testValue")]
+        [InlineData("testKey", "testValue")]
+        public void ResolveKeyVaultReferencesDoesNotThrow(string key, string value)
+        {
+            _settings.Add(key, value);
+            Exception exception = null;
+            try
+            {
+                _keyVaultReferencesManager.ResolveKeyVaultReferences(_settings);
+            }
+            catch (Exception e)
+            {
+                exception = e;
+            }
+            exception.Should().BeNull();
+        }
+
+        [Theory]
+        [InlineData("test", null, false)]
+        [InlineData("test", "@Microsoft.KeyVault()", true)]
+        [InlineData("test", "@Microsoft.KeyVault(string)", true)]
+        // Attempted Key Vault references are seen as those matching the regular expression
+        // "^@Microsoft.KeyVault(\S*)$".
+        public void ParseSecretEmitsWarningWithUnsuccessullyMatchedKeyVaultReferences(string key, string value, bool attemptedKeyVaultReference)
+        {
+            var output = new StringBuilder();
+            var console = Substitute.For<IConsoleWriter>();
+            console.WriteLine(Arg.Do<object>(o => output.AppendLine(o?.ToString()))).Returns(console);
+            console.Write(Arg.Do<object>(o => output.Append(o.ToString()))).Returns(console);
+            ColoredConsole.Out = console;
+            ColoredConsole.Error = console;
+
+            _keyVaultReferencesManager.ParseSecret(key, value);
+            var outputString = output.ToString();
+            if (attemptedKeyVaultReference)
+            {
+                outputString.Should().Contain($"Unable to parse the Key Vault reference for setting: {key}");
+                outputString.Should().NotContain(value);
+            }
+            else
+            {
+                outputString.Should().BeEmpty();
+            }
+            
+        }
+
+        // See https://docs.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
+        // for more detail on supported key vault reference syntax.
+        [Theory]
+        [InlineData("https://sampleURL/secrets/mysecret/", true)]
+        [InlineData("https://sampleURL/secrets/mysecret/version", true)]
+        [InlineData("VaultName=sampleVault;SecretName=mysecret", false)]
+        [InlineData("VaultName=sampleVault;SecretName=mysecret;SecretVersion=secretVersion", false)]
+        public void PrimaryReferenceStringRegexMatchesAppropriately(string value, bool shouldMatch)
+        {
+            var match = _keyVaultReferencesManager.ParsePrimaryRegexSecret(value) != null;
+            Assert.True(!(match ^ shouldMatch));
+        }
+
+        [Theory]
+        [InlineData("https://sampleURL/secrets/mysecret/", false)]
+        [InlineData("https://sampleURL/secrets/mysecret/version", false)]
+        [InlineData("VaultName=sampleVault;SecretName=mysecret", true)]
+        [InlineData("VaultName=sampleVault;SecretName=mysecret;SecretVersion=secretVersion", true)]
+        public void SecondaryReferenceStringRegexMatchesAppropriately(string value, bool shouldMatch)
+        {
+            var match = _keyVaultReferencesManager.ParseSecondaryRegexSecret(value) != null;
+            Assert.True(!(match ^ shouldMatch));
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Resolves #2989. This PR corrects the regular expressions used in matching Key Vault references. Furthermore, issues with parsing Key Vault references should be non-blocking for `func start` (a warning is emitted instead). Support for other Key Vault reference formats that have secret version as an optional parameter has also been added.

#### Old Behavior
The KeyVaultReferencesManager attempts to match items in the configuration with regular expressions intended to capture two Key Vault Reference formats:

1. The "primary format": `@Microsoft.KeyVault(SecretUri=https://myvault.vault.azure.net/secrets/mysecret/version)`
2. The "secondary format":  `@Microsoft.KeyVault(VaultName=myvault;SecretName=mysecret)`

While the regular expressions used indeed match with their corresponding formats, they were not entirely correct, leading to matches where there should be none and the cryptic error `Key Vault Reference format invalid: <config-value>` being thrown upon creation of the `ParseSecretResult` object.

#### Current Behavior
1. Item value is `null`: `func start` proceeds, writing the warning to the console `Skipping <config-item> because value is null`
2. Item value resembles the use of a Key Vault reference, i.e. takes on the form `@Microsoft.KeyVault(.*)`, but does not match any of the syntaxes specified in [this doc](https://docs.microsoft.com/en-us/azure/app-service/app-service-key-vault-references): Core Tools writes the warning `Unable to parse the Key Vault reference: <config-item-value>` to the console and proceeds with `func start`
3. Item value does not resemble the use of a Key Vault reference: `func start` proceeds as normal.
4. Item value matches a syntax specified in [this doc](https://docs.microsoft.com/en-us/azure/app-service/app-service-key-vault-references): Core Tools attempts to retrieve the secret value. If successful, `func start` proceeds as normal. Otherwise, an error is thrown.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [x] Otherwise: This change will be backported to `v3.x`
* [x] I have added all required tests (Unit tests, E2E tests)