### PR TITLE
Fix doc-sync: live doc updates, cross-fork PR, reviewer notifications

### DIFF
--- a/.github/workflows/doc-sync.yml
+++ b/.github/workflows/doc-sync.yml
@@ -227,7 +227,7 @@ jobs:
           Automated documentation update from ${OLD_TAG} → ${NEW_TAG}.
           Source: ${RELEASE_URL}"
 
-          git push origin "$BRANCH"
+          git push --force origin "${BRANCH}:${BRANCH}"
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: Build PR body


### PR DESCRIPTION
## Summary

Follow-up fixes to the doc-sync workflow after testing.

### Fixes
- **Force-push** doc-sync branch to handle re-runs for the same tag
- **Explicit refspec** (`HEAD:branch`) to avoid upstream tracking mismatch
- **Cross-fork PR creation** — uses `continue-on-error` since the App token can't access upstream, then outputs a clickable PR URL in the step summary

### New features
- **`update_docs.py`** — patches `functions-core-tools-reference.md` in-place (adds/removes options, new commands, deprecation notices)
- **Reviewer notification issue** — creates a GitHub Issue with the cross-fork PR link and @mentions from `DOC_SYNC_REVIEWERS`

### New configuration
| Type | Name | Default | Purpose |
|------|------|---------|---------|
| Variable | `DOC_SYNC_REVIEWERS` | `liliankasem` | Comma-separated GitHub usernames to @mention |