### PR TITLE
Fixing Core tools tests

### DIFF
--- a/test/Azure.Functions.Cli.Tests/E2E/CreateFunctionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/CreateFunctionTests.cs
@@ -40,6 +40,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     "new --template TimerTrigger --name testfunc --authlevel function"
                 },
                 HasStandardError = true,
+                ExitInError = true,
                 ErrorContains = new[]
                 {
                     Constants.AuthLevelErrorMessage

--- a/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
@@ -171,6 +171,7 @@ namespace Azure.Functions.Cli.Tests.E2E
             {
                 Commands = new[] { $"init . --worker-runtime {workerRuntime} --model {programmingModel}" },
                 HasStandardError = true,
+                ExitInError = true,
                 ErrorContains = new[]
                 {
                     $"programming model is not supported for worker runtime {workerRuntime}. Supported programming models for worker runtime {workerRuntime} are:"
@@ -278,6 +279,7 @@ namespace Azure.Functions.Cli.Tests.E2E
             {
                 Commands = new[] { $"init . --worker-runtime {unknownWorkerRuntime}" },
                 HasStandardError = true,
+                ExitInError = true,
                 ErrorContains = new[]
                 {
                     $"Worker runtime '{unknownWorkerRuntime}' is not a valid option."
@@ -293,6 +295,7 @@ namespace Azure.Functions.Cli.Tests.E2E
             {
                 Commands = new[] { $"init . --worker-runtime dotnet --target-framework {unsupportedTargetFramework}" },
                 HasStandardError = true,
+                ExitInError = true,
                 ErrorContains = new[]
                 {
                     $"Unable to parse target framework {unsupportedTargetFramework} for worker runtime dotnet. Valid options are net8.0, net6.0"
@@ -669,6 +672,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     $"init . --docker-only"
                 },
                 HasStandardError = true,
+                ExitInError = true,
                 ErrorContains = new[]
                 {
                     $"Can't determine project language from files."
@@ -779,6 +783,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     $"init . --worker-runtime python --managed-dependencies "
                 },
                 HasStandardError = true,
+                ExitInError = true,
                 ErrorContains = new[]
                 {
                     $"Managed dependencies is only supported for PowerShell"

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -733,6 +733,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                         $"start --port {_funcHostPort} --verbose --runtime inproc8"
                     },
                     ExpectExit = true,
+                    ExitInError = true,
                     ErrorContains = ["Failed to locate the inproc8 model host"],
                     Test = async (workingDir, p, _) =>
                     {
@@ -766,6 +767,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                         $"start --port {_funcHostPort} --verbose"
                     },
                     ExpectExit = true,
+                    ExitInError = true,
                     ErrorContains = ["Failed to locate the inproc8 model host"],
                     Test = async (workingDir, p, _) =>
                     {
@@ -885,6 +887,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                         $"start --port {_funcHostPort} --verbose"
                     },
                     ExpectExit = false,
+                    ExitInError = true,
                     ErrorContains = ["Failed to locate the inproc6 model host at"],
                     Test = async (workingDir, p, _) =>
                     {
@@ -918,6 +921,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                         $"start --port {_funcHostPort} --verbose --runtime inproc6"
                     },
                     ExpectExit = false,
+                    ExitInError = true,
                     ErrorContains = ["Failed to locate the inproc6 model host at"],
                     Test = async (workingDir, p, _) =>
                     {
@@ -999,7 +1003,8 @@ namespace Azure.Functions.Cli.Tests.E2E
                     {
                         $"start  --port {_funcHostPort} --verbose --runtime inproc6"
                     },
-                    ExpectExit = false,
+                    ExpectExit = true,
+                    ExitInError = true,
                     ErrorContains = ["The runtime argument value provided, 'inproc6', is invalid. The provided value is only valid for the worker runtime 'dotnet'."],
                     Test = async (workingDir, p, _) =>
                     {
@@ -1033,6 +1038,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                         $"start  --port {_funcHostPort} --verbose --runtime inproc8"
                     },
                     ExpectExit = false,
+                    ExitInError = true,
                     ErrorContains = ["The runtime argument value provided, 'inproc8', is invalid. The provided value is only valid for the worker runtime 'dotnet'."],
                     Test = async (workingDir, p, _) =>
                     {
@@ -1066,6 +1072,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                         $"start  --port {_funcHostPort} --verbose --runtime inproc8"
                     },
                     ExpectExit = false,
+                    ExitInError = true,
                     ErrorContains = ["The runtime argument value provided, 'inproc8', is invalid. For the 'inproc8' runtime, the 'FUNCTIONS_INPROC_NET8_ENABLED' environment variable must be set. See https://aka.ms/azure-functions/dotnet/net8-in-process."],
                     Test = async (workingDir, p, _) =>
                     {
@@ -1099,6 +1106,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                         $"start  --port {_funcHostPort} --verbose --runtime default"
                     },
                     ExpectExit = false,
+                    ExitInError = true,
                     ErrorContains = ["The runtime argument value provided, 'default', is invalid. The provided value is only valid for the worker runtime 'dotnetIsolated'."],
                     Test = async (workingDir, p, _) =>
                     {
@@ -1132,6 +1140,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                         $"start  --port {_funcHostPort} --verbose --runtime default"
                     },
                     ExpectExit = false,
+                    ExitInError = true,
                     ErrorContains = ["The runtime argument value provided, 'default', is invalid. The provided value is only valid for the worker runtime 'dotnetIsolated'."],
                     Test = async (workingDir, p, _) =>
                     {
@@ -1165,6 +1174,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                         $"start  --port {_funcHostPort} --verbose --runtime inproc6"
                     },
                     ExpectExit = false,
+                    ExitInError = true,
                     ErrorContains = ["The runtime argument value provided, 'inproc6', is invalid. For the 'inproc6' runtime, the 'FUNCTIONS_INPROC_NET8_ENABLED' environment variable cannot be be set. See https://aka.ms/azure-functions/dotnet/net8-in-process."],
                     Test = async (workingDir, p, _) =>
                     {
@@ -1199,6 +1209,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                         $"start  --port {_funcHostPort} --verbose --runtime inproc6"
                     },
                     ExpectExit = false,
+                    ExitInError = true,
                     ErrorContains = ["The runtime argument value provided, 'inproc6', is invalid. The provided value is only valid for the worker runtime 'dotnet'."],
                     Test = async (workingDir, p, _) =>
                     {
@@ -1233,6 +1244,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                         $"start  --port {_funcHostPort} --verbose --runtime inproc8"
                     },
                     ExpectExit = false,
+                    ExitInError = true,
                     ErrorContains = ["The runtime argument value provided, 'inproc8', is invalid. The provided value is only valid for the worker runtime 'dotnet'."],
                     Test = async (workingDir, p, _) =>
                     {

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests_default.runsettings
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests_default.runsettings
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RunSettings>
   <RunConfiguration>
-    <TestCaseFilter>(Group != RequiresNestedInProcArtifacts & Group != UseInVisualStudioConsolidatedArtifactGeneration)</TestCaseFilter>
+	  <TestCaseFilter>(Group~'RequiresNestedInProcArtifacts' & Group~'UseInVisualStudioConsolidatedArtifactGeneration')</TestCaseFilter>
   </RunConfiguration>
 </RunSettings>

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests_default.runsettings
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests_default.runsettings
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RunSettings>
   <RunConfiguration>
-    <TestCaseFilter>(Group != RequiresNestedInProcArtifacts AND Group != UseInVisualStudioConsolidatedArtifactGeneration)</TestCaseFilter>
+    <TestCaseFilter>(Group != RequiresNestedInProcArtifacts & Group != UseInVisualStudioConsolidatedArtifactGeneration)</TestCaseFilter>
   </RunConfiguration>
 </RunSettings>

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests_default.runsettings
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests_default.runsettings
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RunSettings>
   <RunConfiguration>
-	  <TestCaseFilter>(Group~'RequiresNestedInProcArtifacts' & Group~'UseInVisualStudioConsolidatedArtifactGeneration')</TestCaseFilter>
+    <TestCaseFilter>(Group != RequiresNestedInProcArtifacts) &amp; (Group != UseInVisualStudioConsolidatedArtifactGeneration)</TestCaseFilter>
   </RunConfiguration>
 </RunSettings>

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests_default.runsettings
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests_default.runsettings
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RunSettings>
   <RunConfiguration>
-    <TestCaseFilter>(Group != RequiresNestedInProcArtifacts) &amp; (Group != UseInVisualStudioConsolidatedArtifactGeneration)</TestCaseFilter>
+    <TestCaseFilter>(Group != RequiresNestedInProcArtifacts) &amp; (Group != UseInVisualStudioConsolidatedArtifactGeneration) &amp; (Group != UseInConsolidatedArtifactGeneration)</TestCaseFilter>
   </RunConfiguration>
 </RunSettings>

--- a/test/Azure.Functions.Cli.Tests/ExtensionsTests/ExtensionBundleTests.cs
+++ b/test/Azure.Functions.Cli.Tests/ExtensionsTests/ExtensionBundleTests.cs
@@ -28,6 +28,7 @@ namespace Azure.Functions.Cli.Tests.ExtensionsTests
                 {
                     "No action performed"
                 },
+                ExitInError = true,
                 CommandTimeout = TimeSpan.FromMinutes(300)
             }, _output);
         }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

I accidently stopped tests from running in my previous PR, so I'm fixing them in this PR  to ensure they still run.

One key change I made previously was that we assert `ExitInError` now to ensure that the tests error out when expected to do so. A lot of the unit tests need to add the assertion as well to make sure the tests pass as expected


### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)