### PR TITLE
Change CI schedule to 12am

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -1,5 +1,5 @@
 schedules:
-- cron: "0 10 * * *"   # 2am PST
+- cron: "0 8 * * *"   # 12am PST
   displayName: Nightly Build
   branches:
     include:


### PR DESCRIPTION
Turns out the in-proc CI takes 2 hours to finish so this needs to run earilier in the night.