### PR TITLE
Updated message when we run .NET 8 inproc app and added warning to migrate when running on .NET 6 inproc6 app

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -516,7 +516,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
 
             void ThrowCliException(string suffix)
             {
-                throw new CliException($"The runtime argument value provided is '{HostRuntime}'. {suffix}");
+                throw new CliException($"The runtime argument value provided, '{HostRuntime}', is invalid. {suffix}");
             }
 
             if (DotnetConstants.ValidRuntimeValues.Contains(HostRuntime, StringComparer.OrdinalIgnoreCase) == false)
@@ -531,7 +531,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
             {
                 if (isInproc6ArgumentValue)
                 {
-                    ColoredConsole.WriteLine(WarningColor($"Warning: Starting application with .NET 6 runtime. .NET 6 is no longer supported, and you should migrate to a supported version. For more information, see https://aka.ms/azure-functions/dotnet/net8-in-process. If you intend to target .NET 8 on the in-process model, make sure that '{Constants.InProcDotNet8EnabledSetting}' is set to '1' in {Constants.LocalSettingsJsonFileName}.\n"));
+                    ColoredConsole.WriteLine(WarningColor($".NET 6 is no longer supported, please consider migrating to a supported version. For more information, see https://aka.ms/azure-functions/dotnet/net8-in-process. If you intend to target .NET 8 on the in-process model, make sure that '{Constants.InProcDotNet8EnabledSetting}' is set to '1' in {Constants.LocalSettingsJsonFileName}.\n"));
                 }
 
                 if (string.Equals(HostRuntime, "default", StringComparison.OrdinalIgnoreCase))
@@ -541,7 +541,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
 
                 if (isInproc8ArgumentValue && !await validateDotNet8ProjectEnablement())
                 {
-                    ThrowCliException($"If you intend to target .NET 8 on the in-process model, make sure that '{Constants.InProcDotNet8EnabledSetting}' is set to '1' in {Constants.LocalSettingsJsonFileName}.For more information, see https://aka.ms/azure-functions/dotnet/net8-in-process.");
+                    ThrowCliException($"For the .NET 8 runtime in the in-proc model, you must set the '{Constants.InProcDotNet8EnabledSetting}' environment variable to '1'. For more information, see https://aka.ms/azure-functions/dotnet/net8-in-process.");
                 }
                 else if (isInproc6ArgumentValue && await validateDotNet8ProjectEnablement())
                 {

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -546,7 +546,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
 
                 if (isInproc8ArgumentValue && !await validateDotNet8ProjectEnablement())
                 {
-                    ThrowCliException($"For the .NET 8 runtime on the in-process, you must set the '{Constants.InProcDotNet8EnabledSetting}' environment variable to '1'. For more information, see https://aka.ms/azure-functions/dotnet/net8-in-process.");
+                    ThrowCliException($"For the .NET 8 runtime on the in-process model, you must set the '{Constants.InProcDotNet8EnabledSetting}' environment variable to '1'. For more information, see https://aka.ms/azure-functions/dotnet/net8-in-process.");
                 }
                 else if (isInproc6ArgumentValue && await validateDotNet8ProjectEnablement())
                 {
@@ -841,6 +841,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
             // Update local.settings.json
             WorkerRuntimeLanguageHelper.SetWorkerRuntime(_secretsManager, GlobalCoreToolsSettings.CurrentWorkerRuntime.ToString());
         }
+
         private void PrintMigrationWarningForDotnet6Inproc() 
         {
             ColoredConsole.WriteLine(WarningColor($".NET 6 is no longer supported. Please consider migrating to a supported version. For more information, see https://aka.ms/azure-functions/dotnet/net8-in-process. If you intend to target .NET 8 on the in-process model, make sure that '{Constants.InProcDotNet8EnabledSetting}' is set to '1' in {Constants.LocalSettingsJsonFileName}.\n"));

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -494,6 +494,11 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 
                 PrintVerboseForHostSelection(selectedRuntime);
 
+                if (selectedRuntime == DotnetConstants.InProc6HostRuntime)
+                {
+                    PrintMigrationWarningForDotnet6Inproc();
+                }
+
                 if (Utilities.IsMinifiedVersion())
                 {
                     ThrowForInProc();
@@ -531,7 +536,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
             {
                 if (isInproc6ArgumentValue)
                 {
-                    ColoredConsole.WriteLine(WarningColor($".NET 6 is no longer supported. Please consider migrating to a supported version. For more information, see https://aka.ms/azure-functions/dotnet/net8-in-process. If you intend to target .NET 8 on the in-process model, make sure that '{Constants.InProcDotNet8EnabledSetting}' is set to '1' in {Constants.LocalSettingsJsonFileName}.\n"));
+                    PrintMigrationWarningForDotnet6Inproc();
                 }
 
                 if (string.Equals(HostRuntime, "default", StringComparison.OrdinalIgnoreCase))
@@ -835,6 +840,10 @@ namespace Azure.Functions.Cli.Actions.HostActions
 
             // Update local.settings.json
             WorkerRuntimeLanguageHelper.SetWorkerRuntime(_secretsManager, GlobalCoreToolsSettings.CurrentWorkerRuntime.ToString());
+        }
+        private void PrintMigrationWarningForDotnet6Inproc() 
+        {
+            ColoredConsole.WriteLine(WarningColor($".NET 6 is no longer supported. Please consider migrating to a supported version. For more information, see https://aka.ms/azure-functions/dotnet/net8-in-process. If you intend to target .NET 8 on the in-process model, make sure that '{Constants.InProcDotNet8EnabledSetting}' is set to '1' in {Constants.LocalSettingsJsonFileName}.\n"));
         }
     }
 }

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -533,6 +533,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 {
                     ColoredConsole.WriteLine(WarningColor($"Warning: Starting application with .NET 6 runtime. .NET 6 is no longer supported, and you should migrate to a supported version. For more information, see https://aka.ms/azure-functions/dotnet/net8-in-process. If you intend to target .NET 8 on the in-process model, make sure that '{Constants.InProcDotNet8EnabledSetting}' is set to '1' in {Constants.LocalSettingsJsonFileName}.\n"));
                 }
+
                 if (string.Equals(HostRuntime, "default", StringComparison.OrdinalIgnoreCase))
                 {
                     ThrowCliException($"The provided value is only valid for the worker runtime '{WorkerRuntime.dotnetIsolated}'.");
@@ -546,6 +547,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 {
                     ThrowCliException($"For the '{DotnetConstants.InProc6HostRuntime}' runtime, the '{Constants.InProcDotNet8EnabledSetting}' environment variable cannot be be set. See https://aka.ms/azure-functions/dotnet/net8-in-process.");
                 }
+
             }
             else if (isInproc8ArgumentValue || isInproc6ArgumentValue)
             {

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -546,9 +546,6 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 {
                     ThrowCliException($"For the '{DotnetConstants.InProc6HostRuntime}' runtime, the '{Constants.InProcDotNet8EnabledSetting}' environment variable cannot be be set. See https://aka.ms/azure-functions/dotnet/net8-in-process.");
                 }
-                else if (isInproc6ArgumentValue) { 
-                }
-
             }
             else if (isInproc8ArgumentValue || isInproc6ArgumentValue)
             {

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -516,7 +516,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
 
             void ThrowCliException(string suffix)
             {
-                throw new CliException($"The runtime argument value provided, '{HostRuntime}', is invalid. {suffix}");
+                throw new CliException($"The runtime argument value provided is '{HostRuntime}'. {suffix}");
             }
 
             if (DotnetConstants.ValidRuntimeValues.Contains(HostRuntime, StringComparer.OrdinalIgnoreCase) == false)

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -531,7 +531,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
             {
                 if (isInproc6ArgumentValue)
                 {
-                    ColoredConsole.WriteLine(WarningColor($".NET 6 is no longer supported, please consider migrating to a supported version. For more information, see https://aka.ms/azure-functions/dotnet/net8-in-process. If you intend to target .NET 8 on the in-process model, make sure that '{Constants.InProcDotNet8EnabledSetting}' is set to '1' in {Constants.LocalSettingsJsonFileName}.\n"));
+                    ColoredConsole.WriteLine(WarningColor($".NET 6 is no longer supported. Please consider migrating to a supported version. For more information, see https://aka.ms/azure-functions/dotnet/net8-in-process. If you intend to target .NET 8 on the in-process model, make sure that '{Constants.InProcDotNet8EnabledSetting}' is set to '1' in {Constants.LocalSettingsJsonFileName}.\n"));
                 }
 
                 if (string.Equals(HostRuntime, "default", StringComparison.OrdinalIgnoreCase))

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -529,6 +529,10 @@ namespace Azure.Functions.Cli.Actions.HostActions
 
             if (currentWorkerRuntime == WorkerRuntime.dotnet)
             {
+                if (isInproc6ArgumentValue)
+                {
+                    ColoredConsole.WriteLine(WarningColor($"Warning: Starting application with .NET 6 runtime. .NET 6 is no longer supported, and you should migrate to a supported version. For more information, see https://aka.ms/azure-functions/dotnet/net8-in-process. If you intend to target .NET 8 on the in-process model, make sure that '{Constants.InProcDotNet8EnabledSetting}' is set to '1' in {Constants.LocalSettingsJsonFileName}.\n"));
+                }
                 if (string.Equals(HostRuntime, "default", StringComparison.OrdinalIgnoreCase))
                 {
                     ThrowCliException($"The provided value is only valid for the worker runtime '{WorkerRuntime.dotnetIsolated}'.");
@@ -536,11 +540,13 @@ namespace Azure.Functions.Cli.Actions.HostActions
 
                 if (isInproc8ArgumentValue && !await validateDotNet8ProjectEnablement())
                 {
-                    ThrowCliException($"For the '{DotnetConstants.InProc8HostRuntime}' runtime, the '{Constants.InProcDotNet8EnabledSetting}' environment variable must be set. See https://aka.ms/azure-functions/dotnet/net8-in-process.");
+                    ThrowCliException($"If you intend to target .NET 8 on the in-process model, make sure that '{Constants.InProcDotNet8EnabledSetting}' is set to '1' in {Constants.LocalSettingsJsonFileName}.For more information, see https://aka.ms/azure-functions/dotnet/net8-in-process.");
                 }
                 else if (isInproc6ArgumentValue && await validateDotNet8ProjectEnablement())
                 {
                     ThrowCliException($"For the '{DotnetConstants.InProc6HostRuntime}' runtime, the '{Constants.InProcDotNet8EnabledSetting}' environment variable cannot be be set. See https://aka.ms/azure-functions/dotnet/net8-in-process.");
+                }
+                else if (isInproc6ArgumentValue) { 
                 }
 
             }

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -541,7 +541,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
 
                 if (isInproc8ArgumentValue && !await validateDotNet8ProjectEnablement())
                 {
-                    ThrowCliException($"For the .NET 8 runtime in the in-proc model, you must set the '{Constants.InProcDotNet8EnabledSetting}' environment variable to '1'. For more information, see https://aka.ms/azure-functions/dotnet/net8-in-process.");
+                    ThrowCliException($"For the .NET 8 runtime on the in-process, you must set the '{Constants.InProcDotNet8EnabledSetting}' environment variable to '1'. For more information, see https://aka.ms/azure-functions/dotnet/net8-in-process.");
                 }
                 else if (isInproc6ArgumentValue && await validateDotNet8ProjectEnablement())
                 {

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -1872,7 +1872,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                 {
                     Commands = new[]
                     {
-                        "init . --worker-runtime dotnet",
+                        "init . --worker-runtime dotnet --target-framework net6.0",
                         "new --template Httptrigger --name HttpTrigger",
                     },
                     CommandTimeout = TimeSpan.FromSeconds(300)

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -1864,6 +1864,7 @@ namespace Azure.Functions.Cli.Tests.E2E
         }
 
         [Fact]
+        [Trait(TestTraits.Group, TestTraits.UseInConsolidatedArtifactGeneration)]
         public async Task Start_InProc6_SpecifiedRuntime_Show_Migration_Warning()
         {
             await CliTester.Run(new RunConfiguration[]

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -1078,7 +1078,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     },
                     ExpectExit = false,
                     ExitInError = true,
-                    ErrorContains = [$"The runtime argument value provided, 'inproc8', is invalid. For the .NET 8 runtime on the in-process, you must set the '{Constants.InProcDotNet8EnabledSetting}' environment variable to '1'. For more information, see https://aka.ms/azure-functions/dotnet/net8-in-process."],
+                    ErrorContains = [$"The runtime argument value provided, 'inproc8', is invalid. For the .NET 8 runtime on the in-process model, you must set the '{Constants.InProcDotNet8EnabledSetting}' environment variable to '1'. For more information, see https://aka.ms/azure-functions/dotnet/net8-in-process."],
                     Test = async (workingDir, p, _) =>
                     {
                         using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}") })

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -1881,7 +1881,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     ExpectExit = false,
                     OutputContains = new[]
                     {
-                        $".NET 6 is no longer supported, please consider migrating to a supported version. For more information, see https://aka.ms/azure-functions/dotnet/net8-in-process. If you intend to target .NET 8 on the in-process model, make sure that '{Constants.InProcDotNet8EnabledSetting}' is set to '1' in {Constants.LocalSettingsJsonFileName}."
+                        $".NET 6 is no longer supported. Please consider migrating to a supported version. For more information, see https://aka.ms/azure-functions/dotnet/net8-in-process. If you intend to target .NET 8 on the in-process model, make sure that '{Constants.InProcDotNet8EnabledSetting}' is set to '1' in {Constants.LocalSettingsJsonFileName}."
                     },
                     Test = async (workingDir, p, _) =>
                     {

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -1005,7 +1005,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     },
                     ExpectExit = true,
                     ExitInError = true,
-                    ErrorContains = ["The runtime argument value provided, 'inproc6', is invalid. The provided value is only valid for the worker runtime 'dotnet'."],
+                    ErrorContains = ["The runtime argument value provided is 'inproc6'. The provided value is only valid for the worker runtime 'dotnet'."],
                     Test = async (workingDir, p, _) =>
                     {
                         using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}") })
@@ -1039,7 +1039,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     },
                     ExpectExit = false,
                     ExitInError = true,
-                    ErrorContains = ["The runtime argument value provided, 'inproc8', is invalid. The provided value is only valid for the worker runtime 'dotnet'."],
+                    ErrorContains = ["The runtime argument value provided is 'inproc8'. The provided value is only valid for the worker runtime 'dotnet'."],
                     Test = async (workingDir, p, _) =>
                     {
                         using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}") })
@@ -1073,7 +1073,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     },
                     ExpectExit = false,
                     ExitInError = true,
-                    ErrorContains = [$"The runtime argument value provided, 'inproc8', is invalid. If you intend to target .NET 8 on the in-process model, make sure that '{Constants.InProcDotNet8EnabledSetting}' is set to '1' in {Constants.LocalSettingsJsonFileName}.For more information, see https://aka.ms/azure-functions/dotnet/net8-in-process."],
+                    ErrorContains = [$"The runtime argument value provided is 'inproc8'. If you intend to target .NET 8 on the in-process model, make sure that '{Constants.InProcDotNet8EnabledSetting}' is set to '1' in {Constants.LocalSettingsJsonFileName}.For more information, see https://aka.ms/azure-functions/dotnet/net8-in-process."],
                     Test = async (workingDir, p, _) =>
                     {
                         using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}") })
@@ -1107,7 +1107,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     },
                     ExpectExit = false,
                     ExitInError = true,
-                    ErrorContains = ["The runtime argument value provided, 'default', is invalid. The provided value is only valid for the worker runtime 'dotnetIsolated'."],
+                    ErrorContains = ["The runtime argument value provided is 'default'. The provided value is only valid for the worker runtime 'dotnetIsolated'."],
                     Test = async (workingDir, p, _) =>
                     {
                         using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}") })
@@ -1141,7 +1141,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     },
                     ExpectExit = false,
                     ExitInError = true,
-                    ErrorContains = ["The runtime argument value provided, 'default', is invalid. The provided value is only valid for the worker runtime 'dotnetIsolated'."],
+                    ErrorContains = ["The runtime argument value provided is 'default'. The provided value is only valid for the worker runtime 'dotnetIsolated'."],
                     Test = async (workingDir, p, _) =>
                     {
                         using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}") })
@@ -1176,7 +1176,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     },
                     ExpectExit = false,
                     ExitInError = true,
-                    ErrorContains = ["The runtime argument value provided, 'inproc6', is invalid. For the 'inproc6' runtime, the 'FUNCTIONS_INPROC_NET8_ENABLED' environment variable cannot be be set. See https://aka.ms/azure-functions/dotnet/net8-in-process."],
+                    ErrorContains = ["The runtime argument value provided is 'inproc6'. For the 'inproc6' runtime, the 'FUNCTIONS_INPROC_NET8_ENABLED' environment variable cannot be be set. See https://aka.ms/azure-functions/dotnet/net8-in-process."],
                     Test = async (workingDir, p, _) =>
                     {
                         using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}") })
@@ -1211,7 +1211,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     },
                     ExpectExit = false,
                     ExitInError = true,
-                    ErrorContains = ["The runtime argument value provided, 'inproc6', is invalid. The provided value is only valid for the worker runtime 'dotnet'."],
+                    ErrorContains = ["The runtime argument value provided is 'inproc6'. The provided value is only valid for the worker runtime 'dotnet'."],
                     Test = async (workingDir, p, _) =>
                     {
                         using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}") })
@@ -1246,7 +1246,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     },
                     ExpectExit = false,
                     ExitInError = true,
