### PR TITLE
Centralizing theme

### DIFF
--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -112,21 +112,47 @@ AddPathArgument(); // adds optional [path] argument
 
 ## Console / UI Layer
 
-**All console I/O goes through `IInteractionService`** — never `Console.Write*` directly. This enables testability (in-memory capture) and non-interactive mode (prompts return defaults).
+**All console I/O goes through `IInteractionService`** — never `Console.Write*` and
+never raw Spectre markup (`[red]…[/]`). This enables testability (in-memory
+capture), non-interactive mode (prompts return defaults), and theming.
+
+### Theming
+
+A single `ITheme` exposes `Style` values for semantic roles (`Command`,
+`Placeholder`, `Path`, `Muted`, `Heading`, `Success`, `Error`, `Warning`, etc.).
+`DefaultTheme` holds the production palette. Swapping the DI registration is the
+only change required to add a no-color or high-contrast variant.
 
 ### Output Methods
 
 | Method | Goes To | Purpose |
 |--------|---------|---------|
-| `WriteLine(text)` | stdout | Plain text output |
-| `WriteMarkup(markup)` | stdout | Spectre markup (colors, styles) |
-| `WriteMarkupLine(markup)` | stdout | Spectre markup with newline |
-| `WriteSuccess(message)` | stdout | Green `✓ message` |
-| `WriteError(message)` | stderr | Red `Error: message` |
-| `WriteWarning(message)` | stderr | Yellow `Warning: message` |
-| `WriteTable(columns, rows)` | stdout | Formatted table |
-| `WriteRule(title)` | stdout | Horizontal rule with title |
+| `WriteLine(text)` | stdout | Plain text |
+| `WriteLine(l => l.Muted("Run ").Command("func new"))` | stdout | Composed styled line via `InlineLine` |
+| `Write(IRenderable)` | stdout | Spectre `Grid`/`Table`/`Panel` escape hatch |
+| `WriteTitle(text)` | stdout | Product / document title |
+| `WriteSectionHeader(title)` | stdout | Horizontal rule with title |
+| `WriteHint(message)` | stdout | Muted informational text |
+| `WriteSuccess(message)` | stdout | `✓ message` in success color |
+| `WriteError(message)` | stderr | `Error: message` in error color |
+| `WriteWarning(message)` | stderr | `Warning: message` in warning color |
+| `WriteDefinitionList(items)` | stdout | Aligned `label    description` rows (Spectre `Grid` — no manual padding) |
+| `WriteTable(columns, rows)` | stdout | Bordered data table |
 | `WriteBlankLine()` | stdout | Empty line |
+
+### `InlineLine` composition
+
+`WriteLine(Action<InlineLine>)` provides a fluent, theme-aware builder for lines
+that mix multiple styles. Role-named methods (`.Command(...)`, `.Placeholder(...)`,
+`.Path(...)`, `.Muted(...)`, …) append styled segments. Literal content is escaped
+automatically — callers never type `[...]` tags or call `EscapeMarkup()`.
+
+```csharp
+interaction.WriteLine(l => l
+    .Muted("Run ")
+    .Command("func workload search")
+    .Muted(" to discover available workloads."));
+```
 
 ### Interactive Prompts
 

--- a/src/Func.Cli/Commands/HelpCommand.cs
+++ b/src/Func.Cli/Commands/HelpCommand.cs
@@ -5,13 +5,11 @@ using System.CommandLine;
 using System.CommandLine.Help;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Console;
-using Spectre.Console;
 
 namespace Azure.Functions.Cli.Commands;
 
 /// <summary>
