### PR TITLE
Exclude python worker for linux-arm64 build

### DIFF
--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -43,7 +43,8 @@ namespace Build
 
         public static readonly string RuntimeSettings = Path.Combine("..", "test", "Cli", "Func.E2E.Tests", ".runsettings", "start_tests", "ci_pipeline", "dotnet_inproc.runsettings");
 
-        public static readonly string[] TargetRuntimes = new[] {
+        public static readonly string[] TargetRuntimes = new[]
+        {
             "min.win-arm64",
             "min.win-x86",
             "min.win-x64",
@@ -56,7 +57,11 @@ namespace Build
             "win-arm64"
         };
 
-        public static readonly string[] UnsupportedPythonRuntimes = new[] { "win-arm64" };
+        public static readonly string[] UnsupportedPythonRuntimes = new[]
+        {
+            "win-arm64",
+            "linux-arm64"
+        };
 
         public static readonly Dictionary<string, string> RuntimesToOS = new Dictionary<string, string>
         {

--- a/src/Cli/func/Azure.Functions.Cli.csproj
+++ b/src/Cli/func/Azure.Functions.Cli.csproj
@@ -297,9 +297,9 @@
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.2" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" />
-    <!-- PythonWorker v4.35 introduced an error when being build for win-arm64. For now, we will not include this package when we build
-      core tools for win-arm64. This is a temporary measure as we figure out how we want this to go. -->
-    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Condition="'$(RuntimeIdentifier)' != 'win-arm64'" />
+    <!-- PythonWorker v4.35 introduced an error when being build for unsupported runtimes. For now, we will not include this package when we build
+      core tools for win-arm64 and linux-arm64. This is a temporary measure as we figure out how we want this to go. -->
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Condition="'$(RuntimeIdentifier)' != 'win-arm64' and '$(RuntimeIdentifier)' != 'linux-arm64'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The python worker now throws an error when built for unsupported runtimes. We are going to exclude it for those builds. This PR is just adding linux-arm64 to the list