### PR TITLE
Add support for win-arm64

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1,0 +1,974 @@
+{
+  "version": "1.0",
+  "tasks": [
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "taskName": "Add needs triage label to new issues",
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isPartOfProject",
+                  "parameters": {}
+                }
+              ]
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isAssignedToSomeone",
+                  "parameters": {}
+                }
+              ]
+            }
+          ]
+        },
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Needs: Triage :mag:"
+            }
+          }
+        ],
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ]
+      },
+      "id": "wmhIXotSu"
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssueCommentResponder",
+      "version": "1.0",
+      "config": {
+        "taskName": "Replace needs author feedback label with needs attention label when the author comments on an issue",
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "created"
+              }
+            },
+            {
+              "name": "isActivitySender",
+              "parameters": {
+                "user": {
+                  "type": "author"
+                }
+              }
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "Needs: Author Feedback"
+              }
+            }
+          ]
+        },
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Needs: Attention :wave:"
+            }
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "Needs: Author Feedback"
+            }
+          }
+        ],
+        "eventType": "issue",
+        "eventNames": [
+          "issue_comment"
+        ]
+      },
+      "id": "6E_nETGi9L"
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "taskName": "Remove no recent activity label from issues",
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "closed"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "no-recent-activity"
+              }
+            }
+          ]
+        },
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "no-recent-activity"
+            }
+          }
+        ],
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ]
+      },
+      "id": "xHN84px8FJ"
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "taskName": "Close stale issues",
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -8
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isIssue",
+            "parameters": {}
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Needs: Author Feedback"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "no-recent-activity"
+            }
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 3
+            }
+          }
+        ],
+        "actions": [
+          {
+            "name": "closeIssue",
+            "parameters": {}
+          }
+        ]
+      },
+      "id": "HbHCVprtxo"
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "taskName": "Add no recent activity label to issues",
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22
+            ],
+            "timezoneOffset": -8
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isIssue",
+            "parameters": {}
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Needs: Author Feedback"
+            }
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 4
+            }
+          },
+          {
+            "name": "noLabel",
+            "parameters": {
+              "label": "no-recent-activity"
+            }
+          }
+        ],
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "no-recent-activity"
+            }
+          },
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "This issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **4 days**. It will be closed if no further activity occurs **within 3 days of this comment**."
+            }
+          }
+        ]
+      },
+      "id": "WPqwzpiszK"
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "taskName": "Close duplicate issues",
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22
+            ],
+            "timezoneOffset": -8
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isIssue",
+            "parameters": {}
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "duplicate"
+            }
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 3
+            }
+          }
+        ],
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "This issue has been marked as duplicate and has not had any activity for **3 days**. It will be closed for housekeeping purposes."
+            }
+          },
+          {
+            "name": "closeIssue",
+            "parameters": {}
+          }
+        ]
+      },
+      "id": "nbdvO3ekCu"
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "closed"
+              }
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "Needs: Triage :mag:"
+              }
+            }
+          ]
+        },
+        "taskName": "Remove needs triage label on closed issues",
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "Needs: Triage :mag:"
+            }
+          }
+        ]
+      },
+      "id": "_zN2QPpREv"
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssueCommentResponder",
+      "version": "1.0",
+      "config": {
+        "eventType": "issue",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "no-recent-activity"
+              }
+            }
+          ]
+        },
+        "taskName": "Remove no recent activity label when an issue is commented on",
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "no-recent-activity"
+            }
+          }
+        ]
+      },
+      "id": "Xnd0VM1x_"
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssueCommentResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isOpen",
+                  "parameters": {}
+                }
+              ]
+            },
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "created"
+              }
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "Status: No Recent Activity"
+              }
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "Needs: Author Feedback"
+              }
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "noActivitySince",
+                  "parameters": {
+                    "days": 7
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isCloseAndComment",
+                  "parameters": {}
+                }
+              ]
+            },
+            {
+              "name": "isActivitySender",
+              "parameters": {
+                "user": {
+                  "type": "author"
+                }
+              }
+            },
+            {
+              "name": "activitySenderHasPermissions",
+              "parameters": {
+                "permissions": "none"
+              }
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "taskName": "For issues closed due to inactivity, re-open an issue if issue author posts a reply within 7 days.",
+        "actions": [
+          {
+            "name": "reopenIssue",
+            "parameters": {}
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "Status: No Recent Activity"
+            }
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "Needs: Author Feedback"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Needs: Attention :wave:"
+            }
+          }
+        ]
+      },
+      "id": "Ua3EVMRZ6"
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssueCommentResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "created"
+              }
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isOpen",
+                  "parameters": {}
+                }
+              ]
+            },
+            {
+              "name": "activitySenderHasPermissions",
+              "parameters": {
+                "permissions": "none"
+              }
+            },
+            {
+              "name": "noActivitySince",
+              "parameters": {
+                "days": 7
+              }
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isCloseAndComment",
+                  "parameters": {}
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "taskName": "For issues closed with no activity over 7 days, ask non-contributor to consider opening a new issue instead.",
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Hello lovely human, thank you for your comment on this issue. Because this issue has been closed for a period of time, please strongly consider opening a new issue linking to this issue instead to ensure better visibility of your comment. Thank you!"
+            }
+          }
+        ]
+      },
+      "id": "oZXCZo9YgY"
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -8
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              0,
+              3,
+              6,
+              9,
+              12,
+              15,
+              18,
+              21
+            ],
+            "timezoneOffset": -8
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isClosed",
+            "parameters": {}
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 30
+            }
+          },
+          {
+            "name": "isUnlocked",
+            "parameters": {}
+          },
+          {
+            "name": "isIssue",
+            "parameters": {}
+          }
+        ],
+        "taskName": "Lock issues closed without activity for over 30 days",
+        "actions": [
+          {
+            "name": "lockIssue",
+            "parameters": {
+              "reason": "resolved"
+            }
+          }
+        ]
+      },
+      "id": "zWIX-aVru4"
+    }
+  ],
+  "userGroups": []
+}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,6 +87,7 @@ jobs:
   - pwsh: |
       .\validateWorkerVersions.ps1
     displayName: 'Validate worker versions'
