### PR TITLE
Update publish dotnet-version help text to .net 6

### DIFF
--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -133,7 +133,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 .Callback(s => DotnetCliParameters = s);
             Parser
                 .Setup<string>("dotnet-version")
-                .WithDescription("Only applies to dotnet-isolated applications. Specifies the .NET version for the function app. For example, set to '5.0' when publishing a .NET 5.0 app.")
+                .WithDescription("Only applies to dotnet-isolated applications. Specifies the .NET version for the function app. For example, set to '6.0' when publishing a .NET 6 app.")
                 .Callback(s => DotnetFrameworkVersion = s);
             return base.ParseArgs(args);
         }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Updated Publish command dotnet-version parameter helper text to show example for .net 6 instead of old example of .net 5

resolves #3437 

### Pull request checklist

* [X] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [X] I have added all required tests (Unit tests, E2E tests)