### PR TITLE
Add `--build-local option` for `func pack` and default to local build for Python apps on windows

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -11,5 +11,8 @@
 - Disable diagnostic events in local development by replacing the `IDiagnosticEventRepository` with a `DiagnosticEventNullRepository` (#4542)
 - Add `func pack` support for in-proc functions (#4529)
 - Default to remote build for `func pack` for python apps (#4530)
-- Add   build-local` option for `func pack` and default to local buidl for Python apps on windows with warning (#4550)
+- Add `--build-local` option for `func pack` for Python apps only. (#4550)
+  - Default to local build for Python apps on windows to avoid breaking existing behavior
+  - Update logging for `func pack` to include more details
+  - Include a 'Deferred' build option for `func pack` that is ready for remote deployment
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -11,3 +11,5 @@
 - Disable diagnostic events in local development by replacing the `IDiagnosticEventRepository` with a `DiagnosticEventNullRepository` (#4542)
 - Add `func pack` support for in-proc functions (#4529)
 - Default to remote build for `func pack` for python apps (#4530)
+- Add   build-local` option for `func pack` and default to local buidl for Python apps on windows with warning (#4550)
+

--- a/src/Cli/func/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Cli/func/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -573,7 +573,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             TelemetryHelpers.AddCommandEventToDictionary(TelemetryCommandEvents, "UseGoZip", useGoZip.ToString());
 
             ColoredConsole.WriteLine(GetLogMessage("Starting the function app deployment..."));
-            Func<Task<Stream>> zipStreamFactory = () => ZipHelper.GetAppZipFile(functionAppRoot, BuildNativeDeps, PublishBuildOption, NoBuild, ignoreParser, AdditionalPackages);
+            Func<Task<Stream>> zipStreamFactory = () => ZipHelper.GetAppZipFile(functionAppRoot, BuildNativeDeps, PublishBuildOption, NoBuild, isPackAction: false, ignoreParser, AdditionalPackages);
 
             bool shouldSyncTriggers = true;
             bool shouldDeferPublishZipDeploy = false;

--- a/src/Cli/func/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Cli/func/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -573,7 +573,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             TelemetryHelpers.AddCommandEventToDictionary(TelemetryCommandEvents, "UseGoZip", useGoZip.ToString());
 
             ColoredConsole.WriteLine(GetLogMessage("Starting the function app deployment..."));
-            Func<Task<Stream>> zipStreamFactory = () => ZipHelper.GetAppZipFile(functionAppRoot, BuildNativeDeps, PublishBuildOption, NoBuild, isPackAction: false, ignoreParser, AdditionalPackages);
+            Func<Task<Stream>> zipStreamFactory = () => ZipHelper.GetAppZipFile(functionAppRoot, BuildNativeDeps, PublishBuildOption, NoBuild, ignoreParser, AdditionalPackages);
 
             bool shouldSyncTriggers = true;
             bool shouldDeferPublishZipDeploy = false;

--- a/src/Cli/func/Actions/LocalActions/PackAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction.cs
@@ -101,10 +101,12 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             {
                 if (workerRuntime != WorkerRuntime.Python)
                 {
-                    throw new CliException("The --build-local option is only applicable for Python function apps.");
+                    ColoredConsole.WriteLine(WarningColor("The --build-local option is only applicable for Python function apps."));
                 }
-
-                defaultBuildOption = BuildOption.Local;
+                else
+                {
+                    defaultBuildOption = BuildOption.Local;
+                }
             }
 
             // Resolve build option to detect if remote build is needed

--- a/src/Cli/func/Actions/LocalActions/PackAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction.cs
@@ -132,7 +132,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             bool useGoZip = EnvironmentHelper.GetEnvironmentVariableAsBool(Constants.UseGoZip);
             TelemetryHelpers.AddCommandEventToDictionary(TelemetryCommandEvents, "UseGoZip", useGoZip.ToString());
 
-            var stream = await ZipHelper.GetAppZipFile(functionAppRoot, BuildNativeDeps, noBuild: false, buildOption: buildOption, additionalPackages: AdditionalPackages);
+            var stream = await ZipHelper.GetAppZipFile(functionAppRoot, BuildNativeDeps, noBuild: false, isPackAction: true, buildOption: buildOption, additionalPackages: AdditionalPackages);
 
             if (Squashfs)
             {

--- a/src/Cli/func/Actions/LocalActions/PackAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Diagnostics;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Helpers;
 using Azure.Functions.Cli.Interfaces;
@@ -137,7 +138,9 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             bool useGoZip = EnvironmentHelper.GetEnvironmentVariableAsBool(Constants.UseGoZip);
             TelemetryHelpers.AddCommandEventToDictionary(TelemetryCommandEvents, "UseGoZip", useGoZip.ToString());
 
-            var stream = await ZipHelper.GetAppZipFile(functionAppRoot, BuildNativeDeps, noBuild: false, buildOption: buildOption, additionalPackages: AdditionalPackages);
+            await DotnetHelpers.BuildAndChangeDirectory(Path.Combine("bin", "publish"), "--configuration release");
+
+            var stream = await ZipHelper.GetAppZipFile(Environment.CurrentDirectory, BuildNativeDeps, noBuild: false, buildOption: buildOption, additionalPackages: AdditionalPackages);
 
             if (Squashfs)
             {

--- a/src/Cli/func/Actions/LocalActions/PackAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction.cs
@@ -7,7 +7,6 @@ using Azure.Functions.Cli.Interfaces;
 using Colors.Net;
 using Fclp;
 using Microsoft.Azure.WebJobs.Script;
-using System.Runtime.InteropServices;
 using static Azure.Functions.Cli.Common.OutputTheme;
 
 namespace Azure.Functions.Cli.Actions.LocalActions
@@ -100,9 +99,9 @@ namespace Azure.Functions.Cli.Actions.LocalActions
 
             if (BuildLocal && workerRuntime != WorkerRuntime.Python)
             {
-                ColoredConsole.WriteLine(WarningColor("The --build-local option is only applicable for Python function apps."));
+                ColoredConsole.WriteLine(WarningColor("The --build-local option is only applicable for Python function apps. Local build setting not applied.\n"));
             }
-            else if (BuildLocal && workerRuntime == WorkerRuntime.Python)
+            else if (BuildLocal)
             {
                 shouldBuildLocal = true;
             }
@@ -114,13 +113,13 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             ColoredConsole.WriteLine($"Detected Runtime: {workerRuntime}");
             ColoredConsole.WriteLine($"Detected Machine OS: {Environment.OSVersion.Platform}");
             ColoredConsole.WriteLine($"Build Option: {buildOption}");
-            ColoredConsole.WriteLine($"Output Path: {Path.GetFullPath(outputPath)}");
+            ColoredConsole.WriteLine($"Output Path: {Path.GetFullPath(outputPath)}\n");
 
             outputPath += Squashfs ? ".squashfs" : ".zip";
 
             if (FileSystemHelpers.FileExists(outputPath))
             {
-                ColoredConsole.WriteLine($"Deleting the old package {outputPath}");
+                ColoredConsole.WriteLine($"Deleting the old package {outputPath}\n");
                 try
                 {
                     FileSystemHelpers.FileDelete(outputPath);
@@ -138,7 +137,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             bool useGoZip = EnvironmentHelper.GetEnvironmentVariableAsBool(Constants.UseGoZip);
             TelemetryHelpers.AddCommandEventToDictionary(TelemetryCommandEvents, "UseGoZip", useGoZip.ToString());
 
-            var stream = await ZipHelper.GetAppZipFile(functionAppRoot, BuildNativeDeps, noBuild: false, isPackAction: true, buildOption: buildOption, additionalPackages: AdditionalPackages);
+            var stream = await ZipHelper.GetAppZipFile(functionAppRoot, BuildNativeDeps, noBuild: false, buildOption: buildOption, additionalPackages: AdditionalPackages);
 
             if (Squashfs)
             {
@@ -147,8 +146,8 @@ namespace Azure.Functions.Cli.Actions.LocalActions
 
             ColoredConsole.WriteLine($"Packaging output...");
             await FileSystemHelpers.WriteToFile(outputPath, stream);
-            ColoredConsole.WriteLine($"Successfully packaged the function app project to: {outputPath}.");
-            Console.WriteLine("----------------------------------------------------------------------");
+            ColoredConsole.WriteLine($"Packaging succeeded.\n");
+            Console.WriteLine("---------------------------------------------------------------------------------------------\n");
             ColoredConsole.WriteLine("To deploy this package run: ");
             ColoredConsole.WriteLine($"az functionapp deployment source config-zip --src \"{outputPath}\" " +
                 $"--name <function_app_name> --build-remote {buildOption == BuildOption.Deferred}");

--- a/src/Cli/func/Common/BuildOption.cs
+++ b/src/Cli/func/Common/BuildOption.cs
@@ -10,6 +10,7 @@ namespace Azure.Functions.Cli.Common
         Local, // will act as "func azure functionapp publish <appname>", use WEBSITE_RUN_FROM_PACKAGE on Linux Consumption, use zipdeploy to others
         Remote, // will act as "func azure functionapp publish <appname> --server-side-build"
         Container, // will act as "func azure functionapp publish <appname> --build-native-deps"
-        Default // will trigger remote build if requirements.txt has content
+        Default, // will trigger remote build if requirements.txt has content
+        Deferred // will create a zip file when running `func pack` that is remote build ready, but does not deploy it
     }
 }

--- a/src/Cli/func/Helpers/PythonHelpers.cs
+++ b/src/Cli/func/Helpers/PythonHelpers.cs
@@ -415,8 +415,8 @@ namespace Azure.Functions.Cli.Helpers
             if (FileSystemHelpers.DirectoryExists(packagesLocation))
             {
                 // Only update packages if checksum of requirements.txt does not match
-                // If build option is remote, we don't need to verify if packages are in sync, as we need to delete them regardless
-                if (buildOption != BuildOption.Remote && await ArePackagesInSync(reqTxtFile, packagesLocation))
+                // If build option is remote or deferred, we don't need to verify if packages are in sync, as we need to delete them regardless
+                if (buildOption != BuildOption.Remote && buildOption != BuildOption.Deferred && await ArePackagesInSync(reqTxtFile, packagesLocation))
                 {
                     ColoredConsole.WriteLine(WarningColor($"Directory {Constants.ExternalPythonPackages} already in sync with {Constants.RequirementsTxt}. Skipping restoring dependencies..."));
                     return await ZipHelper.CreateZip(files.Union(FileSystemHelpers.GetFiles(packagesLocation)), functionAppRoot, Enumerable.Empty<string>());
@@ -440,7 +440,7 @@ namespace Azure.Functions.Cli.Helpers
                     throw new CliException("Docker is required to build native dependencies for python function apps");
                 }
             }
-            else if (buildOption == BuildOption.Remote)
+            else if (buildOption == BuildOption.Remote || buildOption == BuildOption.Deferred)
             {
                 // No-ops, python packages will be resolved on the server side
             }
@@ -449,8 +449,8 @@ namespace Azure.Functions.Cli.Helpers
                 await RestorePythonRequirementsPackapp(functionAppRoot, packagesLocation);
             }
 
-            // No need to generate and compare .md5 when using remote build
-            if (buildOption != BuildOption.Remote)
+            // No need to generate and compare .md5 when using remote or deferred build
+            if (buildOption != BuildOption.Remote && buildOption != BuildOption.Deferred)
             {
                 // Store a checksum of requirements.txt
                 var md5FilePath = Path.Combine(packagesLocation, $"{Constants.RequirementsTxt}.md5");

--- a/src/Cli/func/Helpers/ResolveBuildOptionHelper.cs
+++ b/src/Cli/func/Helpers/ResolveBuildOptionHelper.cs
@@ -1,21 +1,18 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Azure.Functions.Cli.Arm.Models;
 using Azure.Functions.Cli.Common;
+using Colors.Net;
 
 namespace Azure.Functions.Cli.Helpers
 {
     internal class ResolveBuildOptionHelper
     {
-        public static BuildOption ResolveBuildOption(BuildOption currentBuildOption, WorkerRuntime runtime, Site site, bool buildNativeDeps, bool noBuild)
+        public static BuildOption ResolveBuildOption(BuildOption currentBuildOption, WorkerRuntime runtime, Site site, bool buildNativeDeps, bool noBuild, bool includeLocalBuildForWindows = false)
         {
             // --no-build and --build-native-deps will take precedence over --build local and --build remote
+            // Note that --build local and --build remote are options only for publishing the function app, not packing
             if (noBuild)
             {
                 return BuildOption.None;
@@ -33,6 +30,17 @@ namespace Azure.Functions.Cli.Helpers
                     FileSystemHelpers.FileExists(Constants.RequirementsTxt) &&
                     new FileInfo(Path.Combine(Environment.CurrentDirectory, Constants.RequirementsTxt)).Length > 0)
                 {
+                    // Include default (local) build option for Windows as some customers may be using a local build for testing purposes
+                    // Note that this will be deprecated in the future after 4.1.1 is released
+                    if (includeLocalBuildForWindows && OperatingSystem.IsWindows())
+                    {
+                        ColoredConsole.WriteLine("Python runtime detected on Windows. Using local build option.");
+                        ColoredConsole.WriteLine(OutputTheme.WarningColor($"The default build option for python function apps with a valid requirements.txt " +
+                            $"will be switched over to use remote builds after version 4.1.1.\n" +
+                            "If a local build is still needed, please use the `--build-local` flag when running `func pack`."));
+                        return BuildOption.Default;
+                    }
+
                     return BuildOption.Remote;
                 }
             }

--- a/src/Cli/func/Helpers/ResolveBuildOptionHelper.cs
+++ b/src/Cli/func/Helpers/ResolveBuildOptionHelper.cs
@@ -36,12 +36,12 @@ namespace Azure.Functions.Cli.Helpers
                     new FileInfo(Path.Combine(Environment.CurrentDirectory, Constants.RequirementsTxt)).Length > 0)
                 {
                     // Include default (local) build option for Windows as some customers may be using a local build for testing purposes
-                    // Note that this will be deprecated in the future after 4.1.1 is released
+                    // Note that defaulting to the local build for Windows for python function apps will be deprecated in the future after 4.1.1 is released
                     if (isFuncPackAction && OperatingSystem.IsWindows())
                     {
                         ColoredConsole.WriteLine("Python runtime detected on Windows. Using local build option.");
                         ColoredConsole.WriteLine(OutputTheme.WarningColor($"The default build option for python function apps with a valid requirements.txt " +
-                            $"will be switched over to use remote builds after version 4.1.1.\n" +
+                            $"will be switched over to use deferred builds in the future, which are remote build ready.\n" +
                             "If a local build is still needed, please use the `--build-local` flag when running `func pack`."));
                         return BuildOption.Local;
                     }

--- a/src/Cli/func/Helpers/ZipHelper.cs
+++ b/src/Cli/func/Helpers/ZipHelper.cs
@@ -26,18 +26,16 @@ namespace Azure.Functions.Cli.Helpers
             }
             else if (buildOption == BuildOption.Remote)
             {
-                if (isPackAction)
-                {
-                    ColoredConsole.WriteLine(DarkYellow("Skipping local build. Please request a remote build while deploying"));
-                }
-                else
-                {
-                    ColoredConsole.WriteLine(DarkYellow("Performing remote build for functions project."));
-                }
+                ColoredConsole.WriteLine(DarkYellow("Performing remote build for functions project."));
             }
-            else if (buildOption == BuildOption.Local || buildOption == BuildOption.Default)
+            else if (buildOption == BuildOption.Local)
             {
                 ColoredConsole.WriteLine(DarkYellow("Performing local build for functions project."));
+            }
+            else if (buildOption == BuildOption.Deferred)
+            {
+                ColoredConsole.WriteLine(DarkYellow("Performing deferred build (remote build ready) for functions project."));
+                Console.WriteLine(DarkYellow("Please configure a remote build when deploying the package"));
             }
 
             if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.Python && !noBuild)

--- a/src/Cli/func/Helpers/ZipHelper.cs
+++ b/src/Cli/func/Helpers/ZipHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.IO.Compression;
@@ -28,7 +28,7 @@ namespace Azure.Functions.Cli.Helpers
             {
                 ColoredConsole.WriteLine(DarkYellow("Performing remote build for functions project."));
             }
-            else if (buildOption == BuildOption.Local)
+            else if (buildOption == BuildOption.Local || buildOption == BuildOption.Default)
             {
                 ColoredConsole.WriteLine(DarkYellow("Performing local build for functions project."));
             }

--- a/src/Cli/func/Helpers/ZipHelper.cs
+++ b/src/Cli/func/Helpers/ZipHelper.cs
@@ -12,7 +12,7 @@ namespace Azure.Functions.Cli.Helpers
 {
     public static class ZipHelper
     {
-        public static async Task<Stream> GetAppZipFile(string functionAppRoot, bool buildNativeDeps, BuildOption buildOption, bool noBuild, bool isPackAction, GitIgnoreParser ignoreParser = null, string additionalPackages = null)
+        public static async Task<Stream> GetAppZipFile(string functionAppRoot, bool buildNativeDeps, BuildOption buildOption, bool noBuild, GitIgnoreParser ignoreParser = null, string additionalPackages = null)
         {
             var gitIgnorePath = Path.Combine(functionAppRoot, Constants.FuncIgnoreFile);
             if (ignoreParser == null && FileSystemHelpers.FileExists(gitIgnorePath))
@@ -22,20 +22,20 @@ namespace Azure.Functions.Cli.Helpers
 
             if (noBuild)
             {
-                ColoredConsole.WriteLine(DarkYellow("Skipping build event for functions project (--no-build)."));
+                ColoredConsole.WriteLine(DarkYellow("Skipping build event for functions project (--no-build).\n"));
             }
             else if (buildOption == BuildOption.Remote)
             {
-                ColoredConsole.WriteLine(DarkYellow("Performing remote build for functions project."));
+                ColoredConsole.WriteLine(DarkYellow("Performing remote build for functions project.\n"));
             }
             else if (buildOption == BuildOption.Local)
             {
-                ColoredConsole.WriteLine(DarkYellow("Performing local build for functions project."));
+                ColoredConsole.WriteLine(DarkYellow("Performing local build for functions project.\n"));
             }
             else if (buildOption == BuildOption.Deferred)
             {
                 ColoredConsole.WriteLine(DarkYellow("Performing deferred build (remote build ready) for functions project."));
-                Console.WriteLine(DarkYellow("Please configure a remote build when deploying the package"));
+                Console.WriteLine(DarkYellow("Please configure a remote build when deploying the package.\n"));
             }
 
             if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.Python && !noBuild)

--- a/src/Cli/func/Helpers/ZipHelper.cs
+++ b/src/Cli/func/Helpers/ZipHelper.cs
@@ -12,7 +12,7 @@ namespace Azure.Functions.Cli.Helpers
 {
     public static class ZipHelper
     {
-        public static async Task<Stream> GetAppZipFile(string functionAppRoot, bool buildNativeDeps, BuildOption buildOption, bool noBuild, GitIgnoreParser ignoreParser = null, string additionalPackages = null)
+        public static async Task<Stream> GetAppZipFile(string functionAppRoot, bool buildNativeDeps, BuildOption buildOption, bool noBuild, bool isPackAction, GitIgnoreParser ignoreParser = null, string additionalPackages = null)
         {
             var gitIgnorePath = Path.Combine(functionAppRoot, Constants.FuncIgnoreFile);
             if (ignoreParser == null && FileSystemHelpers.FileExists(gitIgnorePath))
@@ -26,7 +26,14 @@ namespace Azure.Functions.Cli.Helpers
             }
             else if (buildOption == BuildOption.Remote)
             {
-                ColoredConsole.WriteLine(DarkYellow("Performing remote build for functions project."));
+                if (isPackAction)
+                {
+                    ColoredConsole.WriteLine(DarkYellow("Skipping local build. Please request a remote build while deploying"));
+                }
+                else
+                {
+                    ColoredConsole.WriteLine(DarkYellow("Performing remote build for functions project."));
+                }
             }
             else if (buildOption == BuildOption.Local || buildOption == BuildOption.Default)
             {

--- a/test/Cli/Func.E2ETests/Commands/FuncPack/BasePackTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncPack/BasePackTests.cs
@@ -64,7 +64,6 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncPack
 
             // Verify pack failed with appropriate error message
             packResult.Should().ExitWith(0);
-            packResult.Should().HaveStdOutContaining("Creating a new package");
 
             if (!isPythonRuntime)
             {

--- a/test/Cli/Func.E2ETests/Commands/FuncPack/BasePackTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncPack/BasePackTests.cs
@@ -14,8 +14,6 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncPack
     {
         internal static void TestBasicPackFunctionality(string workingDir, string testName, string funcPath, ITestOutputHelper log, string[] filesToValidate, bool shouldHaveLocalBuildLogs = false)
         {
-            var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-
             // Run pack command
             var funcPackCommand = new FuncPackCommand(funcPath, testName, log);
             var packResult = funcPackCommand
@@ -24,7 +22,6 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncPack
 
             // Verify pack succeeded
             packResult.Should().ExitWith(0);
-            packResult.Should().HaveStdOutContaining("Creating a new package");
 
             // Verify the logs for python runtime on Windows
             if (shouldHaveLocalBuildLogs)

--- a/test/Cli/Func.E2ETests/Commands/FuncPack/BasePackTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncPack/BasePackTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Runtime.InteropServices;
 using Azure.Functions.Cli.TestFramework.Assertions;
 using Azure.Functions.Cli.TestFramework.Commands;
 using FluentAssertions;
@@ -11,8 +12,10 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncPack
 {
     internal static class BasePackTests
     {
-        internal static void TestBasicPackFunctionality(string workingDir, string testName, string funcPath, ITestOutputHelper log, string[] filesToValidate)
+        internal static void TestBasicPackFunctionality(string workingDir, string testName, string funcPath, ITestOutputHelper log, string[] filesToValidate, bool shouldHaveLocalBuildLogs = false)
         {
+            var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
             // Run pack command
             var funcPackCommand = new FuncPackCommand(funcPath, testName, log);
             var packResult = funcPackCommand
@@ -22,6 +25,12 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncPack
             // Verify pack succeeded
             packResult.Should().ExitWith(0);
             packResult.Should().HaveStdOutContaining("Creating a new package");
+
+            // Verify the logs for python runtime on Windows
+            if (shouldHaveLocalBuildLogs)
+            {
+                packResult.Should().HaveStdOutContaining("Python runtime detected on Windows. Using local build option.");
+            }
 
             // Find any zip files in the working directory
             var zipFiles = Directory.GetFiles(workingDir, "*.zip");
@@ -43,6 +52,19 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncPack
             packResult.Should().ValidateZipContents(zipFiles.First(), filesToValidate, log);
 
             File.Delete(zipFiles.First()); // Clean up the zip file after validation
+        }
+
+        internal static void TestBuildLocalFlagForNonPythonRuntime(string workingDir, string testName, string funcPath, ITestOutputHelper log, string runtime)
+        {
+            // Run pack command with --build-local flag
+            var funcPackCommand = new FuncPackCommand(funcPath, testName, log);
+            var packResult = funcPackCommand
+                .WithWorkingDirectory(workingDir)
+                .Execute(["--build-local"]);
+
+            // Verify pack failed with appropriate error message
+            packResult.Should().ExitWith(1);
+            packResult.Should().HaveStdErrContaining("The --build-local option is only applicable for Python function apps.");
         }
     }
 }

--- a/test/Cli/Func.E2ETests/Commands/FuncPack/BasePackTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncPack/BasePackTests.cs
@@ -54,7 +54,7 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncPack
             File.Delete(zipFiles.First()); // Clean up the zip file after validation
         }
 
-        internal static void TestBuildLocalFlagForNonPythonRuntime(string workingDir, string testName, string funcPath, ITestOutputHelper log, string runtime)
+        internal static void TestBuildLocalFlag(string workingDir, string testName, string funcPath, ITestOutputHelper log, bool isPythonRuntime)
         {
             // Run pack command with --build-local flag
             var funcPackCommand = new FuncPackCommand(funcPath, testName, log);
@@ -63,8 +63,25 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncPack
                 .Execute(["--build-local"]);
 
             // Verify pack failed with appropriate error message
-            packResult.Should().ExitWith(1);
-            packResult.Should().HaveStdErrContaining("The --build-local option is only applicable for Python function apps.");
+            packResult.Should().ExitWith(0);
+            packResult.Should().HaveStdOutContaining("Creating a new package");
+
+            if (!isPythonRuntime)
+            {
+                packResult.Should().HaveStdOutContaining("The --build-local option is only applicable for Python function apps.");
+            }
+            else
+            {
+                packResult.Should().HaveStdOutContaining("Performing local build for functions project.");
+            }
+
+            // Find any zip files in the working directory
+            var zipFiles = Directory.GetFiles(workingDir, "*.zip");
+
+            // Verify at least one zip file exists
+            Assert.True(zipFiles.Length > 0, $"No zip files found in {workingDir}");
+
+            File.Delete(zipFiles.First()); // Clean up the zip file after validation
         }
     }
 }

--- a/test/Cli/Func.E2ETests/Commands/FuncPack/DotnetInProc6PackTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncPack/DotnetInProc6PackTests.cs
@@ -35,5 +35,18 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncPack
                     "TestNet6InProcProject.csproj"
                 });
         }
+
+        [Fact]
+        public void Pack_Dotnet6InProc_WithBuildLocal_ShouldFail()
+        {
+            var testName = nameof(Pack_Dotnet6InProc_WithBuildLocal_ShouldFail);
+
+            BasePackTests.TestBuildLocalFlagForNonPythonRuntime(
+                Dotnet6ProjectPath,
+                testName,
+                FuncPath,
+                Log,
+                "dotnet");
+        }
     }
 }

--- a/test/Cli/Func.E2ETests/Commands/FuncPack/DotnetInProc6PackTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncPack/DotnetInProc6PackTests.cs
@@ -41,12 +41,12 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncPack
         {
             var testName = nameof(Pack_Dotnet6InProc_WithBuildLocal_ShouldFail);
 
-            BasePackTests.TestBuildLocalFlagForNonPythonRuntime(
+            BasePackTests.TestBuildLocalFlag(
                 Dotnet6ProjectPath,
                 testName,
                 FuncPath,
                 Log,
-                "dotnet");
+                false);
         }
     }
 }

--- a/test/Cli/Func.E2ETests/Commands/FuncPack/DotnetInProc8PackTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncPack/DotnetInProc8PackTests.cs
@@ -40,12 +40,12 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncPack
         {
             var testName = nameof(Pack_Dotnet8InProc_WithBuildLocal_ShouldFail);
 
-            BasePackTests.TestBuildLocalFlagForNonPythonRuntime(
+            BasePackTests.TestBuildLocalFlag(
                 Dotnet8ProjectPath,
                 testName,
                 FuncPath,
                 Log,
-                "dotnet");
+                false);
         }
     }
 }

--- a/test/Cli/Func.E2ETests/Commands/FuncPack/DotnetInProc8PackTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncPack/DotnetInProc8PackTests.cs
@@ -34,5 +34,18 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncPack
                     "TestNet8InProcProject.csproj"
                 });
         }
