### PR TITLE
Add func workload install/uninstall commands

### DIFF
--- a/.github/instructions/dotnet.instructions.md
+++ b/.github/instructions/dotnet.instructions.md
@@ -112,6 +112,18 @@ fire:
 - No unused `using` directives.
 - Don't run `dotnet format` across unrelated files; no drive-by reformatting.
 - Don't disable analyzers to silence warnings, fix the underlying issue.
+## Code comments
+
+Comment to explain *why*, not *what*. XML doc summaries
+are one or two sentences; reach for `<remarks>` only when there's a single
+non-obvious clarification, and avoid stacking `<para>` blocks. Don't cite
+spec sections or document URLs from inside code (`§6.2`,
+`workload-package-layout §5.4`). Don't justify naming choices, list
+convention origins ("matches tsconfig.json…"), or narrate the alternative
+you didn't pick. Skip comments that restate the next line (DI registrations,
+obvious defaults, "Empty when no X" on a collection). Lead with the
+operative verb. Keep pointers to follow-up issues, cross-platform quirks,
+and rationale that isn't visible from the surrounding code.
 
 ## Code comments
 

--- a/.github/instructions/dotnet.instructions.md
+++ b/.github/instructions/dotnet.instructions.md
@@ -112,6 +112,7 @@ fire:
 - No unused `using` directives.
 - Don't run `dotnet format` across unrelated files; no drive-by reformatting.
 - Don't disable analyzers to silence warnings, fix the underlying issue.
+
 ## Code comments
 
 Comment to explain *why*, not *what*. XML doc summaries

--- a/.github/instructions/dotnet.instructions.md
+++ b/.github/instructions/dotnet.instructions.md
@@ -71,13 +71,42 @@ the lightest option:
 
 ## Error handling
 
-- Throw `GracefulException` (`Abstractions/Common/`) for **expected,
-  user-facing** errors. `Program.Main` catches it, prints the message, and
-  returns a non-zero exit code without a stack trace.
+Throw the **most specific** exception type at the failure site. Services and
+helpers shouldn't shape exceptions around CLI presentation; commands are the
+boundary that decides what's user-facing.
+
+- Framework / domain exceptions in services / helpers for known failure modes:
+  - `FileNotFoundException` / `DirectoryNotFoundException` for missing paths.
+  - `InvalidOperationException` for "operation isn't valid in current state".
+  - Domain exceptions like `InvalidWorkloadException` for subsystem-specific
+    validation failures.
+  - `ArgumentNullException` / `ArgumentException` for programmer errors on
+    method contracts.
+- **Commands wrap.** A command knows which exceptions from its dependencies
+  are user errors. Catch those at the command and wrap in
+  `GracefulException(message, isUserError: true)` (preserve the inner
+  exception). Anything you don't catch is a runtime bug and surfaces with a
+  stack trace.
+  - Keep the `try` **narrow**, ideally one method call. A wide `try` makes
+    a generic catch (e.g. `FileNotFoundException`) ambiguous about which
+    call site produced it. A one-call `try` plus the `<exception>` tags
+    on that method's xmldoc fully define what each catch arm means.
+  - Catching framework types (`FileNotFoundException`,
+    `InvalidOperationException`, ...) is fine **only when** the `try` is
+    narrow and the called method's xmldoc documents that type as a
+    user-facing failure mode. Otherwise promote the failure to a domain
+    exception so the catch is unambiguous.
+- `GracefulException` (`Abstractions/Common/`) is the CLI-facing wrapper.
+  `Program.Main` only catches `GracefulException`. Do **not** add broad
+  framework types to the top-level catch list, that hides bugs as user
+  errors.
 - Don't call `Environment.Exit` from inside a command.
-- Use specific framework exceptions (`ArgumentNullException`,
-  `InvalidOperationException`, ...) for programmer errors. Don't swallow
-  exceptions silently.
+- Default to rethrowing with context or converting to a more specific
+  domain exception. Swallowing is allowed only for genuine best-effort
+  cleanup paths (e.g. removing a leftover temp directory after another
+  failure), and the `catch` must include a comment explaining why losing
+  the exception is acceptable. Never `catch (Exception)` in business
+  logic.
 
 ## Logging vs user output
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,8 +158,9 @@ real terminal. If you need a new output primitive, add it to
 ### Exit codes
 
 - `0` for success, non-zero for failure.
