### PR TITLE
Fixing custom host string comparison

### DIFF
--- a/host/src/CoreToolsHost/Program.cs
+++ b/host/src/CoreToolsHost/Program.cs
@@ -50,7 +50,7 @@ namespace CoreToolsHost
             return !string.IsNullOrEmpty(key) && !string.IsNullOrEmpty(value)
                 && element.TryGetProperty(key, out JsonElement property) 
                 && !string.IsNullOrEmpty(property.ToString()) 
-                && property.ToString() == value;
+                && string.Equals(property.ToString(), value, StringComparison.OrdinalIgnoreCase);   
         }
 
         private static void LoadHostAssembly(AppLoader appLoader, string[] args, bool isNet8InProc)


### PR DESCRIPTION
Makes the string comparison tolerate different casing for FUNCTIONS_WORKER_RUNTIME

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)