### PR TITLE
Set `AzureWebJobsStorage` to use the storage emulator by default on all platforms 

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -8,3 +8,4 @@
 #### Changes
 
 - Add updated Durable .NET templates (#4692)
+- Set `AzureWebJobsStorage` to use the storage emulator by default on all platforms (#4685)

--- a/src/Cli/func/Actions/LocalActions/InitAction.cs
+++ b/src/Cli/func/Actions/LocalActions/InitAction.cs
@@ -400,14 +400,9 @@ namespace Azure.Functions.Cli.Actions.LocalActions
 
         private static async Task WriteLocalSettingsJson(WorkerRuntime workerRuntime, ProgrammingModel programmingModel)
         {
-            var localSettingsJsonContent = await StaticResources.LocalSettingsJson;
+            string localSettingsJsonContent = await StaticResources.LocalSettingsJson;
             localSettingsJsonContent = localSettingsJsonContent.Replace($"{{{Constants.FunctionsWorkerRuntime}}}", WorkerRuntimeLanguageHelper.GetRuntimeMoniker(workerRuntime));
-
-            var storageConnectionStringValue = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                ? Constants.StorageEmulatorConnectionString
-                : string.Empty;
-
-            localSettingsJsonContent = localSettingsJsonContent.Replace($"{{{Constants.AzureWebJobsStorage}}}", storageConnectionStringValue);
+            localSettingsJsonContent = localSettingsJsonContent.Replace($"{{{Constants.AzureWebJobsStorage}}}", Constants.StorageEmulatorConnectionString);
 
             if (workerRuntime == Helpers.WorkerRuntime.Powershell)
             {

--- a/src/Cli/func/Helpers/DotnetHelpers.cs
+++ b/src/Cli/func/Helpers/DotnetHelpers.cs
@@ -95,9 +95,7 @@ namespace Azure.Functions.Cli.Helpers
                     var frameworkString = string.IsNullOrEmpty(targetFramework)
                         ? string.Empty
                         : $"--Framework \"{targetFramework}\"";
-                    var connectionString = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                        ? $"--StorageConnectionStringValue \"{Constants.StorageEmulatorConnectionString}\""
-                        : string.Empty;
+                    var connectionString = $"--StorageConnectionStringValue \"{Constants.StorageEmulatorConnectionString}\"";
                     TryGetCustomHiveArg(workerRuntime, out string customHive);
                     var exe = new Executable("dotnet", $"new func {frameworkString} --AzureFunctionsVersion v4 --name {name} {connectionString} {(force ? "--force" : string.Empty)}{customHive}");
                     var exitCode = await exe.RunAsync(o => { }, e => ColoredConsole.Error.WriteLine(ErrorColor(e)));


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

n/a

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

We use to only set `UseDevelopmentStorage=true` on windows as the storage emulator did not exist for osx/linux. Now that customers can use azurite for storage emulation, we should set this default value for all new func apps so that `func start` works immediately without additional configuration.
