### PR TITLE
POC - Refactor .NET 8 detection to eliminate FUNCTIONS_INPROC_NET8_ENABLED DLL approach

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -353,25 +353,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
             }
         }
 
-        /// <summary>
-        /// Check local.settings.json to determine whether in-proc .NET8 is enabled.
-        /// </summary>
-        private async Task<bool> IsInProcDotNet8Enabled()
-        {
-            var localSettingsJObject = await GetLocalSettingsJsonAsJObjectAsync();
-            var inProcDotNet8EnabledValue = localSettingsJObject?["Values"]?[Constants.InProcDotNet8EnabledSetting]?.Value<string>();
-            var isInProcDotNet8Enabled = string.Equals("1", inProcDotNet8EnabledValue, StringComparison.Ordinal);
 
-            if (VerboseLogging == true)
-            {
-                var message = isInProcDotNet8Enabled
-                    ? $"{Constants.InProcDotNet8EnabledSetting} app setting enabled in local.settings.json"
-                    : $"{Constants.InProcDotNet8EnabledSetting} app setting is not enabled in local.settings.json";
-                ColoredConsole.WriteLine(VerboseColor(message));
-            }
-
-            return isInProcDotNet8Enabled;
-        }
 
         private async Task<JObject> GetLocalSettingsJsonAsJObjectAsync()
         {
@@ -400,7 +382,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
         {
             await PreRunConditions();
             var isVerbose = VerboseLogging.HasValue && VerboseLogging.Value;
-            
+
             // Return if running is delegated to another version of Core Tools
             if (await TryHandleInProcDotNetLaunchAsync())
             {
@@ -486,12 +468,12 @@ namespace Azure.Functions.Cli.Actions.HostActions
             else if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.dotnet)
             {
                 // Infer host runtime by checking if .NET 8 is enabled
-                var isDotNet8Project = await IsInProcDotNet8Enabled();
+                var isDotNet8Project = await DotnetHelpers.IsDotNet8();
 
                 var selectedRuntime = isDotNet8Project
                     ? DotnetConstants.InProc8HostRuntime
                     : DotnetConstants.InProc6HostRuntime;
-                
+
                 PrintVerboseForHostSelection(selectedRuntime);
 
                 if (Utilities.IsMinifiedVersion())
@@ -510,10 +492,8 @@ namespace Azure.Functions.Cli.Actions.HostActions
         }
 
         internal async Task ValidateHostRuntimeAsync(WorkerRuntime currentWorkerRuntime,
-            Func<Task<bool>> validateDotNet8ProjectEnablement = null)
+            bool? validateDotNet8ProjectEnablement = null)
         {
-            validateDotNet8ProjectEnablement ??= IsInProcDotNet8Enabled;
-
             void ThrowCliException(string suffix)
             {
                 throw new CliException($"The runtime argument value provided, '{HostRuntime}', is invalid. {suffix}");
@@ -534,11 +514,13 @@ namespace Azure.Functions.Cli.Actions.HostActions
                     ThrowCliException($"The provided value is only valid for the worker runtime '{WorkerRuntime.dotnetIsolated}'.");
                 }
 
-                if (isInproc8ArgumentValue && !await validateDotNet8ProjectEnablement())
+                validateDotNet8ProjectEnablement ??= await DotnetHelpers.IsDotNet8();
+
+                if (isInproc8ArgumentValue && !validateDotNet8ProjectEnablement.Value)
                 {
                     ThrowCliException($"For the '{DotnetConstants.InProc8HostRuntime}' runtime, the '{Constants.InProcDotNet8EnabledSetting}' environment variable must be set. See https://aka.ms/azure-functions/dotnet/net8-in-process.");
                 }
-                else if (isInproc6ArgumentValue && await validateDotNet8ProjectEnablement())
+                else if (isInproc6ArgumentValue && validateDotNet8ProjectEnablement.Value)
                 {
                     ThrowCliException($"For the '{DotnetConstants.InProc6HostRuntime}' runtime, the '{Constants.InProcDotNet8EnabledSetting}' environment variable cannot be be set. See https://aka.ms/azure-functions/dotnet/net8-in-process.");
                 }

--- a/src/Azure.Functions.Cli/Helpers/ExtensionsHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/ExtensionsHelper.cs
@@ -51,6 +51,25 @@ namespace Azure.Functions.Cli.Helpers
             return bindings;
         }
 
+        public static string GetScriptFilePath()
+        {
+            // Ignore current implementation, I need help getting the script file path.
+
+            // Below should be the logic to get the script file path...
+
+            // If we don't have functions, this mean we don't have function.json
+            // If we don't have a function.json file, we can't determine the script file
+            var scriptFile =
+                FileSystemHelpers.GetFiles(Environment.CurrentDirectory, searchPattern: Constants.FunctionJsonFileName)
+                    .Select(p =>
+                    {
+                        var functionJsonFileContent = FileSystemHelpers.ReadAllTextFromFile(p);
+                        var functionMetadata = JsonConvert.DeserializeObject<FunctionMetadata>(functionJsonFileContent);
+                        return functionMetadata.ScriptFile[1..];
+                    }).FirstOrDefault();
+            return scriptFile;
+        }
+
         public static IEnumerable<ExtensionPackage> GetExtensionPackages()
         {
             Dictionary<string, ExtensionPackage> packages = new Dictionary<string, ExtensionPackage>();

--- a/test/Azure.Functions.Cli.Tests/ActionsTests/StartHostActionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/ActionsTests/StartHostActionTests.cs
@@ -232,7 +232,7 @@ namespace Azure.Functions.Cli.Tests.ActionsTests
                     HostRuntime = hostRuntimeArgument
                 };
 
-                await startHostAction.ValidateHostRuntimeAsync(currentRuntime, () => Task.FromResult(validNet8Configuration));
+                await startHostAction.ValidateHostRuntimeAsync(currentRuntime, validNet8Configuration);
             }
             catch (CliException)
             {
@@ -240,7 +240,7 @@ namespace Azure.Functions.Cli.Tests.ActionsTests
                 {
                     throw;
                 }
-                
+
                 return;
             }
 


### PR DESCRIPTION
Update target framework detection and add new method

Refactor the way .NET 8 projects are detected by removing the IsInProcDotNet8Enabled method and introducing DotnetHelpers.IsDotNet8. 

The `IsDotNet8` method uses the main DLL file to determine the target framework. Additionally, a new method `GetScriptFilePath` has been added to `ExtensionsHelper.cs` to retrieve the script file path, but it is currently incomplete and requires further implementation.

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)