### PR TITLE
Fix ZipHelperTests CI failure by removing fragile directory traversal

### DIFF
--- a/test/Cli/Func.UnitTests/HelperTests/ZipHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/ZipHelperTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.IO.Abstractions;
@@ -82,17 +82,22 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
                 files.Add(file);
             }
 
-            // walk up to the 'test' directory
+            // Find the repo root by walking up until we find the solution file
             var dir = new DirectoryInfo(Directory.GetCurrentDirectory());
-            dir = dir.Parent!.Parent!.Parent!.Parent!;
+            while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Azure.Functions.Cli.sln")))
+            {
+                dir = dir.Parent;
+            }
 
-            // build the project for the rid
-            var csproj = dir.GetFiles($"{proj}.csproj", SearchOption.AllDirectories).FirstOrDefault();
-            var csprojDir = csproj!.Directory!.FullName;
+            Assert.True(dir is not null, "Could not find repo root (Azure.Functions.Cli.sln).");
+
+            // Use the known path directly — no recursive search needed
+            var csprojDir = Path.Combine(dir!.FullName, "test", "ZippedExe");
+            Assert.True(File.Exists(Path.Combine(csprojDir, $"{proj}.csproj")), $"{proj}.csproj not found at {csprojDir}");
 
             ProcessHelper.RunProcess("dotnet", $"build -r {rid}", csprojDir, writeOutput: WriteOutput);
 
-            string outPath = Path.GetFullPath(Path.Combine(csprojDir, "..", "..", "out", "bin", "ZippedExe", $"debug_{rid}"));
+            string outPath = Path.Combine(dir.FullName, "out", "bin", "ZippedExe", $"debug_{rid}");
 
             // copy the files to the zip dir
             foreach (string fileName in new[] { exe, dll, config })


### PR DESCRIPTION
## Summary

Fixes `ZipHelperTests.CreateZip_Succeeds` failing on certain Windows CI agents with:

`System.UnauthorizedAccessException: Access to the path 'C:\Users\cloudtest\Application Data' is denied.`

## Problem

The test located `ZippedExe.csproj` by walking up exactly 4 parent directories from the CWD, then doing a recursive `GetFiles` search from there. This approach had two issues:

1. **Fragile depth assumption** — the 4-parent walk assumes a specific output directory depth (`out/bin/Azure.Functions.Cli.UnitTests/debug/`), which could break if the build layout changes.
2. **Unsafe recursive enumeration** — searching from the repo root with `SearchOption.AllDirectories` traverses the entire directory tree, including protected Windows junction points (e.g., `Application Data` → `AppData\Roaming`) that throw `UnauthorizedAccessException`.

## Fix

Replaced both the hardcoded parent traversal and recursive search with:

- **Walk up to repo root reliably** by searching for `Azure.Functions.Cli.sln` as a root marker — works regardless of output directory depth.
- **Use the known path directly** (`test/ZippedExe/`) instead of recursively scanning — `ZippedExe.csproj` is always at a fixed location relative to the repo root.
- **Compute `outPath` from repo root** instead of relative `..` navigation from the csproj directory.

No recursive directory enumeration of unknown trees is performed anymore.

## Changes

- `test/Cli/Func.UnitTests/HelperTests/ZipHelperTests.cs` — refactored `BuildAndCopyFileToZipAsync` to find repo root deterministically