### PR TITLE
Setup global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,11 @@
+{
+  "sdk": {
+    "version": "9.0.106",
+    "allowPrerelease": true,
+    "rollForward": "latestFeature"
+  },
+  "msbuild-sdks": {
+    "Microsoft.Build.NoTargets": "3.7.56",
+    "Microsoft.Build.Traversal": "4.1.0"
+  }
+}

--- a/src/CoreToolsHost/global.json
+++ b/src/CoreToolsHost/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "9.0.100-rc",
-    "rollForward": "latestMinor"
-  }
-}


### PR DESCRIPTION
There is a known bug with the .NET SDK for v9.0.200+ on osx. Defaulting the repos dotnet version to .106 until that is fixed.

Related issue: https://github.com/Azure/azure-functions-core-tools/issues/4399