### PR TITLE
Update linuxFxVersion for publishing .NET 7 applications

### DIFF
--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -161,13 +161,9 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 {
                     var projectRoot = ProjectHelpers.GetProject(projectFilePath);
                     var targetFramework = ProjectHelpers.GetPropertyValue(projectRoot, Constants.TargetFrameworkElementName);
-                    switch (targetFramework)
+                    if (targetFramework.Equals("net7.0", StringComparison.InvariantCultureIgnoreCase))
                     {
-                        case "net7.0":
-                            _requiredNetFrameworkVersion = "7.0";
-                            break;
-                        default:
-                            break;
+                        _requiredNetFrameworkVersion = "7.0";
                     }
                 }
                 // We do not change the default targetFramework if no .csproj file is found
@@ -373,9 +369,9 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             }
         }
 
-        private static async Task UpdateNetFrameworkVersionWindows(Site functionApp, string dotnetFramworkVersion, AzureHelperService helperService)
+        private static async Task UpdateNetFrameworkVersionWindows(Site functionApp, string dotnetFrameworkVersion, AzureHelperService helperService)
         {
-            string normalizedVersion = NormalizeDotnetFrameworkVersion(dotnetFramworkVersion);
+            string normalizedVersion = NormalizeDotnetFrameworkVersion(dotnetFrameworkVersion);
 
             // Websites ensure it begins with 'v'.
             string version = $"v{normalizedVersion}";

--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -405,47 +405,28 @@ namespace Azure.Functions.Cli.Actions.AzureActions
         {
             string normalizedVersion = NormalizeDotnetFrameworkVersion(dotnetFramworkVersion);
 
-            string linuxFxVersion;
+            string linuxFxVersion = $"DOTNET-ISOLATED|{normalizedVersion}";
 
-            if (functionApp.IsDynamic)
+            // If things are already set, do nothing
+            if (string.Equals(functionApp.LinuxFxVersion, linuxFxVersion, StringComparison.OrdinalIgnoreCase))
             {
-                if (!string.IsNullOrEmpty(functionApp.LinuxFxVersion))
-                {
-                    linuxFxVersion = string.Empty;
-                }
-                else
-                {
-                    return;
-                }
-            }
-            else
-            {
-                linuxFxVersion = $"DOTNET-ISOLATED|{normalizedVersion}";
-
-                // If things are already set, do nothing
-                if (string.Equals(functionApp.LinuxFxVersion, linuxFxVersion, StringComparison.OrdinalIgnoreCase))
-                {
-                    return;
-                }
+                return;
             }
 
-            if (linuxFxVersion != null)
+            ColoredConsole.WriteLine($"Updating '{Constants.LinuxFxVersion}' to '{linuxFxVersion}'.");
+
+            var updatedSettings = new Dictionary<string, string>
             {
-                ColoredConsole.WriteLine($"Updating '{Constants.LinuxFxVersion}' to '{linuxFxVersion}'.");
+                [Constants.LinuxFxVersion] = linuxFxVersion
+            };
 
-                var updatedSettings = new Dictionary<string, string>
-                {
-                    [Constants.LinuxFxVersion] = linuxFxVersion
-                };
+            var settingsResult = await helperService.UpdateWebSettings(functionApp, updatedSettings);
 
-                var settingsResult = await helperService.UpdateWebSettings(functionApp, updatedSettings);
-
-                if (!settingsResult.IsSuccessful)
-                {
-                    ColoredConsole.Error
-                        .WriteLine(ErrorColor("Error updating linux image property:"))
-                        .WriteLine(ErrorColor(settingsResult.ErrorResult));
-                }
+            if (!settingsResult.IsSuccessful)
+            {
+                ColoredConsole.Error
+                    .WriteLine(ErrorColor("Error updating linux image property:"))
+                    .WriteLine(ErrorColor(settingsResult.ErrorResult));
             }
         }
 

--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -152,7 +152,8 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             var workerRuntime = GlobalCoreToolsSettings.CurrentWorkerRuntime;
 
             // Determine the appropriate default targetFramework
-            // NOTE: .NET 7.0 and .NET Framework 4.8 are only supported on dotnet-isolated
+            // NOTE: .NET 7.0 is only supported on dotnet-isolated
+            // TODO: Include proper steps for publishing a .NET Framework 4.8 application
             if (workerRuntime == WorkerRuntime.dotnetIsolated)
             {
                 string projectFilePath = ProjectHelpers.FindProjectFile(functionAppRoot);
@@ -166,9 +167,6 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                             _requiredNetFrameworkVersion = "7.0";
                             break;
                         case "net6.0":
-                            break;
-                        case "net48":
-                            _requiredNetFrameworkVersion = "4.8";
                             break;
                         default:
                             throw new CliException($"Detected unsupported targetFramework {targetFramework} in {projectFilePath}");

--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -152,7 +152,8 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             var workerRuntime = GlobalCoreToolsSettings.CurrentWorkerRuntime;
 
             // Determine the appropriate default targetFramework
-            if (WorkerRuntimeLanguageHelper.IsDotnet(workerRuntime))
+            // NOTE: .NET 7.0 and .NET Framework 4.8 are only supported on dotnet-isolated
+            if (workerRuntime == WorkerRuntime.dotnetIsolated)
             {
                 string projectFilePath = ProjectHelpers.FindProjectFile(functionAppRoot);
                 if (projectFilePath != null)
@@ -167,7 +168,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                         case "net6.0":
                             break;
                         case "net48":
-                            _requiredNetFrameworkVersion = "48";
+                            _requiredNetFrameworkVersion = "4.8";
                             break;
                         default:
                             throw new CliException($"Detected unsupported targetFramework {targetFramework} in {projectFilePath}");

--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -166,10 +166,8 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                         case "net7.0":
                             _requiredNetFrameworkVersion = "7.0";
                             break;
-                        case "net6.0":
-                            break;
                         default:
-                            throw new CliException($"Detected unsupported targetFramework {targetFramework} in {projectFilePath}");
+                            break;
                     }
                 }
                 // We do not change the default targetFramework if no .csproj file is found

--- a/src/Azure.Functions.Cli/Actions/LocalActions/InstallExtensionAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InstallExtensionAction.cs
@@ -155,7 +155,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             }
 
             var extensionsProjDir = string.IsNullOrEmpty(ConfigPath) ? Environment.CurrentDirectory : ConfigPath;
