### PR TITLE
Read installed workloads from manifest in func workload list

### DIFF
--- a/src/Func/Commands/Workload/WorkloadListCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadListCommand.cs
@@ -3,39 +3,43 @@
 
 using System.CommandLine;
 using Azure.Functions.Cli.Console;
-using Azure.Functions.Cli.Workloads;
+using Azure.Functions.Cli.Workloads.Storage;
 
 namespace Azure.Functions.Cli.Commands.Workload;
 
 /// <summary>
-/// Lists workloads recorded in the global manifest. Source of truth is
-/// <see cref="WorkloadInfo"/>, populated by the install / discovery layer
-/// from each package's <c>workload.json</c>.
+/// Lists workloads recorded in the global manifest. Reads directly from
+/// <see cref="IGlobalManifestStore"/> so listing works without invoking the
+/// workload loader (no assembly loads, no ALC creation).
 /// </summary>
-internal sealed class WorkloadListCommand(IInteractionService interaction, IReadOnlyList<WorkloadInfo> workloads)
+internal sealed class WorkloadListCommand(IInteractionService interaction, IGlobalManifestStore store)
     : FuncCliCommand("list", "List installed workloads.")
 {
-    private readonly IInteractionService _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
-    private readonly IReadOnlyList<WorkloadInfo> _workloads = workloads ?? throw new ArgumentNullException(nameof(workloads));
+    private const string AliasesPlaceholder = "-";
 
-    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    private readonly IInteractionService _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
+    private readonly IGlobalManifestStore _store = store ?? throw new ArgumentNullException(nameof(store));
+
+    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
-        if (_workloads.Count == 0)
+        var workloads = await _store.GetWorkloadsAsync(cancellationToken).ConfigureAwait(false);
+
+        if (workloads.Count == 0)
         {
             _interaction.WriteHint("No workloads installed.");
-            return Task.FromResult(0);
+            return 0;
         }
 
-        var rows = _workloads.Select(w => new[]
+        var rows = workloads.Select(w => new[]
         {
             w.PackageId,
-            w.Aliases.Count == 0 ? "—" : string.Join(", ", w.Aliases),
-            w.DisplayName,
-            w.Description,
-            w.PackageVersion,
+            w.Entry.Aliases.Count == 0 ? AliasesPlaceholder : string.Join(", ", w.Entry.Aliases),
+            w.Entry.DisplayName,
+            w.Entry.Description,
+            w.Version,
         });
 
         _interaction.WriteTable(["Package", "Aliases", "Name", "Description", "Version"], rows);
-        return Task.FromResult(0);
+        return 0;
     }
 }

--- a/src/Func/Func.csproj
+++ b/src/Func/Func.csproj
@@ -13,6 +13,8 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Azure.Functions.Cli.Tests" />
+    <!-- Required for NSubstitute (Castle DynamicProxy) to mock internal interfaces. -->
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Func/Hosting/WorkloadRegistration.cs
+++ b/src/Func/Hosting/WorkloadRegistration.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Workloads;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Azure.Functions.Cli.Hosting;
 
@@ -11,20 +10,19 @@ namespace Azure.Functions.Cli.Hosting;
 /// the global manifest at <c>~/.azure-functions/workloads.json</c>, loads
 /// each workload's entry-point assembly into its own
 /// <see cref="System.Runtime.Loader.AssemblyLoadContext"/>, instantiates the
-/// type named in the per-package <c>workload.json</c>, and invokes
+/// type identified by <c>[assembly: ExportCliWorkload&lt;T&gt;]</c>, and invokes
 /// <see cref="IWorkload.Configure"/>.
 ///
-/// At this stage the loader/installer haven't landed yet.
-/// <see cref="RegisterWorkloads"/> registers an empty
-/// <see cref="WorkloadInfo"/> list so DI consumers (e.g.
-/// <c>func workload list</c>) get a deterministic empty result; the real
-/// loader will replace this in a follow-up PR.
+/// At this stage the loader hasn't landed yet, so <see cref="RegisterWorkloads"/>
+/// is a no-op. Commands that only need to enumerate installed workloads
+/// (e.g. <c>func workload list</c>) read the global manifest directly via
+/// <see cref="Workloads.Storage.IGlobalManifestStore"/>; they don't need the
+/// loader at all.
 /// </summary>
 internal static class WorkloadRegistration
 {
     public static void RegisterWorkloads(FunctionsCliBuilder builder)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        builder.Services.AddSingleton<IReadOnlyList<WorkloadInfo>>(Array.Empty<WorkloadInfo>());
     }
 }

