### PR TITLE
Add job attempt # to test log artifact name

### DIFF
--- a/eng/ci/templates/official/jobs/build-test.yml
+++ b/eng/ci/templates/official/jobs/build-test.yml
@@ -107,7 +107,7 @@ jobs:
     condition: succeededOrFailed()
     inputs:
       targetPath: '$(Build.SourcesDirectory)/TestLogs'
-      artifactName: 'TestLogs'
+      artifactName: 'TestLogs_$(System.JobAttempt)'
       artifactType: 'pipeline'
 
   - template: ci/sign-files.yml@eng

--- a/eng/ci/templates/public/jobs/build-test-public.yml
+++ b/eng/ci/templates/public/jobs/build-test-public.yml
@@ -66,7 +66,7 @@ jobs:
     condition: succeededOrFailed()
     inputs:
       targetPath: '$(Build.SourcesDirectory)/TestLogs'
-      artifactName: 'TestLogs'
+      artifactName: 'TestLogs_$(System.JobAttempt)'
       artifactType: 'pipeline'
 
   - task: PublishTestResults@2


### PR DESCRIPTION
Add job attempt # to test log artifact name to avoid this error on a build retry:

`##[error]Artifact TestLogs already exists for build 218830.`