-            var extensionsProjFile = Path.Combine(extensionsProjDir, Constants.ExtenstionsCsProjFile);
+            var extensionsProjFile = Path.Combine(extensionsProjDir, Constants.ExtensionsCsProjFile);
 
             // CASE 3: No extensions.csproj
             if (!FileSystemHelpers.FileExists(extensionsProjFile))

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -24,7 +24,7 @@ namespace Azure.Functions.Cli.Common
         public const string FunctionJsonFileName = "function.json";
         public const string HostJsonFileName = "host.json";
         public const string ProxiesJsonFileName = "proxies.json";
-        public const string ExtenstionsCsProjFile = "extensions.csproj";
+        public const string ExtensionsCsProjFile = "extensions.csproj";
         public const string DefaultVEnvName = "worker_env";
         public const string ExternalPythonPackages = ".python_packages";
         public const string FunctionsExtensionVersion = "FUNCTIONS_EXTENSION_VERSION";
@@ -55,6 +55,7 @@ namespace Azure.Functions.Cli.Common
         public const string HttpTriggerTemplateName = "HttpTrigger";
         public const string PowerShellWorkerDefaultVersion = "~7";
         public const string UserSecretsIdElementName = "UserSecretsId";
+        public const string TargetFrameworkElementName = "TargetFramework";
         public const string DisplayLogo = "FUNCTIONS_CORE_TOOLS_DISPLAY_LOGO";
         public const string AspNetCoreSupressStatusMessages = "ASPNETCORE_SUPPRESSSTATUSMESSAGES";
         public const string SequentialJobHostRestart = "AzureFunctionsJobHost__SequentialRestart";

