### PR TITLE
Pivot CLI to HostApplicationBuilder with hosted OpenTelemetry

### DIFF
--- a/src/Func.Cli/Func.Cli.csproj
+++ b/src/Func.Cli/Func.Cli.csproj
@@ -24,7 +24,9 @@
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="Spectre.Console" />
     <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>
 
 </Project>

--- a/src/Func.Cli/Program.cs
+++ b/src/Func.Cli/Program.cs
@@ -9,34 +9,41 @@ using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Console.Theme;
 using Azure.Functions.Cli.Telemetry;
 using Azure.Monitor.OpenTelemetry.Exporter;
-using OpenTelemetry;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 
 ITheme theme = new DefaultTheme();
 IInteractionService interaction = new SpectreInteractionService(theme);
 
-// Wire up the OpenTelemetry SDK only when telemetry is configured (build has
-// a real instrumentation key and the user has not opted out). When it isn't,
-// no listener is subscribed and ActivitySource/Meter calls become no-ops.
-TracerProvider? tracerProvider = null;
-MeterProvider? meterProvider = null;
+// Build the host: a CLI process gets the empty variant so we skip the default
+// configuration and logging providers (they're not needed). The host owns
+// shared lifetimes — currently just the OpenTelemetry pipeline, which is
+// registered as hosted services so flush + shutdown happen via host disposal.
+var hostBuilder = Host.CreateEmptyApplicationBuilder(null);
+hostBuilder.Services.AddSingleton(interaction);
+
+// Wire OpenTelemetry only when a real instrumentation key is baked in and
+// the user hasn't opted out. When it isn't, no listener is subscribed and
+// ActivitySource / Meter calls become no-ops.
 if (CliTelemetry.TryGetConnectionString(out var connectionString))
 {
-    var resourceBuilder = CliTelemetry.CreateResourceBuilder();
-
-    tracerProvider = Sdk.CreateTracerProviderBuilder()
-        .SetResourceBuilder(resourceBuilder)
-        .AddSource(CliTelemetry.SourceName)
-        .AddAzureMonitorTraceExporter(o => o.ConnectionString = connectionString)
-        .Build();
-
-    meterProvider = Sdk.CreateMeterProviderBuilder()
-        .SetResourceBuilder(resourceBuilder)
-        .AddMeter(CliTelemetry.SourceName)
-        .AddAzureMonitorMetricExporter(o => o.ConnectionString = connectionString)
-        .Build();
+    hostBuilder.Services.AddOpenTelemetry()
+        .ConfigureResource(r => CliTelemetry.ConfigureResource(r))
+        .WithTracing(t => t
+            .AddSource(CliTelemetry.SourceName)
+            .AddAzureMonitorTraceExporter(o => o.ConnectionString = connectionString))
+        .WithMetrics(m => m
+            .AddMeter(CliTelemetry.SourceName)
+            .AddAzureMonitorMetricExporter(o => o.ConnectionString = connectionString));
 }
+
+using var host = hostBuilder.Build();
+
+// Start the host so hosted services (OTel providers) are running and
+// listeners are subscribed before any command code emits telemetry.
+await host.StartAsync();
 
 // Create the command tree
 var rootCommand = Parser.CreateCommand(interaction);
@@ -103,23 +110,14 @@ using (Activity? activity = CliTelemetry.Trace.StartCommandActivity(commandName)
         stopwatch.Stop();
         CliTelemetry.Metric.RecordCommand(commandName, exitCode, stopwatch.ElapsedMilliseconds);
     }
-} // activity disposed (and stopped) here, before flush
+} // activity disposed (and stopped) here, before host shutdown flushes
 
-try
-{
-    // Print version update notice if available (bounded wait)
-    await PrintVersionNotice(interaction, versionCheckTask);
-}
-finally
-{
-    // Flush + dispose the OTel providers explicitly. The bare ServiceProvider
-    // doesn't own them (they were built outside DI), so we manage them here.
-    tracerProvider?.ForceFlush(3000);
-    meterProvider?.ForceFlush(3000);
-    tracerProvider?.Dispose();
-    meterProvider?.Dispose();
-}
+// Print version update notice if available (bounded wait)
+await PrintVersionNotice(interaction, versionCheckTask);
 
+// Container disposal (triggered by `using var host` going out of scope)
+// disposes the OTel providers, which flushes pending telemetry. No explicit
+// flush needed here.
 return exitCode;
 
 /// <summary>

--- a/src/Func.Cli/Telemetry/CliTelemetry.cs
+++ b/src/Func.Cli/Telemetry/CliTelemetry.cs
@@ -71,6 +71,18 @@ internal static class CliTelemetry
     }
 
     /// <summary>
+    /// Applies the standard CLI service / OS / runtime attributes to an
+    /// existing <see cref="ResourceBuilder"/>. Used by the OTel hosting
+    /// integration via <c>ConfigureResource</c>.
+    /// </summary>
+    public static ResourceBuilder ConfigureResource(ResourceBuilder builder)
+    {
+        return builder
+            .AddService(serviceName: SourceName, serviceVersion: CliVersion)
+            .AddAttributes(GetResourceAttributes());
+    }
+
+    /// <summary>
     /// Returns the Azure Monitor connection string when telemetry is
     /// configured (build has a real instrumentation key) and the user has
     /// not opted out.


### PR DESCRIPTION
Switches Program.cs to Host.CreateEmptyApplicationBuilder and wires the OpenTelemetry SDK through the hosting integration.

## What changes

- Program.cs: build a host, register OTel via AddOpenTelemetry().WithTracing/.WithMetrics (only when a connection string is present), StartAsync before invoking the command, StopAsync(3s) after to flush exporters.
- CliTelemetry.cs: new ConfigureResource(ResourceBuilder) helper used by the hosted pipeline; standalone CreateResourceBuilder() retained for tests.
- Func.Cli.csproj: add OpenTelemetry.Extensions.Hosting and Microsoft.Extensions.Hosting package refs (versions already centralized).

## Why

Sets the stage for DI-based workload extension points (next PR) by giving the CLI a host. Telemetry lifetime is now managed by the host instead of manual ForceFlush + Dispose of providers in Program.cs.

## Verification

- dotnet build clean
- dotnet test — 53/53 pass
- Smoke: func --version and func --help work.

Stacked PR — base: vnext. Next PR (workloads/abstractions) will build on this.