### PR TITLE
Add func setup design proposal

### DIFF
--- a/proposed/func-setup-design.md
+++ b/proposed/func-setup-design.md
@@ -1,0 +1,91 @@
+# `func setup` & Onboarding Design (Draft)
+
+This document sketches the proposed `func setup` command and the broader onboarding story for the Azure Functions CLI (`func`). It is a working draft — open questions are called out inline.
+
+## Goals
+
+- Give new users a single command to go from "I installed `func`" to "I can run a function".
+- Let users pick the workloads they care about up front (language stacks like Node / Python / .NET, plus extensions like Durable Functions, Azure-integration tooling, etc.), instead of discovering workloads ad-hoc.
+- Support a non-interactive mode for CI / scripted environments.
+- Centralize first-run concerns: telemetry opt-in, CLI config, baseline workload install.
+
+## Command Surface (proposed)
+
+```
+func setup [--profile <name>] [--non-interactive] [--yes]
+```
+
+| Option              | Description                                                                 |
+| ------------------- | --------------------------------------------------------------------------- |
+| `--profile <name>`  | Apply a named profile (e.g. `node`, `python`, `dotnet`) without prompting.  |
+| `--non-interactive` | Never prompt; fail if a required answer is missing. Intended for CI.        |
+| `--yes`, `-y`       | Accept defaults for any prompt that would otherwise block.                  |
+
+### Interactive flow (default)
+
+1. Welcome + telemetry opt-in.
+2. Pick workloads to install — language stacks (Node, Python, .NET, Java, …) and/or feature workloads (e.g. Durable Functions, Azure-integration tooling).
+3. Confirm and install the corresponding workloads (or workload meta-packages — see below).
+4. Write `.func/config.json` (or update the user-level config) with the chosen profile.
+5. Print "what's next" hints (`func init`, `func new`, `func start`).
+
+### Non-interactive flow (CI)
+
+```
+func setup --profile node --non-interactive
+```
+
+- No prompts. Telemetry defaults to off (or whatever the env/config says).
+- Installs the workloads implied by the profile.
+- Exits non-zero if anything is ambiguous or missing.
+
+## Workload Meta-Packages
+
+Concept: a meta-package is a workload that pulls in a curated set of other workloads.
+
+- Example: `pythondev` brings in the Python stack workload + related tooling.
+- Example: `durable` brings in Durable Functions tooling on top of whatever stack the user already has.
+- Example: a `base` meta-package brings in everything needed to get started with `func` regardless of stack.
+- Implementation TBD — likely a NuGet package with dependencies on the underlying workload packages, resolved by `func workload install`.
+
+### Open questions
+
+- Naming: `pythondev` vs `python-dev` vs `python.dev`?
+- Do meta-packages live in the same feed as regular workloads?
+- Can a profile reference a meta-package directly, or only individual workloads?
+- Versioning: does the meta-package pin workload versions, or float?
+
+## Profiles
+
+Profiles tie together:
+
+- A set of workloads to install.
+- Defaults for `func start` (host version range, stack — see [func-start-design.md](./func-start-design.md)).
+- Possibly telemetry / CLI defaults.
+
+### Open questions
+
+- Where do built-in profiles live? Shipped with the CLI? Downloaded?
+- Can users define their own profiles, and where?
+- Profile precedence: project-level `.func/config.json` vs user-level config?
+
+## First-Run / Config Touchpoints
+
+- Telemetry opt-in (one-time prompt; respect `DOTNET_CLI_TELEMETRY_OPTOUT`-style env vars).
+- `func` CLI config (user-level, e.g. `~/.azure-functions/config.json`).
+- Project-level `.func/config.json` — checked / created on `func setup` inside a project directory.
+- Workload install via `func workloads install <name>` under the hood.
+
+## Relationship to Other Commands
+
+- `func setup` is the front door; `func workload install/uninstall` remains the lower-level primitive.
+- `func init` should detect a missing setup and either auto-run it or point the user at it (TBD).
+- `func start` consumes the profile written by `func setup` to resolve host + worker versions.
+
+## Open Questions (cross-cutting)
+
+- Is `func setup` re-runnable / idempotent? What does re-running do — diff and reconcile?
+- Does `func setup` ever uninstall workloads it didn't install, to match a profile? Or only additive?
+- How do we surface progress for long-running workload installs (especially in CI)?
+- Should there be a `func setup --check` mode that reports current state without changing anything?
+- What's the story for offline / air-gapped environments?

