### PR TITLE
Updating release pipelines to have correct consolidatedBuildId and linux pipeline to consume new consolidated pipeline

### DIFF
--- a/eng/ci/consolidate-artifacts.yml
+++ b/eng/ci/consolidate-artifacts.yml
@@ -29,6 +29,7 @@ resources:
     - pipeline: core-tools-inproc
       source: azure/azure-functions-core-tools/core-tools.official
       branch: in-proc  # in-proc branch of core-tools.official
+      displayName: core-tools-inproc
       tags:
       - nightly-build
       trigger:
@@ -39,6 +40,7 @@ resources:
     - pipeline: core-tools-default
       source: azure/azure-functions-core-tools/core-tools.official
       branch: main  # main branch of core-tools.official
+      displayName: core-tools-default
       tags:
       - nightly-build
       trigger:

--- a/eng/ci/linux-build.yml
+++ b/eng/ci/linux-build.yml
@@ -18,6 +18,9 @@ resources:
     type: git
     name: engineering
     ref: refs/tags/release
+  pipelines:
+  - pipeline: core-tools-consolidated-artifacts
+    source: azure/azure-functions-core-tools/core-tools-consolidated-artifacts.official
 
 variables:
   - template: /ci/variables/cfs.yml@eng

--- a/eng/ci/templates/official/jobs/assemble-artifacts.yml
+++ b/eng/ci/templates/official/jobs/assemble-artifacts.yml
@@ -71,53 +71,6 @@ jobs:
         arguments: '-ArtifactsPath "$(Pipeline.Workspace)\staging\coretools-cli"'
         workingDirectory: '$(Build.SourcesDirectory)/build'
 
