### PR TITLE
Add network isolation policy to public CI builds

### DIFF
--- a/eng/ci/abstractions-public-build.yml
+++ b/eng/ci/abstractions-public-build.yml
@@ -45,6 +45,7 @@ extends:
          runSourceLanguagesInSourceAnalysis: true
     settings:
       skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+      networkIsolationPolicy: Preferred, GitHub, NuGet
 
     stages:
       - stage: Build

--- a/eng/ci/cli-public-build.yml
+++ b/eng/ci/cli-public-build.yml
@@ -51,6 +51,7 @@ extends:
          runSourceLanguagesInSourceAnalysis: true
     settings:
       skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+      networkIsolationPolicy: Preferred, GitHub, NuGet
 
     stages:
       - stage: Test


### PR DESCRIPTION
Adds `networkIsolationPolicy: Preferred, GitHub, NuGet` under `extends.parameters.settings` for the CLI and Abstractions public CI build pipelines on `vnext`.

Files changed:
- `eng/ci/cli-public-build.yml`
- `eng/ci/abstractions-public-build.yml`