### PR TITLE
Implement force exit on second cancel key

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
             },
             "args": "${input:funcArgs} --script-root ${input:scriptRootArg}",
             "cwd": "${workspaceFolder}/src/Cli/func",
-            "console": "internalConsole",
+            "console": "integratedTerminal",
             "stopAtEntry": false
         },
         {

--- a/docs/debug-with-host.md
+++ b/docs/debug-with-host.md
@@ -1,0 +1,55 @@
+# Guide on debugging Core Tools with the Azure Functions Host
+
+1. Clone the host repo: `azure-functions-host`
+2. In `src/Cli/func/Azure.Functions.Cli.csproj`, replace the WebHost package reference with a local project reference:
+
+    Comment out:
+
+   ```xml
+   <!-- <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" /> -->
+   ```
+
+   Add:
+
+   ```xml
+    <ItemGroup>
+        <ProjectReference Include="<path to host repo>/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj" />
+    </ItemGroup>
+   ```
+
+> [!NOTE]
+> You may also need to update the worker package references
+> in `eng/build/Packages.props` to match the versions references by the host.
+
+You should now be able to debug the host via the `func start` command in the CLI.
+
+#### VS Code
+
+1. Press F5
+2. Provide the command you want to run i.e. `start --verbose`
+3. Provide the path to your test app, e.g. `<path>/MyTestFuncApp`
+
+This will build the CLI and start the host with the provided command and test app path, and automatically attach the debugger.
+
+#### Visual Studio
+
+//todo: Add instructions for Visual Studio
+
+#### Other
+
+You can also run the CLI directly from the repo:
+
+`dotnet run --project src/Cli/func -- start --script-root <path-to-test-app>`
+
+Or, you can also publish the CLI and run via the path:
+
+```bash
+# Publish the CLI for your platform
+dotnet publish src/Cli/func -r osx-arm64 --sc
+
+# Typically '<path>/out/pub/Azure.Functions.Cli/release_osx-arm64/func'
+export FUNC_CLI=<path-to-published-cli>
+
+# Start the host inside the test app directory
+$FUNC_CLI start
+```

--- a/src/Cli/func/Helpers/CancelKeyHandler.cs
+++ b/src/Cli/func/Helpers/CancelKeyHandler.cs
@@ -1,0 +1,47 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Diagnostics;
+using Colors.Net;
+
+namespace Azure.Functions.Cli.Helpers;
+
+public static class CancelKeyHandler
+{
+    private static readonly object _lock = new object();
+    private static int _cancelKeyPressCount = 0;
+    private static Action _onFirstCancel;
+
+    public static void Register(Action onFirstCancel, int exitCode = 1)
+    {
+        _onFirstCancel = onFirstCancel ?? (() => { });
+
+        Console.CancelKeyPress += HandleCancelKeyPress;
+    }
+
+    private static void HandleCancelKeyPress(object sender, ConsoleCancelEventArgs e)
+    {
+        lock (_lock)
+        {
+            _cancelKeyPressCount++;
+
+            if (_cancelKeyPressCount == 1)
+            {
+                ColoredConsole.WriteLine("Press Ctrl+C again to force exit.");
+
+                // Cancel first Ctrl+C to allow graceful cleanup
+                e.Cancel = true;
+                _onFirstCancel?.Invoke();
+            }
+            else if (_cancelKeyPressCount >= 2)
+            {
+                ColoredConsole.WriteLine("Forcing exit...");
+                Console.Out.Flush();
+                Console.Error.Flush();
+
+                // Hard exit
+                Process.GetCurrentProcess().Kill();
+            }
+        }
+    }
+}

--- a/src/Cli/func/Program.cs
+++ b/src/Cli/func/Program.cs
@@ -34,10 +34,10 @@ namespace Azure.Functions.Cli
             _container = InitializeAutofacContainer();
             AppDomain.CurrentDomain.ProcessExit += CurrentDomain_ProcessExit;
 
-            Console.CancelKeyPress += (s, e) =>
+            CancelKeyHandler.Register(() =>
             {
                 _container.Resolve<IProcessManager>()?.KillChildProcesses();
-            };
+            });
 
             ConsoleApp.Run<Program>(args, _container);
         }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #4355

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

- Add handler so that we force exit on a second console cancel key
- Fix bug where we get a null ref error if we shut down the host during startup
- Added docs for how to debug CLI with the host
