### PR TITLE
StartTests: Rename tests & seperate func start commands from init

### DIFF
--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -23,152 +23,19 @@ namespace Azure.Functions.Cli.Tests.E2E
         private const string _serverNotReady = "Host was not ready after 10 seconds";
         public StartTests(ITestOutputHelper output) : base(output) { }
 
-        [Fact]
-        public async Task start_nodejs()
+        [Fact(Skip = "Flaky test")]
+        public async Task Start_PowershellApp_SuccessfulFunctionExecution()
         {
-            await CliTester.Run(new RunConfiguration
-            {
-                Commands = new[]
-                {
-                    "init . --worker-runtime node",
-                    "new --template \"Http trigger\" --name HttpTrigger",
-                    "start"
-                },
-                ExpectExit = false,
-                OutputContains = new[]
-                {
-                    "Functions:",
-                    "HttpTrigger: [GET,POST] http://localhost:7071/api/HttpTrigger"
-                },
-                OutputDoesntContain = new string[]
-                {
-                        "Initializing function HTTP routes",
-                        "Content root path:" // ASPNETCORE_SUPPRESSSTATUSMESSAGES is set to true by default
-                },
-                Test = async (workingDir, p) =>
-                {
-                    using (var client = new HttpClient() { BaseAddress = new Uri("http://localhost:7071/") })
-                    {
-                        (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
-                        var response = await client.GetAsync("/api/HttpTrigger?name=Test");
-                        var result = await response.Content.ReadAsStringAsync();
-                        p.Kill();
-                        result.Should().Be("Hello, Test!", because: "response from default function should be 'Hello, {name}!'");
-                    }
-                },
-                CommandTimeout = TimeSpan.FromSeconds(300),
-            }, _output);
-        }
-
-        [Fact]
-        public async Task start_nodejs_v3()
-        {
-            await CliTester.Run(new RunConfiguration
-            {
-                Commands = new[]
-                {
-                    "init . --worker-runtime node -m v3",
-                    "new --template \"Http trigger\" --name HttpTrigger",
-                    "start"
-                },
-                ExpectExit = false,
-                OutputContains = new[]
-                {
-                    "Functions:",
-                    "HttpTrigger: [GET,POST] http://localhost:7071/api/HttpTrigger"
-                },
-                OutputDoesntContain = new string[]
-                {
-                        "Initializing function HTTP routes",
-                        "Content root path:" // ASPNETCORE_SUPPRESSSTATUSMESSAGES is set to true by default
-                },
-                Test = async (workingDir, p) =>
-                {
-                    using (var client = new HttpClient() { BaseAddress = new Uri("http://localhost:7071/") })
-                    {
-                        (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
-                        var response = await client.GetAsync("/api/HttpTrigger?name=Test");
-                        var result = await response.Content.ReadAsStringAsync();
-                        p.Kill();
-                        result.Should().Be("Hello, Test. This HTTP triggered function executed successfully.", because: "response from default function should be 'Hello, {name}. This HTTP triggered function executed successfully.'");
-                    }
-                },
-                CommandTimeout = TimeSpan.FromSeconds(300),
-            }, _output);
-        }
-
-        [Fact]
-        public async Task start_nodejs_with_inspect()
-        {
-            await CliTester.Run(new RunConfiguration
-            {
-                Commands = new[]
-                {
-                    "init . --worker-runtime node",
-                    "new --template \"Http trigger\" --name HttpTrigger",
-                    "start --verbose --language-worker -- \"--inspect=5050\""
-                },
-                ExpectExit = false,
-                OutputContains = new[]
-                {
-                    "Debugger listening on ws://127.0.0.1:5050"
-                },
-                Test = async (_, p) =>
-                {
-                    await Task.Delay(TimeSpan.FromSeconds(15));
-                    p.Kill();
-                },
-                CommandTimeout = TimeSpan.FromSeconds(300)
-            }, _output);
-
-        }
-
-        [Fact]
-        public async Task start_nodejs_loglevel_overrriden_in_settings()
-        {
-            await CliTester.Run(new RunConfiguration
-            {
-                Commands = new[]
-                {
-                    "init . --worker-runtime node",
-                    "settings add AzureFunctionsJobHost__logging__logLevel__Default Debug",
-                    "new --template \"Http trigger\" --name HttpTrigger",
-                    "start"
-                },
-                ExpectExit = false,
-                OutputContains = new[]
-                {
-                    "Workers Directory set to"
-                },
-                Test = async (_, p) =>
-                {
-                    await Task.Delay(TimeSpan.FromSeconds(15));
-                    p.Kill();
-                },
-                CommandTimeout = TimeSpan.FromSeconds(300),
-            }, _output);
-        }
-
-        [Fact]
-        public async Task start_loglevel_overrriden_in_host_json()
-        {
-            var functionName = "HttpTriggerCSharp";
-
             await CliTester.Run(new RunConfiguration[]
             {
                 new RunConfiguration
                 {
                     Commands = new[]
                     {
-                        "init . --worker-runtime dotnet",
-                        $"new --template Httptrigger --name {functionName}",
+                        "init . --worker-runtime powershell --managed-dependencies false",
+                        "new --template \"Http trigger\" --name HttpTrigger"
                     },
-                    Test = async (workingDir, p) =>
-                    {
-                        var filePath = Path.Combine(workingDir, "host.json");
-                        string hostJsonContent = "{\"version\": \"2.0\",\"logging\": {\"logLevel\": {\"Default\": \"Debug\"}}}";
-                        await File.WriteAllTextAsync(filePath, hostJsonContent);
-                    },
+                    CommandTimeout = TimeSpan.FromMinutes(300),
                 },
                 new RunConfiguration
                 {
@@ -177,40 +44,35 @@ namespace Azure.Functions.Cli.Tests.E2E
                         "start"
                     },
                     ExpectExit = false,
-                    OutputContains = new []
+                    CommandTimeout = TimeSpan.FromMinutes(300),
+                    Test = async (workingDir, p) =>
                     {
-                        "Host configuration applied."
+                        using (var client = new HttpClient() { BaseAddress = new Uri("http://localhost:7071/") })
+                        {
+                            (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
+                            var response = await client.GetAsync("/api/HttpTrigger?name=Test");
+                            var result = await response.Content.ReadAsStringAsync();
+                            p.Kill();
+                            await Task.Delay(TimeSpan.FromSeconds(2));
+                            result.Should().Be("Hello, Test. This HTTP triggered function executed successfully.", because: "response from default function should be 'Hello, {name}. This HTTP triggered function executed successfully.'");
+                        }
                     },
-                    Test = async (_, p) =>
-                    {
-                        // give the host time to load functions and print any errors
-                        await Task.Delay(TimeSpan.FromSeconds(10));
-                        p.Kill();
-                    }
-                },
-            }, _output, startHost: true);
+                }
+            }, _output);
         }
 
         [Fact]
