### PR TITLE
Add CLI artifact zipper

### DIFF
--- a/src/Azure.Functions.ArtifactAssembler/ArtifactAssembler.cs
+++ b/src/Azure.Functions.ArtifactAssembler/ArtifactAssembler.cs
@@ -140,7 +140,7 @@ namespace Azure.Functions.ArtifactAssembler
         // Example output: 4.0.6353
         private static string GetCoreToolsProductVersion(string artifactDirectoryName)
         {
-            var match = Regex.Match(artifactDirectoryName, Constants._coreToolsProductVersionPattern);
+            var match = Regex.Match(artifactDirectoryName, Constants.CoreToolsProductVersionPattern);
             if (match.Success)
             {
                 return match.Value;
@@ -167,7 +167,7 @@ namespace Azure.Functions.ArtifactAssembler
 
                 // Create a new directory to store the custom host with in-proc8 and in-proc6 files.
                 var artifactDirName = Path.GetFileName(inProc8ArtifactDirPath);
-                var consolidatedArtifactDirName = $"{artifactName}{Constants._InProcOutputArtifactNameSuffix}.{GetCoreToolsProductVersion(artifactDirName)}";
+                var consolidatedArtifactDirName = $"{artifactName}{Constants.InProcOutputArtifactNameSuffix}.{GetCoreToolsProductVersion(artifactDirName)}";
                 var consolidatedArtifactDirPath = Path.Combine(customHostTargetArtifactDir, consolidatedArtifactDirName);
                 Directory.CreateDirectory(consolidatedArtifactDirPath);
 
@@ -298,7 +298,7 @@ namespace Azure.Functions.ArtifactAssembler
 
         private string RenameInProcDirectory(string oldArtifactDirPath, string newVersion)
         {
-            Match match = Regex.Match(oldArtifactDirPath, Constants._artifactNameRegexPattern);
+            Match match = Regex.Match(oldArtifactDirPath, Constants.ArtifactNameRegexPattern);
 
             if (!match.Success)
             {

--- a/src/Azure.Functions.ArtifactAssembler/ArtifactAssembler.cs
+++ b/src/Azure.Functions.ArtifactAssembler/ArtifactAssembler.cs
@@ -7,17 +7,6 @@ namespace Azure.Functions.ArtifactAssembler
 {
     internal sealed class ArtifactAssembler
     {
-        private const string StagingDirName = "staging";
-        private const string InProc8DirectoryName = "in-proc8";
-        private const string InProc6DirectoryName = "in-proc6";
-        private const string CoreToolsHostDirectoryName = "host";
-        private const string VisualStudioOutputArtifactDirectoryName = "coretools-visualstudio";
-        private const string _InProcOutputArtifactNameSuffix = "_inproc";
-        private const string _coreToolsProductVersionPattern = @"(\d+\.\d+\.\d+)$";
-        private const string _artifactNameRegexPattern = @"^(.*?)(\d+\.\d+\.\d+)$";
-        private const string OutOfProcDirectoryName = "default";
-        private const string CliOutputArtifactDirectoryName = "coretools-cli";
-
         /// <summary>
         /// The artifacts for which we want to pack a custom host with it.
         /// This dictionary contains the artifact name and the corresponding runtime identifier value.
@@ -103,15 +92,15 @@ namespace Azure.Functions.ArtifactAssembler
             EnsureArtifactDirectoryExist(coreToolsHostArtifactDirPath);
             EnsureArtifactDirectoryExist(outOfProcArtifactDirPath);
 
-            _inProc6ExtractedRootDir = await MoveArtifactsToStagingDirectoryAndExtractIfNeeded(inProc6ArtifactDirPath, Path.Combine(_stagingDirectory, InProc6DirectoryName));
-            _inProc8ExtractedRootDir = await MoveArtifactsToStagingDirectoryAndExtractIfNeeded(inProc8ArtifactDirPath, Path.Combine(_stagingDirectory, InProc8DirectoryName));
+            _inProc6ExtractedRootDir = await MoveArtifactsToStagingDirectoryAndExtractIfNeeded(inProc6ArtifactDirPath, Path.Combine(_stagingDirectory, Constants.InProc6DirectoryName));
+            _inProc8ExtractedRootDir = await MoveArtifactsToStagingDirectoryAndExtractIfNeeded(inProc8ArtifactDirPath, Path.Combine(_stagingDirectory, Constants.InProc8DirectoryName));
 
             Directory.Delete(inProcArtifactDownloadDir, true);
 
-            _coreToolsHostExtractedRootDir = await MoveArtifactsToStagingDirectoryAndExtractIfNeeded(coreToolsHostArtifactDirPath, Path.Combine(_stagingDirectory, CoreToolsHostDirectoryName));
+            _coreToolsHostExtractedRootDir = await MoveArtifactsToStagingDirectoryAndExtractIfNeeded(coreToolsHostArtifactDirPath, Path.Combine(_stagingDirectory, Constants.CoreToolsHostDirectoryName));
             Directory.Delete(coreToolsHostArtifactDownloadDir, true);
 
-            _outOfProcExtractedRootDir = await MoveArtifactsToStagingDirectoryAndExtractIfNeeded(outOfProcArtifactDirPath, Path.Combine(_stagingDirectory, OutOfProcDirectoryName));
+            _outOfProcExtractedRootDir = await MoveArtifactsToStagingDirectoryAndExtractIfNeeded(outOfProcArtifactDirPath, Path.Combine(_stagingDirectory, Constants.OutOfProcDirectoryName));
             Directory.Delete(outOfProcArtifactDownloadDir, true);
         }
 
@@ -125,7 +114,7 @@ namespace Azure.Functions.ArtifactAssembler
 
         private static string CreateStagingDirectory(string rootWorkingDirectory)
         {
-            var stagingDirectory = Path.Combine(rootWorkingDirectory, StagingDirName);
+            var stagingDirectory = Path.Combine(rootWorkingDirectory, Constants.StagingDirName);
 
             if (Directory.Exists(stagingDirectory))
             {
@@ -151,7 +140,7 @@ namespace Azure.Functions.ArtifactAssembler
         // Example output: 4.0.6353
         private static string GetCoreToolsProductVersion(string artifactDirectoryName)
         {
-            var match = Regex.Match(artifactDirectoryName, _coreToolsProductVersionPattern);
+            var match = Regex.Match(artifactDirectoryName, Constants._coreToolsProductVersionPattern);
             if (match.Success)
             {
                 return match.Value;
@@ -164,7 +153,7 @@ namespace Azure.Functions.ArtifactAssembler
         {
             Console.WriteLine("Starting to assemble Visual Studio Core Tools artifacts");
             // Create a directory to store the assembled artifacts.
-            var customHostTargetArtifactDir = Path.Combine(_stagingDirectory, VisualStudioOutputArtifactDirectoryName);
+            var customHostTargetArtifactDir = Path.Combine(_stagingDirectory, Constants.VisualStudioOutputArtifactDirectoryName);
             Directory.CreateDirectory(customHostTargetArtifactDir);
 
             var packTasks = _customHostArtifacts.Keys.Select(async artifactName =>
@@ -178,17 +167,17 @@ namespace Azure.Functions.ArtifactAssembler
 
                 // Create a new directory to store the custom host with in-proc8 and in-proc6 files.
                 var artifactDirName = Path.GetFileName(inProc8ArtifactDirPath);
-                var consolidatedArtifactDirName = $"{artifactName}{_InProcOutputArtifactNameSuffix}.{GetCoreToolsProductVersion(artifactDirName)}";
+                var consolidatedArtifactDirName = $"{artifactName}{Constants._InProcOutputArtifactNameSuffix}.{GetCoreToolsProductVersion(artifactDirName)}";
                 var consolidatedArtifactDirPath = Path.Combine(customHostTargetArtifactDir, consolidatedArtifactDirName);
                 Directory.CreateDirectory(consolidatedArtifactDirPath);
 
                 // Copy in-proc8 files
-                var inProc8CopyTask = Task.Run(() => FileUtilities.CopyDirectory(inProc8ArtifactDirPath, Path.Combine(consolidatedArtifactDirPath, InProc8DirectoryName)));
+                var inProc8CopyTask = Task.Run(() => FileUtilities.CopyDirectory(inProc8ArtifactDirPath, Path.Combine(consolidatedArtifactDirPath, Constants.InProc8DirectoryName)));
 
                 // Copy in-proc6 files
                 var inProc6ArtifactDirPath = Path.Combine(_inProc6ExtractedRootDir, artifactDirName);
                 EnsureArtifactDirectoryExist(inProc6ArtifactDirPath);
-                var inProc6CopyTask = Task.Run(() => FileUtilities.CopyDirectory(inProc6ArtifactDirPath, Path.Combine(consolidatedArtifactDirPath, InProc6DirectoryName)));
+                var inProc6CopyTask = Task.Run(() => FileUtilities.CopyDirectory(inProc6ArtifactDirPath, Path.Combine(consolidatedArtifactDirPath, Constants.InProc6DirectoryName)));
 
                 // Copy core-tools-host files
                 var rid = GetRuntimeIdentifierForArtifactName(artifactName);
@@ -215,7 +204,7 @@ namespace Azure.Functions.ArtifactAssembler
             Console.WriteLine("Starting to assemble CLI Core Tools artifacts");
 
             // Create a directory to store the assembled artifacts.
-            var cliCoreToolsTargetArtifactDir = Path.Combine(_stagingDirectory, CliOutputArtifactDirectoryName);
+            var cliCoreToolsTargetArtifactDir = Path.Combine(_stagingDirectory, Constants.CliOutputArtifactDirectoryName);
             Directory.CreateDirectory(cliCoreToolsTargetArtifactDir);
             string outOfProcVersion = string.Empty,
                    inProcVersion = string.Empty,
@@ -271,7 +260,7 @@ namespace Azure.Functions.ArtifactAssembler
                 string newInProc8ArtifactDirPath = RenameInProcDirectory(inProc8ArtifactDirPath, outOfProcVersion);
 
                 // Copy in-proc8 files and delete old directory
-                await Task.Run(() => FileUtilities.CopyDirectory(newInProc8ArtifactDirPath, Path.Combine(consolidatedArtifactDirPath, InProc8DirectoryName)));
+                await Task.Run(() => FileUtilities.CopyDirectory(newInProc8ArtifactDirPath, Path.Combine(consolidatedArtifactDirPath, Constants.InProc8DirectoryName)));
                 Directory.Delete(newInProc8ArtifactDirPath, true);
 
                 // Rename inproc6 directory to have the same version as the out-of-proc artifact before copying
@@ -281,7 +270,7 @@ namespace Azure.Functions.ArtifactAssembler
                 string newInProc6ArtifactDirPath = RenameInProcDirectory(inProc6ArtifactDirPath, outOfProcVersion);
 
                 // Copy in-proc6 files and delete old directory
-                await Task.Run(() => FileUtilities.CopyDirectory(newInProc6ArtifactDirPath, Path.Combine(consolidatedArtifactDirPath, InProc6DirectoryName)));
+                await Task.Run(() => FileUtilities.CopyDirectory(newInProc6ArtifactDirPath, Path.Combine(consolidatedArtifactDirPath, Constants.InProc6DirectoryName)));
                 Directory.Delete(newInProc6ArtifactDirPath, true);
             }
 
@@ -309,7 +298,7 @@ namespace Azure.Functions.ArtifactAssembler
 
         private string RenameInProcDirectory(string oldArtifactDirPath, string newVersion)
         {
-            Match match = Regex.Match(oldArtifactDirPath, _artifactNameRegexPattern);
+            Match match = Regex.Match(oldArtifactDirPath, Constants._artifactNameRegexPattern);
 
             if (!match.Success)
             {

--- a/src/Azure.Functions.ArtifactAssembler/CliArtifactZipper.cs
+++ b/src/Azure.Functions.ArtifactAssembler/CliArtifactZipper.cs
@@ -12,6 +12,7 @@ namespace Azure.Functions.ArtifactAssembler
         {
             _rootWorkingDirectory = rootWorkingDirectory;
         }
+
         internal void ZipCliArtifacts()
         {
             string stagingDirectory = Path.Combine(_rootWorkingDirectory, Constants.StagingDirName, Constants.CliOutputArtifactDirectoryName);

--- a/src/Azure.Functions.ArtifactAssembler/CliArtifactZipper.cs
+++ b/src/Azure.Functions.ArtifactAssembler/CliArtifactZipper.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO.Compression;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Functions.ArtifactAssembler
+{
+    internal class CliArtifactZipper
+    {
+        private readonly string _rootWorkingDirectory;
+        public CliArtifactZipper(string rootWorkingDirectory)
+        {
+            _rootWorkingDirectory = rootWorkingDirectory;
+
+        }
+        internal void ZipCliArtifacts()
+        {
+            string stagingDirectory = Path.Combine(_rootWorkingDirectory, Constants.StagingDirName, Constants.CliOutputArtifactDirectoryName);
+
+            // Get all directories in the staging directory
+            var directories = Directory.GetDirectories(stagingDirectory);
+
+            foreach (var dir in directories)
+            {
+                string workersPath = Path.Combine(dir, "workers");
+
+                // Ensure 'workers' directory exists
+                if (!Directory.Exists(workersPath))
+                {
+                    Directory.CreateDirectory(workersPath);
+                    Console.WriteLine($"Created missing 'workers' directory in {dir}");
+                }
+                else
+                {
+                    Console.WriteLine($"'workers' directory already exists in {dir}");
+                }
+
+                // Add placeholder file if 'workers' directory is empty
+                if (Directory.GetFiles(workersPath).Length == 0 && Directory.GetDirectories(workersPath).Length == 0)
+                {
+                    File.WriteAllText(Path.Combine(workersPath, "placeholder.txt"), "Placeholder file");
+                    Console.WriteLine($"Created placeholder file in empty 'workers' directory in {dir}");
+                }
+                else
+                {
+                    Console.WriteLine($"'workers' directory is not empty in {dir}");
+                }
+
+                // Define zip file path and name
+                string zipFileName = $"{new DirectoryInfo(dir).Name}.zip";
+                string zipFilePath = Path.Combine(stagingDirectory, zipFileName);
+
+                // Compress directory into zip file
+                ZipFile.CreateFromDirectory(dir, zipFilePath, CompressionLevel.Optimal, includeBaseDirectory: false);
+                Console.WriteLine($"Zipped: {dir} -> {zipFilePath}");
+                
+
+                // Verify zip creation and delete original directory to free up space
+                if (File.Exists(zipFilePath))
+                {
+                    Console.WriteLine($"Successfully created zip: {zipFilePath}");
+                    Directory.Delete(dir, true);
+                    Console.WriteLine($"Deleted original directory: {dir}");
+                }
+                else
+                {
+                    Console.WriteLine($"Failed to create zip for: {dir}");
+                }
+            }
+
+            Console.WriteLine("All directories zipped successfully!");
+
+        }
+    }
+}

--- a/src/Azure.Functions.ArtifactAssembler/CliArtifactZipper.cs
+++ b/src/Azure.Functions.ArtifactAssembler/CliArtifactZipper.cs
@@ -1,20 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 using System.IO.Compression;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Azure.Functions.ArtifactAssembler
 {
-    internal class CliArtifactZipper
+    internal sealed class CliArtifactZipper
     {
         private readonly string _rootWorkingDirectory;
         public CliArtifactZipper(string rootWorkingDirectory)
         {
             _rootWorkingDirectory = rootWorkingDirectory;
-
         }
         internal void ZipCliArtifacts()
         {

--- a/src/Azure.Functions.ArtifactAssembler/CliArtifactZipper.cs
+++ b/src/Azure.Functions.ArtifactAssembler/CliArtifactZipper.cs
@@ -17,33 +17,12 @@ namespace Azure.Functions.ArtifactAssembler
             string stagingDirectory = Path.Combine(_rootWorkingDirectory, Constants.StagingDirName, Constants.CliOutputArtifactDirectoryName);
 
             // Get all directories in the staging directory
-            var directories = Directory.GetDirectories(stagingDirectory);
+            var directories = Directory.EnumerateDirectories(stagingDirectory);
 
             foreach (var dir in directories)
             {
-                string workersPath = Path.Combine(dir, "workers");
-
-                // Ensure 'workers' directory exists
-                if (!Directory.Exists(workersPath))
-                {
-                    Directory.CreateDirectory(workersPath);
-                    Console.WriteLine($"Created missing 'workers' directory in {dir}");
-                }
-                else
-                {
-                    Console.WriteLine($"'workers' directory already exists in {dir}");
-                }
-
-                // Add placeholder file if 'workers' directory is empty
-                if (Directory.GetFiles(workersPath).Length == 0 && Directory.GetDirectories(workersPath).Length == 0)
-                {
-                    File.WriteAllText(Path.Combine(workersPath, "placeholder.txt"), "Placeholder file");
-                    Console.WriteLine($"Created placeholder file in empty 'workers' directory in {dir}");
-                }
-                else
-                {
-                    Console.WriteLine($"'workers' directory is not empty in {dir}");
-                }
+                // Create worker directory if it doesn't already exist
+                CreateWorkerDirectoryIfDoesNotExist(dir);
 
                 // Define zip file path and name
                 string zipFileName = $"{new DirectoryInfo(dir).Name}.zip";
@@ -52,7 +31,6 @@ namespace Azure.Functions.ArtifactAssembler
                 // Compress directory into zip file
                 ZipFile.CreateFromDirectory(dir, zipFilePath, CompressionLevel.Optimal, includeBaseDirectory: false);
                 Console.WriteLine($"Zipped: {dir} -> {zipFilePath}");
-                
 
                 // Verify zip creation and delete original directory to free up space
                 if (File.Exists(zipFilePath))
@@ -68,7 +46,33 @@ namespace Azure.Functions.ArtifactAssembler
             }
 
             Console.WriteLine("All directories zipped successfully!");
+        }
 
+        internal void CreateWorkerDirectoryIfDoesNotExist(string dir)
+        {
+            string workersPath = Path.Combine(dir, "workers");
+
+            // Ensure 'workers' directory exists
+            if (!Directory.Exists(workersPath))
+            {
+                Directory.CreateDirectory(workersPath);
+                Console.WriteLine($"Created missing 'workers' directory in {dir}");
+            }
+            else
+            {
+                Console.WriteLine($"'workers' directory already exists in {dir}");
+            }
+
+            // Add placeholder file if 'workers' directory is empty
+            if (Directory.GetFiles(workersPath).Length == 0 && Directory.GetDirectories(workersPath).Length == 0)
+            {
+                File.WriteAllText(Path.Combine(workersPath, "placeholder.txt"), "Placeholder file");
+                Console.WriteLine($"Created placeholder file in empty 'workers' directory in {dir}");
+            }
+            else
+            {
+                Console.WriteLine($"'workers' directory is not empty in {dir}");
+            }
         }
     }
 }

--- a/src/Azure.Functions.ArtifactAssembler/Constants.cs
+++ b/src/Azure.Functions.ArtifactAssembler/Constants.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Functions.ArtifactAssembler
+{
+    internal static class Constants
+    {
+        internal const string StagingDirName = "staging";
+        internal const string InProc8DirectoryName = "in-proc8";
+        internal const string InProc6DirectoryName = "in-proc6";
+        internal const string CoreToolsHostDirectoryName = "host";
+        internal const string VisualStudioOutputArtifactDirectoryName = "coretools-visualstudio";
+        internal const string _InProcOutputArtifactNameSuffix = "_inproc";
+        internal const string _coreToolsProductVersionPattern = @"(\d+\.\d+\.\d+)$";
+        internal const string _artifactNameRegexPattern = @"^(.*?)(\d+\.\d+\.\d+)$";
+        internal const string OutOfProcDirectoryName = "default";
+        internal const string CliOutputArtifactDirectoryName = "coretools-cli";
+    }
+}

--- a/src/Azure.Functions.ArtifactAssembler/Constants.cs
+++ b/src/Azure.Functions.ArtifactAssembler/Constants.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
 
 namespace Azure.Functions.ArtifactAssembler
 {
@@ -13,9 +10,9 @@ namespace Azure.Functions.ArtifactAssembler
         internal const string InProc6DirectoryName = "in-proc6";
         internal const string CoreToolsHostDirectoryName = "host";
         internal const string VisualStudioOutputArtifactDirectoryName = "coretools-visualstudio";
-        internal const string _InProcOutputArtifactNameSuffix = "_inproc";
-        internal const string _coreToolsProductVersionPattern = @"(\d+\.\d+\.\d+)$";
-        internal const string _artifactNameRegexPattern = @"^(.*?)(\d+\.\d+\.\d+)$";
+        internal const string InProcOutputArtifactNameSuffix = "_inproc";
+        internal const string CoreToolsProductVersionPattern = @"(\d+\.\d+\.\d+)$";
+        internal const string ArtifactNameRegexPattern = @"^(.*?)(\d+\.\d+\.\d+)$";
         internal const string OutOfProcDirectoryName = "default";
         internal const string CliOutputArtifactDirectoryName = "coretools-cli";
     }

--- a/src/Azure.Functions.ArtifactAssembler/Program.cs
+++ b/src/Azure.Functions.ArtifactAssembler/Program.cs
@@ -10,8 +10,18 @@ namespace Azure.Functions.ArtifactAssembler
             try
             {
                 var currentWorkingDirectory = Environment.CurrentDirectory;
-                var artifactAssembler = new ArtifactAssembler(currentWorkingDirectory);
-                await artifactAssembler.AssembleArtifactsAsync();
+
+                // Check if an argument for zipping is passed
+                if (args.Length > 0 && args[0].Equals("zip", StringComparison.OrdinalIgnoreCase))
+                {
+                    var zipCliArtifacts = new CliArtifactZipper(currentWorkingDirectory);
+                    zipCliArtifacts.ZipCliArtifacts();
+                }
+                else
+                {
+                    var artifactAssembler = new ArtifactAssembler(currentWorkingDirectory);
+                    await artifactAssembler.AssembleArtifactsAsync();
+                }
 
                 return 0;
             }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Related to issue: https://github.com/Azure/azure-functions-core-tools/issues/3826

I added the cli artifact zipper to the artifact assembler project, since homebrew fails for linux and mac with zipping through powershell. I tested this out by having homebrew consume a zip file that I uploaded to a blob storage account after running the zip script locally and saw that installation worked as expected.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)