### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,7 +13,7 @@
 *.png 	binary
 *.gif 	binary
 
-*.cs text=auto diff=csharp 
+*.cs text=auto diff=csharp
 *.vb text=auto
 *.c text=auto
 *.cpp text=auto
@@ -49,3 +49,7 @@
 *.fsproj text=auto
 *.dbproj text=auto
 *.sln text=auto eol=crlf
+
+# Use union on release notes to keep both local and remote changes
+# and avoid merge conflicts.
+release_notes.md merge=union


### PR DESCRIPTION
Use union on release notes to keep both local and remote changes and avoid merge conflicts.