### PR TITLE
Fix Issue 3594: Look for csproj and fsproj non-recursively

### DIFF
--- a/src/Azure.Functions.Cli/Common/FileSystemHelpers.cs
+++ b/src/Azure.Functions.Cli/Common/FileSystemHelpers.cs
@@ -170,18 +170,20 @@ namespace Azure.Functions.Cli.Common
                 }
             }
 
-            if (searchOption == SearchOption.AllDirectories)
+            if (searchOption == SearchOption.TopDirectoryOnly)
             {
-                foreach (var directory in Instance.Directory.GetDirectories(directoryPath, "*", SearchOption.TopDirectoryOnly))
+                yield break;
+            }
+                
+            foreach (var directory in Instance.Directory.GetDirectories(directoryPath, "*", SearchOption.TopDirectoryOnly))
+            {
+                var directoryName = Path.GetFileName(directory);
+                if (excludedDirectories == null ||
+                    !excludedDirectories.Any(d => d.Equals(directoryName, StringComparison.OrdinalIgnoreCase)))
                 {
-                    var directoryName = Path.GetFileName(directory);
-                    if (excludedDirectories == null ||
-                        !excludedDirectories.Any(d => d.Equals(directoryName, StringComparison.OrdinalIgnoreCase)))
+                    foreach (var file in GetFiles(directory, excludedDirectories, excludedFiles, searchPattern, searchOption))
                     {
-                        foreach (var file in GetFiles(directory, excludedDirectories, excludedFiles, searchPattern, searchOption))
-                        {
-                            yield return file;
-                        }
+                        yield return file;
                     }
                 }
             }

--- a/src/Azure.Functions.Cli/Common/FileSystemHelpers.cs
+++ b/src/Azure.Functions.Cli/Common/FileSystemHelpers.cs
@@ -158,7 +158,7 @@ namespace Azure.Functions.Cli.Common
             }
         }
 
-        internal static IEnumerable<string> GetFiles(string directoryPath, IEnumerable<string> excludedDirectories = null, IEnumerable<string> excludedFiles = null, string searchPattern = "*")
+        internal static IEnumerable<string> GetFiles(string directoryPath, IEnumerable<string> excludedDirectories = null, IEnumerable<string> excludedFiles = null, string searchPattern = "*", SearchOption searchOption = SearchOption.AllDirectories)
         {
             foreach (var file in Instance.Directory.GetFiles(directoryPath, searchPattern, SearchOption.TopDirectoryOnly))
             {
@@ -170,15 +170,18 @@ namespace Azure.Functions.Cli.Common
                 }
             }
 
-            foreach (var directory in Instance.Directory.GetDirectories(directoryPath, "*", SearchOption.TopDirectoryOnly))
+            if (searchOption == SearchOption.AllDirectories)
             {
-                var directoryName = Path.GetFileName(directory);
-                if (excludedDirectories == null ||
-                    !excludedDirectories.Any(d => d.Equals(directoryName, StringComparison.OrdinalIgnoreCase)))
+                foreach (var directory in Instance.Directory.GetDirectories(directoryPath, "*", SearchOption.TopDirectoryOnly))
                 {
-                    foreach (var file in GetFiles(directory, excludedDirectories, excludedFiles, searchPattern))
+                    var directoryName = Path.GetFileName(directory);
+                    if (excludedDirectories == null ||
+                        !excludedDirectories.Any(d => d.Equals(directoryName, StringComparison.OrdinalIgnoreCase)))
                     {
-                        yield return file;
+                        foreach (var file in GetFiles(directory, excludedDirectories, excludedFiles, searchPattern, searchOption))
+                        {
+                            yield return file;
+                        }
                     }
                 }
             }

--- a/src/Azure.Functions.Cli/Helpers/DotnetHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/DotnetHelpers.cs
@@ -155,8 +155,9 @@ namespace Azure.Functions.Cli.Helpers
         public static bool CanDotnetBuild()
         {
             EnsureDotnet();
-            var csProjFiles = FileSystemHelpers.GetFiles(Environment.CurrentDirectory, searchPattern: "*.csproj").ToList();
-            var fsProjFiles = FileSystemHelpers.GetFiles(Environment.CurrentDirectory, searchPattern: "*.fsproj").ToList();
+            // dotnet build will only search for .csproj files within the current directory (when no .csproj file is passed), so we limit our search to that directory only
+            var csProjFiles = FileSystemHelpers.GetFiles(Environment.CurrentDirectory, searchPattern: "*.csproj", searchOption: SearchOption.TopDirectoryOnly).ToList();
+            var fsProjFiles = FileSystemHelpers.GetFiles(Environment.CurrentDirectory, searchPattern: "*.fsproj", searchOption: SearchOption.TopDirectoryOnly).ToList();
             // If the project name is extensions only then is extensions.csproj a valid csproj file
             if (!Path.GetFileName(Environment.CurrentDirectory).Equals("extensions"))
             {


### PR DESCRIPTION
add searchOption parameter to GetFiles to allow for non-recursive searching

use non-recursive searching when looking for .csproj and .fsproj files during validation.

### Issue describing the changes in this PR

resolves #3594

### Pull request checklist

* [X] My changes **do not** require documentation changes
* [X] My changes **do not** need to be backported to a previous version
* [ ] I have added all required tests (Unit tests, E2E tests)
  * I could not find any existing tests for this function