### PR TITLE
MSI install: change REINSTALLMODE to dmus

### DIFF
--- a/eng/res/msi/funcinstall.wxs
+++ b/eng/res/msi/funcinstall.wxs
@@ -34,7 +34,10 @@
              Languages='1033'
              SummaryCodepage='1252' />
 
-    <!-- Enable verbose logs -->    
+    <!-- Reinstall if the file is missing or a different version is present; it will overwrite newer or older files -->
+    <Property Id="REINSTALLMODE" Value="dmus"/>
+
+    <!-- Enable verbose logs -->
     <Property Id="MsiLogging" Value="voicewarmupx" />
 
     <MajorUpgrade AllowDowngrades='yes' Schedule='afterInstallInitialize' />


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

The `REINSTALLMODE` flag tell Windows Installer exactly how to overwrite files (and rewrite registry entries/shortcuts) when you do a “reinstall”. The default is `omus`. By switching to `dmus` we tell it to reinstall if the file is missing or a different version is present on disk (so it will overwrite newer or older files)