-/// Displays rich help information using Spectre.Console. Generates help from
-/// real Command objects — no separate source of truth for command metadata.
+/// Renders rich help generated from real <see cref="Command"/> metadata.
 /// </summary>
 public class HelpCommand : BaseCommand
 {
@@ -37,67 +35,64 @@ public class HelpCommand : BaseCommand
     {
         var commandName = parseResult.GetValue(CommandArgument);
 
-        if (!string.IsNullOrEmpty(commandName))
-        {
-            return Task.FromResult(ShowCommandHelp(commandName));
-        }
-
-        return Task.FromResult(ShowGeneralHelp());
+        return Task.FromResult(string.IsNullOrEmpty(commandName)
+            ? ShowGeneralHelp()
+            : ShowCommandHelp(commandName));
     }
 
-    /// <summary>
-    /// Shows the top-level help with all available commands and global options.
-    /// </summary>
+    /// <summary>Shows top-level help: product banner, command list, global options.</summary>
     internal int ShowGeneralHelp()
     {
         var version = VersionCommand.GetVersion();
 
         _interaction.WriteBlankLine();
-        _interaction.WriteMarkupLine($"[bold blue]{Constants.ProductName}[/] [dim]({version})[/]");
+        _interaction.WriteLine(l => l
+            .Title(Constants.ProductName)
+            .Plain(" ")
+            .Muted($"({version})"));
         _interaction.WriteBlankLine();
-        _interaction.WriteMarkupLine("[grey]Create, develop, test, and deploy Azure Functions from the command line.[/]");
-        _interaction.WriteBlankLine();
-
-        _interaction.WriteRule("Usage");
-        _interaction.WriteBlankLine();
-        _interaction.WriteMarkupLine("  [white]func[/] [green]<command>[/] [cyan][[path]][/] [grey][[options]][/]");
+        _interaction.WriteHint("Create, develop, test, and deploy Azure Functions from the command line.");
         _interaction.WriteBlankLine();
 
-        // Generate command list from real registered commands
+        _interaction.WriteSectionHeader("Usage");
+        _interaction.WriteBlankLine();
+        _interaction.WriteLine(l => l
+            .Plain("  ")
+            .Command("func ")
+            .Placeholder("<command> ")
+            .OptionalArg("[path] ")
+            .Muted("[options]"));
+        _interaction.WriteBlankLine();
+
         var commands = _rootCommand.Subcommands
             .Where(c => !c.Hidden)
-            .Select(c => (c.Name, c.Description ?? string.Empty))
+            .Select(c => new DefinitionItem(c.Name, c.Description ?? string.Empty))
             .ToList();
         if (commands.Count > 0)
         {
-            _interaction.WriteRule("Commands");
+            _interaction.WriteSectionHeader("Commands");
             _interaction.WriteBlankLine();
-            WriteAlignedList(commands);
+            _interaction.WriteDefinitionList(commands);
             _interaction.WriteBlankLine();
         }
 
-        // Generate global options from real root command options
-        _interaction.WriteRule("Global Options");
+        _interaction.WriteSectionHeader("Global Options");
         _interaction.WriteBlankLine();
-        var globalOptions = _rootCommand.Options
+        var options = _rootCommand.Options
             .Where(o => o is not HelpOption && o.Name != "--version")
-            .Select(o => (FormatOptionName(o), o.Description ?? string.Empty));
-        // Always include --help and --version in the display (with our formatting)
-        var allOptions = globalOptions
-            .Append(("--help, -h, -?", "Show help information"))
-            .Append(("--version", "Display the current version"));
-        WriteAlignedList(allOptions);
+            .Select(o => new DefinitionItem(FormatOptionName(o), o.Description ?? string.Empty))
+            .Append(new DefinitionItem("--help, -h, -?", "Show help information"))
+            .Append(new DefinitionItem("--version", "Display the current version"));
+        _interaction.WriteDefinitionList(options);
         _interaction.WriteBlankLine();
 
-        _interaction.WriteMarkupLine($"[grey]Documentation: {Constants.DocsUrl}[/]");
+        _interaction.WriteLine(l => l.Muted($"Documentation: {Constants.DocsUrl}"));
         _interaction.WriteBlankLine();
 
         return 0;
     }
 
-    /// <summary>
-    /// Shows help for a specific named command, generated from the command's metadata.
-    /// </summary>
+    /// <summary>Shows help for a named subcommand.</summary>
     internal int ShowCommandHelp(string commandName)
     {
         var command = _rootCommand.Subcommands
@@ -114,8 +109,8 @@ public class HelpCommand : BaseCommand
     }
 
     /// <summary>
-    /// Renders help for any System.CommandLine Command, used by both
-    /// 'func help <command>' and the SpectreHelpAction (--help/-h/-?).
+    /// Renders help for any <see cref="Command"/>. Used by both <c>func help &lt;command&gt;</c>
+    /// and the global <c>--help</c> / <c>-h</c> / <c>-?</c> handler.
     /// </summary>
     internal void RenderCommandHelp(Command command)
     {
@@ -123,76 +118,84 @@ public class HelpCommand : BaseCommand
         var commandPath = isRoot ? "func" : $"func {command.Name}";
 
         _interaction.WriteBlankLine();
-        _interaction.WriteMarkupLine($"[bold blue]{commandPath}[/]");
+        _interaction.WriteTitle(commandPath);
         _interaction.WriteBlankLine();
 
         if (!string.IsNullOrEmpty(command.Description))
         {
-            _interaction.WriteMarkupLine($"[grey]{command.Description.EscapeMarkup()}[/]");
+            _interaction.WriteHint(command.Description);
             _interaction.WriteBlankLine();
         }
 
-        // Usage
-        _interaction.WriteRule("Usage");
+        _interaction.WriteSectionHeader("Usage");
         _interaction.WriteBlankLine();
-        var usage = BuildUsageString(command, commandPath);
-        _interaction.WriteMarkupLine($"  {usage}");
+        WriteUsageLine(command, commandPath);
         _interaction.WriteBlankLine();
 
-        // Arguments
         var args = command.Arguments.Where(a => !a.Hidden).ToList();
         if (args.Count > 0)
         {
-            _interaction.WriteRule("Arguments");
+            _interaction.WriteSectionHeader("Arguments");
             _interaction.WriteBlankLine();
-            WriteAlignedList(args.Select(a => ($"<{a.Name}>", a.Description ?? string.Empty)));
+            _interaction.WriteDefinitionList(
+                args.Select(a => new DefinitionItem($"<{a.Name}>", a.Description ?? string.Empty)));
             _interaction.WriteBlankLine();
         }
 
-        // Subcommands
         var subcommands = command.Subcommands.Where(c => !c.Hidden).ToList();
         if (subcommands.Count > 0)
         {
-            _interaction.WriteRule("Commands");
+            _interaction.WriteSectionHeader("Commands");
             _interaction.WriteBlankLine();
-            WriteAlignedList(subcommands.Select(c => (c.Name, c.Description ?? string.Empty)));
+            _interaction.WriteDefinitionList(
+                subcommands.Select(c => new DefinitionItem(c.Name, c.Description ?? string.Empty)));
             _interaction.WriteBlankLine();
         }
 
-        // Options (exclude the built-in help option to avoid clutter)
         var options = command.Options.Where(o => !o.Hidden && o is not HelpOption).ToList();
         if (options.Count > 0)
         {
-            _interaction.WriteRule("Options");
+            _interaction.WriteSectionHeader("Options");
             _interaction.WriteBlankLine();
-            WriteAlignedList(options.Select(o => (FormatOptionName(o), o.Description ?? string.Empty)));
+            _interaction.WriteDefinitionList(
+                options.Select(o => new DefinitionItem(FormatOptionName(o), o.Description ?? string.Empty)));
             _interaction.WriteBlankLine();
         }
     }
 
-    private static string BuildUsageString(Command command, string commandPath)
+    /// <summary>
+    /// Writes the usage line for a command, composing each token with its
+    /// semantic style (command, placeholder, optional arg, options hint).
+    /// </summary>
+    private void WriteUsageLine(Command command, string commandPath)
     {
-        var parts = new List<string> { $"[white]{commandPath}[/]" };
-
-        foreach (var arg in command.Arguments.Where(a => !a.Hidden))
+        _interaction.WriteLine(line =>
         {
-            var argStr = arg.Arity.MinimumNumberOfValues > 0
-                ? $"<{arg.Name}>"
-                : $"[[{arg.Name}]]";
-            parts.Add($"[cyan]{argStr}[/]");
-        }
+            line.Plain("  ").Command(commandPath);
 
-        if (command.Subcommands.Any(c => !c.Hidden))
-        {
-            parts.Add("[green]<command>[/]");
-        }
+            foreach (var arg in command.Arguments.Where(a => !a.Hidden))
+            {
+                line.Plain(" ");
+                if (arg.Arity.MinimumNumberOfValues > 0)
+                {
+                    line.Placeholder($"<{arg.Name}>");
+                }
+                else
+                {
+                    line.OptionalArg($"[{arg.Name}]");
+                }
+            }
 
-        if (command.Options.Any(o => !o.Hidden && o is not HelpOption))
-        {
-            parts.Add("[grey][[options]][/]");
-        }
+            if (command.Subcommands.Any(c => !c.Hidden))
+            {
+                line.Plain(" ").Placeholder("<command>");
+            }
 
-        return string.Join(" ", parts);
+            if (command.Options.Any(o => !o.Hidden && o is not HelpOption))
+            {
+                line.Plain(" ").Muted("[options]");
+            }
+        });
     }
 
     private static string FormatOptionName(Option option)
