### PR TITLE
Fixed `winget` package name 

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ choco install azure-functions-core-tools-2
 ##### v4
 
 ```bash
-winget install Microsoft.AzureFunctionsCoreTools
+winget install Microsoft.Azure.FunctionsCoreTools
 ```
 
 ##### v3
 
 ```bash
-winget install Microsoft.AzureFunctionsCoreTools -v 3.0.3904
+winget install Microsoft.Azure.FunctionsCoreTools -v 3.0.3904
 ```
 
 ### Mac


### PR DESCRIPTION
### Issue describing the changes in this PR

The README.md file listed an incorrect package name for the Winget package. It should be `Microsoft.Azure.FunctionsCoreTools` but was `Microsoft.AzureFunctionsCoreTools` (missing period between `Azure` and `FunctionsCoreTools`)

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [NA] I have added all required tests (Unit tests, E2E tests)