### PR TITLE
Update VersionHelper to utilize GH release tag for version check

### DIFF
--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -95,6 +95,8 @@ namespace Azure.Functions.Cli.Common
         public const string InProcDotNet8EnabledSetting = "FUNCTIONS_INPROC_NET8_ENABLED";
         public const string AzureDevSessionsRemoteHostName = "AzureDevSessionsRemoteHostName";
         public const string AzureDevSessionsPortSuffixPlaceholder = "<port>";
+        public const string GitHubReleaseApiUrl = "https://api.github.com/repos/Azure/azure-functions-core-tools/releases/latest";
+
         // Sample format https://n12abc3t-<port>.asse.devtunnels.ms/
 
 

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -69,7 +69,6 @@ namespace Azure.Functions.Cli.Common
         public const int DefaultGetFunctionReadinessTime = 30000;
         public const int DefaultRestartedWorkerProcessUptimeWithin = 45000;
         public const string HelpCommand = "help";
-        public const string CoreToolsVersionsFeedUrl = "https://functionscdn.azureedge.net/public/cli-feed-v4.json";
         public const string OldCoreToolsVersionMessage = "You are using an old Core Tools version. Please upgrade to the latest version.";
         public const string GetFunctionNameParamId = "trigger-functionName";
         public const string HttpTriggerAuthLevelParamId = "httpTrigger-authLevel";

--- a/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
@@ -210,6 +210,7 @@ namespace Azure.Functions.Cli.Helpers
                     return uri.Segments[2].Replace("/", string.Empty);
                 }
             }
+
             public CoreToolsRelease ReleaseDetail { get; set; }
 
             public string CoreToolsAssemblyZipFile

--- a/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
@@ -75,7 +75,7 @@ namespace Azure.Functions.Cli.Helpers
                 }
                 
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 // ignore exception and no warning when the check fails.
                 return false;

