### PR TITLE
Check if connection key exists in bindings

### DIFF
--- a/src/Azure.Functions.Cli/Kubernetes/KEDA/V2/KedaV2Resource.cs
+++ b/src/Azure.Functions.Cli/Kubernetes/KEDA/V2/KedaV2Resource.cs
@@ -113,11 +113,11 @@ namespace Azure.Functions.Cli.Kubernetes.KEDA.V2
             {
                 case TriggerTypes.AzureBlobStorage:
                 case TriggerTypes.AzureStorageQueue:
-                    metadata[ConnectionFromEnvField] = metadata[ConnectionField] ?? "AzureWebJobsStorage";
+                    metadata[ConnectionFromEnvField] = metadata.ContainsKey(ConnectionField) ? metadata[ConnectionField] : "AzureWebJobsStorage";
                     metadata.Remove(ConnectionField);
                     break;
                 case TriggerTypes.AzureServiceBus:
-                    metadata[ConnectionFromEnvField] = metadata[ConnectionField] ?? "AzureWebJobsServiceBus";
+                    metadata[ConnectionFromEnvField] = metadata.ContainsKey(ConnectionField) ? metadata[ConnectionField] : "AzureWebJobsServiceBus";
                     metadata.Remove(ConnectionField);
                     break;
                 case TriggerTypes.AzureEventHubs:

--- a/test/Azure.Functions.Cli.Tests/KedaHelperUnitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/KedaHelperUnitTests.cs
@@ -55,5 +55,48 @@ namespace Azure.Functions.Cli.Tests
             Assert.Equal("myQueue", metadata["queueName"]);
             Assert.Equal("RabbitMQConnection", metadata["hostFromEnv"]);
         }
+
+        [Fact]
+        public void PopulateMetadataDictionary_KedaV2_CorrectlyPopulatesAzureStorageQueueMetadata()
+        {
+            string jsonText = @"
+            {
+                ""type"": ""queuetrigger"",
+                ""connection"": ""StorageQueueConnection"",
+                ""queueName"": ""myQueue"",
+                ""name"": ""context""
+            }";
+
+            JToken jsonObj = JToken.Parse(jsonText);
+
+            IDictionary<string, string> metadata = new KedaV2Resource().PopulateMetadataDictionary(jsonObj);
+
+            Assert.Equal(2, metadata.Count);
+            Assert.True(metadata.ContainsKey("queueName"));
+            Assert.True(metadata.ContainsKey("connectionFromEnv"));
+            Assert.Equal("myQueue", metadata["queueName"]);
+            Assert.Equal("StorageQueueConnection", metadata["connectionFromEnv"]);
+        }
+
+        [Fact]
+        public void PopulateMetadataDictionary_KedaV2_CorrectlyPopulatesAzureStorageQueueMetadata_WithoutConnection()
+        {
+            string jsonText = @"
+            {
+                ""type"": ""queuetrigger"",
+                ""queueName"": ""myQueue"",
+                ""name"": ""context""
+            }";
+
+            JToken jsonObj = JToken.Parse(jsonText);
+
+            IDictionary<string, string> metadata = new KedaV2Resource().PopulateMetadataDictionary(jsonObj);
+
+            Assert.Equal(2, metadata.Count);
+            Assert.True(metadata.ContainsKey("queueName"));
+            Assert.True(metadata.ContainsKey("connectionFromEnv"));
+            Assert.Equal("myQueue", metadata["queueName"]);
+            Assert.Equal("AzureWebJobsStorage", metadata["connectionFromEnv"]);
+        }
     }
 }


### PR DESCRIPTION
### Description

If a function with Storage Queue trigger or a Service Bus trigger doesn't have a "Connection" parameter, the default is obtained from `AzureWebJobsStorage` and `AzureWebJobsServiceBus` environment variables respectively. In this case, the generated function bindings will not have a `connection` key. While populating metadata dictionary, the code currently directly calls `metadata["connection"]` which throws a `KeyNotFoundException`. 

Hence in this PR, I added a `ContainsKey` check before accessing the `connection` key in the metadata dictionary.


### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)