### PR TITLE
Core tools changes to support .NET8 in-proc

### DIFF
--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -145,7 +145,7 @@ namespace Build
                                 $"/p:SkipNet8Child=\"{skipLaunchingNet8ChildProcess}\" " +
                                 $"/p:CommitHash=\"{Settings.CommitId}\" " +
                                 (string.IsNullOrEmpty(Settings.IntegrationBuildNumber) ? string.Empty : $"/p:IntegrationBuildNumber=\"{Settings.IntegrationBuildNumber}\" ") +
-                                $"-o {outputPath} -c Release -f {targetFramework}" +
+                                $"-o {outputPath} -c Release -f {targetFramework}  --self-contained" +
                                 (string.IsNullOrEmpty(rid) ? string.Empty : $" -r {rid}"));
         }
 

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -332,7 +332,7 @@ namespace Build
 
             Environment.SetEnvironmentVariable("DURABLE_FUNCTION_PATH", Settings.DurableFolder);
 
-            Shell.Run("dotnet", $"test {Settings.TestProjectFile} --logger trx");
+            Shell.Run("dotnet", $"test {Settings.TestProjectFile} -f net6.0 --logger trx");
         }
 
         public static void CopyBinariesToSign()

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -104,7 +104,7 @@ namespace Build
                                 $"/p:TargetFramework=net6.0 " +  // without TargetFramework, the generated nuspec has incorrect path for the copy files operation.
                                 $"/p:CommitHash=\"{Settings.CommitId}\" " +
                                 (string.IsNullOrEmpty(Settings.IntegrationBuildNumber) ? string.Empty : $"/p:IntegrationBuildNumber=\"{Settings.IntegrationBuildNumber}\" ") +
-                                $"-o {outputPath} -c Release --no-build");
+                                $"-o {outputPath} -c Release ");
         }
 
         public static void DotnetPublishForZips()

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -101,7 +101,7 @@ namespace Build
             Shell.Run("dotnet", $"pack {Settings.SrcProjectPath} " +
                                 $"/p:BuildNumber=\"{Settings.BuildNumber}\" " +
                                 $"/p:NoWorkers=\"true\" " +
-                                $"/p:TargetFramework=net6.0 " +
+                                $"/p:TargetFramework=net6.0 " +  // without TargetFramework, the generated nuspec has incorrect path for the copy files operation.
                                 $"/p:CommitHash=\"{Settings.CommitId}\" " +
                                 (string.IsNullOrEmpty(Settings.IntegrationBuildNumber) ? string.Empty : $"/p:IntegrationBuildNumber=\"{Settings.IntegrationBuildNumber}\" ") +
                                 $"-o {outputPath} -c Release ");
@@ -114,6 +114,7 @@ namespace Build
                 var isMinVersion = runtime.StartsWith(Settings.MinifiedVersionPrefix);
                 var outputPath = Path.Combine(Settings.OutputDir, runtime);
                 var rid = GetRuntimeId(runtime);
+
                 ExecuteDotnetPublish(outputPath, rid, "net6.0", skipLaunchingNet8ChildProcess: isMinVersion);
 
                 if (isMinVersion)
@@ -122,6 +123,7 @@ namespace Build
 
                     // For min versions, publish net8.0 as well
                     outputPath = BuildNet8ArtifactPath(runtime);
