### PR TITLE
Sign mac executables

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -166,6 +166,27 @@ jobs:
       MaxConcurrency: '50'
       MaxRetryAttempts: '5'
     condition: and(succeeded(), eq(variables['IsReleaseBuild'], 'true'))
+  - task: EsrpCodeSigning@1
+    displayName: 'Mac signing'
+    inputs:
+      ConnectedServiceName: 'ESRP Service'
+      FolderPath: '$(Build.Repository.LocalPath)\artifacts\ToSign\Mac\'
+      Pattern: '*.zip'
+      signConfigType: 'inlineSignParams'
+      inlineOperation: |
+        [
+          {
+              "KeyCode" : "CP-401337-Apple",
+              "OperationCode" : "MacAppDeveloperSign",
+              "Parameters" : {},
+              "ToolName" : "sign",
+              "ToolVersion" : "1.0"
+          }
+        ]
+      SessionTimeout: '60'
+      MaxConcurrency: '50'
+      MaxRetryAttempts: '5'
+    condition: and(succeeded(), eq(variables['IsReleaseBuild'], 'true'))
   - pwsh: |
       .\repackageBinaries.ps1
     displayName: Repackage signed binaries

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -314,28 +314,45 @@ namespace Build
             string toSignDirPath = Path.Combine(Settings.OutputDir, Settings.SignInfo.ToSignDir);
             string authentiCodeDirectory = Path.Combine(toSignDirPath, Settings.SignInfo.ToAuthenticodeSign);
             string thirdPartyDirectory = Path.Combine(toSignDirPath, Settings.SignInfo.ToThirdPartySign);
+            string macDirectory = Path.Combine(toSignDirPath, Settings.SignInfo.ToMacSign);
 
             Directory.CreateDirectory(authentiCodeDirectory);
             Directory.CreateDirectory(thirdPartyDirectory);
