### PR TITLE
Add argument null checks; primary ctor where applicable

### DIFF
--- a/src/Func.Cli/Commands/HelpCommand.cs
+++ b/src/Func.Cli/Commands/HelpCommand.cs
@@ -25,6 +25,8 @@ public class HelpCommand : BaseCommand
     public HelpCommand(IInteractionService interaction, FuncRootCommand rootCommand)
         : base("help", "Show help information for Azure Functions CLI.")
     {
+        ArgumentNullException.ThrowIfNull(interaction);
+        ArgumentNullException.ThrowIfNull(rootCommand);
         Hidden = true;
         _interaction = interaction;
         _rootCommand = rootCommand;

--- a/src/Func.Cli/Commands/InitCommand.cs
+++ b/src/Func.Cli/Commands/InitCommand.cs
@@ -38,6 +38,7 @@ public class InitCommand : BaseCommand
     public InitCommand(IInteractionService interaction)
         : base("init", "Initialize a new Azure Functions project.")
     {
+        ArgumentNullException.ThrowIfNull(interaction);
         _interaction = interaction;
 
         AddPathArgument();

--- a/src/Func.Cli/Commands/NewCommand.cs
+++ b/src/Func.Cli/Commands/NewCommand.cs
@@ -33,6 +33,7 @@ public class NewCommand : BaseCommand
     public NewCommand(IInteractionService interaction)
         : base("new", "Create a new function from a template.")
     {
+        ArgumentNullException.ThrowIfNull(interaction);
         _interaction = interaction;
 
         AddPathArgument();

--- a/src/Func.Cli/Commands/PackCommand.cs
+++ b/src/Func.Cli/Commands/PackCommand.cs
@@ -28,6 +28,7 @@ public class PackCommand : BaseCommand
     public PackCommand(IInteractionService interaction)
         : base("pack", "Package the function app into a zip ready for deployment.")
     {
+        ArgumentNullException.ThrowIfNull(interaction);
         _interaction = interaction;
 
         AddPathArgument();

--- a/src/Func.Cli/Commands/SpectreHelpAction.cs
+++ b/src/Func.Cli/Commands/SpectreHelpAction.cs
@@ -11,14 +11,9 @@ namespace Azure.Functions.Cli.Commands;
 /// so that --help, -h, and -? all render uniform Spectre-based output.
 /// Uses the HelpCommand's renderer to generate help from real Command metadata.
 /// </summary>
-internal sealed class SpectreHelpAction : SynchronousCommandLineAction
+internal sealed class SpectreHelpAction(HelpCommand helpCommand) : SynchronousCommandLineAction
 {
-    private readonly HelpCommand _helpCommand;
-
-    public SpectreHelpAction(HelpCommand helpCommand)
-    {
-        _helpCommand = helpCommand;
-    }
+    private readonly HelpCommand _helpCommand = helpCommand ?? throw new ArgumentNullException(nameof(helpCommand));
 
     public override int Invoke(ParseResult parseResult)
     {

--- a/src/Func.Cli/Commands/StartCommand.cs
+++ b/src/Func.Cli/Commands/StartCommand.cs
@@ -52,6 +52,7 @@ public class StartCommand : BaseCommand
     public StartCommand(IInteractionService interaction)
         : base("start", "Launch the Azure Functions host runtime.")
     {
+        ArgumentNullException.ThrowIfNull(interaction);
         _interaction = interaction;
 
         AddPathArgument();

--- a/src/Func.Cli/Commands/VersionCommand.cs
+++ b/src/Func.Cli/Commands/VersionCommand.cs
@@ -17,6 +17,7 @@ public class VersionCommand : BaseCommand
     public VersionCommand(IInteractionService interaction)
         : base("version", "Display the current Azure Functions CLI version.")
     {
+        ArgumentNullException.ThrowIfNull(interaction);
         Hidden = true;
         _interaction = interaction;
     }

--- a/src/Func.Cli/Console/SpectreInteractionService.cs
+++ b/src/Func.Cli/Console/SpectreInteractionService.cs
@@ -19,6 +19,7 @@ public class SpectreInteractionService : IInteractionService
 
     public SpectreInteractionService(ITheme theme, IAnsiConsole? stdout = null, IAnsiConsole? stderr = null)
     {
+        ArgumentNullException.ThrowIfNull(theme);
         _theme = theme;
         _stdout = stdout ?? AnsiConsole.Console;
         _stderr = stderr ?? AnsiConsole.Create(new AnsiConsoleSettings


### PR DESCRIPTION
Pass over class ctors in `src/Func.Cli` — add `ArgumentNullException.ThrowIfNull` guards on reference-type params so misuse fails fast at the construction boundary.

`SpectreHelpAction` converts to a primary ctor since its body becomes empty after the null check. The command ctors keep their bodies because they still attach options/arguments to the command tree.

Build green, 53/53 tests pass.