### PR TITLE
Update pipeline references from v4.x to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 |---|---|
 |main|[![Build status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/azure-functions-core-tools?branchName=main)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=11&branchName=main)|
 |in-proc|[![Build status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/azure-functions-core-tools?branchName=in-proc)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=11&branchName=in-proc)|
-|v3.x|[![Build status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/azure-functions-core-tools?branchName=v3.x)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=11&branchName=v3.x)|
-|dev|[![Build Status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/azure-functions-core-tools?branchName=dev)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=11&branchName=dev)
 |v1.x|[![Build status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/azure-functions-core-tools?branchName=v1.x)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=11&branchName=v1.x)|
 
 # Azure Functions Core Tools
@@ -15,10 +13,6 @@ The Azure Functions Core Tools provide a local development experience for creati
 ## Versions
 
 **v1** (v1.x branch): Requires .NET 4.7.1 Windows Only
-
-**v2** (dev branch): Self-contained cross-platform package
-
-**v3**: (v3.x branch): Self-contained cross-platform package
 
 **v4**: (main branch): Self-contained cross-platform package **(recommended)**
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 |Branch|Status|
 |---|---|
-|v4.x|[![Build status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/azure-functions-core-tools?branchName=v4.x)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=11&branchName=v4.x)|
+|main|[![Build status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/azure-functions-core-tools?branchName=main)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=11&branchName=main)|
 |v3.x|[![Build status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/azure-functions-core-tools?branchName=v3.x)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=11&branchName=v3.x)|
 |dev|[![Build Status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/azure-functions-core-tools?branchName=dev)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=11&branchName=dev)
 |v1.x|[![Build status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/azure-functions-core-tools?branchName=v1.x)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=11&branchName=v1.x)|
@@ -19,7 +19,7 @@ The Azure Functions Core Tools provide a local development experience for creati
 
 **v3**: (v3.x branch): Self-contained cross-platform package
 
-**v4**: (v4.x branch): Self-contained cross-platform package **(recommended)**
+**v4**: (main branch): Self-contained cross-platform package **(recommended)**
 
 ## Installing
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 |Branch|Status|
 |---|---|
 |main|[![Build status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/azure-functions-core-tools?branchName=main)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=11&branchName=main)|
+|in-proc|[![Build status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/azure-functions-core-tools?branchName=in-proc)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=11&branchName=in-proc)|
 |v3.x|[![Build status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/azure-functions-core-tools?branchName=v3.x)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=11&branchName=v3.x)|
 |dev|[![Build Status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/azure-functions-core-tools?branchName=dev)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=11&branchName=dev)
 |v1.x|[![Build status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/azure-functions-core-tools?branchName=v1.x)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=11&branchName=v1.x)|

--- a/code-mirror.yml
+++ b/code-mirror.yml
@@ -3,12 +3,12 @@ trigger:
     include:
     # Below branches are examples for Azure/azure-functions-host. Replace with appropriate branches for your repository.
     # Keep this set limited as appropriate (don't mirror individual user branches).
-    - v4.x
     - v3.x
     - release_4.0
     - release_3.0
     - release_4.0_hotfix
-    - feature/*
+    - main
+    - in-proc
 
 resources:
   repositories:

--- a/code-mirror.yml
+++ b/code-mirror.yml
@@ -8,6 +8,7 @@ trigger:
     - release_3.0
     - release_4.0_hotfix
     - main
+    - in-proc
 
 resources:
   repositories:

--- a/code-mirror.yml
+++ b/code-mirror.yml
@@ -8,7 +8,6 @@ trigger:
     - release_3.0
     - release_4.0_hotfix
     - main
-    - in-proc
 
 resources:
   repositories:

--- a/eng/ci/build-core-tools-host-artifacts-windows.yml
+++ b/eng/ci/build-core-tools-host-artifacts-windows.yml
@@ -3,7 +3,7 @@ pr: none
 trigger:
   branches:
     include:
-    - feature/oop-host
+    - main
   paths:
     include:
       - /host/src/**

--- a/eng/ci/linux-build.yml
+++ b/eng/ci/linux-build.yml
@@ -5,8 +5,7 @@ pr: none
 trigger:
   branches:
     include:
-    - v4.x
-    - feature/oop-host
+    - main
 
 resources:
   repositories:

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -3,7 +3,7 @@ schedules:
   displayName: Nightly Build
   branches:
     include:
-      - v4.x
+      - main
   always: true
 
 name: $(Build.SourceBranchName)_$(Build.Reason)
@@ -13,9 +13,9 @@ pr: none
 trigger:
   branches:
     include:
-    - v4.x
     - release_4.0
-    - feature/*
+    - main
+    - in-proc
 
 resources:
   repositories:

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -15,7 +15,6 @@ trigger:
     include:
     - release_4.0
     - main
-    - in-proc
 
 resources:
   repositories:

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -15,6 +15,7 @@ trigger:
     include:
     - release_4.0
     - main
+    - in-proc
 
 resources:
   repositories:

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -13,7 +13,6 @@ pr:
     include:
     - release_4.0
     - main
-    - in-proc
 
 trigger:
   batch: true
@@ -21,7 +20,6 @@ trigger:
     include:
     - release_4.0
     - main
-    - in-proc
 
 resources:
   repositories:

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -3,7 +3,7 @@ schedules:
   displayName: Nightly Build
   branches:
     include:
-      - v4.x
+      - main
   always: true
 
 name: $(Build.SourceBranchName)_$(Build.Reason)
@@ -11,17 +11,17 @@ name: $(Build.SourceBranchName)_$(Build.Reason)
 pr:
   branches:
     include:
-    - v4.x
     - release_4.0
-    - feature/*
+    - main
+    - in-proc
 
 trigger:
   batch: true
   branches:
     include:
-    - v4.x
     - release_4.0
-    - feature/*
+    - main
+    - in-proc
 
 resources:
   repositories:

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -13,6 +13,7 @@ pr:
     include:
     - release_4.0
     - main
+    - in-proc
 
 trigger:
   batch: true
@@ -20,6 +21,7 @@ trigger:
     include:
     - release_4.0
     - main
+    - in-proc
 
 resources:
   repositories:


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

This PR updates the pipeline references from `v4.x` to `main` in the Azure Functions Core Tools repository to let the pipelines build the default host.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)