### PR TITLE
Add v3 tag to npm package

### DIFF
--- a/src/Azure.Functions.Cli/npm/package.json
+++ b/src/Azure.Functions.Cli/npm/package.json
@@ -35,5 +35,8 @@
         "rimraf": "3.0.2",
         "tmp": "0.1.0",
         "unzipper": "0.10.10"
+    },
+    "publishConfig": {
+        "tag": "v3"
     }
 }


### PR DESCRIPTION
By default npm uses the "latest" tag when publishing, regardless of major version. However, we always want "latest" pointing to v4, so I've added config to use "v3" as the tag when publishing v3. I don't expect people to use this tag (you can already specify a major version by doing `azure-functions-core-tools@3` as described in our [readme](https://github.com/Azure/azure-functions-core-tools#to-install-with-npm)), but this was one of the recommended workarounds in https://github.com/npm/npm/issues/6778 and I see other people doing similar things (example [here](https://www.npmjs.com/package/npm) and [here](https://www.npmjs.com/package/@angular/core) if you go to the versions tab)

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [x] Otherwise: https://github.com/Azure/azure-functions-core-tools/pull/3012
* [x] I have added all required tests (Unit tests, E2E tests)