### PR TITLE
#3776 - Latest version reports it is old

### DIFF
--- a/publish-scripts/chocolatey/installps_template
+++ b/publish-scripts/chocolatey/installps_template
@@ -40,7 +40,7 @@ $packageArgs = @{
 Install-ChocolateyZipPackage @packageArgs
 
 # only symlink for func.exe
-$files = Get-ChildItem $toolsDir -include *.exe -recurse
+$files = Get-ChildItem $toolsDir -include *.exe
 foreach ($file in $files) {
   if (!$file.Name.Equals("func.exe")) {
     #generate an ignore file


### PR DESCRIPTION
### Issue describing the changes in this PR
when we install Azure Function Core Tool via chocolatey, the shim is generating twice as we have 3.exe files (in root folder inproc6 and inproc8 folder). we have removed -recurse from installation script as its looking into subfolders(inproc6, inproc8) for the .exe file. 
resolves #3776 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)