### PR TITLE
.NET 6 Testing Update

### DIFF
--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -51,7 +51,7 @@ namespace Azure.Functions.Cli.Common
         public const string ManagedDependencyConfigPropertyName = "managedDependency";
         public const string CustomHandlerPropertyName = "customHandler";
         public const string AuthLevelErrorMessage = "Unable to configure Authorization level. The selected template does not use Http Trigger";
-        public const string HttpTriggerTemplateName = "HttpTrigger";
+        public const string HttpTriggerTemplateName = "http";
         public const string PowerShellWorkerDefaultVersion = "~7";
         public const string UserSecretsIdElementName = "UserSecretsId";
         public const string DisplayLogo = "FUNCTIONS_CORE_TOOLS_DISPLAY_LOGO";

--- a/test/Azure.Functions.Cli.Tests/E2E/CreateFunctionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/CreateFunctionTests.cs
@@ -20,11 +20,11 @@ namespace Azure.Functions.Cli.Tests.E2E
                 Commands = new[]
                 {
                     "init . --worker-runtime dotnet",
-                    "new --template HttpTrigger --name testfunc"
+                    "new --template http --name testfunc"
                 },
                 OutputContains = new[]
                 {
-                    "The function \"testfunc\" was created successfully from the \"HttpTrigger\" template."
+                    "The function \"testfunc\" was created successfully from the \"http\" template."
                 }
             }, _output);
         }
@@ -89,11 +89,11 @@ namespace Azure.Functions.Cli.Tests.E2E
                 Commands = new[]
                 {
                     "init . --worker-runtime dotnet",
-                    "new --template HttpTrigger --name testfunc --authlevel function"
+                    "new --template http --name testfunc --authlevel function"
                 },
                 OutputContains = new[]
                 {
-                    "The function \"testfunc\" was created successfully from the \"HttpTrigger\" template."
+                    "The function \"testfunc\" was created successfully from the \"http\" template."
                 }
             }, _output);
         }
@@ -106,7 +106,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                 Commands = new[]
                 {
                     "init 12n.e.0w-file$ --worker-runtime dotnet",
-                    "new --prefix 12n.e.0w-file$ --template HttpTrigger --name 12@n.other-file$"
+                    "new --prefix 12n.e.0w-file$ --template http --name 12@n.other-file$"
                 },
                 CommandTimeout = new TimeSpan(0, 1, 0),
                 CheckFiles = new[]
@@ -171,23 +171,6 @@ namespace Azure.Functions.Cli.Tests.E2E
                 OutputContains = new[]
                 {
                     "The function \"testfunc\" was created successfully from the \"httptrigger\" template."
-                }
-            }, _output);
-        }
-
-        [Fact]
-        public async Task create_template_function_dotnet_space_name()
-        {
-            await CliTester.Run(new RunConfiguration
-            {
-                Commands = new[]
-                {
-                    "init . --worker-runtime dotnet",
-                    "new --template \"http trigger\" --name testfunc2"
-                },
-                OutputContains = new[]
-                {
-                    "The function \"testfunc2\" was created successfully from the \"http trigger\" template."
                 }
             }, _output);
         }

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -163,7 +163,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     Commands = new[]
                     {
                         "init . --worker-runtime dotnet",
-                        $"new --template Httptrigger --name {functionName}",
+                        $"new --template http --name {functionName}",
                     },
                     Test = async (workingDir, p) =>
                     {
@@ -251,7 +251,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                 Commands = new[]
                 {
                     "init . --worker-runtime dotnet",
-                    "new --template Httptrigger --name HttpTrigger",
+                    "new --template http --name HttpTrigger",
                     "start --build --port 7073"
                 },
                 ExpectExit = false,
@@ -325,7 +325,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     Commands = new[]
                     {
                         "init . --worker-runtime dotnet",
-                        $"new --template Httptrigger --name {functionName}",
+                        $"new --template http --name {functionName}",
 
                     },
                     Test = async (workingDir, p) =>
@@ -361,7 +361,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     Commands = new[]
                     {
                         "init . --worker-runtime dotnet",
-                        $"new --template Httptrigger --name {functionName}",
+                        $"new --template http --name {functionName}",
                     },
                     Test = async (workingDir, p) =>
                     {
@@ -540,8 +540,8 @@ namespace Azure.Functions.Cli.Tests.E2E
                     Commands = new[]
                     {
                         $"init . --worker-runtime {language}",
-                        "new --template \"Http trigger\" --name http1",
-                        "new --template \"Queue trigger\" --name queue1"
+                        "new --template http --name http1",
+                        "new --template queue --name queue1"
                     },
                 },
                 new RunConfiguration


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

With the dotnet 6 SDK templating changed, and the command `dotnet new HttpTrigger` is no longer valid. The new conventioon is `dotnet new http`.

This PR changes dotnet tests that use the old convention. It also removes one test that is no longer valid (as there is no space in http).

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)