### PR TITLE
Updated authlevel in python HTTP template to upper case

### DIFF
--- a/src/Azure.Functions.Cli/Actions/LocalActions/CreateFunctionAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/CreateFunctionAction.cs
@@ -157,7 +157,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                     }
                 }
 
-                var providedInputs = new Dictionary<string, string>() { { GetFunctionNameParamId, FunctionName }, { HttpTriggerAuthLevelParamId, AuthorizationLevel?.ToString().ToUpper() } };
+                var providedInputs = new Dictionary<string, string>() { { GetFunctionNameParamId, FunctionName }, { HttpTriggerAuthLevelParamId, AuthorizationLevel?.ToString().ToUpperInvariant() } };
                 var jobName = "appendToFile";
                 if (FileName != PySteinFunctionAppPy)
                 {

--- a/src/Azure.Functions.Cli/Actions/LocalActions/CreateFunctionAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/CreateFunctionAction.cs
@@ -157,7 +157,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                     }
                 }
 
-                var providedInputs = new Dictionary<string, string>() { { GetFunctionNameParamId, FunctionName }, { HttpTriggerAuthLevelParamId, AuthorizationLevel?.ToString() } };
+                var providedInputs = new Dictionary<string, string>() { { GetFunctionNameParamId, FunctionName }, { HttpTriggerAuthLevelParamId, AuthorizationLevel?.ToString().ToUpper() } };
                 var jobName = "appendToFile";
                 if (FileName != PySteinFunctionAppPy)
                 {


### PR DESCRIPTION
### Issue describing the changes in this PR

Fixes [#3779](https://github.com/Azure/azure-functions-core-tools/issues/3779)

The technical cause of the issue was that value of the '--authlevel' param from the user is first being converted to an AuthorizationLevel enum from the Microsoft.Azure.WebJobs.Extensions.Http package, representing the C# programming model strings.

In the C# programming model, authorization level strings only capitalise the first letter.
In the Python programming model, authorization level strings are entirely upper-case.

Since we are using C# enums, we need to manually convert them to upper-case when making them strings for Python templates.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)