### PR TITLE
Convert consolidated pipeline to a YAML based pipeline and enable nightly builds

### DIFF
--- a/eng/ci/consolidate-artifacts.yml
+++ b/eng/ci/consolidate-artifacts.yml
@@ -48,16 +48,9 @@ resources:
 
 variables:
 - template: /ci/variables/cfs.yml@eng
-  archs:
-    - win-x64
-    - win-x86
-    - min.win-x64
-    - osx-x64
-    - linux-x64
-    - osx-arm64
-    - win-arm64
-    - min.win-arm64
-    - min.win-x86
+- name: archs
+  value: 'win-x64,win-x86,min.win-x64,osx-x64,linux-x64,osx-arm64,win-arm64,min.win-arm64,min.win-x86'
+
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1es
@@ -81,8 +74,8 @@ extends:
       jobs:
       - template: /eng/ci/templates/official/jobs/process-nuget-package.yml@self
       
-      - ${{ each config in variables.archs }}:
+      - ${{ each arch in split(variables.archs,',') }}:
         - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
           parameters:
-            arch: ${{ config.arch }}
+            arch: ${{ arch }}
             displayName: ${{ replace(replace(arch, '-', ''), '.', '') }}

--- a/eng/ci/consolidate-artifacts.yml
+++ b/eng/ci/consolidate-artifacts.yml
@@ -51,7 +51,6 @@ variables:
 - name: archs
   value: 'win-x64,win-x86,min.win-x64,osx-x64,linux-x64,osx-arm64,win-arm64,min.win-arm64,min.win-x86'
 
-
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1es
   parameters:

--- a/eng/ci/consolidate-artifacts.yml
+++ b/eng/ci/consolidate-artifacts.yml
@@ -71,38 +71,38 @@ extends:
       jobs:
       - template: /eng/ci/templates/official/jobs/process-nuget-package.yml@self
       
-      - template: /eng/ci/templates/official/jobs/assemble-artifact.yml@self
+      - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
         parameters:
           arch: 'win-x64'
       
-      - template: /eng/ci/templates/official/jobs/assemble-artifact.yml@self
+      - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
         parameters:
           arch: 'win-x86'
       
-      - template: /eng/ci/templates/official/jobs/assemble-artifact.yml@self
+      - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
         parameters:
           arch: 'min.win-x64'
       
-      - template: /eng/ci/templates/official/jobs/assemble-artifact.yml@self
+      - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
         parameters:
           arch: 'osx-x64'
       
-      - template: /eng/ci/templates/official/jobs/assemble-artifact.yml@self
+      - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
         parameters:
           arch: 'linux-x64'
       
-      - template: /eng/ci/templates/official/jobs/assemble-artifact.yml@self
+      - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
         parameters:
           arch: 'osx-arm64'
       
-      - template: /eng/ci/templates/official/jobs/assemble-artifact.yml@self
+      - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
         parameters:
           arch: 'win-arm64'
       
-      - template: /eng/ci/templates/official/jobs/assemble-artifact.yml@self
+      - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
         parameters:
           arch: 'min.win-arm64'
       
-      - template: /eng/ci/templates/official/jobs/assemble-artifact.yml@self
+      - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
         parameters:
           arch: 'min.win-x86'

--- a/eng/ci/consolidate-artifacts.yml
+++ b/eng/ci/consolidate-artifacts.yml
@@ -7,8 +7,6 @@ schedules:
     include:
       - main
 
-name: $(Build.SourceBranchName)_$(Build.Reason)
-
 trigger: none
 
 # This pipeline is triggered by the completion of scheduled builds
@@ -50,12 +48,12 @@ resources:
 variables:
 - template: /ci/variables/cfs.yml@eng
 
-
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1es
   parameters:
     featureFlags:
       incrementalSDLBinaryAnalysis: true
+      incrementalSDLSourceAnalysis: true
     pool:
       name: 1es-pool-azfunc
       image: 1es-windows-2022
@@ -70,46 +68,21 @@ extends:
     - stage: ConsolidateArticacts
       displayName: "Assemble Artifacts"
       jobs:
-      - job: AssembleArtifacts
-        timeoutInMinutes: 200 # Have this here in case there are new artifacts to be scanned with increment SDL binary analysis
-        displayName: "Assemble Artifacts"
+      - job: ProcessNuGetPackage
+        displayName: "Process NuGet Package"
         templateContext:
-          outputParentDirectory: $(Build.ArtifactStagingDirectory)
           outputs:
-              - output: pipelineArtifact
-                displayName: Publish assembled artifacts
-                path: $(Pipeline.Workspace)\staging
-                artifact: drop
-
+            - output: pipelineArtifact
+              displayName: Publish nuget package
+              targetPath: $(Pipeline.Workspace)/staging
+              artifact: drop-nuget-package
         steps:
-        - checkout: self
-
-        - download: core-tools-host
-          artifact: drop-coretools-host-linux-signed
-          displayName: "Download core-tools-host linux"
-
-        - download: core-tools-host
-          artifact: drop-coretools-host-windows
-          displayName: "Download core-tools-host windows"
-
-        - download: core-tools-inproc
-          artifact: drop-inproc6
-          displayName: "Download inproc6 artifact"
-
-        - download: core-tools-inproc
-          artifact: drop-inproc8
-          displayName: "Download inproc8 artifact"
+        - checkout: none
 
         - download: core-tools-default
           artifact: drop
           displayName: "Download out-of-proc artifact"
 
-        - powershell: |
-            Write-Host "Value of env variable: $(Pipeline.Workspace)"
-            Write-Host "Artifacts are stored in:  D:\a\_work\1"
-            Get-ChildItem -Path "D:\a\_work\1" -Recurse
-          displayName: "List Artifact Paths"
-          
         - powershell: |
             $currentRunName = $env:BUILD_REASON
             Write-Host "Current pipeline run name: $currentRunName"
@@ -135,10 +108,10 @@ extends:
                 exit 1
             }
 
-            # Define the destination path in $(Pipeline.Workspace)/nugetPackage
-            $nugetPackageDirectory = Join-Path -Path $(Pipeline.Workspace) -ChildPath "nugetPackage"
+            # Define the destination path in $(Pipeline.Workspace)/staging
+            $nugetPackageDirectory = Join-Path -Path $(Pipeline.Workspace) -ChildPath "staging"
 
-            # Create the nugetPackage directory if it doesn't exist
+            # Create the staging directory if it doesn't exist
             if (-not (Test-Path $nugetPackageDirectory)) {
                 New-Item -Path $nugetPackageDirectory -ItemType Directory
                 Write-Host "Directory created at: $nugetPackageDirectory"
@@ -148,23 +121,81 @@ extends:
             Move-Item -Path $fileToMove.FullName -Destination $nugetPackageDirectory -Force
 
             Write-Host "File $($fileToMove.Name) moved to $nugetPackageDirectory"
-          displayName: 'Move Microsoft.Azure.Functions.CoreTools.x.x.xxxx.nupkg to nugetPackage directory'
-        
+          displayName: 'Process Microsoft.Azure.Functions.CoreTools NuGet Package'
+
+      - job: AssembleArtifacts
+        strategy:
+          matrix:
+            win-x64:
+              artifactName: 'Azure.Functions.Cli.win-x64'
+              artifactId: 'win-x64'
+            win-x86:
+              artifactName: 'Azure.Functions.Cli.win-x86'
+              artifactId: 'win-x86'
+            osx-x64:
+              artifactName: 'Azure.Functions.Cli.osx-x64'
+              artifactId: 'osx-x64'
+            linux-x64:
+              artifactName: 'Azure.Functions.Cli.linux-x64'
+              artifactId: 'linux-x64'
+            osx-arm64:
+              artifactName: 'Azure.Functions.Cli.osx-arm64'
+              artifactId: 'osx-arm64'
+            win-arm64:
+              artifactName: 'Azure.Functions.Cli.win-arm64'
+              artifactId: 'win-arm64'
+            min.win-x64:
+              artifactName: 'Azure.Functions.Cli.min.win-x64'
+              artifactId: 'min.win-x64'
+            min.win-arm64:
+              artifactName: 'Azure.Functions.Cli.min.win-arm64'
+              artifactId: 'min.win-arm64'
+            min.win-x86:
+              artifactName: 'Azure.Functions.Cli.min.win-x86'
+              artifactId: 'min.win-x86'
+        displayName: "Assemble Artifacts"
+        templateContext:
+          outputs:
+            - output: pipelineArtifact
+              displayName: Publish assembled artifact $(System.JobPositionInPhase)
+              targetPath: $(Build.ArtifactStagingDirectory)
+              artifact: drop-$(artifactId)
+            - output: pipelineArtifact
+              displayName: Publish metadata.json
+              targetPath: $(Pipeline.Workspace)/staging/metadata.json
+              artifact: drop-metadata-json
+              condition: and(succeeded(), eq(variables['artifactName'], 'Azure.Functions.Cli.min.win-x64')) 
+
+        steps:
+        - checkout: self
+
+        - download: core-tools-host
+          artifact: drop-coretools-host-linux-signed
+          displayName: "Download core-tools-host linux"
+
+        - download: core-tools-host
+          artifact: drop-coretools-host-windows
+          displayName: "Download core-tools-host windows"
+
+        - download: core-tools-inproc
+          artifact: drop-inproc6
+          displayName: "Download inproc6 artifact"
+
+        - download: core-tools-inproc
+          artifact: drop-inproc8
+          displayName: "Download inproc8 artifact"
+
+        - download: core-tools-default
+          artifact: drop
+          displayName: "Download out-of-proc artifact"
+                  
         - task: DotNetCoreCLI@2
           displayName: "Run ArtifactAssembler"
           inputs:
             command: run
             projects: "$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/Azure.Functions.ArtifactAssembler.csproj"
-            arguments: ' -c release'
+            arguments: ' -c release "$(artifactName)"'
             workingDirectory: '$(Pipeline.Workspace)'
-
-        
-        - powershell: |
-            Write-Host "Value of env variable: $(Pipeline.Workspace)"
-            Write-Host "Artifacts are stored in:  D:\a\_work\1"
-            Get-ChildItem -Path "D:\a\_work\1" -Recurse
-          displayName: "List Artifact Paths"
-
 
         - task: PowerShell@2
           displayName: 'Generate metadata.json file'
@@ -173,6 +204,7 @@ extends:
             filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateMetadataFile.ps1'
             arguments: '-StagingDirectory "$(Pipeline.Workspace)\staging"'
             workingDirectory: '$(Pipeline.Workspace)'
+            condition: and(succeeded(), eq(variables['artifactName'], 'Azure.Functions.Cli.min.win-x64')) 
 
         - task: PowerShell@2
           displayName: 'Generate MSI files'
@@ -182,8 +214,7 @@ extends:
             arguments: '-ArtifactsPath "$(Pipeline.Workspace)\staging\coretools-cli"'
             workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
 
-
-        - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
+        - task: EsrpCodeSigning@5
           displayName: 'ESRP CodeSigning'
           inputs:
             ConnectedServiceName: 'azfunc-internal-esrp'
@@ -226,6 +257,8 @@ extends:
             filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/testVsArtifacts.ps1'
             arguments: '-StagingDirectory "$(Pipeline.Workspace)\staging\coretools-visualstudio"'
             workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
+          condition: and(succeeded(), eq(variables['artifactName'], 'Azure.Functions.Cli.min.win-x64')) 
+
         - task: PowerShell@2
           displayName: 'Test Artifacts'
           inputs:
@@ -233,13 +266,14 @@ extends:
             filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/testArtifacts.ps1'
             arguments: '-StagingDirectory "$(Pipeline.Workspace)\staging\coretools-cli"'
             workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
+          condition: and(succeeded(), or(eq(variables['artifactName'], 'Azure.Functions.Cli.win-x64'), eq(variables['artifactName'], 'Azure.Functions.Cli.win-x86')))
         - task: DotNetCoreCLI@2
           displayName: 'Zip Artifacts'
           inputs:
             command: run
             projects: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/Azure.Functions.ArtifactAssembler.csproj'
             arguments: 'zip  -c release'
-            workingDirectory: '$(Pipeline.Workspace)''
+            workingDirectory: '$(Pipeline.Workspace)'
         - powershell: |
             $rootPath = "$(Pipeline.Workspace)\staging"
             $zipFiles = Get-ChildItem -Path $rootPath -Filter *.zip  -Recurse
@@ -250,7 +284,7 @@ extends:
                 Out-File -InputObject $sha -Encoding ascii -FilePath $shaFilePath -NoNewline
                 Write-Host "Generated sha for $filePath at $shaFilePath"
             }
-            displayName: 'Generate SHA files'
+          displayName: 'Generate SHA files'
 
         - pwsh: |
             # Guardian files in TEMP add up and can cause the AntiMalware task to timeout.
@@ -261,11 +295,10 @@ extends:
           displayName: 'Copy Files to Artifact Staging Directory'
           inputs:
             SourceFolder: '$(Pipeline.Workspace)/staging'
-            Contents: '**'
+            Contents: 'coretools-*/**'
             TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
         - powershell: |
-            Write-Host "Value of env variable: $(Pipeline.Workspace)"
             Write-Host "Artifacts are stored in:  D:\a\_work\1"
             Get-ChildItem -Path "D:\a\_work\1\a" -Recurse
           displayName: "List Artifact Paths"

--- a/eng/ci/consolidate-artifacts.yml
+++ b/eng/ci/consolidate-artifacts.yml
@@ -50,24 +50,15 @@ variables:
 - template: /ci/variables/cfs.yml@eng
 - name: archs
   value:
-    - arch: 'win-x64'
-      displayName: 'winx64'
-    - arch: 'win-x86'
-      displayName: 'winx86'
-    - arch: 'min.win-x64'
-      displayName: 'minwinx64'
-    - arch: 'osx-x64'
-      displayName: 'osx64'
-    - arch: 'linux-x64'
-      displayName: 'linuxx64'
-    - arch: 'osx-arm64'
-      displayName: 'osxarm64'
-    - arch: 'win-arm64'
-      displayName: 'winarm64'
-    - arch: 'min.win-arm64'
-      displayName: 'minwinarm64'
-    - arch: 'min.win-x86'
-      displayName: 'minwinx86'
+  - { arch: 'win-x64', displayName: 'winx64' }
+  - { arch: 'win-x86', displayName: 'winx86' }
+  - { arch: 'min.win-x64', displayName: 'minwinx64' }
+  - { arch: 'osx-x64', displayName: 'osx64' }
+  - { arch: 'linux-x64', displayName: 'linuxx64' }
+  - { arch: 'osx-arm64', displayName: 'osxarm64' }
+  - { arch: 'win-arm64', displayName: 'winarm64' }
+  - { arch: 'min.win-arm64', displayName: 'minwinarm64' }
+  - { arch: 'min.win-x86', displayName: 'minwinx86' }
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1es

