### PR TITLE
Initializing Dockerfile for .NET isolated project does not honor existing TFM

### DIFF
--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -404,7 +404,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
 
         private static async Task WriteDockerfile(WorkerRuntime workerRuntime, string language, string targetFramework, bool csx)
         {
-            if (WorkerRuntimeLanguageHelper.IsDotnet(workerRuntime) && string.IsNullOrEmpty(targetFramework))
+            if (WorkerRuntimeLanguageHelper.IsDotnet(workerRuntime) && string.IsNullOrEmpty(targetFramework) && !csx)
             {
                 var functionAppRoot = ScriptHostHelpers.GetFunctionAppRootDirectory(Environment.CurrentDirectory);
                 if (functionAppRoot != null)

--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -410,8 +410,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 string projectFilePath = ProjectHelpers.FindProjectFile(functionAppRoot);
                 if (projectFilePath != null)
                 {
-                    string projectFileName = Path.GetFileName(projectFilePath);
-                    targetFramework = await DotnetHelpers.DetermineTargetFramework(Path.GetDirectoryName(projectFilePath), projectFileName);
+                    targetFramework = await DotnetHelpers.DetermineTargetFramework(Path.GetDirectoryName(projectFilePath));
                 }
             }
 

--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -408,10 +408,10 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             {
                 var functionAppRoot = ScriptHostHelpers.GetFunctionAppRootDirectory(Environment.CurrentDirectory);
                 string projectFilePath = ProjectHelpers.FindProjectFile(functionAppRoot);
-                string ProjectFileName = Path.GetFileName(projectFilePath);
                 if (projectFilePath != null)
                 {
-                    targetFramework = await DotnetHelpers.DetermineTargetFramework(Path.GetDirectoryName(projectFilePath), ProjectFileName);
+                    string projectFileName = Path.GetFileName(projectFilePath);
+                    targetFramework = await DotnetHelpers.DetermineTargetFramework(Path.GetDirectoryName(projectFilePath)/*, projectFileName*/);
                 }
             }
 

--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -411,7 +411,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 if (projectFilePath != null)
                 {
                     string projectFileName = Path.GetFileName(projectFilePath);
-                    targetFramework = await DotnetHelpers.DetermineTargetFramework(Path.GetDirectoryName(projectFilePath)/*, projectFileName*/);
+                    targetFramework = await DotnetHelpers.DetermineTargetFramework(Path.GetDirectoryName(projectFilePath), projectFileName);
                 }
             }
 

--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -407,10 +407,9 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             if (WorkerRuntimeLanguageHelper.IsDotnet(workerRuntime) && string.IsNullOrEmpty(targetFramework))
             {
                 var functionAppRoot = ScriptHostHelpers.GetFunctionAppRootDirectory(Environment.CurrentDirectory);
-                string projectFilePath = ProjectHelpers.FindProjectFile(functionAppRoot);
-                if (projectFilePath != null)
+                if (functionAppRoot != null)
                 {
-                    targetFramework = await DotnetHelpers.DetermineTargetFramework(Path.GetDirectoryName(projectFilePath));
+                    targetFramework = await DotnetHelpers.DetermineTargetFramework(functionAppRoot);
                 }
             }
 

