### PR TITLE
Improve publishing speed for Typescript apps

### DIFF
--- a/src/Azure.Functions.Cli/StaticResources/funcignore
+++ b/src/Azure.Functions.Cli/StaticResources/funcignore
@@ -5,8 +5,6 @@
 local.settings.json
 test
 getting_started.md
-node_modules/.bin/
-node_modules/@azure/
 node_modules/@types/
 node_modules/azure-functions-core-tools/
 node_modules/typescript/

--- a/src/Azure.Functions.Cli/StaticResources/funcignore
+++ b/src/Azure.Functions.Cli/StaticResources/funcignore
@@ -5,3 +5,8 @@
 local.settings.json
 test
 getting_started.md
+node_modules/.bin/
+node_modules/@azure/
+node_modules/@types/
+node_modules/azure-functions-core-tools/
+node_modules/typescript/


### PR DESCRIPTION
The default template for a Typescript function app (created using `func init --language typescript --worker-runtime node`) will install development tooling into `node_modules` when you run `npm install`.

Publishing this simple app using `func azure functionapp publish myappname` includes all this, and is therefore very slow.

This PR reduces the amount deployed to Azure by about 181 MB (on Windows) so it is substantially faster to publish.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] ~Otherwise: Documentation issue linked to PR~
* [x] My changes **do not** need to be backported to a previous version
  * [ ] ~Otherwise: Backport tracked by issue/PR #issue_or_pr~
* [ ] ~I have added all required tests (Unit tests, E2E tests)~