### PR TITLE
Fix for flaky OSX test

### DIFF
--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -71,17 +71,17 @@ extends:
 
       # Do we want the E2E tests for the public build?
       # Might need this at first whilst we work on building out solid unit tests
-      - stage: E2ETestWindows
-        dependsOn: ''
+      # - stage: E2ETestWindows
+      #   dependsOn: ''
 
-        jobs:
-        - template: /eng/ci/templates/jobs/test-e2e-windows.yml@self
+      #   jobs:
+      #   - template: /eng/ci/templates/jobs/test-e2e-windows.yml@self
 
-      - stage: E2ETestLinux
-        dependsOn: ''
+      # - stage: E2ETestLinux
+      #   dependsOn: ''
 
-        jobs:
-        - template: /eng/ci/templates/jobs/test-e2e-linux.yml@self
+      #   jobs:
+      #   - template: /eng/ci/templates/jobs/test-e2e-linux.yml@self
 
       - stage: E2ETestOSX
         dependsOn: ''

--- a/eng/ci/templates/jobs/test-e2e-osx.yml
+++ b/eng/ci/templates/jobs/test-e2e-osx.yml
@@ -13,18 +13,18 @@ jobs:
       dotnetIsolated_osx_x64:
         languageWorker: 'DotnetIsolated'
         runtime: 'osx-x64'
-      node_osx_x64:
-        languageWorker: 'Node'
-        runtime: 'osx-x64'
-      powershell_osx_x64:
-        languageWorker: 'Powershell'
-        runtime: 'osx-x64'
-      python_osx_x64:
-        languageWorker: 'Python'
-        runtime: 'osx-x64'
-      custom_osx_x64:
-        languageWorker: 'Custom'
-        runtime: 'osx-x64'
+      # node_osx_x64:
+      #   languageWorker: 'Node'
+      #   runtime: 'osx-x64'
+      # powershell_osx_x64:
+      #   languageWorker: 'Powershell'
+      #   runtime: 'osx-x64'
+      # python_osx_x64:
+      #   languageWorker: 'Python'
+      #   runtime: 'osx-x64'
+      # custom_osx_x64:
+      #   languageWorker: 'Custom'
+      #   runtime: 'osx-x64'
 
   steps:
   - pwsh: ./eng/scripts/start-emulators.ps1

--- a/src/Cli/func/Helpers/DotnetHelpers.cs
+++ b/src/Cli/func/Helpers/DotnetHelpers.cs
@@ -76,6 +76,11 @@ namespace Azure.Functions.Cli.Helpers
             // Extract the target framework moniker (TFM) from the output using regex pattern matching
             var outputString = output.ToString();
 
+            ColoredConsole.WriteLine($"Debug - Raw output: {outputString}"); // Add this
+            ColoredConsole.WriteLine($"Debug - Output length: {outputString.Length}"); // Add this
+
+            var tfm = TargetFrameworkHelper.TfmRegex.Match(outputString);
+
             // Look for a line that looks like a target framework moniker
             var tfm = TargetFrameworkHelper.TfmRegex.Match(outputString);
 

--- a/src/Cli/func/Helpers/DotnetHelpers.cs
+++ b/src/Cli/func/Helpers/DotnetHelpers.cs
@@ -81,9 +81,6 @@ namespace Azure.Functions.Cli.Helpers
 
             var tfm = TargetFrameworkHelper.TfmRegex.Match(outputString);
 
-            // Look for a line that looks like a target framework moniker
-            var tfm = TargetFrameworkHelper.TfmRegex.Match(outputString);
-
             if (!tfm.Success)
             {
                 throw new CliException($"Could not parse target framework from output: {outputString}");

--- a/test/Cli/Func.E2ETests/Commands/FuncStart/Core/BaseUserSecretsTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncStart/Core/BaseUserSecretsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Diagnostics;
@@ -220,11 +220,6 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncStart.Core
             using (var process = Process.Start(initProcess))
             {
                 process?.WaitForExit();
-                if (process?.ExitCode != 0)
-                {
-                    var error = process?.StandardError.ReadToEnd();
-                    throw new Exception($"Failed to init user secrets: {error}");
-                }
             }
 
             // Set each secret
@@ -241,11 +236,6 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncStart.Core
 
                 using var process = Process.Start(setProcess);
                 process?.WaitForExit();
-                if (process?.ExitCode != 0)
-                {
-                    var error = process?.StandardError.ReadToEnd();
-                    throw new Exception($"Failed to set secret {secret.Key}: {error}");
-                }
             }
         }
 

--- a/test/Cli/Func.E2ETests/Commands/FuncStart/Core/BaseUserSecretsTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncStart/Core/BaseUserSecretsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Diagnostics;
@@ -220,6 +220,11 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncStart.Core
             using (var process = Process.Start(initProcess))
             {
                 process?.WaitForExit();
+                if (process?.ExitCode != 0)
+                {
+                    var error = process?.StandardError.ReadToEnd();
+                    throw new Exception($"Failed to init user secrets: {error}");
+                }
             }
 
             // Set each secret
@@ -236,6 +241,11 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncStart.Core
 
                 using var process = Process.Start(setProcess);
                 process?.WaitForExit();
+                if (process?.ExitCode != 0)
+                {
+                    var error = process?.StandardError.ReadToEnd();
+                    throw new Exception($"Failed to set secret {secret.Key}: {error}");
+                }
             }
         }
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #4670


### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

## Additional Information

[Recent example](https://dev.azure.com/azfunc/public/_build/results?buildId=246551&view=logs&j=a84f0933-5bc7-5dba-e8be-4d41f1e90239&t=bd61a0fd-2fc1-52cd-21b3-07d445b45aa9) of flaky test. The error is: `Could not parse target framework from output: 
[xUnit.net 00:08:15.54]         Command 'func init --docker-only' exited with exit code 1.
`

History of CI tests on this branch: https://dev.azure.com/azfunc/public/_build?definitionId=579&_a=summary&view=runs&branchFilter=15852%2C15852%2C15852%2C15852%2C15852%2C15852%2C15852

In draft b/c still testing to make sure this fix worked -- the specific e2e test being targeted hasn't failed again in over six runs.