--- a/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
@@ -45,7 +45,7 @@ namespace Azure.Functions.Cli.Helpers
         {
             try
             {
-                using (client ??= new HttpClient { Timeout = TimeSpan.FromSeconds(1) })
+                using (client ??= new HttpClient())
                 {
                     client.DefaultRequestHeaders.Add("User-Agent", "AzureFunctionsCoreToolsClient");
 

--- a/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
@@ -1,4 +1,5 @@
 ﻿using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Extensions;
 using Colors.Net;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -18,13 +19,8 @@ namespace Azure.Functions.Cli.Helpers
 {
     internal class VersionHelper
     {
-        internal static string _cliVersion = Constants.CliVersion;
-
-        // This method is created only for testing
-        internal static void SetCliVersion(string version)
-        {
-            _cliVersion = version;
-        }
+        // Set the CliVersion for testing
+        internal static string CliVersion { get; set; } = Constants.CliVersion;
 
         public static async Task<string> RunAsync(Task<bool> isRunningOlderVersion = null)
         {
@@ -49,35 +45,21 @@ namespace Azure.Functions.Cli.Helpers
         {
             try
             {
-                using (client ??= new System.Net.Http.HttpClient{Timeout = TimeSpan.FromSeconds(1)})
+                using (client ??= new HttpClient { Timeout = TimeSpan.FromSeconds(1) })
                 {
-                    var response = await client.GetAsync(Constants.CoreToolsVersionsFeedUrl);
+                    client.DefaultRequestHeaders.Add("User-Agent", "AzureFunctionsCoreToolsClient");
+
+                    var response = await client.GetAsync(Constants.GitHubReleaseApiUrl);
+                    response.EnsureSuccessStatusCode();
+
                     var content = await response.Content.ReadAsStringAsync();
-                    var data = JsonConvert.DeserializeObject<CliFeed>(content);
-                    IEnumerable releases = ((IEnumerable)data.Releases);
-                    var releaseList = new List<ReleaseSummary>();
-                    foreach (var item in releases)
-                    {
-                        var jProperty = (Newtonsoft.Json.Linq.JProperty)item;
-                        var releaseDetail = JsonConvert.DeserializeObject<ReleaseDetail>(jProperty.Value.ToString());
-                        releaseList.Add(new ReleaseSummary(jProperty.Name, releaseDetail.ReleaseList.FirstOrDefault()));
-                    }
+                    var release = JsonConvert.DeserializeObject<GitHubRelease>(content);
 
-                    var latestCoreToolsAssemblyZipFile = releaseList.FirstOrDefault(x => x.Release == data.Tags.V4Release.ReleaseVersion)?.CoreToolsAssemblyZipFile;
-
-                    if (!string.IsNullOrEmpty(latestCoreToolsAssemblyZipFile) &&
-                        !latestCoreToolsAssemblyZipFile.Contains($"{_cliVersion}.zip"))
-                    {
-                        return true;
-                    }
-
-                    return false;
+                    return !release.TagName.EqualsIgnoreCase(CliVersion);
                 }
-                
             }
             catch (Exception)
             {
-                // ignore exception and no warning when the check fails.
                 return false;
             }
         }
@@ -132,118 +114,10 @@ namespace Azure.Functions.Cli.Helpers
             return string.Empty;
         }
 
-        private class CliFeed
+        private class GitHubRelease
         {
-            [JsonProperty("tags")]
-            public Tags Tags { get; set; }
-
-            [JsonProperty("releases")]
-            public Object Releases { get; set; }
-        }
-
-        private class Tags
-        {
-            [JsonProperty("v4")]
-            public Release V4Release { get; set; }
-
-            [JsonProperty("v4-prerelease")]
-            public Release V4PreRelease { get; set; }
-
-            [JsonProperty("v3")]
-            public Release V3Release { get; set; }
-
-            [JsonProperty("v3-prerelease")]
-            public Release V3PreRelease { get; set; }
-        }
-
-        private class Release
-        {
-            [JsonProperty("release")]
-            public string ReleaseVersion { get; set; }
-
-            [JsonProperty("releaseQuality")]
-            public string ReleaseQuality { get; set; }
-
-            [JsonProperty("hidden")]
-            public bool Hidden { get; set; }
-        }
-
-        internal class ReleaseSummary
-        {
-            private readonly string _coreToolsAssemblyZipFile;
-
-            public ReleaseSummary(string release, CoreToolsRelease releaseDetail)
-            {
-                Release = release;
-                ReleaseDetail = releaseDetail;
-
-                if (string.IsNullOrEmpty(ReleaseDetail?.DownloadLink))
-                {
-                    _coreToolsAssemblyZipFile = string.Empty;
-                }
-                else
-                {
-                    Uri uri = new UriBuilder(ReleaseDetail?.DownloadLink).Uri;
-                    _coreToolsAssemblyZipFile = uri.Segments.FirstOrDefault(segment => segment.EndsWith(".zip", StringComparison.OrdinalIgnoreCase));
-                }
-            }
-
-            public string Release { get; set; }
-
-            public string CoreToolsReleaseNumber
-            {
-                get
-                {
-                    var downloadLink = ReleaseDetail?.DownloadLink;
-                    if (string.IsNullOrEmpty(ReleaseDetail?.DownloadLink))
-                    {
-                        return string.Empty;
-                    }
-
-                    Uri uri = new UriBuilder(ReleaseDetail?.DownloadLink).Uri;
-
-                    if (uri.Segments.Length < 4)
-                    {
-                        return string.Empty;
-                    }
-
-                    return uri.Segments[2].Replace("/", string.Empty);
-                }
-            }
-
-            public CoreToolsRelease ReleaseDetail { get; set; }
-
-            public string CoreToolsAssemblyZipFile
-            {
-                get
-                {
-                    return _coreToolsAssemblyZipFile;
-                }
-            }
-        }
-
-        internal class ReleaseDetail
-        {
-            [JsonProperty("coreTools")]
-            public IList<CoreToolsRelease> ReleaseList { get; set; }
-        }
-
-        internal class CoreToolsRelease
-        {
-            [JsonProperty("OS")]
-            public string Os { get; set; }
-
-            [JsonProperty("Architecture")]
-            public string Architecture { get; set; }
-
-            [JsonProperty("downloadLink")]
-            public string DownloadLink { get; set; }
-
-            [JsonProperty("size")]
-            public string Size { get; set; }
-
-            [JsonProperty("default")]
-            public bool Default { get; set; }
+            [JsonProperty("tag_name")]
+            public string TagName { get; set; }
         }
     }
 

--- a/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/VersionHelper.cs
@@ -7,6 +7,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -17,6 +18,14 @@ namespace Azure.Functions.Cli.Helpers
 {
     internal class VersionHelper
     {
+        internal static string _cliVersion = Constants.CliVersion;
+
+        // This method is created only for testing
+        internal static void SetCliVersion(string version)
+        {
+            _cliVersion = version;
+        }
+
         public static async Task<string> RunAsync(Task<bool> isRunningOlderVersion = null)
         {
             isRunningOlderVersion ??= IsRunningAnOlderVersion();
@@ -36,37 +45,37 @@ namespace Azure.Functions.Cli.Helpers
         // Check that current core tools is the latest version. 
         // To ensure that it doesn't block other tasks. The HTTP Request timeout is only 1 second. 
         // We simply ingnore the exception if for any reason the check fails. 
-        public static async Task<bool> IsRunningAnOlderVersion()
+        public static async Task<bool> IsRunningAnOlderVersion(HttpClient client = null)
         {
             try
             {
-                var client = new System.Net.Http.HttpClient
+                using (client ??= new System.Net.Http.HttpClient{Timeout = TimeSpan.FromSeconds(1)})
                 {
-                    Timeout = TimeSpan.FromSeconds(1)
-                };
-                var response = await client.GetAsync(Constants.CoreToolsVersionsFeedUrl);
-                var content = await response.Content.ReadAsStringAsync();
-                var data = JsonConvert.DeserializeObject<CliFeed>(content);
-                IEnumerable releases = ((IEnumerable) data.Releases);
-                var releaseList = new List<ReleaseSummary>();
-                foreach (var item in releases)
-                {
-                    var jProperty = (Newtonsoft.Json.Linq.JProperty)item;
-                    var releaseDetail = JsonConvert.DeserializeObject<ReleaseDetail>(jProperty.Value.ToString());
-                    releaseList.Add(new ReleaseSummary() { Release = jProperty.Name, ReleaseDetail = releaseDetail.ReleaseList.FirstOrDefault() });
+                    var response = await client.GetAsync(Constants.CoreToolsVersionsFeedUrl);
+                    var content = await response.Content.ReadAsStringAsync();
+                    var data = JsonConvert.DeserializeObject<CliFeed>(content);
+                    IEnumerable releases = ((IEnumerable)data.Releases);
+                    var releaseList = new List<ReleaseSummary>();
+                    foreach (var item in releases)
+                    {
+                        var jProperty = (Newtonsoft.Json.Linq.JProperty)item;
+                        var releaseDetail = JsonConvert.DeserializeObject<ReleaseDetail>(jProperty.Value.ToString());
+                        releaseList.Add(new ReleaseSummary(jProperty.Name, releaseDetail.ReleaseList.FirstOrDefault()));
+                    }
+
+                    var latestCoreToolsAssemblyZipFile = releaseList.FirstOrDefault(x => x.Release == data.Tags.V4Release.ReleaseVersion)?.CoreToolsAssemblyZipFile;
+
+                    if (!string.IsNullOrEmpty(latestCoreToolsAssemblyZipFile) &&
+                        !latestCoreToolsAssemblyZipFile.Contains($"{_cliVersion}.zip"))
+                    {
+                        return true;
+                    }
+
+                    return false;
                 }
-
-                var latestCoreToolsReleaseVersion = releaseList.FirstOrDefault(x => x.Release == data.Tags.V4Release.ReleaseVersion)?.CoreToolsReleaseNumber;
-
-                if (!string.IsNullOrEmpty(latestCoreToolsReleaseVersion) &&
-                    Constants.CliVersion != latestCoreToolsReleaseVersion)
-                {
-                    return true;
-                }
-
-                return false;
+                
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 // ignore exception and no warning when the check fails.
                 return false;
@@ -159,8 +168,26 @@ namespace Azure.Functions.Cli.Helpers
             public bool Hidden { get; set; }
         }
 
-        private class ReleaseSummary
+        internal class ReleaseSummary
         {
+            private readonly string _coreToolsAssemblyZipFile;
+
+            public ReleaseSummary(string release, CoreToolsRelease releaseDetail)
+            {
+                Release = release;
+                ReleaseDetail = releaseDetail;
+
+                if (string.IsNullOrEmpty(ReleaseDetail?.DownloadLink))
+                {
+                    _coreToolsAssemblyZipFile = string.Empty;
+                }
+                else
+                {
+                    Uri uri = new UriBuilder(ReleaseDetail?.DownloadLink).Uri;
+                    _coreToolsAssemblyZipFile = uri.Segments.FirstOrDefault(segment => segment.EndsWith(".zip", StringComparison.OrdinalIgnoreCase));
+                }
+            }
+
             public string Release { get; set; }
 
             public string CoreToolsReleaseNumber
@@ -184,15 +211,23 @@ namespace Azure.Functions.Cli.Helpers
                 }
             }
             public CoreToolsRelease ReleaseDetail { get; set; }
+
+            public string CoreToolsAssemblyZipFile
+            {
+                get
+                {
+                    return _coreToolsAssemblyZipFile;
+                }
+            }
         }
 
-        private class ReleaseDetail
+        internal class ReleaseDetail
         {
             [JsonProperty("coreTools")]
             public IList<CoreToolsRelease> ReleaseList { get; set; }
         }
 
-        private class CoreToolsRelease
+        internal class CoreToolsRelease
         {
             [JsonProperty("OS")]
             public string Os { get; set; }

--- a/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
@@ -1,9 +1,17 @@
 using System;
+using System.Net.Http;
+using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Helpers;
 using Azure.Functions.Cli.Tests.E2E.Helpers;
+using Moq.Protected;
+using Moq;
 using Xunit;
 using Xunit.Abstractions;
+using static Azure.Functions.Cli.Helpers.VersionHelper;
+using FluentAssertions;
 
 namespace Azure.Functions.Cli.Tests.E2E
 {
@@ -23,6 +31,96 @@ namespace Azure.Functions.Cli.Tests.E2E
                 OutputContains = new[] { "4." },
                 CommandTimeout = TimeSpan.FromSeconds(30)
             }, _output);
+        }
+
+        [Fact]
+        public void CoreToolsAssemblyZipFile_ShouldParseCorrectSegment_WhenValidDownloadLinkIsProvided()
+        {
+            var fakeDownloadLink = "https://example.com/public/coretoolnumber/V4/assemblyfile.zip";
+            var releaseDetail = new CoreToolsRelease { DownloadLink = fakeDownloadLink };
+            var releaseSummary = new ReleaseSummary("V4", releaseDetail);
+
+            var result = releaseSummary.CoreToolsAssemblyZipFile;
+
+            result.Should().Be("assemblyfile.zip"); // We expect the segment "assemblyfile.zip" based on the provided URL
+        }
+
+        [Fact]
+        public void CoreToolsAssemblyZipFile_ShouldReturnEmpty_WhenDownloadLinkIsNull()
+        {
+            var releaseDetail = new CoreToolsRelease { DownloadLink = null };
+            var releaseSummary = new ReleaseSummary("V4", releaseDetail);
+
+            var result = releaseSummary.CoreToolsAssemblyZipFile;
+
+            result.Should().Be(string.Empty); // The result should be empty when there is no link
+        }
+
+        [Fact]
+        public async Task IsRunningAnOlderVersion_ShouldReturnTrue_WhenVersionIsOlder()
+        {
+            // Create the mocked HttpClient with the mock response
+            var mockHttpClient = GetMockHttpClientWithResponse();
+
+            SetCliVersion("4.0.1");
+            var result = await VersionHelper.IsRunningAnOlderVersion(mockHttpClient);
+
+            result.Should().Be(true);
+        }
+
+        [Fact]
+        public async Task IsRunningAnOlderVersion_ShouldReturnFalse_WhenVersionIsUpToDate()
+        {
+            // Create the mocked HttpClient with the mock response
+            var mockHttpClient = GetMockHttpClientWithResponse();
+
+            SetCliVersion("4.0.6610");
+            var result = await VersionHelper.IsRunningAnOlderVersion(mockHttpClient);
+
+            result.Should().Be(false);
+        }
+
+        // Method to return a mocked HttpClient
+        private HttpClient GetMockHttpClientWithResponse()
+        {
+            var mockJsonResponse = @"{
+                'tags': {
+                    'v4': {
+                        'release': '4.0',
+                        'releaseQuality': 'GA',
+                        'hidden': false
+                    },
+                },
+                'releases': {
+                    '4.0': {
+                        'coreTools': [
+                            {
+                                'OS': 'Windows',
+                                'Architecture': 'x86',
+                                'downloadLink': 'https://example.com/public/0.0.1/Azure.Functions.Latest.4.0.6610.zip',
+                                'sha2': 'BB4978D83CFBABAE67D4D720FEC1F1171BE0406B2147EF3FECA476C19ADD9920',
+                                'size': 'full',
+                                'default': 'true'
+                            }
+                        ]
+                    }
+                }
+            }";
+            var mockHandler = new Mock<HttpMessageHandler>();
+
+            // Mock the SendAsync method to return a mocked response
+            mockHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(mockJsonResponse)
+                });
+
+            // Return HttpClient with mocked handler
+            return new HttpClient(mockHandler.Object) { Timeout = TimeSpan.FromSeconds(1) };
         }
     }
 }

