### PR TITLE
Stop dotnet-isolated e2e worker crashing on missing AppInsights conn string

### DIFF
--- a/test/Cli/Func.E2ETests/BaseE2ETests.cs
+++ b/test/Cli/Func.E2ETests/BaseE2ETests.cs
@@ -48,6 +48,20 @@ namespace Azure.Functions.Cli.E2ETests
             // offline behavior pass the `--offline` flag, which still takes precedence.
             Environment.SetEnvironmentVariable(Azure.Functions.Cli.Common.Constants.FunctionsCoreToolsOffline, "false");
 
+            // Provide a sentinel Application Insights connection string. The dotnet-isolated
+            // worker template writes `host.json` with `telemetryMode: "OpenTelemetry"`, which
+            // causes the Azure Monitor exporter inside the worker to validate
+            // APPLICATIONINSIGHTS_CONNECTION_STRING at DI build time. With no value set, the
+            // worker process exits with 0xDEAD before responding to the host, the host
+            // exhausts its restart retries, and `func start` exits -1. The all-zeros key is
+            // the documented sentinel; it satisfies the parser without enabling telemetry.
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")))
+            {
+                Environment.SetEnvironmentVariable(
+                    "APPLICATIONINSIGHTS_CONNECTION_STRING",
+                    "InstrumentationKey=00000000-0000-0000-0000-000000000000");
+            }
+
             Directory.CreateDirectory(WorkingDirectory);
             return Task.CompletedTask;
         }

--- a/test/Cli/Func.E2ETests/Fixtures/BaseFunctionAppFixture.cs
+++ b/test/Cli/Func.E2ETests/Fixtures/BaseFunctionAppFixture.cs
@@ -75,6 +75,20 @@ namespace Azure.Functions.Cli.E2ETests.Fixtures
             // BaseE2ETests; fixture-backed tests don't go through that path.
             Environment.SetEnvironmentVariable(Azure.Functions.Cli.Common.Constants.FunctionsCoreToolsOffline, "false");
 
+            // Provide a sentinel Application Insights connection string. The dotnet-isolated
+            // worker template writes `host.json` with `telemetryMode: "OpenTelemetry"`, which
+            // causes the Azure Monitor exporter inside the worker to validate
+            // APPLICATIONINSIGHTS_CONNECTION_STRING at DI build time. With no value set, the
+            // worker process exits with 0xDEAD before responding to the host, the host
+            // exhausts its restart retries, and `func start` exits -1. The all-zeros key is
+            // the documented sentinel; it satisfies the parser without enabling telemetry.
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")))
+            {
+                Environment.SetEnvironmentVariable(
+                    "APPLICATIONINSIGHTS_CONNECTION_STRING",
+                    "InstrumentationKey=00000000-0000-0000-0000-000000000000");
+            }
+
             var workerRuntime = WorkerRuntimeLanguageHelper.GetRuntimeMoniker(WorkerRuntime);
             var initArgs = new List<string> { ".", "--worker-runtime", workerRuntime }
                 .Concat(TargetFramework != null


### PR DESCRIPTION
## Problem

10+ `WorkerRuntime=DotnetIsolated` e2e tests on `main` have been flaky for a while, all sharing the same root cause in the host log:

```
Microsoft.Azure.WebJobs.Script.Grpc: dotnet.exe exited with code 57005 (0xDEAD).
Unhandled exception. System.InvalidOperationException:
A connection string was not found. Please set your connection string.
   at Azure.Monitor.OpenTelemetry.Exporter.Internals.AzureMonitorTransmitter.InitializeConnectionVars
   at Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorMetricExporter..ctor
   at Microsoft.Extensions.Hosting.Internal.Host.StartAsync
```

The dotnet-isolated worker template generates a `host.json` with `"telemetryMode": "OpenTelemetry"`. That makes the worker auto-wire the Azure Monitor exporter, which validates `APPLICATIONINSIGHTS_CONNECTION_STRING` at DI build time and throws when it's missing. The worker dies before responding to the host. The host exhausts its 3x worker-restart retries, then `func start` exits with -1.

Symptoms vary depending on what the test asserts:

| Test | What you see |
|---|---|
| `Start_Net9_SuccessfulFunctionExecution` | `Expected ... "Welcome to Azure Functions!", but found <null>` |
| `Start_DotnetIsolated_InvalidHostJson_Succeeds` | same |
| `Start_Dotnet_Isolated_LogLevelOverridenWithFilter_LogLevelSetToExpectedValue` | `The command output did not contain expected result: Found the following functions:` |
| `Start_DotnetIsolated_EnableAuthFeature(... "function", True, "")` | `... did not contain expected result: "status": "401"` |
| `Start_WithDotnetIsolated_WithNonAsciiLogging_DisplaysCorrectly` | `... did not contain: Test String: こんにちは` |
| `Start_MissingLocalSettingsJson_DotnetIsolated_*`, `Start_Dotnet_Isolated_WithUserSecrets_*` | various missing-stdout / empty-body |

It's been flaky rather than always-failing because:

1. Local dev machines usually have `APPLICATIONINSIGHTS_CONNECTION_STRING` set in env or user secrets, so the worker boots fine. CI runners don't.
2. Even on CI, some passes happen by luck: a `Start_..._ShouldFail` test passes when the worker dies, and tests that need a working worker have long retry loops. A 2 m 6 s pass for one auth case in the latest run is the host worker-restart loop occasionally producing a working worker before the test gives up.

## Fix

In `BaseE2ETests` and `BaseFunctionAppFixture`, set the all-zeros sentinel connection string before any `func` process is spawned:

```csharp
Environment.SetEnvironmentVariable(
    "APPLICATIONINSIGHTS_CONNECTION_STRING",
    "InstrumentationKey=00000000-0000-0000-0000-000000000000");
```

The sentinel satisfies the Azure Monitor exporter parser without enabling telemetry. Skipped when the env var is already set so local debugging configurations are preserved.