### PR TITLE
Allow user secrets in dotnet-isolated projects

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -1,4 +1,3 @@
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -1,3 +1,4 @@
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -179,7 +180,8 @@ namespace Azure.Functions.Cli.Actions.HostActions
         private async Task<IWebHost> BuildWebHost(ScriptApplicationHostOptions hostOptions, Uri listenAddress, Uri baseAddress, X509Certificate2 certificate)
         {
             LoggingFilterHelper loggingFilterHelper = new LoggingFilterHelper(_hostJsonConfig, VerboseLogging);
-            if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.dotnet)
+            if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.dotnet ||
+                GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.dotnetIsolated)
             {
                 UserSecretsId = ProjectHelpers.GetUserSecretsId(hostOptions.ScriptPath, loggingFilterHelper, new LoggerFilterOptions());
             }

--- a/src/Azure.Functions.Cli/Helpers/ProjectHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/ProjectHelpers.cs
@@ -40,7 +40,7 @@ namespace Azure.Functions.Cli.Helpers
                 {
                     foreach (FileInfo file in projectFiles)
                     {
-                        if (string.Equals(projectFiles[0].Name, Constants.ExtenstionsCsProjFile, StringComparison.OrdinalIgnoreCase)) continue;
+                        if (string.Equals(file.Name, Constants.ExtenstionsCsProjFile, StringComparison.OrdinalIgnoreCase)) continue;
                         logger.LogDebug($"Found {file.FullName}. Using for user secrets file configuration.");
                         return file.FullName;
                     }

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -528,8 +528,10 @@ namespace Azure.Functions.Cli.Tests.E2E
             }, _output);
         }
 
-        [Fact]
-        public async Task start_with_user_secrets()
+        [Theory]
+        [InlineData("dotnet")]
+        [InlineData("dotnet-isolated")]
+        public async Task start_with_user_secrets(string language)
         {
             await CliTester.Run(new RunConfiguration[]
             {
@@ -537,7 +539,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                 {
                     Commands = new[]
                     {
-                        "init . --worker-runtime dotnet",
+                        $"init . --worker-runtime {language}",
                         "new --template \"Http trigger\" --name http1",
                         "new --template \"Queue trigger\" --name queue1"
                     },


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves [#issue_for_this_pr](https://github.com/Azure/azure-functions-dotnet-worker/issues/827)
Reference PR - https://github.com/Azure/azure-functions-core-tools/pull/2464

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)