### PR TITLE
Overwrite AZURE_FUNCTIONS_ENVIRONMENT if it exists

### DIFF
--- a/test/Cli/Func.UnitTests/ActionsTests/StartHostActionTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/StartHostActionTests.cs
@@ -261,6 +261,41 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
             Assert.False(expectException, "Expected validation failure.");
         }
 
+        [Fact]
+        public async Task GetConfigurationSettings_OverwritesAzFuncEnvironment_WhenAlreadyInSecrets()
+        {
+            // Arrange
+            var secretsDict = new Dictionary<string, string>
+            {
+                ["AZURE_FUNCTIONS_ENVIRONMENT"] = "UserEnv"
+            };
+
+            var mockSecretsManager = new Mock<ISecretsManager>();
+            mockSecretsManager.Setup(s => s.GetSecrets())
+                            .Returns(() => new Dictionary<string, string>(secretsDict));
+
+            // Return an empty set of connection strings of the expected type
+            mockSecretsManager.Setup(s => s.GetConnectionStrings())
+                            .Returns(Array.Empty<ConnectionString>);
+
+            // Initialize globals if required by your setup
+            GlobalCoreToolsSettings.Init(mockSecretsManager.Object, []);
+
+            var action = new StartHostAction(mockSecretsManager.Object, Mock.Of<IProcessManager>())
+            {
+                DotNetIsolatedDebug = false,
+                EnableJsonOutput = false,
+                VerboseLogging = false,
+                HostRuntime = "default"
+            };
+
+            // Act
+            var result = await action.GetConfigurationSettings("some/path", new Uri("https://example.com"));
+
+            // Assert
+            Assert.Equal("Development", result["AZURE_FUNCTIONS_ENVIRONMENT"]);
+        }
+
         public void Dispose()
         {
             FileSystemHelpers.Instance = null;


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #2465
### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Due to potential unexpected side effects, we cannot allow users to set `AZURE_FUNCTIONS_ENVIRONMENT`, but I've added a check in place to avoid the exception when there is a duplicate value, ensuring we set it to Development.
