### PR TITLE
Python 3.13 support 

### DIFF
--- a/src/Cli/func/Azure.Functions.Cli.csproj
+++ b/src/Cli/func/Azure.Functions.Cli.csproj
@@ -103,6 +103,9 @@
     <EmbeddedResource Include="StaticResources\Dockerfile.python3.12">
       <LogicalName>$(AssemblyName).Dockerfile.python3.12</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="StaticResources\Dockerfile.python3.13">
+      <LogicalName>$(AssemblyName).Dockerfile.python3.13</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="StaticResources\Dockerfile.javascript">
       <LogicalName>$(AssemblyName).Dockerfile.javascript</LogicalName>
     </EmbeddedResource>

--- a/src/Cli/func/Common/Constants.cs
+++ b/src/Cli/func/Common/Constants.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Collections.ObjectModel;
@@ -189,7 +189,6 @@ namespace Azure.Functions.Cli.Common
             public const string LinuxPython311ImageAmd64 = "mcr.microsoft.com/azure-functions/python:4-python3.11-buildenv";
             public const string LinuxPython312ImageAmd64 = "mcr.microsoft.com/azure-functions/python:4-python3.12-buildenv";
             public const string LinuxPython313ImageAmd64 = "mcr.microsoft.com/azure-functions/python:4-python3.13-buildenv";
-
         }
 
         public static class StaticResourcesNames

--- a/src/Cli/func/Common/Constants.cs
+++ b/src/Cli/func/Common/Constants.cs
@@ -188,6 +188,8 @@ namespace Azure.Functions.Cli.Common
             public const string LinuxPython310ImageAmd64 = "mcr.microsoft.com/azure-functions/python:4-python3.10-buildenv";
             public const string LinuxPython311ImageAmd64 = "mcr.microsoft.com/azure-functions/python:4-python3.11-buildenv";
             public const string LinuxPython312ImageAmd64 = "mcr.microsoft.com/azure-functions/python:4-python3.12-buildenv";
+            public const string LinuxPython313ImageAmd64 = "mcr.microsoft.com/azure-functions/python:4-python3.13-buildenv";
+
         }
 
         public static class StaticResourcesNames

--- a/src/Cli/func/Helpers/PythonHelpers.cs
+++ b/src/Cli/func/Helpers/PythonHelpers.cs
@@ -168,7 +168,7 @@ namespace Azure.Functions.Cli.Helpers
         {
             if (pythonVersion?.Version == null)
             {
-                var message = "Could not find a Python version. 3.7.x, 3.8.x, 3.9.x, 3.10.x, 3.11.x or 3.12.x is recommended, and used in Azure Functions.";
+                var message = "Could not find a Python version. 3.9.x, 3.10.x, 3.11.x, 3.12.x or 3.13.x is recommended, and used in Azure Functions.";
                 if (errorIfNoVersion)
                 {
                     throw new CliException(message);
@@ -191,11 +191,11 @@ namespace Azure.Functions.Cli.Helpers
             {
                 if (errorIfNotSupported)
                 {
-                    throw new CliException($"Python 3.7.x to 3.12.x is required for this operation. " +
-                        $"Please install Python 3.7, 3.8, 3.9, 3.10, 3.11 or 3.12 and use a virtual environment to switch to Python 3.7, 3.8, 3.9, 3.10, 3.11 or 3.12.");
+                    throw new CliException($"Python 3.9.x to 3.13.x is required for this operation. " +
+                        $"Please install Python 3.9, 3.10, 3.11, 3.12 or 3.13 and use a virtual environment to switch to Python 3.9, 3.10, 3.11, 3.12 or 3.13.");
                 }
 
-                ColoredConsole.WriteLine(WarningColor("Python  3.7.x, 3.8.x, 3.9.x, 3.10.x, 3.11.x or 3.12.x is recommended, and used in Azure Functions."));
+                ColoredConsole.WriteLine(WarningColor("Python 3.9.x, 3.10.x, 3.11.x, 3.12.x or 3.13.x is recommended, and used in Azure Functions."));
             }
 
             // No Python 3
@@ -238,6 +238,7 @@ namespace Azure.Functions.Cli.Helpers
             var python310GetVersionTask = GetVersion("python3.10");
             var python311GetVersionTask = GetVersion("python3.11");
             var python312GetVersionTask = GetVersion("python3.12");
+            var python313GetVersionTask = GetVersion("python3.13");
 
             var versions = new List<WorkerLanguageVersionInfo>
             {
@@ -250,7 +251,8 @@ namespace Azure.Functions.Cli.Helpers
                 await python39GetVersionTask,
                 await python310GetVersionTask,
                 await python311GetVersionTask,
-                await python312GetVersionTask
+                await python312GetVersionTask,
+                await python313GetVersionTask
             };
 
             // Highest preference -- Go through the list, if we find the first python 3.6 or python 3.7 worker, we prioritize that.
@@ -586,6 +588,8 @@ namespace Azure.Functions.Cli.Helpers
                         return StaticResources.DockerfilePython311;
                     case 12:
                         return StaticResources.DockerfilePython312;
+                    case 13:
+                        return StaticResources.DockerfilePython313;
                 }
             }
 
@@ -612,6 +616,8 @@ namespace Azure.Functions.Cli.Helpers
                         return Constants.DockerImages.LinuxPython311ImageAmd64;
                     case 12:
                         return Constants.DockerImages.LinuxPython312ImageAmd64;
+                    case 13:
+                        return Constants.DockerImages.LinuxPython313ImageAmd64;
                 }
             }
 
