### PR TITLE
Replace wget in buildNUPKG.py

### DIFF
--- a/eng/tools/publish-tools/chocolatey/buildNUPKG.py
+++ b/eng/tools/publish-tools/chocolatey/buildNUPKG.py
@@ -3,7 +3,7 @@
 # depends on chocolaty
 import os
 from re import sub
-import wget
+import requests
 import sys
 from string import Template
 from shared import constants
@@ -52,7 +52,11 @@ def preparePackage():
         # output to local folder
         if not os.path.exists(fileName):
             print(f"downloading from {url}")
-            wget.download(url)
+            with requests.get(url, stream=True, timeout=600) as r:
+                r.raise_for_status()
+                with open(fileName, 'wb') as dl:
+                    for chunk in r.iter_content(chunk_size=8 * 1024 * 1024):
+                        dl.write(chunk)
 
         # get the checksums
         fileHash = produceHashForfile(fileName, HASH)

--- a/eng/tools/publish-tools/requirements.txt
+++ b/eng/tools/publish-tools/requirements.txt
@@ -1,2 +1,3 @@
 distro~=1.6.0
+requests~=2.33.0
 wget~=3.2


### PR DESCRIPTION
### Issue describing the changes in this PR

The buildNUPKG.py script uses the wget Python package to download Azure Functions CLI zip archives (~505 MB each). Under the hood, wget relies on urllib.urlretrieve, which buffers the entire response in memory before writing to disk. This is unreliable for large files and can cause download failures.

Solution

Replaced wget.download(url) with requests.get(url, stream=True) and chunked writes in buildNUPKG.py. This streams the response body incrementally to disk, avoiding the memory issues inherent to urllib.urlretrieve. A 10-minute connection timeout is included to prevent hung downloads.