### PR TITLE
Add commit-id to metadata.json

### DIFF
--- a/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateMetadataFile.ps1
+++ b/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateMetadataFile.ps1
@@ -16,11 +16,15 @@ $inProcVersion = (Get-ChildItem $stagingCoreToolsVisualStudio -Filter "*.zip" | 
 $releaseNumberFull = $env:RELEASE_RELEASENAME
 $releaseNumber = ($releaseNumberFull -replace '\D', '')
 
+# Get commit id
+$commitId = $env:BUILD_SOURCEVERSION
+
 # Create the JSON file
 $metadata = @{
     defaultArtifactVersion = $oopVersion
     inProcArtifactVersion = $inProcVersion
     consolidatedBuildId = $releaseNumber
+    commitId = $commitId
 }
 
 # Set the output path for the JSON file in the StagingDirectory


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Part of [#3826](https://github.com/Azure/azure-functions-core-tools/issues/3826)

We need the commit id when generating the release tag on GH for the core tools release so adding this as part of the metadata.json generated by the artifact assembler

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)