### PR TITLE
Deb build script should fail if unable to download cli artifacts

### DIFF
--- a/eng/ci/templates/official/jobs/linux-deb-build-pack.yml
+++ b/eng/ci/templates/official/jobs/linux-deb-build-pack.yml
@@ -52,11 +52,12 @@ jobs:
 
   - task: Bash@3
     displayName: 'Build DEB package'
-    failOnStderr: true
     inputs:
       targetType: 'inline'
       script: |
+        # fail fast and make undefined vars an error
         set -euo pipefail
+
         cd eng/tools/publish-tools
         python3 -m venv publish-env
         source publish-env/bin/activate

--- a/eng/tools/publish-tools/shared/helper.py
+++ b/eng/tools/publish-tools/shared/helper.py
@@ -65,7 +65,11 @@ def linuxOutput(buildFolder, arch):
     import wget
     if not os.path.exists(fileName):
         print(f"downloading from {url}")
-        wget.download(url)
+        try:
+            wget.download(url)
+        except Exception as e:
+            print(f"\nERROR: unexpected error downloading {url}: {e}")
+            sys.exit(1)
 
     usr = os.path.join(buildFolder, "usr")
     usrlib = os.path.join(usr, "lib")


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #4690

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

- Update CI to fail on non-zero exit code
- Update python script to catch any exceptions when downloading cli artifacts and exit on failure

Tested in [CI](https://azfunc.visualstudio.com/internal/_build/results?buildId=244127&view=logs&j=9495342e-e483-5015-14aa-17ad5dd9d8f3&t=5e4ea654-e5a5-570e-f857-55bfb48edada) with an invalid blob URL.