-- Prefer letting `GracefulException` flow up to `Program.Main`; it sets the
-  exit code and prints the friendly message without a stack trace.
+- Throw the most specific exception type for the failure (see "Error
+  handling" below). `Program.Main` translates known categories into a
+  non-zero exit code with a clean, user-facing message.
 - Don't call `Environment.Exit` from inside a command, it bypasses cleanup and
   makes commands untestable.
 
@@ -215,13 +216,48 @@ we don't read app-style settings files.
 
 ### Error handling
 
-- Throw `GracefulException` (from `Abstractions/Common/`) for **expected,
-  user-facing** errors. `Program.Main` catches it, prints the friendly message,
-  and returns a non-zero exit code without a stack trace.
-- Use specific framework exceptions (`ArgumentNullException`,
-  `InvalidOperationException`, ...) for programmer errors.
-- Don't swallow exceptions silently; if you catch, log and rethrow or convert
-  to a `GracefulException` with context.
+Throw the most **specific** exception type for the failure at the point it
+happens. Services and helpers shouldn't shape their exceptions around CLI
+presentation; commands are the boundary that decides which failures are
+user-facing.
+
+- **Framework / domain exceptions** in services / helpers for known failure
+  modes:
+  - `FileNotFoundException` / `DirectoryNotFoundException` for missing
+    user-supplied paths.
+  - `InvalidOperationException` for "operation isn't valid in the current
+    state" (e.g. workload already installed).
+  - Domain exceptions like `InvalidWorkloadException` for validation
+    failures specific to a subsystem.
+  - `ArgumentNullException` / `ArgumentException` for programmer errors on
+    method contracts.
+- **Commands are the boundary.** A command knows which exceptions from its
+  direct dependencies are user errors. Catch those at the command and wrap
+  in `GracefulException(message, isUserError: true)` (preserving the inner
+  exception). Anything you don't catch is a runtime bug and should surface
+  unwrapped with a stack trace.
+  - Keep the `try` **narrow**, ideally one method call. A wide `try` makes
+    a generic catch (e.g. `FileNotFoundException`) ambiguous: you can no
+    longer tell which call site produced it. A one-call `try` plus the
+    `<exception>` tags on that method's xmldoc fully define what each
+    catch arm means.
+  - Catching framework types like `FileNotFoundException` /
+    `InvalidOperationException` is fine when (a) the `try` is narrow and
+    (b) the called method's xmldoc documents that type as a user-facing
+    failure mode. If neither holds, promote the failure to a domain
+    exception (e.g. `InvalidWorkloadException`) so the catch is
+    unambiguous.
+- **`GracefulException`** (`Abstractions/Common/`) is the CLI-facing wrapper.
+  `Program.Main` only catches `GracefulException` and prints it cleanly
+  (message + optional `VerboseMessage`, exit code 1). Do **not** add broad
+  framework types (`FileNotFoundException`, `InvalidOperationException`, ...)
+  to the top-level catch list, that hides bugs as user errors.
+- Default to rethrowing with context (preserve the inner exception) or
+  converting to a more specific domain exception. Swallowing an exception
+  silently is allowed only for genuine best-effort cleanup paths (e.g.
+  removing a leftover temp directory after another failure), and the
+  `catch` block must include a comment explaining why losing the
+  exception is acceptable. Never `catch (Exception)` in business logic.
 
 ### Logging
 
@@ -263,7 +299,12 @@ dotnet test --filter "FullyQualifiedName~ClassName"  # Run specific tests
 - **Package IDs**: omit by default, will be based on assembly name.
 - **CI pipelines**: `workload-<name>-public-build.yml` and `workload-<name>-official-build.yml`
 - **Tests**: xUnit with NSubstitute for mocking, `FakeDotnetCliRunner` pattern for CLI wrappers
-- **Error handling**: throw `GracefulException` for user-facing errors (caught in Program.cs)
+- **Error handling**: services throw the most specific exception type at the
+  failure site (`FileNotFoundException`, `InvalidOperationException`, domain
+  exceptions like `InvalidWorkloadException`). Commands are the boundary:
+  catch the exceptions they expect from their dependencies and wrap in
+  `GracefulException(..., isUserError: true)`. `Program.cs` only catches
+  `GracefulException`, so anything unexpected surfaces as a runtime bug.
 - **Cancellation**: all async methods accept `CancellationToken`, pass through to child operations
 - **XML doc summaries**: always put `<summary>` and `</summary>` on their own lines, even for one-line summaries:
 

--- a/docs/building-a-workload.md
+++ b/docs/building-a-workload.md
@@ -2,7 +2,7 @@
 
 This guide walks through building a workload for the Azure Functions Core Tools v5 CLI. A workload is a NuGet package that the CLI loads at runtime to extend its behavior — most commonly to provide `func init` / `func new` support for a specific language stack (e.g. Node.js, Python, Java), but a workload can also contribute brand-new subcommands.
 
-> **Status**: the abstractions and DI host described below are in the tree as of this PR. The runtime loader and `func workload install` / `uninstall` commands land in a follow-up PR; until then, this document describes the contract workload authors can build against.
+> **Status**: the abstractions, DI host, and `func workload install` / `uninstall` commands described below are in the tree as of this PR. Workloads are installed from a local `.nupkg` on disk; NuGet feed acquisition lands in a follow-up.
 
 ## Architecture
 
@@ -58,7 +58,7 @@ The shape mirrors WebJobs' `IWebJobsStartup` — `Configure(FunctionsCliBuilder)
 2. Reference `Azure.Functions.Cli.Abstractions`
 3. Implement `IWorkload`
 4. Inside `Configure`, register an `IProjectInitializer` (and/or contribute top-level commands via `builder.RegisterCommand(...)`, and any supporting services)
-5. Build, package, and (once the loader ships) install with `func workload install`
+5. Build, package, and install with `func workload install <path-to-nupkg>`
 
 ## Step 1: Create the Project
 

--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -2,7 +2,7 @@
 
 This document explains the runtime architecture of the Azure Functions Core Tools v5 CLI — how commands are composed, how telemetry is wired, and how the console layer works.
 
-> **Status**: v5 is in active development. As of this PR, the workload abstractions and the DI host that loads workloads are wired into the CLI; the runtime workload loader and `func workload install` / `uninstall` commands land in a follow-up PR. Until then, the CLI runs with zero installed workloads — built-in commands that depend on workload contributions (e.g. `func init`) report "no workloads installed" and exit cleanly.
+> **Status**: v5 is in active development. As of this PR, the workload abstractions, the DI host that loads workloads, and the `func workload install` / `uninstall` commands are wired into the CLI. Workloads are installed from a local `.nupkg` on disk; NuGet feed acquisition lands in a follow-up. Built-in commands that depend on workload contributions (e.g. `func init`) report "no workloads installed" and exit cleanly until at least one workload is installed.
 
 ## Startup Flow
 

--- a/docs/repo-structure.md
+++ b/docs/repo-structure.md
@@ -4,7 +4,7 @@ This document describes the Azure Functions Core Tools v5 codebase — projects,
 
 ## Overview
 
-The v5 CLI is built with [System.CommandLine](https://github.com/dotnet/command-line-api) and [Spectre.Console](https://spectreconsole.net/), targeting **.NET 10**. It follows a **workload model** (similar to the `dotnet` CLI) where the base CLI provides core commands and infrastructure while language-specific functionality (templates, init, pack) is delivered via independently installable workload packages. The base CLI, the host that loads workloads, and the public abstractions library are in the tree today; the runtime workload loader and `func workload install` / `uninstall` commands land in a follow-up PR.
+The v5 CLI is built with [System.CommandLine](https://github.com/dotnet/command-line-api) and [Spectre.Console](https://spectreconsole.net/), targeting **.NET 10**. It follows a **workload model** (similar to the `dotnet` CLI) where the base CLI provides core commands and infrastructure while language-specific functionality (templates, init, pack) is delivered via independently installable workload packages. The base CLI, the host that loads workloads, the public abstractions library, and the `func workload install` / `uninstall` commands are all in the tree today; NuGet feed-based acquisition lands in a follow-up PR.
 
 ## Project Layout
 

--- a/eng/build/Packages.props
+++ b/eng/build/Packages.props
@@ -7,6 +7,7 @@
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
+    <PackageVersion Include="NuGet.Packaging" Version="6.13.2" />
     <PackageVersion Include="System.CommandLine" Version="2.0.6" />
     <PackageVersion Include="Spectre.Console" Version="0.49.1" />
   </ItemGroup>
@@ -15,7 +16,7 @@
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.7.0" />
-    <PackageVersion Include="NuGet.Versioning" Version="6.12.1" />
+    <PackageVersion Include="NuGet.Versioning" Version="6.13.2" />
   </ItemGroup>
   <!-- analyzers -->
   <ItemGroup>

--- a/src/Abstractions/Workloads/EntryPointSpec.cs
+++ b/src/Abstractions/Workloads/EntryPointSpec.cs
@@ -4,24 +4,19 @@
 namespace Azure.Functions.Cli.Workloads;
 
 /// <summary>
-/// Identifies the type that implements <see cref="Workload"/>. Shared between
-/// the per-workload <see cref="WorkloadMetadata"/> (in the package root) and
-/// the CLI's global workload registry, so a workload's entry-point is
-/// described the same way at author time and at install time.
+/// Identifies the type that implements <see cref="Workload"/>.
 /// </summary>
 public sealed class EntryPointSpec
 {
     /// <summary>
-    /// Path to the assembly relative to the package's content root
-    /// (<c>tools/any/</c> by convention), e.g. <c>Foo.dll</c>.
+    /// Relative path to the workload assembly. In <c>workload.json</c> it is
+    /// relative to the package root; in the global <c>workloads.json</c> it
+    /// is relative to the workloads root. Must not contain <c>..</c> segments.
     /// </summary>
     public required string AssemblyPath { get; init; }
 
     /// <summary>
-    /// Fully-qualified type name implementing <see cref="Workload"/>. Stored
-    /// as a string so the metadata stays loadable even when the assembly
-    /// isn't on the runtime probe path (e.g. listing workloads without
-    /// loading them).
+    /// Fully-qualified type name implementing <see cref="Workload"/>.
     /// </summary>
     public required string Type { get; init; }
 }

--- a/src/Func/Commands/Workload/WorkloadCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadCommand.cs
@@ -7,18 +7,25 @@ namespace Azure.Functions.Cli.Commands.Workload;
 
 /// <summary>
 /// Parent <c>func workload</c> command. Subcommands manage workload installation,
-/// inspection, and updates. Today the only subcommand wired in is
-/// <see cref="WorkloadListCommand"/>; install / uninstall land in a follow-up PR.
+/// inspection, and updates.
 ///
-/// Parent-only — relies on <see cref="FuncCliCommand.ExecuteAsync"/>'s default
+/// Parent-only: relies on <see cref="FuncCliCommand.ExecuteAsync"/>'s default
 /// implementation to render help when invoked without a subcommand.
 /// </summary>
 internal sealed class WorkloadCommand : FuncCliCommand, IBuiltInCommand
 {
-    public WorkloadCommand(WorkloadListCommand listCommand)
+    public WorkloadCommand(
+        WorkloadListCommand listCommand,
+        WorkloadInstallCommand installCommand,
+        WorkloadUninstallCommand uninstallCommand)
         : base("workload", "Manage Func CLI workloads.")
     {
         ArgumentNullException.ThrowIfNull(listCommand);
+        ArgumentNullException.ThrowIfNull(installCommand);
+        ArgumentNullException.ThrowIfNull(uninstallCommand);
+
         Subcommands.Add(listCommand);
+        Subcommands.Add(installCommand);
+        Subcommands.Add(uninstallCommand);
     }
 }

--- a/src/Func/Commands/Workload/WorkloadInstallCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadInstallCommand.cs
@@ -1,0 +1,97 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Workloads;
+using Azure.Functions.Cli.Workloads.Discovery;
+using Azure.Functions.Cli.Workloads.Install;
+using Azure.Functions.Cli.Workloads.Storage;
+
+namespace Azure.Functions.Cli.Commands.Workload;
+
+/// <summary>
+/// <c>func workload install &lt;package&gt;</c>. Installs a workload from a
+/// <c>.nupkg</c> on disk. Feed-based acquisition is not yet supported.
+/// </summary>
+internal sealed class WorkloadInstallCommand : FuncCliCommand
+{
+    private const string NupkgExtension = ".nupkg";
+
+    private readonly IInteractionService _interaction;
+    private readonly IWorkloadInstaller _installer;
+
+    public Argument<string> WorkloadArgument { get; } = new("id")
+    {
+        Description = "Workload to install. Currently must be a path to a .nupkg on disk.",
+    };
+
+    public Option<bool> ForceOption { get; } = new("--force", "-f")
+    {
+        Description = "Overwrite an existing install of the same id and version.",
+    };
+
+    public WorkloadInstallCommand(IInteractionService interaction, IWorkloadInstaller installer)
+        : base("install", "Install a workload.")
+    {
+        _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
+        _installer = installer ?? throw new ArgumentNullException(nameof(installer));
+
+        WorkloadArgument.Validators.Add(result =>
+        {
+            string? value = result.GetValue(WorkloadArgument);
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                result.AddError("A workload id is required.");
+                return;
+            }
+
+            if (!value.EndsWith(NupkgExtension, StringComparison.OrdinalIgnoreCase))
+            {
+                result.AddError(
+                    $"Resolving '{value}' against a NuGet feed is not yet supported. " +
+                    "Pass a path to a .nupkg on disk.");
+            }
+        });
+
+        Arguments.Add(WorkloadArgument);
+        Options.Add(ForceOption);
+    }
+
+    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        string workload = parseResult.GetValue(WorkloadArgument)!;
+        bool force = parseResult.GetValue(ForceOption);
+
+        WorkloadInstallResult result;
+        try
+        {
+            result = await _installer.InstallFromPackageAsync(workload, force, cancellationToken);
+        }
+        catch (Exception ex) when (ex is FileNotFoundException or InvalidWorkloadException or InvalidOperationException)
+        {
+            throw new GracefulException(ex.Message, isUserError: true);
+        }
+
+        _interaction.WriteSuccess(BuildSuccessMessage(result));
+        return 0;
+    }
+
+    private static string BuildSuccessMessage(WorkloadInstallResult result)
+    {
+        WorkloadEntry entry = result.Entry;
+        string verb = result.AlreadyInstalled
+            ? $"Workload '{entry.PackageId}' version '{entry.PackageVersion}' is already installed"
+            : $"Installed workload '{entry.PackageId}' version '{entry.PackageVersion}'";
+
+        return entry.Kind switch
+        {
+            WorkloadKind.Workload when entry.EntryPoint is not null
+                => $"{verb} (entry point: {entry.EntryPoint.Type}).",
+            WorkloadKind.Content
+                => $"{verb} (content at '{entry.Source}').",
+            _ => $"{verb}.",
+        };
+    }
+}

--- a/src/Func/Commands/Workload/WorkloadInstallCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadInstallCommand.cs
@@ -64,18 +64,26 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
         string workload = parseResult.GetValue(WorkloadArgument)!;
         bool force = parseResult.GetValue(ForceOption);
 
-        WorkloadInstallResult result;
         try
         {
-            result = await _installer.InstallFromPackageAsync(workload, force, cancellationToken);
+            WorkloadInstallResult result = await _installer.InstallFromPackageAsync(workload, force, cancellationToken);
+            _interaction.WriteSuccess(BuildSuccessMessage(result));
+            return 0;
         }
-        catch (Exception ex) when (ex is FileNotFoundException or InvalidWorkloadException or InvalidOperationException)
+        catch (FileNotFoundException ex)
         {
             throw new GracefulException(ex.Message, isUserError: true);
         }
-
-        _interaction.WriteSuccess(BuildSuccessMessage(result));
-        return 0;
+        catch (InvalidWorkloadException ex)
+        {
+            throw new GracefulException(ex.Message, isUserError: true);
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw new GracefulException(
+                $"{ex.Message} Pass --force to repair the install.",
+                isUserError: true);
+        }
     }
 
     private static string BuildSuccessMessage(WorkloadInstallResult result)

