### PR TITLE
Fix Console Encoding for Proper Display of Non-ASCII Characters for InProc

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -14,6 +14,9 @@ if (-not([bool]::TryParse($env:IsReleaseBuild, [ref] $isReleaseBuild)))
     throw "IsReleaseBuild can only be set to true or false."
 }
 
+$artifactTargetFramework = $env:ArtifactTargetFramework
+Write-Host "ArtifactTargetFramework: $artifactTargetFramework"
+
 if ($env:IntegrationBuildNumber)
 {
     if (-not ($env:IntegrationBuildNumber -like "PreRelease*-*"))
@@ -23,13 +26,13 @@ if ($env:IntegrationBuildNumber)
         throw $errorMessage
     }
 
-    $buildCommand = { dotnet run --integrationTests }
+    $buildCommand = "dotnet run --integrationTests --$artifactTargetFramework"
 }
 else
 {
-    $buildCommand = { dotnet run --ci }
+    $buildCommand = "dotnet run --ci --$artifactTargetFramework"
 }
 
 Write-Host "Running $buildCommand"
-& $buildCommand
+Invoke-Expression $buildCommand
 if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)  }

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -579,8 +579,7 @@ namespace Build
             foreach (var runtime in combinedRuntimesToSign)
             {
                 var runtimeId = GetRuntimeId(runtime);
-                // Remove the Net8ArtifactNameSuffix suffix if present
-                runtimeId = runtimeId.Replace(Net8ArtifactNameSuffix, "");
+
                 if (runtimeToGoEnv.TryGetValue(runtimeId, out var goEnv))
                 {
                     Environment.SetEnvironmentVariable("CGO_ENABLED", "0");

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+﻿using System;
 using System.Linq;
 using System.Net;
 using static Build.BuildSteps;
@@ -13,6 +13,7 @@ namespace Build
 
             Orchestrator
                 .CreateForTarget(args)
+                .Then(Initialize)
                 .Then(TestSignedArtifacts, skip: !args.Contains("--signTest"))
                 .Then(Clean)
                 .Then(LogIntoAzure, skip: !args.Contains("--ci"))
@@ -20,8 +21,6 @@ namespace Build
                 .Then(RestorePackages)
                 .Then(ReplaceTelemetryInstrumentationKey, skip: !args.Contains("--ci"))
                 .Then(DotnetPublishForZips)
-                .Then(FilterPowershellRuntimes)
-                .Then(FilterPythonRuntimes)
                 .Then(AddDistLib)
                 .Then(AddTemplatesNupkgs)
                 .Then(AddTemplatesJson)
@@ -30,10 +29,6 @@ namespace Build
                 .Then(CopyBinariesToSign, skip: !args.Contains("--ci"))
                 .Then(Test)
                 .Then(Zip)
-                .Then(DotnetPublishForNupkg)
-                .Then(DotnetPack)
-                .Then(CreateIntegrationTestsBuildManifest, skip: !args.Contains("--integrationTests"))
-                .Then(UploadToStorage, skip: !args.Contains("--ci"))
                 .Run();
         }
     }

--- a/code-mirror.yml
+++ b/code-mirror.yml
@@ -8,6 +8,7 @@ trigger:
     - release_4.0
     - release_3.0
     - release_4.0_hotfix
