### PR TITLE
Fix: func new not creating a valid template with Python

### DIFF
--- a/src/Cli/func/Actions/LocalActions/CreateFunctionAction.cs
+++ b/src/Cli/func/Actions/LocalActions/CreateFunctionAction.cs
@@ -99,7 +99,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
 
         public async override Task RunAsync()
         {
-            // Check if the command only ran for help. 
+            // Check if the command only ran for help.
             if (!string.IsNullOrEmpty(TriggerNameForHelp))
             {
                 await ProcessHelpRequest(TriggerNameForHelp, true);
@@ -124,7 +124,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 {
                     ColoredConsole.WriteLine($"Template: {TemplateName}");
                 }
-                
+
                 ColoredConsole.Write("Function name: ");
                 FunctionName = FunctionName ?? Console.ReadLine();
                 ColoredConsole.WriteLine(FunctionName);
@@ -139,7 +139,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                     TemplateName = TemplateName ?? SelectionMenuHelper.DisplaySelectionWizard(GetTriggerNamesFromNewTemplates(Language));
                 }
 
-                // Defaulting the filename to "function_app.py" if the file name is not provided. 
+                // Defaulting the filename to "function_app.py" if the file name is not provided.
                 if (string.IsNullOrWhiteSpace(FileName))
                 {
                     FileName = "function_app.py";
@@ -156,7 +156,12 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                     }
                 }
 
-                var providedInputs = new Dictionary<string, string>() { { GetFunctionNameParamId, FunctionName }, { HttpTriggerAuthLevelParamId, AuthorizationLevel?.ToString() } };
+                var providedInputs = new Dictionary<string, string>()
+                {
+                    { GetFunctionNameParamId, FunctionName },
+                    { HttpTriggerAuthLevelParamId, AuthorizationLevel?.ToString().ToUpper() }
+                };
+
                 var jobName = "appendToFile";
                 if (FileName != PySteinFunctionAppPy)
                 {
@@ -188,7 +193,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 {
                     FunctionName = providedInputs[GetFunctionNameParamId];
                 }
-                
+
                 await _templatesManager.Deploy(templateJob, template, variables);
             }
             else

--- a/src/Cli/func/Actions/LocalActions/CreateFunctionAction.cs
+++ b/src/Cli/func/Actions/LocalActions/CreateFunctionAction.cs
@@ -159,7 +159,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 var providedInputs = new Dictionary<string, string>()
                 {
                     { GetFunctionNameParamId, FunctionName },
-                    { HttpTriggerAuthLevelParamId, AuthorizationLevel?.ToString().ToUpper() }
+                    { HttpTriggerAuthLevelParamId, AuthorizationLevel?.ToString().ToUpperInvariant() }
                 };
 
                 var jobName = "appendToFile";


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

On [https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-python](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-python?tabs=linux%2Cbash%2Cazure-cli%2Cbrowser#create-a-local-function) it is explained that a new function can be created with the command: `func new --name HttpExample --template "HTTP trigger" --authlevel "anonymous"`, however executing this command generates invalid code. When trying to run func start afterwards, an exception is raised.

Expected Generated Code:
@app.route(route="HttpExample", auth_level=func.AuthLevel.ANONYMOUS)
Actual Generated Code:
@app.route(route="HttpExample", auth_level=func.AuthLevel.Anonymous)

This code contains a fix for this issue. The problem is that in python the enums should be completely capitalised, and calling ```AuthorizationLevel?.ToString()``` will generate an incorrectly cased string.

### Issue describing the changes in this PR
[#1525](https://github.com/Azure/azure-functions-python-worker/issues/1525)
[#3695 ](https://github.com/Azure/azure-functions-core-tools/issues/3695)
[#3651](https://github.com/Azure/azure-functions-core-tools/issues/3651)
[#3779](https://github.com/Azure/azure-functions-core-tools/issues/3779)

resolves #3695, #3651, #3779

I tested this for: func.AuthLevel.ANONYMOUS, func.AuthLevel.ADMIN, AND func.AuthLevel.FUNCTION.

### Pull request checklist

* [X] My changes **do not** require documentation changes
* [ ] My changes **do not** need to be backported to a previous version (Comment: I am not sure if it needs to be)
* [X] I have added all required tests (Unit tests, E2E tests)