### PR TITLE
Including workers in inproc8 build

### DIFF
--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -112,8 +112,8 @@ namespace Build
             foreach (var runtime in Settings.TargetRuntimes)
             {
                 // In-proc version does not need language workers for net6.0 or if it's the minified runtime.
-                // We need the inproc8 build for logic apps so we are including it for that scenario.
-                if (_targetFramework != Net6TargetFramework && !runtime.StartsWith(Settings.MinifiedVersionPrefix))
+                // We need workers for the inproc8 build for logic apps.
+                if (_targetFramework == DefaultTargetFramework && !runtime.StartsWith(Settings.MinifiedVersionPrefix))
                 {
                     continue;
                 }
@@ -133,7 +133,7 @@ namespace Build
         {
             Shell.Run("dotnet", $"publish {Settings.ProjectFile} " +
                                 $"/p:BuildNumber={Settings.BuildNumber} " +
-                                (targetFramework == "net6.0" ? $"/p:NoWorkers=\"true\" " : string.Empty) +
+                                (targetFramework == Net6TargetFramework ? $"/p:NoWorkers=\"true\" " : string.Empty) +
                                 $"/p:CommitHash=\"{Settings.CommitId}\" " +
                                 (string.IsNullOrEmpty(Settings.IntegrationBuildNumber) ? string.Empty : $"/p:IntegrationBuildNumber=\"{Settings.IntegrationBuildNumber}\" ") +
                                 $"-o {outputPath} -c Release -f {targetFramework} --no-restore --self-contained" +

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -109,12 +109,15 @@ namespace Build
                 ExecuteDotnetPublish(outputPath, rid, _targetFramework);
             }
 
-            // in-proc version does not need language workers.
-            foreach (var runtime in Settings.TargetRuntimes)
+            // in-proc version does not need language workers for net6.0
+            if (_targetFramework == Net6TargetFramework)
             {
-                var outputPath = Path.Combine(Settings.OutputDir, runtime);
-                RemoveLanguageWorkers(outputPath);
-            };
+                foreach (var runtime in Settings.TargetRuntimes)
+                {
+                    var outputPath = Path.Combine(Settings.OutputDir, runtime);
+                    RemoveLanguageWorkers(outputPath);
+                }
+            }
 
             if (!string.IsNullOrEmpty(Settings.IntegrationBuildNumber) && (_integrationManifest != null))
             {

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -126,7 +126,7 @@ namespace Build
         {
             Shell.Run("dotnet", $"publish {Settings.ProjectFile} " +
                                 $"/p:BuildNumber={Settings.BuildNumber} " +
-                                $"/p:NoWorkers=\"true\" " +
+                                (targetFramework == "net6.0" ? $"/p:NoWorkers=\"true\" " : string.Empty) +
                                 $"/p:CommitHash=\"{Settings.CommitId}\" " +
                                 (string.IsNullOrEmpty(Settings.IntegrationBuildNumber) ? string.Empty : $"/p:IntegrationBuildNumber=\"{Settings.IntegrationBuildNumber}\" ") +
                                 $"-o {outputPath} -c Release -f {targetFramework} --no-restore --self-contained" +

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -109,15 +109,19 @@ namespace Build
                 ExecuteDotnetPublish(outputPath, rid, _targetFramework);
             }
 
-            // in-proc version does not need language workers for net6.0
-            if (_targetFramework == Net6TargetFramework)
+            foreach (var runtime in Settings.TargetRuntimes)
             {
-                foreach (var runtime in Settings.TargetRuntimes)
+                // In-proc version does not need language workers for net6.0 or if it's the minified runtime.
+                // We need the inproc8 build for logic apps so we are including it for that scenario.
+                if (_targetFramework != Net6TargetFramework && !runtime.StartsWith(Settings.MinifiedVersionPrefix))
                 {
-                    var outputPath = Path.Combine(Settings.OutputDir, runtime);
-                    RemoveLanguageWorkers(outputPath);
+                    continue;
                 }
+
+                var outputPath = Path.Combine(Settings.OutputDir, runtime);
+                RemoveLanguageWorkers(outputPath);
             }
+            
 
             if (!string.IsNullOrEmpty(Settings.IntegrationBuildNumber) && (_integrationManifest != null))
             {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #4493

This PR includes adding the contents of the `workers` directory for the inproc8 build,  specifically for the Logic Apps scenario when using core tools. We do not include the contents of the workers directory for minified versions.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] I have added all required tests (Unit tests, E2E tests)

