### PR TITLE
Setting TFM to net6 for ExtensionsProj

### DIFF
--- a/src/Azure.Functions.Cli/StaticResources/ExtensionsProj.csproj.template
+++ b/src/Azure.Functions.Cli/StaticResources/ExtensionsProj.csproj.template
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 	<WarningsAsErrors></WarningsAsErrors>
 	<DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>

--- a/src/Azure.Functions.Cli/StaticResources/ExtensionsProj.csproj.template
+++ b/src/Azure.Functions.Cli/StaticResources/ExtensionsProj.csproj.template
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 	<WarningsAsErrors></WarningsAsErrors>
 	<DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>

--- a/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
@@ -45,7 +45,7 @@ namespace Azure.Functions.Cli.Tests.E2E
 
             return CliTester.Run(new RunConfiguration
             {
-                Commands = new[] { $"init . --worker-runtime {workerRuntime}" },
+                Commands = new[] { $"init . --worker-runtime {workerRuntime} --skip-npm-install" },
                 CheckFiles = files.ToArray(),
                 OutputContains = new[]
                 {
@@ -543,7 +543,7 @@ namespace Azure.Functions.Cli.Tests.E2E
         {
             return CliTester.Run(new RunConfiguration
             {
-                Commands = new[] { "init . --worker-runtime node" },
+                Commands = new[] { "init . --worker-runtime node --skip-npm-install" },
                 CheckFiles = new FileResult[]
                 {
                     new FileResult


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves [#3707 ](https://github.com/Azure/azure-functions-core-tools/issues/3707)

This PR sets the TFM for extensions proj to net6 to address issues compatibility issues.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)