### PR TITLE
Add command stubs for init, new, start, pack with project detection

### DIFF
--- a/src/Func.Cli/Commands/InitCommand.cs
+++ b/src/Func.Cli/Commands/InitCommand.cs
@@ -1,0 +1,68 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Console;
+
+namespace Azure.Functions.Cli.Commands;
+
+/// <summary>
+/// Initializes a new Azure Functions project. The full implementation requires
+/// a language workload to be installed — this defines the command skeleton and options.
+/// </summary>
+public class InitCommand : BaseCommand
+{
+    public static readonly Option<string?> WorkerRuntimeOption = new("--worker-runtime", "-w")
+    {
+        Description = "The worker runtime for the project"
+    };
+
+    public static readonly Option<string?> NameOption = new("--name", "-n")
+    {
+        Description = "The name of the function app project"
+    };
+
+    public static readonly Option<string?> LanguageOption = new("--language", "-l")
+    {
+        Description = "The programming language (e.g., C#, F#, JavaScript, TypeScript, Python)"
+    };
+
+    public static readonly Option<bool> ForceOption = new("--force")
+    {
+        Description = "Force initialization even if the folder is not empty"
+    };
+
+    private readonly IInteractionService _interaction;
+
+    public InitCommand(IInteractionService interaction)
+        : base("init", "Initialize a new Azure Functions project.")
+    {
+        _interaction = interaction;
+
+        AddPathArgument();
+        Options.Add(WorkerRuntimeOption);
+        Options.Add(NameOption);
+        Options.Add(LanguageOption);
+        Options.Add(ForceOption);
+    }
+
+    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        ApplyPath(parseResult, createIfNotExists: true);
+
+        _interaction.WriteError("No language workloads installed.");
+        _interaction.WriteBlankLine();
+        _interaction.WriteMarkupLine(
+            "[grey]Install a workload to initialize a project:[/]");
+        _interaction.WriteBlankLine();
+        _interaction.WriteMarkupLine("  [white]func workload install dotnet[/]       [grey]C#, F#[/]");
+        _interaction.WriteMarkupLine("  [white]func workload install node[/]         [grey]JavaScript, TypeScript[/]");
+        _interaction.WriteMarkupLine("  [white]func workload install python[/]       [grey]Python[/]");
+        _interaction.WriteMarkupLine("  [white]func workload install java[/]         [grey]Java[/]");
+        _interaction.WriteMarkupLine("  [white]func workload install powershell[/]   [grey]PowerShell[/]");
+        _interaction.WriteBlankLine();
+        _interaction.WriteMarkupLine("[grey]Run[/] [white]func workload search[/] [grey]to discover available workloads.[/]");
+
+        return Task.FromResult(1);
+    }
+}

--- a/src/Func.Cli/Commands/InitCommand.cs
+++ b/src/Func.Cli/Commands/InitCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.CommandLine;
+using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Console;
 
 namespace Azure.Functions.Cli.Commands;
@@ -52,14 +53,9 @@ public class InitCommand : BaseCommand
 
         _interaction.WriteError("No language workloads installed.");
         _interaction.WriteBlankLine();
-        _interaction.WriteMarkupLine(
-            "[grey]Install a workload to initialize a project:[/]");
+        _interaction.WriteMarkupLine("[grey]Install a workload to initialize a project:[/]");
         _interaction.WriteBlankLine();
-        _interaction.WriteMarkupLine("  [white]func workload install dotnet[/]       [grey]C#, F#[/]");
-        _interaction.WriteMarkupLine("  [white]func workload install node[/]         [grey]JavaScript, TypeScript[/]");
-        _interaction.WriteMarkupLine("  [white]func workload install python[/]       [grey]Python[/]");
-        _interaction.WriteMarkupLine("  [white]func workload install java[/]         [grey]Java[/]");
-        _interaction.WriteMarkupLine("  [white]func workload install powershell[/]   [grey]PowerShell[/]");
+        WorkerRuntimes.WriteWorkloadInstallHints(_interaction);
         _interaction.WriteBlankLine();
         _interaction.WriteMarkupLine("[grey]Run[/] [white]func workload search[/] [grey]to discover available workloads.[/]");
 

