### PR TITLE
Adding Dotnet 2.1 for Authenticode step

### DIFF
--- a/pipelineUtilities.psm1
+++ b/pipelineUtilities.psm1
@@ -50,6 +50,8 @@ function Install-SBOMUtil
 }
 
 $DotnetSDKVersionRequirements = @{
+
+    # .NET SDK 2.1 is required by Authenticode
     '2.1' = @{
         MinimalPatch = '818'
         DefaultPatch = '818'

--- a/pipelineUtilities.psm1
+++ b/pipelineUtilities.psm1
@@ -50,7 +50,10 @@ function Install-SBOMUtil
 }
 
 $DotnetSDKVersionRequirements = @{
-
+    '2.1' = @{
+        MinimalPatch = '818'
+        DefaultPatch = '818'
+    }
     # .NET SDK 3.1 is required by the Microsoft.ManifestTool.dll tool
     '3.1' = @{
         MinimalPatch = '415'


### PR DESCRIPTION
The release branch builds are failing without .NET 2.1. This step installs it.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)