### PR TITLE
Fix dotnet templates installation check

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -7,4 +7,4 @@
 
 #### Changes
 
-- <entry>
+- Fix dotnet templates installation (#)

--- a/release_notes.md
+++ b/release_notes.md
@@ -7,4 +7,4 @@
 
 #### Changes
 
-- Fix dotnet templates installation (#)
+- Fix dotnet templates installation (#5358)

--- a/src/Cli/func/Helpers/DotnetHelpers.cs
+++ b/src/Cli/func/Helpers/DotnetHelpers.cs
@@ -295,12 +295,12 @@ namespace Azure.Functions.Cli.Helpers
 
         private static async Task EnsureIsolatedTemplatesInstalled()
         {
-            if (await IsTemplatePackageInstalled(WebJobsTemplateBasePackId))
+            if (await AreDotnetTemplatePackagesInstalled(WebJobsTemplateBasePackId))
             {
                 await UninstallWebJobsTemplates();
             }
 
-            if (await IsTemplatePackageInstalled(IsolatedTemplateBasePackId))
+            if (await AreDotnetTemplatePackagesInstalled(IsolatedTemplateBasePackId))
             {
                 return;
             }
@@ -310,12 +310,12 @@ namespace Azure.Functions.Cli.Helpers
 
         private static async Task EnsureWebJobsTemplatesInstalled()
         {
-            if (await IsTemplatePackageInstalled(IsolatedTemplateBasePackId))
+            if (await AreDotnetTemplatePackagesInstalled(IsolatedTemplateBasePackId))
             {
                 await UninstallIsolatedTemplates();
             }
 
-            if (await IsTemplatePackageInstalled(WebJobsTemplateBasePackId))
+            if (await AreDotnetTemplatePackagesInstalled(WebJobsTemplateBasePackId))
             {
                 return;
             }
@@ -323,10 +323,12 @@ namespace Azure.Functions.Cli.Helpers
             await FileLockHelper.WithFileLockAsync(TemplatesLockFileName, InstallWebJobsTemplates);
         }
 
-        private static async Task<bool> IsTemplatePackageInstalled(string packageId)
+        private static async Task<bool> AreDotnetTemplatePackagesInstalled(string packageIdPrefix)
         {
             var templates = await _installedTemplatesList.Value;
-            return templates.Any(id => id.StartsWith(packageId, StringComparison.OrdinalIgnoreCase));
+            return templates.Any(id =>
+                id.Equals($"{packageIdPrefix}.ProjectTemplates", StringComparison.OrdinalIgnoreCase) ||
+                id.Equals($"{packageIdPrefix}.ItemTemplates", StringComparison.OrdinalIgnoreCase));
         }
 
         private static async Task<HashSet<string>> GetInstalledTemplatePackageIds()

--- a/test/Cli/Func.UnitTests/HelperTests/DotnetHelpersTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/DotnetHelpersTests.cs
@@ -1,0 +1,82 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Helpers;
+using Xunit;
+
+namespace Azure.Functions.Cli.UnitTests.HelperTests
+{
+    public class DotnetHelpersTests
+    {
+        [Theory]
+        [InlineData("BlobTrigger", "blob")]
+        [InlineData("HttpTrigger", "http")]
+        [InlineData("TimerTrigger", "timer")]
+        [InlineData("UnknownTrigger", null)]
+        public void GetTemplateShortName_ReturnsExpectedShortName(string input, string expected)
+        {
+            if (expected != null)
+            {
+                var result = DotnetHelpers.GetTemplateShortName(input);
+                Assert.Equal(expected, result);
+            }
+            else
+            {
+                Assert.Throws<ArgumentException>(() => DotnetHelpers.GetTemplateShortName(input));
+            }
+        }
+
+        [Theory]
+        [InlineData(WorkerRuntime.Dotnet, 18)]
+        [InlineData(WorkerRuntime.DotnetIsolated, 13)]
+        public void GetTemplates_ReturnsExpectedTemplates(WorkerRuntime runtime, int expectedCount)
+        {
+            var templates = DotnetHelpers.GetTemplates(runtime);
+            Assert.Equal(expectedCount, templates.Count());
+        }
+
+        [Theory]
+        [InlineData("Microsoft.Azure.Functions.Worker")]
+        [InlineData("Microsoft.Azure.WebJobs")]
+        public void AreDotnetTemplatePackagesInstalled_ReturnsTrue_WhenTemplatesExists(string pkgPrefix)
+        {
+            // Arrange
+            var templates = new HashSet<string> { $"{pkgPrefix}.ProjectTemplates", $"{pkgPrefix}.ItemTemplates" };
+
+            // Act
+            var result = DotnetHelpers.AreDotnetTemplatePackagesInstalled(templates, pkgPrefix);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Theory]
+        [InlineData("ProjectTemplates")]
+        [InlineData("ItemTemplates")]
+        public void AreDotnetTemplatePackagesInstalled_ReturnsFalse_WhenOnlyOneRequiredTemplateExists(string pkgSuffix)
+        {
+            // Arrange
+            var templates = new HashSet<string> { $"Microsoft.Azure.Functions.Worker.{pkgSuffix}" };
+
+            // Act
+            var result = DotnetHelpers.AreDotnetTemplatePackagesInstalled(templates, "Microsoft.Azure.Functions.Worker");
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void AreDotnetTemplatePackagesInstalled_ReturnsFalse_WhenTemplatesDoesNotExist()
+        {
+            // Arrange
+            var templates = new HashSet<string> { "OtherCompany.ProjectTemplates", "OtherCompany.ItemTemplates", "Microsoft.Azure.Functions.Worker" };
+
+            // Act
+            // Should fail as we are looking for Item and Project templates
+            var result = DotnetHelpers.AreDotnetTemplatePackagesInstalled(templates, "Microsoft.Azure.Functions.Worker");
+
+            // Assert
+            Assert.False(result);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #4399

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Fix check for installed templates in the dotnet templates helper. We now check for the entire package name instead of just the prefix i.e. `Microsoft.Azure.Functions.Worker.ItemTemplates` and `Microsoft.Azure.Functions.Worker.ProjectTemplates`. Validated with local build & tests.