### PR TITLE
[Design] Ensuring Core Tools can be used to create and run functions offline

### DIFF
--- a/docs/design/approved/offline-mode-support.md
+++ b/docs/design/approved/offline-mode-support.md
@@ -270,8 +270,8 @@ When you have network connectivity, you can use `func bundles download` to downl
 - Add clear instructions of how to install bundles
 - These changes should fix the issue for both `func start and func new`
 
-### 3: Validate and shortcircuit other network calls
-- Update `func publish` to shortcircut if offline/no network available
+### 3: Validate and short circuit other network calls
+- Update `func publish` to short circuit if offline/no network available
 - Validate `func pack` works offline
 
 ### 4: Offline Flag (Needs design + review)


### PR DESCRIPTION
Design proposal for offline support in Core Tools.

One of the major issues is that today we require internet connectivity to download extension bundles from `cdn.functions.azure.com` during `func start`, causing local development to fail in offline. This design proposes making the tool fully functional offline by implementing cache-first fallbacks for all network operations while maintaining optimal online performance.