### PR TITLE
Support comments and int values of FUNCTIONS_INPROC_NET8_ENABLED

### DIFF
--- a/host/src/CoreToolsHost/LocalSettingsJsonParser.cs
+++ b/host/src/CoreToolsHost/LocalSettingsJsonParser.cs
@@ -23,7 +23,7 @@ namespace CoreToolsHost
                 }
                 if (!string.IsNullOrEmpty(fileContent))
                 {
-                    var localSettingsJObject = JsonDocument.Parse(fileContent);
+                    var localSettingsJObject = JsonDocument.Parse(fileContent, new JsonDocumentOptions { CommentHandling = JsonCommentHandling.Skip });
                     return localSettingsJObject;
                 }
             }

--- a/host/src/CoreToolsHost/Program.cs
+++ b/host/src/CoreToolsHost/Program.cs
@@ -47,11 +47,10 @@ namespace CoreToolsHost
 
         private static bool ElementExistsWithValue(JsonElement element, string key, string value)
         {
-
             return !string.IsNullOrEmpty(key) && !string.IsNullOrEmpty(value)
                 && element.TryGetProperty(key, out JsonElement property) 
-                && !string.IsNullOrEmpty(property.GetString()) 
-                && property.GetString() == value;
+                && !string.IsNullOrEmpty(property.ToString()) 
+                && property.ToString() == value;
         }
 
         private static void LoadHostAssembly(AppLoader appLoader, string[] args, bool isNet8InProc)


### PR DESCRIPTION
This addresses two known issues with the custom host version of the Core Tools.

Previous versions of the Core Tools tolerated JSON comments just fine, but the custom host would break on them. This PR adds tolerance for JSON comments.

It also appears that FUNCTIONS_INPROC_NET8_ENABLED could be set with an integer value rather than a string in previous versions. Although we document this as being a string, the system did not enforce this until the custom host version of the Core Tools. This PR removes that enforcement and re-allows integer values.

I've verified these through local testing.

These changes are connected to https://github.com/Azure/azure-functions-core-tools/issues/3856 and https://github.com/Azure/azure-functions-core-tools/issues/3864. It is not known at present if this is sufficient to resolve them. We are awaiting other known error cases to be reported with repro steps.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)