### PR TITLE
Removing package reference of Microsoft.IdentityModel.JsonWebTokens & System.IdentityModel.Tokens.Jwt packages

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -295,10 +295,8 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="4.834.3" />
     <PackageReference Include="Microsoft.Build" Version="17.0.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NuGet.Packaging" Version="5.11.6" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.1.2" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.1" />
     <PackageReference Include="YamlDotNet" Version="6.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Removing package reference of `Microsoft.IdentityModel.JsonWebTokens` & `System.IdentityModel.Tokens.Jwt` packages. Host will load the appropriate (6x or 7x) version of this package based on the TFM since `Microsoft.Azure.WebJobs.Script.WebHost` is a multi-targeted package(net6.0 and net8.0)


### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)