### PR TITLE
Fixing consolidated pipeline to not create MSI for win-arm64

### DIFF
--- a/eng/ci/templates/official/jobs/assemble-artifacts.yml
+++ b/eng/ci/templates/official/jobs/assemble-artifacts.yml
@@ -114,7 +114,7 @@ jobs:
         arguments: '-StagingDirectory "$(Pipeline.Workspace)/staging"'
         workingDirectory: '$(Pipeline.Workspace)'
 
-  - ${{ if startsWith(parameters.arch, 'win') }}:
+  - ${{ if startsWith(parameters.arch, 'win-x') }}:
     - task: PowerShell@2
       displayName: 'Generate MSI files'
       inputs:


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

There was a bug introduced in the last PR which causes the MSI to try to be created for win-arm64, but the task fails and we don't support MSI for that type today.

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)