@@ -200,21 +203,5 @@ public class HelpCommand : BaseCommand
         var names = new List<string> { option.Name };
         names.AddRange(option.Aliases.Where(a => a != option.Name));
         return string.Join(", ", names);
-    }
-
-    private void WriteAlignedList(IEnumerable<(string Label, string Description)> items)
-    {
-        var itemList = items.ToList();
-        if (itemList.Count == 0) return;
-
-        int maxLabelWidth = itemList.Max(i => Markup.Remove(i.Label).Length);
-        int padding = maxLabelWidth + 4;
-
-        foreach (var (label, description) in itemList)
-        {
-            int plainLength = Markup.Remove(label).Length;
-            string gap = new(' ', padding - plainLength);
-            _interaction.WriteMarkupLine($"  [green]{label.EscapeMarkup()}[/]{gap}[grey]{description.EscapeMarkup()}[/]");
-        }
     }
 }

--- a/src/Func.Cli/Commands/InitCommand.cs
+++ b/src/Func.Cli/Commands/InitCommand.cs
@@ -53,11 +53,14 @@ public class InitCommand : BaseCommand
 
         _interaction.WriteError("No language workloads installed.");
         _interaction.WriteBlankLine();
-        _interaction.WriteMarkupLine("[grey]Install a workload to initialize a project:[/]");
+        _interaction.WriteHint("Install a workload to initialize a project:");
         _interaction.WriteBlankLine();
         WorkerRuntimes.WriteWorkloadInstallHints(_interaction);
         _interaction.WriteBlankLine();
-        _interaction.WriteMarkupLine("[grey]Run[/] [white]func workload search[/] [grey]to discover available workloads.[/]");
+        _interaction.WriteLine(l => l
+            .Muted("Run ")
+            .Command("func workload search")
+            .Muted(" to discover available workloads."));
 
         return Task.FromResult(1);
     }

--- a/src/Func.Cli/Commands/NewCommand.cs
+++ b/src/Func.Cli/Commands/NewCommand.cs
@@ -47,11 +47,14 @@ public class NewCommand : BaseCommand
 
         _interaction.WriteError("No language workloads installed.");
         _interaction.WriteBlankLine();
-        _interaction.WriteMarkupLine("[grey]Install a workload to create functions from templates:[/]");
+        _interaction.WriteHint("Install a workload to create functions from templates:");
         _interaction.WriteBlankLine();
         WorkerRuntimes.WriteWorkloadInstallHints(_interaction);
         _interaction.WriteBlankLine();
-        _interaction.WriteMarkupLine("[grey]Run[/] [white]func workload search[/] [grey]to discover available workloads.[/]");
+        _interaction.WriteLine(l => l
+            .Muted("Run ")
+            .Command("func workload search")
+            .Muted(" to discover available workloads."));
 
         return Task.FromResult(1);
     }

--- a/src/Func.Cli/Commands/PackCommand.cs
+++ b/src/Func.Cli/Commands/PackCommand.cs
@@ -53,12 +53,14 @@ public class PackCommand : BaseCommand
         if (detectedRuntime is null)
         {
             _interaction.WriteError("Could not detect the worker runtime for this project.");
-            _interaction.WriteMarkupLine("[grey]Ensure the project contains the expected project files (e.g., .csproj, package.json).[/]");
+            _interaction.WriteHint("Ensure the project contains the expected project files (e.g., .csproj, package.json).");
             return Task.FromResult(1);
         }
 
         _interaction.WriteError($"No pack provider for runtime '{detectedRuntime}'.");
-        _interaction.WriteMarkupLine($"[grey]Install the workload:[/] [white]func workload install {detectedRuntime}[/]");
+        _interaction.WriteLine(l => l
+            .Muted("Install the workload: ")
+            .Command($"func workload install {detectedRuntime}"));
         return Task.FromResult(1);
     }
 }

--- a/src/Func.Cli/Commands/StartCommand.cs
+++ b/src/Func.Cli/Commands/StartCommand.cs
@@ -68,7 +68,7 @@ public class StartCommand : BaseCommand
     {
         ApplyPath(parseResult);
         _interaction.WriteWarning("The 'start' command is not yet implemented in this version.");
-        _interaction.WriteMarkupLine("[grey]This is a preview build of Azure Functions CLI vNext.[/]");
+        _interaction.WriteHint("This is a preview build of Azure Functions CLI vNext.");
         return Task.FromResult(1);
     }
 }