+            Directory.CreateDirectory(macDirectory);
 
             foreach (var supportedRuntime in Settings.SignInfo.RuntimesToSign)
             {
                 var sourceDir = Path.Combine(Settings.OutputDir, supportedRuntime);
-                var toSignPaths = Settings.SignInfo.authentiCodeBinaries.Select(el => Path.Combine(sourceDir, el));
-                // Grab all the files and filter the extensions not to be signed
-                var toAuthenticodeSignFiles = FileHelpers.GetAllFilesFromFilesAndDirs(FileHelpers.ExpandFileWildCardEntries(toSignPaths))
-                                  .Where(file => !Settings.SignInfo.FilterExtenstionsSign.Any(ext => file.EndsWith(ext))).ToList();
+                var dirName = $"Azure.Functions.Cli.{supportedRuntime}.{CurrentVersion}";
 
-                string dirName = $"Azure.Functions.Cli.{supportedRuntime}.{CurrentVersion}";
-                string targetDirectory = Path.Combine(authentiCodeDirectory, dirName);
-                toAuthenticodeSignFiles.ForEach(f => FileHelpers.CopyFileRelativeToBase(f, targetDirectory, sourceDir));
+                if (supportedRuntime.StartsWith("osx"))
+                {
+                    var toSignMacFiles = Settings.SignInfo.macBinaries.Select(el => Path.Combine(sourceDir, el)).ToList();
+                    var targetMacDirectory = Path.Combine(macDirectory, dirName);
+                    toSignMacFiles.ForEach(f => FileHelpers.CopyFileRelativeToBase(f, targetMacDirectory, sourceDir));
 
-                var toSignThirdPartyPaths = Settings.SignInfo.thirdPartyBinaries.Select(el => Path.Combine(sourceDir, el));
-                // Grab all the files and filter the extensions not to be signed
-                var toSignThirdPartyFiles = FileHelpers.GetAllFilesFromFilesAndDirs(FileHelpers.ExpandFileWildCardEntries(toSignThirdPartyPaths))
-                                            .Where(file => !Settings.SignInfo.FilterExtenstionsSign.Any(ext => file.EndsWith(ext))).ToList();
-                string targetThirdPartyDirectory = Path.Combine(thirdPartyDirectory, dirName);
-                toSignThirdPartyFiles.ForEach(f => FileHelpers.CopyFileRelativeToBase(f, targetThirdPartyDirectory, sourceDir));
+                    // mac signing requires the files to be in a zip
+                    var zipPath = Path.Combine(macDirectory, $"{dirName}.zip");
+                    ColoredConsole.WriteLine($"Creating {zipPath}");
+                    ZipFile.CreateFromDirectory(targetMacDirectory, zipPath, CompressionLevel.Optimal, includeBaseDirectory: false);
+                    Directory.Delete(targetMacDirectory, recursive: true);
+                }
+                else
+                {
+                    var toSignPaths = Settings.SignInfo.authentiCodeBinaries.Select(el => Path.Combine(sourceDir, el));
+                    // Grab all the files and filter the extensions not to be signed
+                    var toAuthenticodeSignFiles = FileHelpers.GetAllFilesFromFilesAndDirs(FileHelpers.ExpandFileWildCardEntries(toSignPaths))
+                                    .Where(file => !Settings.SignInfo.FilterExtenstionsSign.Any(ext => file.EndsWith(ext))).ToList();
+                    string targetAuthenticodeDirectory = Path.Combine(authentiCodeDirectory, dirName);
+                    toAuthenticodeSignFiles.ForEach(f => FileHelpers.CopyFileRelativeToBase(f, targetAuthenticodeDirectory, sourceDir));
+
+                    var toSignThirdPartyPaths = Settings.SignInfo.thirdPartyBinaries.Select(el => Path.Combine(sourceDir, el));
+                    // Grab all the files and filter the extensions not to be signed
+                    var toSignThirdPartyFiles = FileHelpers.GetAllFilesFromFilesAndDirs(FileHelpers.ExpandFileWildCardEntries(toSignThirdPartyPaths))
+                                                .Where(file => !Settings.SignInfo.FilterExtenstionsSign.Any(ext => file.EndsWith(ext))).ToList();
+                    string targetThirdPartyDirectory = Path.Combine(thirdPartyDirectory, dirName);
+                    toSignThirdPartyFiles.ForEach(f => FileHelpers.CopyFileRelativeToBase(f, targetThirdPartyDirectory, sourceDir));
+                }
             }
 
             // binaries we know are unsigned via sigcheck.exe
