### PR TITLE
Fix doc-sync: remove upstream sync step that causes 403

### DIFF
--- a/.github/workflows/doc-sync.yml
+++ b/.github/workflows/doc-sync.yml
@@ -159,13 +159,6 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           path: docs-repo
 
-      - name: Sync fork with upstream
-        run: |
-          cd docs-repo
-          git remote add upstream "https://github.com/${DOCS_UPSTREAM_REPO}.git"
-          git fetch upstream main
-          git checkout -B main upstream/main
-
       - name: Read release notes
         id: release_notes
         run: |


### PR DESCRIPTION
The 'Sync fork with upstream' step fetches MicrosoftDocs/azure-docs-pr using an unauthenticated HTTPS URL. Since that repo is private and the GitHub App is only installed on the fork, this fails with 403.

Remove the step — the fork's default branch is sufficient as a base for the doc-sync branch. The PR targets upstream main regardless.
