### PR TITLE
Fix Console Encoding for Proper Display of Non-ASCII Characters for Inproc

### DIFF
--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -145,7 +145,7 @@ namespace Build
                                 $"/p:SkipNet8Child=\"{skipLaunchingNet8ChildProcess}\" " +
                                 $"/p:CommitHash=\"{Settings.CommitId}\" " +
                                 (string.IsNullOrEmpty(Settings.IntegrationBuildNumber) ? string.Empty : $"/p:IntegrationBuildNumber=\"{Settings.IntegrationBuildNumber}\" ") +
-                                $"-o {outputPath} -c Release -f {targetFramework}" +
+                                $"-o {outputPath} -c Release -f {targetFramework}  --self-contained" +
                                 (string.IsNullOrEmpty(rid) ? string.Empty : $" -r {rid}"));
         }
 

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -31,7 +31,7 @@ namespace Build
                 .Then(Test, skip: args.Contains("--codeql"))
                 .Then(GenerateSBOMManifestForZips, skip: !args.Contains("--generateSBOM"))
                 .Then(Zip)
-                .Then(DotnetPublishForNupkg)
+                //.Then(DotnetPublishForNupkg) // DotnetPack step now does build and pack.
                 .Then(GenerateSBOMManifestForNupkg, skip: !args.Contains("--generateSBOM"))
                 .Then(DotnetPack)
                 .Then(DeleteSBOMTelemetryFolder, skip: !args.Contains("--generateSBOM"))

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -19,10 +19,10 @@ namespace Build
                 : value;
         }
 
-        public const string DotnetIsolatedItemTemplatesVersion = "4.0.2945";
-        public const string DotnetIsolatedProjectTemplatesVersion = "4.0.2945";
-        public const string DotnetItemTemplatesVersion = "4.0.2945";
-        public const string DotnetProjectTemplatesVersion = "4.0.2945";
+        public const string DotnetIsolatedItemTemplatesVersion = "4.0.3038";
+        public const string DotnetIsolatedProjectTemplatesVersion = "4.0.3038";
+        public const string DotnetItemTemplatesVersion = "4.0.3038";
+        public const string DotnetProjectTemplatesVersion = "4.0.3038";
         public const string TemplateJsonVersion = "3.1.1648";
 
         public static readonly string SBOMManifestToolPath = Path.GetFullPath("../ManifestTool/Microsoft.ManifestTool.dll");

--- a/build/Shell.cs
+++ b/build/Shell.cs
@@ -25,7 +25,7 @@ namespace Build
 
             if (exitcode != 0)
             {
-                throw new Exception($"{program} Exit Code == {exitcode}");
+                throw new Exception($"{program} {arguments} Exit Code == {exitcode}");
             }
         }
 

--- a/pipelineUtilities.psm1
+++ b/pipelineUtilities.psm1
@@ -67,6 +67,11 @@ $DotnetSDKVersionRequirements = @{
         MinimalPatch = '417'
         DefaultPatch = '417'
     }
+
+    '8.0' = @{
+        MinimalPatch = '204'
+        DefaultPatch = '204'
+    }
 }
 
 function AddLocalDotnetDirPath {

--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -362,7 +362,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                     throw new CliArgumentsException($"Unable to parse target framework {TargetFramework}. Valid options are \"net8.0\", \"net7.0\", \"net6.0\", and \"net48\"");
                 }
             }
-            else if (!string.IsNullOrEmpty(TargetFramework))
+            else if (ResolvedWorkerRuntime != Helpers.WorkerRuntime.dotnet && !string.IsNullOrEmpty(TargetFramework))
             {
                 throw new CliArgumentsException("The --target-framework option is supported only when --worker-runtime is set to dotnet-isolated");
             }

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk" InitialTargets="ExcludeWorkersFromReadyToRun">
+﻿<Project Sdk="Microsoft.NET.Sdk" InitialTargets="ExcludeWorkersFromReadyToRun">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AssemblyName>func</AssemblyName>
     <RuntimeIdentifiers>win-x64;win-x86;win-arm64;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">1</BuildNumber>
@@ -276,13 +276,13 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage.Internal" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="4.34.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="4.834.1" />
     <PackageReference Include="Microsoft.Build" Version="17.0.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.60.3" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.35.0" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NuGet.Packaging" Version="5.11.6" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.35.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.1.2" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.1" />
     <PackageReference Include="YamlDotNet" Version="6.0.0" />
   </ItemGroup>
@@ -299,4 +299,18 @@
       <Output TaskParameter="Include" ItemName="PublishReadyToRunExclude" />
     </CreateItem>
   </Target>