--- a/src/Func.Cli/Commands/NewCommand.cs
+++ b/src/Func.Cli/Commands/NewCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.CommandLine;
+using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Console;
 
 namespace Azure.Functions.Cli.Commands;
@@ -46,14 +47,9 @@ public class NewCommand : BaseCommand
 
         _interaction.WriteError("No language workloads installed.");
         _interaction.WriteBlankLine();
-        _interaction.WriteMarkupLine(
-            "[grey]Install a workload to create functions from templates:[/]");
+        _interaction.WriteMarkupLine("[grey]Install a workload to create functions from templates:[/]");
         _interaction.WriteBlankLine();
-        _interaction.WriteMarkupLine("  [white]func workload install dotnet[/]       [grey]C#, F#[/]");
-        _interaction.WriteMarkupLine("  [white]func workload install node[/]         [grey]JavaScript, TypeScript[/]");
-        _interaction.WriteMarkupLine("  [white]func workload install python[/]       [grey]Python[/]");
-        _interaction.WriteMarkupLine("  [white]func workload install java[/]         [grey]Java[/]");
-        _interaction.WriteMarkupLine("  [white]func workload install powershell[/]   [grey]PowerShell[/]");
+        WorkerRuntimes.WriteWorkloadInstallHints(_interaction);
         _interaction.WriteBlankLine();
         _interaction.WriteMarkupLine("[grey]Run[/] [white]func workload search[/] [grey]to discover available workloads.[/]");
 

--- a/src/Func.Cli/Commands/NewCommand.cs
+++ b/src/Func.Cli/Commands/NewCommand.cs
@@ -1,0 +1,62 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Console;
+
+namespace Azure.Functions.Cli.Commands;
+
+/// <summary>
+/// Creates a new function from a template. The full implementation requires
+/// a language workload to be installed — this defines the command skeleton and options.
+/// </summary>
+public class NewCommand : BaseCommand
+{
+    public static readonly Option<string?> NameOption = new("--name", "-n")
+    {
+        Description = "The name of the function"
+    };
+
+    public static readonly Option<string?> TemplateOption = new("--template", "-t")
+    {
+        Description = "The function template name"
+    };
+
+    public static readonly Option<bool> ForceOption = new("--force")
+    {
+        Description = "Overwrite existing files"
+    };
+
+    private readonly IInteractionService _interaction;
+
+    public NewCommand(IInteractionService interaction)
+        : base("new", "Create a new function from a template.")
+    {
+        _interaction = interaction;
+
+        AddPathArgument();
+        Options.Add(NameOption);
+        Options.Add(TemplateOption);
+        Options.Add(ForceOption);
+    }
+
+    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        ApplyPath(parseResult, createIfNotExists: true);
+
+        _interaction.WriteError("No language workloads installed.");
+        _interaction.WriteBlankLine();
+        _interaction.WriteMarkupLine(
+            "[grey]Install a workload to create functions from templates:[/]");
+        _interaction.WriteBlankLine();
+        _interaction.WriteMarkupLine("  [white]func workload install dotnet[/]       [grey]C#, F#[/]");
+        _interaction.WriteMarkupLine("  [white]func workload install node[/]         [grey]JavaScript, TypeScript[/]");
+        _interaction.WriteMarkupLine("  [white]func workload install python[/]       [grey]Python[/]");
+        _interaction.WriteMarkupLine("  [white]func workload install java[/]         [grey]Java[/]");
+        _interaction.WriteMarkupLine("  [white]func workload install powershell[/]   [grey]PowerShell[/]");
+        _interaction.WriteBlankLine();
+        _interaction.WriteMarkupLine("[grey]Run[/] [white]func workload search[/] [grey]to discover available workloads.[/]");
+
+        return Task.FromResult(1);
+    }
+}