+
+        [Fact]
+        public void Pack_Dotnet8InProc_WithBuildLocal_ShouldFail()
+        {
+            var testName = nameof(Pack_Dotnet8InProc_WithBuildLocal_ShouldFail);
+
+            BasePackTests.TestBuildLocalFlagForNonPythonRuntime(
+                Dotnet8ProjectPath,
+                testName,
+                FuncPath,
+                Log,
+                "dotnet");
+        }
     }
 }

--- a/test/Cli/Func.E2ETests/Commands/FuncPack/DotnetIsolatedPackTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncPack/DotnetIsolatedPackTests.cs
@@ -38,16 +38,16 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncPack
         }
 
         [Fact]
-        public void Pack_DotnetIsolated_WithBuildLocal_ShouldFail()
+        public void Pack_DotnetIsolated_WithBuildLocal_WorksAsExpected()
         {
-            var testName = nameof(Pack_DotnetIsolated_WithBuildLocal_ShouldFail);
+            var testName = nameof(Pack_DotnetIsolated_WithBuildLocal_WorksAsExpected);
 
-            BasePackTests.TestBuildLocalFlagForNonPythonRuntime(
+            BasePackTests.TestBuildLocalFlag(
                 DotnetIsolatedProjectPath,
                 testName,
                 FuncPath,
                 Log,
-                "dotnet-isolated");
+                false);
         }
     }
 }

