### PR TITLE
Implement measures to fix flakey tests

### DIFF
--- a/src/Azure.Functions.Cli/Common/Executable.cs
+++ b/src/Azure.Functions.Cli/Common/Executable.cs
@@ -141,10 +141,6 @@ namespace Azure.Functions.Cli.Common
             {
                 throw new FileNotFoundException(ex.Message, ex);
             }
-            finally
-            {
-                await DisposeAsync().ConfigureAwait(false);
-            }
         }
 
         public async ValueTask DisposeAsync()

--- a/src/Azure.Functions.Cli/Common/Executable.cs
+++ b/src/Azure.Functions.Cli/Common/Executable.cs
@@ -97,6 +97,7 @@ namespace Azure.Functions.Cli.Common
                 };
                 Process.EnableRaisingEvents = true;
             }
+
             try
             {
                 Process.Start();
@@ -126,16 +127,12 @@ namespace Azure.Functions.Cli.Common
                 }
                 else
                 {
-                    var completedTask = await Task.WhenAny(exitCodeTask, Task.Delay(timeout.Value)).ConfigureAwait(false);
-                    if (completedTask == exitCodeTask)
-                    {
-                        return await exitCodeTask.ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        throw new TimeoutException($"Process {_exeName} didn't exit within the specified timeout.");
-                    }
+                    return await exitCodeTask.WaitAsync(timeout.Value).ConfigureAwait(false);
                 }