+    condition: eq(variables['validateWorkerVersions'], 'true')
   - pwsh: |
       .\build.ps1
     env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,7 +87,7 @@ jobs:
   - pwsh: |
       .\validateWorkerVersions.ps1
     displayName: 'Validate worker versions'
-    condition: eq(variables['validateWorkerVersions'], 'true')
+    condition: ne(variables['skipWorkerVersionValidation'], 'true')
   - pwsh: |
       .\build.ps1
     env:

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -88,15 +88,11 @@ namespace Build
 
         private static string GetRuntimeId(string runtime)
         {
-            switch (runtime)
+            if (runtime.StartsWith(Settings.MinifiedVersionPrefix))
             {
-                case "min.win-arm64":
-                case "min.win-x86":
-                case "min.win-x64":
-                    return runtime.Substring(Settings.MinifiedVersionPrefix.Length);
-                default:
-                    return runtime;
+                return runtime.Substring(Settings.MinifiedVersionPrefix.Length);
             }
+            return runtime;
         }
 
         public static void DotnetPack()

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -342,14 +342,14 @@ namespace Build
                     var toSignPaths = Settings.SignInfo.authentiCodeBinaries.Select(el => Path.Combine(sourceDir, el));
                     // Grab all the files and filter the extensions not to be signed
                     var toAuthenticodeSignFiles = FileHelpers.GetAllFilesFromFilesAndDirs(FileHelpers.ExpandFileWildCardEntries(toSignPaths))
