### PR TITLE
Fix grammar in --no-build flag description

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -129,7 +129,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
 
             Parser
                 .Setup<bool>("no-build")
-                .WithDescription("Do no build current project before running. For dotnet projects only. Default is set to false.")
+                .WithDescription("Do not build the current project before running. For dotnet projects only. Default is set to false.")
                 .SetDefault(false)
                 .Callback(b => NoBuild = b);
 


### PR DESCRIPTION
Modified the description of the --no-build flag for the func start command to match the grammar in the documentation.

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)