### PR TITLE
3776 - Latest version reports it is old

### DIFF
--- a/publish-scripts/chocolatey/installps_template
+++ b/publish-scripts/chocolatey/installps_template
@@ -42,7 +42,8 @@ Install-ChocolateyZipPackage @packageArgs
 # only symlink for func.exe
 $files = Get-ChildItem $toolsDir -filter *.exe -Recurse -File
 foreach ($file in $files) {
-  if (!$file.Name.Equals("func.exe") -or (!($file.DirectoryName -eq $toolsDir) -and $file.Name.Equals("func.exe"))) {
+  if (!$file.Name.Equals("func.exe") -or (!($file.DirectoryName -eq $toolsDir) -and
+      $file.Name.Equals("func.exe"))) {
     #generate an ignore file
     New-Item "$file.ignore" -type file -force | Out-Null
     $ignoreFilePath = Join-Path -Path $file.DirectoryName -ChildPath "$($file.Name).ignore"

--- a/publish-scripts/chocolatey/installps_template
+++ b/publish-scripts/chocolatey/installps_template
@@ -40,11 +40,13 @@ $packageArgs = @{
 Install-ChocolateyZipPackage @packageArgs
 
 # only symlink for func.exe
-$files = Get-ChildItem $toolsDir -include *.exe -recurse
+$files = Get-ChildItem $toolsDir -filter *.exe -Recurse -File
 foreach ($file in $files) {
-  if (!$file.Name.Equals("func.exe")) {
+  if (!$file.Name.Equals("func.exe") -or (!($file.DirectoryName -eq $toolsDir) -and $file.Name.Equals("func.exe"))) {
     #generate an ignore file
     New-Item "$file.ignore" -type file -force | Out-Null
+    $ignoreFilePath = Join-Path -Path $file.DirectoryName -ChildPath "$($file.Name).ignore"
+    New-Item -Path $ignoreFilePath -Type File -Force | Out-Null
   }
 }
 

--- a/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
@@ -49,11 +49,7 @@ namespace Azure.Functions.Cli.Helpers
         {
             try
             {
-                client ??= new System.Net.Http.HttpClient
-                {
-                    Timeout = TimeSpan.FromSeconds(1)
-                };
-                using (client)
+                using (client ??= new System.Net.Http.HttpClient{Timeout = TimeSpan.FromSeconds(1)})
                 {
                     var response = await client.GetAsync(Constants.CoreToolsVersionsFeedUrl);
                     var content = await response.Content.ReadAsStringAsync();

--- a/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
@@ -208,7 +208,9 @@ namespace Azure.Functions.Cli.Helpers
                     return uri.Segments[2].Replace("/", string.Empty);
                 }
             }
+
             public CoreToolsRelease ReleaseDetail { get; set; }
+
             public string CoreToolsAssemblyZipFile
             {
                 get

--- a/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
@@ -1,9 +1,17 @@
 using System;
+using System.Net.Http;
+using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Helpers;
 using Azure.Functions.Cli.Tests.E2E.Helpers;
+using Moq.Protected;
+using Moq;
 using Xunit;
 using Xunit.Abstractions;
+using static Azure.Functions.Cli.Helpers.VersionHelper;
+using FluentAssertions;
 
 namespace Azure.Functions.Cli.Tests.E2E
 {
@@ -23,6 +31,95 @@ namespace Azure.Functions.Cli.Tests.E2E
                 OutputContains = new[] { "4." },
                 CommandTimeout = TimeSpan.FromSeconds(30)
             }, _output);
+        }
+        [Fact]
+        public void CoreToolsAssemblyZipFile_ShouldParseCorrectSegment_WhenValidDownloadLinkIsProvided()
+        {
+            var fakeDownloadLink = "https://example.com/public/coretoolnumber/V4/assemblyfile.zip";
+            var releaseDetail = new CoreToolsRelease { DownloadLink = fakeDownloadLink };
+            var releaseSummary = new ReleaseSummary("V4", releaseDetail);
+
+            var result = releaseSummary.CoreToolsAssemblyZipFile;
+
+            result.Should().Be("assemblyfile.zip"); // We expect the segment "assemblyfile.zip" based on the provided URL
+        }
+
+        [Fact]
+        public void CoreToolsAssemblyZipFile_ShouldReturnEmpty_WhenDownloadLinkIsNull()
+        {
+            var releaseDetail = new CoreToolsRelease { DownloadLink = null };
+            var releaseSummary = new ReleaseSummary("V4", releaseDetail);
+
+            var result = releaseSummary.CoreToolsAssemblyZipFile;
+
+            result.Should().Be(string.Empty); // The result should be empty when there is no link
+        }
+
+        [Fact]
+        public async Task IsRunningAnOlderVersion_ShouldReturnTrue_WhenVersionIsOlder()
+        {
+            // Create the mocked HttpClient with the mock response
+            var mockHttpClient = GetMockHttpClientWithResponse();
+
+            SetCliVersion("4.0.1");
+            var result = await VersionHelper.IsRunningAnOlderVersion(mockHttpClient);
+
+            result.Should().Be(true);
+        }
+
+        [Fact]
+        public async Task IsRunningAnOlderVersion_ShouldReturnFalse_WhenVersionIsUpToDate()
+        {
+            // Create the mocked HttpClient with the mock response
+            var mockHttpClient = GetMockHttpClientWithResponse();
+
+            SetCliVersion("4.0.6610");
+            var result = await VersionHelper.IsRunningAnOlderVersion(mockHttpClient);
+
+            result.Should().Be(false);
+        }
+
+        // Method to return a mocked HttpClient
+        private HttpClient GetMockHttpClientWithResponse()
+        {
+            var mockJsonResponse = @"{
+                'tags': {
+                    'v4': {
+                        'release': '4.0',
+                        'releaseQuality': 'GA',
+                        'hidden': false
+                    },
+                },
+                'releases': {
+                    '4.0': {
+                        'coreTools': [
+                            {
+                                'OS': 'Windows',
+                                'Architecture': 'x86',
+                                'downloadLink': 'https://example.com/public/0.0.1/Azure.Functions.Latest.4.0.6610.zip',
+                                'sha2': 'BB4978D83CFBABAE67D4D720FEC1F1171BE0406B2147EF3FECA476C19ADD9920',
+                                'size': 'full',
+                                'default': 'true'
+                            }
+                        ]
+                    }
+                }
+            }";
+            var mockHandler = new Mock<HttpMessageHandler>();
+
+            // Mock the SendAsync method to return a mocked response
+            mockHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(mockJsonResponse)
+                });
+
+            // Return HttpClient with mocked handler
+            return new HttpClient(mockHandler.Object);
         }
     }
 }

--- a/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
@@ -32,6 +32,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                 CommandTimeout = TimeSpan.FromSeconds(30)
             }, _output);
         }
+
         [Fact]
         public void CoreToolsAssemblyZipFile_ShouldParseCorrectSegment_WhenValidDownloadLinkIsProvided()
         {
@@ -119,7 +120,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                 });
 
             // Return HttpClient with mocked handler
-            return new HttpClient(mockHandler.Object);
+            return new HttpClient(mockHandler.Object) { Timeout = TimeSpan.FromSeconds(1) };
         }
     }
 }


### PR DESCRIPTION
### Issue describing the changes in this PR
Fix1 : when we install Azure Function Core Tool via chocolatey, the shim is generating twice as we have 3.exe files (in root folder inproc6 and inproc8 folder). Now we have added additional checks to ignore func.exe from subfolders (inproc6 and inproc8 folder) and generate shim for func.exe in root directory.

Fix 2 : In VersionHelper.cs we have changed the logic to check whether **latestCoreToolsAssemblyZipFile**( by extracting the segment contains '.zip' from the download link) contains **CliVersion** (by adding '.zip')

resolves #3776 
### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)