### PR TITLE
Add func start support for Go

### DIFF
--- a/eng/build/Minified.targets
+++ b/eng/build/Minified.targets
@@ -6,6 +6,7 @@
     <_LanguageWorkers Include="$(PublishDir)\workers\java" />
     <_LanguageWorkers Include="$(PublishDir)\workers\powershell" />
     <_LanguageWorkers Include="$(PublishDir)\workers\node" />
+    <_LanguageWorkers Include="$(PublishDir)\workers\native" />
   </ItemGroup>
 
   <!-- Remove worker directories from minified builds -->

--- a/eng/build/Workers.Golang.targets
+++ b/eng/build/Workers.Golang.targets
@@ -1,0 +1,15 @@
+<Project>
+
+  <!--
+    Ships the Go (native) worker config alongside the published CLI so the host
+    can discover the Go worker at workers/native/worker.config.json.
+  -->
+  <ItemGroup>
+    <Content Include="$(RepoRoot)src\Cli\func\StaticResources\nativeWorkerConfig.json">
+      <Link>workers\native\worker.config.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
+</Project>

--- a/src/Cli/func/Actions/HostActions/StartHostAction.cs
+++ b/src/Cli/func/Actions/HostActions/StartHostAction.cs
@@ -733,6 +733,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
 
         private async Task PreRunConditions()
         {
+            ResolveNativeWorkerRuntime();
             EnsureWorkerRuntimeIsSet();
 
             if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.Python)
@@ -893,6 +894,37 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 ? await SecurityHelpers.GetOrCreateCertificate(CertPath, CertPassword)
                 : null;
             return (new Uri($"{protocol}://0.0.0.0:{Port}"), new Uri($"{protocol}://localhost:{Port}"), cert);
