### PR TITLE
Remove CI schedule in v4.x

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -1,11 +1,3 @@
-schedules:
-- cron: "0 0 * * *"
-  displayName: Nightly Build
-  branches:
-    include:
-      - v4.x
-  always: true
-
 name: $(Build.SourceBranchName)_$(Build.Reason)
 
 pr: none

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -1,11 +1,3 @@
-schedules:
-- cron: "0 0 * * *"
-  displayName: Nightly Build
-  branches:
-    include:
-      - v4.x
-  always: true
-
 name: $(Build.SourceBranchName)_$(Build.Reason)
 
 pr:


### PR DESCRIPTION
v4.x branch runs automated CI nightly and this is no longer required.