### PR TITLE
Make secret version optional in Key Vault references

### DIFF
--- a/src/Azure.Functions.Cli/Common/KeyVaultReferencesManager.cs
+++ b/src/Azure.Functions.Cli/Common/KeyVaultReferencesManager.cs
@@ -14,9 +14,9 @@ namespace Azure.Functions.Cli.Common
     class KeyVaultReferencesManager
     {
         private const string vaultUriSuffix = "vault.azure.net";
-        private static readonly Regex KeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\([\S]*\)$", RegexOptions.Compiled);
-        private static readonly Regex PrimaryValidKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\(SecretUri=(?<VaultUri>https://[\S^/]+)/(?<Secrets>[\S^/]+)/(?<SecretName>[\S^/]+)/(?<Version>[\S^/]+)\)$", RegexOptions.Compiled);
-        private static readonly Regex SecondaryValidKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\(VaultName=(?<VaultName>[\S^;]+);SecretName=(?<SecretName>[\S^;]+)\)$", RegexOptions.Compiled); 
+        private static readonly Regex BasicKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\([\S]*\)$", RegexOptions.Compiled);
+        private static readonly Regex PrimaryKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\(SecretUri=(?<VaultUri>https://[\S^/]+)/(?<Secrets>[\S^/]+)/(?<SecretName>[\S^/]+)/(?<Version>[\S^/]+)\)$", RegexOptions.Compiled);
+        private static readonly Regex SecondaryKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\(VaultName=(?<VaultName>[\S^;]+);SecretName=(?<SecretName>[\S^;]+)\)$", RegexOptions.Compiled); 
         private readonly ConcurrentDictionary<string, SecretClient> clients = new ConcurrentDictionary<string, SecretClient>();
         private readonly TokenCredential credential = new DefaultAzureCredential();
 
@@ -58,7 +58,7 @@ namespace Azure.Functions.Cli.Common
             }
 
             // Determine if the secret value is attempting to use a key vault reference
-            if (KeyVaultReferenceRegex.Match(value).Success)
+            if (BasicKeyVaultReferenceRegex.Match(value).Success)
             {
                 var result = ParsePrimaryRegexSecret(value) ?? ParseSecondaryRegexSecret(value);
                 // If we detect that a key vault reference was attempted, but did not match any of
@@ -74,7 +74,7 @@ namespace Azure.Functions.Cli.Common
 
         private ParseSecretResult ParsePrimaryRegexSecret(string value)
         {
-            var match = PrimaryValidKeyVaultReferenceRegex.Match(value);
+            var match = PrimaryKeyVaultReferenceRegex.Match(value);
             if (match.Success)
             {
                 return new ParseSecretResult
@@ -89,7 +89,7 @@ namespace Azure.Functions.Cli.Common
 
         private ParseSecretResult ParseSecondaryRegexSecret(string value)
         {
-            var altMatch = SecondaryValidKeyVaultReferenceRegex.Match(value);
+            var altMatch = SecondaryKeyVaultReferenceRegex.Match(value);
             if (altMatch.Success)
             {
                 return new ParseSecretResult

--- a/src/Azure.Functions.Cli/Common/KeyVaultReferencesManager.cs
+++ b/src/Azure.Functions.Cli/Common/KeyVaultReferencesManager.cs
@@ -14,9 +14,9 @@ namespace Azure.Functions.Cli.Common
     class KeyVaultReferencesManager
     {
         private const string vaultUriSuffix = "vault.azure.net";
-        private static readonly Regex BasicKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\([\S]*\)$", RegexOptions.Compiled);
-        private static readonly Regex PrimaryKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\(SecretUri=(?<VaultUri>https://[\S^/]+)/(?<Secrets>[\S^/]+)/(?<SecretName>[\S^/]+)/(?<Version>[\S^/]+)\)$", RegexOptions.Compiled);
-        private static readonly Regex SecondaryKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\(VaultName=(?<VaultName>[\S^;]+);SecretName=(?<SecretName>[\S^;]+)\)$", RegexOptions.Compiled); 
+        private static readonly Regex BasicKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\(\S*\)$", RegexOptions.Compiled);
+        private static readonly Regex PrimaryKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\(SecretUri=(?<VaultUri>https://[^\s/]+)/(?<Secrets>[^\s/]+)/(?<SecretName>[^\s/]+)/(?<Version>[^\s/]+)\)$", RegexOptions.Compiled);
+        private static readonly Regex SecondaryKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\(VaultName=(?<VaultName>[^\s;]+);SecretName=(?<SecretName>[^\s;]+)\)$", RegexOptions.Compiled); 
         private readonly ConcurrentDictionary<string, SecretClient> clients = new ConcurrentDictionary<string, SecretClient>();
         private readonly TokenCredential credential = new DefaultAzureCredential();
 
@@ -65,7 +65,7 @@ namespace Azure.Functions.Cli.Common
                 // the supported formats, we write a warning to the console.
                 if (result == null)
                 {
-                    ColoredConsole.WriteLine(WarningColor($"Invalid Key Vault reference format: {value}"));
+                    ColoredConsole.WriteLine(WarningColor($"Unable to parse the Key Vault reference: {value}"));
                 }
                 return result;
             }

--- a/src/Azure.Functions.Cli/Common/KeyVaultReferencesManager.cs
+++ b/src/Azure.Functions.Cli/Common/KeyVaultReferencesManager.cs
@@ -15,7 +15,7 @@ namespace Azure.Functions.Cli.Common
     {
         private const string vaultUriSuffix = "vault.azure.net";
         private static readonly Regex BasicKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\((?<ReferenceString>\S*)\)$", RegexOptions.Compiled);
-        private static readonly Regex PrimaryReferenceStringRegex = new Regex(@"^SecretUri=(?<VaultUri>https://[^\s/]+)/(?<Secrets>[^\s/]+)/(?<SecretName>[^\s/]+)/(?<Version>[^\s/]+)$", RegexOptions.Compiled);
+        private static readonly Regex PrimaryReferenceStringRegex = new Regex(@"^SecretUri=(?<VaultUri>https://[^\s/]+)/secrets/(?<SecretName>[^\s/]+)/(?<Version>[^\s/]+)$", RegexOptions.Compiled);
         private static readonly Regex SecondaryReferenceStringRegex = new Regex(@"^VaultName=(?<VaultName>[^\s;]+);SecretName=(?<SecretName>[^\s;]+)$", RegexOptions.Compiled); 
         private readonly ConcurrentDictionary<string, SecretClient> clients = new ConcurrentDictionary<string, SecretClient>();
         private readonly TokenCredential credential = new DefaultAzureCredential();

--- a/src/Azure.Functions.Cli/Common/KeyVaultReferencesManager.cs
+++ b/src/Azure.Functions.Cli/Common/KeyVaultReferencesManager.cs
@@ -15,8 +15,8 @@ namespace Azure.Functions.Cli.Common
     {
         private const string vaultUriSuffix = "vault.azure.net";
         private static readonly Regex BasicKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\((?<ReferenceString>\S*)\)$", RegexOptions.Compiled);
-        private static readonly Regex PrimaryReferenceStringRegex = new Regex(@"^SecretUri=(?<VaultUri>https://[^\s/]+)/secrets/(?<SecretName>[^\s/]+)/(?<Version>[^\s/]+)$", RegexOptions.Compiled);
-        private static readonly Regex SecondaryReferenceStringRegex = new Regex(@"^VaultName=(?<VaultName>[^\s;]+);SecretName=(?<SecretName>[^\s;]+)$", RegexOptions.Compiled); 
+        private static readonly Regex PrimaryReferenceStringRegex = new Regex(@"^SecretUri=(?<VaultUri>https://[^\s/]+)/secrets/(?<SecretName>[^\s/]+)/(?<Version>[^\s/]*)$", RegexOptions.Compiled);
+        private static readonly Regex SecondaryReferenceStringRegex = new Regex(@"^VaultName=(?<VaultName>[^\s;]+);SecretName=(?<SecretName>[^\s;]+)(;SecretVersion=(?<Version>[^\s;]+))?$", RegexOptions.Compiled); 
         private readonly ConcurrentDictionary<string, SecretClient> clients = new ConcurrentDictionary<string, SecretClient>();
         private readonly TokenCredential credential = new DefaultAzureCredential();
 

--- a/src/Azure.Functions.Cli/Common/KeyVaultReferencesManager.cs
+++ b/src/Azure.Functions.Cli/Common/KeyVaultReferencesManager.cs
@@ -67,6 +67,7 @@ namespace Azure.Functions.Cli.Common
                 if (result == null)
                 {
                     ColoredConsole.WriteLine(WarningColor($"Unable to parse the Key Vault reference: {value}"));
+                    ColoredConsole.WriteLine(AdditionalInfoColor("Please see https://docs.microsoft.com/en-us/azure/app-service/app-service-key-vault-references for more detail on Key Vault reference syntax."));
                 }
                 return result;
             }
@@ -90,13 +91,14 @@ namespace Azure.Functions.Cli.Common
 
         private ParseSecretResult ParseSecondaryRegexSecret(string value)
         {
-            var altMatch = SecondaryReferenceStringRegex.Match(value);
-            if (altMatch.Success)
+            var match = SecondaryReferenceStringRegex.Match(value);
+            if (match.Success)
             {
                 return new ParseSecretResult
                 {
-                    Uri = new Uri($"https://{altMatch.Groups["VaultName"]}.{vaultUriSuffix}"),
-                    Name = altMatch.Groups["SecretName"].Value
+                    Uri = new Uri($"https://{match.Groups["VaultName"]}.{vaultUriSuffix}"),
+                    Name = match.Groups["SecretName"].Value,
+                    Version = match.Groups["Version"].Value
                 };
             }
             return null;

--- a/src/Azure.Functions.Cli/Common/KeyVaultReferencesManager.cs
+++ b/src/Azure.Functions.Cli/Common/KeyVaultReferencesManager.cs
@@ -3,17 +3,20 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Colors.Net;
 using Azure.Core;
 using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
+using static Azure.Functions.Cli.Common.OutputTheme;
 
 namespace Azure.Functions.Cli.Common
 {
     class KeyVaultReferencesManager
     {
         private const string vaultUriSuffix = "vault.azure.net";
-        private static readonly Regex PrimaryKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\(SecretUri=(?<VaultUri>[\S^/]+)/(?<Secrets>[\S^/]+)/(?<SecretName>[\S^/]+)/(?<Version>[\S^/]+)\)$", RegexOptions.Compiled);
-        private static readonly Regex SecondaryKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\(VaultName=(?<VaultName>[\S^;]+);SecretName=(?<SecretName>[\S^;]+)\)$", RegexOptions.Compiled); 
+        private static readonly Regex KeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\([\S]*\)$", RegexOptions.Compiled);
+        private static readonly Regex PrimaryValidKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\(SecretUri=(?<VaultUri>https://[\S^/]+)/(?<Secrets>[\S^/]+)/(?<SecretName>[\S^/]+)/(?<Version>[\S^/]+)\)$", RegexOptions.Compiled);
+        private static readonly Regex SecondaryValidKeyVaultReferenceRegex = new Regex(@"^@Microsoft.KeyVault\(VaultName=(?<VaultName>[\S^;]+);SecretName=(?<SecretName>[\S^;]+)\)$", RegexOptions.Compiled); 
         private readonly ConcurrentDictionary<string, SecretClient> clients = new ConcurrentDictionary<string, SecretClient>();
         private readonly TokenCredential credential = new DefaultAzureCredential();
 
@@ -45,19 +48,33 @@ namespace Azure.Functions.Cli.Common
 
         private ParseSecretResult ParseSecret(string value)
         {
-            try
+            // If the value is null, then we return nothing, as the subsequent call to
+            // UpdateEnvironmentVariables(settings) will log to the user that the setting
+            // is skipped. We check here, because Regex.Match throws when supplied with a
+            // null value.
+            if (value == null)
             {
-                return ParsePrimaryRegexSecret(value) ?? ParseSecondaryRegexSecret(value);
+                return null;
             }
-            catch
+
+            // Determine if the secret value is attempting to use a key vault reference
+            if (KeyVaultReferenceRegex.Match(value).Success)
             {
-                throw new FormatException($"Key Vault Reference format invalid: {value}");
+                var result = ParsePrimaryRegexSecret(value) ?? ParseSecondaryRegexSecret(value);
+                // If we detect that a key vault reference was attempted, but did not match any of
+                // the supported formats, we write a warning to the console.
+                if (result == null)
+                {
+                    ColoredConsole.WriteLine(WarningColor($"Invalid Key Vault Reference format: {value}"));
+                }
+                return result;
             }
+            return null;
         }
 
         private ParseSecretResult ParsePrimaryRegexSecret(string value)
         {
-            var match = PrimaryKeyVaultReferenceRegex.Match(value);
+            var match = PrimaryValidKeyVaultReferenceRegex.Match(value);
             if (match.Success)
             {
                 return new ParseSecretResult
@@ -72,7 +89,7 @@ namespace Azure.Functions.Cli.Common
 
         private ParseSecretResult ParseSecondaryRegexSecret(string value)
         {
-            var altMatch = SecondaryKeyVaultReferenceRegex.Match(value);
+            var altMatch = SecondaryValidKeyVaultReferenceRegex.Match(value);
             if (altMatch.Success)
             {
                 return new ParseSecretResult

--- a/src/Azure.Functions.Cli/Common/KeyVaultReferencesManager.cs
+++ b/src/Azure.Functions.Cli/Common/KeyVaultReferencesManager.cs
@@ -65,7 +65,7 @@ namespace Azure.Functions.Cli.Common
                 // the supported formats, we write a warning to the console.
                 if (result == null)
                 {
-                    ColoredConsole.WriteLine(WarningColor($"Invalid Key Vault Reference format: {value}"));
+                    ColoredConsole.WriteLine(WarningColor($"Invalid Key Vault reference format: {value}"));
                 }
                 return result;
             }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Along with #2991, resolves #2989. Adds support for other syntaxes for Key Vault references mentioned in [this document](https://docs.microsoft.com/en-us/azure/app-service/app-service-key-vault-references). Additional information pointing to that document is also emitted in the case that a value resembling a Key Vault reference, i.e. `@Microsoft.KeyVault(\S*)`, is not able to be successfully resolved into the Key Vault reference syntaxes. This is marked as a draft until #2991 is merged.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: This will be backported to `v3.x` once #2991 is successfully backported to `v3.x`
* [x] I have added all required tests (Unit tests, E2E tests)