### PR TITLE
Use dynamic port generator for StartTests

### DIFF
--- a/test/Azure.Functions.Cli.Tests/E2E/Helpers/ProcessHelper.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/Helpers/ProcessHelper.cs
@@ -78,35 +78,15 @@ namespace Azure.Functions.Cli.Tests.E2E.Helpers
             }
         }
 
-        public static int GetAvailablePort(int minPort = 7000, int maxPort = 8000)
+        public static int GetAvailablePort()
         {
-            for (int port = minPort; port <= maxPort; port++)
+            using (TcpListener listener = new TcpListener(IPAddress.Loopback, 0))
             {
-                if (IsPortAvailable(port))
-                {
-                    return port;
-                }
-            }
-
-            throw new InvalidOperationException("No available ports found in the specified range.");
-        }
-
-        private static bool IsPortAvailable(int port)
-        {
-            bool isAvailable = true;
-
-            try
-            {
-                TcpListener listener = new TcpListener(IPAddress.Any, port);
                 listener.Start();
+                int port = ((IPEndPoint)listener.LocalEndpoint).Port;
                 listener.Stop();
+                return port;
             }
-            catch (SocketException)
-            {
-                isAvailable = false;
-            }
-
-            return isAvailable;
         }
 
         private static string ExecuteCommand(string command)

--- a/test/Azure.Functions.Cli.Tests/E2E/Helpers/ProcessHelper.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/Helpers/ProcessHelper.cs
@@ -80,12 +80,17 @@ namespace Azure.Functions.Cli.Tests.E2E.Helpers
 
         public static int GetAvailablePort()
         {
-            using (TcpListener listener = new TcpListener(IPAddress.Loopback, 0))
+            TcpListener listener = new TcpListener(IPAddress.Loopback, 0);
+            try
             {
                 listener.Start();
                 int port = ((IPEndPoint)listener.LocalEndpoint).Port;
-                listener.Stop();
                 return port;
+            }
+            finally
+            {
+                listener.Stop();
+                listener.Server.Dispose();
             }
         }
 

--- a/test/Azure.Functions.Cli.Tests/E2E/Helpers/RunConfiguration.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/Helpers/RunConfiguration.cs
@@ -21,7 +21,7 @@ namespace Azure.Functions.Cli.Tests.E2E.Helpers
         public Func<string, Process, StringBuilder, Task> Test { get; set; }
         public TimeSpan CommandTimeout { get; set; } = TimeSpan.FromSeconds(40);
         public string CommandsStr => $"{string.Join(", ", Commands)}";
