### PR TITLE
Make Func.Cli internals internal

### DIFF
--- a/src/Func.Cli/Commands/BaseCommand.cs
+++ b/src/Func.Cli/Commands/BaseCommand.cs
@@ -15,7 +15,7 @@ namespace Azure.Functions.Cli.Commands;
 /// constructor and ApplyPath(parseResult) in their execute method to support
 /// 'func start [path]', 'func init [path]', etc.
 /// </summary>
-public abstract class BaseCommand : Command
+internal abstract class BaseCommand : Command
 {
     /// <summary>
     /// Shared path argument definition for commands that need project directory support.

--- a/src/Func.Cli/Commands/FuncRootCommand.cs
+++ b/src/Func.Cli/Commands/FuncRootCommand.cs
@@ -9,7 +9,7 @@ namespace Azure.Functions.Cli.Commands;
 /// Root 'func' command definition. Separate from BaseCommand because RootCommand
 /// has distinct behavior (no-args → help, global options, version display).
 /// </summary>
-public class FuncRootCommand : RootCommand
+internal class FuncRootCommand : RootCommand
 {
     public static readonly Option<bool> VerboseOption = new("--verbose", "-v")
     {

--- a/src/Func.Cli/Commands/HelpCommand.cs
+++ b/src/Func.Cli/Commands/HelpCommand.cs
@@ -11,7 +11,7 @@ namespace Azure.Functions.Cli.Commands;
 /// <summary>
 /// Renders rich help generated from real <see cref="Command"/> metadata.
 /// </summary>
-public class HelpCommand : BaseCommand
+internal class HelpCommand : BaseCommand
 {
     public static readonly Argument<string?> CommandArgument = new("command")
     {

--- a/src/Func.Cli/Commands/InitCommand.cs
+++ b/src/Func.Cli/Commands/InitCommand.cs
@@ -11,7 +11,7 @@ namespace Azure.Functions.Cli.Commands;
 /// Initializes a new Azure Functions project. The full implementation requires
 /// a language workload to be installed — this defines the command skeleton and options.
 /// </summary>
-public class InitCommand : BaseCommand
+internal class InitCommand : BaseCommand
 {
     public static readonly Option<string?> StackOption = new("--stack", "-s")
     {

--- a/src/Func.Cli/Commands/NewCommand.cs
+++ b/src/Func.Cli/Commands/NewCommand.cs
@@ -11,7 +11,7 @@ namespace Azure.Functions.Cli.Commands;
 /// Creates a new function from a template. The full implementation requires
 /// a language workload to be installed — this defines the command skeleton and options.
 /// </summary>
-public class NewCommand : BaseCommand
+internal class NewCommand : BaseCommand
 {
     public static readonly Option<string?> NameOption = new("--name", "-n")
     {

--- a/src/Func.Cli/Commands/PackCommand.cs
+++ b/src/Func.Cli/Commands/PackCommand.cs
@@ -11,7 +11,7 @@ namespace Azure.Functions.Cli.Commands;
 /// The full implementation requires a language workload — this defines
 /// the command skeleton and options.
 /// </summary>
-public class PackCommand : BaseCommand
+internal class PackCommand : BaseCommand
 {
     public static readonly Option<string?> OutputOption = new("--output", "-o")
     {

--- a/src/Func.Cli/Commands/StartCommand.cs
+++ b/src/Func.Cli/Commands/StartCommand.cs
@@ -9,7 +9,7 @@ namespace Azure.Functions.Cli.Commands;
 /// <summary>
 /// Launches the Azure Functions host runtime via 'func start'.
 /// </summary>
-public class StartCommand : BaseCommand
+internal class StartCommand : BaseCommand
 {
     public static readonly Option<int?> PortOption = new("--port", "-p")
     {

--- a/src/Func.Cli/Commands/VersionCommand.cs
+++ b/src/Func.Cli/Commands/VersionCommand.cs
@@ -10,7 +10,7 @@ namespace Azure.Functions.Cli.Commands;
 /// <summary>
 /// Displays Azure Functions CLI version information.
 /// </summary>
-public class VersionCommand : BaseCommand
+internal class VersionCommand : BaseCommand
 {
     private readonly IInteractionService _interaction;
 

--- a/src/Func.Cli/Common/Constants.cs
+++ b/src/Func.Cli/Common/Constants.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 
 namespace Azure.Functions.Cli.Common;
 
-public static class Constants
+internal static class Constants
 {
     public const string ProductName = "Azure Functions CLI";
     public const string CliName = "func";

--- a/src/Func.Cli/Common/Stacks.cs
+++ b/src/Func.Cli/Common/Stacks.cs
@@ -9,7 +9,7 @@ namespace Azure.Functions.Cli.Common;
 /// <summary>
 /// Central registry of stacks (language / runtime targets) and their supported languages.
 /// </summary>
-public static class Stacks
+internal static class Stacks
 {
     public static readonly FrozenDictionary<string, string[]> LanguageMap =
         new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)

--- a/src/Func.Cli/Console/DefinitionItem.cs
+++ b/src/Func.Cli/Console/DefinitionItem.cs
@@ -7,4 +7,4 @@ namespace Azure.Functions.Cli.Console;
 /// A label + description pair rendered as an aligned row in a definition list
 /// (used for command listings, option listings, etc.).
 /// </summary>
-public readonly record struct DefinitionItem(string Label, string Description);
+internal readonly record struct DefinitionItem(string Label, string Description);

--- a/src/Func.Cli/Console/IInteractionService.cs
+++ b/src/Func.Cli/Console/IInteractionService.cs
@@ -20,7 +20,7 @@ namespace Azure.Functions.Cli.Console;
 /// stderr; all other output goes to stdout.
 /// </para>
 /// </remarks>
-public interface IInteractionService
+internal interface IInteractionService
 {
     /// <summary>Active visual theme. Exposed so callers can use ad-hoc styles where needed.</summary>
     public ITheme Theme { get; }

--- a/src/Func.Cli/Console/InlineLine.cs
+++ b/src/Func.Cli/Console/InlineLine.cs
@@ -17,7 +17,7 @@ namespace Azure.Functions.Cli.Console;
 /// Typical use via <c>IInteractionService.WriteLine(l =&gt; l.Muted("Run ").Command("func new"))</c>.
 /// The builder itself is just a segment accumulator; rendering is performed by the interaction service.
 /// </remarks>
-public sealed class InlineLine
+internal sealed class InlineLine
 {
     private readonly ITheme _theme;
     private readonly List<Segment> _segments = new();

--- a/src/Func.Cli/Console/SpectreInteractionService.cs
+++ b/src/Func.Cli/Console/SpectreInteractionService.cs
@@ -11,7 +11,7 @@ namespace Azure.Functions.Cli.Console;
 /// Rich console implementation backed by Spectre.Console. All styled output
 /// flows through <see cref="ITheme"/>.
 /// </summary>
-public class SpectreInteractionService : IInteractionService
+internal class SpectreInteractionService : IInteractionService
 {
     private readonly IAnsiConsole _stdout;
     private readonly IAnsiConsole _stderr;

--- a/src/Func.Cli/Console/Theme/DefaultTheme.cs
+++ b/src/Func.Cli/Console/Theme/DefaultTheme.cs
@@ -8,7 +8,7 @@ namespace Azure.Functions.Cli.Console.Theme;
 /// <summary>
 /// Default color theme. Preserves the palette used prior to the theming refactor.
 /// </summary>
-public sealed class DefaultTheme : ITheme
+internal sealed class DefaultTheme : ITheme
 {
     public Style Title { get; } = new(Color.Blue, decoration: Decoration.Bold);
 

--- a/src/Func.Cli/Console/Theme/ITheme.cs
+++ b/src/Func.Cli/Console/Theme/ITheme.cs
@@ -11,7 +11,7 @@ namespace Azure.Functions.Cli.Console.Theme;
 /// Swapping implementations (e.g. a no-color theme) requires no changes in
 /// command or help code.
 /// </summary>
-public interface ITheme
+internal interface ITheme
 {
     /// <summary>Product and section titles (e.g. "Azure Functions CLI").</summary>
     public Style Title { get; }

--- a/src/Func.Cli/Parser.cs
+++ b/src/Func.Cli/Parser.cs
@@ -13,7 +13,7 @@ namespace Azure.Functions.Cli;
 /// (commands are constructed here, not auto-discovered) so the command
 /// tree is deterministic and easy to reason about.
 /// </summary>
-public static class Parser
+internal static class Parser
 {
     /// <summary>
     /// Creates and configures the root CLI command with all subcommands registered.

--- a/src/Func.Cli/Telemetry/ActivityExtensions.cs
+++ b/src/Func.Cli/Telemetry/ActivityExtensions.cs
@@ -18,7 +18,7 @@ namespace Azure.Functions.Cli.Telemetry;
 /// <see cref="OpenTelemetry.Resources.ResourceBuilder"/> and inherited by
 /// every span — they should not be set per span here.
 /// </remarks>
-public static class ActivityExtensions
+internal static class ActivityExtensions
 {
     extension(ActivitySource source)
     {

--- a/src/Func.Cli/Telemetry/CliTelemetry.cs
+++ b/src/Func.Cli/Telemetry/CliTelemetry.cs
@@ -22,7 +22,7 @@ namespace Azure.Functions.Cli.Telemetry;
 /// listener is subscribed and the .NET diagnostic APIs are effectively
 /// no-ops — so call sites stay free of opt-out branches.
 /// </remarks>
-public static class CliTelemetry
+internal static class CliTelemetry
 {
     /// <summary>
     /// OTel source / service name. Lowercase, dotted form to match the

--- a/src/Func.Cli/Telemetry/MeterExtensions.cs
+++ b/src/Func.Cli/Telemetry/MeterExtensions.cs
@@ -15,7 +15,7 @@ namespace Azure.Functions.Cli.Telemetry;
 /// <see cref="MeterListener"/> is subscribed, the underlying instruments are
 /// effectively no-ops, so callers do not need to branch on opt-out state.
 /// </remarks>
-public static class MeterExtensions
+internal static class MeterExtensions
 {
     private static readonly Counter<long> _commandCount =
         CliTelemetry.Metric.CreateCounter<long>(

--- a/test/Func.Cli.Tests/TestInteractionService.cs
+++ b/test/Func.Cli.Tests/TestInteractionService.cs
@@ -14,7 +14,7 @@ namespace Azure.Functions.Cli.Tests;
 /// so tests can assert on both content and role.
 /// Interactive methods return defaults (non-interactive mode).
 /// </summary>
-public class TestInteractionService : IInteractionService
+internal class TestInteractionService : IInteractionService
 {
     private readonly List<string> _lines = new();
 


### PR DESCRIPTION
Func.Cli is the executable assembly — nothing outside it consumes its types (`Func.Cli.Tests` sees them via `InternalsVisibleTo`). Flip every public type under `src/Func.Cli/` to internal so we plan for internal-by-default and only expose what genuinely needs to be public.

21 type-decl flips. No behavior change.

Build green, 53/53 tests pass.