### PR TITLE
Update linux build pipeline to not upload to storage by default

### DIFF
--- a/eng/ci/linux-build.yml
+++ b/eng/ci/linux-build.yml
@@ -28,8 +28,7 @@ extends:
       name: 1es-pool-azfunc
       image: 1es-windows-2022
       os: windows
-    stages:     
+    stages:
       - stage: BuildAndTest
         jobs:
         - template: /eng/ci/templates/official/jobs/linux-package.yml@self
-

--- a/eng/ci/templates/official/jobs/linux-package.yml
+++ b/eng/ci/templates/official/jobs/linux-package.yml
@@ -2,16 +2,29 @@ jobs:
 - job: LinuxPackage
   condition: and(ne(variables['LinuxPackageBuildTag'], ''), ne(variables['ConsolidatedBuildId'], ''))
   timeoutInMinutes: "120"
+
   pool:
     name: 1es-pool-azfunc
     image: 1es-ubuntu-22.04
     os: linux
+
+  variables:
+    drop_path: $(Build.ArtifactStagingDirectory)
+    pkg_drop_path: $(drop_path)/drop_debian
+
+  templateContext:
+    outputParentDirectory: $(drop_path)
+    outputs:
+    - output: pipelineArtifact
+      displayName: Publish debian package
+      path: $(pkg_drop_path)
+      artifact: drop_debian
+
   steps:
-  # Bash v3
-  # Run a Bash script on macOS, Linux, or Windows.
   - task: Bash@3
+    displayName: 'Build DEB package'
     inputs:
-      targetType: 'inline'  # Specify 'filePath' if you want to use an external script file.
+      targetType: 'inline'
       script: |
         cd publish-scripts
         python3 -m venv publish-env
@@ -29,10 +42,13 @@ jobs:
       bashEnvValue: '~/.profile'  # Set value for BASH_ENV environment variable
     env:
       linuxBuildNumber: $(LinuxPackageBuildTag)
-      consolidatedBuildId: $(ConsolidatedBuildId)      
+      consolidatedBuildId: $(ConsolidatedBuildId)
+
   - pwsh: |
-      echo $env:LinuxPackageAccountName
       $majorVersion = [math]::Floor([double]$env:LinuxPackageBuildTag.Split(".")[0])
+      echo $env:LinuxPackageBuildTag
+      echo $majorVersion
+
       az storage blob upload -f /mnt/vss/_work/1/s/publish-scripts/artifact/azure-functions-core-tools_$env:LinuxPackageBuildTag-1.deb -c unsigned -n azure-functions-core-tools_$env:LinuxPackageBuildTag-1.deb --account-name $env:LinuxPackageAccountName --account-key $env:LinuxPackageAccountKey
       az storage blob upload -f /mnt/vss/_work/1/s/publish-scripts/artifact/azure-functions-core-tools-$($majorVersion)_$env:LinuxPackageBuildTag-1.deb -c unsigned -n azure-functions-core-tools-$($majorVersion)_$env:LinuxPackageBuildTag-1.deb --account-name $env:LinuxPackageAccountName --account-key $env:LinuxPackageAccountKey
     env:
@@ -40,22 +56,26 @@ jobs:
       LinuxPackageAccountKey: $(LinuxPackageAccountKey)
       LinuxPackageBuildTag: $(LinuxPackageBuildTag)
     displayName: 'Upload Core Tools Unsigned Linux Package to the storage'
-  - template: ci/sign-files.yml@eng
-    parameters:
-      displayName: 'Sign'
-      folderPath: '/mnt/vss/_work/1/s/publish-scripts/artifact'
-      pattern: '*.deb'
-      signType: inline
-      inlineOperation: |
-        [
-          {
-            "keyCode": "CP-450779-Pgp",
-            "operationSetCode": "LinuxSign",
-            "parameters": [],
-            "toolName": "signtool.exe",
-            "toolVersion": "1.0"
-          }
-        ]
+    condition: eq(variables['BuildOnly'], 'false')
+
+  - ${{ if eq(variables.BuildOnly, false) }}:
+    - template: ci/sign-files.yml@eng
+      parameters:
+        displayName: 'Sign'
+        folderPath: '/mnt/vss/_work/1/s/publish-scripts/artifact'
+        pattern: '*.deb'
+        signType: inline
+        inlineOperation: |
+          [
+            {
+              "keyCode": "CP-450779-Pgp",
+              "operationSetCode": "LinuxSign",
+              "parameters": [],
+              "toolName": "signtool.exe",
+              "toolVersion": "1.0"
+            }
+          ]
+
   - pwsh: |
       echo $env:LinuxPackageAccountName
       $majorVersion = [math]::Floor([double]$env:LinuxPackageBuildTag.Split(".")[0])
