### PR TITLE
Fix build to remove uploadToStorage

### DIFF
--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -679,55 +679,6 @@ namespace Build
             Directory.Delete(Settings.SBOMManifestTelemetryDir, recursive: true);
         }
 
-        public static void UploadToStorage()
-        {
-            // Don't upload for public build.
-            if (Settings.IsPublicBuild)
-            {
-                ColoredConsole.WriteLine($"Skipping upload for public build.");
-                return;
-            }
-
-            ColoredConsole.WriteLine($"Going to run the UploadToStorage. Setting is {Settings.IsPublicBuild}");
-
-            
-            if (!string.IsNullOrEmpty(Settings.BuildArtifactsStorage))
-            {
-                var version = new Version(CurrentVersion);
-                var storageAccount = CloudStorageAccount.Parse(Settings.BuildArtifactsStorage);
-                var blobClient = storageAccount.CreateCloudBlobClient();
-                var container = blobClient.GetContainerReference("builds");
-                container.CreateIfNotExistsAsync().Wait();
-
-                container.SetPermissionsAsync(new BlobContainerPermissions
-                {
-                    PublicAccess = BlobContainerPublicAccessType.Blob
-                });
-
-                foreach (var file in Directory.GetFiles(Settings.OutputDir, "Azure.Functions.Cli.*", SearchOption.TopDirectoryOnly))
-                {
-                    var fileName = Path.GetFileName(file);
-                    ColoredConsole.Write($"Uploading {fileName}...");
-
-                    var versionedBlob = container.GetBlockBlobReference($"{version.ToString()}/{fileName}");
-                    var latestBlob = container.GetBlockBlobReference($"{version.Major}/latest/{fileName.Replace($".{version.ToString()}", string.Empty)}");
-                    versionedBlob.UploadFromFileAsync(file).Wait();
-                    latestBlob.StartCopyAsync(versionedBlob).Wait();
-
-                    ColoredConsole.WriteLine("Done");
-                }
-
-                var latestVersionBlob = container.GetBlockBlobReference($"{version.Major}/latest/version.txt");
-                latestVersionBlob.UploadTextAsync(version.ToString()).Wait();
-            }
-            else
-            {
-                var error = $"{nameof(Settings.BuildArtifactsStorage)} is null or empty. Can't run {nameof(UploadToStorage)} target";
-                ColoredConsole.Error.WriteLine(error.Red());
-                throw new Exception(error);
-            }
-        }
-
         public static void LogIntoAzure()
         {
             var directoryId = Environment.GetEnvironmentVariable("AZURE_DIRECTORY_ID");

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -672,55 +672,6 @@ namespace Build
             Directory.Delete(Settings.SBOMManifestTelemetryDir, recursive: true);
         }
 
-        public static void UploadToStorage()
-        {
-            // Don't upload for public build.
-            if (Settings.IsPublicBuild)
-            {
-                ColoredConsole.WriteLine($"Skipping upload for public build.");
-                return;
-            }
-
-            ColoredConsole.WriteLine($"Going to run the UploadToStorage. Setting is {Settings.IsPublicBuild}");
-
-            
-            if (!string.IsNullOrEmpty(Settings.BuildArtifactsStorage))
-            {
-                var version = new Version(CurrentVersion);
-                var storageAccount = CloudStorageAccount.Parse(Settings.BuildArtifactsStorage);
-                var blobClient = storageAccount.CreateCloudBlobClient();
-                var container = blobClient.GetContainerReference("builds");
-                container.CreateIfNotExistsAsync().Wait();
-
-                container.SetPermissionsAsync(new BlobContainerPermissions
-                {
-                    PublicAccess = BlobContainerPublicAccessType.Blob
-                });
-
-                foreach (var file in Directory.GetFiles(Settings.OutputDir, "Azure.Functions.Cli.*", SearchOption.TopDirectoryOnly))
-                {
-                    var fileName = Path.GetFileName(file);
-                    ColoredConsole.Write($"Uploading {fileName}...");
-
-                    var versionedBlob = container.GetBlockBlobReference($"{version.ToString()}/{fileName}");
-                    var latestBlob = container.GetBlockBlobReference($"{version.Major}/latest/{fileName.Replace($".{version.ToString()}", string.Empty)}");
-                    versionedBlob.UploadFromFileAsync(file).Wait();
-                    latestBlob.StartCopyAsync(versionedBlob).Wait();
-
-                    ColoredConsole.WriteLine("Done");
-                }
-
-                var latestVersionBlob = container.GetBlockBlobReference($"{version.Major}/latest/version.txt");
-                latestVersionBlob.UploadTextAsync(version.ToString()).Wait();
-            }
-            else
-            {
-                var error = $"{nameof(Settings.BuildArtifactsStorage)} is null or empty. Can't run {nameof(UploadToStorage)} target";
-                ColoredConsole.Error.WriteLine(error.Red());
-                throw new Exception(error);
-            }
-        }
-
         public static void LogIntoAzure()
         {
             var directoryId = Environment.GetEnvironmentVariable("AZURE_DIRECTORY_ID");

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -33,6 +33,7 @@ namespace Build
                 .Then(DotnetPublishForNupkg)
                 .Then(DotnetPack)
                 .Then(CreateIntegrationTestsBuildManifest, skip: !args.Contains("--integrationTests"))
+                .Then(UploadToStorage, skip: !args.Contains("--ci"))
                 .Run();
         }
     }

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -33,7 +33,6 @@ namespace Build
                 .Then(DotnetPublishForNupkg)
                 .Then(DotnetPack)
                 .Then(CreateIntegrationTestsBuildManifest, skip: !args.Contains("--integrationTests"))
-                .Then(UploadToStorage, skip: !args.Contains("--ci"))
                 .Run();
         }
     }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

We don't want `UploadToStorage` to run as part of the build process, since this causes the daily build to run this version of core tools.

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)