### PR TITLE
Add workload loader

### DIFF
--- a/Azure.Functions.Cli.sln
+++ b/Azure.Functions.Cli.sln
@@ -13,7 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Func.Cli.Tests", "test\Func
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Func.Cli.Abstractions", "src\Func.Cli.Abstractions\Func.Cli.Abstractions.csproj", "{9EDC7E42-3409-4B59-9F83-BDC40E779706}"
 EndProject
-
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Func.Cli.Tests.Fixtures.Workload", "test\Func.Cli.Tests.Fixtures.Workload\Func.Cli.Tests.Fixtures.Workload.csproj", "{D9F302C2-5F6C-4658-96A2-49E6D505E377}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -60,6 +61,18 @@ Global
 		{9EDC7E42-3409-4B59-9F83-BDC40E779706}.Release|x64.Build.0 = Release|Any CPU
 		{9EDC7E42-3409-4B59-9F83-BDC40E779706}.Release|x86.ActiveCfg = Release|Any CPU
 		{9EDC7E42-3409-4B59-9F83-BDC40E779706}.Release|x86.Build.0 = Release|Any CPU
+		{D9F302C2-5F6C-4658-96A2-49E6D505E377}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9F302C2-5F6C-4658-96A2-49E6D505E377}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9F302C2-5F6C-4658-96A2-49E6D505E377}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D9F302C2-5F6C-4658-96A2-49E6D505E377}.Debug|x64.Build.0 = Debug|Any CPU
+		{D9F302C2-5F6C-4658-96A2-49E6D505E377}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D9F302C2-5F6C-4658-96A2-49E6D505E377}.Debug|x86.Build.0 = Debug|Any CPU
+		{D9F302C2-5F6C-4658-96A2-49E6D505E377}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D9F302C2-5F6C-4658-96A2-49E6D505E377}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D9F302C2-5F6C-4658-96A2-49E6D505E377}.Release|x64.ActiveCfg = Release|Any CPU
+		{D9F302C2-5F6C-4658-96A2-49E6D505E377}.Release|x64.Build.0 = Release|Any CPU
+		{D9F302C2-5F6C-4658-96A2-49E6D505E377}.Release|x86.ActiveCfg = Release|Any CPU
+		{D9F302C2-5F6C-4658-96A2-49E6D505E377}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -68,6 +81,7 @@ Global
 		{AC5C7EDC-91EF-4F9F-B3D2-9889CE5905D5} = {5F51C958-39C0-4E0C-9165-71D0BCE647BC}
 		{FD96A3E2-4880-4F54-A11F-951C7FC62EE7} = {342A349A-D343-8551-4064-2E2800C39E13}
 		{9EDC7E42-3409-4B59-9F83-BDC40E779706} = {5F51C958-39C0-4E0C-9165-71D0BCE647BC}
+		{D9F302C2-5F6C-4658-96A2-49E6D505E377} = {342A349A-D343-8551-4064-2E2800C39E13}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FA1E01D6-A57B-4061-A333-EDC511D283C0}

--- a/src/Func.Cli/Workloads/Loading/LoadedWorkload.cs
+++ b/src/Func.Cli/Workloads/Loading/LoadedWorkload.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workloads.Loading;
+
+/// <summary>
+/// A workload that has been hydrated from the global manifest and is
+/// ready to participate in DI. Pairs the runtime <see cref="IWorkload"/>
+/// instance with its manifest-sourced display info.
+/// </summary>
+/// <param name="Instance">The workload's runtime instance.</param>
+/// <param name="Info">CLI-side metadata sourced from the global manifest.</param>
+internal sealed record LoadedWorkload(IWorkload Instance, WorkloadInfo Info);

