### PR TITLE
When local.settings.json is absent, runnig func host start does not work for newer worker models #3544 (Refreshed Branch Changes)

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -728,6 +728,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 : null;
             return (new Uri($"{protocol}://0.0.0.0:{Port}"), new Uri($"{protocol}://localhost:{Port}"), cert);
         }
+
         private void EnsureWorkerRuntimeIsSet()
         {
             var workerRuntimeSettingValue = _secretsManager.GetSecrets().FirstOrDefault(s => s.Key.Equals(Constants.FunctionsWorkerRuntime, StringComparison.OrdinalIgnoreCase)).Value;
@@ -735,6 +736,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
             {
                 return;
             }
+
             if (GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone == WorkerRuntime.None)
             {
                 SelectionMenuHelper.DisplaySelectionWizardPrompt("worker runtime");

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -585,6 +585,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
 
         private async Task PreRunConditions()
         {
+            EnsureWorkerRuntimeIsSet();
             if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.python)
             {
                 var pythonVersion = await PythonHelpers.GetEnvironmentPythonVersion();
@@ -726,6 +727,25 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 ? await SecurityHelpers.GetOrCreateCertificate(CertPath, CertPassword)
                 : null;
             return (new Uri($"{protocol}://0.0.0.0:{Port}"), new Uri($"{protocol}://localhost:{Port}"), cert);
+        }
+        private void EnsureWorkerRuntimeIsSet()
+        {
+            var workerRuntimeSettingValue = _secretsManager.GetSecrets().FirstOrDefault(s => s.Key.Equals(Constants.FunctionsWorkerRuntime, StringComparison.OrdinalIgnoreCase)).Value;
+            if (workerRuntimeSettingValue is not null)
+            {
+                return;
+            }
+            if (GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone == WorkerRuntime.None)
+            {
+                SelectionMenuHelper.DisplaySelectionWizardPrompt("worker runtime");
+                IDictionary<WorkerRuntime, string> workerRuntimeToDisplayString = WorkerRuntimeLanguageHelper.GetWorkerToDisplayStrings();
+                string workerRuntimeDisplay = SelectionMenuHelper.DisplaySelectionWizard(workerRuntimeToDisplayString.Values);
+                GlobalCoreToolsSettings.CurrentWorkerRuntime = workerRuntimeToDisplayString.FirstOrDefault(wr => wr.Value.Equals(workerRuntimeDisplay)).Key;
+            }
+
+            var workerRuntime = WorkerRuntimeLanguageHelper.GetRuntimeMoniker(GlobalCoreToolsSettings.CurrentWorkerRuntime);
+            _secretsManager.SetSecret(Constants.FunctionsWorkerRuntime, workerRuntime);
+            ColoredConsole.WriteLine(WarningColor($"'{workerRuntime}' has been set in your local.settings.json"));
         }
     }
 }

--- a/src/Azure.Functions.Cli/Helpers/GlobalCoreToolsSettings.cs
+++ b/src/Azure.Functions.Cli/Helpers/GlobalCoreToolsSettings.cs
@@ -23,6 +23,10 @@ namespace Azure.Functions.Cli.Helpers
                 }
                 return _currentWorkerRuntime;
             }
+            set
+            {
+                _currentWorkerRuntime = value;
+            }
         }
 
         public static WorkerRuntime CurrentWorkerRuntimeOrNone

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -1008,7 +1008,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                         "Functions:",
                         $"HttpTriggerFunc: [GET,POST] http://localhost:{_funcHostPort}/api/HttpTriggerFunc"
                     },
-                OutputDoesntContain = new string[]
+                    OutputDoesntContain = new string[]
                     {
                         "Initializing function HTTP routes"
                     },
@@ -1026,89 +1026,91 @@ namespace Azure.Functions.Cli.Tests.E2E
                 }
             }, _output);
         }