--- a/eng/ci/consolidate-artifacts.yml
+++ b/eng/ci/consolidate-artifacts.yml
@@ -48,6 +48,26 @@ resources:
 
 variables:
 - template: /ci/variables/cfs.yml@eng
+- name: archs
+  value:
+    - arch: 'win-x64'
+      displayName: 'winx64'
+    - arch: 'win-x86'
+      displayName: 'winx86'
+    - arch: 'min.win-x64'
+      displayName: 'minwinx64'
+    - arch: 'osx-x64'
+      displayName: 'osx64'
+    - arch: 'linux-x64'
+      displayName: 'linuxx64'
+    - arch: 'osx-arm64'
+      displayName: 'osxarm64'
+    - arch: 'win-arm64'
+      displayName: 'winarm64'
+    - arch: 'min.win-arm64'
+      displayName: 'minwinarm64'
+    - arch: 'min.win-x86'
+      displayName: 'minwinx86'
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1es
@@ -71,47 +91,8 @@ extends:
       jobs:
       - template: /eng/ci/templates/official/jobs/process-nuget-package.yml@self
       
-      - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
-        parameters:
-          arch: 'win-x64'
-          displayName: 'winx64'
-      
-      - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
-        parameters:
-          arch: 'win-x86'
-          displayName: 'winx86'
-      
-      - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
-        parameters:
-          arch: 'min.win-x64'
-          displayName: 'minwinx64'
-      
-      - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
-        parameters:
-          arch: 'osx-x64'
-          displayName: 'osx64'
-      
-      - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
-        parameters:
-          arch: 'linux-x64'
-          displayName: 'linuxx64'
-      
-      - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
-        parameters:
-          arch: 'osx-arm64'
-          displayName: 'osxarm64'
-      
-      - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
-        parameters:
-          arch: 'win-arm64'
-          displayName: 'winarm64'
-      
-      - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
-        parameters:
-          arch: 'min.win-arm64'
-          displayName: 'minwinarm64'
-      
-      - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
-        parameters:
-          arch: 'min.win-x86'
-          displayName: 'minwinx86'
+      - ${{ each config in variables.archs }}:
+        - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
+          parameters:
+            arch: ${{ config.arch }}
+            displayName: ${{ config.displayName }}

--- a/eng/ci/consolidate-artifacts.yml
+++ b/eng/ci/consolidate-artifacts.yml
@@ -74,35 +74,44 @@ extends:
       - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
         parameters:
           arch: 'win-x64'
+          displayName: 'winx64'
       
       - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
         parameters:
           arch: 'win-x86'
+          displayName: 'winx86'
       
       - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
         parameters:
           arch: 'min.win-x64'
+          displayName: 'minwinx64'
       
       - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
         parameters:
           arch: 'osx-x64'
+          displayName: 'osx64'
       
       - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
         parameters:
           arch: 'linux-x64'
+          displayName: 'linuxx64'
       
       - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
         parameters:
           arch: 'osx-arm64'
+          displayName: 'osxarm64'
       
       - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
         parameters:
           arch: 'win-arm64'
+          displayName: 'winarm64'
       
       - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
         parameters:
           arch: 'min.win-arm64'
+          displayName: 'minwinarm64'
       
       - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
         parameters:
           arch: 'min.win-x86'
+          displayName: 'minwinx86'

--- a/eng/ci/consolidate-artifacts.yml
+++ b/eng/ci/consolidate-artifacts.yml
@@ -50,15 +50,15 @@ variables:
 - template: /ci/variables/cfs.yml@eng
 - name: archs
   value:
-  - { arch: 'win-x64', displayName: 'winx64' }
-  - { arch: 'win-x86', displayName: 'winx86' }
-  - { arch: 'min.win-x64', displayName: 'minwinx64' }
-  - { arch: 'osx-x64', displayName: 'osx64' }
-  - { arch: 'linux-x64', displayName: 'linuxx64' }
-  - { arch: 'osx-arm64', displayName: 'osxarm64' }
-  - { arch: 'win-arm64', displayName: 'winarm64' }
-  - { arch: 'min.win-arm64', displayName: 'minwinarm64' }
-  - { arch: 'min.win-x86', displayName: 'minwinx86' }
+  - win-x64
+  - win-x86
+  - min.win-x64
+  - osx-x64
+  - linux-x64
+  - osx-arm64
+  - win-arm64
+  - min.win-arm64
+  - min.win-x86
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1es
@@ -86,4 +86,4 @@ extends:
         - template: /eng/ci/templates/official/jobs/assemble-artifacts.yml@self
           parameters:
             arch: ${{ config.arch }}
-            displayName: ${{ config.displayName }}
+            displayName: ${{ replace(replace(arch, '-', ''), '.', '') }}

