### PR TITLE
Fix flaky FuncNew and FuncStart e2e tests

### DIFF
--- a/src/Cli/func/Helpers/EnvironmentHelper.cs
+++ b/src/Cli/func/Helpers/EnvironmentHelper.cs
@@ -17,6 +17,35 @@ namespace Azure.Functions.Cli.Helpers
             return val.Equals("1") || val.Equals("true", StringComparison.OrdinalIgnoreCase);
         }
 
+        /// <summary>
+        /// Reads an environment variable as a tri-state boolean.
+        /// </summary>
+        /// <returns>
+        /// true if the value is "1" or "true" (case-insensitive); false if the value
+        /// is "0" or "false"; null if unset or unrecognized.
+        /// </returns>
+        public static bool? GetEnvironmentVariableAsNullableBool(string keyName)
+        {
+            string val = Environment.GetEnvironmentVariable(keyName);
+
+            if (string.IsNullOrEmpty(val))
+            {
+                return null;
+            }
+
+            if (val.Equals("1") || val.Equals("true", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (val.Equals("0") || val.Equals("false", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            return null;
+        }
+
         public static void SetEnvironmentVariableAsBoolIfNotExists(string keyName)
         {
             if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(keyName)))

--- a/src/Cli/func/Helpers/GlobalCoreToolsSettings.cs
+++ b/src/Cli/func/Helpers/GlobalCoreToolsSettings.cs
@@ -71,14 +71,32 @@ namespace Azure.Functions.Cli.Helpers
         public static void Init(ISecretsManager secretsManager, string[] args)
         {
             _isVerbose = args.Contains("--verbose");
-            _explicitOffline = args.Contains("--offline") || EnvironmentHelper.GetEnvironmentVariableAsBool(Constants.FunctionsCoreToolsOffline);
 
-            // Lazy network probe — only runs on first access of IsOfflineMode when no explicit offline flag was set.
-            // No SynchronizationContext in this CLI app, so .GetAwaiter().GetResult() is safe without Task.Run.
+            // FUNCTIONS_CORE_TOOLS_OFFLINE is tri-state:
+            //   true/1  => force offline (skip probe)
+            //   false/0 => force online  (skip probe)
+            //   unset   => probe normally
+            bool? envOfflineOverride = EnvironmentHelper.GetEnvironmentVariableAsNullableBool(Constants.FunctionsCoreToolsOffline);
+            _explicitOffline = args.Contains("--offline") || envOfflineOverride == true;
+            bool forceOnline = envOfflineOverride == false;
+
+            // Lazy network probe — only runs on first access of IsOfflineMode when no explicit
+            // offline/online override was set. No SynchronizationContext in this CLI app, so
+            // .GetAwaiter().GetResult() is safe without Task.Run.
             _networkOffline = new Lazy<bool>(() =>
-                _explicitOffline
-                    ? true
-                    : OfflineHelper.IsOfflineAsync().GetAwaiter().GetResult());
+            {
+                if (_explicitOffline)
+                {
+                    return true;
+                }
+
+                if (forceOnline)
+                {
+                    return false;
+                }
+
+                return OfflineHelper.IsOfflineAsync().GetAwaiter().GetResult();
+            });
 
             try
             {

--- a/src/Cli/func/Helpers/OfflineHelper.cs
+++ b/src/Cli/func/Helpers/OfflineHelper.cs
@@ -16,36 +16,43 @@ namespace Azure.Functions.Cli.Helpers
     internal static class OfflineHelper
     {
         private const string ConnectivityCheckUrl = "https://cdn.functions.azure.com/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/staticProperties.json";
+        private static readonly TimeSpan _probeTimeout = TimeSpan.FromSeconds(2);
+        private static readonly TimeSpan _retryDelay = TimeSpan.FromMilliseconds(250);
 
         /// <summary>
         /// Performs a network connectivity check by sending a HEAD request.
-        /// Only returns true on connection failure (exception), not on HTTP error codes
+        /// Only returns true on connection failure, not on HTTP error codes
         /// such as 404 or 500 which indicate the server is reachable.
+        /// Times out after 2 seconds; on a timeout, retries once after a short delay.
+        /// Hard failures (DNS / socket) fail fast without retry.
         /// </summary>
         /// <returns>True if offline (connection failure), false if online.</returns>
         internal static async Task<bool> IsOfflineAsync()
         {
-            try
+            var firstFailure = await TryProbeAsync().ConfigureAwait(false);
+            if (firstFailure is null)
             {
-                using var quickClient = new HttpClient { Timeout = TimeSpan.FromSeconds(1) };
-                using var request = new HttpRequestMessage(HttpMethod.Head, ConnectivityCheckUrl);
-                request.Headers.Add("User-Agent", Constants.CliUserAgent);
-                using var response = await quickClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
-
-                // Any HTTP response (even 4xx/5xx) means the network is reachable
                 return false;
             }
-            catch (Exception ex)
-            {
-                ColoredConsole.WriteLine(WarningColor("Unable to resolve network connection, running the CLI in offline mode."));
 
-                if (GlobalCoreToolsSettings.IsVerbose)
+            // Retry once, but only if the first failure was a timeout. Hard failures
+            // (e.g. DNS resolution failure) are definitive and should fail fast.
+            if (firstFailure is TaskCanceledException or OperationCanceledException)
+            {
+                await Task.Delay(_retryDelay).ConfigureAwait(false);
+
+                var secondFailure = await TryProbeAsync().ConfigureAwait(false);
+                if (secondFailure is null)
                 {
-                    ColoredConsole.WriteLine(VerboseColor($"Details: {ex.Message}"));
+                    return false;
                 }
 
+                ReportOffline(secondFailure);
                 return true;
             }
+
+            ReportOffline(firstFailure);
+            return true;
         }
 
         /// <summary>
@@ -62,6 +69,37 @@ namespace Azure.Functions.Cli.Helpers
         internal static void MarkAsOnline()
         {
             GlobalCoreToolsSettings.SetOffline(false);
+        }
+
+        /// <summary>
+        /// Returns null on success (network reachable), or the exception that caused the probe to fail.
+        /// </summary>
+        private static async Task<Exception> TryProbeAsync()
+        {
+            try
+            {
+                using var quickClient = new HttpClient { Timeout = _probeTimeout };
+                using var request = new HttpRequestMessage(HttpMethod.Head, ConnectivityCheckUrl);
+                request.Headers.Add("User-Agent", Constants.CliUserAgent);
+                using var response = await quickClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+
+                // Any HTTP response (even 4xx/5xx) means the network is reachable.
+                return null;
+            }
+            catch (Exception ex)
+            {
+                return ex;
+            }
+        }
+
+        private static void ReportOffline(Exception ex)
+        {
+            ColoredConsole.WriteLine(WarningColor("Unable to resolve network connection, running the CLI in offline mode."));
+
+            if (GlobalCoreToolsSettings.IsVerbose && ex is not null)
+            {
+                ColoredConsole.WriteLine(VerboseColor($"Details: {ex.GetType().Name}: {ex.Message}"));
+            }
         }
     }
 }

--- a/test/Cli/Func.E2ETests/BaseE2ETests.cs
+++ b/test/Cli/Func.E2ETests/BaseE2ETests.cs
@@ -42,6 +42,12 @@ namespace Azure.Functions.Cli.E2ETests
             Environment.SetEnvironmentVariable(DotnetHelpers.CustomHiveRoot, hiveRoot);
             Directory.CreateDirectory(hiveRoot);
 
+            // Skip the live network connectivity probe in spawned `func` processes. E2E tests
+            // are not testing connectivity; relying on a real probe makes them flake when the
+            // CI runner is slow on the first DNS/TLS handshake. Tests that explicitly want
+            // offline behavior pass the `--offline` flag, which still takes precedence.
+            Environment.SetEnvironmentVariable(Azure.Functions.Cli.Common.Constants.FunctionsCoreToolsOffline, "false");
+
             Directory.CreateDirectory(WorkingDirectory);
             return Task.CompletedTask;
         }

--- a/test/Cli/Func.E2ETests/Commands/FuncNew/PowerShellTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncNew/PowerShellTests.cs
@@ -27,7 +27,7 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncNew
             // Create HTTP Trigger function with anonymous authlevel
             var result = new FuncNewCommand(FuncPath, testName, Log)
                 .WithWorkingDirectory(WorkingDirectory)
-                .Execute([".", "--template", "HttpTrigger", "--name", "MyHttpTriggerFunction", "--authlevel", "Anonymous", "-a"]);
+                .Execute([".", "--template", "HttpTrigger", "--name", "MyHttpTriggerFunction", "--authlevel", "Anonymous"]);
 
             // Verify output contains success message
             result.Should().HaveStdOutContaining("The function \"MyHttpTriggerFunction\" was created successfully from the \"HttpTrigger\" template.");

--- a/test/Cli/Func.E2ETests/Fixtures/BaseFunctionAppFixture.cs
+++ b/test/Cli/Func.E2ETests/Fixtures/BaseFunctionAppFixture.cs
@@ -71,6 +71,10 @@ namespace Azure.Functions.Cli.E2ETests.Fixtures
 
         public async Task InitializeAsync()
         {
+            // Skip the live network connectivity probe in spawned `func` processes. Mirrors
+            // BaseE2ETests; fixture-backed tests don't go through that path.
+            Environment.SetEnvironmentVariable(Azure.Functions.Cli.Common.Constants.FunctionsCoreToolsOffline, "false");
+
             var workerRuntime = WorkerRuntimeLanguageHelper.GetRuntimeMoniker(WorkerRuntime);
             var initArgs = new List<string> { ".", "--worker-runtime", workerRuntime }
                 .Concat(TargetFramework != null

--- a/test/Cli/Func.UnitTests/HelperTests/EnvironmentHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/EnvironmentHelperTests.cs
@@ -1,0 +1,55 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Helpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Azure.Functions.Cli.UnitTests.HelperTests
+{
+    public class EnvironmentHelperTests : IDisposable
+    {
+        private const string TestKey = "FUNC_CLI_ENV_HELPER_TEST_KEY";
+        private readonly string _previousValue;
+
+        public EnvironmentHelperTests()
+        {
+            _previousValue = Environment.GetEnvironmentVariable(TestKey);
+            Environment.SetEnvironmentVariable(TestKey, null);
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable(TestKey, _previousValue);
+        }
+
+        [Theory]
+        [InlineData("true", true)]
+        [InlineData("True", true)]
+        [InlineData("TRUE", true)]
+        [InlineData("1", true)]
+        [InlineData("false", false)]
+        [InlineData("False", false)]
+        [InlineData("FALSE", false)]
+        [InlineData("0", false)]
+        public void GetEnvironmentVariableAsNullableBool_ParsesKnownValues(string value, bool expected)
+        {
+            Environment.SetEnvironmentVariable(TestKey, value);
+
+            EnvironmentHelper.GetEnvironmentVariableAsNullableBool(TestKey).Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("yes")]
+        [InlineData("no")]
+        [InlineData("garbage")]
+        public void GetEnvironmentVariableAsNullableBool_ReturnsNullForUnsetOrUnknown(string value)
+        {
+            Environment.SetEnvironmentVariable(TestKey, value);
+
+            EnvironmentHelper.GetEnvironmentVariableAsNullableBool(TestKey).Should().BeNull();
+        }
+    }
+}

--- a/test/Cli/Func.UnitTests/HelperTests/OfflineHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/OfflineHelperTests.cs
@@ -106,6 +106,37 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
                 "FUNCTIONS_CORE_TOOLS_OFFLINE env var should set offline mode");
         }
 
+        [Theory]
+        [InlineData("false")]
+        [InlineData("0")]
+        [InlineData("FALSE")]
+        public void Init_WithEnvVarFalse_ForcesOnlineWithoutNetworkCheck(string envValue)
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable(Constants.FunctionsCoreToolsOffline, envValue);
+
+            // Act
+            GlobalCoreToolsSettings.Init(null, Array.Empty<string>());
+
+            // Assert – probe is skipped; offline mode is false regardless of real connectivity
+            GlobalCoreToolsSettings.IsOfflineMode.Should().BeFalse(
+                "FUNCTIONS_CORE_TOOLS_OFFLINE=false should force online and skip the probe");
+        }
+
+        [Fact]
+        public void Init_WithOfflineFlagAndEnvVarFalse_FlagWins()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable(Constants.FunctionsCoreToolsOffline, "false");
+
+            // Act – explicit --offline flag should still take precedence over env var override
+            GlobalCoreToolsSettings.Init(null, new[] { "--offline" });
+
+            // Assert
+            GlobalCoreToolsSettings.IsOfflineMode.Should().BeTrue(
+                "--offline flag should take precedence over FUNCTIONS_CORE_TOOLS_OFFLINE=false");
+        }
+
         // ─── SetOffline ─────────────────────────────────────────────────
         [Fact]
         public void SetOffline_True_SetsIsOfflineMode()

--- a/test/Cli/Func.UnitTests/HelperTests/UtilitiesTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/UtilitiesTests.cs
@@ -68,14 +68,23 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
         [InlineData(false)]
         public void Test_IsMinifiedVersion(bool expected)
         {
-            var filePath = Path.Combine("artifactsconfig.json");
+            // IsMinifiedVersion uses ConfigurationBuilder.AddJsonFile with a relative path,
+            // which resolves against AppContext.BaseDirectory — not the test's current working directory.
+            // CI runners may launch tests from a working dir different from the test assembly location,
+            // so write the artifactsconfig.json next to the test binary to keep this test deterministic.
+            var filePath = Path.Combine(AppContext.BaseDirectory, "artifactsconfig.json");
             string artifactsJsonContent = "{\"minifiedVersion\": " + expected.ToString().ToLower() + "}";
             File.WriteAllTextAsync(filePath, artifactsJsonContent).GetAwaiter().GetResult();
 
-            bool output = Utilities.IsMinifiedVersion();
-
-            File.Delete(filePath);
-            Assert.Equal(expected, output);
+            try
+            {
+                bool output = Utilities.IsMinifiedVersion();
+                Assert.Equal(expected, output);
+            }
+            finally
+            {
+                File.Delete(filePath);
+            }
         }
     }
 }

