### PR TITLE
Fixing Linux signing step

### DIFF
--- a/eng/ci/templates/official/jobs/linux-deb-build-pack.yml
+++ b/eng/ci/templates/official/jobs/linux-deb-build-pack.yml
@@ -85,6 +85,12 @@ jobs:
         chmod +x $(Build.SourcesDirectory)/eng/scripts/validate-deb-arch.sh
         bash $(Build.SourcesDirectory)/eng/scripts/validate-deb-arch.sh /mnt/vss/_work/1/s/eng/tools/publish-tools/artifact
 
+  - task: UseDotNet@2
+    displayName: 'Install .NET SDK'
+    inputs:
+      packageType: 'sdk'
+      version: '8.x'
+
   - template: ci/sign-files.yml@eng
     parameters:
       displayName: 'Sign'


### PR DESCRIPTION
Linux pipeline was failing with signing as it did not detect the .NET tool: https://azfunc.visualstudio.com/internal/_build/results?buildId=261430&view=results

This PR adds the .NET task

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
