### PR TITLE
Return HostStartSettings if local.settings.json is not loaded

### DIFF
--- a/src/Cli/func/Common/SecretsManager.cs
+++ b/src/Cli/func/Common/SecretsManager.cs
@@ -110,7 +110,14 @@ namespace Azure.Functions.Cli.Common
 
         public HostStartSettings GetHostStartSettings()
         {
-            return Settings.Host ?? new HostStartSettings();
+            try
+            {
+                return Settings?.Host ?? new HostStartSettings();
+            }
+            catch (CliException)
+            {
+                return new HostStartSettings();
+            }
         }
 
         public void DeleteConnectionString(string name)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #4604

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This is an unfortunate overlap with how the help command is designed today, and how the start action's args use customer options.

Unfortunately the way that the help action is designed today makes it so that we need to load an action to get it's arguements/options. So in a situation like this where you run `func` to see the commands, we run the StartAction.ParseArgs -> which inits the secret manager to get host options (if any) -> secret manager looks for local.settings.json -> that doesn't exist outside of a func app dir -> exception. 

This will all be reworked as part of our upcoming refactor, which will seperate these two things and cleanup the help command in general.

Updated `GetHostStartSettings` to catch the exception when local.settings.json does not exist and return a new `HostStartSettings`. If a customer configures these settings, then local.settings.json and/or host.json will exist and the exception won't occur. If a customer does not configure these settings, we use the default.