+
                     ExecuteDotnetPublish(outputPath, rid, "net8.0", skipLaunchingNet8ChildProcess: true);
                     RemoveLanguageWorkers(outputPath);
                 }

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -144,7 +144,7 @@ namespace Build
         {
             Shell.Run("dotnet", $"publish {Settings.ProjectFile} " +
                                 $"/p:BuildNumber=\"{Settings.BuildNumber}\" " +
-                                $"/p:SkipNet8Child=\"{skipLaunchingNet8ChildProcess}\" " +
+                                $"/p:SkipInProcessHost=\"{skipLaunchingNet8ChildProcess}\" " +
                                 $"/p:CommitHash=\"{Settings.CommitId}\" " +
                                 (string.IsNullOrEmpty(Settings.IntegrationBuildNumber) ? string.Empty : $"/p:IntegrationBuildNumber=\"{Settings.IntegrationBuildNumber}\" ") +
                                 $"-o {outputPath} -c Release -f {targetFramework}  --self-contained" +

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -120,13 +120,12 @@ namespace Build
                 if (isMinVersion)
                 {
                     RemoveLanguageWorkers(outputPath);
-
-                    // For min versions, publish net8.0 as well
-                    outputPath = BuildNet8ArtifactPath(runtime);
-
-                    ExecuteDotnetPublish(outputPath, rid, "net8.0", skipLaunchingNet8ChildProcess: true);
-                    RemoveLanguageWorkers(outputPath);
                 }
+
+                // Publish net8 version of the artifact as well.
+                var outputPathNet8 = BuildNet8ArtifactPath(runtime);
+                ExecuteDotnetPublish(outputPathNet8, rid, "net8.0", skipLaunchingNet8ChildProcess: true);
+                RemoveLanguageWorkers(outputPathNet8);
             }
 
             if (!string.IsNullOrEmpty(Settings.IntegrationBuildNumber) && (_integrationManifest != null))
@@ -553,13 +552,11 @@ namespace Build
                 var zipPath = Path.Combine(Settings.OutputDir, $"Azure.Functions.Cli.{runtime}.{version}.zip");
                 CreateZipFromArtifact(artifactPath, zipPath);
 
-                if (isMinVersion)
-                {
-                    // Zip the .net8 version as well.
-                    var net8Path = BuildNet8ArtifactPath(runtime);
-                    var net8ZipPath = zipPath.Replace(".zip", "_net8.0.zip");
-                    CreateZipFromArtifact(net8Path, net8ZipPath);
-                }
+                // Zip the .net8 version as well.
+                var net8Path = BuildNet8ArtifactPath(runtime);
+                var net8ZipPath = zipPath.Replace(".zip", "_net8.0.zip");
+                CreateZipFromArtifact(net8Path, net8ZipPath);
+                
 
                 // We leave the folders beginning with 'win' to generate the .msi files. They will be deleted in
                 // the ./generateMsiFiles.ps1 script

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -104,7 +104,7 @@ namespace Build
                                 $"/p:TargetFramework=net6.0 " +  // without TargetFramework, the generated nuspec has incorrect path for the copy files operation.
                                 $"/p:CommitHash=\"{Settings.CommitId}\" " +
                                 (string.IsNullOrEmpty(Settings.IntegrationBuildNumber) ? string.Empty : $"/p:IntegrationBuildNumber=\"{Settings.IntegrationBuildNumber}\" ") +
-                                $"-o {outputPath} -c Release ");
+                                $"-o {outputPath} -c Release --no-build");
         }
 
         public static void DotnetPublishForZips()

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -31,7 +31,7 @@ namespace Build
                 .Then(Test, skip: args.Contains("--codeql"))
                 .Then(GenerateSBOMManifestForZips, skip: !args.Contains("--generateSBOM"))
                 .Then(Zip)
-                .Then(DotnetPublishForNupkg)
+                //.Then(DotnetPublishForNupkg) // DotnetPack step now does build and pack.
                 .Then(GenerateSBOMManifestForNupkg, skip: !args.Contains("--generateSBOM"))
                 .Then(DotnetPack)
                 .Then(DeleteSBOMTelemetryFolder, skip: !args.Contains("--generateSBOM"))

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -31,7 +31,7 @@ namespace Build
                 .Then(Test, skip: args.Contains("--codeql"))
                 .Then(GenerateSBOMManifestForZips, skip: !args.Contains("--generateSBOM"))
                 .Then(Zip)
-                //.Then(DotnetPublishForNupkg) // DotnetPack step now does build and pack.
+                .Then(DotnetPublishForNupkg)
                 .Then(GenerateSBOMManifestForNupkg, skip: !args.Contains("--generateSBOM"))
                 .Then(DotnetPack)
                 .Then(DeleteSBOMTelemetryFolder, skip: !args.Contains("--generateSBOM"))

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -19,10 +19,10 @@ namespace Build
                 : value;
         }
 
-        public const string DotnetIsolatedItemTemplatesVersion = "4.0.2945";
-        public const string DotnetIsolatedProjectTemplatesVersion = "4.0.2945";
-        public const string DotnetItemTemplatesVersion = "4.0.2945";
-        public const string DotnetProjectTemplatesVersion = "4.0.2945";
+        public const string DotnetIsolatedItemTemplatesVersion = "4.0.3038";
+        public const string DotnetIsolatedProjectTemplatesVersion = "4.0.3038";
+        public const string DotnetItemTemplatesVersion = "4.0.3038";
+        public const string DotnetProjectTemplatesVersion = "4.0.3038";
         public const string TemplateJsonVersion = "3.1.1648";
 
         public static readonly string SBOMManifestToolPath = Path.GetFullPath("../ManifestTool/Microsoft.ManifestTool.dll");

