### PR TITLE
Fix --nozip publish when run-from-package is set

### DIFF
--- a/src/Cli/func/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Cli/func/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -650,11 +650,13 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             else if (functionApp.IsLinux && functionApp.IsDynamic)
             {
                 // Consumption Linux
+                WarnIfNoZipIsUnsupported(functionApp);
                 shouldSyncTriggers = await HandleLinuxConsumptionPublish(functionApp, zipStreamFactory);
             }
             else if (functionApp.IsFlex)
             {
                 // Flex
+                WarnIfNoZipIsUnsupported(functionApp);
                 shouldSyncTriggers = await HandleFlexConsumptionPublish(functionApp, zipStreamFactory);
             }
             else if (functionApp.IsLinux && functionApp.IsElasticPremium)
@@ -684,6 +686,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 shouldSyncTriggers = false;
 
                 // "--no-zip"
+                await EnsureNoRunFromPackageSetting(functionApp);
                 await PublishZipDeploy(functionApp, zipStreamFactory);
             }
 
@@ -716,6 +719,18 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             {
                 await AzureHelper.PrintFunctionsInfo(functionApp, AccessToken, ManagementURL, showKeys: ShowKeys);
             }
+        }
+
+        private void WarnIfNoZipIsUnsupported(Site functionApp)
+        {
+            if (RunFromPackageDeploy)
+            {
+                return;
+            }
+
+            var plan = functionApp.IsFlex ? "Flex Consumption" : "Linux Consumption";
+            ColoredConsole.WriteLine(WarningColor(
+                $"The --nozip flag is not supported for {plan} Function Apps. This deployment will use Run-From-Package."));
         }
 
         private async Task SyncTriggers(Site functionApp)
@@ -1011,6 +1026,42 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             ColoredConsole.WriteLine("Deployment completed successfully.");
         }
 
+        private async Task EnsureNoRunFromPackageSetting(Site functionApp)
+        {
+            if (!RemoveRunFromPackageSetting(functionApp, out _))
+            {
+                return;
+            }
+
+            ColoredConsole.WriteLine(WarningColor(
+                $"Removing {Constants.WebsiteRunFromPackage} app setting before --nozip deployment."));
+            var result = await AzureHelper.UpdateFunctionAppAppSettings(functionApp, AccessToken, ManagementURL);
+            if (!result.IsSuccessful)
+            {
+                throw new CliException($"Error when removing app settings: {result.ErrorResult}.");
+            }
+
+            await WaitForAppSettingUpdateSCM(
+                functionApp,
+                shouldHaveSettings: functionApp.AzureAppSettings,
+                shouldNotHaveSettings: new Dictionary<string, string> { { Constants.WebsiteRunFromPackage, null } },
+                timeOutSeconds: 300);
+        }
+
+        internal static bool RemoveRunFromPackageSetting(Site functionApp, out IDictionary<string, string> removedSettings)
+        {
+            removedSettings = new Dictionary<string, string>();
+
+            if (functionApp.AzureAppSettings.TryGetValue(Constants.WebsiteRunFromPackage, out string value))
+            {
+                removedSettings[Constants.WebsiteRunFromPackage] = value;
+                functionApp.AzureAppSettings.Remove(Constants.WebsiteRunFromPackage);
+                return true;
+            }
+
+            return false;
+        }
+
         private async Task WaitForAppSettingUpdateSCM(
             Site functionApp,
             IDictionary<string, string> shouldHaveSettings = null,
@@ -1063,7 +1114,8 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                         {
                             foreach (KeyValuePair<string, string> keyValuePair in shouldNotHaveSettings)
                             {
-                                if (scmSettingsDict.ContainsKey(keyValuePair.Key) && scmSettingsDict[keyValuePair.Key] == keyValuePair.Value)
+                                if (scmSettingsDict.ContainsKey(keyValuePair.Key) &&
+                                    (keyValuePair.Value == null || scmSettingsDict[keyValuePair.Key] == keyValuePair.Value))
                                 {
                                     scmUpdated = false;
                                     break;

--- a/test/Cli/Func.UnitTests/ActionsTests/PublishFunctionAppActionTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/PublishFunctionAppActionTests.cs
@@ -3,6 +3,7 @@
 
 using Azure.Functions.Cli.Actions.AzureActions;
 using Azure.Functions.Cli.Arm.Models;
+using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Helpers;
 using Azure.Functions.Cli.StacksApi;
 using Moq;
@@ -200,6 +201,53 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
             helperServiceMock.Verify(
                 x => x.UpdateWebSettings(It.IsAny<Site>(), It.IsAny<Dictionary<string, string>>()),
                 Times.Never);
+        }
+
+        [Theory]
+        [InlineData("1")]
+        [InlineData("0")]
+        [InlineData("")]
+        public void RemoveRunFromPackageSetting_RemovesExistingSettingRegardlessOfValue(string value)
+        {
+            // Arrange
+            var site = new Site("test-site")
+            {
+                AzureAppSettings = new Dictionary<string, string>
+                {
+                    { Constants.WebsiteRunFromPackage, value },
+                    { "OTHER_SETTING", "present" }
+                }
+            };
+
+            // Act
+            var removed = PublishFunctionAppAction.RemoveRunFromPackageSetting(site, out var removedSettings);
+
+            // Assert
+            Assert.True(removed);
+            Assert.False(site.AzureAppSettings.ContainsKey(Constants.WebsiteRunFromPackage));
+            Assert.Equal("present", site.AzureAppSettings["OTHER_SETTING"]);
+            Assert.Equal(value, removedSettings[Constants.WebsiteRunFromPackage]);
+        }
+
+        [Fact]
+        public void RemoveRunFromPackageSetting_WhenAbsent_DoesNotMutateSettings()
+        {
+            // Arrange
+            var site = new Site("test-site")
+            {
+                AzureAppSettings = new Dictionary<string, string>
+                {
+                    { "OTHER_SETTING", "present" }
+                }
+            };
+
+            // Act
+            var removed = PublishFunctionAppAction.RemoveRunFromPackageSetting(site, out var removedSettings);
+
+            // Assert
+            Assert.False(removed);
+            Assert.Equal("present", site.AzureAppSettings["OTHER_SETTING"]);
+            Assert.Empty(removedSettings);
         }
 
         private static FlexFunctionsStacks CreateMockFlexStacks()


### PR DESCRIPTION
Fixes #3352.

## Summary
- remove `WEBSITE_RUN_FROM_PACKAGE` before the Windows `--nozip` zipdeploy path so Kudu does not keep treating the upload as Run-From-Package
- wait for SCM settings to observe the removal before calling zipdeploy
- warn when `--nozip` is requested for Linux Consumption or Flex Consumption, where publish still has to use Run-From-Package
- add unit coverage for removing `WEBSITE_RUN_FROM_PACKAGE` regardless of whether the existing value is `1`, `0`, or empty

## Validation
- `git diff --check`
- Not run locally: this machine does not have the .NET SDK (`dotnet`, `csc`, and `msbuild` are unavailable).