### PR TITLE
Add workload loader

### DIFF
--- a/Azure.Functions.Cli.slnx
+++ b/Azure.Functions.Cli.slnx
@@ -10,5 +10,6 @@
   </Folder>
   <Folder Name="/test/">
     <Project Path="test/Func.Tests/Func.Tests.csproj" />
+    <Project Path="test/Func.Tests.Fixtures.Workload/Func.Tests.Fixtures.Workload.csproj" />
   </Folder>
 </Solution>

--- a/src/Func/Workloads/Loading/IWorkloadLoader.cs
+++ b/src/Func/Workloads/Loading/IWorkloadLoader.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads.Storage;
+
+namespace Azure.Functions.Cli.Workloads.Loading;
+
+/// <summary>
+/// Hydrates workload manifest entries into runnable <see cref="LoadedWorkload"/>
+/// instances. Pure: takes manifest entries in, returns loaded workloads out.
+/// The composition root reads the entries from <see cref="IGlobalManifestStore"/>
+/// and hands them here, keeping the storage and assembly-loading concerns
+/// independently testable.
+/// </summary>
+internal interface IWorkloadLoader
+{
+    /// <summary>
+    /// Loads each entry into its own <see cref="System.Runtime.Loader.AssemblyLoadContext"/>
+    /// and activates the declared <see cref="IWorkload"/> type.
+    /// </summary>
+    /// <param name="installed">The installed workloads to hydrate.</param>
+    /// <returns>One <see cref="LoadedWorkload"/> per input, in the same order.</returns>
+    /// <exception cref="Common.GracefulException">
+    /// Thrown when an entry's assembly is missing, the declared type cannot be
+    /// found, or the type does not implement <see cref="IWorkload"/>. Other
+    /// entries are not partially loaded — the operation is all-or-nothing.
+    /// </exception>
+    public IReadOnlyList<LoadedWorkload> LoadInstalled(IReadOnlyList<InstalledWorkload> installed);
+}

--- a/src/Func/Workloads/Loading/LoadedWorkload.cs
+++ b/src/Func/Workloads/Loading/LoadedWorkload.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workloads.Loading;
+
+/// <summary>
+/// A workload that has been hydrated from the global manifest and is
+/// ready to participate in DI. Pairs the runtime <see cref="IWorkload"/>
+/// instance with its manifest-sourced display info.
+/// </summary>
+/// <param name="Instance">The workload's runtime instance.</param>
+/// <param name="Info">CLI-side metadata sourced from the global manifest.</param>
+internal sealed record LoadedWorkload(IWorkload Instance, WorkloadInfo Info);

