### PR TITLE
Update host and worker versions, dependencies,  and migrate to .NET 10

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,7 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="LocalNuGet" value="/Users/likasem/source/localnuget" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="Microsoft.Azure.Functions.PowerShellWorker" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/Microsoft.Azure.Functions.PowerShellWorker/nuget/v3/index.json" />
     <add key="AzureFunctions" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctions/nuget/v3/index.json" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,6 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
+    <add key="LocalNuGet" value="/Users/likasem/source/localnuget" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="Microsoft.Azure.Functions.PowerShellWorker" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/Microsoft.Azure.Functions.PowerShellWorker/nuget/v3/index.json" />
     <add key="AzureFunctions" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctions/nuget/v3/index.json" />

--- a/eng/build/Packages.props
+++ b/eng/build/Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- common -->
   <ItemGroup>
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Colors.Net" Version="1.1.0" />
     <PackageVersion Include="WindowsAzure.Storage" Version="9.3.3" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
@@ -16,8 +16,8 @@
   <!-- func -->
   <ItemGroup>
     <PackageVersion Include="Autofac" Version="4.6.2" />
-    <PackageVersion Include="Azure.Identity" Version="1.20.0" />
-    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.9.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.17.1" />
+    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageVersion Include="AccentedCommandLineParser" Version="2.0.1" />
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.23.0" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="2.2.0" />
@@ -29,7 +29,6 @@
     <PackageVersion Include="YamlDotNet" Version="6.0.0" />
   </ItemGroup>
   <!-- workers -->
-  <!-- //todo: validate these are the latest versions-->
   <ItemGroup>
     <PackageVersion Include="Microsoft.Azure.Functions.JavaWorker" Version="2.19.4" />
     <PackageVersion Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.13.0" />

--- a/eng/build/Packages.props
+++ b/eng/build/Packages.props
@@ -1,35 +1,35 @@
 <Project>
   <!-- common -->
   <ItemGroup>
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Colors.Net" Version="1.1.0" />
-    <PackageVersion Include="WindowsAzure.Storage" Version="9.3.1" />
+    <PackageVersion Include="WindowsAzure.Storage" Version="9.3.3" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
   </ItemGroup>
   <!-- abstractions-->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta5.25306.101" />
   </ItemGroup>
   <!-- func -->
   <ItemGroup>
     <PackageVersion Include="Autofac" Version="4.6.2" />
-    <PackageVersion Include="Azure.Identity" Version="1.17.1" />
-    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
-    <PackageVersion Include="AccentedCommandLineParser" Version="2.0.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.20.0" />
+    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.9.0" />
+    <PackageVersion Include="AccentedCommandLineParser" Version="2.0.1" />
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.23.0" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Azure.DurableTask.AzureStorage.Internal" Version="1.4.0" />
-    <PackageVersion Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="4.1048.200" />
+    <PackageVersion Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="4.1049.100-ci.26208.6" /> <!-- //todo: update to production version -->
     <PackageVersion Include="Microsoft.Build" Version="17.0.0" />
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.78.0" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.83.3" />
     <PackageVersion Include="NuGet.Packaging" Version="5.11.6" />
-    <PackageVersion Include="System.Formats.Asn1" Version="6.0.1" />
     <PackageVersion Include="YamlDotNet" Version="6.0.0" />
-    <!-- Transitive dependency -->
-    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
   <!-- workers -->
+  <!-- //todo: validate these are the latest versions-->
   <ItemGroup>
     <PackageVersion Include="Microsoft.Azure.Functions.JavaWorker" Version="2.19.4" />
     <PackageVersion Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.13.0" />
@@ -37,11 +37,11 @@
     <PackageVersion Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.2" Version="4.0.4025" />
     <PackageVersion Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" Version="4.0.4759" />
     <PackageVersion Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.6" Version="4.0.4778" />
-    <PackageVersion Include="Microsoft.Azure.Functions.PythonWorker" Version="4.43.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.PythonWorker" Version="4.44.0" />
   </ItemGroup>
   <!-- host -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.NETCore.DotNetAppHost" Version="8.0.8" />
+    <PackageVersion Include="Microsoft.NETCore.DotNetAppHost" Version="10.0.0" />
   </ItemGroup>
   <!-- test projects -->
   <ItemGroup>

--- a/eng/build/Packages.props
+++ b/eng/build/Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.23.0" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Azure.DurableTask.AzureStorage.Internal" Version="1.4.0" />
-    <PackageVersion Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="4.1049.100-ci.26208.6" /> <!-- //todo: update to production version -->
+    <PackageVersion Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="4.1049.200" />
     <PackageVersion Include="Microsoft.Build" Version="17.0.0" />
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.83.3" />
     <PackageVersion Include="NuGet.Packaging" Version="5.11.6" />

--- a/eng/build/Packages.props
+++ b/eng/build/Packages.props
@@ -21,7 +21,7 @@
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.23.0" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Azure.DurableTask.AzureStorage.Internal" Version="1.4.0" />
-    <PackageVersion Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="4.1051.100" />
+    <PackageVersion Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="4.1051.300" />
     <PackageVersion Include="Microsoft.Build" Version="17.11.48" />
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.84.2" />
     <PackageVersion Include="NuGet.Packaging" Version="5.11.7" />

--- a/eng/build/Packages.props
+++ b/eng/build/Packages.props
@@ -43,11 +43,11 @@
   </ItemGroup>
   <!-- test projects -->
   <ItemGroup>
-    <PackageVersion Include="Azure.Data.Tables" Version="12.8.3" />
+    <PackageVersion Include="Azure.Data.Tables" Version="12.9.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.22.1" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.27.0" />
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="15.6.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Moq" Version="4.8.2" />
     <PackageVersion Include="NSubstitute" Version="3.1.0" />
     <PackageVersion Include="Octokit" Version="0.29.0" />

--- a/eng/build/Packages.props
+++ b/eng/build/Packages.props
@@ -1,53 +1,51 @@
 <Project>
   <!-- common -->
   <ItemGroup>
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Colors.Net" Version="1.1.0" />
-    <PackageVersion Include="WindowsAzure.Storage" Version="9.3.1" />
+    <PackageVersion Include="WindowsAzure.Storage" Version="9.3.3" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
   </ItemGroup>
   <!-- abstractions-->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.2" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.0-beta5.25306.101" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
   </ItemGroup>
   <!-- func -->
   <ItemGroup>
     <PackageVersion Include="Autofac" Version="9.1.0" />
     <PackageVersion Include="Azure.Identity" Version="1.17.1" />
-    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
+    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageVersion Include="AccentedCommandLineParser" Version="2.0.1" />
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.23.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Azure.DurableTask.AzureStorage.Internal" Version="1.4.0" />
-    <PackageVersion Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="4.1048.200" />
-    <PackageVersion Include="Microsoft.Build" Version="17.0.0" />
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.78.0" />
-    <PackageVersion Include="NuGet.Packaging" Version="5.11.6" />
-    <PackageVersion Include="System.Formats.Asn1" Version="6.0.1" />
-    <PackageVersion Include="YamlDotNet" Version="6.0.0" />
-    <!-- Transitive dependency -->
-    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+    <PackageVersion Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="4.1051.100" />
+    <PackageVersion Include="Microsoft.Build" Version="17.11.48" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.84.2" />
+    <PackageVersion Include="NuGet.Packaging" Version="5.11.7" />
+    <PackageVersion Include="YamlDotNet" Version="6.1.2" />
   </ItemGroup>
   <!-- workers -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.Azure.Functions.JavaWorker" Version="2.19.4" />