--- a/src/Func.Cli/Workloads/Loading/WorkloadLoadContext.cs
+++ b/src/Func.Cli/Workloads/Loading/WorkloadLoadContext.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace Azure.Functions.Cli.Workloads.Loading;
+
+/// <summary>
+/// Per-workload <see cref="AssemblyLoadContext"/>. Each installed workload
+/// gets its own so dependency versions don't collide across workloads.
+/// Assemblies shared with the host (e.g. <c>Azure.Functions.Cli.Abstractions</c>)
+/// are delegated back to the default context so type identity is preserved
+/// across the boundary — without this, a cast to <see cref="IWorkload"/>
+/// would fail because the host and the workload would see two different
+/// <c>IWorkload</c> types.
+/// </summary>
+internal sealed class WorkloadLoadContext : AssemblyLoadContext
+{
+    private readonly AssemblyDependencyResolver _resolver;
+
+    public WorkloadLoadContext(string assemblyPath)
+        : base(name: Path.GetFileNameWithoutExtension(assemblyPath), isCollectible: false)
+    {
+        _resolver = new AssemblyDependencyResolver(assemblyPath);
+    }
+
+    protected override Assembly? Load(AssemblyName assemblyName)
+    {
+        // Anything the host has already loaded (Abstractions, BCL, etc.) must come from
+        // the default context to keep type identity consistent.
+        if (Default.Assemblies.Any(a => a.GetName().Name == assemblyName.Name))
+        {
+            return null;
+        }
+
+        var resolved = _resolver.ResolveAssemblyToPath(assemblyName);
+        return resolved is null ? null : LoadFromAssemblyPath(resolved);
+    }
+}

--- a/src/Func.Cli/Workloads/Loading/WorkloadLoader.cs
+++ b/src/Func.Cli/Workloads/Loading/WorkloadLoader.cs
@@ -1,0 +1,67 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Workloads.Storage;
+
+namespace Azure.Functions.Cli.Workloads.Loading;
+
+/// <summary>
+/// Hydrates installed workloads from the global manifest into runnable
+/// <see cref="LoadedWorkload"/> instances. Each workload is loaded into
+/// its own <see cref="System.Runtime.Loader.AssemblyLoadContext"/> so
+/// dependency versions don't collide across workloads.
+/// </summary>
+internal sealed class WorkloadLoader
+{
+    public Task<IReadOnlyList<LoadedWorkload>> LoadInstalledAsync(
+        GlobalManifest manifest,
+        CancellationToken cancellationToken)
+    {
+        var results = new List<LoadedWorkload>(manifest.Workloads.Count);
+        foreach (var entry in manifest.Workloads)
+        {
+            results.Add(LoadEntry(entry));
+        }
+
+        return Task.FromResult<IReadOnlyList<LoadedWorkload>>(results);
+    }
+
+    private static LoadedWorkload LoadEntry(GlobalManifestEntry entry)
+    {
+        var assemblyPath = Path.Combine(entry.InstallPath, entry.EntryPoint.Assembly);
+        if (!File.Exists(assemblyPath))
+        {
+            throw new GracefulException(
+                $"Workload '{entry.PackageId}' could not be loaded: assembly '{entry.EntryPoint.Assembly}' was not found at '{entry.InstallPath}'.",
+                isUserError: true);
+        }
+
+        var assembly = new WorkloadLoadContext(assemblyPath).LoadFromAssemblyPath(assemblyPath);
+        var type = assembly.GetType(entry.EntryPoint.Type, throwOnError: false);
+        if (type is null)
+        {
+            throw new GracefulException(
+                $"Workload '{entry.PackageId}' could not be loaded: type '{entry.EntryPoint.Type}' was not found in '{entry.EntryPoint.Assembly}'.",
+                isUserError: true);
+        }
+
+        if (!typeof(IWorkload).IsAssignableFrom(type))
+        {
+            throw new GracefulException(
+                $"Workload '{entry.PackageId}' could not be loaded: type '{entry.EntryPoint.Type}' does not implement {nameof(IWorkload)}.",
+                isUserError: true);
+        }
+
+        var instance = (IWorkload)Activator.CreateInstance(type)!;
+
+        var info = new WorkloadInfo(
+            PackageId: entry.PackageId,
+            PackageVersion: entry.Version,
+            DisplayName: entry.DisplayName,
+            Description: entry.Description,
+            Aliases: entry.Aliases);
+
+        return new LoadedWorkload(instance, info);
+    }
+}

--- a/test/Func.Cli.Tests.Fixtures.Workload/Func.Cli.Tests.Fixtures.Workload.csproj
+++ b/test/Func.Cli.Tests.Fixtures.Workload/Func.Cli.Tests.Fixtures.Workload.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Azure.Functions.Cli.Tests.Fixtures.Workload</RootNamespace>
+    <AssemblyName>Azure.Functions.Cli.Tests.Fixtures.Workload</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Func.Cli.Abstractions\Func.Cli.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Func.Cli.Tests.Fixtures.Workload/NotAWorkload.cs
+++ b/test/Func.Cli.Tests.Fixtures.Workload/NotAWorkload.cs
@@ -1,0 +1,8 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Tests.Fixtures.Workload;
+
+public sealed class NotAWorkload
+{
+}

