### PR TITLE
Enable verbose logging in our MSI

### DIFF
--- a/eng/res/msi/funcinstall.wxs
+++ b/eng/res/msi/funcinstall.wxs
@@ -34,6 +34,9 @@
              Languages='1033'
              SummaryCodepage='1252' />
 
+    <!-- Enable verbose logs -->    
+    <Property Id="MsiLogging" Value="voicewarmupx" />
+
     <MajorUpgrade AllowDowngrades='yes' Schedule='afterInstallInitialize' />
 
     <Media Id='1' Cabinet='funchost.cab' EmbedCab='yes' />


### PR DESCRIPTION
This change enables verbose logs in our MSI to help troubleshoot recent issues we've been seeing with missing files in the upgrade path.

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

related to #3602

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] I have added all required tests (Unit tests, E2E tests)

