### PR TITLE
Latest version reports it is old (Target: main)

### DIFF
--- a/publish-scripts/chocolatey/installps_template
+++ b/publish-scripts/chocolatey/installps_template
@@ -40,7 +40,7 @@ $packageArgs = @{
 Install-ChocolateyZipPackage @packageArgs
 
 # only symlink for func.exe
-$files = Get-ChildItem $toolsDir -include *.exe -recurse
+$files = Get-ChildItem $toolsDir -include *.exe 
 foreach ($file in $files) {
   if (!$file.Name.Equals("func.exe")) {
     #generate an ignore file

--- a/publish-scripts/chocolatey/installps_template
+++ b/publish-scripts/chocolatey/installps_template
@@ -40,11 +40,12 @@ $packageArgs = @{
 Install-ChocolateyZipPackage @packageArgs
 
 # only symlink for func.exe
-$files = Get-ChildItem $toolsDir -include *.exe 
+$files = Get-ChildItem $toolsDir -filter *.exe -Recurse -File
 foreach ($file in $files) {
-  if (!$file.Name.Equals("func.exe")) {
+  if (!$file.Name.Equals("func.exe") -or (!($file.DirectoryName -eq $toolsDir) -and $file.Name.Equals("func.exe"))) {
     #generate an ignore file
-    New-Item "$file.ignore" -type file -force | Out-Null
+    $ignoreFilePath = Join-Path -Path $file.DirectoryName -ChildPath "$($file.Name).ignore"
+    New-Item -Path $ignoreFilePath -Type File -Force | Out-Null
   }
 }
 

--- a/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
@@ -164,7 +164,6 @@ namespace Azure.Functions.Cli.Helpers
             public ReleaseSummary(string _Release, CoreToolsRelease _ReleaseDetail)
             {
                 Release = _Release;
-
                 ReleaseDetail = _ReleaseDetail;
 
                 if (string.IsNullOrEmpty(ReleaseDetail?.DownloadLink))
@@ -174,11 +173,8 @@ namespace Azure.Functions.Cli.Helpers
                 else
                 {
                     Uri uri = new UriBuilder(ReleaseDetail?.DownloadLink).Uri;
-
                     CoreToolsAssemblyZipFile = uri.Segments.FirstOrDefault(segment => segment.EndsWith(".zip", StringComparison.OrdinalIgnoreCase)); ;
                 }
-
-
             }
             public string Release { get; set; }
 

--- a/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
@@ -56,10 +56,10 @@ namespace Azure.Functions.Cli.Helpers
                     releaseList.Add(new ReleaseSummary() { Release = jProperty.Name, ReleaseDetail = releaseDetail.ReleaseList.FirstOrDefault() });
                 }
 
-                var latestReleaseZipFile = releaseList.FirstOrDefault(x => x.Release == data.Tags.V4Release.ReleaseVersion)?.coreToolsReleaseZipfile;
+                var latestCoreToolsReleaseZipFile = releaseList.FirstOrDefault(x => x.Release == data.Tags.V4Release.ReleaseVersion)?.CoreToolsReleaseZipfile;
 
-                if (!string.IsNullOrEmpty(latestReleaseZipFile) &&
-                    !latestReleaseZipFile.Contains($"{Constants.CliVersion}.zip"))
+                if (!string.IsNullOrEmpty(latestCoreToolsReleaseZipFile) &&
+                    !latestCoreToolsReleaseZipFile.Contains($"{Constants.CliVersion}.zip"))
                 {
                     return true;
                 }
@@ -184,7 +184,7 @@ namespace Azure.Functions.Cli.Helpers
                 }
             }
             public CoreToolsRelease ReleaseDetail { get; set; }
-            public string coreToolsReleaseZipfile
+            public string CoreToolsReleaseZipfile
             {
                 get
                 {

--- a/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
@@ -53,7 +53,7 @@ namespace Azure.Functions.Cli.Helpers
                 {
                     var jProperty = (Newtonsoft.Json.Linq.JProperty)item;
                     var releaseDetail = JsonConvert.DeserializeObject<ReleaseDetail>(jProperty.Value.ToString());
-                    releaseList.Add(new ReleaseSummary() { Release = jProperty.Name, ReleaseDetail = releaseDetail.ReleaseList.FirstOrDefault() });
+                    releaseList.Add(new ReleaseSummary(jProperty.Name, releaseDetail.ReleaseList.FirstOrDefault()));
                 }
 
                 var latestCoreToolsAssemblyZipFile = releaseList.FirstOrDefault(x => x.Release == data.Tags.V4Release.ReleaseVersion)?.CoreToolsAssemblyZipFile;
@@ -161,6 +161,25 @@ namespace Azure.Functions.Cli.Helpers
 
         internal class ReleaseSummary
         {
+            public ReleaseSummary(string _Release, CoreToolsRelease _ReleaseDetail)
+            {
+                Release = _Release;
+
+                ReleaseDetail = _ReleaseDetail;
+
+                if (string.IsNullOrEmpty(ReleaseDetail?.DownloadLink))
+                {
+                    CoreToolsAssemblyZipFile = string.Empty;
+                }
+                else
+                {
+                    Uri uri = new UriBuilder(ReleaseDetail?.DownloadLink).Uri;
+
+                    CoreToolsAssemblyZipFile = uri.Segments.FirstOrDefault(segment => segment.EndsWith(".zip", StringComparison.OrdinalIgnoreCase)); ;
+                }
+
+
+            }
             public string Release { get; set; }
 
             public string CoreToolsReleaseNumber
@@ -184,27 +203,7 @@ namespace Azure.Functions.Cli.Helpers
                 }
             }
             public CoreToolsRelease ReleaseDetail { get; set; }
-            public string CoreToolsAssemblyZipFile
-            {
-                get
-                {
-                    var downloadLink = ReleaseDetail?.DownloadLink;
-                    if (string.IsNullOrEmpty(ReleaseDetail?.DownloadLink))
-                    {
-                        return string.Empty;
-                    }
-
-                    Uri uri = new UriBuilder(ReleaseDetail?.DownloadLink).Uri;
-
-                    if (uri.Segments.Length < 4)
-                    {
-                        return string.Empty;
-                    }
-
-                    return uri.Segments[3];
-
-                }
-            }
+            public string CoreToolsAssemblyZipFile { get; set; }
 
         }
 

--- a/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
@@ -161,7 +161,7 @@ namespace Azure.Functions.Cli.Helpers
 
         internal class ReleaseSummary
         {
-            private readonly string _CoreToolsAssemblyZipFile;
+            private readonly string _coreToolsAssemblyZipFile;
             public ReleaseSummary(string release, CoreToolsRelease releaseDetail)
             {
                 Release = release;
@@ -169,12 +169,12 @@ namespace Azure.Functions.Cli.Helpers
 
                 if (string.IsNullOrEmpty(ReleaseDetail?.DownloadLink))
                 {
-                    _CoreToolsAssemblyZipFile = string.Empty;
+                    _coreToolsAssemblyZipFile = string.Empty;
                 }
                 else
                 {
                     Uri uri = new UriBuilder(ReleaseDetail?.DownloadLink).Uri;
-                    _CoreToolsAssemblyZipFile = uri.Segments.FirstOrDefault(segment => segment.EndsWith(".zip", StringComparison.OrdinalIgnoreCase));
+                    _coreToolsAssemblyZipFile = uri.Segments.FirstOrDefault(segment => segment.EndsWith(".zip", StringComparison.OrdinalIgnoreCase));
                 }
             }
             public string Release { get; set; }
@@ -204,7 +204,7 @@ namespace Azure.Functions.Cli.Helpers
             {
                 get
                 {
-                    return _CoreToolsAssemblyZipFile;
+                    return _coreToolsAssemblyZipFile;
                 }
             }
 

--- a/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
@@ -18,11 +18,13 @@ namespace Azure.Functions.Cli.Helpers
     internal class VersionHelper
     {
         private static string _cliVersion = Constants.CliVersion;
+        private static string _latestCoreToolsAssemblyZipFile;
 
         // This method is created only for testing
-        public static void SetCliVersion(string version)
+        public static void SetCliVersion(string version, string assemblyZipfile)
         {
             _cliVersion = version;
+            _latestCoreToolsAssemblyZipFile = assemblyZipfile;
         }
 
         public static async Task<string> RunAsync(Task<bool> isRunningOlderVersion = null)
@@ -64,7 +66,7 @@ namespace Azure.Functions.Cli.Helpers
                     releaseList.Add(new ReleaseSummary(jProperty.Name, releaseDetail.ReleaseList.FirstOrDefault()));
                 }
 
-                var latestCoreToolsAssemblyZipFile = releaseList.FirstOrDefault(x => x.Release == data.Tags.V4Release.ReleaseVersion)?.CoreToolsAssemblyZipFile;
+                var latestCoreToolsAssemblyZipFile = _latestCoreToolsAssemblyZipFile ?? releaseList.FirstOrDefault(x => x.Release == data.Tags.V4Release.ReleaseVersion)?.CoreToolsAssemblyZipFile;
 
                 if (!string.IsNullOrEmpty(latestCoreToolsAssemblyZipFile) &&
                     !latestCoreToolsAssemblyZipFile.Contains($"{_cliVersion}.zip"))

--- a/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
@@ -56,10 +56,10 @@ namespace Azure.Functions.Cli.Helpers
                     releaseList.Add(new ReleaseSummary() { Release = jProperty.Name, ReleaseDetail = releaseDetail.ReleaseList.FirstOrDefault() });
                 }
 
-                var latestCoreToolsReleaseZipFile = releaseList.FirstOrDefault(x => x.Release == data.Tags.V4Release.ReleaseVersion)?.CoreToolsReleaseZipfile;
+                var latestCoreToolsAssemblyZipFile = releaseList.FirstOrDefault(x => x.Release == data.Tags.V4Release.ReleaseVersion)?.CoreToolsAssemblyZipFile;
 
-                if (!string.IsNullOrEmpty(latestCoreToolsReleaseZipFile) &&
-                    !latestCoreToolsReleaseZipFile.Contains($"{Constants.CliVersion}.zip"))
+                if (!string.IsNullOrEmpty(latestCoreToolsAssemblyZipFile) &&
+                    !latestCoreToolsAssemblyZipFile.Contains($"{Constants.CliVersion}.zip"))
                 {
                     return true;
                 }
@@ -159,7 +159,7 @@ namespace Azure.Functions.Cli.Helpers
             public bool Hidden { get; set; }
         }
 
-        private class ReleaseSummary
+        internal class ReleaseSummary
         {
             public string Release { get; set; }
 
@@ -184,7 +184,7 @@ namespace Azure.Functions.Cli.Helpers
                 }
             }
             public CoreToolsRelease ReleaseDetail { get; set; }