--- a/src/Azure.Functions.Cli/Helpers/ExtensionsHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/ExtensionsHelper.cs
@@ -26,7 +26,7 @@ namespace Azure.Functions.Cli.Helpers
                 extensionsDir = Environment.CurrentDirectory;
             }
 
-            var extensionsProj = Path.Combine(extensionsDir, Constants.ExtenstionsCsProjFile);
+            var extensionsProj = Path.Combine(extensionsDir, Constants.ExtensionsCsProjFile);
             if (!FileSystemHelpers.FileExists(extensionsProj))
             {
                 FileSystemHelpers.EnsureDirectory(extensionsDir);

--- a/src/Azure.Functions.Cli/Helpers/ProjectHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/ProjectHelpers.cs
@@ -36,7 +36,7 @@ namespace Azure.Functions.Cli.Helpers
             {
                 logger = new ColoredConsoleLogger("ProjectHelpers", loggingFilterHelper, loggerFilterOptions);
             }
-            var shouldLog = logger == null;
+            bool shouldLog = logger != null;
             
             DirectoryInfo filePath = new DirectoryInfo(path);
             do

--- a/src/Azure.Functions.Cli/Helpers/ProjectHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/ProjectHelpers.cs
@@ -29,9 +29,15 @@ namespace Azure.Functions.Cli.Helpers
             return userSecretsId;
         }
 
-        public static string FindProjectFile(string path, LoggingFilterHelper loggingFilterHelper, LoggerFilterOptions loggerFilterOptions)
+        public static string FindProjectFile(string path, LoggingFilterHelper loggingFilterHelper = null, LoggerFilterOptions loggerFilterOptions = null)
         {
-            ColoredConsoleLogger logger = new ColoredConsoleLogger("ProjectHelpers", loggingFilterHelper, loggerFilterOptions);
+            ColoredConsoleLogger logger = null;
+            if (loggingFilterHelper != null && loggerFilterOptions != null)
+            {
+                logger = new ColoredConsoleLogger("ProjectHelpers", loggingFilterHelper, loggerFilterOptions);
+            }
+            var shouldLog = logger == null;
+            
             DirectoryInfo filePath = new DirectoryInfo(path);
             do
             {
@@ -40,8 +46,11 @@ namespace Azure.Functions.Cli.Helpers
                 {
                     foreach (FileInfo file in projectFiles)
                     {
-                        if (string.Equals(file.Name, Constants.ExtenstionsCsProjFile, StringComparison.OrdinalIgnoreCase)) continue;
-                        logger.LogDebug($"Found {file.FullName}. Using for user secrets file configuration.");
+                        if (string.Equals(file.Name, Constants.ExtensionsCsProjFile, StringComparison.OrdinalIgnoreCase)) continue;
+                        if (shouldLog)
+                        {
+                            logger.LogDebug($"Found {file.FullName}. Using for user secrets file configuration.");
+                        }
                         return file.FullName;
                     }
                 }
@@ -49,7 +58,10 @@ namespace Azure.Functions.Cli.Helpers
             }
             while (filePath.FullName != filePath.Root.FullName);
 
-            logger.LogDebug($"Csproj not found in {path} directory tree. Skipping user secrets file configuration.");
+            if (shouldLog)
+            {
+                logger.LogDebug($"Csproj not found in {path} directory tree. Skipping user secrets file configuration.");
+            }
             return null;
         }
 

--- a/test/Azure.Functions.Cli.Tests/PublishActionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/PublishActionTests.cs
@@ -33,7 +33,7 @@ namespace Azure.Functions.Cli.Tests
             // update it to empty
             var setting = _helperService.UpdatedSettings.Single();
             Assert.Equal(Constants.LinuxFxVersion, setting.Key);
-            Assert.Equal(expectedNetFrameworkVersion, setting.Value);
+            Assert.Equal($"DOTNET-ISOLATED|{expectedNetFrameworkVersion}", setting.Value);
         }
 
         [Theory]

