### PR TITLE
Fixing in-proc pipeline

### DIFF
--- a/check-vulnerabilities.ps1
+++ b/check-vulnerabilities.ps1
@@ -1,13 +1,7 @@
-$projectPath = ".\src\Azure.Functions.Cli"
 $projectFileName = ".\Azure.Functions.Cli.csproj"
 $logFilePath = "..\..\build.log"
 $skipCveFilePath = "..\..\skipPackagesCve.json"
-if (-not (Test-Path $projectPath))
-{
-    throw "Project path '$projectPath' does not exist."
-}
 
-cd $projectPath
 
 $cmd = "restore"
 Write-Host "dotnet $cmd"
@@ -63,5 +57,3 @@ if ($logFileExists)
 {
   Remove-Item $logFilePath
 }
-
-cd ../..

--- a/check-vulnerabilities.ps1
+++ b/check-vulnerabilities.ps1
@@ -1,6 +1,7 @@
 $projectPath = ".\src\Azure.Functions.Cli"
 $projectFileName = ".\Azure.Functions.Cli.csproj"
 $logFilePath = "..\..\build.log"
+$skipCveFilePath = "..\..\skipPackagesCve.json"
 if (-not (Test-Path $projectPath))
 {
     throw "Project path '$projectPath' does not exist."
@@ -12,11 +13,50 @@ $cmd = "restore"
 Write-Host "dotnet $cmd"
 dotnet $cmd | Tee-Object $logFilePath
 
-$cmd = "list", "package", "--include-transitive", "--vulnerable"
+$cmd = "list", "package", "--include-transitive", "--vulnerable", "--format", "json"
 Write-Host "dotnet $cmd"
 dotnet $cmd | Tee-Object $logFilePath
 
-$result = Get-content $logFilePath | select-string "has no vulnerable packages given the current sources"
+# Parse JSON output
+$logContent = Get-Content $logFilePath -Raw | ConvertFrom-Json
+$topLevelPackages = $logContent.projects.frameworks.topLevelPackages
+
+# Load skip-cve.json
+$skipCveContent = Get-Content $skipCveFilePath -Raw | ConvertFrom-Json
+$skipPackages = $skipCveContent.packages
+
+# Validate files in skipPackagesCve.json are still valid security vulnerabilities
+$topLevelPackageIds = $topLevelPackages.id
+$invalidSkips = $skipPackages | Where-Object { $_ -notin $topLevelPackageIds }
+
+if ($invalidSkips.Count -gt 0) {
+    Write-Host "The following packages in 'skipPackagesCve.json' do not exist in the vulnerable packages list: $($invalidSkips -join ', '). Please remove these packages from the JSON file."
+    Exit 1
+}
+
+# Filter vulnerabilities
+$vulnerablePackages = @()
+foreach ($package in $topLevelPackages) {
+    if ($skipPackages -notcontains $package.id) {
+        $vulnerablePackages += $package
+    }
+}
+
+# Check for remaining vulnerabilities
+if ($vulnerablePackages.Count -gt 0) {
+    Write-Host "Security vulnerabilities found (excluding skipped packages):"
+    $vulnerablePackages | ForEach-Object {
+        Write-Host "Package: $($_.id)"
+        Write-Host "Version: $($_.resolvedVersion)"
+        $_.vulnerabilities | ForEach-Object {
+            Write-Host "Severity: $($_.severity)"
+            Write-Host "Advisory: $($_.advisoryurl)"
+        }
+    }
+    Exit 1
+} else {
+    Write-Host "No security vulnerabilities found (excluding skipped packages)."
+}
 
 $logFileExists = Test-Path $logFilePath -PathType Leaf
 if ($logFileExists)
@@ -25,9 +65,3 @@ if ($logFileExists)
 }
 
 cd ../..
-
-if (!$result)
-{
-  Write-Host "Vulnerabilities found" 
-  Exit 1
-}

--- a/eng/ci/templates/official/jobs/build-test.yml
+++ b/eng/ci/templates/official/jobs/build-test.yml
@@ -96,9 +96,6 @@ jobs:
       TELEMETRY_INSTRUMENTATION_KEY: $(TELEMETRY_INSTRUMENTATION_KEY)
       IntegrationBuildNumber: $(INTEGRATIONBUILDNUMBER)
     displayName: 'Executing build script'
-  - pwsh: |
-      .\check-vulnerabilities.ps1
-    displayName: "Check for security vulnerabilities"
 
   - template: ci/sign-files.yml@eng
     parameters:

--- a/eng/ci/templates/official/jobs/build-test.yml
+++ b/eng/ci/templates/official/jobs/build-test.yml
@@ -82,9 +82,11 @@ jobs:
       .\validateWorkerVersions.ps1
     displayName: 'Validate worker versions'
     condition: ne(variables['skipWorkerVersionValidation'], 'true')
