### PR TITLE
Limelight forwarding URL display

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -473,7 +473,8 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 var forwardedHttpUrl = _secretsManager.GetSecrets().FirstOrDefault(
                     s => s.Key.Equals(Constants.AzureDevSessionsRemoteHostName, StringComparison.OrdinalIgnoreCase)).Value;
                 if (forwardedHttpUrl != null){
-                    baseUri = forwardedHttpUrl.Replace(Constants.AzureDevSessionsPortSuffixPlaceholder, Port.ToString(), StringComparison.OrdinalIgnoreCase);
+                    var baseUrl = forwardedHttpUrl.Replace(Constants.AzureDevSessionsPortSuffixPlaceholder, Port.ToString(), StringComparison.OrdinalIgnoreCase);
+                    baseUri = new Uri(baseUrl);
                 }
 
                 DisplayFunctionsInfoUtilities.DisplayFunctionsInfo(scriptHost.Functions, httpOptions.Value, baseUri);

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -473,8 +473,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 var forwardedHttpUrl = _secretsManager.GetSecrets().FirstOrDefault(
                     s => s.Key.Equals(Constants.AzureDevSessionsRemoteHostName, StringComparison.OrdinalIgnoreCase)).Value;
                 if (forwardedHttpUrl != null){
-                    Regex rgx = new Regex("<port>");
-                    baseUri = rgx.Replace(forwardedHttpUrl, Port.ToString(), 1);
+                    baseUri = forwardedHttpUrl.Replace(Constants.AzureDevSessionsPortSuffixPlaceholder, Port.ToString(), StringComparison.OrdinalIgnoreCase);
                 }
 
                 DisplayFunctionsInfoUtilities.DisplayFunctionsInfo(scriptHost.Functions, httpOptions.Value, baseUri);

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Diagnostics;
@@ -468,6 +469,14 @@ namespace Azure.Functions.Cli.Actions.HostActions
             var httpOptions = hostService.Services.GetRequiredService<IOptions<HttpOptions>>();
             if (scriptHost != null && scriptHost.Functions.Any())
             {
+                // Checking if in Limelight - it should have a `AzureDevSessionsRemoteHostName` value in local.settings.json.
+                var forwardedHttpUrl = _secretsManager.GetSecrets().FirstOrDefault(
+                    s => s.Key.Equals(Constants.AzureDevSessionsRemoteHostName, StringComparison.OrdinalIgnoreCase)).Value;
+                if (forwardedHttpUrl != null){
+                    Regex rgx = new Regex("<port>");
+                    baseUri = rgx.Replace(forwardedHttpUrl, Port.ToString(), 1);
+                }
+
                 DisplayFunctionsInfoUtilities.DisplayFunctionsInfo(scriptHost.Functions, httpOptions.Value, baseUri);
             }
             if (VerboseLogging == null || !VerboseLogging.Value)

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -93,7 +93,7 @@ namespace Azure.Functions.Cli.Common
         public const string Dotnet = "dotnet";
         public const string FunctionsInProcNet8Enabled = "FUNCTIONS_INPROC_NET8_ENABLED";
         public const string AzureDevSessionsRemoteHostName = "AzureDevSessionsRemoteHostName";
-        public const string AzureDevSessionsPortSuffixPlaceholder = "<port>"
+        public const string AzureDevSessionsPortSuffixPlaceholder = "<port>";
         // Sample format https://n12abc3t-<port>.asse.devtunnels.ms/
 
 

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -92,6 +92,8 @@ namespace Azure.Functions.Cli.Common
         public const string EnableWorkerIndexEnvironmentVariableName = "FunctionsHostingConfig__WORKER_INDEXING_ENABLED";
         public const string Dotnet = "dotnet";
         public const string FunctionsInProcNet8Enabled = "FUNCTIONS_INPROC_NET8_ENABLED";
+        public const string AzureDevSessionsRemoteHostName = "AzureDevSessionsRemoteHostName";
+        // Sample format https://n12abc3t-<port>.asse.devtunnels.ms/
 
 
         public static string CliVersion => typeof(Constants).GetTypeInfo().Assembly.GetName().Version.ToString(3);

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -93,6 +93,7 @@ namespace Azure.Functions.Cli.Common
         public const string Dotnet = "dotnet";
         public const string FunctionsInProcNet8Enabled = "FUNCTIONS_INPROC_NET8_ENABLED";
         public const string AzureDevSessionsRemoteHostName = "AzureDevSessionsRemoteHostName";
+        public const string AzureDevSessionsPortSuffixPlaceholder = "<port>"
         // Sample format https://n12abc3t-<port>.asse.devtunnels.ms/
 
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

This change allows Core Tools to show the forwarded URL in Core Tools when displaying the Functions during debugging - for easier invocation and debugging.

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)