### PR TITLE
updating template version to 4.0.5086

### DIFF
--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -19,10 +19,10 @@ namespace Build
                 : value;
         }
 
-        public const string DotnetIsolatedItemTemplatesVersion = "4.0.5051";
-        public const string DotnetIsolatedProjectTemplatesVersion = "4.0.5051";
-        public const string DotnetItemTemplatesVersion = "4.0.5051";
-        public const string DotnetProjectTemplatesVersion = "4.0.5051";
+        public const string DotnetIsolatedItemTemplatesVersion = "4.0.5086";
+        public const string DotnetIsolatedProjectTemplatesVersion = "4.0.5086";
+        public const string DotnetItemTemplatesVersion = "4.0.5086";
+        public const string DotnetProjectTemplatesVersion = "4.0.5086";
         public const string TemplateJsonVersion = "3.1.1648";
 
         public static readonly string SBOMManifestToolPath = Path.GetFullPath("../ManifestTool/Microsoft.ManifestTool.dll");


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

This pull request updates the version constants for various .NET templates in the `build/Settings.cs` file.

Version updates:

* Updated the following constants to version `4.0.5086`:
  - `DotnetIsolatedItemTemplatesVersion`
  - `DotnetIsolatedProjectTemplatesVersion`
  - `DotnetItemTemplatesVersion`
  - `DotnetProjectTemplatesVersion`

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)