### PR TITLE
Mark Node.js 24 as GA in stacks.json

### DIFF
--- a/src/Cli/func/StaticResources/stacks.json
+++ b/src/Cli/func/StaticResources/stacks.json
@@ -931,7 +931,7 @@
                                 "stackSettings": {
                                     "windowsRuntimeSettings": {
                                         "runtimeVersion": "~24",
-                                        "isPreview": true,
+                                        "isPreview": false,
                                         "isDefault": false,
                                         "isHidden": false,
                                         "remoteDebuggingSupported": false,
@@ -964,7 +964,7 @@
                                     },
                                     "linuxRuntimeSettings": {
                                         "runtimeVersion": "Node|24",
-                                        "isPreview": true,
+                                        "isPreview": false,
                                         "isDefault": false,
                                         "isHidden": false,
                                         "remoteDebuggingSupported": false,
@@ -993,7 +993,36 @@
                                             }
                                         ],
                                         "endOfLifeDate": "Mon Apr 30 2029 00:00:00 GMT+0000 (Coordinated Universal Time)",
-                                        "Sku": null
+                                        "Sku": [
+                                            {
+                                                "skuCode": "FC1",
+                                                "instanceMemoryMB": [
+                                                    {
+                                                        "size": 512,
+                                                        "isDefault": false
+                                                    },
+                                                    {
+                                                        "size": 2048,
+                                                        "isDefault": true
+                                                    },
+                                                    {
+                                                        "size": 4096,
+                                                        "isDefault": false
+                                                    }
+                                                ],
+                                                "maximumInstanceCount": {
+                                                    "lowestMaximumInstanceCount": 40,
+                                                    "highestMaximumInstanceCount": 1000,
+                                                    "defaultValue": 100
+                                                },
+                                                "functionAppConfigProperties": {
+                                                    "runtime": {
+                                                        "name": "node",
+                                                        "version": "24"
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary
Mark Node.js 24 as GA in the offline stacks.json used by Core Tools.

## Changes
- Set `isPreview` to `false` for both Windows and Linux Node 24 runtimeSettings
- Add FC1 Sku configuration for Linux (matching Node 22 GA pattern)
  - instanceMemoryMB: 512, 2048 (default), 4096
  - maximumInstanceCount: 40-1000, default 100
  - runtime: node version 24

## Context
This is part of the Node.js 24 GA rollout. The online Stack API PR has been submitted separately (ADO PR #15482197 in AAPT-Antares-AzureFunctionsUx). This PR mirrors those changes in the Core Tools offline stacks.json.

## Testing
- JSON validated (valid after edit)
- Changes modeled after Node.js 22 GA pattern (which is already live)