### PR TITLE
Fix linux package pipeline

### DIFF
--- a/eng/ci/linux-build.yml
+++ b/eng/ci/linux-build.yml
@@ -6,6 +6,7 @@ trigger:
   branches:
     include:
     - v4.x
+    - feature/oop-host
 
 resources:
   repositories:

--- a/eng/ci/templates/official/jobs/linux-package.yml
+++ b/eng/ci/templates/official/jobs/linux-package.yml
@@ -17,7 +17,7 @@ jobs:
         python3 -m venv publish-env
         source publish-env/bin/activate
         pip install -r requirements.txt
-        apt-get install fakeroot
+        sudo apt-get install fakeroot
         major_version=$(echo "$linuxBuildNumber" | cut -d'.' -f1)
         sudo python driver.py "$linuxBuildNumber" "$consolidatedBuildId" "$major_version"
         sudo python driver.py "$linuxBuildNumber" "$consolidatedBuildId"

--- a/eng/ci/templates/official/jobs/linux-package.yml
+++ b/eng/ci/templates/official/jobs/linux-package.yml
@@ -16,7 +16,10 @@ jobs:
         cd publish-scripts
         python3 -m venv publish-env
         source publish-env/bin/activate
+
         pip install -r requirements.txt
+        pip install wget
+        
         sudo apt-get install fakeroot
         major_version=$(echo "$linuxBuildNumber" | cut -d'.' -f1)
         sudo python driver.py "$linuxBuildNumber" "$consolidatedBuildId" "$major_version"

--- a/eng/ci/templates/official/jobs/linux-package.yml
+++ b/eng/ci/templates/official/jobs/linux-package.yml
@@ -19,11 +19,11 @@ jobs:
 
         pip install -r requirements.txt
         pip install wget
-        
+
         sudo apt-get install fakeroot
         major_version=$(echo "$linuxBuildNumber" | cut -d'.' -f1)
-        sudo python driver.py "$linuxBuildNumber" "$consolidatedBuildId" "$major_version"
-        sudo python driver.py "$linuxBuildNumber" "$consolidatedBuildId"
+        python driver.py "$linuxBuildNumber" "$consolidatedBuildId" "$major_version"
+        python driver.py "$linuxBuildNumber" "$consolidatedBuildId"
         export DEB_PACKAGE="$(readlink -f artifact/*$RELEASE_VERSION*)"
         echo "${DEB_PACKAGE}"
       bashEnvValue: '~/.profile'  # Set value for BASH_ENV environment variable

--- a/eng/ci/templates/official/jobs/linux-package.yml
+++ b/eng/ci/templates/official/jobs/linux-package.yml
@@ -19,13 +19,14 @@ jobs:
         pip install -r requirements.txt
         apt-get install fakeroot
         major_version=$(echo "$linuxBuildNumber" | cut -d'.' -f1)
-        python driver.py "$linuxBuildNumber" "$consolidatedBuildId" "$major_version"
-        python driver.py "$linuxBuildNumber" "$consolidatedBuildId"
+        sudo python driver.py "$linuxBuildNumber" "$consolidatedBuildId" "$major_version"
+        sudo python driver.py "$linuxBuildNumber" "$consolidatedBuildId"
         export DEB_PACKAGE="$(readlink -f artifact/*$RELEASE_VERSION*)"
         echo "${DEB_PACKAGE}"
       bashEnvValue: '~/.profile'  # Set value for BASH_ENV environment variable
     env:
-      linuxBuildNumber: $(LinuxPackageBuildTag)      
+      linuxBuildNumber: $(LinuxPackageBuildTag)
+      consolidatedBuildId: $(ConsolidatedBuildId)      
   - pwsh: |
       echo $env:LinuxPackageAccountName
       $majorVersion = [math]::Floor([double]$env:LinuxPackageBuildTag.Split(".")[0])

--- a/eng/ci/templates/official/jobs/linux-package.yml
+++ b/eng/ci/templates/official/jobs/linux-package.yml
@@ -1,6 +1,6 @@
 jobs:
 - job: LinuxPackage
-  condition: ne(variables['LinuxPackageBuildTag'], '')
+  condition: and(ne(variables['LinuxPackageBuildTag'], ''), ne(variables['ConsolidatedBuildId'], ''))
   timeoutInMinutes: "120"
   pool:
     name: 1es-pool-azfunc
@@ -19,8 +19,8 @@ jobs:
         pip install -r requirements.txt
         apt-get install fakeroot
         major_version=$(echo "$linuxBuildNumber" | cut -d'.' -f1)
-        python driver.py "$linuxBuildNumber" "$major_version"
-        python driver.py "$linuxBuildNumber"
+        python driver.py "$linuxBuildNumber" "$consolidatedBuildId" "$major_version"
+        python driver.py "$linuxBuildNumber" "$consolidatedBuildId"
         export DEB_PACKAGE="$(readlink -f artifact/*$RELEASE_VERSION*)"
         echo "${DEB_PACKAGE}"
       bashEnvValue: '~/.profile'  # Set value for BASH_ENV environment variable

--- a/publish-scripts/driver.py
+++ b/publish-scripts/driver.py
@@ -13,7 +13,7 @@ def main(*args):
     
     print(f"args: {args}  {len(args)}")
     if (len(args) >= 4):
-        packageNamePostfix = "-" + args[2]
+        packageNamePostfix = "-" + args[3]
     
     constants.PACKAGENAME = constants.PACKAGENAME + packageNamePostfix
     print(f"constants.PACKAGENAME: {constants.PACKAGENAME}")

--- a/publish-scripts/shared/helper.py
+++ b/publish-scripts/shared/helper.py
@@ -58,7 +58,7 @@ def linuxOutput(buildFolder):
 
     # ubuntu dropped 64, fedora supports both
     fileName = f"Azure.Functions.Cli.linux-x64.{constants.VERSION}.zip"
-    url = f'https://functionscdn.azureedge.net/public/{constants.VERSION}/{fileName}'
+    url = f'https://functionscdn.azureedge.net/public/4.0.{constants.CONSOLIDATED_BUILD_ID}/{fileName}'
 
     # download the zip
     # output to local folder


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Part of issue [#3826](https://github.com/Azure/azure-functions-core-tools/issues/3826)

This PR fixes the linux package pipeline by adding the `feature/oop-host` branch to the `trigger:` in the `linux-build.yml` file and corrects the CDN link. The runner of the pipeline now has to update the `ConsolidatedBuildId` variable manually when running the pipeline, but this will create the linux packages that are needed for the APT step.

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)