### PR TITLE
Update check-vulernabilities.ps1 to skip packages specified in JSON file

### DIFF
--- a/check-vulnerabilities.ps1
+++ b/check-vulnerabilities.ps1
@@ -25,6 +25,15 @@ $topLevelPackages = $logContent.projects.frameworks.topLevelPackages
 $skipCveContent = Get-Content $skipCveFilePath -Raw | ConvertFrom-Json
 $skipPackages = $skipCveContent.packages
 
+# Validate files in skipPackagesCve.json are still valid security vulnerabilities
+$topLevelPackageIds = $topLevelPackages.id
+$invalidSkips = $skipPackages | Where-Object { $_ -notin $topLevelPackageIds }
+
+if ($invalidSkips.Count -gt 0) {
+    Write-Host "The following packages in 'skipPackagesCve.json' do not exist in the vulnerable packages list: $($invalidSkips -join ', '). Please remove these packages from the JSON file."
+    Exit 1
+}
+
 # Filter vulnerabilities
 $vulnerablePackages = @()
 foreach ($package in $topLevelPackages) {

--- a/check-vulnerabilities.ps1
+++ b/check-vulnerabilities.ps1
@@ -1,6 +1,7 @@
 $projectPath = ".\src\Azure.Functions.Cli"
 $projectFileName = ".\Azure.Functions.Cli.csproj"
 $logFilePath = "..\..\build.log"
+$skipCveFilePath = "..\..\skipPackagesCve.json"
 if (-not (Test-Path $projectPath))
 {
     throw "Project path '$projectPath' does not exist."
@@ -12,11 +13,41 @@ $cmd = "restore"
 Write-Host "dotnet $cmd"
 dotnet $cmd | Tee-Object $logFilePath
 
-$cmd = "list", "package", "--include-transitive", "--vulnerable"
+$cmd = "list", "package", "--include-transitive", "--vulnerable", "--format", "json"
 Write-Host "dotnet $cmd"
 dotnet $cmd | Tee-Object $logFilePath
 
-$result = Get-content $logFilePath | select-string "has no vulnerable packages given the current sources"
+# Parse JSON output
+$logContent = Get-Content $logFilePath -Raw | ConvertFrom-Json
+$topLevelPackages = $logContent.projects.frameworks.topLevelPackages
+
+# Load skip-cve.json
+$skipCveContent = Get-Content $skipCveFilePath -Raw | ConvertFrom-Json
+$skipPackages = $skipCveContent.packages
+
+# Filter vulnerabilities
+$vulnerablePackages = @()
+foreach ($package in $topLevelPackages) {
+    if ($skipPackages -notcontains $package.id) {
+        $vulnerablePackages += $package
+    }
+}
+
+# Check for remaining vulnerabilities
+if ($vulnerablePackages.Count -gt 0) {
+    Write-Host "Security vulnerabilities found (excluding skipped packages):"
+    $vulnerablePackages | ForEach-Object {
+        Write-Host "Package: $($_.id)"
+        Write-Host "Version: $($_.resolvedVersion)"
+        $_.vulnerabilities | ForEach-Object {
+            Write-Host "Severity: $($_.severity)"
+            Write-Host "Advisory: $($_.advisoryurl)"
+        }
+    }
+    Exit 1
+} else {
+    Write-Host "No security vulnerabilities found (excluding skipped packages)."
+}
 
 $logFileExists = Test-Path $logFilePath -PathType Leaf
 if ($logFileExists)
@@ -25,9 +56,3 @@ if ($logFileExists)
 }
 
 cd ../..
-
-if (!$result)
-{
-  Write-Host "Vulnerabilities found" 
-  Exit 1
-}

--- a/skipPackagesCve.json
+++ b/skipPackagesCve.json
@@ -1,4 +1,5 @@
 {
+  // Note that once the CVEs listed here have been addressed and resolved, the specified package will have to be removed from this JSON file.
   "packages": [
     "DotNetZip"
   ]

--- a/skipPackagesCve.json
+++ b/skipPackagesCve.json
@@ -1,5 +1,4 @@
 {
-  // Note that once the CVEs listed here have been addressed and resolved, the specified package will have to be removed from this JSON file.
   "packages": [
     "DotNetZip"
   ]

--- a/skipPackagesCve.json
+++ b/skipPackagesCve.json
@@ -1,0 +1,5 @@
+{
+  "packages": [
+    "DotNetZip"
+  ]
+}


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

The core tools pipeline today is blocked due to the CVE for `DotNetZip`. Brett has a PR out for resolving the changes [here](https://github.com/Azure/azure-functions-core-tools/pull/4212), but in order to unblock the daily builds and pending PRs, I have created a workaround for any CVEs that we want to skip when running the security vulnerability check to be specified in `skipPackagesCve.json`. 

Please note that any CVEs that have been addressed after will have to be removed from the JSON file. If the CVE is resolved and the package is not removed from the JSON file, the security vulnerability check will fail.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)