### PR TITLE
Switch logstream command to use Bearer token when basic auth is not a…

### DIFF
--- a/src/Azure.Functions.Cli/Actions/AzureActions/LogStreamAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/LogStreamAction.cs
@@ -51,11 +51,29 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 throw new CliException("Log stream is not currently supported in Linux Consumption Apps. " +
                     "Please use --browser to open Azure Application Insights Live Stream in the Azure portal.");
             }
-            var basicHeaderValue = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{functionApp.PublishingUserName}:{functionApp.PublishingPassword}"));
-
+            
             using (var client = new HttpClient())
             {
-                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", basicHeaderValue);
+                var isBasicAuthAllowed = true;
+                try
+                {
+                    isBasicAuthAllowed = await AzureHelper.IsBasicAuthAllowedForSCM(functionApp, AccessToken, ManagementURL);
+                }
+                catch (Exception)
+                {
+                    // ignore: We don't want to fail the command on basic auth check. There is extremely low likelihood of getting the exception here. 
+                }
+
+                if (isBasicAuthAllowed)
+                {
+                    var basicHeaderValue = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{functionApp.PublishingUserName}:{functionApp.PublishingPassword}"));
+                    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", basicHeaderValue);
+                }
+                else
+                {
+                    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", AccessToken);
+                }
+                
                 client.DefaultRequestHeaders.Add("User-Agent", Constants.CliUserAgent);
                 var response = await client.GetStreamAsync(new Uri($"https://{functionApp.ScmUri}/api/logstream/application"));
                 using (var reader = new StreamReader(response))

--- a/src/Azure.Functions.Cli/Arm/ArmUriTemplates.cs
+++ b/src/Azure.Functions.Cli/Arm/ArmUriTemplates.cs
@@ -10,6 +10,7 @@ namespace Azure.Functions.Cli.Arm
         public const string WebsitesApiVersion = "2015-08-01";
         public const string SyncTriggersApiVersion = "2016-08-01";
         public const string ArgApiVersion = "2019-04-01";
+        public const string BasicAuthCheckApiVersion = "2022-03-01";
 
         public const string ArgUri = "providers/Microsoft.ResourceGraph/resources";
 

--- a/src/Azure.Functions.Cli/Arm/Models/BasicAuthCheckResponse.cs
+++ b/src/Azure.Functions.Cli/Arm/Models/BasicAuthCheckResponse.cs
@@ -1,0 +1,34 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static NuGet.Client.ManagedCodeConventions;
+
+namespace Azure.Functions.Cli.Arm.Models
+{
+    class BasicAuthCheckResponse
+    {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; set; }
+
+        [JsonProperty(PropertyName = "name")]
+        public string ResourceName { get; set; }
+
+        [JsonProperty(PropertyName = "type")]
+        public string ResourceType { get; set; }
+
+        [JsonProperty(PropertyName = "location")]
+        public string Location { get; set; }
+
+        [JsonProperty(PropertyName = "properties")]
+        public BasicAuthCheckResponseProperties Properties { get; set; }
+    }
+
+    class BasicAuthCheckResponseProperties
+    {
+        [JsonProperty(PropertyName = "allow")]
+        public bool Allow { get; set; }
+    }
+}

--- a/src/Azure.Functions.Cli/Helpers/AzureHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/AzureHelper.cs
@@ -106,6 +106,19 @@ namespace Azure.Functions.Cli.Helpers
                 ?? throw new CliException("Error finding the Azure Resource information.");
         }
 
+        internal static async Task<bool> IsBasicAuthAllowedForSCM(Site functionApp, string accessToken, string managementURL)
+        {
+            var url = new Uri($"{managementURL}{functionApp.SiteId}/basicPublishingCredentialsPolicies/scm?api-version={ArmUriTemplates.BasicAuthCheckApiVersion}");
+            
+            var response = await ArmClient.HttpInvoke(HttpMethod.Get, url, accessToken);
+            response.EnsureSuccessStatusCode();
+
+            var result = await response.Content.ReadAsStringAsync();
+            var basicAuthResponse = JsonConvert.DeserializeObject<BasicAuthCheckResponse>(result);
+
+            return basicAuthResponse.Properties.Allow;
+        }
+
         internal static ArmResourceId ParseResourceId(string resourceId)
         {
             if (string.IsNullOrEmpty(resourceId))


### PR DESCRIPTION
…llowed.

<!-- Please provide all the information below.  -->
Changing the log stream command to use bearer token when basic auth is not enabled/allowed.

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)