-    <PackageVersion Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.13.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.14.1" />
     <PackageVersion Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" Version="4.0.3148" />
     <PackageVersion Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.2" Version="4.0.4025" />
     <PackageVersion Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" Version="4.0.4759" />
     <PackageVersion Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.6" Version="4.0.4778" />
-    <PackageVersion Include="Microsoft.Azure.Functions.PythonWorker" Version="4.43.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.PythonWorker" Version="4.44.0" />
   </ItemGroup>
   <!-- host -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.NETCore.DotNetAppHost" Version="8.0.8" />
+    <PackageVersion Include="Microsoft.NETCore.DotNetAppHost" Version="10.0.9" />
   </ItemGroup>
   <!-- test projects -->
   <ItemGroup>
-    <PackageVersion Include="Azure.Data.Tables" Version="12.9.0" />
+    <PackageVersion Include="Azure.Data.Tables" Version="12.8.3" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.22.1" />
-    <PackageVersion Include="Azure.Storage.Queues" Version="12.19.1" />
+    <PackageVersion Include="Azure.Storage.Queues" Version="12.27.0" />
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="15.6.2" />
     <PackageVersion Include="Moq" Version="4.8.2" />
@@ -55,9 +53,9 @@
     <PackageVersion Include="Octokit" Version="0.29.0" />
     <PackageVersion Include="RichardSzalay.MockHttp" Version="5.0.0" />
     <PackageVersion Include="SuaveServerWrapper" Version="0.0.3" />
-    <PackageVersion Include="xunit" Version="2.4.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageVersion Include="Xunit.SkippableFact" Version="1.3.6" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="Xunit.SkippableFact" Version="1.5.61" />
     <!-- sample test projects -->
     <PackageVersion Include="Microsoft.NET.Sdk.Functions" Version="4.5.0" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="1.8.2" />

--- a/eng/ci/templates/jobs/test-e2e-linux.yml
+++ b/eng/ci/templates/jobs/test-e2e-linux.yml
@@ -42,7 +42,7 @@ jobs:
   - pwsh: |
       dotnet publish src/Cli/func/Azure.Functions.Cli.csproj `
         -c Release `
-        -f net8.0 `
+        -f net10.0 `
         -r $(runtime) `
         --self-contained `
         -o $(Build.ArtifactStagingDirectory)/artifacts/$(runtime)

--- a/eng/ci/templates/jobs/test-e2e-linux.yml
+++ b/eng/ci/templates/jobs/test-e2e-linux.yml
@@ -48,7 +48,7 @@ jobs:
   - pwsh: |
       dotnet publish src/Cli/func/Azure.Functions.Cli.csproj `
         -c Release `
-        -f net8.0 `
+        -f net10.0 `
         -r $(runtime) `
         --self-contained `
         -o $(Build.ArtifactStagingDirectory)/artifacts/$(runtime)

--- a/eng/ci/templates/jobs/test-e2e-osx.yml
+++ b/eng/ci/templates/jobs/test-e2e-osx.yml
@@ -47,7 +47,7 @@ jobs:
   - pwsh: |
       dotnet publish src/Cli/func/Azure.Functions.Cli.csproj `
       -c Release `
-      -f net8.0 `
+      -f net10.0 `
       -r $(runtime) `
       --self-contained `
       -o $(Build.ArtifactStagingDirectory)/artifacts/$(runtime)

--- a/eng/ci/templates/jobs/test-e2e-osx.yml
+++ b/eng/ci/templates/jobs/test-e2e-osx.yml
@@ -64,7 +64,7 @@ jobs:
   - pwsh: |
       dotnet publish src/Cli/func/Azure.Functions.Cli.csproj `
       -c Release `
-      -f net8.0 `
+      -f net10.0 `
       -r $(runtime) `
       --self-contained `
       -o $(Build.ArtifactStagingDirectory)/artifacts/$(runtime)

--- a/eng/ci/templates/jobs/test-e2e-windows.yml
+++ b/eng/ci/templates/jobs/test-e2e-windows.yml
@@ -37,7 +37,7 @@ jobs:
   - pwsh: |
       dotnet publish src/Cli/func/Azure.Functions.Cli.csproj `
       -c Release `
-      -f net8.0 `
+      -f net10.0 `
       -r $(runtime) `
       --self-contained `
       -o $(Build.ArtifactStagingDirectory)/artifacts/$(runtime)

--- a/eng/ci/templates/jobs/test-e2e-windows.yml
+++ b/eng/ci/templates/jobs/test-e2e-windows.yml
@@ -40,7 +40,7 @@ jobs:
   - pwsh: |
       dotnet publish src/Cli/func/Azure.Functions.Cli.csproj `
       -c Release `
-      -f net8.0 `
+      -f net10.0 `
       -r $(runtime) `
       --self-contained `
       -o $(Build.ArtifactStagingDirectory)/artifacts/$(runtime)

--- a/eng/ci/templates/official/jobs/pack-cli.yml
+++ b/eng/ci/templates/official/jobs/pack-cli.yml
@@ -18,7 +18,7 @@ jobs:
   - pwsh: |
       dotnet build src/Cli/func/Azure.Functions.Cli.csproj `
         -c Release `
-        -f net8.0 `
+        -f net10.0 `
         --no-restore `
         /p:NoWorkers="true" `
         /p:SkipTemplates="true" `

--- a/eng/ci/templates/official/jobs/publish-cli.yml
+++ b/eng/ci/templates/official/jobs/publish-cli.yml
@@ -33,7 +33,7 @@ jobs:
       dotnet publish src/Cli/func/Azure.Functions.Cli.csproj `
         -o "$(Build.Repository.LocalPath)/artifacts/${{ parameters.runtime }}" `
         -c Release `
-        -f net8.0 `
+        -f net10.0 `
         -r $runtime `
         --self-contained `
         --no-restore `

--- a/eng/ci/templates/public/jobs/build-cli.yml
+++ b/eng/ci/templates/public/jobs/build-cli.yml
@@ -37,7 +37,7 @@ jobs:
       dotnet publish src/Cli/func/Azure.Functions.Cli.csproj `
         -o "$(Build.ArtifactStagingDirectory)/artifacts/$runtime" `
         -c Release `
