### PR TITLE
Updating default file encoding configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ root = true
 # All files | Don't use tabs for indentation.
 [*]
 indent_style = space
+charset = utf-8
 
 # Code files
 [*.{cs,csx,vb,vbx}]
@@ -16,7 +17,6 @@ xml_header = false
 indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
-charset = utf-8-bom
 
 #############################
 # Script Coding Conventions #


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

This pull request makes a minor update to the `.editorconfig` file to standardize file encoding settings across the project. The main change is the addition of a `charset = utf-8` (no BOM) setting for all files, replacing the previous `utf-8-bom` setting for code files.

I am **not** changing all files with this PR to avoid the churn and history mess. This will ensure the configuration is enforced as we continue to work on the repo. We can evaluate changes to other files if needed.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [x] Otherwise: Backport tracked by issue/PR #11248
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