-  - pwsh: |
-      .\check-vulnerabilities.ps1
-    displayName: "Check for security vulnerabilities"
+  - task: PowerShell@2
+    displayName: "Run Check Vulnerabilities Script"
+    inputs:
+      filePath: '$(Build.SourcesDirectory)/check-vulnerabilities.ps1'
+      workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.Cli'
   - pwsh: |
       .\build.ps1
     env:

--- a/eng/ci/templates/public/jobs/build-test-public.yml
+++ b/eng/ci/templates/public/jobs/build-test-public.yml
@@ -43,10 +43,11 @@ jobs:
   - pwsh: |
       .\validateWorkerVersions.ps1
     displayName: 'Validate worker versions'
-  - pwsh: |
-      .\check-vulnerabilities.ps1
-    displayName: "Check for security vulnerabilities"
-    condition: ne(variables['skipWorkerVersionValidation'], 'true')
+  - task: PowerShell@2
+    displayName: "Run Check Vulnerabilities Script"
+    inputs:
+      filePath: './checkVulnerabilities.ps1'
+      workingDirectory: './src/Azure.Functions.Cli'
   - pwsh: |
       .\build.ps1
     env:

--- a/eng/ci/templates/public/jobs/build-test-public.yml
+++ b/eng/ci/templates/public/jobs/build-test-public.yml
@@ -43,6 +43,9 @@ jobs:
   - pwsh: |
       .\validateWorkerVersions.ps1
     displayName: 'Validate worker versions'
+  - pwsh: |
+      .\check-vulnerabilities.ps1
+    displayName: "Check for security vulnerabilities"
     condition: ne(variables['skipWorkerVersionValidation'], 'true')
   - pwsh: |
       .\build.ps1
@@ -53,9 +56,6 @@ jobs:
       IsPublicBuild: true
       IsCodeqlBuild: false
     displayName: 'Executing build script'
-  - pwsh: |
-      .\check-vulnerabilities.ps1
-    displayName: "Check for security vulnerabilities"
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: 'VSTest'

--- a/eng/ci/templates/public/jobs/build-test-public.yml
+++ b/eng/ci/templates/public/jobs/build-test-public.yml
@@ -7,7 +7,7 @@ jobs:
   timeoutInMinutes: "180"
   pool:
     name: 1es-pool-azfunc-public
-    image: 1es-windows-202
+    image: 1es-windows-2022
     os: windows
 
   variables:

--- a/eng/ci/templates/public/jobs/build-test-public.yml
+++ b/eng/ci/templates/public/jobs/build-test-public.yml
@@ -41,14 +41,13 @@ jobs:
       versionSpec:
     displayName: Install Nuget tool
   - pwsh: |
-      ls $(Build.SourcesDirectory)
       .\validateWorkerVersions.ps1
     displayName: 'Validate worker versions'
   - task: PowerShell@2
     displayName: "Run Check Vulnerabilities Script"
     inputs:
-      filePath: '$(Build.SourcesDirectory)/checkVulnerabilities.ps1'
-      workingDirectory: './src/Azure.Functions.Cli'
+      filePath: '$(Build.SourcesDirectory)/check-vulnerabilities.ps1'
+      workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.Cli'
   - pwsh: |
       .\build.ps1
     env:

--- a/eng/ci/templates/public/jobs/build-test-public.yml
+++ b/eng/ci/templates/public/jobs/build-test-public.yml
@@ -7,7 +7,7 @@ jobs:
   timeoutInMinutes: "180"
   pool:
     name: 1es-pool-azfunc-public
-    image: 1es-windows-2022
+    image: 1es-windows-202
     os: windows
 
   variables:
@@ -41,12 +41,13 @@ jobs:
       versionSpec:
     displayName: Install Nuget tool
   - pwsh: |
+      ls $(Build.SourcesDirectory)
       .\validateWorkerVersions.ps1
     displayName: 'Validate worker versions'
   - task: PowerShell@2
     displayName: "Run Check Vulnerabilities Script"
     inputs:
-      filePath: './checkVulnerabilities.ps1'
+      filePath: '$(Build.SourcesDirectory)/checkVulnerabilities.ps1'
       workingDirectory: './src/Azure.Functions.Cli'
   - pwsh: |
       .\build.ps1

--- a/pipelineUtilities.psm1
+++ b/pipelineUtilities.psm1
@@ -74,8 +74,8 @@ $DotnetSDKVersionRequirements = @{
     }
     # Update .NET 9 patch once .NET 9 has been released out of preview
     '9.0' = @{
-        MinimalPatch = '100-preview.6.24328.19'
-        DefaultPatch = '100-preview.6.24328.19'
+        MinimalPatch = '100-rc.1.24452.12'
+        DefaultPatch = '100-rc.1.24452.12'
 
     }
 }

