### PR TITLE
Remove "-alpha" from node.js v4 model templates

### DIFF
--- a/src/Azure.Functions.Cli/StaticResources/package-js-v4.json
+++ b/src/Azure.Functions.Cli/StaticResources/package-js-v4.json
@@ -8,7 +8,7 @@
     "test": "echo \"No tests yet...\""
   },
   "dependencies": {
-    "@azure/functions": "^4.0.0-alpha.1"
+    "@azure/functions": "^4.0.0"
   },
   "devDependencies": {
     "azure-functions-core-tools": "^4.x"

--- a/src/Azure.Functions.Cli/StaticResources/package-ts-v4.json
+++ b/src/Azure.Functions.Cli/StaticResources/package-ts-v4.json
@@ -12,7 +12,7 @@
     "test": "echo \"No tests yet...\""
   },
   "dependencies": {
-    "@azure/functions": "^4.0.0-alpha.9"
+    "@azure/functions": "^4.0.0"
   },
   "devDependencies": {
     "azure-functions-core-tools": "^4.x",


### PR DESCRIPTION
I just released 4.0.0, so we can clean these versions up now.