### PR TITLE
Update Microsoft.ApplicationInsights to version 2.21.0

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -165,7 +165,7 @@
     <PackageReference Include="Colors.Net" Version="1.1.0" />
     <PackageReference Include="AccentedCommandLineParser" Version="2.0.0" />
     <PackageReference Include="DotNetZip" Version="1.13.3" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.20.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage.Internal" Version="1.4.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="4.12.2" />


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Resolves https://github.com/Azure/azure-functions-core-tools/issues/3183

This is a follow up PR for https://github.com/Azure/azure-functions-core-tools/pull/3184. I had a typo and meant to update `Microsoft.ApplicationInsights` to version `2.21.0` instead of `2.20.1`

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)