### PR TITLE
Updating Core Tools to default to bundles v4

### DIFF
--- a/src/Azure.Functions.Cli/StaticResources/bundleConfig.json
+++ b/src/Azure.Functions.Cli/StaticResources/bundleConfig.json
@@ -1,4 +1,4 @@
 {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
-    "version": "[3.*, 4.0.0)"
+    "version": "[4.*, 5.0.0)"
 }

--- a/src/Azure.Functions.Cli/StaticResources/bundleConfigNodeV4.json
+++ b/src/Azure.Functions.Cli/StaticResources/bundleConfigNodeV4.json
@@ -1,4 +1,4 @@
 {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
-    "version": "[3.15.0, 4.0.0)"
+    "version": "[4.*, 5.0.0)"
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Updating Core Tools to default to Bundles v4

At some point, we should just keep one bundleConfig file instead of the 3 we have now. 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)