### PR TITLE
Adding OpenAI plugin required files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,4 @@ launchSettings.json
 publish-env
 
 # MacOS related
-.DS_Store
+*.DS_Store

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -20,6 +20,9 @@ namespace Azure.Functions.Cli.Common
         public const string FunctionsWorkerRuntime = "FUNCTIONS_WORKER_RUNTIME";
         public const string FunctionsWorkerRuntimeVersion = "FUNCTIONS_WORKER_RUNTIME_VERSION";
         public const string RequirementsTxt = "requirements.txt";
+        public const string AIPlugin = "ai-plugin.json";
+        public const string WellKnown = ".well-known";
+        public const string OpenAPIYaml = "openapi.yaml";
         public const string PythonGettingStarted = "getting_started.md";
         public const string PySteinFunctionAppPy = "function_app.py";
         public const string FunctionJsonFileName = "function.json";
@@ -119,7 +122,7 @@ namespace Azure.Functions.Cli.Common
             public const string WebJobsStorageNotFoundWithUserSecrets = "Missing value for AzureWebJobsStorage in {0} and User Secrets. This is required for all triggers other than {1}. You can run 'func azure functionapp fetch-app-settings <functionAppName>' or specify a connection string in {2} or User Secrets.";
             public const string AppSettingNotFound = "Warning: Cannot find value named '{0}' in {1} that matches '{2}' property set on '{3}' in '{4}'. You can run 'func azure functionapp fetch-app-settings <functionAppName>' or specify a connection string in {5}.";
             public const string AppSettingNotFoundWithUserSecrets = "Warning: Cannot find value named '{0}' in {1} or User Secrets that matches '{2}' property set on '{3}' in '{4}'. You can run 'func azure functionapp fetch-app-settings <functionAppName>' or specify a connection string in {5} or User Secrets.";
-            public const string ProxiesNotSupported = $"Warning: Proxies are not supported in Azure Functions v4. Instead of '{Constants.ProxiesJsonFileName}', try Azure API Management: https://aka.ms/AAfiueq";
+            public const string ProxiesNotSupported = "";//$"Warning: Proxies are not supported in Azure Functions v4. Instead of '{Constants.ProxiesJsonFileName}', try Azure API Management: https://aka.ms/AAfiueq";
         }
 
         public static class Languages

--- a/src/Azure.Functions.Cli/Helpers/OpenAIHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/OpenAIHelper.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Azure.Functions.Cli.Common;
+using Colors.Net;
+
+namespace Azure.Functions.Cli.Helpers
+{
+    public class OpenAIHelper
+    {
+
+        public async static Task CreateOpenAIPluginJsonFile()
+        {
+            var wellKnownPath = Path.Join(Environment.CurrentDirectory, Constants.WellKnown);
+            var aiPluginPath = Path.Join(wellKnownPath, Constants.AIPlugin);
+
+            if (!FileSystemHelpers.DirectoryExists(wellKnownPath) && !FileSystemHelpers.FileExists(aiPluginPath))
+            {
+                FileSystemHelpers.EnsureDirectory(wellKnownPath);
+                ColoredConsole.WriteLine($"Writing {Constants.AIPlugin} at {aiPluginPath}");
+                string aiPluginJsonFileContent = await StaticResources.AIPluginJsonFile;
+                await FileSystemHelpers.WriteAllTextToFileAsync(aiPluginPath, aiPluginJsonFileContent);
+            }
+            else
+            {
+                ColoredConsole.WriteLine($"{Constants.AIPlugin} already exists at {aiPluginPath}. Skipped!");
+            }
+        }
+
+        public async static Task CreateOpenAIOpenAPIYamlFile()
+        {
+            var openAIOpenAPIYaml = Path.Join(Environment.CurrentDirectory, Constants.OpenAPIYaml);
+
+            if (!FileSystemHelpers.FileExists(openAIOpenAPIYaml))
+            {
+                ColoredConsole.WriteLine($"Writing {Constants.OpenAPIYaml} at {openAIOpenAPIYaml}");
+                string openAIOpenAPIYamlFileContent = await StaticResources.OpenAIOpenAPIYamlFile;
+                await FileSystemHelpers.WriteAllTextToFileAsync(openAIOpenAPIYaml, openAIOpenAPIYamlFileContent);
+            }
+            else
+            {
+                ColoredConsole.WriteLine($"{Constants.OpenAPIYaml} already exists at {openAIOpenAPIYaml}. Skipped!");
+            }
+        }
+    }
+}

--- a/src/Azure.Functions.Cli/StaticResources/OpenAPI.yaml
+++ b/src/Azure.Functions.Cli/StaticResources/OpenAPI.yaml
@@ -1,0 +1,29 @@
+﻿openapi: 3.0.1
+info:
+  title: TODO Plugin
+  description: A plugin that allows the user to create and manage a TODO list using ChatGPT.
+  version: 'v1'
+servers:
+  - url: http://localhost:3333
+paths:
+  /todos:
+    get:
+      operationId: getTodos
+      summary: Get the list of todos
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/getTodosResponse'
+components:
+  schemas:
+    getTodosResponse:
+      type: object
+      properties:
+        todos:
+          type: array
+          items:
+            type: string
+          description: The list of todos.

