### PR TITLE
Support dotnet-isolated runtime when deploying to KEDA

### DIFF
--- a/src/Azure.Functions.Cli/StaticResources/print-functions.sh
+++ b/src/Azure.Functions.Cli/StaticResources/print-functions.sh
@@ -18,13 +18,18 @@ echo ','
 
 echo '"functionsJson": {'
 
-for d in */; do
-    d=$(echo $d | tr -d '/')
-    if [ -f "${d}/function.json" ]; then
-        echo "\"${d}\": "
-        cat "${d}/function.json"
-        echo ','
-    fi
-done
+if [ -f "functions.metadata" ]; then
+    sed -nzE 's/^\[(.+\n {4}"name": "([^"]+)".+)\]$/"\2": \1/p' functions.metadata
+else
+    for d in */; do
+        d=$(echo $d | tr -d '/')
+        if [ -f "${d}/function.json" ]; then
+            echo "\"${d}\": "
+            cat "${d}/function.json"
+            echo ','
+        fi
+    done
+fi
+
 echo '}'
 echo '}'


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Resolves #2825

Apparently, the Kubernetes deployment part of the function tools was not updated to support `dotnet-isolated` worker runtime since it still looks for `function.json` files which [are not being generated with the new runtime](https://docs.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide#differences-with-net-class-library-functions).

That being said, the functions metadata still gets created in the `functions.metadata` file which is essentially an array of objects with similar to `function.json` structure.

This PR adds support of `dotnet-isolated` runtime functions by reading the metadata from the new `functions.metadata` file.

To test this, create a new `dotnet-isolated` function project with at least one trigger and run `func kubernetes deploy --name testname --registry testregistry --dry-run --dotnet-isolated`
The output should contain yamls for `Deployment` and `ScaledObject` with corresponding data.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [x] Otherwise: Backport tracked by issue/PR #2556
* [ ] I have added all required tests (Unit tests, E2E tests)