### PR TITLE
#4751 - Fix: resolve storage account lookup failure in func fetch-connection-string

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -15,3 +15,4 @@
 - Fix `func kubernetes deploy` race condition where `kubectl rollout status` ran before the Deployment was registered (#4919)
 - Fix `func kubernetes delete` to honor `--no-docker` instead of failing on registry auth (#4919)
 - Add `McpPromptTrigger` template for dotnet-isolated `func new` (#4891)
+- Fix func azure storage fetch-connection-string failing with "Cannot find storage account" due to ARM eventual consistency (#4884)

--- a/src/Cli/func/Arm/ArmUriTemplates.cs
+++ b/src/Cli/func/Arm/ArmUriTemplates.cs
@@ -17,12 +17,9 @@ namespace Azure.Functions.Cli.Arm
         public const string BasicAuthCheckApiVersion = "2022-03-01";
         public const string FunctionsStacksApiVersion = "2020-10-01";
         public const string FlexFunctionsStacksApiVersion = "2020-10-01";
-        public const string StorageApiVersion = "2018-02-01";
         public const string ArgUri = "providers/Microsoft.ResourceGraph/resources";
 
         public static readonly ArmUriTemplate SubscriptionResourceByNameAndType = new ArmUriTemplate($"resources?$filter=(SubscriptionId eq '{{subscriptionId}}' and name eq '{{resourceName}}' and resourceType eq '{{resourceType}}')", ArmApiVersion);
-        public static readonly ArmUriTemplate StorageAccountsList = new ArmUriTemplate("subscriptions/{subscriptionId}/providers/Microsoft.Storage/storageAccounts", StorageApiVersion);
-        public static readonly ArmUriTemplate StorageAccountByResourceGroup = new ArmUriTemplate("subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Storage/storageAccounts/{storageAccountName}", StorageApiVersion);
     }
 
     public class ArmUriTemplate

--- a/src/Cli/func/Arm/ArmUriTemplates.cs
+++ b/src/Cli/func/Arm/ArmUriTemplates.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Text.RegularExpressions;
@@ -17,10 +17,12 @@ namespace Azure.Functions.Cli.Arm
         public const string BasicAuthCheckApiVersion = "2022-03-01";
         public const string FunctionsStacksApiVersion = "2020-10-01";
         public const string FlexFunctionsStacksApiVersion = "2020-10-01";
-
+        public const string StorageApiVersion = "2018-02-01";
         public const string ArgUri = "providers/Microsoft.ResourceGraph/resources";
 
         public static readonly ArmUriTemplate SubscriptionResourceByNameAndType = new ArmUriTemplate($"resources?$filter=(SubscriptionId eq '{{subscriptionId}}' and name eq '{{resourceName}}' and resourceType eq '{{resourceType}}')", ArmApiVersion);
+        public static readonly ArmUriTemplate StorageAccountsList = new ArmUriTemplate("subscriptions/{subscriptionId}/providers/Microsoft.Storage/storageAccounts", StorageApiVersion);
+        public static readonly ArmUriTemplate StorageAccountByResourceGroup = new ArmUriTemplate("subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Storage/storageAccounts/{storageAccountName}", StorageApiVersion);
     }
 
     public class ArmUriTemplate

--- a/src/Cli/func/Arm/ArmUriTemplates.cs
+++ b/src/Cli/func/Arm/ArmUriTemplates.cs
@@ -18,8 +18,6 @@ namespace Azure.Functions.Cli.Arm
         public const string FunctionsStacksApiVersion = "2020-10-01";
         public const string FlexFunctionsStacksApiVersion = "2020-10-01";
         public const string ArgUri = "providers/Microsoft.ResourceGraph/resources";
-
-        public static readonly ArmUriTemplate SubscriptionResourceByNameAndType = new ArmUriTemplate($"resources?$filter=(SubscriptionId eq '{{subscriptionId}}' and name eq '{{resourceName}}' and resourceType eq '{{resourceType}}')", ArmApiVersion);
     }
 
     public class ArmUriTemplate

--- a/src/Cli/func/Helpers/AzureHelper.cs
+++ b/src/Cli/func/Helpers/AzureHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Arm;
@@ -17,6 +17,8 @@ namespace Azure.Functions.Cli.Helpers
     public static class AzureHelper
     {
         private static readonly string _storageApiVersion = "2018-02-01";
+
+        internal static Func<Func<Task<object>>, Task<object>> ArmCallOverrideAsync { get; set; }
 
         internal static async Task<Site> GetFunctionApp(string name, string accessToken, string managementURL, string slot = null, string defaultSubscription = null, IEnumerable<ArmSubscription> allSubs = null, Func<Site, string, string, Task<Site>> loadFunction = null)
         {
@@ -288,20 +290,63 @@ namespace Azure.Functions.Cli.Helpers
             var subscriptions = await GetSubscriptions(accessToken, managementURL);
             foreach (var subscription in subscriptions)
             {
-                var storageAccount =
-                    await ArmHttpAsync<ArmArrayWrapper<ArmGenericResource>>(
-                        HttpMethod.Get,
-                        ArmUriTemplates.SubscriptionResourceByNameAndType.Bind(managementURL, new
-                        {
-                            subscriptionId = subscription.SubscriptionId,
-                            resourceName = storageAccountName,
-                            resourceType = "Microsoft.Storage/storageAccounts"
-                        }),
-                        accessToken);
-
-                if (storageAccount.Value.Any())
+                try
                 {
-                    return await GetStorageAccount(storageAccount.Value.First(), accessToken, managementURL);
+                    // List all storage accounts in the subscription
+                    var listUrl = new Uri(
+                        $"{managementURL}/subscriptions/{subscription.SubscriptionId}" +
+                        $"/providers/Microsoft.Storage/storageAccounts" +
+                        $"?api-version={_storageApiVersion}");
+
+                    var accounts =
+                        await ExecuteArmCallAsync(() => ArmHttpAsync<ArmArrayWrapper<ArmGenericResource>>(
+                            HttpMethod.Get,
+                            listUrl,
+                            accessToken));
+
+                    if (accounts?.Value == null || !accounts.Value.Any())
+                    {
+                        continue;
+                    }
+
+                    // Filter in-memory by storage account name
+                    var match = accounts?.Value?
+                        .FirstOrDefault(a => string.Equals(
+                            a.Name,
+                            storageAccountName,
+                            StringComparison.OrdinalIgnoreCase));
+
+                    if (match == null)
+                    {
+                        continue;
+                    }
+
+                    var resourceGroup = ExtractResourceGroupFromId(match.Id);
+
+                    // Fetch storage account using RG-specific endpoint
+                    var getUrl = new Uri(
+                        $"{managementURL}/subscriptions/{subscription.SubscriptionId}" +
+                        $"/resourceGroups/{resourceGroup}" +
+                        $"/providers/Microsoft.Storage/storageAccounts/{storageAccountName}" +
+                        $"?api-version={_storageApiVersion}");
+
+                    var storageAccount =
+                        await ArmHttpAsync<ArmWrapper<ArmGenericResource>>(
+                            HttpMethod.Get,
+                            getUrl,
+                            accessToken);
+
+                    if (storageAccount != null)
+                    {
+                        return await GetStorageAccount(storageAccount, accessToken, managementURL);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    if (StaticSettings.IsDebug)
+                    {
+                        ColoredConsole.Error.WriteLine(ErrorColor(ex.ToString()));
+                    }
                 }
             }
 
@@ -758,6 +803,32 @@ namespace Azure.Functions.Cli.Helpers
             {
                 return null;
             }
+        }
+
+        private static string ExtractResourceGroupFromId(string resourceId)
+        {
+            var parts = resourceId.Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+            for (int i = 0; i < parts.Length; i++)
+            {
+                if (parts[i].Equals("resourceGroups", StringComparison.OrdinalIgnoreCase))
+                {
+                    return parts[i + 1];
+                }
+            }
+
+            throw new InvalidOperationException("Resource group not found in resource ID");
+        }
+
+        private static async Task<T> ExecuteArmCallAsync<T>(Func<Task<T>> actualCall)
+        {
+            if (ArmCallOverrideAsync != null)
+            {
+                var result = await ArmCallOverrideAsync(() => actualCall().ContinueWith(t => (object)t.Result));
+                return (T)result;
+            }
+
+            return await actualCall();
         }
     }
 }

--- a/src/Cli/func/Helpers/AzureHelper.cs
+++ b/src/Cli/func/Helpers/AzureHelper.cs
@@ -286,89 +286,34 @@ namespace Azure.Functions.Cli.Helpers
         public static async Task<StorageAccount> GetStorageAccount(string storageAccountName, string accessToken, string managementURL)
         {
             var subscriptions = await GetSubscriptions(accessToken, managementURL);
-            Exception lastException = null;
+            var subIds = subscriptions?.Select(s => s.SubscriptionId).ToList();
 
-            foreach (var subscription in subscriptions)
+            if (subIds == null || subIds.Count == 0)
             {
-                try
-                {
-                    // Build URL using ArmUriTemplates
-                    var listUrl = ArmUriTemplates.StorageAccountsList.Bind(managementURL, new
-                    {
-                        subscriptionId = subscription.SubscriptionId
-                    });
-
-                    // Fetch all pages
-                    var allAccounts = new List<ArmWrapper<ArmGenericResource>>();
-
-                    var response = await ArmHttpAsync<ArmArrayWrapper<ArmGenericResource>>(
-                        HttpMethod.Get,
-                        listUrl,
-                        accessToken);
-
-                    while (response != null)
-                    {
-                        if (response.Value != null)
-                        {
-                            allAccounts.AddRange(response.Value);
-                        }
-
-                        if (string.IsNullOrEmpty(response.NextLink))
-                        {
-                            break;
-                        }
-
-                        response = await ArmHttpAsync<ArmArrayWrapper<ArmGenericResource>>(
-                        HttpMethod.Get,
-                        new Uri(response.NextLink),
-                        accessToken);
-                    }
-
-                    var match = allAccounts.FirstOrDefault(a =>
-                        string.Equals(a.Name, storageAccountName, StringComparison.OrdinalIgnoreCase));
-
-                    if (match == null)
-                    {
-                        continue;
-                    }
-
-                    var resourceGroup = ExtractResourceGroupFromId(match.Id);
-
-                    var getUrl = ArmUriTemplates.StorageAccountByResourceGroup.Bind(managementURL, new
-                    {
-                        subscriptionId = subscription.SubscriptionId,
-                        resourceGroup = resourceGroup,
-                        storageAccountName = storageAccountName
-                    });
-
-                    var storageAccount =
-                        await ArmHttpAsync<ArmWrapper<ArmGenericResource>>(
-                            HttpMethod.Get,
-                            getUrl,
-                            accessToken);
-
-                    if (storageAccount != null)
-                    {
-                        return await GetStorageAccount(storageAccount, accessToken, managementURL);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    lastException = ex;
-
-                    if (StaticSettings.IsDebug)
-                    {
-                        ColoredConsole.Error.WriteLine(ErrorColor(ex.ToString()));
-                    }
-                }
+                throw new InvalidOperationException("No subscriptions found for the current account.");
             }
 
-            if (lastException != null)
+            // Resolve storage account via Azure Resource Graph (ARG)
+            var query =
+                $"Resources | where type =~ 'microsoft.storage/storageaccounts' " +
+                $"and name =~ '{storageAccountName}' | project id | limit 1";
+
+            var resourceId = await GetResourceIDFromArg(subIds, query, accessToken, managementURL);
+
+            if (string.IsNullOrWhiteSpace(resourceId))
             {
-                throw lastException;
+                throw new ArmResourceNotFoundException(
+                    $"Cannot find storage account with name {storageAccountName}");
             }
 
-            throw new ArmResourceNotFoundException($"Cannot find storage account with name {storageAccountName}");
+            return await GetStorageAccount(
+                new ArmWrapper<ArmGenericResource>
+                {
+                    Id = resourceId,
+                    Name = storageAccountName
+                },
+                accessToken,
+                managementURL);
         }
 
         private static async Task<StorageAccount> GetStorageAccount(ArmWrapper<ArmGenericResource> armWrapper, string accessToken, string managementURL)
@@ -821,21 +766,6 @@ namespace Azure.Functions.Cli.Helpers
             {
                 return null;
             }
-        }
-
-        private static string ExtractResourceGroupFromId(string resourceId)
-        {
-            var parts = resourceId.Split('/', StringSplitOptions.RemoveEmptyEntries);
-
-            for (int i = 0; i < parts.Length; i++)
-            {
-                if (parts[i].Equals("resourceGroups", StringComparison.OrdinalIgnoreCase) && i + 1 < parts.Length)
-                {
-                    return parts[i + 1];
-                }
-            }
-
-            throw new InvalidOperationException("Resource group not found in resource ID");
         }
     }
 }