-            public string CoreToolsReleaseZipfile
+            public string CoreToolsAssemblyZipFile
             {
                 get
                 {
@@ -208,13 +208,13 @@ namespace Azure.Functions.Cli.Helpers
 
         }
 
-        private class ReleaseDetail
+        internal class ReleaseDetail
         {
             [JsonProperty("coreTools")]
             public IList<CoreToolsRelease> ReleaseList { get; set; }
         }
 
-        private class CoreToolsRelease
+        internal class CoreToolsRelease
         {
             [JsonProperty("OS")]
             public string Os { get; set; }

--- a/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
@@ -7,7 +7,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net.Http;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;

--- a/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
@@ -56,10 +56,10 @@ namespace Azure.Functions.Cli.Helpers
                     releaseList.Add(new ReleaseSummary() { Release = jProperty.Name, ReleaseDetail = releaseDetail.ReleaseList.FirstOrDefault() });
                 }
 
-                var latestCoreToolsReleaseVersion = releaseList.FirstOrDefault(x => x.Release == data.Tags.V4Release.ReleaseVersion)?.CoreToolsReleaseNumber;
+                var latestReleaseZipFile = releaseList.FirstOrDefault(x => x.Release == data.Tags.V4Release.ReleaseVersion)?.coreToolsReleaseZipfile;
 
-                if (!string.IsNullOrEmpty(latestCoreToolsReleaseVersion) &&
-                    Constants.CliVersion != latestCoreToolsReleaseVersion)
+                if (!string.IsNullOrEmpty(latestReleaseZipFile) &&
+                    !latestReleaseZipFile.Contains($"{Constants.CliVersion}.zip"))
                 {
                     return true;
                 }
@@ -184,6 +184,28 @@ namespace Azure.Functions.Cli.Helpers
                 }
             }
             public CoreToolsRelease ReleaseDetail { get; set; }