--- a/src/Func.Cli/Commands/VersionCommand.cs
+++ b/src/Func.Cli/Commands/VersionCommand.cs
@@ -28,22 +28,21 @@ public class VersionCommand : BaseCommand
     }
 
     /// <summary>
-    /// Prints detailed version info including build hash when --verbose is specified.
+    /// Prints detailed version info.
     /// </summary>
     internal int ExecuteDetailed()
     {
-        _interaction.WriteMarkupLine("[bold blue]Azure Functions CLI[/]");
+        _interaction.WriteTitle("Azure Functions CLI");
         _interaction.WriteBlankLine();
         _interaction.WriteTable(
             ["Property", "Value"],
-            new string[][]
-            {
+            [
                 ["Version", GetVersion()],
                 ["Build", GetInformationalVersion()],
                 ["Runtime", System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription],
                 ["OS", System.Runtime.InteropServices.RuntimeInformation.OSDescription],
                 ["Architecture", System.Runtime.InteropServices.RuntimeInformation.OSArchitecture.ToString()],
-            }
+            ]
         );
 
         return 0;

--- a/src/Func.Cli/Common/WorkerRuntimes.cs
+++ b/src/Func.Cli/Common/WorkerRuntimes.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Collections.Frozen;
+using Azure.Functions.Cli.Console;
 
 namespace Azure.Functions.Cli.Common;
 
@@ -21,15 +22,12 @@ public static class WorkerRuntimes
         }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
-    /// Writes the workload install hints for all known runtimes.
+    /// Writes the workload install hints for all known runtimes as an aligned list.
     /// </summary>
-    public static void WriteWorkloadInstallHints(Console.IInteractionService interaction)
+    public static void WriteWorkloadInstallHints(IInteractionService interaction)
     {
-        foreach (var (worker, languages) in LanguageMap)
-        {
-            var langList = string.Join(", ", languages);
-            var padded = $"func workload install {worker}".PadRight(38);
-            interaction.WriteMarkupLine($"  [white]{padded}[/][grey]{langList}[/]");
-        }
+        var items = LanguageMap.Select(static kvp => new DefinitionItem($"func workload install {kvp.Key}", string.Join(", ", kvp.Value)));
+
+        interaction.WriteDefinitionList(items);
     }
 }

--- a/src/Func.Cli/Console/DefinitionItem.cs
+++ b/src/Func.Cli/Console/DefinitionItem.cs
@@ -1,0 +1,10 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Console;
+
+/// <summary>
+/// A label + description pair rendered as an aligned row in a definition list
+/// (used for command listings, option listings, etc.).
+/// </summary>
+public readonly record struct DefinitionItem(string Label, string Description);

--- a/src/Func.Cli/Console/IInteractionService.cs
+++ b/src/Func.Cli/Console/IInteractionService.cs
@@ -1,60 +1,102 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Console.Theme;
+using Spectre.Console.Rendering;
+
 namespace Azure.Functions.Cli.Console;
 
 /// <summary>
