### PR TITLE
Add support for Python 3.14

### DIFF
--- a/src/Cli/func/Azure.Functions.Cli.csproj
+++ b/src/Cli/func/Azure.Functions.Cli.csproj
@@ -98,6 +98,9 @@
     <EmbeddedResource Include="StaticResources\Dockerfile.python3.13">
       <LogicalName>$(AssemblyName).Dockerfile.python3.13</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="StaticResources\Dockerfile.python314buildenv">
+      <LogicalName>$(AssemblyName).Dockerfile.python314buildenv</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="StaticResources\Dockerfile.javascript">
       <LogicalName>$(AssemblyName).Dockerfile.javascript</LogicalName>
     </EmbeddedResource>

--- a/src/Cli/func/Common/Constants.cs
+++ b/src/Cli/func/Common/Constants.cs
@@ -190,6 +190,7 @@ namespace Azure.Functions.Cli.Common
             public const string LinuxPython311ImageAmd64 = "mcr.microsoft.com/azure-functions/python:4-python3.11-buildenv";
             public const string LinuxPython312ImageAmd64 = "mcr.microsoft.com/azure-functions/python:4-python3.12-buildenv";
             public const string LinuxPython313ImageAmd64 = "mcr.microsoft.com/azure-functions/python:4-python3.13-buildenv";
+            public const string LinuxPython313ImageAmd64 = "mcr.microsoft.com/azure-functions/python:4-python3.14-buildenv";
         }
 
         public static class StaticResourcesNames

--- a/src/Cli/func/Helpers/PythonHelpers.cs
+++ b/src/Cli/func/Helpers/PythonHelpers.cs
@@ -168,7 +168,7 @@ namespace Azure.Functions.Cli.Helpers
         {
             if (pythonVersion?.Version == null)
             {
-                var message = "Could not find a Python version. 3.9.x, 3.10.x, 3.11.x, 3.12.x or 3.13.x is recommended, and used in Azure Functions.";
+                var message = "Could not find a Python version. 3.10.x, 3.11.x, 3.12.x, 3.13.x, or 3.14.x is recommended, and used in Azure Functions.";
                 if (errorIfNoVersion)
                 {
                     throw new CliException(message);
@@ -191,15 +191,15 @@ namespace Azure.Functions.Cli.Helpers
             {
                 if (errorIfNotSupported)
                 {
-                    throw new CliException($"Python 3.9.x to 3.13.x is required for this operation. " +
-                        $"Please install Python 3.9, 3.10, 3.11, 3.12 or 3.13 and use a virtual environment to switch to Python 3.9, 3.10, 3.11, 3.12 or 3.13.");
+                    throw new CliException($"Python 3.10.x to 3.14.x is required for this operation. " +
+                        $"Please install Python 3.10, 3.11, 3.12, 3.13 or 3.14 and use a virtual environment to switch to Python 3.10, 3.11, 3.12, 3.13 or 3.14.");
                 }
 
-                ColoredConsole.WriteLine(WarningColor("Python 3.9.x, 3.10.x, 3.11.x, 3.12.x or 3.13.x is recommended, and used in Azure Functions."));
+                ColoredConsole.WriteLine(WarningColor("Python 3.10.x, 3.11.x, 3.12.x, 3.13.x or 3.14.x is recommended, and used in Azure Functions."));
             }
 
             // No Python 3
-            var error = "Python 3.x (recommended version 3.[7|8|9|10|11|12]) is required.";
+            var error = "Python 3.x (recommended version 3.[10|11|12|13|14]) is required.";
             if (errorIfNoVersion)
             {
                 throw new CliException(error);
@@ -239,6 +239,7 @@ namespace Azure.Functions.Cli.Helpers
             var python311GetVersionTask = GetVersion("python3.11");
             var python312GetVersionTask = GetVersion("python3.12");
             var python313GetVersionTask = GetVersion("python3.13");
+            var python314GetVersionTask = GetVersion("python3.14");
 
             var versions = new List<WorkerLanguageVersionInfo>
             {
@@ -252,7 +253,8 @@ namespace Azure.Functions.Cli.Helpers
                 await python310GetVersionTask,
                 await python311GetVersionTask,
                 await python312GetVersionTask,
-                await python313GetVersionTask
+                await python313GetVersionTask,
+                await python314GetVersionTask
             };
 
             // Highest preference -- Go through the list, if we find the first python 3.6 or python 3.7 worker, we prioritize that.
@@ -590,6 +592,8 @@ namespace Azure.Functions.Cli.Helpers
                         return StaticResources.DockerfilePython312;
                     case 13:
                         return StaticResources.DockerfilePython313;
+                    case 14:
+                        return StaticResources.DockerfilePython314;
                 }
             }
 
@@ -618,10 +622,12 @@ namespace Azure.Functions.Cli.Helpers
                         return Constants.DockerImages.LinuxPython312ImageAmd64;
                     case 13:
                         return Constants.DockerImages.LinuxPython313ImageAmd64;
+                    case 14:
+                        return Constants.DockerImages.LinuxPython314ImageAmd64;
                 }
             }
 