--- a/test/Func.Cli.Tests.Fixtures.Workload/StubWorkload.cs
+++ b/test/Func.Cli.Tests.Fixtures.Workload/StubWorkload.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads;
+
+namespace Azure.Functions.Cli.Tests.Fixtures.Workload;
+
+public sealed class StubWorkload : IWorkload
+{
+    public string PackageId => "Azure.Functions.Cli.Tests.Fixtures.Workload";
+
+    public string PackageVersion => "1.0.0";
+
+    public string DisplayName => "Stub";
+
+    public string Description => "Test fixture workload.";
+
+    public void Configure(FunctionsCliBuilder builder)
+    {
+    }
+}

--- a/test/Func.Cli.Tests/Func.Cli.Tests.csproj
+++ b/test/Func.Cli.Tests/Func.Cli.Tests.csproj
@@ -21,6 +21,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Func.Cli\Func.Cli.csproj" />
+    <ProjectReference Include="..\Func.Cli.Tests.Fixtures.Workload\Func.Cli.Tests.Fixtures.Workload.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </ProjectReference>
   </ItemGroup>
 
 </Project>

--- a/test/Func.Cli.Tests/Workloads/Loading/WorkloadLoaderTests.cs
+++ b/test/Func.Cli.Tests/Workloads/Loading/WorkloadLoaderTests.cs
@@ -1,0 +1,147 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Workloads;
+using Azure.Functions.Cli.Workloads.Loading;
+using Azure.Functions.Cli.Workloads.Storage;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Workloads.Loading;
+
+public class WorkloadLoaderTests
+{
+    private const string FixtureAssemblyFile = "Azure.Functions.Cli.Tests.Fixtures.Workload.dll";
+    private const string FixtureTypeName = "Azure.Functions.Cli.Tests.Fixtures.Workload.StubWorkload";
+
+    [Fact]
+    public async Task LoadInstalledAsync_ReturnsEmpty_WhenManifestIsEmpty()
+    {
+        var loader = new WorkloadLoader();
+
+        var loaded = await loader.LoadInstalledAsync(new GlobalManifest(), CancellationToken.None);
+
+        Assert.Empty(loaded);
+    }
+
+    [Fact]
+    public async Task LoadInstalledAsync_HydratesEntry_FromAssemblyOnDisk()
+    {
+        var manifest = ManifestForFixture();
+        var loader = new WorkloadLoader();
+
+        var loaded = await loader.LoadInstalledAsync(manifest, CancellationToken.None);
+
+        var item = Assert.Single(loaded);
+        Assert.Equal(FixtureTypeName, item.Instance.GetType().FullName);
+        Assert.Equal("Azure.Functions.Cli.Tests.Fixtures.Workload", item.Info.PackageId);
+    }
+
+    [Fact]
+    public async Task LoadInstalledAsync_Throws_WhenAssemblyFileMissing()
+    {
+        var manifest = ManifestForFixture(assemblyFileOverride: "DoesNotExist.dll");
+        var loader = new WorkloadLoader();
+
+        var ex = await Assert.ThrowsAsync<GracefulException>(
+            () => loader.LoadInstalledAsync(manifest, CancellationToken.None));
+
+        Assert.True(ex.IsUserError);
+        Assert.Contains("Azure.Functions.Cli.Tests.Fixtures.Workload", ex.Message);
+        Assert.Contains("DoesNotExist.dll", ex.Message);
+    }
+
+    [Fact]
+    public async Task LoadInstalledAsync_Throws_WhenTypeNotFoundInAssembly()
+    {
+        var manifest = ManifestForFixture(typeNameOverride: "Some.Missing.Type");
+        var loader = new WorkloadLoader();
+
+        var ex = await Assert.ThrowsAsync<GracefulException>(
+            () => loader.LoadInstalledAsync(manifest, CancellationToken.None));
+
+        Assert.True(ex.IsUserError);
+        Assert.Contains("Azure.Functions.Cli.Tests.Fixtures.Workload", ex.Message);
+        Assert.Contains("Some.Missing.Type", ex.Message);
+    }
+
+    [Fact]
+    public async Task LoadInstalledAsync_Throws_WhenTypeDoesNotImplementIWorkload()
+    {
+        var manifest = ManifestForFixture(
+            typeNameOverride: "Azure.Functions.Cli.Tests.Fixtures.Workload.NotAWorkload");
+        var loader = new WorkloadLoader();
+
+        var ex = await Assert.ThrowsAsync<GracefulException>(
+            () => loader.LoadInstalledAsync(manifest, CancellationToken.None));
+
+        Assert.True(ex.IsUserError);
+        Assert.Contains("NotAWorkload", ex.Message);
+        Assert.Contains(nameof(IWorkload), ex.Message);
+    }
+
+    [Fact]
+    public async Task LoadInstalledAsync_LoadsEachWorkloadInOwnAssemblyLoadContext()
+    {
+        var dir = AppContext.BaseDirectory;
+        var manifest = new GlobalManifest
+        {
+            Workloads =
+            {
+                FixtureEntry(packageId: "fixture-a", dir),
+                FixtureEntry(packageId: "fixture-b", dir),
+            },
+        };
+        var loader = new WorkloadLoader();
+
+        var loaded = await loader.LoadInstalledAsync(manifest, CancellationToken.None);
+
+        Assert.Equal(2, loaded.Count);
+        var ctxA = System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(loaded[0].Instance.GetType().Assembly);
+        var ctxB = System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(loaded[1].Instance.GetType().Assembly);
+        Assert.NotNull(ctxA);
+        Assert.NotNull(ctxB);
+        Assert.NotSame(ctxA, ctxB);
+        Assert.NotSame(System.Runtime.Loader.AssemblyLoadContext.Default, ctxA);
+    }
+
+    private static GlobalManifestEntry FixtureEntry(string packageId, string dir) => new()
+    {
+        PackageId = packageId,
+        DisplayName = packageId,
+        Description = string.Empty,
+        Version = "1.0.0",
+        InstallPath = dir,
+        EntryPoint = new EntryPointSpec
+        {
+            Assembly = FixtureAssemblyFile,
+            Type = FixtureTypeName,
+        },
+    };
+
+    private static GlobalManifest ManifestForFixture(
+        string? assemblyFileOverride = null,
+        string? typeNameOverride = null)
+    {
+        var dir = AppContext.BaseDirectory;
+        return new GlobalManifest
+        {
+            Workloads =
+            {
+                new GlobalManifestEntry
+                {
+                    PackageId = "Azure.Functions.Cli.Tests.Fixtures.Workload",
+                    DisplayName = "Stub",
+                    Description = string.Empty,
+                    Version = "1.0.0",
+                    InstallPath = dir,
+                    EntryPoint = new EntryPointSpec
+                    {
+                        Assembly = assemblyFileOverride ?? FixtureAssemblyFile,
+                        Type = typeNameOverride ?? FixtureTypeName,
+                    },
+                },
+            },
+        };
+    }
+}


