### PR TITLE
Shim in MinorVersionPrefix in PrintVersion

### DIFF
--- a/src/Azure.Functions.Cli/Common/Utilities.cs
+++ b/src/Azure.Functions.Cli/Common/Utilities.cs
@@ -47,10 +47,28 @@ namespace Azure.Functions.Cli
 
         internal static void PrintVersion()
         {
+#if NET6_0
+            const string prefix = "6";
+#elif NET8_0
+            const string prefix = "8";
+#else
+            const string prefix = "";
+#endif
+
+            string version = ScriptHost.Version;
+            string[] parts = version.Split('.');
+
+            if (parts[1].Length == 2)
+            {
+                // no prefix, add it
+                parts[1] = prefix + parts[1];
+            }
+
+            version = string.Join(".", parts);
             ColoredConsole
                 .WriteLine($"\nAzure Functions Core Tools")
                 .WriteLine($"Core Tools Version:       {Constants.CliDetailedVersion + (Environment.Is64BitProcess ? " (64-bit)" : " (32-bit)")}".DarkGray())
-                .WriteLine($"Function Runtime Version: {ScriptHost.Version}\n".DarkGray());
+                .WriteLine($"Function Runtime Version: {version}\n".DarkGray());
         }
 
         private static RichString AlternateLogoColor(string str, int firstColorCount = -1)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #4460

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Shims in `MinorVersionPrefix` of `6` or `8` (based on TFM) during `PrintVersion`. This is to handle versions of `WebJobs.Script.dll` which do not differentiate net6 and net8 version in its assembly.
