### PR TITLE
Check for non-Azure Storage backends

### DIFF
--- a/src/Azure.Functions.Cli/Common/DurableManager.cs
+++ b/src/Azure.Functions.Cli/Common/DurableManager.cs
@@ -171,7 +171,10 @@ namespace Azure.Functions.Cli.Common
 
             if (this.BackendType != BackendType.AzureStorage)
             {
-                throw new CliException($"The {this.BackendType} storage provider for Durable Functions is not yet supported by this command.");
+                throw new CliException(
+                    $"The {this.BackendType} storage provider for Durable Functions is not yet supported by this command. " +
+                    $"However, it may be supported by an SDK API or an HTTP API. " +
+                    $"To learn about alternate ways issue commands for Durable Functions, see https://aka.ms/durable-functions-instance-management.");
             }
 
             CheckAssemblies();

--- a/test/Azure.Functions.Cli.Tests/Azure.Functions.Cli.Tests.csproj
+++ b/test/Azure.Functions.Cli.Tests/Azure.Functions.Cli.Tests.csproj
@@ -37,10 +37,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Include="..\..\NuGet.Config" Link="NuGet.Config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/test/Azure.Functions.Cli.Tests/E2E/Helpers/CliTester.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/Helpers/CliTester.cs
@@ -11,9 +11,24 @@ namespace Azure.Functions.Cli.Tests.E2E.Helpers
 {
     public static class CliTester
     {
-        private static string _func = System.Environment.GetEnvironmentVariable("FUNC_PATH");
+        private static readonly string _func;
 
         private const string StartHostCommand = "start --build";
+
+        static CliTester()
+        {
+            _func = Environment.GetEnvironmentVariable("FUNC_PATH");
+
+            if (_func == null)
+            {
+                // Fallback for local testing in Visual Studio, etc.
+                _func = $@"{Environment.CurrentDirectory}\func.exe";
+                if (!File.Exists(_func))
+                {
+                    throw new ApplicationException("Could not locate the func.exe to use for testing. Make sure the FUNC_PATH environment variable is set to the full path of the func executable.");
+                }    
+            }
+        }
 
         public static Task Run(RunConfiguration runConfiguration, ITestOutputHelper output = null, string workingDir = null, bool startHost = false) => Run(new[] { runConfiguration }, output, workingDir, startHost);
 

--- a/test/Azure.Functions.Cli.Tests/E2E/Helpers/DurableHelper.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/Helpers/DurableHelper.cs
@@ -22,7 +22,7 @@ namespace Azure.Functions.Cli.Tests.E2E.Helpers
                 if (version?.Equals("2.0") == true)
                 {
                     // If the version is (explicitly) 2.0, prepend path to 'durableTask' with 'extensions'
-                    hostSettings["extensions"]["durableTask"]["HubName"] = taskHubName;
+                    hostSettings["extensions"]["durableTask"]["hubName"] = taskHubName;
                 }
                 else
                 {


### PR DESCRIPTION
The Durable commands currently only work with the Azure Storage backend, and not when users configure alternate backends, like MSSQL or Netherite. This PR adds detection for those other backend types and returns an error if the user tries to run a command against function apps that use those other backend types.

### Issue describing the changes in this PR

(I'm not aware of any issue opened for this)

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [x] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)