### PR TITLE
Update check-vulnerabilities.ps1 to error out if dotnet command fails and update build project dependencies

### DIFF
--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -6,5 +6,8 @@
   <ItemGroup>
     <PackageReference Include="Colors.Net" Version="1.1.0" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

This PR contains the following changes:
* Fixes https://github.com/Azure/azure-functions-core-tools/issues/3783
* Updated `check-vulnerabilities.ps1` to validate the packages for the following projects are up-to-date: 
"$PSScriptRoot/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj"       "$PSScriptRoot/test/Azure.Functions.Cli.Tests/Azure.Functions.Cli.Tests.csproj"
"$PSScriptRoot/build/Build.csproj"
* Updated project dependencies for `Build.csproj` 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)