### PR TITLE
Fixing core-tools.official pipeline

### DIFF
--- a/eng/ci/templates/official/jobs/pack-cli.yml
+++ b/eng/ci/templates/official/jobs/pack-cli.yml
@@ -23,7 +23,7 @@ jobs:
         /p:NoWorkers="true" `
         /p:SkipTemplates="true" `
         /p:RuntimeIdentifiers=
-    displayName: 'Build CLI for all platforms'
+    displayName: 'Build CLI'
 
   - template: /eng/ci/templates/official/steps/sign-authenticode.yml@self
     parameters:


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Fixing core-tools.official pipeline by ensuring each RID is not required to be built

Example run: https://azfunc.visualstudio.com/internal/_build/results?buildId=259627&view=results

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