--- a/pipelineUtilities.psm1
+++ b/pipelineUtilities.psm1
@@ -124,7 +124,7 @@ function Install-DotnetVersion($Version,$Channel) {
     if ($IsWindows) {
         & .\$installScript -InstallDir "$env:ProgramFiles/dotnet" -Channel $Channel -Version $Version
         # Installing .NET into x86 directory since the E2E App runs the tests on x86 and looks for the specified framework there
-        & .\$installScript -InstallDir "$env:ProgramFiles (x86)/dotnet" -Channel $Channel -Version $Version
+        & .\$installScript -InstallDir "$env:ProgramFiles (x86)/dotnet" -Channel $Channel -Version $Version  -Architecture x86
     } else {
         bash ./$installScript --install-dir /usr/share/dotnet -c $Channel -v $Version
     }

--- a/skipPackagesCve.json
+++ b/skipPackagesCve.json
@@ -1,0 +1,5 @@
+{
+  "packages": [
+    "DotNetZip"
+  ]
+}

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" InitialTargets="ExcludeWorkersFromReadyToRun">
+<Project Sdk="Microsoft.NET.Sdk" InitialTargets="ExcludeWorkersFromReadyToRun">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
@@ -66,9 +66,9 @@
     <EmbeddedResource Include="StaticResources\Dockerfile.dotnet8Isolated">
       <LogicalName>$(AssemblyName).Dockerfile.dotnet8Isolated</LogicalName>
     </EmbeddedResource>
-	<EmbeddedResource Include="StaticResources\Dockerfile.dotnet9Isolated">
+    <EmbeddedResource Include="StaticResources\Dockerfile.dotnet9Isolated">
       <LogicalName>$(AssemblyName).Dockerfile.dotnet9Isolated</LogicalName>
-	</EmbeddedResource>
+    </EmbeddedResource>
     <EmbeddedResource Include="StaticResources\ExtensionsProj.csproj.template">
       <LogicalName>$(AssemblyName).ExtensionsProj.csproj</LogicalName>
     </EmbeddedResource>
@@ -287,7 +287,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage.Internal" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="4.35.4" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="4.37.0" />
     <PackageReference Include="Microsoft.Build" Version="17.0.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
@@ -295,7 +295,6 @@
     <PackageReference Include="System.Formats.Asn1" Version="6.0.1" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.1" />
     <PackageReference Include="YamlDotNet" Version="6.0.0" />
-
     <!-- Transitive dependency -->
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
@@ -307,12 +306,12 @@
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
   <ItemGroup Condition="'$(NoWorkers)' != 'true'">
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="2.14.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.10.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="2.17.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.10.1" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" Version="4.0.3148" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.2" Version="4.0.3220" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" Version="4.0.3219" />
-    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="4.29.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.2" Version="4.0.4025" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" Version="4.0.4026" />
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="4.34.0" />
   </ItemGroup>
   <Target Name="ExcludeWorkersFromReadyToRun">
     <CreateItem Include="%(None.Filename)%(None.Extension)" Condition="$([System.String]::new('%(None.TargetPath)').StartsWith('workers'))" PreserveExistingMetadata="false">

--- a/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
@@ -45,7 +45,7 @@ namespace Azure.Functions.Cli.Tests.E2E
 
             return CliTester.Run(new RunConfiguration
             {
-                Commands = new[] { $"init . --worker-runtime {workerRuntime}" },
+                Commands = new[] { $"init . --worker-runtime {workerRuntime} --skip-npm-install" },
                 CheckFiles = files.ToArray(),
                 OutputContains = new[]
                 {

--- a/validateWorkerVersions.ps1
+++ b/validateWorkerVersions.ps1
@@ -59,7 +59,7 @@ if (-Not $hostVersion) {
 
 function getHostFileContent([string]$filePath) {
     $uri = "https://raw.githubusercontent.com/Azure/azure-functions-host/v$hostVersion/$filePath"
-    return removeBomIfExists((Invoke-WebRequest -Uri $uri -MaximumRetryCount 5 -RetryIntervalSec 2).Content)
+    return removeBomIfExists((Invoke-WebRequest -Uri $uri).Content)
 }
 $hostCsprojContent = getHostFileContent "src/WebJobs.Script/WebJobs.Script.csproj"
 $pythonPropsContent = getHostFileContent "build/python.props"


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

The in-proc builds for the core tools pipeline breaks, due to the architecture of the build not being specified like how it is for the main branch. This PR also addresses the CVE for DotnetZip which will be addressed by Brett's PR [here](https://github.com/Azure/azure-functions-core-tools/pull/4212)

This PR also addresses bumping up the host and worker versions as well which will be used in the next release.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)