@@ -359,6 +376,12 @@ namespace Build
         {
             foreach (var supportedRuntime in Settings.SignInfo.RuntimesToSign)
             {
+                if (supportedRuntime.StartsWith("osx"))
+                {
+                    // sigcheck.exe does not work for mac signatures
+                    continue;
+                }
+
                 var sourceDir = Path.Combine(Settings.OutputDir, supportedRuntime);
                 var targetDir = Path.Combine(Settings.OutputDir, Settings.PreSignTestDir, supportedRuntime);
                 Directory.CreateDirectory(targetDir);
@@ -391,6 +414,12 @@ namespace Build
 
             foreach (string zipFilePath in zipFiles)
             {
+                if (zipFilePath.Contains("osx"))
+                {
+                    // sigcheck.exe does not work for mac signatures
+                    continue;
+                }
+
                 bool isSignedRuntime = Settings.SignInfo.RuntimesToSign.Any(r => zipFilePath.Contains(r));
                 if (isSignedRuntime)
                 {

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -145,7 +145,8 @@ namespace Build
             public static readonly string ToAuthenticodeSign = "Authenticode";
             public static readonly string ThirdParty = "Sign3rdParty";
             public static readonly string ToThirdPartySign = "ThirdParty";
-            public static readonly string[] RuntimesToSign = new string[] { "min.win-x86", "min.win-x64" };
+            public static readonly string ToMacSign = "Mac";
+            public static readonly string[] RuntimesToSign = new string[] { "min.win-x86", "min.win-x64", "osx-arm64", "osx-x64" };
             public static readonly string[] FilterExtenstionsSign = new[] { ".json", ".spec", ".cfg", ".pdb", ".config", ".nupkg", ".py", ".md" };
             public static readonly string SigcheckDownloadURL = "https://functionsbay.blob.core.windows.net/public/tools/sigcheck64.exe";
 
@@ -153,6 +154,11 @@ namespace Build
                 "aspnetcorev2_inprocess.dll",
                 "Microsoft.AspNetCore.Buffering.dll",
                 "Microsoft.AspNetCore.Server.IIS.dll"
+            };
+
+            public static readonly string[] macBinaries = new[] {
+                "func",
+                "gozip"
             };
 
             public static readonly string[] authentiCodeBinaries = new[] {

--- a/repackageBinaries.ps1
+++ b/repackageBinaries.ps1
@@ -49,14 +49,14 @@ try
     }
 
     # Runtimes with signed binaries
-    $runtimesIdentifiers = @("min.win-x86","min.win-x64")
+    $runtimesIdentifiers = @("min.win-x86","min.win-x64", "osx-arm64", "osx-x64")
     $tempDirectory = New-Item $tempDirectoryPath -ItemType Directory
     LogSuccess "$tempDirectoryPath created"
 
     # Unzip the coretools artifact to add signed binaries
     foreach($rid in $runtimesIdentifiers)
     {
-        $files= Get-ChildItem -Recurse -Path "..\artifacts\*.zip"
+        $files= Get-ChildItem -Path "..\artifacts\*.zip"
         foreach($file in $files)
         {
             if ($file.Name.Contains($rid))
@@ -97,6 +97,15 @@ try
     {
         $sourcePath = $directory.FullName
         Copy-Item -Path $sourcePath -Destination $tempDirectoryPath -Recurse -Force
+    }
+
+    # mac signing requires the files to be in a zip to sign, so we have to extract the zip before copying over the signed files
+    $macZipFiles  = Get-ChildItem "..\artifacts\ToSign\Mac\*.zip"
+    foreach($macZipFile in $macZipFiles)
+    {
+        $macUnzippedDir = Join-Path $macZipFile.DirectoryName $macZipFile.BaseName
+        Unzip $macZipFile.FullName $macUnzippedDir
+        Copy-Item -Path $macUnzippedDir -Destination $tempDirectoryPath -Recurse -Force
     }
 
     $fileCountAfter = (Get-ChildItem $tempDirectoryPath -Recurse | Measure-Object).Count


### PR DESCRIPTION
Related to https://github.com/Azure/azure-functions-core-tools/issues/2834, Apple [requires](https://eclecticlight.co/2020/08/22/apple-silicon-macs-will-require-signed-code/) arm64 executables to be signed in order to run. Without signing, any command just silently fails. A few notes:
1. This requirement does not apply to x64 executables, but it's still encouraged to sign binaries when possible and it's trivial for us to sign both x64 and arm64 at the same time
1. The requirement does not extend to dlls or other binaries. My changes are the minimum required to unblock users from running `func`, but we may want to consider signing those other bits in the future
1. The `.exe` file extension is unique to windows. Mac executables have _no_ file extension
1. Mac signatures are completely different than Windows signatures, so I had to reflect that in our build pipeline. For example, they do not use `sigcheck.exe`, rather a tool called `codesign` that ships with XCode on Mac. A few example commands:
    1. List signature information: `codesign -dv <file path>`
    1. Test sign a file: `codesign -s - <file path>` (This is how I originally tested arm64 bits before the last release. At the time, I didn't fully understand what the command was doing and thought it was only necessary because I was testing pre-release bits as opposed to using an official release channel like npm/brew)
1. For some reason, mac signing (through the ESRP dev ops task) requires us to zip up the files before sending them over. If I don't do that, I get an error like `Incorrect file type used for command -z. It needs to be a .zip or .dmg file.`. Importantly, it still signs the individual files _in_ the zip, not the zip itself

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)