--- a/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
@@ -39,7 +39,7 @@ namespace Azure.Functions.Cli.Tests.E2E
             // Create the mocked HttpClient with the mock response
             var mockHttpClient = GetMockHttpClientWithResponse();
 
-            VersionHelper.CliVersion = "OlderVersion";
+            VersionHelper.CliVersion = "4.0.5";
             var result = await VersionHelper.IsRunningAnOlderVersion(mockHttpClient);
 
             result.Should().Be(true);
@@ -51,7 +51,7 @@ namespace Azure.Functions.Cli.Tests.E2E
             // Create the mocked HttpClient with the mock response
             var mockHttpClient = GetMockHttpClientWithResponse();
 
-            VersionHelper.CliVersion = "LatestVersion-4.0";
+            VersionHelper.CliVersion = "4.0.6610";
             var result = await VersionHelper.IsRunningAnOlderVersion(mockHttpClient);
 
             result.Should().Be(false);
@@ -61,7 +61,7 @@ namespace Azure.Functions.Cli.Tests.E2E
         private HttpClient GetMockHttpClientWithResponse()
         {
             var mockJsonResponse = @"{
-                'tag_name':'LatestVersion-4.0',
+                'tag_name':'4.0.6610',
                 'target_commitish': '48490a7ee744ed435fdce62f5e1f2f39c61c5309',
                 'name': '4.0.6610',
                 'draft': false,
@@ -83,7 +83,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                 });
 
             // Return HttpClient with mocked handler