--- a/build/Shell.cs
+++ b/build/Shell.cs
@@ -25,7 +25,7 @@ namespace Build
 
             if (exitcode != 0)
             {
-                throw new Exception($"{program} Exit Code == {exitcode}");
+                throw new Exception($"{program} {arguments} Exit Code == {exitcode}");
             }
         }
 

--- a/pipelineUtilities.psm1
+++ b/pipelineUtilities.psm1
@@ -67,6 +67,11 @@ $DotnetSDKVersionRequirements = @{
         MinimalPatch = '417'
         DefaultPatch = '417'
     }
+
+    '8.0' = @{
+        MinimalPatch = '204'
+        DefaultPatch = '204'
+    }
 }
 
 function AddLocalDotnetDirPath {

--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -362,7 +362,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                     throw new CliArgumentsException($"Unable to parse target framework {TargetFramework}. Valid options are \"net8.0\", \"net7.0\", \"net6.0\", and \"net48\"");
                 }
             }
-            else if (!string.IsNullOrEmpty(TargetFramework))
+            else if (ResolvedWorkerRuntime != Helpers.WorkerRuntime.dotnet && !string.IsNullOrEmpty(TargetFramework))
             {
                 throw new CliArgumentsException("The --target-framework option is supported only when --worker-runtime is set to dotnet-isolated");
             }

--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -364,7 +364,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             }
             else if (ResolvedWorkerRuntime != Helpers.WorkerRuntime.dotnet && !string.IsNullOrEmpty(TargetFramework))
             {
-                throw new CliArgumentsException("The --target-framework option is supported only when --worker-runtime is set to dotnet-isolated");
+                throw new CliArgumentsException("The --target-framework option is supported only when --worker-runtime is set to dotnet-isolated or dotnet");
             }
         }
 