-/// Abstraction over console interaction for testability. Provides output methods
-/// and interactive prompts (status spinners, confirmations, selections).
+/// Abstraction over console interaction. Exposes semantic output methods,
+/// theme-aware line composition, and interactive prompts.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Callers must not write raw Spectre markup (<c>[red]…[/]</c>). Use role-named
+/// helpers or compose with <see cref="WriteLine(Action{InlineLine})"/>.
+/// </para>
+/// <para>
+/// Output routing: <see cref="WriteError"/> and <see cref="WriteWarning"/> go to
+/// stderr; all other output goes to stdout.
+/// </para>
+/// </remarks>
 public interface IInteractionService
 {
-    // --- Output ---
+    /// <summary>Active visual theme. Exposed so callers can use ad-hoc styles where needed.</summary>
+    public ITheme Theme { get; }
+
+    /// <summary>True when the console supports interactive prompts (not redirected, not CI).</summary>
+    public bool IsInteractive { get; }
+
+    /// <summary>Writes a single line of unstyled text to stdout.</summary>
     public void WriteLine(string text);
-    public void WriteMarkup(string markup);
-    public void WriteMarkupLine(string markup);
-    public void WriteError(string message);
-    public void WriteWarning(string message);
-    public void WriteSuccess(string message);
-    public void WriteTable(string[] columns, IEnumerable<string[]> rows);
-    public void WriteRule(string title);
+
+    /// <summary>Writes a blank line to stdout.</summary>
     public void WriteBlankLine();
 
-    // --- Interactive ---
+    /// <summary>
+    /// Writes a styled line built via a fluent <see cref="InlineLine"/>. Example:
+    /// <code>WriteLine(l =&gt; l.Muted("Run ").Command("func new").Muted(" to begin."));</code>
+    /// </summary>
+    public void WriteLine(Action<InlineLine> build);
 
     /// <summary>
-    /// Displays a status spinner while executing an async operation.
+    /// Writes any Spectre <see cref="IRenderable"/> (e.g. <c>Grid</c>, <c>Table</c>,
+    /// <c>Panel</c>). The typed escape hatch for layout needs not covered by the
+    /// semantic helpers.
     /// </summary>
+    public void Write(IRenderable renderable);
+
+    /// <summary>Writes a product or document title (e.g. the CLI banner line).</summary>
+    public void WriteTitle(string text);
+
+    /// <summary>Writes a section header rendered as a left-justified horizontal rule.</summary>
+    public void WriteSectionHeader(string title);
+
+    /// <summary>Writes an informational hint styled as muted text.</summary>
+    public void WriteHint(string message);
+
+    /// <summary>Writes a success marker (✓) followed by the message, to stdout.</summary>
+    public void WriteSuccess(string message);
+
+    /// <summary>Writes a red "Error:" prefix followed by the message, to stderr.</summary>
+    public void WriteError(string message);
+
+    /// <summary>Writes a yellow "Warning:" prefix followed by the message, to stderr.</summary>
+    public void WriteWarning(string message);
+
+    /// <summary>
+    /// Writes an aligned list of label/description rows. Labels are styled with the
+    /// theme's command role; descriptions with the muted role. Alignment is handled
+    /// by Spectre internally — no manual padding.
+    /// </summary>
+    public void WriteDefinitionList(IEnumerable<DefinitionItem> items);
+
+    /// <summary>Writes a bordered data table.</summary>
+    public void WriteTable(string[] columns, IEnumerable<string[]> rows);
+
+    /// <summary>Displays a status spinner while executing an async operation.</summary>
     public Task<T> ShowStatusAsync<T>(string statusMessage, Func<CancellationToken, Task<T>> action, CancellationToken cancellationToken = default);
 
-    /// <summary>
-    /// Displays a status spinner while executing an async operation (no return value).
-    /// </summary>
+    /// <summary>Displays a status spinner while executing an async operation (no return value).</summary>
     public Task StatusAsync(string statusMessage, Func<CancellationToken, Task> action, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Prompts the user with a yes/no confirmation.
-    /// Returns <paramref name="defaultValue"/> in non-interactive mode.
-    /// Throws <see cref="OperationCanceledException"/> on Ctrl+C.
+    /// Prompts the user with a yes/no confirmation. Returns <paramref name="defaultValue"/>
+    /// in non-interactive mode. Throws <see cref="OperationCanceledException"/> on Ctrl+C.
     /// </summary>
     public Task<bool> ConfirmAsync(string prompt, bool defaultValue = false, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Prompts the user to select from a list of choices.
-    /// Returns the first choice in non-interactive mode.
-    /// Throws <see cref="OperationCanceledException"/> on Ctrl+C.
+    /// Prompts the user to select from a list of choices. Returns the first choice in
+    /// non-interactive mode. Throws <see cref="OperationCanceledException"/> on Ctrl+C.
     /// </summary>
     public Task<string> PromptForSelectionAsync(string title, IEnumerable<string> choices, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Prompts the user for free-form text input with an optional default value.
-    /// Returns <paramref name="defaultValue"/> in non-interactive mode.
-    /// Throws <see cref="OperationCanceledException"/> on Ctrl+C.
+    /// Prompts the user for free-form text with an optional default. Returns
+    /// <paramref name="defaultValue"/> in non-interactive mode. Throws
+    /// <see cref="OperationCanceledException"/> on Ctrl+C.
     /// </summary>
     public Task<string> PromptForInputAsync(string prompt, string? defaultValue = null, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Returns true if the console supports interactive prompts (not redirected, not CI).
-    /// </summary>
-    public bool IsInteractive { get; }
 }

--- a/src/Func.Cli/Console/InlineLine.cs
+++ b/src/Func.Cli/Console/InlineLine.cs
@@ -1,0 +1,94 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Console.Theme;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace Azure.Functions.Cli.Console;
+
+/// <summary>
+/// A fluent, theme-aware builder for a single line of styled text.
+/// Each role-named method (e.g. <see cref="Command"/>, <see cref="Muted"/>)
+/// appends a text segment styled with the theme's value for that role.
+/// Literal text is escaped automatically — callers never write Spectre markup.
+/// </summary>
+/// <remarks>
+/// Typical use via <c>IInteractionService.WriteLine(l =&gt; l.Muted("Run ").Command("func new"))</c>.
+/// The builder itself is just a segment accumulator; rendering is performed by the interaction service.
+/// </remarks>
+public sealed class InlineLine
+{
+    private readonly ITheme _theme;
+    private readonly List<Segment> _segments = new();
+
+    internal InlineLine(ITheme theme)
+    {
+        _theme = theme;
+    }
+
+    /// <summary>Gets the theme bound to this builder (for ad-hoc styled segments).</summary>
+    public ITheme Theme => _theme;
+
+    /// <summary>Appends unstyled text.</summary>
+    public InlineLine Plain(string text) => Add(text, null);
+
+    /// <summary>Appends text with an ad-hoc style (escape hatch — prefer role-named methods).</summary>
+    public InlineLine Styled(string text, Style style) => Add(text, style);
+
+    public InlineLine Title(string text) => Add(text, _theme.Title);
+
+    public InlineLine Heading(string text) => Add(text, _theme.Heading);
+
+    public InlineLine Command(string text) => Add(text, _theme.Command);
+
+    public InlineLine Placeholder(string text) => Add(text, _theme.Placeholder);
+
+    public InlineLine OptionalArg(string text) => Add(text, _theme.OptionalArg);
+    public InlineLine Path(string text) => Add(text, _theme.Path);
+
+    public InlineLine Muted(string text) => Add(text, _theme.Muted);
+
+    public InlineLine Code(string text) => Add(text, _theme.Code);
+
+    public InlineLine Emphasis(string text) => Add(text, _theme.Emphasis);
+
+    public InlineLine Success(string text) => Add(text, _theme.Success);
+
+    public InlineLine Error(string text) => Add(text, _theme.Error);
+
+    public InlineLine Warning(string text) => Add(text, _theme.Warning);
+
+    /// <summary>Appends a single space (shorthand for <c>Plain(" ")</c>).</summary>
+    public InlineLine Space() => Add(" ", null);
+
+    /// <summary>
+    /// Materializes the accumulated segments into a renderable paragraph.
+    /// Text is escaped at segment boundaries so raw brackets in content are
+    /// preserved verbatim.
+    /// </summary>
+    public IRenderable ToRenderable()
+    {
+        var paragraph = new Paragraph();
+        foreach (var segment in _segments)
+        {
+            paragraph.Append(segment.Text, segment.Style ?? Style.Plain);
+        }
+        return paragraph;
+    }
+
+    /// <summary>Returns the concatenated unstyled text (for testing and logging).</summary>
+    public string ToPlainString()
+        => string.Concat(_segments.Select(s => s.Text));
+
+    private InlineLine Add(string text, Style? style)
+    {
+        if (!string.IsNullOrEmpty(text))
+        {
+            _segments.Add(new Segment(text, style));
+        }
+        return this;
+    }
+
+    private readonly record struct Segment(string Text, Style? Style);
+}

--- a/src/Func.Cli/Console/SpectreInteractionService.cs
+++ b/src/Func.Cli/Console/SpectreInteractionService.cs
@@ -1,21 +1,25 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Console.Theme;
 using Spectre.Console;
+using Spectre.Console.Rendering;
 
 namespace Azure.Functions.Cli.Console;
 
 /// <summary>
-/// Rich console interaction using Spectre.Console, implementing both output
-/// and interactive prompt capabilities.
+/// Rich console implementation backed by Spectre.Console. All styled output
+/// flows through <see cref="ITheme"/>.
 /// </summary>
 public class SpectreInteractionService : IInteractionService
 {
     private readonly IAnsiConsole _stdout;
     private readonly IAnsiConsole _stderr;
+    private readonly ITheme _theme;
 
-    public SpectreInteractionService(IAnsiConsole? stdout = null, IAnsiConsole? stderr = null)
+    public SpectreInteractionService(ITheme theme, IAnsiConsole? stdout = null, IAnsiConsole? stderr = null)
     {
+        _theme = theme;
         _stdout = stdout ?? AnsiConsole.Console;
         _stderr = stderr ?? AnsiConsole.Create(new AnsiConsoleSettings
         {
@@ -23,27 +27,75 @@ public class SpectreInteractionService : IInteractionService
         });
     }
 
+    public ITheme Theme => _theme;
+
     public bool IsInteractive =>
         !System.Console.IsInputRedirected &&
         !System.Console.IsOutputRedirected &&
         Environment.GetEnvironmentVariable("CI") is null;
 
-    // --- Output (to stdout) ---
-
     public void WriteLine(string text) => _stdout.WriteLine(text);
 
-    public void WriteMarkup(string markup) => _stdout.Markup(markup);
+    public void WriteBlankLine() => _stdout.WriteLine();
 
-    public void WriteMarkupLine(string markup) => _stdout.MarkupLine(markup);
+    public void WriteLine(Action<InlineLine> build)
+    {
+        var line = new InlineLine(_theme);
+        build(line);
+        _stdout.Write(line.ToRenderable());
+        _stdout.WriteLine();
+    }
 
-    public void WriteError(string message) =>
-        _stderr.MarkupLine($"[red bold]Error:[/] [red]{message.EscapeMarkup()}[/]");
+    public void Write(IRenderable renderable) => _stdout.Write(renderable);
 
-    public void WriteWarning(string message) =>
-        _stderr.MarkupLine($"[yellow bold]Warning:[/] [yellow]{message.EscapeMarkup()}[/]");
+    public void WriteTitle(string text) =>
+        _stdout.Write(new Paragraph(text, _theme.Title).Append(Environment.NewLine));
 
-    public void WriteSuccess(string message) =>
-        _stdout.MarkupLine($"[green bold]✓[/] [green]{message.EscapeMarkup()}[/]");
+    public void WriteSectionHeader(string title) =>
+        _stdout.Write(new Rule(title).LeftJustified().RuleStyle(_theme.Heading));
+
+    public void WriteHint(string message) =>
+        _stdout.Write(new Paragraph(message, _theme.Muted).Append(Environment.NewLine));
+
+    public void WriteSuccess(string message)
+    {
+        _stdout.Write(new Paragraph()
+            .Append("✓ ", _theme.Success)
+            .Append(message, _theme.Success)
+            .Append(Environment.NewLine));
+    }
+
+    public void WriteError(string message)
+    {
+        _stderr.Write(new Paragraph()
+            .Append("Error: ", _theme.Error)
+            .Append(message, _theme.Error)
+            .Append(Environment.NewLine));
+    }
+
+    public void WriteWarning(string message)
+    {
+        _stderr.Write(new Paragraph()
+            .Append("Warning: ", _theme.Warning)
+            .Append(message, _theme.Warning)
+            .Append(Environment.NewLine));
+    }
+
+    public void WriteDefinitionList(IEnumerable<DefinitionItem> items)
+    {
+        var grid = new Grid()
+            .AddColumn(new GridColumn().PadLeft(2).PadRight(4).NoWrap())
+            .AddColumn(new GridColumn().PadRight(0));
+
+        foreach (var item in items)
+        {
+            grid.AddRow(
+                new Text(item.Label, _theme.Command),
+                new Text(item.Description, _theme.Muted));
+        }
+
+        _stdout.Write(grid);
+    }
 
     public void WriteTable(string[] columns, IEnumerable<string[]> rows)
     {
@@ -53,29 +105,22 @@ public class SpectreInteractionService : IInteractionService
 
         foreach (var column in columns)
         {
-            table.AddColumn(new TableColumn(column).Centered());
+            table.AddColumn(new TableColumn(new Text(column, _theme.Heading)).Centered());
         }
 
         foreach (var row in rows)
         {
-            table.AddRow(row.Select(cell => new Markup(cell)).ToArray());
+            table.AddRow(row.Select(cell => (IRenderable)new Text(cell)).ToArray());
         }
 
         _stdout.Write(table);
     }
 
-    public void WriteRule(string title) =>
-        _stdout.Write(new Rule($"[blue]{title.EscapeMarkup()}[/]").LeftJustified());
-
-    public void WriteBlankLine() => _stdout.WriteLine();
-
-    // --- Interactive ---
-
     public async Task<T> ShowStatusAsync<T>(string statusMessage, Func<CancellationToken, Task<T>> action, CancellationToken cancellationToken = default)
     {
         if (!IsInteractive)
         {
-            _stderr.MarkupLine($"[grey]{statusMessage.EscapeMarkup()}...[/]");
+            _stderr.Write(new Paragraph($"{statusMessage}...", _theme.Muted).Append(Environment.NewLine));
             return await action(cancellationToken);
         }
 
@@ -106,16 +151,13 @@ public class SpectreInteractionService : IInteractionService
             return defaultValue;
         }
 
-        return await new ConfirmationPrompt(prompt)
-        {
-            DefaultValue = defaultValue
-        }.ShowAsync(_stderr, cancellationToken);
+        return await new ConfirmationPrompt(prompt) { DefaultValue = defaultValue }
+            .ShowAsync(_stderr, cancellationToken);
     }
 
     public async Task<string> PromptForSelectionAsync(string title, IEnumerable<string> choices, CancellationToken cancellationToken = default)
     {
         var choiceList = choices.ToList();
-
         if (!IsInteractive || choiceList.Count == 0)
         {
             return choiceList.FirstOrDefault() ?? string.Empty;
@@ -134,17 +176,13 @@ public class SpectreInteractionService : IInteractionService
             return defaultValue ?? string.Empty;
         }
 
-        var textPrompt = new TextPrompt<string>(prompt)
-            .AllowEmpty();
-
+        var textPrompt = new TextPrompt<string>(prompt).AllowEmpty();
         if (defaultValue is not null)
         {
             textPrompt.DefaultValue(defaultValue);
         }
 
         var result = await textPrompt.ShowAsync(_stderr, cancellationToken);
-        return string.IsNullOrEmpty(result) && defaultValue is not null
-            ? defaultValue
-            : result;
+        return string.IsNullOrEmpty(result) && defaultValue is not null ? defaultValue : result;
     }
 }

--- a/src/Func.Cli/Console/Theme/DefaultTheme.cs
+++ b/src/Func.Cli/Console/Theme/DefaultTheme.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Spectre.Console;
+
+namespace Azure.Functions.Cli.Console.Theme;
+
+/// <summary>
+/// Default color theme. Preserves the palette used prior to the theming refactor.
+/// </summary>
+public sealed class DefaultTheme : ITheme
+{
+    public Style Title { get; } = new(Color.Blue, decoration: Decoration.Bold);
+
+    public Style Heading { get; } = new(Color.Blue);
+
+    public Style Command { get; } = new(Color.White);
+
+    public Style Placeholder { get; } = new(Color.Green);
+
+    public Style OptionalArg { get; } = new(Color.Cyan1);
+
+    public Style Path { get; } = new(Color.Cyan1);
+
+    public Style Muted { get; } = new(Color.Grey);
+
+    public Style Code { get; } = new(Color.White);
+
+    public Style Emphasis { get; } = new(decoration: Decoration.Bold);
+
+    public Style Success { get; } = new(Color.Green, decoration: Decoration.Bold);
+
+    public Style Error { get; } = new(Color.Red, decoration: Decoration.Bold);
+
+    public Style Warning { get; } = new(Color.Yellow, decoration: Decoration.Bold);
+}

--- a/src/Func.Cli/Console/Theme/ITheme.cs
+++ b/src/Func.Cli/Console/Theme/ITheme.cs
@@ -1,0 +1,51 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Spectre.Console;
+
+namespace Azure.Functions.Cli.Console.Theme;
+
+/// <summary>
+/// Visual theme for CLI output. Provides semantic <see cref="Style"/> values so
+/// that callers reference roles (command, path, muted…) instead of colors.
+/// Swapping implementations (e.g. a no-color theme) requires no changes in
+/// command or help code.
+/// </summary>
+public interface ITheme
+{
+    /// <summary>Product and section titles (e.g. "Azure Functions CLI").</summary>
+    public Style Title { get; }
+
+    /// <summary>Section headers rendered as rules (e.g. "Usage", "Commands").</summary>
+    public Style Heading { get; }
+
+    /// <summary>Command, subcommand, and option names (e.g. <c>func new</c>).</summary>
+    public Style Command { get; }
+
+    /// <summary>Argument placeholders like <c>&lt;command&gt;</c>.</summary>
+    public Style Placeholder { get; }
+
+    /// <summary>Optional argument placeholders like <c>[path]</c>.</summary>
+    public Style OptionalArg { get; }
+
+    /// <summary>File system paths.</summary>
+    public Style Path { get; }
+
+    /// <summary>Descriptions, hints, and secondary text.</summary>
+    public Style Muted { get; }
+
+    /// <summary>Inline code, literal values, and URLs in prose.</summary>
+    public Style Code { get; }
+
+    /// <summary>Emphasized text (version numbers, highlighted tokens).</summary>
+    public Style Emphasis { get; }
+
+    /// <summary>Successful operation indicators.</summary>
+    public Style Success { get; }
+
+    /// <summary>Error messages.</summary>
+    public Style Error { get; }
+
+    /// <summary>Warning messages.</summary>
+    public Style Warning { get; }
+}

--- a/src/Func.Cli/Program.cs
+++ b/src/Func.Cli/Program.cs
@@ -5,9 +5,9 @@ using System.CommandLine;
 using Azure.Functions.Cli;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Console.Theme;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Spectre.Console;
 
 // Build the host with DI
 var builder = Host.CreateEmptyApplicationBuilder(new HostApplicationBuilderSettings
@@ -16,6 +16,7 @@ var builder = Host.CreateEmptyApplicationBuilder(new HostApplicationBuilderSetti
     DisableDefaults = true
 });
 
+builder.Services.AddSingleton<ITheme, DefaultTheme>();
 builder.Services.AddSingleton<IInteractionService, SpectreInteractionService>();
 
 var host = builder.Build();
@@ -67,7 +68,7 @@ catch (GracefulException ex)
 
     if (ex.VerboseMessage is not null)
     {
-        interaction.WriteMarkupLine($"[grey]{ex.VerboseMessage.EscapeMarkup()}[/]");
+        interaction.WriteHint(ex.VerboseMessage);
     }
 
     return ex.IsUserError ? 1 : 2;
@@ -101,10 +102,11 @@ static async Task PrintVersionNotice(IInteractionService interaction, Task<strin
         if (latestVersion is not null)
         {
             interaction.WriteBlankLine();
-            interaction.WriteMarkupLine(
-                $"[yellow]A newer version of Azure Functions Core Tools is available ({latestVersion}).[/]");
-            interaction.WriteMarkupLine(
-                "[grey]Update with:[/] [white]npm i -g azure-functions-core-tools@5 --unsafe-perm true[/]");
+            interaction.WriteLine(l => l
+                .Warning($"A newer version of Azure Functions Core Tools is available ({latestVersion})."));
+            interaction.WriteLine(l => l
+                .Muted("Update with: ")
+                .Code("npm i -g azure-functions-core-tools@5 --unsafe-perm true"));
         }
     }
     catch

--- a/test/Func.Cli.Tests/TestInteractionService.cs
+++ b/test/Func.Cli.Tests/TestInteractionService.cs
@@ -2,11 +2,16 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Console.Theme;
+using Spectre.Console.Rendering;
 
 namespace Azure.Functions.Cli.Tests;
 
 /// <summary>
-/// A test interaction service that captures all output for assertions.
+/// Test double that captures output as plain text for assertions.
+/// Styles are discarded; semantic roles are captured as prefixes
+/// (ERROR:, WARNING:, SUCCESS:, HINT:, TITLE:, RULE:, STATUS:…)
+/// so tests can assert on both content and role.
 /// Interactive methods return defaults (non-interactive mode).
 /// </summary>
 public class TestInteractionService : IInteractionService
@@ -16,25 +21,57 @@ public class TestInteractionService : IInteractionService
     public IReadOnlyList<string> Lines => _lines;
     public string AllOutput => string.Join(Environment.NewLine, _lines);
     public bool IsInteractive => false;
+    public ITheme Theme { get; } = new DefaultTheme();
+
+    // --- Plain output ---
 
     public void WriteLine(string text) => _lines.Add(text);
-    public void WriteMarkup(string markup) => _lines.Add(StripMarkup(markup));
-    public void WriteMarkupLine(string markup) => _lines.Add(StripMarkup(markup));
-    public void WriteError(string message) => _lines.Add($"ERROR: {message}");
-    public void WriteWarning(string message) => _lines.Add($"WARNING: {message}");
+
+    public void WriteBlankLine() => _lines.Add(string.Empty);
+
+    // --- Composed styled output ---
+
+    public void WriteLine(Action<InlineLine> build)
+    {
+        var line = new InlineLine(Theme);
+        build(line);
+        _lines.Add(line.ToPlainString());
+    }
+
+    public void Write(IRenderable renderable) => _lines.Add($"RENDERABLE: {renderable.GetType().Name}");
+
+    // --- Semantic output ---
+
+    public void WriteTitle(string text) => _lines.Add($"TITLE: {text}");
+
+    public void WriteSectionHeader(string title) => _lines.Add($"RULE: {title}");
+
+    public void WriteHint(string message) => _lines.Add($"HINT: {message}");
+
     public void WriteSuccess(string message) => _lines.Add($"SUCCESS: {message}");
+
+    public void WriteError(string message) => _lines.Add($"ERROR: {message}");
+
+    public void WriteWarning(string message) => _lines.Add($"WARNING: {message}");
+
+    public void WriteDefinitionList(IEnumerable<DefinitionItem> items)
+    {
+        foreach (var item in items)
+        {
+            _lines.Add($"  {item.Label}    {item.Description}");
+        }
+    }
 
     public void WriteTable(string[] columns, IEnumerable<string[]> rows)
     {
         _lines.Add($"TABLE: [{string.Join(", ", columns)}]");
         foreach (var row in rows)
         {
-            _lines.Add($"  ROW: [{string.Join(", ", row.Select(StripMarkup))}]");
+            _lines.Add($"  ROW: [{string.Join(", ", row)}]");
         }
     }
 
-    public void WriteRule(string title) => _lines.Add($"RULE: {StripMarkup(title)}");
-    public void WriteBlankLine() => _lines.Add("");
+    // --- Interactive ---
 
     public async Task<T> ShowStatusAsync<T>(string statusMessage, Func<CancellationToken, Task<T>> action, CancellationToken cancellationToken = default)
     {
@@ -70,10 +107,5 @@ public class TestInteractionService : IInteractionService
         cancellationToken.ThrowIfCancellationRequested();
         _lines.Add($"INPUT: {prompt} (default: {defaultValue})");
         return Task.FromResult(defaultValue ?? string.Empty);
-    }
-
-    private static string StripMarkup(string text)
-    {
-        return System.Text.RegularExpressions.Regex.Replace(text, @"\[/?[^\]]*\]", "");
     }
 }


### PR DESCRIPTION
Replaces scattered Spectre markup strings (e.g. [white]...[/], [[path…]]) with a semantic theming layer. Callers now reference roles (Command, Path, Muted, Heading, ...) instead of colors, and compose styled lines via a fluent builder.


### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

