### PR TITLE
Updating command registration models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ and .NET 10 using a workload-based extensibility model (similar to `dotnet` CLI 
 
 See `docs/adding-a-command.md` for the full guide. Summary:
 
-1. Create a class in `src/Func.Cli/Commands/` extending `BaseCommand`
+1. Create a class in `src/Func.Cli/Commands/` extending `FuncCliCommand`
 2. Register it in `Parser.cs`
 3. Add tests in `test/Func.Cli.Tests/Commands/`
 4. Update `docs/cli-architecture.md` command tree

--- a/docs/adding-a-command.md
+++ b/docs/adding-a-command.md
@@ -9,13 +9,13 @@ The repo includes agent instructions (`AGENTS.md`) with
 conventions and patterns. Try a prompt like:
 
 > Scaffold a new "func deploy" command with options for app name and resource group.
-> Follow the command guide in docs/adding-a-command.md, register it in Parser.cs,
+> Follow the command guide in docs/adding-a-command.md, register it in BuiltInCommands.cs,
 > and add a test file.
 
 ## Quick Start
 
 1. Create a new command class in `src/Func.Cli/Commands/`
-2. Register it in `Parser.cs`
+2. Register it in `src/Func.Cli/Hosting/BuiltInCommands.cs`
 3. Add tests in `test/Func.Cli.Tests/`
 
 ## Step 1: Create the Command Class
@@ -120,28 +120,27 @@ var arg = new Argument<string>("resource") { Description = "The resource to depl
 Arguments.Add(arg);
 ```
 
-## Step 2: Register in Parser.cs
+## Step 2: Register in BuiltInCommands.cs
 
-Open `src/Func.Cli/Parser.cs` and add the command to the tree:
+Open `src/Func.Cli/Hosting/BuiltInCommands.cs` and register the command as a `BaseCommand` so the parser picks it up. Built-in commands also implement the `IBuiltInCommand` marker interface so the parser distinguishes them from workload-contributed commands:
 
 ```csharp
-public static FuncRootCommand CreateCommand(
-    IInteractionService interaction,
-    IWorkloadManager? workloadManager = null)
+// src/Func.Cli/Commands/DeployCommand.cs
+internal class DeployCommand : BaseCommand, IBuiltInCommand
 {
-    var rootCommand = new FuncRootCommand();
+    // …
+}
 
-    // ... existing commands ...
-    var deployCommand = new DeployCommand(interaction);  // ← add this
-
+// src/Func.Cli/Hosting/BuiltInCommands.cs
+public static IServiceCollection AddBuiltInCommands(this IServiceCollection services)
+{
     // ... existing registrations ...
-    rootCommand.Subcommands.Add(deployCommand);          // ← add this
-
-    // ... rest of method ...
+    services.AddSingleton<BaseCommand, DeployCommand>();   // ← add this
+    return services;
 }
 ```
 
-The help system will automatically include the new command — no additional registration needed.
+`Parser.CreateCommand` resolves every `BaseCommand` from DI, partitions them into built-ins (`IBuiltInCommand`) and workload-contributed (`ExternalCommand`), and adds them to the root tree. The help system picks up the new command automatically.
 
 ## Step 3: Add Tests
 
@@ -244,7 +243,7 @@ This produces: `func azure login`, `func azure list`.
 ## Checklist
 
 - [ ] Command class in `src/Func.Cli/Commands/`
-- [ ] Registered in `Parser.CreateCommand()`
+- [ ] Implements `IBuiltInCommand` and registered as a `BaseCommand` in `BuiltInCommands.cs`
 - [ ] Uses `IInteractionService` for all I/O
 - [ ] Uses `GracefulException` for user-facing errors
 - [ ] Tests cover registration, options, and happy path

--- a/docs/adding-a-command.md
+++ b/docs/adding-a-command.md
@@ -20,7 +20,7 @@ conventions and patterns. Try a prompt like:
 
 ## Step 1: Create the Command Class
 
-Create a new file in `src/Func.Cli/Commands/`. All commands extend `BaseCommand`.
+Create a new file in `src/Func.Cli/Commands/`. All commands extend `FuncCliCommand`.
 
 ```csharp
 // src/Func.Cli/Commands/DeployCommand.cs
@@ -31,7 +31,7 @@ using Azure.Functions.Cli.Console;
 
 namespace Azure.Functions.Cli.Commands;
 
-internal class DeployCommand : BaseCommand
+internal class DeployCommand : FuncCliCommand
 {
     // Define options as instance properties
     public Option<string> AppNameOption { get; } = new("--app-name", "-a")
@@ -115,18 +115,18 @@ public Option<int> TimeoutOption { get; } = new("--timeout")
     DefaultValueFactory = _ => 30
 };
 
-// Arguments: positional (use BaseCommand.AddPathArgument for [path])
+// Arguments: positional (use FuncCliCommand.AddPathArgument for [path])
 var arg = new Argument<string>("resource") { Description = "The resource to deploy" };
 Arguments.Add(arg);
 ```
 
 ## Step 2: Register in BuiltInCommands.cs
 
-Open `src/Func.Cli/Hosting/BuiltInCommands.cs` and register the command as a `BaseCommand` so the parser picks it up. Built-in commands also implement the `IBuiltInCommand` marker interface so the parser distinguishes them from workload-contributed commands:
+Open `src/Func.Cli/Hosting/BuiltInCommands.cs` and register the command as a `FuncCliCommand` so the parser picks it up. Built-in commands also implement the `IBuiltInCommand` marker interface so the parser distinguishes them from workload-contributed commands:
 
 ```csharp
 // src/Func.Cli/Commands/DeployCommand.cs
-internal class DeployCommand : BaseCommand, IBuiltInCommand
+internal class DeployCommand : FuncCliCommand, IBuiltInCommand
 {
     // …
 }
@@ -135,12 +135,12 @@ internal class DeployCommand : BaseCommand, IBuiltInCommand
 public static IServiceCollection AddBuiltInCommands(this IServiceCollection services)
 {
     // ... existing registrations ...
-    services.AddSingleton<BaseCommand, DeployCommand>();   // ← add this
+    services.AddSingleton<FuncCliCommand, DeployCommand>();   // ← add this
     return services;
 }
 ```
 
-`Parser.CreateCommand` resolves every `BaseCommand` from DI, partitions them into built-ins (`IBuiltInCommand`) and workload-contributed (`ExternalCommand`), and adds them to the root tree. The help system picks up the new command automatically.
+`Parser.CreateCommand` resolves every `FuncCliCommand` from DI, partitions them into built-ins (`IBuiltInCommand`) and workload-contributed (`ExternalCommand`), and adds them to the root tree. The help system picks up the new command automatically.
 
 ## Step 3: Add Tests
 
@@ -214,7 +214,7 @@ dotnet run --project src/Func.Cli/ -- deploy --app-name myapp --dry-run
 For grouped commands (like `func workload install`), create a parent command:
 
 ```csharp
-public class AzureCommand : BaseCommand
+public class AzureCommand : FuncCliCommand
 {
     public AzureCommand(IInteractionService interaction)
         : base("azure", "Azure resource management commands")
@@ -225,7 +225,7 @@ public class AzureCommand : BaseCommand
     }
 }
 
-public class AzureLoginCommand : BaseCommand
+public class AzureLoginCommand : FuncCliCommand
 {
     public AzureLoginCommand(IInteractionService interaction)
         : base("login", "Log in to Azure")
@@ -243,7 +243,7 @@ This produces: `func azure login`, `func azure list`.
 ## Checklist
 
 - [ ] Command class in `src/Func.Cli/Commands/`
-- [ ] Implements `IBuiltInCommand` and registered as a `BaseCommand` in `BuiltInCommands.cs`
+- [ ] Implements `IBuiltInCommand` and registered as a `FuncCliCommand` in `BuiltInCommands.cs`
 - [ ] Uses `IInteractionService` for all I/O
 - [ ] Uses `GracefulException` for user-facing errors
 - [ ] Tests cover registration, options, and happy path

--- a/docs/building-a-workload.md
+++ b/docs/building-a-workload.md
@@ -45,7 +45,8 @@ The CLI builds a `HostApplicationBuilder` at startup. Each installed workload is
 3. CLI builds the root command tree from DI
      ├── Built-in commands resolve workload-contributed services they consume
      │   (e.g. InitCommand consumes IEnumerable<IProjectInitializer>)
-     └── Every Command registered in DI is added as a root subcommand
+     └── Every command registered through builder.RegisterCommand(...) is
+         added as a root subcommand, tagged with the workload that registered it
 4. Command dispatch
 ```
 
@@ -56,7 +57,7 @@ The shape mirrors WebJobs' `IWebJobsStartup` — `Configure(FunctionsCliBuilder)
 1. Create a class library project that targets `net10.0`
 2. Reference `Azure.Functions.Cli.Abstractions`
 3. Implement `IWorkload`
-4. Inside `Configure`, register an `IProjectInitializer` (and/or top-level `Command` services, and any supporting services)
+4. Inside `Configure`, register an `IProjectInitializer` (and/or contribute top-level commands via `builder.RegisterCommand(...)`, and any supporting services)
 5. Build, package, and (once the loader ships) install with `func workload install`
 
 ## Step 1: Create the Project
@@ -115,7 +116,7 @@ public sealed class NodeWorkload : IWorkload
     public void Configure(FunctionsCliBuilder builder)
     {
         builder.Services.AddSingleton<IProjectInitializer, NodeProjectInitializer>();
-        // builder.Services.AddSingleton<Command>(new NodeTopLevelCommand());
+        // builder.RegisterCommand(new NodeTopLevelCommand());
         // …any other services your providers depend on
     }
 }
@@ -192,15 +193,57 @@ Workload-specific option values flow through the `ParseResult`, so the CLI never
 
 ## Step 4 (optional): Contribute New Commands
 
-For "feature" workloads that aren't tied to a stack — say a Durable Functions workload — register `Command` instances directly in DI alongside (or instead of) an `IProjectInitializer`. The CLI picks up every `Command` registered in the container and attaches it to the root.
+For "feature" workloads that aren't tied to a stack — say a Durable Functions workload — register top-level commands through `builder.RegisterCommand(...)`. Workload commands derive from `FuncCommand` (in `Azure.Functions.Cli.Workloads`), which is parser-independent: you describe the command's name, description, options, arguments, and subcommands using lightweight descriptors, and read parsed values through a `FuncCommandInvocationContext` at execution time. The CLI tracks which workload each command came from for diagnostics and collision reporting.
 
 ```csharp
-internal sealed class DurableCommand : Command
+using Azure.Functions.Cli.Workloads;
+
+internal sealed class DurableCommand : FuncCommand
 {
-    public DurableCommand() : base("durable", "Manage Durable Functions")
+    private static readonly FuncCommandOption<string> InstanceOption =
+        new("--instance-id", "-i", "Orchestration instance id");
+
+    public override string Name => "durable";
+
+    public override string Description => "Manage Durable Functions";
+
+    public override IReadOnlyList<FuncCommand> Subcommands =>
+    [
+        new ListInstancesCommand(),
+        new StartNewCommand(),
+    ];
+
+    public override Task<int> ExecuteAsync(
+        FuncCommandInvocationContext context,
+        CancellationToken cancellationToken) => Task.FromResult(0);
+
+    private sealed class ListInstancesCommand : FuncCommand
     {
-        Subcommands.Add(new Command("get-instances", "List orchestration instances"));
-        Subcommands.Add(new Command("start-new",     "Start a new orchestration"));
+        public override string Name => "get-instances";
+
+        public override string Description => "List orchestration instances.";
+
+        public override IReadOnlyList<FuncCommandOption> Options => [InstanceOption];
+
+        public override Task<int> ExecuteAsync(
+            FuncCommandInvocationContext context,
+            CancellationToken cancellationToken)
+        {
+            var instanceId = context.GetValue(InstanceOption);
+            // …list instances…
+            return Task.FromResult(0);
+        }
+    }
+
+    private sealed class StartNewCommand : FuncCommand
+    {
+        public override string Name => "start-new";
+
+        public override string Description => "Start a new orchestration.";
+
+        public override Task<int> ExecuteAsync(
+            FuncCommandInvocationContext context,
+            CancellationToken cancellationToken) => Task.FromResult(0);
     }
 }
 
@@ -213,12 +256,18 @@ public sealed class DurableWorkload : IWorkload
 
     public void Configure(FunctionsCliBuilder builder)
     {
-        builder.Services.AddSingleton<Command>(new DurableCommand());
+        // Pick the overload that fits how your command is constructed:
+        //   builder.RegisterCommand(new DurableCommand());        // simple instance
+        //   builder.RegisterCommand<DurableCommand>();            // DI-constructed
+        //   builder.RegisterCommand(sp => new DurableCommand(...)); // custom factory
+        builder.RegisterCommand<DurableCommand>();
     }
 }
 ```
 
-This produces `func durable get-instances`, `func durable start-new`, and so on.
+This produces `func durable get-instances`, `func durable start-new`, and so on. Reading parsed values goes through the supplied `FuncCommandInvocationContext` using the **same descriptor instance** the command exposes through `Options` / `Arguments` — descriptors are looked up by reference identity, so don't construct a new descriptor every time you read a value.
+
+> The host wraps your `FuncCommand` in an internal adapter that carries the owning `WorkloadInfo`, so `func` can identify the source workload in collision warnings and diagnostics. Don't register raw `System.CommandLine.Command` services through `builder.Services` — the parser only consumes commands registered through `RegisterCommand`.
 
 ## Reading Workload-Specific Options
 
@@ -272,7 +321,7 @@ Add path-scoped public + official CI pipelines in `eng/ci/` (mirror the abstract
 
 - [ ] New project in `src/Func.Cli.Workload.<Name>/`, references `Func.Cli.Abstractions` only
 - [ ] `IWorkload` with parameterless constructor and the five identity properties (`PackageId`, `PackageVersion`, `Type`, `DisplayName`, `Description`)
-- [ ] `Configure(FunctionsCliBuilder)` registers an `IProjectInitializer` and/or top-level `Command` services
+- [ ] `Configure(FunctionsCliBuilder)` registers an `IProjectInitializer` and/or top-level commands via `builder.RegisterCommand(...)`
 - [ ] `IProjectInitializer.GetInitOptions()` returns any extra options the initializer needs
 - [ ] Test project in `test/Func.Cli.Workload.<Name>.Tests/`
 - [ ] `Directory.Build.props`, `Directory.Build.targets`, `Directory.Version.props` created

--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -26,7 +26,7 @@ Program.cs
   │
   ├── Parser.CreateCommand(host.Services)
   │   ├── Build root command
-  │   ├── Resolve every BaseCommand from DI:
+  │   ├── Resolve every FuncCliCommand from DI:
   │   │     ├── Built-in commands (IBuiltInCommand): init, new, start, version, help, workload
   │   │     └── ExternalCommand wrappers (each carries the WorkloadInfo for the
   │   │         workload that called RegisterCommand)
@@ -70,9 +70,9 @@ Workloads can add their own subcommands by calling `builder.RegisterCommand(...)
 
 ## Command Architecture
 
-All commands extend `BaseCommand` → `System.CommandLine.Command`.
+All commands extend `FuncCliCommand` → `System.CommandLine.Command`.
 
-### BaseCommand
+### FuncCliCommand
 
 Provides shared infrastructure:
 - **`SetAction`** wiring — connects `ExecuteAsync` to the command
@@ -115,7 +115,7 @@ public Option<string> FrameworkOption { get; } = new("--target-framework")
     DefaultValueFactory = _ => "net10.0"
 };
 
-// Positional argument (via BaseCommand)
+// Positional argument (via FuncCliCommand)
 AddPathArgument(); // adds optional [path] argument
 ```
 
@@ -237,7 +237,7 @@ Configure (CLI startup):
                 builder.RegisterCommand(sp => new MyFactoryCommand(...)) // optional
 
 Build commands (Parser.CreateCommand):
-  ├── Resolve every BaseCommand from DI:
+  ├── Resolve every FuncCliCommand from DI:
   │     ├── Built-ins (IBuiltInCommand) — names form the reserved set
   │     └── ExternalCommand wrappers — each carries the source WorkloadInfo
   ├── Built-in collisions throw (CLI bug); workload commands that collide with

--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -17,15 +17,21 @@ Program.cs
   │   │   ├── WithTracing → AzureMonitorTraceExporter
   │   │   └── WithMetrics → AzureMonitorMetricExporter
   │   └── WorkloadRegistration.RegisterWorkloads(FunctionsCliBuilder)
-  │       └── For each installed workload: workload.Configure(builder)
-  │           (registers IProjectInitializer, top-level Command instances, etc.)
+  │       └── For each installed workload: workload.Configure(workloadBuilder)
+  │           (workloadBuilder is scoped to the WorkloadInfo so RegisterCommand
+  │            calls tag commands with the owning workload; the builder also
+  │            registers IProjectInitializer and any supporting services)
   │
   ├── host.StartAsync()    ← OTel listeners subscribed before any tracing
   │
   ├── Parser.CreateCommand(host.Services)
   │   ├── Build root command
-  │   ├── Resolve built-in commands from DI (init, new, start, version, help, workload)
-  │   ├── Add every Command registered in DI (workload-contributed top-level subcommands)
+  │   ├── Resolve every BaseCommand from DI:
+  │   │     ├── Built-in commands (IBuiltInCommand): init, new, start, version, help, workload
+  │   │     └── ExternalCommand wrappers (each carries the WorkloadInfo for the
+  │   │         workload that called RegisterCommand)
+  │   ├── Skip workload commands that collide with built-ins or with each
+  │   │   other; emit a warning to stderr that names the offending workload(s)
   │   └── Replace help rendering with Spectre on all commands
   │
   ├── Wire cancellation (Ctrl+C / SIGTERM via CancellationTokenSource)
@@ -60,7 +66,7 @@ func
 └── help (hidden)         Print help
 ```
 
-Workloads can add their own subcommands by registering `Command` instances in DI (see [building-a-workload.md](building-a-workload.md)).
+Workloads can add their own subcommands by calling `builder.RegisterCommand(...)` from inside `IWorkload.Configure` (see [building-a-workload.md](building-a-workload.md)). Workload commands are described in parser-independent terms via `FuncCommand` / `FuncCommandOption` / `FuncCommandArgument`; the host wraps each one in an internal `ExternalCommand` adapter that translates the descriptors to `System.CommandLine` and tracks the registering workload for diagnostics.
 
 ## Command Architecture
 
@@ -205,9 +211,12 @@ The abstractions library exposes the surface workload authors program against:
 | Type | Role |
 |------|------|
 | `IWorkload` | Entry point. Identity (`PackageId`, `PackageVersion`, `DisplayName`, `Description`) plus `Configure(FunctionsCliBuilder)`. |
-| `FunctionsCliBuilder` | The DI seam handed to a workload — exposes `IServiceCollection` for service registration. Abstract base so we can grow the surface without breaking workloads. |
+| `FunctionsCliBuilder` | The DI seam handed to a workload. Exposes `Services` for plain DI registrations and `RegisterCommand(...)` overloads (instance / type / factory) for contributing top-level commands. Abstract base so we can grow the surface without breaking workloads. |
 | `IProjectInitializer` | Owns `func init` for a stack. Declares `Stack`, `SupportedLanguages`, contributes init options, and runs `InitializeAsync(InitContext, ParseResult, CancellationToken)`. |
 | `WorkloadContext` / `InitContext` | Records carrying common + command-specific inputs to providers. |
+| `FuncCommand` | Parser-independent base for workload-contributed top-level commands. Describes `Name`, `Description`, `Options`, `Arguments`, `Subcommands`, and an `ExecuteAsync(FuncCommandInvocationContext, CancellationToken)`. |
+| `FuncCommandOption` / `FuncCommandArgument` | Typed descriptors used by `FuncCommand`. Identity matters — pass the same descriptor instance to `context.GetValue(...)` to read parsed values. |
+| `FuncCommandInvocationContext` | Read parsed option / argument values without depending on `System.CommandLine`. |
 
 `WorkloadInfo` (the render-ready manifest entry consumed by `func workload list`) is a CLI-internal type — workload authors don't see it.
 
@@ -220,13 +229,20 @@ Configure (CLI startup):
     └── WorkloadRegistration.RegisterWorkloads(builder)
         ├── Discover installed workloads               ← future PR (loader)
         ├── Activate each IWorkload type
-        └── workload.Configure(builder)
+        └── workload.Configure(workloadBuilder)        ← per-workload, scoped
+                                                        to a WorkloadInfo
             └── builder.Services.AddSingleton<IProjectInitializer, …>()
-                builder.Services.AddSingleton<Command>(new MyTopLevelCommand())  // optional
+                builder.RegisterCommand(new MyTopLevelCommand())     // optional
+                builder.RegisterCommand<MyDiCommand>()               // optional
+                builder.RegisterCommand(sp => new MyFactoryCommand(...)) // optional
 
 Build commands (Parser.CreateCommand):
-  ├── Pull every Command from DI (built-ins + workload-contributed)
-  ├── Validate names are unique (throws on collision)
+  ├── Resolve every BaseCommand from DI:
+  │     ├── Built-ins (IBuiltInCommand) — names form the reserved set
+  │     └── ExternalCommand wrappers — each carries the source WorkloadInfo
+  ├── Built-in collisions throw (CLI bug); workload commands that collide with
+  │   built-ins or with each other are skipped with a warning that names the
+  │   workload(s)
   ├── InitCommand sees IEnumerable<IProjectInitializer>, attaches their options
   ├── WorkloadListCommand sees IReadOnlyList<WorkloadInfo>
   └── HelpCommand built last with a back-reference to the constructed root

--- a/docs/repo-structure.md
+++ b/docs/repo-structure.md
@@ -39,15 +39,15 @@ The main tool users install and run. Assembly name is `func`.
 
 | Directory          | Purpose |
 |--------------------|---------|
-| `Commands/`        | Built-in commands (init, new, pack, start, version, help) + `BaseCommand`, `FuncRootCommand`, `ProjectDetector`, `SpectreHelpAction`, `WorkloadHints` |
+| `Commands/`        | Built-in commands (init, new, pack, start, version, help) + `FuncCliCommand`, `FuncRootCommand`, `ProjectDetector`, `SpectreHelpAction`, `WorkloadHints` |
 | `Commands/Workload/` | `func workload` parent command + `func workload list` |
 | `Console/`         | `IInteractionService` abstraction + Spectre.Console implementation, theme |
 | `Common/`          | Shared utilities — `Constants`, `Stacks` (stack registry), `VersionChecker` |
 | `Hosting/`         | `DefaultFunctionsCliBuilder` (internal `FunctionsCliBuilder` impl), `BuiltInCommands` DI registrations, and `WorkloadRegistration` (workload bootstrap seam) |
-| `Workloads/`       | `ExternalCommand` — internal `BaseCommand` adapter that wraps a workload-supplied `FuncCommand` and carries the owning `WorkloadInfo` |
+| `Workloads/`       | `ExternalCommand` — internal `FuncCliCommand` adapter that wraps a workload-supplied `FuncCommand` and carries the owning `WorkloadInfo` |
 | `Telemetry/`       | `CliTelemetry` (ActivitySource + Meter), Azure Monitor exporter wiring, activity / metric extensions |
 | `Program.cs`       | Entry point — host, telemetry, command tree, error handling |
-| `Parser.cs`        | Command tree composition — resolves every `BaseCommand` from DI, partitions into built-ins (`IBuiltInCommand`) and workload-contributed (`ExternalCommand`), wires Spectre help |
+| `Parser.cs`        | Command tree composition — resolves every `FuncCliCommand` from DI, partitions into built-ins (`IBuiltInCommand`) and workload-contributed (`ExternalCommand`), wires Spectre help |
 
 ### `src/Func.Cli.Abstractions` — Workload Contracts
 

--- a/docs/repo-structure.md
+++ b/docs/repo-structure.md
@@ -44,9 +44,10 @@ The main tool users install and run. Assembly name is `func`.
 | `Console/`         | `IInteractionService` abstraction + Spectre.Console implementation, theme |
 | `Common/`          | Shared utilities — `Constants`, `Stacks` (stack registry), `VersionChecker` |
 | `Hosting/`         | `DefaultFunctionsCliBuilder` (internal `FunctionsCliBuilder` impl), `BuiltInCommands` DI registrations, and `WorkloadRegistration` (workload bootstrap seam) |
+| `Workloads/`       | `ExternalCommand` — internal `BaseCommand` adapter that wraps a workload-supplied `FuncCommand` and carries the owning `WorkloadInfo` |
 | `Telemetry/`       | `CliTelemetry` (ActivitySource + Meter), Azure Monitor exporter wiring, activity / metric extensions |
 | `Program.cs`       | Entry point — host, telemetry, command tree, error handling |
-| `Parser.cs`        | Command tree composition — resolves built-ins from DI, picks up workload-contributed `Command` services, wires Spectre help |
+| `Parser.cs`        | Command tree composition — resolves every `BaseCommand` from DI, partitions into built-ins (`IBuiltInCommand`) and workload-contributed (`ExternalCommand`), wires Spectre help |
 
 ### `src/Func.Cli.Abstractions` — Workload Contracts
 
@@ -56,7 +57,9 @@ A packable NuGet library (`Azure.Functions.Cli.Abstractions`) hosting the public
 |-------------|------|
 | `Common/GracefulException` | User-friendly exception with optional verbose detail; drives non-zero exit codes |
 | `Workloads/IWorkload` | Workload entry point — identity properties + `Configure(FunctionsCliBuilder)` |
-| `Workloads/FunctionsCliBuilder` | DI seam (abstract base) — exposes `IServiceCollection` to workloads |
+| `Workloads/FunctionsCliBuilder` | DI seam (abstract base) — `Services` for plain DI plus `RegisterCommand(...)` overloads for top-level commands |
+| `Workloads/FuncCommand` | Parser-independent base for workload-contributed top-level commands (Name, Description, Options, Arguments, Subcommands, ExecuteAsync) |
+| `Workloads/FuncCommandOption`, `FuncCommandArgument`, `FuncCommandInvocationContext` | Typed descriptors and the invocation context used by `FuncCommand` |
 | `Workloads/IProjectInitializer` | `func init` extension point for a stack |
 | `Workloads/WorkloadContext`, `InitContext` | Records carrying inputs to providers |
 

--- a/src/Func.Cli.Abstractions/Func.Cli.Abstractions.csproj
+++ b/src/Func.Cli.Abstractions/Func.Cli.Abstractions.csproj
@@ -16,8 +16,4 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
-  <ItemGroup>
-    <InternalsVisibleTo Include="func" />
-  </ItemGroup>
-
 </Project>

--- a/src/Func.Cli.Abstractions/Func.Cli.Abstractions.csproj
+++ b/src/Func.Cli.Abstractions/Func.Cli.Abstractions.csproj
@@ -16,4 +16,8 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="func" />
+  </ItemGroup>
+
 </Project>

--- a/src/Func.Cli.Abstractions/Workloads/FuncCommand.cs
+++ b/src/Func.Cli.Abstractions/Workloads/FuncCommand.cs
@@ -9,14 +9,6 @@ namespace Azure.Functions.Cli.Workloads;
 /// type/factory overloads); the host wraps it in an internal adapter that maps the
 /// declared <see cref="Options"/>, <see cref="Arguments"/>, and <see cref="Subcommands"/>
 /// onto the underlying parser and tracks which workload owns the registration.
-///
-/// The contract is intentionally parser-independent — workload authors describe their
-/// command shape with <see cref="FuncCommandOption"/> / <see cref="FuncCommandArgument"/>
-/// descriptors and read parsed values through <see cref="FuncCommandInvocationContext"/>,
-/// so the CLI can change parser implementations without breaking workloads.
-///
-/// Implementations are typically singletons; do not assume a fresh instance per
-/// invocation.
 /// </summary>
 public abstract class FuncCommand
 {
@@ -57,7 +49,5 @@ public abstract class FuncCommand
     /// this command (reference identity is required).
     /// </summary>
     /// <returns>Process exit code. <c>0</c> for success.</returns>
-    public abstract Task<int> ExecuteAsync(
-        FuncCommandInvocationContext context,
-        CancellationToken cancellationToken);
+    public abstract Task<int> ExecuteAsync(FuncCommandInvocationContext context, CancellationToken cancellationToken);
 }

--- a/src/Func.Cli.Abstractions/Workloads/FuncCommand.cs
+++ b/src/Func.Cli.Abstractions/Workloads/FuncCommand.cs
@@ -1,0 +1,63 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workloads;
+
+/// <summary>
+/// A workload-contributed CLI command. Workloads register a <see cref="FuncCommand"/>
+/// with <see cref="FunctionsCliBuilder.RegisterCommand(FuncCommand)"/> (or one of its
+/// type/factory overloads); the host wraps it in an internal adapter that maps the
+/// declared <see cref="Options"/>, <see cref="Arguments"/>, and <see cref="Subcommands"/>
+/// onto the underlying parser and tracks which workload owns the registration.
+///
+/// The contract is intentionally parser-independent — workload authors describe their
+/// command shape with <see cref="FuncCommandOption"/> / <see cref="FuncCommandArgument"/>
+/// descriptors and read parsed values through <see cref="FuncCommandInvocationContext"/>,
+/// so the CLI can change parser implementations without breaking workloads.
+///
+/// Implementations are typically singletons; do not assume a fresh instance per
+/// invocation.
+/// </summary>
+public abstract class FuncCommand
+{
+    /// <summary>
+    /// Name used at the command line (e.g. <c>"deploy"</c>). Must be unique among
+    /// top-level commands; collisions with built-ins or other workloads are reported
+    /// at startup and the colliding registrations are skipped.
+    /// </summary>
+    public abstract string Name { get; }
+
+    /// <summary>One-line description shown in <c>--help</c> output.</summary>
+    public abstract string Description { get; }
+
+    /// <summary>
+    /// Options accepted by this command. Return a stable list — descriptors are
+    /// snapshotted once at command-tree construction. The same descriptor instance
+    /// passed to <see cref="FuncCommandInvocationContext.GetValue{T}(FuncCommandOption{T})"/>
+    /// is required to read the parsed value.
+    /// </summary>
+    public virtual IReadOnlyList<FuncCommandOption> Options => [];
+
+    /// <summary>
+    /// Positional arguments accepted by this command. Same stability and identity
+    /// rules as <see cref="Options"/>.
+    /// </summary>
+    public virtual IReadOnlyList<FuncCommandArgument> Arguments => [];
+
+    /// <summary>
+    /// Nested subcommands. Read once when the parent is materialized; the host
+    /// does not re-read this property later. Subcommands are not registered as
+    /// separate top-level commands, so they cannot accidentally float to the root.
+    /// </summary>
+    public virtual IReadOnlyList<FuncCommand> Subcommands => [];
+
+    /// <summary>
+    /// Executes the command. Read parsed option / argument values through
+    /// <paramref name="context"/> using the same descriptor instances declared on
+    /// this command (reference identity is required).
+    /// </summary>
+    /// <returns>Process exit code. <c>0</c> for success.</returns>
+    public abstract Task<int> ExecuteAsync(
+        FuncCommandInvocationContext context,
+        CancellationToken cancellationToken);
+}

--- a/src/Func.Cli.Abstractions/Workloads/FuncCommandArgument.cs
+++ b/src/Func.Cli.Abstractions/Workloads/FuncCommandArgument.cs
@@ -1,0 +1,58 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workloads;
+
+/// <summary>
+/// Parser-independent description of a positional argument accepted by a
+/// <see cref="FuncCommand"/>. Use <see cref="FuncCommandArgument{T}"/> to declare
+/// arguments of a specific value type; instances are kept by reference (identity)
+/// and used as the lookup key when reading parsed values from
+/// <see cref="FuncCommandInvocationContext"/>.
+/// </summary>
+public abstract class FuncCommandArgument
+{
+    /// <param name="name">Argument name shown in usage / help (e.g. <c>"path"</c>). Required.</param>
+    /// <param name="description">Help text shown in <c>--help</c> output.</param>
+    /// <param name="isRequired">When <c>true</c>, the argument must be supplied; when <c>false</c>, it is optional.</param>
+    private protected FuncCommandArgument(string name, string description, bool isRequired)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(description);
+
+        Name = name;
+        Description = description;
+        IsRequired = isRequired;
+    }
+
+    /// <summary>Argument name (e.g. <c>"path"</c>).</summary>
+    public string Name { get; }
+
+    /// <summary>Help text shown in <c>--help</c> output.</summary>
+    public string Description { get; }
+
+    /// <summary>
+    /// <c>true</c> if the argument is required (parser arity <c>ExactlyOne</c>);
+    /// <c>false</c> if it is optional (<c>ZeroOrOne</c>).
+    /// </summary>
+    public bool IsRequired { get; }
+
+    /// <summary>The runtime value type carried by this argument (used by the parser adapter).</summary>
+    internal abstract Type ValueType { get; }
+}
+
+/// <summary>
+/// A typed <see cref="FuncCommandArgument"/>. Read parsed values via
+/// <see cref="FuncCommandInvocationContext.GetValue{T}(FuncCommandArgument{T})"/>
+/// using the same descriptor instance.
+/// </summary>
+/// <typeparam name="T">Value type read by <see cref="FuncCommandInvocationContext.GetValue{T}(FuncCommandArgument{T})"/>.</typeparam>
+public sealed class FuncCommandArgument<T> : FuncCommandArgument
+{
+    public FuncCommandArgument(string name, string description, bool isRequired = false)
+        : base(name, description, isRequired)
+    {
+    }
+
+    internal override Type ValueType => typeof(T);
+}

--- a/src/Func.Cli.Abstractions/Workloads/FuncCommandArgument.cs
+++ b/src/Func.Cli.Abstractions/Workloads/FuncCommandArgument.cs
@@ -38,7 +38,7 @@ public abstract class FuncCommandArgument
     public bool IsRequired { get; }
 
     /// <summary>The runtime value type carried by this argument (used by the parser adapter).</summary>
-    internal abstract Type ValueType { get; }
+    public abstract Type ValueType { get; }
 }
 
 /// <summary>
@@ -54,5 +54,5 @@ public sealed class FuncCommandArgument<T> : FuncCommandArgument
     {
     }
 
-    internal override Type ValueType => typeof(T);
+    public override Type ValueType => typeof(T);
 }

--- a/src/Func.Cli.Abstractions/Workloads/FuncCommandInvocationContext.cs
+++ b/src/Func.Cli.Abstractions/Workloads/FuncCommandInvocationContext.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workloads;
+
+/// <summary>
+/// Surface a <see cref="FuncCommand"/> uses at execution time to read parsed option
+/// and argument values. The host supplies a concrete subclass that bridges to the
+/// underlying parser; workload authors only see this abstract type.
+///
+/// Lookups use reference identity on the descriptor — pass the same
+/// <see cref="FuncCommandOption{T}"/> / <see cref="FuncCommandArgument{T}"/> instance
+/// that the command declared in <see cref="FuncCommand.Options"/> /
+/// <see cref="FuncCommand.Arguments"/>. Two distinct descriptors with identical
+/// fields are treated as different keys.
+/// </summary>
+public abstract class FuncCommandInvocationContext
+{
+    /// <summary>Reads the parsed value of a typed option.</summary>
+    /// <returns>
+    /// The parsed value when supplied on the command line, the option's
+    /// <see cref="FuncCommandOption{T}.DefaultValue"/> when not supplied and a default
+    /// was declared, or <c>default(T)</c> otherwise.
+    /// </returns>
+    /// <exception cref="ArgumentException">The option was not declared on the
+    /// command being executed.</exception>
+    public abstract T? GetValue<T>(FuncCommandOption<T> option);
+
+    /// <summary>Reads the parsed value of a typed positional argument.</summary>
+    /// <returns>
+    /// The parsed value when supplied on the command line, or <c>default(T)</c>
+    /// otherwise (including when the argument is optional and was omitted).
+    /// </returns>
+    /// <exception cref="ArgumentException">The argument was not declared on the
+    /// command being executed.</exception>
+    public abstract T? GetValue<T>(FuncCommandArgument<T> argument);
+}

--- a/src/Func.Cli.Abstractions/Workloads/FuncCommandOption.cs
+++ b/src/Func.Cli.Abstractions/Workloads/FuncCommandOption.cs
@@ -34,7 +34,7 @@ public abstract class FuncCommandOption
     public string Description { get; }
 
     /// <summary>Type-erased view of the value type carried by this option (used by the parser adapter to construct a typed parser option).</summary>
-    internal abstract Type ValueType { get; }
+    public abstract Type ValueType { get; }
 }
 
 /// <summary>
@@ -76,5 +76,5 @@ public sealed class FuncCommandOption<T> : FuncCommandOption
     /// </summary>
     public T DefaultValue { get; }
 
-    internal override Type ValueType => typeof(T);
+    public override Type ValueType => typeof(T);
 }

--- a/src/Func.Cli.Abstractions/Workloads/FuncCommandOption.cs
+++ b/src/Func.Cli.Abstractions/Workloads/FuncCommandOption.cs
@@ -1,0 +1,80 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workloads;
+
+/// <summary>
+/// Parser-independent description of an option accepted by a <see cref="FuncCommand"/>.
+/// Use <see cref="FuncCommandOption{T}"/> to declare options of a specific value type;
+/// instances are kept by reference (identity) and used as the lookup key when reading
+/// parsed values from <see cref="FuncCommandInvocationContext"/>.
+/// </summary>
+public abstract class FuncCommandOption
+{
+    /// <param name="name">Long form (e.g. <c>"--name"</c>). Required.</param>
+    /// <param name="shortName">Optional short form (e.g. <c>"-n"</c>). Pass <c>null</c> for none.</param>
+    /// <param name="description">Help text shown in <c>--help</c> output.</param>
+    private protected FuncCommandOption(string name, string? shortName, string description)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(description);
+
+        Name = name;
+        ShortName = shortName;
+        Description = description;
+    }
+
+    /// <summary>Long form (e.g. <c>"--name"</c>).</summary>
+    public string Name { get; }
+
+    /// <summary>Short form (e.g. <c>"-n"</c>), or <c>null</c> if the option has only a long form.</summary>
+    public string? ShortName { get; }
+
+    /// <summary>Help text shown in <c>--help</c> output.</summary>
+    public string Description { get; }
+
+    /// <summary>Type-erased view of the value type carried by this option (used by the parser adapter to construct a typed parser option).</summary>
+    internal abstract Type ValueType { get; }
+}
+
+/// <summary>
+/// A typed <see cref="FuncCommandOption"/>. Construct with one of the two
+/// constructors: omit <c>defaultValue</c> for a non-defaulting option, or pass
+/// it to provide an explicit default. The two-constructor shape distinguishes
+/// "no default" from "default is <c>default(T)</c>" — for value types like
+/// <see langword="int"/>, the unset case is <c>HasDefaultValue == false</c>,
+/// not <c>DefaultValue == 0</c>.
+/// </summary>
+/// <typeparam name="T">Value type read by <see cref="FuncCommandInvocationContext.GetValue{T}(FuncCommandOption{T})"/>.</typeparam>
+public sealed class FuncCommandOption<T> : FuncCommandOption
+{
+    /// <summary>Declares an option without a default value.</summary>
+    public FuncCommandOption(string name, string? shortName, string description)
+        : base(name, shortName, description)
+    {
+        HasDefaultValue = false;
+        DefaultValue = default!;
+    }
+
+    /// <summary>Declares an option with an explicit default value.</summary>
+    public FuncCommandOption(string name, string? shortName, string description, T defaultValue)
+        : base(name, shortName, description)
+    {
+        HasDefaultValue = true;
+        DefaultValue = defaultValue;
+    }
+
+    /// <summary>
+    /// <c>true</c> if a default value was supplied at construction. When <c>false</c>,
+    /// the value of <see cref="DefaultValue"/> is unspecified and should not be read.
+    /// </summary>
+    public bool HasDefaultValue { get; }
+
+    /// <summary>
+    /// The default value supplied at construction. Read only when
+    /// <see cref="HasDefaultValue"/> is <c>true</c>.
+    /// </summary>
+    public T DefaultValue { get; }
+
+    internal override Type ValueType => typeof(T);
+}

--- a/src/Func.Cli.Abstractions/Workloads/FunctionsCliBuilder.cs
+++ b/src/Func.Cli.Abstractions/Workloads/FunctionsCliBuilder.cs
@@ -8,7 +8,8 @@ namespace Azure.Functions.Cli.Workloads;
 /// <summary>
 /// Bootstrap surface passed to <see cref="IWorkload.Configure"/>.
 /// Workloads register their services — project initializers, commands, and
-/// any other supporting types — through <see cref="Services"/>.
+/// any other supporting types — through <see cref="Services"/> and the
+/// <see cref="RegisterCommand(FuncCommand)"/> overloads.
 ///
 /// Modeled after WebJobs' <c>IWebJobsBuilder</c>: the builder exposes the DI
 /// container so workloads can use any standard .NET DI extension method, and
@@ -22,4 +23,59 @@ public abstract class FunctionsCliBuilder
 {
     /// <summary>The DI service collection workloads contribute to.</summary>
     public abstract IServiceCollection Services { get; }
+
+    /// <summary>
+    /// Registers a top-level <see cref="FuncCommand"/> instance. The same
+    /// instance is used for every invocation; do not depend on per-invocation
+    /// state being held on the command itself.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="command"/> is <c>null</c>.</exception>
+    public void RegisterCommand(FuncCommand command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        OnRegisterCommand(command);
+    }
+
+    /// <summary>
+    /// Registers a top-level command by type. The command is constructed by
+    /// the DI container, so it can request services through its constructor.
+    /// </summary>
+    /// <typeparam name="TCommand">A concrete <see cref="FuncCommand"/>.</typeparam>
+    /// <exception cref="ArgumentException"><typeparamref name="TCommand"/> is abstract.</exception>
+    public void RegisterCommand<TCommand>()
+        where TCommand : FuncCommand
+    {
+        if (typeof(TCommand).IsAbstract)
+        {
+            throw new ArgumentException(
+                $"Cannot register abstract command type '{typeof(TCommand)}'. Pass a concrete FuncCommand subclass.",
+                nameof(TCommand));
+        }
+
+        OnRegisterCommand<TCommand>();
+    }
+
+    /// <summary>
+    /// Registers a top-level command produced by <paramref name="factory"/>.
+    /// Useful when the command needs services not registered through
+    /// <see cref="Services"/>, or when constructing the command requires
+    /// custom logic.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="factory"/> is <c>null</c>.</exception>
+    public void RegisterCommand(Func<IServiceProvider, FuncCommand> factory)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        OnRegisterCommand(factory);
+    }
+
+    /// <summary>Hook implemented by the host to wire a <see cref="FuncCommand"/> instance.</summary>
+    protected abstract void OnRegisterCommand(FuncCommand command);
+
+    /// <summary>Hook implemented by the host to wire a <see cref="FuncCommand"/> by type.</summary>
+    protected abstract void OnRegisterCommand<TCommand>()
+        where TCommand : FuncCommand;
+
+    /// <summary>Hook implemented by the host to wire a <see cref="FuncCommand"/> via a factory.</summary>
+    protected abstract void OnRegisterCommand(Func<IServiceProvider, FuncCommand> factory);
 }
+

--- a/src/Func.Cli/Commands/BaseCommand.cs
+++ b/src/Func.Cli/Commands/BaseCommand.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.CommandLine;
+using System.CommandLine.Help;
+using System.CommandLine.Invocation;
 using Azure.Functions.Cli.Common;
 
 namespace Azure.Functions.Cli.Commands;
@@ -32,9 +34,43 @@ internal abstract class BaseCommand : Command
     }
 
     /// <summary>
-    /// Executes the command asynchronously with cancellation support.
+    /// Executes the command asynchronously with cancellation support. Parent-only
+    /// commands that have subcommands but no execution logic of their own can
+    /// inherit the default implementation, which invokes the help action wired
+    /// to the root command's <see cref="HelpOption"/> (e.g. Spectre help). The
+    /// help action itself decides which command to render help for based on
+    /// <see cref="ParseResult.CommandResult"/>, so the user sees help for this
+    /// command, not the root.
     /// </summary>
-    protected abstract Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken);
+    protected virtual Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        // SCL 2.0.6 adds HelpOption to RootCommand, not to subcommands. Walk
+        // from this command up through parents to find the nearest HelpOption.
+        Command? current = this;
+        while (current is not null)
+        {
+            var helpOption = current.Options.OfType<HelpOption>().FirstOrDefault();
+            if (helpOption?.Action is SynchronousCommandLineAction sync)
+            {
+                return Task.FromResult(sync.Invoke(parseResult));
+            }
+
+            current = current.Parents.OfType<Command>().FirstOrDefault();
+        }
+
+        // Fallback: if we still can't find a help action, look at the root
+        // result. In practice this is the same lookup, but it's defensive
+        // against constructed-but-unparented commands.
+        var rootHelp = parseResult.RootCommandResult.Command.Options.OfType<HelpOption>().FirstOrDefault();
+        if (rootHelp?.Action is SynchronousCommandLineAction rootSync)
+        {
+            return Task.FromResult(rootSync.Invoke(parseResult));
+        }
+
+        // Help action not wired (command was constructed outside Parser.CreateCommand,
+        // or there is no HelpOption). Nothing meaningful to render — return success.
+        return Task.FromResult(0);
+    }
 
     /// <summary>
     /// Adds the optional [path] argument to this command. Call from the constructor

--- a/src/Func.Cli/Commands/FuncCliCommand.cs
+++ b/src/Func.Cli/Commands/FuncCliCommand.cs
@@ -17,7 +17,7 @@ namespace Azure.Functions.Cli.Commands;
 /// constructor and ApplyPath(parseResult) in their execute method to support
 /// 'func start [path]', 'func init [path]', etc.
 /// </summary>
-internal abstract class BaseCommand : Command
+internal abstract class FuncCliCommand : Command
 {
     /// <summary>
     /// Path argument for commands that operate on a project directory. Created
@@ -25,7 +25,7 @@ internal abstract class BaseCommand : Command
     /// </summary>
     protected Argument<string?>? PathArgument { get; private set; }
 
-    protected BaseCommand(string name, string description) : base(name, description)
+    protected FuncCliCommand(string name, string description) : base(name, description)
     {
         SetAction(async (parseResult, cancellationToken) =>
         {

--- a/src/Func.Cli/Commands/FuncRootCommand.cs
+++ b/src/Func.Cli/Commands/FuncRootCommand.cs
@@ -6,7 +6,7 @@ using System.CommandLine;
 namespace Azure.Functions.Cli.Commands;
 
 /// <summary>
-/// Root 'func' command definition. Separate from BaseCommand because RootCommand
+/// Root 'func' command definition. Separate from FuncCliCommand because RootCommand
 /// has distinct behavior (no-args → help, global options, version display).
 /// </summary>
 internal class FuncRootCommand : RootCommand

--- a/src/Func.Cli/Commands/HelpCommand.cs
+++ b/src/Func.Cli/Commands/HelpCommand.cs
@@ -11,7 +11,7 @@ namespace Azure.Functions.Cli.Commands;
 /// <summary>
 /// Renders rich help generated from real <see cref="Command"/> metadata.
 /// </summary>
-internal class HelpCommand : BaseCommand
+internal class HelpCommand : FuncCliCommand
 {
     public Argument<string?> CommandArgument { get; } = new("command")
     {

--- a/src/Func.Cli/Commands/InitCommand.cs
+++ b/src/Func.Cli/Commands/InitCommand.cs
@@ -14,7 +14,7 @@ namespace Azure.Functions.Cli.Commands;
 /// Each registered initializer may also contribute additional options to this
 /// command (e.g. dotnet's <c>--target-framework</c>).
 /// </summary>
-internal class InitCommand : BaseCommand, IBuiltInCommand
+internal class InitCommand : FuncCliCommand, IBuiltInCommand
 {
     public Option<string?> StackOption { get; } = new("--stack", "-s")
     {

--- a/src/Func.Cli/Commands/NewCommand.cs
+++ b/src/Func.Cli/Commands/NewCommand.cs
@@ -11,7 +11,7 @@ namespace Azure.Functions.Cli.Commands;
 /// Creates a new function from a template. The full implementation requires
 /// a language workload to be installed — this defines the command skeleton and options.
 /// </summary>
-internal class NewCommand : BaseCommand, IBuiltInCommand
+internal class NewCommand : FuncCliCommand, IBuiltInCommand
 {
     public Option<string?> NameOption { get; } = new("--name", "-n")
     {

--- a/src/Func.Cli/Commands/StartCommand.cs
+++ b/src/Func.Cli/Commands/StartCommand.cs
@@ -10,7 +10,7 @@ namespace Azure.Functions.Cli.Commands;
 /// <summary>
 /// Launches the Azure Functions host runtime via 'func start'.
 /// </summary>
-internal class StartCommand : BaseCommand, IBuiltInCommand
+internal class StartCommand : FuncCliCommand, IBuiltInCommand
 {
     public Option<int?> PortOption { get; } = new("--port", "-p")
     {

--- a/src/Func.Cli/Commands/VersionCommand.cs
+++ b/src/Func.Cli/Commands/VersionCommand.cs
@@ -11,7 +11,7 @@ namespace Azure.Functions.Cli.Commands;
 /// <summary>
 /// Displays Azure Functions CLI version information.
 /// </summary>
-internal class VersionCommand : BaseCommand, IBuiltInCommand
+internal class VersionCommand : FuncCliCommand, IBuiltInCommand
 {
     private readonly IInteractionService _interaction;
 

--- a/src/Func.Cli/Commands/Workload/WorkloadCommand.cs
+++ b/src/Func.Cli/Commands/Workload/WorkloadCommand.cs
@@ -10,10 +10,10 @@ namespace Azure.Functions.Cli.Commands.Workload;
 /// inspection, and updates. Today the only subcommand wired in is
 /// <see cref="WorkloadListCommand"/>; install / uninstall land in a follow-up PR.
 ///
-/// Parent-only — relies on <see cref="BaseCommand.ExecuteAsync"/>'s default
+/// Parent-only — relies on <see cref="FuncCliCommand.ExecuteAsync"/>'s default
 /// implementation to render help when invoked without a subcommand.
 /// </summary>
-internal sealed class WorkloadCommand : BaseCommand, IBuiltInCommand
+internal sealed class WorkloadCommand : FuncCliCommand, IBuiltInCommand
 {
     public WorkloadCommand(WorkloadListCommand listCommand)
         : base("workload", "Manage Func CLI workloads.")

--- a/src/Func.Cli/Commands/Workload/WorkloadCommand.cs
+++ b/src/Func.Cli/Commands/Workload/WorkloadCommand.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.CommandLine;
 using Azure.Functions.Cli.Hosting;
 
 namespace Azure.Functions.Cli.Commands.Workload;
@@ -10,8 +9,11 @@ namespace Azure.Functions.Cli.Commands.Workload;
 /// Parent <c>func workload</c> command. Subcommands manage workload installation,
 /// inspection, and updates. Today the only subcommand wired in is
 /// <see cref="WorkloadListCommand"/>; install / uninstall land in a follow-up PR.
+///
+/// Parent-only — relies on <see cref="BaseCommand.ExecuteAsync"/>'s default
+/// implementation to render help when invoked without a subcommand.
 /// </summary>
-internal sealed class WorkloadCommand : Command, IBuiltInCommand
+internal sealed class WorkloadCommand : BaseCommand, IBuiltInCommand
 {
     public WorkloadCommand(WorkloadListCommand listCommand)
         : base("workload", "Manage Func CLI workloads.")

--- a/src/Func.Cli/Commands/Workload/WorkloadListCommand.cs
+++ b/src/Func.Cli/Commands/Workload/WorkloadListCommand.cs
@@ -13,7 +13,7 @@ namespace Azure.Functions.Cli.Commands.Workload;
 /// from each package's <c>workload.json</c>.
 /// </summary>
 internal sealed class WorkloadListCommand(IInteractionService interaction, IReadOnlyList<WorkloadInfo> workloads)
-    : BaseCommand("list", "List installed workloads.")
+    : FuncCliCommand("list", "List installed workloads.")
 {
     private readonly IInteractionService _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
     private readonly IReadOnlyList<WorkloadInfo> _workloads = workloads ?? throw new ArgumentNullException(nameof(workloads));

--- a/src/Func.Cli/Hosting/BuiltInCommands.cs
+++ b/src/Func.Cli/Hosting/BuiltInCommands.cs
@@ -25,19 +25,19 @@ internal static class BuiltInCommands
 
         // VersionCommand is also resolved by Parser to wire `func` (no args)
         // to detailed-version output, so register the concrete type and
-        // surface it as a top-level BaseCommand.
+        // surface it as a top-level FuncCliCommand.
         services.AddSingleton<VersionCommand>();
-        services.AddSingleton<BaseCommand>(sp => sp.GetRequiredService<VersionCommand>());
+        services.AddSingleton<FuncCliCommand>(sp => sp.GetRequiredService<VersionCommand>());
 
-        services.AddSingleton<BaseCommand, InitCommand>();
-        services.AddSingleton<BaseCommand, NewCommand>();
-        services.AddSingleton<BaseCommand, StartCommand>();
+        services.AddSingleton<FuncCliCommand, InitCommand>();
+        services.AddSingleton<FuncCliCommand, NewCommand>();
+        services.AddSingleton<FuncCliCommand, StartCommand>();
 
         // WorkloadCommand has WorkloadListCommand as a subcommand. Register
-        // the list command as its own concrete type (not as BaseCommand) so
-        // it doesn't get added at the top level by GetServices<BaseCommand>().
+        // the list command as its own concrete type (not as FuncCliCommand) so
+        // it doesn't get added at the top level by GetServices<FuncCliCommand>().
         services.AddSingleton<WorkloadListCommand>();
-        services.AddSingleton<BaseCommand, WorkloadCommand>();
+        services.AddSingleton<FuncCliCommand, WorkloadCommand>();
 
         return services;
     }

--- a/src/Func.Cli/Hosting/BuiltInCommands.cs
+++ b/src/Func.Cli/Hosting/BuiltInCommands.cs
@@ -25,20 +25,21 @@ internal static class BuiltInCommands
 
         // VersionCommand is also resolved by Parser to wire `func` (no args)
         // to detailed-version output, so register the concrete type and
-        // surface it as a top-level Command.
+        // surface it as a top-level BaseCommand.
         services.AddSingleton<VersionCommand>();
-        services.AddSingleton<Command>(sp => sp.GetRequiredService<VersionCommand>());
+        services.AddSingleton<BaseCommand>(sp => sp.GetRequiredService<VersionCommand>());
 
-        services.AddSingleton<Command, InitCommand>();
-        services.AddSingleton<Command, NewCommand>();
-        services.AddSingleton<Command, StartCommand>();
+        services.AddSingleton<BaseCommand, InitCommand>();
+        services.AddSingleton<BaseCommand, NewCommand>();
+        services.AddSingleton<BaseCommand, StartCommand>();
 
         // WorkloadCommand has WorkloadListCommand as a subcommand. Register
-        // the list command as its own concrete type (not as Command) so it
-        // doesn't get added at the top level by GetServices<Command>().
+        // the list command as its own concrete type (not as BaseCommand) so
+        // it doesn't get added at the top level by GetServices<BaseCommand>().
         services.AddSingleton<WorkloadListCommand>();
-        services.AddSingleton<Command, WorkloadCommand>();
+        services.AddSingleton<BaseCommand, WorkloadCommand>();
 
         return services;
     }
 }
+

--- a/src/Func.Cli/Hosting/DefaultFunctionsCliBuilder.cs
+++ b/src/Func.Cli/Hosting/DefaultFunctionsCliBuilder.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Commands;
 using Azure.Functions.Cli.Workloads;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -9,8 +10,69 @@ namespace Azure.Functions.Cli.Hosting;
 /// <summary>
 /// Default <see cref="FunctionsCliBuilder"/> implementation. Internal so
 /// workloads only see the abstract base type.
+///
+/// Each invocation of <see cref="IWorkload.Configure"/> gets its own instance
+/// constructed with the corresponding <see cref="WorkloadInfo"/>; the
+/// underlying <see cref="IServiceCollection"/> is the same global container
+/// the host uses, so workloads contributing the same service interface all
+/// flow into <c>GetServices&lt;T&gt;()</c>. The per-workload instance only
+/// scopes the command-tracking metadata — when
+/// <see cref="FunctionsCliBuilder.RegisterCommand(FuncCommand)"/> (or one of
+/// its overloads) is called, it produces an <see cref="ExternalCommand"/>
+/// tagged with the calling workload's <see cref="WorkloadInfo"/>.
+///
+/// A builder can also be constructed without a workload (used during host
+/// bootstrap before any workload has been loaded). Calls to
+/// <c>RegisterCommand</c> on a non-workload builder fail fast with a clear
+/// error so an untracked command can never reach the parser.
 /// </summary>
-internal sealed class DefaultFunctionsCliBuilder(IServiceCollection services) : FunctionsCliBuilder
+internal sealed class DefaultFunctionsCliBuilder : FunctionsCliBuilder
 {
-    public override IServiceCollection Services { get; } = services ?? throw new ArgumentNullException(nameof(services));
+    private readonly WorkloadInfo? _workload;
+
+    public DefaultFunctionsCliBuilder(IServiceCollection services)
+        : this(services, workload: null)
+    {
+    }
+
+    public DefaultFunctionsCliBuilder(IServiceCollection services, WorkloadInfo? workload)
+    {
+        Services = services ?? throw new ArgumentNullException(nameof(services));
+        _workload = workload;
+    }
+
+    public override IServiceCollection Services { get; }
+
+    protected override void OnRegisterCommand(FuncCommand command)
+    {
+        var workload = RequireWorkload();
+        Services.AddSingleton<BaseCommand>(_ => new ExternalCommand(workload, command));
+    }
+
+    protected override void OnRegisterCommand<TCommand>()
+    {
+        var workload = RequireWorkload();
+        Services.AddSingleton<TCommand>();
+        Services.AddSingleton<BaseCommand>(sp =>
+            new ExternalCommand(workload, sp.GetRequiredService<TCommand>()));
+    }
+
+    protected override void OnRegisterCommand(Func<IServiceProvider, FuncCommand> factory)
+    {
+        var workload = RequireWorkload();
+        Services.AddSingleton<BaseCommand>(sp =>
+        {
+            var command = factory(sp)
+                ?? throw new InvalidOperationException(
+                    $"Factory registered by workload '{workload.PackageId}' returned null.");
+            return new ExternalCommand(workload, command);
+        });
+    }
+
+    private WorkloadInfo RequireWorkload()
+        => _workload ?? throw new InvalidOperationException(
+            "Commands can only be registered through a workload-scoped builder. " +
+            "RegisterCommand is invoked by the workload loader during IWorkload.Configure; " +
+            "calling it on the host's global builder is a CLI bug.");
 }
+

--- a/src/Func.Cli/Hosting/DefaultFunctionsCliBuilder.cs
+++ b/src/Func.Cli/Hosting/DefaultFunctionsCliBuilder.cs
@@ -46,21 +46,21 @@ internal sealed class DefaultFunctionsCliBuilder : FunctionsCliBuilder
     protected override void OnRegisterCommand(FuncCommand command)
     {
         var workload = RequireWorkload();
-        Services.AddSingleton<BaseCommand>(_ => new ExternalCommand(workload, command));
+        Services.AddSingleton<FuncCliCommand>(_ => new ExternalCommand(workload, command));
     }
 
     protected override void OnRegisterCommand<TCommand>()
     {
         var workload = RequireWorkload();
         Services.AddSingleton<TCommand>();
-        Services.AddSingleton<BaseCommand>(sp =>
+        Services.AddSingleton<FuncCliCommand>(sp =>
             new ExternalCommand(workload, sp.GetRequiredService<TCommand>()));
     }
 
     protected override void OnRegisterCommand(Func<IServiceProvider, FuncCommand> factory)
     {
         var workload = RequireWorkload();
-        Services.AddSingleton<BaseCommand>(sp =>
+        Services.AddSingleton<FuncCliCommand>(sp =>
         {
             var command = factory(sp)
                 ?? throw new InvalidOperationException(

--- a/src/Func.Cli/Parser.cs
+++ b/src/Func.Cli/Parser.cs
@@ -13,7 +13,7 @@ namespace Azure.Functions.Cli;
 
 /// <summary>
 /// Assembles the root command tree from DI. Every top-level command —
-/// built-in or workload-contributed — is resolved as a <see cref="BaseCommand"/>
+/// built-in or workload-contributed — is resolved as a <see cref="FuncCliCommand"/>
 /// from the container so the composition path is uniform. HelpCommand is
 /// constructed inline because it needs a back-reference to the constructed
 /// root.
@@ -30,7 +30,7 @@ internal static class Parser
 {
     /// <summary>
     /// Creates and configures the root CLI command, resolving all
-    /// <see cref="BaseCommand"/> services from <paramref name="services"/>.
+    /// <see cref="FuncCliCommand"/> services from <paramref name="services"/>.
     /// </summary>
     public static FuncRootCommand CreateCommand(IServiceProvider services)
     {
@@ -45,9 +45,9 @@ internal static class Parser
         var helpCommand = new HelpCommand(interaction, rootCommand, versionCommand);
         rootCommand.Subcommands.Add(helpCommand);
 
-        var allCommands = services.GetServices<BaseCommand>().ToList();
+        var allCommands = services.GetServices<FuncCliCommand>().ToList();
 
-        // Defensive: every BaseCommand resolved from DI must be either a
+        // Defensive: every FuncCliCommand resolved from DI must be either a
         // built-in or an ExternalCommand (workload-contributed). Anything
         // else is a CLI bug — fail fast at startup so it's caught in tests
         // rather than producing untraceable workload commands.
@@ -57,7 +57,7 @@ internal static class Parser
             {
                 throw new InvalidOperationException(
                     $"Top-level command '{command.GetType().FullName}' (name: '{command.Name}') is registered " +
-                    "as a BaseCommand but is neither IBuiltInCommand nor ExternalCommand. " +
+                    "as a FuncCliCommand but is neither IBuiltInCommand nor ExternalCommand. " +
                     "Built-in commands must implement IBuiltInCommand; workload commands must be registered " +
                     "through FunctionsCliBuilder.RegisterCommand. This is a CLI bug.");
             }
@@ -68,7 +68,7 @@ internal static class Parser
         // collision among them is a CLI bug, not a workload problem, so we
         // throw rather than skip.
         var reservedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { helpCommand.Name };
-        foreach (var command in allCommands.OfType<IBuiltInCommand>().Cast<BaseCommand>())
+        foreach (var command in allCommands.OfType<IBuiltInCommand>().Cast<FuncCliCommand>())
         {
             if (!reservedNames.Add(command.Name))
             {

--- a/src/Func.Cli/Parser.cs
+++ b/src/Func.Cli/Parser.cs
@@ -6,27 +6,31 @@ using System.CommandLine.Help;
 using Azure.Functions.Cli.Commands;
 using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Hosting;
+using Azure.Functions.Cli.Workloads;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Azure.Functions.Cli;
 
 /// <summary>
 /// Assembles the root command tree from DI. Every top-level command —
-/// built-in or workload-contributed — is resolved as a <see cref="Command"/>
+/// built-in or workload-contributed — is resolved as a <see cref="BaseCommand"/>
 /// from the container so the composition path is uniform. HelpCommand is
 /// constructed inline because it needs a back-reference to the constructed
 /// root.
 ///
 /// Built-in commands are tagged with <see cref="IBuiltInCommand"/>; their
-/// names form the reserved set. Workload-contributed commands whose name
-/// collides with a built-in (or with another workload command) are skipped
-/// at startup with a warning to stderr, leaving the rest of the CLI usable.
+/// names form the reserved set. Workload-contributed commands flow through
+/// <see cref="ExternalCommand"/>, which carries the owning
+/// <see cref="WorkloadInfo"/>. Workload commands whose name collides with a
+/// built-in (or with another workload command) are skipped at startup with
+/// a warning to stderr that names the workload, leaving the rest of the CLI
+/// usable.
 /// </summary>
 internal static class Parser
 {
     /// <summary>
     /// Creates and configures the root CLI command, resolving all
-    /// <see cref="Command"/> services from <paramref name="services"/>.
+    /// <see cref="BaseCommand"/> services from <paramref name="services"/>.
     /// </summary>
     public static FuncRootCommand CreateCommand(IServiceProvider services)
     {
@@ -41,14 +45,30 @@ internal static class Parser
         var helpCommand = new HelpCommand(interaction, rootCommand, versionCommand);
         rootCommand.Subcommands.Add(helpCommand);
 
-        var allCommands = services.GetServices<Command>().ToList();
+        var allCommands = services.GetServices<BaseCommand>().ToList();
+
+        // Defensive: every BaseCommand resolved from DI must be either a
+        // built-in or an ExternalCommand (workload-contributed). Anything
+        // else is a CLI bug — fail fast at startup so it's caught in tests
+        // rather than producing untraceable workload commands.
+        foreach (var command in allCommands)
+        {
+            if (command is not IBuiltInCommand && command is not ExternalCommand)
+            {
+                throw new InvalidOperationException(
+                    $"Top-level command '{command.GetType().FullName}' (name: '{command.Name}') is registered " +
+                    "as a BaseCommand but is neither IBuiltInCommand nor ExternalCommand. " +
+                    "Built-in commands must implement IBuiltInCommand; workload commands must be registered " +
+                    "through FunctionsCliBuilder.RegisterCommand. This is a CLI bug.");
+            }
+        }
 
         // First pass: built-ins. Their names form the reserved set, plus
         // help (added above). Built-ins are trusted by construction — any
         // collision among them is a CLI bug, not a workload problem, so we
         // throw rather than skip.
         var reservedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { helpCommand.Name };
-        foreach (var command in allCommands.Where(c => c is IBuiltInCommand))
+        foreach (var command in allCommands.OfType<IBuiltInCommand>().Cast<BaseCommand>())
         {
             if (!reservedNames.Add(command.Name))
             {
@@ -63,24 +83,30 @@ internal static class Parser
         // collides with a built-in is skipped (built-in wins). Two workload
         // commands colliding with each other are both skipped — picking one
         // would be non-deterministic from the user's perspective.
-        var workloadCommands = allCommands.Where(c => c is not IBuiltInCommand).ToList();
-        var workloadNameCounts = workloadCommands
+        var workloadCommands = allCommands.OfType<ExternalCommand>().ToList();
+        var workloadNameGroups = workloadCommands
             .GroupBy(c => c.Name, StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(g => g.Key, g => g.Count(), StringComparer.OrdinalIgnoreCase);
+            .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.OrdinalIgnoreCase);
 
         foreach (var command in workloadCommands)
         {
             if (reservedNames.Contains(command.Name))
             {
                 interaction.WriteWarning(
-                    $"A workload tried to register top-level command '{command.Name}', which is reserved by the CLI. This command was not loaded.");
+                    $"Workload '{command.Workload.PackageId}' tried to register top-level command " +
+                    $"'{command.Name}', which is reserved by the CLI. This command was not loaded.");
                 continue;
             }
 
-            if (workloadNameCounts[command.Name] > 1)
+            var siblings = workloadNameGroups[command.Name];
+            if (siblings.Count > 1)
             {
+                var workloadList = string.Join(", ", siblings
+                    .Select(c => $"'{c.Workload.PackageId}'")
+                    .Distinct(StringComparer.Ordinal));
                 interaction.WriteWarning(
-                    $"Multiple workloads registered top-level command '{command.Name}'. All conflicting registrations were skipped. " +
+                    $"Workloads {workloadList} all registered top-level command '{command.Name}'. " +
+                    "All conflicting registrations were skipped. " +
                     "Run `func workload uninstall <name>` to keep one.");
                 continue;
             }
@@ -136,3 +162,4 @@ internal static class Parser
         });
     }
 }
+

--- a/src/Func.Cli/Workloads/ExternalCommand.cs
+++ b/src/Func.Cli/Workloads/ExternalCommand.cs
@@ -10,7 +10,7 @@ namespace Azure.Functions.Cli.Workloads;
 
 /// <summary>
 /// Internal adapter that wraps a workload-contributed <see cref="FuncCommand"/>
-/// in a <see cref="BaseCommand"/> the parser can execute, while carrying the
+/// in a <see cref="FuncCliCommand"/> the parser can execute, while carrying the
 /// owning <see cref="WorkloadInfo"/> for diagnostics and tracing.
 ///
 /// Translates the parser-independent descriptors on <see cref="FuncCommand"/>
@@ -24,7 +24,7 @@ namespace Azure.Functions.Cli.Workloads;
 /// The descriptors on the source command are read once at construction;
 /// subsequent changes are not reflected.
 /// </summary>
-internal sealed class ExternalCommand : BaseCommand
+internal sealed class ExternalCommand : FuncCliCommand
 {
     private static readonly MethodInfo _createOptionMethod =
         typeof(ExternalCommand).GetMethod(nameof(CreateTypedOption), BindingFlags.NonPublic | BindingFlags.Static)!;

--- a/src/Func.Cli/Workloads/ExternalCommand.cs
+++ b/src/Func.Cli/Workloads/ExternalCommand.cs
@@ -1,0 +1,264 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.Reflection;
+using Azure.Functions.Cli.Commands;
+
+namespace Azure.Functions.Cli.Workloads;
+
+/// <summary>
+/// Internal adapter that wraps a workload-contributed <see cref="FuncCommand"/>
+/// in a <see cref="BaseCommand"/> the parser can execute, while carrying the
+/// owning <see cref="WorkloadInfo"/> for diagnostics and tracing.
+///
+/// Translates the parser-independent descriptors on <see cref="FuncCommand"/>
+/// (<see cref="FuncCommand.Options"/>, <see cref="FuncCommand.Arguments"/>,
+/// <see cref="FuncCommand.Subcommands"/>) into <see cref="System.CommandLine"/>
+/// equivalents at construction. Subcommands are translated recursively as
+/// nested <see cref="ExternalCommand"/> instances under this parent — they are
+/// not registered as separate top-level services, so they cannot float to the
+/// root.
+///
+/// The descriptors on the source command are read once at construction;
+/// subsequent changes are not reflected.
+/// </summary>
+internal sealed class ExternalCommand : BaseCommand
+{
+    private static readonly MethodInfo _createOptionMethod =
+        typeof(ExternalCommand).GetMethod(nameof(CreateTypedOption), BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    private static readonly MethodInfo _createArgumentMethod =
+        typeof(ExternalCommand).GetMethod(nameof(CreateTypedArgument), BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    private readonly Dictionary<FuncCommandOption, Option> _optionLookup;
+    private readonly Dictionary<FuncCommandArgument, Argument> _argumentLookup;
+
+    public ExternalCommand(WorkloadInfo workload, FuncCommand source)
+        : base(ValidateName(source), ValidateDescription(source))
+    {
+        ArgumentNullException.ThrowIfNull(workload);
+
+        Workload = workload;
+        Source = source;
+
+        _optionLookup = new Dictionary<FuncCommandOption, Option>(ReferenceEqualityComparer.Instance);
+        _argumentLookup = new Dictionary<FuncCommandArgument, Argument>(ReferenceEqualityComparer.Instance);
+
+        AddOptions(source.Options);
+        AddArguments(source.Arguments);
+        AddSubcommands(source.Subcommands);
+    }
+
+    /// <summary>The workload that registered the underlying <see cref="FuncCommand"/>.</summary>
+    public WorkloadInfo Workload { get; }
+
+    /// <summary>The workload-supplied command this adapter is wrapping.</summary>
+    public FuncCommand Source { get; }
+
+    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        var context = new ParseResultInvocationContext(parseResult, _optionLookup, _argumentLookup);
+        return Source.ExecuteAsync(context, cancellationToken);
+    }
+
+    private static string ValidateName(FuncCommand source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        if (string.IsNullOrWhiteSpace(source.Name))
+        {
+            throw new InvalidOperationException(
+                $"FuncCommand '{source.GetType().FullName}' returned a null or empty Name.");
+        }
+        return source.Name;
+    }
+
+    private static string ValidateDescription(FuncCommand source)
+    {
+        // Source already null-checked in ValidateName via base call ordering.
+        return source.Description ?? string.Empty;
+    }
+
+    private void AddOptions(IReadOnlyList<FuncCommandOption> options)
+    {
+        if (options is null)
+        {
+            return;
+        }
+
+        var seenTokens = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var descriptor in options)
+        {
+            if (descriptor is null)
+            {
+                throw BuildSourceError($"command '{Source.Name}' declared a null option.");
+            }
+
+            if (!seenTokens.Add(descriptor.Name))
+            {
+                throw BuildSourceError(
+                    $"command '{Source.Name}' declared option '{descriptor.Name}' more than once.");
+            }
+
+            if (descriptor.ShortName is not null && !seenTokens.Add(descriptor.ShortName))
+            {
+                throw BuildSourceError(
+                    $"command '{Source.Name}' declared a duplicate option token '{descriptor.ShortName}'.");
+            }
+
+            var sclOption = (Option)_createOptionMethod
+                .MakeGenericMethod(descriptor.ValueType)
+                .Invoke(null, [descriptor])!;
+
+            Options.Add(sclOption);
+            _optionLookup.Add(descriptor, sclOption);
+        }
+    }
+
+    private void AddArguments(IReadOnlyList<FuncCommandArgument> arguments)
+    {
+        if (arguments is null)
+        {
+            return;
+        }
+
+        var seenNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var descriptor in arguments)
+        {
+            if (descriptor is null)
+            {
+                throw BuildSourceError($"command '{Source.Name}' declared a null argument.");
+            }
+
+            if (!seenNames.Add(descriptor.Name))
+            {
+                throw BuildSourceError(
+                    $"command '{Source.Name}' declared argument '{descriptor.Name}' more than once.");
+            }
+
+            var sclArgument = (Argument)_createArgumentMethod
+                .MakeGenericMethod(descriptor.ValueType)
+                .Invoke(null, [descriptor])!;
+
+            Arguments.Add(sclArgument);
+            _argumentLookup.Add(descriptor, sclArgument);
+        }
+    }
+
+    private void AddSubcommands(IReadOnlyList<FuncCommand> subcommands)
+    {
+        if (subcommands is null)
+        {
+            return;
+        }
+
+        var seenNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var subcommand in subcommands)
+        {
+            if (subcommand is null)
+            {
+                throw BuildSourceError($"command '{Source.Name}' declared a null subcommand.");
+            }
+
+            if (string.IsNullOrWhiteSpace(subcommand.Name))
+            {
+                throw BuildSourceError(
+                    $"command '{Source.Name}' declared a subcommand with a null or empty Name.");
+            }
+
+            if (!seenNames.Add(subcommand.Name))
+            {
+                throw BuildSourceError(
+                    $"command '{Source.Name}' declared subcommand '{subcommand.Name}' more than once.");
+            }
+
+            Subcommands.Add(new ExternalCommand(Workload, subcommand));
+        }
+    }
+
+    private InvalidOperationException BuildSourceError(string message)
+        => new($"Workload '{Workload.PackageId}' {message}");
+
+    private static Option<T> CreateTypedOption<T>(FuncCommandOption descriptor)
+    {
+        var typed = (FuncCommandOption<T>)descriptor;
+        var aliases = typed.ShortName is null ? [] : new[] { typed.ShortName };
+        var option = new Option<T>(typed.Name, aliases)
+        {
+            Description = typed.Description,
+        };
+
+        if (typed.HasDefaultValue)
+        {
+            var defaultValue = typed.DefaultValue;
+            option.DefaultValueFactory = _ => defaultValue;
+        }
+
+        return option;
+    }
+
+    private static Argument<T> CreateTypedArgument<T>(FuncCommandArgument descriptor)
+    {
+        var typed = (FuncCommandArgument<T>)descriptor;
+        return new Argument<T>(typed.Name)
+        {
+            Description = typed.Description,
+            Arity = typed.IsRequired ? ArgumentArity.ExactlyOne : ArgumentArity.ZeroOrOne,
+        };
+    }
+
+    /// <summary>
+    /// <see cref="FuncCommandInvocationContext"/> implementation backed by the
+    /// parser's <see cref="ParseResult"/>. Lookups go through reference-keyed
+    /// dictionaries built at <see cref="ExternalCommand"/> construction, so
+    /// passing a different descriptor instance with the same name is reported
+    /// as an unknown descriptor (matching the abstractions contract).
+    /// </summary>
+    private sealed class ParseResultInvocationContext : FuncCommandInvocationContext
+    {
+        private readonly ParseResult _parseResult;
+        private readonly IReadOnlyDictionary<FuncCommandOption, Option> _options;
+        private readonly IReadOnlyDictionary<FuncCommandArgument, Argument> _arguments;
+
+        public ParseResultInvocationContext(
+            ParseResult parseResult,
+            IReadOnlyDictionary<FuncCommandOption, Option> options,
+            IReadOnlyDictionary<FuncCommandArgument, Argument> arguments)
+        {
+            _parseResult = parseResult;
+            _options = options;
+            _arguments = arguments;
+        }
+
+        public override T? GetValue<T>(FuncCommandOption<T> option)
+            where T : default
+        {
+            ArgumentNullException.ThrowIfNull(option);
+            if (!_options.TryGetValue(option, out var sclOption))
+            {
+                throw new ArgumentException(
+                    $"Option '{option.Name}' is not declared on the command being executed. " +
+                    "Pass the same FuncCommandOption instance the command exposed through Options.",
+                    nameof(option));
+            }
+
+            return _parseResult.GetValue((Option<T>)sclOption);
+        }
+
+        public override T? GetValue<T>(FuncCommandArgument<T> argument)
+            where T : default
+        {
+            ArgumentNullException.ThrowIfNull(argument);
+            if (!_arguments.TryGetValue(argument, out var sclArgument))
+            {
+                throw new ArgumentException(
+                    $"Argument '{argument.Name}' is not declared on the command being executed. " +
+                    "Pass the same FuncCommandArgument instance the command exposed through Arguments.",
+                    nameof(argument));
+            }
+
+            return _parseResult.GetValue((Argument<T>)sclArgument);
+        }
+    }
+}

--- a/test/Func.Cli.Tests/Commands/FuncCliCommandTests.cs
+++ b/test/Func.Cli.Tests/Commands/FuncCliCommandTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 namespace Azure.Functions.Cli.Tests.Commands;
 
 [Collection(nameof(WorkingDirectoryTests))]
-public class BaseCommandTests : IDisposable
+public class FuncCliCommandTests : IDisposable
 {
     // Use a well-known stable path so constructors don't fail when a previous
     // test left cwd in a since-deleted temp directory.
@@ -17,7 +17,7 @@ public class BaseCommandTests : IDisposable
     private readonly string _tempDir;
     private readonly TestInteractionService _interaction = new();
 
-    public BaseCommandTests()
+    public FuncCliCommandTests()
     {
         Directory.SetCurrentDirectory(_safeDir);
         _tempDir = Path.Combine(Path.GetTempPath(), $"func-base-{Guid.NewGuid():N}");

--- a/test/Func.Cli.Tests/Hosting/DefaultFunctionsCliBuilderTests.cs
+++ b/test/Func.Cli.Tests/Hosting/DefaultFunctionsCliBuilderTests.cs
@@ -36,7 +36,7 @@ public class DefaultFunctionsCliBuilderTests
 
         builder.RegisterCommand(stub);
 
-        var resolved = services.BuildServiceProvider().GetServices<BaseCommand>().ToList();
+        var resolved = services.BuildServiceProvider().GetServices<FuncCliCommand>().ToList();
         var external = Assert.Single(resolved.OfType<ExternalCommand>());
         Assert.Same(workload, external.Workload);
         Assert.Same(stub, external.Source);
@@ -53,7 +53,7 @@ public class DefaultFunctionsCliBuilderTests
 
         builder.RegisterCommand<GenericTestCommand>();
 
-        var resolved = services.BuildServiceProvider().GetServices<BaseCommand>().ToList();
+        var resolved = services.BuildServiceProvider().GetServices<FuncCliCommand>().ToList();
         var external = Assert.Single(resolved.OfType<ExternalCommand>());
         var source = Assert.IsType<GenericTestCommand>(external.Source);
         Assert.Equal("from-di", source.Payload.Value);
@@ -79,7 +79,7 @@ public class DefaultFunctionsCliBuilderTests
 
         builder.RegisterCommand(_ => new TestWorkloads.StubFuncCommand("from-factory"));
 
-        var resolved = services.BuildServiceProvider().GetServices<BaseCommand>().ToList();
+        var resolved = services.BuildServiceProvider().GetServices<FuncCliCommand>().ToList();
         var external = Assert.Single(resolved.OfType<ExternalCommand>());
         Assert.Equal("from-factory", external.Name);
     }
@@ -103,7 +103,7 @@ public class DefaultFunctionsCliBuilderTests
         builder.RegisterCommand(_ => null!);
 
         var sp = services.BuildServiceProvider();
-        var ex = Assert.Throws<InvalidOperationException>(() => sp.GetServices<BaseCommand>().ToList());
+        var ex = Assert.Throws<InvalidOperationException>(() => sp.GetServices<FuncCliCommand>().ToList());
         Assert.Contains("Workload.With.NullFactory", ex.Message);
     }
 

--- a/test/Func.Cli.Tests/Hosting/DefaultFunctionsCliBuilderTests.cs
+++ b/test/Func.Cli.Tests/Hosting/DefaultFunctionsCliBuilderTests.cs
@@ -1,0 +1,166 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Commands;
+using Azure.Functions.Cli.Hosting;
+using Azure.Functions.Cli.Workloads;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Hosting;
+
+public class DefaultFunctionsCliBuilderTests
+{
+    [Fact]
+    public void Services_ReturnsBackingCollection()
+    {
+        var services = new ServiceCollection();
+        var builder = new DefaultFunctionsCliBuilder(services);
+
+        Assert.Same(services, builder.Services);
+    }
+
+    [Fact]
+    public void Ctor_NullServices_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new DefaultFunctionsCliBuilder(null!));
+    }
+
+    [Fact]
+    public void RegisterCommand_Instance_ProducesExternalCommandWithWorkloadInfo()
+    {
+        var services = new ServiceCollection();
+        var workload = TestWorkloads.CreateInfo("My.Workload");
+        var builder = new DefaultFunctionsCliBuilder(services, workload);
+        var stub = new TestWorkloads.StubFuncCommand("hello");
+
+        builder.RegisterCommand(stub);
+
+        var resolved = services.BuildServiceProvider().GetServices<BaseCommand>().ToList();
+        var external = Assert.Single(resolved.OfType<ExternalCommand>());
+        Assert.Same(workload, external.Workload);
+        Assert.Same(stub, external.Source);
+        Assert.Equal("hello", external.Name);
+    }
+
+    [Fact]
+    public void RegisterCommand_Generic_ResolvesThroughDi()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new GenericTestPayload("from-di"));
+        var workload = TestWorkloads.CreateInfo();
+        var builder = new DefaultFunctionsCliBuilder(services, workload);
+
+        builder.RegisterCommand<GenericTestCommand>();
+
+        var resolved = services.BuildServiceProvider().GetServices<BaseCommand>().ToList();
+        var external = Assert.Single(resolved.OfType<ExternalCommand>());
+        var source = Assert.IsType<GenericTestCommand>(external.Source);
+        Assert.Equal("from-di", source.Payload.Value);
+    }
+
+    [Fact]
+    public void RegisterCommand_Generic_AbstractType_Throws()
+    {
+        var services = new ServiceCollection();
+        var builder = new DefaultFunctionsCliBuilder(services, TestWorkloads.CreateInfo());
+
+        var ex = Assert.Throws<ArgumentException>(() => builder.RegisterCommand<AbstractFuncCommand>());
+        Assert.Contains("abstract command type", ex.Message);
+        Assert.Contains(nameof(AbstractFuncCommand), ex.Message);
+    }
+
+    [Fact]
+    public void RegisterCommand_Factory_InvokedPerResolution()
+    {
+        var services = new ServiceCollection();
+        var workload = TestWorkloads.CreateInfo();
+        var builder = new DefaultFunctionsCliBuilder(services, workload);
+
+        builder.RegisterCommand(_ => new TestWorkloads.StubFuncCommand("from-factory"));
+
+        var resolved = services.BuildServiceProvider().GetServices<BaseCommand>().ToList();
+        var external = Assert.Single(resolved.OfType<ExternalCommand>());
+        Assert.Equal("from-factory", external.Name);
+    }
+
+    [Fact]
+    public void RegisterCommand_Factory_Null_Throws()
+    {
+        var builder = new DefaultFunctionsCliBuilder(new ServiceCollection(), TestWorkloads.CreateInfo());
+
+        Assert.Throws<ArgumentNullException>(
+            () => builder.RegisterCommand((Func<IServiceProvider, FuncCommand>)null!));
+    }
+
+    [Fact]
+    public void RegisterCommand_Factory_ReturnsNull_FailsAtResolutionTime()
+    {
+        var services = new ServiceCollection();
+        var workload = TestWorkloads.CreateInfo("Workload.With.NullFactory");
+        var builder = new DefaultFunctionsCliBuilder(services, workload);
+
+        builder.RegisterCommand(_ => null!);
+
+        var sp = services.BuildServiceProvider();
+        var ex = Assert.Throws<InvalidOperationException>(() => sp.GetServices<BaseCommand>().ToList());
+        Assert.Contains("Workload.With.NullFactory", ex.Message);
+    }
+
+    [Fact]
+    public void RegisterCommand_Instance_Null_Throws()
+    {
+        var builder = new DefaultFunctionsCliBuilder(new ServiceCollection(), TestWorkloads.CreateInfo());
+
+        Assert.Throws<ArgumentNullException>(() => builder.RegisterCommand((FuncCommand)null!));
+    }
+
+    [Fact]
+    public void RegisterCommand_WithoutWorkloadContext_Throws()
+    {
+        var builder = new DefaultFunctionsCliBuilder(new ServiceCollection());
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => builder.RegisterCommand(new TestWorkloads.StubFuncCommand("oops")));
+        Assert.Contains("workload-scoped builder", ex.Message);
+    }
+
+    [Fact]
+    public void RegisterCommand_Generic_WithoutWorkloadContext_Throws()
+    {
+        var builder = new DefaultFunctionsCliBuilder(new ServiceCollection());
+
+        Assert.Throws<InvalidOperationException>(() => builder.RegisterCommand<GenericTestCommand>());
+    }
+
+    [Fact]
+    public void RegisterCommand_Factory_WithoutWorkloadContext_Throws()
+    {
+        var builder = new DefaultFunctionsCliBuilder(new ServiceCollection());
+
+        Assert.Throws<InvalidOperationException>(
+            () => builder.RegisterCommand(_ => new TestWorkloads.StubFuncCommand("oops")));
+    }
+
+    private sealed class GenericTestPayload(string value)
+    {
+        public string Value { get; } = value;
+    }
+
+    private sealed class GenericTestCommand(GenericTestPayload payload) : FuncCommand
+    {
+        public GenericTestPayload Payload { get; } = payload;
+
+        public override string Name => "generic";
+
+        public override string Description => "Generic test command.";
+
+        public override Task<int> ExecuteAsync(
+            FuncCommandInvocationContext context,
+            CancellationToken cancellationToken) => Task.FromResult(0);
+    }
+
+    private abstract class AbstractFuncCommand : FuncCommand
+    {
+    }
+}

--- a/test/Func.Cli.Tests/ParserTests.cs
+++ b/test/Func.Cli.Tests/ParserTests.cs
@@ -115,22 +115,22 @@ public class ParserTests
     }
 
     [Fact]
-    public void CreateCommand_BaseCommandNotBuiltInOrExternal_Throws()
+    public void CreateCommand_FuncCliCommandNotBuiltInOrExternal_Throws()
     {
         var services = TestParser.BuildServiceProviderWith(_interaction, s =>
         {
-            s.AddSingleton<BaseCommand, RogueBaseCommand>();
+            s.AddSingleton<FuncCliCommand, RogueFuncCliCommand>();
         });
 
         var ex = Assert.Throws<InvalidOperationException>(() => Parser.CreateCommand(services));
-        Assert.Contains(nameof(RogueBaseCommand), ex.Message);
+        Assert.Contains(nameof(RogueFuncCliCommand), ex.Message);
         Assert.Contains("rogue", ex.Message);
     }
 
     [Fact]
     public async Task Parse_BuiltInWorkloadParentCommand_NoSubcommand_RendersHelp()
     {
-        // After switching to BaseCommand with the virtual default ExecuteAsync,
+        // After switching to FuncCliCommand with the virtual default ExecuteAsync,
         // `func workload` (no subcommand) should print help and exit 0. The
         // default impl walks parent commands to find the root's HelpOption and
         // invokes its (Spectre-wired) action.
@@ -143,10 +143,10 @@ public class ParserTests
         Assert.NotEmpty(_interaction.Lines);
     }
 
-    private sealed class RogueBaseCommand : BaseCommand
+    private sealed class RogueFuncCliCommand : FuncCliCommand
     {
-        public RogueBaseCommand()
-            : base("rogue", "A BaseCommand that is neither built-in nor external.")
+        public RogueFuncCliCommand()
+            : base("rogue", "A FuncCliCommand that is neither built-in nor external.")
         {
         }
     }

--- a/test/Func.Cli.Tests/ParserTests.cs
+++ b/test/Func.Cli.Tests/ParserTests.cs
@@ -4,6 +4,9 @@
 using System.CommandLine;
 using Azure.Functions.Cli.Commands;
 using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Hosting;
+using Azure.Functions.Cli.Workloads;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Azure.Functions.Cli.Tests;
@@ -54,5 +57,97 @@ public class ParserTests
         var result = root.Parse(commandName);
 
         Assert.Empty(result.Errors);
+    }
+
+    // --- Workload command tracking ---
+
+    [Fact]
+    public void CreateCommand_WorkloadRegisteredCommand_AppearsAsRootSubcommand()
+    {
+        var workload = TestWorkloads.CreateInfo("My.Workload");
+        var root = TestParser.CreateRootWithWorkload(
+            _interaction,
+            workload,
+            builder => builder.RegisterCommand(new TestWorkloads.StubFuncCommand("workload-cmd", "wd")));
+
+        var added = root.Subcommands.OfType<ExternalCommand>().SingleOrDefault();
+        Assert.NotNull(added);
+        Assert.Equal("workload-cmd", added!.Name);
+        Assert.Same(workload, added.Workload);
+    }
+
+    [Fact]
+    public void CreateCommand_WorkloadCommandCollidesWithBuiltIn_IsSkippedWithNamedWarning()
+    {
+        var workload = TestWorkloads.CreateInfo("Wl.Bar");
+        var root = TestParser.CreateRootWithWorkload(
+            _interaction,
+            workload,
+            builder => builder.RegisterCommand(new TestWorkloads.StubFuncCommand("init")));
+
+        // init is a built-in name; the workload registration is skipped.
+        var initCommands = root.Subcommands.Where(c => c.Name == "init").ToList();
+        Assert.Single(initCommands);
+        Assert.IsNotType<ExternalCommand>(initCommands[0]);
+
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("WARNING:") && l.Contains("Wl.Bar") && l.Contains("'init'"));
+    }
+
+    [Fact]
+    public void CreateCommand_TwoWorkloadCommandsSameName_BothSkippedWithNamedWarning()
+    {
+        var workloadA = TestWorkloads.CreateInfo("Wl.A");
+        var workloadB = TestWorkloads.CreateInfo("Wl.B");
+
+        var services = TestParser.BuildServiceProviderWith(_interaction, s =>
+        {
+            new DefaultFunctionsCliBuilder(s, workloadA)
+                .RegisterCommand(new TestWorkloads.StubFuncCommand("dup"));
+            new DefaultFunctionsCliBuilder(s, workloadB)
+                .RegisterCommand(new TestWorkloads.StubFuncCommand("dup"));
+        });
+
+        var root = Parser.CreateCommand(services);
+
+        Assert.DoesNotContain(root.Subcommands, c => c.Name == "dup");
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("WARNING:")
+            && l.Contains("Wl.A") && l.Contains("Wl.B") && l.Contains("'dup'"));
+    }
+
+    [Fact]
+    public void CreateCommand_BaseCommandNotBuiltInOrExternal_Throws()
+    {
+        var services = TestParser.BuildServiceProviderWith(_interaction, s =>
+        {
+            s.AddSingleton<BaseCommand, RogueBaseCommand>();
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() => Parser.CreateCommand(services));
+        Assert.Contains(nameof(RogueBaseCommand), ex.Message);
+        Assert.Contains("rogue", ex.Message);
+    }
+
+    [Fact]
+    public async Task Parse_BuiltInWorkloadParentCommand_NoSubcommand_RendersHelp()
+    {
+        // After switching to BaseCommand with the virtual default ExecuteAsync,
+        // `func workload` (no subcommand) should print help and exit 0. The
+        // default impl walks parent commands to find the root's HelpOption and
+        // invokes its (Spectre-wired) action.
+        var root = TestParser.CreateRoot(_interaction);
+        var parseResult = root.Parse("workload");
+
+        var exit = await parseResult.InvokeAsync();
+
+        Assert.Equal(0, exit);
+        Assert.NotEmpty(_interaction.Lines);
+    }
+
+    private sealed class RogueBaseCommand : BaseCommand
+    {
+        public RogueBaseCommand()
+            : base("rogue", "A BaseCommand that is neither built-in nor external.")
+        {
+        }
     }
 }

--- a/test/Func.Cli.Tests/TestParser.cs
+++ b/test/Func.Cli.Tests/TestParser.cs
@@ -18,10 +18,49 @@ internal static class TestParser
 {
     public static FuncRootCommand CreateRoot(IInteractionService interaction)
     {
+        var services = BuildBaseServices(interaction);
+        return Parser.CreateCommand(services.BuildServiceProvider());
+    }
+
+    /// <summary>
+    /// Builds a root command tree with a workload-scoped
+    /// <see cref="DefaultFunctionsCliBuilder"/> available to <paramref name="configure"/>.
+    /// Lets tests exercise <see cref="FunctionsCliBuilder.RegisterCommand(FuncCommand)"/>
+    /// without booting the (not-yet-implemented) workload loader.
+    /// </summary>
+    public static FuncRootCommand CreateRootWithWorkload(
+        IInteractionService interaction,
+        WorkloadInfo workload,
+        Action<FunctionsCliBuilder> configure)
+    {
+        var services = BuildBaseServices(interaction);
+        var builder = new DefaultFunctionsCliBuilder(services, workload);
+        configure(builder);
+        return Parser.CreateCommand(services.BuildServiceProvider());
+    }
+
+    /// <summary>
+    /// Builds an <see cref="IServiceProvider"/> wired with all built-in commands
+    /// plus any extra registrations applied by <paramref name="configure"/>.
+    /// Exposed for tests that need to resolve <see cref="BaseCommand"/> services
+    /// directly without going through <see cref="Parser.CreateCommand"/>.
+    /// </summary>
+    public static IServiceProvider BuildServiceProviderWith(
+        IInteractionService interaction,
+        Action<IServiceCollection>? configure = null)
+    {
+        var services = BuildBaseServices(interaction);
+        configure?.Invoke(services);
+        return services.BuildServiceProvider();
+    }
+
+    private static ServiceCollection BuildBaseServices(IInteractionService interaction)
+    {
         var services = new ServiceCollection();
         services.AddSingleton(interaction);
         services.AddBuiltInCommands();
         services.AddSingleton<IReadOnlyList<WorkloadInfo>>(Array.Empty<WorkloadInfo>());
-        return Parser.CreateCommand(services.BuildServiceProvider());
+        return services;
     }
 }
+

--- a/test/Func.Cli.Tests/TestParser.cs
+++ b/test/Func.Cli.Tests/TestParser.cs
@@ -42,7 +42,7 @@ internal static class TestParser
     /// <summary>
     /// Builds an <see cref="IServiceProvider"/> wired with all built-in commands
     /// plus any extra registrations applied by <paramref name="configure"/>.
-    /// Exposed for tests that need to resolve <see cref="BaseCommand"/> services
+    /// Exposed for tests that need to resolve <see cref="FuncCliCommand"/> services
     /// directly without going through <see cref="Parser.CreateCommand"/>.
     /// </summary>
     public static IServiceProvider BuildServiceProviderWith(

--- a/test/Func.Cli.Tests/TestWorkloads.cs
+++ b/test/Func.Cli.Tests/TestWorkloads.cs
@@ -1,0 +1,56 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads;
+
+namespace Azure.Functions.Cli.Tests;
+
+/// <summary>
+/// Shared test fixtures for workload command registration scenarios. Kept
+/// internal because they reference internal types like <see cref="WorkloadInfo"/>.
+/// </summary>
+internal static class TestWorkloads
+{
+    public static WorkloadInfo CreateInfo(string packageId = "Test.Workload.A", string version = "1.0.0")
+        => new(packageId, version, packageId, $"{packageId} for tests", Aliases: Array.Empty<string>());
+
+    /// <summary>
+    /// Minimal <see cref="FuncCommand"/> backed by a delegate so tests can
+    /// observe what the wrapper passed into <see cref="FuncCommand.ExecuteAsync"/>.
+    /// </summary>
+    public sealed class StubFuncCommand : FuncCommand
+    {
+        private readonly Func<FuncCommandInvocationContext, CancellationToken, Task<int>> _execute;
+
+        public StubFuncCommand(
+            string name,
+            string description = "stub",
+            IReadOnlyList<FuncCommandOption>? options = null,
+            IReadOnlyList<FuncCommandArgument>? arguments = null,
+            IReadOnlyList<FuncCommand>? subcommands = null,
+            Func<FuncCommandInvocationContext, CancellationToken, Task<int>>? execute = null)
+        {
+            Name = name;
+            Description = description;
+            Options = options ?? [];
+            Arguments = arguments ?? [];
+            Subcommands = subcommands ?? [];
+            _execute = execute ?? ((_, _) => Task.FromResult(0));
+        }
+
+        public override string Name { get; }
+
+        public override string Description { get; }
+
+        public override IReadOnlyList<FuncCommandOption> Options { get; }
+
+        public override IReadOnlyList<FuncCommandArgument> Arguments { get; }
+
+        public override IReadOnlyList<FuncCommand> Subcommands { get; }
+
+        public override Task<int> ExecuteAsync(
+            FuncCommandInvocationContext context,
+            CancellationToken cancellationToken)
+            => _execute(context, cancellationToken);
+    }
+}

--- a/test/Func.Cli.Tests/Workloads/ExternalCommandTests.cs
+++ b/test/Func.Cli.Tests/Workloads/ExternalCommandTests.cs
@@ -1,0 +1,260 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Workloads;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Workloads;
+
+public class ExternalCommandTests
+{
+    [Fact]
+    public void Ctor_CopiesNameAndDescription()
+    {
+        var source = new TestWorkloads.StubFuncCommand("deploy", "Deploy the app.");
+        var external = new ExternalCommand(TestWorkloads.CreateInfo(), source);
+
+        Assert.Equal("deploy", external.Name);
+        Assert.Equal("Deploy the app.", external.Description);
+    }
+
+    [Fact]
+    public void Ctor_TranslatesOptionsToParser()
+    {
+        var stack = new FuncCommandOption<string>("--stack", "-s", "Project stack");
+        var verbose = new FuncCommandOption<bool>("--verbose", null, "Verbose output");
+        var source = new TestWorkloads.StubFuncCommand("deploy", options: [stack, verbose]);
+
+        var external = new ExternalCommand(TestWorkloads.CreateInfo(), source);
+
+        var parserOptions = external.Options.Select(o => o.Name).ToList();
+        Assert.Contains("--stack", parserOptions);
+        Assert.Contains("--verbose", parserOptions);
+
+        var stackOption = external.Options.Single(o => o.Name == "--stack");
+        Assert.Contains("-s", stackOption.Aliases);
+    }
+
+    [Fact]
+    public void Ctor_DefaultValue_FlowsThroughToParser()
+    {
+        var port = new FuncCommandOption<int>("--port", "-p", "Port", defaultValue: 7071);
+        var source = new TestWorkloads.StubFuncCommand("start", options: [port]);
+        var external = new ExternalCommand(TestWorkloads.CreateInfo(), source);
+
+        var typed = (Option<int>)external.Options.Single(o => o.Name == "--port");
+        var parseResult = external.Parse(string.Empty);
+        Assert.Equal(7071, parseResult.GetValue(typed));
+    }
+
+    [Fact]
+    public void Ctor_TranslatesArgumentsAndArity()
+    {
+        var optional = new FuncCommandArgument<string>("path", "Path");
+        var required = new FuncCommandArgument<string>("name", "Name", isRequired: true);
+        var source = new TestWorkloads.StubFuncCommand("deploy", arguments: [optional, required]);
+
+        var external = new ExternalCommand(TestWorkloads.CreateInfo(), source);
+
+        var pathArg = external.Arguments.Single(a => a.Name == "path");
+        var nameArg = external.Arguments.Single(a => a.Name == "name");
+        Assert.Equal(ArgumentArity.ZeroOrOne, pathArg.Arity);
+        Assert.Equal(ArgumentArity.ExactlyOne, nameArg.Arity);
+    }
+
+    [Fact]
+    public void Ctor_TranslatesSubcommandsRecursively()
+    {
+        var leaf = new TestWorkloads.StubFuncCommand("leaf");
+        var middle = new TestWorkloads.StubFuncCommand("middle", subcommands: [leaf]);
+        var top = new TestWorkloads.StubFuncCommand("top", subcommands: [middle]);
+
+        var external = new ExternalCommand(TestWorkloads.CreateInfo(), top);
+
+        var middleSub = Assert.Single(external.Subcommands);
+        Assert.Equal("middle", middleSub.Name);
+        var leafSub = Assert.Single(middleSub.Subcommands);
+        Assert.Equal("leaf", leafSub.Name);
+    }
+
+    [Fact]
+    public void Ctor_DuplicateOptionName_Throws()
+    {
+        var a = new FuncCommandOption<string>("--name", null, "first");
+        var b = new FuncCommandOption<string>("--name", null, "second");
+        var source = new TestWorkloads.StubFuncCommand("deploy", options: [a, b]);
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => new ExternalCommand(TestWorkloads.CreateInfo("Workload.A"), source));
+        Assert.Contains("Workload.A", ex.Message);
+        Assert.Contains("--name", ex.Message);
+    }
+
+    [Fact]
+    public void Ctor_DuplicateOptionShortName_Throws()
+    {
+        var a = new FuncCommandOption<string>("--first", "-x", "first");
+        var b = new FuncCommandOption<string>("--second", "-x", "second");
+        var source = new TestWorkloads.StubFuncCommand("deploy", options: [a, b]);
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => new ExternalCommand(TestWorkloads.CreateInfo(), source));
+        Assert.Contains("-x", ex.Message);
+    }
+
+    [Fact]
+    public void Ctor_DuplicateArgumentName_Throws()
+    {
+        var a = new FuncCommandArgument<string>("path", "first");
+        var b = new FuncCommandArgument<string>("path", "second");
+        var source = new TestWorkloads.StubFuncCommand("deploy", arguments: [a, b]);
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => new ExternalCommand(TestWorkloads.CreateInfo(), source));
+        Assert.Contains("path", ex.Message);
+    }
+
+    [Fact]
+    public void Ctor_DuplicateSubcommandName_Throws()
+    {
+        var a = new TestWorkloads.StubFuncCommand("dup");
+        var b = new TestWorkloads.StubFuncCommand("dup");
+        var source = new TestWorkloads.StubFuncCommand("parent", subcommands: [a, b]);
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => new ExternalCommand(TestWorkloads.CreateInfo(), source));
+        Assert.Contains("dup", ex.Message);
+    }
+
+    [Fact]
+    public void Ctor_NullSourceCommand_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => new ExternalCommand(TestWorkloads.CreateInfo(), null!));
+    }
+
+    [Fact]
+    public void Ctor_NullWorkload_Throws()
+    {
+        var source = new TestWorkloads.StubFuncCommand("ok");
+        Assert.Throws<ArgumentNullException>(() => new ExternalCommand(null!, source));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PassesParsedOptionValues()
+    {
+        var stack = new FuncCommandOption<string>("--stack", "-s", "Stack");
+        string? captured = null;
+        var source = new TestWorkloads.StubFuncCommand(
+            "deploy",
+            options: [stack],
+            execute: (ctx, _) =>
+            {
+                captured = ctx.GetValue(stack);
+                return Task.FromResult(0);
+            });
+        var external = new ExternalCommand(TestWorkloads.CreateInfo(), source);
+
+        var parseResult = external.Parse("--stack dotnet");
+        var exit = await parseResult.InvokeAsync();
+
+        Assert.Equal(0, exit);
+        Assert.Equal("dotnet", captured);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PassesParsedArgumentValues()
+    {
+        var name = new FuncCommandArgument<string>("name", "Name", isRequired: true);
+        string? captured = null;
+        var source = new TestWorkloads.StubFuncCommand(
+            "deploy",
+            arguments: [name],
+            execute: (ctx, _) =>
+            {
+                captured = ctx.GetValue(name);
+                return Task.FromResult(0);
+            });
+        var external = new ExternalCommand(TestWorkloads.CreateInfo(), source);
+
+        await external.Parse("my-app").InvokeAsync();
+
+        Assert.Equal("my-app", captured);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DefaultValue_AppliedWhenOptionOmitted()
+    {
+        var port = new FuncCommandOption<int>("--port", null, "Port", defaultValue: 7071);
+        int captured = -1;
+        var source = new TestWorkloads.StubFuncCommand(
+            "start",
+            options: [port],
+            execute: (ctx, _) =>
+            {
+                captured = ctx.GetValue(port);
+                return Task.FromResult(0);
+            });
+        var external = new ExternalCommand(TestWorkloads.CreateInfo(), source);
+
+        await external.Parse(string.Empty).InvokeAsync();
+
+        Assert.Equal(7071, captured);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_GetValue_UsesReferenceIdentityOnDescriptor()
+    {
+        var declared = new FuncCommandOption<string>("--name", null, "Name");
+        var lookalike = new FuncCommandOption<string>("--name", null, "Name");
+        Exception? captured = null;
+
+        var source = new TestWorkloads.StubFuncCommand(
+            "deploy",
+            options: [declared],
+            execute: (ctx, _) =>
+            {
+                try
+                {
+                    ctx.GetValue(lookalike);
+                }
+                catch (Exception ex)
+                {
+                    captured = ex;
+                }
+                return Task.FromResult(0);
+            });
+        var external = new ExternalCommand(TestWorkloads.CreateInfo(), source);
+
+        await external.Parse("--name foo").InvokeAsync();
+
+        Assert.IsType<ArgumentException>(captured);
+        Assert.Contains("--name", captured!.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_GetValue_NullDescriptor_Throws()
+    {
+        Exception? captured = null;
+        var source = new TestWorkloads.StubFuncCommand(
+            "deploy",
+            execute: (ctx, _) =>
+            {
+                try
+                {
+                    ctx.GetValue<string>((FuncCommandOption<string>)null!);
+                }
+                catch (Exception ex)
+                {
+                    captured = ex;
+                }
+                return Task.FromResult(0);
+            });
+        var external = new ExternalCommand(TestWorkloads.CreateInfo(), source);
+
+        await external.Parse(string.Empty).InvokeAsync();
+
+        Assert.IsType<ArgumentNullException>(captured);
+    }
+}


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

This pull request updates the documentation to reflect significant architectural changes in how commands are contributed and registered in the CLI, especially around extensibility for workloads. The changes clarify the distinction between built-in and workload-contributed commands, introduce new abstractions (`FuncCliCommand`, `FuncCommand`), and update all guides and diagrams to match the new model. The documentation now consistently instructs contributors to use the new registration patterns and base classes.

**Key documentation and architectural updates:**

### Built-in Commands and Registration Model

- All built-in commands now extend `FuncCliCommand` instead of `BaseCommand`, and should be registered in `BuiltInCommands.cs` as `FuncCliCommand` instances implementing `IBuiltInCommand`. Registration and checklist steps have been updated throughout the docs to reflect this. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L12-R12) [[2]](diffhunk://#diff-6c92b9c800ca63d85253b2dd9b0a117e2ab08aa3a89ab1c1bb4867aa87d62f00L12-R23) [[3]](diffhunk://#diff-6c92b9c800ca63d85253b2dd9b0a117e2ab08aa3a89ab1c1bb4867aa87d62f00L34-R34) [[4]](diffhunk://#diff-6c92b9c800ca63d85253b2dd9b0a117e2ab08aa3a89ab1c1bb4867aa87d62f00L118-R143) [[5]](diffhunk://#diff-6c92b9c800ca63d85253b2dd9b0a117e2ab08aa3a89ab1c1bb4867aa87d62f00L218-R217) [[6]](diffhunk://#diff-6c92b9c800ca63d85253b2dd9b0a117e2ab08aa3a89ab1c1bb4867aa87d62f00L229-R228) [[7]](diffhunk://#diff-6c92b9c800ca63d85253b2dd9b0a117e2ab08aa3a89ab1c1bb4867aa87d62f00L247-R246)

### Workload-Contributed Commands

- Workloads now contribute commands by calling `builder.RegisterCommand(...)` in `IWorkload.Configure`, not by registering raw `Command` instances in DI. The documentation introduces the new `FuncCommand` abstraction for parser-independent command definitions, and explains the new registration overloads and options. [[1]](diffhunk://#diff-b0dcd1381bda45e1202f8452362a84c05b6c9c876ba98d85a278b9f57cd80448L48-R49) [[2]](diffhunk://#diff-b0dcd1381bda45e1202f8452362a84c05b6c9c876ba98d85a278b9f57cd80448L59-R60) [[3]](diffhunk://#diff-b0dcd1381bda45e1202f8452362a84c05b6c9c876ba98d85a278b9f57cd80448L118-R119) [[4]](diffhunk://#diff-b0dcd1381bda45e1202f8452362a84c05b6c9c876ba98d85a278b9f57cd80448L195-R246) [[5]](diffhunk://#diff-b0dcd1381bda45e1202f8452362a84c05b6c9c876ba98d85a278b9f57cd80448L216-R270) [[6]](diffhunk://#diff-b0dcd1381bda45e1202f8452362a84c05b6c9c876ba98d85a278b9f57cd80448L275-R324) [[7]](diffhunk://#diff-2a79134c003d258441e742e0ad07b3ccfc1fce3b55b50af234305a6fdb6ca583L20-R34) [[8]](diffhunk://#diff-2a79134c003d258441e742e0ad07b3ccfc1fce3b55b50af234305a6fdb6ca583L223-R245)

### Command Tree Composition and Collision Handling

- The CLI now resolves all `FuncCliCommand` instances from DI, partitions them into built-in and workload-contributed (via `ExternalCommand` wrappers), and handles name collisions by skipping conflicting workload commands and emitting warnings. This is reflected in updated architecture diagrams and explanations. [[1]](diffhunk://#diff-2a79134c003d258441e742e0ad07b3ccfc1fce3b55b50af234305a6fdb6ca583L20-R34) [[2]](diffhunk://#diff-2a79134c003d258441e742e0ad07b3ccfc1fce3b55b50af234305a6fdb6ca583L63-R75) [[3]](diffhunk://#diff-2a79134c003d258441e742e0ad07b3ccfc1fce3b55b50af234305a6fdb6ca583L223-R245)

### Abstractions and Directory Structure

- Documentation now describes new abstractions (`FuncCommand`, `FuncCommandOption`, `FuncCommandInvocationContext`, etc.) and updates the repo structure to include the new `Workloads/` directory for `ExternalCommand` adapters. [[1]](diffhunk://#diff-2a79134c003d258441e742e0ad07b3ccfc1fce3b55b50af234305a6fdb6ca583L208-R219) [[2]](diffhunk://#diff-bdd4f9ee6075a30ad6c61495a199188afcb9d9827b37ca7ec09749d02262c17bL42-R50)

### Consistency and Clarity in Command Authoring

- All code samples and guides now use `FuncCliCommand` (for built-ins) and `FuncCommand` (for workloads), and clarify the use of descriptor instances for option/argument parsing. Checklist and quickstart sections have been updated for clarity and accuracy. [[1]](diffhunk://#diff-6c92b9c800ca63d85253b2dd9b0a117e2ab08aa3a89ab1c1bb4867aa87d62f00L12-R23) [[2]](diffhunk://#diff-6c92b9c800ca63d85253b2dd9b0a117e2ab08aa3a89ab1c1bb4867aa87d62f00L34-R34) [[3]](diffhunk://#diff-6c92b9c800ca63d85253b2dd9b0a117e2ab08aa3a89ab1c1bb4867aa87d62f00L118-R143) [[4]](diffhunk://#diff-6c92b9c800ca63d85253b2dd9b0a117e2ab08aa3a89ab1c1bb4867aa87d62f00L218-R217) [[5]](diffhunk://#diff-6c92b9c800ca63d85253b2dd9b0a117e2ab08aa3a89ab1c1bb4867aa87d62f00L229-R228) [[6]](diffhunk://#diff-6c92b9c800ca63d85253b2dd9b0a117e2ab08aa3a89ab1c1bb4867aa87d62f00L247-R246) [[7]](diffhunk://#diff-2a79134c003d258441e742e0ad07b3ccfc1fce3b55b50af234305a6fdb6ca583L112-R118)

These updates ensure that both internal and external contributors follow the new extensibility model and that the documentation accurately reflects the current CLI architecture.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] I have added all required tests (Unit tests, E2E tests)