--- a/test/Cli/Func.E2ETests/Commands/FuncPack/DotnetIsolatedPackTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncPack/DotnetIsolatedPackTests.cs
@@ -36,5 +36,18 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncPack
                     "Function1.cs"
                 });
         }
+
+        [Fact]
+        public void Pack_DotnetIsolated_WithBuildLocal_ShouldFail()
+        {
+            var testName = nameof(Pack_DotnetIsolated_WithBuildLocal_ShouldFail);
+
+            BasePackTests.TestBuildLocalFlagForNonPythonRuntime(
+                DotnetIsolatedProjectPath,
+                testName,
+                FuncPath,
+                Log,
+                "dotnet-isolated");
+        }
     }
 }

--- a/test/Cli/Func.E2ETests/Commands/FuncPack/NodePackTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncPack/NodePackTests.cs
@@ -35,5 +35,18 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncPack
                     "package-lock.json"
                 });
         }
+
+        [Fact]
+        public void Pack_Node_WithBuildLocal_ShouldFail()
+        {
+            var testName = nameof(Pack_Node_WithBuildLocal_ShouldFail);
+
+            BasePackTests.TestBuildLocalFlagForNonPythonRuntime(
+                NodeProjectPath,
+                testName,
+                FuncPath,
+                Log,
+                "node");
+        }
     }
 }

