### PR TITLE
Fixed for debugging fails to detect job functions due to inconsistent…

### DIFF
--- a/src/Cli/func/Common/AppSettingsFile.cs
+++ b/src/Cli/func/Common/AppSettingsFile.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Text;
+using Azure.Functions.Cli.Helpers;
 using Colors.Net;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -30,7 +31,8 @@ namespace Azure.Functions.Cli.Common
                 });
 
                 IsEncrypted = appSettings.Value<bool?>("IsEncrypted") ?? true;
-                Values = appSettings["Values"]?.ToObject<Dictionary<string, string>>(localSerializer) ?? new Dictionary<string, string>();
+                var rawValues = appSettings["Values"]?.ToObject<Dictionary<string, string>>(localSerializer) ?? new Dictionary<string, string>();
+                Values = EnvironmentHelper.NormalizeBooleanValues(rawValues);
                 ConnectionStrings = appSettings["ConnectionStrings"]?.ToObject<Dictionary<string, JToken>>(localSerializer) ?? new Dictionary<string, JToken>();
                 Host = appSettings["Host"]?.ToObject<HostStartSettings>(localSerializer) ?? new HostStartSettings();
             }

--- a/src/Cli/func/Helpers/EnvironmentHelper.cs
+++ b/src/Cli/func/Helpers/EnvironmentHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 namespace Azure.Functions.Cli.Helpers
@@ -23,6 +23,25 @@ namespace Azure.Functions.Cli.Helpers
             {
                 Environment.SetEnvironmentVariable(keyName, "true");
             }
+        }
+
+        public static Dictionary<string, string> NormalizeBooleanValues(Dictionary<string, string> values)
+        {
+            if (values == null || values.Count == 0)
+            {
+                return values ?? new Dictionary<string, string>();
+            }
+
+            foreach (var key in values.Keys.ToList())
+            {
+                var value = values[key];
+                if (string.Equals(value, "True", StringComparison.OrdinalIgnoreCase) || string.Equals(value, "False", StringComparison.OrdinalIgnoreCase))
+                {
+                    values[key] = value.ToLowerInvariant();
+                }
+            }
+
+            return values;
         }
     }
 }

--- a/test/Cli/Func.UnitTests/AppSettingsFileTests.cs
+++ b/test/Cli/Func.UnitTests/AppSettingsFileTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Helpers;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -86,6 +87,39 @@ public class AppSettingsFileTests : IDisposable
         Assert.Empty(settings.Values);
         Assert.Empty(settings.ConnectionStrings);
         Assert.Null(settings.Host);
+    }
+
+    [Fact]
+    public void NormalizeBooleanValues_ShouldConvertPascalCaseBooleansToLowercase()
+    {
+        // Arrange
+        var input = new Dictionary<string, string>
+       {
+           { "AzureWebJobs.RestHandler.Disabled", "False" },
+           { "AzureWebJobs.StorageHandler.Disabled", "True" },
+           { "SomeOtherKey", "customValue" }
+       };
+
+        // Act
+        var result = EnvironmentHelper.NormalizeBooleanValues(input);
+
+        // Assert
+        Assert.Equal("false", result["AzureWebJobs.RestHandler.Disabled"]);
+        Assert.Equal("true", result["AzureWebJobs.StorageHandler.Disabled"]);
+        Assert.Equal("customValue", result["SomeOtherKey"]);
+    }
+
+    [Fact]
+    public void NormalizeBooleanValues_ShouldHandleEmptyDictionary()
+    {
+        // Arrange
+        var input = new Dictionary<string, string>();
+
+        // Act
+        var result = EnvironmentHelper.NormalizeBooleanValues(input);
+
+        // Assert
+        Assert.Empty(result);
     }
 
     public void Dispose()


### PR DESCRIPTION
… Boolean values in `local.settings.json`.#4663

<!-- Please provide all the information below.  -->

### This PR resolves the issue where Azure Functions Core Tools failed to detect job functions due to inconsistent Boolean values in `local.settings.json`. The root cause was that Boolean values were not consistently normalized, leading to unexpected behavior during startup.
- To fix this, I've introduced a helper method that normalizes Boolean values from the local settings to lowercase strings.
- Tested against the HelloWorldNodejs.zip workspace and confirmed that the regression seen in v4.2.1 and v4.2.2 is resolved.

resolves #4663 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