### PR DESCRIPTION
Closes #4897

Stacked on #4893. Second in the workload install/loader stack.

**Adds**
- `WorkloadLoader.LoadInstalledAsync(GlobalManifest, CancellationToken)` — pure: manifest in, `IReadOnlyList<LoadedWorkload>` out (instance + display info). DI registration is a separate concern handled by callers.
- `WorkloadLoadContext` — per-workload `AssemblyLoadContext` so dep versions don't collide between workloads. Delegates host-shared assemblies (`Azure.Functions.Cli.Abstractions`, BCL) back to the default context to preserve type identity for the cast to `IWorkload`.
- `LoadedWorkload` record.

**Validation** (each throws `GracefulException` naming the workload):
- assembly file missing
- type missing in assembly
- type doesn't implement `IWorkload`

**Test infrastructure**: new `Func.Cli.Tests.Fixtures.Workload` project provides a real `StubWorkload` and `NotAWorkload` for the loader to exercise on disk. Built via `ReferenceOutputAssembly=false` ProjectReference so the test project doesn't link it directly.

**Excluded** (next PRs)
- Install commands (`func workload install/uninstall/list`) — PR-C
- DI registration of loaded workloads' contributions
- Probing for the entry point (install-time)

**TDD**: 6 vertical slices (red→green per cycle). 67/67 total.