### PR TITLE
Fix Console Encoding for Proper Display of Non-ASCII Characters for InProc

### DIFF
--- a/src/Azure.Functions.Cli/Helpers/ConsoleHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/ConsoleHelper.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Text;
+
+namespace Azure.Functions.Cli.Helpers
+{
+    internal static class ConsoleHelper
+    {
+        /// <summary>
+        /// Attempts to switch the console to UTF-8.
+        /// Falls back silently if the code page isn’t registered or the host refuses.
+        /// </summary>
+        internal static void ConfigureConsoleOutputEncoding()
+        {
+            try
+            {
+                Console.OutputEncoding = Encoding.UTF8;
+            }
+            catch
+            {
+                // UTF-8 encoding not available, international characters may not display correctly.
+            }
+        }
+    }
+}

--- a/src/Azure.Functions.Cli/Program.cs
+++ b/src/Azure.Functions.Cli/Program.cs
@@ -15,6 +15,9 @@ namespace Azure.Functions.Cli
 
         internal static void Main(string[] args)
         {
+            // Configure console encoding
+            ConsoleHelper.ConfigureConsoleOutputEncoding();
+
             // Check for version arg up front and prioritize speed over all else
             // Tools like VS Code may call this often and we want their UI to be responsive
             if (args.Length == 1 && _versionArgs.Any(va => args[0].Replace("-", "").Equals(va, StringComparison.OrdinalIgnoreCase)))


### PR DESCRIPTION
### Issue describing the changes in this PR
Azure Functions Core Tools was not correctly displaying non-ASCII characters in console output. Japanese characters (and other non-Latin scripts) were showing as question marks (?????) when logging from a function.

Root Cause
The console output encoding was not explicitly set to UTF-8 at application startup, causing the console to use the default encoding of the system, which often doesn't support the full range of Unicode characters.

Solution
Added a single line at the start of the application to configure the console output encoding to UTF-8:

Console.OutputEncoding = Encoding.UTF8;
This ensures that all Unicode characters, including Japanese and other non-Latin scripts, are properly displayed in the console.
when running functions locally:
![image](https://github.com/user-attachments/assets/08b6aadc-f3d2-4adf-970f-098343cee494)

Partially resolves #4429 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] I have added all required tests (Unit tests, E2E tests)

Additional PR information