--- a/eng/ci/consolidate-artifacts.yml
+++ b/eng/ci/consolidate-artifacts.yml
@@ -1,0 +1,271 @@
+
+schedules:
+- cron: "30 2 * * *"
+  displayName: Nightly Consolidation
+  always: true
+  branches:
+    include:
+      - main
+
+name: $(Build.SourceBranchName)_$(Build.Reason)
+
+trigger: none
+
+# This pipeline is triggered by the completion of scheduled builds
+# in the core-tools-inproc and core-tools-default pipelines
+resources:
+  repositories:
+  - repository: 1es
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+  - repository: eng
+    type: git
+    name: engineering
+    ref: refs/tags/release
+  pipelines:
+    - pipeline: core-tools-host
+      source: azure\azure-functions-core-tools\core-tools-host.official
+
+    - pipeline: core-tools-inproc
+      source: azure\azure-functions-core-tools\core-tools.official
+      branch: in-proc  # in-proc branch of core-tools.official
+      tags:
+      - nightly-build
+      trigger: 
+        branches:
+          include:
+            - in-proc
+
+    - pipeline: core-tools-default
+      source: azure\azure-functions-core-tools\core-tools.official
+      branch: main  # main branch of core-tools.official
+      tags:
+      - nightly-build
+      trigger:
+        branches:
+          include:
+            - main
+
+variables:
+- template: /ci/variables/cfs.yml@eng
+
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1es
+  parameters:
+    featureFlags:
+      incrementalSDLBinaryAnalysis: true
+    pool:
+      name: 1es-pool-azfunc
+      image: 1es-windows-2022
+      os: windows
+    sdl:
+      codeql:
+         compiled:
+           enabled: true
+         runSourceLanguagesInSourceAnalysis: true
+     
+    stages:
+    - stage: ConsolidateArticacts
+      displayName: "Assemble Artifacts"
+      jobs:
+      - job: AssembleArtifacts
+        timeoutInMinutes: 200 # Have this here in case there are new artifacts to be scanned with increment SDL binary analysis
+        displayName: "Assemble Artifacts"
+        templateContext:
+          outputParentDirectory: $(Build.ArtifactStagingDirectory)
+          outputs:
+              - output: pipelineArtifact
+                displayName: Publish assembled artifacts
+                path: $(Pipeline.Workspace)\staging
+                artifact: drop
+
+        steps:
+        - checkout: self
+
+        - download: core-tools-host
+          artifact: drop-coretools-host-linux-signed
+          displayName: "Download core-tools-host linux"
+
+        - download: core-tools-host
+          artifact: drop-coretools-host-windows
+          displayName: "Download core-tools-host windows"
+
+        - download: core-tools-inproc
+          artifact: drop-inproc6
+          displayName: "Download inproc6 artifact"
+
+        - download: core-tools-inproc
+          artifact: drop-inproc8
+          displayName: "Download inproc8 artifact"
+
+        - download: core-tools-default
+          artifact: drop
+          displayName: "Download out-of-proc artifact"
+
+        - powershell: |
+            Write-Host "Value of env variable: $(Pipeline.Workspace)"
+            Write-Host "Artifacts are stored in:  D:\a\_work\1"
+            Get-ChildItem -Path "D:\a\_work\1" -Recurse
+          displayName: "List Artifact Paths"
+          
+        - powershell: |
+            $currentRunName = $env:BUILD_REASON
+            Write-Host "Current pipeline run name: $currentRunName"
+            # Retrieve environment variables
+            $defaultArtifactAlias = $env:DEFAULT_ARTIFACT_ALIAS
+            $defaultArtifactName = $env:DEFAULT_ARTIFACT_NAME
+
+            # Get the current working directory
+            $currentDirectory = "$(Pipeline.Workspace)"
+
+            # Construct the path using current directory, and environment variables
+            $artifactPath = Join-Path -Path $currentDirectory -ChildPath "$defaultArtifactAlias\$defaultArtifactName"
+
+            # Define the regex pattern to match the nupkg file (digit.digit.4digits)
+            $regexPattern = "^Microsoft\.Azure\.Functions\.CoreTools\.\d+\.\d+\.\d{4}\.nupkg$"
+
+            # Look for the first nupkg file that matches the pattern in the constructed path
+            $fileToMove = Get-ChildItem -Path $artifactPath -Filter "*.nupkg" | Where-Object { $_.Name -match $regexPattern } | Select-Object -First 1
+
+            # Check if a matching file was found
+            if ($fileToMove -eq $null) {
+                Write-Host "No .nupkg file matching the pattern was found in $artifactPath"
+                exit 1
+            }
+
+            # Define the destination path in $(Pipeline.Workspace)/nugetPackage
+            $nugetPackageDirectory = Join-Path -Path $(Pipeline.Workspace) -ChildPath "nugetPackage"
+
+            # Create the nugetPackage directory if it doesn't exist
+            if (-not (Test-Path $nugetPackageDirectory)) {
+                New-Item -Path $nugetPackageDirectory -ItemType Directory
+                Write-Host "Directory created at: $nugetPackageDirectory"
+            }
+
+            # Move the file to the staging directory
+            Move-Item -Path $fileToMove.FullName -Destination $nugetPackageDirectory -Force
+
+            Write-Host "File $($fileToMove.Name) moved to $nugetPackageDirectory"
+          displayName: 'Move Microsoft.Azure.Functions.CoreTools.x.x.xxxx.nupkg to nugetPackage directory'
+        
+        - task: DotNetCoreCLI@2
+          displayName: "Run ArtifactAssembler"
+          inputs:
+            command: run
+            projects: "$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/Azure.Functions.ArtifactAssembler.csproj"
+            arguments: ' -c release'
+            workingDirectory: '$(Pipeline.Workspace)'
+
+        
+        - powershell: |
+            Write-Host "Value of env variable: $(Pipeline.Workspace)"
+            Write-Host "Artifacts are stored in:  D:\a\_work\1"
+            Get-ChildItem -Path "D:\a\_work\1" -Recurse
+          displayName: "List Artifact Paths"
+
+
+        - task: PowerShell@2
+          displayName: 'Generate metadata.json file'
+          inputs:
+            targetType: filePath
+            filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateMetadataFile.ps1'
+            arguments: '-StagingDirectory "$(Pipeline.Workspace)\staging"'
+            workingDirectory: '$(Pipeline.Workspace)'
+
+        - task: PowerShell@2
+          displayName: 'Generate MSI files'
+          inputs:
+            targetType: filePath
+            filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateMsiFiles.ps1'
+            arguments: '-ArtifactsPath "$(Pipeline.Workspace)\staging\coretools-cli"'
+            workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
+
+
+        - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
+          displayName: 'ESRP CodeSigning'
+          inputs:
+            ConnectedServiceName: 'azfunc-internal-esrp'
+            AppRegistrationClientId: 'a31bf239-3e15-498e-a335-f6ec0c9d9ccf'
+            AppRegistrationTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'
+            AuthAKVName: 'kv-azfunc-esrp'
+            AuthCertName: 'azfunc-internal-esrp-auth'
+            AuthSignCertName: 'azfunc-internal-esrp-sign'
+            FolderPath: '$(Pipeline.Workspace)\staging\coretools-cli'
+            Pattern: '*.msi'
+            signConfigType: inlineSignParams
+            inlineOperation: |
+              [
+                          {
+                            "KeyCode": "CP-230012",
+                            "OperationCode": "SigntoolSign",
+                            "Parameters": {
+                              "OpusName": "Microsoft",
+                              "OpusInfo": "http://www.microsoft.com",
+                              "FileDigest": "/fd \"SHA256\"",
+                              "PageHash": "/NPH",
+                              "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                            },
+                            "ToolName": "sign",
+                            "ToolVersion": "1.0"
+                          },
+                          {
+                            "KeyCode": "CP-230012",
+                            "OperationCode": "SigntoolVerify",
+                            "Parameters": {},
+                            "ToolName": "sign",
+                            "ToolVersion": "1.0"
+                          }
+              ]
+            VerboseLogin: true
+        - task: PowerShell@2
+          displayName: 'Test Artifacts - Visual Studio'
+          inputs:
+            targetType: filePath
+            filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/testVsArtifacts.ps1'
+            arguments: '-StagingDirectory "$(Pipeline.Workspace)\staging\coretools-visualstudio"'
+            workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
+        - task: PowerShell@2
+          displayName: 'Test Artifacts'
+          inputs:
+            targetType: filePath
+            filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/testArtifacts.ps1'
+            arguments: '-StagingDirectory "$(Pipeline.Workspace)\staging\coretools-cli"'
+            workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
+        - task: DotNetCoreCLI@2
+          displayName: 'Zip Artifacts'
+          inputs:
+            command: run
+            projects: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/Azure.Functions.ArtifactAssembler.csproj'
+            arguments: 'zip  -c release'
+            workingDirectory: '$(Pipeline.Workspace)''
+        - powershell: |
+            $rootPath = "$(Pipeline.Workspace)\staging"
+            $zipFiles = Get-ChildItem -Path $rootPath -Filter *.zip  -Recurse
+            foreach ($file in $zipfiles) 
+            {
+                $sha = (Get-FileHash $file.FullName).Hash.ToLower()
+                $shaFilePath = $file.FullName + ".sha2"
+                Out-File -InputObject $sha -Encoding ascii -FilePath $shaFilePath -NoNewline
+                Write-Host "Generated sha for $filePath at $shaFilePath"
+            }
+            displayName: 'Generate SHA files'
+
+        - pwsh: |
+            # Guardian files in TEMP add up and can cause the AntiMalware task to timeout.
+            Get-ChildItem -Path $env:TEMP -Filter 'MpCmdRun.*' -Recurse -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force
+          displayName: Cleanup Guardian related files in TEMP
+
+        - task: CopyFiles@2
+          displayName: 'Copy Files to Artifact Staging Directory'
+          inputs:
+            SourceFolder: '$(Pipeline.Workspace)/staging'
+            Contents: '**'
+            TargetFolder: '$(Build.ArtifactStagingDirectory)'
+
+        - powershell: |
+            Write-Host "Value of env variable: $(Pipeline.Workspace)"
+            Write-Host "Artifacts are stored in:  D:\a\_work\1"
+            Get-ChildItem -Path "D:\a\_work\1\a" -Recurse
+          displayName: "List Artifact Paths"

--- a/eng/ci/consolidate-artifacts.yml
+++ b/eng/ci/consolidate-artifacts.yml
@@ -48,17 +48,16 @@ resources:
 
 variables:
 - template: /ci/variables/cfs.yml@eng
-- name: archs
-  value:
-  - win-x64
-  - win-x86
-  - min.win-x64
-  - osx-x64
-  - linux-x64
-  - osx-arm64
-  - win-arm64
-  - min.win-arm64
-  - min.win-x86
+  archs:
+    - win-x64
+    - win-x86
+    - min.win-x64
+    - osx-x64
+    - linux-x64
+    - osx-arm64
+    - win-arm64
+    - min.win-arm64
+    - min.win-x86
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1es

--- a/eng/ci/consolidate-artifacts.yml
+++ b/eng/ci/consolidate-artifacts.yml
@@ -1,4 +1,3 @@
-
 schedules:
 - cron: "30 2 * * *"
   displayName: Nightly Consolidation
@@ -6,6 +5,8 @@ schedules:
   branches:
     include:
       - main
+
+name: $(Build.SourceBranchName)_$(Build.Reason)
 
 trigger: none
 
@@ -68,237 +69,40 @@ extends:
     - stage: ConsolidateArticacts
       displayName: "Assemble Artifacts"
       jobs:
-      - job: ProcessNuGetPackage
-        displayName: "Process NuGet Package"
-        templateContext:
-          outputs:
-            - output: pipelineArtifact
-              displayName: Publish nuget package
-              targetPath: $(Pipeline.Workspace)/staging
-              artifact: drop-nuget-package
-        steps:
-        - checkout: none
-
-        - download: core-tools-default
-          artifact: drop
-          displayName: "Download out-of-proc artifact"
-
-        - powershell: |
-            $currentRunName = $env:BUILD_REASON
-            Write-Host "Current pipeline run name: $currentRunName"
-            # Retrieve environment variables
-            $defaultArtifactAlias = $env:DEFAULT_ARTIFACT_ALIAS
-            $defaultArtifactName = $env:DEFAULT_ARTIFACT_NAME
-
-            # Get the current working directory
-            $currentDirectory = "$(Pipeline.Workspace)"
-
-            # Construct the path using current directory, and environment variables
-            $artifactPath = Join-Path -Path $currentDirectory -ChildPath "$defaultArtifactAlias\$defaultArtifactName"
-
-            # Define the regex pattern to match the nupkg file (digit.digit.4digits)
-            $regexPattern = "^Microsoft\.Azure\.Functions\.CoreTools\.\d+\.\d+\.\d{4}\.nupkg$"
-
-            # Look for the first nupkg file that matches the pattern in the constructed path
-            $fileToMove = Get-ChildItem -Path $artifactPath -Filter "*.nupkg" | Where-Object { $_.Name -match $regexPattern } | Select-Object -First 1
-
-            # Check if a matching file was found
-            if ($fileToMove -eq $null) {
-                Write-Host "No .nupkg file matching the pattern was found in $artifactPath"
-                exit 1
-            }
-
-            # Define the destination path in $(Pipeline.Workspace)/staging
-            $nugetPackageDirectory = Join-Path -Path $(Pipeline.Workspace) -ChildPath "staging"
-
-            # Create the staging directory if it doesn't exist
-            if (-not (Test-Path $nugetPackageDirectory)) {
-                New-Item -Path $nugetPackageDirectory -ItemType Directory
-                Write-Host "Directory created at: $nugetPackageDirectory"
-            }
-
-            # Move the file to the staging directory
-            Move-Item -Path $fileToMove.FullName -Destination $nugetPackageDirectory -Force
-
-            Write-Host "File $($fileToMove.Name) moved to $nugetPackageDirectory"
-          displayName: 'Process Microsoft.Azure.Functions.CoreTools NuGet Package'
-
-      - job: AssembleArtifacts
-        strategy:
-          matrix:
-            win-x64:
-              artifactName: 'Azure.Functions.Cli.win-x64'
-              artifactId: 'win-x64'
-            win-x86:
-              artifactName: 'Azure.Functions.Cli.win-x86'
-              artifactId: 'win-x86'
-            osx-x64:
-              artifactName: 'Azure.Functions.Cli.osx-x64'
-              artifactId: 'osx-x64'
-            linux-x64:
-              artifactName: 'Azure.Functions.Cli.linux-x64'
-              artifactId: 'linux-x64'
-            osx-arm64:
-              artifactName: 'Azure.Functions.Cli.osx-arm64'
-              artifactId: 'osx-arm64'
-            win-arm64:
-              artifactName: 'Azure.Functions.Cli.win-arm64'
-              artifactId: 'win-arm64'
-            min.win-x64:
-              artifactName: 'Azure.Functions.Cli.min.win-x64'
-              artifactId: 'min.win-x64'
-            min.win-arm64:
-              artifactName: 'Azure.Functions.Cli.min.win-arm64'
-              artifactId: 'min.win-arm64'
-            min.win-x86:
-              artifactName: 'Azure.Functions.Cli.min.win-x86'
-              artifactId: 'min.win-x86'
-        displayName: "Assemble Artifacts"
-        templateContext:
-          outputs:
-            - output: pipelineArtifact
-              displayName: Publish assembled artifact $(System.JobPositionInPhase)
-              targetPath: $(Build.ArtifactStagingDirectory)
-              artifact: drop-$(artifactId)
-            - output: pipelineArtifact
-              displayName: Publish metadata.json
-              targetPath: $(Pipeline.Workspace)/staging/metadata.json
-              artifact: drop-metadata-json
-              condition: and(succeeded(), eq(variables['artifactName'], 'Azure.Functions.Cli.min.win-x64')) 
-
-        steps:
-        - checkout: self
-
-        - download: core-tools-host
-          artifact: drop-coretools-host-linux-signed
-          displayName: "Download core-tools-host linux"
-
-        - download: core-tools-host
-          artifact: drop-coretools-host-windows
-          displayName: "Download core-tools-host windows"
-
-        - download: core-tools-inproc
-          artifact: drop-inproc6
-          displayName: "Download inproc6 artifact"
-
-        - download: core-tools-inproc
-          artifact: drop-inproc8
-          displayName: "Download inproc8 artifact"
-
-        - download: core-tools-default
-          artifact: drop
-          displayName: "Download out-of-proc artifact"
-                  
-        - task: DotNetCoreCLI@2
-          displayName: "Run ArtifactAssembler"
-          inputs:
-            command: run
-            projects: "$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/Azure.Functions.ArtifactAssembler.csproj"
-            arguments: ' -c release "$(artifactName)"'
-            workingDirectory: '$(Pipeline.Workspace)'
-
-        - task: PowerShell@2
-          displayName: 'Generate metadata.json file'
-          inputs:
-            targetType: filePath
-            filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateMetadataFile.ps1'
-            arguments: '-StagingDirectory "$(Pipeline.Workspace)\staging"'
-            workingDirectory: '$(Pipeline.Workspace)'
-            condition: and(succeeded(), eq(variables['artifactName'], 'Azure.Functions.Cli.min.win-x64')) 
-
-        - task: PowerShell@2
-          displayName: 'Generate MSI files'
-          inputs:
-            targetType: filePath
-            filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateMsiFiles.ps1'
-            arguments: '-ArtifactsPath "$(Pipeline.Workspace)\staging\coretools-cli"'
-            workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
-
-        - task: EsrpCodeSigning@5
-          displayName: 'ESRP CodeSigning'
-          inputs:
-            ConnectedServiceName: 'azfunc-internal-esrp'
-            AppRegistrationClientId: 'a31bf239-3e15-498e-a335-f6ec0c9d9ccf'
-            AppRegistrationTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'
-            AuthAKVName: 'kv-azfunc-esrp'
-            AuthCertName: 'azfunc-internal-esrp-auth'
-            AuthSignCertName: 'azfunc-internal-esrp-sign'
-            FolderPath: '$(Pipeline.Workspace)\staging\coretools-cli'
-            Pattern: '*.msi'
-            signConfigType: inlineSignParams
-            inlineOperation: |
-              [
-                          {
-                            "KeyCode": "CP-230012",
-                            "OperationCode": "SigntoolSign",
-                            "Parameters": {
-                              "OpusName": "Microsoft",
-                              "OpusInfo": "http://www.microsoft.com",
-                              "FileDigest": "/fd \"SHA256\"",
-                              "PageHash": "/NPH",
-                              "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                            },
-                            "ToolName": "sign",
-                            "ToolVersion": "1.0"
-                          },
-                          {
-                            "KeyCode": "CP-230012",
-                            "OperationCode": "SigntoolVerify",
-                            "Parameters": {},
-                            "ToolName": "sign",
-                            "ToolVersion": "1.0"
-                          }
-              ]
-            VerboseLogin: true
-        - task: PowerShell@2
-          displayName: 'Test Artifacts - Visual Studio'
-          inputs:
-            targetType: filePath
-            filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/testVsArtifacts.ps1'
-            arguments: '-StagingDirectory "$(Pipeline.Workspace)\staging\coretools-visualstudio"'
-            workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
-          condition: and(succeeded(), eq(variables['artifactName'], 'Azure.Functions.Cli.min.win-x64')) 
-
-        - task: PowerShell@2
-          displayName: 'Test Artifacts'
-          inputs:
-            targetType: filePath
-            filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/testArtifacts.ps1'
-            arguments: '-StagingDirectory "$(Pipeline.Workspace)\staging\coretools-cli"'
-            workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
-          condition: and(succeeded(), or(eq(variables['artifactName'], 'Azure.Functions.Cli.win-x64'), eq(variables['artifactName'], 'Azure.Functions.Cli.win-x86')))
-        - task: DotNetCoreCLI@2
-          displayName: 'Zip Artifacts'
-          inputs:
-            command: run
-            projects: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/Azure.Functions.ArtifactAssembler.csproj'
-            arguments: 'zip  -c release'
-            workingDirectory: '$(Pipeline.Workspace)'
-        - powershell: |
-            $rootPath = "$(Pipeline.Workspace)\staging"
-            $zipFiles = Get-ChildItem -Path $rootPath -Filter *.zip  -Recurse
-            foreach ($file in $zipfiles) 
-            {
-                $sha = (Get-FileHash $file.FullName).Hash.ToLower()
-                $shaFilePath = $file.FullName + ".sha2"
-                Out-File -InputObject $sha -Encoding ascii -FilePath $shaFilePath -NoNewline
-                Write-Host "Generated sha for $filePath at $shaFilePath"
-            }
-          displayName: 'Generate SHA files'
-
-        - pwsh: |
-            # Guardian files in TEMP add up and can cause the AntiMalware task to timeout.
-            Get-ChildItem -Path $env:TEMP -Filter 'MpCmdRun.*' -Recurse -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force
-          displayName: Cleanup Guardian related files in TEMP
-
-        - task: CopyFiles@2
-          displayName: 'Copy Files to Artifact Staging Directory'
-          inputs:
-            SourceFolder: '$(Pipeline.Workspace)/staging'
-            Contents: 'coretools-*/**'
-            TargetFolder: '$(Build.ArtifactStagingDirectory)'
-
-        - powershell: |
-            Write-Host "Artifacts are stored in:  D:\a\_work\1"
-            Get-ChildItem -Path "D:\a\_work\1\a" -Recurse
-          displayName: "List Artifact Paths"
+      - template: /eng/ci/templates/official/jobs/process-nuget-package.yml@self
+      
+      - template: /eng/ci/templates/official/jobs/assemble-artifact.yml@self
+        parameters:
+          arch: 'win-x64'
+      
+      - template: /eng/ci/templates/official/jobs/assemble-artifact.yml@self
+        parameters:
+          arch: 'win-x86'
+      
+      - template: /eng/ci/templates/official/jobs/assemble-artifact.yml@self
+        parameters:
+          arch: 'min.win-x64'
+      
+      - template: /eng/ci/templates/official/jobs/assemble-artifact.yml@self
+        parameters:
+          arch: 'osx-x64'
+      
+      - template: /eng/ci/templates/official/jobs/assemble-artifact.yml@self
+        parameters:
+          arch: 'linux-x64'
+      
+      - template: /eng/ci/templates/official/jobs/assemble-artifact.yml@self
+        parameters:
+          arch: 'osx-arm64'
+      
+      - template: /eng/ci/templates/official/jobs/assemble-artifact.yml@self
+        parameters:
+          arch: 'win-arm64'
+      
+      - template: /eng/ci/templates/official/jobs/assemble-artifact.yml@self
+        parameters:
+          arch: 'min.win-arm64'
+      
+      - template: /eng/ci/templates/official/jobs/assemble-artifact.yml@self
+        parameters:
+          arch: 'min.win-x86'

--- a/eng/ci/templates/official/jobs/assemble-artifacts.yml
+++ b/eng/ci/templates/official/jobs/assemble-artifacts.yml
@@ -10,19 +10,20 @@ jobs:
   templateContext:
     inputs:
       - input: pipelineArtifact
-        artifactName: drop-coretools-host-linux-signed
-        pipeline: azure\azure-functions-core-tools\core-tools-host.official
+        source: core-tools-host
+        artifact: drop-coretools-host-linux-signed
       - input: pipelineArtifact
-        artifactName: drop-coretools-host-windows
-        pipeline: azure\azure-functions-core-tools\core-tools-host.official
+        source: core-tools-host
+        artifact: drop-coretools-host-windows
       - input: pipelineArtifact
-        artifactName: drop-inproc6
-        pipeline: azure\azure-functions-core-tools\core-tools.official
+        source: core-tools-inproc
+        artifact: drop-inproc6
       - input: pipelineArtifact
-        artifactName: drop-inproc8
+        source: core-tools-inproc
+        artifact: drop-inproc8
       - input: pipelineArtifact
-        artifactName: drop
-        pipeline: azure\azure-functions-core-tools\core-tools.official
+        source: core-tools-default
+        artifact: drop
   
     outputs:
       - output: pipelineArtifact

--- a/eng/ci/templates/official/jobs/assemble-artifacts.yml
+++ b/eng/ci/templates/official/jobs/assemble-artifacts.yml
@@ -10,20 +10,20 @@ jobs:
   templateContext:
     inputs:
       - input: pipelineArtifact
-        source: core-tools-host
-        artifact: drop-coretools-host-linux-signed
+        pipeline: core-tools-host
+        artifactName: drop-coretools-host-linux-signed
       - input: pipelineArtifact
-        source: core-tools-host
-        artifact: drop-coretools-host-windows
+        pipeline: core-tools-host
+        artifactName: drop-coretools-host-windows
       - input: pipelineArtifact
-        source: core-tools-inproc
-        artifact: drop-inproc6
+        pipeline: core-tools-inproc
+        artifactName: drop-inproc6
       - input: pipelineArtifact
-        source: core-tools-inproc
-        artifact: drop-inproc8
+        pipeline: core-tools-inproc
+        artifactName: drop-inproc8
       - input: pipelineArtifact
-        source: core-tools-default
-        artifact: drop
+        pipeline: core-tools-default
+        artifactName: drop
   
     outputs:
       - output: pipelineArtifact

--- a/eng/ci/templates/official/jobs/assemble-artifacts.yml
+++ b/eng/ci/templates/official/jobs/assemble-artifacts.yml
@@ -3,7 +3,7 @@ parameters:
     type: string
 
 jobs:
-- job: AssembleArtifact_${{ parameters.arch }}
+- job: AssembleArtifact
   displayName: "Assemble ${{ parameters.arch }}"
   templateContext:
     inputs:

--- a/eng/ci/templates/official/jobs/assemble-artifacts.yml
+++ b/eng/ci/templates/official/jobs/assemble-artifacts.yml
@@ -96,4 +96,93 @@ jobs:
     displayName: 'Generate metadata.json file'
     inputs:
       targetType: filePath
-      filePath: '$(Build.SourcesDir
+      filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateMetadataFile.ps1'
+      arguments: '-StagingDirectory "$(Pipeline.Workspace)\staging"'
+      workingDirectory: '$(Pipeline.Workspace)'
+    condition: and(succeeded(), eq('${{ parameters.arch }}', 'min.win-x64'))
+
+  - task: PowerShell@2
+    displayName: 'Generate MSI files'
+    inputs:
+      targetType: filePath
+      filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateMsiFiles.ps1'
+      arguments: '-ArtifactsPath "$(Pipeline.Workspace)\staging\coretools-cli"'
+      workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
+    condition: and(succeeded(), startsWith('${{ parameters.arch }}', 'win'))
+
+  - task: EsrpCodeSigning@5
+    displayName: 'ESRP CodeSigning'
+    inputs:
+      ConnectedServiceName: 'azfunc-internal-esrp'
+      AppRegistrationClientId: 'a31bf239-3e15-498e-a335-f6ec0c9d9ccf'
+      AppRegistrationTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'
+      AuthAKVName: 'kv-azfunc-esrp'
+      AuthCertName: 'azfunc-internal-esrp-auth'
+      AuthSignCertName: 'azfunc-internal-esrp-sign'
+      FolderPath: '$(Pipeline.Workspace)\staging\coretools-cli'
+      Pattern: '*.msi'
+      signConfigType: inlineSignParams
+      inlineOperation: |
+        [
+          {
+            "KeyCode": "CP-230012",
+            "OperationCode": "SigntoolSign",
+            "Parameters": {
+              "OpusName": "Microsoft",
+              "OpusInfo": "http://www.microsoft.com",
+              "FileDigest": "/fd \"SHA256\"",
+              "PageHash": "/NPH",
+              "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+            },
+            "ToolName": "sign",
+            "ToolVersion": "1.0"
+          },
+          {
+            "KeyCode": "CP-230012",
+            "OperationCode": "SigntoolVerify",
+            "Parameters": {},
+            "ToolName": "sign",
+            "ToolVersion": "1.0"
+          }
+        ]
+      VerboseLogin: true
+    condition: and(succeeded(), startsWith('${{ parameters.arch }}', 'win'))
+
+  - task: PowerShell@2
+    displayName: 'Test Artifacts - Visual Studio'
+    inputs:
+      targetType: filePath
+      filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/testVsArtifacts.ps1'
+      arguments: '-StagingDirectory "$(Pipeline.Workspace)\staging\coretools-visualstudio"'
+      workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
+    condition: and(succeeded(), eq('${{ parameters.arch }}', 'min.win-x64'))
+
+  - task: PowerShell@2
+    displayName: 'Test Artifacts'
+    inputs:
+      targetType: filePath
+      filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/testArtifacts.ps1'
+      arguments: '-StagingDirectory "$(Pipeline.Workspace)\staging\coretools-cli"'
+      workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
+    condition: and(succeeded(), startsWith('${{ parameters.arch }}', 'win'))
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Zip Artifacts'
+    inputs:
+      command: run
+      projects: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/Azure.Functions.ArtifactAssembler.csproj'
+      arguments: 'zip -c release'
+      workingDirectory: '$(Pipeline.Workspace)'
+
+  - task: PowerShell@2
+    displayName: 'Generate SHA files'
+    inputs:
+      targetType: filePath
+      filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateSha.ps1'
+
+  - task: CopyFiles@2
+    displayName: 'Copy Files to Artifact Staging Directory'
+    inputs:
+      SourceFolder: '$(Pipeline.Workspace)/staging'
+      Contents: 'coretools-*/**'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'

--- a/eng/ci/templates/official/jobs/assemble-artifacts.yml
+++ b/eng/ci/templates/official/jobs/assemble-artifacts.yml
@@ -97,7 +97,7 @@ jobs:
     inputs:
       command: run
       projects: "$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/Azure.Functions.ArtifactAssembler.csproj"
-      arguments: '--no-build -c release -- "Azure.Functions.Cli.${{ parameters.arch }}"'
+      arguments: '-c release -- "Azure.Functions.Cli.${{ parameters.arch }}"'
       workingDirectory: '$(Pipeline.Workspace)'
 
   - ${{ if eq('${{ parameters.arch }}', 'min.win-x64') }}:

--- a/eng/ci/templates/official/jobs/assemble-artifacts.yml
+++ b/eng/ci/templates/official/jobs/assemble-artifacts.yml
@@ -1,0 +1,136 @@
+parameters:
+  - name: arch
+    type: string
+
+jobs:
+- job: AssembleArtifact_${{ parameters.arch }}
+  displayName: "Assemble ${{ parameters.arch }}"
+  templateContext:
+    inputs:
+      - input: pipelineArtifact
+        artifactName: drop-coretools-host-linux-signed
+      - input: pipelineArtifact
+        artifactName: drop-coretools-host-windows
+      - input: pipelineArtifact
+        artifactName: drop-inproc6
+      - input: pipelineArtifact
+        artifactName: drop-inproc8
+      - input: pipelineArtifact
+        artifactName: drop
+  
+    outputs:
+      - output: pipelineArtifact
+        displayName: Publish assembled artifact ${{ parameters.arch }}
+        targetPath: $(Build.ArtifactStagingDirectory)
+        artifact: drop-${{ parameters.arch }}
+      - output: pipelineArtifact
+        displayName: Publish metadata.json
+        targetPath: $(Pipeline.Workspace)/staging/metadata.json
+        artifact: drop-metadata-json
+        condition: and(succeeded(), eq('${{ parameters.arch }}', 'min.win-x64'))
+
+  steps:
+  - checkout: self
+                
+  - task: DotNetCoreCLI@2
+    displayName: "Run ArtifactAssembler"
+    inputs:
+      command: run
+      projects: "$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/Azure.Functions.ArtifactAssembler.csproj"
+      arguments: ' -c release "Azure.Functions.Cli.${{ parameters.arch }}"'
+      workingDirectory: '$(Pipeline.Workspace)'
+
+  - task: PowerShell@2
+    displayName: 'Generate metadata.json file'
+    inputs:
+      targetType: filePath
+      filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateMetadataFile.ps1'
+      arguments: '-StagingDirectory "$(Pipeline.Workspace)\staging"'
+      workingDirectory: '$(Pipeline.Workspace)'
+    condition: and(succeeded(), eq('${{ parameters.arch }}', 'min.win-x64'))
+
+  - task: PowerShell@2
+    displayName: 'Generate MSI files'
+    inputs:
+      targetType: filePath
+      filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateMsiFiles.ps1'
+      arguments: '-ArtifactsPath "$(Pipeline.Workspace)\staging\coretools-cli"'
+      workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
+    condition: and(succeeded(), startsWith('${{ parameters.arch }}', 'win'))
+
+  - task: EsrpCodeSigning@5
+    displayName: 'ESRP CodeSigning'
+    inputs:
+      ConnectedServiceName: 'azfunc-internal-esrp'
+      AppRegistrationClientId: 'a31bf239-3e15-498e-a335-f6ec0c9d9ccf'
+      AppRegistrationTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'
+      AuthAKVName: 'kv-azfunc-esrp'
+      AuthCertName: 'azfunc-internal-esrp-auth'
+      AuthSignCertName: 'azfunc-internal-esrp-sign'
+      FolderPath: '$(Pipeline.Workspace)\staging\coretools-cli'
+      Pattern: '*.msi'
+      signConfigType: inlineSignParams
+      inlineOperation: |
+        [
+          {
+            "KeyCode": "CP-230012",
+            "OperationCode": "SigntoolSign",
+            "Parameters": {
+              "OpusName": "Microsoft",
+              "OpusInfo": "http://www.microsoft.com",
+              "FileDigest": "/fd \"SHA256\"",
+              "PageHash": "/NPH",
+              "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+            },
+            "ToolName": "sign",
+            "ToolVersion": "1.0"
+          },
+          {
+            "KeyCode": "CP-230012",
+            "OperationCode": "SigntoolVerify",
+            "Parameters": {},
+            "ToolName": "sign",
+            "ToolVersion": "1.0"
+          }
+        ]
+      VerboseLogin: true
+    condition: and(succeeded(), startsWith('${{ parameters.arch }}', 'win'))
+
+  - task: PowerShell@2
+    displayName: 'Test Artifacts - Visual Studio'
+    inputs:
+      targetType: filePath
+      filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/testVsArtifacts.ps1'
+      arguments: '-StagingDirectory "$(Pipeline.Workspace)\staging\coretools-visualstudio"'
+      workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
+    condition: and(succeeded(), eq('${{ parameters.arch }}', 'min.win-x64'))
+
+  - task: PowerShell@2
+    displayName: 'Test Artifacts'
+    inputs:
+      targetType: filePath
+      filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/testArtifacts.ps1'
+      arguments: '-StagingDirectory "$(Pipeline.Workspace)\staging\coretools-cli"'
+      workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
+    condition: and(succeeded(), startsWith('${{ parameters.arch }}', 'win'))
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Zip Artifacts'
+    inputs:
+      command: run
+      projects: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/Azure.Functions.ArtifactAssembler.csproj'
+      arguments: 'zip -c release'
+      workingDirectory: '$(Pipeline.Workspace)'
+
+  - task: PowerShell@2
+    displayName: 'Generate SHA files'
+    inputs:
+      targetType: filePath
+      filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateSha.ps1'
+
+  - task: CopyFiles@2
+    displayName: 'Copy Files to Artifact Staging Directory'
+    inputs:
+      SourceFolder: '$(Pipeline.Workspace)/staging'
+      Contents: 'coretools-*/**'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'

--- a/eng/ci/templates/official/jobs/assemble-artifacts.yml
+++ b/eng/ci/templates/official/jobs/assemble-artifacts.yml
@@ -44,46 +44,6 @@ jobs:
 
   steps:
   - checkout: self
-  
-  - pwsh: |
-      Write-Host "Recursively listing all files in Pipeline.Workspace..."
-
-      $workspacePath = $env:PIPELINE_WORKSPACE
-      if (-not $workspacePath) {
-          $workspacePath = "$(Pipeline.Workspace)"
-      }
-
-      Write-Host "Pipeline Workspace path: $workspacePath"
-
-      function Show-RecursiveContents {
-          param (
-              [string]$Path,
-              [int]$Depth = 0
-          )
-
-          $indent = "  " * $Depth
-  
-          try {
-              $items = Get-ChildItem -Path $Path -ErrorAction Stop
-      
-              foreach ($item in $items) {
-                  if ($item.PSIsContainer) {
-                      # Directory
-                      Write-Host "$indent$($item.FullName) [DIR]"
-                      Show-RecursiveContents -Path $item.FullName -Depth ($Depth + 1)
-                  } else {
-                      # File
-                      $sizeKB = [math]::Round($item.Length / 1KB, 2)
-                      Write-Host "$indent$($item.FullName) ($sizeKB KB)"
-                  }
-              }
-          } catch {
-              Write-Host "$indentError accessing $Path : $($_.Exception.Message)"
-          }
-      }
-
-      Show-RecursiveContents -Path $workspacePath
-    displayName: 'List Pipeline Workspace Contents'
 
   - task: DotNetCoreCLI@2
     displayName: "Run ArtifactAssembler"
@@ -159,6 +119,46 @@ jobs:
         filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/testArtifacts.ps1'
         arguments: '-StagingDirectory "$(Pipeline.Workspace)\staging\coretools-cli"'
         workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
+
+  - pwsh: |
+      Write-Host "Recursively listing all files in Pipeline.Workspace..."
+
+      $workspacePath = $env:PIPELINE_WORKSPACE
+      if (-not $workspacePath) {
+          $workspacePath = "$(Pipeline.Workspace)"
+      }
+
+      Write-Host "Pipeline Workspace path: $workspacePath"
+
+      function Show-RecursiveContents {
+          param (
+              [string]$Path,
+              [int]$Depth = 0
+          )
+
+          $indent = "  " * $Depth
+  
+          try {
+              $items = Get-ChildItem -Path $Path -ErrorAction Stop
+      
+              foreach ($item in $items) {
+                  if ($item.PSIsContainer) {
+                      # Directory
+                      Write-Host "$indent$($item.FullName) [DIR]"
+                      Show-RecursiveContents -Path $item.FullName -Depth ($Depth + 1)
+                  } else {
+                      # File
+                      $sizeKB = [math]::Round($item.Length / 1KB, 2)
+                      Write-Host "$indent$($item.FullName) ($sizeKB KB)"
+                  }
+              }
+          } catch {
+              Write-Host "$indentError accessing $Path : $($_.Exception.Message)"
+          }
+      }
+
+      Show-RecursiveContents -Path $workspacePath
+    displayName: 'List Pipeline Workspace Contents'
 
   - task: DotNetCoreCLI@2
     displayName: 'Zip Artifacts'

--- a/eng/ci/templates/official/jobs/assemble-artifacts.yml
+++ b/eng/ci/templates/official/jobs/assemble-artifacts.yml
@@ -12,18 +12,23 @@ jobs:
       - input: pipelineArtifact
         pipeline: core-tools-host
         artifactName: drop-coretools-host-linux-signed
+        targetPath: $(Pipeline.Workspace)/core-tools-host
       - input: pipelineArtifact
         pipeline: core-tools-host
         artifactName: drop-coretools-host-windows
+        targetPath: $(Pipeline.Workspace)/core-tools-host
       - input: pipelineArtifact
         pipeline: core-tools-inproc
         artifactName: drop-inproc6
+        targetPath: $(Pipeline.Workspace)/core-tools-inproc
       - input: pipelineArtifact
         pipeline: core-tools-inproc
         artifactName: drop-inproc8
+        targetPath: $(Pipeline.Workspace)/core-tools-inproc
       - input: pipelineArtifact
         pipeline: core-tools-default
         artifactName: drop
+        targetPath: $(Pipeline.Workspace)/core-tools-default
   
     outputs:
       - output: pipelineArtifact

--- a/eng/ci/templates/official/jobs/assemble-artifacts.yml
+++ b/eng/ci/templates/official/jobs/assemble-artifacts.yml
@@ -12,23 +12,23 @@ jobs:
       - input: pipelineArtifact
         pipeline: core-tools-host
         artifactName: drop-coretools-host-linux-signed
-        targetPath: $(Pipeline.Workspace)/core-tools-host
+        targetPath: $(Pipeline.Workspace)\core-tools-host
       - input: pipelineArtifact
         pipeline: core-tools-host
         artifactName: drop-coretools-host-windows
-        targetPath: $(Pipeline.Workspace)/core-tools-host
+        targetPath: $(Pipeline.Workspace)\core-tools-host
       - input: pipelineArtifact
         pipeline: core-tools-inproc
         artifactName: drop-inproc6
-        targetPath: $(Pipeline.Workspace)/core-tools-inproc
+        targetPath: $(Pipeline.Workspace)\core-tools-inproc
       - input: pipelineArtifact
         pipeline: core-tools-inproc
         artifactName: drop-inproc8
-        targetPath: $(Pipeline.Workspace)/core-tools-inproc
+        targetPath: $(Pipeline.Workspace)\core-tools-inproc
       - input: pipelineArtifact
         pipeline: core-tools-default
         artifactName: drop
-        targetPath: $(Pipeline.Workspace)/core-tools-default
+        targetPath: $(Pipeline.Workspace)\core-tools-default
   
     outputs:
       - output: pipelineArtifact
@@ -43,6 +43,46 @@ jobs:
 
   steps:
   - checkout: self
+  
+  - pwsh: |
+      Write-Host "Recursively listing all files in Pipeline.Workspace..."
+
+      $workspacePath = $env:PIPELINE_WORKSPACE
+      if (-not $workspacePath) {
+          $workspacePath = "$(Pipeline.Workspace)"
+      }
+
+      Write-Host "Pipeline Workspace path: $workspacePath"
+
+      function Show-RecursiveContents {
+          param (
+              [string]$Path,
+              [int]$Depth = 0
+          )
+
+          $indent = "  " * $Depth
+  
+          try {
+              $items = Get-ChildItem -Path $Path -ErrorAction Stop
+      
+              foreach ($item in $items) {
+                  if ($item.PSIsContainer) {
+                      # Directory
+                      Write-Host "$indent$($item.FullName) [DIR]"
+                      Show-RecursiveContents -Path $item.FullName -Depth ($Depth + 1)
+                  } else {
+                      # File
+                      $sizeKB = [math]::Round($item.Length / 1KB, 2)
+                      Write-Host "$indent$($item.FullName) ($sizeKB KB)"
+                  }
+              }
+          } catch {
+              Write-Host "$indentError accessing $Path : $($_.Exception.Message)"
+          }
+      }
+
+      Show-RecursiveContents -Path $workspacePath
+    displayName: 'List Pipeline Workspace Contents'
                 
   - task: DotNetCoreCLI@2
     displayName: "Run ArtifactAssembler"
@@ -56,93 +96,4 @@ jobs:
     displayName: 'Generate metadata.json file'
     inputs:
       targetType: filePath
-      filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateMetadataFile.ps1'
-      arguments: '-StagingDirectory "$(Pipeline.Workspace)\staging"'
-      workingDirectory: '$(Pipeline.Workspace)'
-    condition: and(succeeded(), eq('${{ parameters.arch }}', 'min.win-x64'))
-
-  - task: PowerShell@2
-    displayName: 'Generate MSI files'
-    inputs:
-      targetType: filePath
-      filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateMsiFiles.ps1'
-      arguments: '-ArtifactsPath "$(Pipeline.Workspace)\staging\coretools-cli"'
-      workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
-    condition: and(succeeded(), startsWith('${{ parameters.arch }}', 'win'))
-
-  - task: EsrpCodeSigning@5
-    displayName: 'ESRP CodeSigning'
-    inputs:
-      ConnectedServiceName: 'azfunc-internal-esrp'
-      AppRegistrationClientId: 'a31bf239-3e15-498e-a335-f6ec0c9d9ccf'
-      AppRegistrationTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'
-      AuthAKVName: 'kv-azfunc-esrp'
-      AuthCertName: 'azfunc-internal-esrp-auth'
-      AuthSignCertName: 'azfunc-internal-esrp-sign'
-      FolderPath: '$(Pipeline.Workspace)\staging\coretools-cli'
-      Pattern: '*.msi'
-      signConfigType: inlineSignParams
-      inlineOperation: |
-        [
-          {
-            "KeyCode": "CP-230012",
-            "OperationCode": "SigntoolSign",
-            "Parameters": {
-              "OpusName": "Microsoft",
-              "OpusInfo": "http://www.microsoft.com",
-              "FileDigest": "/fd \"SHA256\"",
-              "PageHash": "/NPH",
-              "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-            },
-            "ToolName": "sign",
-            "ToolVersion": "1.0"
-          },
-          {
-            "KeyCode": "CP-230012",
-            "OperationCode": "SigntoolVerify",
-            "Parameters": {},
-            "ToolName": "sign",
-            "ToolVersion": "1.0"
-          }
-        ]
-      VerboseLogin: true
-    condition: and(succeeded(), startsWith('${{ parameters.arch }}', 'win'))
-
-  - task: PowerShell@2
-    displayName: 'Test Artifacts - Visual Studio'
-    inputs:
-      targetType: filePath
-      filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/testVsArtifacts.ps1'
-      arguments: '-StagingDirectory "$(Pipeline.Workspace)\staging\coretools-visualstudio"'
-      workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
-    condition: and(succeeded(), eq('${{ parameters.arch }}', 'min.win-x64'))
-
-  - task: PowerShell@2
-    displayName: 'Test Artifacts'
-    inputs:
-      targetType: filePath
-      filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/testArtifacts.ps1'
-      arguments: '-StagingDirectory "$(Pipeline.Workspace)\staging\coretools-cli"'
-      workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
-    condition: and(succeeded(), startsWith('${{ parameters.arch }}', 'win'))
-
-  - task: DotNetCoreCLI@2
-    displayName: 'Zip Artifacts'
-    inputs:
-      command: run
-      projects: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/Azure.Functions.ArtifactAssembler.csproj'
-      arguments: 'zip -c release'
-      workingDirectory: '$(Pipeline.Workspace)'
-
-  - task: PowerShell@2
-    displayName: 'Generate SHA files'
-    inputs:
-      targetType: filePath
-      filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateSha.ps1'
-
-  - task: CopyFiles@2
-    displayName: 'Copy Files to Artifact Staging Directory'
-    inputs:
-      SourceFolder: '$(Pipeline.Workspace)/staging'
-      Contents: 'coretools-*/**'
-      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+      filePath: '$(Build.SourcesDir

--- a/eng/ci/templates/official/jobs/assemble-artifacts.yml
+++ b/eng/ci/templates/official/jobs/assemble-artifacts.yml
@@ -118,6 +118,29 @@ jobs:
         folderPath: $(Pipeline.Workspace)\staging\coretools-cli
         pattern: '*.msi'
         signType: 'inline'
+        inlineOperation: |
+          [
+            {
+              "KeyCode": "CP-230012",
+              "OperationCode": "SigntoolSign",
+              "Parameters": {
+                "OpusName": "Microsoft",
+                "OpusInfo": "http://www.microsoft.com",
+                "FileDigest": "/fd \"SHA256\"",
+                "PageHash": "/NPH",
+                "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+              },
+              "ToolName": "sign",
+              "ToolVersion": "1.0"
+            },
+            {
+              "KeyCode": "CP-230012",
+              "OperationCode": "SigntoolVerify",
+              "Parameters": {},
+              "ToolName": "sign",
+              "ToolVersion": "1.0"
+            }
+          ]
 
   - ${{ if eq(parameters.arch, 'min.win-x64') }}:
     - task: PowerShell@2

--- a/eng/ci/templates/official/jobs/assemble-artifacts.yml
+++ b/eng/ci/templates/official/jobs/assemble-artifacts.yml
@@ -11,14 +11,18 @@ jobs:
     inputs:
       - input: pipelineArtifact
         artifactName: drop-coretools-host-linux-signed
+        pipeline: azure\azure-functions-core-tools\core-tools-host.official
       - input: pipelineArtifact
         artifactName: drop-coretools-host-windows
+        pipeline: azure\azure-functions-core-tools\core-tools-host.official
       - input: pipelineArtifact
         artifactName: drop-inproc6
+        pipeline: azure\azure-functions-core-tools\core-tools.official
       - input: pipelineArtifact
         artifactName: drop-inproc8
       - input: pipelineArtifact
         artifactName: drop
+        pipeline: azure\azure-functions-core-tools\core-tools.official
   
     outputs:
       - output: pipelineArtifact

--- a/eng/ci/templates/official/jobs/assemble-artifacts.yml
+++ b/eng/ci/templates/official/jobs/assemble-artifacts.yml
@@ -111,7 +111,7 @@ jobs:
         arguments: '-ArtifactsPath "$(Pipeline.Workspace)\staging\coretools-cli"'
         workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
 
-  - ${{ if startsWith(parameters.arch, 'win') }}:
+  - ${{ if startsWith(parameters.arch, 'win-x') }}:
     - template: ci/sign-files.yml@eng
       parameters:
         displayName: Sign MSI files

--- a/eng/ci/templates/official/jobs/assemble-artifacts.yml
+++ b/eng/ci/templates/official/jobs/assemble-artifacts.yml
@@ -12,23 +12,23 @@ jobs:
       - input: pipelineArtifact
         pipeline: core-tools-host
         artifactName: drop-coretools-host-linux-signed
-        targetPath: $(Pipeline.Workspace)\core-tools-host
+        targetPath: $(Pipeline.Workspace)\core-tools-host\drop-coretools-host-linux-signed
       - input: pipelineArtifact
         pipeline: core-tools-host
         artifactName: drop-coretools-host-windows
-        targetPath: $(Pipeline.Workspace)\core-tools-host
+        targetPath: $(Pipeline.Workspace)\core-tools-host\drop-coretools-host-windows
       - input: pipelineArtifact
         pipeline: core-tools-inproc
         artifactName: drop-inproc6
-        targetPath: $(Pipeline.Workspace)\core-tools-inproc
+        targetPath: $(Pipeline.Workspace)\core-tools-inproc\drop-inproc6
       - input: pipelineArtifact
         pipeline: core-tools-inproc
         artifactName: drop-inproc8
-        targetPath: $(Pipeline.Workspace)\core-tools-inproc
+        targetPath: $(Pipeline.Workspace)\core-tools-inproc\drop-inproc8
       - input: pipelineArtifact
         pipeline: core-tools-default
         artifactName: drop
-        targetPath: $(Pipeline.Workspace)\core-tools-default
+        targetPath: $(Pipeline.Workspace)\core-tools-default\drop
   
     outputs:
       - output: pipelineArtifact

--- a/eng/ci/templates/official/jobs/assemble-artifacts.yml
+++ b/eng/ci/templates/official/jobs/assemble-artifacts.yml
@@ -30,14 +30,15 @@ jobs:
         artifactName: drop
         targetPath: $(Pipeline.Workspace)\core-tools-default\drop
   
+    outputParentDirectory: $(Build.ArtifactStagingDirectory)
     outputs:
       - output: pipelineArtifact
         displayName: Publish assembled artifact ${{ parameters.arch }}
-        targetPath: $(Build.ArtifactStagingDirectory)
+        targetPath: $(Build.ArtifactStagingDirectory)/core-tools
         artifact: drop-${{ parameters.arch }}
       - output: pipelineArtifact
         displayName: Publish metadata.json
-        targetPath: $(Pipeline.Workspace)/staging/metadata.json
+        targetPath: $(Build.ArtifactStagingDirectory)/metadata.json
         artifact: drop-metadata-json
         condition: and(succeeded(), eq('${{ parameters.arch }}', 'min.win-x64'))
 
@@ -83,95 +84,72 @@ jobs:
 
       Show-RecursiveContents -Path $workspacePath
     displayName: 'List Pipeline Workspace Contents'
-                
+              
+  - task: DotNetCoreCLI@2
+    displayName: 'Build ArtifactAssembler'
+    inputs:
+      command: build
+      projects: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/Azure.Functions.ArtifactAssembler.csproj'
+      workingDirectory: '$(Pipeline.Workspace)'
+
   - task: DotNetCoreCLI@2
     displayName: "Run ArtifactAssembler"
     inputs:
       command: run
       projects: "$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/Azure.Functions.ArtifactAssembler.csproj"
-      arguments: ' -c release "Azure.Functions.Cli.${{ parameters.arch }}"'
+      arguments: '--no-build -c release -- "Azure.Functions.Cli.${{ parameters.arch }}"'
       workingDirectory: '$(Pipeline.Workspace)'
 
-  - task: PowerShell@2
-    displayName: 'Generate metadata.json file'
-    inputs:
-      targetType: filePath
-      filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateMetadataFile.ps1'
-      arguments: '-StagingDirectory "$(Pipeline.Workspace)\staging"'
-      workingDirectory: '$(Pipeline.Workspace)'
-    condition: and(succeeded(), eq('${{ parameters.arch }}', 'min.win-x64'))
+  - ${{ if eq('${{ parameters.arch }}', 'min.win-x64') }}:
+    - task: PowerShell@2
+      displayName: 'Generate metadata.json file'
+      inputs:
+        targetType: filePath
+        filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateMetadataFile.ps1'
+        arguments: '-StagingDirectory "$(Pipeline.Workspace)\staging"'
+        workingDirectory: '$(Pipeline.Workspace)'
 
-  - task: PowerShell@2
-    displayName: 'Generate MSI files'
-    inputs:
-      targetType: filePath
-      filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateMsiFiles.ps1'
-      arguments: '-ArtifactsPath "$(Pipeline.Workspace)\staging\coretools-cli"'
-      workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
-    condition: and(succeeded(), startsWith('${{ parameters.arch }}', 'win'))
+  - ${{ if startsWith('${{ parameters.arch }}', 'win') }}:
+    - task: PowerShell@2
+      displayName: 'Generate MSI files'
+      inputs:
+        targetType: filePath
+        filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateMsiFiles.ps1'
+        arguments: '-ArtifactsPath "$(Pipeline.Workspace)\staging\coretools-cli"'
+        workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
 
-  - task: EsrpCodeSigning@5
-    displayName: 'ESRP CodeSigning'
-    inputs:
-      ConnectedServiceName: 'azfunc-internal-esrp'
-      AppRegistrationClientId: 'a31bf239-3e15-498e-a335-f6ec0c9d9ccf'
-      AppRegistrationTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'
-      AuthAKVName: 'kv-azfunc-esrp'
-      AuthCertName: 'azfunc-internal-esrp-auth'
-      AuthSignCertName: 'azfunc-internal-esrp-sign'
-      FolderPath: '$(Pipeline.Workspace)\staging\coretools-cli'
-      Pattern: '*.msi'
-      signConfigType: inlineSignParams
-      inlineOperation: |
-        [
-          {
-            "KeyCode": "CP-230012",
-            "OperationCode": "SigntoolSign",
-            "Parameters": {
-              "OpusName": "Microsoft",
-              "OpusInfo": "http://www.microsoft.com",
-              "FileDigest": "/fd \"SHA256\"",
-              "PageHash": "/NPH",
-              "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-            },
-            "ToolName": "sign",
-            "ToolVersion": "1.0"
-          },
-          {
-            "KeyCode": "CP-230012",
-            "OperationCode": "SigntoolVerify",
-            "Parameters": {},
-            "ToolName": "sign",
-            "ToolVersion": "1.0"
-          }
-        ]
-      VerboseLogin: true
-    condition: and(succeeded(), startsWith('${{ parameters.arch }}', 'win'))
+  - ${{ if startsWith('${{ parameters.arch }}', 'win') }}:
+    - template: ci/sign-files.yml@eng
+      parameters:
+        displayName: Sign MSI files
+        folderPath: $(Pipeline.Workspace)\staging\coretools-cli
+        pattern: '*.msi'
+        signType: 'inline'
 
-  - task: PowerShell@2
-    displayName: 'Test Artifacts - Visual Studio'
-    inputs:
-      targetType: filePath
-      filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/testVsArtifacts.ps1'
-      arguments: '-StagingDirectory "$(Pipeline.Workspace)\staging\coretools-visualstudio"'
-      workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
-    condition: and(succeeded(), eq('${{ parameters.arch }}', 'min.win-x64'))
+  - ${{ if eq('${{ parameters.arch }}', 'min.win-x64') }}:
+    - task: PowerShell@2
+      displayName: 'Test Artifacts - Visual Studio'
+      inputs:
+        targetType: filePath
+        filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/testVsArtifacts.ps1'
+        arguments: '-StagingDirectory "$(Pipeline.Workspace)\staging\coretools-visualstudio"'
+        workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
 
-  - task: PowerShell@2
-    displayName: 'Test Artifacts'
-    inputs:
-      targetType: filePath
-      filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/testArtifacts.ps1'
-      arguments: '-StagingDirectory "$(Pipeline.Workspace)\staging\coretools-cli"'
-      workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
-    condition: and(succeeded(), startsWith('${{ parameters.arch }}', 'win'))
+  - ${{ if startsWith('${{ parameters.arch }}', 'win') }}:
+    - task: PowerShell@2
+      displayName: 'Test Artifacts'
+      inputs:
+        targetType: filePath
+        filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/testArtifacts.ps1'
+        arguments: '-StagingDirectory "$(Pipeline.Workspace)\staging\coretools-cli"'
+        workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
 
   - task: DotNetCoreCLI@2
     displayName: 'Zip Artifacts'
     inputs:
       command: run
       projects: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/Azure.Functions.ArtifactAssembler.csproj'
-      arguments: 'zip -c release'
+      arguments: '--no-build -c release -- zip'
       workingDirectory: '$(Pipeline.Workspace)'
 
   - task: PowerShell@2
@@ -179,10 +157,19 @@ jobs:
     inputs:
       targetType: filePath
       filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateSha.ps1'
+      arguments: '-CurrentDirectory "$(Pipeline.Workspace)"'
 
   - task: CopyFiles@2
     displayName: 'Copy Files to Artifact Staging Directory'
     inputs:
       SourceFolder: '$(Pipeline.Workspace)/staging'
       Contents: 'coretools-*/**'
-      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)/core-tools'
+
+  - ${{ if eq('${{ parameters.arch }}', 'min.win-x64') }}:
+    - task: CopyFiles@2
+      displayName: 'Copy metadata.json to Artifact Staging Directory'
+      inputs:
+        SourceFolder: '$(Pipeline.Workspace)/staging'
+        Contents: 'metadata.json'
+        TargetFolder: '$(Build.ArtifactStagingDirectory)'

--- a/eng/ci/templates/official/jobs/assemble-artifacts.yml
+++ b/eng/ci/templates/official/jobs/assemble-artifacts.yml
@@ -1,9 +1,11 @@
 parameters:
   - name: arch
     type: string
+  - name: displayName
+    type: string
 
 jobs:
-- job: AssembleArtifact
+- job: AssembleArtifact${{ parameters.displayName }}
   displayName: "Assemble ${{ parameters.arch }}"
   templateContext:
     inputs:

--- a/eng/ci/templates/official/jobs/assemble-artifacts.yml
+++ b/eng/ci/templates/official/jobs/assemble-artifacts.yml
@@ -84,13 +84,6 @@ jobs:
 
       Show-RecursiveContents -Path $workspacePath
     displayName: 'List Pipeline Workspace Contents'
-              
-  - task: DotNetCoreCLI@2
-    displayName: 'Build ArtifactAssembler'
-    inputs:
-      command: build
-      projects: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/Azure.Functions.ArtifactAssembler.csproj'
-      workingDirectory: '$(Pipeline.Workspace)'
 
   - task: DotNetCoreCLI@2
     displayName: "Run ArtifactAssembler"
@@ -100,7 +93,7 @@ jobs:
       arguments: '-c release -- "Azure.Functions.Cli.${{ parameters.arch }}"'
       workingDirectory: '$(Pipeline.Workspace)'
 
-  - ${{ if eq('${{ parameters.arch }}', 'min.win-x64') }}:
+  - ${{ if eq(parameters.arch, 'min.win-x64') }}:
     - task: PowerShell@2
       displayName: 'Generate metadata.json file'
       inputs:
@@ -109,7 +102,7 @@ jobs:
         arguments: '-StagingDirectory "$(Pipeline.Workspace)\staging"'
         workingDirectory: '$(Pipeline.Workspace)'
 
-  - ${{ if startsWith('${{ parameters.arch }}', 'win') }}:
+  - ${{ if startsWith(parameters.arch, 'win') }}:
     - task: PowerShell@2
       displayName: 'Generate MSI files'
       inputs:
@@ -118,7 +111,7 @@ jobs:
         arguments: '-ArtifactsPath "$(Pipeline.Workspace)\staging\coretools-cli"'
         workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
 
-  - ${{ if startsWith('${{ parameters.arch }}', 'win') }}:
+  - ${{ if startsWith(parameters.arch, 'win') }}:
     - template: ci/sign-files.yml@eng
       parameters:
         displayName: Sign MSI files
@@ -126,7 +119,7 @@ jobs:
         pattern: '*.msi'
         signType: 'inline'
 
-  - ${{ if eq('${{ parameters.arch }}', 'min.win-x64') }}:
+  - ${{ if eq(parameters.arch, 'min.win-x64') }}:
     - task: PowerShell@2
       displayName: 'Test Artifacts - Visual Studio'
       inputs:
@@ -135,7 +128,7 @@ jobs:
         arguments: '-StagingDirectory "$(Pipeline.Workspace)\staging\coretools-visualstudio"'
         workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
 
-  - ${{ if startsWith('${{ parameters.arch }}', 'win') }}:
+  - ${{ if startsWith(parameters.arch, 'win') }}:
     - task: PowerShell@2
       displayName: 'Test Artifacts'
       inputs:
@@ -166,7 +159,7 @@ jobs:
       Contents: 'coretools-*/**'
       TargetFolder: '$(Build.ArtifactStagingDirectory)/core-tools'
 
-  - ${{ if eq('${{ parameters.arch }}', 'min.win-x64') }}:
+  - ${{ if eq(parameters.arch, 'min.win-x64') }}:
     - task: CopyFiles@2
       displayName: 'Copy metadata.json to Artifact Staging Directory'
       inputs:

--- a/eng/ci/templates/official/jobs/assemble-artifacts.yml
+++ b/eng/ci/templates/official/jobs/assemble-artifacts.yml
@@ -120,46 +120,6 @@ jobs:
         arguments: '-StagingDirectory "$(Pipeline.Workspace)\staging\coretools-cli"'
         workingDirectory: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler'
 
-  - pwsh: |
-      Write-Host "Recursively listing all files in Pipeline.Workspace..."
-
-      $workspacePath = $env:PIPELINE_WORKSPACE
-      if (-not $workspacePath) {
-          $workspacePath = "$(Pipeline.Workspace)"
-      }
-
-      Write-Host "Pipeline Workspace path: $workspacePath"
-
-      function Show-RecursiveContents {
-          param (
-              [string]$Path,
-              [int]$Depth = 0
-          )
-
-          $indent = "  " * $Depth
-  
-          try {
-              $items = Get-ChildItem -Path $Path -ErrorAction Stop
-      
-              foreach ($item in $items) {
-                  if ($item.PSIsContainer) {
-                      # Directory
-                      Write-Host "$indent$($item.FullName) [DIR]"
-                      Show-RecursiveContents -Path $item.FullName -Depth ($Depth + 1)
-                  } else {
-                      # File
-                      $sizeKB = [math]::Round($item.Length / 1KB, 2)
-                      Write-Host "$indent$($item.FullName) ($sizeKB KB)"
-                  }
-              }
-          } catch {
-              Write-Host "$indentError accessing $Path : $($_.Exception.Message)"
-          }
-      }
-
-      Show-RecursiveContents -Path $workspacePath
-    displayName: 'List Pipeline Workspace Contents'
-
   - task: DotNetCoreCLI@2
     displayName: 'Zip Artifacts'
     inputs:

--- a/eng/ci/templates/official/jobs/build-test.yml
+++ b/eng/ci/templates/official/jobs/build-test.yml
@@ -81,17 +81,10 @@ jobs:
   - pwsh: |
       .\check-vulnerabilities.ps1
     displayName: "Check for security vulnerabilities"
-  - pwsh: |
-      # Check if this is a scheduled build
-      $buildReason = $env:BUILD_REASON
-      Write-Host "Current build reason: $buildReason"
-      
-      if ($buildReason -eq "Schedule") {
-          Write-Host "This is a scheduled nightly build - adding nightly-build tag"
-          Write-Host "##vso[build.addbuildtag]nightly-build"
-      } else {
-          Write-Host "This is not a scheduled build (reason: $buildReason) - no tag added"
-      }
+  - ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
+    - pwsh: |
+        # Check if this is a scheduled build
+        Write-Host "##vso[build.addbuildtag]nightly-build"
   - pwsh: |
       .\build.ps1
     env:

--- a/eng/ci/templates/official/jobs/build-test.yml
+++ b/eng/ci/templates/official/jobs/build-test.yml
@@ -82,6 +82,17 @@ jobs:
       .\check-vulnerabilities.ps1
     displayName: "Check for security vulnerabilities"
   - pwsh: |
+      # Check if this is a scheduled build
+      $buildReason = $env:BUILD_REASON
+      Write-Host "Current build reason: $buildReason"
+      
+      if ($buildReason -eq "Schedule") {
+          Write-Host "This is a scheduled nightly build - adding nightly-build tag"
+          Write-Host "##vso[build.addbuildtag]nightly-build"
+      } else {
+          Write-Host "This is not a scheduled build (reason: $buildReason) - no tag added"
+      }
+  - pwsh: |
       .\build.ps1
     env:
       AzureBlobSigningConnectionString: $(AzureBlobSigningConnectionString)

--- a/eng/ci/templates/official/jobs/process-nuget-package.yml
+++ b/eng/ci/templates/official/jobs/process-nuget-package.yml
@@ -19,5 +19,5 @@ jobs:
     displayName: 'Process and move nuget package to staging directory'
     inputs:
       targetType: filePath
-      filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/moveNugetPacakge.ps1'
-      workingDirectory: '$(Pipeline.Workspace)'
+      filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/moveNugetPackage.ps1'
+      arguments: '-CurrentDirectory "$(Pipeline.Workspace)"'

--- a/eng/ci/templates/official/jobs/process-nuget-package.yml
+++ b/eng/ci/templates/official/jobs/process-nuget-package.yml
@@ -6,7 +6,7 @@ jobs:
       - input: pipelineArtifact
         pipeline: core-tools-default
         artifactName: drop
-        targetPath: $(Pipeline.Workspace)/core-tools-default
+        targetPath: $(Pipeline.Workspace)\core-tools-default\drop
     outputs:
       - output: pipelineArtifact
         displayName: Publish nuget package

--- a/eng/ci/templates/official/jobs/process-nuget-package.yml
+++ b/eng/ci/templates/official/jobs/process-nuget-package.yml
@@ -1,0 +1,21 @@
+jobs:
+- job: ProcessNuGetPackage
+  displayName: "Process NuGet Package"
+  templateContext:
+    inputs:
+      - input: pipelineArtifact
+        artifactName: drop
+    outputs:
+      - output: pipelineArtifact
+        displayName: Publish nuget package
+        targetPath: $(Pipeline.Workspace)/staging
+        artifact: drop-nuget-package
+  steps:
+  - checkout: self
+
+  - task: PowerShell@2
+    displayName: 'Process and move nuget package to staging directory'
+    inputs:
+      targetType: filePath
+      filePath: '$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/moveNugetPacakge.ps1'
+      workingDirectory: '$(Pipeline.Workspace)'

--- a/eng/ci/templates/official/jobs/process-nuget-package.yml
+++ b/eng/ci/templates/official/jobs/process-nuget-package.yml
@@ -10,7 +10,7 @@ jobs:
     outputs:
       - output: pipelineArtifact
         displayName: Publish nuget package
-        targetPath: $(Pipeline.Workspace)/staging
+        targetPath: $(Pipeline.Workspace)/nugetPackage
         artifact: drop-nuget-package
   steps:
   - checkout: self

--- a/eng/ci/templates/official/jobs/process-nuget-package.yml
+++ b/eng/ci/templates/official/jobs/process-nuget-package.yml
@@ -4,7 +4,9 @@ jobs:
   templateContext:
     inputs:
       - input: pipelineArtifact
+        pipeline: core-tools-default
         artifactName: drop
+        targetPath: $(Pipeline.Workspace)/core-tools-default
     outputs:
       - output: pipelineArtifact
         displayName: Publish nuget package

--- a/src/Azure.Functions.ArtifactAssembler/ArtifactAssembler.cs
+++ b/src/Azure.Functions.ArtifactAssembler/ArtifactAssembler.cs
@@ -398,7 +398,7 @@ namespace Azure.Functions.ArtifactAssembler
                 return;
             }
 
-            var zipFiles = Directory.GetFiles(zipSo, "*.zip");
+            var zipFiles = Directory.GetFiles(zipSourceDir, "*.zip");
             if (!string.IsNullOrEmpty(_artifactName))
             {
                 zipFiles = zipFiles.Where(file => Path.GetFileName(file).StartsWith(_artifactName)).ToArray();

--- a/src/Azure.Functions.ArtifactAssembler/ArtifactAssembler.cs
+++ b/src/Azure.Functions.ArtifactAssembler/ArtifactAssembler.cs
@@ -164,7 +164,7 @@ namespace Azure.Functions.ArtifactAssembler
                         var destinationDirectoryWithArtifactFolder = Path.Combine(destinationDirectory, fileNameToSearchFor);
                         if (Directory.Exists(directory))
                         {
-                            await Task.Run(() => FileUtilities.CopyDirectory(directory, destinationDirectoryWithArtifactFolder));
+                            FileUtilities.CopyDirectory(directory, destinationDirectoryWithArtifactFolder);
                         }
 
                     }
@@ -174,7 +174,7 @@ namespace Azure.Functions.ArtifactAssembler
             }
             else
             {
-                await Task.Run(() => FileUtilities.CopyDirectory(artifactZipPath, destinationDirectory));
+                FileUtilities.CopyDirectory(artifactZipPath, destinationDirectory);
                 await ExtractZipFilesInDirectoryAsync(artifactZipPath, destinationDirectory);
             }
             // Delete additional files that are not needed
@@ -226,14 +226,14 @@ namespace Azure.Functions.ArtifactAssembler
                 // Copy in-proc6 files and delete directory after
                 var inProc6ArtifactDirPath = Path.Combine(_inProc6ExtractedRootDir, artifactDirName);
                 EnsureArtifactDirectoryExist(inProc6ArtifactDirPath);
-                await Task.Run(() => FileUtilities.CopyDirectory(inProc6ArtifactDirPath, Path.Combine(consolidatedArtifactDirPath, Constants.InProc6DirectoryName)));
+                FileUtilities.CopyDirectory(inProc6ArtifactDirPath, Path.Combine(consolidatedArtifactDirPath, Constants.InProc6DirectoryName));
                 Directory.Delete(inProc6ArtifactDirPath, true);
 
                 // Copy core-tools-host files
                 var rid = GetRuntimeIdentifierForArtifactName(artifactName);
                 var coreToolsHostArtifactDirPath = Path.Combine(_coreToolsHostExtractedRootDir, rid);
                 EnsureArtifactDirectoryExist(coreToolsHostArtifactDirPath);
-                await Task.Run(() => FileUtilities.CopyDirectory(coreToolsHostArtifactDirPath, consolidatedArtifactDirPath));
+                FileUtilities.CopyDirectory(coreToolsHostArtifactDirPath, consolidatedArtifactDirPath);
                 Directory.Delete(coreToolsHostArtifactDirPath, true);
             }
             if ((!String.IsNullOrEmpty(_artifactName) && _net8OsxArtifacts.Contains(_artifactName)))
@@ -274,7 +274,7 @@ namespace Azure.Functions.ArtifactAssembler
             Directory.CreateDirectory(consolidatedArtifactDirPath);
 
             // Copy in-proc8 files and delete directory after
-            await Task.Run(() => FileUtilities.CopyDirectory(inProcArtifactDirPath, createDirectory ? Path.Combine(consolidatedArtifactDirPath, Constants.InProc8DirectoryName) : consolidatedArtifactDirPath));
+            FileUtilities.CopyDirectory(inProcArtifactDirPath, createDirectory ? Path.Combine(consolidatedArtifactDirPath, Constants.InProc8DirectoryName) : consolidatedArtifactDirPath);
             Directory.Delete(inProcArtifactDirPath, true);
 
             return (artifactDirName, consolidatedArtifactDirPath);
@@ -316,7 +316,7 @@ namespace Azure.Functions.ArtifactAssembler
 
                 // Copy oop core tools and delete old directory
                 EnsureArtifactDirectoryExist(outOfProcArtifactDirPath);
-                await Task.Run(() => FileUtilities.CopyDirectory(outOfProcArtifactDirPath, consolidatedArtifactDirPath));
+                FileUtilities.CopyDirectory(outOfProcArtifactDirPath, consolidatedArtifactDirPath);
                 Directory.Delete(outOfProcArtifactDirPath, true);
 
                 // If we are currently on the minified version of the artifacts, we do not want the inproc6/inproc8 subfolders
@@ -343,7 +343,7 @@ namespace Azure.Functions.ArtifactAssembler
 
                 // Copy in-proc8 files
                 var inProc8FinalDestination = Path.Combine(consolidatedArtifactDirPath, Constants.InProc8DirectoryName);
-                await Task.Run(() => FileUtilities.CopyDirectory(inProc8ArtifactDirPath, Path.Combine(consolidatedArtifactDirPath, Constants.InProc8DirectoryName)));
+                FileUtilities.CopyDirectory(inProc8ArtifactDirPath, Path.Combine(consolidatedArtifactDirPath, Constants.InProc8DirectoryName));
                 Console.WriteLine($"Copied files from {inProc8ArtifactDirPath} => {inProc8FinalDestination}");
 
                 // Rename inproc6 directory to have the same version as the out-of-proc artifact before copying
@@ -353,7 +353,7 @@ namespace Azure.Functions.ArtifactAssembler
 
                 // Copy in-proc6 files
                 var inProc6FinalDestination = Path.Combine(consolidatedArtifactDirPath, Constants.InProc6DirectoryName);
-                await Task.Run(() => FileUtilities.CopyDirectory(inProc6ArtifactDirPath, Path.Combine(consolidatedArtifactDirPath, Constants.InProc6DirectoryName)));
+                FileUtilities.CopyDirectory(inProc6ArtifactDirPath, Path.Combine(consolidatedArtifactDirPath, Constants.InProc6DirectoryName));
                 Console.WriteLine($"Copied files from {inProc8ArtifactDirPath} => {inProc8FinalDestination}");
 
                 Console.WriteLine($"Finished assembling {consolidatedArtifactDirPath}");
@@ -417,7 +417,7 @@ namespace Azure.Functions.ArtifactAssembler
                 }
                 var destinationDir = Path.Combine(extractDestinationDir, Path.GetFileNameWithoutExtension(zipFile));
                 Console.WriteLine($"Extracting {zipFile} to {destinationDir}");
-                await Task.Run(() => FileUtilities.ExtractToDirectory(zipFile, destinationDir));
+                FileUtilities.ExtractToDirectory(zipFile, destinationDir);
                 File.Delete(zipFile);
             }
         }

