### PR TITLE
Print warning if preview version

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,12 +2,11 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": ".NET Core Launch (console)",
+            "name": "Run func cli (console)",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/out/bin/Azure.Functions.Cli/debug_net8.0/func.dll",
+            "program": "${workspaceFolder}/out/bin/Azure.Functions.Cli/debug/func.dll",
             "env": {
                 "CLI_DEBUG": "1"
             },
@@ -27,6 +26,7 @@
             "id": "funcArgs",
             "type": "promptString",
             "description": "Args to pass to the 'func' command",
+            // use `--script-root` to set func app directory e.g. `--script-root ${workspaceFolder}/MyTestFuncApp`
             "default": "--version"
         }
     ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,8 @@
             "env": {
                 "CLI_DEBUG": "1"
             },
+            // use `--script-root` to set func app directory e.g.
+            // "args": "${input:funcArgs} --script-root ${workspaceFolder}/_testapp",
             "args": "${input:funcArgs}",
             "cwd": "${workspaceFolder}/src/Cli/func",
             "console": "internalConsole",
@@ -26,7 +28,6 @@
             "id": "funcArgs",
             "type": "promptString",
             "description": "Args to pass to the 'func' command",
-            // use `--script-root` to set func app directory e.g. `--script-root ${workspaceFolder}/MyTestFuncApp`
             "default": "--version"
         }
     ]

--- a/src/Cli/func/Actions/HelpAction.cs
+++ b/src/Cli/func/Actions/HelpAction.cs
@@ -177,8 +177,8 @@ namespace Azure.Functions.Cli.Actions
                 .Where(c => c != Context.None)
                 .Distinct()
                 .OrderBy(c => c.ToLowerCaseString());
-            Utilities.PrintVersion();
             Utilities.WarnIfPreviewVersion();
+            Utilities.PrintVersion();
             ColoredConsole
                 .WriteLine("Usage: func [context] [context] <action> [-/--options]")
                 .WriteLine();

--- a/src/Cli/func/Actions/HelpAction.cs
+++ b/src/Cli/func/Actions/HelpAction.cs
@@ -178,6 +178,7 @@ namespace Azure.Functions.Cli.Actions
                 .Distinct()
                 .OrderBy(c => c.ToLowerCaseString());
             Utilities.PrintVersion();
+            Utilities.WarnIfPreviewVersion();
             ColoredConsole
                 .WriteLine("Usage: func [context] [context] <action> [-/--options]")
                 .WriteLine();

