### PR TITLE
Add PowerShell 7.4 language worker for integration testing

### DIFF
--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -26,7 +26,7 @@ namespace Build
         public const string TemplateJsonVersion = "3.1.1648";
 
         public static readonly string SBOMManifestToolPath = Path.GetFullPath("../ManifestTool/Microsoft.ManifestTool.dll");
-        
+
         public static readonly string SrcProjectPath = Path.GetFullPath("../src/Azure.Functions.Cli/");
 
         public static readonly string ConstantsFile = Path.Combine(SrcProjectPath, "Common", "Constants.cs");
@@ -79,6 +79,43 @@ namespace Build
             "win7-x64"
         };
 
+        private static readonly string[] _linPowershellRuntimes = new[]
+        {
+            "linux",
+            "linux-x64",
+            "unix",
+            "linux-musl-x64"
+        };
+
+        private static readonly string[] _osxPowershellRuntimes = new[]
+        {
+            "osx",
+            "osx-x64",
+            "unix"
+        };
+
+        private static readonly string[] _osxARMPowershellRuntimes = new[]
+        {
+            "osx",
+            "osx-arm64",
+            "unix"
+        };
+
+        private static Dictionary<string, string[]> GetPowerShellRuntimes()
+        {
+            var runtimes = new Dictionary<string, string[]>
+            {
+                { "win-x86", _winPowershellRuntimes },
+                { "win-x64", _winPowershellRuntimes },
+                { "win-arm64", _winPowershellRuntimes },
+                { "linux-x64", _linPowershellRuntimes },
+                { "osx-x64", _osxPowershellRuntimes },
+                { "osx-arm64", _osxARMPowershellRuntimes }
+            };
+
+            return runtimes;
+        }
+
         public static readonly Dictionary<string, Dictionary<string, string[]>> ToolsRuntimeToPowershellRuntimes = new Dictionary<string, Dictionary<string, string[]>>
         {
             {
@@ -88,8 +125,8 @@ namespace Build
                     { "win-x86", _winPowershellRuntimes },
                     { "win-x64", _winPowershellRuntimes },
                     { "win-arm64", _winPowershellRuntimes },
-                    { "linux-x64", new [] { "linux", "linux-x64", "unix", "linux-musl-x64" } },
-                    { "osx-x64", new [] { "osx", "osx-x64", "unix" } },
+                    { "linux-x64", _linPowershellRuntimes },
+                    { "osx-x64", _osxPowershellRuntimes },
                     // NOTE: PowerShell 7.0 does not support arm. First version supporting it is 7.2
                     // https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-macos?view=powershell-7.2#supported-versions
                     // That being said, we might as well include "osx" and "unix" since it'll hardly affect package size and should lead to more accurate error messages
@@ -98,15 +135,11 @@ namespace Build
             },
             {
                 "7.2",
-                new Dictionary<string, string[]>
-                {
-                    { "win-x86", _winPowershellRuntimes },
-                    { "win-x64", _winPowershellRuntimes },
-                    { "win-arm64", _winPowershellRuntimes },
-                    { "linux-x64", new [] { "linux", "linux-x64", "unix", "linux-musl-x64" } },
-                    { "osx-x64", new [] { "osx", "osx-x64", "unix" } },
-                    { "osx-arm64", new [] { "osx", "osx-arm64", "unix" } }
-                }
+                GetPowerShellRuntimes()
+            },
+            {
+                "7.4",
+                GetPowerShellRuntimes()
             }
         };
 

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -257,6 +257,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.5.2" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" Version="4.0.2302" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.2" Version="4.0.2673" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" Version="4.0.2669" />
     <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="4.10.1" />
   </ItemGroup>
   <Target Name="ExcludeWorkersFromReadyToRun">

--- a/validateWorkerVersions.ps1
+++ b/validateWorkerVersions.ps1
@@ -64,7 +64,7 @@ function getHostFileContent([string]$filePath) {
 $hostCsprojContent = getHostFileContent "src/WebJobs.Script/WebJobs.Script.csproj"
 $pythonPropsContent = getHostFileContent "build/python.props"
 
-$workers = "JavaWorker", "NodeJsWorker", "PowerShellWorker.PS7.0", "PowerShellWorker.PS7.2", "PythonWorker"
+$workers = "JavaWorker", "NodeJsWorker", "PowerShellWorker.PS7.0", "PowerShellWorker.PS7.2", "PowerShellWorker.PS7.4", "PythonWorker"
 
 $failedValidation = $false
 foreach($worker in $workers) {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
This PR contains the following change:
* Add PowerShell 7.4 language worker to the Core Tools for integration testing -- Partially resolves https://github.com/Azure/azure-functions-core-tools/issues/3266 
* Update Functions Host to version `4.17.0`

Please note that I have removed the the `worker.config.json` from the `PowerShell 7.2` language worker. Going forward, the Functions Host will use the `worker.config.json` included in the `PowerShell 7.4` language worker nuget package.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)