### PR TITLE
Add azure-functions-core-tools as a dev dependency to init templates package.json

### DIFF
--- a/src/Azure.Functions.Cli/StaticResources/javascriptPackage.json
+++ b/src/Azure.Functions.Cli/StaticResources/javascriptPackage.json
@@ -7,5 +7,7 @@
     "test": "echo \"No tests yet...\""
   },
   "dependencies": {},
-  "devDependencies": {}
+  "devDependencies": {
+    "azure-functions-core-tools": "^4.x"
+  }
 }

--- a/src/Azure.Functions.Cli/StaticResources/package.json
+++ b/src/Azure.Functions.Cli/StaticResources/package.json
@@ -12,6 +12,7 @@
   "dependencies": {},
   "devDependencies": {
     "@azure/functions": "^3.0.0",
+    "azure-functions-core-tools": "^4.x",
     "@types/node": "16.x",
     "typescript": "^4.0.0"
   }


### PR DESCRIPTION
Add azure-functions-core-tools as a dev dependency to init templates

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Adds the node package of these tools as a dev dependency in package.json by default, thus enabling users to actually run `npm start` right off the bat on a fresh template without needing the core tools globally installed.

Resolves #255 

### Pull request checklist

* [X] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)