--- a/test/Cli/Func.UnitTests/HelperTests/ZipHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/ZipHelperTests.cs
@@ -82,8 +82,10 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
                 files.Add(file);
             }
 
-            // Find the repo root by walking up until we find the solution file
-            var dir = new DirectoryInfo(Directory.GetCurrentDirectory());
+            // Find the repo root by walking up from the test assembly location until we find
+            // the solution file. Avoid Directory.GetCurrentDirectory() because some CI runners
+            // (e.g. CloudTest) launch tests from a working directory outside the source tree.
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
             while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Azure.Functions.Cli.sln")))
             {
                 dir = dir.Parent;

--- a/test/Cli/TestFramework/Helpers/ProcessHelper.cs
+++ b/test/Cli/TestFramework/Helpers/ProcessHelper.cs
@@ -139,7 +139,7 @@ namespace Azure.Functions.Cli.TestFramework.Helpers
         {
             using var client = new HttpClient();
             var deadline = DateTime.UtcNow + _functionInvocationPollTimeout;
-            HttpResponseMessage lastResponse = null;
+            HttpResponseMessage? lastResponse = null;
             string lastBody = string.Empty;
 
             while (true)

--- a/test/Cli/TestFramework/Helpers/ProcessHelper.cs
+++ b/test/Cli/TestFramework/Helpers/ProcessHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Diagnostics;
@@ -10,6 +10,8 @@ namespace Azure.Functions.Cli.TestFramework.Helpers
     public class ProcessHelper
     {
         private static readonly string _functionsHostUrl = "http://localhost";
+        private static readonly TimeSpan _functionInvocationPollInterval = TimeSpan.FromMilliseconds(500);
+        private static readonly TimeSpan _functionInvocationPollTimeout = TimeSpan.FromSeconds(10);
 
         public static async Task WaitForFunctionHostToStart(
             Process funcProcess,
@@ -41,7 +43,7 @@ namespace Azure.Functions.Cli.TestFramework.Helpers
                     if (funcProcess.HasExited)
                     {
                         LogMessage($"Function host process exited with code {funcProcess.ExitCode} - cannot continue waiting");
-                        return true;
+                        throw new HostExitedBeforeReadyException(funcProcess.ExitCode);
                     }
 
                     // Try ping endpoint
@@ -55,6 +57,10 @@ namespace Azure.Functions.Cli.TestFramework.Helpers
                     }
 
                     return false;
+                }
+                catch (HostExitedBeforeReadyException)
+                {
+                    throw;
                 }
                 catch (Exception ex)
                 {
@@ -86,8 +92,6 @@ namespace Azure.Functions.Cli.TestFramework.Helpers
             try
             {
                 fileWriter.WriteLine("[HANDLER] Starting process started handler helper");
-                fileWriter.Flush();
-
                 fileWriter.WriteLine($"[HANDLER] Process working directory: {process.StartInfo.WorkingDirectory}");
                 fileWriter.Flush();
 
@@ -98,21 +102,14 @@ namespace Azure.Functions.Cli.TestFramework.Helpers
 
                 if (!string.IsNullOrEmpty(functionCall))
                 {
-                    using var client = new HttpClient();
-                    HttpResponseMessage response = await client.GetAsync($"http://localhost:{port}/api/{functionCall}");
-                    capturedContent = await response.Content.ReadAsStringAsync();
+                    capturedContent = await InvokeFunctionWithRetryAsync(port, functionCall, fileWriter);
                     fileWriter.WriteLine($"[HANDLER] Captured content: {capturedContent}");
                     fileWriter.Flush();
                 }
             }
-            catch (Exception ex)
-            {
-                fileWriter.WriteLine($"[HANDLER] Caught the following exception: {ex.Message}");
-                fileWriter.Flush();
-            }
             finally
             {
-                fileWriter.WriteLine($"[HANDLER] Going to kill process");
+                fileWriter.WriteLine("[HANDLER] Going to kill process");
                 fileWriter.Flush();
 
                 // Wait 5 seconds for all the logs to show up first if we need them
@@ -121,12 +118,68 @@ namespace Azure.Functions.Cli.TestFramework.Helpers
                     await Task.Delay(5000);
                 }
 
-                process.Kill(true);
+                if (!process.HasExited)
+                {
+                    process.Kill(true);
+                }
             }
 
-            fileWriter.WriteLine($"[HANDLER] Returning captured content");
+            fileWriter.WriteLine("[HANDLER] Returning captured content");
             fileWriter.Flush();
             return capturedContent;
         }
+
+        /// <summary>
+        /// Polls the function endpoint until it returns a 2xx response, the host process exits,
+        /// or the timeout elapses. The host's /admin/host/ping endpoint can return success before
+        /// functions are fully indexed; this absorbs the indexing race so callers see content,
+        /// not an opaque empty body.
+        /// </summary>
+        private static async Task<string> InvokeFunctionWithRetryAsync(int port, string functionCall, StreamWriter fileWriter)
+        {
+            using var client = new HttpClient();
+            var deadline = DateTime.UtcNow + _functionInvocationPollTimeout;
+            HttpResponseMessage lastResponse = null;
+            string lastBody = string.Empty;
+
+            while (true)
+            {
+                lastResponse = await client.GetAsync($"http://localhost:{port}/api/{functionCall}");
+                lastBody = await lastResponse.Content.ReadAsStringAsync();
+
+                if (lastResponse.IsSuccessStatusCode)
+                {
+                    return lastBody;
+                }
+
+                fileWriter.WriteLine($"[HANDLER] Function returned {(int)lastResponse.StatusCode}; retrying...");
+                fileWriter.Flush();
+
+                if (DateTime.UtcNow >= deadline)
+                {
+                    throw new HttpRequestException(
+                        $"Function call '{functionCall}' did not return success within {_functionInvocationPollTimeout.TotalSeconds:F0}s. " +
+                        $"Last status: {(int)lastResponse.StatusCode} {lastResponse.ReasonPhrase}. Body: {lastBody}");
+                }
+
+                await Task.Delay(_functionInvocationPollInterval);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Thrown by <see cref="ProcessHelper.WaitForFunctionHostToStart"/> when the host process
+    /// exits before it becomes ready to serve requests. Carries the host's exit code so test
+    /// failures point at the real cause instead of a downstream empty-body assertion.
+    /// </summary>
+    public class HostExitedBeforeReadyException : Exception
+    {
+        public HostExitedBeforeReadyException(int exitCode)
+            : base($"Function host process exited with code {exitCode} before becoming ready.")
+        {
+            ExitCode = exitCode;
+        }
+
+        public int ExitCode { get; }
     }
 }


### PR DESCRIPTION
Fixes two flaky e2e tests with two unrelated root causes.

## `FuncNew_HttpTrigger_AuthLevelConfigured_PowerShell_Succeeds`

`OfflineHelper.IsOfflineAsync` did one HEAD request with a 1s timeout. On a cold CI macOS runner, DNS+TLS for that first call routinely exceeds 1s, the CLI flips itself to "offline", and `func new` aborts with `Unable to download extension bundle`.

- Bump the probe timeout to 2s and add 1 retry (250ms delay) — but only on `TaskCanceledException`. Hard failures (DNS/socket) still fail fast.
- Extend `FUNCTIONS_CORE_TOOLS_OFFLINE` to a tri-state: `true`/`1` forces offline (existing), `false`/`0` now forces online and skips the probe entirely. Unset still probes.
- E2E tests set the env var to `false` so they never depend on real network for an unrelated assertion. The `--offline` flag still wins for tests that explicitly want offline behavior.
- The test also passed `--authlevel Anonymous -a` — `-a` is the short alias of `--authlevel`, so the flag was duplicated. Dropped the dupe.

## `Start_WithSpecifyingDefaultHost_SuccessfulFunctionExecution` (and friends)

Two issues in `ProcessHelper`:

1. `WaitForFunctionHostToStart` returned `true` when `funcProcess.HasExited`, treating a crashed host as ready. The handler then issued the function GET against a dead process, the exception was swallowed, and the test asserted on an empty body. Now throws `HostExitedBeforeReadyException(exitCode)`.
2. `ProcessStartedHandlerHelper` did one GET and didn't check `IsSuccessStatusCode`. The host's `/admin/host/ping` can return 200 before functions are fully indexed, so the function call would 404 and silently capture `""`. Now polls until 2xx for up to 10s. Removed the inner swallow so failures surface in the log instead of being silently dropped.

## Tests

- New unit tests for `EnvironmentHelper.GetEnvironmentVariableAsNullableBool` and the new tri-state behavior on `FUNCTIONS_CORE_TOOLS_OFFLINE`.
- Existing `OfflineHelperTests` still pass.

## Out of scope

There's also a theoretical TOCTOU race in `ProcessHelper.GetAvailablePort` (port released before `func` binds), but the failure logs don't show port collision. Left for a follow-up to keep this PR tight.