--- a/src/Func.Cli/Commands/PackCommand.cs
+++ b/src/Func.Cli/Commands/PackCommand.cs
@@ -1,0 +1,65 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Console;
+
+namespace Azure.Functions.Cli.Commands;
+
+/// <summary>
+/// Packages an Azure Functions project into a zip ready for deployment.
+/// The full implementation requires a language workload — this defines
+/// the command skeleton and options.
+/// </summary>
+public class PackCommand : BaseCommand
+{
+    public static readonly Option<string?> OutputOption = new("--output", "-o")
+    {
+        Description = "The directory to place the output zip file in"
+    };
+
+    public static readonly Option<bool> NoBuildOption = new("--no-build")
+    {
+        Description = "Skip building the project before packaging"
+    };
+
+    private readonly IInteractionService _interaction;
+
+    public PackCommand(IInteractionService interaction)
+        : base("pack", "Package the function app into a zip ready for deployment.")
+    {
+        _interaction = interaction;
+
+        AddPathArgument();
+        Options.Add(OutputOption);
+        Options.Add(NoBuildOption);
+    }
+
+    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        ApplyPath(parseResult);
+
+        var projectPath = Directory.GetCurrentDirectory();
+
+        // Verify this is a Functions project
+        if (!File.Exists(Path.Combine(projectPath, "host.json")))
+        {
+            _interaction.WriteError("No Azure Functions project found. Run func init first.");
+            return Task.FromResult(1);
+        }
+
+        // Detect the runtime
+        var detectedRuntime = ProjectDetector.DetectRuntime(projectPath);
+        if (detectedRuntime is null)
+        {
+            _interaction.WriteError("Could not detect the worker runtime for this project.");
+            _interaction.WriteMarkupLine("[grey]Ensure the project contains the expected project files (e.g., .csproj, package.json).[/]");
+            return Task.FromResult(1);
+        }
+
+        _interaction.WriteError($"No pack provider for runtime '{detectedRuntime}'.");
+        _interaction.WriteMarkupLine(
+            $"[grey]Install the workload:[/] [white]func workload install {detectedRuntime}[/]");
+        return Task.FromResult(1);
+    }
+}

--- a/src/Func.Cli/Commands/PackCommand.cs
+++ b/src/Func.Cli/Commands/PackCommand.cs
@@ -58,8 +58,7 @@ public class PackCommand : BaseCommand
         }
 
         _interaction.WriteError($"No pack provider for runtime '{detectedRuntime}'.");
-        _interaction.WriteMarkupLine(
-            $"[grey]Install the workload:[/] [white]func workload install {detectedRuntime}[/]");
+        _interaction.WriteMarkupLine($"[grey]Install the workload:[/] [white]func workload install {detectedRuntime}[/]");
         return Task.FromResult(1);
     }
 }

--- a/src/Func.Cli/Commands/ProjectDetector.cs
+++ b/src/Func.Cli/Commands/ProjectDetector.cs
@@ -1,0 +1,62 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Commands;
+
+/// <summary>
+/// Shared utility for detecting the worker runtime and language of a Functions project.
+/// </summary>
+internal static class ProjectDetector
+{
+    /// <summary>
+    /// Detects the worker runtime and language from the project files in the given directory.
+    /// </summary>
+    public static (string? Runtime, string? Language) DetectRuntimeAndLanguage(string directory)
+    {
+        // Check for .csproj → dotnet C#
+        if (Directory.EnumerateFiles(directory, "*.csproj").Any())
+        {
+            return ("dotnet", "C#");
+        }
+
+        // Check for .fsproj → dotnet F#
+        if (Directory.EnumerateFiles(directory, "*.fsproj").Any())
+        {
+            return ("dotnet", "F#");
+        }
+
+        // Check for package.json → node
+        if (File.Exists(Path.Combine(directory, "package.json")))
+        {
+            return ("node", null);
+        }
+
+        // Check for requirements.txt or pyproject.toml → python
+        if (File.Exists(Path.Combine(directory, "requirements.txt"))
+            || File.Exists(Path.Combine(directory, "pyproject.toml")))
+        {
+            return ("python", null);
+        }
+
+        // Check for pom.xml or build.gradle → java
+        if (File.Exists(Path.Combine(directory, "pom.xml"))
+            || File.Exists(Path.Combine(directory, "build.gradle")))
+        {
+            return ("java", null);
+        }
+
+        // Check for profile.ps1 → powershell
+        if (File.Exists(Path.Combine(directory, "profile.ps1")))
+        {
+            return ("powershell", null);
+        }
+
+        return (null, null);
+    }
+
+    /// <summary>
+    /// Detects just the worker runtime from the project files in the given directory.
+    /// </summary>
+    public static string? DetectRuntime(string directory)
+        => DetectRuntimeAndLanguage(directory).Runtime;
+}

