### PR TITLE
Update Chocolatey script for CDN download

### DIFF
--- a/publish-scripts/chocolatey/buildNUPKG.py
+++ b/publish-scripts/chocolatey/buildNUPKG.py
@@ -45,7 +45,7 @@ def preparePackage():
 
     for arch in archList:
         fileName = f"Azure.Functions.Cli.win-{arch.lower()}.{constants.VERSION}.zip"
-        url = f'https://functionscdn.azureedge.net/public/{constants.VERSION}/{fileName}'
+        url = f'https://functionscdn.azureedge.net/public/4.0.{constants.CONSOLIDATED_BUILD_ID}/{fileName}'
         substitutionMapping[f"ZIPURL_{arch}"] = url
 
         # download the zip

--- a/publish-scripts/driver.py
+++ b/publish-scripts/driver.py
@@ -10,7 +10,6 @@ def main(*args):
     # assume follow semantic versioning 2.0.0
     
     packageNamePostfix = ""
-    consolidatedBuildId = ""
     
     print(f"args: {args}  {len(args)}")
     if (len(args) >= 3):

--- a/publish-scripts/driver.py
+++ b/publish-scripts/driver.py
@@ -10,6 +10,7 @@ def main(*args):
     # assume follow semantic versioning 2.0.0
     
     packageNamePostfix = ""
+    consolidatedBuildId = ""
     
     print(f"args: {args}  {len(args)}")
     if (len(args) >= 3):
@@ -17,6 +18,10 @@ def main(*args):
     
     constants.PACKAGENAME = constants.PACKAGENAME + packageNamePostfix
     print(f"constants.PACKAGENAME: {constants.PACKAGENAME}")
+
+    constants.CONSOLIDATED_BUILD_ID = args[2]  # New argument for consolidatedBuildId
+    print(f"Consolidated Build ID: {constants.CONSOLIDATED_BUILD_ID}")  # Print the new argument
+
     constants.VERSION = args[1]
     constants.DRIVERROOTDIR = os.path.dirname(os.path.abspath(__file__))
     platformSystem = platform.system()


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Related to issue: https://github.com/Azure/azure-functions-core-tools/issues/3826

We need to update the driver.py script so that we download the correct version of the artifacts with the updated CDN link

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)