--- a/src/Azure.Functions.ArtifactAssembler/ArtifactAssembler.cs
+++ b/src/Azure.Functions.ArtifactAssembler/ArtifactAssembler.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.IO;
+using System.IO.Compression;
 using System.Text.RegularExpressions;
 
 namespace Azure.Functions.ArtifactAssembler
@@ -55,8 +57,9 @@ namespace Azure.Functions.ArtifactAssembler
         private string _inProc8ExtractedRootDir = string.Empty;
         private string _coreToolsHostExtractedRootDir = string.Empty;
         private string _outOfProcExtractedRootDir = string.Empty;
+        private string _artifactName = string.Empty;
 
-        internal ArtifactAssembler(string rootWorkingDirectory)
+        internal ArtifactAssembler(string rootWorkingDirectory, string artifactName)
         {
             _inProcArtifactDirectoryName = GetRequiredEnvironmentVariable(EnvironmentVariables.InProcArtifactAlias);
             _coreToolsHostArtifactDirectoryName = GetRequiredEnvironmentVariable(EnvironmentVariables.CoreToolsHostArtifactAlias);
@@ -70,6 +73,7 @@ namespace Azure.Functions.ArtifactAssembler
 
             _rootWorkingDirectory = rootWorkingDirectory;
             _stagingDirectory = CreateStagingDirectory(_rootWorkingDirectory);
+            _artifactName = artifactName;
         }
 
         internal async Task AssembleArtifactsAsync()
