### PR TITLE
Forcing dotnet 2.1 install for ESRP Authenticode

### DIFF
--- a/pipelineUtilities.psm1
+++ b/pipelineUtilities.psm1
@@ -52,6 +52,12 @@ function Install-SBOMUtil
 $DotnetSDKVersionRequirements = @{
 
     # .NET SDK 3.1 is required by the Microsoft.ManifestTool.dll tool
+    '2.1' = @{
+        MinimalPatch = '818'
+        DefaultPatch = '818'
+    }
+
+    # .NET SDK 3.1 is required by the Microsoft.ManifestTool.dll tool
     '3.1' = @{
         MinimalPatch = '415'
         DefaultPatch = '415'


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

Fixes error where commit was merged into `release_4.0` before `v4.x`.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)