### PR TITLE
Fix metadata.json file

### DIFF
--- a/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateMetadataFile.ps1
+++ b/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateMetadataFile.ps1
@@ -11,7 +11,7 @@ $stagingCoreToolsVisualStudio = Join-Path $StagingDirectory "coretools-visualstu
 $oopVersion = (Get-ChildItem $stagingCoreToolsCli | Where-Object { $_.Name -match "^Azure\.Functions\.Cli\..*\.(\d+\.\d+\.\d+)$" } | Select-Object -First 1).Name -replace "^Azure\.Functions\.Cli\..*\.(\d+\.\d+\.\d+)$", '$1'
 
 # Get inProc Artifact Version
-$inProcVersion = (Get-ChildItem $stagingCoreToolsVisualStudio -Filter "*.zip" | Where-Object { $_.Name -match "^Azure\.Functions\.Cli\.min\.win.*\.(\d+\.\d+\.\d+)\.zip$" } | Select-Object -First 1).Name -replace "^Azure\.Functions\.Cli\.min\.win.*\.(\d+\.\d+\.\d+)\.zip$", '$1'
+$inProcVersion = (Get-ChildItem $stagingCoreToolsVisualStudio -Filter "*.zip" | Where-Object { $_.Name -match "^Azure\.Functions\.Cli\.min\.win.*\.(\d+\.\d+\.\d+)$" } | Select-Object -First 1).Name -replace "^Azure\.Functions\.Cli\.min\.win.*\.(\d+\.\d+\.\d+)$", '$1'
 
 # Get the current release number from ADO
 $releaseNumberFull = $env:RELEASE_RELEASENAME

--- a/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateMetadataFile.ps1
+++ b/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateMetadataFile.ps1
@@ -11,7 +11,7 @@ $stagingCoreToolsVisualStudio = Join-Path $StagingDirectory "coretools-visualstu
 $oopVersion = (Get-ChildItem $stagingCoreToolsCli | Where-Object { $_.Name -match "^Azure\.Functions\.Cli\..*\.(\d+\.\d+\.\d+)$" } | Select-Object -First 1).Name -replace "^Azure\.Functions\.Cli\..*\.(\d+\.\d+\.\d+)$", '$1'
 
 # Get inProc Artifact Version
-$inProcVersion = (Get-ChildItem $stagingCoreToolsVisualStudio -Filter "*.zip" | Where-Object { $_.Name -match "^Azure\.Functions\.Cli\.min\.win.*\.(\d+\.\d+\.\d+)$" } | Select-Object -First 1).Name -replace "^Azure\.Functions\.Cli\.min\.win.*\.(\d+\.\d+\.\d+)$", '$1'
+$inProcVersion = (Get-ChildItem $stagingCoreToolsVisualStudio | Where-Object { $_.Name -match "^Azure\.Functions\.Cli\.min\.win.*\.(\d+\.\d+\.\d+)$" } | Select-Object -First 1).Name -replace "^Azure\.Functions\.Cli\.min\.win.*\.(\d+\.\d+\.\d+)$", '$1'
 
 # Get the current release number from ADO
 $releaseNumberFull = $env:RELEASE_RELEASENAME


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
The `metadata.json` file was not being generated correctly due to a bug in the script for parsing the visual studio files to have a `.zip` ending in the name, which is not valid anymore. This PR fixes the bug by updating the regular expression to match the correct file name.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)