+            public string coreToolsReleaseZipfile
+            {
+                get
+                {
+                    var downloadLink = ReleaseDetail?.DownloadLink;
+                    if (string.IsNullOrEmpty(ReleaseDetail?.DownloadLink))
+                    {
+                        return string.Empty;
+                    }
+
+                    Uri uri = new UriBuilder(ReleaseDetail?.DownloadLink).Uri;
+
+                    if (uri.Segments.Length < 4)
+                    {
+                        return string.Empty;
+                    }
+
+                    return uri.Segments[3];
+
+                }
+            }
+
         }
 
         private class ReleaseDetail

--- a/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
@@ -7,6 +7,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -17,6 +18,14 @@ namespace Azure.Functions.Cli.Helpers
 {
     internal class VersionHelper
     {
+        private static string _cliVersion = Constants.CliVersion;
+
+        // This method is created only for testing
+        public static void SetCliVersion(string version)
+        {
+            _cliVersion = version;
+        }
+
         public static async Task<string> RunAsync(Task<bool> isRunningOlderVersion = null)
         {
             isRunningOlderVersion ??= IsRunningAnOlderVersion();
@@ -59,7 +68,7 @@ namespace Azure.Functions.Cli.Helpers
                 var latestCoreToolsAssemblyZipFile = releaseList.FirstOrDefault(x => x.Release == data.Tags.V4Release.ReleaseVersion)?.CoreToolsAssemblyZipFile;
 
                 if (!string.IsNullOrEmpty(latestCoreToolsAssemblyZipFile) &&
-                    !latestCoreToolsAssemblyZipFile.Contains($"{Constants.CliVersion}.zip"))
+                    !latestCoreToolsAssemblyZipFile.Contains($"{_cliVersion}.zip"))
                 {
                     return true;
                 }

--- a/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
@@ -42,7 +42,7 @@ namespace Azure.Functions.Cli.Helpers
             {
                 var client = new System.Net.Http.HttpClient
                 {
-                    Timeout = TimeSpan.FromSeconds(1)
+                    Timeout = TimeSpan.FromSeconds(5)
                 };
                 var response = await client.GetAsync(Constants.CoreToolsVersionsFeedUrl);
                 var content = await response.Content.ReadAsStringAsync();
@@ -161,6 +161,7 @@ namespace Azure.Functions.Cli.Helpers
 
         internal class ReleaseSummary
         {
+            private readonly string _CoreToolsAssemblyZipFile;
             public ReleaseSummary(string release, CoreToolsRelease releaseDetail)
             {
                 Release = release;
@@ -168,12 +169,12 @@ namespace Azure.Functions.Cli.Helpers
 
                 if (string.IsNullOrEmpty(ReleaseDetail?.DownloadLink))
                 {
-                    CoreToolsAssemblyZipFile = string.Empty;
+                    _CoreToolsAssemblyZipFile = string.Empty;
                 }
                 else
                 {
                     Uri uri = new UriBuilder(ReleaseDetail?.DownloadLink).Uri;
-                    CoreToolsAssemblyZipFile = uri.Segments.FirstOrDefault(segment => segment.EndsWith(".zip", StringComparison.OrdinalIgnoreCase));
+                    _CoreToolsAssemblyZipFile = uri.Segments.FirstOrDefault(segment => segment.EndsWith(".zip", StringComparison.OrdinalIgnoreCase));
                 }
             }
             public string Release { get; set; }
@@ -199,7 +200,13 @@ namespace Azure.Functions.Cli.Helpers
                 }
             }
             public CoreToolsRelease ReleaseDetail { get; set; }
-            public string CoreToolsAssemblyZipFile { get; set; }
+            public string CoreToolsAssemblyZipFile
+            {
+                get
+                {
+                    return _CoreToolsAssemblyZipFile;
+                }
+            }
 
         }
 

--- a/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
@@ -173,7 +173,7 @@ namespace Azure.Functions.Cli.Helpers
                 else
                 {
                     Uri uri = new UriBuilder(ReleaseDetail?.DownloadLink).Uri;
-                    CoreToolsAssemblyZipFile = uri.Segments.FirstOrDefault(segment => segment.EndsWith(".zip", StringComparison.OrdinalIgnoreCase)); ;
+                    CoreToolsAssemblyZipFile = uri.Segments.FirstOrDefault(segment => segment.EndsWith(".zip", StringComparison.OrdinalIgnoreCase));
                 }
             }
             public string Release { get; set; }

