### PR TITLE
Added --skip-npm-install option for NodeJS V4 programming model

### DIFF
--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -49,6 +49,8 @@ namespace Azure.Functions.Cli.Actions.LocalActions
 
         public string ProgrammingModel { get; set; }
 
+        public bool SkipNpmInstall { get; set; } = false;
+
         public WorkerRuntime ResolvedWorkerRuntime { get; set; }
 
         public string ResolvedLanguage { get; set; }
@@ -128,6 +130,11 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 .Setup<string>('m', "model")
                 .WithDescription($"Selects the programming model for the function app. Note this flag is now only applicable to Python and JavaScript/TypeScript. Options are V1 and V2 for Python; V3 and V4 for JavaScript/TypeScript. Currently, the V2 and V4 programming models are in preview.")
                 .Callback(m => ProgrammingModel = m);
+
+            Parser
+                .Setup<bool>("skip-npm-install")
+                .WithDescription("Skips the npm installation phase when using V4 programming model for NodeJS")
+                .Callback(skip => SkipNpmInstall = skip);
 
             Parser
                 .Setup<bool>("no-bundle")
@@ -223,7 +230,14 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 await WriteDockerfile(ResolvedWorkerRuntime, ResolvedLanguage, TargetFramework, Csx);
             }
 
-            await FetchPackages(ResolvedWorkerRuntime, ResolvedProgrammingModel);
+            if (!SkipNpmInstall)
+            {
+                await FetchPackages(ResolvedWorkerRuntime, ResolvedProgrammingModel);
+            }
+            else
+            {
+                ColoredConsole.Write(AdditionalInfoColor("You skipped \"npm install\". You must run \"npm install\" manually"));
+            }
         }
 
         private static (WorkerRuntime, string) ResolveWorkerRuntimeAndLanguage(string workerRuntimeString, string languageString)

--- a/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
@@ -450,18 +450,6 @@ namespace Azure.Functions.Cli.Tests.E2E
             return CliTester.Run(new RunConfiguration
             {
                 Commands = new[] { "init . --worker-runtime typescript" },
-                CheckFiles = new FileResult[]
-                {
-                    new FileResult
-                    {
-                        Name = "local.settings.json",
-                        ContentContains = new []
-                        {
-                            "FUNCTIONS_WORKER_RUNTIME",
-                            "node"
-                        }
-                    }
-                },
                 OutputContains = new[]
                 {
                     "Writing tsconfig.json",
@@ -471,6 +459,31 @@ namespace Azure.Functions.Cli.Tests.E2E
                     "Writing host.json",
                     "Writing local.settings.json",
                     $".vscode{Path.DirectorySeparatorChar}extensions.json",
+                }
+            }, _output);
+        }
+
+        [Fact]
+        public Task ini_ts_app_v4_with_skip_npm_install()
+        {
+            return CliTester.Run(new RunConfiguration
+            {
+                Commands = new[] { "init . --worker-runtime node --language typescript --model V4 --skip-npm-install" },
+                CheckDirectories = new DirectoryResult[]
+                {
+                    new DirectoryResult
+                    {
+                        Name = "node_modules",
+                        Exists = false
+                    }
+                },
+                OutputContains = new[]
+                {
+                    "You skipped \"npm install\". You must run \"npm install\" manually"
+                },
+                OutputDoesntContain = new[]
+                {
+                    "Running 'npm install'..."
                 }
             }, _output);
         }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
This really helps in mono-repo scenarios in which the NPM install is not actually needed but takes a significant time to initialize a new project. (A proper warning is added if NPM installation is skipped)
resolves #3332 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)