-        public async Task start_loglevel_overrriden_in_host_json_category_filter()
+        public async Task Start_NodeJsApp_SuccessfulFunctionExecution()
         {
-            var functionName = "HttpTriggerCSharp";
-
             await CliTester.Run(new RunConfiguration[]
             {
                 new RunConfiguration
                 {
                     Commands = new[]
                     {
-                        "init . --worker-runtime dotnet",
-                        $"new --template Httptrigger --name {functionName}",
-                    },
-                    Test = async (workingDir, p) =>
-                    {
-                        var filePath = Path.Combine(workingDir, "host.json");
-                        string hostJsonContent = "{\"version\": \"2.0\",\"logging\": {\"logLevel\": {\"Default\": \"None\", \"Host.Startup\": \"Information\"}}}";
-                        await File.WriteAllTextAsync(filePath, hostJsonContent);
-                    },
+                        "init . --worker-runtime node",
+                        "new --template \"Http trigger\" --name HttpTrigger"
+                    }
                 },
                 new RunConfiguration
                 {
@@ -219,26 +81,409 @@ namespace Azure.Functions.Cli.Tests.E2E
                         "start"
                     },
                     ExpectExit = false,
-                    OutputContains = new []
+                    OutputContains = new[]
                     {
-                        "Found the following functions:"
+                        "Functions:",
+                        "HttpTrigger: [GET,POST] http://localhost:7071/api/HttpTrigger"
                     },
                     OutputDoesntContain = new string[]
                     {
-                        "Reading host configuration file"
+                            "Initializing function HTTP routes",
+                            "Content root path:" // ASPNETCORE_SUPPRESSSTATUSMESSAGES is set to true by default
                     },
-                    Test = async (_, p) =>
+                    Test = async (workingDir, p) =>
                     {
-                        // give the host time to load functions and print any errors
-                        await Task.Delay(TimeSpan.FromSeconds(10));
-                        p.Kill();
-                    }
-                },
-            }, _output, startHost: true);
+                        using (var client = new HttpClient() { BaseAddress = new Uri("http://localhost:7071/") })
+                        {
+                            (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
+                            var response = await client.GetAsync("/api/HttpTrigger?name=Test");
+                            var result = await response.Content.ReadAsStringAsync();
+                            p.Kill();
+                            result.Should().Be("Hello, Test!", because: "response from default function should be 'Hello, {name}!'");
+                        }
+                    },
+                    CommandTimeout = TimeSpan.FromSeconds(300)
+                }
+            }, _output);
         }
 
         [Fact]