--- a/test/Cli/Func.E2ETests/Commands/FuncPack/NodePackTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncPack/NodePackTests.cs
@@ -37,16 +37,16 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncPack
         }
 
         [Fact]
-        public void Pack_Node_WithBuildLocal_ShouldFail()
+        public void Pack_Node_WithBuildLocal_WorksAsExpected()
         {
-            var testName = nameof(Pack_Node_WithBuildLocal_ShouldFail);
+            var testName = nameof(Pack_Node_WithBuildLocal_WorksAsExpected);
 
-            BasePackTests.TestBuildLocalFlagForNonPythonRuntime(
+            BasePackTests.TestBuildLocalFlag(
                 NodeProjectPath,
                 testName,
                 FuncPath,
                 Log,
-                "node");
+                false);
         }
     }
 }

--- a/test/Cli/Func.E2ETests/Commands/FuncPack/PowershellPackTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncPack/PowershellPackTests.cs
@@ -36,5 +36,18 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncPack
                     Path.Combine("HttpTrigger", "function.json")
                 });
         }
+
+        [Fact]
+        public void Pack_Powershell_WithBuildLocal_ShouldFail()
+        {
+            var testName = nameof(Pack_Powershell_WithBuildLocal_ShouldFail);
+
+            BasePackTests.TestBuildLocalFlagForNonPythonRuntime(
+                PowershellProjectPath,
+                testName,
+                FuncPath,
+                Log,
+                "powershell");
+        }
     }
 }