--- a/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
@@ -161,10 +161,10 @@ namespace Azure.Functions.Cli.Helpers
 
         internal class ReleaseSummary
         {
-            public ReleaseSummary(string _Release, CoreToolsRelease _ReleaseDetail)
+            public ReleaseSummary(string release, CoreToolsRelease releaseDetail)
             {
-                Release = _Release;
-                ReleaseDetail = _ReleaseDetail;
+                Release = release;
+                ReleaseDetail = releaseDetail;
 
                 if (string.IsNullOrEmpty(ReleaseDetail?.DownloadLink))
                 {

--- a/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
@@ -42,7 +42,7 @@ namespace Azure.Functions.Cli.Helpers
             {
                 var client = new System.Net.Http.HttpClient
                 {
-                    Timeout = TimeSpan.FromSeconds(5)
+                    Timeout = TimeSpan.FromSeconds(1)
                 };
                 var response = await client.GetAsync(Constants.CoreToolsVersionsFeedUrl);
                 var content = await response.Content.ReadAsStringAsync();

--- a/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
@@ -71,7 +71,5 @@ namespace Azure.Functions.Cli.Tests.E2E
 
             return false;
         }
-
-
     }
 }

--- a/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
@@ -30,9 +30,9 @@ namespace Azure.Functions.Cli.Tests.E2E
         [Fact]
         public void CoreToolsAssemblyZipFile_ShouldParseCorrectSegment_WhenValidDownloadLinkIsProvided()
         {
-            var fakeDownloadLink = "https://example.com/public/coretoolnumber/assemblyfile.zip";
+            var fakeDownloadLink = "https://example.com/public/coretoolnumber/V4/assemblyfile.zip";
             var releaseDetail = new CoreToolsRelease { DownloadLink = fakeDownloadLink };
-            var releaseSummary = new ReleaseSummary { ReleaseDetail = releaseDetail };
+            var releaseSummary = new ReleaseSummary ("V4",releaseDetail);
 
             var result = releaseSummary.CoreToolsAssemblyZipFile;
 
@@ -40,22 +40,10 @@ namespace Azure.Functions.Cli.Tests.E2E
         }
 
         [Fact]
-        public void CoreToolsAssemblyZipFile_ShouldReturnEmpty_WhenDownloadLinkHasLessThanFourSegments()
-        {
-            var fakeDownloadLink = "https://example.com/path/to/";
-            var releaseDetail = new CoreToolsRelease { DownloadLink = fakeDownloadLink };
-            var releaseSummary = new ReleaseSummary { ReleaseDetail = releaseDetail };
-
-            var result = releaseSummary.CoreToolsAssemblyZipFile;
-
-            result.Should().Be(string.Empty); // There are fewer than 4 segments, so the result should be empty
-        }
-
-        [Fact]
         public void CoreToolsAssemblyZipFile_ShouldReturnEmpty_WhenDownloadLinkIsNull()
         {
             var releaseDetail = new CoreToolsRelease { DownloadLink = null };
-            var releaseSummary = new ReleaseSummary { ReleaseDetail = releaseDetail };
+            var releaseSummary = new ReleaseSummary("V4", releaseDetail);
 
             var result = releaseSummary.CoreToolsAssemblyZipFile; 
 

--- a/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
@@ -49,5 +49,29 @@ namespace Azure.Functions.Cli.Tests.E2E
 
             result.Should().Be(string.Empty); // The result should be empty when there is no link
         }
+
+        [Theory]
+        [InlineData("4.0.6610", "Azure.Functions.Cli.linux-x64.4.0.6610.zip", false)]
+        [InlineData("4.0.1", "Azure.Functions.Cli.linux-x64.4.0.6610.zip", true)]
+
+        public void Test_IsRunningAnOlderVersion(string cliVersion, string latestCoreToolsAssemblyZipFile, bool expected)
+        {
+            bool result = IsRunningAnOlderVersion(cliVersion, latestCoreToolsAssemblyZipFile);
+
+            result.Should().Be(expected);
+        }
+
+        private bool IsRunningAnOlderVersion(string cliVersion, string latestCoreToolsAssemblyZipFile)
+        {
+            if (!string.IsNullOrEmpty(latestCoreToolsAssemblyZipFile) &&
+                !latestCoreToolsAssemblyZipFile.Contains($"{cliVersion}.zip"))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+
     }
 }

