### PR TITLE
Kill child process when Ctrl + break key is pressed. 

### DIFF
--- a/src/Azure.Functions.Cli/Program.cs
+++ b/src/Azure.Functions.Cli/Program.cs
@@ -18,6 +18,11 @@ namespace Azure.Functions.Cli
             _container = InitializeAutofacContainer();
             AppDomain.CurrentDomain.ProcessExit += CurrentDomain_ProcessExit;
 
+            Console.CancelKeyPress += (s, e) =>
+            {
+                _container.Resolve<IProcessManager>()?.KillChildProcesses();
+            };
+
             ConsoleApp.Run<Program>(args, _container);
         }
 
@@ -74,7 +79,8 @@ namespace Azure.Functions.Cli
                 .ExternallyOwned();
 
             builder.RegisterType<ProcessManager>()
-                .As<IProcessManager>();
+                .As<IProcessManager>()
+                .SingleInstance();
 
             builder.RegisterType<SecretsManager>()
                 .As<ISecretsManager>();

--- a/test/Azure.Functions.Cli.Tests/ActionsTests/ResolveActionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/ActionsTests/ResolveActionTests.cs
@@ -93,7 +93,8 @@ namespace Azure.Functions.Cli.Tests.ActionsTests
                 .SingleInstance();
 
             builder.RegisterType<ProcessManager>()
-                .As<IProcessManager>();
+                .As<IProcessManager>()
+                .SingleInstance();
 
             var mockedSecretsManager = Substitute.For<ISecretsManager>();
             builder.RegisterInstance(mockedSecretsManager)


### PR DESCRIPTION
Kill child process when Ctrl + break key is pressed. 
Also made `IProcessManager` dependency singleton. This is a safe change because the current implementation does not store any state other than the child process count). We want a single instance (which was used to register the child process) so that we have the same child processes when we handle the Ctrl + Break key event handler, where we terminate the child processes.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)