-  - ${{ if startsWith(parameters.arch, 'win-x') }}:
-    - template: ci/sign-files.yml@eng
-      parameters:
-        displayName: Sign MSI files
-        folderPath: $(Pipeline.Workspace)/staging/coretools-cli
-        pattern: '*.msi'
-        signType: 'inline'
-        inlineOperation: |
-          [
-            {
-              "KeyCode": "CP-230012",
-              "OperationCode": "SigntoolSign",
-              "Parameters": {
-                "OpusName": "Microsoft",
-                "OpusInfo": "http://www.microsoft.com",
-                "FileDigest": "/fd \"SHA256\"",
-                "PageHash": "/NPH",
-                "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-              },
-              "ToolName": "sign",
-              "ToolVersion": "1.0"
-            },
-            {
-              "KeyCode": "CP-230012",
-              "OperationCode": "SigntoolVerify",
-              "Parameters": {},
-              "ToolName": "sign",
-              "ToolVersion": "1.0"
-            }
-          ]
-
-  - ${{ if eq(parameters.arch, 'min.win-x64') }}:
-    - task: PowerShell@2
-      displayName: 'Test Artifacts - Visual Studio'
-      inputs:
-        targetType: filePath
-        filePath: '$(Build.SourcesDirectory)/eng/scripts/ArtifactAssemblerHelpers/testVsArtifacts.ps1'
-        arguments: '-StagingDirectory "$(Pipeline.Workspace)/staging/coretools-visualstudio"'
-
-  - ${{ if startsWith(parameters.arch, 'win') }}:
-    - task: PowerShell@2
-      displayName: 'Test Artifacts'
-      inputs:
-        targetType: filePath
-        filePath: '$(Build.SourcesDirectory)/eng/scripts/ArtifactAssemblerHelpers/testArtifacts.ps1'
-        arguments: '-StagingDirectory "$(Pipeline.Workspace)/staging/coretools-cli"'
-
   - task: DotNetCoreCLI@2
     displayName: 'Zip Artifacts'
     inputs:

--- a/eng/ci/templates/official/jobs/assemble-artifacts.yml
+++ b/eng/ci/templates/official/jobs/assemble-artifacts.yml
@@ -71,6 +71,53 @@ jobs:
         arguments: '-ArtifactsPath "$(Pipeline.Workspace)\staging\coretools-cli"'
         workingDirectory: '$(Build.SourcesDirectory)/build'
 
+  - ${{ if startsWith(parameters.arch, 'win-x') }}:
+    - template: ci/sign-files.yml@eng
+      parameters:
+        displayName: Sign MSI files
+        folderPath: $(Pipeline.Workspace)/staging/coretools-cli
+        pattern: '*.msi'
+        signType: 'inline'
+        inlineOperation: |
+          [
+            {
+              "KeyCode": "CP-230012",
+              "OperationCode": "SigntoolSign",
+              "Parameters": {
+                "OpusName": "Microsoft",
+                "OpusInfo": "http://www.microsoft.com",
+                "FileDigest": "/fd \"SHA256\"",
+                "PageHash": "/NPH",
+                "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+              },
+              "ToolName": "sign",
+              "ToolVersion": "1.0"
+            },
+            {
+              "KeyCode": "CP-230012",
+              "OperationCode": "SigntoolVerify",
+              "Parameters": {},
+              "ToolName": "sign",
+              "ToolVersion": "1.0"
+            }
+          ]
+
+  - ${{ if eq(parameters.arch, 'min.win-x64') }}:
+    - task: PowerShell@2
+      displayName: 'Test Artifacts - Visual Studio'
+      inputs:
+        targetType: filePath
+        filePath: '$(Build.SourcesDirectory)/eng/scripts/ArtifactAssemblerHelpers/testVsArtifacts.ps1'
+        arguments: '-StagingDirectory "$(Pipeline.Workspace)/staging/coretools-visualstudio"'
+
+  - ${{ if startsWith(parameters.arch, 'win') }}:
+    - task: PowerShell@2
+      displayName: 'Test Artifacts'
+      inputs:
+        targetType: filePath
+        filePath: '$(Build.SourcesDirectory)/eng/scripts/ArtifactAssemblerHelpers/testArtifacts.ps1'
+        arguments: '-StagingDirectory "$(Pipeline.Workspace)/staging/coretools-cli"'
+
   - task: DotNetCoreCLI@2
     displayName: 'Zip Artifacts'
     inputs:

--- a/eng/ci/templates/official/jobs/linux-package.yml
+++ b/eng/ci/templates/official/jobs/linux-package.yml
@@ -13,10 +13,10 @@ jobs:
 
   templateContext:
     inputs:
-      - input: pipelineArtifact
-        pipeline: core-tools-consolidated-artifacts
-        artifactName: drop-metadata-json
-        targetPath: $(Pipeline.Workspace)/core-tools-consolidated-artifacts/drop-metadata-json
+    - input: pipelineArtifact
+      pipeline: core-tools-consolidated-artifacts
+      artifactName: drop-metadata-json
+      targetPath: $(Pipeline.Workspace)/core-tools-consolidated-artifacts/drop-metadata-json
     outputParentDirectory: $(drop_path)
     outputs:
     - output: pipelineArtifact

--- a/eng/ci/templates/official/jobs/linux-package.yml
+++ b/eng/ci/templates/official/jobs/linux-package.yml
@@ -43,9 +43,6 @@ jobs:
   - task: Bash@3
     displayName: 'Build DEB package'
     inputs:
-  - task: Bash@3
-    displayName: 'Build DEB package'
-    inputs:
       targetType: 'inline'
       script: |
         cd publish-scripts

--- a/eng/ci/templates/official/jobs/linux-package.yml
+++ b/eng/ci/templates/official/jobs/linux-package.yml
@@ -1,6 +1,5 @@
 jobs:
 - job: LinuxPackage
-  condition: and(ne(variables['LinuxPackageBuildTag'], ''))
   timeoutInMinutes: "120"
 
   pool:
@@ -39,6 +38,7 @@ jobs:
         
         # Set as pipeline variables for later steps
         Write-Host "##vso[task.setvariable variable=ConsolidatedBuildId]$($metadata.consolidatedBuildId)"
+        Write-Host "##vso[task.setvariable variable=DefaultArtifactVersion]$($metadata.defaultArtifactVersion)"
 
   - task: Bash@3
     displayName: 'Build DEB package'
@@ -57,14 +57,13 @@ jobs:
 
         sudo apt-get install fakeroot
         major_version=$(echo "$linuxBuildNumber" | cut -d'.' -f1)
-        echo "$consolidatedBuildId"
-        #python driver.py "$linuxBuildNumber" "$consolidatedBuildId" "$major_version"
-        #python driver.py "$linuxBuildNumber" "$consolidatedBuildId"
-        #export DEB_PACKAGE="$(readlink -f artifact/*$RELEASE_VERSION*)"
-        #echo "${DEB_PACKAGE}"
+        python driver.py "$linuxBuildNumber" "$consolidatedBuildId" "$major_version"
+        python driver.py "$linuxBuildNumber" "$consolidatedBuildId"
+        export DEB_PACKAGE="$(readlink -f artifact/*$RELEASE_VERSION*)"
+        echo "${DEB_PACKAGE}"
       bashEnvValue: '~/.profile'  # Set value for BASH_ENV environment variable
     env:
-      linuxBuildNumber: $(LinuxPackageBuildTag)
+      linuxBuildNumber: $(DefaultArtifactVersion)
       consolidatedBuildId: $(ConsolidatedBuildId)
 
   - template: ci/sign-files.yml@eng

--- a/eng/ci/templates/official/jobs/linux-package.yml
+++ b/eng/ci/templates/official/jobs/linux-package.yml
@@ -1,6 +1,6 @@
 jobs:
 - job: LinuxPackage
-  condition: and(ne(variables['LinuxPackageBuildTag'], ''), ne(variables['ConsolidatedBuildId'], ''))
+  condition: and(ne(variables['LinuxPackageBuildTag'], ''))
   timeoutInMinutes: "120"
 
   pool:
@@ -13,6 +13,11 @@ jobs:
     pkg_drop_path: $(drop_path)/drop_debian
 
   templateContext:
+    inputs:
+      - input: pipelineArtifact
+        pipeline: core-tools-consolidated-artifacts
+        artifactName: drop-metadata-json
+        targetPath: $(Pipeline.Workspace)/core-tools-consolidated-artifacts/drop-metadata-json
     outputParentDirectory: $(drop_path)
     outputs:
     - output: pipelineArtifact
@@ -21,6 +26,24 @@ jobs:
       artifact: drop_debian
 
   steps:
+  - task: PowerShell@2
+    displayName: 'Read metadata from consolidated build'
+    inputs:
+      targetType: 'inline'
+      script: |
+        $metadataPath = "$(Pipeline.Workspace)/core-tools-consolidated-artifacts/drop-metadata-json/metadata.json"
+        Write-Host "Reading metadata from $metadataPath"
+        $metadata = Get-Content -Path $metadataPath | ConvertFrom-Json
+        Write-Host "Consolidated Build ID: $($metadata.consolidatedBuildId)"
+        Write-Host "Default Artifact Version: $($metadata.defaultArtifactVersion)"
+        
+        # Set as pipeline variables for later steps
+        Write-Host "##vso[task.setvariable variable=ConsolidatedBuildId]$($metadata.consolidatedBuildId)"
+        Write-Host "##vso[task.setvariable variable=DefaultArtifactVersion]$($metadata.defaultArtifactVersion)"
+
+  - task: Bash@3
+    displayName: 'Build DEB package'
+    inputs:
   - task: Bash@3
     displayName: 'Build DEB package'
     inputs:

--- a/eng/ci/templates/official/jobs/linux-package.yml
+++ b/eng/ci/templates/official/jobs/linux-package.yml
@@ -39,7 +39,6 @@ jobs:
         
         # Set as pipeline variables for later steps
         Write-Host "##vso[task.setvariable variable=ConsolidatedBuildId]$($metadata.consolidatedBuildId)"
-        Write-Host "##vso[task.setvariable variable=DefaultArtifactVersion]$($metadata.defaultArtifactVersion)"
 
   - task: Bash@3
     displayName: 'Build DEB package'
@@ -58,10 +57,11 @@ jobs:
 
         sudo apt-get install fakeroot
         major_version=$(echo "$linuxBuildNumber" | cut -d'.' -f1)
-        python driver.py "$linuxBuildNumber" "$consolidatedBuildId" "$major_version"
-        python driver.py "$linuxBuildNumber" "$consolidatedBuildId"
-        export DEB_PACKAGE="$(readlink -f artifact/*$RELEASE_VERSION*)"
-        echo "${DEB_PACKAGE}"
+        echo "$consolidatedBuildId"
+        #python driver.py "$linuxBuildNumber" "$consolidatedBuildId" "$major_version"
+        #python driver.py "$linuxBuildNumber" "$consolidatedBuildId"
+        #export DEB_PACKAGE="$(readlink -f artifact/*$RELEASE_VERSION*)"
+        #echo "${DEB_PACKAGE}"
       bashEnvValue: '~/.profile'  # Set value for BASH_ENV environment variable
     env:
       linuxBuildNumber: $(LinuxPackageBuildTag)

--- a/eng/scripts/ArtifactAssemblerHelpers/generateMetadataFile.ps1
+++ b/eng/scripts/ArtifactAssemblerHelpers/generateMetadataFile.ps1
@@ -14,8 +14,7 @@ $oopVersion = (Get-ChildItem $stagingCoreToolsCli | Where-Object { $_.Name -matc
 $inProcVersion = (Get-ChildItem $stagingCoreToolsVisualStudio | Where-Object { $_.Name -match "^Azure\.Functions\.Cli\.min\.win.*\.(\d+\.\d+\.\d+)$" } | Select-Object -First 1).Name -replace "^Azure\.Functions\.Cli\.min\.win.*\.(\d+\.\d+\.\d+)$", '$1'
 
 # Get the current release number from ADO
-$releaseNumberFull = $env:RELEASE_RELEASENAME
-$releaseNumber = ($releaseNumberFull -replace '\D', '')
+$releaseNumber = $(Build.BuildId)
 
 # Get commit id
 $commitId = $env:BUILD_SOURCEVERSION

--- a/eng/scripts/ArtifactAssemblerHelpers/generateMetadataFile.ps1
+++ b/eng/scripts/ArtifactAssemblerHelpers/generateMetadataFile.ps1
@@ -14,7 +14,7 @@ $oopVersion = (Get-ChildItem $stagingCoreToolsCli | Where-Object { $_.Name -matc
 $inProcVersion = (Get-ChildItem $stagingCoreToolsVisualStudio | Where-Object { $_.Name -match "^Azure\.Functions\.Cli\.min\.win.*\.(\d+\.\d+\.\d+)$" } | Select-Object -First 1).Name -replace "^Azure\.Functions\.Cli\.min\.win.*\.(\d+\.\d+\.\d+)$", '$1'
 
 # Get the current release number from ADO
-$releaseNumber = $(Build.BuildId)
+$releaseNumber = $env:BUILD_BUILDID
 
 # Get commit id
 $commitId = $env:BUILD_SOURCEVERSION


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

I updated the script for generating the metadata.json to correctly get the consolidated pipeline build id and upated the linux build pipeline to consume the new consolidated pipeline as an artifact, rather than having to input the consolidated build id.

Here's an example of metadata.json being generated in the consolidated pipeline: https://azfunc.visualstudio.com/internal/_build/results?buildId=217027&view=logs&j=e71a84ac-0726-52c9-51bd-2f019fee3725&t=310f7c14-8c13-538c-6908-6321dc994c01
 
and this is an example of the linux build pipeline: https://azfunc.visualstudio.com/internal/_build/results?buildId=217115&view=results. It fails since it can't find the blob on CDN but it produces the right output for the CDN link
        

 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)