--- a/test/Cli/Func.E2ETests/Commands/FuncPack/PowershellPackTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncPack/PowershellPackTests.cs
@@ -38,16 +38,16 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncPack
         }
 
         [Fact]
-        public void Pack_Powershell_WithBuildLocal_ShouldFail()
+        public void Pack_Powershell_WithBuildLocal_WorksAsExpected()
         {
-            var testName = nameof(Pack_Powershell_WithBuildLocal_ShouldFail);
+            var testName = nameof(Pack_Powershell_WithBuildLocal_WorksAsExpected);
 
-            BasePackTests.TestBuildLocalFlagForNonPythonRuntime(
+            BasePackTests.TestBuildLocalFlag(
                 PowershellProjectPath,
                 testName,
                 FuncPath,
                 Log,
-                "powershell");
+                false);
         }
     }
 }

--- a/test/Cli/Func.E2ETests/Commands/FuncPack/PythonPackTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncPack/PythonPackTests.cs
@@ -148,26 +148,14 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncPack
         [Fact]
         public void Pack_Python_WithBuildLocal_WorksAsExpected()
         {
-            var testName = nameof(Pack_PythonFromCache_WorksAsExpected);
+            var testName = nameof(Pack_Python_WithBuildLocal_WorksAsExpected);
 
-            // Run pack command with --build-local flag
-            var funcPackCommand = new FuncPackCommand(FuncPath, testName, Log);
-            var packResult = funcPackCommand
-                .WithWorkingDirectory(PythonProjectPath)
-                .Execute(["--build-local"]);
-
-            // Verify pack succeeded
-            packResult.Should().ExitWith(0);
-            packResult.Should().HaveStdOutContaining("Creating a new package");
-            packResult.Should().HaveStdOutContaining("Performing local build for functions project.");
-
-            // Find any zip files in the working directory
-            var zipFiles = Directory.GetFiles(PythonProjectPath, "*.zip");
-
-            // Verify at least one zip file exists
-            Assert.True(zipFiles.Length > 0, $"No zip files found in {PythonProjectPath}");
-
-            File.Delete(zipFiles.First()); // Clean up the zip file after validation
+            BasePackTests.TestBuildLocalFlag(
+                PythonProjectPath,
+                testName,
+                FuncPath,
+                Log,
+                true);
         }
     }
 }

