### PR TITLE
Implement file locking mechanism for templates/bundle installation

### DIFF
--- a/src/Cli/func/Actions/LocalActions/CreateFunctionAction.cs
+++ b/src/Cli/func/Actions/LocalActions/CreateFunctionAction.cs
@@ -115,7 +115,8 @@ namespace Azure.Functions.Cli.Actions.LocalActions
 
             await UpdateLanguageAndRuntime();
 
-            if (IsNewPythonProgrammingModel()) // depends on UpdateLanguageAndRuntime to set 'Language'
+            // Depends on UpdateLanguageAndRuntime to set 'Language'
+            if (IsNewPythonProgrammingModel())
             {
                 _newTemplates = await _templatesManager.NewTemplates;
                 _userPrompts = await _templatesManager.UserPrompts;

--- a/src/Cli/func/Actions/LocalActions/CreateFunctionAction.cs
+++ b/src/Cli/func/Actions/LocalActions/CreateFunctionAction.cs
@@ -40,9 +40,9 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             _contextHelpManager = contextHelpManager;
             _initAction = new InitAction(_templatesManager, _secretsManager);
             _userInputHandler = new UserInputHandler(_templatesManager);
-            _templates = new Lazy<IEnumerable<Template>>(() => { return _templatesManager.Templates.Result; });
-            _newTemplates = new Lazy<IEnumerable<NewTemplate>>(() => { return _templatesManager.NewTemplates.Result; });
-            _userPrompts = new Lazy<IEnumerable<UserPrompt>>(() => { return _templatesManager.UserPrompts.Result; });
+            _templates = new Lazy<IEnumerable<Template>>(() => EnsureTemplatesLoaded(tm => tm.Templates, "Templates"));
+            _newTemplates = new Lazy<IEnumerable<NewTemplate>>(() => EnsureTemplatesLoaded(tm => tm.NewTemplates, "New Templates"));
+            _userPrompts = new Lazy<IEnumerable<UserPrompt>>(() => EnsureTemplatesLoaded(tm => tm.UserPrompts, "User Prompts"));
         }
 
         public string Language { get; set; }
@@ -309,12 +309,29 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 else if (!WorkerRuntimeLanguageHelper.IsDotnet(_workerRuntime) || Csx)
                 {
                     var languages = WorkerRuntimeLanguageHelper.LanguagesForWorker(_workerRuntime);
-                    var displayList = _templates.Value
+
+                    // If templates are not loaded yet, we need to check the task status and force it to populate if it hasn't already
+                    if (!_templates.IsValueCreated)
+                    {
+                        ColoredConsole.WriteLine("Templates not loaded yet, checking task status...");
+                        var taskStatus = _templatesManager.Templates.Status;
+                        ColoredConsole.WriteLine($"Templates task status: {taskStatus}");
+
+                        if (taskStatus == TaskStatus.Created)
+                        {
+                            // Task hasn't even started yet
+                            ColoredConsole.WriteLine("Forcing task to start...");
+                            _ = _templatesManager.Templates.Result; // This should force _templates to populate
+                        }
+                    }
+
+                    var displayList = _templates.Value?
                             .Select(t => t.Metadata.Language)
                             .Where(l => languages.Contains(l, StringComparer.OrdinalIgnoreCase))
                             .Distinct(StringComparer.OrdinalIgnoreCase)
                             .ToArray();
-                    if (displayList.Length == 1)
+
+                    if (displayList?.Length == 1)
                     {
                         Language = displayList.First();
                     }
@@ -536,6 +553,26 @@ namespace Azure.Functions.Cli.Actions.LocalActions
         private bool CurrentPathHasLocalSettings()
         {
             return FileSystemHelpers.FileExists(Path.Combine(Environment.CurrentDirectory, "local.settings.json"));
+        }
+
+        private IEnumerable<T> EnsureTemplatesLoaded<T>(Func<ITemplatesManager, Task<IEnumerable<T>>> templateGetter, string templateType)
+        {
+            try
+            {
+                IEnumerable<T> templates = templateGetter(_templatesManager).Result;
+                if (templates == null)
+                {
+                    ColoredConsole.WriteLine(ErrorColor($"{templateType} could not be loaded - returning empty collection"));
+                    return [];
+                }
+
+                return templates;
+            }
+            catch (Exception ex)
+            {
+                ColoredConsole.WriteLine(ErrorColor($"Failed to load {templateType.ToLowerInvariant()}: {ex.Message}"));
+                return [];
+            }
         }
     }
 }

--- a/src/Cli/func/Actions/LocalActions/CreateFunctionAction.cs
+++ b/src/Cli/func/Actions/LocalActions/CreateFunctionAction.cs
@@ -96,16 +96,6 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             return base.ParseArgs(args);
         }
 
-        public async Task InitializeTemplatesAndPrompts()
-        {
-            _templates = await _templatesManager.Templates;
-            if (IsNewPythonProgrammingModel())
-            {
-                _newTemplates = await _templatesManager.NewTemplates;
-                _userPrompts = await _templatesManager.UserPrompts;
-            }
-        }
-
         public override async Task RunAsync()
         {
             // Check if the command only ran for help.
@@ -120,10 +110,16 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 return;
             }
 
