### PR TITLE
Ycode/improve cs template error

### DIFF
--- a/src/Cli/func/Actions/LocalActions/ListTemplatesAction.cs
+++ b/src/Cli/func/Actions/LocalActions/ListTemplatesAction.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
-using Azure.Functions.Cli.Interfaces;
+﻿using Azure.Functions.Cli.Interfaces;
+using Azure.Functions.Cli.Common;
 using Colors.Net;
 using Fclp;
 using static Azure.Functions.Cli.Common.OutputTheme;
@@ -45,6 +43,13 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 {
                     ColoredConsole.WriteLine($"  {template.Metadata.Name}");
                 }
+
+                if (Constants.Languages.CSharp.Equals(languageGrouping.Key, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    ColoredConsole.WriteLine($"(Use the templates above with 'func function new ls--csx --template' command within in-process model projects.)");
+                    ColoredConsole.WriteLine($"(More templates are available for C#. To list those run 'func funciton new' command without '--template'.)");
+                }
+
                 ColoredConsole.WriteLine();
             }
         }

--- a/src/Cli/func/Exceptions/CsTemplateNotFoundException.cs
+++ b/src/Cli/func/Exceptions/CsTemplateNotFoundException.cs
@@ -1,0 +1,4 @@
+namespace Azure.Functions.Cli.Exceptions;
+
+public class CsTemplateNotFoundException(string templateName)
+    : Exception($"Unknown template '{templateName}'. Retry without --template option to see available templates.") {}

--- a/src/Cli/func/Exceptions/CsxTemplateReferredWithoutCsxOptionException.cs
+++ b/src/Cli/func/Exceptions/CsxTemplateReferredWithoutCsxOptionException.cs
@@ -1,0 +1,4 @@
+namespace Azure.Functions.Cli.Exceptions;
+
+public class CsxTemplateReferredWithoutCsxOptionException(string templateName)
+    : Exception($"Template '{templateName}' is for C# script in in-process model. Retry with --csx option to use the template. Or, retry without --template option to see available templates.") {}

--- a/src/Cli/func/Helpers/DotnetHelpers.cs
+++ b/src/Cli/func/Helpers/DotnetHelpers.cs
@@ -1,12 +1,8 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading.Tasks;
 using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Exceptions;
 using Colors.Net;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using static Azure.Functions.Cli.Common.OutputTheme;
@@ -145,7 +141,7 @@ namespace Azure.Functions.Cli.Helpers
             "daprpublishoutputbinding" => "daprPublishOutputBinding",
             "daprserviceinvocationtrigger" => "daprServiceInvocationTrigger",
             "daprtopictrigger" => "daprTopicTrigger",
-            _ => throw new ArgumentException($"Unknown template '{templateName}'", nameof(templateName))
+            _ => throw new CsTemplateNotFoundException(templateName)
         };
 
         internal static IEnumerable<string> GetTemplates(WorkerRuntime workerRuntime)

--- a/src/Cli/func/Helpers/DotnetHelpers.cs
+++ b/src/Cli/func/Helpers/DotnetHelpers.cs
@@ -242,14 +242,14 @@ namespace Azure.Functions.Cli.Helpers
         public static string GetCsprojOrFsproj()
         {
             EnsureDotnet();
-            var csProjFiles = FileSystemHelpers.GetFiles(Environment.CurrentDirectory, searchPattern: "*.csproj").ToList();
+            var csProjFiles = FileSystemHelpers.GetFiles(Environment.CurrentDirectory, searchPattern: "*.csproj", excludedDirectories: ["obj"]).ToList();
             if (csProjFiles.Count == 1)
             {
                 return csProjFiles.First();
             }
             else
             {
-                var fsProjFiles = FileSystemHelpers.GetFiles(Environment.CurrentDirectory, searchPattern: "*.fsproj").ToList();
+                var fsProjFiles = FileSystemHelpers.GetFiles(Environment.CurrentDirectory, searchPattern: "*.fsproj", excludedDirectories: ["obj"]).ToList();
                 if (fsProjFiles.Count == 1)
                 {
                     return fsProjFiles.First();


### PR DESCRIPTION
The template list provided by `func templates list` confused me when I used the template names with `func function new --template` command because neither of them worked. After looking into the tool's code, I learnt they can be used only within in-process model Functions projects, and we need to specify the `--csx` option. I also learnt that the tool uses `dotnet new` templates for the newer C# templates although the `func templates list` command does list the templates from `dotnet new`.

As the tool has complexity due to the two template management systems behind the scenes, it should be more self-explanatory and provide clear guidance to users.

This PR adds notes to the tool's outputs, assuming that the most recommended approach is to start simply with `func function new` without specifying the `--template` option. There are no functional changes.

It should effectively resolve #2955

## Changes

### Command 'func templates list'

The command will have two lines of notes under the C# template list.

> (Use the templates above with 'func function new ls--csx --template' command within in-process model projects.)
> (More templates are available for C#. To list those run 'func funciton new' command without '--template'.)

### Command 'func function new --template' with Template Name from 'func templates list'

The command will output the error message:

> Template 'Azure Cosmos DB trigger' is for C# script in in-process model. Retry with --csx option to use the template. Or, retry without --template option to see available templates.

### Command 'func function new --template' with Invalid Template Name

The command will output the error message:

> Unknown template 'AzureDBtrigger'. Retry without --template option to see available templates.

## Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)