--- a/test/Cli/Func.E2ETests/Commands/FuncPack/PythonPackTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncPack/PythonPackTests.cs
@@ -168,5 +168,4 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncPack
             Assert.True(zipFiles.Length > 0, $"No zip files found in {workingDir}");
         }
     }
-    }
 }

--- a/test/Cli/Func.E2ETests/Commands/FuncPack/PythonPackTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncPack/PythonPackTests.cs
@@ -148,24 +148,26 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncPack
         [Fact]
         public void Pack_Python_WithBuildLocal_WorksAsExpected()
         {
-            var workingDir = WorkingDirectory;
             var testName = nameof(Pack_PythonFromCache_WorksAsExpected);
 
             // Run pack command with --build-local flag
             var funcPackCommand = new FuncPackCommand(FuncPath, testName, Log);
             var packResult = funcPackCommand
-                .WithWorkingDirectory(workingDir)
+                .WithWorkingDirectory(PythonProjectPath)
                 .Execute(["--build-local"]);
 
             // Verify pack succeeded
             packResult.Should().ExitWith(0);
             packResult.Should().HaveStdOutContaining("Creating a new package");
+            packResult.Should().HaveStdOutContaining("Performing local build for functions project.");
 
             // Find any zip files in the working directory
-            var zipFiles = Directory.GetFiles(workingDir, "*.zip");
+            var zipFiles = Directory.GetFiles(PythonProjectPath, "*.zip");
 
             // Verify at least one zip file exists
-            Assert.True(zipFiles.Length > 0, $"No zip files found in {workingDir}");
+            Assert.True(zipFiles.Length > 0, $"No zip files found in {PythonProjectPath}");
+
+            File.Delete(zipFiles.First()); // Clean up the zip file after validation
         }
     }
 }

