### PR TITLE
Setting executable permissions for `in-proc8/func` executable in install path

### DIFF
--- a/src/Azure.Functions.Cli/npm/lib/install.js
+++ b/src/Azure.Functions.Cli/npm/lib/install.js
@@ -98,6 +98,7 @@ https.get(options, response => {
                     if (os.platform() === 'linux' || os.platform() === 'darwin') {
                         fs.chmodSync(`${installPath}/func`, 0o755);
                         fs.chmodSync(`${installPath}/gozip`, 0o755);
+                        fs.chmodSync(`${installPath}/in-proc8/func`, 0o755);
                     }
                 });
             });


### PR DESCRIPTION
resolves #3766

Setting executable permissions for `in-proc8/func` executable in install path, for unix scenarios.

Validation pending on OSX.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)