+  <!-- Build/Publish for net8.0 TFM as well-->
+  <Target Name="BuildInProcNet8" AfterTargets="Build" Condition="'$(TargetFramework)'=='net6.0'">
+    <PropertyGroup>
+      <RuntimeIdentifierOption Condition="'$(RuntimeIdentifier)' != ''">-r $(RuntimeIdentifier)</RuntimeIdentifierOption>
+    </PropertyGroup>
+    <Exec Command="dotnet publish -c $(Configuration) -f net8.0 --output $(OutputPath)/in-proc8 $(RuntimeIdentifierOption) -p:NoWorkers=True" />
+  </Target>
+  <Target Name="PublishInProcNet8" AfterTargets="Publish" Condition="'$(TargetFramework)'=='net6.0'">
+    <PropertyGroup>
+      <RuntimeIdentifierOption Condition="'$(RuntimeIdentifier)' != ''">-r $(RuntimeIdentifier)</RuntimeIdentifierOption>
+    </PropertyGroup>
+    <Exec Command="dotnet publish -c $(Configuration) -f net8.0 --output $(PublishDir)/in-proc8 $(RuntimeIdentifierOption) -p:NoWorkers=True" />
+  </Target>
+
 </Project>

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -28,6 +28,12 @@
     <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
     <NuspecFile>Azure.Functions.Cli.nuspec</NuspecFile>
     <NuspecProperties>configuration=$(Configuration);targetFramework=$(TargetFramework);version=$(Version)</NuspecProperties>
+    <CoreToolsTargetRuntime>$(CoreToolsTargetRuntime)</CoreToolsTargetRuntime>
+  </PropertyGroup>
+
+  <!-- SkipNet8Child build property will be True for artifacts used by VS feed -->
+  <PropertyGroup Condition="'$(SkipNet8Child)' == 'True'">
+    <DefineConstants>SkipNet8Child</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'win-x64' OR '$(RuntimeIdentifier)' == 'win-x86'">
     <PublishReadyToRun>false</PublishReadyToRun>
@@ -300,13 +306,13 @@
     </CreateItem>
   </Target>
   <!-- Build/Publish for net8.0 TFM as well-->
-  <Target Name="BuildInProcNet8" AfterTargets="Build" Condition="'$(TargetFramework)'=='net6.0'">
+  <Target Name="BuildInProcNet8" AfterTargets="Build" Condition="'$(TargetFramework)'=='net6.0' AND '$(SkipNet8Child)'!='True'">
     <PropertyGroup>
       <RuntimeIdentifierOption Condition="'$(RuntimeIdentifier)' != ''">-r $(RuntimeIdentifier)</RuntimeIdentifierOption>
     </PropertyGroup>
     <Exec Command="dotnet publish -c $(Configuration) -f net8.0 --output $(OutputPath)/in-proc8 $(RuntimeIdentifierOption) -p:NoWorkers=True" />
   </Target>
-  <Target Name="PublishInProcNet8" AfterTargets="Publish" Condition="'$(TargetFramework)'=='net6.0'">
+  <Target Name="PublishInProcNet8" AfterTargets="Publish" Condition="'$(TargetFramework)'=='net6.0' AND '$(SkipNet8Child)'!='True'">
     <PropertyGroup>
       <RuntimeIdentifierOption Condition="'$(RuntimeIdentifier)' != ''">-r $(RuntimeIdentifier)</RuntimeIdentifierOption>
     </PropertyGroup>

--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -91,7 +91,7 @@ namespace Azure.Functions.Cli.Common
         public const string LocalSettingsJsonFileName = "local.settings.json";
         public const string EnableWorkerIndexEnvironmentVariableName = "FunctionsHostingConfig__WORKER_INDEXING_ENABLED";
         public const string Dotnet = "dotnet";
-
+        public const string FunctionsInProcNet8Enabled = "FUNCTIONS_INPROC_NET8_ENABLED";
 
 
         public static string CliVersion => typeof(Constants).GetTypeInfo().Assembly.GetName().Version.ToString(3);