--- a/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
@@ -1,13 +1,8 @@
 using System;
-using System.Net.Http;
-using System.Net;
-using System.Threading;
 using System.Threading.Tasks;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Tests.E2E.Helpers;
 using FluentAssertions;
-using Moq.Protected;
-using Moq;
 using Xunit;
 using Xunit.Abstractions;
 using static Azure.Functions.Cli.Helpers.VersionHelper;

--- a/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
@@ -2,8 +2,10 @@ using System;
 using System.Threading.Tasks;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Tests.E2E.Helpers;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
+using static Azure.Functions.Cli.Helpers.VersionHelper;
 
 namespace Azure.Functions.Cli.Tests.E2E
 {
@@ -23,6 +25,41 @@ namespace Azure.Functions.Cli.Tests.E2E
                 OutputContains = new[] { "4." },
                 CommandTimeout = TimeSpan.FromSeconds(30)
             }, _output);
+        }
+
+        [Fact]
+        public void CoreToolsAssemblyZipFile_ShouldParseCorrectSegment_WhenValidDownloadLinkIsProvided()
+        {
+            var fakeDownloadLink = "https://example.com/public/coretoolnumber/assemblyfile.zip";
+            var releaseDetail = new CoreToolsRelease { DownloadLink = fakeDownloadLink };
+            var releaseSummary = new ReleaseSummary { ReleaseDetail = releaseDetail };
+
+            var result = releaseSummary.CoreToolsAssemblyZipFile;
+
+            Assert.Equal("assemblyfile.zip", result);  // We expect the segment "assembly.zip" based on the provided URL
+        }
+
+        [Fact]
+        public void CoreToolsAssemblyZipFile_ShouldReturnEmpty_WhenDownloadLinkHasLessThanFourSegments()
+        {
+            var fakeDownloadLink = "https://example.com/path/to/";
+            var releaseDetail = new CoreToolsRelease { DownloadLink = fakeDownloadLink };
+            var releaseSummary = new ReleaseSummary { ReleaseDetail = releaseDetail };
+
+            var result = releaseSummary.CoreToolsAssemblyZipFile;
+
+            Assert.Equal(string.Empty, result);  // There are fewer than 4 segments, so the result should be empty
+        }
+
+        [Fact]
+        public void CoreToolsAssemblyZipFile_ShouldReturnEmpty_WhenDownloadLinkIsNull()
+        {
+            var releaseDetail = new CoreToolsRelease { DownloadLink = null };
+            var releaseSummary = new ReleaseSummary { ReleaseDetail = releaseDetail };
+
+            var result = releaseSummary.CoreToolsAssemblyZipFile;
+
+            Assert.Equal(string.Empty, result);  // The result should be empty when there is no link
         }
     }
 }

