### PR TITLE
Skip chmod on inproc func executable for arm64

### DIFF
--- a/publish-scripts/npm/lib/install.js
+++ b/publish-scripts/npm/lib/install.js
@@ -47,11 +47,14 @@ if (os.platform() === 'win32') {
 
 const fileName = 'Azure.Functions.Cli.' + platform + '.' + version + '.zip';
 const endpoint = 'https://cdn.functions.azure.com/public/' + consolidatedBuildId + '/' + fileName;
+
 console.log('attempting to GET %j', endpoint);
 const options = url.parse(endpoint);
+
 // npm config preceed system environment
 // https://github.com/npm/npm/blob/19397ad523434656af3d3765e80e22d7e6305f48/lib/config/reg-client.js#L7-L8
 // https://github.com/request/request/blob/b12a6245d9acdb1e13c6486d427801e123fdafae/lib/getProxyFromURI.js#L66-L71
+
 const proxy = process.env.npm_config_https_proxy ||
             process.env.npm_config_proxy ||
             process.env.HTTPS_PROXY ||
@@ -103,8 +106,12 @@ https.get(options, response => {
                     if (os.platform() === 'linux' || os.platform() === 'darwin') {
                         fs.chmodSync(`${installPath}/func`, 0o755);
                         fs.chmodSync(`${installPath}/gozip`, 0o755);
-                        fs.chmodSync(`${installPath}/in-proc8/func`, 0o755);
-                        fs.chmodSync(`${installPath}/in-proc6/func`, 0o755);
+
+                        // Skip for arm64 as it is not supported in the preview version
+                        if (os.arch() != 'arm64') {
+                            fs.chmodSync(`${installPath}/in-proc8/func`, 0o755);
+                            fs.chmodSync(`${installPath}/in-proc6/func`, 0o755);
+                        }
                     }
                 });
             });


### PR DESCRIPTION
We are not shipping in-proc dotnet for the linux arm64 preview so we need to skip the chmod commands on the in-proc executables.