--- a/src/Cli/func/Actions/HostActions/StartHostAction.cs
+++ b/src/Cli/func/Actions/HostActions/StartHostAction.cs
@@ -400,12 +400,14 @@ namespace Azure.Functions.Cli.Actions.HostActions
         {
             await PreRunConditions();
             var isVerbose = VerboseLogging.HasValue && VerboseLogging.Value;
-            
+
             // Return if running is delegated to another version of Core Tools
             if (await TryHandleInProcDotNetLaunchAsync())
             {
                 return;
             }
+
+            Utilities.WarnIfPreviewVersion();
 
             if (isVerbose || EnvironmentHelper.GetEnvironmentVariableAsBool(Constants.DisplayLogo))
             {

--- a/src/Cli/func/Actions/LocalActions/InitAction.cs
+++ b/src/Cli/func/Actions/LocalActions/InitAction.cs
@@ -161,6 +161,8 @@ namespace Azure.Functions.Cli.Actions.LocalActions
 
         public override async Task RunAsync()
         {
+            Utilities.WarnIfPreviewVersion();
+
             if (SourceControl != SourceControl.Git)
             {
                 throw new Exception("Only Git is supported right now for vsc");

--- a/src/Cli/func/Azure.Functions.Cli.csproj
+++ b/src/Cli/func/Azure.Functions.Cli.csproj
@@ -20,14 +20,18 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <BuildNumber Condition=" '$(BuildNumber)' == '' ">1</BuildNumber>
+    <!-- Base version components -->
     <MajorMinorProductVersion>4.0</MajorMinorProductVersion>
-    <Version>$(MajorMinorProductVersion).$(BuildNumber)</Version>
+    <BuildNumber Condition=" '$(BuildNumber)' == '' ">1</BuildNumber>
+    <CommitHash Condition="$(CommitHash) == ''">N/A</CommitHash>
+
+    <!-- Final version properties -->
+    <Version>$(MajorMinorProductVersion).$(BuildNumber)-preview1</Version>
     <AssemblyVersion>$(MajorMinorProductVersion).$(BuildNumber)</AssemblyVersion>
     <FileVersion>$(MajorMinorProductVersion).$(BuildNumber)</FileVersion>
-    <CommitHash Condition="$(CommitHash) == ''">N/A</CommitHash>
+
+    <InformationalVersion>$(Version) Commit hash: $(CommitHash) $(IntegrationBuildNumberInfo)</InformationalVersion>
     <IntegrationBuildNumberInfo Condition="$(IntegrationBuildNumber) != ''">Integration build number: $(IntegrationBuildNumber)</IntegrationBuildNumberInfo>
-    <InformationalVersion>$(FileVersion) Commit hash: $(CommitHash) $(IntegrationBuildNumberInfo)</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Cli/func/Common/Constants.cs
+++ b/src/Cli/func/Common/Constants.cs
@@ -107,7 +107,7 @@ namespace Azure.Functions.Cli.Common
         // Helper method to extract version from CliDetailedVersion
         private static string GetSemanticVersion()
         {
-            var infoVersion = CliDetailedVersion;
+            var infoVersion = typeof(Constants).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
 
             if (string.IsNullOrEmpty(infoVersion))
             {

--- a/src/Cli/func/Common/Constants.cs
+++ b/src/Cli/func/Common/Constants.cs
@@ -99,8 +99,8 @@ namespace Azure.Functions.Cli.Common
         public const string GitHubReleaseApiUrl = "https://api.github.com/repos/Azure/azure-functions-core-tools/releases/latest";
         public const string PreviewVersionSuffixLabel = "preview";
 
-        private static readonly Lazy<string> _cliVersion = new(GetSemanticVersion);
-        public static string CliVersion => _cliVersion.Value;
+        private static readonly string _cliVersion = GetSemanticVersion();
+        public static string CliVersion => _cliVersion;
         public static string CliDetailedVersion = typeof(Constants).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty;
         public static string CliUserAgent = $"functions-core-tools/{CliVersion}";
 

--- a/src/Cli/func/Common/Constants.cs
+++ b/src/Cli/func/Common/Constants.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using Azure.Functions.Cli.Helpers;
 
 namespace Azure.Functions.Cli.Common
@@ -94,17 +95,28 @@ namespace Azure.Functions.Cli.Common
         public const string Dotnet = "dotnet";
         public const string InProcDotNet8EnabledSetting = "FUNCTIONS_INPROC_NET8_ENABLED";
         public const string AzureDevSessionsRemoteHostName = "AzureDevSessionsRemoteHostName";
-        public const string AzureDevSessionsPortSuffixPlaceholder = "<port>";
+        public const string AzureDevSessionsPortSuffixPlaceholder = "<port>"; // forwardedHttpUrl sample format: https://n12abc3t-<port>.asse.devtunnels.ms/
         public const string GitHubReleaseApiUrl = "https://api.github.com/repos/Azure/azure-functions-core-tools/releases/latest";
+        public const string PreviewVersionSuffixLabel = "preview";
 
-        // Sample format https://n12abc3t-<port>.asse.devtunnels.ms/
-
-
-        public static string CliVersion => typeof(Constants).GetTypeInfo().Assembly.GetName().Version.ToString(3);
-
+        private static readonly Lazy<string> _cliVersion = new(GetSemanticVersion);
+        public static string CliVersion => _cliVersion.Value;
         public static string CliDetailedVersion = typeof(Constants).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty;
+        public static string CliUserAgent = $"functions-core-tools/{CliVersion}";
 
-        public static string CliUserAgent = $"functions-core-tools/{Constants.CliVersion}";
+        // Helper method to extract version from CliDetailedVersion
+        private static string GetSemanticVersion()
+        {
+            var infoVersion = CliDetailedVersion;
+
+            if (string.IsNullOrEmpty(infoVersion))
+            {
+                return Assembly.GetExecutingAssembly().GetName().Version.ToString(3);
+            }
+
+            var match = Regex.Match(infoVersion, @"^(\S+)");
+            return match.Success ? match.Groups[1].Value : infoVersion;
+        }
 
         public static readonly Dictionary<WorkerRuntime, IEnumerable<string>> WorkerRuntimeImages = new Dictionary<WorkerRuntime, IEnumerable<string>>
         {

--- a/src/Cli/func/Common/Utilities.cs
+++ b/src/Cli/func/Common/Utilities.cs
@@ -69,7 +69,7 @@ namespace Azure.Functions.Cli
             if (isLinux && arch == Architecture.Arm64)
             {
                 ColoredConsole
-                    .WriteLine("This version currently doesn't support linux-arm64 with Python or PowerShell workers, or with in-process dotnet applications.".DarkYellow());
+                    .WriteLine("This version of the Azure Functions Core Tools currently doesn't support linux-arm64 with Python workers, with PowerShell workers, or with .NET applications using the in-process model.".DarkYellow());
             }
 
             ColoredConsole.WriteLine();

--- a/src/Cli/func/Common/Utilities.cs
+++ b/src/Cli/func/Common/Utilities.cs
@@ -69,7 +69,7 @@ namespace Azure.Functions.Cli
             if (isLinux && arch == Architecture.Arm64)
             {
                 ColoredConsole
-                    .WriteLine("This version currently doesn't support linux-arm64 with Python or PowerShell workers.".DarkYellow());
+                    .WriteLine("This version currently doesn't support linux-arm64 with Python or PowerShell workers, or with in-process dotnet applications.".DarkYellow());
             }
 
             ColoredConsole.WriteLine();

--- a/src/Cli/func/Common/Utilities.cs
+++ b/src/Cli/func/Common/Utilities.cs
@@ -53,6 +53,19 @@ namespace Azure.Functions.Cli
                 .WriteLine($"Function Runtime Version: {ScriptHost.Version}\n".DarkGray());
         }
 
+        internal static void WarnIfPreviewVersion()
+        {
+            if (!Constants.CliVersion.Contains(Constants.PreviewVersionSuffixLabel, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            ColoredConsole
+                .WriteLine("You are running a preview version of Azure Functions Core Tools.".DarkYellow())
+                .WriteLine("In this preview 'python' and 'powershell' worker support is not available for linux-arm64.".DarkYellow())
+                .WriteLine();
+        }
+
         private static RichString AlternateLogoColor(string str, int firstColorCount = -1)
         {
             if (str.Length == 1)

--- a/src/Cli/func/Common/Utilities.cs
+++ b/src/Cli/func/Common/Utilities.cs
@@ -61,9 +61,18 @@ namespace Azure.Functions.Cli
             }
 
             ColoredConsole
-                .WriteLine("You are running a preview version of Azure Functions Core Tools.".DarkYellow())
-                .WriteLine("In this preview 'python' and 'powershell' worker support is not available for linux-arm64.".DarkYellow())
-                .WriteLine();
+                .WriteLine("You are running a preview version of Azure Functions Core Tools.".DarkYellow());
+
+            bool isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+            Architecture arch = RuntimeInformation.ProcessArchitecture;
+
+            if (isLinux && arch == Architecture.Arm64)
+            {
+                ColoredConsole
+                    .WriteLine("This version currently doesn't support linux-arm64 with Python or PowerShell workers.".DarkYellow());
+            }
+
+            ColoredConsole.WriteLine();
         }
 
         private static RichString AlternateLogoColor(string str, int firstColorCount = -1)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

### Details

- Refactored the CliVersion prop so we get the full version and not the assembley version. This ensures that when `func --version` is called, the user should see 4.0.8050-preview1` and not just `4.0.8050`.
- Updated project version to add `-preview1` suffix
- Implemented `WarnIfPreviewVersion` method to notify users that they are on a preview version of the CLI. This should print when in preview when `func`, `func --version`, `func init`, `func new`, or `func start` is invoked.

![Screenshot 2025-04-29 at 5 30 24 PM](https://github.com/user-attachments/assets/5a619e50-f0ed-4174-86a8-f1cd1d2318e8)