--- a/src/Azure.Functions.Cli/StaticResources/StaticResources.cs
+++ b/src/Azure.Functions.Cli/StaticResources/StaticResources.cs
@@ -30,38 +30,26 @@ namespace Azure.Functions.Cli
         public static Task<string> GitIgnore => GetValue("gitignore");
 
         public static Task<string> DockerfileDotNet => GetValue("Dockerfile.dotnet");
-
         public static Task<string> DockerfileCustom => GetValue("Dockerfile.custom");
-
         public static Task<string> DockerfileCsxDotNet => GetValue("Dockerfile.csx.dotnet");
-
         public static Task<string> DockerfileDotnetIsolated => GetValue("Dockerfile.dotnetIsolated");
         public static Task<string> DockerfileDotnet7Isolated => GetValue("Dockerfile.dotnet7Isolated");
 
         public static Task<string> DockerfileJava8 => GetValue("Dockerfile.java8");
-
         public static Task<string> DockerfileJava11 => GetValue("Dockerfile.java11");
 
         public static Task<string> DockerfilePython37 => GetValue("Dockerfile.python3.7");
-        
         public static Task<string> DockerfilePython38 => GetValue("Dockerfile.python3.8");
-
         public static Task<string> DockerfilePython39 => GetValue("Dockerfile.python3.9");
-        
         public static Task<string> DockerfilePython310 => GetValue("Dockerfile.python3.10");
-
         public static Task<string> DockerfilePython311 => GetValue("Dockerfile.python3.11");
 
         public static Task<string> DockerfilePowershell7 => GetValue("Dockerfile.powershell7");
-
         public static Task<string> DockerfilePowershell72 => GetValue("Dockerfile.powershell7.2");
 
         public static Task<string> DockerfileNode14 => GetValue("Dockerfile.node14");
-
         public static Task<string> DockerfileNode16 => GetValue("Dockerfile.node16");
-
         public static Task<string> DockerfileNode18 => GetValue("Dockerfile.node18");
-
         public static Task<string> DockerfileTypescript => GetValue("Dockerfile.typescript");
 
         public static Task<string> DockerfileTypescriptNode18 => GetValue("Dockerfile.typescript.node18");
@@ -79,7 +67,6 @@ namespace Azure.Functions.Cli
         public static Task<string> BundleConfigPyStein => GetValue("bundleConfigPyStein.json");
 
         public static Task<string> BundleConfigNodeV4 => GetValue("bundleConfigNodeV4.json");
-
 
         public static Task<string> CustomHandlerConfig => GetValue("customHandlerConfig.json");
 
@@ -114,5 +101,9 @@ namespace Azure.Functions.Cli
         public static Task<string> KedaV2Template => GetValue("keda-v2.yaml");
 
         public static Task<string> ZipToSquashfsScript => GetValue("ziptofs.sh");
+
+        // OpenAI Plugin related files
+        public static Task<string> AIPluginJsonFile=> GetValue("ai-plugin.json");
+        public static Task<string> OpenAIOpenAPIYamlFile => GetValue("OpenAPI.yml");
     }
 }

--- a/src/Azure.Functions.Cli/StaticResources/ai-plugin.json
+++ b/src/Azure.Functions.Cli/StaticResources/ai-plugin.json
@@ -1,0 +1,17 @@
+﻿{
+  "schema_version": "v1",
+  "name_for_human": "TODO List",
+  "name_for_model": "todo",
+  "description_for_human": "Manage your TODO list. You can add, remove and view your TODOs.",
+  "description_for_model": "Help the user with managing a TODO list. You can add, remove and view your TODOs.",
+  "auth": {
+    "type": "none"
+  },
+  "api": {
+    "type": "openapi",
+    "url": "http://localhost:3333/openapi.yaml"
+  },
+  "logo_url": "http://localhost:3333/logo.png",
+  "contact_email": "support@example.com",
+  "legal_info_url": "http://www.example.com/legal"
+}

--- a/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
@@ -541,6 +541,28 @@ namespace Azure.Functions.Cli.Tests.E2E
         }
 
         [Fact]
+        public Task init_openai_plugins_only_no_project()
+        {
+            return CliTester.Run(new RunConfiguration
+            {
+                Commands = new[]
+                {
+                    $"init . --openai-plugin"
+                },
+                CheckFiles = new[]
+                {
+                    new FileResult
+                    {
+                        Name = "ai-plugin.json",
+
+                        ContentContains = new[] { "description_for_model" }
+                    }
+                },
+                OutputContains = new[] { "ai-plugin" }
+            }, _output);
+        }
+
+        [Fact]
         public Task init_function_app_powershell_enable_managed_dependencies_and_set_default_version()
         {
             return CliTester.Run(new RunConfiguration


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
This PR creates a new CLI option during init to create stub files for OpenAI plugins. This can help enable an HTTP function app to become an OpenAPI plugin. The new flag `--openai-plugin` should create `ai-plugin.json` and `openapi.yaml` files as described in the [OpenAPI Plugin Documentation](https://platform.openai.com/docs/plugins/getting-started/plugin-manifest)

Expectation:
```bash
$ func init --openai-plugin
.well_known/ai-plugn.json Created
openapi.yaml Created
```
### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)