### PR TITLE
Update preview warning message

### DIFF
--- a/src/Cli/func/Common/Utilities.cs
+++ b/src/Cli/func/Common/Utilities.cs
@@ -67,7 +67,7 @@ namespace Azure.Functions.Cli
             if (isLinux && arch == Architecture.Arm64)
             {
                 ColoredConsole
-                    .WriteLine("This version of the Azure Functions Core Tools currently doesn't support linux-arm64 with Python workers, with PowerShell workers, or with .NET applications using the in-process model.".DarkYellow());
+                    .WriteLine("This version of the Azure Functions Core Tools currently doesn't support linux-arm64 with Python workers, or with .NET applications using the in-process model.".DarkYellow());
             }
 
             ColoredConsole.WriteLine();


### PR DESCRIPTION
PowerShell does work in the preview with linux-arm64; removing from warning message