--- a/test/Cli/Func.E2ETests/Commands/FuncPack/PythonPackTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncPack/PythonPackTests.cs
@@ -47,7 +47,7 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncPack
                 FuncPath,
                 Log,
                 expectedFiles,
-                shouldHaveLocalBuildLogs: true);
+                shouldHaveLocalBuildLogs: isWindows);
         }
 
         [Fact]

--- a/test/Cli/Func.UnitTests/HelperTests/ResolveBuildOptionTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/ResolveBuildOptionTests.cs
@@ -58,28 +58,28 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
 
             // Act
             var result = ResolveBuildOptionHelper.ResolveBuildOption(
-                BuildOption.Default,
+                BuildOption.Local,
                 WorkerRuntime.Python,
                 site: null,
                 buildNativeDeps: false,
                 noBuild: false,
-                includeLocalBuildForWindows: true);
+                isFuncPackAction: true);
 
             // Assert
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // On Windows, we expect the default behavior to be Remote
-                Assert.Equal(BuildOption.Default, result);
+                Assert.Equal(BuildOption.Local, result);
             }
             else
             {
-                // On non-Windows, it should still return Remote
-                Assert.Equal(BuildOption.Remote, result);
+                // On non-Windows, it should return Deferred
+                Assert.Equal(BuildOption.Deferred, result);
             }
         }
 
         [Fact]
