### PR TITLE
fix: gozip across different host OS architectures

### DIFF
--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -766,13 +766,16 @@ namespace Build
             var combinedRuntimesToSign = GetAllTargetRuntimes();
             foreach (var runtime in combinedRuntimesToSign)
             {
-                if (runtimeToGoEnv.TryGetValue(GetRuntimeId(runtime), out var goEnv))
+                var runtimeId = GetRuntimeId(runtime);
+                // Remove the Net8ArtifactNameSuffix suffix if present
+                runtimeId = runtimeId.Replace(Net8ArtifactNameSuffix, "");
+                if (runtimeToGoEnv.TryGetValue(runtimeId, out var goEnv))
                 {
                     Environment.SetEnvironmentVariable("CGO_ENABLED", "0");
                     Environment.SetEnvironmentVariable("GOOS", goEnv.GOOS);
                     Environment.SetEnvironmentVariable("GOARCH", goEnv.GOARCH);
                     var outputPath = Path.Combine(Settings.OutputDir, runtime, "gozip");
-                    var output = runtime.Contains("win") ? $"{outputPath}.exe" : outputPath;
+                    var output = runtimeId.Contains("win") ? $"{outputPath}.exe" : outputPath;
                     var goFile = Path.GetFullPath("../tools/go/gozip/main.go");
                     Shell.Run("go", $"build -o {output} {goFile}");
                 }

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -667,27 +667,30 @@ namespace Build
 
         public static void AddGoZip()
         {
+            var runtimeToGoEnv = new Dictionary<string, (string GOOS, string GOARCH)>
+            {
+                { "win-x86", ("windows", "386") },
+                { "win-arm64", ("windows", "arm64") },
+                { "win-x64", ("windows", "amd64") },
+                { "linux-x64", ("linux", "amd64") },
+                { "osx-arm64", ("darwin", "arm64") },
+                { "osx-x64", ("darwin", "amd64") }
+            };
             foreach (var runtime in Settings.TargetRuntimes)
             {
-                var outputPath = Path.Combine(Settings.OutputDir, runtime, "gozip");
-                Environment.SetEnvironmentVariable("GOARCH", "amd64");
-                Environment.SetEnvironmentVariable("CGO_ENABLED", "0");
-                var goFile = Path.GetFullPath("../tools/go/gozip/main.go");
-
-                if (runtime.Contains("win"))
+                if (runtimeToGoEnv.TryGetValue(GetRuntimeId(runtime), out var goEnv))
                 {
-                    Environment.SetEnvironmentVariable("GOOS", "windows");
-                    Shell.Run("go", $"build -o {outputPath}.exe {goFile}");
+                    Environment.SetEnvironmentVariable("CGO_ENABLED", "0");
+                    Environment.SetEnvironmentVariable("GOOS", goEnv.GOOS);
+                    Environment.SetEnvironmentVariable("GOARCH", goEnv.GOARCH);
+                    var outputPath = Path.Combine(Settings.OutputDir, runtime, "gozip");
+                    var output = runtime.Contains("win") ? $"{outputPath}.exe" : outputPath;
+                    var goFile = Path.GetFullPath("../tools/go/gozip/main.go");
+                    Shell.Run("go", $"build -o {output} {goFile}");
                 }
-                else if (runtime.Contains("linux"))
+                else
                 {
-                    Environment.SetEnvironmentVariable("GOOS", "linux");
-                    Shell.Run("go", $"build -o {outputPath} {goFile}");
-                }
-                else if (runtime.Contains("osx"))
-                {
-                    Environment.SetEnvironmentVariable("GOOS", "darwin");
-                    Shell.Run("go", $"build -o {outputPath} {goFile}");
+                    throw new Exception($"Unsupported runtime: {runtime}");
                 }
             }
         }


### PR DESCRIPTION
Before for e.g. macOS or Windows the `gozip` executable did not match the target OS architecture. This PR fixes that:

<img width="1127" alt="image" src="https://github.com/Azure/azure-functions-core-tools/assets/17984549/cd63ae0b-bdad-45e8-bc3d-d9e744d64b3f">

### Issue describing the changes in this PR

Fixes https://github.com/Azure/azure-functions-core-tools/issues/3648

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

cc @arroyc