### PR TITLE
Update DefaultInProcTargetFramework to .NET 8

### DIFF
--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -61,7 +61,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
         // Default to .NET 8 if the target framework is not specified
         private const string DefaultTargetFramework = Common.TargetFramework.net8;
 
-        private const string DefaultInProcTargetFramework = Common.TargetFramework.net6;
+        private const string DefaultInProcTargetFramework = Common.TargetFramework.net8;
 
         internal static readonly Dictionary<Lazy<string>, Task<string>> fileToContentMap = new Dictionary<Lazy<string>, Task<string>>
         {


### PR DESCRIPTION
Updated the DefaultInProcTargetFramework constant in the InitAction class from .NET 6 to .NET 8, setting the default in-process target framework to .NET 8.

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #4215

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)