### PR TITLE
Specify framework in VS Code publish task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,7 +21,9 @@
                 "publish",
                 "${workspaceFolder}/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj",
                 "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
+                "/consoleloggerparameters:NoSummary",
+                "--framework",
+                "${input:targetFramework}"
             ],
             "problemMatcher": "$msCompile"
         },
@@ -36,6 +38,17 @@
                 "${workspaceFolder}/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj"
             ],
             "problemMatcher": "$msCompile"
+        }
+    ],
+    "inputs": [
+        {
+            "id": "targetFramework",
+            "type": "pickString",
+            "options": [
+                "net8.0",
+                "net6.0"
+            ],
+            "description": "Target framework"
         }
     ]
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

I use the VS Code publish task when I work on core tools and it's currently giving this error:

> The 'Publish' target is not supported without specifying a target framework. The current project targets multiple frameworks, you must specify one of the following frameworks in order to publish: net6.0, net8.0

So I added config that allows you to pick the framework when running the task.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)