### PR TITLE
Fix Console Encoding for Proper Display of Non-ASCII Characters for out of proc

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -9,3 +9,5 @@
 
 - Add exception details to error message during `func publish` (#4503)
 - Chocolatey: Update default installation to x64 (#4506)
+- Add console output encoding to support international chars (#4429)
+

--- a/src/Cli/func/Helpers/ConsoleHelper.cs
+++ b/src/Cli/func/Helpers/ConsoleHelper.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Functions.Cli.Helpers
+{
+    internal class ConsoleHelper
+    {
+        /// <summary>
+        /// Attempts to switch the console to UTF-8.
+        /// Falls back silently if the code page isn’t registered or the host refuses.
+        /// </summary>
+        internal static void ConfigureConsoleOutputEncoding()
+        {
+            try
+            {
+                Console.OutputEncoding = Encoding.UTF8;
+            }
+            catch
+            {
+                // UTF-8 encoding not available, international characters may not display correctly.
+            }
+        }
+    }
+}

--- a/src/Cli/func/Program.cs
+++ b/src/Cli/func/Program.cs
@@ -16,6 +16,9 @@ namespace Azure.Functions.Cli
 
         internal static void Main(string[] args)
         {
+            // Configure console encoding
+            ConsoleHelper.ConfigureConsoleOutputEncoding();
+
             // Check for version arg up front and prioritize speed over all else
             // Tools like VS Code may call this often and we want their UI to be responsive
             if (args.Length == 1 && _versionArgs.Any(va => args[0].Replace("-", string.Empty).Equals(va, StringComparison.OrdinalIgnoreCase)))

--- a/test/Cli/Func.E2E.Tests/Commands/FuncStart/ConsoleEncodingTests.cs
+++ b/test/Cli/Func.E2E.Tests/Commands/FuncStart/ConsoleEncodingTests.cs
@@ -1,0 +1,158 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.E2E.Tests.Traits;
+using Azure.Functions.Cli.TestFramework.Assertions;
+using Azure.Functions.Cli.TestFramework.Commands;
+using Azure.Functions.Cli.TestFramework.Helpers;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Azure.Functions.Cli.E2E.Tests.Commands.FuncStart
+{
+    public class ConsoleEncodingTests(ITestOutputHelper log) : BaseE2ETests(log)
+    {
+        [Fact]
+        [Trait(WorkerRuntimeTraits.WorkerRuntime, WorkerRuntimeTraits.Node)]
+        public async Task Start_WithNode_WithNonAsciiLogging_DisplaysCorrectly()
+        {
+            var port = ProcessHelper.GetAvailablePort();
+            var testName = nameof(Start_WithNode_WithNonAsciiLogging_DisplaysCorrectly);
+            var japaneseText = "こんにちは";
+
+            // Initialize Node.js function app
+            await FuncInitWithRetryAsync(testName, [".", "--worker-runtime", "node", "-m", "v4"]);
+
+            // Add HTTP trigger
+            await FuncNewWithRetryAsync(testName, [".", "--template", "HttpTrigger", "--name", "HttpTrigger", "--language", "node"], workerRuntime: "node");
+
+            // Modify the function to log non-ASCII text
+            string jsFilePath = Path.Combine(WorkingDirectory, "src", "functions", "HttpTrigger.js");
+            string originalContent = File.ReadAllText(jsFilePath);
+
+            // Find the handler function's opening '{'
+            var handlerSignature = "handler: async (request, context) => {";
+            int handlerIndex = originalContent.IndexOf(handlerSignature, StringComparison.Ordinal);
+            if (handlerIndex >= 0)
+            {
+                int bodyStart = originalContent.IndexOf('{', handlerIndex);
+                if (bodyStart >= 0)
+                {
+                    bodyStart++; // Move past the '{'
+                    string logStatement = $"\n        context.log(\"Test String: {japaneseText}\");";
+                    string modifiedContent = originalContent.Insert(bodyStart, logStatement);
+                    File.WriteAllText(jsFilePath, modifiedContent);
+                }
+            }
+
+            // Execute the function
+            var funcStartCommand = new FuncStartCommand(FuncPath, testName, Log);
+            funcStartCommand.ProcessStartedHandler = async (process) =>
+            {
+                await ProcessHelper.ProcessStartedHandlerHelper(port, process, funcStartCommand.FileWriter ?? throw new ArgumentNullException(nameof(funcStartCommand.FileWriter)), "HttpTrigger?name=Test");
+            };
+
+            var result = funcStartCommand
+                .WithWorkingDirectory(WorkingDirectory)
+                .WithEnvironmentVariable(Common.Constants.FunctionsWorkerRuntime, "node")
+                .Execute(["--port", port.ToString()]);
+
+            // Verify the Japanese text was correctly displayed (not as question marks)
+            result.Should().HaveStdOutContaining($"Test String: {japaneseText}");
+            result.Should().NotHaveStdOutContaining("Test String: ?????");
+        }
+
+        [Fact]
+        [Trait(WorkerRuntimeTraits.WorkerRuntime, WorkerRuntimeTraits.DotnetIsolated)]
+        public async Task Start_WithDotnetIsolated_WithNonAsciiLogging_DisplaysCorrectly()
+        {
+            var port = ProcessHelper.GetAvailablePort();
+            var testName = nameof(Start_WithDotnetIsolated_WithNonAsciiLogging_DisplaysCorrectly);
+            var japaneseText = "こんにちは";
+
+            // Initialize .NET function app
+            await FuncInitWithRetryAsync(testName, [".", "--worker-runtime", "dotnet-isolated"]);
+
+            // Add HTTP trigger
+            await FuncNewWithRetryAsync(testName, [".", "--template", "HttpTrigger", "--name", "HttpTrigger"]);
+
+            // Modify the function to log non-ASCII text
+            var csFilesPath = Path.Combine(WorkingDirectory, "HttpTrigger.cs");
+            string originalContent = File.ReadAllText(csFilesPath);
+
+            // Find the Run method signature
+            var methodSignature = "IActionResult Run(";
+            int methodIndex = originalContent.IndexOf(methodSignature, StringComparison.Ordinal);
+            if (methodIndex >= 0)
+            {
+                // Find the first '{' after the method signature
+                int bodyStart = originalContent.IndexOf('{', methodIndex);
+                if (bodyStart >= 0)
+                {
+                    bodyStart++; // Move past the '{'
+                    string logStatement = $"\n        _logger.LogInformation(\"Test String: {japaneseText}\");";
+                    string modifiedContent = originalContent.Insert(bodyStart, logStatement);
+                    File.WriteAllText(csFilesPath, modifiedContent);
+                }
+            }
+
+            // Execute the function
+            var funcStartCommand = new FuncStartCommand(FuncPath, testName, Log);
+            funcStartCommand.ProcessStartedHandler = async (process) =>
+            {
+                await ProcessHelper.ProcessStartedHandlerHelper(port, process, funcStartCommand.FileWriter ?? throw new ArgumentNullException(nameof(funcStartCommand.FileWriter)), "HttpTrigger?name=Test");
+            };
+
+            var result = funcStartCommand
+                .WithWorkingDirectory(WorkingDirectory)
+                .Execute(["--port", port.ToString()]);
+
+            // Verify the Japanese text was correctly displayed (not as question marks)
+            result.Should().HaveStdOutContaining($"Test String: {japaneseText}");
+            result.Should().NotHaveStdOutContaining("Test String: ?????");
+        }
+
+        [Fact]
+        [Trait(WorkerRuntimeTraits.WorkerRuntime, WorkerRuntimeTraits.Powershell)]
+        public async Task Start_WithPowerShell_WithNonAsciiLogging_DisplaysCorrectly()
+        {
+            var port = ProcessHelper.GetAvailablePort();
+            var testName = nameof(Start_WithPowerShell_WithNonAsciiLogging_DisplaysCorrectly);
+            var japaneseText = "こんにちは";
+
+            // Initialize PowerShell function app
+            await FuncInitWithRetryAsync(testName, [".", "--worker-runtime", "powershell"]);
+
+            // Add HTTP trigger
+            await FuncNewWithRetryAsync(testName, [".", "--template", "HttpTrigger", "--name", "HttpTrigger", "--language", "powershell"], workerRuntime: "powershell");
+
+            // Modify the function to log non-ASCII text
+            string ps1FilePath = Path.Combine(WorkingDirectory, "HttpTrigger", "run.ps1");
+            string originalContent = File.ReadAllText(ps1FilePath);
+
+            // Replace the existing log statement with both original and test log
+            string oldLogStatement = "Write-Host \"PowerShell HTTP trigger function processed a request.\"";
+            string newLogStatement = $"Write-Host \"PowerShell HTTP trigger function processed a request.\"\nWrite-Host \"Test String: {japaneseText}\"";
+            string modifiedContent = originalContent.Replace(oldLogStatement, newLogStatement);
+            File.WriteAllText(ps1FilePath, modifiedContent);
+
+            // Execute the function
+            var funcStartCommand = new FuncStartCommand(FuncPath, testName, Log);
+            funcStartCommand.ProcessStartedHandler = async (process) =>
+            {
+                await ProcessHelper.ProcessStartedHandlerHelper(port, process, funcStartCommand.FileWriter ?? throw new ArgumentNullException(nameof(funcStartCommand.FileWriter)), "HttpTrigger?name=Test");
+            };
+
+            var result = funcStartCommand
+                .WithWorkingDirectory(WorkingDirectory)
+                .WithEnvironmentVariable(Common.Constants.FunctionsWorkerRuntime, "powershell")
+                .Execute(["--port", port.ToString()]);
+
+            // Verify the Japanese text was correctly displayed (not as question marks)
+            result.Should().HaveStdOutContaining($"Test String: {japaneseText}");
+            result.Should().NotHaveStdOutContaining("Test String: ?????");
+        }
+    }
+}


### PR DESCRIPTION
### Issue describing the changes in this PR
Azure Functions Core Tools was not correctly displaying non-ASCII characters in console output. Japanese characters (and other non-Latin scripts) were showing as question marks (?????) when logging from a function.

Root Cause
The console output encoding was not explicitly set to UTF-8 at application startup, causing the console to use the default encoding of the system, which often doesn't support the full range of Unicode characters.

Solution
Added a single line at the start of the application to configure the console output encoding to UTF-8:

Console.OutputEncoding = Encoding.UTF8;
This ensures that all Unicode characters, including Japanese and other non-Latin scripts, are properly displayed in the console when running functions locally.

[Change Document](https://microsoftapc-my.sharepoint.com/:w:/g/personal/v-vreyya_microsoft_com/EWrINPUfIftFkjPYvAX1GnIB0ThttUi5JR75HimCLoVi5Q?e=8CfZmC)
Partially resolves #4429 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

