### PR TITLE
Fix SCA warnings

### DIFF
--- a/eng/ci/code-mirror.yml
+++ b/eng/ci/code-mirror.yml
@@ -20,6 +20,8 @@ resources:
 
 variables:
   - template: ci/variables/cfs.yml@eng
+  - name: DisableKubernetesDeploymentDetector
+    value: true
 
 extends:
   template: ci/code-mirror.yml@eng

--- a/eng/ci/consolidate-artifacts-build.yml
+++ b/eng/ci/consolidate-artifacts-build.yml
@@ -47,6 +47,8 @@ resources:
 
 variables:
 - template: /ci/variables/cfs.yml@eng
+- name: DisableKubernetesDeploymentDetector
+  value: true
 - name: supportedRuntimes
   value: 'linux-x64,osx-x64,osx-arm64,win-arm64,win-x64,win-x86,min.win-arm64,min.win-x86,min.win-x64'
 

--- a/eng/ci/host-artifacts-build.yml
+++ b/eng/ci/host-artifacts-build.yml
@@ -29,6 +29,8 @@ resources:
 
 variables:
   - template: /ci/variables/cfs.yml@eng
+  - name: DisableKubernetesDeploymentDetector
+    value: true
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1es

--- a/eng/ci/linux-artifacts-build.yml
+++ b/eng/ci/linux-artifacts-build.yml
@@ -22,6 +22,8 @@ resources:
 
 variables:
   - template: /ci/variables/cfs.yml@eng
+  - name: DisableKubernetesDeploymentDetector
+    value: true
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1es

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -29,6 +29,8 @@ resources:
 
 variables:
   - template: /ci/variables/cfs.yml@eng
+  - name: DisableKubernetesDeploymentDetector
+    value: true
   - name: supportedRuntimes
     value: 'linux-x64,osx-x64,osx-arm64,win-arm64,win-x64,win-x86,min.win-arm64,min.win-x86,min.win-x64'
 

--- a/src/Cli/func/StaticResources/Dockerfile.custom
+++ b/src/Cli/func/StaticResources/Dockerfile.custom
@@ -1,4 +1,5 @@
-# FROM mcr.microsoft.com/azure-functions/dotnet:4-appservice 
+# DisableDockerDetector "Base docker file that is consumed by the other Dockerfiles in this directory. It is not intended to be used directly."
+# FROM mcr.microsoft.com/azure-functions/dotnet:4-appservice
 FROM mcr.microsoft.com/azure-functions/dotnet:4
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Fixes SCA warnings in our official CI pipelines.

**Docker**: Ignoring base file as it is technically compliant but the detector cannot detect the dependencies between multiple Dockerfiles, giving us a false positive.

**Kubernetes**: Disabling as the only kubernetes definitons we have are sample static templates for users to customize - they are non-prod and do not need to be scanned. 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)