### PR TITLE
Rename worker-runtime to stack

### DIFF
--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -1,42 +1,39 @@
 # How the CLI Works
 
-This document explains the runtime architecture of the Azure Functions Core Tools v5 CLI — how commands are composed, how workloads integrate, and how the console layer works.
+This document explains the runtime architecture of the Azure Functions Core Tools v5 CLI — how commands are composed, how telemetry is wired, and how the console layer works.
+
+> **Status**: v5 is in active development. The workload extensibility model described in [building-a-workload.md](building-a-workload.md) is being staged in follow-up PRs and is not yet wired into the CLI on `vnext`.
 
 ## Startup Flow
 
 ```
 Program.cs
-  ├── Build DI container (Host)
-  │   ├── IInteractionService → SpectreInteractionService
-  │   ├── ITelemetry → AppInsightsTelemetryClient or NoOpTelemetryClient
-  │   └── IWorkloadManager → WorkloadManager
+  ├── Build IInteractionService (Spectre + DefaultTheme)
   │
-  ├── Start telemetry activity (wraps entire command execution)
+  ├── Wire up OpenTelemetry SDK (when a connection string is baked in)
+  │   ├── TracerProvider — exports to Azure Monitor
+  │   └── MeterProvider — exports to Azure Monitor
   │
-  ├── Start background version check (non-blocking)
-  │
-  ├── Parser.CreateCommand(interaction, workloadManager)
-  │   ├── Create built-in commands (version, help, init, new, pack, start)
-  │   ├── Add workload management command (install, uninstall, list, update)
-  │   ├── workloadManager.LoadWorkloads()
-  │   │   ├── Read ~/.azure-functions/workloads/workloads.json
-  │   │   ├── For each workload: AssemblyLoadContext → load DLL → find IWorkload
-  │   │   └── Fire background update check (non-blocking)
-  │   ├── For each loaded workload: workload.RegisterCommands(rootCommand)
+  ├── Parser.CreateCommand(interaction)
+  │   ├── Build the root command and its subcommands
   │   └── Replace help rendering with Spectre on all commands
+  │
+  ├── Wire cancellation (Ctrl+C / SIGTERM via CancellationTokenSource)
+  ├── Fire background CLI version check (non-blocking)
+  │
+  ├── Start root command activity (telemetry wraps the entire invocation)
   │
   ├── rootCommand.Parse(args).InvokeAsync()
   │
-  ├── workloadManager.PrintUpdateNoticesAsync()  ← shows workload update notices
   ├── Print CLI version upgrade notice (if newer v5 release available)
   │
-  ├── Track telemetry (command name, success/failure, duration)
-  ├── Flush telemetry
+  ├── Record command metrics (name, exit code, duration)
+  ├── Flush + dispose the OpenTelemetry providers
   │
   └── Error handling
       ├── OperationCanceledException → exit 130
-      ├── GracefulException → user-friendly error, exit 1 or 2
-      └── Exception → "unexpected error", exit 2
+      ├── GracefulException → user-friendly error, exit 1
+      └── Exception → "unexpected error", exit 1
 ```
 
 ## Command Tree
@@ -47,16 +44,9 @@ func
 ├── new [path]            Create a new function from a template
 ├── pack [path]           Package the function app for deployment
 ├── start [path]          Start the Functions host (placeholder)
-├── workload
-│   ├── install           Install a workload package
-│   ├── uninstall         Uninstall a workload
-│   ├── list              List installed workloads
-│   └── update            Update a workload to the latest version
 ├── version (hidden)      Print version info
 └── help (hidden)         Print help
 ```
-
-Workloads can add their own commands to the tree via `IWorkload.RegisterCommands()`.
 
 ## Command Architecture
 
@@ -84,7 +74,6 @@ Provides shared infrastructure:
    └── handler(parseResult, cancellationToken)
        ├── Read option/argument values from parseResult
        ├── Use IInteractionService for prompts and output
-       ├── Delegate to workload providers as needed
        └── Return exit code (0 = success)
 ```
 