-            return new HttpClient(mockHandler.Object) { Timeout = TimeSpan.FromSeconds(1) };
+            return new HttpClient(mockHandler.Object);
         }
     }
 }

--- a/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/VersionTests.cs
@@ -34,35 +34,12 @@ namespace Azure.Functions.Cli.Tests.E2E
         }
 
         [Fact]
-        public void CoreToolsAssemblyZipFile_ShouldParseCorrectSegment_WhenValidDownloadLinkIsProvided()
-        {
-            var fakeDownloadLink = "https://example.com/public/coretoolnumber/V4/assemblyfile.zip";
-            var releaseDetail = new CoreToolsRelease { DownloadLink = fakeDownloadLink };
-            var releaseSummary = new ReleaseSummary("V4", releaseDetail);
-
-            var result = releaseSummary.CoreToolsAssemblyZipFile;
-
-            result.Should().Be("assemblyfile.zip"); // We expect the segment "assemblyfile.zip" based on the provided URL
-        }
-
-        [Fact]
-        public void CoreToolsAssemblyZipFile_ShouldReturnEmpty_WhenDownloadLinkIsNull()
-        {
-            var releaseDetail = new CoreToolsRelease { DownloadLink = null };
-            var releaseSummary = new ReleaseSummary("V4", releaseDetail);
-
-            var result = releaseSummary.CoreToolsAssemblyZipFile;
-
-            result.Should().Be(string.Empty); // The result should be empty when there is no link
-        }
-
-        [Fact]
         public async Task IsRunningAnOlderVersion_ShouldReturnTrue_WhenVersionIsOlder()
         {
             // Create the mocked HttpClient with the mock response
             var mockHttpClient = GetMockHttpClientWithResponse();
 
-            SetCliVersion("4.0.1");
+            VersionHelper.CliVersion = "OlderVersion";
             var result = await VersionHelper.IsRunningAnOlderVersion(mockHttpClient);
 
             result.Should().Be(true);
@@ -74,7 +51,7 @@ namespace Azure.Functions.Cli.Tests.E2E
             // Create the mocked HttpClient with the mock response
             var mockHttpClient = GetMockHttpClientWithResponse();
 
-            SetCliVersion("4.0.6610");
+            VersionHelper.CliVersion = "LatestVersion-4.0";
             var result = await VersionHelper.IsRunningAnOlderVersion(mockHttpClient);
 
             result.Should().Be(false);
@@ -84,27 +61,13 @@ namespace Azure.Functions.Cli.Tests.E2E
         private HttpClient GetMockHttpClientWithResponse()
         {
             var mockJsonResponse = @"{
-                'tags': {
-                    'v4': {
-                        'release': '4.0',
-                        'releaseQuality': 'GA',
-                        'hidden': false
-                    },
-                },
-                'releases': {
-                    '4.0': {
-                        'coreTools': [
-                            {
-                                'OS': 'Windows',
-                                'Architecture': 'x86',
-                                'downloadLink': 'https://example.com/public/0.0.1/Azure.Functions.Latest.4.0.6610.zip',
-                                'sha2': 'BB4978D83CFBABAE67D4D720FEC1F1171BE0406B2147EF3FECA476C19ADD9920',
-                                'size': 'full',
-                                'default': 'true'
-                            }
-                        ]
-                    }
-                }
+                'tag_name':'LatestVersion-4.0',
+                'target_commitish': '48490a7ee744ed435fdce62f5e1f2f39c61c5309',
+                'name': '4.0.6610',
+                'draft': false,
+                'prerelease': false,
+                'created_at': '',
+                'published_at': '2024-11-13T22:08:49Z',
             }";
             var mockHandler = new Mock<HttpMessageHandler>();
 


### PR DESCRIPTION
### Issue describing the changes in this PR
Part II: we are getting message of older version when we install Azure Function Core Tool latest version via Windows and macOS. 
To resolve this In **VersionHelper.cs** 'IsRunningOlderversion' method we have changed the logic to get the **Latest Release version** from [GitHubReleaseApiUrl](https://api.github.com/repos/Azure/azure-functions-core-tools/releases/latest)  by extracting it from **tag_name** and compare it with **Cliversion**

resolves #3776

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)