@@ -109,8 +113,8 @@ namespace Azure.Functions.ArtifactAssembler
 
             Directory.Delete(inProcArtifactDownloadDir, true);
 
-            _coreToolsHostExtractedRootDir = await MoveArtifactsToStagingDirectoryAndExtractIfNeeded(coreToolsHostWindowsArtifactDirPath, Path.Combine(_stagingDirectory, Constants.CoreToolsHostDirectoryName));
-            await MoveArtifactsToStagingDirectoryAndExtractIfNeeded(coreToolsHostLinuxArtifactDirPath, Path.Combine(_stagingDirectory, Constants.CoreToolsHostDirectoryName));
+            _coreToolsHostExtractedRootDir = await MoveArtifactsToStagingDirectoryAndExtractIfNeeded(coreToolsHostWindowsArtifactDirPath, Path.Combine(_stagingDirectory, Constants.CoreToolsHostDirectoryName), true);
+            await MoveArtifactsToStagingDirectoryAndExtractIfNeeded(coreToolsHostLinuxArtifactDirPath, Path.Combine(_stagingDirectory, Constants.CoreToolsHostDirectoryName), true);
             Directory.Delete(coreToolsHostArtifactDownloadDir, true);
 
             _outOfProcExtractedRootDir = await MoveArtifactsToStagingDirectoryAndExtractIfNeeded(outOfProcArtifactDirPath, Path.Combine(_stagingDirectory, Constants.OutOfProcDirectoryName));