-            return Constants.DockerImages.LinuxPython312ImageAmd64;
+            return Constants.DockerImages.LinuxPython313ImageAmd64;
         }
 
         private static bool IsVersionSupported(WorkerLanguageVersionInfo info)
@@ -630,6 +636,7 @@ namespace Azure.Functions.Cli.Helpers
             {
                 switch (info?.Minor)
                 {
+                    case 14:
                     case 13:
                     case 12:
                     case 11:
@@ -648,11 +655,11 @@ namespace Azure.Functions.Cli.Helpers
 
         public static bool IsLinuxFxVersionRuntimeVersionMatched(string linuxFxVersion, int? major, int? minor)
         {
-            // No linux fx version will default to python 3.12
+            // No linux fx version will default to python 3.13
             if (string.IsNullOrEmpty(linuxFxVersion))
             {
-                // Match if version is 3.12
-                return major == 3 && minor == 12;
+                // Match if version is 3.13
+                return major == 3 && minor == 13;
             }
 
             // Only validate on LinuxFxVersion that follows the pattern PYTHON|<version>
@@ -669,8 +676,8 @@ namespace Azure.Functions.Cli.Helpers
         {
             if (string.IsNullOrEmpty(flexRuntime) || string.IsNullOrEmpty(flexRuntimeVersion))
             {
-                // Match if version is 3.12
-                return major == 3 && minor == 12;
+                // Match if version is 3.13
+                return major == 3 && minor == 13;
             }
 
             // Only validate for python.

--- a/src/Cli/func/StaticResources/Dockerfile.python3.14
+++ b/src/Cli/func/StaticResources/Dockerfile.python3.14
@@ -1,0 +1,11 @@
+# To enable ssh & remote debugging on app service change the base image to the one below
+# FROM mcr.microsoft.com/azure-functions/python:4-python3.14-appservice
+FROM mcr.microsoft.com/azure-functions/python:4-python3.14
+
+ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
+    AzureFunctionsJobHost__Logging__Console__IsEnabled=true
+
+COPY requirements.txt /
+RUN pip install -r /requirements.txt
+
+COPY . /home/site/wwwroot

--- a/src/Cli/func/StaticResources/StaticResources.cs
+++ b/src/Cli/func/StaticResources/StaticResources.cs
@@ -48,6 +48,8 @@ namespace Azure.Functions.Cli
 
         public static Task<string> DockerfilePython313 => GetValue("Dockerfile.python3.13");
 
+        public static Task<string> DockerfilePython314 => GetValue("Dockerfile.python3.14");
+
         public static Task<string> DockerfilePowershell7 => GetValue("Dockerfile.powershell7");
 
         public static Task<string> DockerfilePowershell72 => GetValue("Dockerfile.powershell7.2");

--- a/test/Cli/Func.UnitTests/HelperTests/PythonHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/PythonHelperTests.cs
@@ -57,6 +57,7 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
         [InlineData("Python|3.11", 3, 11, true)]
         [InlineData("Python|3.12", 3, 12, true)]
         [InlineData("Python|3.13", 3, 13, true)]
+        [InlineData("Python|3.14", 3, 14, true)]
         public void ShouldHaveMatchingLinuxFxVersion(string linuxFxVersion, int? major, int? minor, bool expectedResult)
         {
             bool result = PythonHelpers.IsLinuxFxVersionRuntimeVersionMatched(linuxFxVersion, major, minor);
@@ -77,6 +78,7 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
         [InlineData("3.11.0", false)]
         [InlineData("3.12.0", false)]
         [InlineData("3.13.0", false)]
+        [InlineData("3.14.0", false)]
         public void AssertPythonVersion(string pythonVersion, bool expectException)
         {
             WorkerLanguageVersionInfo worker = new WorkerLanguageVersionInfo(WorkerRuntime.Python, pythonVersion, "python");
@@ -98,11 +100,11 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
             string[] pythons;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                pythons = new string[] { "python.exe", "python3.exe", "python39.exe", "python310.exe", "python311.exe", "python312.exe", "python313.exe", "py.exe" };
+                pythons = new string[] { "python.exe", "python3.exe", "python310.exe", "python311.exe", "python312.exe", "python313.exe", "python314.exe", "py.exe" };
             }
             else
             {
-                pythons = new string[] { "python", "python3", "python39", "python310", "python311", "python312", "python313" };
+                pythons = new string[] { "python", "python3", "python310", "python311", "python312", "python313", "python314" };
             }
 
             string pythonExe = pythons.FirstOrDefault(p => CheckIfPythonExist(p));


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
- Adds support for Python 3.14
- Updates error messages to say 3.10 - 3.14 (3.9 is now deprecated)
- If no linux fx version detected, default to python 3.13

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