+        }
+
+        internal void ResolveNativeWorkerRuntime()
+        {
+            // 'native' is the host's runtime identifier for any worker registered with
+            // language="native" (today: Go via workers/native/worker.config.json).
+            // Resolve it here by inspecting project markers; add new arms as additional native
+            // workers (e.g. Rust) are onboarded.
+            var setting = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime)
+                          ?? _secretsManager.GetSecrets().FirstOrDefault(s => s.Key.Equals(Constants.FunctionsWorkerRuntime, StringComparison.OrdinalIgnoreCase)).Value;
+
+            if (string.IsNullOrWhiteSpace(setting)
+                || !string.Equals(setting, "native", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            if (FileSystemHelpers.FileExists(Path.Combine(Environment.CurrentDirectory, "go.mod")))
+            {
+                if (VerboseLogging == true)
+                {
+                    ColoredConsole.WriteLine(VerboseColor("Resolving native worker runtime to 'go' (go.mod found)."));
+                }
+
+                GlobalCoreToolsSettings.CurrentWorkerRuntime = WorkerRuntime.Go;
+                return;
+            }
+
+            throw new CliException(
+                $"Could not determine the worker language for the project at '{Environment.CurrentDirectory}'. " +
+                "Run 'func init' to initialize a supported function app in this directory.");
         }
 
         private void EnsureWorkerRuntimeIsSet()

--- a/src/Cli/func/Actions/HostActions/StartHostAction.cs
+++ b/src/Cli/func/Actions/HostActions/StartHostAction.cs
@@ -750,6 +750,20 @@ namespace Azure.Functions.Cli.Actions.HostActions
             {
                 throw new CliException("Dotnet is required for PowerShell Functions. Please install dotnet (.NET Core SDK) for your system from https://www.microsoft.com/net/download");
             }
+            else if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.Go)
+            {
+                var goVersion = await GoHelpers.GetEnvironmentGoVersion();
+                GoHelpers.AssertGoVersion(goVersion);
+
+                if (NoBuild)
+                {
+                    GoHelpers.AssertBinaryExists();
+                }
+                else
+                {
+                    await GoHelpers.BuildProject();
+                }
+            }
 
             if (!NetworkHelpers.IsPortAvailable(Port))
             {

--- a/src/Cli/func/Directory.Build.targets
+++ b/src/Cli/func/Directory.Build.targets
@@ -6,6 +6,7 @@
   <Import Project="$(EngBuildRoot)Templates.targets" Condition="'$(SkipTemplates)' != 'true'" />
 
   <Import Project="$(EngBuildRoot)Workers.Powershell.targets" />
+  <Import Project="$(EngBuildRoot)Workers.Golang.targets" />
   <Import Project="$(EngBuildRoot)Workers.Python.Workaround.targets" Condition="'$(RuntimeIdentifier)' == 'win-arm64'" />
 
 </Project>

--- a/src/Cli/func/Helpers/GoHelpers.cs
+++ b/src/Cli/func/Helpers/GoHelpers.cs
@@ -9,11 +9,11 @@ using static Azure.Functions.Cli.Common.OutputTheme;
 
 namespace Azure.Functions.Cli.Helpers
 {
-    public static class GoHelpers
+    internal static class GoHelpers
     {
         private const int MinimumGoMajorVersion = 1;
         private const int MinimumGoMinorVersion = 24;
-        public const string GoBinaryName = "app";
+        private const string GoBinaryName = "app";
 
         public static async Task<WorkerLanguageVersionInfo> GetEnvironmentGoVersion()
         {
@@ -95,19 +95,13 @@ namespace Azure.Functions.Cli.Helpers
             ColoredConsole.WriteLine($"Building Go worker binary '{outputName}'...");
 
             var exe = new Executable("go", $"build -o \"{outputName}\" .", workingDirectory: workingDirectory);
-            var stderr = new StringBuilder();
             var exitCode = await exe.RunAsync(
                 l => ColoredConsole.WriteLine(l),
-                e =>
-                {
-                    stderr.AppendLine(e);
-                    ColoredConsole.Error.WriteLine(ErrorColor(e));
-                });
+                e => ColoredConsole.Error.WriteLine(ErrorColor(e)));
 
             if (exitCode != 0)
             {
-                var detail = stderr.Length == 0 ? string.Empty : $" {stderr.ToString().Trim()}";
-                throw new CliException($"Go build failed with exit code {exitCode}.{detail}");
+                throw new CliException($"Go build failed with exit code {exitCode}. See output above for details.");
             }
         }
 

--- a/src/Cli/func/Helpers/GoHelpers.cs
+++ b/src/Cli/func/Helpers/GoHelpers.cs
@@ -13,6 +13,7 @@ namespace Azure.Functions.Cli.Helpers
     {
         private const int MinimumGoMajorVersion = 1;
         private const int MinimumGoMinorVersion = 24;
+        public const string GoBinaryName = "app";
 
         public static async Task<WorkerLanguageVersionInfo> GetEnvironmentGoVersion()
         {
@@ -78,6 +79,54 @@ namespace Azure.Functions.Cli.Helpers
             else
             {
                 ColoredConsole.WriteLine(AdditionalInfoColor("Skipped \"go mod tidy\". You must run \"go mod tidy\" manually."));
+            }
+        }
+
+        /// <summary>
+        /// Compiles the user's Go project into a binary named <see cref="GoBinaryName"/>
+        /// in <paramref name="workingDirectory"/>. The host resolves this binary via
+        /// <c>defaultExecutablePath</c> in <c>workers/native/worker.config.json</c>
+        /// (the host appends <c>.exe</c> on Windows automatically).
+        /// </summary>
+        public static async Task BuildProject(string workingDirectory = null)
+        {
+            workingDirectory ??= Environment.CurrentDirectory;
+            var outputName = OperatingSystem.IsWindows() ? $"{GoBinaryName}.exe" : GoBinaryName;
+            ColoredConsole.WriteLine($"Building Go worker binary '{outputName}'...");
+
+            var exe = new Executable("go", $"build -o \"{outputName}\" .", workingDirectory: workingDirectory);
+            var stderr = new StringBuilder();
+            var exitCode = await exe.RunAsync(
+                l => ColoredConsole.WriteLine(l),
+                e =>
+                {
+                    stderr.AppendLine(e);
+                    ColoredConsole.Error.WriteLine(ErrorColor(e));
+                });
+
+            if (exitCode != 0)
+            {
+                var detail = stderr.Length == 0 ? string.Empty : $" {stderr.ToString().Trim()}";
+                throw new CliException($"Go build failed with exit code {exitCode}.{detail}");
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the compiled Go worker binary exists in
+        /// <paramref name="workingDirectory"/>. Throws a <see cref="CliException"/>
+        /// with an actionable message when missing — used by <c>func start --no-build</c>.
+        /// </summary>
+        public static void AssertBinaryExists(string workingDirectory = null)
+        {
+            workingDirectory ??= Environment.CurrentDirectory;
+            var binaryName = OperatingSystem.IsWindows() ? $"{GoBinaryName}.exe" : GoBinaryName;
+            var binaryPath = Path.Combine(workingDirectory, binaryName);
+
+            if (!FileSystemHelpers.FileExists(binaryPath))
+            {
+                throw new CliException(
+                    $"Could not find a built Go binary '{binaryName}' in '{workingDirectory}'. " +
+                    $"Run 'func start' without '--no-build' to compile, or run 'go build -o {binaryName} .' manually.");
             }
         }
 

--- a/src/Cli/func/Helpers/WorkerRuntimeLanguageHelper.cs
+++ b/src/Cli/func/Helpers/WorkerRuntimeLanguageHelper.cs
@@ -41,7 +41,7 @@ namespace Azure.Functions.Cli.Helpers
             { WorkerRuntime.Java, new string[] { } },
             { WorkerRuntime.Powershell, new[] { "pwsh" } },
             { WorkerRuntime.Custom, new string[] { } },
-            { WorkerRuntime.Go, new[] { "golang" } }
+            { WorkerRuntime.Go, new[] { "golang", "native" } }
         };
 
         private static readonly IDictionary<string, WorkerRuntime> _normalizeMap = _availableWorkersRuntime

--- a/src/Cli/func/Helpers/WorkerRuntimeLanguageHelper.cs
+++ b/src/Cli/func/Helpers/WorkerRuntimeLanguageHelper.cs
@@ -196,29 +196,6 @@ namespace Azure.Functions.Cli.Helpers
             var setting = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime)
                           ?? secretsManager.GetSecrets(refreshSecrets)?.FirstOrDefault(s => s.Key.Equals(Constants.FunctionsWorkerRuntime, StringComparison.OrdinalIgnoreCase)).Value;
 
-            // 'native' is the host's runtime identifier for any worker registered with
-            // language="native" (today: Go via workers/native/worker.config.json). It is not a
-            // language moniker and is intentionally not in _normalizeMap. Resolve it to a concrete
-            // worker runtime by inspecting project markers; add new arms here as additional native
-            // workers (e.g. Rust) are onboarded.
-            if (!string.IsNullOrWhiteSpace(setting)
-                && string.Equals(setting, "native", StringComparison.OrdinalIgnoreCase))
-            {
-                if (FileSystemHelpers.FileExists(Path.Combine(Environment.CurrentDirectory, "go.mod")))
-                {
-                    if (GlobalCoreToolsSettings.IsVerbose)
-                    {
-                        ColoredConsole.WriteLine(VerboseColor("Resolving native worker runtime to 'go' (go.mod found)."));
-                    }
-
-                    return WorkerRuntime.Go;
-                }
-
-                throw new CliException(
-                    $"Could not determine the worker language for the project at '{Environment.CurrentDirectory}'. " +
-                    "Run 'func init' to initialize a supported function app in this directory.");
-            }
-
             try
             {
                 WorkerRuntime workerRuntime = NormalizeWorkerRuntime(setting);

--- a/src/Cli/func/Helpers/WorkerRuntimeLanguageHelper.cs
+++ b/src/Cli/func/Helpers/WorkerRuntimeLanguageHelper.cs
@@ -41,7 +41,7 @@ namespace Azure.Functions.Cli.Helpers
             { WorkerRuntime.Java, new string[] { } },
             { WorkerRuntime.Powershell, new[] { "pwsh" } },
             { WorkerRuntime.Custom, new string[] { } },
-            { WorkerRuntime.Go, new[] { "golang", "native" } }
+            { WorkerRuntime.Go, new[] { "golang" } }
         };
 
         private static readonly IDictionary<string, WorkerRuntime> _normalizeMap = _availableWorkersRuntime
@@ -195,6 +195,29 @@ namespace Azure.Functions.Cli.Helpers
         {
             var setting = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime)
                           ?? secretsManager.GetSecrets(refreshSecrets)?.FirstOrDefault(s => s.Key.Equals(Constants.FunctionsWorkerRuntime, StringComparison.OrdinalIgnoreCase)).Value;
+
+            // 'native' is the host's runtime identifier for any worker registered with
+            // language="native" (today: Go via workers/native/worker.config.json). It is not a
+            // language moniker and is intentionally not in _normalizeMap. Resolve it to a concrete
+            // worker runtime by inspecting project markers; add new arms here as additional native
+            // workers (e.g. Rust) are onboarded.
+            if (!string.IsNullOrWhiteSpace(setting)
+                && string.Equals(setting, "native", StringComparison.OrdinalIgnoreCase))
+            {
+                if (FileSystemHelpers.FileExists(Path.Combine(Environment.CurrentDirectory, "go.mod")))
+                {
+                    if (GlobalCoreToolsSettings.IsVerbose)
+                    {
+                        ColoredConsole.WriteLine(VerboseColor("Resolving native worker runtime to 'go' (go.mod found)."));
+                    }
+
+                    return WorkerRuntime.Go;
+                }
+
+                throw new CliException(
+                    $"Could not determine the worker language for the project at '{Environment.CurrentDirectory}'. " +
+                    "Run 'func init' to initialize a supported function app in this directory.");
+            }
 
             try
             {

--- a/src/Cli/func/StaticResources/nativeWorkerConfig.json
+++ b/src/Cli/func/StaticResources/nativeWorkerConfig.json
@@ -1,0 +1,11 @@
+{
+    "description": {
+        "language": "native",
+        "defaultExecutablePath": "app",
+        "workerIndexing": "true"
+    },
+    "processOptions": {
+        "initializationTimeout": "00:02:00",
+        "environmentReloadTimeout": "00:02:00"
+    }
+}

--- a/test/Cli/Func.UnitTests/ActionsTests/StartHostActionTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/StartHostActionTests.cs
@@ -511,5 +511,98 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
                 Environment.SetEnvironmentVariable(pythonEnvVar, originalValue);
             }
         }
+
+        [Fact]
+        public void ResolveNativeWorkerRuntime_NativeWithGoMod_ResolvesToGo()
+        {
+            string envVar = Constants.FunctionsWorkerRuntime;
+            string original = Environment.GetEnvironmentVariable(envVar);
+            Environment.SetEnvironmentVariable(envVar, "native");
+
+            var fileSystem = Substitute.For<IFileSystem>();
+            fileSystem.File.Exists(Arg.Is<string>(p => p.EndsWith("go.mod"))).Returns(true);
+
+            var secretsManager = new Mock<ISecretsManager>();
+            secretsManager.Setup(s => s.GetSecrets()).Returns(new Dictionary<string, string>());
+
+            var previous = GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone;
+
+            try
+            {
+                using (FileSystemHelpers.Override(fileSystem))
+                {
+                    GlobalCoreToolsSettings.CurrentWorkerRuntime = WorkerRuntime.None;
+                    var action = new StartHostAction(secretsManager.Object, Mock.Of<IProcessManager>());
+
+                    action.ResolveNativeWorkerRuntime();
+
+                    GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone.Should().Be(WorkerRuntime.Go);
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(envVar, original);
+                GlobalCoreToolsSettings.CurrentWorkerRuntime = previous;
+            }
+        }
+
+        [Fact]
+        public void ResolveNativeWorkerRuntime_NativeWithoutGoMod_Throws()
+        {
+            string envVar = Constants.FunctionsWorkerRuntime;
+            string original = Environment.GetEnvironmentVariable(envVar);
+            Environment.SetEnvironmentVariable(envVar, "native");
+
+            var fileSystem = Substitute.For<IFileSystem>();
+            fileSystem.File.Exists(Arg.Any<string>()).Returns(false);
+
+            var secretsManager = new Mock<ISecretsManager>();
+            secretsManager.Setup(s => s.GetSecrets()).Returns(new Dictionary<string, string>());
+
+            try
+            {
+                using (FileSystemHelpers.Override(fileSystem))
+                {
+                    var action = new StartHostAction(secretsManager.Object, Mock.Of<IProcessManager>());
+
+                    Action act = () => action.ResolveNativeWorkerRuntime();
+
+                    act.Should().Throw<CliException>()
+                        .Which.Message.Should().Contain("Run 'func init'");
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(envVar, original);
+            }
+        }
+
+        [Fact]
+        public void ResolveNativeWorkerRuntime_NonNativeRuntime_NoOp()
+        {
+            string envVar = Constants.FunctionsWorkerRuntime;
+            string original = Environment.GetEnvironmentVariable(envVar);
+            Environment.SetEnvironmentVariable(envVar, "python");
+
+            var secretsManager = new Mock<ISecretsManager>();
+            secretsManager.Setup(s => s.GetSecrets()).Returns(new Dictionary<string, string>());
+
+            var previous = GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone;
+
+            try
+            {
+                GlobalCoreToolsSettings.CurrentWorkerRuntime = WorkerRuntime.Python;
+                var action = new StartHostAction(secretsManager.Object, Mock.Of<IProcessManager>());
+
+                action.ResolveNativeWorkerRuntime();
+
+                GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone.Should().Be(WorkerRuntime.Python);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(envVar, original);
+                GlobalCoreToolsSettings.CurrentWorkerRuntime = previous;
+            }
+        }
     }
 }

--- a/test/Cli/Func.UnitTests/HelperTests/GoHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/GoHelperTests.cs
@@ -97,8 +97,8 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
             try
             {
                 var binaryName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                    ? GoHelpers.GoBinaryName + ".exe"
-                    : GoHelpers.GoBinaryName;
+                    ? "app.exe"
+                    : "app";
                 File.WriteAllText(Path.Combine(dir, binaryName), "stub");
 
                 var action = () => GoHelpers.AssertBinaryExists(dir);
@@ -143,8 +143,8 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
                 await GoHelpers.BuildProject(dir);
 
                 var binaryName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                    ? GoHelpers.GoBinaryName + ".exe"
-                    : GoHelpers.GoBinaryName;
+                    ? "app.exe"
+                    : "app";
                 File.Exists(Path.Combine(dir, binaryName)).Should().BeTrue("BuildProject should produce the worker binary");
             }
             finally
@@ -154,7 +154,7 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
         }
 
         [SkipIfGoNonExistFact]
-        public async Task BuildProject_InvalidProject_ThrowsCliException()
+        public Task BuildProject_InvalidProject_ThrowsCliException()
         {
             var dir = Path.Combine(Path.GetTempPath(), "func-go-build-fail-" + Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(dir);
@@ -163,18 +163,10 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
                 File.WriteAllText(Path.Combine(dir, "go.mod"), "module example.com/test\n\ngo 1.24\n");
                 File.WriteAllText(Path.Combine(dir, "main.go"), "package main\n\nthis is not valid go\n");
 
-                CliException caught = null;
-                try
-                {
-                    await GoHelpers.BuildProject(dir);
-                }
-                catch (CliException ex)
-                {
-                    caught = ex;
-                }
-
-                caught.Should().NotBeNull("BuildProject should throw when go build fails");
-                caught.Message.Should().Contain("Go build failed");
+                Func<Task> act = () => GoHelpers.BuildProject(dir);
+                act.Should().Throw<CliException>("BuildProject should throw when go build fails")
+                    .Which.Message.Should().Contain("Go build failed");
+                return Task.CompletedTask;
             }
             finally
             {

--- a/test/Cli/Func.UnitTests/HelperTests/GoHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/GoHelperTests.cs
@@ -154,7 +154,7 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
         }
 
         [SkipIfGoNonExistFact]
-        public Task BuildProject_InvalidProject_ThrowsCliException()
+        public async Task BuildProject_InvalidProject_ThrowsCliException()
         {
             var dir = Path.Combine(Path.GetTempPath(), "func-go-build-fail-" + Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(dir);
@@ -164,9 +164,8 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
                 File.WriteAllText(Path.Combine(dir, "main.go"), "package main\n\nthis is not valid go\n");
 
                 Func<Task> act = () => GoHelpers.BuildProject(dir);
-                act.Should().Throw<CliException>("BuildProject should throw when go build fails")
-                    .Which.Message.Should().Contain("Go build failed");
-                return Task.CompletedTask;
+                var ex = await Assert.ThrowsAsync<CliException>(act);
+                ex.Message.Should().Contain("Go build failed");
             }
             finally
             {

--- a/test/Cli/Func.UnitTests/HelperTests/GoHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/GoHelperTests.cs
@@ -88,6 +88,99 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
 
             GoHelpers.AssertGoVersion(worker);
         }
+
+        [Fact]
+        public void AssertBinaryExists_BinaryPresent_DoesNotThrow()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "func-go-test-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                var binaryName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    ? GoHelpers.GoBinaryName + ".exe"
+                    : GoHelpers.GoBinaryName;
+                File.WriteAllText(Path.Combine(dir, binaryName), "stub");
+
+                var action = () => GoHelpers.AssertBinaryExists(dir);
+                action.Should().NotThrow();
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void AssertBinaryExists_BinaryMissing_ThrowsActionableCliException()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "func-go-test-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                var action = () => GoHelpers.AssertBinaryExists(dir);
+
+                action.Should().Throw<CliException>()
+                    .Which.Message.Should().Contain("Could not find a built Go binary")
+                                  .And.Contain("--no-build")
+                                  .And.Contain("go build");
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [SkipIfGoNonExistFact]
+        public async Task BuildProject_ValidProject_ProducesBinary()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "func-go-build-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                File.WriteAllText(Path.Combine(dir, "go.mod"), "module example.com/test\n\ngo 1.24\n");
+                File.WriteAllText(Path.Combine(dir, "main.go"), "package main\n\nfunc main() {}\n");
+
+                await GoHelpers.BuildProject(dir);
+
+                var binaryName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    ? GoHelpers.GoBinaryName + ".exe"
+                    : GoHelpers.GoBinaryName;
+                File.Exists(Path.Combine(dir, binaryName)).Should().BeTrue("BuildProject should produce the worker binary");
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [SkipIfGoNonExistFact]
+        public async Task BuildProject_InvalidProject_ThrowsCliException()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "func-go-build-fail-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                File.WriteAllText(Path.Combine(dir, "go.mod"), "module example.com/test\n\ngo 1.24\n");
+                File.WriteAllText(Path.Combine(dir, "main.go"), "package main\n\nthis is not valid go\n");
+
+                CliException caught = null;
+                try
+                {
+                    await GoHelpers.BuildProject(dir);
+                }
+                catch (CliException ex)
+                {
+                    caught = ex;
+                }
+
+                caught.Should().NotBeNull("BuildProject should throw when go build fails");
+                caught.Message.Should().Contain("Go build failed");
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
     }
 
     public sealed class SkipIfGoNonExistFact : FactAttribute


### PR DESCRIPTION
Implements func start for the Go worker runtime. Builds the user's Go project and launches the Functions host with the Go worker registered under the native runtime identifier

**Build & Launch Flow**
- src/Cli/func/Helpers/GoHelpers.cs:
  - BuildProject() runs go build -o app[.exe] . and surfaces stderr / non-zero exits as CliException
  - AssertBinaryExists() validates the compiled binary for the --no-build path with an actionable error
 - src/Cli/func/Actions/HostActions/StartHostAction.cs: PreRunConditions adds a Go branch — version check, then BuildProject() or AssertBinaryExists() based on --no-build
 - src/Cli/func/Helpers/WorkerRuntimeLanguageHelper.cs: maps FUNCTIONS_WORKER_RUNTIME=native → WorkerRuntime.Go so the host's runtime identifier resolves correctly inside
 the CLI

**How it works**
 1. func start resolves runtime via FUNCTIONS_WORKER_RUNTIME=native (written by func init)
 2. CLI verifies Go ≥
  1.24, then builds app (or app.exe on Windows)
 3. Host loads workers/native/worker.config.json and launches the binary