### PR TITLE
Adding azure-monitor to requirements.txt file

### DIFF
--- a/src/Cli/func/StaticResources/requirements.txt
+++ b/src/Cli/func/StaticResources/requirements.txt
@@ -1,5 +1,5 @@
-﻿# Do not include azure-functions-worker in this file
-# The Python Worker is managed by the Azure Functions platform
-# Manually managing azure-functions-worker may cause unexpected issues
+﻿# Uncomment to enable Azure Monitor OpenTelemetry
+# Ref: aka.ms/functions-azure-monitor-python 
+# azure-monitor-opentelemetry 
 
 azure-functions

--- a/test/Cli/Func.E2E.Tests/Commands/FuncInit/PythonInitTests.cs
+++ b/test/Cli/Func.E2E.Tests/Commands/FuncInit/PythonInitTests.cs
@@ -25,7 +25,7 @@ namespace Azure.Functions.Cli.E2E.Tests.Commands.FuncInit
             var localSettingsPath = Path.Combine(workingDir, Common.Constants.LocalSettingsJsonFileName);
             var expectedcontent = new[] { Common.Constants.FunctionsWorkerRuntime, "python" };
             var requirementsPath = Path.Combine(workingDir, "requirements.txt");
-            var expectedRequirementsContent = new[] { "# Do not include azure-functions-worker", "azure-functions" };
+            var expectedRequirementsContent = new[] { "# azure-monitor-opentelemetry", "azure-functions" };
 
             var filesToValidate = new List<(string FilePath, string[] ExpectedContent)>
             {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
Adding azure-monitor-opentelemetry to requirements.txt file. 

`func init --python` will create a requirements.txt file with a comment on how to use azure-monitor-opentelemetry.

![image](https://github.com/user-attachments/assets/81e4c607-d605-4197-baa9-9c056405dc27)


resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)