--- a/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Net.Http;
+using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Tests.E2E.Helpers;
 using FluentAssertions;
+using Moq.Protected;
+using Moq;
 using Xunit;
 using Xunit.Abstractions;
 using static Azure.Functions.Cli.Helpers.VersionHelper;
+using Azure.Functions.Cli.Helpers;
 
 namespace Azure.Functions.Cli.Tests.E2E
 {
@@ -51,25 +57,15 @@ namespace Azure.Functions.Cli.Tests.E2E
         }
 
         [Theory]
-        [InlineData("4.0.6610", "Azure.Functions.Cli.linux-x64.4.0.6610.zip", false)]
-        [InlineData("4.0.1", "Azure.Functions.Cli.linux-x64.4.0.6610.zip", true)]
-
-        public void Test_IsRunningAnOlderVersion(string cliVersion, string latestCoreToolsAssemblyZipFile, bool expected)
+        [InlineData("4.0.6610", false)]
+        [InlineData("4.0.1", true)]
+        public async Task IsRunningAnOlderVersion_ReturnsExpected_WhenOlderVersion(string cliVersion, bool expected)
         {
-            bool result = IsRunningAnOlderVersion(cliVersion, latestCoreToolsAssemblyZipFile);
+            VersionHelper.SetCliVersion(cliVersion);
+
+            var result = await VersionHelper.IsRunningAnOlderVersion();
 
             result.Should().Be(expected);
-        }
-
-        private bool IsRunningAnOlderVersion(string cliVersion, string latestCoreToolsAssemblyZipFile)
-        {
-            if (!string.IsNullOrEmpty(latestCoreToolsAssemblyZipFile) &&
-                !latestCoreToolsAssemblyZipFile.Contains($"{cliVersion}.zip"))
-            {
-                return true;
-            }
-
-            return false;
         }
     }
 }

