### PR TITLE
Updated error message to reflect unmentioned language options

### DIFF
--- a/src/Azure.Functions.Cli/Helpers/GlobalCoreToolsSettings.cs
+++ b/src/Azure.Functions.Cli/Helpers/GlobalCoreToolsSettings.cs
@@ -16,7 +16,7 @@ namespace Azure.Functions.Cli.Helpers
             {
                 if (_currentWorkerRuntime == WorkerRuntime.None)
                 {
-                    ColoredConsole.Error.WriteLine(QuietWarningColor("Can't determine project language from files. Please use one of [--csharp, --javascript, --typescript, --java, --python, --powershell, --custom]"));
+                    ColoredConsole.Error.WriteLine(QuietWarningColor("Can't determine project language from files. Please use one of [--csharp, --javascript, --typescript, --java, --python, --powershell, --dotnet-isolated, --node, --custom]"));
                 }
                 return _currentWorkerRuntime;
             }


### PR DESCRIPTION
Extending the error message to reflect the missing language options. Currently if you try to run or (publish) a function app you get the following error message if the local.settings.json isn't present.
![image](https://github.com/Azure/azure-functions-core-tools/assets/20532954/2b23b7c2-4823-43ed-9cea-1d43e27d46ee)

But this does not mention the other options, like dotnet-isolated. Just by reading this message, it seems to suggest --csharp as the right option. https://github.com/Azure/azure-functions-core-tools/blob/fc93cca9640179f934cefb71f641f5e6243a1ac5/src/Azure.Functions.Cli/Helpers/GlobalCoreToolsSettings.cs#L40 but this will set the workerruntime to dotnet instead of dotnet isolated. The option --dotnet-isolated isn't mentioned here at all. 

### Issue describing the changes in this PR

Related to #3537 (if not resolving that one)


### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)