### PR TITLE
docs: add func start and func setup design drafts

### DIFF
--- a/docs/design/func-setup-design.md
+++ b/docs/design/func-setup-design.md
@@ -1,0 +1,91 @@
+# `func setup` & Onboarding Design (Draft)
+
+This document sketches the proposed `func setup` command and the broader onboarding story for the Azure Functions CLI (`func`). It is a working draft — open questions are called out inline.
+
+## Goals
+
+- Give new users a single command to go from "I installed `func`" to "I can run a function".
+- Let users pick the workloads they care about up front (language stacks like Node / Python / .NET, plus extensions like Durable Functions, Azure-integration tooling, etc.), instead of discovering workloads ad-hoc.
+- Support a non-interactive mode for CI / scripted environments.
+- Centralize first-run concerns: telemetry opt-in, CLI config, baseline workload install.
+
+## Command Surface (proposed)
+
+```
+func setup [--profile <name>] [--non-interactive] [--yes]
+```
+
+| Option              | Description                                                                 |
+| ------------------- | --------------------------------------------------------------------------- |
+| `--profile <name>`  | Apply a named profile (e.g. `node`, `python`, `dotnet`) without prompting.  |
+| `--non-interactive` | Never prompt; fail if a required answer is missing. Intended for CI.        |
+| `--yes`, `-y`       | Accept defaults for any prompt that would otherwise block.                  |
+
+### Interactive flow (default)
+
+1. Welcome + telemetry opt-in.
+2. Pick workloads to install — language stacks (Node, Python, .NET, Java, …) and/or feature workloads (e.g. Durable Functions, Azure-integration tooling).
+3. Confirm and install the corresponding workloads (or workload meta-packages — see below).
+4. Write `.func/config.json` (or update the user-level config) with the chosen profile.
+5. Print "what's next" hints (`func init`, `func new`, `func start`).
+
+### Non-interactive flow (CI)
+
+```
+func setup --profile node --non-interactive
+```
+
+- No prompts. Telemetry defaults to off (or whatever the env/config says).
+- Installs the workloads implied by the profile.
+- Exits non-zero if anything is ambiguous or missing.
+
+## Workload Meta-Packages
+
+Concept: a meta-package is a workload that pulls in a curated set of other workloads.
+
+- Example: `pythondev` brings in the Python stack workload + related tooling.
+- Example: `durable` brings in Durable Functions tooling on top of whatever stack the user already has.
+- Example: a `base` meta-package brings in everything needed to get started with `func` regardless of stack.
+- Implementation TBD — likely a NuGet package with dependencies on the underlying workload packages, resolved by `func workload install`.
+
+### Open questions
+
+- Naming: `pythondev` vs `python-dev` vs `python.dev`?
+- Do meta-packages live in the same feed as regular workloads?
+- Can a profile reference a meta-package directly, or only individual workloads?
+- Versioning: does the meta-package pin workload versions, or float?
+
+## Profiles
+
+Profiles tie together:
+
+- A set of workloads to install.
+- Defaults for `func start` (host version range, stack — see [func-start-design.md](./func-start-design.md)).
+- Possibly telemetry / CLI defaults.
+
+### Open questions
+
+- Where do built-in profiles live? Shipped with the CLI? Downloaded?
+- Can users define their own profiles, and where?
+- Profile precedence: project-level `.func/config.json` vs user-level config?
+
+## First-Run / Config Touchpoints
+
+- Telemetry opt-in (one-time prompt; respect `DOTNET_CLI_TELEMETRY_OPTOUT`-style env vars).
+- `func` CLI config (user-level, e.g. `~/.azure-functions/config.json`).
+- Project-level `.func/config.json` — checked / created on `func setup` inside a project directory.
+- Workload install via `func workloads install <name>` under the hood.
+
+## Relationship to Other Commands
+
+- `func setup` is the front door; `func workload install/uninstall` remains the lower-level primitive.
+- `func init` should detect a missing setup and either auto-run it or point the user at it (TBD).
+- `func start` consumes the profile written by `func setup` to resolve host + worker versions.
+
+## Open Questions (cross-cutting)
+
+- Is `func setup` re-runnable / idempotent? What does re-running do — diff and reconcile?
+- Does `func setup` ever uninstall workloads it didn't install, to match a profile? Or only additive?
+- How do we surface progress for long-running workload installs (especially in CI)?
+- Should there be a `func setup --check` mode that reports current state without changing anything?
+- What's the story for offline / air-gapped environments?