@@ -66,3 +86,14 @@ jobs:
       LinuxPackageAccountKey: $(LinuxPackageAccountKey)
       LinuxPackageBuildTag: $(LinuxPackageBuildTag)
     displayName: 'Upload Core Tools Signed Linux Package to the storage'
+    condition: eq(variables['BuildOnly'], 'false')
+
+  - task: Bash@3
+    displayName: 'Copy DEB package to drop'
+    inputs:
+      targetType: 'inline'
+      script: |
+        mkdir -p $drop
+        cp -r /mnt/vss/_work/1/s/publish-scripts/artifact/* $drop
+    env:
+      drop: $(pkg_drop_path)

--- a/eng/ci/templates/official/jobs/linux-package.yml
+++ b/eng/ci/templates/official/jobs/linux-package.yml
@@ -44,37 +44,22 @@ jobs:
       linuxBuildNumber: $(LinuxPackageBuildTag)
       consolidatedBuildId: $(ConsolidatedBuildId)
 
-  - pwsh: |
-      $majorVersion = [math]::Floor([double]$env:LinuxPackageBuildTag.Split(".")[0])
-      echo $env:LinuxPackageBuildTag
-      echo $majorVersion
-
-      az storage blob upload -f /mnt/vss/_work/1/s/publish-scripts/artifact/azure-functions-core-tools_$env:LinuxPackageBuildTag-1.deb -c unsigned -n azure-functions-core-tools_$env:LinuxPackageBuildTag-1.deb --account-name $env:LinuxPackageAccountName --account-key $env:LinuxPackageAccountKey
-      az storage blob upload -f /mnt/vss/_work/1/s/publish-scripts/artifact/azure-functions-core-tools-$($majorVersion)_$env:LinuxPackageBuildTag-1.deb -c unsigned -n azure-functions-core-tools-$($majorVersion)_$env:LinuxPackageBuildTag-1.deb --account-name $env:LinuxPackageAccountName --account-key $env:LinuxPackageAccountKey
-    env:
-      LinuxPackageAccountName: $(LinuxPackageAccountName)
-      LinuxPackageAccountKey: $(LinuxPackageAccountKey)
-      LinuxPackageBuildTag: $(LinuxPackageBuildTag)
-    displayName: 'Upload Core Tools Unsigned Linux Package to the storage'
-    condition: eq(variables['BuildOnly'], 'false')
-
-  - ${{ if eq(variables.BuildOnly, false) }}:
-    - template: ci/sign-files.yml@eng
-      parameters:
-        displayName: 'Sign'
-        folderPath: '/mnt/vss/_work/1/s/publish-scripts/artifact'
-        pattern: '*.deb'
-        signType: inline
-        inlineOperation: |
-          [
-            {
-              "keyCode": "CP-450779-Pgp",
-              "operationSetCode": "LinuxSign",
-              "parameters": [],
-              "toolName": "signtool.exe",
-              "toolVersion": "1.0"
-            }
-          ]
+  - template: ci/sign-files.yml@eng
+    parameters:
+      displayName: 'Sign'
+      folderPath: '/mnt/vss/_work/1/s/publish-scripts/artifact'
+      pattern: '*.deb'
+      signType: inline
+      inlineOperation: |
+        [
+          {
+            "keyCode": "CP-450779-Pgp",
+            "operationSetCode": "LinuxSign",
+            "parameters": [],
+            "toolName": "signtool.exe",
+            "toolVersion": "1.0"
+          }
+        ]
 
   - pwsh: |
       echo $env:LinuxPackageAccountName
@@ -86,7 +71,7 @@ jobs:
       LinuxPackageAccountKey: $(LinuxPackageAccountKey)
       LinuxPackageBuildTag: $(LinuxPackageBuildTag)
     displayName: 'Upload Core Tools Signed Linux Package to the storage'
-    condition: eq(variables['BuildOnly'], 'false')
+    condition: eq(variables['UploadSignedPackages'], 'true') # This is a UI variable that defaults to false
 
   - task: Bash@3
     displayName: 'Copy DEB package to drop'


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

The linux build pipeline fails on every single run as its always trying to upload the package to blob, and since the version of core tools its trying to upload already exists, the upload step fails leading to a pipeline failure.

Instead, I want to change the pipeline so thay when it runs on main, it just builds the pipeline, and when we want to upload the pkg to storage, we can set that variable.

This is a temp fix for now, and we are planning to redesign this pipeline in future. The upload step should move to a release pipeline.