--- a/test/Func.Tests/Commands/Workload/WorkloadListCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadListCommandTests.cs
@@ -1,0 +1,117 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Commands.Workload;
+using Azure.Functions.Cli.Workloads.Storage;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Commands.Workload;
+
+public class WorkloadListCommandTests
+{
+    private readonly TestInteractionService _interaction = new();
+    private readonly IGlobalManifestStore _store = Substitute.For<IGlobalManifestStore>();
+
+    [Fact]
+    public async Task EmptyManifest_WritesNoWorkloadsHint_ReturnsZero()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<InstalledWorkload>());
+
+        var cmd = new WorkloadListCommand(_interaction, _store);
+        var exit = await InvokeAsync(cmd);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("HINT: No workloads installed.", _interaction.Lines);
+        Assert.DoesNotContain(_interaction.Lines, l => l.StartsWith("TABLE:"));
+    }
+
+    [Fact]
+    public async Task SingleEntry_WritesTableWithRow()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                CreateInstalled(
+                    packageId: "Azure.Functions.Cli.Workload.Dotnet",
+                    version: "1.0.0",
+                    displayName: ".NET",
+                    description: "C# / F# workload.",
+                    aliases: new[] { "dotnet", "dotnet-isolated" }),
+            });
+
+        var cmd = new WorkloadListCommand(_interaction, _store);
+        var exit = await InvokeAsync(cmd);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("TABLE: [Package, Aliases, Name, Description, Version]", _interaction.Lines);
+        Assert.Contains(
+            "  ROW: [Azure.Functions.Cli.Workload.Dotnet, dotnet, dotnet-isolated, .NET, C# / F# workload., 1.0.0]",
+            _interaction.Lines);
+    }
+
+    [Fact]
+    public async Task MissingAliases_RendersDashPlaceholder()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                CreateInstalled(
+                    packageId: "Azure.Functions.Cli.Workload.Custom",
+                    version: "0.1.0",
+                    aliases: Array.Empty<string>()),
+            });
+
+        var cmd = new WorkloadListCommand(_interaction, _store);
+        await InvokeAsync(cmd);
+
+        var rowLine = _interaction.Lines.Single(l => l.StartsWith("  ROW:"));
+        Assert.Contains(", -, ", rowLine);
+        Assert.DoesNotContain("\u2014", rowLine);
+    }
+
+    [Fact]
+    public async Task MultipleEntries_WritesOneRowEach()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                CreateInstalled(packageId: "Pkg.A", version: "1.0.0"),
+                CreateInstalled(packageId: "Pkg.B", version: "2.0.0"),
+                CreateInstalled(packageId: "Pkg.A", version: "1.1.0"),
+            });
+
+        var cmd = new WorkloadListCommand(_interaction, _store);
+        await InvokeAsync(cmd);
+
+        var rows = _interaction.Lines.Where(l => l.StartsWith("  ROW:")).ToList();
+        Assert.Equal(3, rows.Count);
+    }
+
+    private static Task<int> InvokeAsync(WorkloadListCommand cmd, params string[] args)
+    {
+        var root = new RootCommand();
+        root.Subcommands.Add(cmd);
+        return root.Parse(new[] { cmd.Name }.Concat(args).ToArray()).InvokeAsync();
+    }
+
+    private static InstalledWorkload CreateInstalled(
+        string packageId,
+        string version,
+        string displayName = "Test Workload",
+        string description = "A workload for tests.",
+        IReadOnlyList<string>? aliases = null)
+        => new(
+            packageId,
+            version,
+            new GlobalManifestEntry
+            {
+                DisplayName = displayName,
+                Description = description,
+                Aliases = aliases ?? Array.Empty<string>(),
+                InstallPath = $"/install/{packageId}/{version}",
+                EntryPoint = new EntryPointSpec { Assembly = "test.dll", Type = "T" },
+            });
+}

--- a/test/Func.Tests/TestParser.cs
+++ b/test/Func.Tests/TestParser.cs
@@ -5,7 +5,9 @@ using Azure.Functions.Cli.Commands;
 using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Hosting;
 using Azure.Functions.Cli.Workloads;
+using Azure.Functions.Cli.Workloads.Storage;
 using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
 
 namespace Azure.Functions.Cli.Tests;
 
@@ -59,7 +61,15 @@ internal static class TestParser
         var services = new ServiceCollection();
         services.AddSingleton(interaction);
         services.AddBuiltInCommands();
-        services.AddSingleton<IReadOnlyList<WorkloadInfo>>(Array.Empty<WorkloadInfo>());
+
+        // Stub manifest store so commands that depend on it (e.g.
+        // WorkloadListCommand) resolve without booting the storage subsystem.
+        // Tests that exercise listing register their own substitute.
+        var emptyStore = Substitute.For<IGlobalManifestStore>();
+        emptyStore.GetWorkloadsAsync(Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<InstalledWorkload>());
+        services.AddSingleton(emptyStore);
+
         return services;
     }
 }


### PR DESCRIPTION
Resolves #4900

## Summary

Wires `func workload list` to actually read the global workload manifest. Until now the command resolved an `IReadOnlyList<WorkloadInfo>` registered as `Array.Empty<WorkloadInfo>()`, so it always printed "No workloads installed." regardless of what was on disk.

## What changes

- **`WorkloadListCommand`** now depends on `IGlobalManifestStore` (already in DI from `AddWorkloadStorage`) and projects each `InstalledWorkload` entry into a table row at execute time. No assembly loads, no `AssemblyLoadContext` creation: listing works entirely from the manifest JSON.
- **`WorkloadRegistration.RegisterWorkloads`** drops the empty `IReadOnlyList<WorkloadInfo>` stub and is now a no-op until the loader lands ([#4915](https://github.com/Azure/azure-functions-core-tools/pull/4915)).
- **`Func.csproj`** exposes internals to `DynamicProxyGenAssembly2` so NSubstitute (Castle DynamicProxy) can mock the internal `IGlobalManifestStore` from tests.
- **`TestParser`** registers a stub `IGlobalManifestStore` in place of the old empty-list registration so existing parser tests still build.

## Drive-by

Replaced the em-dash placeholder for empty aliases with `-`.

## Tests

`WorkloadListCommandTests` (4 cases): empty manifest, single entry, missing aliases, multiple entries. Full suite: 88/88 passing.

## Out of scope

Install / uninstall commands and `NuspecReader` land in the next slice. The manifest writers are already in `IGlobalManifestStore`; the next PR adds the install pipeline that populates them.