### PR TITLE
Fix templates path & MSI version

### DIFF
--- a/eng/build/Templates.targets
+++ b/eng/build/Templates.targets
@@ -57,7 +57,7 @@
     <ItemGroup>
       <!-- Resolve the .nupkg file paths in the NuGet cache -->
       <TemplatePackagesResolved Include="@(_TemplatePackages)">
-        <PackagePath>$(NuGetPackageRoot)%(Identity)/%(Version)/%(Identity).%(Version).nupkg</PackagePath>
+        <PackagePath>$(NuGetPackageRoot)/%(Identity)/%(Version)/%(Identity).%(Version).nupkg</PackagePath>
       </TemplatePackagesResolved>
     </ItemGroup>
 

--- a/eng/ci/templates/official/jobs/publish-cli.yml
+++ b/eng/ci/templates/official/jobs/publish-cli.yml
@@ -79,6 +79,7 @@ jobs:
         ./eng/scripts/generate-msi-files.ps1
         -artifactsPath "$(Build.Repository.LocalPath)/artifacts"
         -runtime "${{ parameters.runtime }}"
+        -cliVersion "$(Build.BuildNumber)"
       displayName: 'Generate MSI files'
 
     - template: /eng/ci/templates/official/steps/sign-msi.yml@self


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

n/a

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

I noticed in the latest release that the CLI version used for the MSI builds included the ADO build ID when it should not have. Updating the script so that it no longer uses FileVersion, and instead grabs the version from the folder path or can be provided via script args.

Also added `/` to nuget path in Templates.targets as it was failing on my devbox when building the sln.