-            // Ensure that the templates, new templates, and user prompts are loaded before proceeding.
-            await InitializeTemplatesAndPrompts();
+            // Ensure that the _templates are loaded before we proceed
+            _templates = await _templatesManager.Templates;
 
             await UpdateLanguageAndRuntime();
+
+            if (IsNewPythonProgrammingModel()) // depends on UpdateLanguageAndRuntime to set 'Language'
+            {
+                _newTemplates = await _templatesManager.NewTemplates;
+                _userPrompts = await _templatesManager.UserPrompts;
+            }
 
             if (WorkerRuntimeLanguageHelper.IsDotnet(_workerRuntime) && !Csx)
             {

--- a/src/Cli/func/Actions/LocalActions/CreateFunctionAction.cs
+++ b/src/Cli/func/Actions/LocalActions/CreateFunctionAction.cs
@@ -316,13 +316,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                         ColoredConsole.WriteLine("Templates not loaded yet, checking task status...");
                         var taskStatus = _templatesManager.Templates.Status;
                         ColoredConsole.WriteLine($"Templates task status: {taskStatus}");
-
-                        if (taskStatus == TaskStatus.Created)
-                        {
-                            // Task hasn't even started yet
-                            ColoredConsole.WriteLine("Forcing task to start...");
-                            _ = _templatesManager.Templates.Result; // This should force _templates to populate
-                        }
+                        _ = _templatesManager.Templates.Result; // This should force _templates to populate
                     }
 
                     var displayList = _templates.Value?

--- a/src/Cli/func/Actions/LocalActions/CreateFunctionAction.cs
+++ b/src/Cli/func/Actions/LocalActions/CreateFunctionAction.cs
@@ -316,7 +316,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                         ColoredConsole.WriteLine("Templates not loaded yet, checking task status...");
                         var taskStatus = _templatesManager.Templates.Status;
                         ColoredConsole.WriteLine($"Templates task status: {taskStatus}");
-                        _ = _templatesManager.Templates.Result; // This should force _templates to populate
+                        _ = _templatesManager.Templates.Result; // This should force templates to load in templatesManager
                     }
 
                     var displayList = _templates.Value?