--- a/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
@@ -57,7 +57,6 @@ namespace Azure.Functions.Cli.Tests.E2E
         }
 
         [Theory]
-        [InlineData("4.0.6610", false)]
         [InlineData("4.0.1", true)]
         public async Task IsRunningAnOlderVersion_ReturnsExpected_WhenOlderVersion(string cliVersion, bool expected)
         {

--- a/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
@@ -53,9 +53,10 @@ namespace Azure.Functions.Cli.Tests.E2E
 
         [Theory]
         [InlineData("4.0.1", true)]
+        [InlineData("4.0.6610", false)]
         public async Task IsRunningAnOlderVersion_ReturnsExpected_WhenOlderVersion(string cliVersion, bool expected)
         {
-            VersionHelper.SetCliVersion(cliVersion);
+            VersionHelper.SetCliVersion(cliVersion, "Azure.Functions.Cli.linux-x64.4.0.6610.zip");
 
             var result = await VersionHelper.IsRunningAnOlderVersion();
 

--- a/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
@@ -36,7 +36,7 @@ namespace Azure.Functions.Cli.Tests.E2E
 
             var result = releaseSummary.CoreToolsAssemblyZipFile;
 
-            Assert.Equal("assemblyfile.zip", result);  // We expect the segment "assembly.zip" based on the provided URL
+            result.Should().Be("assemblyfile.zip"); // We expect the segment "assemblyfile.zip" based on the provided URL
         }
 
         [Fact]
@@ -48,7 +48,7 @@ namespace Azure.Functions.Cli.Tests.E2E
 
             var result = releaseSummary.CoreToolsAssemblyZipFile;
 
-            Assert.Equal(string.Empty, result);  // There are fewer than 4 segments, so the result should be empty
+            result.Should().Be(string.Empty); // There are fewer than 4 segments, so the result should be empty
         }
 
         [Fact]
@@ -57,9 +57,9 @@ namespace Azure.Functions.Cli.Tests.E2E
             var releaseDetail = new CoreToolsRelease { DownloadLink = null };
             var releaseSummary = new ReleaseSummary { ReleaseDetail = releaseDetail };
 
-            var result = releaseSummary.CoreToolsAssemblyZipFile;
+            var result = releaseSummary.CoreToolsAssemblyZipFile; // The result should be empty when there is no link
 
-            Assert.Equal(string.Empty, result);  // The result should be empty when there is no link
+            result.Should().Be(string.Empty);
         }
     }
 }

--- a/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
@@ -60,27 +60,28 @@ namespace Azure.Functions.Cli.Tests.E2E
         public async Task IsRunningAnOlderVersion_ShouldReturnTrue_WhenVersionIsOlder()
         {
             // Create the mocked HttpClient with the mock response
-            var mockHttpClient = GetMockHttpClient();
+            var mockHttpClient = GetMockHttpClientWithResponse();
 
             SetCliVersion("4.0.1");
             var result = await VersionHelper.IsRunningAnOlderVersion(mockHttpClient);
 
-            Assert.True(result);
+            result.Should().Be(true);
         }
 
         [Fact]
         public async Task IsRunningAnOlderVersion_ShouldReturnFalse_WhenVersionIsUpToDate()
         {
             // Create the mocked HttpClient with the mock response
-            var mockHttpClient = GetMockHttpClient();
+            var mockHttpClient = GetMockHttpClientWithResponse();
 
             SetCliVersion("4.0.6610");
             var result = await VersionHelper.IsRunningAnOlderVersion(mockHttpClient);
 
-            Assert.False(result);
+            result.Should().Be(false);
         }