--- a/test/Azure.Functions.Cli.Tests/PublishActionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/PublishActionTests.cs
@@ -14,38 +14,26 @@ namespace Azure.Functions.Cli.Tests
     {
         TestAzureHelperService _helperService = new TestAzureHelperService();
 
-        [Fact]
-        public async Task NetFrameworkVersion_DotnetIsolated_Linux_Consumption_AlreadyEmpty()
+        [Theory]
+        [InlineData(null)]
+        [InlineData("something")]
+        public async Task NetFrameworkVersion_DotnetIsolated_Linux_Consumption_Updated(string initialLinuxFxVersion)
         {
+            var expectedNetFrameworkVersion = "6.0";
+
             var site = new Site("test")
             {
                 Kind = "linux",
                 Sku = "dynamic",
-                LinuxFxVersion = null
+                LinuxFxVersion = initialLinuxFxVersion
             };
 
-            await PublishFunctionAppAction.UpdateFrameworkVersions(site, WorkerRuntime.dotnetIsolated, "6.0", false, _helperService);
-
-            // no-op if already null or empty
-            Assert.Null(_helperService.UpdatedSettings);
-        }
-
-        [Fact]
-        public async Task NetFrameworkVersion_DotnetIsolated_Linux_Consumption_Updated()
-        {
-            var site = new Site("test")
-            {
-                Kind = "linux",
-                Sku = "dynamic",
-                LinuxFxVersion = "something"
-            };
-
-            await PublishFunctionAppAction.UpdateFrameworkVersions(site, WorkerRuntime.dotnetIsolated, "6.0", false, _helperService);
+            await PublishFunctionAppAction.UpdateFrameworkVersions(site, WorkerRuntime.dotnetIsolated, expectedNetFrameworkVersion, false, _helperService);
 
             // update it to empty
             var setting = _helperService.UpdatedSettings.Single();
             Assert.Equal(Constants.LinuxFxVersion, setting.Key);
-            Assert.Equal(string.Empty, setting.Value);
+            Assert.Equal(expectedNetFrameworkVersion, setting.Value);
         }
 
         [Theory]

--- a/test/Azure.Functions.Cli.Tests/PublishActionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/PublishActionTests.cs
@@ -15,12 +15,12 @@ namespace Azure.Functions.Cli.Tests
         TestAzureHelperService _helperService = new TestAzureHelperService();
 
         [Theory]
-        [InlineData(null)]
+        [InlineData(null, "6.0")]
         [InlineData("something")]
-        public async Task NetFrameworkVersion_DotnetIsolated_Linux_Consumption_Updated(string initialLinuxFxVersion)
+        [InlineData("6.0", "6.0")]
+        [InlineData("7.0", "7.0")]
+        public async Task NetFrameworkVersion_DotnetIsolated_Linux_Consumption_Updated(string initialLinuxFxVersion, string expectedNetFrameworkVersion)
         {
-            var expectedNetFrameworkVersion = "6.0";
-
             var site = new Site("test")
             {
                 Kind = "linux",

--- a/test/Azure.Functions.Cli.Tests/PublishActionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/PublishActionTests.cs
@@ -16,7 +16,7 @@ namespace Azure.Functions.Cli.Tests
 
         [Theory]
         [InlineData(null, "6.0")]
-        [InlineData("something")]
+        [InlineData("something", "6.0")]
         [InlineData("6.0", "6.0")]
         [InlineData("7.0", "7.0")]
         public async Task NetFrameworkVersion_DotnetIsolated_Linux_Consumption_Updated(string initialLinuxFxVersion, string expectedNetFrameworkVersion)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
Currently, Core Tools V4 ensures the `linuxFxVersion` setting remains empty for Linux Consumption applications, updating it only for other SKUs. However, with .NET 7 function apps on Linux, we rely on setting the value to `DOTNET-ISOLATED|7.0`. This PR:

1. Updates the `linuxFxVersion` setting for Linux Consumption publishing. 
2. Automatically detects the target framework version for .NET isolated function apps by parsing the .csproj file.


### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)