### PR TITLE
Set the default PowerShell worker to 7.4

### DIFF
--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -57,7 +57,7 @@ namespace Azure.Functions.Cli.Common
         public const string CustomHandlerPropertyName = "customHandler";
         public const string AuthLevelErrorMessage = "Unable to configure Authorization level. The selected template does not use Http Trigger";
         public const string HttpTriggerTemplateName = "HttpTrigger";
-        public const string PowerShellWorkerDefaultVersion = "7.2";
+        public const string PowerShellWorkerDefaultVersion = "7.4";
         public const string EnableWorkerIndexing = "EnableWorkerIndexing";
         public const string UserSecretsIdElementName = "UserSecretsId";
         public const string TargetFrameworkElementName = "TargetFramework";

--- a/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
@@ -725,7 +725,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                             "FUNCTIONS_WORKER_RUNTIME",
                             "powershell",
                             "FUNCTIONS_WORKER_RUNTIME_VERSION",
-                            "7.2"
+                            "7.4"
                         }
                     }
                 },


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Set the default PowerShell worker version to 7.4 
Item pending GA of PowerShell 7.4 by 8/31 and matching Stacks API change here: https://github.com/Azure/azure-functions-ux/pull/7768
Does this need to be backported? 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)