--- a/src/Func/Commands/Workload/WorkloadUninstallCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadUninstallCommand.cs
@@ -1,0 +1,166 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Workloads.Install;
+using Azure.Functions.Cli.Workloads.Storage;
+
+namespace Azure.Functions.Cli.Commands.Workload;
+
+/// <summary>
+/// <c>func workload uninstall &lt;packageId&gt; [--version &lt;v&gt;] [--all-versions] [--exact]</c>.
+/// Removes one or all installed versions of a workload.
+/// </summary>
+internal sealed class WorkloadUninstallCommand : FuncCliCommand
+{
+    private readonly IInteractionService _interaction;
+    private readonly IWorkloadInstaller _installer;
+    private readonly IWorkloadStore _store;
+
+    public Argument<string> WorkloadArgument { get; } = new("id")
+    {
+        Description = "ID or alias of the workload to uninstall.",
+    };
+
+    public Option<string?> VersionOption { get; } = new("--version", "-v")
+    {
+        Description = "Specific version to uninstall. Omit when only one version is installed.",
+    };
+
+    public Option<bool> AllVersionsOption { get; } = new("--all-versions", "-a")
+    {
+        Description = "Uninstall every installed version of the workload.",
+    };
+
+    public Option<bool> ExactOption { get; } = new("--exact", "-e")
+    {
+        Description = "Match the argument as a literal package id; do not look up aliases.",
+    };
+
+    public WorkloadUninstallCommand(
+        IInteractionService interaction,
+        IWorkloadInstaller installer,
+        IWorkloadStore store)
+        : base("uninstall", "Uninstall a workload.")
+    {
+        _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
+        _installer = installer ?? throw new ArgumentNullException(nameof(installer));
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+
+        WorkloadArgument.Validators.Add(result =>
+        {
+            string? value = result.GetValue(WorkloadArgument);
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                result.AddError("A workload id is required.");
+            }
+        });
+
+        Arguments.Add(WorkloadArgument);
+        Options.Add(VersionOption);
+        Options.Add(AllVersionsOption);
+        Options.Add(ExactOption);
+
+        Validators.Add(result =>
+        {
+            int specified = result.Children
+                .OfType<OptionResult>()
+                .Count(or => or.Option == VersionOption || or.Option == AllVersionsOption);
+
+            if (specified > 1)
+            {
+                result.AddError("--all-versions and --version cannot be combined.");
+            }
+        });
+    }
+
+    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        string identifier = parseResult.GetValue(WorkloadArgument)!;
+        string? version = parseResult.GetValue(VersionOption);
+        bool all = parseResult.GetValue(AllVersionsOption);
+        bool exact = parseResult.GetValue(ExactOption);
+
+        IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
+        List<WorkloadEntry> matches = [.. installed
+            .Where(w => string.Equals(w.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
+                || (!exact && (w.Aliases?.Any(a => string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)) ?? false)))];
+
+        if (matches.Count == 0)
+        {
+            _interaction.WriteWarning(
+                $"Workload '{identifier}' is not installed; nothing to do.");
+            return 0;
+        }
+
+        string[] distinctPackageIds = [.. matches
+            .Select(m => m.PackageId)
+            .Distinct(StringComparer.OrdinalIgnoreCase)];
+
+        if (distinctPackageIds.Length > 1)
+        {
+            throw new GracefulException(
+                $"Alias '{identifier}' matches multiple installed workloads ({string.Join(", ", distinctPackageIds)}). " +
+                "Pass the workload ID instead.",
+                isUserError: true);
+        }
+
+        string packageId = distinctPackageIds[0];
+        IReadOnlyList<WorkloadEntry> toRemove = ResolveVersionsToRemove(packageId, version, all, matches);
+
+        foreach (WorkloadEntry candidate in toRemove)
+        {
+            bool removed = await _installer.UninstallAsync(candidate.PackageId, candidate.PackageVersion, cancellationToken);
+            if (removed)
+            {
+                _interaction.WriteSuccess(
+                    $"Uninstalled workload '{candidate.PackageId}' version '{candidate.PackageVersion}'.");
+            }
+        }
+
+        return 0;
+    }
+
+    private static IReadOnlyList<WorkloadEntry> ResolveVersionsToRemove(
+        string packageId,
+        string? version,
+        bool all,
+        IReadOnlyList<WorkloadEntry> matches)
+    {
+        if (all)
+        {
+            return matches;
+        }
+
+        if (!string.IsNullOrEmpty(version))
+        {
+            WorkloadEntry? match = matches.FirstOrDefault(
+                m => string.Equals(m.PackageVersion, version, StringComparison.Ordinal));
+
+            if (match is null)
+            {
+                string available = string.Join(", ", matches.Select(m => m.PackageVersion));
+                throw new GracefulException(
+                    $"Workload '{packageId}' version '{version}' is not installed. " +
+                    $"Installed versions: {available}.",
+                    isUserError: true);
+            }
+
+            return [match];
+        }
+
+        if (matches.Count > 1)
+        {
+            string available = string.Join(", ", matches.Select(m => m.PackageVersion));
+            throw new GracefulException(
+                $"Multiple versions of '{packageId}' are installed ({available}). " +
+                "Pass --version <v> or --all-versions.",
+                isUserError: true);
+        }
+
+        return matches;
+    }
+}

--- a/src/Func/Func.csproj
+++ b/src/Func/Func.csproj
@@ -26,6 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="NuGet.Packaging" />
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="Spectre.Console" />
     <PackageReference Include="OpenTelemetry" />

--- a/src/Func/Hosting/BuiltInCommands.cs
+++ b/src/Func/Hosting/BuiltInCommands.cs
@@ -38,6 +38,8 @@ internal static class BuiltInCommands
         // the list command as its own concrete type (not as FuncCliCommand) so
         // it doesn't get added at the top level by GetServices<FuncCliCommand>().
         services.AddSingleton<WorkloadListCommand>();
+        services.AddSingleton<WorkloadInstallCommand>();
+        services.AddSingleton<WorkloadUninstallCommand>();
         services.AddSingleton<FuncCliCommand, WorkloadCommand>();
 
         return services;

--- a/src/Func/Hosting/CliHostFactory.cs
+++ b/src/Func/Hosting/CliHostFactory.cs
@@ -60,6 +60,7 @@ internal static class CliHostFactory
         hostBuilder.Configuration.AddEnvironmentVariables(prefix: Constants.EnvironmentVariablePrefix);
         configureConfiguration?.Invoke(hostBuilder.Configuration);
         hostBuilder.Services.AddWorkloadStorage();
+        hostBuilder.Services.AddWorkloadInstaller();
 
         // Runs before Build() so workloads can still mutate IServiceCollection.
         // The boot duration is recorded after StartAsync below — OTel listeners

--- a/src/Func/Hosting/WorkloadInstallRegistration.cs
+++ b/src/Func/Hosting/WorkloadInstallRegistration.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads.Install;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Azure.Functions.Cli.Hosting;
+
+/// <summary>
+/// Wires the install pipeline (<see cref="IWorkloadInstaller"/>) into DI.
+/// Requires <see cref="WorkloadStorageRegistration.AddWorkloadStorage"/> to
+/// be registered first.
+/// </summary>
+internal static class WorkloadInstallRegistration
+{
+    public static IServiceCollection AddWorkloadInstaller(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton<IWorkloadInstaller, WorkloadInstaller>();
+
+        return services;
+    }
+}

