### PR TITLE
Copy dev branch readme to v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,47 +16,98 @@ The Azure Functions Core Tools provide a local development experience for creati
 
 **v2** (master branch): Self-contained cross-platform package
 
-**v3**: Self-contained cross-platform package
+**v3**: (v3.x branch): Self-contained cross-platform package
+
+**v4**: (v4.x branch): Self-contained cross-platform package **(recommended)**
 
 ## Installing
 
 ### Windows
 
-To install runtime with npm:
+#### To download and install with MSI:
 
-**v2**
+##### v4
+
+- [Windows 64-bit](https://go.microsoft.com/fwlink/?linkid=2174087) (VS Code debugging requires 64-bit)
+- [Windows 32-bit](https://go.microsoft.com/fwlink/?linkid=2174159)
+
+##### v3
+
+- [Windows 64-bit](https://go.microsoft.com/fwlink/?linkid=2135274) (VS Code debugging requires 64-bit)
+- [Windows 32-bit](https://go.microsoft.com/fwlink/?linkid=2135275)
+
+#### To install with npm:
+
+##### v4
 ```bash
-npm i -g azure-functions-core-tools@2 --unsafe-perm true
+npm i -g azure-functions-core-tools@4 --unsafe-perm true
 ```
 
-**v3**
+##### v3
 ```bash
 npm i -g azure-functions-core-tools@3 --unsafe-perm true
 ```
 
-To install with chocolatey:
+##### v2
+```bash
+npm i -g azure-functions-core-tools@2 --unsafe-perm true
+```
+
+#### To install with chocolatey:
+
+##### v3
+```bash
+choco install azure-functions-core-tools-3
+```
+
+*Notice: To debug functions under vscode, the 64-bit version is required*
+```bash
+choco install azure-functions-core-tools-3 --params "'/x64'"
+```
+
+##### v2
+```bash
+choco install azure-functions-core-tools-2
+```
+
+#### To install with winget:
+
+##### v4
 
 ```bash
-choco install azure-functions-core-tools
+winget install Microsoft.AzureFunctionsCoreTools
+```
+
+##### v3
+
+```bash
+winget install Microsoft.AzureFunctionsCoreTools -v 3.0.3904
 ```
 
 ### Mac
 
-**Homebrew**:
+#### Homebrew:
 
-**v2**
+##### v4
+    
 ```bash
 brew tap azure/functions
-brew install azure-functions-core-tools@2
+brew install azure-functions-core-tools@4
 ```
 
-**v3**
+##### v3
 ```bash
 brew tap azure/functions
 brew install azure-functions-core-tools@3
 ```
 
-Homebrew allow side by side installation of v2 and v3, you can switch between the versions using
+##### v2
+```bash
+brew tap azure/functions
+brew install azure-functions-core-tools@2
+```
+
+Homebrew allows side by side installation of v2 and v3, you can switch between the versions using
 ```bash
 brew link --overwrite azure-functions-core-tools@3
 ```
@@ -64,10 +115,14 @@ brew link --overwrite azure-functions-core-tools@3
 
 ### Linux
 
-#### Ubuntu
+#### 1. Set up package feed
 
-1. Set up package feed
+##### Ubuntu 20.04
 
+```bash
+wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb
+```
 
 ##### Ubuntu 19.04
 
@@ -97,63 +152,77 @@ wget -q https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-pr
 sudo dpkg -i packages-microsoft-prod.deb
 ```
 
-##### Debian 9
+##### Debian 9 / 10
 
 ```bash
+# set to 9 or 10
+DEBIAN_VERSION=10
+
 wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg
 sudo mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/
-wget -q https://packages.microsoft.com/config/debian/9/prod.list
+wget -q https://packages.microsoft.com/config/debian/$DEBIAN_VERSION/prod.list
 sudo mv prod.list /etc/apt/sources.list.d/microsoft-prod.list
 sudo chown root:root /etc/apt/trusted.gpg.d/microsoft.asc.gpg
 sudo chown root:root /etc/apt/sources.list.d/microsoft-prod.list
 ```
 
-2. Install
+#### 2. Install
 
+##### v4
 ```bash
 sudo apt-get update
-sudo apt-get install azure-functions-core-tools
+sudo apt-get install azure-functions-core-tools-4
+```
+
+##### v3
+```bash
+sudo apt-get update
+sudo apt-get install azure-functions-core-tools-3
+```
+
+##### v2
+```bash
+sudo apt-get update
+sudo apt-get install azure-functions-core-tools-2
 ```
 
 #### Other Linux Distributions
 
 1. Download latest release
 
-Download the latest release for your platform from [here](https://github.com/Azure/azure-functions-core-tools/releases).
+    Download the latest release for your platform from [here](https://github.com/Azure/azure-functions-core-tools/releases).
 
 2. Unzip release zip
 
-Using your preferred tool, unzip the downloaded release. To unzip into an `azure-functions-cli` directory using the `unzip` tool, run this command from the directory containing the downloaded release zip:
+    Using your preferred tool, unzip the downloaded release. To unzip into an `azure-functions-cli` directory using the `unzip` tool, run this command from the directory containing the downloaded release zip:
 
-```bash
-unzip -d azure-functions-cli Azure.Functions.Cli.linux-x64.*.zip
-```
+    ```bash
+    unzip -d azure-functions-cli Azure.Functions.Cli.linux-x64.*.zip
+    ```
 
 3. Make the `func` command executable
 
-Zip files do not maintain the executable bit on binaries. So, you'll need to make the `func` binary executable. Assuming you used the instructions above to unzip:
+    Zip files do not maintain the executable bit on binaries. So, you'll need to make the `func` binary, as well as `gozip` (used by func during packaging) executables. Assuming you used the instructions above to unzip:
 
-```bash
-cd azure-functions-cli
-chmod +x func
-./func
-```
+    ```bash
+    cd azure-functions-cli
+    chmod +x func
+    chmod +x gozip
+    ./func
+    ```
 
 4. Optionally add `func` to your `$PATH`
 
-To execute the `func` command without specifying the full path to the binary, add its directory to your `$PATH` environment variable. Assuming you're still following along from above:
+    To execute the `func` command without specifying the full path to the binary, add its directory to your `$PATH` environment variable. Assuming you're still following along from above:
 
-```bash
-export PATH=`pwd`:$PATH
-func
-```
+    ```bash
+    export PATH=`pwd`:$PATH
+    func
+    ```
 
 [Code and test Azure Functions locally](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local)
 
 **NOTE**: npm can be used on all platforms. On unix platforms, you may need to specify `--unsafe-perm` if you are running npm with sudo. That's due to npm behavior of post install script.
-
-
-**NOTE**: If you're running the v2 on Windows, Linux, or Mac, make sure to [enable the `beta` runtime](https://docs.microsoft.com/en-us/azure/azure-functions/functions-versions#target-the-version-20-runtime) in function app settings, otherwise you may not see the same results as running locally.
 
 ## Getting Started on Kubernetes
 
@@ -202,7 +271,7 @@ func kubernetes deploy --name myfunction --registry <docker-hub-id or registry-s
 
 #### Prerequisites
 
-* [Knative](https://github.com/knative/docs/tree/master/install/)
+* [Knative](https://github.com/knative/docs/tree/master/docs/install)
 
 Deploying Azure Functions to knative is supported with the ```--platform knative``` flag.
 The Core Tools CLI identifies non HTTP trigger functions and annotates the knative manifest with the the ```minScale``` annotation to opt out of scale-to-zero.
@@ -273,7 +342,7 @@ Azure Functions running on Kubernetes can take advantage of true serverless cont
 Functions deployed to Kubernetes already contain all the tolerations needed to be schedulable to Virtual Kubelet nodes.
 All you need to do is to set up VKubelet on your Kubernetes cluster:
 
-* [Install VKubelet with ACI](https://github.com/virtual-kubelet/virtual-kubelet/tree/master/providers/azure)
+* [Install VKubelet with ACI](https://github.com/virtual-kubelet/azure-aci)
 
 * [Install VKubelet with ACI on AKS](https://docs.microsoft.com/en-us/cli/azure/aks?view=azure-cli-latest#az-aks-install-connector)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 |Branch|Status|
 |---|---|
-|master|[![Build Status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/azure-functions-core-tools?branchName=master)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=11&branchName=master)
+|v4.x|[![Build status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/azure-functions-core-tools?branchName=v4.x)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=11&branchName=v4.x)|
+|v3.x|[![Build status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/azure-functions-core-tools?branchName=v3.x)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=11&branchName=v3.x)|
 |dev|[![Build Status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/azure-functions-core-tools?branchName=dev)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=11&branchName=dev)
 |v1.x|[![Build status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/azure-functions-core-tools?branchName=v1.x)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=11&branchName=v1.x)|
 
@@ -14,7 +15,7 @@ The Azure Functions Core Tools provide a local development experience for creati
 
 **v1** (v1.x branch): Requires .NET 4.7.1 Windows Only
 
-**v2** (master branch): Self-contained cross-platform package
+**v2** (dev branch): Self-contained cross-platform package
 
 **v3**: (v3.x branch): Self-contained cross-platform package
 


### PR DESCRIPTION
The "dev" branch has been our default for a while, so that's why it has the most up to date README. However, I want to copy it over to the "v4.x" branch for a few reasons:
1. The npm module gets it's readme from "v4.x" which means right now it looks out of date: https://www.npmjs.com/package/azure-functions-core-tools
2. Soon we will make v4.x the default branch