-                    ErrorContains = ["The runtime argument value provided, 'inproc8', is invalid. The provided value is only valid for the worker runtime 'dotnet'."],
+                    ErrorContains = ["The runtime argument value provided is 'inproc8'. The provided value is only valid for the worker runtime 'dotnet'."],
                     Test = async (workingDir, p, _) =>
                     {
                         using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}") })

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -1073,7 +1073,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     },
                     ExpectExit = false,
                     ExitInError = true,
-                    ErrorContains = [$"The runtime argument value provided, 'inproc8', is invalid. For the .NET 8 runtime in the in-proc model, you must set the '{Constants.InProcDotNet8EnabledSetting}' environment variable to '1'. For more information, see https://aka.ms/azure-functions/dotnet/net8-in-process."],
+                    ErrorContains = [$"The runtime argument value provided, 'inproc8', is invalid. For the .NET 8 runtime on the in-process, you must set the '{Constants.InProcDotNet8EnabledSetting}' environment variable to '1'. For more information, see https://aka.ms/azure-functions/dotnet/net8-in-process."],
                     Test = async (workingDir, p, _) =>
                     {
                         using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}") })

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -1005,7 +1005,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     },
                     ExpectExit = true,
                     ExitInError = true,
-                    ErrorContains = ["The runtime argument value provided is 'inproc6'. The provided value is only valid for the worker runtime 'dotnet'."],
+                    ErrorContains = ["The runtime argument value provided, 'inproc6', is invalid. The provided value is only valid for the worker runtime 'dotnet'."],
                     Test = async (workingDir, p, _) =>
                     {
                         using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}") })