--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -370,7 +370,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
 
             if (!supportedFrameworks.Contains(TargetFramework, StringComparer.InvariantCultureIgnoreCase))
             {
-                throw new CliArgumentsException($"Unable to parse target framework {TargetFramework}. Valid options are {string.Join(", ", supportedFrameworks)}");
+                throw new CliArgumentsException($"Unable to parse target framework {TargetFramework} for worker runtime {ResolvedWorkerRuntime}. Valid options are {string.Join(", ", supportedFrameworks)}");
             }
             else if (ResolvedWorkerRuntime != Helpers.WorkerRuntime.dotnetIsolated && ResolvedWorkerRuntime != Helpers.WorkerRuntime.dotnet)
             {

--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -11,10 +11,7 @@ using Azure.Functions.Cli.Helpers;
 using Azure.Functions.Cli.Interfaces;
 using Azure.Functions.Cli.StacksApi;
 using Colors.Net;
-using DurableTask.Core;
-using Dynamitey;
 using Fclp;
-using Microsoft.Azure.AppService.Proxy.Common.Constants;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using static Azure.Functions.Cli.Common.OutputTheme;
@@ -127,7 +124,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
 
             Parser
                 .Setup<string>("target-framework")
-                .WithDescription("Initialize a project with the given target framework moniker. Currently supported only when --worker-runtime set to dotnet-isolated. Options are - \"net8.0\", \"net7.0\", \"net6.0\", and \"net48\"")
+                .WithDescription($"Initialize a project with the given target framework moniker. Currently supported only when --worker-runtime set to dotnet-isolated or dotnet. Options are - {string.Join(", ", TargetFrameworkHelper.GetSupportedTargetFrameworks())}")
                 .Callback(tf => TargetFramework = tf);
 
             Parser

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk" InitialTargets="ExcludeWorkersFromReadyToRun">
+﻿<Project Sdk="Microsoft.NET.Sdk" InitialTargets="ExcludeWorkersFromReadyToRun">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AssemblyName>func</AssemblyName>
     <RuntimeIdentifiers>win-x64;win-x86;win-arm64;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">1</BuildNumber>
@@ -276,13 +276,13 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage.Internal" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="4.34.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="4.834.1" />
     <PackageReference Include="Microsoft.Build" Version="17.0.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.60.3" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.35.0" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NuGet.Packaging" Version="5.11.6" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.35.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.1.2" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.1" />
     <PackageReference Include="YamlDotNet" Version="6.0.0" />
   </ItemGroup>
@@ -299,4 +299,18 @@
       <Output TaskParameter="Include" ItemName="PublishReadyToRunExclude" />
     </CreateItem>
   </Target>
+  <!-- Build/Publish for net8.0 TFM as well-->
+  <Target Name="BuildInProcNet8" AfterTargets="Build" Condition="'$(TargetFramework)'=='net6.0'">
+    <PropertyGroup>
+      <RuntimeIdentifierOption Condition="'$(RuntimeIdentifier)' != ''">-r $(RuntimeIdentifier)</RuntimeIdentifierOption>
+    </PropertyGroup>
+    <Exec Command="dotnet publish -c $(Configuration) -f net8.0 --output $(OutputPath)/in-proc8 $(RuntimeIdentifierOption) -p:NoWorkers=True" />
+  </Target>
+  <Target Name="PublishInProcNet8" AfterTargets="Publish" Condition="'$(TargetFramework)'=='net6.0'">
+    <PropertyGroup>
+      <RuntimeIdentifierOption Condition="'$(RuntimeIdentifier)' != ''">-r $(RuntimeIdentifier)</RuntimeIdentifierOption>
+    </PropertyGroup>
+    <Exec Command="dotnet publish -c $(Configuration) -f net8.0 --output $(PublishDir)/in-proc8 $(RuntimeIdentifierOption) -p:NoWorkers=True" />
+  </Target>
+
 </Project>

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -282,7 +282,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage.Internal" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="4.834.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="4.834.2" />
     <PackageReference Include="Microsoft.Build" Version="17.0.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.60.3" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.1.2" />

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -28,6 +28,12 @@
     <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
     <NuspecFile>Azure.Functions.Cli.nuspec</NuspecFile>
     <NuspecProperties>configuration=$(Configuration);targetFramework=$(TargetFramework);version=$(Version)</NuspecProperties>
+    <CoreToolsTargetRuntime>$(CoreToolsTargetRuntime)</CoreToolsTargetRuntime>
+  </PropertyGroup>
+
+  <!-- SkipNet8Child build property will be True for artifacts used by VS feed -->
+  <PropertyGroup Condition="'$(SkipNet8Child)' == 'True'">
+    <DefineConstants>SkipNet8Child</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'win-x64' OR '$(RuntimeIdentifier)' == 'win-x86'">
     <PublishReadyToRun>false</PublishReadyToRun>
@@ -300,13 +306,13 @@
     </CreateItem>
   </Target>
   <!-- Build/Publish for net8.0 TFM as well-->
-  <Target Name="BuildInProcNet8" AfterTargets="Build" Condition="'$(TargetFramework)'=='net6.0'">
+  <Target Name="BuildInProcNet8" AfterTargets="Build" Condition="'$(TargetFramework)'=='net6.0' AND '$(SkipNet8Child)'!='True'">
     <PropertyGroup>
       <RuntimeIdentifierOption Condition="'$(RuntimeIdentifier)' != ''">-r $(RuntimeIdentifier)</RuntimeIdentifierOption>
     </PropertyGroup>
     <Exec Command="dotnet publish -c $(Configuration) -f net8.0 --output $(OutputPath)/in-proc8 $(RuntimeIdentifierOption) -p:NoWorkers=True" />
   </Target>
-  <Target Name="PublishInProcNet8" AfterTargets="Publish" Condition="'$(TargetFramework)'=='net6.0'">
+  <Target Name="PublishInProcNet8" AfterTargets="Publish" Condition="'$(TargetFramework)'=='net6.0' AND '$(SkipNet8Child)'!='True'">
     <PropertyGroup>
       <RuntimeIdentifierOption Condition="'$(RuntimeIdentifier)' != ''">-r $(RuntimeIdentifier)</RuntimeIdentifierOption>
     </PropertyGroup>

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -22,14 +22,22 @@
     <ApplicationIcon>AzureFunctions-CLI.ico</ApplicationIcon>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <PackageId>Microsoft.Azure.Functions.CoreTools</PackageId>
-    <PackAsTool>true</PackAsTool>
-    <ToolCommandName>func</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
     <NuspecFile>Azure.Functions.Cli.nuspec</NuspecFile>
     <NuspecProperties>configuration=$(Configuration);targetFramework=$(TargetFramework);version=$(Version)</NuspecProperties>
   </PropertyGroup>
 
+  <!-- Pack only the net6.0 version (which will include the bits needed for net8.0 usecase) -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <IsPackable>true</IsPackable>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>func</ToolCommandName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  
   <!-- SkipInProcessHost build property will be True for artifacts used by VS feed -->
   <PropertyGroup Condition="'$(SkipInProcessHost)' == 'True'">
     <DefineConstants>SkipInProcessHost</DefineConstants>

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -28,7 +28,6 @@
     <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
     <NuspecFile>Azure.Functions.Cli.nuspec</NuspecFile>
     <NuspecProperties>configuration=$(Configuration);targetFramework=$(TargetFramework);version=$(Version)</NuspecProperties>
-    <CoreToolsTargetRuntime>$(CoreToolsTargetRuntime)</CoreToolsTargetRuntime>
   </PropertyGroup>
 
   <!-- SkipNet8Child build property will be True for artifacts used by VS feed -->

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -30,9 +30,9 @@
     <NuspecProperties>configuration=$(Configuration);targetFramework=$(TargetFramework);version=$(Version)</NuspecProperties>
   </PropertyGroup>
 
-  <!-- SkipNet8Child build property will be True for artifacts used by VS feed -->
-  <PropertyGroup Condition="'$(SkipNet8Child)' == 'True'">
-    <DefineConstants>SkipNet8Child</DefineConstants>
+  <!-- SkipInProcessHost build property will be True for artifacts used by VS feed -->
+  <PropertyGroup Condition="'$(SkipInProcessHost)' == 'True'">
+    <DefineConstants>SkipInProcessHost</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'win-x64' OR '$(RuntimeIdentifier)' == 'win-x86'">
     <PublishReadyToRun>false</PublishReadyToRun>
@@ -305,17 +305,17 @@
     </CreateItem>
   </Target>
   <!-- Build/Publish for net8.0 TFM as well-->
-  <Target Name="BuildInProcNet8" AfterTargets="Build" Condition="'$(TargetFramework)'=='net6.0' AND '$(SkipNet8Child)'!='True'">
+  <Target Name="BuildInProcNet8" AfterTargets="Build" Condition="'$(TargetFramework)'=='net6.0' AND '$(SkipInProcessHost)'!='True'">
     <PropertyGroup>
       <RuntimeIdentifierOption Condition="'$(RuntimeIdentifier)' != ''">-r $(RuntimeIdentifier)</RuntimeIdentifierOption>
     </PropertyGroup>
-    <Exec Command="dotnet publish -c $(Configuration) -f net8.0 --output $(OutputPath)/in-proc8 $(RuntimeIdentifierOption) -p:NoWorkers=True" />
+    <Exec Command="dotnet publish -c $(Configuration) -f net8.0 --output $(OutputPath)/in-proc8 $(RuntimeIdentifierOption) -p:NoWorkers=True --self-contained" />
   </Target>
-  <Target Name="PublishInProcNet8" AfterTargets="Publish" Condition="'$(TargetFramework)'=='net6.0' AND '$(SkipNet8Child)'!='True'">
+  <Target Name="PublishInProcNet8" AfterTargets="Publish" Condition="'$(TargetFramework)'=='net6.0' AND '$(SkipInProcessHost)'!='True'">
     <PropertyGroup>
       <RuntimeIdentifierOption Condition="'$(RuntimeIdentifier)' != ''">-r $(RuntimeIdentifier)</RuntimeIdentifierOption>
     </PropertyGroup>
-    <Exec Command="dotnet publish -c $(Configuration) -f net8.0 --output $(PublishDir)/in-proc8 $(RuntimeIdentifierOption) -p:NoWorkers=True" />
+    <Exec Command="dotnet publish -c $(Configuration) -f net8.0 --output $(PublishDir)/in-proc8 $(RuntimeIdentifierOption) -p:NoWorkers=True --self-contained" />
   </Target>
 
 </Project>

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -91,7 +91,7 @@ namespace Azure.Functions.Cli.Common
         public const string LocalSettingsJsonFileName = "local.settings.json";
         public const string EnableWorkerIndexEnvironmentVariableName = "FunctionsHostingConfig__WORKER_INDEXING_ENABLED";
         public const string Dotnet = "dotnet";
-
+        public const string FunctionsInProcNet8Enabled = "FUNCTIONS_INPROC_NET8_ENABLED";
 
 
         public static string CliVersion => typeof(Constants).GetTypeInfo().Assembly.GetName().Version.ToString(3);

--- a/src/Azure.Functions.Cli/Common/ProcessManager.cs
+++ b/src/Azure.Functions.Cli/Common/ProcessManager.cs
@@ -7,6 +7,7 @@ namespace Azure.Functions.Cli.Common
 {
     internal class ProcessManager : IProcessManager
     {
+        private IList<Process> _childProcesses;
         public IProcessInfo GetCurrentProcess()
         {
             return new ProcessInfo(Process.GetCurrentProcess());
@@ -21,6 +22,36 @@ namespace Azure.Functions.Cli.Common
         {
             return Process.GetProcessesByName(processName)
                 .Select(p => new ProcessInfo(p));
+        }
+
+        public void KillChildProcesses()
+        {
+            if (_childProcesses == null)
+            {
+                return;
+            }
+
+            foreach (var childProcess in _childProcesses)
+            {
+                if (!childProcess.HasExited)
+                {
+                    childProcess.Kill();
+                }
+            }
+        }
+
+        public bool RegisterChildProcess(Process childProcess)
+        {
+            _childProcesses ??= new List<Process>();
+
+            // be graceful if someone calls this method with the same process multiple times.
+            if (_childProcesses.Any(p=>p.Id == childProcess.Id))
+            {
+                return false;
+            }
+
+            _childProcesses.Add(childProcess);
+            return true;
         }
     }
 }

--- a/src/Azure.Functions.Cli/Helpers/GlobalCoreToolsSettings.cs
+++ b/src/Azure.Functions.Cli/Helpers/GlobalCoreToolsSettings.cs
@@ -11,6 +11,12 @@ namespace Azure.Functions.Cli.Helpers
     {
         private static WorkerRuntime _currentWorkerRuntime;
         public static ProgrammingModel? CurrentProgrammingModel { get; set; }
+
+        /// <summary>
+        /// Gets the root path of the function app from where the func exe was invoked.
+        /// </summary>
+        public static string? FunctionAppRootPath { get; private set; }
+
         public static WorkerRuntime CurrentWorkerRuntime
         {
             get
@@ -37,6 +43,8 @@ namespace Azure.Functions.Cli.Helpers
         {
             try
             {
+                FunctionAppRootPath = Environment.CurrentDirectory;
+
                 if (args.Contains("--csharp"))
                 {
                     _currentWorkerRuntime = WorkerRuntime.dotnet;

--- a/src/Azure.Functions.Cli/Helpers/GlobalCoreToolsSettings.cs
+++ b/src/Azure.Functions.Cli/Helpers/GlobalCoreToolsSettings.cs
@@ -12,11 +12,6 @@ namespace Azure.Functions.Cli.Helpers
         private static WorkerRuntime _currentWorkerRuntime;
         public static ProgrammingModel? CurrentProgrammingModel { get; set; }
 
-        /// <summary>
-        /// Gets the root path of the function app from where the func exe was invoked.
-        /// </summary>
-        public static string? FunctionAppRootPath { get; private set; }
-
         public static WorkerRuntime CurrentWorkerRuntime
         {
             get
@@ -43,8 +38,6 @@ namespace Azure.Functions.Cli.Helpers
         {
             try
             {
-                FunctionAppRootPath = Environment.CurrentDirectory;
-
                 if (args.Contains("--csharp"))
                 {
                     _currentWorkerRuntime = WorkerRuntime.dotnet;
@@ -84,7 +77,7 @@ namespace Azure.Functions.Cli.Helpers
                 {
                     _currentWorkerRuntime = WorkerRuntime.powershell;
                 }
-                else if(args.Contains("--custom"))
+                else if (args.Contains("--custom"))
                 {
                     _currentWorkerRuntime = WorkerRuntime.custom;
                 }

--- a/src/Azure.Functions.Cli/Helpers/TargetFrameworkHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/TargetFrameworkHelper.cs
@@ -5,8 +5,8 @@ namespace Azure.Functions.Cli.Helpers
 {
     public static class TargetFrameworkHelper
     {
-        private static readonly IEnumerable<string> supportedTargetFrameworks = new string[] { TargetFramework.net48, TargetFramework.net6, TargetFramework.net7, TargetFramework.net8 };
-        private static readonly IEnumerable<string> supportedInProcTargetFrameworks = new string[] { TargetFramework.net6, TargetFramework.net8 };
+        private static readonly IEnumerable<string> supportedTargetFrameworks = new string[] { TargetFramework.net8, TargetFramework.net7, TargetFramework.net6, TargetFramework.net48 };
+        private static readonly IEnumerable<string> supportedInProcTargetFrameworks = new string[] { TargetFramework.net8, TargetFramework.net6 };
 
         public static IEnumerable<string> GetSupportedTargetFrameworks()
         {

--- a/src/Azure.Functions.Cli/Helpers/TargetFrameworkHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/TargetFrameworkHelper.cs
@@ -5,11 +5,17 @@ namespace Azure.Functions.Cli.Helpers
 {
     public static class TargetFrameworkHelper
     {
-        private static IEnumerable<string> supportedTargetFrameworks = new string[] { TargetFramework.net48, TargetFramework.net6, TargetFramework.net7, TargetFramework.net8 };
+        private static readonly IEnumerable<string> supportedTargetFrameworks = new string[] { TargetFramework.net48, TargetFramework.net6, TargetFramework.net7, TargetFramework.net8 };
+        private static readonly IEnumerable<string> supportedInProcTargetFrameworks = new string[] { TargetFramework.net6, TargetFramework.net8 };
 
         public static IEnumerable<string> GetSupportedTargetFrameworks()
         {
             return supportedTargetFrameworks;
+        }
+
+        public static IEnumerable<string> GetSupportedInProcTargetFrameworks()
+        {
+            return supportedInProcTargetFrameworks;
         }
     }
 }

--- a/src/Azure.Functions.Cli/Interfaces/IProcessManager.cs
+++ b/src/Azure.Functions.Cli/Interfaces/IProcessManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Azure.Functions.Cli.Interfaces
 {
@@ -7,5 +8,15 @@ namespace Azure.Functions.Cli.Interfaces
         IEnumerable<IProcessInfo> GetProcessesByName(string processName);
         IProcessInfo GetCurrentProcess();
         IProcessInfo GetProcessById(int processId);
+
+        /// <summary>
+        /// Register a child process spawned by the current process.
+        /// </summary>
+        /// <param name="childProcess"></param>
+        /// <returns>True if the process was registered, else False.</returns>
+        bool RegisterChildProcess(Process childProcess);
+
+        // Kill all child processes spawned by the current process.
+        void KillChildProcesses();
     }
 }

--- a/src/Azure.Functions.Cli/Program.cs
+++ b/src/Azure.Functions.Cli/Program.cs
@@ -1,23 +1,30 @@
 ﻿using System;
 using System.Linq;
 using Autofac;
-using Colors.Net;
-using Azure.Functions.Cli.Arm;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Helpers;
 using Azure.Functions.Cli.Interfaces;
-using static Azure.Functions.Cli.Common.OutputTheme;
 
 namespace Azure.Functions.Cli
 {
     internal class Program
     {
+        static IContainer _container;
         internal static void Main(string[] args)
         {
             FirstTimeCliExperience();
             SetupGlobalExceptionHandler();
             SetCoreToolsEnvironmentVariables(args);
-            ConsoleApp.Run<Program>(args, InitializeAutofacContainer());
+            _container = InitializeAutofacContainer();
+            AppDomain.CurrentDomain.ProcessExit += CurrentDomain_ProcessExit;
+
+            ConsoleApp.Run<Program>(args, _container);
+        }
+
+        private static void CurrentDomain_ProcessExit(object sender, EventArgs e)
+        {
+            var processManager = _container.Resolve<IProcessManager>();
+            processManager?.KillChildProcesses();
         }
 
         private static void SetupGlobalExceptionHandler()

--- a/test/Azure.Functions.Cli.Tests/Azure.Functions.Cli.Tests.csproj
+++ b/test/Azure.Functions.Cli.Tests/Azure.Functions.Cli.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AssemblyName>Azure.Functions.Cli.Tests</AssemblyName>
     <RootNamespace>Azure.Functions.Cli.Tests</RootNamespace>
@@ -45,4 +45,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Azure.Functions.Cli\Azure.Functions.Cli.csproj" />
   </ItemGroup>
+  <!-- The "in-proc8" directory content is created using an msbuild target in "Azure.Functions.Cli" project and they don't automatically gets copied to the test project output directory -->
+  <Target Name="CopyInProc8" AfterTargets="Build" Condition="'$(TargetFramework)'=='net6.0'">
+    <Exec Command="xcopy /Y /I /E &quot;$(MSBuildThisFileDirectory)..\..\src\Azure.Functions.Cli\bin\$(Configuration)\$(TargetFramework)\in-proc8\*&quot; &quot;$(OutDir)in-proc8\&quot;" />
+  </Target>
 </Project>

--- a/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
@@ -209,6 +209,37 @@ namespace Azure.Functions.Cli.Tests.E2E
         }
 
         [Fact]
+        public Task init_dotnet_app_net8()
+        {
+            return CliTester.Run(new RunConfiguration
+            {
+                Commands = new[] { "init dotnet-funcs --worker-runtime dotnet --target-framework net8.0" },
+                CheckFiles = new[]
+                {
+                    new FileResult
+                    {
+                        Name = Path.Combine("dotnet-funcs", "local.settings.json"),
+                        ContentContains = new[]
+                        {
+                            "FUNCTIONS_WORKER_RUNTIME",
+                            "dotnet",
+                            "FUNCTIONS_INPROC_NET8_ENABLED",
+                        }
+                    },
+                    new FileResult
+                    {
+                        Name = Path.Combine("dotnet-funcs", "dotnet-funcs.csproj"),
+                        ContentContains = new[]
+                        {
+                            "Microsoft.NET.Sdk.Functions",
+                            "v4"
+                        }
+                    }
+                }
+            }, _output);
+        }
+
+        [Fact]
         public Task init_with_unknown_worker_runtime()
         {
             const string unknownWorkerRuntime = "foo";

--- a/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
@@ -263,7 +263,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                 HasStandardError = true,
                 ErrorContains = new[]
                 {
-                    $"Unable to parse target framework {unsupportedTargetFramework}. Valid options are net8.0, net6.0"
+                    $"Unable to parse target framework {unsupportedTargetFramework} for worker runtime dotnet. Valid options are net8.0, net6.0"
                 }
             }, _output);
         }

--- a/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Helpers;
@@ -250,6 +249,21 @@ namespace Azure.Functions.Cli.Tests.E2E
                 ErrorContains = new[]
                 {
                     $"Worker runtime '{unknownWorkerRuntime}' is not a valid option."
+                }
+            }, _output);
+        }
+
+        [Fact]
+        public Task init_with_unsupported_target_framework_for_dotnet()
+        {
+            const string unsupportedTargetFramework = "net7.0";
+            return CliTester.Run(new RunConfiguration
+            {
+                Commands = new[] { $"init . --worker-runtime dotnet --target-framework {unsupportedTargetFramework}" },
+                HasStandardError = true,
+                ErrorContains = new[]
+                {
+                    $"Unable to parse target framework {unsupportedTargetFramework}. Valid options are net8.0, net6.0"
                 }
             }, _output);
         }

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -336,7 +336,8 @@ namespace Azure.Functions.Cli.Tests.E2E
 
                         if (_output is Xunit.Sdk.TestOutputHelper testOutputHelper)
                         {
-                            testOutputHelper.Output.Should().Contain("Starting child process for .NET8 In-proc.");
+                            testOutputHelper.Output.Should().Contain($"{Constants.FunctionsInProcNet8Enabled} app setting enabled in local.settings.json");
+                            testOutputHelper.Output.Should().Contain("Starting child process for in-process model host");
                             testOutputHelper.Output.Should().Contain("Started child process with ID");
                         }
                     }

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -320,7 +320,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                 {
                     "init . --worker-runtime dotnet --target-framework net8.0",
                     "new --template Httptrigger --name HttpTrigger",
-                    "start --build --port 7073 --verbose"
+                    "start --port 7073 --verbose"
                 },
                 ExpectExit = false,
                 Test = async (workingDir, p) =>

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -312,6 +312,40 @@ namespace Azure.Functions.Cli.Tests.E2E
         }
 
         [Fact]
+        public async Task start_dotnet8_inproc()
+        {
+            await CliTester.Run(new RunConfiguration
+            {
+                Commands = new[]
+                {
+                    "init . --worker-runtime dotnet --target-framework net8.0",
+                    "new --template Httptrigger --name HttpTrigger",
+                    "start --build --port 7073 --verbose"
+                },
+                ExpectExit = false,
+                Test = async (workingDir, p) =>
+                {
+                    using (var client = new HttpClient() { BaseAddress = new Uri("http://localhost:7073") })
+                    {
+                        (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
+                        var response = await client.GetAsync("/api/HttpTrigger?name=Test");
+                        var result = await response.Content.ReadAsStringAsync();
+                        p.Kill();
+                        await Task.Delay(TimeSpan.FromSeconds(2));
+                        result.Should().Be("Hello, Test. This HTTP triggered function executed successfully.", because: "response from default function should be 'Hello, {name}. This HTTP triggered function executed successfully.'");
+
+                        if (_output is Xunit.Sdk.TestOutputHelper testOutputHelper)
+                        {
+                            testOutputHelper.Output.Should().Contain("Starting child process for .NET8 In-proc.");
+                            testOutputHelper.Output.Should().Contain("Started child process with ID");
+                        }
+                    }
+                },
+                CommandTimeout = TimeSpan.FromSeconds(120),
+            }, _output);
+        }
+
+        [Fact]
         public async Task start_displays_error_on_invalid_function_json()
         {
             var functionName = "HttpTriggerJS";


### PR DESCRIPTION
Core tools changes to support .NET8 in-proc.

The core tools artifact will now have a child folder called "in-proc8" which is the output of `dotnet publish -f net8.0` (We use an MSbuild target to do this publishing). In the `start` action, we will inspect the local.settings.json file for the presence of `FUNCTIONS_INPROC_NET8_ENABLED` setting. If this is present, that indicates the app is an in-proc net8 app. Instead of starting the app with the current core tools process (which is built for net6.0), we will launch a child func.exe process from the "in-proc8" folder.

Updated Microsoft.Azure.WebJobs.Script.WebHost to 4.834.2


### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)