@@ -141,11 +145,38 @@ namespace Azure.Functions.ArtifactAssembler
             return stagingDirectory;
         }
 
-        private static async Task<string> MoveArtifactsToStagingDirectoryAndExtractIfNeeded(string artifactZipPath, string destinationDirectory)
+        private async Task<string> MoveArtifactsToStagingDirectoryAndExtractIfNeeded(string artifactZipPath, string destinationDirectory, bool isCoreToolsHost = false)
         {
-            await Task.Run(() => FileUtilities.CopyDirectory(artifactZipPath, destinationDirectory));
-            await ExtractZipFilesInDirectoryAsync(artifactZipPath, destinationDirectory);
+            // Perform different steps if _artifactName is specified
+            if (!String.IsNullOrEmpty(_artifactName))
+            {
+                if (!Directory.Exists(destinationDirectory))
+                {
+                    Directory.CreateDirectory(destinationDirectory);
+                }
 
+                if (isCoreToolsHost)
+                {
+                    _visualStudioArtifacts.TryGetValue(_artifactName, out var fileNameToSearchFor);
+                    if (!string.IsNullOrEmpty(fileNameToSearchFor))
+                    {
+                        var directory = Path.Combine(artifactZipPath, fileNameToSearchFor);
+                        var destinationDirectoryWithArtifactFolder = Path.Combine(destinationDirectory, fileNameToSearchFor);
+                        if (Directory.Exists(directory))
+                        {
+                            await Task.Run(() => FileUtilities.CopyDirectory(directory, destinationDirectoryWithArtifactFolder));
+                        }
+
+                    }
+                    return destinationDirectory;
+                }
+                await ExtractZipFilesInDirectoryAsync(artifactZipPath, destinationDirectory);
+            }
+            else
+            {
+                await Task.Run(() => FileUtilities.CopyDirectory(artifactZipPath, destinationDirectory));
+                await ExtractZipFilesInDirectoryAsync(artifactZipPath, destinationDirectory);
+            }
             // Delete additional files that are not needed
             var filesToBeDeleted = Directory.EnumerateFiles(destinationDirectory);
             foreach (var file in filesToBeDeleted)
@@ -172,12 +203,24 @@ namespace Azure.Functions.ArtifactAssembler
         private async Task CreateVisualStudioCoreToolsAsync()
         {
             Console.WriteLine("Starting to assemble Visual Studio Core Tools artifacts");
+
+            bool isValidVisualStudioArtifact = _visualStudioArtifacts.ContainsKey(_artifactName);
             // Create a directory to store the assembled artifacts.
             var customHostTargetArtifactDir = Path.Combine(_stagingDirectory, Constants.VisualStudioOutputArtifactDirectoryName);
             Directory.CreateDirectory(customHostTargetArtifactDir);
 
-            foreach (string artifactName in _visualStudioArtifacts.Keys)
+            string[] visualStudioArtifactList = String.IsNullOrEmpty(_artifactName) ? _visualStudioArtifacts.Keys.ToArray() : new string[] { _artifactName };
+
+            foreach (string artifactName in visualStudioArtifactList)
             {
+                if (!String.IsNullOrEmpty(_artifactName))
+                {
+                    // Break early if we don't need to assemble VS artifacts for specified artifactName
+                    if (!isValidVisualStudioArtifact)
+                    {
+                        break;
+                    }
+                }
                 (string artifactDirName, string consolidatedArtifactDirPath) = await CreateInProc8CoreToolsHostHelper(artifactName, customHostTargetArtifactDir, createDirectory: true);
 
                 // Copy in-proc6 files and delete directory after
@@ -193,11 +236,17 @@ namespace Azure.Functions.ArtifactAssembler
                 await Task.Run(() => FileUtilities.CopyDirectory(coreToolsHostArtifactDirPath, consolidatedArtifactDirPath));
                 Directory.Delete(coreToolsHostArtifactDirPath, true);
             }
-
-            // Create artifacts for .NET 8 OSX to use instead of the custom host
-            foreach (string artifactName in _net8OsxArtifacts)
+            if ((!String.IsNullOrEmpty(_artifactName) && _net8OsxArtifacts.Contains(_artifactName)))
             {
-                _ = await CreateInProc8CoreToolsHostHelper(artifactName, customHostTargetArtifactDir, createDirectory: false);
+                _ = await CreateInProc8CoreToolsHostHelper(_artifactName, customHostTargetArtifactDir, createDirectory: false);
+            }
+            else if (String.IsNullOrEmpty(_artifactName))
+            {
+                // Create artifacts for .NET 8 OSX to use instead of the custom host
+                foreach (string artifactName in _net8OsxArtifacts)
+                {
+                    _ = await CreateInProc8CoreToolsHostHelper(_artifactName, customHostTargetArtifactDir, createDirectory: false);
+                }
             }
 
             // Delete directories
@@ -225,7 +274,7 @@ namespace Azure.Functions.ArtifactAssembler
             Directory.CreateDirectory(consolidatedArtifactDirPath);
 
             // Copy in-proc8 files and delete directory after
-            await Task.Run(() => FileUtilities.CopyDirectory(inProcArtifactDirPath, createDirectory ? Path.Combine(consolidatedArtifactDirPath, Constants.InProc8DirectoryName): consolidatedArtifactDirPath));
+            await Task.Run(() => FileUtilities.CopyDirectory(inProcArtifactDirPath, createDirectory ? Path.Combine(consolidatedArtifactDirPath, Constants.InProc8DirectoryName) : consolidatedArtifactDirPath));
             Directory.Delete(inProcArtifactDirPath, true);
 
             return (artifactDirName, consolidatedArtifactDirPath);
@@ -243,7 +292,9 @@ namespace Azure.Functions.ArtifactAssembler
                    outOfProcArtifactDirPath = string.Empty,
                    inProc8ArtifactDirPath = string.Empty;
 
-            foreach (var artifactName in _cliArtifacts)
+            string[] cliArtifactList = String.IsNullOrEmpty(_artifactName) ? _cliArtifacts : new string[] { _artifactName };
+
+            foreach (var artifactName in cliArtifactList)
             {
                 // If we are running this for the first time, extract the directory path and out of proc version
                 if (String.IsNullOrEmpty(outOfProcArtifactDirPath))
@@ -339,7 +390,7 @@ namespace Azure.Functions.ArtifactAssembler
             throw new InvalidOperationException($"Runtime identifier (RID) not found for artifact name '{artifactName}'.");
         }
 
-        private static async Task ExtractZipFilesInDirectoryAsync(string zipSourceDir, string extractDestinationDir)
+        private async Task ExtractZipFilesInDirectoryAsync(string zipSourceDir, string extractDestinationDir)
         {
             if (!Directory.Exists(zipSourceDir))
             {
@@ -347,12 +398,23 @@ namespace Azure.Functions.ArtifactAssembler
                 return;
             }
 
-            var zipFiles = Directory.GetFiles(zipSourceDir, "*.zip");
+            var zipFiles = Directory.GetFiles(zipSo, "*.zip");
+            if (!string.IsNullOrEmpty(_artifactName))
+            {
+                zipFiles = zipFiles.Where(file => Path.GetFileName(file).StartsWith(_artifactName)).ToArray();
+            }
             Console.WriteLine($"{zipFiles.Length} zip files found in {zipSourceDir}");
 
             // Extract each zip file and delete
             foreach (var zipFile in zipFiles)
             {
+                // Copy file over first if we are extracting a particular artifact
+                if (!string.IsNullOrEmpty(_artifactName))
+                {
+                    var destZipFile = Path.Combine(extractDestinationDir, Path.GetFileName(zipFile));
+                    File.Copy(zipFile, destZipFile, overwrite: true);
+                    Console.WriteLine($"Copied {zipFile} to {destZipFile}");
+                }
                 var destinationDir = Path.Combine(extractDestinationDir, Path.GetFileNameWithoutExtension(zipFile));
                 Console.WriteLine($"Extracting {zipFile} to {destinationDir}");
                 await Task.Run(() => FileUtilities.ExtractToDirectory(zipFile, destinationDir));

--- a/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateSha.ps1
+++ b/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateSha.ps1
@@ -1,0 +1,9 @@
+$rootPath = "$(Pipeline.Workspace)\staging"
+$zipFiles = Get-ChildItem -Path $rootPath -Filter *.zip  -Recurse
+foreach ($file in $zipfiles) 
+{
+	$sha = (Get-FileHash $file.FullName).Hash.ToLower()
+	$shaFilePath = $file.FullName + ".sha2"
+	Out-File -InputObject $sha -Encoding ascii -FilePath $shaFilePath -NoNewline
+	Write-Host "Generated sha for $filePath at $shaFilePath"
+}

--- a/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateSha.ps1
+++ b/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/generateSha.ps1
@@ -1,4 +1,8 @@
-$rootPath = "$(Pipeline.Workspace)\staging"
+param (
+    [string]$CurrentDirectory
+)
+
+$rootPath = Join-Path $CurrentDirectory "staging"
 $zipFiles = Get-ChildItem -Path $rootPath -Filter *.zip  -Recurse
 foreach ($file in $zipfiles) 
 {

--- a/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/moveNugetPackage.ps1
+++ b/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/moveNugetPackage.ps1
@@ -22,7 +22,7 @@ if ($fileToMove -eq $null) {
 }
 
 # Define the destination path in $(Pipeline.Workspace)/nugetPackage
-$nugetPackageDirectory = Join-Path -Path $(Pipeline.Workspace) -ChildPath "nugetPackage"
+$nugetPackageDirectory = Join-Path -Path $CurrentDirectory -ChildPath "nugetPackage"
 
 # Create the nugetPackage directory if it doesn't exist
 if (-not (Test-Path $nugetPackageDirectory)) {

--- a/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/moveNugetPackage.ps1
+++ b/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/moveNugetPackage.ps1
@@ -1,12 +1,13 @@
-﻿# Retrieve environment variables
+﻿param (
+    [string]$CurrentDirectory
+)
+
+# Retrieve environment variables
 $defaultArtifactAlias = $env:DEFAULT_ARTIFACT_ALIAS
 $defaultArtifactName = $env:DEFAULT_ARTIFACT_NAME
 
-# Get the current working directory
-$currentDirectory = "$(Pipeline.Workspace)"
-
 # Construct the path using current directory, and environment variables
-$artifactPath = Join-Path -Path $currentDirectory -ChildPath "$defaultArtifactAlias\$defaultArtifactName"
+$artifactPath = Join-Path -Path $CurrentDirectory -ChildPath "$defaultArtifactAlias\$defaultArtifactName"
 
 # Define the regex pattern to match the nupkg file (digit.digit.4digits)
 $regexPattern = "^Microsoft\.Azure\.Functions\.CoreTools\.\d+\.\d+\.\d{4}\.nupkg$"

--- a/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/moveNugetPackage.ps1
+++ b/src/Azure.Functions.ArtifactAssembler/PipelineHelpers/moveNugetPackage.ps1
@@ -1,0 +1,35 @@
+﻿# Retrieve environment variables
+$defaultArtifactAlias = $env:DEFAULT_ARTIFACT_ALIAS
+$defaultArtifactName = $env:DEFAULT_ARTIFACT_NAME
+
+# Get the current working directory
+$currentDirectory = "$(Pipeline.Workspace)"
+
+# Construct the path using current directory, and environment variables
+$artifactPath = Join-Path -Path $currentDirectory -ChildPath "$defaultArtifactAlias\$defaultArtifactName"
+
+# Define the regex pattern to match the nupkg file (digit.digit.4digits)
+$regexPattern = "^Microsoft\.Azure\.Functions\.CoreTools\.\d+\.\d+\.\d{4}\.nupkg$"
+
+# Look for the first nupkg file that matches the pattern in the constructed path
+$fileToMove = Get-ChildItem -Path $artifactPath -Filter "*.nupkg" | Where-Object { $_.Name -match $regexPattern } | Select-Object -First 1
+
+# Check if a matching file was found
+if ($fileToMove -eq $null) {
+    Write-Host "No .nupkg file matching the pattern was found in $artifactPath"
+    exit 1
+}
+
+# Define the destination path in $(Pipeline.Workspace)/nugetPackage
+$nugetPackageDirectory = Join-Path -Path $(Pipeline.Workspace) -ChildPath "nugetPackage"
+
+# Create the nugetPackage directory if it doesn't exist
+if (-not (Test-Path $nugetPackageDirectory)) {
+    New-Item -Path $nugetPackageDirectory -ItemType Directory
+    Write-Host "Directory created at: $nugetPackageDirectory"
+}
+
+# Move the file to the staging directory
+Move-Item -Path $fileToMove.FullName -Destination $nugetPackageDirectory -Force
+
+Write-Host "File $($fileToMove.Name) moved to $nugetPackageDirectory"

--- a/src/Azure.Functions.ArtifactAssembler/Program.cs
+++ b/src/Azure.Functions.ArtifactAssembler/Program.cs
@@ -20,7 +20,8 @@ namespace Azure.Functions.ArtifactAssembler
                 }
                 else
                 {
-                    var artifactAssembler = new ArtifactAssembler(currentWorkingDirectory);
+                    string? artifactName = args.Length > 0 ? args[0] : string.Empty;
+                    var artifactAssembler = new ArtifactAssembler(currentWorkingDirectory, artifactName);
                     await artifactAssembler.AssembleArtifactsAsync();
                 }
 

--- a/src/Azure.Functions.ArtifactAssembler/REAME.MD
+++ b/src/Azure.Functions.ArtifactAssembler/REAME.MD
@@ -44,5 +44,13 @@ You can set these environment variables in your terminal or through Visual Studi
 ##### Sample Artifacts in the output directory, matching the environment variables:
 ![Diagram](assets/sample-artifacts-for-local-debug.png)
 
+2. If you only want to test generating one artifact rid type (ex: win-x64), you may pass in an argument when running the assembler. The argument must be formatted as `Azure.Functions.Cli.[RID]`
+```
+dotnet run "$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/Azure.Functions.ArtifactAssembler.csproj -c release Azure.Functions.Cli.win-x64"
+```
+3. To zip up the artifacts generated that are currently in the staging directory, you may pass in a zip parameter. Ex:
+```
+dotnet run "$(Build.SourcesDirectory)/src/Azure.Functions.ArtifactAssembler/Azure.Functions.ArtifactAssembler.csproj -c release zip"
+```
 
     


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #4270 #4271
This PR converts the consolidated pipeline which was initially based off of azure classic pipelines UX to a yaml based pipeline.

I have updated the `ArtifactAssembler` within core tools to be able to process each artifact type one at a time. For example, if I were to pass in `Azure.Functions.Cli.win-x64` when running the artifact assembler, the artifact assembler would only assemble artifacts for that win-x64. This enables us to use parallelization when running the consolidated pipeline, which significantly improves the run time overall.

The consolidated pipeline also publishes the artifacts to the pipeline directly, rather than publishing to a storage account. Please look at [this run](https://azfunc.visualstudio.com/internal/_build/results?buildId=206028&view=results) for an example of what this would look like.

This pipeline also runs significantly faster than the azure classic based pipeline, as this pipeline takes on average 35-37 min, whereas previous runs would easily take over an hour. This runtime will increase even more once the E2E tests are updated to run in a more efficient and parallel manner outside of the consolidated pipeline.

Finally, nightly builds are enabled for the consolidated artifact pipeline to run every night, after the `in-proc` and `main` artifacts have been created from their nightly builds. This PR also adds a tag called `nightly-build` to those builds for the `in-proc` and `main` branch to distinguish scheduled builds from manually triggered ones. That way the consolidated pipeline knows which builds to pick for the nightly builds.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)