### PR TITLE
Restructuring CI to reduce time-to-failure for scanning

### DIFF
--- a/check-vulnerabilities.ps1
+++ b/check-vulnerabilities.ps1
@@ -7,6 +7,11 @@ if (-not (Test-Path $projectPath))
 }
 
 cd $projectPath
+
+$cmd = "restore"
+Write-Host "dotnet $cmd"
+dotnet $cmd | Tee-Object $logFilePath
+
 $cmd = "list", "package", "--include-transitive", "--vulnerable"
 Write-Host "dotnet $cmd"
 dotnet $cmd | Tee-Object $logFilePath

--- a/eng/ci/templates/public/jobs/build-test-public.yml
+++ b/eng/ci/templates/public/jobs/build-test-public.yml
@@ -39,6 +39,9 @@ jobs:
     displayName: 'Validate worker versions'
     condition: ne(variables['skipWorkerVersionValidation'], 'true')
   - pwsh: |
+      .\check-vulnerabilities.ps1
+    displayName: "Check for security vulnerabilities"
+  - pwsh: |
       .\build.ps1
     env:
       BuildArtifactsStorage: $(BuildArtifactsStorage)
@@ -46,9 +49,6 @@ jobs:
       IsPublicBuild: true
       IsCodeqlBuild: false
     displayName: 'Executing build script'
-  - pwsh: |
-      .\check-vulnerabilities.ps1
-    displayName: "Check for security vulnerabilities"
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: 'VSTest'


### PR DESCRIPTION
Moving the scan ahead of the build so we can exit early instead of waiting for over an hour of tests before an easily detected fail state. Also removed behavior where older .NET versions we wouldn't even use were installed.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)