### PR TITLE
Updating namespaces in `Azure.Functions.Cli.TestFramework`

### DIFF
--- a/test/Cli/TestFramework/Assertions/CommandResultAssertions.cs
+++ b/test/Cli/TestFramework/Assertions/CommandResultAssertions.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 // Based off of: https://github.com/dotnet/sdk/blob/e793aa4709d28cd783712df40413448250e26fea/test/Microsoft.NET.TestFramework/Assertions/CommandResultAssertions.cs
-using Azure.Functions.Cli.Abstractions.Command;
+using Azure.Functions.Cli.Abstractions;
 using FluentAssertions;
 using FluentAssertions.Execution;
 

--- a/test/Cli/TestFramework/Assertions/CommandResultExtensions.cs
+++ b/test/Cli/TestFramework/Assertions/CommandResultExtensions.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 // Copied from: https://github.com/dotnet/sdk/blob/e793aa4709d28cd783712df40413448250e26fea/test/Microsoft.NET.TestFramework/Assertions/CommandResultExtensions.cs
-using Azure.Functions.Cli.Abstractions.Command;
+using Azure.Functions.Cli.Abstractions;
 
 namespace Azure.Functions.Cli.TestFramework.Assertions
 {

--- a/test/Cli/TestFramework/CommandInfo.cs
+++ b/test/Cli/TestFramework/CommandInfo.cs
@@ -3,7 +3,7 @@
 
 // Based off of: https://github.com/dotnet/sdk/blob/e793aa4709d28cd783712df40413448250e26fea/test/Microsoft.NET.TestFramework/Commands/SdkCommandSpec.cs
 using System.Diagnostics;
-using Azure.Functions.Cli.Abstractions.Command;
+using Azure.Functions.Cli.Abstractions;
 
 namespace Azure.Functions.Cli.TestFramework
 {

--- a/test/Cli/TestFramework/Commands/FuncCommand.cs
+++ b/test/Cli/TestFramework/Commands/FuncCommand.cs
@@ -3,7 +3,7 @@
 
 // Based off of: https://github.com/dotnet/sdk/blob/e793aa4709d28cd783712df40413448250e26fea/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
 using System.Diagnostics;
-using Azure.Functions.Cli.Abstractions.Command;
+using Azure.Functions.Cli.Abstractions;
 using Xunit.Abstractions;
 
 namespace Azure.Functions.Cli.TestFramework.Commands

--- a/test/Cli/TestFramework/Helpers/FunctionAppSetupHelper.cs
+++ b/test/Cli/TestFramework/Helpers/FunctionAppSetupHelper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Abstractions;
 using Azure.Functions.Cli.TestFramework.Commands;
 using Xunit.Abstractions;
 
@@ -31,7 +32,7 @@ namespace Azure.Functions.Cli.TestFramework.Helpers
                         // Apply any additional configuration
                         configureCommand?.Invoke(command);
 
-                        Abstractions.CommandResult result = command
+                        CommandResult result = command
                             .WithWorkingDirectory(workingDirectory)
                             .Execute(args);
 

--- a/test/Cli/TestFramework/Helpers/FunctionAppSetupHelper.cs
+++ b/test/Cli/TestFramework/Helpers/FunctionAppSetupHelper.cs
@@ -31,7 +31,7 @@ namespace Azure.Functions.Cli.TestFramework.Helpers
                         // Apply any additional configuration
                         configureCommand?.Invoke(command);
 
-                        Abstractions.Command.CommandResult result = command
+                        Abstractions.CommandResult result = command
                             .WithWorkingDirectory(workingDirectory)
                             .Execute(args);
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

When merging in the PR for adding the `Azure.Functions.Cli.TestFramework.csproj`, the namespaces were not updated to reflect the latest changes of being `Azure.Functions.Cli.Abstractions.Command` versus `Azure.Functions.Cli.Abstractions`.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)