--- a/src/Cli/func/Helpers/AzureHelper.cs
+++ b/src/Cli/func/Helpers/AzureHelper.cs
@@ -18,8 +18,6 @@ namespace Azure.Functions.Cli.Helpers
     {
         private static readonly string _storageApiVersion = "2018-02-01";
 
-        internal static Func<Func<Task<object>>, Task<object>> ArmCallOverrideAsync { get; set; }
-
         internal static async Task<Site> GetFunctionApp(string name, string accessToken, string managementURL, string slot = null, string defaultSubscription = null, IEnumerable<ArmSubscription> allSubs = null, Func<Site, string, string, Task<Site>> loadFunction = null)
         {
             IEnumerable<string> allSubscriptionIds;
@@ -288,33 +286,46 @@ namespace Azure.Functions.Cli.Helpers
         public static async Task<StorageAccount> GetStorageAccount(string storageAccountName, string accessToken, string managementURL)
         {
             var subscriptions = await GetSubscriptions(accessToken, managementURL);
+            Exception lastException = null;
+
             foreach (var subscription in subscriptions)
             {
                 try
                 {
-                    // List all storage accounts in the subscription
-                    var listUrl = new Uri(
-                        $"{managementURL}/subscriptions/{subscription.SubscriptionId}" +
-                        $"/providers/Microsoft.Storage/storageAccounts" +
-                        $"?api-version={_storageApiVersion}");
-
-                    var accounts =
-                        await ExecuteArmCallAsync(() => ArmHttpAsync<ArmArrayWrapper<ArmGenericResource>>(
-                            HttpMethod.Get,
-                            listUrl,
-                            accessToken));
-
-                    if (accounts?.Value == null || !accounts.Value.Any())
+                    // Build URL using ArmUriTemplates
+                    var listUrl = ArmUriTemplates.StorageAccountsList.Bind(managementURL, new
                     {
-                        continue;
+                        subscriptionId = subscription.SubscriptionId
+                    });
+
+                    // Fetch all pages
+                    var allAccounts = new List<ArmWrapper<ArmGenericResource>>();
+
+                    var response = await ArmHttpAsync<ArmArrayWrapper<ArmGenericResource>>(
+                        HttpMethod.Get,
+                        listUrl,
+                        accessToken);
+
+                    while (response != null)
+                    {
+                        if (response.Value != null)
+                        {
+                            allAccounts.AddRange(response.Value);
+                        }
+
+                        if (string.IsNullOrEmpty(response.NextLink))
+                        {
+                            break;
+                        }
+
+                        response = await ArmHttpAsync<ArmArrayWrapper<ArmGenericResource>>(
+                        HttpMethod.Get,
+                        new Uri(response.NextLink),
+                        accessToken);
                     }
 
-                    // Filter in-memory by storage account name
-                    var match = accounts?.Value?
-                        .FirstOrDefault(a => string.Equals(
-                            a.Name,
-                            storageAccountName,
-                            StringComparison.OrdinalIgnoreCase));
+                    var match = allAccounts.FirstOrDefault(a =>
+                        string.Equals(a.Name, storageAccountName, StringComparison.OrdinalIgnoreCase));
 
                     if (match == null)
                     {
@@ -323,12 +334,12 @@ namespace Azure.Functions.Cli.Helpers
 
                     var resourceGroup = ExtractResourceGroupFromId(match.Id);
 
-                    // Fetch storage account using RG-specific endpoint
-                    var getUrl = new Uri(
-                        $"{managementURL}/subscriptions/{subscription.SubscriptionId}" +
-                        $"/resourceGroups/{resourceGroup}" +
-                        $"/providers/Microsoft.Storage/storageAccounts/{storageAccountName}" +
-                        $"?api-version={_storageApiVersion}");
+                    var getUrl = ArmUriTemplates.StorageAccountByResourceGroup.Bind(managementURL, new
+                    {
+                        subscriptionId = subscription.SubscriptionId,
+                        resourceGroup = resourceGroup,
+                        storageAccountName = storageAccountName
+                    });
 
                     var storageAccount =
                         await ArmHttpAsync<ArmWrapper<ArmGenericResource>>(
@@ -343,11 +354,18 @@ namespace Azure.Functions.Cli.Helpers
                 }
                 catch (Exception ex)
                 {
+                    lastException = ex;
+
                     if (StaticSettings.IsDebug)
                     {
                         ColoredConsole.Error.WriteLine(ErrorColor(ex.ToString()));
                     }
                 }
+            }
+
+            if (lastException != null)
+            {
+                throw lastException;
             }
 
             throw new ArmResourceNotFoundException($"Cannot find storage account with name {storageAccountName}");
@@ -811,24 +829,13 @@ namespace Azure.Functions.Cli.Helpers
 
             for (int i = 0; i < parts.Length; i++)
             {
-                if (parts[i].Equals("resourceGroups", StringComparison.OrdinalIgnoreCase))
+                if (parts[i].Equals("resourceGroups", StringComparison.OrdinalIgnoreCase) && i + 1 < parts.Length)
                 {
                     return parts[i + 1];
                 }
             }
 
             throw new InvalidOperationException("Resource group not found in resource ID");
-        }
-
-        private static async Task<T> ExecuteArmCallAsync<T>(Func<Task<T>> actualCall)
-        {
-            if (ArmCallOverrideAsync != null)
-            {
-                var result = await ArmCallOverrideAsync(() => actualCall().ContinueWith(t => (object)t.Result));
-                return (T)result;
-            }
-
-            return await actualCall();
         }
     }
 }

--- a/src/Cli/func/Helpers/AzureHelper.cs
+++ b/src/Cli/func/Helpers/AzureHelper.cs
@@ -288,19 +288,28 @@ namespace Azure.Functions.Cli.Helpers
             var subscriptions = await GetSubscriptions(accessToken, managementURL);
             var subIds = subscriptions?.Select(s => s.SubscriptionId).ToList();
 
-            if (subIds == null || subIds.Count == 0)
+            if (subIds.Count == 0)
             {
                 throw new InvalidOperationException("No subscriptions found for the current account.");
             }
 
             // Resolve storage account via Azure Resource Graph (ARG)
+            var escapedStorageAccountName = storageAccountName.Replace("'", "''");
             var query =
-                $"Resources | where type =~ 'microsoft.storage/storageaccounts' " +
-                $"and name =~ '{storageAccountName}' | project id | limit 1";
+               $"where type =~ 'microsoft.storage/storageaccounts' " +
+               $"and name =~ '{escapedStorageAccountName}' | project id | limit 1";
 
-            var resourceId = await GetResourceIDFromArg(subIds, query, accessToken, managementURL);
-
-            if (string.IsNullOrWhiteSpace(resourceId))
+            string resourceId;
+            try
+            {
+                resourceId = await GetResourceIDFromArg(
+                    subIds,
+                    query,
+                    accessToken,
+                    managementURL);
+            }
+            catch (CliException ex) when (
+               ex.Message == "Error finding the Azure Resource information.")
             {
                 throw new ArmResourceNotFoundException(
                     $"Cannot find storage account with name {storageAccountName}");

--- a/src/Cli/func/Helpers/AzureHelper.cs
+++ b/src/Cli/func/Helpers/AzureHelper.cs
@@ -116,7 +116,7 @@ namespace Azure.Functions.Cli.Helpers
 
             // we need the first item of the first row
             return argResponse.Data?.Rows?.FirstOrDefault()?.FirstOrDefault()
-                ?? throw new CliException("Error finding the Azure Resource information.");
+                ?? throw new ArmResourceNotFoundException("Error finding the Azure Resource information.");
         }
 
         internal static async Task<bool> IsBasicAuthAllowedForSCM(Site functionApp, string accessToken, string managementURL)
@@ -286,7 +286,7 @@ namespace Azure.Functions.Cli.Helpers
         public static async Task<StorageAccount> GetStorageAccount(string storageAccountName, string accessToken, string managementURL)
         {
             var subscriptions = await GetSubscriptions(accessToken, managementURL);
-            var subIds = subscriptions?.Select(s => s.SubscriptionId).ToList();
+            var subIds = subscriptions.Select(s => s.SubscriptionId).ToList();
 
             if (subIds.Count == 0)
             {
@@ -308,8 +308,7 @@ namespace Azure.Functions.Cli.Helpers
                     accessToken,
                     managementURL);
             }
-            catch (CliException ex) when (
-               ex.Message == "Error finding the Azure Resource information.")
+            catch (ArmResourceNotFoundException)
             {
                 throw new ArmResourceNotFoundException(
                     $"Cannot find storage account with name {storageAccountName}");

--- a/test/Cli/Func.UnitTests/HelperTests/AzureHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/AzureHelperTests.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Arm;
+using Azure.Functions.Cli.Arm.Models;
 using Azure.Functions.Cli.Helpers;
 using FluentAssertions;
+using Moq;
 using RichardSzalay.MockHttp;
 using Xunit;
 
@@ -33,6 +35,102 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
 
                 var result = await AzureHelper.GetFunctionKey(functionName, AppId, AccessToken, ManagementUrl);
                 result.Should().Be(value);
+            }
+            finally
+            {
+                ArmClient.SetTestHandler(null);
+            }
+        }
+
+        [Fact]
+        public async Task GetStorageAccount_ShouldReturn_WhenStorageExists()
+        {
+            try
+            {
+                const string managementUrl = "https://management.azure.com";
+                const string subscriptionId = "sub";
+                const string storageName = "mystorage";
+                const string resourceGroup = "rg";
+                const string accessToken = "token";
+
+                var listUrl =
+                    $"{managementUrl}/subscriptions/{subscriptionId}/providers/Microsoft.Storage/storageAccounts?api-version=2018-02-01";
+
+                var getUrl =
+                    $"{managementUrl}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Storage/storageAccounts/{storageName}?api-version=2018-02-01";
+
+                var keysUrl =
+                    $"{managementUrl}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Storage/storageAccounts/{storageName}/listKeys?api-version=2018-02-01";
+
+                var subscriptionsUrl =
+                    $"{managementUrl}/subscriptions?api-version=2018-09-01";
+
+                var mockHttp = new MockHttpMessageHandler();
+
+                // Mock subscriptions
+                mockHttp.When(HttpMethod.Get, subscriptionsUrl).Respond("application/json", @"{'value': [{ 'subscriptionId': 'sub', 'displayName': 'Test Sub' }]}");
+
+                // Mock list storage accounts
+                mockHttp.When(HttpMethod.Get, listUrl).Respond("application/json", @"{'value': [{'name': 'mystorage','id': '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/mystorage'}]}");
+
+                // Mock get storage account
+                mockHttp.When(HttpMethod.Get, getUrl).Respond("application/json", @"{'name': 'mystorage','id': '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/mystorage'}");
+
+                // Mock listKeys
+                mockHttp.When(HttpMethod.Post, keysUrl).Respond("application/json", @"{'keys': [{'keyName': 'key1','value': 'test-key','permissions': 'FULL'}]}");
+
+                // Attach mock handler
+                ArmClient.SetTestHandler(mockHttp);
+
+                // Act
+                var result = await AzureHelper.GetStorageAccount(
+                    storageName,
+                    accessToken,
+                    managementUrl);
+
+                // Assert
+                result.Should().NotBeNull();
+                result.StorageAccountName.Should().Be(storageName);
+                result.StorageAccountKey.Should().Be("test-key");
+            }
+            finally
+            {
+                ArmClient.SetTestHandler(null);
+            }
+        }
+
+        [Fact]
+        public async Task GetStorageAccount_ShouldThrow_WhenStorageNotFound()
+        {
+            try
+            {
+                const string managementUrl = "https://management.azure.com";
+                const string subscriptionId = "sub";
+                const string storageName = "mystorage";
+                const string accessToken = "token";
+
+                var subscriptionsUrl =
+                    $"{managementUrl}/subscriptions?api-version=2018-09-01";
+
+                var listUrl =
+                    $"{managementUrl}/subscriptions/{subscriptionId}/providers/Microsoft.Storage/storageAccounts?api-version=2018-02-01";
+
+                var mockHttp = new MockHttpMessageHandler();
+
+                // Mock subscriptions
+                mockHttp.When(HttpMethod.Get, subscriptionsUrl).Respond("application/json", @"{'value': [{ 'subscriptionId': 'sub', 'displayName': 'Test Sub' }]}");
+
+                // Mock empty storage accounts list
+                mockHttp.When(HttpMethod.Get, listUrl).Respond("application/json", @"{ 'value': [] }");
+
+                ArmClient.SetTestHandler(mockHttp);
+
+                // Act
+                Func<Task> act = async () =>
+                    await AzureHelper.GetStorageAccount(storageName, accessToken, managementUrl);
+
+                // Assert
+                await Assert.ThrowsAsync<ArmResourceNotFoundException>(() => AzureHelper.GetStorageAccount(storageName, accessToken, managementUrl));
             }
             finally
             {

--- a/test/Cli/Func.UnitTests/HelperTests/AzureHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/AzureHelperTests.cs
@@ -1,8 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Net;
 using Azure.Functions.Cli.Arm;
+using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Helpers;
 using FluentAssertions;
 using RichardSzalay.MockHttp;
@@ -49,36 +49,31 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
                 const string managementUrl = "https://management.azure.com";
                 const string subscriptionId = "sub";
                 const string storageName = "mystorage";
-                const string resourceGroup = "rg";
                 const string accessToken = "token";
-
-                var listUrl =
-                    $"{managementUrl}/subscriptions/{subscriptionId}/providers/Microsoft.Storage/storageAccounts?api-version=2018-02-01";
-
-                var getUrl =
-                    $"{managementUrl}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Storage/storageAccounts/{storageName}?api-version=2018-02-01";
-
-                var keysUrl =
-                    $"{managementUrl}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Storage/storageAccounts/{storageName}/listKeys?api-version=2018-02-01";
 
                 var subscriptionsUrl =
                     $"{managementUrl}/subscriptions?api-version=2018-09-01";
+
+                var argUrl =
+                    $"{managementUrl}/providers/Microsoft.ResourceGraph/resources?api-version=2019-04-01";
+
+                var keysUrl =
+                    $"{managementUrl}/subscriptions/{subscriptionId}/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/{storageName}/listKeys?api-version=2018-02-01";
+
+                var resourceId =
+                    $"/subscriptions/{subscriptionId}/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/{storageName}";
 
                 var mockHttp = new MockHttpMessageHandler();
 
                 // Mock subscriptions
                 mockHttp.When(HttpMethod.Get, subscriptionsUrl).Respond("application/json", @"{'value': [{ 'subscriptionId': 'sub', 'displayName': 'Test Sub' }]}");
 
-                // Mock list storage accounts
-                mockHttp.When(HttpMethod.Get, listUrl).Respond("application/json", @"{'value': [{'name': 'mystorage','id': '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/mystorage'}]}");
-
-                // Mock get storage account
-                mockHttp.When(HttpMethod.Get, getUrl).Respond("application/json", @"{'name': 'mystorage','id': '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/mystorage'}");
+                // Mock ARG response
+                mockHttp.When(HttpMethod.Post, argUrl).Respond("application/json", $@"{{'data': {{'rows': [[ '{resourceId}' ]]}}}}");
 
                 // Mock listKeys
-                mockHttp.When(HttpMethod.Post, keysUrl).Respond("application/json", @"{'keys': [{'keyName': 'key1','value': 'test-key','permissions': 'FULL'}]}");
+                mockHttp.When(HttpMethod.Post, keysUrl).Respond("application/json", @"{'keys': [{ 'keyName': 'key1', 'value': 'test-key', 'permissions': 'FULL' }]}");
 
-                // Attach mock handler
                 ArmClient.SetTestHandler(mockHttp);
 
                 // Act
@@ -104,62 +99,28 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
             try
             {
                 const string managementUrl = "https://management.azure.com";
-                const string subscriptionId = "sub";
-                const string storageName = "mystorage";
                 const string accessToken = "token";
+                const string storageName = "mystorage";
 
                 var subscriptionsUrl =
                     $"{managementUrl}/subscriptions?api-version=2018-09-01";
 
-                var listUrl =
-                    $"{managementUrl}/subscriptions/{subscriptionId}/providers/Microsoft.Storage/storageAccounts?api-version=2018-02-01";
+                var argUrl =
+                    $"{managementUrl}/providers/Microsoft.ResourceGraph/resources?api-version=2019-04-01";
 
                 var mockHttp = new MockHttpMessageHandler();
 
                 // Mock subscriptions
                 mockHttp.When(HttpMethod.Get, subscriptionsUrl).Respond("application/json", @"{'value': [{ 'subscriptionId': 'sub', 'displayName': 'Test Sub' }]}");
 
-                // Mock empty storage accounts list
-                mockHttp.When(HttpMethod.Get, listUrl).Respond("application/json", @"{ 'value': [] }");
+                // ARG returns empty
+                mockHttp.When(HttpMethod.Post, argUrl).Respond("application/json", @"{'data':{rows: []}}");
 
                 ArmClient.SetTestHandler(mockHttp);
 
-                // Act & Assert
-                await Assert.ThrowsAsync<ArmResourceNotFoundException>(() => AzureHelper.GetStorageAccount(storageName, accessToken, managementUrl));
-            }
-            finally
-            {
-                ArmClient.SetTestHandler(null);
-            }
-        }
-
-        [Fact]
-        public async Task GetStorageAccount_ShouldThrow_LastException_WhenAllSubscriptionsFail()
-        {
-            try
-            {
-                const string managementUrl = "https://management.azure.com";
-                const string accessToken = "token";
-
-                var subscriptionsUrl =
-                    $"{managementUrl}/subscriptions?api-version=2018-09-01";
-
-                var listUrl =
-                    $"{managementUrl}/subscriptions/sub/providers/Microsoft.Storage/storageAccounts?api-version=2018-02-01";
-
-                var mockHttp = new MockHttpMessageHandler();
-
-                // Subscriptions
-                mockHttp.When(HttpMethod.Get, subscriptionsUrl).Respond("application/json", @"{ 'value': [ { 'subscriptionId': 'sub' } ] }");
-
-                // Simulate failure (403)
-                mockHttp.When(HttpMethod.Get, listUrl)
-                    .Respond(HttpStatusCode.Forbidden);
-                ArmClient.SetTestHandler(mockHttp);
-
-                // Act & Assert
-                await Assert.ThrowsAsync<HttpRequestException>(() =>
-                    AzureHelper.GetStorageAccount("mystorage", accessToken, managementUrl));
+                // Act + Assert
+                await Assert.ThrowsAsync<CliException>(() =>
+                    AzureHelper.GetStorageAccount(storageName, accessToken, managementUrl));
             }
             finally
             {

--- a/test/Cli/Func.UnitTests/HelperTests/AzureHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/AzureHelperTests.cs
@@ -1,11 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Net;
 using Azure.Functions.Cli.Arm;
-using Azure.Functions.Cli.Arm.Models;
 using Azure.Functions.Cli.Helpers;
 using FluentAssertions;
-using Moq;
 using RichardSzalay.MockHttp;
 using Xunit;
 
@@ -125,12 +124,42 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
 
                 ArmClient.SetTestHandler(mockHttp);
 
-                // Act
-                Func<Task> act = async () =>
-                    await AzureHelper.GetStorageAccount(storageName, accessToken, managementUrl);
-
-                // Assert
+                // Act & Assert
                 await Assert.ThrowsAsync<ArmResourceNotFoundException>(() => AzureHelper.GetStorageAccount(storageName, accessToken, managementUrl));
+            }
+            finally
+            {
+                ArmClient.SetTestHandler(null);
+            }
+        }
+
+        [Fact]
+        public async Task GetStorageAccount_ShouldThrow_LastException_WhenAllSubscriptionsFail()
+        {
+            try
+            {
+                const string managementUrl = "https://management.azure.com";
+                const string accessToken = "token";
+
+                var subscriptionsUrl =
+                    $"{managementUrl}/subscriptions?api-version=2018-09-01";
+
+                var listUrl =
+                    $"{managementUrl}/subscriptions/sub/providers/Microsoft.Storage/storageAccounts?api-version=2018-02-01";
+
+                var mockHttp = new MockHttpMessageHandler();
+
+                // Subscriptions
+                mockHttp.When(HttpMethod.Get, subscriptionsUrl).Respond("application/json", @"{ 'value': [ { 'subscriptionId': 'sub' } ] }");
+
+                // Simulate failure (403)
+                mockHttp.When(HttpMethod.Get, listUrl)
+                    .Respond(HttpStatusCode.Forbidden);
+                ArmClient.SetTestHandler(mockHttp);
+
+                // Act & Assert
+                await Assert.ThrowsAsync<HttpRequestException>(() =>
+                    AzureHelper.GetStorageAccount("mystorage", accessToken, managementUrl));
             }
             finally
             {

--- a/test/Cli/Func.UnitTests/HelperTests/AzureHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/AzureHelperTests.cs
@@ -144,7 +144,7 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
                 var mockHttp = new MockHttpMessageHandler();
 
                 // Mock multiple subscriptions
-                mockHttp.When(HttpMethod.Get, subscriptionsUrl).Respond("application/json", @"{'value': [{ 'subscriptionId': 'sub1', 'displayName': 'Sub One' }, { 'subscriptionId': 'sub2', 'displayName': 'Sub Two' },{ 'subscriptionId': 'sub2', 'displayName': 'Sub Three' }]}");
+                mockHttp.When(HttpMethod.Get, subscriptionsUrl).Respond("application/json", @"{'value': [{ 'subscriptionId': 'sub1', 'displayName': 'Sub One' }, { 'subscriptionId': 'sub2', 'displayName': 'Sub Two' },{ 'subscriptionId': 'sub3', 'displayName': 'Sub Three' }]}");
 
                 // ARG resolves storage account from sub2
                 mockHttp.When(HttpMethod.Post, argUrl).Respond("application/json", $@"{{'data': {{'rows': [[ '{resourceId}' ]]}}}}");

--- a/test/Cli/Func.UnitTests/HelperTests/AzureHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/AzureHelperTests.cs
@@ -119,8 +119,50 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
                 ArmClient.SetTestHandler(mockHttp);
 
                 // Act + Assert
-                await Assert.ThrowsAsync<CliException>(() =>
+                await Assert.ThrowsAsync<ArmResourceNotFoundException>(() =>
                     AzureHelper.GetStorageAccount(storageName, accessToken, managementUrl));
+            }
+            finally
+            {
+                ArmClient.SetTestHandler(null);
+            }
+        }
+
+        [Fact]
+        public async Task GetStorageAccount_ShouldResolveAcrossMultipleSubscriptions()
+        {
+            try
+            {
+                const string managementUrl = "https://management.azure.com";
+                const string storageName = "mystorage";
+                const string accessToken = "token";
+
+                var subscriptionsUrl = $"{managementUrl}/subscriptions?api-version=2018-09-01";
+                var argUrl = $"{managementUrl}/providers/Microsoft.ResourceGraph/resources?api-version=2019-04-01";
+                var resourceId = "/subscriptions/sub2/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/mystorage";
+                var keysUrl = $"{managementUrl}/subscriptions/sub2/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/{storageName}/listKeys?api-version=2018-02-01";
+                var mockHttp = new MockHttpMessageHandler();
+
+                // Mock multiple subscriptions
+                mockHttp.When(HttpMethod.Get, subscriptionsUrl).Respond("application/json", @"{'value': [{ 'subscriptionId': 'sub1', 'displayName': 'Sub One' }, { 'subscriptionId': 'sub2', 'displayName': 'Sub Two' },{ 'subscriptionId': 'sub2', 'displayName': 'Sub Three' }]}");
+
+                // ARG resolves storage account from sub2
+                mockHttp.When(HttpMethod.Post, argUrl).Respond("application/json", $@"{{'data': {{'rows': [[ '{resourceId}' ]]}}}}");
+
+                // listKeys call
+                mockHttp.When(HttpMethod.Post, keysUrl).Respond("application/json", @"{'keys': [{'keyName': 'key1','value': 'test-key','permissions': 'FULL'}]}");
+                ArmClient.SetTestHandler(mockHttp);
+
+                // Act
+                var result = await AzureHelper.GetStorageAccount(
+                    storageName,
+                    accessToken,
+                    managementUrl);
+
+                // Assert
+                result.Should().NotBeNull();
+                result.StorageAccountName.Should().Be(storageName);
+                result.StorageAccountKey.Should().Be("test-key");
             }
             finally
             {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Replaces /subscriptions/{id}/resources lookup (eventually consistent) with provider-specific storage API. Fixes intermittent “Cannot find storage account” errors.

resolves #4751

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Added unit tests with MockHttpMessageHandler and validated against real Azure.
