### PR TITLE
Check environment for 'FUNCTIONS_WORKER_RUNTIME' on start

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -814,8 +814,8 @@ namespace Azure.Functions.Cli.Actions.HostActions
 
         private void EnsureWorkerRuntimeIsSet()
         {
-            if (_secretsManager.GetSecrets().Any(s => s.Key.Equals(Constants.FunctionsWorkerRuntime, StringComparison.OrdinalIgnoreCase))
-               || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime)))
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime))
+                || _secretsManager.GetSecrets().Any(s => s.Key.Equals(Constants.FunctionsWorkerRuntime, StringComparison.OrdinalIgnoreCase)))
             {
                 return;
             }

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -667,7 +667,8 @@ namespace Azure.Functions.Cli.Actions.HostActions
 
         private async Task PreRunConditions()
         {
-            EnsureWorkerRuntimeIsSet();
+            PromptForWorkerRuntimeIfNotSet();
+
             if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.python)
             {
                 var pythonVersion = await PythonHelpers.GetEnvironmentPythonVersion();
@@ -811,25 +812,21 @@ namespace Azure.Functions.Cli.Actions.HostActions
             return (new Uri($"{protocol}://0.0.0.0:{Port}"), new Uri($"{protocol}://localhost:{Port}"), cert);
         }
 
-        private void EnsureWorkerRuntimeIsSet()
+        private void PromptForWorkerRuntimeIfNotSet()
         {
-            var workerRuntimeSettingValue = _secretsManager.GetSecrets().FirstOrDefault(s => s.Key.Equals(Constants.FunctionsWorkerRuntime, StringComparison.OrdinalIgnoreCase)).Value;
-            if (workerRuntimeSettingValue is not null)
+            if (GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone is not WorkerRuntime.None)
             {
                 return;
             }
 
-            if (GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone == WorkerRuntime.None)
-            {
-                SelectionMenuHelper.DisplaySelectionWizardPrompt("worker runtime");
-                IDictionary<WorkerRuntime, string> workerRuntimeToDisplayString = WorkerRuntimeLanguageHelper.GetWorkerToDisplayStrings();
-                string workerRuntimeDisplay = SelectionMenuHelper.DisplaySelectionWizard(workerRuntimeToDisplayString.Values);
-                GlobalCoreToolsSettings.CurrentWorkerRuntime = workerRuntimeToDisplayString.FirstOrDefault(wr => wr.Value.Equals(workerRuntimeDisplay)).Key;
-            }
+            SelectionMenuHelper.DisplaySelectionWizardPrompt("worker runtime");
+            IDictionary<WorkerRuntime, string> workerRuntimeToDisplayString = WorkerRuntimeLanguageHelper.GetWorkerToDisplayStrings();
+            string workerRuntimeDisplay = SelectionMenuHelper.DisplaySelectionWizard(workerRuntimeToDisplayString.Values);
+            GlobalCoreToolsSettings.CurrentWorkerRuntime = workerRuntimeToDisplayString.FirstOrDefault(wr => wr.Value.Equals(workerRuntimeDisplay)).Key;
 
             var workerRuntime = WorkerRuntimeLanguageHelper.GetRuntimeMoniker(GlobalCoreToolsSettings.CurrentWorkerRuntime);
             _secretsManager.SetSecret(Constants.FunctionsWorkerRuntime, workerRuntime);
-            ColoredConsole.WriteLine(WarningColor($"'{workerRuntime}' has been set in your local.settings.json"));
+            ColoredConsole.WriteLine(WarningColor($"'{workerRuntime}' has been set in in '{SecretsManager.AppSettingsFilePath}'"));
         }
     }
 }

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -815,7 +815,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
         private void EnsureWorkerRuntimeIsSet()
         {
             if (_secretsManager.GetSecrets().Any(s => s.Key.Equals(Constants.FunctionsWorkerRuntime, StringComparison.OrdinalIgnoreCase))
-               || string.IsNullOrEmpty(Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime)))
+               || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime)))
             {
                 return;
             }

--- a/src/Azure.Functions.Cli/Helpers/WorkerRuntimeLanguageHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/WorkerRuntimeLanguageHelper.cs
@@ -181,14 +181,16 @@ namespace Azure.Functions.Cli.Helpers
 
         internal static WorkerRuntime SetWorkerRuntime(ISecretsManager secretsManager, string language)
         {
-            var worker = NormalizeWorkerRuntime(language);
+            var workerRuntime = NormalizeWorkerRuntime(language);
+            var runtimeMoniker = GetRuntimeMoniker(workerRuntime);
 
-            secretsManager.SetSecret(Constants.FunctionsWorkerRuntime, worker.ToString());
+            secretsManager.SetSecret(Constants.FunctionsWorkerRuntime, runtimeMoniker);
+
             ColoredConsole
-                .WriteLine(WarningColor("Starting from 2.0.1-beta.26 it's required to set a language for your project in your settings"))
-                .WriteLine(WarningColor($"'{worker}' has been set in your local.settings.json"));
+                .WriteLine(WarningColor("Starting from 2.0.1-beta.26 it's required to set a language for your project in your settings."))
+                .WriteLine(WarningColor($"Worker runtime '{runtimeMoniker}' has been set in '{SecretsManager.AppSettingsFilePath}'."));
 
-            return worker;
+            return workerRuntime;
         }
 
         public static string GetDefaultTemplateLanguageFromWorker(WorkerRuntime worker)