--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -404,13 +404,14 @@ namespace Azure.Functions.Cli.Actions.LocalActions
 
         private static async Task WriteDockerfile(WorkerRuntime workerRuntime, string language, string targetFramework, bool csx)
         {
-            if (WorkerRuntimeLanguageHelper.IsDotnet(workerRuntime))
+            if (WorkerRuntimeLanguageHelper.IsDotnet(workerRuntime) && string.IsNullOrEmpty(targetFramework))
             {
                 var functionAppRoot = ScriptHostHelpers.GetFunctionAppRootDirectory(Environment.CurrentDirectory);
                 string projectFilePath = ProjectHelpers.FindProjectFile(functionAppRoot);
                 if (projectFilePath != null)
                 {
-                    targetFramework = await DotnetHelpers.DetermineTargetFramework(Path.GetDirectoryName(projectFilePath));
+                    var projectroot = ProjectHelpers.GetProject(projectFilePath);
+                    targetFramework = ProjectHelpers.GetPropertyValue(projectroot, Constants.TargetFrameworkElementName);
                 }
             }
             if (workerRuntime == Helpers.WorkerRuntime.dotnet)

--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -404,6 +404,15 @@ namespace Azure.Functions.Cli.Actions.LocalActions
 
         private static async Task WriteDockerfile(WorkerRuntime workerRuntime, string language, string targetFramework, bool csx)
         {
+            if (WorkerRuntimeLanguageHelper.IsDotnet(workerRuntime))
+            {
+                var functionAppRoot = ScriptHostHelpers.GetFunctionAppRootDirectory(Environment.CurrentDirectory);
+                string projectFilePath = ProjectHelpers.FindProjectFile(functionAppRoot);
+                if (projectFilePath != null)
+                {
+                    targetFramework = await DotnetHelpers.DetermineTargetFramework(Path.GetDirectoryName(projectFilePath));
+                }
+            }
             if (workerRuntime == Helpers.WorkerRuntime.dotnet)
             {
                 if (csx)

--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -404,7 +404,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
 
         private static async Task WriteDockerfile(WorkerRuntime workerRuntime, string language, string targetFramework, bool csx)
         {
-            if (WorkerRuntimeLanguageHelper.IsDotnet(workerRuntime))
+            if (WorkerRuntimeLanguageHelper.IsDotnet(workerRuntime) && string.IsNullOrEmpty(targetFramework))
             {
                 var functionAppRoot = ScriptHostHelpers.GetFunctionAppRootDirectory(Environment.CurrentDirectory);
                 string projectFilePath = ProjectHelpers.FindProjectFile(functionAppRoot);

--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -404,16 +404,17 @@ namespace Azure.Functions.Cli.Actions.LocalActions
 
         private static async Task WriteDockerfile(WorkerRuntime workerRuntime, string language, string targetFramework, bool csx)
         {
-            if (WorkerRuntimeLanguageHelper.IsDotnet(workerRuntime) && string.IsNullOrEmpty(targetFramework))
+            if (WorkerRuntimeLanguageHelper.IsDotnet(workerRuntime))
             {
                 var functionAppRoot = ScriptHostHelpers.GetFunctionAppRootDirectory(Environment.CurrentDirectory);
                 string projectFilePath = ProjectHelpers.FindProjectFile(functionAppRoot);
+                string ProjectFileName = Path.GetFileName(projectFilePath);
                 if (projectFilePath != null)
                 {
-                    var projectroot = ProjectHelpers.GetProject(projectFilePath);
-                    targetFramework = ProjectHelpers.GetPropertyValue(projectroot, Constants.TargetFrameworkElementName);
+                    targetFramework = await DotnetHelpers.DetermineTargetFramework(Path.GetDirectoryName(projectFilePath), ProjectFileName);
                 }
             }
+
             if (workerRuntime == Helpers.WorkerRuntime.dotnet)
             {
                 if (csx)

--- a/src/Azure.Functions.Cli/Helpers/DotnetHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/DotnetHelpers.cs
@@ -33,12 +33,12 @@ namespace Azure.Functions.Cli.Helpers
         /// <param name="projectDirectory">Directory containing the .csproj file</param>
         /// <returns>Target framework, e.g. net8.0</returns>
         /// <exception cref="CliException"></exception>
-        public static async Task<string> DetermineTargetFramework(string projectDirectory)
+        public static async Task<string> DetermineTargetFramework(string projectDirectory, string projectFilename = "")
         {
             EnsureDotnet();
             var exe = new Executable(
                 "dotnet",
-                "build -getproperty:TargetFramework",
+                $"build {projectFilename} -getproperty:TargetFramework",
                 workingDirectory: projectDirectory,
                 environmentVariables: new Dictionary<string, string>
                 {

--- a/src/Azure.Functions.Cli/Helpers/DotnetHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/DotnetHelpers.cs
@@ -31,19 +31,16 @@ namespace Azure.Functions.Cli.Helpers
         /// e.g. in Directory.Build.props
         /// </summary>
         /// <param name="projectDirectory">Directory containing the .csproj file</param>
-        /// <param name="projectFilename">Name of the .csproj File</param>
         /// <returns>Target framework, e.g. net8.0</returns>
         /// <exception cref="CliException"></exception>
-        public static async Task<string> DetermineTargetFramework(string projectDirectory, string projectFilename = null)
+        public static async Task<string> DetermineTargetFramework(string projectDirectory)
         {
             EnsureDotnet();
-            if (projectFilename == null)
+            string projectFilename = null;
+            var projectFilePath = ProjectHelpers.FindProjectFile(projectDirectory);
+            if (projectFilePath != null)
             {
-                var projectFilePath = ProjectHelpers.FindProjectFile(projectDirectory);
-                if (projectFilePath != null)
-                {
-                    projectFilename = Path.GetFileName(projectFilePath);
-                }
+                projectFilename = Path.GetFileName(projectFilePath);
             }
             var exe = new Executable(
                 "dotnet",

--- a/src/Azure.Functions.Cli/Helpers/DotnetHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/DotnetHelpers.cs
@@ -31,11 +31,20 @@ namespace Azure.Functions.Cli.Helpers
         /// e.g. in Directory.Build.props
         /// </summary>
         /// <param name="projectDirectory">Directory containing the .csproj file</param>
+        /// <param name="projectFilename">Name of the .csproj File</param>
         /// <returns>Target framework, e.g. net8.0</returns>
         /// <exception cref="CliException"></exception>
-        public static async Task<string> DetermineTargetFramework(string projectDirectory, string projectFilename = "")
+        public static async Task<string> DetermineTargetFramework(string projectDirectory, string projectFilename = null)
         {
             EnsureDotnet();
+            if (projectFilename == null)
+            {
+                var projectFilePath = ProjectHelpers.FindProjectFile(projectDirectory);
+                if (projectFilePath != null)
+                {
+                    projectFilename = Path.GetFileName(projectFilePath);
+                }
+            }
             var exe = new Executable(
                 "dotnet",
                 $"build {projectFilename} -getproperty:TargetFramework",

--- a/src/Azure.Functions.Cli/Helpers/DotnetHelpers.cs
+++ b/src/Azure.Functions.Cli/Helpers/DotnetHelpers.cs
@@ -31,16 +31,19 @@ namespace Azure.Functions.Cli.Helpers
         /// e.g. in Directory.Build.props
         /// </summary>
         /// <param name="projectDirectory">Directory containing the .csproj file</param>
+        /// <param name="projectFilename">Name of the .csproj file</param>
         /// <returns>Target framework, e.g. net8.0</returns>
         /// <exception cref="CliException"></exception>
-        public static async Task<string> DetermineTargetFramework(string projectDirectory)
+        public static async Task<string> DetermineTargetFramework(string projectDirectory, string projectFilename = null)
         {
             EnsureDotnet();
-            string projectFilename = null;
-            var projectFilePath = ProjectHelpers.FindProjectFile(projectDirectory);
-            if (projectFilePath != null)
+            if (projectFilename == null) 
             {
-                projectFilename = Path.GetFileName(projectFilePath);
+                var projectFilePath = ProjectHelpers.FindProjectFile(projectDirectory);
+                if (projectFilePath != null)
+                {
+                    projectFilename = Path.GetFileName(projectFilePath);
+                }
             }
             var exe = new Executable(
                 "dotnet",

--- a/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Helpers;
 using Azure.Functions.Cli.Tests.E2E.Helpers;
-using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Helpers;
 using Azure.Functions.Cli.Tests.E2E.Helpers;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -875,6 +876,33 @@ namespace Azure.Functions.Cli.Tests.E2E
                         }
                     }
                 },
+            }, _output);
+        }
+
+        [Theory]
+        [InlineData("dotnet-isolated","4", "net6.0")]
+        [InlineData("dotnet-isolated", "4", "net7.0")]
+        [InlineData("dotnet-isolated","4", "net8.0")]
+        public Task init_docker_only_for_existing_project_TargetFramework(string workerRuntime, string version, string TargetFramework)
+        {
+           var TargetFrameworkstr = TargetFramework.Replace("net", string.Empty);
+            return CliTester.Run(new RunConfiguration
+            {
+                Commands = new[]
+                {
+                    $"init . --worker-runtime {workerRuntime} --target-framework {TargetFramework}",
+                    $"init . --docker-only",
+                },
+                CheckFiles = new[]
+                {
+                    new FileResult
+                    {
+                        Name = "Dockerfile",
+                        ContentContains = new[] { $"FROM mcr.microsoft.com/azure-functions/{workerRuntime}:{version}-{workerRuntime}{TargetFrameworkstr}" }
+                    }
+                },
+                OutputContains = new[] { "Dockerfile" },
+                CommandTimeout = TimeSpan.FromSeconds(300)
             }, _output);
         }
     }


### PR DESCRIPTION
### Issue describing the changes in this PR
resolves #3771 
-> This PR checks the current worker runtime of function app is dotnet and gets the target framework from the directory of function app, locating to the project file(.csproj). later in the method used to configure the Docker file 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)