### PR TITLE
docs: update package id in winget install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ choco install azure-functions-core-tools-2
 ##### v4
 
 ```bash
-winget install Microsoft.AzureFunctionsCoreTools
+winget install --id Microsoft.Azure.FunctionsCoreTools
 ```
 
 ##### v3
 
 ```bash
-winget install Microsoft.AzureFunctionsCoreTools -v 3.0.3904
+winget install --id Microsoft.Azure.FunctionsCoreTools --version 3.0.4899
 ```
 
 ### Mac


### PR DESCRIPTION
### Issue describing the changes in this PR

Updates installation examples using `winget install` - these haven't been updated when the package id changed at some point. Also updated example installing an older version to use the latest patch level for v3.x.

### Pull request checklist

I'm not entirely sure what the "documentation changes" below refer to, but I assume it's about updating pages like [this one](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local?tabs=v4%2Cwindows%2Ccsharp%2Cportal%2Cbash) (which shouldn't be needed based on my update of the readme in this PR).

Furthermore, the readme on [v3.x](https://github.com/Azure/azure-functions-core-tools/tree/v3.x) doesn't refer to `winget` at all, so I assume that point is moot as well.

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests) (no tests are needed, pure documentation update)