--- a/docs/design/func-start-design.md
+++ b/docs/design/func-start-design.md
@@ -1,0 +1,141 @@
+# `func start` Design (Draft)
+
+This document sketches the proposed design for `func start` in the Azure Functions CLI (`func`). It is a working draft — open questions are called out inline.
+
+## Goals
+
+- Launch the Azure Functions host runtime with the correct host version, worker, and script root.
+- Resolve those inputs from a layered configuration model (profile → config → environment).
+- Keep the host runtime and language workers out of the base CLI; deliver them as workloads that the CLI loads at runtime (consistent with the existing workload model — see [building-a-workload.md](./building-a-workload.md)).
+
+## High-Level Flow
+
+```
+func start [<path>] [--profile <name>] [--host-version <v>] [--port ...] ...
+        │
+        ▼
+1. Build FuncRunContext from CLI args + .func/config.json + .env + appsettings.json
+        │   (fallback: local.settings.json)
+        ▼
+2. Resolve host version
+        ├── from --host-version, else
+        └── from profile (--profile or default)
+        ▼
+3. Select an IHostRunner that supports the resolved host version
+        ▼
+4. Resolve stack + worker
+        ├── Stack comes from config
+        ├── Ask the IHostRunner's WorkerStackVersionMap which worker versions it supports
+        └── Resolve stack handler → worker path
+        ▼
+5. Resolve script root path
+        ├── default: stack handler's output dir
+        └── overridden when <path> is provided (workingPathDefined = true on context)
+        ▼
+6. IHostRunner.RunAsync(context)
+```
+
+## Configuration Layering
+
+In precedence order (highest first):
+
+1. CLI options (`--host-version`, `--port`, `--functions`, …)
+2. `.func/config.json` — profiles, host version resolution, stack
+3. `.env`
+4. `appsettings.json`
+5. `local.settings.json` (fallback for back-compat)
+
+## Host Version Resolution
+
+- Resolve from the active profile (`--profile`, else default).
+- Look through installed host workloads and pick the latest version that matches the profile's range.
+- If multiple match, take the latest in range.
+- `--force-latest`: install the newest available host workload even if it falls outside the profile's range.
+
+### Open questions
+
+- Do we warn when a newer host exists outside the profile's range? After how many days stale?
+- Stale-host check: background process? On every `func start`? How often?
+- Where does the "last checked" timestamp live — user profile?
+- Do we rely on the workload manifest as the source of truth for available versions?
+
+## Host Workload Shape
+
+A host workload is a special workload type that contributes:
+
+1. A **harness** — the `func start` implementation (a console app) that wraps `WebHost`.
+2. A **WorkerStackVersionMap** — declares which stacks and worker versions the host supports, so workers do not need to be packaged inside the host workload.
+
+Workers themselves ship in **worker workloads**. Each worker workload knows where its workers live; the host workload locates them via the stack/version map.
+
+### Open design choices
+
+1. Harness wraps `WebHost` in-proc.
+2. Fully out-of-process host.
+3. _(third option TBD)_
+
+## Key Types
+
+```csharp
+internal interface IHostRunner
+{
+    HostVersion HostVersion { get; }
+
+    // Stacks + worker versions this host runner supports.
+    // Keyed by stack (e.g. "node", "python") → supported worker version range.
+    // Avoids packaging workers inside the host workload.
+    IReadOnlyDictionary<string, WorkerVersionRange> WorkerStackVersionMap { get; }
+
+    Task RunAsync(FuncRunContext context);
+}
+```
+
+```csharp
+internal sealed class FuncRunContext
+{
+    // Set when `func start <path>` is invoked.
+    // When true, the path overrides the stack runner's computed output dir.
+    public bool WorkingPathDefined { get; init; }
+
+    public string? Path { get; init; }
+    public HostVersion HostVersion { get; init; }
+    public Stack Stack { get; init; }
+    public string WorkerPath { get; init; }
+    public string ScriptRootPath { get; init; }
+    // …host options (port, cors, functions filter, enable-auth, …)
+}
+```
+
+```csharp
+internal interface IStackRunHandler
+{
+    bool CanHandle(FuncRunContext context);
+
+    // Pre-run: produce worker path, decide where to run the host from.
+    Task PreRunAsync(FuncRunContext context, CancellationToken ct);
+
+    // Post-run: cleanup, telemetry, etc.
+    Task PostRunAsync(FuncRunContext context, CancellationToken ct);
+}
+```
+
+## CLI Surface (initial)
+
+| Option                | Description                                              |
+| --------------------- | -------------------------------------------------------- |
+| `<path>`              | Optional script root override                            |
+| `--port`, `-p`        | Port to listen on (default 7071)                         |
+| `--cors`              | Comma-separated CORS origins                             |
+| `--cors-credentials`  | Allow cross-origin authenticated requests                |
+| `--functions`         | Space-separated list of functions to load                |
+| `--no-build`          | Skip build before running                                |
+| `--enable-auth`       | Enable full auth handling                                |
+| `--host-version`      | Explicit host runtime version (e.g. `4.1049.0`)          |
+| `--profile`           | Profile to drive host version resolution                 |
+| `--force-latest`      | _(proposed)_ Install newest host even if outside profile |
+
+## Related / Follow-up Work
+
+- **Workload pruning** — separate PRD; remove unused host/worker workloads.
+- **Stale host version checks** — background detection + user-profile persistence.
+- **Profile schema** in `.func/config.json` — to be specified.


### PR DESCRIPTION
Adds two working-draft design docs under `docs/design/`:

- **`func-start-design.md`** — sketches `func start` flow: layered config (CLI → `.func/config.json` → `.env` → `appsettings.json` → `local.settings.json`), profile-driven host version resolution, host workload shape (harness + `WorkerStackVersionMap` as a stack→version-range dict), and the `IHostRunner` / `FuncRunContext` / `IStackRunHandler` types.
- **`func-setup-design.md`** — sketches `func setup` and the onboarding story: interactive + non-interactive (CI) flows, workload meta-packages (`pythondev`, `durable`, `base`, …), profiles, and first-run touchpoints (telemetry, CLI config, `.func/config.json`).

Both docs intentionally leave open questions inline to drive follow-up discussion.