### PR TITLE
Add exception details if publishing function app has an error with host status

### DIFF
--- a/src/Cli/func/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Cli/func/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -853,9 +853,9 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                     {
                         await AzureHelper.CheckFunctionHostStatusForFlex(functionApp, AccessToken, ManagementURL);
                     }
-                    catch (Exception)
+                    catch (Exception ex)
                     {
-                        throw new CliException("Deployment was successful but the app appears to be unhealthy, please check the app logs.");
+                        throw new CliException("Deployment was successful but the app appears to be unhealthy, please check the app logs.", ex);
                     }
 
                     ColoredConsole.WriteLine(VerboseColor(GetLogMessage("The deployment was successful!")));


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

As per [this teams thread](https://teams.microsoft.com/l/message/19:Bnp6k3byWyjErBrl4ZPm8YM1MUxEEYasnnv1DwPFX3E1@thread.tacv2/1751901676838?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=201c2bb2-812d-4986-ac92-9bfad0d6cc59&parentMessageId=1751373684116&teamName=Azure%20Functions%20Team&channelName=%5BInternal%5DAzure%20Functions%20Cognite%20Support&createdTime=1751901676838&ngc=true&allowXTenantAccess=true), adding more logs for what the exception is in the use case where the function app deploys successfully but has an error when trying to check the host status of it.

> The main problem as I see it is this exception handling will mask the underlaying error. I.e we have no clue if it times out after 15 retries checking status code of function app, or if there are some policies in the customer tenant that disallows this call. Every possible error is masked by "Deployment was successful but the app appears to be unhealthy, please check the app logs.".

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)