### PR TITLE
Added PSScriptRoot to validateWorkerVersions script V4

### DIFF
--- a/validateWorkerVersions.ps1
+++ b/validateWorkerVersions.ps1
@@ -26,7 +26,7 @@ function removeBomIfExists([string]$data)
     return $data
 }
 
-$cliCsprojPath = "./src/Azure.Functions.Cli/Azure.Functions.Cli.csproj"
+$cliCsprojPath = "$PSScriptRoot/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj"
 $cliCsprojContent = removeBomIfExists(Get-Content $cliCsprojPath)
 $cliCsprojXml = [xml]$cliCsprojContent
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Alters the path specified for the Core Tools .csproj file in the validateWorkerVersions.ps1 script to use `$PSScriptRoot` rather than `.`. Currently, on a Windows machine, the use of `.` sets the path to be `C:`, which causes issues when attempting to save changes to the .csproj. This change is to be ported over to the `v3.x` branch.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: This is to be ported over to the `v3.x` branch
* [x] I have added all required tests (Unit tests, E2E tests)