### PR TITLE
Restructuring custom host to improve error handling

### DIFF
--- a/host/src/CoreToolsHost/Logger.cs
+++ b/host/src/CoreToolsHost/Logger.cs
@@ -10,17 +10,17 @@ namespace CoreToolsHost
         /// <summary>
         /// Logs a message.
         /// </summary>
-        internal static void Log(string message)
+        internal static void Log(string message, bool includeTimeStamp = true)
         {
-            var ts = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture);
-            Console.WriteLine($"[{ts}] [CoreToolsHost] {message}");
+            var timeStampPrefix = includeTimeStamp ? $"[{DateTime.UtcNow.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffZ", CultureInfo.InvariantCulture)}] " : string.Empty;
+            Console.WriteLine($"{timeStampPrefix}[CoreToolsHost] {message}");
         }
 
         internal static void LogVerbose(bool isVerbose, string message)
         {
             if (isVerbose)
             {
-                Console.WriteLine($"{message}");
+                Log(message);
             }
         }
     }

--- a/host/src/CoreToolsHost/Program.cs
+++ b/host/src/CoreToolsHost/Program.cs
@@ -9,66 +9,58 @@ namespace CoreToolsHost
     internal class Program
     {
         static bool isVerbose = false;
+        
         static async Task Main(string[] args)
         {
+            isVerbose = args.Contains(DotnetConstants.Verbose);
+
+            Logger.LogVerbose(isVerbose, "Starting CoreToolsHost");
+
+            var localSettingsJson = await LocalSettingsJsonParser.GetLocalSettingsJsonAsJObjectAsync();
+
+            if (localSettingsJson is null)
+            {
+                Logger.LogVerbose(isVerbose, "No local.settings.json file was found");
+            }
+
+            bool projectOptsIntoDotnet8 = 
+                // local.settings.json must be the source of the configuration
+                localSettingsJson is not null && localSettingsJson.RootElement.TryGetProperty("Values", out JsonElement valuesElement)
+                // The runtime must be specified as "dotnet"
+                && ElementExistsWithValue(valuesElement, EnvironmentVariables.FunctionsWorkerRuntime, DotnetConstants.DotnetWorkerRuntime)
+                // The .NET 8 enablement configuration must be provided
+                && ElementExistsWithValue(valuesElement, EnvironmentVariables.FunctionsInProcNet8Enabled, "1");
+
+            Logger.LogVerbose(isVerbose, $"Loading .NET {(projectOptsIntoDotnet8 ? 8 : 6)} host");
+
             try
             {
-                isVerbose = args.Contains(DotnetConstants.Verbose);
-
-                Logger.LogVerbose(isVerbose, "Starting CoreToolsHost");
-
                 using var appLoader = new AppLoader();
-
-                var localSettingsJson = await LocalSettingsJsonParser.GetLocalSettingsJsonAsJObjectAsync();
-                localSettingsJson.RootElement.TryGetProperty("Values", out JsonElement valuesElement);
-                string workerRuntime = string.Empty;
-
-                if (valuesElement.TryGetProperty(EnvironmentVariables.FunctionsWorkerRuntime, out JsonElement workerRuntimeElement))
-                {
-                    workerRuntime = workerRuntimeElement.GetString();
-                }
-                
-                if (string.IsNullOrEmpty(workerRuntime))
-                {
-                    Logger.Log($"Environment variable '{EnvironmentVariables.FunctionsWorkerRuntime}' is not set.");
-                    return;
-                }
-
-                if (workerRuntime == DotnetConstants.DotnetWorkerRuntime)
-                {
-                    string isInProc8 = "";
-                    if (valuesElement.TryGetProperty(EnvironmentVariables.FunctionsInProcNet8Enabled, out JsonElement inProc8EnabledElement))
-                    {
-                        isInProc8 = inProc8EnabledElement.GetString();
-                    }
-
-                    // Load host assembly for .NET 8 in proc host
-                    if (!string.IsNullOrEmpty(isInProc8) && string.Equals("1", isInProc8))
-                    {
-                        Logger.LogVerbose(isVerbose, "Loading inproc8 host");
-                        LoadHostAssembly(appLoader, args, isNet8InProc: true);
-                    }
-                    else
-                    {
-                        // Load host assembly for .NET 6 in proc host
-                        Logger.LogVerbose(isVerbose, "Loading inproc6 host");
-                        LoadHostAssembly(appLoader, args, isNet8InProc: false);
-                    }
-                }
+                LoadHostAssembly(appLoader, args, projectOptsIntoDotnet8);
             }
             catch (Exception exception)
             {
-                Logger.Log($"An error occurred while running CoreToolsHost.{exception}");
+                Logger.Log($"An error occurred while running CoreToolsHost: {exception}");
+                Environment.Exit(1);
             }
+        }
+
+        private static bool ElementExistsWithValue(JsonElement element, string key, string value)
+        {
+
+            return !string.IsNullOrEmpty(key) && !string.IsNullOrEmpty(value)
+                && element.TryGetProperty(key, out JsonElement property) 
+                && !string.IsNullOrEmpty(property.GetString()) 
+                && property.GetString() == value;
         }
 
         private static void LoadHostAssembly(AppLoader appLoader, string[] args, bool isNet8InProc)
         {
-            var currentDirectory = AppContext.BaseDirectory;
-            var executableName = DotnetConstants.ExecutableName;
+            string filePath = Path.Combine(
+                AppContext.BaseDirectory, // current directory
+                isNet8InProc ? DotnetConstants.InProc8DirectoryName: DotnetConstants.InProc6DirectoryName,
+                DotnetConstants.ExecutableName);
 
-            string filePath = "";
-            filePath = Path.Combine(currentDirectory, isNet8InProc ? DotnetConstants.InProc8DirectoryName: DotnetConstants.InProc6DirectoryName, executableName);
             Logger.LogVerbose(isVerbose, $"File path to load: {filePath}");
 
             appLoader.RunApplication(filePath, args);


### PR DESCRIPTION
Resolves #3858

The existing setup allows for early exits with an error code of 0. This should be 1 to reflect the error state. These changes also add defensiveness and reduce the set of scenarios that can cause us to exit. The logic is more tolerant of the project lacking or having a malformed `local.settings.json`. My justification for this is that we should not care if `FUNCTIONS_WORKER_RUNTIME` is present or not from the custom host's perspective. That state simply implies that .NET 6 should be used. For .NET 8 on the in-process model, we hard-require the two settings are provided through `local.settings.json`. The custom host logic just needs to determine if those .NET 8 criteria are met.

Also included are some minor changes to the custom host logger to make it more consistent with the rest of the Core Tools. We should unify instead of copying, but that is outside the scope of this PR.

I have manually validated these changes for the in-process model with .NET 6 and .NET 8, both with and without `local.settings.json`. In the case that was previously early exiting with an opaque error, we now see traditional symptoms of a .NET 8 project being loaded from a .NET 6 process. The communication of that state also needs some work, but that is also outside the scope of this PR.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)