### PR TITLE
Updating the inproc artifact name to include "_inproc" suffix in the name

### DIFF
--- a/src/Azure.Functions.ArtifactAssembler/Program.cs
+++ b/src/Azure.Functions.ArtifactAssembler/Program.cs
@@ -9,7 +9,7 @@ namespace Azure.Functions.ArtifactAssembler
         {
             try
             {
-                var currentWorkingDirectory = Environment.CurrentDirectory;             
+                var currentWorkingDirectory = Environment.CurrentDirectory;
                 var artifactAssembler = new ArtifactAssembler(currentWorkingDirectory);
                 await artifactAssembler.AssembleArtifactsAsync();
 


### PR DESCRIPTION
Updating the inproc artifact name to include "_inproc" suffix in the name. Example value after this change `Azure.Functions.Cli.min.win-x64_inproc.4.0.6353.zip`

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)