### PR TITLE
Fix Typo for tests "Host.json is missing"

### DIFF
--- a/src/Cli/func/Actions/HostActions/StartHostAction.cs
+++ b/src/Cli/func/Actions/HostActions/StartHostAction.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Collections;
@@ -670,7 +670,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
             var hostJsonPath = Path.Combine(Environment.CurrentDirectory, Constants.HostJsonFileName);
             if (isPreCompiledApp && !File.Exists(hostJsonPath))
             {
-                throw new CliException($"Host.json file in missing. Please make sure host.json file is present at {Environment.CurrentDirectory}");
+                throw new CliException($"Host.json file is missing. Please make sure host.json file is present at {Environment.CurrentDirectory}");
             }
 
             // BuildHostJsonConfigutation only if host.json file exists.

--- a/test/Cli/Func.E2E.Tests/Commands/FuncStart/TestsWithFixtures/DotnetInProc6Tests.cs
+++ b/test/Cli/Func.E2E.Tests/Commands/FuncStart/TestsWithFixtures/DotnetInProc6Tests.cs
@@ -194,7 +194,7 @@ namespace Azure.Functions.Cli.E2E.Tests.Commands.FuncStart.TestsWithFixtures
             // We are expecting an exit to happen gracefully here;
             // if func start were to succeed, the user would have to manually kill the process and exit with -1
             result.Should().ExitWith(0);
-            result.Should().HaveStdOutContaining("Host.json file in missing");
+            result.Should().HaveStdOutContaining("Host.json file is missing");
 
             // Clean up temporary directory
             Directory.Delete(tempDir, true);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Fixing typo from "Host.json in missing" to "Host.json is missing" to let tests pass.

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)