### PR TITLE
Add env var check for worker runtime in StartHostAction

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -737,7 +737,13 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 return;
             }
 
-            if (GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone == WorkerRuntime.None)
+            var environmentRuntimeSettingValue = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime);
+            if (environmentRuntimeSettingValue is not null)
+            {
+                GlobalCoreToolsSettings.CurrentWorkerRuntime = WorkerRuntimeLanguageHelper.NormalizeWorkerRuntime(environmentRuntimeSettingValue);
+            }
+
+            else if (GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone == WorkerRuntime.None)
             {
                 SelectionMenuHelper.DisplaySelectionWizardPrompt("worker runtime");
                 IDictionary<WorkerRuntime, string> workerRuntimeToDisplayString = WorkerRuntimeLanguageHelper.GetWorkerToDisplayStrings();


### PR DESCRIPTION
Adds a check to StartHostAction to use the environment variable "FUNCTIONS_WORKER_RUNTIME" if available, before displaying the Wizard Prompt. 

This enables setting the runtime through environment variables as was the case in the past.

### Issue describing the changes in this PR

resolves #4193

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

~~Note: I was unable to run or write unit tests and only validated manually by running the tool against a function with/without environment variables set:
https://github.com/Azure/azure-functions-core-tools/blob/v4.x/CONTRIBUTING.md#running-the-test-suite~~

I was able to run the tests and added a unit test. It would be helpful if the link above was updated.