--- a/src/Cli/func/Common/TemplatesManager.cs
+++ b/src/Cli/func/Common/TemplatesManager.cs
@@ -71,7 +71,6 @@ namespace Azure.Functions.Cli.Common
 
             if (extensionBundleManager.IsExtensionBundleConfigured())
             {
-                Console.WriteLine("in extension bundle configured");
                 templatesJson = await FileLockHelper.WithFileLockAsync(BundleTemplatesLockFileName, async () =>
                 {
                     await ExtensionBundleHelper.GetExtensionBundle();

--- a/src/Cli/func/Common/TemplatesManager.cs
+++ b/src/Cli/func/Common/TemplatesManager.cs
@@ -4,6 +4,7 @@
 using System.Reflection;
 using Azure.Functions.Cli.Actions.LocalActions;
 using Azure.Functions.Cli.ExtensionBundle;
+using Azure.Functions.Cli.Helpers;
 using Azure.Functions.Cli.Interfaces;
 using Colors.Net;
 using Newtonsoft.Json;
@@ -12,6 +13,7 @@ namespace Azure.Functions.Cli.Common
 {
     internal class TemplatesManager : ITemplatesManager
     {
+        private const string BundleTemplatesLockFileName = "func_bundle_templates.lock";
         private readonly ISecretsManager _secretsManager;
 
         public TemplatesManager(ISecretsManager secretsManager)
@@ -20,7 +22,7 @@ namespace Azure.Functions.Cli.Common
         }
 
         /// <summary>
-        /// Gets get new templates.
+        /// Gets new (v2) templates.
         /// </summary>
         public Task<IEnumerable<NewTemplate>> NewTemplates
         {
@@ -69,13 +71,22 @@ namespace Azure.Functions.Cli.Common
 
             if (extensionBundleManager.IsExtensionBundleConfigured())
             {
-                await ExtensionBundleHelper.GetExtensionBundle();
-                var contentProvider = ExtensionBundleHelper.GetExtensionBundleContentProvider();
-                templatesJson = await contentProvider.GetTemplates();
+                Console.WriteLine("in extension bundle configured");
+                templatesJson = await FileLockHelper.WithFileLockAsync(BundleTemplatesLockFileName, async () =>
+                {
+                    await ExtensionBundleHelper.GetExtensionBundle();
+                    var contentProvider = ExtensionBundleHelper.GetExtensionBundleContentProvider();
+                    return await contentProvider.GetTemplates();
+                });
             }
             else
             {
                 templatesJson = GetTemplatesJson();
+            }
+
+            if (string.IsNullOrEmpty(templatesJson))
+            {
+                throw new CliException("Templates JSON is empty. Please check the templates location.");
             }
 
             var templates = JsonConvert.DeserializeObject<IEnumerable<Template>>(templatesJson);
@@ -280,6 +291,11 @@ namespace Azure.Functions.Cli.Common
             else
             {
                 templateJson = await GetV2TemplatesJson();
+            }
+
+            if (string.IsNullOrEmpty(templateJson))
+            {
+                throw new CliException("Templates JSON is empty. Please check the templates location.");
             }
 
             return JsonConvert.DeserializeObject<IEnumerable<NewTemplate>>(templateJson);

--- a/src/Cli/func/Helpers/DotnetHelpers.cs
+++ b/src/Cli/func/Helpers/DotnetHelpers.cs
@@ -297,44 +297,30 @@ namespace Azure.Functions.Cli.Helpers
         {
             if (await IsTemplatePackageInstalled(WebJobsTemplateBasePackId))
             {
-                ColoredConsole.WriteLine("WebJobs templates found, uninstalling to avoid conflicts.");
                 await UninstallWebJobsTemplates();
             }
 
             if (await IsTemplatePackageInstalled(IsolatedTemplateBasePackId))
             {
-                ColoredConsole.WriteLine("Isolated templates are already available; skipping installation.");
                 return;
             }
 
-            await FileLockHelper.WithFileLockAsync(TemplatesLockFileName, async () =>
-            {
-                await InstallIsolatedTemplates();
-
-                ColoredConsole.WriteLine("Isolated templates installed successfully.");
-            });
+            await FileLockHelper.WithFileLockAsync(TemplatesLockFileName, InstallIsolatedTemplates);
         }
 
         private static async Task EnsureWebJobsTemplatesInstalled()
         {
             if (await IsTemplatePackageInstalled(IsolatedTemplateBasePackId))
             {
-                ColoredConsole.WriteLine("Isolated templates found, uninstalling to avoid conflicts.");
                 await UninstallIsolatedTemplates();
             }
 
             if (await IsTemplatePackageInstalled(WebJobsTemplateBasePackId))
             {
-                ColoredConsole.WriteLine("WebJobs templates already installed; skipping installation.");
                 return;
             }
 
-            await FileLockHelper.WithFileLockAsync(TemplatesLockFileName, async () =>
-            {
-                await InstallWebJobsTemplates();
-
-                ColoredConsole.WriteLine("WebJobs templates installed successfully.");
-            });
+            await FileLockHelper.WithFileLockAsync(TemplatesLockFileName, InstallWebJobsTemplates);
         }
 
         private static async Task<bool> IsTemplatePackageInstalled(string packageId)

--- a/src/Cli/func/Helpers/FileLockHelper.cs
+++ b/src/Cli/func/Helpers/FileLockHelper.cs
@@ -1,0 +1,52 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Helpers
+{
+    public static class FileLockHelper
+    {
+        private const string DefaultLockFileName = "func.lock";
+        private static readonly string _templatesLockFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".azurefunctions");
+
+        public static async Task<T> WithFileLockAsync<T>(string lockFileName, Func<Task<T>> action)
+        {
+            lockFileName ??= DefaultLockFileName;
+            var lockFile = Path.Combine(_templatesLockFilePath, lockFileName);
+
+            for (int attempt = 0; attempt < 20; attempt++)
+            {
+                FileStream stream = null;
+                try
+                {
+                    stream = new FileStream(
+                        lockFile,
+                        FileMode.OpenOrCreate,
+                        FileAccess.ReadWrite,
+                        FileShare.Delete);
+
+                    return await action();
+                }
+                catch (IOException)
+                {
+                    stream?.Dispose();
+                    await Task.Delay(1000);
+                }
+                finally
+                {
+                    stream?.Dispose();
+                }
+            }
+
+            throw new IOException($"Could not acquire file lock on {lockFile} after multiple attempts.");
+        }
+
+        public static Task WithFileLockAsync(string lockFileName, Func<Task> action)
+        {
+            return WithFileLockAsync(lockFileName, async () =>
+            {
+                await action();
+                return true;
+            });
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #4458

When we run dotnet new func, we are expecting the project and item templates to already be installed since they happen right before that  command for func new and func init. For some reason, when the tests run in parallel, the templateconfig.json somehow gets messed up when we have multiple instances of func new and func init running on the same machine, so it doesn't find the template for func. If we isolate each test so it isn't run in parallel, we don't see this error anymore.

I've come up with a fix where we install web jobs/isolated templates only if we need it, given that the template isn't already installed.

There also is a race condition when running E2E func new tests where `templatesManager.Templates.Result` is not set, so fetching the templates fail. This change adds more logs and forces `templatesManager.Templates.Result` to populate if it hasn't already, since the value is lazily loaded.

 The error message that is shown today to the user is: 

`One or more errors occurred. (Value cannot be null. (Parameter 'value'))`

This error message should still show up but with more logs on what exactly it's doing before, in case this error pops up again.

Example of race condition: https://dev.azure.com/azfunc/public/_build/results?buildId=224520&view=logs&j=da439e82-8265-5962-85f8-172d6600cb6f&t=17f2655d-abad-5398-83c4-ac47d6b8119e&l=162

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)