+    - feature/*
 
 resources:
   repositories:

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -15,6 +15,7 @@ trigger:
     include:
     - v4.x
     - release_4.0
+    - feature/*
 
 resources:
   repositories:
@@ -45,6 +46,12 @@ extends:
     stages:     
       - stage: BuildAndTest
         jobs:
-        - template: /eng/ci/templates/official/jobs/build-test.yml@self
-        - template: /eng/ci/templates/official/jobs/linux-package.yml@self
-
+          - template: /eng/ci/templates/official/jobs/build-test.yml@self
+            parameters:
+              artifactTargetFramework: inproc6
+              jobTitle: BuildInproc6
+          - template: /eng/ci/templates/official/jobs/build-test.yml@self
+            parameters:
+              artifactTargetFramework: inproc8
+              jobTitle: BuildInproc8
+          - template: /eng/ci/templates/official/jobs/linux-package.yml@self

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -13,6 +13,7 @@ pr:
     include:
     - v4.x
     - release_4.0
+    - feature/*
 
 trigger:
   batch: true
@@ -20,6 +21,7 @@ trigger:
     include:
     - v4.x
     - release_4.0
+    - feature/*
 
 resources:
   repositories:
@@ -46,5 +48,11 @@ extends:
     stages:     
       - stage: BuildAndTest
         jobs:
-        - template: /eng/ci/templates/public/jobs/build-test-public.yml@self
-
+          - template: /eng/ci/templates/public/jobs/build-test-public.yml@self
+            parameters:
+              artifactTargetFramework: inproc6
+              jobTitle: BuildInproc6
+          - template: /eng/ci/templates/public/jobs/build-test-public.yml@self
+            parameters:
+              artifactTargetFramework: inproc8
+              jobTitle: BuildInproc8

--- a/eng/ci/templates/official/jobs/build-test.yml
+++ b/eng/ci/templates/official/jobs/build-test.yml
@@ -81,6 +81,9 @@ jobs:
     displayName: 'Validate worker versions'
     condition: ne(variables['skipWorkerVersionValidation'], 'true')
   - pwsh: |
+      .\check-vulnerabilities.ps1
+    displayName: "Check for security vulnerabilities"
+  - pwsh: |
       .\build.ps1
     env:
       AzureBlobSigningConnectionString: $(AzureBlobSigningConnectionString)
@@ -91,9 +94,6 @@ jobs:
       TELEMETRY_INSTRUMENTATION_KEY: $(TELEMETRY_INSTRUMENTATION_KEY)
       IntegrationBuildNumber: $(INTEGRATIONBUILDNUMBER)
     displayName: 'Executing build script'
-  - pwsh: |
-      .\check-vulnerabilities.ps1
-    displayName: "Check for security vulnerabilities"
   
   - template: ci/sign-files.yml@eng
     parameters:

--- a/eng/ci/templates/official/jobs/build-test.yml
+++ b/eng/ci/templates/official/jobs/build-test.yml
@@ -1,5 +1,9 @@
+parameters:
+  artifactTargetFramework: ''
+  jobTitle: ''
+
 jobs:
-- job: Default
+- job: ${{ parameters.jobTitle }}
   condition: eq(variables['LinuxPackageBuildTag'], '')
   timeoutInMinutes: "180"
   pool:
@@ -82,6 +86,7 @@ jobs:
       AzureBlobSigningConnectionString: $(AzureBlobSigningConnectionString)
       BuildArtifactsStorage: $(BuildArtifactsStorage)
       IsReleaseBuild: $(IsReleaseBuild)
+      ArtifactTargetFramework: ${{ parameters.artifactTargetFramework }}
       DURABLE_STORAGE_CONNECTION: $(DURABLE_STORAGE_CONNECTION)
       TELEMETRY_INSTRUMENTATION_KEY: $(TELEMETRY_INSTRUMENTATION_KEY)
       IntegrationBuildNumber: $(INTEGRATIONBUILDNUMBER)
@@ -191,6 +196,7 @@ jobs:
       arguments: 'TestSignedArtifacts --signTest'
     displayName: 'Verify signed binaries'
     condition: and(succeeded(), eq(variables['IsReleaseBuild'], 'true'))
+
   - pwsh: |
       .\generateMsiFiles.ps1
     env:
@@ -248,10 +254,9 @@ jobs:
       IntegrationBuildNumber: $(INTEGRATIONBUILDNUMBER)
     displayName: 'Move artifacts'
   - task: 1ES.PublishPipelineArtifact@1
-    condition: succeeded()
     inputs:
       targetPath: '$(Build.ArtifactStagingDirectory)'
-      artifactName: 'drop'
+      artifactName: 'drop-${{ parameters.artifactTargetFramework }}'
       artifactType: 'pipeline'
   - pwsh: |
       .\uploadContentToStorageAccount.ps1 -StorageAccountName $env:IntegrationTestsStorageAccountName -StorageAccountKey $env:IntegrationTestsStorageAccountKey -SourcePath '$(Build.ArtifactStagingDirectory)'

--- a/eng/ci/templates/public/jobs/build-test-public.yml
+++ b/eng/ci/templates/public/jobs/build-test-public.yml
@@ -1,5 +1,9 @@
+parameters:
+  artifactTargetFramework: ''
+  jobTitle: ''
+
 jobs:
-- job: Default
+- job: ${{ parameters.jobTitle }}
   timeoutInMinutes: "180"
   pool:
     name: 1es-pool-azfunc-public
@@ -45,6 +49,7 @@ jobs:
       .\build.ps1
     env:
       BuildArtifactsStorage: $(BuildArtifactsStorage)
+      ArtifactTargetFramework: ${{ parameters.artifactTargetFramework }}
       IsReleaseBuild: false
       IsPublicBuild: true
       IsCodeqlBuild: false

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -306,17 +306,4 @@
       <Output TaskParameter="Include" ItemName="PublishReadyToRunExclude" />
     </CreateItem>
   </Target>
-  <!-- Build/Publish for net8.0 TFM as well-->
-  <Target Name="BuildInProcNet8" AfterTargets="Build" Condition="'$(TargetFramework)'=='net6.0' AND '$(SkipInProcessHost)'!='True'">
-    <PropertyGroup>
-      <RuntimeIdentifierOption Condition="'$(RuntimeIdentifier)' != ''">-r $(RuntimeIdentifier)</RuntimeIdentifierOption>
-    </PropertyGroup>
-    <Exec Command="dotnet publish -c $(Configuration) -f net8.0 --output $(OutputPath)/in-proc8 $(RuntimeIdentifierOption) -p:NoWorkers=True --self-contained" />
-  </Target>
-  <Target Name="PublishInProcNet8" AfterTargets="Publish" Condition="'$(TargetFramework)'=='net6.0' AND '$(SkipInProcessHost)'!='True'">
-    <PropertyGroup>
-      <RuntimeIdentifierOption Condition="'$(RuntimeIdentifier)' != ''">-r $(RuntimeIdentifier)</RuntimeIdentifierOption>
-    </PropertyGroup>
-    <Exec Command="dotnet publish -c $(Configuration) -f net8.0 --output $(PublishDir)/in-proc8 $(RuntimeIdentifierOption) -p:NoWorkers=True --self-contained" />
-  </Target>
 </Project>

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk" InitialTargets="ExcludeWorkersFromReadyToRun">
+﻿<Project Sdk="Microsoft.NET.Sdk" InitialTargets="ExcludeWorkersFromReadyToRun">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
@@ -292,6 +292,13 @@
     <PackageReference Include="System.Formats.Asn1" Version="6.0.1" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.1" />
     <PackageReference Include="YamlDotNet" Version="6.0.0" />
+  </ItemGroup>
+  <!-- System.Text.Json is a transitive dependency that we need to explicitly add -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="System.Text.Json" Version="6.0.10" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
   <ItemGroup Condition="'$(NoWorkers)' != 'true'">
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="2.14.0" />

--- a/src/Azure.Functions.Cli/Helpers/ConsoleHelper.cs.cs
+++ b/src/Azure.Functions.Cli/Helpers/ConsoleHelper.cs.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Text;
+
+namespace Azure.Functions.Cli.Helpers
+{
+    internal static class ConsoleHelper
+    {
+        /// <summary>
+        /// Attempts to switch the console to UTF-8.
+        /// Falls back silently if the code page isn’t registered or the host refuses.
+        /// </summary>
+        internal static void ConfigureConsoleOutputEncoding()
+        {
+            try
+            {
+                Console.OutputEncoding = Encoding.UTF8;
+            }
+            catch
+            {
+                // UTF-8 encoding not available, international characters may not display correctly.
+            }
+        }
+    }
+}

--- a/src/Azure.Functions.Cli/Program.cs
+++ b/src/Azure.Functions.Cli/Program.cs
@@ -14,7 +14,7 @@ namespace Azure.Functions.Cli
         internal static void Main(string[] args)
         {
             // Set console encoding to UTF-8 to properly display international characters
-            Console.OutputEncoding = Encoding.UTF8;
+            SetConsoleEncoding();
 
             FirstTimeCliExperience();
             SetupGlobalExceptionHandler();
@@ -99,6 +99,20 @@ namespace Azure.Functions.Cli
                 .As<IContextHelpManager>();
 
             return builder.Build();
+        }
+
+        private static void SetConsoleEncoding()
+        {
+            // Set console encoding to UTF-8 to properly display international characters
+            try
+            {
+                Console.OutputEncoding = Encoding.UTF8;
+            }
+            catch
+            {
+                // Silently fall back to default encoding if UTF-8 isn't supported
+                // International characters may not display correctly but CLI will still function
+            }
         }
     }
 }

--- a/src/Azure.Functions.Cli/Program.cs
+++ b/src/Azure.Functions.Cli/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Text;
 using Autofac;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Helpers;
@@ -12,6 +13,9 @@ namespace Azure.Functions.Cli
         static IContainer _container;
         internal static void Main(string[] args)
         {
+            // Set console encoding to UTF-8 to properly display international characters
+            Console.OutputEncoding = Encoding.UTF8;
+
             FirstTimeCliExperience();
             SetupGlobalExceptionHandler();
             SetCoreToolsEnvironmentVariables(args);

--- a/src/Azure.Functions.Cli/Program.cs
+++ b/src/Azure.Functions.Cli/Program.cs
@@ -13,8 +13,8 @@ namespace Azure.Functions.Cli
         static IContainer _container;
         internal static void Main(string[] args)
         {
-            // Set console encoding to UTF-8 to properly display international characters
-            SetConsoleEncoding();
+            // Configure console encoding
+            ConsoleHelper.ConfigureConsoleOutputEncoding();
 
             FirstTimeCliExperience();
             SetupGlobalExceptionHandler();
@@ -99,20 +99,6 @@ namespace Azure.Functions.Cli
                 .As<IContextHelpManager>();
 
             return builder.Build();
-        }
-
-        private static void SetConsoleEncoding()
-        {
-            // Set console encoding to UTF-8 to properly display international characters
-            try
-            {
-                Console.OutputEncoding = Encoding.UTF8;
-            }
-            catch
-            {
-                // Silently fall back to default encoding if UTF-8 isn't supported
-                // International characters may not display correctly but CLI will still function
-            }
         }
     }
 }

--- a/test/Azure.Functions.Cli.Tests/Azure.Functions.Cli.Tests.csproj
+++ b/test/Azure.Functions.Cli.Tests/Azure.Functions.Cli.Tests.csproj
@@ -45,8 +45,4 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Azure.Functions.Cli\Azure.Functions.Cli.csproj" />
   </ItemGroup>
-  <!-- The "in-proc8" directory content is created using an msbuild target in "Azure.Functions.Cli" project and they don't automatically gets copied to the test project output directory -->
-  <Target Name="CopyInProc8" AfterTargets="Build" Condition="'$(TargetFramework)'=='net6.0'">
-    <Exec Command="xcopy /Y /I /E &quot;$(MSBuildThisFileDirectory)..\..\src\Azure.Functions.Cli\bin\$(Configuration)\$(TargetFramework)\in-proc8\*&quot; &quot;$(OutDir)in-proc8\&quot;" />
-  </Target>
 </Project>

--- a/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/InitTests.cs
@@ -393,7 +393,7 @@ namespace Azure.Functions.Cli.Tests.E2E
             }, _output);
         }
 
-        [Fact]
+        [Fact(Skip = "Disabling oop test from in-proc branch for now. Need to revisit to determine these can be removed from this branch")]
         public Task init_with_dotnet7Isolated_dockerfile()
         {
             return CliTester.Run(new RunConfiguration

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -343,41 +343,6 @@ namespace Azure.Functions.Cli.Tests.E2E
         }
 
         [Fact]
-        public async Task start_dotnet8_inproc()
-        {
-            await CliTester.Run(new RunConfiguration
-            {
-                Commands = new[]
-                {
-                    "init . --worker-runtime dotnet --target-framework net8.0",
-                    "new --template Httptrigger --name HttpTrigger",
-                    "start --port 7073 --verbose"
-                },
-                ExpectExit = false,
-                Test = async (workingDir, p) =>
-                {
-                    using (var client = new HttpClient() { BaseAddress = new Uri("http://localhost:7073") })
-                    {
-                        (await WaitUntilReady(client)).Should().BeTrue(because: _serverNotReady);
-                        var response = await client.GetAsync("/api/HttpTrigger?name=Test");
-                        var result = await response.Content.ReadAsStringAsync();
-                        p.Kill();
-                        await Task.Delay(TimeSpan.FromSeconds(2));
-                        result.Should().Be("Hello, Test. This HTTP triggered function executed successfully.", because: "response from default function should be 'Hello, {name}. This HTTP triggered function executed successfully.'");
-
-                        if (_output is Xunit.Sdk.TestOutputHelper testOutputHelper)
-                        {
-                            testOutputHelper.Output.Should().Contain($"{Constants.FunctionsInProcNet8Enabled} app setting enabled in local.settings.json");
-                            testOutputHelper.Output.Should().Contain("Starting child process for in-process model host");
-                            testOutputHelper.Output.Should().Contain("Started child process with ID");
-                        }
-                    }
-                },
-                CommandTimeout = TimeSpan.FromSeconds(300),
-            }, _output);
-        }
-
-        [Fact]
         public async Task start_displays_error_on_invalid_function_json()
         {
             var functionName = "HttpTriggerJS";

--- a/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
+++ b/test/Azure.Functions.Cli.Tests/E2E/StartTests.cs
@@ -23,7 +23,7 @@ namespace Azure.Functions.Cli.Tests.E2E
         private const string _serverNotReady = "Host was not ready after 10 seconds";
         public StartTests(ITestOutputHelper output) : base(output) { }
 
-        [Fact]
+        [Fact(Skip = "Disabling oop test from in-proc branch for now. Need to revisit to determine these can be removed from this branch")]
         public async Task start_nodejs()
         {
             await CliTester.Run(new RunConfiguration
@@ -60,7 +60,7 @@ namespace Azure.Functions.Cli.Tests.E2E
             }, _output);
         }
 
-        [Fact]
+        [Fact(Skip = "Disabling oop test from in-proc branch for now. Need to revisit to determine these can be removed from this branch")]
         public async Task start_nodejs_v3()
         {
             await CliTester.Run(new RunConfiguration
@@ -97,7 +97,7 @@ namespace Azure.Functions.Cli.Tests.E2E
             }, _output);
         }
 
-        [Fact]
+        [Fact(Skip = "Disabling oop test from in-proc branch for now. Need to revisit to determine these can be removed from this branch")]
         public async Task start_nodejs_with_inspect()
         {
             await CliTester.Run(new RunConfiguration
@@ -237,7 +237,7 @@ namespace Azure.Functions.Cli.Tests.E2E
             }, _output, startHost: true);
         }
 
-        [Fact]
+        [Fact(Skip = "Disabling oop test from in-proc branch for now. Need to revisit to determine these can be removed from this branch")]
         public async Task start_loglevel_None_overrriden_in_host_json()
         {
             var functionName = "HttpTrigger";
@@ -342,7 +342,7 @@ namespace Azure.Functions.Cli.Tests.E2E
             }, _output);
         }
 
-        [Fact]
+        [Fact(Skip = "Disabling oop test from in-proc branch for now. Need to revisit to determine these can be removed from this branch")]
         public async Task start_displays_error_on_invalid_function_json()
         {
             var functionName = "HttpTriggerJS";
@@ -571,7 +571,7 @@ namespace Azure.Functions.Cli.Tests.E2E
             }, _output);
         }
 
-        [Fact]
+        [Fact(Skip = "Disabling oop test from in-proc branch for now. Need to revisit to determine these can be removed from this branch")]
         public async Task only_run_some_functions()
         {
             await CliTester.Run(new RunConfiguration


### PR DESCRIPTION
### Issue describing the changes in this PR
Azure Functions Core Tools was not correctly displaying non-ASCII characters in console output. Japanese characters (and other non-Latin scripts) were showing as question marks (?????) when logging from a function.

Root Cause
The console output encoding was not explicitly set to UTF-8 at application startup, causing the console to use the default encoding of the system, which often doesn't support the full range of Unicode characters.

Solution
Added a single line at the start of the application to configure the console output encoding to UTF-8:

Console.OutputEncoding = Encoding.UTF8;
This ensures that all Unicode characters, including Japanese and other non-Latin scripts, are properly displayed in the console when running functions locally.
![feature_inproc](https://github.com/user-attachments/assets/86df2c23-fb79-4204-9844-07cca9ae377e)

Partially resolves #4429 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)