### PR TITLE
Remove PyStein awareness message for non-Python apps

### DIFF
--- a/src/Azure.Functions.Cli/Actions/LocalActions/CreateFunctionAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/CreateFunctionAction.cs
@@ -216,7 +216,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 }
             }
             ColoredConsole.WriteLine($"The function \"{FunctionName}\" was created successfully from the \"{TemplateName}\" template.");
-            if (!isNewPythonProgrammingModel())
+            if (string.Equals(Language, Languages.Python, StringComparison.CurrentCultureIgnoreCase) && !isNewPythonProgrammingModel())
             {
                 PythonHelpers.PrintPySteinAwarenessMessage();
             }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Prevents the PyStein awareness message from being printed for apps using a different language.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)