### PR TITLE
add instructions for ubuntu 22.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ brew link --overwrite azure-functions-core-tools@3
 
 #### 1. Set up package feed
 
+##### Ubuntu 22.04
+
+```bash
+wget -q https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb
+```
+
 ##### Ubuntu 20.04
 
 ```bash


### PR DESCRIPTION
The instructions currently end at ubuntu 20.04, which can give the impression that 22.04 is not supported.

Tested for 22.04 and worked.

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)