### PR TITLE
Allow for the UserLogDefaultLogLevel to be set independent of system logs

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -77,6 +77,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
         public string JsonOutputFile { get; set; }
 
         public string? HostRuntime { get; set; }
+
         public string UserLogLevel { get; set; }
 
         public StartHostAction(ISecretsManager secretsManager, IProcessManager processManager)

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -599,8 +599,6 @@ namespace Azure.Functions.Cli.Actions.HostActions
 
             try
             {
-                childProcessInfo.Environment["AzureFunctionsJobHost"] = "true";
-                childProcessInfo.Environment["FUNCTIONS_LOG_LEVEL"] = "debug";
                 var childProcess = Process.Start(childProcessInfo);
                 if (VerboseLogging == true)
                 {

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -77,6 +77,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
         public string JsonOutputFile { get; set; }
 
         public string? HostRuntime { get; set; }
+        public string UserLogLevel { get; set; }
 
         public StartHostAction(ISecretsManager secretsManager, IProcessManager processManager)
         {
@@ -178,6 +179,11 @@ namespace Azure.Functions.Cli.Actions.HostActions
                .WithDescription($"If provided, determines which version of the host to start. Allowed values are '{DotnetConstants.InProc6HostRuntime}', '{DotnetConstants.InProc8HostRuntime}', and 'default' (which runs the out-of-process host).")
                .Callback(startHostFromRuntime => HostRuntime = startHostFromRuntime);
 
+            Parser
+               .Setup<string>("userLogLevel")
+               .WithDescription($"If provided, determines the loglevel of user logs. Allowed values are '{LogLevel.Trace}', '{LogLevel.Debug}', '{LogLevel.Information}', '{LogLevel.Warning}', '{LogLevel.Error}', '{LogLevel.Critical}' and '{LogLevel.None}'.")
+               .Callback(userLogLevel => UserLogLevel = userLogLevel);
+
             var parserResult = base.ParseArgs(args);
             bool verboseLoggingArgExists = parserResult.UnMatchedOptions.Any(o => o.LongName.Equals("verbose", StringComparison.OrdinalIgnoreCase));
             // Input args do not contain --verbose flag
@@ -190,7 +196,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
 
         private async Task<IWebHost> BuildWebHost(ScriptApplicationHostOptions hostOptions, Uri listenAddress, Uri baseAddress, X509Certificate2 certificate)
         {
-            LoggingFilterHelper loggingFilterHelper = new LoggingFilterHelper(_hostJsonConfig, VerboseLogging);
+            LoggingFilterHelper loggingFilterHelper = new LoggingFilterHelper(_hostJsonConfig, VerboseLogging, UserLogLevel);
             if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.dotnet ||
                 GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.dotnetIsolated)
             {

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -408,18 +408,8 @@ namespace Azure.Functions.Cli.Actions.HostActions
             await PreRunConditions();
             var isVerbose = VerboseLogging.HasValue && VerboseLogging.Value;
 
-            //set  flag --userLogLevel as Enviroment variable
-            if (!string.IsNullOrEmpty(UserLogLevel))
-            {
-                if (IsValidUserLogLevel(UserLogLevel))
-                {
-                    Environment.SetEnvironmentVariable("AzureFunctionsJobHost__Logging__LogLevel__Function", UserLogLevel);
-                }
-            }
-            else
-            {
-                UserLogLevel = GetUserLogLevelFromLocalSettings();
-            }
+            //set --userLogLevel flag
+            ConfigureUserLogLevelFromFlagOrSettings();
 
             // Return if running is delegated to another version of Core Tools
             if (await TryHandleInProcDotNetLaunchAsync())
@@ -850,6 +840,21 @@ namespace Azure.Functions.Cli.Actions.HostActions
 
             // Update local.settings.json
             WorkerRuntimeLanguageHelper.SetWorkerRuntime(_secretsManager, GlobalCoreToolsSettings.CurrentWorkerRuntime.ToString());
+        }
+        
+        private void ConfigureUserLogLevelFromFlagOrSettings()
+        {
+            if (!string.IsNullOrEmpty(UserLogLevel))
+            {
+                if (IsValidUserLogLevel(UserLogLevel))
+                {
+                    Environment.SetEnvironmentVariable("AzureFunctionsJobHost__Logging__LogLevel__Function", UserLogLevel);
+                }
+            }
+            else
+            {
+                UserLogLevel = GetUserLogLevelFromLocalSettings();
+            }
         }
 
         private bool IsValidUserLogLevel(string UserLogLevel)

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -96,6 +96,7 @@ namespace Azure.Functions.Cli.Common
         public const string AzureDevSessionsRemoteHostName = "AzureDevSessionsRemoteHostName";
         public const string AzureDevSessionsPortSuffixPlaceholder = "<port>";
         public const string GitHubReleaseApiUrl = "https://api.github.com/repos/Azure/azure-functions-core-tools/releases/latest";
+        public const string FunctionsLoggingLogLevel = "AzureFunctionsJobHost__Logging__LogLevel__Function";
 
         // Sample format https://n12abc3t-<port>.asse.devtunnels.ms/
 

--- a/src/Azure.Functions.Cli/Common/Utilities.cs
+++ b/src/Azure.Functions.Cli/Common/Utilities.cs
@@ -26,6 +26,7 @@ namespace Azure.Functions.Cli
     {
         public const string LogLevelSection = "loglevel";
         public const string LogLevelDefaultSection = "Default";
+        public const string LogLevelFunctionSection = "Function";
 
         internal static void PrintLogo()
         {

--- a/src/Azure.Functions.Cli/Diagnostics/LoggingFilterHelper.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/LoggingFilterHelper.cs
@@ -18,7 +18,6 @@ namespace Azure.Functions.Cli
         public const string Ci_Continuous_Integration = "CONTINUOUS_INTEGRATION";  // Travis CI, Cirrus CI
         public const string Ci_Build_Number = "BUILD_NUMBER";  // Travis CI, Cirrus CI
         public const string Ci_Run_Id = "RUN_ID"; // TaskCluster, dsari
-        public static readonly string[] ValidUserLogLevels = ["Trace", "Debug", "Information", "Warning", "Error","Critical", "None"];
 
         public LoggingFilterHelper(IConfigurationRoot hostJsonConfig, bool? verboseLogging, string userLogLevel = null)
         {

--- a/src/Azure.Functions.Cli/Diagnostics/LoggingFilterHelper.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/LoggingFilterHelper.cs
@@ -32,18 +32,22 @@ namespace Azure.Functions.Cli
             {
                 SystemLogDefaultLogLevel = LogLevel.Information;
             }
-            if (Utilities.LogLevelExists(hostJsonConfig, Utilities.LogLevelDefaultSection, out LogLevel logLevel))
+            if (Utilities.LogLevelExists(hostJsonConfig, Utilities.LogLevelDefaultSection, out LogLevel defaultLogLevel))
             {
-                SystemLogDefaultLogLevel = logLevel;
+                SystemLogDefaultLogLevel = defaultLogLevel;
+                UserLogDefaultLogLevel = defaultLogLevel;
             }
 
-            // Check for user log level
-            if (!string.IsNullOrEmpty(userLogLevel))
+            // set user log value to Function
+            if ( Utilities.LogLevelExists(hostJsonConfig, Utilities.LogLevelFunctionSection, out LogLevel functionLogLevel))
             {
-                if (Enum.TryParse(userLogLevel, true, out LogLevel UserLogLevel))
-                {
-                    UserLogDefaultLogLevel = UserLogLevel;
-                }
+                UserLogDefaultLogLevel = functionLogLevel;
+            }
+
+            // set user log value to --userLoglevel Flag
+            if (!string.IsNullOrEmpty(userLogLevel) && Enum.TryParse(userLogLevel, true, out LogLevel UserLogLevel))
+            {
+                UserLogDefaultLogLevel = UserLogLevel;
             }
         }
 

--- a/src/Azure.Functions.Cli/Diagnostics/LoggingFilterHelper.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/LoggingFilterHelper.cs
@@ -18,8 +18,9 @@ namespace Azure.Functions.Cli
         public const string Ci_Continuous_Integration = "CONTINUOUS_INTEGRATION";  // Travis CI, Cirrus CI
         public const string Ci_Build_Number = "BUILD_NUMBER";  // Travis CI, Cirrus CI
         public const string Ci_Run_Id = "RUN_ID"; // TaskCluster, dsari
+        public static readonly string[] ValidUserLogLevels = ["Trace", "Debug", "Information", "Warning", "Error","Critical", "None"];
 
-        public LoggingFilterHelper(IConfigurationRoot hostJsonConfig, bool? verboseLogging)
+        public LoggingFilterHelper(IConfigurationRoot hostJsonConfig, bool? verboseLogging, string userLogLevel = null)
         {
             VerboseLogging = verboseLogging.HasValue && verboseLogging.Value;
 
@@ -34,7 +35,16 @@ namespace Azure.Functions.Cli
             if (Utilities.LogLevelExists(hostJsonConfig, Utilities.LogLevelDefaultSection, out LogLevel logLevel))
             {
                 SystemLogDefaultLogLevel = logLevel;
-                UserLogDefaultLogLevel = logLevel;
+            }
+
+            // Check for user log level
+            if (!string.IsNullOrEmpty(userLogLevel))
+            { 
+                ValidateUserLogLevel(userLogLevel);
+                if (Enum.TryParse(userLogLevel, true, out LogLevel UserLogLevel))
+                {
+                    UserLogDefaultLogLevel = UserLogLevel;
+                }
             }
         }
 
@@ -67,6 +77,13 @@ namespace Azure.Functions.Cli
                 return true;
             }
             return false;
+        }
+        private void ValidateUserLogLevel(string UserLogLevel)
+        {
+            if (LoggingFilterHelper.ValidUserLogLevels.Contains(UserLogLevel, StringComparer.OrdinalIgnoreCase) == false)
+            {
+                throw new CliException($"The userLogLevel value provided, '{UserLogLevel}', is invalid. Valid values are '{string.Join("', '", LoggingFilterHelper.ValidUserLogLevels)}'.");
+            }
         }
     }
 }

--- a/src/Azure.Functions.Cli/Diagnostics/LoggingFilterHelper.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/LoggingFilterHelper.cs
@@ -18,6 +18,7 @@ namespace Azure.Functions.Cli
         public const string Ci_Continuous_Integration = "CONTINUOUS_INTEGRATION";  // Travis CI, Cirrus CI
         public const string Ci_Build_Number = "BUILD_NUMBER";  // Travis CI, Cirrus CI
         public const string Ci_Run_Id = "RUN_ID"; // TaskCluster, dsari
+        public static readonly string[] ValidUserLogLevels = ["Trace", "Debug", "Information", "Warning", "Error", "Critical", "None"];
 
         public LoggingFilterHelper(IConfigurationRoot hostJsonConfig, bool? verboseLogging, string userLogLevel = null)
         {
@@ -38,7 +39,7 @@ namespace Azure.Functions.Cli
 
             // Check for user log level
             if (!string.IsNullOrEmpty(userLogLevel))
-            { 
+            {
                 if (Enum.TryParse(userLogLevel, true, out LogLevel UserLogLevel))
                 {
                     UserLogDefaultLogLevel = UserLogLevel;

--- a/src/Azure.Functions.Cli/Diagnostics/LoggingFilterHelper.cs
+++ b/src/Azure.Functions.Cli/Diagnostics/LoggingFilterHelper.cs
@@ -40,7 +40,6 @@ namespace Azure.Functions.Cli
             // Check for user log level
             if (!string.IsNullOrEmpty(userLogLevel))
             { 
-                ValidateUserLogLevel(userLogLevel);
                 if (Enum.TryParse(userLogLevel, true, out LogLevel UserLogLevel))
                 {
                     UserLogDefaultLogLevel = UserLogLevel;
@@ -78,12 +77,6 @@ namespace Azure.Functions.Cli
             }
             return false;
         }
-        private void ValidateUserLogLevel(string UserLogLevel)
-        {
-            if (LoggingFilterHelper.ValidUserLogLevels.Contains(UserLogLevel, StringComparer.OrdinalIgnoreCase) == false)
-            {
-                throw new CliException($"The userLogLevel value provided, '{UserLogLevel}', is invalid. Valid values are '{string.Join("', '", LoggingFilterHelper.ValidUserLogLevels)}'.");
-            }
-        }
+
     }
 }

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -1859,6 +1859,7 @@ namespace Azure.Functions.Cli.Tests.E2E
         }
 
         [Fact]
+        [Trait(TestTraits.Group, TestTraits.RequiresNestedInProcArtifacts)]
         public async Task Start_DotnetApp_WithDebugLogs_DisplaysDebugLogsInConsole()
         {
             var DebugLogMessage = "This is a debug log message";

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -1860,6 +1860,63 @@ namespace Azure.Functions.Cli.Tests.E2E
 
         [Fact]
         [Trait(TestTraits.Group, TestTraits.RequiresNestedInProcArtifacts)]
+        public async Task Start_DotnetApp_WithUserLogLevelFlag_ShowDebugLogsInConsole()
+        {
+            var DebugLogMessage = "This is a debug log message";
+
+            await CliTester.Run(new RunConfiguration[]
+            {
+                new RunConfiguration
+                {
+                    Commands = new[]
+                    {
+                        "init . --worker-runtime dotnet",
+                        "new --template Httptrigger --name HttpTrigger"
+                    },
+                    Test = async (workingDir, _, _) =>
+                    {
+                        // Add debug logs to FunctionApp.cs
+                        var functionAppPath = Path.Combine(workingDir, "HttpTrigger.cs");
+                        if (File.Exists(functionAppPath))
+                        {
+                            var content = await File.ReadAllTextAsync(functionAppPath);
+                            content = content.Replace(
+                                "log.LogInformation(\"C# HTTP trigger function processed a request.\");",
+                                $"log.LogInformation(\"C# HTTP trigger function processed a request.\");\nlog.LogDebug(\"{DebugLogMessage}\");"
+                            );
+                            await File.WriteAllTextAsync(functionAppPath, content);
+                        }
+                    },
+                    CommandTimeout = TimeSpan.FromSeconds(300)
+                },
+                new RunConfiguration
+                {
+                    Commands = new[]
+                    {
+                        $"start --port {_funcHostPort} --userLogLevel Debug"
+                    },
+                    ExpectExit = false,
+                    OutputContains = new[]
+                    {
+                        DebugLogMessage
+                    },
+                    Test = async (_, p, stdout) =>
+                    {
+                        using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}/") })
+                        {
+                            (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
+                            var response = await client.GetAsync("/api/HttpTrigger?name=Test");
+                            response.StatusCode.Should().Be(HttpStatusCode.OK);
+                            p.Kill();
+                        }
+                    },
+                    CommandTimeout = TimeSpan.FromSeconds(300)
+                }
+            }, _output);
+        }
+
+        [Fact]
+        [Trait(TestTraits.Group, TestTraits.RequiresNestedInProcArtifacts)]
         public async Task Start_DotnetApp_WithDebugLogs_DisplaysDebugLogsInConsole()
         {
             var DebugLogMessage = "This is a debug log message";
@@ -1911,6 +1968,60 @@ namespace Azure.Functions.Cli.Tests.E2E
                     OutputContains = new[]
                     {
                         DebugLogMessage
+                    },
+                    Test = async (_, p, stdout) =>
+                    {
+                        using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}/") })
+                        {
+                            (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
+                            var response = await client.GetAsync("/api/HttpTrigger?name=Test");
+                            response.StatusCode.Should().Be(HttpStatusCode.OK);
+                            p.Kill();
+                        }
+                    },
+                    CommandTimeout = TimeSpan.FromSeconds(300)
+                }
+            }, _output);
+        }
+        [Fact]
+        [Trait(TestTraits.Group, TestTraits.RequiresNestedInProcArtifacts)]
+        public async Task Start_NodeApp_DisplaysDebugLogsInConsole()
+        {
+            await CliTester.Run(new RunConfiguration[]
+            {
+                new RunConfiguration
+                {
+                    Commands = new[]
+                    {
+                        "init . --worker-runtime node",
+                        "new --template Httptrigger --name HttpTrigger"
+                    },
+                    Test = async (workingDir, _, _) =>
+                    {
+                        // Add debug logs to FunctionApp.cs
+                        var functionAppPath = Path.Combine(workingDir,"src", "functions", "HttpTrigger.js");
+                        if (File.Exists(functionAppPath))
+                        {
+                            var content = await File.ReadAllTextAsync(functionAppPath);
+                            content = content.Replace(
+                                $"context.log(`Http function processed request for url \"${{request.url}}\"`);",
+                                $"context.log(`Http function processed request for url \"${{request.url}}\"`);\ncontext.debug(\"This is a debug log message\");"
+                            );
+                            await File.WriteAllTextAsync(functionAppPath, content);
+                        }
+                    },
+                    CommandTimeout = TimeSpan.FromSeconds(300)
+                },
+                new RunConfiguration
+                {
+                    Commands = new[]
+                    {
+                        $"start --port {_funcHostPort} --userLogLevel Debug"
+                    },
+                    ExpectExit = false,
+                    OutputContains = new[]
+                    {
+                        "This is a debug log message"
                     },
                     Test = async (_, p, stdout) =>
                     {

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -1857,6 +1857,80 @@ namespace Azure.Functions.Cli.Tests.E2E
             }
         }
 
+        [Theory]
+        [InlineData("dotnet-isolated", "debug")]
+        [InlineData("dotnet", "debug")]
+        public async Task Start_Host_SpecifieduserLogLevel_SuccessfulFunctionExecution(string WorkerRuntime, string UserLogLevel)
+        {
+            await CliTester.Run(new RunConfiguration[]
+            {
+                new RunConfiguration
+                {
+                    Commands = new[]
+                    {
+                        $"init . --worker-runtime {WorkerRuntime}",
+                        $"new --template Httptrigger --name HttpTrigger",
+                    },
+                    CommandTimeout = TimeSpan.FromSeconds(300),
+                },
+                new RunConfiguration
+                {
+                    Commands = new[]
+                    {
+                        $"start  --port {_funcHostPort} --userLogLevel {UserLogLevel}"
+                    },
+                    ExpectExit = false,
+                    Test = async (workingDir, p, _) =>
+                    {
+                        using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}") })
+                        {
+                            (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
+                             var response = await client.GetAsync("/api/HttpTriggerFunc?name=Test");
+                             response.StatusCode.Should().Be(HttpStatusCode.OK);
+                             await Task.Delay(TimeSpan.FromSeconds(2));
+                             p.Kill();
+                        }
+                    },
+                    CommandTimeout = TimeSpan.FromSeconds(100),
+                },
+            }, _output);
+        }
+
+        [Theory]
+        [InlineData("TestLogLevel")]
+        public async Task Start_Host_Validate_SpecifieduserLogLevel( string UserLogLevel)
+        {
+            await CliTester.Run(new RunConfiguration[]
+            {
+                new RunConfiguration
+                {
+                    Commands = new[]
+                    {
+                        "init . --worker-runtime dotnet-isolated",
+                        "new --template Httptrigger --name HttpTrigger",
+                    }
+                },
+                new RunConfiguration
+                {
+                    Commands = new[]
+                    {
+                        $"start  --port {_funcHostPort} --userLogLevel {UserLogLevel}"
+                    },
+                    ExpectExit = true,
+                    ExitInError = true,
+                    ErrorContains = [$"The userLogLevel value provided, '{UserLogLevel}', is invalid. Valid values are '{string.Join("', '", LoggingFilterHelper.ValidUserLogLevels)}'."],
+                    Test = async (workingDir, p, _) =>
+                    {
+                        using (var client = new HttpClient() { BaseAddress = new Uri($"http://localhost:{_funcHostPort}") })
+                        {
+                            await Task.Delay(TimeSpan.FromSeconds(2));
+                        }
+                    },
+                    CommandTimeout = TimeSpan.FromSeconds(100),
+                },
+            }, _output);
+        }
+
         private async Task<bool> WaitUntilReady(HttpClient client)
         {
             for (var limit = 0; limit < 10; limit++)

--- a/test/Azure.Functions.Cli.Tests/LoggingFilterHelperTests.cs
+++ b/test/Azure.Functions.Cli.Tests/LoggingFilterHelperTests.cs
@@ -30,6 +30,7 @@ namespace Azure.Functions.Cli.Tests
             }
             if ( !string.IsNullOrEmpty(categoryKey) && categoryKey.Equals("Default", StringComparison.OrdinalIgnoreCase))
             {
+                Assert.Equal(expectedDefaultLogLevel, loggingFilterHelper.UserLogDefaultLogLevel);
                 Assert.Equal(expectedDefaultLogLevel, loggingFilterHelper.SystemLogDefaultLogLevel);
             }
             else

--- a/test/Azure.Functions.Cli.Tests/LoggingFilterHelperTests.cs
+++ b/test/Azure.Functions.Cli.Tests/LoggingFilterHelperTests.cs
@@ -30,7 +30,6 @@ namespace Azure.Functions.Cli.Tests
             }
             if ( !string.IsNullOrEmpty(categoryKey) && categoryKey.Equals("Default", StringComparison.OrdinalIgnoreCase))
             {
-                Assert.Equal(expectedDefaultLogLevel, loggingFilterHelper.UserLogDefaultLogLevel);
                 Assert.Equal(expectedDefaultLogLevel, loggingFilterHelper.SystemLogDefaultLogLevel);
             }
             else


### PR DESCRIPTION
### Issue describing the changes in this PR
Added --flag userLogLevel to set UserLogDefaultLogLevel without having to set the default log level, and without having to also set the SystemLogDefaultLogLevel to the same value.

resolves #4295 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)