+            }
+            catch (TimeoutException)
+            {
+                throw new TimeoutException($"Process {_exeName} didn't exit within the specified timeout.");
             }
             catch (Win32Exception ex) when (ex.Message.Contains("cannot find the file specified"))
             {

--- a/src/Azure.Functions.Cli/Common/JobObjectRegistry.cs
+++ b/src/Azure.Functions.Cli/Common/JobObjectRegistry.cs
@@ -1,0 +1,146 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace Azure.Functions.Cli.Common
+{
+    // Taken from: https://github.com/Azure/azure-functions-host/blob/69111926ee920d4ba10829c8fa34303bb8165a42/src/WebJobs.Script/Workers/ProcessManagement/JobObjectRegistry.cs
+    // This kills child func.exe even if tests are killed from VS mid-run.
+
+    // Registers processes on windows with a job object to ensure disposal after parent exit.
+    internal class JobObjectRegistry : IDisposable
+    {
+        private IntPtr _handle;
+        private bool _disposed = false;
+
+        public JobObjectRegistry()
+        {
+            _handle = CreateJobObject(null, null);
+
+            var info = new JOBOBJECT_BASIC_LIMIT_INFORMATION
+            {
+                LimitFlags = 0x2000
+            };
+
+            var extendedInfo = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+            {
+                BasicLimitInformation = info
+            };
+
+            int length = Marshal.SizeOf(typeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION));
+            IntPtr extendedInfoPtr = Marshal.AllocHGlobal(length);
+            Marshal.StructureToPtr(extendedInfo, extendedInfoPtr, false);
+
+            if (!SetInformationJobObject(_handle, JobObjectInfoType.ExtendedLimitInformation, extendedInfoPtr, (uint)length))
+            {
+                throw new Exception(string.Format("Unable to set information.  Error: {0}", Marshal.GetLastWin32Error()));
+            }
+        }
+
+        public bool Register(Process proc)
+        {
+            return AssignProcessToJobObject(_handle, proc.Handle);
+        }
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern IntPtr CreateJobObject(object a, string lpName);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool SetInformationJobObject(IntPtr hJob, JobObjectInfoType infoType, IntPtr lpJobObjectInfo, uint cbJobObjectInfoLength);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool AssignProcessToJobObject(IntPtr job, IntPtr process);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool CloseHandle(IntPtr job);
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                // Dispose of managed resources.
+            }
+
+            Close();
+            _disposed = true;
+        }
+
+        public void Close()
+        {
+            if (_handle != IntPtr.Zero)
+            {
+                CloseHandle(_handle);
+            }
+            _handle = IntPtr.Zero;
+        }
+    }
+
+    public enum JobObjectInfoType
+    {
+        AssociateCompletionPortInformation = 7,
+        BasicLimitInformation = 2,
+        BasicUIRestrictions = 4,
+        EndOfJobTimeInformation = 6,
+        ExtendedLimitInformation = 9,
+        SecurityLimitInformation = 5,
+        GroupInformation = 11
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct IO_COUNTERS
+    {
+        public ulong ReadOperationCount;
+        public ulong WriteOperationCount;
+        public ulong OtherOperationCount;
+        public ulong ReadTransferCount;
+        public ulong WriteTransferCount;
+        public ulong OtherTransferCount;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct JOBOBJECT_BASIC_LIMIT_INFORMATION
+    {
+        public long PerProcessUserTimeLimit;
+        public long PerJobUserTimeLimit;
+        public uint LimitFlags;
+        public UIntPtr MinimumWorkingSetSize;
+        public UIntPtr MaximumWorkingSetSize;
+        public uint ActiveProcessLimit;
+        public UIntPtr Affinity;
+        public uint PriorityClass;
+        public uint SchedulingClass;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct SECURITY_ATTRIBUTES
+    {
+        public uint nLength;
+        public IntPtr lpSecurityDescriptor;
+        public int bInheritHandle;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+    {
+        public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+        public IO_COUNTERS IoInfo;
+        public UIntPtr ProcessMemoryLimit;
+        public UIntPtr JobMemoryLimit;
+        public UIntPtr PeakProcessMemoryUsed;
+        public UIntPtr PeakJobMemoryUsed;
+    }
+}

--- a/test/Azure.Functions.Cli.Tests/E2E/Helpers/CliTester.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/Helpers/CliTester.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Azure.Functions.Cli.Common;
@@ -22,11 +23,17 @@ namespace Azure.Functions.Cli.Tests.E2E.Helpers
             if (_func == null)
             {
                 // Fallback for local testing in Visual Studio, etc.
-                _func = $@"{Environment.CurrentDirectory}\func.exe";
+                _func = Path.Combine(Environment.CurrentDirectory, "func");
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    _func += ".exe";
+                }
+
                 if (!File.Exists(_func))
                 {
-                    throw new ApplicationException("Could not locate the func.exe to use for testing. Make sure the FUNC_PATH environment variable is set to the full path of the func executable.");
-                }    
+                    throw new ApplicationException("Could not locate the 'func' executable to use for testing. Make sure the FUNC_PATH environment variable is set to the full path of the func executable.");
+                }
             }
         }
 