--- a/src/Azure.Functions.Cli/Helpers/WorkerRuntimeLanguageHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/WorkerRuntimeLanguageHelper.cs
@@ -166,8 +166,8 @@ namespace Azure.Functions.Cli.Helpers
 
         public static WorkerRuntime GetCurrentWorkerRuntimeLanguage(ISecretsManager secretsManager)
         {
-            var setting = secretsManager.GetSecrets().FirstOrDefault(s => s.Key.Equals(Constants.FunctionsWorkerRuntime, StringComparison.OrdinalIgnoreCase)).Value
-                          ?? Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime);
+            var setting = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime);
+                          ?? secretsManager.GetSecrets().FirstOrDefault(s => s.Key.Equals(Constants.FunctionsWorkerRuntime, StringComparison.OrdinalIgnoreCase)).Value;
 
             try
             {

--- a/src/Azure.Functions.Cli/Helpers/WorkerRuntimeLanguageHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/WorkerRuntimeLanguageHelper.cs
@@ -166,7 +166,9 @@ namespace Azure.Functions.Cli.Helpers
 
         public static WorkerRuntime GetCurrentWorkerRuntimeLanguage(ISecretsManager secretsManager)
         {
-            var setting = secretsManager.GetSecrets().FirstOrDefault(s => s.Key.Equals(Constants.FunctionsWorkerRuntime, StringComparison.OrdinalIgnoreCase)).Value;
+            var setting = secretsManager.GetSecrets().FirstOrDefault(s => s.Key.Equals(Constants.FunctionsWorkerRuntime, StringComparison.OrdinalIgnoreCase)).Value
+                          ?? Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime);
+
             try
             {
                 return NormalizeWorkerRuntime(setting);

--- a/src/Azure.Functions.Cli/Helpers/WorkerRuntimeLanguageHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/WorkerRuntimeLanguageHelper.cs
@@ -166,7 +166,7 @@ namespace Azure.Functions.Cli.Helpers
 
         public static WorkerRuntime GetCurrentWorkerRuntimeLanguage(ISecretsManager secretsManager)
         {
-            var setting = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime);
+            var setting = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime)
                           ?? secretsManager.GetSecrets().FirstOrDefault(s => s.Key.Equals(Constants.FunctionsWorkerRuntime, StringComparison.OrdinalIgnoreCase)).Value;
 
             try

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -1662,11 +1662,11 @@ namespace Azure.Functions.Cli.Tests.E2E
         }
 
         [Theory]
-        [InlineData("dotnet-isolated", "--dotnet-isolated", "HttpTriggerFunc: [GET,POST] http://localhost:{_funcHostPort}/api/HttpTriggerFunc", true, false)] // Runtime parameter set (dni), successful startup & invocation
-        [InlineData("node", "--node", "HttpTriggerFunc: [GET,POST] http://localhost:{_funcHostPort}/api/HttpTriggerFunc", true, false)] // Runtime parameter set (node), successful startup & invocation
+        [InlineData("dotnet-isolated", "--dotnet-isolated", "HttpTriggerFunc: [GET,POST] http://localhost:", true, false)] // Runtime parameter set (dni), successful startup & invocation
+        [InlineData("node", "--node", "HttpTriggerFunc: [GET,POST] http://localhost:", true, false)] // Runtime parameter set (node), successful startup & invocation
         [InlineData("dotnet", "--worker-runtime None", $"Use the up/down arrow keys to select a worker runtime:", false, false)] // Runtime parameter set to None, worker runtime prompt displayed
         [InlineData("dotnet", "", $"Use the up/down arrow keys to select a worker runtime:", false, false)] // Runtime parameter not provided, worker runtime prompt displayed