-        public void ResolveBuildOption_PythonWithRequirementsTxt_WithWindowsBuild_AndLocalBuild_ReturnsDefault()
+        public void ResolveBuildOption_PythonWithRequirementsTxt_WithLocalBuildOption_ReturnsLocal()
         {
             // Arrange
             var requirementsTxtPath = Path.Combine(_tempDirectory, Constants.RequirementsTxt);
@@ -92,7 +92,8 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
                 site: null,
                 buildNativeDeps: false,
                 noBuild: false,
-                includeLocalBuildForWindows: true);
+                isFuncPackAction: true,
+                buildOptionLocal: true);
 
             // Assert
             Assert.Equal(BuildOption.Local, result);

--- a/test/Cli/Func.UnitTests/HelperTests/ResolveBuildOptionTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/ResolveBuildOptionTests.cs
@@ -49,6 +49,46 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
         }
 
         [Fact]
+        public void ResolveBuildOption_PythonWithRequirementsTxt_WithWindowsBuild_ReturnsDefault()
+        {
+            // Arrange
+            var requirementsTxtPath = Path.Combine(_tempDirectory, Constants.RequirementsTxt);
+            File.WriteAllText(requirementsTxtPath, "requests==2.25.1\nnumpy==1.21.0");
+
+            // Act
+            var result = ResolveBuildOptionHelper.ResolveBuildOption(
+                BuildOption.Default,
+                WorkerRuntime.Python,
+                site: null,
+                buildNativeDeps: false,
+                noBuild: false,
+                includeLocalBuildForWindows: true);
+
+            // Assert
+            Assert.Equal(BuildOption.Default, result);
+        }
+
+        [Fact]
+        public void ResolveBuildOption_PythonWithRequirementsTxt_WithWindowsBuild_AndLocalBuild_ReturnsDefault()
+        {
+            // Arrange
+            var requirementsTxtPath = Path.Combine(_tempDirectory, Constants.RequirementsTxt);
+            File.WriteAllText(requirementsTxtPath, "requests==2.25.1\nnumpy==1.21.0");
+
+            // Act
+            var result = ResolveBuildOptionHelper.ResolveBuildOption(
+                BuildOption.Local,
+                WorkerRuntime.Python,
+                site: null,
+                buildNativeDeps: false,
+                noBuild: false,
+                includeLocalBuildForWindows: true);
+
+            // Assert
+            Assert.Equal(BuildOption.Local, result);
+        }
+
+        [Fact]
         public void ResolveBuildOption_PythonWithEmptyRequirementsTxt_ReturnsDefault()
         {
             // Arrange

--- a/test/Cli/Func.UnitTests/HelperTests/ResolveBuildOptionTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/ResolveBuildOptionTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Runtime.InteropServices;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Helpers;
 using Xunit;
@@ -49,7 +50,7 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
         }
 
         [Fact]
-        public void ResolveBuildOption_PythonWithRequirementsTxt_WithWindowsBuild_ReturnsDefault()
+        public void ResolveBuildOption_PythonWithRequirementsTxt_DependingOnOs_ReturnsExpectedValue()
         {
             // Arrange
             var requirementsTxtPath = Path.Combine(_tempDirectory, Constants.RequirementsTxt);
@@ -65,7 +66,16 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
                 includeLocalBuildForWindows: true);
 
             // Assert
-            Assert.Equal(BuildOption.Default, result);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // On Windows, we expect the default behavior to be Remote
+                Assert.Equal(BuildOption.Default, result);
+            }
+            else
+            {
+                // On non-Windows, it should still return Remote
+                Assert.Equal(BuildOption.Remote, result);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Resolves [#4551](https://github.com/Azure/azure-functions-core-tools/issues/4551)
After having a discussion with the python team, we decided that it makes sense for the default build option to be remote, as this was done in [this PR](https://github.com/Azure/azure-functions-core-tools/pull/4530/files#diff-7a6ec14c3ba2de03fa733467285f0c19c45b456051b7ecaf03f9d7abec4afe45). However this may be a regression in Windows for those using GH Actions or ADO pipelines, as the customer may want to keep the default build to be local. 

This PR therefore reverts the behavior back to defaulting to a local build if the customer the function app is a python runtime with a requirements.txt and is on a windows machine. We warn the customer that in the next release, we will have all apps default to using a remote build and they may enable a local build by using the `--build-local` flag. 

This PR also adds additional logging as specified by this doc:
<img width="936" height="783" alt="image" src="https://github.com/user-attachments/assets/c0828488-7c54-41be-88ff-1a68c89da9db" />

We now also have a deferred build which is ready for remote deployment when running func pack as well.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