--- a/src/Func/Workloads/Loading/WorkloadLoadContext.cs
+++ b/src/Func/Workloads/Loading/WorkloadLoadContext.cs
@@ -1,0 +1,87 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace Azure.Functions.Cli.Workloads.Loading;
+
+/// <summary>
+/// Per-workload <see cref="AssemblyLoadContext"/>. Each installed workload
+/// gets its own so dependency versions don't collide across workloads.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Collectible so a future <c>func workload unload</c> / hot-reload can
+/// release the context. Probe path is scoped to the workload's install
+/// directory only — workloads do not see each other's dependencies.
+/// </para>
+/// <para>
+/// Assemblies on <see cref="_sharedAssemblyPrefixes"/> are delegated back to
+/// the default context so type identity is preserved across the host /
+/// workload boundary. Without this, a cast to <see cref="IWorkload"/> would
+/// fail because the host and the workload would each load their own copy
+/// of <c>Azure.Functions.Cli.Abstractions</c> and see two different
+/// <c>IWorkload</c> types. The list is intentionally explicit (rather than
+/// "whatever the default context has loaded") so the boundary is
+/// deterministic regardless of host warm-up state.
+/// </para>
+/// </remarks>
+internal sealed class WorkloadLoadContext : AssemblyLoadContext
+{
+    /// <summary>
+    /// Assembly-name prefixes that must resolve from the default context to
+    /// preserve type identity across the host / workload boundary. Order
+    /// doesn't matter; matching is case-sensitive (CLR convention).
+    /// </summary>
+    private static readonly string[] _sharedAssemblyPrefixes =
+    [
+        "Azure.Functions.Cli.Abstractions",
+        "Microsoft.Extensions.",
+        "System.",
+        "Microsoft.Win32.",
+        "netstandard",
+        "mscorlib",
+    ];
+
+    private readonly AssemblyDependencyResolver _resolver;
+
+    public WorkloadLoadContext(string assemblyPath)
+        : base(name: Path.GetFileNameWithoutExtension(assemblyPath), isCollectible: true)
+    {
+        _resolver = new AssemblyDependencyResolver(assemblyPath);
+    }
+
+    protected override Assembly? Load(AssemblyName assemblyName)
+    {
+        if (IsShared(assemblyName))
+        {
+            // Returning null delegates to the default context, which is what
+            // we want for shared host types so identity matches across the
+            // boundary.
+            return null;
+        }
+
+        var resolved = _resolver.ResolveAssemblyToPath(assemblyName);
+        return resolved is null ? null : LoadFromAssemblyPath(resolved);
+    }
+
+    private static bool IsShared(AssemblyName assemblyName)
+    {
+        var name = assemblyName.Name;
+        if (string.IsNullOrEmpty(name))
+        {
+            return false;
+        }
+
+        foreach (var prefix in _sharedAssemblyPrefixes)
+        {
+            if (name.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Func/Workloads/Loading/WorkloadLoader.cs
+++ b/src/Func/Workloads/Loading/WorkloadLoader.cs
@@ -1,0 +1,69 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Workloads.Storage;
+
+namespace Azure.Functions.Cli.Workloads.Loading;
+
+/// <summary>
+/// Default <see cref="IWorkloadLoader"/>. Loads each entry into its own
+/// collectible <see cref="WorkloadLoadContext"/> so dependency versions
+/// don't collide across workloads.
+/// </summary>
+internal sealed class WorkloadLoader : IWorkloadLoader
+{
+    /// <inheritdoc />
+    public IReadOnlyList<LoadedWorkload> LoadInstalled(IReadOnlyList<InstalledWorkload> installed)
+    {
+        ArgumentNullException.ThrowIfNull(installed);
+
+        var results = new List<LoadedWorkload>(installed.Count);
+        foreach (var item in installed)
+        {
+            results.Add(LoadEntry(item));
+        }
+
+        return results;
+    }
+
+    private static LoadedWorkload LoadEntry(InstalledWorkload installed)
+    {
+        var entry = installed.Entry;
+        var assemblyPath = Path.Combine(entry.InstallPath, entry.EntryPoint.Assembly);
+        if (!File.Exists(assemblyPath))
+        {
+            throw new GracefulException(
+                $"[{installed.PackageId}] Could not load workload: assembly '{entry.EntryPoint.Assembly}' was not found at '{entry.InstallPath}'.",
+                isUserError: true);
+        }
+
+        var assembly = new WorkloadLoadContext(assemblyPath).LoadFromAssemblyPath(assemblyPath);
+
+        var type = assembly.GetType(entry.EntryPoint.Type, throwOnError: false);
+        if (type is null)
+        {
+            throw new GracefulException(
+                $"[{installed.PackageId}] Could not load workload: type '{entry.EntryPoint.Type}' was not found in '{entry.EntryPoint.Assembly}' (install path: '{entry.InstallPath}').",
+                isUserError: true);
+        }
+
+        if (!typeof(IWorkload).IsAssignableFrom(type))
+        {
+            throw new GracefulException(
+                $"[{installed.PackageId}] Could not load workload: type '{entry.EntryPoint.Type}' does not implement {nameof(IWorkload)} (install path: '{entry.InstallPath}').",
+                isUserError: true);
+        }
+
+        var instance = (IWorkload)Activator.CreateInstance(type)!;
+
+        var info = new WorkloadInfo(
+            PackageId: installed.PackageId,
+            PackageVersion: installed.Version,
+            DisplayName: entry.DisplayName,
+            Description: entry.Description,
+            Aliases: entry.Aliases);
+
+        return new LoadedWorkload(instance, info);
+    }
+}

--- a/test/Func.Tests.Fixtures.Workload/Func.Tests.Fixtures.Workload.csproj
+++ b/test/Func.Tests.Fixtures.Workload/Func.Tests.Fixtures.Workload.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyName>$(TopLevelNamespace).Tests.Fixtures.Workload</AssemblyName>
+    <RootNamespace>$(AssemblyName)</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(SrcRoot)Abstractions/Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Func.Tests.Fixtures.Workload/NotAWorkload.cs
+++ b/test/Func.Tests.Fixtures.Workload/NotAWorkload.cs
@@ -1,0 +1,8 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Tests.Fixtures.Workload;
+
+public sealed class NotAWorkload
+{
+}

--- a/test/Func.Tests.Fixtures.Workload/StubWorkload.cs
+++ b/test/Func.Tests.Fixtures.Workload/StubWorkload.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads;
+
+namespace Azure.Functions.Cli.Tests.Fixtures.Workload;
+
+public sealed class StubWorkload : IWorkload
+{
+    public string PackageId => "Azure.Functions.Cli.Tests.Fixtures.Workload";
+
+    public string PackageVersion => "1.0.0";
+
+    public string DisplayName => "Stub";
+
+    public string Description => "Test fixture workload.";
+
+    public void Configure(FunctionsCliBuilder builder)
+    {
+    }
+}

--- a/test/Func.Tests/Func.Tests.csproj
+++ b/test/Func.Tests/Func.Tests.csproj
@@ -10,4 +10,13 @@
     <ProjectReference Include="$(SrcRoot)Func/Func.csproj" />
   </ItemGroup>
 
+  <!-- Test fixtures: built and copied to output as content; loaded via reflection. -->
+  <ItemGroup>
+    <ProjectReference Include="..\Func.Tests.Fixtures.Workload\Func.Tests.Fixtures.Workload.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </ProjectReference>
+  </ItemGroup>
+
 </Project>

--- a/test/Func.Tests/Workloads/Loading/WorkloadLoaderTests.cs
+++ b/test/Func.Tests/Workloads/Loading/WorkloadLoaderTests.cs
@@ -1,0 +1,155 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Runtime.Loader;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Workloads;
+using Azure.Functions.Cli.Workloads.Loading;
+using Azure.Functions.Cli.Workloads.Storage;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Workloads.Loading;
+
+public class WorkloadLoaderTests
+{
+    private const string FixturePackageId = "Azure.Functions.Cli.Tests.Fixtures.Workload";
+    private const string FixtureAssemblyFile = "Azure.Functions.Cli.Tests.Fixtures.Workload.dll";
+    private const string FixtureTypeName = "Azure.Functions.Cli.Tests.Fixtures.Workload.StubWorkload";
+
+    [Fact]
+    public void LoadInstalled_ReturnsEmpty_WhenNoEntries()
+    {
+        var loader = new WorkloadLoader();
+
+        var loaded = loader.LoadInstalled(Array.Empty<InstalledWorkload>());
+
+        Assert.Empty(loaded);
+    }
+
+    [Fact]
+    public void LoadInstalled_HydratesEntry_FromAssemblyOnDisk()
+    {
+        var loader = new WorkloadLoader();
+
+        var loaded = loader.LoadInstalled(new[] { FixtureEntry(FixturePackageId) });
+
+        var item = Assert.Single(loaded);
+        Assert.Equal(FixtureTypeName, item.Instance.GetType().FullName);
+        Assert.Equal(FixturePackageId, item.Info.PackageId);
+    }
+
+    [Fact]
+    public void LoadInstalled_Throws_WhenAssemblyFileMissing()
+    {
+        var loader = new WorkloadLoader();
+        var entry = FixtureEntry(FixturePackageId, assemblyFileOverride: "DoesNotExist.dll");
+
+        var ex = Assert.Throws<GracefulException>(() => loader.LoadInstalled(new[] { entry }));
+
+        Assert.True(ex.IsUserError);
+        Assert.StartsWith($"[{FixturePackageId}]", ex.Message);
+        Assert.Contains("DoesNotExist.dll", ex.Message);
+        Assert.Contains(entry.Entry.InstallPath, ex.Message);
+    }
+
+    [Fact]
+    public void LoadInstalled_Throws_WhenTypeNotFoundInAssembly()
+    {
+        var loader = new WorkloadLoader();
+        var entry = FixtureEntry(FixturePackageId, typeNameOverride: "Some.Missing.Type");
+
+        var ex = Assert.Throws<GracefulException>(() => loader.LoadInstalled(new[] { entry }));
+
+        Assert.True(ex.IsUserError);
+        Assert.StartsWith($"[{FixturePackageId}]", ex.Message);
+        Assert.Contains("Some.Missing.Type", ex.Message);
+        Assert.Contains(entry.Entry.InstallPath, ex.Message);
+    }
+
+    [Fact]
+    public void LoadInstalled_Throws_WhenTypeDoesNotImplementIWorkload()
+    {
+        var loader = new WorkloadLoader();
+        var entry = FixtureEntry(
+            FixturePackageId,
+            typeNameOverride: "Azure.Functions.Cli.Tests.Fixtures.Workload.NotAWorkload");
+
+        var ex = Assert.Throws<GracefulException>(() => loader.LoadInstalled(new[] { entry }));
+
+        Assert.True(ex.IsUserError);
+        Assert.StartsWith($"[{FixturePackageId}]", ex.Message);
+        Assert.Contains("NotAWorkload", ex.Message);
+        Assert.Contains(nameof(IWorkload), ex.Message);
+        Assert.Contains(entry.Entry.InstallPath, ex.Message);
+    }
+
+    [Fact]
+    public void LoadInstalled_LoadsEachWorkloadInOwnAssemblyLoadContext()
+    {
+        var loader = new WorkloadLoader();
+        var entries = new[]
+        {
+            FixtureEntry("fixture-a"),
+            FixtureEntry("fixture-b"),
+        };
+
+        var loaded = loader.LoadInstalled(entries);
+
+        Assert.Equal(2, loaded.Count);
+        var ctxA = AssemblyLoadContext.GetLoadContext(loaded[0].Instance.GetType().Assembly);
+        var ctxB = AssemblyLoadContext.GetLoadContext(loaded[1].Instance.GetType().Assembly);
+        Assert.NotNull(ctxA);
+        Assert.NotNull(ctxB);
+        Assert.NotSame(ctxA, ctxB);
+        Assert.NotSame(AssemblyLoadContext.Default, ctxA);
+    }
+
+    [Fact]
+    public void LoadInstalled_LoadContextIsCollectible()
+    {
+        var loader = new WorkloadLoader();
+
+        var loaded = loader.LoadInstalled(new[] { FixtureEntry("collectible-fixture") });
+
+        var ctx = AssemblyLoadContext.GetLoadContext(loaded[0].Instance.GetType().Assembly);
+        Assert.NotNull(ctx);
+        Assert.True(ctx!.IsCollectible, "WorkloadLoadContext must be collectible to support unload/hot-reload.");
+    }
+
+    [Fact]
+    public void LoadInstalled_DelegatesAbstractionsAssemblyToDefaultContext()
+    {
+        var loader = new WorkloadLoader();
+
+        var loaded = loader.LoadInstalled(new[] { FixtureEntry("identity-fixture") });
+
+        // The IWorkload type the workload was activated as must be the same Type
+        // identity the host knows. If the load context loaded its own copy of
+        // Azure.Functions.Cli.Abstractions, the cast in WorkloadLoader would
+        // have failed; this test pins that contract.
+        var hostIWorkload = typeof(IWorkload);
+        var workloadIWorkload = loaded[0].Instance.GetType()
+            .GetInterfaces()
+            .Single(i => i.FullName == hostIWorkload.FullName);
+        Assert.Same(hostIWorkload, workloadIWorkload);
+        Assert.Same(hostIWorkload.Assembly, workloadIWorkload.Assembly);
+    }
+
+    private static InstalledWorkload FixtureEntry(
+        string packageId,
+        string? assemblyFileOverride = null,
+        string? typeNameOverride = null) => new(
+            packageId,
+            "1.0.0",
+            new GlobalManifestEntry
+            {
+                DisplayName = packageId,
+                Description = string.Empty,
+                InstallPath = AppContext.BaseDirectory,
+                EntryPoint = new EntryPointSpec
+                {
+                    Assembly = assemblyFileOverride ?? FixtureAssemblyFile,
+                    Type = typeNameOverride ?? FixtureTypeName,
+                },
+            });
+}


### PR DESCRIPTION
Resolves #4897

## Summary

Adds the workload loader: turns persisted manifest entries (from #4893, now in `vnext`) into runnable `IWorkload` instances, each loaded into its own collectible `AssemblyLoadContext` so dependency versions don't collide across workloads.

The discovery/scanner side (`[assembly: ExportCliWorkload<T>]`) is intentionally deferred to a follow-up install-pipeline PR.

## What this PR adds

- **`IWorkloadLoader` / `WorkloadLoader`** — pure: takes `IReadOnlyList<InstalledWorkload>`, returns `IReadOnlyList<LoadedWorkload>`. No I/O on the manifest, no DI surface yet — the composition root reads from `IGlobalManifestStore` and hands entries here.
- **`WorkloadLoadContext`** — per-workload **collectible** `AssemblyLoadContext`. Resolves probe-path dependencies (`AssemblyDependencyResolver`) and **delegates a small allow-list of host assemblies** (`Azure.Functions.Cli.Abstractions`, `Microsoft.Extensions.*`, `System.*`, `Microsoft.Win32.*`, `netstandard`, `mscorlib`) to `Default` so type identity for `IWorkload` and DI primitives is preserved across the boundary.
- **`LoadedWorkload`** — pairs the activated `IWorkload` instance with its `WorkloadInfo`.
- **Test fixture project** (`Func.Cli.Tests.Fixtures.Workload`) — real on-disk assembly the loader tests load through the ALC; not referenced by the test project at compile time.

## Design decisions

- **Sync, pure API.** `LoadInstalled` is synchronous and accepts an in-memory list rather than the store. Reflection/`Activator.CreateInstance` is CPU-bound, and decoupling from the store keeps loader tests free of filesystem fixtures.
- **Collectible ALCs.** `isCollectible: true` enables future unload/hot-reload (e.g. `func workload uninstall` while the host is alive). Cost is small; the option can't be added later without a breaking change to ALC identity.
- **Explicit shared-assembly allow-list** instead of `AssemblyLoadContext.Default.Assemblies.Any(...)`. The latter accidentally shares any assembly the host happens to have loaded; the allow-list makes the contract explicit and reviewable.
- **All-or-nothing loading.** A failure on any entry throws `GracefulException` — no partially-loaded workload set. Errors are prefixed `[<package-id>]` and include `InstallPath` per spec §6.3 / §7.

## Tests

- `LoadInstalled_ReturnsEmpty_WhenNoEntries`
- `LoadInstalled_HydratesEntry_FromAssemblyOnDisk`
- `LoadInstalled_Throws_WhenAssemblyFileMissing` / `WhenTypeNotFoundInAssembly` / `WhenTypeDoesNotImplementIWorkload`
- `LoadInstalled_LoadsEachWorkloadInOwnAssemblyLoadContext`
- `LoadInstalled_LoadContextIsCollectible`
- `LoadInstalled_DelegatesAbstractionsAssemblyToDefaultContext` — pins the type-identity contract; if the ALC ever loaded its own copy of `Azure.Functions.Cli.Abstractions`, the cast in `WorkloadLoader` would fail.

## Out of scope (follow-up PR)

- `[assembly: ExportCliWorkload<T>]` attribute + scanner
- `func workload install / uninstall / list` commands
- Composition root wiring (DI registration, command parser bridge)

## Spec
[`docs/workload-spec.md`](https://github.com/Azure/azure-functions-core-tools/blob/liliankasem/docs/workloads/docs/workload-spec.md)