@@ -110,6 +99,13 @@ public static readonly Option<string> FrameworkOption = new("--target-framework"
 AddPathArgument(); // adds optional [path] argument
 ```
 
+## Stacks
+
+A "stack" describes a language/runtime target (`dotnet`, `node`, `python`, `java`, `powershell`, `custom`). The `Stacks` registry in `Common/Stacks.cs` is the single source of truth for stack identifiers and the languages each one supports.
+
+- `--stack` / `-s` is the user-facing option on `func init`.
+- `ProjectDetector.DetectStack(AndLanguage)` infers the stack of an existing project by inspecting files on disk (`*.csproj`, `package.json`, `host.json` `metadata.workerRuntime`, etc.).
+
 ## Console / UI Layer
 
 **All console I/O goes through `IInteractionService`** — never `Console.Write*` and
@@ -120,7 +116,7 @@ capture), non-interactive mode (prompts return defaults), and theming.
 
 A single `ITheme` exposes `Style` values for semantic roles (`Command`,
 `Placeholder`, `Path`, `Muted`, `Heading`, `Success`, `Error`, `Warning`, etc.).
-`DefaultTheme` holds the production palette. Swapping the DI registration is the
+`DefaultTheme` holds the production palette. Swapping the implementation is the
 only change required to add a no-color or high-contrast variant.
 
 ### Output Methods
@@ -150,8 +146,8 @@ automatically — callers never type `[...]` tags or call `EscapeMarkup()`.
 ```csharp
 interaction.WriteLine(l => l
     .Muted("Run ")
-    .Command("func workload search")
-    .Muted(" to discover available workloads."));
+    .Command("func new")
+    .Muted(" to create a function."));
 ```
 
 ### Interactive Prompts
@@ -168,83 +164,9 @@ interaction.WriteLine(l => l
 
 Returns `true` when the console supports prompts (not redirected, not CI). Commands should check this before offering interactive flows.
 
-## Workload System
-
-### Architecture
-
-```
-CLI (Func.Cli)
-  │
-  │ references
-  ▼
-Abstractions (Func.Cli.Abstractions)    ← NuGet package
-  │
-  │ referenced by
-  ▼
-Workload (e.g., Func.Cli.Workload.Dotnet)  ← NuGet package, loaded at runtime
-```
-
-The CLI never has a compile-time reference to any workload. Workloads are loaded dynamically via `AssemblyLoadContext`.
-
-### Workload Lifecycle
-
-```
-Install:
-  func workload install dotnet
-  ├── Resolve alias: "dotnet" → "Azure.Functions.Cli.Workload.Dotnet"
-  ├── Download NuGet package (TODO: currently creates placeholder)
-  ├── Extract to ~/.azure-functions/workloads/dotnet/{version}/
-  └── Update workloads.json manifest
-
-Load (at CLI startup):
-  ├── Read workloads.json
-  ├── For each entry:
-  │   ├── Create AssemblyLoadContext (isolation)
-  │   ├── LoadFromAssemblyPath(dll)
-  │   ├── Find type implementing IWorkload (reflection)
-  │   └── Activator.CreateInstance() (parameterless ctor required)
-  └── Fire background update check
-
-Contribute:
-  ├── RegisterCommands() — add commands to CLI tree
-  ├── GetTemplateProviders() — provide templates for `func new`
-  ├── GetProjectInitializer() — handle `func init` for the runtime
-  └── GetPackProvider() — handle `func pack` build/publish step
-```
-
-### Well-Known Aliases
-
-Users can use short names instead of full NuGet package IDs:
-
-| Alias       | Package ID |
-|-------------|-----------|
-| `dotnet`    | `Azure.Functions.Cli.Workload.Dotnet` |
-| `node`      | `Azure.Functions.Cli.Workload.Node` |
-| `python`    | `Azure.Functions.Cli.Workload.Python` |
-| `java`      | `Azure.Functions.Cli.Workload.Java` |
-| `powershell`| `Azure.Functions.Cli.Workload.PowerShell` |
-
-### Update Notifications
-
-`WorkloadUpdateChecker` runs a background NuGet check when workloads are loaded:
-- Queries `api.nuget.org/v3-flatcontainer/{id}/index.json` for each installed workload
-- Caches results in `~/.azure-functions/workload-update-cache.json` (24h TTL)
-- Prints notices after the command completes (waits up to 2s, then silently skips)
-- Never blocks or fails the command
-
-### Workload-Contributed Options
-
-When a workload provides options for `func init` (e.g., `--target-framework`), they are labeled in help output:
-
-```
-  --target-framework      [dotnet] The target framework (default: net10.0)
-```
-
-The `[dotnet]` prefix indicates which workload contributed the option.
-
 ## Error Handling
 
-The CLI uses `GracefulException` for all user-facing errors:
+The CLI uses `GracefulException` (defined in `Func.Cli.Abstractions`) for all user-facing errors:
 
 ```csharp
 throw new GracefulException(
@@ -253,9 +175,8 @@ throw new GracefulException(
 );
 ```
 
-- `IsUserError = true` (default) → exit code 1
-- `IsUserError = false` → exit code 2 (internal/unexpected)
-- Unhandled exceptions → "An unexpected error occurred", exit code 2
+- `GracefulException` → exit code 1 (the message, plus verbose detail if present, is printed to stderr)
+- Unhandled exceptions → "An unexpected error occurred", exit code 1
 - `Ctrl+C` / `SIGTERM` → exit code 130
 
 ## Telemetry
@@ -264,13 +185,14 @@ The CLI uses [OpenTelemetry](https://opentelemetry.io/) with the Azure Monitor e
 
 ### How It Works
 
-- An `ActivitySource` ("Azure.Functions.Cli") creates a root span that wraps the entire command execution
-- Command name, success/failure, duration, OS, and runtime version are recorded as span attributes
-- `TracerProvider` exports via `Azure.Monitor.OpenTelemetry.Exporter` with a 3-second flush timeout on exit
+- `CliTelemetry` owns a single `ActivitySource` and `Meter`, both named `Azure.Functions.Cli`.
+- The root activity wraps the entire command invocation; command name, exit code, OS, and runtime version land as activity tags / resource attributes.
+- A `Counter<long>` records command-execution counts with the same dimensions, plus a `Histogram<double>` for command duration in milliseconds.
+- `TracerProvider` and `MeterProvider` flush via `ForceFlush(3000)` and dispose on exit.
 
 ### Opt-Out
 
-Set `FUNCTIONS_CORE_TOOLS_TELEMETRY_OPTOUT=1` or `true` to disable telemetry. When disabled, a `NoOpTelemetryClient` is used (zero startup cost — no `TracerProvider` created).
+The CLI is opt-out: when no instrumentation key is baked in (the default for local builds) or `CliTelemetry.TryGetConnectionString` returns `false`, no providers are created and the `ActivitySource` / `Meter` calls become no-ops.
 
 ### Instrumentation Key
 
@@ -286,48 +208,37 @@ At startup, the CLI runs a non-blocking background check for newer v5 releases v
 - **Scope**: Only checks for v5 releases (tags starting with `5.`), ignoring drafts and prereleases
 - **Rate limits**: GitHub allows 60 unauthenticated requests/hour; the 24h cache prevents hitting this
 
-If a newer version is found, a notice is printed after the command completes:
+If a newer version is found, a notice is printed after the command completes.
 
-```
-💡 A newer version of Azure Functions Core Tools is available (5.1.0 → 5.2.0).
-   Update with: dotnet tool update -g Azure.Functions.Cli
-```
+## Init, New, and Pack Command Flow
 
-## Init and New Command Flow
+Today these commands operate on the stack inferred from the user (`--stack`) or from project files on disk. The full template / project-initializer / pack-provider extensibility model — where each stack's behavior is contributed by an installable workload — is documented in [building-a-workload.md](building-a-workload.md) and is being added in follow-up PRs.
 
 ### `func init`
 
 ```
-1. Determine worker runtime (--worker-runtime or prompt)
-2. If no workload installed for that runtime:
-   ├── Offer to install it
-   ├── After install, continue (no "re-run" needed)
-   └── Find the project initializer from the newly loaded workload
-3. Determine language (--language or prompt from workload's SupportedLanguages)
-4. Delegate to IProjectInitializer.InitializeAsync(context, parseResult)
+1. Determine stack (--stack or prompt)
+2. Determine language (--language or prompt from the stack's supported languages)
+3. Scaffold the project for that stack
 ```
 
 ### `func new`
 
 ```
-1. Detect worker runtime and language from project files (ProjectDetector)
+1. Detect stack and language from project files (ProjectDetector)
 2. If no project detected, run func init first (interactive flow)
-3. Discover templates from all loaded workload template providers
-4. Filter by detected worker runtime
-5. Select template (--template or prompt)
-6. Get function name (--name or prompt with editable default)
-7. Delegate to ITemplateProvider.ScaffoldAsync(context)
+3. Select template (--template or prompt)
+4. Get function name (--name or prompt with editable default)
+5. Scaffold the function
 ```
 
 ### `func pack`
 
 ```
-1. Detect worker runtime from project files (ProjectDetector)
-2. Find matching IPackProvider from loaded workloads
-3. Validate the project (provider-specific checks)
-4. If --no-build: skip build step, use project dir as-is
-5. Otherwise: delegate to IPackProvider.PrepareAsync() (e.g., dotnet publish)
-6. Zip the output directory using System.IO.Compression.ZipFile
-7. Output: <project-name>.zip in the --output directory (or current dir)
-8. Cleanup temporary build artifacts via IPackProvider.CleanupAsync()
+1. Detect stack from project files (ProjectDetector)
+2. Validate the project (stack-specific checks)
+3. If --no-build: skip build step, use project dir as-is
+4. Otherwise: prepare the project (e.g., dotnet publish for the dotnet stack)
+5. Zip the output directory using System.IO.Compression.ZipFile
+6. Output: <project-name>.zip in the --output directory (or current dir)
 ```

--- a/docs/repo-structure.md
+++ b/docs/repo-structure.md
@@ -4,7 +4,7 @@ This document describes the Azure Functions Core Tools v5 codebase — projects,
 
 ## Overview
 
-The v5 CLI is built with [System.CommandLine](https://github.com/dotnet/command-line-api) and [Spectre.Console](https://spectreconsole.net/), targeting **.NET 10**. It follows a **workload model** (similar to `dotnet` CLI) where the base CLI provides core commands and infrastructure, while language-specific functionality (init, templates, etc.) is delivered via independently installable workload packages.
+The v5 CLI is built with [System.CommandLine](https://github.com/dotnet/command-line-api) and [Spectre.Console](https://spectreconsole.net/), targeting **.NET 10**. It is being designed around a **workload model** (similar to the `dotnet` CLI) where the base CLI provides core commands and infrastructure while language-specific functionality (templates, init, pack) is delivered via independently installable workload packages. The base CLI and the abstractions library are in the tree today; the workload runtime + first-party workload packages are being staged in follow-up PRs.
 
 ## Project Layout
 
@@ -12,24 +12,23 @@ The v5 CLI is built with [System.CommandLine](https://github.com/dotnet/command-
 azure-functions-core-tools/
 ├── src/
 │   ├── Func.Cli/                      # Main CLI executable (assembly: func)
-│   ├── Func.Cli.Abstractions/         # Shared interfaces for workload authors
-│   └── Func.Cli.Workload.Dotnet/      # .NET workload (separate branch)
+│   └── Func.Cli.Abstractions/         # Shared types for workload authors (NuGet)
 ├── test/
-│   ├── Func.Cli.Tests/                # CLI unit tests
-│   └── Func.Cli.Workload.Dotnet.Tests/ # Workload tests (separate branch)
+│   └── Func.Cli.Tests/                # CLI unit tests
 ├── eng/
 │   ├── build/                         # MSBuild props/targets
 │   │   ├── Packages.props             # Central package version pins
-│   │   └── Engineering.targets        # Shared build targets
+│   │   ├── Engineering.targets        # Shared build targets
+│   │   └── Telemetry.props            # Telemetry key injection
 │   └── ci/                            # Azure Pipelines YAML
-│       ├── cli-public-build.yml        # CLI PR validation + nightly
-│       ├── cli-official-build.yml     # CLI release builds
-│       ├── abstractions-public-build.yml  # Abstractions PR validation
+│       ├── cli-public-build.yml          # CLI PR validation + nightly
+│       ├── cli-official-build.yml        # CLI release builds
+│       ├── abstractions-public-build.yml # Abstractions PR validation
 │       ├── abstractions-official-build.yml # Abstractions release + NuGet pack
-│       └── workload-dotnet-build.yml  # Dotnet workload CI
+│       ├── code-mirror.yml               # Mirror to engineering repo
+│       └── templates/                    # Shared pipeline templates
 ├── docs/                              # Developer documentation
-├── out/                               # Build artifacts (gitignored)
-└── nupkg/                             # NuGet package output (gitignored)
+└── out/                               # Build artifacts (gitignored)
 ```
 
 ## Projects
@@ -40,31 +39,21 @@ The main tool users install and run. Assembly name is `func`.
 
 | Directory         | Purpose |
 |-------------------|---------|
-| `Commands/`       | All CLI commands (init, new, pack, start, version, help, workload) + ProjectDetector |
-| `Console/`        | `IInteractionService` abstraction + Spectre.Console implementation |
-| `Workloads/`      | Workload manager, manifest, update checker |
-| `Telemetry/`      | OpenTelemetry client + Azure Monitor exporter |
-| `Common/`         | Shared utilities (Constants, VersionChecker) |
-| `Program.cs`      | Entry point — DI container, command tree, error handling |
-| `Parser.cs`       | Command tree composition — registers all commands, wires help |
+| `Commands/`       | All CLI commands (init, new, pack, start, version, help) + `BaseCommand`, `FuncRootCommand`, `ProjectDetector`, `SpectreHelpAction` |
+| `Console/`        | `IInteractionService` abstraction + Spectre.Console implementation, theme |
+| `Common/`         | Shared utilities — `Constants`, `Stacks` (stack registry), `VersionChecker` |
+| `Telemetry/`      | `CliTelemetry` (ActivitySource + Meter), Azure Monitor exporter wiring, activity / metric extensions |
+| `Program.cs`      | Entry point — telemetry setup, command tree, error handling |
+| `Parser.cs`       | Command tree composition — registers all commands, wires Spectre help |
 
 ### `src/Func.Cli.Abstractions` — Workload Contracts
 
-A packable NuGet library (`Azure.Functions.Cli.Abstractions`) that defines the interfaces workloads must implement. Workload authors reference this package — they never reference `Func.Cli` directly.
+A packable NuGet library (`Azure.Functions.Cli.Abstractions`) intended to host the public types that workload authors will reference. Workload authors will reference this package — they will never reference `Func.Cli` directly.
 
-Key types:
-- **`IWorkload`** — Main workload entry point (id, name, register commands, provide templates, initializer, and pack provider)
-- **`ITemplateProvider`** — Provides function templates for `func new`
-- **`IProjectInitializer`** — Handles `func init` for a worker runtime
-- **`IPackProvider`** — Handles `func pack` build/publish for a worker runtime
-- **`FunctionTemplate`** / **`FunctionScaffoldContext`** / **`ProjectInitContext`** / **`PackContext`** — Data records passed to workloads
-- **`GracefulException`** — User-friendly exception with optional verbose detail and exit codes
+Today it contains:
+- **`GracefulException`** — User-friendly exception used by the CLI (and, eventually, by workloads) to surface a primary message plus optional verbose detail and to drive a non-zero exit code.
 
-### `src/Func.Cli.Workload.Dotnet` — .NET Workload
-
-> Lives on the `feature/dotnet-workload` branch and is independently versioned and released.
-
-Implements `IWorkload` for .NET (C#, F#). Delegates to `dotnet new` for project and function scaffolding. See [building-a-workload.md](building-a-workload.md) for details.
+The remaining workload extension types (`IWorkload`, `IProjectInitializer`, `ITemplateProvider`, `IPackProvider`, related context records) are being added in follow-up PRs.
 
 ## Build System
 
@@ -76,7 +65,7 @@ Implements `IWorkload` for .NET (C#, F#). Delegates to `dotnet new` for project 
 | `Directory.Packages.props` | Enables Central Package Management, imports `eng/build/Packages.props` |
 | `eng/build/Packages.props` | Pins all NuGet package versions centrally |
 | `eng/build/Telemetry.props` | Injects telemetry instrumentation key as assembly attribute |
-| `src/Directory.Build.props` | Sets `IsPackable=true`, package output to `nupkg/` |
+| `src/Directory.Build.props` | Sets `IsPackable=true`, package output to `out/pkg/` |
 
 Each project also has its own `Directory.Version.props` for independent versioning.
 
@@ -100,23 +89,21 @@ out/
 
 ## CI Pipelines
 
-Each project has its own CI pipeline with **path-scoped triggers**, enabling independent build and release cadences.
+Each component has its own CI pipeline with **path-scoped triggers**, enabling independent build and release cadences.
 
 | Pipeline | File | Triggers On |
-|----------|------|------------|
-| CLI public build | `eng/ci/cli-public-build.yml` | PRs, nightly schedule |
+|----------|------|-------------|
+| CLI public build | `eng/ci/cli-public-build.yml` | PRs touching the CLI, nightly schedule |
 | CLI official build | `eng/ci/cli-official-build.yml` | Release branches |
 | Abstractions public | `eng/ci/abstractions-public-build.yml` | PRs touching `src/Func.Cli.Abstractions/` |
 | Abstractions official | `eng/ci/abstractions-official-build.yml` | Release builds, NuGet pack |
-| Dotnet workload | `eng/ci/workload-dotnet-build.yml` | Changes to `src/Func.Cli.Workload.Dotnet/` |
 | Code mirror | `eng/ci/code-mirror.yml` | Mirror to engineering repo |
 
 ## Test Patterns
 
 - **Framework**: xUnit + NSubstitute
 - **`TestInteractionService`**: In-memory `IInteractionService` that captures all output and returns deterministic values for prompts
-- **Temp directories**: Workload/manager tests create temp dirs and clean up via `IDisposable`
-- **`FakeDotnetCliRunner`**: (workload branch) Simulates `dotnet` CLI responses without invoking dotnet
+- **Temp directories**: Tests that touch the filesystem create temp dirs and clean up via `IDisposable`
 
 ```bash
 dotnet test                             # All projects
@@ -127,7 +114,6 @@ dotnet test test/Func.Cli.Tests/        # CLI tests only
 
 | Branch | Purpose |
 |--------|---------|
+| `main` | Stable v4 release branch |
 | `vnext` | Base branch for v5 development |
-| `feature/vnext-init` | CLI framework, abstractions, and infrastructure |
-| `feature/dotnet-workload` | .NET workload (branches from vnext-init) |
-| `feature/<lang>-workload` | Future language workloads |
+| `liliankasem/workloads/*` | Stacked PRs landing the v5 workload extensibility model |

--- a/docs/repo-structure.md
+++ b/docs/repo-structure.md
@@ -116,4 +116,3 @@ dotnet test test/Func.Cli.Tests/        # CLI tests only
 |--------|---------|
 | `main` | Stable v4 release branch |
 | `vnext` | Base branch for v5 development |
-| `liliankasem/workloads/*` | Stacked PRs landing the v5 workload extensibility model |

--- a/src/Func.Cli/Commands/InitCommand.cs
+++ b/src/Func.Cli/Commands/InitCommand.cs
@@ -13,9 +13,9 @@ namespace Azure.Functions.Cli.Commands;
 /// </summary>
 public class InitCommand : BaseCommand
 {
-    public static readonly Option<string?> WorkerRuntimeOption = new("--worker-runtime", "-w")
+    public static readonly Option<string?> StackOption = new("--stack", "-s")
     {
-        Description = "The worker runtime for the project"
+        Description = "The stack (language / runtime) for the project"
     };
 
     public static readonly Option<string?> NameOption = new("--name", "-n")
@@ -41,7 +41,7 @@ public class InitCommand : BaseCommand
         _interaction = interaction;
 
         AddPathArgument();
-        Options.Add(WorkerRuntimeOption);
+        Options.Add(StackOption);
         Options.Add(NameOption);
         Options.Add(LanguageOption);
         Options.Add(ForceOption);
@@ -55,7 +55,7 @@ public class InitCommand : BaseCommand
         _interaction.WriteBlankLine();
         _interaction.WriteHint("Install a workload to initialize a project:");
         _interaction.WriteBlankLine();
-        WorkerRuntimes.WriteWorkloadInstallHints(_interaction);
+        Stacks.WriteWorkloadInstallHints(_interaction);
         _interaction.WriteBlankLine();
         _interaction.WriteLine(l => l
             .Muted("Run ")

--- a/src/Func.Cli/Commands/NewCommand.cs
+++ b/src/Func.Cli/Commands/NewCommand.cs
@@ -49,7 +49,7 @@ public class NewCommand : BaseCommand
         _interaction.WriteBlankLine();
         _interaction.WriteHint("Install a workload to create functions from templates:");
         _interaction.WriteBlankLine();
-        WorkerRuntimes.WriteWorkloadInstallHints(_interaction);
+        Stacks.WriteWorkloadInstallHints(_interaction);
         _interaction.WriteBlankLine();
         _interaction.WriteLine(l => l
             .Muted("Run ")

--- a/src/Func.Cli/Commands/PackCommand.cs
+++ b/src/Func.Cli/Commands/PackCommand.cs
@@ -48,19 +48,19 @@ public class PackCommand : BaseCommand
             return Task.FromResult(1);
         }
 
-        // Detect the runtime
-        var detectedRuntime = ProjectDetector.DetectRuntime(projectPath);
-        if (detectedRuntime is null)
+        // Detect the stack
+        var detectedStack = ProjectDetector.DetectStack(projectPath);
+        if (detectedStack is null)
         {
-            _interaction.WriteError("Could not detect the worker runtime for this project.");
+            _interaction.WriteError("Could not detect the stack for this project.");
             _interaction.WriteHint("Ensure the project contains the expected project files (e.g., .csproj, package.json).");
             return Task.FromResult(1);
         }
 
-        _interaction.WriteError($"No pack provider for runtime '{detectedRuntime}'.");
+        _interaction.WriteError($"No pack provider for stack '{detectedStack}'.");
         _interaction.WriteLine(l => l
             .Muted("Install the workload: ")
-            .Command($"func workload install {detectedRuntime}"));
+            .Command($"func workload install {detectedStack}"));
         return Task.FromResult(1);
     }
 }

--- a/src/Func.Cli/Commands/ProjectDetector.cs
+++ b/src/Func.Cli/Commands/ProjectDetector.cs
@@ -4,14 +4,14 @@
 namespace Azure.Functions.Cli.Commands;
 
 /// <summary>
-/// Shared utility for detecting the worker runtime and language of a Functions project.
+/// Shared utility for detecting the stack and language of a Functions project.
 /// </summary>
 internal static class ProjectDetector
 {
     /// <summary>
-    /// Detects the worker runtime and language from the project files in the given directory.
+    /// Detects the stack and language from the project files in the given directory.
     /// </summary>
-    public static (string? Runtime, string? Language) DetectRuntimeAndLanguage(string directory)
+    public static (string? Stack, string? Language) DetectStackAndLanguage(string directory)
     {
         // Check for .csproj → dotnet C#
         if (Directory.EnumerateFiles(directory, "*.csproj").Any())
@@ -55,8 +55,8 @@ internal static class ProjectDetector
     }
 
     /// <summary>
-    /// Detects just the worker runtime from the project files in the given directory.
+    /// Detects just the stack from the project files in the given directory.
     /// </summary>
-    public static string? DetectRuntime(string directory)
-        => DetectRuntimeAndLanguage(directory).Runtime;
+    public static string? DetectStack(string directory)
+        => DetectStackAndLanguage(directory).Stack;
 }

--- a/src/Func.Cli/Common/Stacks.cs
+++ b/src/Func.Cli/Common/Stacks.cs
@@ -7,9 +7,9 @@ using Azure.Functions.Cli.Console;
 namespace Azure.Functions.Cli.Common;
 
 /// <summary>
-/// Central registry of worker runtimes and their supported languages.
+/// Central registry of stacks (language / runtime targets) and their supported languages.
 /// </summary>
-public static class WorkerRuntimes
+public static class Stacks
 {
     public static readonly FrozenDictionary<string, string[]> LanguageMap =
         new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
@@ -22,7 +22,7 @@ public static class WorkerRuntimes
         }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
-    /// Writes the workload install hints for all known runtimes as an aligned list.
+    /// Writes the workload install hints for all known stacks as an aligned list.
     /// </summary>
     public static void WriteWorkloadInstallHints(IInteractionService interaction)
     {

--- a/test/Func.Cli.Tests/Commands/InitCommandTests.cs
+++ b/test/Func.Cli.Tests/Commands/InitCommandTests.cs
@@ -21,7 +21,7 @@ public class InitCommandTests
         var cmd = new InitCommand(_interaction);
         var optionNames = cmd.Options.Select(o => o.Name).ToList();
 
-        Assert.Contains("--worker-runtime", optionNames);
+        Assert.Contains("--stack", optionNames);
         Assert.Contains("--name", optionNames);
         Assert.Contains("--language", optionNames);
         Assert.Contains("--force", optionNames);

--- a/test/Func.Cli.Tests/Commands/ProjectDetectorTests.cs
+++ b/test/Func.Cli.Tests/Commands/ProjectDetectorTests.cs
@@ -25,130 +25,130 @@ public class ProjectDetectorTests : IDisposable
     }
 
     [Fact]
-    public void DetectRuntimeAndLanguage_CSharpProject_ReturnsDotnetCSharp()
+    public void DetectStackAndLanguage_CSharpProject_ReturnsDotnetCSharp()
     {
         File.WriteAllText(Path.Combine(_tempDir, "MyApp.csproj"), "<Project/>");
 
-        var (runtime, language) = ProjectDetector.DetectRuntimeAndLanguage(_tempDir);
+        var (stack, language) = ProjectDetector.DetectStackAndLanguage(_tempDir);
 
-        Assert.Equal("dotnet", runtime);
+        Assert.Equal("dotnet", stack);
         Assert.Equal("C#", language);
     }
 
     [Fact]
-    public void DetectRuntimeAndLanguage_FSharpProject_ReturnsDotnetFSharp()
+    public void DetectStackAndLanguage_FSharpProject_ReturnsDotnetFSharp()
     {
         File.WriteAllText(Path.Combine(_tempDir, "MyApp.fsproj"), "<Project/>");
 
-        var (runtime, language) = ProjectDetector.DetectRuntimeAndLanguage(_tempDir);
+        var (stack, language) = ProjectDetector.DetectStackAndLanguage(_tempDir);
 
-        Assert.Equal("dotnet", runtime);
+        Assert.Equal("dotnet", stack);
         Assert.Equal("F#", language);
     }
 
     [Fact]
-    public void DetectRuntimeAndLanguage_NodeProject_ReturnsNode()
+    public void DetectStackAndLanguage_NodeProject_ReturnsNode()
     {
         File.WriteAllText(Path.Combine(_tempDir, "package.json"), "{}");
 
-        var (runtime, language) = ProjectDetector.DetectRuntimeAndLanguage(_tempDir);
+        var (stack, language) = ProjectDetector.DetectStackAndLanguage(_tempDir);
 
-        Assert.Equal("node", runtime);
+        Assert.Equal("node", stack);
         Assert.Null(language);
     }
 
     [Fact]
-    public void DetectRuntimeAndLanguage_PythonRequirements_ReturnsPython()
+    public void DetectStackAndLanguage_PythonRequirements_ReturnsPython()
     {
         File.WriteAllText(Path.Combine(_tempDir, "requirements.txt"), "");
 
-        var (runtime, language) = ProjectDetector.DetectRuntimeAndLanguage(_tempDir);
+        var (stack, language) = ProjectDetector.DetectStackAndLanguage(_tempDir);
 
-        Assert.Equal("python", runtime);
+        Assert.Equal("python", stack);
         Assert.Null(language);
     }
 
     [Fact]
-    public void DetectRuntimeAndLanguage_PyProject_ReturnsPython()
+    public void DetectStackAndLanguage_PyProject_ReturnsPython()
     {
         File.WriteAllText(Path.Combine(_tempDir, "pyproject.toml"), "");
 
-        var (runtime, language) = ProjectDetector.DetectRuntimeAndLanguage(_tempDir);
+        var (stack, language) = ProjectDetector.DetectStackAndLanguage(_tempDir);
 
-        Assert.Equal("python", runtime);
+        Assert.Equal("python", stack);
         Assert.Null(language);
     }
 
     [Fact]
-    public void DetectRuntimeAndLanguage_PomXml_ReturnsJava()
+    public void DetectStackAndLanguage_PomXml_ReturnsJava()
     {
         File.WriteAllText(Path.Combine(_tempDir, "pom.xml"), "<project/>");
 
-        var (runtime, language) = ProjectDetector.DetectRuntimeAndLanguage(_tempDir);
+        var (stack, language) = ProjectDetector.DetectStackAndLanguage(_tempDir);
 
-        Assert.Equal("java", runtime);
+        Assert.Equal("java", stack);
         Assert.Null(language);
     }
 
     [Fact]
-    public void DetectRuntimeAndLanguage_BuildGradle_ReturnsJava()
+    public void DetectStackAndLanguage_BuildGradle_ReturnsJava()
     {
         File.WriteAllText(Path.Combine(_tempDir, "build.gradle"), "");
 
-        var (runtime, language) = ProjectDetector.DetectRuntimeAndLanguage(_tempDir);
+        var (stack, language) = ProjectDetector.DetectStackAndLanguage(_tempDir);
 
-        Assert.Equal("java", runtime);
+        Assert.Equal("java", stack);
         Assert.Null(language);
     }
 
     [Fact]
-    public void DetectRuntimeAndLanguage_ProfilePs1_ReturnsPowerShell()
+    public void DetectStackAndLanguage_ProfilePs1_ReturnsPowerShell()
     {
         File.WriteAllText(Path.Combine(_tempDir, "profile.ps1"), "");
 
-        var (runtime, language) = ProjectDetector.DetectRuntimeAndLanguage(_tempDir);
+        var (stack, language) = ProjectDetector.DetectStackAndLanguage(_tempDir);
 
-        Assert.Equal("powershell", runtime);
+        Assert.Equal("powershell", stack);
         Assert.Null(language);
     }
 
     [Fact]
-    public void DetectRuntimeAndLanguage_EmptyDir_ReturnsNulls()
+    public void DetectStackAndLanguage_EmptyDir_ReturnsNulls()
     {
-        var (runtime, language) = ProjectDetector.DetectRuntimeAndLanguage(_tempDir);
+        var (stack, language) = ProjectDetector.DetectStackAndLanguage(_tempDir);
 
-        Assert.Null(runtime);
+        Assert.Null(stack);
         Assert.Null(language);
     }
 
     [Fact]
-    public void DetectRuntimeAndLanguage_CSharpTakesPriorityOverNode()
+    public void DetectStackAndLanguage_CSharpTakesPriorityOverNode()
     {
         // If both .csproj and package.json exist, .csproj wins
         File.WriteAllText(Path.Combine(_tempDir, "MyApp.csproj"), "<Project/>");
         File.WriteAllText(Path.Combine(_tempDir, "package.json"), "{}");
 
-        var (runtime, language) = ProjectDetector.DetectRuntimeAndLanguage(_tempDir);
+        var (stack, language) = ProjectDetector.DetectStackAndLanguage(_tempDir);
 
-        Assert.Equal("dotnet", runtime);
+        Assert.Equal("dotnet", stack);
         Assert.Equal("C#", language);
     }
 
     [Fact]
-    public void DetectRuntime_ReturnRuntimeOnly()
+    public void DetectStack_ReturnStackOnly()
     {
         File.WriteAllText(Path.Combine(_tempDir, "MyApp.fsproj"), "<Project/>");
 
-        var runtime = ProjectDetector.DetectRuntime(_tempDir);
+        var stack = ProjectDetector.DetectStack(_tempDir);
 
-        Assert.Equal("dotnet", runtime);
+        Assert.Equal("dotnet", stack);
     }
 
     [Fact]
-    public void DetectRuntime_EmptyDir_ReturnsNull()
+    public void DetectStack_EmptyDir_ReturnsNull()
     {
-        var runtime = ProjectDetector.DetectRuntime(_tempDir);
+        var stack = ProjectDetector.DetectStack(_tempDir);
 
-        Assert.Null(runtime);
+        Assert.Null(stack);
     }
 }


### PR DESCRIPTION
## Summary

Renames "worker runtime" to "stack" throughout the v5 CLI to better describe what the concept actually is — a language/runtime target a Functions project is built on top of.

## Changes

- **User-facing option**: `--worker-runtime` / `-w` → `--stack` / `-s` on `func init`
- **Registry**: `WorkerRuntimes` class → `Stacks` (file renamed)
- **Project detection**: `ProjectDetector.DetectRuntimeAndLanguage` → `DetectStackAndLanguage`; `DetectRuntime` → `DetectStack`
- **Tests** and **docs** updated to match

No behavior changes — pure rename.

## Test plan

- `dotnet build` — clean
- `dotnet test` — 53/53 pass