### PR TITLE
Adding additional command line param of sync-access-token

### DIFF
--- a/src/Azure.Functions.Cli/Actions/AzureActions/BaseAzureAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/BaseAzureAction.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
-using Azure.Functions.Cli.Arm;
 using Azure.Functions.Cli.Common;
 using static Azure.Functions.Cli.Common.OutputTheme;
 using Azure.Functions.Cli.Interfaces;
@@ -11,9 +9,6 @@ using Colors.Net;
 using Fclp;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using static Colors.Net.StringStaticMethods;
-using Azure.Functions.Cli.Helpers;
-using Microsoft.Identity.Client;
 
 namespace Azure.Functions.Cli.Actions.AzureActions
 {

--- a/src/Azure.Functions.Cli/Actions/AzureActions/BaseAzureAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/BaseAzureAction.cs
@@ -13,6 +13,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using static Colors.Net.StringStaticMethods;
 using Azure.Functions.Cli.Helpers;
+using Microsoft.Identity.Client;
 
 namespace Azure.Functions.Cli.Actions.AzureActions
 {
@@ -33,6 +34,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
         private const string _defaultManagementURL = Constants.DefaultManagementURL;
 
         public string AccessToken { get; set; }
+        public string SyncAccessToken { get; set; }
         public bool ReadStdin { get; set; }
         public string ManagementURL { get; set; }
         public string Subscription { get; private set; }
@@ -43,6 +45,10 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 .Setup<string>("access-token")
                 .WithDescription("Access token to use for performing authenticated azure actions")
                 .Callback(t => AccessToken = t);
+            Parser
+                .Setup<string>("sync-access-token")
+                .WithDescription("Access token to use for performing trigger sync azure action (if different to normal)")
+                .Callback(t => SyncAccessToken = t);
             Parser
                 .Setup<bool>("access-token-stdin")
                 .WithDescription("Read access token from stdin e.g: az account get-access-token | func ... --access-token-stdin")

--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -648,7 +648,11 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 ColoredConsole.WriteLine(GetLogMessage("Syncing triggers..."));
                 HttpResponseMessage response = null;
                 // This SyncTriggers function calls the endpoint for linux syncTriggers
-                response = await AzureHelper.SyncTriggers(functionApp, AccessToken, ManagementURL);
+                if (string.IsNullOrEmpty(SyncAccessToken))
+                {
+                    SyncAccessToken = AccessToken;
+                }
+                response = await AzureHelper.SyncTriggers(functionApp, SyncAccessToken, ManagementURL);
                 if (!response.IsSuccessStatusCode)
                 {
                     var errorMessage = $"Error calling sync triggers ({response.StatusCode}). ";


### PR DESCRIPTION
### Issue describing the changes in this PR

Related to the issue linked below, adds the ability to pass a different access token to be used for the sync triggers call.

resolves #4196

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)