--- a/src/Func.Cli/Commands/SpectreHelpAction.cs
+++ b/src/Func.Cli/Commands/SpectreHelpAction.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.CommandLine;
-using System.CommandLine.Help;
 using System.CommandLine.Invocation;
-using Azure.Functions.Cli.Console;
 
 namespace Azure.Functions.Cli.Commands;
 

--- a/src/Func.Cli/Commands/StartCommand.cs
+++ b/src/Func.Cli/Commands/StartCommand.cs
@@ -1,0 +1,75 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Console;
+
+namespace Azure.Functions.Cli.Commands;
+
+/// <summary>
+/// Launches the Azure Functions host runtime. Supports 'func start' and
+/// Placeholder for 'func start' (not yet implemented).
+/// </summary>
+public class StartCommand : BaseCommand
+{
+    public static readonly Option<int?> PortOption = new("--port", "-p")
+    {
+        Description = "The port to listen on (default: 7071)"
+    };
+
+    public static readonly Option<string?> CorsOption = new("--cors")
+    {
+        Description = "A comma-separated list of CORS origins"
+    };
+
+    public static readonly Option<bool> CorsCredentialsOption = new("--cors-credentials")
+    {
+        Description = "Allow cross-origin authenticated requests"
+    };
+
+    public static readonly Option<string[]?> FunctionsOption = new("--functions")
+    {
+        Description = "A space-separated list of functions to load",
+        Arity = ArgumentArity.ZeroOrMore
+    };
+
+    public static readonly Option<bool> NoBuildOption = new("--no-build")
+    {
+        Description = "Do not build the project before running"
+    };
+
+    public static readonly Option<bool> EnableAuthOption = new("--enable-auth")
+    {
+        Description = "Enable full authentication handling"
+    };
+
+    public static readonly Option<string?> HostVersionOption = new("--host-version")
+    {
+        Description = "The host runtime version to use (e.g., 4.1049.0)"
+    };
+
+    private readonly IInteractionService _interaction;
+
+    public StartCommand(IInteractionService interaction)
+        : base("start", "Launch the Azure Functions host runtime.")
+    {
+        _interaction = interaction;
+
+        AddPathArgument();
+        Options.Add(PortOption);
+        Options.Add(CorsOption);
+        Options.Add(CorsCredentialsOption);
+        Options.Add(FunctionsOption);
+        Options.Add(NoBuildOption);
+        Options.Add(EnableAuthOption);
+        Options.Add(HostVersionOption);
+    }
+
+    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        ApplyPath(parseResult);
+        _interaction.WriteWarning("The 'start' command is not yet implemented in this version.");
+        _interaction.WriteMarkupLine("[grey]This is a preview build of Azure Functions CLI vNext.[/]");
+        return Task.FromResult(1);
+    }
+}

--- a/src/Func.Cli/Commands/StartCommand.cs
+++ b/src/Func.Cli/Commands/StartCommand.cs
@@ -7,8 +7,7 @@ using Azure.Functions.Cli.Console;
 namespace Azure.Functions.Cli.Commands;
 
 /// <summary>
