### PR TITLE
Return non-zero exit status if failed to parse the action

### DIFF
--- a/src/Azure.Functions.Cli/ConsoleApp.cs
+++ b/src/Azure.Functions.Cli/ConsoleApp.cs
@@ -387,14 +387,14 @@ namespace Azure.Functions.Cli
             {
                 // TODO: we can probably display help here as well.
                 // This happens for actions that expect an ordered untyped options.
-                ColoredConsole.Error.WriteLine(ex.Message);
+
                 // If we matched the action, we can log the invoke command
                 _telemetryEvent.CommandName = invokeCommand.ToString();
                 _telemetryEvent.IActionName = action.GetType().Name;
                 _telemetryEvent.Parameters = new List<string>();
                 _telemetryEvent.ParseError = true;
                 _telemetryEvent.IsSuccessful = false;
-                return null;
+                throw;
             }
         }
 

--- a/test/Azure.Functions.Cli.Tests/ActionsTests/ResolveActionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/ActionsTests/ResolveActionTests.cs
@@ -22,6 +22,7 @@ namespace Azure.Functions.Cli.Tests.ActionsTests
         [InlineData("azure functionapp enable-git-repo appName", typeof(DeprecatedAzureActions))]
         [InlineData("azure functionapp fetch-app-settings appName", typeof(FetchAppSettingsAction))]
         [InlineData("azure functionapp fetch appName", typeof(FetchAppSettingsAction))]
+        [InlineData("azure functionapp publish app-name -g resource-group", typeof(FetchAppSettingsAction))]
         [InlineData("azure get-publish-username", typeof(DeprecatedAzureActions))]
         [InlineData("azure account list", typeof(DeprecatedAzureActions))]
         [InlineData("azure subscriptions list", typeof(DeprecatedAzureActions))]
@@ -81,6 +82,20 @@ namespace Azure.Functions.Cli.Tests.ActionsTests
             }
         }
 
+        [Theory]
+        [InlineData("azure functionapp publish -g resource-group app-name-not-the-first-arg")]
+        public void ThrowErrorOnIncorrectCommandLine(string args)
+        {
+            var fileSystem = Substitute.For<IFileSystem>();
+            fileSystem.File.Exists(Arg.Any<string>()).Returns(true);
+            FileSystemHelpers.Instance = fileSystem;
+
+            var container = InitializeContainerForTests();
+            var app = new ConsoleApp(args.Split(' ').ToArray(), typeof(Program).Assembly, container);
+
+            Assert.Throws<CliArgumentsException>(app.Parse);
+        }
+        
         private IContainer InitializeContainerForTests()
         {
             var builder = new ContainerBuilder();

--- a/test/Azure.Functions.Cli.Tests/ActionsTests/ResolveActionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/ActionsTests/ResolveActionTests.cs
@@ -22,7 +22,7 @@ namespace Azure.Functions.Cli.Tests.ActionsTests
         [InlineData("azure functionapp enable-git-repo appName", typeof(DeprecatedAzureActions))]
         [InlineData("azure functionapp fetch-app-settings appName", typeof(FetchAppSettingsAction))]
         [InlineData("azure functionapp fetch appName", typeof(FetchAppSettingsAction))]
-        [InlineData("azure functionapp publish app-name -g resource-group", typeof(FetchAppSettingsAction))]
+        [InlineData("azure functionapp publish app-name -g resource-group", typeof(PublishFunctionAppAction))]
         [InlineData("azure get-publish-username", typeof(DeprecatedAzureActions))]
         [InlineData("azure account list", typeof(DeprecatedAzureActions))]
         [InlineData("azure subscriptions list", typeof(DeprecatedAzureActions))]


### PR DESCRIPTION
### Issue describing the changes in this PR

Do not swallow `CliArgumentsException`. Return non-zero exit code if CLI arguments are incorrect.

Fixes https://github.com/Azure/azure-functions-core-tools/issues/3277

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)