### PR TITLE
Warn on JsonException when parsing local.settings.json

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -13,3 +13,4 @@
 - Update KEDA templates & `kubernetes create` command to correctly use a provided namespace, or use default namespace (#4558)
 - Update `func init` to default to the .NET 8 template for in-proc apps (#4557)
 - Implement (2 second) graceful timeout period for the CLI shutdown (#4540)
+- Warn if there is a `JsonException` when parsing the `local.settings.json` file (#4571)

--- a/src/Cli/func/Common/AppSettingsFile.cs
+++ b/src/Cli/func/Common/AppSettingsFile.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Text;
+using Colors.Net;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using static Azure.Functions.Cli.Common.OutputTheme;
 
 namespace Azure.Functions.Cli.Common
 {
@@ -24,8 +26,13 @@ namespace Azure.Functions.Cli.Common
                 ConnectionStrings = appSettings.ConnectionStrings;
                 Host = appSettings.Host;
             }
-            catch
+            catch (Exception ex)
             {
+                if (ex is JsonException)
+                {
+                    ColoredConsole.WriteLine(WarningColor($"Failed to read app settings file at '{_filePath}'. Ensure it is a valid JSON file. {ex.Message}"));
+                }
+
                 Values = new Dictionary<string, string>();
                 ConnectionStrings = new Dictionary<string, JToken>();
                 IsEncrypted = true;

--- a/src/Cli/func/Common/SecretsManager.cs
+++ b/src/Cli/func/Common/SecretsManager.cs
@@ -9,6 +9,10 @@ namespace Azure.Functions.Cli.Common
 {
     internal class SecretsManager : ISecretsManager
     {
+        private static readonly Lazy<AppSettingsFile> _lazySettings = new Lazy<AppSettingsFile>(() => new AppSettingsFile(AppSettingsFilePath));
+
+        private static AppSettingsFile Settings => _lazySettings.Value;
+
         public static string AppSettingsFilePath
         {
             get
@@ -34,94 +38,85 @@ namespace Azure.Functions.Cli.Common
 
         public IDictionary<string, string> GetSecrets()
         {
-            var appSettingsFile = new AppSettingsFile(AppSettingsFilePath);
-            return appSettingsFile.GetValues();
+            return Settings.GetValues();
         }
 
         public IEnumerable<ConnectionString> GetConnectionStrings()
         {
-            var appSettingsFile = new AppSettingsFile(AppSettingsFilePath);
-            return appSettingsFile.GetConnectionStrings();
+            return Settings.GetConnectionStrings();
         }
 
         public void SetSecret(string name, string value)
         {
-            var appSettingsFile = new AppSettingsFile(AppSettingsFilePath);
-            appSettingsFile.SetSecret(name, value);
-            appSettingsFile.Commit();
+            Settings.SetSecret(name, value);
+            Settings.Commit();
         }
 
         public void SetConnectionString(string name, string value)
         {
-            var appSettingsFile = new AppSettingsFile(AppSettingsFilePath);
-            appSettingsFile.SetConnectionString(name, value, Constants.DefaultSqlProviderName);
-            appSettingsFile.Commit();
+            Settings.SetConnectionString(name, value, Constants.DefaultSqlProviderName);
+            Settings.Commit();
         }
 
         public void DecryptSettings()
         {
-            var settingsFile = new AppSettingsFile(AppSettingsFilePath);
-            if (settingsFile.IsEncrypted)
+            if (Settings.IsEncrypted)
             {
-                var values = settingsFile.GetValues();
-                var connectionStrings = settingsFile.GetConnectionStrings();
-                settingsFile.IsEncrypted = false;
+                var values = Settings.GetValues();
+                var connectionStrings = Settings.GetConnectionStrings();
+                Settings.IsEncrypted = false;
 
                 foreach (var pair in values)
                 {
-                    settingsFile.SetSecret(pair.Key, pair.Value);
+                    Settings.SetSecret(pair.Key, pair.Value);
                 }
 
                 foreach (var connectionString in connectionStrings)
                 {
-                    settingsFile.SetConnectionString(connectionString.Name, connectionString.Value, connectionString.ProviderName);
+                    Settings.SetConnectionString(connectionString.Name, connectionString.Value, connectionString.ProviderName);
                 }
 
-                settingsFile.Commit();
+                Settings.Commit();
             }
         }
 
         public void EncryptSettings()
         {
-            var settingsFile = new AppSettingsFile(AppSettingsFilePath);
-            if (!settingsFile.IsEncrypted)
+            if (!Settings.IsEncrypted)
             {
-                var values = settingsFile.GetValues();
-                var connectionStrings = settingsFile.GetConnectionStrings();
-                settingsFile.IsEncrypted = true;
+                var values = Settings.GetValues();
+                var connectionStrings = Settings.GetConnectionStrings();
+                Settings.IsEncrypted = true;
 
                 foreach (var pair in values)
                 {
-                    settingsFile.SetSecret(pair.Key, pair.Value);
+                    Settings.SetSecret(pair.Key, pair.Value);
                 }
 
                 foreach (var connectionString in connectionStrings)
                 {
-                    settingsFile.SetConnectionString(connectionString.Name, connectionString.Value, connectionString.ProviderName);
+                    Settings.SetConnectionString(connectionString.Name, connectionString.Value, connectionString.ProviderName);
                 }
 
-                settingsFile.Commit();
+                Settings.Commit();
             }
         }
 
         public void DeleteSecret(string name)
         {
-            var settingsFile = new AppSettingsFile(AppSettingsFilePath);
-            settingsFile.RemoveSetting(name);
-            settingsFile.Commit();
+            Settings.RemoveSetting(name);
+            Settings.Commit();
         }
 
         public HostStartSettings GetHostStartSettings()
         {
-            var settingsFile = new AppSettingsFile(AppSettingsFilePath);
-            return settingsFile.Host ?? new HostStartSettings();
+            return Settings.Host ?? new HostStartSettings();
         }
 
         public void DeleteConnectionString(string name)
         {
-            var settingsFile = new AppSettingsFile(AppSettingsFilePath);
-            settingsFile.RemoveConnectionString(name);
-            settingsFile.Commit();
+            Settings.RemoveConnectionString(name);
+            Settings.Commit();
         }
     }
 }

--- a/src/Cli/func/NativeMethods/EnvironmentNativeMethods.cs
+++ b/src/Cli/func/NativeMethods/EnvironmentNativeMethods.cs
@@ -28,7 +28,7 @@ namespace Azure.Functions.Cli.NativeMethods
                 // Any changes through setenv() are ignored.
                 if (StaticSettings.IsDebug)
                 {
-                    ColoredConsole.WriteLine("Setting unsupported .NET environment variables (empty string) is not implemented for this platform.");
+                    ColoredConsole.WriteLine($"Setting an environment variable ('{key}') to an empty string is not implemented for this platform.");
                 }
             }
         }

--- a/test/Cli/Func.UnitTests/AppSettingsFileTests.cs
+++ b/test/Cli/Func.UnitTests/AppSettingsFileTests.cs
@@ -1,0 +1,98 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Common;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Azure.Functions.Cli.UnitTests;
+
+public class AppSettingsFileTests : IDisposable
+{
+    private readonly string _tempFilePath;
+
+    public AppSettingsFileTests()
+    {
+        _tempFilePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".json");
+    }
+
+    [Fact]
+    public void Ctor_WithValidJson_LoadsAllProperties()
+    {
+        // Arrange
+        var json = @"
+            {
+              ""IsEncrypted"": false,
+              ""Values"": {
+                ""MySecret"": ""PlainTextValue""
+              },
+              ""ConnectionStrings"": {
+                ""MyConn"": {
+                  ""ConnectionString"": ""Server=.;Database=MyDb;"",
+                  ""ProviderName"": ""System.Data.SqlClient""
+                }
+              },
+              ""Host"": {}
+            }";
+        File.WriteAllText(_tempFilePath, json);
+
+        // Act
+        var settings = new AppSettingsFile(_tempFilePath);
+
+        // Assert
+        Assert.False(settings.IsEncrypted);
+        Assert.Single(settings.Values);
+        Assert.Equal("PlainTextValue", settings.Values["MySecret"]);
+
+        Assert.Single(settings.ConnectionStrings);
+        var token = settings.ConnectionStrings["MyConn"];
+        Assert.Equal(JTokenType.Object, token.Type);
+        Assert.Equal("Server=.;Database=MyDb;", token["ConnectionString"]?.ToString());
+        Assert.Equal("System.Data.SqlClient", token["ProviderName"]?.ToString());
+
+        Assert.NotNull(settings.Host);
+    }
+
+    [Fact]
+    public void Ctor_WithInvalidJson_FallsBackToDefaults()
+    {
+        // Arrange: write syntactically invalid JSON
+        File.WriteAllText(_tempFilePath, "{ this is : not valid JSON }");
+
+        // Act
+        var settings = new AppSettingsFile(_tempFilePath);
+
+        // Assert: constructor should catch the JsonException and reset
+        Assert.True(settings.IsEncrypted, "Defaults to encrypted");
+        Assert.Empty(settings.Values);
+        Assert.Empty(settings.ConnectionStrings);
+        Assert.Null(settings.Host);
+    }
+
+    [Fact]
+    public void Ctor_WithMissingFile_FallsBackToDefaults()
+    {
+        // Arrange: ensure the file does not exist
+        if (File.Exists(_tempFilePath))
+        {
+            File.Delete(_tempFilePath);
+        }
+
+        // Act
+        var settings = new AppSettingsFile(_tempFilePath);
+
+        // Assert: missing‐file (FileNotFoundException) is also caught
+        Assert.True(settings.IsEncrypted, "Defaults to encrypted");
+        Assert.Empty(settings.Values);
+        Assert.Empty(settings.ConnectionStrings);
+        Assert.Null(settings.Host);
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(_tempFilePath))
+        {
+            File.Delete(_tempFilePath);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #1401

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

- Warn if unable to parse local settings json due to json exception. Did not want to throw to avoid breaking behaviour
- Lazy init for AppSettingsFile as we do not need to read the local settings json every time we check the secrets.
- Minor fix to the SetEnvironmentVariable console log to include the key