--- a/proposed/func-setup-design.md
+++ b/proposed/func-setup-design.md
@@ -45,7 +45,7 @@ func setup [--workloads <list>] [--profiles <list>]
 
 ### 3.1 Interactive flow (default)
 
-1. If running inside a project directory, infer suggested workloads from project files (read-only).
+1. If running inside a project directory, infer suggested workloads via the shared **project detection** module (see §9.6). This is a read-only signal source reused from the workloads spec's "find missing workloads" flow ([workload-spec.md](./workload-spec.md)).
 2. Present a grouped picker (language stacks, feature workloads).
 3. Confirm and install the selected workloads via the workload subsystem.
 4. If `.func/config.json` declares profiles (see [cli-profiles.md](./cli-profiles.md)), pre-install their dependencies.
@@ -156,6 +156,16 @@ Single non-zero on any drift, or distinct codes per drift type?
 
 What signals does `setup` read, and how is the inference surfaced?
 
-**Decision:** `setup` reads everything it reasonably can (e.g. `host.json` `workerRuntime`, language manifests like `package.json` / `requirements.txt` / `*.csproj` / `pom.xml`, `.func/config.json` for declared profiles). The inference is **informational only**: the picker shows what was detected, but the user still picks explicitly. Nothing is pre-selected from inference alone.
+**Decision:** `setup` does not implement its own detection. It calls the shared **project detection** module owned by the workloads spec (see [workload-spec.md](./workload-spec.md), and PR #4923 thread r3190018800 for the original signal list). Signals include:
 
-> Note: this is in tension with §9.3, which pre-selects recommended defaults *per detected language*. The reconciled rule is: detection surfaces information; *recommendations* (curated workload sets shipped with the CLI) are what get pre-selected. If detection finds Python, the picker shows "detected: Python" and pre-selects the **Python recommendation** (a CLI-curated set), not raw inference output. The user remains the decider.
+- `--stack <name>` (explicit override, when provided).
+- `local.settings.json` `FUNCTIONS_WORKER_RUNTIME`.
+- `host.json` (presence and `workerRuntime`).
+- Project marker files: `*.csproj`, `requirements.txt`, `package.json`, `pom.xml`, etc.
+- `.func/config.json` (for declared profiles, per [cli-profiles.md](./cli-profiles.md)).
+
+The inference is **informational**: the picker surfaces what was detected ("detected: Python"). What gets *pre-selected* in the picker comes from §9.3's curated recommendations, not raw detection output. The user remains the decider.
+
+Reusing the same detection module as the workloads "missing workloads" flow ensures the two callers cannot drift apart.
+
+

--- a/proposed/func-setup-design.md
+++ b/proposed/func-setup-design.md
@@ -61,7 +61,24 @@ func setup --workloads node,python --profiles flex --non-interactive --yes
 - Installs the listed workloads. Pre-installs dependencies for the listed profiles.
 - Exits non-zero on any failure or ambiguity.
 
-### 3.3 `--check` mode
+### 3.3 Catalog and recommendations
+
+The picker draws from two sources, owned by different layers:
+
+| Zone                  | Source                                                       | Owned by                               |
+| --------------------- | ------------------------------------------------------------ | -------------------------------------- |
+| Featured / recommended | CLI-curated stack list (`node`, `python`, `dotnet-isolated`, `java`, `powershell`, `custom`) plus a per-stack **recommendation bundle** | Func CLI (hard-coded, small)           |
+| Browse all            | `func workload search` against the configured NuGet feed     | Workload subsystem ([workload-spec.md](./workload-spec.md) §4.1) |
+
+**Featured** is what gets *surfaced first* and what counts as "the Python recommendation" for §9.3 pre-selection. Members are the well-known Functions worker runtimes; the same list already exists in the workloads spec for the install-hint flow (workload-spec §4.2). `setup` reuses that list, it does not introduce a new one.
+
+**Browse all** is the full dynamic catalog. Third-party workloads, less-common stacks, and anything the user reaches via search live here. `setup` does not maintain this list; it is whatever `func workload search` returns.
+
+A recommendation bundle is initially the single canonical workload for that stack (e.g. Python recommendation = `python`). Bundles can grow over time (e.g. `python` + `azure-tools` + `durable`) without changing the picker UX.
+
+This split avoids two failure modes: all hard-coded means stale catalogs and no third-party visibility; all catalog means no opinion and a slow path for new users.
+
+### 3.4 `--check` mode
 
 Same resolution logic as a real run, no mutations. Reports what is missing (workloads, profile dependencies, caches). Useful for verifying a pre-baked CI image.
 

--- a/proposed/func-setup-design.md
+++ b/proposed/func-setup-design.md
@@ -1,91 +1,130 @@
-# `func setup` & Onboarding Design (Draft)
+# `func setup` Design (Draft)
 
-This document sketches the proposed `func setup` command and the broader onboarding story for the Azure Functions CLI (`func`). It is a working draft — open questions are called out inline.
+This document describes the proposed `func setup` command for the Azure Functions CLI (`func`). It is a working draft. Open questions are called out inline.
 
-## Goals
+## 1. Identity
 
-- Give new users a single command to go from "I installed `func`" to "I can run a function".
-- Let users pick the workloads they care about up front (language stacks like Node / Python / .NET, plus extensions like Durable Functions, Azure-integration tooling, etc.), instead of discovering workloads ad-hoc.
-- Support a non-interactive mode for CI / scripted environments.
-- Centralize first-run concerns: telemetry opt-in, CLI config, baseline workload install.
+`func setup` is a **machine readiness orchestrator**. It coordinates several subsystems so that a freshly installed `func` is ready to develop or run Azure Functions, in one command, idempotently, in both interactive and CI environments.
 
-## Command Surface (proposed)
+It is intentionally a small, thin command. Its interface is small ("ready this machine for func"), but behind that interface it sequences work across:
+
+- Workload installation (via `func workload install`).
+- Profile pre-install for runtime constraint sets (via `func profile install`, see [cli-profiles.md](./cli-profiles.md)).
+- Cache priming (extension bundle cache, profile registry cache).
+- First-run hints (telemetry consent is handled separately, see §6).
+
+### What it is *not*
+
+- **Not an alias for `func workload install`.** That command is a sharp tool ("install this specific workload"). `setup` is an orchestration verb ("ready this machine"). The distinction is by intent, not capability.
+- **Not a project bootstrapper.** That is `func init`. `setup` may *read* project files for inference, but it never writes to the project.
+- **Not the telemetry owner.** Telemetry consent is a global first-CLI-invocation concern, not a `setup` concern. See §6.
+- **Not a profile authoring tool.** Profile authoring lives with [cli-profiles.md](./cli-profiles.md) (`.func/profiles.json`, `~/.azure-functions/profiles.json`).
+- **Has no "profile" concept of its own.** The word *profile* is reserved for [cli-profiles.md](./cli-profiles.md).
+
+## 2. Goals
+
+- Give a new user a single command to go from "I installed `func`" to "I can run a function".
+- Give CI a single command to bring a fresh runner to a known-ready state.
+- Be idempotent: safe to re-run on every CI job, on a developer's machine after adding new languages, after partial failures.
+- Keep responsibilities narrow: orchestrate, do not own. Each underlying subsystem remains the source of truth for its own state.
+
+## 3. Command Surface
 
 ```
-func setup [--profile <name>] [--non-interactive] [--yes]
+func setup [--workloads <list>] [--profiles <list>]
+           [--non-interactive] [--yes] [--check]
 ```
 
-| Option              | Description                                                                 |
-| ------------------- | --------------------------------------------------------------------------- |
-| `--profile <name>`  | Apply a named profile (e.g. `node`, `python`, `dotnet`) without prompting.  |
-| `--non-interactive` | Never prompt; fail if a required answer is missing. Intended for CI.        |
-| `--yes`, `-y`       | Accept defaults for any prompt that would otherwise block.                  |
+| Option              | Description                                                                                                         |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `--workloads <list>`| Comma-separated workload IDs to ensure are installed (e.g. `node,python,durable`).                                  |
+| `--profiles <list>` | Comma-separated profile names whose dependencies should be pre-installed (see [cli-profiles.md](./cli-profiles.md)).|
+| `--non-interactive` | Never prompt. Fail if a required answer is missing or a step would otherwise block.                                 |
+| `--yes`, `-y`       | Accept defaults for any prompt that would otherwise block. Implies non-interactive.                                 |
+| `--check`           | Report what would change. Make no mutations. Exits non-zero if anything is missing.                                 |
 
-### Interactive flow (default)
+### 3.1 Interactive flow (default)
 
-1. Welcome + telemetry opt-in.
-2. Pick workloads to install — language stacks (Node, Python, .NET, Java, …) and/or feature workloads (e.g. Durable Functions, Azure-integration tooling).
-3. Confirm and install the corresponding workloads (or workload meta-packages — see below).
-4. Write `.func/config.json` (or update the user-level config) with the chosen profile.
+1. If running inside a project directory, infer suggested workloads from project files (read-only).
+2. Present a grouped picker (language stacks, feature workloads).
+3. Confirm and install the selected workloads via the workload subsystem.
+4. If `.func/config.json` declares profiles (see [cli-profiles.md](./cli-profiles.md)), pre-install their dependencies.
 5. Print "what's next" hints (`func init`, `func new`, `func start`).
 
-### Non-interactive flow (CI)
+### 3.2 Non-interactive flow (CI)
 
 ```
-func setup --profile node --non-interactive
+func setup --workloads node,python --profiles flex --non-interactive --yes
 ```
 
-- No prompts. Telemetry defaults to off (or whatever the env/config says).
-- Installs the workloads implied by the profile.
-- Exits non-zero if anything is ambiguous or missing.
+- No prompts. Telemetry default is whatever the env/config dictates (see §6).
+- Installs the listed workloads. Pre-installs dependencies for the listed profiles.
+- Exits non-zero on any failure or ambiguity.
 
-## Workload Meta-Packages
+### 3.3 `--check` mode
 
-Concept: a meta-package is a workload that pulls in a curated set of other workloads.
+Same resolution logic as a real run, no mutations. Reports what is missing (workloads, profile dependencies, caches). Useful for verifying a pre-baked CI image.
 
-- Example: `pythondev` brings in the Python stack workload + related tooling.
-- Example: `durable` brings in Durable Functions tooling on top of whatever stack the user already has.
-- Example: a `base` meta-package brings in everything needed to get started with `func` regardless of stack.
-- Implementation TBD — likely a NuGet package with dependencies on the underlying workload packages, resolved by `func workload install`.
+## 4. Re-run Model: Idempotent Additive Reconciliation
 
-### Open questions
+Each invocation ensures the requested set is *present*. It never removes.
 
-- Naming: `pythondev` vs `python-dev` vs `python.dev`?
-- Do meta-packages live in the same feed as regular workloads?
-- Can a profile reference a meta-package directly, or only individual workloads?
-- Versioning: does the meta-package pin workload versions, or float?
+- Workloads already installed are skipped.
+- Workloads not yet installed are installed.
+- Profile dependencies already cached are skipped.
+- Profile dependencies not yet cached are fetched.
 
-## Profiles
+`setup` does not maintain a manifest of "what setup installed." The workload subsystem and profile registry are the source of truth for installed state. Removing a workload is `func workload uninstall`'s job, not `setup`'s.
 
-Profiles tie together:
+The only state `setup` writes is a **first-run completed** marker (user-level), used to suppress first-run hints on subsequent invocations.
 
-- A set of workloads to install.
-- Defaults for `func start` (host version range, stack — see [func-start-design.md](./func-start-design.md)).
-- Possibly telemetry / CLI defaults.
+## 5. Boundaries with `init` and `start`
 
-### Open questions
+The three commands each own one verb (scaffold, ready, run). They do not call each other. They communicate through state on disk and installed workloads, not through invocation.
 
-- Where do built-in profiles live? Shipped with the CLI? Downloaded?
-- Can users define their own profiles, and where?
-- Profile precedence: project-level `.func/config.json` vs user-level config?
+| Scenario                                                            | Behavior                                                                                                       |
+| ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `func init` on a fresh machine (no workloads installed)             | `init` succeeds. It does not check or auto-run `setup`. Project scaffolding does not gate on machine state.    |
+| `func start` on a fresh machine (no host workload installed)        | Uses the auto-install pattern from [cli-profiles.md](./cli-profiles.md) §13.2: prompt interactive, error in CI.|
+| `func setup` inside an existing project                             | Reads project files (read-only) for inference. Reads `.func/config.json` for declared profiles. No project writes.|
 
-## First-Run / Config Touchpoints
+## 6. Telemetry
 
-- Telemetry opt-in (one-time prompt; respect `DOTNET_CLI_TELEMETRY_OPTOUT`-style env vars).
-- `func` CLI config (user-level, e.g. `~/.azure-functions/config.json`).
-- Project-level `.func/config.json` — checked / created on `func setup` inside a project directory.
-- Workload install via `func workloads install <name>` under the hood.
+Telemetry consent is **out of scope for `func setup`**. It is a global concern, prompted on first invocation of any `func` command, owned by the CLI bootstrap path. `setup` happens to be one such command but is not special in this regard. Env vars (`DOTNET_CLI_TELEMETRY_OPTOUT`-style) override the prompt as expected.
 
-## Relationship to Other Commands
+This avoids the failure mode where a user runs `func init` first, never sees `setup`, and is silently never asked about telemetry.
 
-- `func setup` is the front door; `func workload install/uninstall` remains the lower-level primitive.
-- `func init` should detect a missing setup and either auto-run it or point the user at it (TBD).
-- `func start` consumes the profile written by `func setup` to resolve host + worker versions.
+## 7. State and File Layout
 
-## Open Questions (cross-cutting)
+`func setup` mutates only user-level state:
 
-- Is `func setup` re-runnable / idempotent? What does re-running do — diff and reconcile?
-- Does `func setup` ever uninstall workloads it didn't install, to match a profile? Or only additive?
-- How do we surface progress for long-running workload installs (especially in CI)?
-- Should there be a `func setup --check` mode that reports current state without changing anything?
-- What's the story for offline / air-gapped environments?
+```
+~/.azure-functions/
+  .first-run                     # Marker: first-run hints already shown
+  workloads/                     # Owned by the workload subsystem
+  profiles/                      # Owned by the profiles subsystem
+```
+
+`setup` does not write to:
+
+- `.func/config.json` (owned by the profiles proposal).
+- `.func/profiles.json` (owned by the profiles proposal).
+- `host.json`, `local.settings.json` (owned by `func init`).
+
+## 8. Failure Semantics
+
+- Each underlying subsystem call is atomic per its own contract (e.g. workload install per the Workloads spec).
+- `setup` itself accepts partial completion: a re-run finishes the job. There is no rollback.
+- Errors clearly state what completed and what did not, with the exact command to retry the failed step.
+- Non-zero exit on any failure in `--non-interactive` or `--check` mode.
+
+## 9. Open Questions
+
+These are concrete, lower-level questions. The foundational architecture (identity, scope, re-run model, boundaries) is settled above.
+
+- **Progress reporting.** How is long-running workload install progress surfaced in CI logs (where TTY tricks fail)? Plain-text periodic lines, structured JSON via a flag, or both?
+- **Offline / air-gapped.** Should `setup` accept a `--offline` flag that skips network attempts and only validates that already-cached artifacts satisfy the request? (Likely yes, mirroring `func start --offline` from the profiles proposal.)
+- **Picker UX.** Categorized prompt vs flat list. Do we ship a recommended-defaults set per detected language?
+- **Discoverability after install.** Where does the "next step is `func setup`" hint surface? Post-install message from the package, output of `func` with no args, both?
+- **`--check` exit codes.** Single non-zero on any drift, or distinct codes for "missing workload" vs "missing profile cache" vs "stale registry"?
+- **Inferring workloads from a project.** What signals do we read (e.g. `host.json`, presence of `requirements.txt` / `package.json` / `*.csproj`)? How is the inference surfaced (pre-selected in picker vs informational only)?

--- a/proposed/func-setup-design.md
+++ b/proposed/func-setup-design.md
@@ -118,13 +118,44 @@ This avoids the failure mode where a user runs `func init` first, never sees `se
 - Errors clearly state what completed and what did not, with the exact command to retry the failed step.
 - Non-zero exit on any failure in `--non-interactive` or `--check` mode.
 
-## 9. Open Questions
+## 9. Resolved Questions
 
-These are concrete, lower-level questions. The foundational architecture (identity, scope, re-run model, boundaries) is settled above.
+These are concrete, lower-level decisions. The foundational architecture (identity, scope, re-run model, boundaries) is in §1 through §8.
 
-- **Progress reporting.** How is long-running workload install progress surfaced in CI logs (where TTY tricks fail)? Plain-text periodic lines, structured JSON via a flag, or both?
-- **Offline / air-gapped.** Should `setup` accept a `--offline` flag that skips network attempts and only validates that already-cached artifacts satisfy the request? (Likely yes, mirroring `func start --offline` from the profiles proposal.)
-- **Picker UX.** Categorized prompt vs flat list. Do we ship a recommended-defaults set per detected language?
-- **Discoverability after install.** Where does the "next step is `func setup`" hint surface? Post-install message from the package, output of `func` with no args, both?
-- **`--check` exit codes.** Single non-zero on any drift, or distinct codes for "missing workload" vs "missing profile cache" vs "stale registry"?
-- **Inferring workloads from a project.** What signals do we read (e.g. `host.json`, presence of `requirements.txt` / `package.json` / `*.csproj`)? How is the inference surfaced (pre-selected in picker vs informational only)?
+### 9.1 Progress reporting
+
+How is long-running workload install progress surfaced in CI logs (where TTY tricks fail)?
+
+**Decision:** Spinner / progress bar when a TTY is detected. Plain-text periodic lines otherwise (the default for CI). Opt-in structured output via `--output json` for tooling that wants to parse progress events.
+
+### 9.2 Offline / air-gapped
+
+Should `setup` accept a `--offline` flag that skips network attempts and only validates that already-cached artifacts satisfy the request?
+
+**Decision:** Deferred. Offline / air-gapped support will be addressed in a separate proposal that covers the CLI as a whole, not bolted onto `setup` in isolation. `setup` does not ship an `--offline` flag in v1.
+
+### 9.3 Picker UX
+
+Categorized prompt vs flat list. Do we ship a recommended-defaults set per detected language?
+
+**Decision:** Categorized picker (Languages / Features / Tools). When project inference suggests a language, that language's recommended defaults are pre-selected. The user can deselect or add to the recommendation before confirming.
+
+### 9.4 Discoverability after install
+
+Where does the "next step is `func setup`" hint surface?
+
+**Decision:** Both. The package installer prints a post-install message pointing at `func setup`, and `func` with no arguments shows a getting-started hint that includes `func setup`.
+
+### 9.5 `--check` exit codes
+
+Single non-zero on any drift, or distinct codes per drift type?
+
+**Decision:** Single non-zero exit (`exit 1`) on any drift. Drift details (which workloads are missing, which profile caches are stale, etc.) are written to stdout/stderr in human-readable form. No distinct exit codes per drift type. Tooling that needs structured drift information can use `--output json` (see §9.1).
+
+### 9.6 Inferring workloads from a project
+
+What signals does `setup` read, and how is the inference surfaced?
+
+**Decision:** `setup` reads everything it reasonably can (e.g. `host.json` `workerRuntime`, language manifests like `package.json` / `requirements.txt` / `*.csproj` / `pom.xml`, `.func/config.json` for declared profiles). The inference is **informational only**: the picker shows what was detected, but the user still picks explicitly. Nothing is pre-selected from inference alone.
+
+> Note: this is in tension with §9.3, which pre-selects recommended defaults *per detected language*. The reconciled rule is: detection surfaces information; *recommendations* (curated workload sets shipped with the CLI) are what get pre-selected. If detection finds Python, the picker shows "detected: Python" and pre-selects the **Python recommendation** (a CLI-curated set), not raw inference output. The user remains the decider.


### PR DESCRIPTION
Purpose of this design is to figure out the onboarding story for the new CLI now that a lot of base functionality from v4 is coming from workloads. Given that workloads are essential to the use of the new CLI - we need to make it easy for users to onboard in the CLI, whether that is setting up a new local environment, or CI environment. 