@@ -1039,7 +1039,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     },
                     ExpectExit = false,
                     ExitInError = true,
-                    ErrorContains = ["The runtime argument value provided is 'inproc8'. The provided value is only valid for the worker runtime 'dotnet'."],
+                    ErrorContains = ["The runtime argument value provided, 'inproc8', is invalid. The provided value is only valid for the worker runtime 'dotnet'."],
                     Test = async (workingDir, p, _) =>
                     {
                         using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}") })
@@ -1073,7 +1073,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     },
                     ExpectExit = false,
                     ExitInError = true,
-                    ErrorContains = [$"The runtime argument value provided is 'inproc8'. If you intend to target .NET 8 on the in-process model, make sure that '{Constants.InProcDotNet8EnabledSetting}' is set to '1' in {Constants.LocalSettingsJsonFileName}.For more information, see https://aka.ms/azure-functions/dotnet/net8-in-process."],
+                    ErrorContains = [$"The runtime argument value provided, 'inproc8', is invalid. For the .NET 8 runtime in the in-proc model, you must set the '{Constants.InProcDotNet8EnabledSetting}' environment variable to '1'. For more information, see https://aka.ms/azure-functions/dotnet/net8-in-process."],
                     Test = async (workingDir, p, _) =>
                     {
                         using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}") })
