### PR TITLE
Sourcing bash from usr env

### DIFF
--- a/src/Azure.Functions.Cli/Common/CommandChecker.cs
+++ b/src/Azure.Functions.Cli/Common/CommandChecker.cs
@@ -13,7 +13,7 @@ namespace Azure.Functions.Cli.Common
         public static bool CommandExists(string command)
             => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
             ? CheckExitCode("where", command)
-            : CheckExitCode("/bin/bash", $"-c \"command -v {command}\"");
+            : CheckExitCode("/usr/bin/env bash", $"-c \"command -v {command}\"");
 
         public static async Task<bool> PowerShellModuleExistsAsync(string powershellExecutable, string module)
         {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

https://github.com/NixOS/nixpkgs/issues/139102

In NixOS bash is not stored in `/bin/bash` I am working on getting this to compile in the derivation but as an alternative I figured I would ask if changing `bash` out for `/usr/bin/env bash` is an acceptable change for this project. Feel free to close if not.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)