### PR TITLE
Allow File.Open to create the logging file with the correct sharing permissions

### DIFF
--- a/src/Cli/func/Diagnostics/ColoredConsoleLogger.cs
+++ b/src/Cli/func/Diagnostics/ColoredConsoleLogger.cs
@@ -41,14 +41,7 @@ namespace Azure.Functions.Cli.Diagnostics
 
             if (jsonOutputFilePath != null)
             {
-                if (!File.Exists(jsonOutputFilePath))
-                {
-                    _jsonOutputFileStream = File.Create(jsonOutputFilePath);
-                }
-                else
-                {
-                    _jsonOutputFileStream = File.Open(jsonOutputFilePath, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
-                }
+                _jsonOutputFileStream = File.Open(jsonOutputFilePath, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
 
                 _logJsonOutput = LogJsonToFile;
 


### PR DESCRIPTION
Seems to be throwing an exception when opening the json file when the provider creates new instances, File.Create seems to lock the file. 

Unsure what's changed recently to cause this, will try do some additional investigation later, but for now a custom build of this has unblocked me

### Issue describing the changes in this PR

resolves #4263 

### Pull request checklist

* [X] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)