### PR TITLE
kubernetes deploy: --image-build fix help text

### DIFF
--- a/src/Azure.Functions.Cli/Actions/KubernetesActions/KubernetesDeployAction.cs
+++ b/src/Azure.Functions.Cli/Actions/KubernetesActions/KubernetesDeployAction.cs
@@ -92,7 +92,7 @@ namespace Azure.Functions.Cli.Actions.KubernetesActions
             SetFlag<bool>("write-configs", "Output the kubernetes configurations as YAML files instead of deploying", f => WriteConfigs = f);
             SetFlag<string>("config-file", "if --write-configs is true, write configs to this file (default: 'functions.yaml')", f => ConfigFile = f);
             SetFlag<string>("hash-files", "Files to hash to determine the image version", f => HashFilesPattern = f);
-            SetFlag<bool>("image-build", "If true, skip the docker build", f => BuildImage = f);
+            SetFlag<bool>("image-build", "If false, skip the docker build", f => BuildImage = f);
 
             return base.ParseArgs(args);
         }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

--build-image sets `BuildImage` property

the code in src/Azure.Functions.Cli/Actions/KubernetesActions/KubernetesDeployAction.cs:L117 needs false to skip building

Update helpstring to reflect reality.


### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)