@@ -69,27 +76,30 @@ namespace Azure.Functions.Cli.Tests.E2E.Helpers
         private static async Task InternalRun(string workingDir, RunConfiguration[] runConfigurations, ITestOutputHelper output, bool startHost)
         {
             var hostExe = new Executable(_func, StartHostCommand, workingDirectory: workingDir);
-
             var stdout = new StringBuilder();
             var stderr = new StringBuilder();
+
             foreach (var runConfiguration in runConfigurations)
             {
                 Task hostTask = startHost ? hostExe.RunAsync(logStd, logErr) : Task.Delay(runConfiguration.CommandTimeout);
                 stdout.Clear();
                 stderr.Clear();
+                var exitCode = 0;
                 var exitError = false;
                 runConfiguration.PreTest?.Invoke(workingDir);
 
                 for (var i = 0; i < runConfiguration.Commands.Length; i++)
                 {
                     var command = runConfiguration.Commands[i];
-                    var exe = new Executable(_func, command, workingDirectory: workingDir);
-                    // Special case for dotnet commands
-                    if (command.StartsWith("dotnet", StringComparison.OrdinalIgnoreCase))
+
+                    var exe = command switch
                     {
-                        // we have to remove the "dotnet" part of the command so we pass in command.Substring(7) as the second arg
-                        exe = new Executable("dotnet", command.Substring(7), workingDirectory: workingDir);
-                    }
+                        string cmd when cmd.StartsWith("dotnet", StringComparison.OrdinalIgnoreCase) =>
+                            new Executable("dotnet", command.Substring(7), workingDirectory: workingDir),
+
+                        // default to func
+                        _ => new Executable(_func, command, workingDirectory: workingDir)
+                    };
 
                     if (startHost && i == runConfiguration.Commands.Length - 1)
                     {
@@ -103,16 +113,25 @@ namespace Azure.Functions.Cli.Tests.E2E.Helpers
 
                     if (runConfiguration.ExpectExit || (i + 1) < runConfiguration.Commands.Length)
                     {
-                        var exitCode = await exe.RunAsync(logStd, logErr, timeout: runConfiguration.CommandTimeout);
-                        exitError |= exitCode != 0;
+                        exitCode = await exe.RunAsync(logStd, logErr, timeout: runConfiguration.CommandTimeout);
                     }
-                    else
+
+                    if (!runConfiguration.ExpectExit && runConfiguration.Test is not null)
                     {
                         var exitCodeTask = exe.RunAsync(logStd, logErr);
 
+                        if (runConfiguration.WaitForRunningHostState)
+                        {
+                            await ProcessHelper.WaitForFunctionHostToStart(exe.Process, runConfiguration.HostProcessPort);
+                        }
+
                         try
                         {
-                            await runConfiguration.Test.Invoke(workingDir, exe.Process);
+                            await runConfiguration.Test.Invoke(workingDir, exe.Process, stdout);
+                        }
+                        catch (Exception e)
+                        {
+                            logErr($"Error while running test: {e.Message}");
                         }
                         finally
                         {
@@ -120,19 +139,22 @@ namespace Azure.Functions.Cli.Tests.E2E.Helpers
                             if (!exitCodeTask.IsCompleted)
                             {
                                 exe.Process.Kill();
-                                throw new Exception("Expected process to exit after calling Test() and within timeout, but it didn't.");
+                                logErr("Expected process to exit after calling Test() and within timeout, but it didn't.");
                             }
                             else
                             {
-                                exitError |= exitCodeTask.Result != 0;
+                                exitCode = exitCodeTask.Result;
                             }
                         }
                     }
+
+                    // -1 means we intentionally killed the process via p.Kill() - this is not an error
+                    exitError |= exitCode != 0 && exitCode != -1;
                 }
 
                 if (runConfiguration.ExpectExit && runConfiguration.Test != null)
                 {
-                    await runConfiguration.Test.Invoke(workingDir, null);
+                    await runConfiguration.Test.Invoke(workingDir, null, null);
                 }
 
                 if (startHost)
@@ -144,14 +166,13 @@ namespace Azure.Functions.Cli.Tests.E2E.Helpers
                     }
                 }
 
-
                 // AssertExitError(runConfiguration, exitError);
                 AssertFiles(runConfiguration, workingDir);
                 AssertDirectories(runConfiguration, workingDir);
                 AssertOutputContent(runConfiguration, stdout);
                 AssertErrorContent(runConfiguration, stderr);
-
             }