-/// Launches the Azure Functions host runtime. Supports 'func start' and
-/// Placeholder for 'func start' (not yet implemented).
+/// Launches the Azure Functions host runtime via 'func start'.
 /// </summary>
 public class StartCommand : BaseCommand
 {

--- a/src/Func.Cli/Common/WorkerRuntimes.cs
+++ b/src/Func.Cli/Common/WorkerRuntimes.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Collections.Frozen;
+
+namespace Azure.Functions.Cli.Common;
+
+/// <summary>
+/// Central registry of worker runtimes and their supported languages.
+/// </summary>
+public static class WorkerRuntimes
+{
+    public static readonly FrozenDictionary<string, string[]> LanguageMap =
+        new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["dotnet"] = ["C#", "F#"],
+            ["node"] = ["JavaScript", "TypeScript"],
+            ["python"] = ["Python"],
+            ["java"] = ["Java"],
+            ["powershell"] = ["PowerShell"],
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Writes the workload install hints for all known runtimes.
+    /// </summary>
+    public static void WriteWorkloadInstallHints(Console.IInteractionService interaction)
+    {
+        foreach (var (worker, languages) in LanguageMap)
+        {
+            var langList = string.Join(", ", languages);
+            var padded = $"func workload install {worker}".PadRight(38);
+            interaction.WriteMarkupLine($"  [white]{padded}[/][grey]{langList}[/]");
+        }
+    }
+}

--- a/src/Func.Cli/Parser.cs
+++ b/src/Func.Cli/Parser.cs
@@ -25,10 +25,18 @@ public static class Parser
         // Create built-in commands
         var helpCommand = new HelpCommand(interaction, rootCommand);
         var versionCommand = new VersionCommand(interaction);
+        var initCommand = new InitCommand(interaction);
+        var newCommand = new NewCommand(interaction);
+        var packCommand = new PackCommand(interaction);
+        var startCommand = new StartCommand(interaction);
 
         // Register built-in commands
         rootCommand.Subcommands.Add(versionCommand);
         rootCommand.Subcommands.Add(helpCommand);
+        rootCommand.Subcommands.Add(initCommand);
+        rootCommand.Subcommands.Add(newCommand);
+        rootCommand.Subcommands.Add(packCommand);
+        rootCommand.Subcommands.Add(startCommand);
 
         // Replace built-in help rendering with Spectre on all commands
         ReplaceHelpAction(rootCommand, helpCommand);

--- a/test/Func.Cli.Tests/Commands/BaseCommandTests.cs
+++ b/test/Func.Cli.Tests/Commands/BaseCommandTests.cs
@@ -1,0 +1,99 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Commands;
+using Azure.Functions.Cli.Common;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Commands;
+
+[Collection(nameof(WorkingDirectoryTests))]
+public class BaseCommandTests : IDisposable
+{
+    // Use a well-known stable path so constructors don't fail when a previous
+    // test left cwd in a since-deleted temp directory.
+    private static readonly string _safeDir = Path.GetTempPath();
+    private readonly string _tempDir;
+    private readonly TestInteractionService _interaction = new();
+
+    public BaseCommandTests()
+    {
+        Directory.SetCurrentDirectory(_safeDir);
+        _tempDir = Path.Combine(Path.GetTempPath(), $"func-base-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.SetCurrentDirectory(_safeDir); } catch { }
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task PathArgument_ChangesWorkingDirectory()
+    {
+        var root = Parser.CreateCommand(_interaction);
+        var result = root.Parse($"start {_tempDir}");
+
+        await result.InvokeAsync();
+
+        // Verify cwd changed to the temp dir (use EndsWith to avoid macOS /var vs /private/var)
+        var dirName = Path.GetFileName(_tempDir);
+        Assert.EndsWith(dirName, Directory.GetCurrentDirectory());
+    }
+
+    [Fact]
+    public async Task PathArgument_NonExistentDir_ThrowsGracefulException()
+    {
+        var nonExistent = Path.Combine(_tempDir, "does-not-exist");
+        var root = Parser.CreateCommand(_interaction);
+        var result = root.Parse($"start {nonExistent}");
+
+        // Match production behavior: disable default exception handler so GracefulException propagates
+        var config = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
+        var ex = await Assert.ThrowsAsync<GracefulException>(
+            () => result.InvokeAsync(config));
+        Assert.Contains("does not exist", ex.Message);
+    }
+
+    [Fact]
+    public async Task PathArgument_CreateIfNotExists_CreatesDir()
+    {
+        var newDir = Path.Combine(_tempDir, "new-project");
+        Assert.False(Directory.Exists(newDir));
+
+        // Init uses createIfNotExists: true
+        var root = Parser.CreateCommand(_interaction);
+        var result = root.Parse($"init {newDir}");
+        await result.InvokeAsync();
+
+        Assert.True(Directory.Exists(newDir));
+    }
+
+    [Fact]
+    public void PathArgument_DashPrefix_RejectsAsUnrecognizedOption()
+    {
+        var root = Parser.CreateCommand(_interaction);
+        var result = root.Parse("init --bogus");
+
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public async Task PathArgument_NoPath_UsesCurrentDirectory()
+    {
+        Directory.SetCurrentDirectory(_tempDir);
+
+        var root = Parser.CreateCommand(_interaction);
+        var result = root.Parse("start");
+        await result.InvokeAsync();
+
+        // cwd should remain at _tempDir
+        var dirName = Path.GetFileName(_tempDir);
+        Assert.EndsWith(dirName, Directory.GetCurrentDirectory());
+    }
+}

--- a/test/Func.Cli.Tests/Commands/InitCommandTests.cs
+++ b/test/Func.Cli.Tests/Commands/InitCommandTests.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Commands;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Commands;
+
+public class InitCommandTests
+{
+    private readonly TestInteractionService _interaction;
+
+    public InitCommandTests()
+    {
+        _interaction = new TestInteractionService();
+    }
+
+    [Fact]
+    public void InitCommand_HasExpectedOptions()
+    {
+        var cmd = new InitCommand(_interaction);
+        var optionNames = cmd.Options.Select(o => o.Name).ToList();
+
+        Assert.Contains("--worker-runtime", optionNames);
+        Assert.Contains("--name", optionNames);
+        Assert.Contains("--language", optionNames);
+        Assert.Contains("--force", optionNames);
+    }
+
+    [Fact]
+    public void InitCommand_RegisteredInParser()
+    {
+        var root = Parser.CreateCommand(_interaction);
+        var names = root.Subcommands.Select(c => c.Name).ToList();
+
+        Assert.Contains("init", names);
+    }
+
+    [Fact]
+    public void InitCommand_HasPathArgument()
+    {
+        var cmd = new InitCommand(_interaction);
+        Assert.Single(cmd.Arguments);
+        Assert.Equal("path", cmd.Arguments[0].Name);
+    }
+}

--- a/test/Func.Cli.Tests/Commands/NewCommandTests.cs
+++ b/test/Func.Cli.Tests/Commands/NewCommandTests.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Commands;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Commands;
+
+public class NewCommandTests
+{
+    private readonly TestInteractionService _interaction;
+
+    public NewCommandTests()
+    {
+        _interaction = new TestInteractionService();
+    }
+
+    [Fact]
+    public void NewCommand_HasExpectedOptions()
+    {
+        var cmd = new NewCommand(_interaction);
+        var optionNames = cmd.Options.Select(o => o.Name).ToList();
+
+        Assert.Contains("--name", optionNames);
+        Assert.Contains("--template", optionNames);
+        Assert.Contains("--force", optionNames);
+    }
+
+    [Fact]
+    public void NewCommand_RegisteredInParser()
+    {
+        var root = Parser.CreateCommand(_interaction);
+        var names = root.Subcommands.Select(c => c.Name).ToList();
+
+        Assert.Contains("new", names);
+    }
+
+    [Fact]
+    public void NewCommand_HasPathArgument()
+    {
+        var cmd = new NewCommand(_interaction);
+        Assert.Single(cmd.Arguments);
+        Assert.Equal("path", cmd.Arguments[0].Name);
+    }
+}

--- a/test/Func.Cli.Tests/Commands/PackCommandTests.cs
+++ b/test/Func.Cli.Tests/Commands/PackCommandTests.cs
@@ -1,0 +1,139 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Commands;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Commands;
+
+[Collection(nameof(WorkingDirectoryTests))]
+public class PackCommandTests
+{
+    private readonly TestInteractionService _interaction;
+
+    public PackCommandTests()
+    {
+        _interaction = new TestInteractionService();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoHostJson_ReturnsError()
+    {
+        // Use a temp dir with no host.json
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var command = new PackCommand(_interaction);
+            var parseResult = command.Parse([tempDir]);
+
+            var exitCode = await parseResult.InvokeAsync();
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains(_interaction.Lines, l => l.Contains("No Azure Functions project found"));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoWorkload_ReturnsError()
+    {
+        // Create a temp dir with host.json and a .csproj so runtime is detected
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        File.WriteAllText(Path.Combine(tempDir, "host.json"), "{}");
+        File.WriteAllText(Path.Combine(tempDir, "test.csproj"), "<Project/>");
+        try
+        {
+            var command = new PackCommand(_interaction);
+            var parseResult = command.Parse([tempDir]);
+
+            var exitCode = await parseResult.InvokeAsync();
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains(_interaction.Lines, l => l.Contains("No pack provider"));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoRuntimeDetected_ReturnsError()
+    {
+        // Create a temp dir with host.json but no project files
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        File.WriteAllText(Path.Combine(tempDir, "host.json"), "{}");
+        try
+        {
+            var command = new PackCommand(_interaction);
+            var parseResult = command.Parse([tempDir]);
+
+            var exitCode = await parseResult.InvokeAsync();
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains(_interaction.Lines, l => l.Contains("Could not detect"));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void PackCommand_HasExpectedOptions()
+    {
+        var command = new PackCommand(_interaction);
+
+        var options = command.Options.Select(o => o.Name).ToList();
+        Assert.Contains("--output", options);
+        Assert.Contains("--no-build", options);
+    }
+
+    [Fact]
+    public void PackCommand_RegisteredInParser()
+    {
+        var root = Parser.CreateCommand(_interaction);
+        var names = root.Subcommands.Select(c => c.Name).ToList();
+        Assert.Contains("pack", names);
+    }
+
+    [Fact]
+    public void PackCommand_HasPathArgument()
+    {
+        var command = new PackCommand(_interaction);
+        Assert.Contains(command.Arguments, a => a.Name == "path");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithOutput_CreatesOutputDirectory()
+    {
+        // host.json + csproj but no workload → will fail at "no pack provider"
+        // but we verify the path arg and detection work up to that point
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        File.WriteAllText(Path.Combine(tempDir, "host.json"), "{}");
+        File.WriteAllText(Path.Combine(tempDir, "test.csproj"), "<Project/>");
+        try
+        {
+            var command = new PackCommand(_interaction);
+            var parseResult = command.Parse(["--output", "myoutput", tempDir]);
+
+            var exitCode = await parseResult.InvokeAsync();
+
+            // Should fail because no workload installed, but runtime should be detected
+            Assert.Equal(1, exitCode);
+            Assert.Contains(_interaction.Lines, l => l.Contains("No pack provider") && l.Contains("dotnet"));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+}

--- a/test/Func.Cli.Tests/Commands/ProjectDetectorTests.cs
+++ b/test/Func.Cli.Tests/Commands/ProjectDetectorTests.cs
@@ -1,0 +1,154 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Commands;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Commands;
+
+public class ProjectDetectorTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public ProjectDetectorTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"func-projdetect-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void DetectRuntimeAndLanguage_CSharpProject_ReturnsDotnetCSharp()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "MyApp.csproj"), "<Project/>");
+
+        var (runtime, language) = ProjectDetector.DetectRuntimeAndLanguage(_tempDir);
+
+        Assert.Equal("dotnet", runtime);
+        Assert.Equal("C#", language);
+    }
+
+    [Fact]
+    public void DetectRuntimeAndLanguage_FSharpProject_ReturnsDotnetFSharp()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "MyApp.fsproj"), "<Project/>");
+
+        var (runtime, language) = ProjectDetector.DetectRuntimeAndLanguage(_tempDir);
+
+        Assert.Equal("dotnet", runtime);
+        Assert.Equal("F#", language);
+    }
+
+    [Fact]
+    public void DetectRuntimeAndLanguage_NodeProject_ReturnsNode()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "package.json"), "{}");
+
+        var (runtime, language) = ProjectDetector.DetectRuntimeAndLanguage(_tempDir);
+
+        Assert.Equal("node", runtime);
+        Assert.Null(language);
+    }
+
+    [Fact]
+    public void DetectRuntimeAndLanguage_PythonRequirements_ReturnsPython()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "requirements.txt"), "");
+
+        var (runtime, language) = ProjectDetector.DetectRuntimeAndLanguage(_tempDir);
+
+        Assert.Equal("python", runtime);
+        Assert.Null(language);
+    }
+
+    [Fact]
+    public void DetectRuntimeAndLanguage_PyProject_ReturnsPython()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "pyproject.toml"), "");
+
+        var (runtime, language) = ProjectDetector.DetectRuntimeAndLanguage(_tempDir);
+
+        Assert.Equal("python", runtime);
+        Assert.Null(language);
+    }
+
+    [Fact]
+    public void DetectRuntimeAndLanguage_PomXml_ReturnsJava()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "pom.xml"), "<project/>");
+
+        var (runtime, language) = ProjectDetector.DetectRuntimeAndLanguage(_tempDir);
+
+        Assert.Equal("java", runtime);
+        Assert.Null(language);
+    }
+
+    [Fact]
+    public void DetectRuntimeAndLanguage_BuildGradle_ReturnsJava()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "build.gradle"), "");
+
+        var (runtime, language) = ProjectDetector.DetectRuntimeAndLanguage(_tempDir);
+
+        Assert.Equal("java", runtime);
+        Assert.Null(language);
+    }
+
+    [Fact]
+    public void DetectRuntimeAndLanguage_ProfilePs1_ReturnsPowerShell()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "profile.ps1"), "");
+
+        var (runtime, language) = ProjectDetector.DetectRuntimeAndLanguage(_tempDir);
+
+        Assert.Equal("powershell", runtime);
+        Assert.Null(language);
+    }
+
+    [Fact]
+    public void DetectRuntimeAndLanguage_EmptyDir_ReturnsNulls()
+    {
+        var (runtime, language) = ProjectDetector.DetectRuntimeAndLanguage(_tempDir);
+
+        Assert.Null(runtime);
+        Assert.Null(language);
+    }
+
+    [Fact]
+    public void DetectRuntimeAndLanguage_CSharpTakesPriorityOverNode()
+    {
+        // If both .csproj and package.json exist, .csproj wins
+        File.WriteAllText(Path.Combine(_tempDir, "MyApp.csproj"), "<Project/>");
+        File.WriteAllText(Path.Combine(_tempDir, "package.json"), "{}");
+
+        var (runtime, language) = ProjectDetector.DetectRuntimeAndLanguage(_tempDir);
+
+        Assert.Equal("dotnet", runtime);
+        Assert.Equal("C#", language);
+    }
+
+    [Fact]
+    public void DetectRuntime_ReturnRuntimeOnly()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "MyApp.fsproj"), "<Project/>");
+
+        var runtime = ProjectDetector.DetectRuntime(_tempDir);
+
+        Assert.Equal("dotnet", runtime);
+    }
+
+    [Fact]
+    public void DetectRuntime_EmptyDir_ReturnsNull()
+    {
+        var runtime = ProjectDetector.DetectRuntime(_tempDir);
+
+        Assert.Null(runtime);
+    }
+}

