### PR TITLE
Fix flaky UtilitiesTests and ZipHelperTests in CI

### DIFF
--- a/test/Cli/Func.UnitTests/HelperTests/UtilitiesTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/UtilitiesTests.cs
@@ -68,14 +68,23 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
         [InlineData(false)]
         public void Test_IsMinifiedVersion(bool expected)
         {
-            var filePath = Path.Combine("artifactsconfig.json");
+            // IsMinifiedVersion uses ConfigurationBuilder.AddJsonFile with a relative path,
+            // which resolves against AppContext.BaseDirectory — not the test's current working directory.
+            // CI runners may launch tests from a working dir different from the test assembly location,
+            // so write the artifactsconfig.json next to the test binary to keep this test deterministic.
+            var filePath = Path.Combine(AppContext.BaseDirectory, "artifactsconfig.json");
             string artifactsJsonContent = "{\"minifiedVersion\": " + expected.ToString().ToLower() + "}";
             File.WriteAllTextAsync(filePath, artifactsJsonContent).GetAwaiter().GetResult();
 
-            bool output = Utilities.IsMinifiedVersion();
-
-            File.Delete(filePath);
-            Assert.Equal(expected, output);
+            try
+            {
+                bool output = Utilities.IsMinifiedVersion();
+                Assert.Equal(expected, output);
+            }
+            finally
+            {
+                File.Delete(filePath);
+            }
         }
     }
 }

--- a/test/Cli/Func.UnitTests/HelperTests/ZipHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/ZipHelperTests.cs
@@ -82,8 +82,10 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
                 files.Add(file);
             }
 
-            // Find the repo root by walking up until we find the solution file
-            var dir = new DirectoryInfo(Directory.GetCurrentDirectory());
+            // Find the repo root by walking up from the test assembly location until we find
+            // the solution file. Avoid Directory.GetCurrentDirectory() because some CI runners
+            // (e.g. CloudTest) launch tests from a working directory outside the source tree.
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
             while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Azure.Functions.Cli.sln")))
             {
                 dir = dir.Parent;


### PR DESCRIPTION
Both tests resolved paths against Directory.GetCurrentDirectory(), which is not guaranteed to match the test assembly location in CloudTest runners. Anchor lookups to AppContext.BaseDirectory instead.

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