+
         [Fact]
         public async Task Start_MissingLocalSettingsJson_Runtime_None_HandledAsExpected()
         {
             await CliTester.Run(new RunConfiguration[]
             {
-         new RunConfiguration
-         {
-             Commands = new[]
-             {
-                 $"init . --worker-runtime dotnet",
-                 $"new --template Httptrigger --name HttpTriggerFunc",
-             },
-             CommandTimeout = TimeSpan.FromSeconds(300),
-         },
-         new RunConfiguration
-         {
-             PreTest = (workingDir) =>
-             {
-                var LocalSettingsJson = Path.Combine(workingDir, "local.settings.json");
-                 File.Delete(LocalSettingsJson);
-             },
-             Commands = new[]
-             {
-                 $"start --worker-runtime None --port {_funcHostPort}",
-             },
-             ExpectExit = false,
-             OutputContains = new[]
-             {
-                 $"Use the up/down arrow keys to select a worker runtime:"
-             },
-         OutputDoesntContain = new string[]
-             {
-                 "Initializing function HTTP routes"
-             },
-             Test = async (_, p,_) =>
-             {
-                     await Task.Delay(TimeSpan.FromSeconds(2));
-                     p.Kill();
-             }
-         }
+                 new RunConfiguration
+                 {
+                     Commands = new[]
+                     {
+                         $"init . --worker-runtime dotnet",
+                         $"new --template Httptrigger --name HttpTriggerFunc",
+                     },
+                     CommandTimeout = TimeSpan.FromSeconds(300),
+                 },
+                 new RunConfiguration
+                 {
+                     PreTest = (workingDir) =>
+                     {
+                        var LocalSettingsJson = Path.Combine(workingDir, "local.settings.json");
+                         File.Delete(LocalSettingsJson);
+                     },
+                     Commands = new[]
+                     {
+                         $"start --worker-runtime None --port {_funcHostPort}",
+                     },
+                     ExpectExit = false,
+                     OutputContains = new[]
+                     {
+                         $"Use the up/down arrow keys to select a worker runtime:"
+                     },
+                     OutputDoesntContain = new string[]
+                     {
+                         "Initializing function HTTP routes"
+                     },
+                     Test = async (_, p,_) =>
+                     {
+                             await Task.Delay(TimeSpan.FromSeconds(2));
+                             p.Kill();
+                     }
+                 }
             }, _output);
 
         }
+
         [Fact]
         public async Task Start_MissingLocalSettingsJson_Runtime_NotProvided_HandledAsExpected()
         {
             await CliTester.Run(new RunConfiguration[]
             {
-         new RunConfiguration
-         {
-             Commands = new[]
-             {
-                 $"init . --worker-runtime dotnet",
-                 $"new --template Httptrigger --name HttpTriggerFunc",
-             },
-             CommandTimeout = TimeSpan.FromSeconds(300),
-         },
-         new RunConfiguration
-         {
-             PreTest = (workingDir) =>
-             {
-                var LocalSettingsJson = Path.Combine(workingDir, "local.settings.json");
-                 File.Delete(LocalSettingsJson);
-             },
-             Commands = new[]
-             {
-                 $"start --port {_funcHostPort}",
-             },
-             ExpectExit = false,
-             OutputContains = new[]
-             {
-                 $"Use the up/down arrow keys to select a worker runtime:"
-             },
-         OutputDoesntContain = new string[]
-             {
-                 "Initializing function HTTP routes"
-             },
-             Test = async (_, p,_) =>
-             {
-                     await Task.Delay(TimeSpan.FromSeconds(2));
-                     p.Kill();
-             }
-         }
+                 new RunConfiguration
+                 {
+                     Commands = new[]
+                     {
+                         $"init . --worker-runtime dotnet",
+                         $"new --template Httptrigger --name HttpTriggerFunc",
+                     },
+                     CommandTimeout = TimeSpan.FromSeconds(300),
+                 },
+                 new RunConfiguration
+                 {
+                     PreTest = (workingDir) =>
+                     {
+                        var LocalSettingsJson = Path.Combine(workingDir, "local.settings.json");
+                         File.Delete(LocalSettingsJson);
+                     },
+                     Commands = new[]
+                     {
+                         $"start --port {_funcHostPort}",
+                     },
+                     ExpectExit = false,
+                     OutputContains = new[]
+                     {
+                         $"Use the up/down arrow keys to select a worker runtime:"
+                     },
+                     OutputDoesntContain = new string[]
+                     {
+                         "Initializing function HTTP routes"
+                     },
+                     Test = async (_, p,_) =>
+                     {
+                             await Task.Delay(TimeSpan.FromSeconds(2));
+                             p.Kill();
+                     }
+                 }
             }, _output);
 
         }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
-> when local.settings.json is absent.
Scenario1: running 'func host start' will Display Available WorkerRuntime on the screen and user can select the Runtime from the list so the FUNCTION_WORKER_RUNTIME setting is added and start hosting the function app
Scenario2: running 'func host start --{WorkerRuntime}' will add FUNCTION_WORKER_RUNTIME setting and start hosting the function app.
resolves #3544 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)