--- a/test/Func.Cli.Tests/Commands/StartCommandTests.cs
+++ b/test/Func.Cli.Tests/Commands/StartCommandTests.cs
@@ -1,0 +1,67 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Commands;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Commands;
+
+[Collection(nameof(WorkingDirectoryTests))]
+public class StartCommandTests : IDisposable
+{
+    private static readonly string _safeDir = Path.GetTempPath();
+    private readonly string _tempDir;
+    private readonly TestInteractionService _interaction = new();
+
+    public StartCommandTests()
+    {
+        Directory.SetCurrentDirectory(_safeDir);
+        _tempDir = Path.Combine(Path.GetTempPath(), $"func-start-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.SetCurrentDirectory(_safeDir); } catch { }
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void StartCommand_HasExpectedOptions()
+    {
+        var cmd = new StartCommand(_interaction);
+        var optionNames = cmd.Options.Select(o => o.Name).ToList();
+
+        Assert.Contains("--port", optionNames);
+        Assert.Contains("--cors", optionNames);
+        Assert.Contains("--cors-credentials", optionNames);
+        Assert.Contains("--functions", optionNames);
+        Assert.Contains("--no-build", optionNames);
+        Assert.Contains("--enable-auth", optionNames);
+        Assert.Contains("--host-version", optionNames);
+    }
+
+    [Fact]
+    public async Task StartCommand_PrintsNotImplementedWarning()
+    {
+        var cmd = new StartCommand(_interaction);
+        var parseResult = cmd.Parse([_tempDir]);
+
+        var exitCode = await parseResult.InvokeAsync();
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains(_interaction.Lines, l => l.Contains("not yet implemented"));
+    }
+
+    [Fact]
+    public void StartCommand_RegisteredInParser()
+    {
+        var root = Parser.CreateCommand(_interaction);
+        var names = root.Subcommands.Select(c => c.Name).ToList();
+
+        Assert.Contains("start", names);
+    }
+}


### PR DESCRIPTION
Register init, new, start, and pack commands with their CLI options. Commands display workload install guidance until workloads are available. Includes ProjectDetector for runtime detection from project files.

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
