### PR TITLE
Fix locale-sensitive version parsing causing .NET 10 publish failures

### DIFF
--- a/src/Cli/func/Helpers/StacksApiHelper.cs
+++ b/src/Cli/func/Helpers/StacksApiHelper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Globalization;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.StacksApi;
 
@@ -41,7 +42,7 @@ namespace Azure.Functions.Cli.Helpers
             }
 
             var versionStr = dotnetVersionFromConfig?.ToLower()?.Replace("net", string.Empty);
-            if (double.TryParse(versionStr, out double version))
+            if (double.TryParse(versionStr, NumberStyles.Float, CultureInfo.InvariantCulture, out double version))
             {
                 return (int)version;
             }

--- a/src/Cli/func/Services/RuntimeEolChecker.cs
+++ b/src/Cli/func/Services/RuntimeEolChecker.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Globalization;
 using Azure.Functions.Cli.Arm.Models;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Helpers;
@@ -204,7 +205,7 @@ namespace Azure.Functions.Cli.Services
             }
 
             var versionStr = targetFramework.ToLower().Replace("net", string.Empty).Replace("v", string.Empty);
-            if (double.TryParse(versionStr, out double version))
+            if (double.TryParse(versionStr, NumberStyles.Float, CultureInfo.InvariantCulture, out double version))
             {
                 return (int)version;
             }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #4794

### Additional information

- Root cause: `double.TryParse` without `CultureInfo.InvariantCulture` in two version-parsing methods. In locales where `.` is a thousands separator (e.g., `fr-FR`, `de-DE`), the string `"10.0"` (extracted from TFM `"net10.0"`) is interpreted as `100`, causing `_requiredNetFrameworkVersion` to be set to `"100.0"` and failing Flex SKU validation.
- Fix: pass `NumberStyles.Float` and `CultureInfo.InvariantCulture` to both `double.TryParse` call sites

### Testing

Tested with:

- `func azure functionapp publish func-fileresourcemcpserver --dotnet-isolated --dotnet-version 10.0`
- `func azure functionapp publish func-fileresourcemcpserver --dotnet-isolated --dotnet-version 9.0`
- `func azure functionapp publish func-fileresourcemcpserver --dotnet-isolated --dotnet-version 8.0`