--- a/src/Azure.Functions.Cli/Common/ProcessManager.cs
+++ b/src/Azure.Functions.Cli/Common/ProcessManager.cs
@@ -7,6 +7,7 @@ namespace Azure.Functions.Cli.Common
 {
     internal class ProcessManager : IProcessManager
     {
+        private IList<Process> _childProcesses;
         public IProcessInfo GetCurrentProcess()
         {
             return new ProcessInfo(Process.GetCurrentProcess());
@@ -21,6 +22,36 @@ namespace Azure.Functions.Cli.Common
         {
             return Process.GetProcessesByName(processName)
                 .Select(p => new ProcessInfo(p));
+        }
+
+        public void KillChildProcesses()
+        {
+            if (_childProcesses == null)
+            {
+                return;
+            }
+
+            foreach (var childProcess in _childProcesses)
+            {
+                if (!childProcess.HasExited)
+                {
+                    childProcess.Kill();
+                }
+            }
+        }
+
+        public bool RegisterChildProcess(Process childProcess)
+        {
+            _childProcesses ??= new List<Process>();
+
+            // be graceful if someone calls this method with the same process multiple times.
+            if (_childProcesses.Any(p=>p.Id == childProcess.Id))
+            {
+                return false;
+            }
+
+            _childProcesses.Add(childProcess);
+            return true;
         }
     }
 }

--- a/src/Azure.Functions.Cli/Helpers/GlobalCoreToolsSettings.cs
+++ b/src/Azure.Functions.Cli/Helpers/GlobalCoreToolsSettings.cs
@@ -11,6 +11,12 @@ namespace Azure.Functions.Cli.Helpers
     {
         private static WorkerRuntime _currentWorkerRuntime;
         public static ProgrammingModel? CurrentProgrammingModel { get; set; }
+
+        /// <summary>
+        /// Gets the root path of the function app from where the func exe was invoked.
+        /// </summary>
+        public static string? FunctionAppRootPath { get; private set; }
+
         public static WorkerRuntime CurrentWorkerRuntime
         {
             get
@@ -37,6 +43,8 @@ namespace Azure.Functions.Cli.Helpers
         {
             try
             {
+                FunctionAppRootPath = Environment.CurrentDirectory;
+
                 if (args.Contains("--csharp"))
                 {
                     _currentWorkerRuntime = WorkerRuntime.dotnet;

--- a/src/Azure.Functions.Cli/Interfaces/IProcessManager.cs
+++ b/src/Azure.Functions.Cli/Interfaces/IProcessManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Azure.Functions.Cli.Interfaces
 {
@@ -7,5 +8,15 @@ namespace Azure.Functions.Cli.Interfaces
         IEnumerable<IProcessInfo> GetProcessesByName(string processName);
         IProcessInfo GetCurrentProcess();
         IProcessInfo GetProcessById(int processId);
+
+        /// <summary>
+        /// Register a child process spawned by the current process.
+        /// </summary>
+        /// <param name="childProcess"></param>
+        /// <returns>True if the process was registered, else False.</returns>
+        bool RegisterChildProcess(Process childProcess);
+
+        // Kill all child processes spawned by the current process.
+        void KillChildProcesses();
     }
 }

--- a/src/Azure.Functions.Cli/Program.cs
+++ b/src/Azure.Functions.Cli/Program.cs
@@ -1,23 +1,30 @@
 ﻿using System;
 using System.Linq;
 using Autofac;
-using Colors.Net;
-using Azure.Functions.Cli.Arm;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Helpers;
 using Azure.Functions.Cli.Interfaces;
-using static Azure.Functions.Cli.Common.OutputTheme;
 
 namespace Azure.Functions.Cli
 {
     internal class Program
     {
+        static IContainer _container;
         internal static void Main(string[] args)
         {
             FirstTimeCliExperience();
             SetupGlobalExceptionHandler();
             SetCoreToolsEnvironmentVariables(args);
-            ConsoleApp.Run<Program>(args, InitializeAutofacContainer());
+            _container = InitializeAutofacContainer();
+            AppDomain.CurrentDomain.ProcessExit += CurrentDomain_ProcessExit;
+
+            ConsoleApp.Run<Program>(args, _container);
+        }
+
+        private static void CurrentDomain_ProcessExit(object sender, EventArgs e)
+        {
+            var processManager = _container.Resolve<IProcessManager>();
+            processManager?.KillChildProcesses();
         }
 
         private static void SetupGlobalExceptionHandler()

--- a/src/Azure.Functions.Cli/Program.cs
+++ b/src/Azure.Functions.Cli/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Text;
 using Autofac;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Helpers;
@@ -12,6 +13,9 @@ namespace Azure.Functions.Cli
         static IContainer _container;
         internal static void Main(string[] args)
         {
+            // Set console encoding to UTF-8 to properly display international characters
+            Console.OutputEncoding = Encoding.UTF8;
+
             FirstTimeCliExperience();
             SetupGlobalExceptionHandler();
             SetCoreToolsEnvironmentVariables(args);


### PR DESCRIPTION
### Issue describing the changes in this PR
Azure Functions Core Tools was not correctly displaying non-ASCII characters in console output. Japanese characters (and other non-Latin scripts) were showing as question marks (?????) when logging from a function.

Root Cause
The console output encoding was not explicitly set to UTF-8 at application startup, causing the console to use the default encoding of the system, which often doesn't support the full range of Unicode characters.

Solution
Added a single line at the start of the application to configure the console output encoding to UTF-8:

Console.OutputEncoding = Encoding.UTF8;
This ensures that all Unicode characters, including Japanese and other non-Latin scripts, are properly displayed in the console when running functions locally.
![feature_inproc](https://github.com/user-attachments/assets/5bd99b0a-ebf5-4ce1-87b1-1ff5826b0d18)

Partially resolves #4429

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)