### PR TITLE
Ensure only root level func.exe is symlinked in Chocolatey package

### DIFF
--- a/publish-scripts/chocolatey/installps_template
+++ b/publish-scripts/chocolatey/installps_template
@@ -40,11 +40,14 @@ $packageArgs = @{
 Install-ChocolateyZipPackage @packageArgs
 
 # only symlink for func.exe
-$files = Get-ChildItem $toolsDir -include *.exe -recurse
+$files = Get-ChildItem $toolsDir -filter *.exe -Recurse -File
 foreach ($file in $files) {
-  if (!$file.Name.Equals("func.exe")) {
+  if (!$file.Name.Equals("func.exe") -or (!($file.DirectoryName -eq $toolsDir) -and
+      $file.Name.Equals("func.exe"))) {
     #generate an ignore file
     New-Item "$file.ignore" -type file -force | Out-Null
+    $ignoreFilePath = Join-Path -Path $file.DirectoryName -ChildPath "$($file.Name).ignore"
+    New-Item -Path $ignoreFilePath -Type File -Force | Out-Null
   }
 }
 


### PR DESCRIPTION
### Issue describing the changes in this PR
Part I:  when we install Azure Function Core Tool via chocolatey, the shim is generating twice as we have 3.exe files (in root folder inproc6 and inproc8 folder). Now we have added additional checks to ignore func.exe from subfolders (inproc6 and inproc8 folder) and generate shim for func.exe in root directory.
resolves #3776 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)