### PR TITLE
Fixing official pipeline

### DIFF
--- a/eng/ci/templates/official/jobs/build-test.yml
+++ b/eng/ci/templates/official/jobs/build-test.yml
@@ -60,14 +60,6 @@ jobs:
       Install-Dotnet
     displayName: 'Install .NET 6.0 and 3.1'
 
-  - pwsh: |
-      Import-Module "./eng/scripts/modules/pipelineUtilities.psm1" -Force
-      Install-SBOMUtil -SBOMUtilSASUrl $env:SBOMUtilSASUrl
-    env:
-      SBOMUtilSASUrl: $(SBOMUtilSASUrl)
-    condition: eq(variables['IsReleaseBuild'], 'true')
-    displayName: 'Install SBOM ManifestTool'
-
   - task: NuGetToolInstaller@1
     inputs:
       versionSpec:

--- a/eng/scripts/modules/pipelineUtilities.psm1
+++ b/eng/scripts/modules/pipelineUtilities.psm1
@@ -7,48 +7,6 @@
 
 using namespace System.Runtime.InteropServices
 
-$DLL_NAME = "Microsoft.ManifestTool.dll"
-$MANIFESTOOLNAME = "ManifestTool"
-$MANIFESTOOL_DIRECTORY = Join-Path $PSScriptRoot $MANIFESTOOLNAME
-$MANIFEST_TOOL_PATH = "$MANIFESTOOL_DIRECTORY/$DLL_NAME"
-
-function Get-ManifestToolPath
-{
-    if (Test-Path $MANIFEST_TOOL_PATH)
-    {
-        return $MANIFEST_TOOL_PATH
-    }
-    throw "The SBOM Manifest Tool is not installed. Please run Install-SBOMUtil -SBOMUtilSASUrl <SASUrl>"
-}
-
-function Install-SBOMUtil
-{
-    param(
-        [string]
-        $SBOMUtilSASUrl
-    )
-
-    if ([string]::IsNullOrEmpty($SBOMUtilSASUrl))
-    {
-        throw "The `$SBOMUtilSASUrl parameter cannot be null or empty when specifying `$(addSBOM)"
-    }
-
-    Write-Host "Installing $MANIFESTOOLNAME..."
-    Remove-Item -Recurse -Force $MANIFESTOOL_DIRECTORY -ErrorAction Ignore
-
-    Invoke-RestMethod -Uri $SBOMUtilSASUrl -OutFile "$MANIFESTOOL_DIRECTORY.zip"
-    Expand-Archive "$MANIFESTOOL_DIRECTORY.zip" -DestinationPath $MANIFESTOOL_DIRECTORY
-
-    if (-not (Test-Path $MANIFEST_TOOL_PATH))
-    {
-        throw "$MANIFESTOOL_DIRECTORY does not contain '$DLL_NAME'"
-    }
-
-    Write-Host 'Done.'
-
-    return $MANIFEST_TOOL_PATH
-}
-
 $DotnetSDKVersionRequirements = @{
 
     # .NET SDK 3.1 is required by the Microsoft.ManifestTool.dll tool


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

The official pipeline was broken due to the SBOM Manifest step failing due to an expired token. This is already handled by the 1ES template, so this PR removes that step completely and restores the official pipeline.

Example of pipeline passing: https://azfunc.visualstudio.com/internal/_build/results?buildId=214274&view=logs&s=2b1cf740-7e83-5b38-9f56-89c750cf5d77&j=6ce172a1-8e70-5920-fc7b-153ca736e7e6

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)