### PR TITLE
Update versioning logic & move TelemetryInstrumentationKey to its own Constants file

### DIFF
--- a/src/Cli/func/Common/Constants.Build.cs
+++ b/src/Cli/func/Common/Constants.Build.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+namespace Azure.Functions.Cli.Common
+{
+    internal static partial class Constants
+    {
+#if IS_PUBLIC_RELEASE
+        public const string TelemetryInstrumentationKey = "__TELEMETRY_KEY__";
+#else
+        public const string TelemetryInstrumentationKey = "00000000-0000-0000-0000-000000000000";
+#endif
+    }
+}

--- a/src/Cli/func/Common/Constants.cs
+++ b/src/Cli/func/Common/Constants.cs
@@ -2,12 +2,12 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Collections.ObjectModel;
-using System.Reflection;
+using Azure.Functions.Cli.Extensions;
 using Azure.Functions.Cli.Helpers;
 
 namespace Azure.Functions.Cli.Common
 {
-    internal static class Constants
+    internal static partial class Constants
     {
         public const string StorageConnectionStringTemplate = "DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1}";
         public const string FunctionsStorageAccountNamePrefix = "AzureFunctions";
@@ -46,7 +46,6 @@ namespace Azure.Functions.Cli.Common
         public const string FunctionsCoreToolsEnvironment = "FUNCTIONS_CORETOOLS_ENVIRONMENT";
         public const string EnablePersistenceChannelDebugSetting = "FUNCTIONS_CORE_TOOLS_ENABLE_PERSISTENCE_CHANNEL_DEBUG_OUTPUT";
         public const string TelemetryOptOutVariable = "FUNCTIONS_CORE_TOOLS_TELEMETRY_OPTOUT";
-        public const string TelemetryInstrumentationKey = "00000000-0000-0000-0000-000000000000";
         public const string ScmRunFromPackage = "SCM_RUN_FROM_PACKAGE";
         public const string ScmDoBuildDuringDeployment = "SCM_DO_BUILD_DURING_DEPLOYMENT";
         public const string WebsiteRunFromPackage = "WEBSITE_RUN_FROM_PACKAGE";
@@ -120,12 +119,11 @@ namespace Azure.Functions.Cli.Common
             "entityTrigger",
         ];
 
-#pragma warning disable SA1401 // Fields should be private
-        public static string CliDetailedVersion = typeof(Constants).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty;
-        public static string CliUserAgent = $"functions-core-tools/{CliVersion}";
-#pragma warning restore SA1401 // Fields should be private
+        public static string CliVersion => typeof(Constants).Assembly.GetCliVersion();
 
-        public static string CliVersion => typeof(Constants).GetTypeInfo().Assembly.GetName().Version.ToString(3);
+        public static string CliDetailedVersion => typeof(Constants).Assembly.GetInformationalVersion();
+
+        public static string CliUserAgent => $"functions-core-tools/{CliVersion}";
 
         public static ExtensionPackage ExtensionsMetadataGeneratorPackage => new ExtensionPackage { Name = "Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" };
 

--- a/src/Cli/func/Extensions/AssemblyExtensions.cs
+++ b/src/Cli/func/Extensions/AssemblyExtensions.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Reflection;
+
+namespace Azure.Functions.Cli.Extensions
+{
+    internal static class AssemblyExtensions
+    {
+        public static string GetInformationalVersion(this Assembly assembly)
+        {
+            var informationalVersion = assembly
+                .GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false)
+                .OfType<AssemblyInformationalVersionAttribute>()
+                .FirstOrDefault()?.InformationalVersion;
+
+            return informationalVersion ?? string.Empty;
+        }
+
+        public static string GetCliVersion(this Assembly assembly)
+        {
+            // The package version is stamped into the assembly's AssemblyInformationalVersionAttribute at build time, followed by a '+'
+            // and the commit hash, e.g.: "4.0.10000-dev+67bd99a8ce2ec3cf833f25c039f60222caf44573 (64-bit)"
+            var version = assembly.GetInformationalVersion();
+
+            if (version is not null)
+            {
+                var plusIndex = version.IndexOf('+');
+
+                if (plusIndex > 0)
+                {
+                    return version[..plusIndex];
+                }
+
+                return version;
+            }
+
+            // Fallback to the file version, which is based on the CI build number, and then fallback to the assembly version, which is
+            // product stable version, e.g. 4.0.0.0
+            version = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version
+                ?? assembly.GetCustomAttribute<AssemblyVersionAttribute>()?.Version;
+
+            return version;
+        }
+    }
+}

--- a/src/Cli/func/Program.cs
+++ b/src/Cli/func/Program.cs
@@ -11,7 +11,7 @@ namespace Azure.Functions.Cli
 {
     internal class Program
     {
-        private static readonly string[] _versionArgs = new[] { "version", "v" };
+        private static readonly string[] _versionArgs = ["version", "v"];
         private static IContainer _container;
 
         internal static void Main(string[] args)


### PR DESCRIPTION
This PR introduces an AssembleyExtensions.cs file to help us get the CLI version. The `InformationalVersion` looks like this:

- `4.0.10000-dev+67bd99a8ce2ec3cf833f25c039f60222caf44573 (64-bit)`

And the `GetCliVersion` method allows us extract the first part if it i.e. `4.0.10000-dev`

(Note: on release -dev or -ci will not be part of the CLI version)

Second, we convert constants to a partial class so that we can override the value of TelemetryInstrumentationKey as part of the build process.