### PR TITLE
POC - Refactor .NET 8 detection to eliminate FUNCTIONS_INPROC_NET8_ENABLED

### DIFF
--- a/test/Azure.Functions.Cli.Tests/ActionsTests/StartHostActionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/ActionsTests/StartHostActionTests.cs
@@ -232,7 +232,7 @@ namespace Azure.Functions.Cli.Tests.ActionsTests
                     HostRuntime = hostRuntimeArgument
                 };
 
-                await startHostAction.ValidateHostRuntimeAsync(currentRuntime, () => Task.FromResult(validNet8Configuration));
+                await startHostAction.ValidateHostRuntimeAsync(currentRuntime, validNet8Configuration);
             }
             catch (CliException)
             {


### PR DESCRIPTION
This suggestion could help us eliminate the need for FUNCTIONS_INPROC_NET8_ENABLED

Refactor the way .NET 8 projects are detected by removing the `IsInProcDotNet8Enabled` method and introducing `DotnetHelpers.IsDotNet8` which checks the target framework in the `.csproj` file. Updated `StartHostAction.cs` methods to use the new detection logic and added necessary `using` directives and methods in `DotnetHelpers.cs`. Adjusted tests in `StartHostActionTests.cs` to align with the new logic.

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)