### PR TITLE
Adding Dotnet 2.1 for Authenticode

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ jobs:
   - pwsh: |
       Import-Module ".\pipelineUtilities.psm1" -Force
       Install-Dotnet
-    displayName: 'Install .NET 6.0 and 3.1'
+    displayName: 'Install .NET 6.0, 3.1, and 2.1'
   - pwsh: |
       Import-Module ".\pipelineUtilities.psm1" -Force
       Install-SBOMUtil -SBOMUtilSASUrl $env:SBOMUtilSASUrl

--- a/pipelineUtilities.psm1
+++ b/pipelineUtilities.psm1
@@ -50,6 +50,12 @@ function Install-SBOMUtil
 }
 
 $DotnetSDKVersionRequirements = @{
+    
+    # .NET SDK 2.1 is required by the Authenticode tool
+    '2.1' = @{
+        MinimalPatch = '818'
+        DefaultPatch = '818'
+    }
 
     # .NET SDK 3.1 is required by the Microsoft.ManifestTool.dll tool
     '3.1' = @{


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

Checks are failing for core tools release pipelines as Dotnet 2.1 was removed from default install. Dotnet 2.1 is required for Authenticode. This will add it back in.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)