### PR TITLE
Remove EnableWorkerIndexing flag

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -199,7 +199,6 @@ namespace Azure.Functions.Cli.Actions.HostActions
             settings.AddRange(LanguageWorkerHelper.GetWorkerConfiguration(LanguageWorkerSetting));
             _keyVaultReferencesManager.ResolveKeyVaultReferences(settings);
             UpdateEnvironmentVariables(settings);
-            EnableWorkerIndexing(settings);
 
             var defaultBuilder = Microsoft.AspNetCore.WebHost.CreateDefaultBuilder(Array.Empty<string>());
 
@@ -315,15 +314,6 @@ namespace Azure.Functions.Cli.Actions.HostActions
         private void EnableDotNetWorkerStartup()
         {
             Environment.SetEnvironmentVariable("DOTNET_STARTUP_HOOKS", "Microsoft.Azure.Functions.Worker.Core");
-        }
-
-        private void EnableWorkerIndexing(IDictionary<string, string> secrets)
-        {
-            // Set only if the environment variable already doesn't exist and app setting doesn't have this setting.
-            if (Environment.GetEnvironmentVariable(Constants.EnableWorkerIndexEnvironmentVariableName) == null && !secrets.ContainsKey(Constants.EnableWorkerIndexEnvironmentVariableName))
-            {
-                Environment.SetEnvironmentVariable(Constants.EnableWorkerIndexEnvironmentVariableName, 1.ToString());
-            }
         }
 
         private void UpdateEnvironmentVariables(IDictionary<string, string> secrets)

--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -394,11 +394,6 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 localSettingsJsonContent = AddLocalSetting(localSettingsJsonContent, Constants.FunctionsWorkerRuntimeVersion, Constants.PowerShellWorkerDefaultVersion);
             }
 
-            if ((workerRuntime == Helpers.WorkerRuntime.python && programmingModel == Common.ProgrammingModel.V2) || (workerRuntime == Helpers.WorkerRuntime.node && programmingModel == Common.ProgrammingModel.V4))
-            {
-                localSettingsJsonContent = AddLocalSetting(localSettingsJsonContent, Constants.AzureWebJobsFeatureFlags, Constants.EnableWorkerIndexing);
-            }
-
             await FileSystemHelpers.WriteFileIfNotExists("local.settings.json", localSettingsJsonContent);
         }
 

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -58,7 +58,6 @@ namespace Azure.Functions.Cli.Common
         public const string AuthLevelErrorMessage = "Unable to configure Authorization level. The selected template does not use Http Trigger";
         public const string HttpTriggerTemplateName = "HttpTrigger";
         public const string PowerShellWorkerDefaultVersion = "7.2";
-        public const string EnableWorkerIndexing = "EnableWorkerIndexing";
         public const string UserSecretsIdElementName = "UserSecretsId";
         public const string TargetFrameworkElementName = "TargetFramework";
         public const string DisplayLogo = "FUNCTIONS_CORE_TOOLS_DISPLAY_LOGO";


### PR DESCRIPTION
### Issue describing the changes in this PR

The flag is no longer required as of host v4.28 which finished rolling out in January. Release notes [here](https://github.com/Azure/azure-functions-host/releases/tag/v4.28.0) and PR [here](https://github.com/Azure/azure-functions-host/pull/9574).

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [x] Otherwise: Glenn has actually removed EnableWorkerIndexing from most docs already
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)