-        -f net8.0 `
+        -f net10.0 `
         -r $runtime `
         --self-contained `
         /p:ZipAfterPublish=true `

--- a/eng/ci/templates/public/steps/run-unit-tests.yml
+++ b/eng/ci/templates/public/steps/run-unit-tests.yml
@@ -4,7 +4,7 @@ steps:
   inputs:
     command: 'test'
     projects: '**/Azure.Functions.Cli.UnitTests.csproj'
-    arguments: '--framework net8.0'
+    arguments: '--framework net10.0'
 
 - task: PublishTestResults@2
   displayName: 'Publish test results'

--- a/eng/ci/templates/steps/run-e2e-tests.yml
+++ b/eng/ci/templates/steps/run-e2e-tests.yml
@@ -42,7 +42,7 @@ steps:
     $worker = '${{ parameters.worker }}'
     $proj = '$(Build.SourcesDirectory)/test/Cli/Func.E2ETests/Azure.Functions.Cli.E2ETests.csproj'
     $baseArgs = @(
-      '--framework', 'net8.0'
+      '--framework', 'net10.0'
       '--blame-hang-timeout', '10m'
       '--logger', 'console;verbosity=detailed'
       '--logger', 'trx'

--- a/eng/tools/publish-tools/npm/npm-shrinkwrap.json
+++ b/eng/tools/publish-tools/npm/npm-shrinkwrap.json
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "25.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -249,9 +249,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"

--- a/eng/tools/publish-tools/npm/npm-shrinkwrap.json
+++ b/eng/tools/publish-tools/npm/npm-shrinkwrap.json
@@ -17,7 +17,7 @@
       "dependencies": {
         "chalk": "^4.1.2",
         "extract-zip": "^2.0.1",
-        "https-proxy-agent": "9.0.0",
+        "https-proxy-agent": "9.1.0",
         "progress": "2.0.3",
         "rimraf": "^6.1.3"
       },
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "25.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -235,22 +235,23 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.0.0.tgz",
-      "integrity": "sha512-/MVmHp58WkOypgFhCLk4fzpPcFQvTJ/e6LBI7irpIO2HfxUbpmYoHF+KzipzJpxxzJu7aJNWQ0xojJ/dzV2G5g==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
+      "integrity": "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==",
       "license": "MIT",
       "dependencies": {
         "agent-base": "9.0.0",
-        "debug": "^4.3.4"
+        "debug": "^4.3.4",
+        "proxy-agent-negotiate": "1.1.0"
       },
       "engines": {
         "node": ">= 20"
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -330,6 +331,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-agent-negotiate": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent-negotiate/-/proxy-agent-negotiate-1.1.0.tgz",
+      "integrity": "sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "kerberos": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "kerberos": {
+          "optional": true
+        }
       }
     },
     "node_modules/pump": {

--- a/eng/tools/publish-tools/npm/package.json
+++ b/eng/tools/publish-tools/npm/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "chalk": "^4.1.2",
-    "https-proxy-agent": "9.0.0",
+    "https-proxy-agent": "9.1.0",
     "extract-zip": "^2.0.1",
     "progress": "2.0.3",
     "rimraf": "^6.1.3"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.201",
+    "version": "10.0.103",
     "allowPrerelease": true,
     "rollForward": "latestMajor"
   },

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "10.0.300",
+    "version": "10.0.301",
     "allowPrerelease": true,
     "rollForward": "latestMajor"
   },
   "msbuild-sdks": {
-    "Microsoft.Build.NoTargets": "3.7.56",
-    "Microsoft.Build.Traversal": "4.1.0"
+    "Microsoft.Build.NoTargets": "3.7.134",
+    "Microsoft.Build.Traversal": "4.1.82"
   }
 }

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,6 +3,11 @@
 #### Host Version
 
 - Host Runtime Version: 4.1048.200
+# Azure Functions CLI 4.9.0 //todo: update this when ready
+
+#### Host Version
+
+- Host Runtime Version: 4.1049.100
 - In-Proc CLI:
   - CLI Version: 4.4.0
   - Host Runtime Version: 4.46.100 (includes 4.846.100, 4.646.100)
@@ -11,3 +16,14 @@
 
 - Fixed `func pack --python` stripping `.dist-info` directories from packaged dependencies (#4853)
 - Add support for PowerShell 7.6
+- Updated target framework to .NET 10
+- Migrated from deprecated `Microsoft.DotNet.PlatformAbstractions` to `System.Runtime.InteropServices.RuntimeInformation`
+- Migrated from `IWebHost` to `IHost` in `StartHostAction`
+- Migrated from deprecated `X509Certificate2` constructor to `X509CertificateLoader`
+- Bumped `Microsoft.Extensions.DependencyInjection` to 10.0.0
+- Bumped `Microsoft.Extensions.Logging` / `Logging.Abstractions` to 10.0.0 / 10.0.3
+- Bumped `Azure.Identity` to 1.20.0, `Azure.Security.KeyVault.Secrets` to 4.9.0
+- Bumped `Microsoft.Identity.Client` to 4.83.3
+- Bumped `Newtonsoft.Json` to 13.0.4, `WindowsAzure.Storage` to 9.3.3
+- Removed unnecessary transitive pinning of `System.Text.Json`, `System.Formats.Asn1`, `System.Private.Uri`
+- Updated worker versions to match host requirements (NodeJs 3.13.0, PS7.4 4.0.4759, Python 4.44.0)

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,8 +1,8 @@
-# Azure Functions CLI 4.11.0 //todo: validate this is the right next version
+# Azure Functions CLI 4.9.0
 
 #### Host Version
 
-- Host Runtime Version: 4.1049.100
+- Host Runtime Version: 4.1049.200
 - In-Proc CLI:
   - CLI Version: 4.4.0
   - Host Runtime Version: 4.46.100 (includes 4.846.100, 4.646.100)

--- a/release_notes.md
+++ b/release_notes.md
@@ -20,3 +20,13 @@
 - Removed unnecessary transitive pinning of `System.Text.Json`, `System.Formats.Asn1`, `System.Private.Uri`
 - Updated worker versions to match host requirements (NodeJs 3.13.0, PS7.4 4.0.4759, Python 4.44.0)
 
+    - Migrated from deprecated `Microsoft.DotNet.PlatformAbstractions` to `System.Runtime.InteropServices.RuntimeInformation`
+    - Migrated from deprecated `X509Certificate2` constructor to `X509CertificateLoader`
+    - Bumped `Microsoft.Extensions.DependencyInjection` to 10.0.0
+    - Bumped `Microsoft.Extensions.Logging` / `Logging.Abstractions` to 10.0.0 / 10.0.3
+    - Bumped `Azure.Identity` to 1.17.1, `Azure.Security.KeyVault.Secrets` to 4.6.0
+    - Bumped `Microsoft.Identity.Client` to 4.83.3
+    - Bumped `WindowsAzure.Storage` to 9.3.3
+    - Removed unnecessary transitive pinning of `System.Text.Json`, `System.Formats.Asn1`, `System.Private.Uri`
+    - Updated worker versions to match host requirements (NodeJs 3.13.0, PS7.4 4.0.4759, Python 4.44.0)
+- Fixed `func pack --python` stripping `.dist-info` directories from packaged dependencies (#4853)

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,4 +1,4 @@
-# Azure Functions CLI 4.9.0
+# Azure Functions CLI 4.11.0
 
 #### Host Version
 
@@ -10,23 +10,13 @@
 #### Changes
 
 - Updated target framework to .NET 10
-- Migrated from deprecated `Microsoft.DotNet.PlatformAbstractions` to `System.Runtime.InteropServices.RuntimeInformation`
-- Migrated from deprecated `X509Certificate2` constructor to `X509CertificateLoader`
-- Bumped `Microsoft.Extensions.DependencyInjection` to 10.0.0
-- Bumped `Microsoft.Extensions.Logging` / `Logging.Abstractions` to 10.0.0 / 10.0.3
-- Bumped `Azure.Identity` to 1.20.0, `Azure.Security.KeyVault.Secrets` to 4.9.0
-- Bumped `Microsoft.Identity.Client` to 4.83.3
-- Bumped `Newtonsoft.Json` to 13.0.4, `WindowsAzure.Storage` to 9.3.3
-- Removed unnecessary transitive pinning of `System.Text.Json`, `System.Formats.Asn1`, `System.Private.Uri`
-- Updated worker versions to match host requirements (NodeJs 3.13.0, PS7.4 4.0.4759, Python 4.44.0)
-
     - Migrated from deprecated `Microsoft.DotNet.PlatformAbstractions` to `System.Runtime.InteropServices.RuntimeInformation`
     - Migrated from deprecated `X509Certificate2` constructor to `X509CertificateLoader`
     - Bumped `Microsoft.Extensions.DependencyInjection` to 10.0.0
     - Bumped `Microsoft.Extensions.Logging` / `Logging.Abstractions` to 10.0.0 / 10.0.3
-    - Bumped `Azure.Identity` to 1.17.1, `Azure.Security.KeyVault.Secrets` to 4.6.0
+    - Bumped `Azure.Identity` to 1.20.0, `Azure.Security.KeyVault.Secrets` to 4.9.0
     - Bumped `Microsoft.Identity.Client` to 4.83.3
-    - Bumped `WindowsAzure.Storage` to 9.3.3
+    - Bumped `Newtonsoft.Json` to 13.0.4, `WindowsAzure.Storage` to 9.3.3
     - Removed unnecessary transitive pinning of `System.Text.Json`, `System.Formats.Asn1`, `System.Private.Uri`
-    - Updated worker versions to match host requirements (NodeJs 3.13.0, PS7.4 4.0.4759, Python 4.44.0)
-- Fixed `func pack --python` stripping `.dist-info` directories from packaged dependencies (#4853)
+    - Updated worker versions to match host requirements (NodeJs 3.13.0, Python 4.44.0)
+

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,9 +1,4 @@
-# Azure Functions CLI 4.10.0
-
-#### Host Version
-
-- Host Runtime Version: 4.1048.200
-# Azure Functions CLI 4.9.0 //todo: update this when ready
+# Azure Functions CLI 4.11.0 //todo: validate this is the right next version
 
 #### Host Version
 
@@ -14,8 +9,6 @@
 
 #### Changes
 
-- Fixed `func pack --python` stripping `.dist-info` directories from packaged dependencies (#4853)
-- Add support for PowerShell 7.6
 - Updated target framework to .NET 10
 - Migrated from deprecated `Microsoft.DotNet.PlatformAbstractions` to `System.Runtime.InteropServices.RuntimeInformation`
 - Migrated from `IWebHost` to `IHost` in `StartHostAction`
@@ -27,3 +20,4 @@
 - Bumped `Newtonsoft.Json` to 13.0.4, `WindowsAzure.Storage` to 9.3.3
 - Removed unnecessary transitive pinning of `System.Text.Json`, `System.Formats.Asn1`, `System.Private.Uri`
 - Updated worker versions to match host requirements (NodeJs 3.13.0, PS7.4 4.0.4759, Python 4.44.0)
+

--- a/release_notes.md
+++ b/release_notes.md
@@ -11,7 +11,6 @@
 
 - Updated target framework to .NET 10
 - Migrated from deprecated `Microsoft.DotNet.PlatformAbstractions` to `System.Runtime.InteropServices.RuntimeInformation`
-- Migrated from `IWebHost` to `IHost` in `StartHostAction`
 - Migrated from deprecated `X509Certificate2` constructor to `X509CertificateLoader`
 - Bumped `Microsoft.Extensions.DependencyInjection` to 10.0.0
 - Bumped `Microsoft.Extensions.Logging` / `Logging.Abstractions` to 10.0.0 / 10.0.3

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,10 +1,13 @@
-# Azure Functions CLI 4.12.0
+# Azure Functions CLI 4.13.0
 
 #### Host Version
 
-- Host Runtime Version: 4.1048.200
+- Host Runtime Version: 4.1051.100
 - In-Proc CLI:
   - CLI Version: 4.5.0
   - Host Runtime Version: 4.48.100 (includes 4.848.100, 4.648.100)
 
 #### Changes
+
+- Updated host to 4.1051.100
+- Updated target framework to .NET 10

--- a/release_notes.md
+++ b/release_notes.md
@@ -8,7 +8,13 @@
   - Host Runtime Version: 4.49.100 (includes 4.849.100, 4.649.100)
 
 #### Changes
-- Removed warning log for remote build with Python 3.14 Flex apps, as remote build is now supported (#5375)
 
-- Updated host to 4.1051.300
-- Updated target framework to .NET 10
+- Removed warning log for remote build with Python 3.14 Flex apps, as remote build is now supported (#5375)
+- Fixed npm postinstall silently swallowing extraction errors (#5281)
+- Added lazy first-use install for npm RFC #868 compatibility (#5291)
+- Added warning when key vault references fail to resolve (#5373)
+- Replaced deprecated `url.parse` in npm installer (#5371)
+- Enhanced func CLI static gitignore and streamlined Azurite entries (#5084)
+- Bumped dotnet templates version to 4.0.5590 (#5271)
+- Bumped https-proxy-agent dependency (#5335)
+- Updated target framework to .NET 10 (#4850)

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,11 +1,14 @@
-# Azure Functions CLI 4.12.0
+# Azure Functions CLI 4.13.0
 
 #### Host Version
 
-- Host Runtime Version: 4.1048.200
+- Host Runtime Version: 4.1051.100
 - In-Proc CLI:
   - CLI Version: 4.6.0
   - Host Runtime Version: 4.49.100 (includes 4.849.100, 4.649.100)
 
 #### Changes
 - Removed warning log for remote build with Python 3.14 Flex apps, as remote build is now supported (#5375)
+
+- Updated host to 4.1051.100
+- Updated target framework to .NET 10

--- a/release_notes.md
+++ b/release_notes.md
@@ -2,7 +2,7 @@
 
 #### Host Version
 
-- Host Runtime Version: 4.1051.100
+- Host Runtime Version: 4.1051.300
 - In-Proc CLI:
   - CLI Version: 4.6.0
   - Host Runtime Version: 4.49.100 (includes 4.849.100, 4.649.100)
@@ -10,5 +10,5 @@
 #### Changes
 - Removed warning log for remote build with Python 3.14 Flex apps, as remote build is now supported (#5375)
 
-- Updated host to 4.1051.100
+- Updated host to 4.1051.300
 - Updated target framework to .NET 10

--- a/skipPackagesCve.json
+++ b/skipPackagesCve.json
@@ -1,8 +1,4 @@
 {
-  "_comments": {
-    "NuGet.Packaging": "Pinned to 5.11.6 transitively by the Functions host (Microsoft.Azure.WebJobs.Script.WebHost -> NuGet.ProjectModel -> NuGet.DependencyResolver.Core -> NuGet.Protocol -> NuGet.Packaging). Cannot upgrade independently until the host moves to NuGet 6.x. Advisory: GHSA-g4vj-cjjj-v7hg (Low)."
-  },
-  "packages": [
-    "NuGet.Packaging"
-  ]
+  "_comments": {},
+  "packages": []
 }

--- a/src/ArtifactAssembler/ArtifactAssembler.csproj
+++ b/src/ArtifactAssembler/ArtifactAssembler.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/src/Cli/Abstractions/Azure.Functions.Cli.Abstractions.csproj
+++ b/src/Cli/Abstractions/Azure.Functions.Cli.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
   </PropertyGroup>

--- a/src/Cli/Abstractions/Azure.Functions.Cli.Abstractions.csproj
+++ b/src/Cli/Abstractions/Azure.Functions.Cli.Abstractions.csproj
@@ -1,14 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="System.CommandLine" />
     <PackageReference Include="StyleCop.Analyzers" />
   </ItemGroup>
 

--- a/src/Cli/func/Actions/HostActions/StartHostAction.cs
+++ b/src/Cli/func/Actions/HostActions/StartHostAction.cs
@@ -185,6 +185,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
             return base.ParseArgs(args);
         }
 
+#pragma warning disable ASPDEPR008 // Startup implements IStartup which requires IWebHost lifecycle
         private async Task<IWebHost> BuildWebHost(ScriptApplicationHostOptions hostOptions, Uri listenAddress, Uri baseAddress, X509Certificate2 certificate)
         {
             LoggingFilterHelper loggingFilterHelper = new LoggingFilterHelper(_hostJsonConfig, VerboseLogging, UserLogLevel);
@@ -281,6 +282,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 })
                 .Build();
         }
+#pragma warning restore ASPDEPR008
 
         internal async Task<IDictionary<string, string>> GetConfigurationSettings(string scriptPath, Uri uri)
         {
@@ -465,7 +467,9 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 await ExtensionBundleHelper.GetExtensionBundle();
             }
 
+#pragma warning disable ASPDEPR008
             IWebHost host = await BuildWebHost(hostOptions, listenUri, baseUri, certificate);
+#pragma warning restore ASPDEPR008
             var runTask = host.RunAsync();
             var hostService = host.Services.GetRequiredService<WebJobsScriptHostService>();
 

--- a/src/Cli/func/Actions/HostActions/StartHostAction.cs
+++ b/src/Cli/func/Actions/HostActions/StartHostAction.cs
@@ -25,6 +25,7 @@ using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
@@ -185,7 +186,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
             return base.ParseArgs(args);
         }
 
-        private async Task<IWebHost> BuildWebHost(ScriptApplicationHostOptions hostOptions, Uri listenAddress, Uri baseAddress, X509Certificate2 certificate)
+        private async Task<IHost> BuildWebHost(ScriptApplicationHostOptions hostOptions, Uri listenAddress, Uri baseAddress, X509Certificate2 certificate)
         {
             LoggingFilterHelper loggingFilterHelper = new LoggingFilterHelper(_hostJsonConfig, VerboseLogging, UserLogLevel);
 
@@ -209,28 +210,41 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 ColoredConsole.WriteLine(ErrorColor("CONTAINER_NAME is a reserved environment variable for the Functions Host. Please remove or rename this setting."));
             }
 
-            var defaultBuilder = Microsoft.AspNetCore.WebHost.CreateDefaultBuilder(Array.Empty<string>());
-
-            if (UseHttps)
-            {
-                defaultBuilder
-                .UseKestrel(options =>
+            return Host.CreateDefaultBuilder(Array.Empty<string>())
+                .ConfigureWebHostDefaults(webBuilder =>
                 {
-                    options.Listen(IPAddress.Any, listenAddress.Port, listenOptins =>
+                    if (UseHttps)
                     {
-                        listenOptins.UseHttps(certificate);
-                    });
-                });
-            }
+                        webBuilder.UseKestrel(options =>
+                        {
+                            options.Listen(IPAddress.Any, listenAddress.Port, listenOptins =>
+                            {
+                                listenOptins.UseHttps(certificate);
+                            });
+                        });
+                    }
 
-            return defaultBuilder
-                .ConfigureKestrel(o =>
-                {
-                    // Setting it to match the default RequestBodySize in host
-                    o.Limits.MaxRequestBodySize = Constants.DefaultMaxRequestBodySize;
+                    webBuilder
+                        .ConfigureKestrel(o =>
+                        {
+                            // Setting it to match the default RequestBodySize in host
+                            o.Limits.MaxRequestBodySize = Constants.DefaultMaxRequestBodySize;
+                        })
+                        .UseSetting(WebHostDefaults.ApplicationKey, typeof(Startup).Assembly.GetName().Name)
+                        .UseUrls(listenAddress.ToString())
+                        .ConfigureServices((context, services) =>
+                        {
+                            services.AddSingleton<IStartup>(new Startup(context, hostOptions, CorsOrigins, CorsCredentials, EnableAuth, UserSecretsId, loggingFilterHelper, JsonOutputFile));
+
+                            if (DotNetIsolatedDebug != null && DotNetIsolatedDebug.Value)
+                            {
+                                services.AddSingleton<IConfigureBuilder<IServiceCollection>>(_ => new DotNetIsolatedDebugConfigureBuilder());
+                            }
+
+                            // We do not need diagnostic events for local development, so we replace it with a null repository
+                            services.AddSingleton<IDiagnosticEventRepository, DiagnosticEventNullRepository>();
+                        });
                 })
-                .UseSetting(WebHostDefaults.ApplicationKey, typeof(Startup).Assembly.GetName().Name)
-                .UseUrls(listenAddress.ToString())
                 .ConfigureAppConfiguration(configBuilder =>
                 {
                     configBuilder.AddEnvironmentVariables();
@@ -266,18 +280,6 @@ namespace Azure.Functions.Cli.Actions.HostActions
 
                         return !isSharedMemoryWarning && !isAppInsightsExtensionWarning;
                     });
-                })
-                .ConfigureServices((context, services) =>
-                {
-                    services.AddSingleton<IStartup>(new Startup(context, hostOptions, CorsOrigins, CorsCredentials, EnableAuth, UserSecretsId, loggingFilterHelper, JsonOutputFile));
-
-                    if (DotNetIsolatedDebug != null && DotNetIsolatedDebug.Value)
-                    {
-                        services.AddSingleton<IConfigureBuilder<IServiceCollection>>(_ => new DotNetIsolatedDebugConfigureBuilder());
-                    }
-
-                    // We do not need diagnostic events for local development, so we replace it with a null repository
-                    services.AddSingleton<IDiagnosticEventRepository, DiagnosticEventNullRepository>();
                 })
                 .Build();
         }
@@ -465,7 +467,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 await ExtensionBundleHelper.GetExtensionBundle();
             }
 
-            IWebHost host = await BuildWebHost(hostOptions, listenUri, baseUri, certificate);
+            IHost host = await BuildWebHost(hostOptions, listenUri, baseUri, certificate);
             var runTask = host.RunAsync();
             var hostService = host.Services.GetRequiredService<WebJobsScriptHostService>();
 

--- a/src/Cli/func/Actions/HostActions/StartHostAction.cs
+++ b/src/Cli/func/Actions/HostActions/StartHostAction.cs
@@ -25,7 +25,6 @@ using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
@@ -186,7 +185,8 @@ namespace Azure.Functions.Cli.Actions.HostActions
             return base.ParseArgs(args);
         }
 
-        private async Task<IHost> BuildWebHost(ScriptApplicationHostOptions hostOptions, Uri listenAddress, Uri baseAddress, X509Certificate2 certificate)
+#pragma warning disable ASPDEPR008 // Startup implements IStartup which requires IWebHost lifecycle
+        private async Task<IWebHost> BuildWebHost(ScriptApplicationHostOptions hostOptions, Uri listenAddress, Uri baseAddress, X509Certificate2 certificate)
         {
             LoggingFilterHelper loggingFilterHelper = new LoggingFilterHelper(_hostJsonConfig, VerboseLogging, UserLogLevel);
 
@@ -210,41 +210,28 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 ColoredConsole.WriteLine(ErrorColor("CONTAINER_NAME is a reserved environment variable for the Functions Host. Please remove or rename this setting."));
             }
 
-            return Host.CreateDefaultBuilder(Array.Empty<string>())
-                .ConfigureWebHostDefaults(webBuilder =>
+            var defaultBuilder = Microsoft.AspNetCore.WebHost.CreateDefaultBuilder(Array.Empty<string>());
+
+            if (UseHttps)
+            {
+                defaultBuilder
+                .UseKestrel(options =>
                 {
-                    if (UseHttps)
+                    options.Listen(IPAddress.Any, listenAddress.Port, listenOptins =>
                     {
-                        webBuilder.UseKestrel(options =>
-                        {
-                            options.Listen(IPAddress.Any, listenAddress.Port, listenOptins =>
-                            {
-                                listenOptins.UseHttps(certificate);
-                            });
-                        });
-                    }
+                        listenOptins.UseHttps(certificate);
+                    });
+                });
+            }
 
-                    webBuilder
-                        .ConfigureKestrel(o =>
-                        {
-                            // Setting it to match the default RequestBodySize in host
-                            o.Limits.MaxRequestBodySize = Constants.DefaultMaxRequestBodySize;
-                        })
-                        .UseSetting(WebHostDefaults.ApplicationKey, typeof(Startup).Assembly.GetName().Name)
-                        .UseUrls(listenAddress.ToString())
-                        .ConfigureServices((context, services) =>
-                        {
-                            services.AddSingleton<IStartup>(new Startup(context, hostOptions, CorsOrigins, CorsCredentials, EnableAuth, UserSecretsId, loggingFilterHelper, JsonOutputFile));
-
-                            if (DotNetIsolatedDebug != null && DotNetIsolatedDebug.Value)
-                            {
-                                services.AddSingleton<IConfigureBuilder<IServiceCollection>>(_ => new DotNetIsolatedDebugConfigureBuilder());
-                            }
-
-                            // We do not need diagnostic events for local development, so we replace it with a null repository
-                            services.AddSingleton<IDiagnosticEventRepository, DiagnosticEventNullRepository>();
-                        });
+            return defaultBuilder
+                .ConfigureKestrel(o =>
+                {
+                    // Setting it to match the default RequestBodySize in host
+                    o.Limits.MaxRequestBodySize = Constants.DefaultMaxRequestBodySize;
                 })
+                .UseSetting(WebHostDefaults.ApplicationKey, typeof(Startup).Assembly.GetName().Name)
+                .UseUrls(listenAddress.ToString())
                 .ConfigureAppConfiguration(configBuilder =>
                 {
                     configBuilder.AddEnvironmentVariables();
@@ -281,8 +268,21 @@ namespace Azure.Functions.Cli.Actions.HostActions
                         return !isSharedMemoryWarning && !isAppInsightsExtensionWarning;
                     });
                 })
+                .ConfigureServices((context, services) =>
+                {
+                    services.AddSingleton<IStartup>(new Startup(context, hostOptions, CorsOrigins, CorsCredentials, EnableAuth, UserSecretsId, loggingFilterHelper, JsonOutputFile));
+
+                    if (DotNetIsolatedDebug != null && DotNetIsolatedDebug.Value)
+                    {
+                        services.AddSingleton<IConfigureBuilder<IServiceCollection>>(_ => new DotNetIsolatedDebugConfigureBuilder());
+                    }
+
+                    // We do not need diagnostic events for local development, so we replace it with a null repository
+                    services.AddSingleton<IDiagnosticEventRepository, DiagnosticEventNullRepository>();
+                })
                 .Build();
         }
+#pragma warning restore ASPDEPR008
 
         internal async Task<IDictionary<string, string>> GetConfigurationSettings(string scriptPath, Uri uri)
         {
@@ -467,7 +467,9 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 await ExtensionBundleHelper.GetExtensionBundle();
             }
 
-            IHost host = await BuildWebHost(hostOptions, listenUri, baseUri, certificate);
+#pragma warning disable ASPDEPR008
+            IWebHost host = await BuildWebHost(hostOptions, listenUri, baseUri, certificate);
+#pragma warning restore ASPDEPR008
             var runTask = host.RunAsync();
             var hostService = host.Services.GetRequiredService<WebJobsScriptHostService>();
 

--- a/src/Cli/func/Azure.Functions.Cli.csproj
+++ b/src/Cli/func/Azure.Functions.Cli.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" InitialTargets="ExcludeWorkersFromReadyToRun">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <AssemblyName>func</AssemblyName>
     <RuntimeIdentifiers>win-x64;win-x86;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
@@ -42,12 +42,9 @@
     <PackageReference Include="Microsoft.Identity.Client" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NuGet.Packaging" />
-    <PackageReference Include="System.Formats.Asn1" />
     <PackageReference Include="StyleCop.Analyzers" />
     <PackageReference Include="WindowsAzure.Storage" />
     <PackageReference Include="YamlDotNet" />
-    <!-- Transitive dependency -->
-    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(NoWorkers)' != 'true'">

--- a/src/Cli/func/Directory.Version.props
+++ b/src/Cli/func/Directory.Version.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>4.10.0</VersionPrefix>
+    <VersionPrefix>4.11.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>

--- a/src/Cli/func/Directory.Version.props
+++ b/src/Cli/func/Directory.Version.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>4.12.0</VersionPrefix>
+    <VersionPrefix>4.13.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>

--- a/src/Cli/func/Helpers/SecurityHelpers.cs
+++ b/src/Cli/func/Helpers/SecurityHelpers.cs
@@ -54,7 +54,7 @@ namespace Azure.Functions.Cli.Helpers
                 certPassword = File.Exists(certPassword)
                     ? File.ReadAllText(certPassword).Trim()
                     : certPassword;
-                return new X509Certificate2(certPath, certPassword);
+                return X509CertificateLoader.LoadPkcs12FromFile(certPath, certPassword);
             }
             else if (CommandChecker.CommandExists("openssl"))
             {
@@ -116,7 +116,7 @@ namespace Azure.Functions.Cli.Helpers
                 throw new CliException($"Could not create a Certificate using openssl.");
             }
 
-            return new X509Certificate2($"{certFileNames}certificate.pfx", DEFAULT_PASSWORD);
+            return X509CertificateLoader.LoadPkcs12FromFile($"{certFileNames}certificate.pfx", DEFAULT_PASSWORD);
         }
 
         public static string CalculateMd5(Stream stream)

--- a/src/Cli/func/StaticResources/StaticResources.cs
+++ b/src/Cli/func/StaticResources/StaticResources.cs
@@ -118,10 +118,15 @@ namespace Azure.Functions.Cli
             using (var reader = new StreamReader(stream))
             {
                 var sb = new StringBuilder();
-                while (!reader.EndOfStream)
+                string line;
+                while ((line = await reader.ReadLineAsync()) != null)
                 {
-                    var line = await reader.ReadLineAsync();
-                    sb.AppendFormat("{0}{1}", line, reader.EndOfStream ? string.Empty : Environment.NewLine);
+                    if (sb.Length > 0)
+                    {
+                        sb.Append(Environment.NewLine);
+                    }
+
+                    sb.Append(line);
                 }
 
                 return sb.ToString();

--- a/src/Cli/func/StaticResources/StaticResources.cs
+++ b/src/Cli/func/StaticResources/StaticResources.cs
@@ -122,10 +122,15 @@ namespace Azure.Functions.Cli
             using (var reader = new StreamReader(stream))
             {
                 var sb = new StringBuilder();
-                while (!reader.EndOfStream)
+                string line;
+                while ((line = await reader.ReadLineAsync()) != null)
                 {
-                    var line = await reader.ReadLineAsync();
-                    sb.AppendFormat("{0}{1}", line, reader.EndOfStream ? string.Empty : Environment.NewLine);
+                    if (sb.Length > 0)
+                    {
+                        sb.Append(Environment.NewLine);
+                    }
+
+                    sb.Append(line);
                 }
 
                 return sb.ToString();

--- a/src/Cli/func/Telemetry/DockerContainerDetectorForTelemetry.cs
+++ b/src/Cli/func/Telemetry/DockerContainerDetectorForTelemetry.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Runtime.InteropServices;
 using System.Security;
-using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.Win32;
 
 namespace Azure.Functions.Cli.Telemetry
@@ -18,46 +18,48 @@ namespace Azure.Functions.Cli.Telemetry
     {
         public DockerContainer IsDockerContainer()
         {
-            switch (RuntimeEnvironment.OperatingSystemPlatform)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                case Platform.Windows:
-                    try
-                    {
+                try
+                {
 #pragma warning disable CA1416 // Validate platform compatibility - This is a windows only code path.
 
-                        using var subkey = Registry.LocalMachine.OpenSubKey("System\\CurrentControlSet\\Control");
+                    using var subkey = Registry.LocalMachine.OpenSubKey("System\\CurrentControlSet\\Control");
 
-                        return subkey?.GetValue("ContainerType") != null
-                            ? DockerContainer.True
-                            : DockerContainer.False;
+                    return subkey?.GetValue("ContainerType") != null
+                        ? DockerContainer.True
+                        : DockerContainer.False;
 
 #pragma warning restore CA1416 // Validate platform compatibility
-                    }
-                    catch (SecurityException)
-                    {
-                        return DockerContainer.Unknown;
-                    }
-
-                case Platform.Linux:
-                    try
-                    {
-                        return ReadProcToDetectDockerInLinux()
-                            ? DockerContainer.True
-                            : DockerContainer.False;
-                    }
-                    catch (Exception ex) when (ex is IOException || ex.InnerException is IOException)
-                    {
-                        // In some environments (restricted docker container, shared hosting etc.),
-                        // procfs is not accessible and we get UnauthorizedAccessException while the
-                        // inner exception is set to IOException. In this case, it is unknown.
-                        return DockerContainer.Unknown;
-                    }
-
-                case Platform.Unknown:
+                }
+                catch (SecurityException)
+                {
                     return DockerContainer.Unknown;
-                case Platform.Darwin:
-                default:
-                    return DockerContainer.False;
+                }
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                try
+                {
+                    return ReadProcToDetectDockerInLinux()
+                        ? DockerContainer.True
+                        : DockerContainer.False;
+                }
+                catch (Exception ex) when (ex is IOException || ex.InnerException is IOException)
+                {
+                    // In some environments (restricted docker container, shared hosting etc.),
+                    // procfs is not accessible and we get UnauthorizedAccessException while the
+                    // inner exception is set to IOException. In this case, it is unknown.
+                    return DockerContainer.Unknown;
+                }
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return DockerContainer.False;
+            }
+            else
+            {
+                return DockerContainer.Unknown;
             }
         }
 

--- a/src/Cli/func/Telemetry/ExternalTelemetryProperties.cs
+++ b/src/Cli/func/Telemetry/ExternalTelemetryProperties.cs
@@ -5,9 +5,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Security;
-using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.Win32;
-using RuntimeEnvironment = Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment;
 
 namespace Azure.Functions.Cli.Telemetry
 {
@@ -53,7 +51,7 @@ namespace Azure.Functions.Cli.Telemetry
         /// </summary>
         internal static string GetProductType()
         {
-            if (RuntimeEnvironment.OperatingSystemPlatform != Platform.Windows)
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 return string.Empty;
             }
@@ -96,7 +94,7 @@ namespace Azure.Functions.Cli.Telemetry
         /// </summary>
         internal static string GetLibcRelease()
         {
-            if (RuntimeEnvironment.OperatingSystemPlatform == Platform.Windows)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 return string.Empty;
             }
@@ -121,7 +119,7 @@ namespace Azure.Functions.Cli.Telemetry
         /// </summary>
         internal static string GetLibcVersion()
         {
-            if (RuntimeEnvironment.OperatingSystemPlatform == Platform.Windows)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 return string.Empty;
             }

--- a/src/Cli/func/Telemetry/Telemetry.cs
+++ b/src/Cli/func/Telemetry/Telemetry.cs
@@ -1,11 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Runtime.InteropServices;
 using Azure.Functions.Cli.Common;
 using Colors.Net;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.DotNet.PlatformAbstractions;
 
 namespace Azure.Functions.Cli.Telemetry
 {
@@ -93,7 +93,7 @@ namespace Azure.Functions.Cli.Telemetry
                 };
                 _client = new TelemetryClient(telemetryConfiguration);
                 _client.Context.Session.Id = _currentSessionId;
-                _client.Context.Device.OperatingSystem = RuntimeEnvironment.OperatingSystem;
+                _client.Context.Device.OperatingSystem = RuntimeInformation.OSDescription;
 
                 // We don't want to log this.
                 // Setting it to null doesn't work. So might as well log the session id.

--- a/src/Cli/func/Telemetry/TelemetryCommonProperties.cs
+++ b/src/Cli/func/Telemetry/TelemetryCommonProperties.cs
@@ -3,7 +3,6 @@
 
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Interfaces;
-using RuntimeEnvironment = Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment;
 using RuntimeInformation = System.Runtime.InteropServices.RuntimeInformation;
 
 namespace Azure.Functions.Cli.Telemetry
@@ -49,10 +48,10 @@ namespace Azure.Functions.Cli.Telemetry
         {
             return new Dictionary<string, string>
             {
-                { OSVersion, RuntimeEnvironment.OperatingSystemVersion },
-                { OSPlatform, RuntimeEnvironment.OperatingSystemPlatform.ToString() },
+                { OSVersion, Environment.OSVersion.VersionString },
+                { OSPlatform, RuntimeInformation.OSDescription },
                 { OutputRedirected, Console.IsOutputRedirected.ToString() },
-                { RuntimeId, RuntimeEnvironment.GetRuntimeIdentifier() },
+                { RuntimeId, RuntimeInformation.RuntimeIdentifier },
                 { ProductVersion, Constants.CliVersion },
                 { TelemetryProfile, Environment.GetEnvironmentVariable(TelemetryProfileEnvironmentVariable) },
                 { DockerContainer, IsDockerContainerCache() },

--- a/src/CoreToolsHost/CoreToolsHost.csproj
+++ b/src/CoreToolsHost/CoreToolsHost.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <PublishAot>true</PublishAot>
     <ControlFlowGuard>Guard</ControlFlowGuard>

--- a/src/GoZipTool/GoZipTool.csproj
+++ b/src/GoZipTool/GoZipTool.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ResolvedRuntimeIdentifier Condition="'$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier)</ResolvedRuntimeIdentifier>
   </PropertyGroup>
 

--- a/test/Cli/Func.E2ETests/Azure.Functions.Cli.E2ETests.csproj
+++ b/test/Cli/Func.E2ETests/Azure.Functions.Cli.E2ETests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 	<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
   </PropertyGroup>
 

--- a/test/Cli/Func.E2ETests/Azure.Functions.Cli.E2ETests.csproj
+++ b/test/Cli/Func.E2ETests/Azure.Functions.Cli.E2ETests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
 	<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="StyleCop.Analyzers" />
     <PackageReference Include="xunit" />

--- a/test/Cli/Func.E2ETests/Commands/FuncInit/DotnetIsolatedInitTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncInit/DotnetIsolatedInitTests.cs
@@ -126,7 +126,7 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncInit
         [InlineData("net8.0")]
         [InlineData("net9.0")]
         [InlineData("net10.0")]
-        public async void Init_DockerOnlyOnExistingProjectWithTargetFramework_GeneratesDockerfile(string targetFramework)
+        public async Task Init_DockerOnlyOnExistingProjectWithTargetFramework_GeneratesDockerfile(string targetFramework)
         {
             var workingDir = Path.Combine(WorkingDirectory, targetFramework);
 

--- a/test/Cli/Func.E2ETests/Commands/FuncInit/NodeInitTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncInit/NodeInitTests.cs
@@ -140,7 +140,7 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncInit
         }
 
         [Fact]
-        public async void Init_DockerOnlyOnExistingProject_GeneratesDockerfile()
+        public async Task Init_DockerOnlyOnExistingProject_GeneratesDockerfile()
         {
             var workingDir = WorkingDirectory;
             var testName = nameof(Init_DockerOnlyOnExistingProject_GeneratesDockerfile);

--- a/test/Cli/Func.E2ETests/Commands/FuncInit/PythonInitTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncInit/PythonInitTests.cs
@@ -121,7 +121,7 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncInit
         }
 
         [Fact]
-        public async void Init_WithExistingProject_SkipsExistingFilesCreation()
+        public async Task Init_WithExistingProject_SkipsExistingFilesCreation()
         {
             var workingDir = WorkingDirectory;
             var testName = nameof(Init_WithExistingProject_SkipsExistingFilesCreation);

--- a/test/Cli/Func.E2ETests/Commands/FuncNew/NodeTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncNew/NodeTests.cs
@@ -5,7 +5,6 @@ using AwesomeAssertions;
 using Azure.Functions.Cli.E2ETests.Traits;
 using Azure.Functions.Cli.TestFramework.Assertions;
 using Azure.Functions.Cli.TestFramework.Commands;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/Cli/Func.E2ETests/Commands/FuncStart/Core/BaseUserSecretsTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncStart/Core/BaseUserSecretsTests.cs
@@ -13,7 +13,7 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncStart.Core
 {
     public class BaseUserSecretsTests(ITestOutputHelper log) : BaseE2ETests(log)
     {
-        public async Task RunUserSecretsTest(string language, string testName)
+        internal async Task RunUserSecretsTest(string language, string testName)
         {
             var port = ProcessHelper.GetAvailablePort();
 
@@ -72,7 +72,7 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncStart.Core
             result.Should().HaveStdOutContaining("Using for user secrets file configuration.");
         }
 
-        public async Task RunMissingStorageConnString(string languageWorker, bool shouldFail, string testName)
+        internal async Task RunMissingStorageConnString(string languageWorker, bool shouldFail, string testName)
         {
             var azureWebJobsStorage = Environment.GetEnvironmentVariable("AzureWebJobsStorage");
             if (!string.IsNullOrEmpty(azureWebJobsStorage))
@@ -142,7 +142,7 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncStart.Core
             }
         }
 
-        public async Task RunWithUserSecrets_MissingBindingSettings(string languageWorker, string testName)
+        internal async Task RunWithUserSecrets_MissingBindingSettings(string languageWorker, string testName)
         {
             var azureWebJobsStorage = Environment.GetEnvironmentVariable("AzureWebJobsStorage");
             if (!string.IsNullOrEmpty(azureWebJobsStorage))

--- a/test/Cli/Func.UnitTests/Azure.Functions.Cli.UnitTests.csproj
+++ b/test/Cli/Func.UnitTests/Azure.Functions.Cli.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/test/Cli/Func.UnitTests/Azure.Functions.Cli.UnitTests.csproj
+++ b/test/Cli/Func.UnitTests/Azure.Functions.Cli.UnitTests.csproj
@@ -6,10 +6,12 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <Nullable>disable</Nullable>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NSubstitute" />

--- a/test/Cli/Func.UnitTests/HelperTests/UtilitiesTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/UtilitiesTests.cs
@@ -66,7 +66,7 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void Test_IsMinifiedVersion(bool expected)
+        public async Task Test_IsMinifiedVersion(bool expected)
         {
             // IsMinifiedVersion uses ConfigurationBuilder.AddJsonFile with a relative path,
             // which resolves against AppContext.BaseDirectory — not the test's current working directory.
@@ -74,7 +74,7 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
             // so write the artifactsconfig.json next to the test binary to keep this test deterministic.
             var filePath = Path.Combine(AppContext.BaseDirectory, "artifactsconfig.json");
             string artifactsJsonContent = "{\"minifiedVersion\": " + expected.ToString().ToLower() + "}";
-            File.WriteAllTextAsync(filePath, artifactsJsonContent).GetAwaiter().GetResult();
+            await File.WriteAllTextAsync(filePath, artifactsJsonContent);
 
             try
             {

--- a/test/Cli/Func.UnitTests/ParserTests/GitIgnoreParserTests.cs
+++ b/test/Cli/Func.UnitTests/ParserTests/GitIgnoreParserTests.cs
@@ -150,7 +150,7 @@ othernonexistent/**/what
         }
 
         [Fact]
-        public async void PowerShellModuleBinFoldersShouldBeHandledCorrectly()
+        public async Task PowerShellModuleBinFoldersShouldBeHandledCorrectly()
         {
             // Test the current gitignore content from the actual static resource
             var currentGitIgnore = await StaticResources.GitIgnore;

--- a/test/Cli/TestFramework/Azure.Functions.Cli.TestFramework.csproj
+++ b/test/Cli/TestFramework/Azure.Functions.Cli.TestFramework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/test/ZippedExe/ZippedExe.csproj
+++ b/test/ZippedExe/ZippedExe.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <IsPackable>true</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Right now, I am suppressing `IWebHost` deprecation warning  because `Startup : IStartup` requires the `IWebHost` lifecycle. We should discuss if we want to address this in this release or a future one.
