### PR TITLE
AuthLevel flag on HttpTrigger generates upper case values fix - 2250

### DIFF
--- a/src/Azure.Functions.Cli/Actions/LocalActions/CreateFunctionAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/CreateFunctionAction.cs
@@ -376,7 +376,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             else
             {
                 var binding = bindings.Where(b => b["type"].ToString().Equals(HttpTriggerTemplateName, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
-                binding["authLevel"] = AuthorizationLevel.ToString();
+                binding["authLevel"] = AuthorizationLevel.ToString().ToLowerInvariant();
             }
         }
 

--- a/test/Azure.Functions.Cli.Tests/E2E/CreateFunctionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/CreateFunctionTests.cs
@@ -402,5 +402,34 @@ namespace Azure.Functions.Cli.Tests.E2E
                 }
             }, _output);
         }
+
+        [Fact]
+        public async Task create_httpTrigger_configAuthLevel_powershell()
+        {
+            await CliTester.Run(new RunConfiguration
+            {
+                Commands = new[]
+                {
+                    "init . --worker-runtime powershell",
+                    "new --template \"HttpTrigger\" --name MyHttpTriggerFunction --authlevel Anonymous -a"
+                },
+                CheckFiles = new FileResult[]
+                {
+                    new FileResult
+                    {
+                        Name = Path.Combine("MyHttpTriggerFunction", "function.json"),
+                        ContentContains = new []
+                        {
+                            "\"authLevel\": \"anonymous\"",
+                            "\"type\": \"httpTrigger\""
+                        }
+                    }
+                },
+                OutputContains = new[]
+                {
+                    "The function \"MyHttpTriggerFunction\" was created successfully from the \"HttpTrigger\" template."
+                }
+            }, _output);
+        }
     }
 }


### PR DESCRIPTION
### Issue describing the changes in this PR

resolves #2250 

### Changes
Updated the 'ConfigureAuthorizationLevel' method in 'CreateFunctionAction.cs', to change the 'authLevel' value from PascalCase to camelCase in the 'function.json' file when creating an 'HttpTrigger' function in the PowerShell worker runtime.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)