--- a/src/Func/Workloads/Install/IWorkloadInstaller.cs
+++ b/src/Func/Workloads/Install/IWorkloadInstaller.cs
@@ -1,0 +1,52 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads.Storage;
+
+namespace Azure.Functions.Cli.Workloads.Install;
+
+/// <summary>
+/// Coordinates installing and uninstalling workloads on disk and in the
+/// global workload registry.
+/// </summary>
+internal interface IWorkloadInstaller
+{
+    /// <summary>
+    /// Installs a workload from the <c>.nupkg</c> at <paramref name="nupkgPath"/>.
+    /// The package is extracted into <see cref="IWorkloadPaths.GetInstallDirectory"/>
+    /// and recorded in the global registry; the source <c>.nupkg</c> is left untouched.
+    /// </summary>
+    /// <param name="nupkgPath">Path to a <c>.nupkg</c> on disk.</param>
+    /// <param name="force">
+    /// When <c>true</c>, an existing install of the same id+version is removed
+    /// before extraction.
+    /// </param>
+    /// <param name="cancellationToken">Token to cancel the install.</param>
+    /// <returns>
+    /// The registry entry plus a flag indicating whether the install was a
+    /// no-op because the same <c>(packageId, version)</c> was already present.
+    /// </returns>
+    /// <exception cref="FileNotFoundException">The <c>.nupkg</c> does not exist.</exception>
+    /// <exception cref="Discovery.InvalidWorkloadException">
+    /// The package is unreadable, missing the <c>FuncCliWorkload</c> package
+    /// type, or its <c>workload.json</c> is missing or malformed.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// The install directory exists without a matching registry entry and
+    /// <paramref name="force"/> is <c>false</c>.
+    /// </exception>
+    public Task<WorkloadInstallResult> InstallFromPackageAsync(
+        string nupkgPath,
+        bool force = false,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes the install directory and registry entry for
+    /// (<paramref name="packageId"/>, <paramref name="version"/>). Returns
+    /// <c>true</c> when an entry was removed, <c>false</c> when none existed.
+    /// </summary>
+    public Task<bool> UninstallAsync(
+        string packageId,
+        string version,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Func/Workloads/Install/WorkloadInstallResult.cs
+++ b/src/Func/Workloads/Install/WorkloadInstallResult.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads.Storage;
+
+namespace Azure.Functions.Cli.Workloads.Install;
+
+/// <summary>
+/// Outcome of <see cref="IWorkloadInstaller.InstallFromPackageAsync"/>.
+/// </summary>
+/// <param name="Entry">The registry entry for the installed workload.</param>
+/// <param name="AlreadyInstalled">
+/// <see langword="true"/> when the same (<c>packageId</c>, <c>version</c>)
+/// was already installed and the call was a no-op.
+/// </param>
+internal sealed record WorkloadInstallResult(WorkloadEntry Entry, bool AlreadyInstalled);

--- a/src/Func/Workloads/Install/WorkloadInstaller.cs
+++ b/src/Func/Workloads/Install/WorkloadInstaller.cs
@@ -1,0 +1,233 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads.Discovery;
+using Azure.Functions.Cli.Workloads.Storage;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+
+namespace Azure.Functions.Cli.Workloads.Install;
+
+/// <summary>
+/// Default <see cref="IWorkloadInstaller"/>. Extracts a <c>.nupkg</c> into
+/// the install directory, validates its <c>workload.json</c>, then writes
+/// the registry entry. On any failure after the install directory is
+/// created, the directory is rolled back so disk and registry stay in sync.
+/// </summary>
+internal sealed class WorkloadInstaller(
+    IWorkloadPaths paths,
+    IWorkloadStore store,
+    IWorkloadMetadataReader metadataReader) : IWorkloadInstaller
+{
+    /// <summary>
+    /// Prefix on nuspec tags that marks the tag as a CLI-facing alias, so
+    /// workloads can keep using other tags for search/categories without
+    /// leaking them into alias resolution.
+    /// </summary>
+    public const string AliasTagPrefix = "alias:";
+
+    /// <summary>
+    /// Package-type name a workload package must declare in its .nuspec so
+    /// the installer can refuse arbitrary .nupkgs. Mirrors dotnet's
+    /// <c>DotnetTool</c> convention.
+    /// </summary>
+    public const string FuncCliWorkloadPackageType = "FuncCliWorkload";
+
+    private readonly IWorkloadPaths _paths = paths ?? throw new ArgumentNullException(nameof(paths));
+    private readonly IWorkloadStore _store = store ?? throw new ArgumentNullException(nameof(store));
+    private readonly IWorkloadMetadataReader _metadataReader = metadataReader ?? throw new ArgumentNullException(nameof(metadataReader));
+
+    /// <inheritdoc />
+    public async Task<WorkloadInstallResult> InstallFromPackageAsync(
+        string nupkgPath,
+        bool force = false,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(nupkgPath);
+
+        if (!File.Exists(nupkgPath))
+        {
+            throw new FileNotFoundException(
+                $"Package file '{nupkgPath}' does not exist.",
+                nupkgPath);
+        }
+
+        using PackageArchiveReader reader = OpenPackage(nupkgPath);
+        NuspecReader nuspec = reader.NuspecReader;
+
+        // NuGet package ids are case-insensitive; lowercase so the install
+        // path, registry key, and later lookups all agree.
+        string packageId = nuspec.GetId().ToLowerInvariant();
+        string version = nuspec.GetVersion().ToNormalizedString();
+        IReadOnlyList<string> aliases = ParseAliases(nuspec.GetTags());
+
+        if (!nuspec.GetPackageTypes().Any(t => string.Equals(t.Name, FuncCliWorkloadPackageType, StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new InvalidWorkloadException(
+                $"Package '{packageId}' is not a func CLI workload " +
+                $"(missing package type '{FuncCliWorkloadPackageType}' in its .nuspec).");
+        }
+
+        string installPath = _paths.GetInstallDirectory(packageId, version);
+
+        // Idempotent re-install: same (id, version) already on disk and in
+        // the registry returns success without re-extracting. Force still
+        // re-extracts so users can repair a broken install.
+        if (!force)
+        {
+            IReadOnlyList<WorkloadEntry> existing = await _store.GetWorkloadsAsync(cancellationToken);
+            WorkloadEntry? prior = existing.FirstOrDefault(e =>
+                string.Equals(e.PackageId, packageId, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(e.PackageVersion, version, StringComparison.Ordinal));
+
+            if (prior is not null && Directory.Exists(installPath))
+            {
+                return new WorkloadInstallResult(prior, AlreadyInstalled: true);
+            }
+        }
+
+        if (Directory.Exists(installPath))
+        {
+            if (!force)
+            {
+                throw new InvalidOperationException(
+                    $"Workload '{packageId}' version '{version}' is already installed at '{installPath}' " +
+                    "but is missing from the registry. Pass --force to repair the install.");
+            }
+
+            // Drop registry and on-disk directory before extracting fresh
+            // so files dropped by the new package don't linger.
+            await _store.RemoveWorkloadAsync(packageId, version, cancellationToken);
+            Directory.Delete(installPath, recursive: true);
+        }
+
+        Directory.CreateDirectory(Path.GetDirectoryName(installPath)!);
+        Directory.CreateDirectory(installPath);
+
+        WorkloadEntry entry;
+        try
+        {
+            await ExtractPackageAsync(reader, installPath, cancellationToken);
+
+            WorkloadMetadata metadata = _metadataReader.Read(installPath);
+
+            entry = new WorkloadEntry
+            {
+                PackageId = packageId,
+                PackageVersion = version,
+                Aliases = aliases,
+                EntryPoint = metadata.EntryPoint,
+                Kind = metadata.Kind,
+                Source = Path.GetFullPath(nupkgPath),
+                InstalledExplicitly = true,
+            };
+
+            await _store.SaveWorkloadAsync(entry, cancellationToken);
+        }
+        catch
+        {
+            TryDeleteDirectory(installPath);
+            throw;
+        }
+
+        return new WorkloadInstallResult(entry, AlreadyInstalled: false);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> UninstallAsync(
+        string packageId,
+        string version,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(version);
+
+        bool removed = await _store.RemoveWorkloadAsync(packageId, version, cancellationToken);
+        if (!removed)
+        {
+            return false;
+        }
+
+        string installPath = _paths.GetInstallDirectory(packageId, version);
+        TryDeleteDirectory(installPath);
+        return true;
+    }
+
+    private static PackageArchiveReader OpenPackage(string nupkgPath)
+    {
+        try
+        {
+            return new PackageArchiveReader(File.OpenRead(nupkgPath));
+        }
+        catch (Exception ex) when (ex is InvalidDataException or PackagingException)
+        {
+            throw new InvalidWorkloadException(
+                $"Failed to read .nupkg at '{nupkgPath}': {ex.Message}",
+                ex);
+        }
+    }
+
+    private static async Task ExtractPackageAsync(
+        PackageArchiveReader reader,
+        string destination,
+        CancellationToken cancellationToken)
+    {
+        // PackageArchiveReader already filters OPC metadata and rejects
+        // path-escape entries, so we don't re-filter here.
+        foreach (string packageFile in await reader.GetFilesAsync(cancellationToken))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            string targetPath = Path.Combine(destination, packageFile.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
+
+            using Stream entryStream = await reader.GetStreamAsync(packageFile, cancellationToken);
+            using FileStream output = File.Create(targetPath);
+            await entryStream.CopyToAsync(output, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Extracts CLI aliases from nuspec tags. Only tags prefixed with
+    /// <see cref="AliasTagPrefix"/> are surfaced.
+    /// </summary>
+    private static IReadOnlyList<string> ParseAliases(string? tags)
+    {
+        if (string.IsNullOrWhiteSpace(tags))
+        {
+            return [];
+        }
+
+        List<string> aliases = [];
+        foreach (string tag in tags.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (tag.StartsWith(AliasTagPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                string alias = tag[AliasTagPrefix.Length..].Trim();
+                if (alias.Length > 0)
+                {
+                    aliases.Add(alias);
+                }
+            }
+        }
+
+        return aliases;
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best-effort: if the directory can't be removed (e.g. AV holds
+            // an assembly open), the registry is already consistent and the
+            // user can clean up manually.
+        }
+    }
+}

--- a/src/Func/Workloads/Install/WorkloadInstaller.cs
+++ b/src/Func/Workloads/Install/WorkloadInstaller.cs
@@ -92,7 +92,7 @@ internal sealed class WorkloadInstaller(
             {
                 throw new InvalidOperationException(
                     $"Workload '{packageId}' version '{version}' is already installed at '{installPath}' " +
-                    "but is missing from the registry. Pass --force to repair the install.");
+                    "but is missing from the registry.");
             }
 
             // Drop registry and on-disk directory before extracting fresh

--- a/src/Func/Workloads/Storage/WorkloadRegistry.cs
+++ b/src/Func/Workloads/Storage/WorkloadRegistry.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Text.Json.Serialization;
-using Azure.Functions.Cli.Workloads;
 
 namespace Azure.Functions.Cli.Workloads.Storage;
 

--- a/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
@@ -127,7 +127,6 @@ public class WorkloadInstallCommandTests
     [Theory]
     [InlineData(typeof(FileNotFoundException), "missing nupkg")]
     [InlineData(typeof(InvalidWorkloadException), "bad package")]
-    [InlineData(typeof(InvalidOperationException), "already installed")]
     public async Task Install_InstallerThrowsExpectedFailure_WrappedInGracefulException(Type exceptionType, string message)
     {
         var inner = (Exception)Activator.CreateInstance(exceptionType, message)!;
@@ -138,6 +137,20 @@ public class WorkloadInstallCommandTests
         GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
             () => InvokeAsync(cmd, "Test.Workload.1.0.0.nupkg"));
         Assert.Equal(message, ex.Message);
+        Assert.True(ex.IsUserError);
+    }
+
+    [Fact]
+    public async Task Install_InstallerThrowsBrokenInstall_AppendsForceHint()
+    {
+        _installer.InstallFromPackageAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Throws(new InvalidOperationException("Workload 'x' version '1' is already installed at '/p' but is missing from the registry."));
+
+        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => InvokeAsync(cmd, "Test.Workload.1.0.0.nupkg"));
+        Assert.Contains("missing from the registry", ex.Message);
+        Assert.Contains("--force", ex.Message);
         Assert.True(ex.IsUserError);
     }
 

--- a/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
@@ -1,0 +1,175 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Commands.Workload;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Workloads;
+using Azure.Functions.Cli.Workloads.Discovery;
+using Azure.Functions.Cli.Workloads.Install;
+using Azure.Functions.Cli.Workloads.Storage;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Commands.Workload;
+
+public class WorkloadInstallCommandTests
+{
+    private readonly TestInteractionService _interaction = new();
+    private readonly IWorkloadInstaller _installer = Substitute.For<IWorkloadInstaller>();
+
+    [Fact]
+    public void Install_HasWorkloadArgumentAndForceOption()
+    {
+        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        Assert.Single(cmd.Arguments, a => a.Name == "id");
+        Assert.Single(cmd.Options, o => o.Name == "--force");
+    }
+
+    [Fact]
+    public void Install_NonNupkgArgument_FailsValidation()
+    {
+        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        var root = new RootCommand();
+        root.Subcommands.Add(cmd);
+
+        ParseResult parse = root.Parse([cmd.Name, "Test.Workload"]);
+
+        Assert.NotEmpty(parse.Errors);
+        Assert.Contains(parse.Errors, e => e.Message.Contains("not yet supported") && e.Message.Contains(".nupkg"));
+    }
+
+    [Fact]
+    public async Task Install_NupkgArgument_DelegatesToInstaller_WritesSuccess()
+    {
+        StubResult(alreadyInstalled: false);
+
+        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        int exit = await InvokeAsync(cmd, "Test.Workload.1.0.0.nupkg");
+
+        Assert.Equal(0, exit);
+        await _installer.Received(1).InstallFromPackageAsync("Test.Workload.1.0.0.nupkg", false, Arg.Any<CancellationToken>());
+        Assert.Contains(
+            _interaction.Lines,
+            l => l.StartsWith("SUCCESS:")
+                && l.Contains("Installed workload")
+                && l.Contains("test.workload")
+                && l.Contains("1.0.0")
+                && l.Contains("entry point: T"));
+    }
+
+    [Fact]
+    public async Task Install_AlreadyInstalled_WritesIdempotentMessage()
+    {
+        StubResult(alreadyInstalled: true);
+
+        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        int exit = await InvokeAsync(cmd, "Test.Workload.1.0.0.nupkg");
+
+        Assert.Equal(0, exit);
+        Assert.Contains(
+            _interaction.Lines,
+            l => l.StartsWith("SUCCESS:")
+                && l.Contains("already installed")
+                && l.Contains("test.workload"));
+    }
+
+    [Fact]
+    public async Task Install_ContentKind_MessageMentionsContentPath()
+    {
+        _installer.InstallFromPackageAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(new WorkloadInstallResult(
+                new WorkloadEntry
+                {
+                    PackageId = "test.content",
+                    PackageVersion = "1.0.0",
+                    Kind = WorkloadKind.Content,
+                    Source = "/abs/path/to/test.content.1.0.0.nupkg",
+                },
+                AlreadyInstalled: false));
+
+        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        int exit = await InvokeAsync(cmd, "test.content.1.0.0.nupkg");
+
+        Assert.Equal(0, exit);
+        Assert.Contains(
+            _interaction.Lines,
+            l => l.StartsWith("SUCCESS:")
+                && l.Contains("content at")
+                && l.Contains("/abs/path/to/test.content.1.0.0.nupkg"));
+    }
+
+    [Fact]
+    public async Task Install_ForceFlag_PassesForceToInstaller()
+    {
+        StubResult(alreadyInstalled: false);
+
+        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        int exit = await InvokeAsync(cmd, "Test.Workload.1.0.0.nupkg", "--force");
+
+        Assert.Equal(0, exit);
+        await _installer.Received(1).InstallFromPackageAsync("Test.Workload.1.0.0.nupkg", true, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Install_ForceShortAlias_PassesForceToInstaller()
+    {
+        StubResult(alreadyInstalled: false);
+
+        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        int exit = await InvokeAsync(cmd, "Test.Workload.1.0.0.nupkg", "-f");
+
+        Assert.Equal(0, exit);
+        await _installer.Received(1).InstallFromPackageAsync("Test.Workload.1.0.0.nupkg", true, Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(typeof(FileNotFoundException), "missing nupkg")]
+    [InlineData(typeof(InvalidWorkloadException), "bad package")]
+    [InlineData(typeof(InvalidOperationException), "already installed")]
+    public async Task Install_InstallerThrowsExpectedFailure_WrappedInGracefulException(Type exceptionType, string message)
+    {
+        var inner = (Exception)Activator.CreateInstance(exceptionType, message)!;
+        _installer.InstallFromPackageAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Throws(inner);
+
+        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => InvokeAsync(cmd, "Test.Workload.1.0.0.nupkg"));
+        Assert.Equal(message, ex.Message);
+        Assert.True(ex.IsUserError);
+    }
+
+    [Fact]
+    public async Task Install_InstallerThrowsUnexpected_PropagatesUnchanged()
+    {
+        // Anything outside the catch list is treated as a runtime bug and
+        // surfaces unwrapped so Program.cs prints a stack trace.
+        _installer.InstallFromPackageAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Throws(new NullReferenceException("oops"));
+
+        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        await Assert.ThrowsAsync<NullReferenceException>(
+            () => InvokeAsync(cmd, "Test.Workload.1.0.0.nupkg"));
+    }
+
+    private void StubResult(bool alreadyInstalled) =>
+        _installer.InstallFromPackageAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(new WorkloadInstallResult(
+                new WorkloadEntry
+                {
+                    PackageId = "test.workload",
+                    PackageVersion = "1.0.0",
+                    EntryPoint = new EntryPointSpec { AssemblyPath = "x.dll", Type = "T" },
+                },
+                alreadyInstalled));
+
+    private static Task<int> InvokeAsync(WorkloadInstallCommand cmd, params string[] args)
+    {
+        var root = new RootCommand();
+        root.Subcommands.Add(cmd);
+        var config = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
+        return root.Parse(new[] { cmd.Name }.Concat(args).ToArray()).InvokeAsync(config);
+    }
+}

--- a/test/Func.Tests/Commands/Workload/WorkloadUninstallCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadUninstallCommandTests.cs
@@ -1,0 +1,272 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Commands.Workload;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Workloads;
+using Azure.Functions.Cli.Workloads.Install;
+using Azure.Functions.Cli.Workloads.Storage;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Commands.Workload;
+
+public class WorkloadUninstallCommandTests
+{
+    private readonly TestInteractionService _interaction = new();
+    private readonly IWorkloadInstaller _installer = Substitute.For<IWorkloadInstaller>();
+    private readonly IWorkloadStore _store = Substitute.For<IWorkloadStore>();
+
+    [Fact]
+    public async Task Uninstall_NoVersionsInstalled_WarnsAndSucceeds()
+    {
+        StubInstalled();
+
+        var cmd = NewCommand();
+        int exit = await InvokeAsync(cmd, "Test.Workload");
+
+        Assert.Equal(0, exit);
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("WARNING:") && l.Contains("not installed"));
+        await _installer.DidNotReceive().UninstallAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Uninstall_SingleVersionInstalled_NoFlags_Removes()
+    {
+        StubInstalled(("Test.Workload", "1.0.0"));
+        _installer.UninstallAsync("Test.Workload", "1.0.0", Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var cmd = NewCommand();
+        int exit = await InvokeAsync(cmd, "Test.Workload");
+
+        Assert.Equal(0, exit);
+        await _installer.Received(1).UninstallAsync("Test.Workload", "1.0.0", Arg.Any<CancellationToken>());
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("SUCCESS:") && l.Contains("1.0.0"));
+    }
+
+    [Fact]
+    public async Task Uninstall_MultipleVersions_NoFlags_Throws()
+    {
+        StubInstalled(("Test.Workload", "1.0.0"), ("Test.Workload", "2.0.0"));
+
+        var cmd = NewCommand();
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => InvokeAsync(cmd, "Test.Workload"));
+
+        Assert.Contains("Multiple versions", ex.Message);
+        Assert.Contains("--all-versions", ex.Message);
+    }
+
+    [Fact]
+    public async Task Uninstall_VersionFlag_RemovesOnlyThatVersion()
+    {
+        StubInstalled(("Test.Workload", "1.0.0"), ("Test.Workload", "2.0.0"));
+        _installer.UninstallAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var cmd = NewCommand();
+        await InvokeAsync(cmd, "Test.Workload", "--version", "2.0.0");
+
+        await _installer.Received(1).UninstallAsync("Test.Workload", "2.0.0", Arg.Any<CancellationToken>());
+        await _installer.DidNotReceive().UninstallAsync("Test.Workload", "1.0.0", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Uninstall_VersionFlag_UnknownVersion_Throws()
+    {
+        StubInstalled(("Test.Workload", "1.0.0"));
+
+        var cmd = NewCommand();
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => InvokeAsync(cmd, "Test.Workload", "--version", "9.9.9"));
+
+        Assert.Contains("9.9.9", ex.Message);
+        Assert.Contains("Installed versions: 1.0.0", ex.Message);
+    }
+
+    [Fact]
+    public async Task Uninstall_AllFlag_RemovesEveryVersion()
+    {
+        StubInstalled(("Test.Workload", "1.0.0"), ("Test.Workload", "2.0.0"));
+        _installer.UninstallAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var cmd = NewCommand();
+        await InvokeAsync(cmd, "Test.Workload", "--all-versions");
+
+        await _installer.Received(1).UninstallAsync("Test.Workload", "1.0.0", Arg.Any<CancellationToken>());
+        await _installer.Received(1).UninstallAsync("Test.Workload", "2.0.0", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Uninstall_VersionFlag_ShortAlias_RemovesOnlyThatVersion()
+    {
+        StubInstalled(("Test.Workload", "1.0.0"), ("Test.Workload", "2.0.0"));
+        _installer.UninstallAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var cmd = NewCommand();
+        await InvokeAsync(cmd, "Test.Workload", "-v", "2.0.0");
+
+        await _installer.Received(1).UninstallAsync("Test.Workload", "2.0.0", Arg.Any<CancellationToken>());
+        await _installer.DidNotReceive().UninstallAsync("Test.Workload", "1.0.0", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Uninstall_AllFlag_ShortAlias_RemovesEveryVersion()
+    {
+        StubInstalled(("Test.Workload", "1.0.0"), ("Test.Workload", "2.0.0"));
+        _installer.UninstallAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var cmd = NewCommand();
+        await InvokeAsync(cmd, "Test.Workload", "-a");
+
+        await _installer.Received(1).UninstallAsync("Test.Workload", "1.0.0", Arg.Any<CancellationToken>());
+        await _installer.Received(1).UninstallAsync("Test.Workload", "2.0.0", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void Uninstall_AllAndVersion_FailsValidation()
+    {
+        var cmd = NewCommand();
+        var root = new RootCommand();
+        root.Subcommands.Add(cmd);
+
+        ParseResult parse = root.Parse([cmd.Name, "Test.Workload", "--all-versions", "--version", "1.0.0"]);
+
+        Assert.NotEmpty(parse.Errors);
+        Assert.Contains(parse.Errors, e => e.Message.Contains("--all-versions and --version"));
+    }
+
+    [Fact]
+    public async Task Uninstall_PackageIdMatchIsCaseInsensitive()
+    {
+        StubInstalled(("Test.Workload", "1.0.0"));
+        _installer.UninstallAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var cmd = NewCommand();
+        int exit = await InvokeAsync(cmd, "test.workload");
+
+        Assert.Equal(0, exit);
+        await _installer.Received(1).UninstallAsync("Test.Workload", "1.0.0", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Uninstall_ByAlias_RemovesMatchingPackage()
+    {
+        StubInstalledWithAliases((PackageId: "Test.Workload", Version: "1.0.0", Aliases: new[] { "stub", "test-workload" }));
+        _installer.UninstallAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var cmd = NewCommand();
+        int exit = await InvokeAsync(cmd, "stub");
+
+        Assert.Equal(0, exit);
+        await _installer.Received(1).UninstallAsync("Test.Workload", "1.0.0", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Uninstall_ByAlias_IsCaseInsensitive()
+    {
+        StubInstalledWithAliases((PackageId: "Test.Workload", Version: "1.0.0", Aliases: new[] { "stub" }));
+        _installer.UninstallAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var cmd = NewCommand();
+        int exit = await InvokeAsync(cmd, "STUB");
+
+        Assert.Equal(0, exit);
+        await _installer.Received(1).UninstallAsync("Test.Workload", "1.0.0", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Uninstall_AmbiguousAlias_Throws()
+    {
+        StubInstalledWithAliases(
+            (PackageId: "First.Workload", Version: "1.0.0", Aliases: new[] { "shared" }),
+            (PackageId: "Second.Workload", Version: "1.0.0", Aliases: new[] { "shared" }));
+
+        var cmd = NewCommand();
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => InvokeAsync(cmd, "shared"));
+
+        Assert.Contains("matches multiple installed workloads", ex.Message);
+        Assert.Contains("First.Workload", ex.Message);
+        Assert.Contains("Second.Workload", ex.Message);
+    }
+
+    [Fact]
+    public async Task Uninstall_ExactFlag_SuppressesAliasMatching()
+    {
+        // Without --exact, "shared" would resolve via the alias and uninstall
+        // would proceed. With --exact, the argument must be a literal package
+        // id; an unmatched id warns and exits 0.
+        StubInstalledWithAliases(
+            (PackageId: "First.Workload", Version: "1.0.0", Aliases: new[] { "shared" }));
+
+        var cmd = NewCommand();
+        int exit = await InvokeAsync(cmd, "shared", "--exact");
+
+        Assert.Equal(0, exit);
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("WARNING:") && l.Contains("not installed"));
+        await _installer.DidNotReceive().UninstallAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Uninstall_ExactFlag_StillMatchesByPackageId()
+    {
+        // --exact only suppresses alias matching; the literal package id
+        // still resolves (case-insensitive, per NuGet).
+        StubInstalledWithAliases(
+            (PackageId: "First.Workload", Version: "1.0.0", Aliases: new[] { "shared" }));
+        _installer.UninstallAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var cmd = NewCommand();
+        int exit = await InvokeAsync(cmd, "First.Workload", "-e");
+
+        Assert.Equal(0, exit);
+        await _installer.Received(1).UninstallAsync("First.Workload", "1.0.0", Arg.Any<CancellationToken>());
+    }
+
+    private WorkloadUninstallCommand NewCommand() => new(_interaction, _installer, _store);
+
+    private void StubInstalled(params (string PackageId, string Version)[] entries)
+    {
+        WorkloadEntry[] workloads = [.. entries
+            .Select(e => new WorkloadEntry
+            {
+                PackageId = e.PackageId,
+                PackageVersion = e.Version,
+                EntryPoint = new EntryPointSpec { AssemblyPath = "x.dll", Type = "T" },
+            })];
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(workloads);
+    }
+
+    private void StubInstalledWithAliases(params (string PackageId, string Version, string[] Aliases)[] entries)
+    {
+        WorkloadEntry[] workloads = [.. entries
+            .Select(e => new WorkloadEntry
+            {
+                PackageId = e.PackageId,
+                PackageVersion = e.Version,
+                Aliases = e.Aliases,
+                EntryPoint = new EntryPointSpec { AssemblyPath = "x.dll", Type = "T" },
+            })];
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(workloads);
+    }
+
+    private static Task<int> InvokeAsync(WorkloadUninstallCommand cmd, params string[] args)
+    {
+        var root = new RootCommand();
+        root.Subcommands.Add(cmd);
+        var config = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
+        return root.Parse(new[] { cmd.Name }.Concat(args).ToArray()).InvokeAsync(config);
+    }
+}

--- a/test/Func.Tests/Func.Tests.csproj
+++ b/test/Func.Tests/Func.Tests.csproj
@@ -23,8 +23,9 @@
     Workload package layout convention: each installed workload is a directory
     containing a workload.json manifest at the root and a `tools/any/`
     sub-folder with the workload's assemblies + deps. Tests need that shape on
-    disk so the loader can resolve fixture assemblies via the same path
-    combination it uses in production (see WorkloadMetadataReader.ContentDirectoryName).
+    disk so the loader can resolve fixture assemblies the same way it does
+    in production (workload.json's `entryPoint.assemblyPath` is interpreted
+    relative to the package root and includes the `tools/any/...` prefix).
 
     The fixtures themselves build into a flat bin output (the standard SDK
     layout); this target reshapes them in the test project's bin so the

--- a/test/Func.Tests/TestParser.cs
+++ b/test/Func.Tests/TestParser.cs
@@ -80,6 +80,10 @@ internal static class TestParser
         emptyProvider.GetWorkloads().Returns([]);
         services.AddSingleton(emptyProvider);
 
+        // Workload install pipeline: substitute the installer so commands
+        // resolve without standing up the real install/uninstall side effects.
+        services.AddSingleton(Substitute.For<Cli.Workloads.Install.IWorkloadInstaller>());
+
         return services;
     }
 }

--- a/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
+++ b/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
@@ -151,8 +151,9 @@ public sealed class WorkloadInstallerTests : IDisposable
     public async Task InstallFromPackage_AlreadyInstalled_DirOnly_NoRegistryEntry_Throws()
     {
         // Half-installed leftover (directory exists but registry has no
-        // matching row) is treated as a broken install: tell the user to
-        // pass --force to repair.
+        // matching row) is treated as a broken install. The remedy
+        // ("pass --force") is the command's responsibility, not the
+        // service's, so we only assert on the state description here.
         string installDir = _paths.GetInstallDirectory("test.workload", "1.0.0");
         Directory.CreateDirectory(installDir);
 
@@ -162,7 +163,7 @@ public sealed class WorkloadInstallerTests : IDisposable
         InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(
             () => installer.InstallFromPackageAsync(nupkg));
         Assert.Contains("missing from the registry", ex.Message);
-        Assert.Contains("--force", ex.Message);
+        Assert.DoesNotContain("--force", ex.Message);
     }
 
     [Fact]

--- a/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
+++ b/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
@@ -1,0 +1,295 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads;
+using Azure.Functions.Cli.Workloads.Discovery;
+using Azure.Functions.Cli.Workloads.Install;
+using Azure.Functions.Cli.Workloads.Storage;
+using NSubstitute;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Workloads.Install;
+
+public sealed class WorkloadInstallerTests : IDisposable
+{
+    private readonly string _root = Directory.CreateTempSubdirectory("workload-installer-").FullName;
+    private readonly IWorkloadStore _store = Substitute.For<IWorkloadStore>();
+    private readonly IWorkloadMetadataReader _metadataReader = Substitute.For<IWorkloadMetadataReader>();
+    private readonly IWorkloadPaths _paths;
+
+    public WorkloadInstallerTests()
+    {
+        _paths = new WorkloadPathsOptions { Home = Path.Combine(_root, ".azure-functions") };
+        _metadataReader.Read(Arg.Any<string>())
+            .Returns(new WorkloadMetadata
+            {
+                Schema = "https://example/workload.schema.json",
+                EntryPoint = new EntryPointSpec { AssemblyPath = "Test.dll", Type = "Test.Type" },
+            });
+    }
+
+    public void Dispose() => Directory.Delete(_root, recursive: true);
+
+    [Fact]
+    public async Task InstallFromPackage_HappyPath_ExtractsAndPersists()
+    {
+        string nupkg = BuildNupkg(tags: $"{WorkloadInstaller.AliasTagPrefix}test {WorkloadInstaller.AliasTagPrefix}stub other-tag");
+
+        WorkloadInstaller installer = NewInstaller();
+        WorkloadInstallResult result = await installer.InstallFromPackageAsync(nupkg);
+
+        Assert.False(result.AlreadyInstalled);
+        Assert.Equal("test.workload", result.Entry.PackageId);
+        Assert.Equal("1.0.0", result.Entry.PackageVersion);
+        Assert.Equal(["test", "stub"], result.Entry.Aliases);
+        Assert.Equal("Test.dll", result.Entry.EntryPoint!.AssemblyPath);
+        Assert.Equal(Path.GetFullPath(nupkg), result.Entry.Source);
+        Assert.True(result.Entry.InstalledExplicitly);
+
+        string installDir = _paths.GetInstallDirectory("test.workload", "1.0.0");
+        Assert.True(Directory.Exists(installDir));
+        Assert.True(File.Exists(Path.Combine(installDir, "tools", "any", "Test.dll")));
+        Assert.True(File.Exists(nupkg), "Source .nupkg must be left in place.");
+
+        await _store.Received(1).SaveWorkloadAsync(
+            Arg.Is<WorkloadEntry>(e =>
+                e.PackageId == "test.workload" &&
+                e.PackageVersion == "1.0.0" &&
+                e.EntryPoint!.AssemblyPath == "Test.dll" &&
+                e.Source == Path.GetFullPath(nupkg) &&
+                e.InstalledExplicitly &&
+                e.Aliases.SequenceEqual(new[] { "test", "stub" })),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InstallFromPackage_NonAliasTagsIgnored()
+    {
+        string nupkg = BuildNupkg(tags: "search-keyword another-keyword");
+
+        WorkloadInstaller installer = NewInstaller();
+        WorkloadInstallResult result = await installer.InstallFromPackageAsync(nupkg);
+
+        Assert.Empty(result.Entry.Aliases);
+    }
+
+    [Fact]
+    public async Task InstallFromPackage_InvalidWorkloadJson_Throws_RollsBack()
+    {
+        string nupkg = BuildNupkg();
+        _metadataReader.Read(Arg.Any<string>())
+            .Returns(_ => throw new InvalidWorkloadException("missing workload.json"));
+
+        WorkloadInstaller installer = NewInstaller();
+        InvalidWorkloadException ex = await Assert.ThrowsAsync<InvalidWorkloadException>(
+            () => installer.InstallFromPackageAsync(nupkg));
+
+        Assert.Contains("missing workload.json", ex.Message);
+        Assert.False(Directory.Exists(_paths.GetInstallDirectory("test.workload", "1.0.0")));
+        await _store.DidNotReceive().SaveWorkloadAsync(Arg.Any<WorkloadEntry>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InstallFromPackage_MissingFuncCliWorkloadPackageType_Throws_NoExtraction()
+    {
+        string nupkg = BuildNupkg(includeFuncCliWorkloadType: false);
+
+        WorkloadInstaller installer = NewInstaller();
+        InvalidWorkloadException ex = await Assert.ThrowsAsync<InvalidWorkloadException>(
+            () => installer.InstallFromPackageAsync(nupkg));
+
+        Assert.Contains("FuncCliWorkload", ex.Message);
+        Assert.False(Directory.Exists(_paths.GetInstallDirectory("test.workload", "1.0.0")));
+        await _store.DidNotReceive().SaveWorkloadAsync(Arg.Any<WorkloadEntry>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InstallFromPackage_MissingFile_Throws()
+    {
+        WorkloadInstaller installer = NewInstaller();
+        FileNotFoundException ex = await Assert.ThrowsAsync<FileNotFoundException>(
+            () => installer.InstallFromPackageAsync(Path.Combine(_root, "missing.nupkg")));
+        Assert.Contains("does not exist", ex.Message);
+    }
+
+    [Fact]
+    public async Task InstallFromPackage_AlreadyInRegistry_AndOnDisk_IsNoOp()
+    {
+        // Spec §6.1 step 0: same (id, version) already present and intact →
+        // exit success without re-extracting. The pre-existing registry
+        // entry is returned verbatim and SaveWorkloadAsync is not called
+        // again.
+        string installDir = _paths.GetInstallDirectory("test.workload", "1.0.0");
+        Directory.CreateDirectory(installDir);
+        WorkloadEntry priorEntry = new()
+        {
+            PackageId = "test.workload",
+            PackageVersion = "1.0.0",
+            Aliases = ["stub"],
+            Kind = WorkloadKind.Workload,
+            EntryPoint = new EntryPointSpec { AssemblyPath = "Test.dll", Type = "Test.Type" },
+        };
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns([priorEntry]);
+
+        string nupkg = BuildNupkg();
+
+        WorkloadInstaller installer = NewInstaller();
+        WorkloadInstallResult result = await installer.InstallFromPackageAsync(nupkg);
+
+        Assert.True(result.AlreadyInstalled);
+        Assert.Same(priorEntry, result.Entry);
+        await _store.DidNotReceive().SaveWorkloadAsync(Arg.Any<WorkloadEntry>(), Arg.Any<CancellationToken>());
+        await _store.DidNotReceive().RemoveWorkloadAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InstallFromPackage_AlreadyInstalled_DirOnly_NoRegistryEntry_Throws()
+    {
+        // Half-installed leftover (directory exists but registry has no
+        // matching row) is treated as a broken install: tell the user to
+        // pass --force to repair.
+        string installDir = _paths.GetInstallDirectory("test.workload", "1.0.0");
+        Directory.CreateDirectory(installDir);
+
+        string nupkg = BuildNupkg();
+
+        WorkloadInstaller installer = NewInstaller();
+        InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => installer.InstallFromPackageAsync(nupkg));
+        Assert.Contains("missing from the registry", ex.Message);
+        Assert.Contains("--force", ex.Message);
+    }
+
+    [Fact]
+    public async Task InstallFromPackage_AlreadyInstalled_Force_ReplacesInstall()
+    {
+        string installDir = _paths.GetInstallDirectory("test.workload", "1.0.0");
+        Directory.CreateDirectory(installDir);
+        string stalePath = Path.Combine(installDir, "stale.txt");
+        File.WriteAllText(stalePath, "leftover from prior install");
+
+        string nupkg = BuildNupkg();
+        _store.RemoveWorkloadAsync("test.workload", "1.0.0", Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        WorkloadInstaller installer = NewInstaller();
+        WorkloadInstallResult result = await installer.InstallFromPackageAsync(nupkg, force: true);
+
+        Assert.False(result.AlreadyInstalled);
+        Assert.Equal("test.workload", result.Entry.PackageId);
+        Assert.False(File.Exists(stalePath), "Stale files from the prior install must be gone after a forced reinstall.");
+        Assert.True(File.Exists(Path.Combine(installDir, "tools", "any", "Test.dll")));
+        await _store.Received(1).RemoveWorkloadAsync("test.workload", "1.0.0", Arg.Any<CancellationToken>());
+        await _store.Received(1).SaveWorkloadAsync(Arg.Any<WorkloadEntry>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InstallFromPackage_StoreFails_RollsBackInstallDir()
+    {
+        string nupkg = BuildNupkg();
+        _store.SaveWorkloadAsync(Arg.Any<WorkloadEntry>(), Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("disk full"));
+
+        WorkloadInstaller installer = NewInstaller();
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => installer.InstallFromPackageAsync(nupkg));
+
+        Assert.False(Directory.Exists(_paths.GetInstallDirectory("test.workload", "1.0.0")));
+    }
+
+    [Fact]
+    public async Task Uninstall_RemovesEntryAndDirectory()
+    {
+        string installDir = _paths.GetInstallDirectory("test.workload", "1.0.0");
+        Directory.CreateDirectory(installDir);
+        File.WriteAllText(Path.Combine(installDir, "Test.dll"), "stub");
+        _store.RemoveWorkloadAsync("test.workload", "1.0.0", Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        WorkloadInstaller installer = NewInstaller();
+        bool removed = await installer.UninstallAsync("test.workload", "1.0.0");
+
+        Assert.True(removed);
+        Assert.False(Directory.Exists(installDir));
+    }
+
+    [Fact]
+    public async Task Uninstall_NoSuchEntry_ReturnsFalse_LeavesDirectoryAlone()
+    {
+        string installDir = _paths.GetInstallDirectory("test.workload", "1.0.0");
+        Directory.CreateDirectory(installDir);
+        _store.RemoveWorkloadAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        WorkloadInstaller installer = NewInstaller();
+        bool removed = await installer.UninstallAsync("test.workload", "1.0.0");
+
+        Assert.False(removed);
+        Assert.True(Directory.Exists(installDir));
+    }
+
+    [Fact]
+    public async Task InstallFromPackage_ContentOnly_PersistsContentKind()
+    {
+        string nupkg = BuildNupkg();
+        _metadataReader.Read(Arg.Any<string>())
+            .Returns(new WorkloadMetadata { Schema = "https://example/workload.schema.json", Kind = WorkloadKind.Content });
+
+        WorkloadInstaller installer = NewInstaller();
+        WorkloadInstallResult result = await installer.InstallFromPackageAsync(nupkg);
+
+        Assert.Equal(WorkloadKind.Content, result.Entry.Kind);
+        Assert.Null(result.Entry.EntryPoint);
+
+        await _store.Received(1).SaveWorkloadAsync(
+            Arg.Is<WorkloadEntry>(e => e.Kind == WorkloadKind.Content && e.EntryPoint == null),
+            Arg.Any<CancellationToken>());
+    }
+
+    private WorkloadInstaller NewInstaller() => new(_paths, _store, _metadataReader);
+
+    private string BuildNupkg(string? tags = null, bool includeFuncCliWorkloadType = true)
+    {
+        string stubAssembly = Path.Combine(_root, $"stub-{Guid.NewGuid():N}.dll");
+        File.WriteAllBytes(stubAssembly, [0x4D, 0x5A]);
+
+        var builder = new PackageBuilder
+        {
+            Id = "Test.Workload",
+            Version = NuGetVersion.Parse("1.0.0"),
+            Description = "For tests.",
+        };
+        builder.Authors.Add("test");
+        if (tags is not null)
+        {
+            foreach (string tag in tags.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+            {
+                builder.Tags.Add(tag);
+            }
+        }
+
+        if (includeFuncCliWorkloadType)
+        {
+            builder.PackageTypes.Add(new PackageType(WorkloadInstaller.FuncCliWorkloadPackageType, new Version(0, 0)));
+        }
+
+        builder.Files.Add(new PhysicalPackageFile
+        {
+            SourcePath = stubAssembly,
+            TargetPath = $"tools/{NuGetFramework.Parse("any").GetShortFolderName()}/Test.dll",
+        });
+
+        string path = Path.Combine(_root, $"Test.Workload.{Guid.NewGuid():N}.nupkg");
+        using (FileStream stream = File.Create(path))
+        {
+            builder.Save(stream);
+        }
+
+        return path;
+    }
+}

--- a/test/Func.Tests/Workloads/Loading/WorkloadLoaderTests.cs
+++ b/test/Func.Tests/Workloads/Loading/WorkloadLoaderTests.cs
@@ -212,10 +212,13 @@ public class WorkloadLoaderTests
 
     private static IWorkloadPaths StubPaths()
     {
-        // Loader resolves the assembly via paths.GetInstallDirectory(...).
-        // Test fixtures sit next to the test bin directory, so return that
-        // for any (packageId, version) pair the tests pass.
+        // Loader resolves assemblies via paths.GetInstallDirectory + tools/any.
+        // Fixture dlls land at <BaseDirectory>/tools/any/<file> via test
+        // project copies, so returning BaseDirectory as the install directory
+        // lines up with a registry entry of AssemblyPath = "<file>" without
+        // having to materialise a <pkgid>/<version>/tools/any tree.
         var paths = Substitute.For<IWorkloadPaths>();
+        paths.WorkloadsRoot.Returns(AppContext.BaseDirectory);
         paths.GetInstallDirectory(Arg.Any<string>(), Arg.Any<string>())
             .Returns(AppContext.BaseDirectory);
         return paths;


### PR DESCRIPTION
Adds `func workload install` and `func workload uninstall`. Read-side (`func workload list`) already shipped on `vnext` (#4925, #4937). Stacked on the workload abstraction refactor in #4939.

## `func workload install <id>`

```
func workload install <id> [options]

Arguments:
  <id>   Workload to install. Currently must be a path to a .nupkg on disk.
```

- Nupkg-on-disk only for now. Resolving an id against a NuGet feed is a follow-up.
- Validates the package's nuspec carries the `FuncCliWorkload` package type.
- Extracts to `~/.azure-functions/workloads/<id>/<version>/` and records a registry entry.
- Aliases come from nuspec tags prefixed `alias:` (e.g. `alias:dotnet alias:dotnet-isolated`).

## `func workload uninstall <id> [-v <version>] [-a]`

```
func workload uninstall <id> [options]

Arguments:
  <id>   ID or alias of the workload to uninstall.

Options:
  --version, -v       Specific version to uninstall. Omit when only one version is installed.
  --all-versions, -a  Uninstall every installed version of the workload.
```

- Resolves `<id>` against `PackageId` first, then aliases (case-insensitive). Ambiguous aliases prompt for an id.
- With multiple installed versions and no `--version` / `--all-versions`, fails and lists the installed versions.
- `--version` and `--all-versions` are mutually exclusive.
- Removes the `<id>/<version>/` directory and the registry entry.

## Path shape

`assemblyPath` has two shapes that the installer translates between:

- **`workload.json` (package-root-relative)** - what the author writes, e.g. `tools/any/Foo.dll`.
- **`workloads.json` (workloads-root-relative)** - what the installer persists, e.g. `<id>/<version>/tools/any/Foo.dll`.

Loader resolves entries with a single concat against `WorkloadsRoot`. No magic `tools/any` injection.

## Tests

188 pass. New: `WorkloadInstallCommandTests`, `WorkloadUninstallCommandTests`, `WorkloadInstallerTests`.

## Docs

`docs/building-a-workload.md`, `docs/cli-architecture.md`, `docs/repo-structure.md` updated.
