### PR TITLE
Fixed winget Module spelling error in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ choco install azure-functions-core-tools-2
 ##### v4
 
 ```bash
-winget install Microsoft.AzureFunctionsCoreTools
+winget install Microsoft.Azure.FunctionsCoreTools
 ```
 
 ##### v3
 
 ```bash
-winget install Microsoft.AzureFunctionsCoreTools -v 3.0.3904
+winget install Microsoft.Azure.FunctionsCoreTools -v 3.0.3904
 ```
 
 ### Mac


### PR DESCRIPTION
Found a spelling issue with the winget module while troubleshooting a VSCode issue. 
The initial command shown below fails to install and returns 'No package found matching input criteria'

```
winget install Microsoft.AzureFunctionsCoreTools 
```

Doing a winget search on Microsoft. I found 

```
Azure Functions Core Tools                      Microsoft.Azure.FunctionsCoreTools              4.0.5455        winget
```

Noticed that the module name is Micrsoft.Azure**.**FunctionsCoreTools 

Updated Read me to show 

```
winget install Microsoft.Azure.FunctionsCoreTools
```

and installed 

```
# winget install Microsoft.Azure.FunctionsCoreTools
Found Azure Functions Core Tools [Microsoft.Azure.FunctionsCoreTools] Version 4.0.5455
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://github.com/Azure/azure-functions-core-tools/releases/download/4.0.5455/func-cli-4.0.5455-x64.msi
  ██████████████████████████████   210 MB /  210 MB
Successfully verified installer hash
Starting package install...
Successfully installed
```