### PR TITLE
Fix public builds from fork

### DIFF
--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -40,6 +40,9 @@ extends:
          compiled:
            enabled: true
          runSourceLanguagesInSourceAnalysis: true
+    settings:
+      # PR's from forks do not have sufficient permissions to set tags.
+      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
     stages:     
       - stage: BuildAndTest
         jobs:


### PR DESCRIPTION
Public builds from forks are currently failing, for example on [this PR](https://github.com/Azure/azure-functions-core-tools/pull/3371).

I copied the fix from the host: https://github.com/Azure/azure-functions-host/pull/10256

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)