@@ -623,7 +629,8 @@ namespace Azure.Functions.Cli.Helpers
             if (info?.Major == 3)
             {
                 switch (info?.Minor)
-                {
+                {   
+                    case 13:
                     case 12:
                     case 11:
                     case 10:
@@ -644,8 +651,8 @@ namespace Azure.Functions.Cli.Helpers
             // No linux fx version will default to python 3.11
             if (string.IsNullOrEmpty(linuxFxVersion))
             {
-                // Match if version is 3.11
-                return major == 3 && minor == 11;
+                // Match if version is 3.12
+                return major == 3 && minor == 12;
             }
 
             // Only validate on LinuxFxVersion that follows the pattern PYTHON|<version>
@@ -662,8 +669,8 @@ namespace Azure.Functions.Cli.Helpers
         {
             if (string.IsNullOrEmpty(flexRuntime) || string.IsNullOrEmpty(flexRuntimeVersion))
             {
-                // Match if version is 3.10
-                return major == 3 && minor == 10;
+                // Match if version is 3.12
+                return major == 3 && minor == 12;
             }
 
             // Only validate for python.

--- a/src/Cli/func/Helpers/PythonHelpers.cs
+++ b/src/Cli/func/Helpers/PythonHelpers.cs
@@ -621,7 +621,7 @@ namespace Azure.Functions.Cli.Helpers
                 }
             }
 
-            return Constants.DockerImages.LinuxPython36ImageAmd64;
+            return Constants.DockerImages.LinuxPython312ImageAmd64;
         }
 
         private static bool IsVersionSupported(WorkerLanguageVersionInfo info)
@@ -629,7 +629,7 @@ namespace Azure.Functions.Cli.Helpers
             if (info?.Major == 3)
             {
                 switch (info?.Minor)
-                {   
+                {
                     case 13:
                     case 12:
                     case 11:
@@ -648,7 +648,7 @@ namespace Azure.Functions.Cli.Helpers
 
         public static bool IsLinuxFxVersionRuntimeVersionMatched(string linuxFxVersion, int? major, int? minor)
         {
-            // No linux fx version will default to python 3.11
+            // No linux fx version will default to python 3.12
             if (string.IsNullOrEmpty(linuxFxVersion))
             {
                 // Match if version is 3.12

--- a/src/Cli/func/StaticResources/Dockerfile.python3.13
+++ b/src/Cli/func/StaticResources/Dockerfile.python3.13
@@ -1,0 +1,11 @@
+# To enable ssh & remote debugging on app service change the base image to the one below
+# FROM mcr.microsoft.com/azure-functions/python:4-python3.13-appservice
+FROM mcr.microsoft.com/azure-functions/python:4-python3.13
+
+ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
+    AzureFunctionsJobHost__Logging__Console__IsEnabled=true
+
+COPY requirements.txt /
+RUN pip install -r /requirements.txt
+
+COPY . /home/site/wwwroot

--- a/src/Cli/func/StaticResources/StaticResources.cs
+++ b/src/Cli/func/StaticResources/StaticResources.cs
@@ -44,6 +44,8 @@ namespace Azure.Functions.Cli
 
         public static Task<string> DockerfilePython312 => GetValue("Dockerfile.python3.12");
 
+        public static Task<string> DockerfilePython313 => GetValue("Dockerfile.python3.13");
+
         public static Task<string> DockerfilePowershell7 => GetValue("Dockerfile.powershell7");
 
         public static Task<string> DockerfilePowershell72 => GetValue("Dockerfile.powershell7.2");

--- a/test/Azure.Functions.Cli.Tests/PythonHelperTests.cs
+++ b/test/Azure.Functions.Cli.Tests/PythonHelperTests.cs
@@ -56,6 +56,7 @@ namespace Azure.Functions.Cli.Tests
         [InlineData("Python|3.10", 3, 10, true)]
         [InlineData("Python|3.11", 3, 11, true)]
         [InlineData("Python|3.12", 3, 12, true)]
+        [InlineData("Python|3.13", 3, 13, true)]
         public void ShouldHaveMatchingLinuxFxVersion(string linuxFxVersion, int? major, int? minor, bool expectedResult)
         {
             bool result = PythonHelpers.IsLinuxFxVersionRuntimeVersionMatched(linuxFxVersion, major, minor);
@@ -75,6 +76,7 @@ namespace Azure.Functions.Cli.Tests
         [InlineData("3.10.0", false)]
         [InlineData("3.11.0", false)]
         [InlineData("3.12.0", false)]
+        [InlineData("3.13.0", false)]
         public void AssertPythonVersion(string pythonVersion, bool expectException)
         {
             WorkerLanguageVersionInfo worker = new WorkerLanguageVersionInfo(WorkerRuntime.Python, pythonVersion, "python");
@@ -96,11 +98,11 @@ namespace Azure.Functions.Cli.Tests
             string[] pythons;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                pythons = new string[] { "python.exe", "python3.exe", "python37.exe", "python38.exe", "python39.exe", "python310.exe", "python311.exe", "python312.exe", "py.exe" };
+                pythons = new string[] { "python.exe", "python3.exe", "python39.exe", "python310.exe", "python311.exe", "python312.exe", "python313.exe", "py.exe" };
             }
             else
             {
-                pythons = new string[] { "python", "python3", "python37", "python38", "python39", "python310", "python311", "python312" };
+                pythons = new string[] { "python", "python3", "python39", "python310", "python311", "python312", "python313" };
             }
 
             string pythonExe = pythons.FirstOrDefault(p => CheckIfPythonExist(p));


### PR DESCRIPTION
<!-- Please provide all the information below.  -->
Supporting python 3.13 for core tools.
Updated warning logs to remove python 3.7 and 3.8. 


### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)