-                                    .Where(file => !Settings.SignInfo.FilterExtenstionsSign.Any(ext => file.EndsWith(ext))).ToList();
+                                    .Where(file => !Settings.SignInfo.FilterExtensionsSign.Any(ext => file.EndsWith(ext))).ToList();
                     string targetAuthenticodeDirectory = Path.Combine(authentiCodeDirectory, dirName);
                     toAuthenticodeSignFiles.ForEach(f => FileHelpers.CopyFileRelativeToBase(f, targetAuthenticodeDirectory, sourceDir));
 
                     var toSignThirdPartyPaths = Settings.SignInfo.thirdPartyBinaries.Select(el => Path.Combine(sourceDir, el));
                     // Grab all the files and filter the extensions not to be signed
                     var toSignThirdPartyFiles = FileHelpers.GetAllFilesFromFilesAndDirs(FileHelpers.ExpandFileWildCardEntries(toSignThirdPartyPaths))
-                                                .Where(file => !Settings.SignInfo.FilterExtenstionsSign.Any(ext => file.EndsWith(ext))).ToList();
+                                                .Where(file => !Settings.SignInfo.FilterExtensionsSign.Any(ext => file.EndsWith(ext))).ToList();
                     string targetThirdPartyDirectory = Path.Combine(thirdPartyDirectory, dirName);
                     toSignThirdPartyFiles.ForEach(f => FileHelpers.CopyFileRelativeToBase(f, targetThirdPartyDirectory, sourceDir));
                 }
@@ -390,10 +390,10 @@ namespace Build
                 var toSignPaths = Settings.SignInfo.authentiCodeBinaries.Select(el => Path.Combine(targetDir, el));
                 var toSignThirdPartyPaths = Settings.SignInfo.thirdPartyBinaries.Select(el => Path.Combine(targetDir, el));
                 var unSignedFiles = FileHelpers.GetAllFilesFromFilesAndDirs(FileHelpers.ExpandFileWildCardEntries(toSignPaths))
-                                    .Where(file => !Settings.SignInfo.FilterExtenstionsSign.Any(ext => file.EndsWith(ext))).ToList();
+                                    .Where(file => !Settings.SignInfo.FilterExtensionsSign.Any(ext => file.EndsWith(ext))).ToList();
 
                 unSignedFiles.AddRange(FileHelpers.GetAllFilesFromFilesAndDirs(FileHelpers.ExpandFileWildCardEntries(toSignThirdPartyPaths))
-                                        .Where(file => !Settings.SignInfo.FilterExtenstionsSign.Any(ext => file.EndsWith(ext))));
+                                        .Where(file => !Settings.SignInfo.FilterExtensionsSign.Any(ext => file.EndsWith(ext))));
 
                 unSignedFiles.ForEach(filePath => File.Delete(filePath));
 
@@ -481,7 +481,7 @@ namespace Build
             unSignedPackages = unSignedPackages.Skip(1).ToList();
 
             // Filter out the extensions we didn't want to sign