-        public async Task start_loglevel_None_overrriden_in_host_json()
+        public async Task Start_NodeJsApp_V3_SuccessfulFunctionExecution()
+        {
+            await CliTester.Run(new RunConfiguration[]
+            {
+                new RunConfiguration
+                {
+                    Commands = new[]
+                    {
+                        "init . --worker-runtime node -m v3",
+                        "new --template \"Http trigger\" --name HttpTrigger"
+                    }
+                },
+                new RunConfiguration
+                {
+                    Commands = new[]
+                    {
+                        "start"
+                    },
+                    ExpectExit = false,
+                    OutputContains = new[]
+                    {
+                        "Functions:",
+                        "HttpTrigger: [GET,POST] http://localhost:7071/api/HttpTrigger"
+                    },
+                    OutputDoesntContain = new string[]
+                    {
+                            "Initializing function HTTP routes",
+                            "Content root path:" // ASPNETCORE_SUPPRESSSTATUSMESSAGES is set to true by default
+                    },
+                    Test = async (workingDir, p) =>
+                    {
+                        using (var client = new HttpClient() { BaseAddress = new Uri("http://localhost:7071/") })
+                        {
+                            (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
+                            var response = await client.GetAsync("/api/HttpTrigger?name=Test");
+                            var result = await response.Content.ReadAsStringAsync();
+                            p.Kill();
+                            result.Should().Be("Hello, Test. This HTTP triggered function executed successfully.", because: "response from default function should be 'Hello, {name}. This HTTP triggered function executed successfully.'");
+                        }
+                    },
+                    CommandTimeout = TimeSpan.FromSeconds(300)
+                }
+            }, _output);
+        }
+
+        [Fact]
+        public async Task Start_InProc_SuccessfulFunctionExecution()
+        {
+            await CliTester.Run(new RunConfiguration[]
+            {
+                new RunConfiguration
+                {
+                    Commands = new[]
+                    {
+                        "init . --worker-runtime dotnet",
+                        "new --template Httptrigger --name HttpTrigger"
+                    }
+                },
+                new RunConfiguration
+                {
+                    Commands = new[]
+                    {
+                        "start --build --port 7073"
+                    },
+                    ExpectExit = false,
+                    Test = async (workingDir, p) =>
+                    {
+                        using (var client = new HttpClient() { BaseAddress = new Uri("http://localhost:7073") })
+                        {
+                            (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
+                            var response = await client.GetAsync("/api/HttpTrigger?name=Test");
+                            var result = await response.Content.ReadAsStringAsync();
+                            p.Kill();
+                            await Task.Delay(TimeSpan.FromSeconds(2));
+                            result.Should().Be("Hello, Test. This HTTP triggered function executed successfully.", because: "response from default function should be 'Hello, {name}. This HTTP triggered function executed successfully.'");
+                        }
+                    },
+                    CommandTimeout = TimeSpan.FromSeconds(300)
+                }
+            }, _output);
+        }
+
+        [Fact]
+        public async Task Start_InProc_Net8_SuccessfulFunctionExecution()
+        {
+            await CliTester.Run(new RunConfiguration[]
+            {
+                new RunConfiguration
+                {
+                    Commands = new[]
+                    {
+                        "init . --worker-runtime dotnet --target-framework net8.0",
+                        "new --template Httptrigger --name HttpTrigger",
+                    }
+                },
+                new RunConfiguration
+                {
+                    Commands = new[]
+                    {
+                        "start --port 7073 --verbose"
+                    },
+                    ExpectExit = false,
+                    Test = async (workingDir, p) =>
+                    {
+                        using (var client = new HttpClient() { BaseAddress = new Uri("http://localhost:7073") })
+                        {
+                            (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
+                            var response = await client.GetAsync("/api/HttpTrigger?name=Test");
+                            var result = await response.Content.ReadAsStringAsync();
+                            p.Kill();
+                            result.Should().Be("Hello, Test. This HTTP triggered function executed successfully.", because: "response from default function should be 'Hello, {name}. This HTTP triggered function executed successfully.'");
+
+                            if (_output is Xunit.Sdk.TestOutputHelper testOutputHelper)
+                            {
+                                testOutputHelper.Output.Should().Contain($"{Constants.FunctionsInProcNet8Enabled} app setting enabled in local.settings.json");
+                                testOutputHelper.Output.Should().Contain("Starting child process for in-process model host");
+                                testOutputHelper.Output.Should().Contain("Started child process with ID");
+                            }
+                        }
+                    },
+                    CommandTimeout = TimeSpan.FromSeconds(300)
+                }
+            }, _output);
+        }
+
+        [Fact]
+        public async Task Start_DotnetIsolated_Net9_SuccessfulFunctionExecution()
+        {
+            await CliTester.Run(new RunConfiguration[]
+            {
+                new RunConfiguration
+                {
+                    // TODO: Remove dotnet add package step once the worker package is available in public feed
+                    Commands = new[]
+                    {
+                        "init . --worker-runtime dotnet-isolated --target-framework net9.0",
+                        "new --template Httptrigger --name HttpTrigger",
+                        "dotnet add package Microsoft.Azure.Functions.Worker.Sdk --version 1.18.0-preview1-20240723.1 --source https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json"
+                    },
+                },
+                new RunConfiguration
+                {
+                    Commands = new[]
+                    {
+                        "start --build --port 7073"
+                    },
+                    ExpectExit = false,
+                    Test = async (workingDir, p) =>
+                    {
+                        using (var client = new HttpClient() { BaseAddress = new Uri("http://localhost:7073") })
+                        {
+                            (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
+                            var response = await client.GetAsync("/api/HttpTrigger?name=Test");
+                            var result = await response.Content.ReadAsStringAsync();
+                            p.Kill();
+                            result.Should().Be("Welcome to Azure Functions!", because: "response from default function should be 'Welcome to Azure Functions!'");
+                        }
+                    },
+                    CommandTimeout = TimeSpan.FromSeconds(300)
+                }
+            }, _output);
+        }
+
+        [Fact]
+        public async Task Start_WithInspect_DebuggerIsStarted()
+        {
+           await CliTester.Run(new RunConfiguration[]
+           {
+               new RunConfiguration
+               {
+                   Commands = new[]
+                   {
+                       "init . --worker-runtime node",
+                       "new --template \"Http trigger\" --name HttpTrigger",
+                   }
+               },
+               new RunConfiguration
+               {
+                   Commands = new[]
+                   {
+                       "start --verbose --language-worker -- \"--inspect=5050\""
+                   },
+                   ExpectExit = false,
+                   OutputContains = new[]
+                   {
+                       "Debugger listening on ws://127.0.0.1:5050"
+                   },
+                   Test = async (_, p) =>
+                   {
+                       //TODO: Replace with call to wait on host start
+                       await Task.Delay(5000);
+                       p.Kill();
+                   },
+                   CommandTimeout = TimeSpan.FromSeconds(300)
+               }
+           }, _output);
+        }
+
+        [Fact]
+        public async Task Start_PortInUse_FailsWithExpectedError()
+        {
+           var tcpListner = new TcpListener(IPAddress.Any, 8081);
+           try
+           {
+               tcpListner.Start();
+
+               await CliTester.Run(new RunConfiguration[]
+               {
+                   new RunConfiguration
+                   {
+                       Commands = new[]
+                       {
+                           "init . --worker-runtime node",
+                           "new --template \"Http Trigger\" --name HttpTrigger"
+                       },
+                   },
+                   new RunConfiguration
+                   {
+                       Commands = new[]
+                       {
+                           "start --port 8081"
+                       },
+                       ExpectExit = true,
+                       ExitInError = true,
+                       ErrorContains = new[] { "Port 8081 is unavailable" },
+                       CommandTimeout = TimeSpan.FromSeconds(300)
+                   }
+               }, _output);
+           }
+           finally
+           {
+               tcpListner.Stop();
+           }
+        }
+
+        [Fact]
+        public async Task Start_EmptyEnvVars_HandledAsExpected()
+        {
+           await CliTester.Run(new RunConfiguration[]
+           {
+               new RunConfiguration
+               {
+                   Commands = new[]
+                   {
+                       "init . --worker-runtime node",
+                       "new --template \"Http trigger\" --name HttpTrigger",
+                       "settings add emptySetting EMPTY_VALUE",
+                   },
+                   Test = async (workingDir, p) =>
+                   {
+                       var settingsFile = Path.Combine(workingDir, "local.settings.json");
+                       var content = File.ReadAllText(settingsFile);
+                       content = content.Replace("EMPTY_VALUE", "");
+                       File.WriteAllText(settingsFile,content);
+                   },
+                   CommandTimeout = TimeSpan.FromSeconds(300),
+               },
+               new RunConfiguration
+               {
+                   Commands = new[]
+                   {
+                       "start --port 6543"
+                   },
+                   ExpectExit = false,
+                   Test = async (w, p) =>
+                   {
+                       using (var client = new HttpClient() { BaseAddress = new Uri("http://localhost:6543/") })
+                       {
+                           client.Timeout = TimeSpan.FromSeconds(2);
+                           for (var i = 0; i < 10; i++)
+                           {
+                               try
+                               {
+                                   var response = await client.GetAsync("/api/HttpTrigger?name=Test");
+                                   response.EnsureSuccessStatusCode();
+                                   break;
+                               }
+                               catch
+                               {
+                                   await Task.Delay(TimeSpan.FromSeconds(2));
+                               }
+                           }
+                       }
+                       p.Kill();
+                   },
+                   OutputDoesntContain = new string[]
+                   {
+                       "Skipping 'emptySetting' from local settings as it's already defined in current environment variables."
+                   },
+                   CommandTimeout = TimeSpan.FromSeconds(300),
+               }
+           }, _output);
+        }
+
+        [Fact]
+        public async Task Start_FunctionsStartArgument_OnlySelectedFunctionsRun()
+        {
+           await CliTester.Run(new RunConfiguration[]
+           {
+               new RunConfiguration
+               {
+                   Commands = new[]
+                   {
+                       "init . --worker-runtime javascript",
+                       "new --template \"Http trigger\" --name http1",
+                       "new --template \"Http trigger\" --name http2",
+                       "new --template \"Http trigger\" --name http3"
+                   },
+                    CommandTimeout = TimeSpan.FromSeconds(300)
+               },
+               new RunConfiguration
+               {
+                   Commands = new[]
+                   {
+                       "start --functions http2 http1"
+                   },
+                   ExpectExit = false,
+                   Test = async (workingDir, p) =>
+                   {
+                       using (var client = new HttpClient() { BaseAddress = new Uri("http://localhost:7071/") })
+                       {
+                           (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
+                           var response = await client.GetAsync("/api/http1?name=Test");
+                           response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+                           response = await client.GetAsync("/api/http2?name=Test");
+                           response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+                           response = await client.GetAsync("/api/http3?name=Test");
+                           response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+                           p.Kill();
+                       }
+                   },
+                   CommandTimeout = TimeSpan.FromSeconds(300)
+               }
+           }, _output);
+        }
+
+        [Fact]
+        public async Task Start_LanguageWorker_LogLevelOverridenViaSettings_LogLevelSetToExpectedValue()
+        {
+           await CliTester.Run(new RunConfiguration[]
+           {
+               new RunConfiguration
+               {
+                   Commands = new[]
+                   {
+                       "init . --worker-runtime node",
+                       "settings add AzureFunctionsJobHost__logging__logLevel__Default Debug",
+                       "new --template \"Http trigger\" --name HttpTrigger",
+                   }
+               },
+               new RunConfiguration
+               {
+                   Commands = new[]
+                   {
+                       "start"
+                   },
+                   ExpectExit = false,
+                   OutputContains = new[]
+                   {
+                       "Workers Directory set to"
+                   },
+                   Test = async (_, p) =>
+                   {
+                       //TODO: Replace with call to wait on host start
+                       await Task.Delay(5000);
+                       p.Kill();
+                   },
+                   CommandTimeout = TimeSpan.FromSeconds(300)
+               }
+           }, _output);
+        }
+
+        [Fact]
+        public async Task Start_LanguageWorker_LogLevelOverridenViaHostJson_LogLevelSetToExpectedValue()
         {
             var functionName = "HttpTrigger";
 
@@ -257,7 +502,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                         string hostJsonContent = "{\"version\": \"2.0\",\"logging\": {\"logLevel\": {\"Default\": \"None\"}}}";
                         await File.WriteAllTextAsync(filePath, hostJsonContent);
                     },
-                    CommandTimeout = TimeSpan.FromSeconds(300),
+                    CommandTimeout = TimeSpan.FromSeconds(300)
                 },
                 new RunConfiguration
                 {
@@ -276,374 +521,220 @@ namespace Azure.Functions.Cli.Tests.E2E
                     },
                     Test = async (_, p) =>
                     {
-                        // give the host time to load functions and print any errors
-                        await Task.Delay(TimeSpan.FromSeconds(10));
+                        //TODO: Replace with call to wait on host start
+                        await Task.Delay(5000);
                         p.Kill();
                     },
-                    CommandTimeout = TimeSpan.FromSeconds(300),
-                },
-            }, _output, startHost: true);
-        }
-
-        [Fact]
-        public async Task start_dotnet_csharp()
-        {
-            await CliTester.Run(new RunConfiguration
-            {
-                Commands = new[]
-                {
-                    "init . --worker-runtime dotnet",
-                    "new --template Httptrigger --name HttpTrigger",
-                    "start --build --port 7073"
-                },
-                ExpectExit = false,
-                Test = async (workingDir, p) =>
-                {
-                    using (var client = new HttpClient() { BaseAddress = new Uri("http://localhost:7073") })
-                    {
-                        (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
-                        var response = await client.GetAsync("/api/HttpTrigger?name=Test");
-                        var result = await response.Content.ReadAsStringAsync();
-                        p.Kill();
-                        await Task.Delay(TimeSpan.FromSeconds(2));
-                        result.Should().Be("Hello, Test. This HTTP triggered function executed successfully.", because: "response from default function should be 'Hello, {name}. This HTTP triggered function executed successfully.'");
-                    }
-                },
-                CommandTimeout = TimeSpan.FromSeconds(300),
-            }, _output);
-        }
-
-        [Fact]
-        public async Task start_dotnet_isolated_csharp_net9()
-        {
-            await CliTester.Run(new RunConfiguration
-            {
-                // TODO: Remove dotnet add package step once the worker package is available in public feed
-                Commands = new[]
-                {
-                    "init . --worker-runtime dotnet-isolated --target-framework net9.0",
-                    "new --template Httptrigger --name HttpTrigger",
-                    "dotnet add package Microsoft.Azure.Functions.Worker.Sdk --version 1.18.0-preview1-20240723.1 --source https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json",
-                    "start --build --port 7073"
-                },
-                ExpectExit = false,
-                Test = async (workingDir, p) =>
-                {
-                    using (var client = new HttpClient() { BaseAddress = new Uri("http://localhost:7073") })
-                    {
-                        (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
-                        var response = await client.GetAsync("/api/HttpTrigger?name=Test");
-                        var result = await response.Content.ReadAsStringAsync();
-                        p.Kill();
-                        result.Should().Be("Welcome to Azure Functions!", because: "response from default function should be 'Welcome to Azure Functions!'");
-                    }
-                },
-                CommandTimeout = TimeSpan.FromSeconds(300),
-            }, _output);
-        }
-
-        [Fact]
-        public async Task start_dotnet8_inproc()
-        {
-            await CliTester.Run(new RunConfiguration
-            {
-                Commands = new[]
-                {
-                    "init . --worker-runtime dotnet --target-framework net8.0",
-                    "new --template Httptrigger --name HttpTrigger",
-                    "start --port 7073 --verbose"
-                },
-                ExpectExit = false,
-                Test = async (workingDir, p) =>
-                {
-                    using (var client = new HttpClient() { BaseAddress = new Uri("http://localhost:7073") })
-                    {
-                        (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
-                        var response = await client.GetAsync("/api/HttpTrigger?name=Test");
-                        var result = await response.Content.ReadAsStringAsync();
-                        p.Kill();
-                        await Task.Delay(TimeSpan.FromSeconds(2));
-                        result.Should().Be("Hello, Test. This HTTP triggered function executed successfully.", because: "response from default function should be 'Hello, {name}. This HTTP triggered function executed successfully.'");
-
-                        if (_output is Xunit.Sdk.TestOutputHelper testOutputHelper)
-                        {
-                            testOutputHelper.Output.Should().Contain($"{Constants.FunctionsInProcNet8Enabled} app setting enabled in local.settings.json");
-                            testOutputHelper.Output.Should().Contain("Starting child process for in-process model host");
-                            testOutputHelper.Output.Should().Contain("Started child process with ID");
-                        }
-                    }
-                },
-                CommandTimeout = TimeSpan.FromSeconds(300),
-            }, _output);
-        }
-
-        [Fact]
-        public async Task start_displays_error_on_invalid_function_json()
-        {
-            var functionName = "HttpTriggerJS";
-
-            await CliTester.Run(new RunConfiguration[]
-            {
-                new RunConfiguration
-                {
-                    Commands = new[]
-                    {
-                        "init . --worker-runtime node -m v3",
-                        $"new --template \"Http Trigger\" --name {functionName}",
-                    },
-                    Test = async (workingDir, _) =>
-                    {
-                        var filePath = Path.Combine(workingDir, functionName, "function.json");
-                        var functionJson = await File.ReadAllTextAsync(filePath);
-                        functionJson = functionJson.Replace("\"type\": \"http\"", "\"type\": \"http2\"");
-                        await File.WriteAllTextAsync(filePath, functionJson);
-                    },
-                    CommandTimeout = TimeSpan.FromSeconds(300),
-                },
-                new RunConfiguration
-                {
-                    Commands = new[]
-                    {
-                        "start"
-                    },
-                    ExpectExit = false,
-                    OutputContains = new []
-                    {
-                        "The binding type(s) 'http2' were not found in the configured extension bundle. Please ensure the type is correct and the correct version of extension bundle is configured."
-                    },
-                    Test = async (_, p) =>
-                    {
-                        // give the host time to load functions and print any errors
-                        await Task.Delay(TimeSpan.FromSeconds(10));
-                        p.Kill();
-                    }
-                }
-            }, _output);
-        }
-
-        [Fact]
-        public async Task start_displays_error_on_invalid_host_json()
-        {
-            var functionName = "HttpTriggerCSharp";
-
-            await CliTester.Run(new RunConfiguration[]
-            {
-                new RunConfiguration
-                {
-                    Commands = new[]
-                    {
-                        "init . --worker-runtime dotnet",
-                        $"new --template Httptrigger --name {functionName}",
-
-                    },
-                    Test = async (workingDir, p) =>
-                    {
-                        var filePath = Path.Combine(workingDir, "host.json");
-                        string hostJsonContent = "{ \"version\": \"2.0\", \"extensionBundle\": { \"id\": \"Microsoft.Azure.Functions.ExtensionBundle\", \"version\": \"[2.*, 3.0.0)\" }}";
-                        await File.WriteAllTextAsync(filePath, hostJsonContent);
-                    },
-                },
-                new RunConfiguration
-                {
-                    Commands = new[]
-                    {
-                        "start"
-                    },
-                    ExpectExit = true,
-                    ExitInError = true,
-                    ErrorContains = new[] { "Extension bundle configuration should not be present" },
-                },
-            }, _output, startHost: true);
-        }
-
-
-        [Fact]
-        public async Task start_displays_error_on_missing_host_json()
-        {
-            var functionName = "HttpTriggerCSharp";
-
-            await CliTester.Run(new RunConfiguration[]
-            {
-                new RunConfiguration
-                {
-                    Commands = new[]
-                    {
-                        "init . --worker-runtime dotnet",
-                        $"new --template Httptrigger --name {functionName}",
-                    },
-                    Test = async (workingDir, p) =>
-                    {
-                        var hostJsonPath = Path.Combine(workingDir, "host.json");
-                        File.Delete(hostJsonPath);
-
-                    },
-                },
-                new RunConfiguration
-                {
-                    Commands = new[]
-                    {
-                        "start"
-                    },
-                    ExpectExit = true,
-                    ExitInError = true,
-                    ErrorContains = new[] { "Host.json file in missing" },
+                    CommandTimeout = TimeSpan.FromSeconds(300)
                 },
             }, _output);
         }
 
         [Fact]
-        public async Task start_host_port_in_use()
+        public async Task Start_LanguageWorker_InvalidFunctionJson_FailsWithExpectedError()
         {
-            var tcpListner = new TcpListener(IPAddress.Any, 8081);
-            try
-            {
-                tcpListner.Start();
+           var functionName = "HttpTriggerJS";
 
-                await CliTester.Run(new RunConfiguration
-                {
-                    Commands = new[]
-                    {
-                    "init . --worker-runtime node",
-                    "new --template \"Http Trigger\" --name HttpTrigger",
-                    "start --port 8081"
-                },
-                    ExpectExit = true,
-                    ExitInError = true,
-                    ErrorContains = new[] { "Port 8081 is unavailable" },
-                    CommandTimeout = TimeSpan.FromSeconds(300),
-                }, _output);
-            }
-            finally
-            {
-                tcpListner.Stop();
-            }
+           await CliTester.Run(new RunConfiguration[]
+           {
+               new RunConfiguration
+               {
+                   Commands = new[]
+                   {
+                       "init . --worker-runtime node -m v3",
+                       $"new --template \"Http Trigger\" --name {functionName}",
+                   },
+                   Test = async (workingDir, _) =>
+                   {
+                       var filePath = Path.Combine(workingDir, functionName, "function.json");
+                       var functionJson = await File.ReadAllTextAsync(filePath);
+                       functionJson = functionJson.Replace("\"type\": \"http\"", "\"type\": \"http2\"");
+                       await File.WriteAllTextAsync(filePath, functionJson);
+                   },
+                   CommandTimeout = TimeSpan.FromSeconds(300)
+               },
+               new RunConfiguration
+               {
+                   Commands = new[]
+                   {
+                       "start"
+                   },
+                   ExpectExit = false,
+                   OutputContains = new []
+                   {
+                       "The binding type(s) 'http2' were not found in the configured extension bundle. Please ensure the type is correct and the correct version of extension bundle is configured."
+                   },
+                   Test = async (_, p) =>
+                   {
+                       //TODO: Replace with call to wait on host start
+                       await Task.Delay(TimeSpan.FromSeconds(10));
+                       p.Kill();
+                   }
+               }
+           }, _output);
         }
 
         [Fact]
-        public async Task start_handles_empty_envvars_correctly()
+        public async Task Start_InProc_LogLevelOverridenViaHostJson_LogLevelSetToExpectedValue()
         {
-            await CliTester.Run(new RunConfiguration[]
-            {
-                new RunConfiguration
-                {
-                    Commands = new[]
-                    {
-                        "init . --worker-runtime node",
-                        "new --template \"Http trigger\" --name HttpTrigger",
-                        "settings add emptySetting EMPTY_VALUE",
-                    },
-                    Test = async (workingDir, p) =>
-                    {
-                        var settingsFile = Path.Combine(workingDir, "local.settings.json");
-                        var content = File.ReadAllText(settingsFile);
-                        content = content.Replace("EMPTY_VALUE", "");
-                        File.WriteAllText(settingsFile,content);
-                    },
-                    CommandTimeout = TimeSpan.FromSeconds(300),
-                },
-                new RunConfiguration
-                {
-                    Commands = new[]
-                    {
-                        "start --port 6543"
-                    },
-                    ExpectExit = false,
-                    Test = async (w, p) =>
-                    {
-                        using (var client = new HttpClient() { BaseAddress = new Uri("http://localhost:6543/") })
-                        {
-                            client.Timeout = TimeSpan.FromSeconds(2);
-                            for (var i = 0; i < 10; i++)
-                            {
-                                try
-                                {
-                                    var response = await client.GetAsync("/api/HttpTrigger?name=Test");
-                                    response.EnsureSuccessStatusCode();
-                                    break;
-                                }
-                                catch
-                                {
-                                    await Task.Delay(TimeSpan.FromSeconds(2));
-                                }
-                            }
-                        }
-                        p.Kill();
-                    },
-                    OutputDoesntContain = new string[]
-                    {
-                        "Skipping 'emptySetting' from local settings as it's already defined in current environment variables."
-                    },
-                    CommandTimeout = TimeSpan.FromSeconds(300),
-                }
-            }, _output);
-        }
+           var functionName = "HttpTriggerCSharp";
 
-        [Fact(Skip = "Flaky test")]
-        public async Task start_powershell()
-        {
-            await CliTester.Run(new RunConfiguration
-            {
-                Commands = new[]
-                {
-                    "init . --worker-runtime powershell --managed-dependencies false",
-                    "new --template \"Http trigger\" --name HttpTrigger",
-                    "start"
-                },
-                ExpectExit = false,
-                CommandTimeout = TimeSpan.FromMinutes(1),
-                Test = async (workingDir, p) =>
-                {
-                    using (var client = new HttpClient() { BaseAddress = new Uri("http://localhost:7071/") })
-                    {
-                        (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
-                        var response = await client.GetAsync("/api/HttpTrigger?name=Test");
-                        var result = await response.Content.ReadAsStringAsync();
-                        p.Kill();
-                        await Task.Delay(TimeSpan.FromSeconds(2));
-                        result.Should().Be("Hello, Test. This HTTP triggered function executed successfully.", because: "response from default function should be 'Hello, {name}. This HTTP triggered function executed successfully.'");
-                    }
-                },
-            }, _output);
+           await CliTester.Run(new RunConfiguration[]
+           {
+               new RunConfiguration
+               {
+                   Commands = new[]
+                   {
+                       "init . --worker-runtime dotnet",
+                       $"new --template Httptrigger --name {functionName}",
+                   },
+                   Test = async (workingDir, p) =>
+                   {
+                       var filePath = Path.Combine(workingDir, "host.json");
+                       string hostJsonContent = "{\"version\": \"2.0\",\"logging\": {\"logLevel\": {\"Default\": \"Debug\"}}}";
+                       await File.WriteAllTextAsync(filePath, hostJsonContent);
+                   },
+               },
+               new RunConfiguration
+               {
+                   Commands = new[]
+                   {
+                       "start"
+                   },
+                   ExpectExit = false,
+                   OutputContains = new []
+                   {
+                       "Host configuration applied."
+                   },
+                   Test = async (_, p) =>
+                   {
+                       //TODO: Replace with call to wait on host start
+                       await Task.Delay(TimeSpan.FromSeconds(10));
+                       p.Kill();
+                   }
+               },
+           }, _output);
         }
 
         [Fact]
-        public async Task only_run_some_functions()
+        public async Task Start_InProc_LogLevelOverridenWithFilter_LogLevelSetToExpectedValue()
         {
-            await CliTester.Run(new RunConfiguration
-            {
-                Commands = new[]
-                {
-                    "init . --worker-runtime javascript",
-                    "new --template \"Http trigger\" --name http1",
-                    "new --template \"Http trigger\" --name http2",
-                    "new --template \"Http trigger\" --name http3",
-                    "start --functions http2 http1"
-                },
-                ExpectExit = false,
-                Test = async (workingDir, p) =>
-                {
-                    using (var client = new HttpClient() { BaseAddress = new Uri("http://localhost:7071/") })
-                    {
-                        (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
-                        var response = await client.GetAsync("/api/http1?name=Test");
-                        response.StatusCode.Should().Be(HttpStatusCode.OK);
+           var functionName = "HttpTriggerCSharp";
 
-                        response = await client.GetAsync("/api/http2?name=Test");
-                        response.StatusCode.Should().Be(HttpStatusCode.OK);
+           await CliTester.Run(new RunConfiguration[]
+           {
+               new RunConfiguration
+               {
+                   Commands = new[]
+                   {
+                       "init . --worker-runtime dotnet",
+                       $"new --template Httptrigger --name {functionName}",
+                   },
+                   Test = async (workingDir, p) =>
+                   {
+                       var filePath = Path.Combine(workingDir, "host.json");
+                       string hostJsonContent = "{\"version\": \"2.0\",\"logging\": {\"logLevel\": {\"Default\": \"None\", \"Host.Startup\": \"Information\"}}}";
+                       await File.WriteAllTextAsync(filePath, hostJsonContent);
+                   },
+               },
+               new RunConfiguration
+               {
+                   Commands = new[]
+                   {
+                       "start"
+                   },
+                   ExpectExit = false,
+                   OutputContains = new []
+                   {
+                       "Found the following functions:"
+                   },
+                   OutputDoesntContain = new string[]
+                   {
+                       "Reading host configuration file"
+                   },
+                   Test = async (_, p) =>
+                   {
+                       //TODO: Replace with call to wait on host start
+                       await Task.Delay(TimeSpan.FromSeconds(10));
+                       p.Kill();
+                   }
+               },
+           }, _output);
+        }
 
-                        response = await client.GetAsync("/api/http3?name=Test");
-                        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
-                        p.Kill();
-                    }
-                },
-                CommandTimeout = TimeSpan.FromSeconds(300)
+        [Fact]
+        public async Task Start_InProc_InvalidHostJson_FailsWithExpectedError()
+        {
+           var functionName = "HttpTriggerCSharp";
+
+           await CliTester.Run(new RunConfiguration[]
+           {
+               new RunConfiguration
+               {
+                   Commands = new[]
+                   {
+                       "init . --worker-runtime dotnet",
+                       $"new --template Httptrigger --name {functionName}",
+
+                   },
+                   Test = async (workingDir, p) =>
+                   {
+                       var filePath = Path.Combine(workingDir, "host.json");
+                       string hostJsonContent = "{ \"version\": \"2.0\", \"extensionBundle\": { \"id\": \"Microsoft.Azure.Functions.ExtensionBundle\", \"version\": \"[2.*, 3.0.0)\" }}";
+                       await File.WriteAllTextAsync(filePath, hostJsonContent);
+                   },
+               },
+               new RunConfiguration
+               {
+                   Commands = new[]
+                   {
+                       "start"
+                   },
+                   ExpectExit = true,
+                   ExitInError = true,
+                   ErrorContains = new[] { "Extension bundle configuration should not be present" },
+               },
+           }, _output);
+        }
+
+        [Fact]
+        public async Task Start_InProc_MissingHostJson_FailsWithExpectedError()
+        {
+           var functionName = "HttpTriggerCSharp";
+
+           await CliTester.Run(new RunConfiguration[]
+           {
+               new RunConfiguration
+               {
+                   Commands = new[]
+                   {
+                       "init . --worker-runtime dotnet",
+                       $"new --template Httptrigger --name {functionName}",
+                   },
+                   Test = async (workingDir, p) =>
+                   {
+                       var hostJsonPath = Path.Combine(workingDir, "host.json");
+                       File.Delete(hostJsonPath);
+
+                   },
+               },
+               new RunConfiguration
+               {
+                   Commands = new[]
+                   {
+                       "start"
+                   },
+                   ExpectExit = true,
+                   ExitInError = true,
+                   ErrorContains = new[] { "Host.json file in missing" },
+               },
             }, _output);
         }
 
         [Theory(Skip = "https://github.com/Azure/azure-functions-core-tools/issues/3644")]
         [InlineData("dotnet")]
         [InlineData("dotnet-isolated")]
-        public async Task start_with_user_secrets(string language)
+        public async Task Start_Dotnet_WithUserSecrets_SuccessfulFunctionExecution(string language)
         {
             await CliTester.Run(new RunConfiguration[]
             {
@@ -681,7 +772,7 @@ namespace Azure.Functions.Cli.Tests.E2E
 
                         // clear local.settings.json
                         var localSettingsPath = Path.Combine(workingDir, "local.settings.json");
-                        Assert.True(File.Exists(queueCodePath));
+                        Assert.True(File.Exists(localSettingsPath));
                         _output.WriteLine($"Writing to file {localSettingsPath}");
                         File.WriteAllText(localSettingsPath, "{ \"IsEncrypted\": false, \"Values\": {\""+ Constants.FunctionsWorkerRuntime + "\": \"" + language + "\", \"AzureWebJobsSecretStorageType\": \"files\"} }");
 
@@ -718,7 +809,7 @@ namespace Azure.Functions.Cli.Tests.E2E
         }
 
         [Fact(Skip = "Flaky test")]
-        public async Task start_with_user_secrets_missing_storage()
+        public async Task Start_Dotnet_WithUserSecrets_MissingStorageConnString_FailsWithExpectedError()
         {
             string AzureWebJobsStorageConnectionString = Environment.GetEnvironmentVariable("AzureWebJobsStorage");
             Skip.If(!string.IsNullOrEmpty(AzureWebJobsStorageConnectionString),
@@ -785,7 +876,7 @@ namespace Azure.Functions.Cli.Tests.E2E
         }
 
         [Fact(Skip = "Flaky test")]
-        public async Task start_with_user_secrets_missing_binding_setting()
+        public async Task Start_Dotnet_WithUserSecrets_MissingBindingSetting_FailsWithExpectedError()
         {
             string AzureWebJobsStorageConnectionString = Environment.GetEnvironmentVariable("AzureWebJobsStorage");
             Skip.If(!string.IsNullOrEmpty(AzureWebJobsStorageConnectionString),


### PR DESCRIPTION
Rename tests to follow csharp naming patterns & separate func start commands from func init commands.

There should be no functional changes in this PR other than fixing one path mistake (I'll point this out below)

Chain of PRs:
1. #3847
2. #3850 
3. #3846