### PR TITLE
Refactor command options/arguments to instance members

### DIFF
--- a/docs/adding-a-command.md
+++ b/docs/adding-a-command.md
@@ -31,21 +31,21 @@ using Azure.Functions.Cli.Console;
 
 namespace Azure.Functions.Cli.Commands;
 
-public class DeployCommand : BaseCommand
+internal class DeployCommand : BaseCommand
 {
-    private readonly IInteractionService _interaction;
-
-    // Define options as static readonly fields
-    public static readonly Option<string> AppNameOption = new("--app-name", "-a")
+    // Define options as instance properties
+    public Option<string> AppNameOption { get; } = new("--app-name", "-a")
     {
         Description = "The Azure Functions app name to deploy to",
         Required = true
     };
 
-    public static readonly Option<bool> DryRunOption = new("--dry-run")
+    public Option<bool> DryRunOption { get; } = new("--dry-run")
     {
         Description = "Preview the deployment without making changes"
     };
+
+    private readonly IInteractionService _interaction;
 
     public DeployCommand(IInteractionService interaction)
         : base("deploy", "Deploy the function app to Azure")
@@ -92,7 +92,7 @@ public class DeployCommand : BaseCommand
 ### Key Conventions
 
 - **Constructor injection**: Take `IInteractionService` (and `IWorkloadManager` if needed)
-- **Static option fields**: Options are `static readonly` so tests and other code can reference them
+- **Instance option properties**: Options are `public Option<T> XOption { get; } = new(...)` — instance, not static. Tests and other code reach them through the resolved command instance (DI). Avoid `static readonly` so each command instance owns its own options and parallel test runs cannot share mutable parser state.
 - **`SetAction`**: Wire handler in the constructor, not via override
 - **`ApplyPath`**: Call this first if you added `AddPathArgument()`
 - **Never use `Console.Write*`**: Always go through `IInteractionService`
@@ -102,14 +102,14 @@ public class DeployCommand : BaseCommand
 
 ```csharp
 // Options: named, optional by default
-public static readonly Option<string> NameOption = new("--name", "-n")
+public Option<string> NameOption { get; } = new("--name", "-n")
 {
     Description = "The resource name",
     Required = true  // make it required
 };
 
 // Options with defaults
-public static readonly Option<int> TimeoutOption = new("--timeout")
+public Option<int> TimeoutOption { get; } = new("--timeout")
 {
     Description = "Timeout in seconds",
     DefaultValueFactory = _ => 30

--- a/docs/building-a-workload.md
+++ b/docs/building-a-workload.md
@@ -148,7 +148,7 @@ internal sealed class NodeProjectInitializer : IProjectInitializer
 
     // Workload-specific options. Attached to `func init` during command construction
     // and visible in --help. Read back inside InitializeAsync via the ParseResult.
-    public static readonly Option<string> PackageManagerOption = new("--package-manager")
+    public Option<string> PackageManagerOption { get; } = new("--package-manager")
     {
         Description = "The package manager to use (npm, yarn, pnpm)",
         DefaultValueFactory = _ => "npm"

--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -93,17 +93,17 @@ Provides shared infrastructure:
 
 ### Option/Argument Conventions
 
-Options and arguments are defined as `static readonly` fields on the command class:
+Options and arguments are defined as instance properties on the command class so each resolved command owns its own option instances (no shared mutable parser state across tests):
 
 ```csharp
 // Option with short alias and default value
-public static readonly Option<string> NameOption = new("--name", "-n")
+public Option<string> NameOption { get; } = new("--name", "-n")
 {
     Description = "The name of the function app project"
 };
 
 // Option with default value factory
-public static readonly Option<string> FrameworkOption = new("--target-framework")
+public Option<string> FrameworkOption { get; } = new("--target-framework")
 {
     Description = "The target framework (default: net10.0)",
     DefaultValueFactory = _ => "net10.0"

--- a/src/Func.Cli/Commands/BaseCommand.cs
+++ b/src/Func.Cli/Commands/BaseCommand.cs
@@ -18,23 +18,10 @@ namespace Azure.Functions.Cli.Commands;
 internal abstract class BaseCommand : Command
 {
     /// <summary>
-    /// Shared path argument definition for commands that need project directory support.
+    /// Path argument for commands that operate on a project directory. Created
+    /// per command instance so each command owns its own argument graph.
     /// </summary>
-    protected static readonly Argument<string?> PathArgument = new("path")
-    {
-        Description = "The project directory to use (defaults to current directory)",
-        Arity = ArgumentArity.ZeroOrOne,
-        CustomParser = result =>
-        {
-            var token = result.Tokens.Count > 0 ? result.Tokens[0].Value : null;
-            if (token is not null && token.StartsWith('-'))
-            {
-                result.AddError($"Unrecognized option '{token}'.");
-                return null;
-            }
-            return token;
-        }
-    };
+    protected Argument<string?>? PathArgument { get; private set; }
 
     protected BaseCommand(string name, string description) : base(name, description)
     {
@@ -55,6 +42,21 @@ internal abstract class BaseCommand : Command
     /// </summary>
     protected void AddPathArgument()
     {
+        PathArgument = new("path")
+        {
+            Description = "The project directory to use (defaults to current directory)",
+            Arity = ArgumentArity.ZeroOrOne,
+            CustomParser = result =>
+            {
+                var token = result.Tokens.Count > 0 ? result.Tokens[0].Value : null;
+                if (token is not null && token.StartsWith('-'))
+                {
+                    result.AddError($"Unrecognized option '{token}'.");
+                    return null;
+                }
+                return token;
+            }
+        };
         Arguments.Add(PathArgument);
     }
 
@@ -64,8 +66,13 @@ internal abstract class BaseCommand : Command
     /// When <paramref name="createIfNotExists"/> is true, the directory is created
     /// if it does not exist (useful for init/new).
     /// </summary>
-    protected static void ApplyPath(ParseResult parseResult, bool createIfNotExists = false)
+    protected void ApplyPath(ParseResult parseResult, bool createIfNotExists = false)
     {
+        if (PathArgument is null)
+        {
+            return;
+        }
+
         var path = parseResult.GetValue(PathArgument);
         if (string.IsNullOrEmpty(path))
         {

--- a/src/Func.Cli/Commands/FuncRootCommand.cs
+++ b/src/Func.Cli/Commands/FuncRootCommand.cs
@@ -11,7 +11,7 @@ namespace Azure.Functions.Cli.Commands;
 /// </summary>
 internal class FuncRootCommand : RootCommand
 {
-    public static readonly Option<bool> VerboseOption = new("--verbose", "-v")
+    public Option<bool> VerboseOption { get; } = new("--verbose", "-v")
     {
         Description = "Enable verbose output",
         Recursive = true

--- a/src/Func.Cli/Commands/HelpCommand.cs
+++ b/src/Func.Cli/Commands/HelpCommand.cs
@@ -13,7 +13,7 @@ namespace Azure.Functions.Cli.Commands;
 /// </summary>
 internal class HelpCommand : BaseCommand
 {
-    public static readonly Argument<string?> CommandArgument = new("command")
+    public Argument<string?> CommandArgument { get; } = new("command")
     {
         Description = "The command to get help for.",
         Arity = ArgumentArity.ZeroOrOne
@@ -21,15 +21,18 @@ internal class HelpCommand : BaseCommand
 
     private readonly IInteractionService _interaction;
     private readonly FuncRootCommand _rootCommand;
+    private readonly VersionCommand _versionCommand;
 
-    public HelpCommand(IInteractionService interaction, FuncRootCommand rootCommand)
+    public HelpCommand(IInteractionService interaction, FuncRootCommand rootCommand, VersionCommand versionCommand)
         : base("help", "Show help information for Azure Functions CLI.")
     {
         ArgumentNullException.ThrowIfNull(interaction);
         ArgumentNullException.ThrowIfNull(rootCommand);
+        ArgumentNullException.ThrowIfNull(versionCommand);
         Hidden = true;
         _interaction = interaction;
         _rootCommand = rootCommand;
+        _versionCommand = versionCommand;
         Arguments.Add(CommandArgument);
     }
 
@@ -45,7 +48,7 @@ internal class HelpCommand : BaseCommand
     /// <summary>Shows top-level help: product banner, command list, global options.</summary>
     internal int ShowGeneralHelp()
     {
-        var version = VersionCommand.GetVersion();
+        var version = _versionCommand.GetVersion();
 
         _interaction.WriteBlankLine();
         _interaction.WriteLine(l => l
@@ -200,7 +203,7 @@ internal class HelpCommand : BaseCommand
         });
     }
 
-    private static string FormatOptionName(Option option)
+    private string FormatOptionName(Option option)
     {
         var names = new List<string> { option.Name };
         names.AddRange(option.Aliases.Where(a => a != option.Name));

--- a/src/Func.Cli/Commands/InitCommand.cs
+++ b/src/Func.Cli/Commands/InitCommand.cs
@@ -16,22 +16,22 @@ namespace Azure.Functions.Cli.Commands;
 /// </summary>
 internal class InitCommand : BaseCommand, IBuiltInCommand
 {
-    public static readonly Option<string?> StackOption = new("--stack", "-s")
+    public Option<string?> StackOption { get; } = new("--stack", "-s")
     {
         Description = "The stack to use. Run `func workload list` to see what's installed."
     };
 
-    public static readonly Option<string?> NameOption = new("--name", "-n")
+    public Option<string?> NameOption { get; } = new("--name", "-n")
     {
         Description = "The name of the function app project"
     };
 
-    public static readonly Option<string?> LanguageOption = new("--language", "-l")
+    public Option<string?> LanguageOption { get; } = new("--language", "-l")
     {
         Description = "The programming language (e.g., C#, F#, JavaScript, TypeScript, Python)"
     };
 
-    public static readonly Option<bool> ForceOption = new("--force")
+    public Option<bool> ForceOption { get; } = new("--force")
     {
         Description = "Force initialization even if the folder is not empty"
     };

--- a/src/Func.Cli/Commands/NewCommand.cs
+++ b/src/Func.Cli/Commands/NewCommand.cs
@@ -13,17 +13,17 @@ namespace Azure.Functions.Cli.Commands;
 /// </summary>
 internal class NewCommand : BaseCommand, IBuiltInCommand
 {
-    public static readonly Option<string?> NameOption = new("--name", "-n")
+    public Option<string?> NameOption { get; } = new("--name", "-n")
     {
         Description = "The name of the function"
     };
 
-    public static readonly Option<string?> TemplateOption = new("--template", "-t")
+    public Option<string?> TemplateOption { get; } = new("--template", "-t")
     {
         Description = "The function template name"
     };
 
-    public static readonly Option<bool> ForceOption = new("--force")
+    public Option<bool> ForceOption { get; } = new("--force")
     {
         Description = "Overwrite existing files"
     };

--- a/src/Func.Cli/Commands/StartCommand.cs
+++ b/src/Func.Cli/Commands/StartCommand.cs
@@ -12,38 +12,38 @@ namespace Azure.Functions.Cli.Commands;
 /// </summary>
 internal class StartCommand : BaseCommand, IBuiltInCommand
 {
-    public static readonly Option<int?> PortOption = new("--port", "-p")
+    public Option<int?> PortOption { get; } = new("--port", "-p")
     {
         Description = "The port to listen on (default: 7071)"
     };
 
-    public static readonly Option<string?> CorsOption = new("--cors")
+    public Option<string?> CorsOption { get; } = new("--cors")
     {
         Description = "A comma-separated list of CORS origins"
     };
 
-    public static readonly Option<bool> CorsCredentialsOption = new("--cors-credentials")
+    public Option<bool> CorsCredentialsOption { get; } = new("--cors-credentials")
     {
         Description = "Allow cross-origin authenticated requests"
     };
 
-    public static readonly Option<string[]?> FunctionsOption = new("--functions")
+    public Option<string[]?> FunctionsOption { get; } = new("--functions")
     {
         Description = "A space-separated list of functions to load",
         Arity = ArgumentArity.ZeroOrMore
     };
 
-    public static readonly Option<bool> NoBuildOption = new("--no-build")
+    public Option<bool> NoBuildOption { get; } = new("--no-build")
     {
         Description = "Do not build the project before running"
     };
 
-    public static readonly Option<bool> EnableAuthOption = new("--enable-auth")
+    public Option<bool> EnableAuthOption { get; } = new("--enable-auth")
     {
         Description = "Enable full authentication handling"
     };
 
-    public static readonly Option<string?> HostVersionOption = new("--host-version")
+    public Option<string?> HostVersionOption { get; } = new("--host-version")
     {
         Description = "The host runtime version to use (e.g., 4.1049.0)"
     };

--- a/src/Func.Cli/Commands/VersionCommand.cs
+++ b/src/Func.Cli/Commands/VersionCommand.cs
@@ -50,7 +50,7 @@ internal class VersionCommand : BaseCommand, IBuiltInCommand
         return 0;
     }
 
-    public static string GetVersion()
+    public string GetVersion()
     {
         return Assembly.GetExecutingAssembly()
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
@@ -60,7 +60,7 @@ internal class VersionCommand : BaseCommand, IBuiltInCommand
             ?? "unknown";
     }
 
-    private static string GetInformationalVersion()
+    private string GetInformationalVersion()
     {
         return Assembly.GetExecutingAssembly()
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()

--- a/src/Func.Cli/Parser.cs
+++ b/src/Func.Cli/Parser.cs
@@ -34,10 +34,11 @@ internal static class Parser
 
         var interaction = services.GetRequiredService<IInteractionService>();
         var rootCommand = new FuncRootCommand();
+        var versionCommand = services.GetRequiredService<VersionCommand>();
 
         // HelpCommand needs the constructed root, so it can't be DI-resolved
         // ahead of the root. Built inline and added first.
-        var helpCommand = new HelpCommand(interaction, rootCommand);
+        var helpCommand = new HelpCommand(interaction, rootCommand, versionCommand);
         rootCommand.Subcommands.Add(helpCommand);
 
         var allCommands = services.GetServices<Command>().ToList();
@@ -87,8 +88,6 @@ internal static class Parser
             rootCommand.Subcommands.Add(command);
         }
 
-        var versionCommand = services.GetRequiredService<VersionCommand>();
-
         ReplaceHelpAction(rootCommand, helpCommand);
         ConfigureRootAction(rootCommand, helpCommand, versionCommand);
 
@@ -128,7 +127,7 @@ internal static class Parser
     {
         rootCommand.SetAction(parseResult =>
         {
-            if (parseResult.GetValue(FuncRootCommand.VerboseOption))
+            if (parseResult.GetValue(rootCommand.VerboseOption))
             {
                 return versionCommand.ExecuteDetailed();
             }

--- a/test/Func.Cli.Tests/Commands/VersionCommandTests.cs
+++ b/test/Func.Cli.Tests/Commands/VersionCommandTests.cs
@@ -33,7 +33,7 @@ public class VersionCommandTests
     [Fact]
     public void GetVersion_ReturnsNonEmptyString()
     {
-        var version = VersionCommand.GetVersion();
+        var version = new VersionCommand(_interaction).GetVersion();
 
         Assert.False(string.IsNullOrWhiteSpace(version));
         Assert.Contains("5.0.0", version);


### PR DESCRIPTION
Converts static `Option`/`Argument` fields and helper methods on commands to instance members so each command owns its own argument graph and DI-resolved state.

- `Option`/`Argument` fields on `FuncRootCommand`, `StartCommand`, `InitCommand`, `NewCommand`, `PackCommand`, `HelpCommand` → instance properties
- `BaseCommand.PathArgument` / `ApplyPath` → instance (argument created in `AddPathArgument`)
- `VersionCommand.GetVersion` / `GetInformationalVersion` → instance; `HelpCommand` now takes `VersionCommand` via ctor
- `HelpCommand.FormatOptionName` → instance
- `Parser.cs` and `VersionCommandTests.cs` updated for new shapes
- Static utility classes (`ProjectDetector`, `WorkloadHints`) left as-is

All 53 tests pass.