@@ -1107,7 +1107,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     },
                     ExpectExit = false,
                     ExitInError = true,
-                    ErrorContains = ["The runtime argument value provided is 'default'. The provided value is only valid for the worker runtime 'dotnetIsolated'."],
+                    ErrorContains = ["The runtime argument value provided, 'default', is invalid. The provided value is only valid for the worker runtime 'dotnetIsolated'."],
                     Test = async (workingDir, p, _) =>
                     {
                         using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}") })
@@ -1141,7 +1141,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     },
                     ExpectExit = false,
                     ExitInError = true,
-                    ErrorContains = ["The runtime argument value provided is 'default'. The provided value is only valid for the worker runtime 'dotnetIsolated'."],
+                    ErrorContains = ["The runtime argument value provided, 'default', is invalid. The provided value is only valid for the worker runtime 'dotnetIsolated'."],
                     Test = async (workingDir, p, _) =>
                     {
                         using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}") })
@@ -1176,7 +1176,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     },
                     ExpectExit = false,
                     ExitInError = true,
-                    ErrorContains = ["The runtime argument value provided is 'inproc6'. For the 'inproc6' runtime, the 'FUNCTIONS_INPROC_NET8_ENABLED' environment variable cannot be be set. See https://aka.ms/azure-functions/dotnet/net8-in-process."],
+                    ErrorContains = ["The runtime argument value provided, 'inproc6', is invalid. For the 'inproc6' runtime, the 'FUNCTIONS_INPROC_NET8_ENABLED' environment variable cannot be be set. See https://aka.ms/azure-functions/dotnet/net8-in-process."],
                     Test = async (workingDir, p, _) =>
                     {
                         using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}") })
