### PR TITLE
fix: outputs local.settings.json found even though it isnt

### DIFF
--- a/src/Cli/func/Common/SecretsManager.cs
+++ b/src/Cli/func/Common/SecretsManager.cs
@@ -27,7 +27,7 @@ namespace Azure.Functions.Cli.Common
                 });
                 var secretsFilePath = Path.Combine(rootPath, secretsFile);
 
-                ColoredConsole.WriteLine(DarkGray($"'{secretsFile}' found in root directory ({rootPath})."));
+                ColoredConsole.WriteLine(DarkGray($"'{secretsFile}' should be in root directory ({rootPath})."));
                 return secretsFilePath;
             }
         }


### PR DESCRIPTION
### Issue describing the changes in this PR

I wondered why I'm asked for the worker runtime, although it told me the `local.settings.json` was found. Turns out it is a new clone and the file is not there. The output is just wrong.

```
local.settings.json found in root directory (C:\Users\WhiteTom\src\api).
Use the up/down arrow keys to select a worker runtime:
dotnet (isolated worker model)
dotnet (in-process model)
Node
Python
Powershell
Custom
```

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
  * Or should they be added to release notes?
* [ ] I have added all required tests (Unit tests, E2E tests)
  * I don't think tests are required for that?