+
             void logStd(string line)
             {
                 try

--- a/test/Azure.Functions.Cli.Tests/E2E/Helpers/CliTester.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/Helpers/CliTester.cs
@@ -75,7 +75,7 @@ namespace Azure.Functions.Cli.Tests.E2E.Helpers
 
         private static async Task InternalRun(string workingDir, RunConfiguration[] runConfigurations, ITestOutputHelper output, bool startHost)
         {
-            var hostExe = new Executable(_func, StartHostCommand, workingDirectory: workingDir);
+            await using var hostExe = new Executable(_func, StartHostCommand, workingDirectory: workingDir);
             var stdout = new StringBuilder();
             var stderr = new StringBuilder();
 
@@ -92,7 +92,7 @@ namespace Azure.Functions.Cli.Tests.E2E.Helpers
                 {
                     var command = runConfiguration.Commands[i];
 
-                    var exe = command switch
+                    await using var exe = command switch
                     {
                         string cmd when cmd.StartsWith("dotnet", StringComparison.OrdinalIgnoreCase) =>
                             new Executable("dotnet", command.Substring(7), workingDirectory: workingDir),

--- a/test/Azure.Functions.Cli.Tests/E2E/Helpers/LogWatcher.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/Helpers/LogWatcher.cs
@@ -13,7 +13,7 @@ namespace Azure.Functions.Cli.Tests.E2E.Helpers
         public static async Task WaitForLogOutput(StringBuilder stdout, string expectedOutput, TimeSpan timeout)
         {
             var tcs = new TaskCompletionSource<bool>();
-            var cancellationTokenSource = new CancellationTokenSource(timeout);
+            using var cancellationTokenSource = new CancellationTokenSource(timeout);
 
             if (stdout.ToString().Contains(expectedOutput))
             {

--- a/test/Azure.Functions.Cli.Tests/E2E/Helpers/LogWatcher.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/Helpers/LogWatcher.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+
+namespace Azure.Functions.Cli.Tests.E2E.Helpers
+{
+    public static class LogWatcher
+    {
+        public static async Task WaitForLogOutput(StringBuilder stdout, string expectedOutput, TimeSpan timeout)
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            var cancellationTokenSource = new CancellationTokenSource(timeout);
+
+            if (stdout.ToString().Contains(expectedOutput))
+            {
+                tcs.SetResult(true);
+            }
+            else
+            {
+                var timer = new Timer(state =>
+                {
+                    if (stdout.ToString().Contains(expectedOutput))
+                    {
+                        tcs.TrySetResult(true);
+                    }
+                }, null, TimeSpan.Zero, TimeSpan.FromSeconds(1));
+
+                // Cancel the waiting task if the timeout is reached
+                cancellationTokenSource.Token.Register(() =>
+                {
+                    tcs.TrySetCanceled();
+                    timer.Dispose();
+                });
+            }
+
+            await tcs.Task;
+        }
+    }
+}

--- a/test/Azure.Functions.Cli.Tests/E2E/Helpers/ProcessHelper.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/Helpers/ProcessHelper.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Azure.Functions.Cli.Tests.E2E.Helpers
+{
+    internal class ProcessHelper
+    {
+        private const string CommandExe = "cmd";
+        private static readonly Regex pidRegex = new Regex(@"LISTENING\s+(\d+)\s*$");
+        private static string FunctionsHostUrl = "http://localhost";
+
+        public static async Task WaitForFunctionHostToStart(Process funcProcess, string port)
+        {
+            var url = $"{FunctionsHostUrl}:{port}";
+            using var httpClient = new HttpClient();
+
+            await RetryHelper.RetryAsync(async () =>
+            {
+                try
+                {
+                    var response = await httpClient.GetAsync($"{url}/admin/host/status");
+                    var content = await response.Content.ReadAsStringAsync();
+                    var doc = JsonDocument.Parse(content);
+
+                    if (doc.RootElement.TryGetProperty("state", out JsonElement value) && value.GetString() == "Running")
+                    {
+                        return true;
+                    }
+
+                    return false;
+                }
+                catch
+                {
+                    return false;
+                }
+            });
+        }
+
+        public static void TryKillProcessForPort(string port)
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // Can only use these commands on a windows device
+                return;
+            }
+
+            string searchCommand = string.Format("/c netstat -anop tcp|findstr \":{0}.*LISTENING\"", port);
+            string searchResult = ExecuteCommand(searchCommand).Trim();
+
+            if (string.IsNullOrEmpty(searchResult))
+            {
+                // No process running on given port
+                return;
+            }
+
+            Match match = pidRegex.Match(searchResult);
+
+            if (!match.Success)
+            {
+                Console.WriteLine($"Unable to parse the PID for the process running on port '{port}'");
+                return;
+            }
+
+            string pid = match.Groups[1].Value;
+            string killCommand = $"/c taskkill /PID {pid} /F";
+            string killResult = ExecuteCommand(killCommand);
+
+            if (killResult == null)
+            {
+                Console.WriteLine($"Unable to kill the process (PID: {pid}) running on port '{port}'");
+            }
+        }
+
+        private static string ExecuteCommand(string command)
+        {
+            using (Process p = new Process())
+            {
+                string commandOut = string.Empty;
+
+                p.StartInfo.FileName = CommandExe;
+                p.StartInfo.Arguments = command;
+                p.StartInfo.UseShellExecute = false;
+                p.StartInfo.CreateNoWindow = true;
+                p.StartInfo.RedirectStandardOutput = true;
+                p.StartInfo.RedirectStandardError = true;
+                p.Start();
+
+                commandOut = p.StandardOutput.ReadToEnd();
+                string errors = p.StandardError.ReadToEnd();
+
+                try
+                {
+                    p.WaitForExit(TimeSpan.FromSeconds(2).Milliseconds);
+                }
+                catch (Exception exp)
+                {
+                    Console.WriteLine(exp.ToString());
+                }
+
+                return commandOut;
+            }
+        }
+    }
+}

--- a/test/Azure.Functions.Cli.Tests/E2E/Helpers/RetryHelper.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/Helpers/RetryHelper.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+
+namespace Azure.Functions.Cli.Tests.E2E.Helpers
+{
+    public static class RetryHelper
+    {
+        public static async Task RetryAsync(Func<Task<bool>> condition, int timeout = 60 * 1000, int pollingInterval = 2 * 1000, bool throwWhenDebugging = false, Func<string> userMessageCallback = null)
+        {
+            DateTime start = DateTime.Now;
+            while (!await condition())
+            {
+                await Task.Delay(pollingInterval);
+
+                bool shouldThrow = !Debugger.IsAttached || (Debugger.IsAttached && throwWhenDebugging);
+                if (shouldThrow && (DateTime.Now - start).TotalMilliseconds > timeout)
+                {
+                    string error = "Condition not reached within timeout.";
+                    if (userMessageCallback != null)
+                    {
+                        error += " " + userMessageCallback();
+                    }
+                    throw new ApplicationException(error);
+                }
+            }
+        }
+    }
+}

--- a/test/Azure.Functions.Cli.Tests/E2E/Helpers/RunConfiguration.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/Helpers/RunConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace Azure.Functions.Cli.Tests.E2E.Helpers
@@ -17,8 +18,10 @@ namespace Azure.Functions.Cli.Tests.E2E.Helpers
         public string[] OutputDoesntContain { get; set; } = Array.Empty<string>();
         public string[] ErrorDoesntContain { get; set; } = Array.Empty<string>();
         public Action<string> PreTest { get; set; }
-        public Func<string, Process, Task> Test { get; set; }
+        public Func<string, Process, StringBuilder, Task> Test { get; set; }
         public TimeSpan CommandTimeout { get; set; } = TimeSpan.FromSeconds(40);
         public string CommandsStr => $"{string.Join(", ", Commands)}";
+        public bool WaitForRunningHostState = false;
+        public string HostProcessPort = "7071";
     }
 }


### PR DESCRIPTION
- Implement test cleanup measure to kill processes on a given port 
- Make `Executable` class disposable by implementing `IAsyncDisposable` interface
- Add job registry to clean up child processes
- Add log watcher with timeout to check for a specific log message
- Add logic to wait for function host to be in a running state

Chain of PRs:
1. #3847
2. #3850 
3. #3846