-        public bool WaitForRunningHostState = false;
-        public string HostProcessPort = "7071";
+        public bool WaitForRunningHostState { get; set; } = false;
+        public int HostProcessPort { get; set; } = 7071;
     }
 }

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -30,7 +30,7 @@ namespace Azure.Functions.Cli.Tests.E2E
             }
             catch
             {
-                // Use default func host port if issue with getting available port
+                // Just use default func host port if we encounter any issues
                 _funcHostPort = 7071;
             }
 

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -17,15 +17,23 @@ namespace Azure.Functions.Cli.Tests.E2E
 {
     public class StartTests : BaseE2ETest, IAsyncLifetime
     {
-        private int _port;
+        private int _funcHostPort;
         private const string _serverNotReady = "Host was not ready after 10 seconds";
 
         public StartTests(ITestOutputHelper output) : base(output) { }
 
         public async Task InitializeAsync()
         {
-            // Set as default port for majority of tests
-            _port = 7071;
+            try
+            {
+                _funcHostPort = ProcessHelper.GetAvailablePort();
+            }
+            catch
+            {
+                // Use default func host port if issue with getting available port
+                _funcHostPort = 7071;
+            }
+
             await Task.CompletedTask;
         }
 
@@ -47,13 +55,13 @@ namespace Azure.Functions.Cli.Tests.E2E
                 {
                     Commands = new[]
                     {
-                        "start"
+                        $"start --port {_funcHostPort}"
                     },
                     ExpectExit = false,
                     CommandTimeout = TimeSpan.FromMinutes(300),
                     Test = async (workingDir, p, _) =>
                     {
-                        using (var client = new HttpClient() { BaseAddress = new Uri("http://localhost:7071/") })
+                        using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}/") })
                         {
                             (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
                             var response = await client.GetAsync("/api/HttpTrigger?name=Test");
@@ -84,13 +92,13 @@ namespace Azure.Functions.Cli.Tests.E2E
                 {
                     Commands = new[]
                     {
-                        "start"
+                        $"start --port {_funcHostPort}"
                     },
                     ExpectExit = false,
                     OutputContains = new[]
                     {
                         "Functions:",
-                        "HttpTrigger: [GET,POST] http://localhost:7071/api/HttpTrigger"
+                        $"HttpTrigger: [GET,POST] http://localhost:{_funcHostPort}/api/HttpTrigger"
                     },
                     OutputDoesntContain = new string[]
                     {
@@ -99,7 +107,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     },
                     Test = async (workingDir, p, _) =>
                     {
-                        using (var client = new HttpClient() { BaseAddress = new Uri("http://localhost:7071/") })
+                        using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}/") })
                         {
                             (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
                             var response = await client.GetAsync("/api/HttpTrigger?name=Test");
@@ -130,13 +138,13 @@ namespace Azure.Functions.Cli.Tests.E2E
                 {
                     Commands = new[]
                     {
-                        "start"
+                        $"start --port {_funcHostPort}"
                     },
                     ExpectExit = false,
                     OutputContains = new[]
                     {
                         "Functions:",
-                        "HttpTrigger: [GET,POST] http://localhost:7071/api/HttpTrigger"
+                        $"HttpTrigger: [GET,POST] http://localhost:{_funcHostPort}/api/HttpTrigger"
                     },
                     OutputDoesntContain = new string[]
                     {
@@ -145,7 +153,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     },
                     Test = async (workingDir, p, _) =>
                     {
-                        using (var client = new HttpClient() { BaseAddress = new Uri("http://localhost:7071/") })
+                        using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}/") })
                         {
                             (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
                             var response = await client.GetAsync("/api/HttpTrigger?name=Test");
@@ -162,8 +170,6 @@ namespace Azure.Functions.Cli.Tests.E2E
         [Fact]
         public async Task Start_InProc_SuccessfulFunctionExecution()
         {
-            _port = 7073;
-
             await CliTester.Run(new RunConfiguration[]
             {
                 new RunConfiguration
@@ -176,15 +182,14 @@ namespace Azure.Functions.Cli.Tests.E2E
                 },
                 new RunConfiguration
                 {
-                    HostProcessPort = "7073",
                     Commands = new[]
                     {
-                        "start --build --port 7073"
+                        $"start --build --port {_funcHostPort}"
                     },
                     ExpectExit = false,
                     Test = async (workingDir, p, _) =>
                     {
-                        using (var client = new HttpClient() { BaseAddress = new Uri("http://localhost:7073") })
+                        using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}") })
                         {
                             (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
                             var response = await client.GetAsync("/api/HttpTrigger?name=Test");
@@ -202,8 +207,6 @@ namespace Azure.Functions.Cli.Tests.E2E
         [Fact]
         public async Task Start_InProc_Net8_SuccessfulFunctionExecution()
         {
-            _port = 7073;
-
             await CliTester.Run(new RunConfiguration[]
             {
                 new RunConfiguration
@@ -216,15 +219,14 @@ namespace Azure.Functions.Cli.Tests.E2E
                 },
                 new RunConfiguration
                 {
-                    HostProcessPort = "7073",
                     Commands = new[]
                     {
-                        "start --port 7073 --verbose"
+                        $"start --port {_funcHostPort} --verbose"
                     },
                     ExpectExit = false,
                     Test = async (workingDir, p, _) =>
                     {
-                        using (var client = new HttpClient() { BaseAddress = new Uri("http://localhost:7073") })
+                        using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}") })
                         {
                             (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
                             var response = await client.GetAsync("/api/HttpTrigger?name=Test");
@@ -248,8 +250,6 @@ namespace Azure.Functions.Cli.Tests.E2E
         [Fact]
         public async Task Start_DotnetIsolated_Net9_SuccessfulFunctionExecution()
         {
-            _port = 7073;
-
             await CliTester.Run(new RunConfiguration[]
             {
                 new RunConfiguration
@@ -264,15 +264,14 @@ namespace Azure.Functions.Cli.Tests.E2E
                 },
                 new RunConfiguration
                 {
-                    HostProcessPort = "7073",
                     Commands = new[]
                     {
-                        "start --build --port 7073"
+                        $"start --build --port {_funcHostPort}"
                     },
                     ExpectExit = false,
                     Test = async (workingDir, p, _) =>
                     {
-                        using (var client = new HttpClient() { BaseAddress = new Uri("http://localhost:7073") })
+                        using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}") })
                         {
                             (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
                             var response = await client.GetAsync("/api/HttpTrigger?name=Test");
@@ -302,9 +301,10 @@ namespace Azure.Functions.Cli.Tests.E2E
                new RunConfiguration
                {
                    WaitForRunningHostState = true,
+                   HostProcessPort = _funcHostPort,
                    Commands = new[]
                    {
-                       "start --verbose --language-worker -- \"--inspect=5050\""
+                       $"start --port {_funcHostPort} --verbose --language-worker -- \"--inspect=5050\""
                    },
                    ExpectExit = false,
                    OutputContains = new[]
@@ -324,7 +324,7 @@ namespace Azure.Functions.Cli.Tests.E2E
         [Fact]
         public async Task Start_PortInUse_FailsWithExpectedError()
         {
-           var tcpListner = new TcpListener(IPAddress.Any, 8081);
+           var tcpListner = new TcpListener(IPAddress.Any, _funcHostPort);
            try
            {
                tcpListner.Start();
@@ -341,14 +341,13 @@ namespace Azure.Functions.Cli.Tests.E2E
                    },
                    new RunConfiguration
                    {
-                       HostProcessPort = "8081",
                        Commands = new[]
                        {
-                           "start --port 8081"
+                            $"start --port {_funcHostPort}"
                        },
                        ExpectExit = true,
                        ExitInError = true,
-                       ErrorContains = new[] { "Port 8081 is unavailable" },
+                       ErrorContains = new[] { $"Port {_funcHostPort} is unavailable" },
                        CommandTimeout = TimeSpan.FromSeconds(300)
                    }
                }, _output);
@@ -362,8 +361,6 @@ namespace Azure.Functions.Cli.Tests.E2E
         [Fact]
         public async Task Start_EmptyEnvVars_HandledAsExpected()
         {
-            _port = 6543;
-
            await CliTester.Run(new RunConfiguration[]
            {
                new RunConfiguration
@@ -385,15 +382,14 @@ namespace Azure.Functions.Cli.Tests.E2E
                },
                new RunConfiguration
                {
-                   HostProcessPort = "6543",
                    Commands = new[]
                    {
-                       "start --port 6543"
+                        $"start --port {_funcHostPort}"
                    },
                    ExpectExit = false,
                    Test = async (w, p, _) =>
                    {
-                       using (var client = new HttpClient() { BaseAddress = new Uri("http://localhost:6543/") })
+                       using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}/") })
                        {
                             (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
                             var response = await client.GetAsync("/api/HttpTrigger?name=Test");
@@ -430,12 +426,12 @@ namespace Azure.Functions.Cli.Tests.E2E
                {
                    Commands = new[]
                    {
-                       "start --functions http2 http1"
+                       $"start --functions http2 http1 --port {_funcHostPort}"
                    },
                    ExpectExit = false,
                    Test = async (workingDir, p, _) =>
                    {
-                       using (var client = new HttpClient() { BaseAddress = new Uri("http://localhost:7071/") })
+                       using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}/") })
                        {
                            (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
                            var response = await client.GetAsync("/api/http1?name=Test");
@@ -471,9 +467,10 @@ namespace Azure.Functions.Cli.Tests.E2E
                new RunConfiguration
                {
                    WaitForRunningHostState = true,
+                   HostProcessPort = _funcHostPort,
                    Commands = new[]
                    {
-                       "start"
+                       $"start --port {_funcHostPort}"
                    },
                    ExpectExit = false,
                    OutputContains = new[]
@@ -515,9 +512,10 @@ namespace Azure.Functions.Cli.Tests.E2E
                 new RunConfiguration
                 {
                     WaitForRunningHostState = true,
+                    HostProcessPort = _funcHostPort,
                     Commands = new[]
                     {
-                        "start"
+                        $"start --port {_funcHostPort}"
                     },
                     ExpectExit = false,
                     OutputContains = new []
@@ -564,9 +562,10 @@ namespace Azure.Functions.Cli.Tests.E2E
                new RunConfiguration
                {
                    WaitForRunningHostState = true,
+                   HostProcessPort = _funcHostPort,
                    Commands = new[]
                    {
-                       "start"
+                       $"start --port {_funcHostPort}"
                    },
                    ExpectExit = false,
                    OutputContains = new []
@@ -606,9 +605,10 @@ namespace Azure.Functions.Cli.Tests.E2E
                new RunConfiguration
                {
                    WaitForRunningHostState = true,
+                   HostProcessPort = _funcHostPort,
                    Commands = new[]
                    {
-                       "start"
+                       $"start --port {_funcHostPort}"
                    },
                    ExpectExit = false,
                    OutputContains = new []
@@ -648,9 +648,10 @@ namespace Azure.Functions.Cli.Tests.E2E
                new RunConfiguration
                {
                    WaitForRunningHostState = true,
+                   HostProcessPort = _funcHostPort,
                    Commands = new[]
                    {
-                       "start"
+                       $"start --port {_funcHostPort}"
                    },
                    ExpectExit = false,
                    OutputContains = new []
@@ -696,7 +697,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                {
                    Commands = new[]
                    {
-                       "start"
+                       $"start --port {_funcHostPort}"
                    },
                    ExpectExit = true,
                    ExitInError = true,
@@ -730,7 +731,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                {
                    Commands = new[]
                    {
-                       "start"
+                       $"start --port {_funcHostPort}"
                    },
                    ExpectExit = true,
                    ExitInError = true,
@@ -794,7 +795,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     },
                     Commands = new[]
                     {
-                        "start --functions http1 --" + language,
+                        $"start --functions http1 --{language} --port {_funcHostPort}",
                     },
                     ExpectExit = false,
                     OutputContains = new string[]
@@ -804,7 +805,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     CommandTimeout = TimeSpan.FromSeconds(300),
                     Test = async (workingDir, p, _) =>
                     {
-                        using (var client = new HttpClient() { BaseAddress = new Uri("http://localhost:7071/") })
+                        using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}/") })
                         {
                             (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
                             var response = await client.GetAsync("/api/http1?name=Test");
@@ -873,7 +874,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     },
                     Commands = new[]
                     {
-                        "start --functions http1 --csharp",
+                        $"start --functions http1 --csharp --port {_funcHostPort}",
                     },
                     CommandTimeout = TimeSpan.FromSeconds(300),
                     ExpectExit = true,
@@ -940,7 +941,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     },
                     Commands = new[]
                     {
-                        "start --functions http1 --csharp",
+                        $"start --functions http1 --csharp --port {_funcHostPort}",
                     },
                     ExpectExit = false,
                     OutputContains = new[]
@@ -950,7 +951,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     },
                     Test = async (workingDir, p, _) =>
                     {
-                        using (var client = new HttpClient() { BaseAddress = new Uri("http://localhost:7071/") })
+                        using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}/") })
                         {
                             (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
                             var response = await client.GetAsync("/api/http1?name=Test");
@@ -1015,7 +1016,7 @@ namespace Azure.Functions.Cli.Tests.E2E
 
         public async Task DisposeAsync()
         {
-            ProcessHelper.TryKillProcessForPort(_port.ToString());
+            ProcessHelper.TryKillProcessForPort(_funcHostPort);
             await Task.CompletedTask;
         }
     }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

Following up on PR feedback from my last [PR](https://github.com/Azure/azure-functions-core-tools/pull/3850), to address potential port issues:

https://github.com/Azure/azure-functions-core-tools/pull/3850#discussion_r1786874896