-        [InlineData("dotnet-isolated", "", "HttpTriggerFunc: [GET, POST] http://localhost:{_funcHostPort}/api/HttpTriggerFunc", true, true)] // Runtime value is set via environment variable,  successful startup & invocation
+        [InlineData("dotnet-isolated", "", "HttpTriggerFunc: [GET, POST] http://localhost:", true, true)] // Runtime value is set via environment variable, successful startup & invocation
         public async Task Start_MissingLocalSettingsJson_BehavesAsExpected(string language, string runtimeParameter, string expectedOutput, bool invokeFunction, bool setRuntimeViaEnvironment)
         {
             try

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -1666,7 +1666,7 @@ namespace Azure.Functions.Cli.Tests.E2E
         [InlineData("node", "--node", "HttpTriggerFunc: [GET,POST] http://localhost:", true, false)] // Runtime parameter set (node), successful startup & invocation
         [InlineData("dotnet", "--worker-runtime None", $"Use the up/down arrow keys to select a worker runtime:", false, false)] // Runtime parameter set to None, worker runtime prompt displayed
         [InlineData("dotnet", "", $"Use the up/down arrow keys to select a worker runtime:", false, false)] // Runtime parameter not provided, worker runtime prompt displayed
-        [InlineData("dotnet-isolated", "", "HttpTriggerFunc: [GET, POST] http://localhost:", true, true)] // Runtime value is set via environment variable, successful startup & invocation
+        [InlineData("dotnet-isolated", "", "HttpTriggerFunc: [GET,POST] http://localhost:", true, true)] // Runtime value is set via environment variable, successful startup & invocation
         public async Task Start_MissingLocalSettingsJson_BehavesAsExpected(string language, string runtimeParameter, string expectedOutput, bool invokeFunction, bool setRuntimeViaEnvironment)
         {
             try

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -1662,144 +1662,74 @@ namespace Azure.Functions.Cli.Tests.E2E
         }
 
         [Theory]
-        [InlineData("dotnet-isolated")]
-        [InlineData("node")]
-        public async Task Start_MissingLocalSettingsJson_SuccessfulFunctionExecution(string language)
+        [InlineData("dotnet-isolated", "--dotnet-isolated", "HttpTriggerFunc: [GET,POST] http://localhost:{_funcHostPort}/api/HttpTriggerFunc", true, false)] // Runtime parameter set (dni), successful startup & invocation
+        [InlineData("node", "--node", "HttpTriggerFunc: [GET,POST] http://localhost:{_funcHostPort}/api/HttpTriggerFunc", true, false)] // Runtime parameter set (node), successful startup & invocation
+        [InlineData("dotnet", "--worker-runtime None", $"Use the up/down arrow keys to select a worker runtime:", false, false)] // Runtime parameter set to None, worker runtime prompt displayed
+        [InlineData("dotnet", "", $"Use the up/down arrow keys to select a worker runtime:", false, false)] // Runtime parameter not provided, worker runtime prompt displayed
+        [InlineData("dotnet-isolated", "", "HttpTriggerFunc: [GET, POST] http://localhost:{_funcHostPort}/api/HttpTriggerFunc", true, true)] // Runtime value is set via environment variable,  successful startup & invocation
+        public async Task Start_MissingLocalSettingsJson_BehavesAsExpected(string language, string runtimeParameter, string expectedOutput, bool invokeFunction, bool setRuntimeViaEnvironment)
         {
-            await CliTester.Run(new RunConfiguration[]
+            try
             {
-                new RunConfiguration
+                if (setRuntimeViaEnvironment)
                 {
-                    Commands = new[]
-                    {
-                        $"init . --worker-runtime {language}",
-                        $"new --template Httptrigger --name HttpTriggerFunc",
-                    },
-                    CommandTimeout = TimeSpan.FromSeconds(300),
-                },
-                new RunConfiguration
+                    Environment.SetEnvironmentVariable("FUNCTIONS_WORKER_RUNTIME", "dotnet-isolated");
+                }
+
+                await CliTester.Run(new RunConfiguration[]
                 {
-                    PreTest = (workingDir) =>
+                    new RunConfiguration
                     {
-                       var LocalSettingsJson = Path.Combine(workingDir, "local.settings.json");
-                        File.Delete(LocalSettingsJson);
-                    },
-                    Commands = new[]
-                    {
-                        $"start --{language} --port {_funcHostPort}",
-                    },
-                    ExpectExit = false,
-                    OutputContains = new[]
-                    {
-                        $"local.settings.json",
-                        "Functions:",
-                        $"HttpTriggerFunc: [GET,POST] http://localhost:{_funcHostPort}/api/HttpTriggerFunc"
-                    },
-                    OutputDoesntContain = new string[]
-                    {
-                        "Initializing function HTTP routes"
-                    },
-                    Test = async (_, p,_) =>
-                    {
-                        using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}/") })
+                        Commands = new[]
                         {
-                            (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
-                            var response = await client.GetAsync("/api/HttpTriggerFunc?name=Test");
-                            response.StatusCode.Should().Be(HttpStatusCode.OK);
-                            await Task.Delay(TimeSpan.FromSeconds(2));
-                            p.Kill();
+                            $"init . --worker-runtime {language}",
+                            $"new --template Httptrigger --name HttpTriggerFunc",
+                        },
+                        CommandTimeout = TimeSpan.FromSeconds(300),
+                    },
+                    new RunConfiguration
+                    {
+                        PreTest = (workingDir) =>
+                        {
+                           var localSettingsJson = Path.Combine(workingDir, "local.settings.json");
+                           File.Delete(localSettingsJson);
+                        },
+                        Commands = new[]
+                        {
+                            $"start {runtimeParameter} --port {_funcHostPort}",
+                        },
+                        ExpectExit = false,
+                        OutputContains = new[]
+                        {
+                            expectedOutput
+                        },
+                        Test = async (_, p,_) =>
+                        {
+                            if (invokeFunction)
+                            {
+                                using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}/") })
+                                {
+                                    (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
+                                    var response = await client.GetAsync("/api/HttpTriggerFunc?name=Test");
+                                    response.StatusCode.Should().Be(HttpStatusCode.OK);
+                                    await Task.Delay(TimeSpan.FromSeconds(2));
+                                    p.Kill();
+                                }
+                            }
+                            else
+                            {
+                                await Task.Delay(TimeSpan.FromSeconds(2));
+                                p.Kill();
+                            }
+
                         }
                     }
-                }
-            }, _output);
-        }
-
-        [Fact]
-        public async Task Start_MissingLocalSettingsJson_Runtime_None_HandledAsExpected()
-        {
-            await CliTester.Run(new RunConfiguration[]
+                }, _output);
+            }
+            finally
             {
-                 new RunConfiguration
-                 {
-                     Commands = new[]
-                     {
-                         $"init . --worker-runtime dotnet",
-                         $"new --template Httptrigger --name HttpTriggerFunc",
-                     },
-                     CommandTimeout = TimeSpan.FromSeconds(300),
-                 },
-                 new RunConfiguration
-                 {
-                     PreTest = (workingDir) =>
-                     {
-                        var LocalSettingsJson = Path.Combine(workingDir, "local.settings.json");
-                         File.Delete(LocalSettingsJson);
-                     },
-                     Commands = new[]
-                     {
-                         $"start --worker-runtime None --port {_funcHostPort}",
-                     },
-                     ExpectExit = false,
-                     OutputContains = new[]
-                     {
-                         $"Use the up/down arrow keys to select a worker runtime:"
-                     },
-                     OutputDoesntContain = new string[]
-                     {
-                         "Initializing function HTTP routes"
-                     },
-                     Test = async (_, p,_) =>
-                     {
-                             await Task.Delay(TimeSpan.FromSeconds(2));
-                             p.Kill();
-                     }
-                 }
-            }, _output);
-
-        }
-
-        [Fact]
-        public async Task Start_MissingLocalSettingsJson_Runtime_NotProvided_HandledAsExpected()
-        {
-            await CliTester.Run(new RunConfiguration[]
-            {
-                 new RunConfiguration
-                 {
-                     Commands = new[]
-                     {
-                         $"init . --worker-runtime dotnet",
-                         $"new --template Httptrigger --name HttpTriggerFunc",
-                     },
-                     CommandTimeout = TimeSpan.FromSeconds(300),
-                 },
-                 new RunConfiguration
-                 {
-                     PreTest = (workingDir) =>
-                     {
-                        var LocalSettingsJson = Path.Combine(workingDir, "local.settings.json");
-                         File.Delete(LocalSettingsJson);
-                     },
-                     Commands = new[]
-                     {
-                         $"start --port {_funcHostPort}",
-                     },
-                     ExpectExit = false,
-                     OutputContains = new[]
-                     {
-                         $"Use the up/down arrow keys to select a worker runtime:"
-                     },
-                     OutputDoesntContain = new string[]
-                     {
-                         "Initializing function HTTP routes"
-                     },
-                     Test = async (_, p,_) =>
-                     {
-                             await Task.Delay(TimeSpan.FromSeconds(2));
-                             p.Kill();
-                     }
-                 }
-            }, _output);
-
+                Environment.SetEnvironmentVariable("FUNCTIONS_WORKER_RUNTIME", null);
+            }
         }
 
         private async Task<bool> WaitUntilReady(HttpClient client)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves https://github.com/Azure/azure-functions-core-tools/issues/4193

There was a regression in a previous core tools release where the environment was no longer being check for `FUNCTIONS_WORKER_RUNTIME`. This PR fixes this by checking for the worker runtime in the environment during the start operation. This PR also cleans up the tests for "MissingLocalSettingsJson".

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version _(tbd if this needs to be backported)_
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)