-            unSignedPackages = unSignedPackages.Where(file => !Settings.SignInfo.FilterExtenstionsSign.Any(ext => file.EndsWith(ext))).ToList();
+            unSignedPackages = unSignedPackages.Where(file => !Settings.SignInfo.FilterExtensionsSign.Any(ext => file.EndsWith(ext))).ToList();
 
             // Filter out files we don't want to verify
             unSignedPackages = unSignedPackages.Where(file => !Settings.SignInfo.SkipSigcheckTest.Any(ext => file.EndsWith(ext))).ToList();

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -90,6 +90,7 @@ namespace Build
         {
             switch (runtime)
             {
+                case "min.win-arm64":
                 case "min.win-x86":
                 case "min.win-x64":
                     return runtime.Substring(Settings.MinifiedVersionPrefix.Length);

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -200,7 +200,7 @@ namespace Build
                 Path.Combine("templates", "itemTemplates.2.0.10328.nupkg"),
                 Path.Combine("templates", "projectTemplates.2.0.10328.nupkg"),
                 Path.Combine("tools", "python", "packapp", "__main__.py"),
-                Path.Combine("workers", "python")
+                Path.Combine("workers", "*")
             };
 
             public static readonly string[] thirdPartyBinaries = new[] {

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -40,6 +40,7 @@ namespace Build
         public static readonly string DurableFolder = Path.Combine(TestProjectPath, "Resources", "DurableTestFolder");
 
         public static readonly string[] TargetRuntimes = new[] {
+            "min.win-arm64",
             "min.win-x86",
             "min.win-x64",
             "linux-x64",
@@ -59,6 +60,7 @@ namespace Build
             { "osx-arm64", "OSX" },
             { "min.win-x86", "WINDOWS" },
             { "min.win-x64", "WINDOWS" },
+            { "min.win-arm64", "WINDOWS"},
         };
 
         private static readonly string[] _winPowershellRuntimes = new[] {
@@ -165,7 +167,7 @@ namespace Build
             public static readonly string ThirdParty = "Sign3rdParty";
             public static readonly string ToThirdPartySign = "ThirdParty";
             public static readonly string ToMacSign = "Mac";
-            public static readonly string[] RuntimesToSign = new string[] { "win-arm64", "min.win-x86", "min.win-x64", "osx-arm64", "osx-x64" };
+            public static readonly string[] RuntimesToSign = new string[] { "min.win-arm64", "min.win-x86", "min.win-x64", "osx-arm64", "osx-x64" };
             public static readonly string[] FilterExtensionsSign = new[] { ".json", ".spec", ".cfg", ".pdb", ".config", ".nupkg", ".py", ".md" };
             public static readonly string SigcheckDownloadURL = "https://functionsbay.blob.core.windows.net/public/tools/sigcheck64.exe";
 
@@ -197,10 +199,7 @@ namespace Build
                 "Microsoft.Extensions.Azure.dll",
                 "Microsoft.Identity.Client.dll",
                 "Microsoft.Identity.Client.Extensions.Msal.dll",
-                Path.Combine("templates", "itemTemplates.2.0.10328.nupkg"),
-                Path.Combine("templates", "projectTemplates.2.0.10328.nupkg"),
-                Path.Combine("tools", "python", "packapp", "__main__.py"),
-                Path.Combine("workers", "*")
+                Path.Combine("workers", "python")
             };
 
             public static readonly string[] thirdPartyBinaries = new[] {

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -63,20 +63,20 @@ namespace Build
             { "min.win-arm64", "WINDOWS"},
         };
 
-        private static readonly string[] _winPowershellRuntimes = new[] {
-            "win-x64",
+        private static readonly string[] _winPowershellRuntimes = new[]
+        {
             "win-x86",
-            "win-arm64",
             "win",
             "win10-x86",
             "win8-x86",
             "win81-x86",
             "win7-x86",
+            "win-arm64",
             "win-x64",
             "win10-x64",
             "win8-x64",
             "win81-x64",
-            "win7-x64" 
+            "win7-x64"
         };
 
         public static readonly Dictionary<string, Dictionary<string, string[]>> ToolsRuntimeToPowershellRuntimes = new Dictionary<string, Dictionary<string, string[]>>

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -46,12 +46,14 @@ namespace Build
             "osx-x64",
             "osx-arm64",
             "win-x86",
-            "win-x64" };
+            "win-x64",
+            "win-arm64" };
 
         public static readonly Dictionary<string, string> RuntimesToOS = new Dictionary<string, string>
         {
             { "win-x86", "WINDOWS" },
             { "win-x64", "WINDOWS" },
+            { "win-arm64", "WINDOWS"},
             { "linux-x64", "LINUX" },
             { "osx-x64", "OSX" },
             { "osx-arm64", "OSX" },
@@ -59,7 +61,22 @@ namespace Build
             { "min.win-x64", "WINDOWS" },
         };
 
-        private static readonly string[] _winPowershellRuntimes = new[] { "win-x86", "win", "win10-x86", "win8-x86", "win81-x86", "win7-x86", "win-x64", "win10-x64", "win8-x64", "win81-x64", "win7-x64" };
+        private static readonly string[] _winPowershellRuntimes = new[] {
+            "win-x64",
+            "win-x86",
+            "win-arm64",
+            "win",
+            "win10-x86",
+            "win8-x86",
+            "win81-x86",
+            "win7-x86",
+            "win-x64",
+            "win10-x64",
+            "win8-x64",
+            "win81-x64",
+            "win7-x64" 
+        };
+
         public static readonly Dictionary<string, Dictionary<string, string[]>> ToolsRuntimeToPowershellRuntimes = new Dictionary<string, Dictionary<string, string[]>>
         {
             {
@@ -68,10 +85,11 @@ namespace Build
                 {
                     { "win-x86", _winPowershellRuntimes },
                     { "win-x64", _winPowershellRuntimes },
+                    { "win-arm64", _winPowershellRuntimes },
                     { "linux-x64", new [] { "linux", "linux-x64", "unix", "linux-musl-x64" } },
                     { "osx-x64", new [] { "osx", "osx-x64", "unix" } },
                     // NOTE: PowerShell 7.0 does not support arm. First version supporting it is 7.2
-                    // https://docs.microsoft.com/powershell/scripting/install/installing-powershell-on-macos?view=powershell-7.2#installation-via-direct-download
+                    // https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-macos?view=powershell-7.2#supported-versions
                     // That being said, we might as well include "osx" and "unix" since it'll hardly affect package size and should lead to more accurate error messages
                     { "osx-arm64", new [] { "osx", "unix" } }
                 }
@@ -82,6 +100,7 @@ namespace Build
                 {
                     { "win-x86", _winPowershellRuntimes },
                     { "win-x64", _winPowershellRuntimes },
+                    { "win-arm64", _winPowershellRuntimes },
                     { "linux-x64", new [] { "linux", "linux-x64", "unix", "linux-musl-x64" } },
                     { "osx-x64", new [] { "osx", "osx-x64", "unix" } },
                     { "osx-arm64", new [] { "osx", "osx-arm64", "unix" } }
@@ -146,8 +165,8 @@ namespace Build
             public static readonly string ThirdParty = "Sign3rdParty";
             public static readonly string ToThirdPartySign = "ThirdParty";
             public static readonly string ToMacSign = "Mac";
-            public static readonly string[] RuntimesToSign = new string[] { "min.win-x86", "min.win-x64", "osx-arm64", "osx-x64" };
-            public static readonly string[] FilterExtenstionsSign = new[] { ".json", ".spec", ".cfg", ".pdb", ".config", ".nupkg", ".py", ".md" };
+            public static readonly string[] RuntimesToSign = new string[] { "win-arm64", "min.win-x86", "min.win-x64", "osx-arm64", "osx-x64" };
+            public static readonly string[] FilterExtensionsSign = new[] { ".json", ".spec", ".cfg", ".pdb", ".config", ".nupkg", ".py", ".md" };
             public static readonly string SigcheckDownloadURL = "https://functionsbay.blob.core.windows.net/public/tools/sigcheck64.exe";
 
             public static readonly string[] SkipSigcheckTest = new[] {

--- a/generateMsiFiles.ps1
+++ b/generateMsiFiles.ps1
@@ -23,7 +23,10 @@ $cli = Get-ChildItem -Path $artifactsPath -Include func.dll -Recurse | Select-Ob
 $cliVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($cli).FileVersion
 
 # Generate MSI installers for Windows
-@('arm64', 'x64', 'x86') | ForEach-Object { 
+# TODO: add 'arm64' to the below array once a production-ready version of the WiX toolset supporting
+# it is released. Currently, only v3.14 and v4 preview support it: https://github.com/wixtoolset/issues/issues/6513
+# However, neither are production-ready: https://wixtoolset.org/releases/
+@('x64', 'x86') | ForEach-Object { 
     $platform = $_
     $targetDir = "$artifactsPath\win-$platform"
 

--- a/generateMsiFiles.ps1
+++ b/generateMsiFiles.ps1
@@ -24,8 +24,7 @@ $cliVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($cli).FileVer
 
 # Generate MSI installers for Windows
 # TODO: add 'arm64' to the below array once a production-ready version of the WiX toolset supporting
-# it is released. Currently, only v3.14 and v4 preview support it: https://github.com/wixtoolset/issues/issues/6513
-# However, neither are production-ready: https://wixtoolset.org/releases/
+# it is released. See https://github.com/Azure/azure-functions-core-tools/issues/3122
 @('x64', 'x86') | ForEach-Object { 
     $platform = $_
     $targetDir = "$artifactsPath\win-$platform"

--- a/generateMsiFiles.ps1
+++ b/generateMsiFiles.ps1
@@ -23,7 +23,7 @@ $cli = Get-ChildItem -Path $artifactsPath -Include func.dll -Recurse | Select-Ob
 $cliVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($cli).FileVersion
 
 # Generate MSI installers for Windows
-@('x64', 'x86') | ForEach-Object { 
+@('arm64', 'x64', 'x86') | ForEach-Object { 
     $platform = $_
     $targetDir = "$artifactsPath\win-$platform"
 

--- a/publish-scripts/chocolatey/buildNUPKG.py
+++ b/publish-scripts/chocolatey/buildNUPKG.py
@@ -2,6 +2,7 @@
 
 # depends on chocolaty
 import os
+from re import sub
 import wget
 import sys
 from string import Template
@@ -28,32 +29,30 @@ def getChocoVersion(version):
 # output a deb nupkg
 # depends on chocolatey
 def preparePackage():
-    fileName_x86 = f"Azure.Functions.Cli.win-x86.{constants.VERSION}.zip"
-    fileName_x64 = f"Azure.Functions.Cli.win-x64.{constants.VERSION}.zip"
-    url_x86 = f'https://functionscdn.azureedge.net/public/{constants.VERSION}/{fileName_x86}'
-    url_x64 = f'https://functionscdn.azureedge.net/public/{constants.VERSION}/{fileName_x64}'
-
-    # version used in url is provided from user input
-    # version used for packaging nuget packages needs a slight modification
-    chocoVersion = getChocoVersion(constants.VERSION)
-
-    # download the zip
-    # output to local folder
-    #  -- For 32 bit
-    if not os.path.exists(fileName_x86):
-        print(f"downloading from {url_x86}")
-        wget.download(url_x86)
-    #  -- For 64 bit
-    if not os.path.exists(fileName_x64):
-        print(f"downloading from {url_x64}")
-        wget.download(url_x64)
-
-    # get the checksums
-    fileHash_x86 = produceHashForfile(fileName_x86, HASH)
-    fileHash_x64 = produceHashForfile(fileName_x64, HASH)
+    archList = ["ARM64", "X86", "X64"]
+    substitutionMapping = {
+        "PACKAGENAME": constants.PACKAGENAME,
+        "HASHALG": HASH,
+        "CHOCOVERSION": getChocoVersion(constants.VERSION)
+    }
 
     tools = os.path.join(constants.BUILDFOLDER, "tools")
     os.makedirs(tools)
+
+    for arch in archList:
+        fileName = f"Azure.Functions.Cli.{arch}.{constants.VERSION}.zip"
+        url = f'https://functionscdn.azureedge.net/public/{constants.VERSION}/{fileName}'
+        substitutionMapping[f"ZIPURL_{arch}"] = url
+
+        # download the zip
+        # output to local folder
+        if not os.path.exists(fileName):
+            print(f"downloading from {url}")
+            wget.download(url)
+
+        # get the checksums
+        fileHash = produceHashForfile(fileName, HASH)
+        substitutionMapping[f"CHECKSUM_{arch}"] = fileHash
 
     # write install powershell script
     scriptDir = os.path.abspath(os.path.dirname(__file__))
@@ -63,17 +62,16 @@ def preparePackage():
     t = Template(stringData)
     with open(os.path.join(tools, "chocolateyinstall.ps1"), "w") as f:
         print("writing install powershell script")
-        f.write(t.safe_substitute(ZIPURL_X86=url_x86, ZIPURL_X64=url_x64, PACKAGENAME=constants.PACKAGENAME,
-                                  CHECKSUM_X86=fileHash_x86, CHECKSUM_X64=fileHash_x64, HASHALG=HASH))
+    f.write(t.safe_substitute(substitutionMapping))
 
     # write nuspec package metadata
     with open(os.path.join(scriptDir,"nuspec_template")) as f:
         stringData = f.read()
     t = Template(stringData)
     nuspecFile = os.path.join(constants.BUILDFOLDER, constants.PACKAGENAME+".nuspec")
-    with open(nuspecFile,'w') as f:
+    with open(nuspecFile, 'w') as f:
         print("writing nuspec")
-        f.write(t.safe_substitute(PACKAGENAME=constants.PACKAGENAME, CHOCOVERSION=chocoVersion))
+        f.write(t.safe_substitute(substitutionMapping))
 
     # run choco pack, stdout is merged into python interpreter stdout
     output = printReturnOutput(["choco", "pack", nuspecFile, "--outputdirectory", constants.ARTIFACTFOLDER])

--- a/publish-scripts/chocolatey/installps_template
+++ b/publish-scripts/chocolatey/installps_template
@@ -1,9 +1,11 @@
-$ErrorActionPreference = 'Stop';
+$ErrorActionPreference = 'STOP';
 
 $packageName= '$PACKAGENAME'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$url_arm64      = '$ZIPURL_ARM64'
 $url_x86        = '$ZIPURL_X86'
 $url_x64        = '$ZIPURL_X64'
+$checksum_arm64 = '$CHECKSUM_ARM64'
 $checksum_x86   = '$CHECKSUM_X86'
 $checksum_x64   = '$CHECKSUM_X64'
 
@@ -13,10 +15,15 @@ $checksum = $checksum_x86
 
 # If specifically asked for 64-bit, we use that
 $pp = Get-PackageParameters
-if ($pp['x64'] -eq 'true')
+if ($pp['x64'])
 {
   $url = $url_x64
   $checksum = $checksum_x64
+}
+elseif ($pp['arm64'])
+{
+  $url =  $url_arm64
+  $checksum = $checksum_arm64
 }
 
 $packageArgs = @{
@@ -30,7 +37,7 @@ $packageArgs = @{
 Install-ChocolateyZipPackage @packageArgs
 
 # only symlink for func.exe
-$files = get-childitem $toolsDir -include *.exe -recurse
+$files = Get-ChildItem $toolsDir -include *.exe -recurse
 foreach ($file in $files) {
   if (!$file.Name.Equals("func.exe")) {
     #generate an ignore file

--- a/publish-scripts/chocolatey/installps_template
+++ b/publish-scripts/chocolatey/installps_template
@@ -9,11 +9,7 @@ $checksum_arm64 = '$CHECKSUM_ARM64'
 $checksum_x86   = '$CHECKSUM_X86'
 $checksum_x64   = '$CHECKSUM_X64'
 
-# By default, we want 32-bit installer
-$url = $url_x86
-$checksum = $checksum_x86
-
-# If specifically asked for 64-bit, we use that
+# If specifically asked for x64 or arm64, we use that
 $pp = Get-PackageParameters
 if ($pp['x64'])
 {
@@ -24,6 +20,12 @@ elseif ($pp['arm64'])
 {
   $url =  $url_arm64
   $checksum = $checksum_arm64
+}
+else
+{
+  # By default, we want the x86 installer
+  $url = $url_x86
+  $checksum = $checksum_x86
 }
 
 $packageArgs = @{

--- a/publish-scripts/chocolatey/installps_template
+++ b/publish-scripts/chocolatey/installps_template
@@ -9,14 +9,15 @@ $checksum_arm64 = '$CHECKSUM_ARM64'
 $checksum_x86   = '$CHECKSUM_X86'
 $checksum_x64   = '$CHECKSUM_X64'
 
-# If specifically asked for x64 or arm64, we use that
+# Get-PackageParameters returns a hash table array of values
 $pp = Get-PackageParameters
-if ($pp['x64'])
+# If specifically asked for x64 or arm64, we use that
+if ($pp.ContainsKey('x64'))
 {
   $url = $url_x64
   $checksum = $checksum_x64
 }
-elseif ($pp['arm64'])
+elseif ($pp.ContainsKey('arm64'))
 {
   $url =  $url_arm64
   $checksum = $checksum_arm64

--- a/repackageBinaries.ps1
+++ b/repackageBinaries.ps1
@@ -49,7 +49,7 @@ try
     }
 
     # Runtimes with signed binaries
-    $runtimesIdentifiers = @("min.win-x86","min.win-x64", "osx-arm64", "osx-x64")
+    $runtimesIdentifiers = @("win-x64", "min.win-x86","min.win-x64", "osx-arm64", "osx-x64")
     $tempDirectory = New-Item $tempDirectoryPath -ItemType Directory
     LogSuccess "$tempDirectoryPath created"
 

--- a/repackageBinaries.ps1
+++ b/repackageBinaries.ps1
@@ -49,7 +49,7 @@ try
     }
 
     # Runtimes with signed binaries
-    $runtimesIdentifiers = @("win-arm64", "min.win-x86","min.win-x64", "osx-arm64", "osx-x64")
+    $runtimesIdentifiers = @("min.win-arm64", "min.win-x86","min.win-x64", "osx-arm64", "osx-x64")
     $tempDirectory = New-Item $tempDirectoryPath -ItemType Directory
     LogSuccess "$tempDirectoryPath created"
 

--- a/repackageBinaries.ps1
+++ b/repackageBinaries.ps1
@@ -49,7 +49,7 @@ try
     }
 
     # Runtimes with signed binaries
-    $runtimesIdentifiers = @("win-x64", "min.win-x86","min.win-x64", "osx-arm64", "osx-x64")
+    $runtimesIdentifiers = @("win-arm64", "min.win-x86","min.win-x64", "osx-arm64", "osx-x64")
     $tempDirectory = New-Item $tempDirectoryPath -ItemType Directory
     LogSuccess "$tempDirectoryPath created"
 

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -159,18 +159,18 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.20.0" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage.Internal" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="4.7.3" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="4.11.0-19110" />
     <PackageReference Include="Microsoft.Build" Version="17.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.1" />
     <PackageReference Include="YamlDotNet" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(NoWorkers)' != 'true'">
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="2.2.3" />
-    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.4.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" Version="4.0.2045" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.2" Version="4.0.2040" />
-    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="4.2.0-hotfix" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="2.4.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.5.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" Version="4.0.2255" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.2" Version="4.0.2258" />
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="4.6.0" />
   </ItemGroup>
   <Target Name="ExcludeWorkersFromReadyToRun">
     <CreateItem Include="%(None.Filename)%(None.Extension)" Condition="$([System.String]::new('%(None.TargetPath)').StartsWith('workers'))" PreserveExistingMetadata="false">

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>func</AssemblyName>
-    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;win-arm64;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">1</BuildNumber>
     <MajorMinorProductVersion>4.0</MajorMinorProductVersion>
     <Version>$(MajorMinorProductVersion).$(BuildNumber)</Version>

--- a/src/Azure.Functions.Cli/npm/lib/install.js
+++ b/src/Azure.Functions.Cli/npm/lib/install.js
@@ -25,7 +25,11 @@ function getPath() {
 let platform = '';
 
 if (os.platform() === 'win32') {
-    platform = 'win-x64';
+    if (os.arch() === 'arm64') {
+        platform = 'win-arm64';
+    } else {
+        platform = 'win-x64';
+    }
 } else if (os.platform() === 'darwin') {
     if (os.arch() === 'arm64') {
         platform = 'osx-arm64';


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Adds support for the `win-arm64` target runtime for Core Tools V4. These changes are to be ported to the `v3.x`.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)