### PR TITLE
Disabling CET compatiblity for custom host

### DIFF
--- a/host/src/CoreToolsHost/CoreToolsHost.csproj
+++ b/host/src/CoreToolsHost/CoreToolsHost.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <PublishAot>true</PublishAot>
+    <CETCompat>false</CETCompat>
     <OptimizationPreference>Speed</OptimizationPreference>
     <AssemblyName>func</AssemblyName>
 	<IlcExportUnmanagedEntrypoints>true</IlcExportUnmanagedEntrypoints>


### PR DESCRIPTION
We observed an issue with the custom host when using .NET 6 in-process on some devices. This would lead to a VS launch getting `...\4.90.0-inprocess\cli_x64\func.exe (process 25096) exited with code -1073740791 (0xc0000409)`. After checking with the .NET team, it was determined that this was due to the changes described in https://github.com/dotnet/docs/issues/42600. Disabling CET worked for my own repro.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)