### PR TITLE
Display a default function name for new dotnet functions

### DIFF
--- a/src/Cli/func/Actions/LocalActions/CreateFunctionAction.cs
+++ b/src/Cli/func/Actions/LocalActions/CreateFunctionAction.cs
@@ -134,8 +134,9 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                     ColoredConsole.WriteLine($"Template: {TemplateName}");
                 }
 
-                ColoredConsole.Write("Function name: ");
+                ColoredConsole.Write($"Function name: [{TemplateName}] ");
                 FunctionName = FunctionName ?? Console.ReadLine();
+                FunctionName = string.IsNullOrEmpty(FunctionName) ? TemplateName : FunctionName;
                 ColoredConsole.WriteLine(FunctionName);
                 var namespaceStr = Path.GetFileName(Environment.CurrentDirectory);
                 await DotnetHelpers.DeployDotnetFunction(TemplateName.Replace(" ", string.Empty), Utilities.SanitizeClassName(FunctionName), Utilities.SanitizeNameSpace(namespaceStr), Language.Replace("-isolated", string.Empty), _workerRuntime, AuthorizationLevel);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

n/a

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Similar to other languages, display a default name for a new Function. Default name is based on the template name. Validated this works with both the in-proc and out-of-proc templates.

```log
> $testcli new -t HttpTrigger
Template: HttpTrigger
Function name: [HttpTrigger]
HttpTrigger

Creating dotnet function...
The template "HttpTrigger" was created successfully.

The function "HttpTrigger" was created successfully from the "HttpTrigger" template.

-----
> $testcli new
Select a number for template:
1. QueueTrigger
2. HttpTrigger
3. BlobTrigger
4. TimerTrigger
5. KafkaTrigger
6. KafkaOutput
7. DurableFunctionsOrchestration
8. SendGrid
9. EventHubTrigger
10. ServiceBusQueueTrigger
11. ServiceBusTopicTrigger
12. EventGridTrigger
13. EventGridCloudEventTrigger
14. CosmosDBTrigger
15. IotHubTrigger
16. DaprPublishOutputBinding
17. DaprServiceInvocationTrigger
18. DaprTopicTrigger
Choose option: 7
Function name: [DurableFunctionsOrchestration]
DurableFunctionsOrchestration

Creating dotnet function...
The template "DurableFunctionsOrchestration" was created successfully.

```