@@ -1211,7 +1211,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     },
                     ExpectExit = false,
                     ExitInError = true,
-                    ErrorContains = ["The runtime argument value provided is 'inproc6'. The provided value is only valid for the worker runtime 'dotnet'."],
+                    ErrorContains = ["The runtime argument value provided, 'inproc6', is invalid. The provided value is only valid for the worker runtime 'dotnet'."],
                     Test = async (workingDir, p, _) =>
                     {
                         using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}") })
@@ -1246,7 +1246,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     },
                     ExpectExit = false,
                     ExitInError = true,
-                    ErrorContains = ["The runtime argument value provided is 'inproc8'. The provided value is only valid for the worker runtime 'dotnet'."],
+                    ErrorContains = ["The runtime argument value provided, 'inproc8', is invalid. The provided value is only valid for the worker runtime 'dotnet'."],
                     Test = async (workingDir, p, _) =>
                     {
                         using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}") })
@@ -1881,7 +1881,7 @@ namespace Azure.Functions.Cli.Tests.E2E
                     ExpectExit = false,
                     OutputContains = new[]
                     {
-                        $"Warning: Starting application with .NET 6 runtime. .NET 6 is no longer supported, and you should migrate to a supported version. For more information, see https://aka.ms/azure-functions/dotnet/net8-in-process."
+                        $".NET 6 is no longer supported, please consider migrating to a supported version. For more information, see https://aka.ms/azure-functions/dotnet/net8-in-process. If you intend to target .NET 8 on the in-process model, make sure that '{Constants.InProcDotNet8EnabledSetting}' is set to '1' in {Constants.LocalSettingsJsonFileName}."
                     },
                     Test = async (workingDir, p, _) =>
                     {


### PR DESCRIPTION
### Issue describing the changes in this PR
->updated message precisely to set 'FUNCTIONS_INPROC_NET8_ENABLED' to 1 when we are running .NET 8 inproc app
-> Also added a warning to migrate to supported version if user intended to run in .NET 6 inproc6 app
resolves #4155 
### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)