+
         // Method to return a mocked HttpClient
-        private HttpClient GetMockHttpClient()
+        private HttpClient GetMockHttpClientWithResponse()
         {
             var mockJsonResponse = @"{
                 'tags': {

--- a/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
@@ -57,9 +57,9 @@ namespace Azure.Functions.Cli.Tests.E2E
             var releaseDetail = new CoreToolsRelease { DownloadLink = null };
             var releaseSummary = new ReleaseSummary { ReleaseDetail = releaseDetail };
 
-            var result = releaseSummary.CoreToolsAssemblyZipFile; // The result should be empty when there is no link
+            var result = releaseSummary.CoreToolsAssemblyZipFile; 
 
-            result.Should().Be(string.Empty);
+            result.Should().Be(string.Empty); // The result should be empty when there is no link
         }
     }
 }

--- a/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
@@ -7,6 +7,11 @@ using Xunit;
 using Xunit.Abstractions;
 using static Azure.Functions.Cli.Helpers.VersionHelper;
 using Azure.Functions.Cli.Helpers;
+using Moq.Protected;
+using Moq;
+using System.Net.Http;
+using System.Net;
+using System.Threading;
 
 namespace Azure.Functions.Cli.Tests.E2E
 {
@@ -51,16 +56,70 @@ namespace Azure.Functions.Cli.Tests.E2E
             result.Should().Be(string.Empty); // The result should be empty when there is no link
         }
 
-        [Theory]
-        [InlineData("4.0.1", true)]
-        [InlineData("4.0.6610", false)]
-        public async Task IsRunningAnOlderVersion_ReturnsExpected_WhenOlderVersion(string cliVersion, bool expected)
+        [Fact]
+        public async Task IsRunningAnOlderVersion_ShouldReturnTrue_WhenVersionIsOlder()
         {
-            VersionHelper.SetCliVersion(cliVersion, "Azure.Functions.Cli.linux-x64.4.0.6610.zip");
+            // Create the mocked HttpClient with the mock response
+            var mockHttpClient = GetMockHttpClient();
 
-            var result = await VersionHelper.IsRunningAnOlderVersion();
+            SetCliVersion("4.0.1");
+            var result = await VersionHelper.IsRunningAnOlderVersion(mockHttpClient);
 
-            result.Should().Be(expected);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task IsRunningAnOlderVersion_ShouldReturnFalse_WhenVersionIsUpToDate()
+        {
+            // Create the mocked HttpClient with the mock response
+            var mockHttpClient = GetMockHttpClient();
+
+            SetCliVersion("4.0.6610");
+            var result = await VersionHelper.IsRunningAnOlderVersion(mockHttpClient);
+
+            Assert.False(result);
+        }
+        // Method to return a mocked HttpClient
+        private HttpClient GetMockHttpClient()
+        {
+            var mockJsonResponse = @"{
+                'tags': {
+                    'v4': {
+                        'release': '4.0',
+                        'releaseQuality': 'GA',
+                        'hidden': false
+                    },
+                },
+                'releases': {
+                    '4.0': {
+                        'coreTools': [
+                            {
+                                'OS': 'Windows',
+                                'Architecture': 'x86',
+                                'downloadLink': 'https://example.com/public/0.0.1/Azure.Functions.Latest.4.0.6610.zip',
+                                'sha2': 'BB4978D83CFBABAE67D4D720FEC1F1171BE0406B2147EF3FECA476C19ADD9920',
+                                'size': 'full',
+                                'default': 'true'
+                            }
+                        ]
+                    }
+                }
+            }";
+            var mockHandler = new Mock<HttpMessageHandler>();
+
+            // Mock the SendAsync method to return a mocked response
+            mockHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(mockJsonResponse)
+                });
+
+            // Return HttpClient with mocked handler
+            return new HttpClient(mockHandler.Object);
         }
     }
 }


### PR DESCRIPTION
### Issue describing the changes in this PR
when we install Azure Function Core Tool via chocolatey, the shim is generating twice as we have 3.exe files (in root folder inproc6 and inproc8 folder). Now we have added additional checks to ignore func.exe from subfolders (inproc6 and inproc8 folder) and generate shim for func.exe in root directory.
resolves #3776 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)