### PR TITLE
Choose unique default names for func new

### DIFF
--- a/src/Cli/func/Actions/LocalActions/CreateFunctionAction.cs
+++ b/src/Cli/func/Actions/LocalActions/CreateFunctionAction.cs
@@ -270,9 +270,12 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                         ConfigureAuthorizationLevel(template);
                     }
 
-                    ColoredConsole.Write($"Function name: [{template.Metadata.DefaultFunctionName}] ");
+                    var defaultFunctionName = GetUniqueDefaultFunctionName(
+                        template.Metadata.DefaultFunctionName,
+                        functionName => FunctionArtifactExists(functionName, FileName, template));
+                    ColoredConsole.Write($"Function name: [{defaultFunctionName}] ");
                     FunctionName = FunctionName ?? Console.ReadLine();
-                    FunctionName = string.IsNullOrEmpty(FunctionName) ? template.Metadata.DefaultFunctionName : FunctionName;
+                    FunctionName = string.IsNullOrEmpty(FunctionName) ? defaultFunctionName : FunctionName;
                     await _templatesManager.Deploy(FunctionName, FileName, template);
                     PerformPostDeployTasks(FunctionName, Language);
                 }
@@ -468,6 +471,45 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 var binding = bindings.Where(b => b["type"].ToString().Equals(HttpTriggerTemplateName, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
                 binding["authLevel"] = AuthorizationLevel.ToString().ToLowerInvariant();
             }
+        }
+
+        internal static string GetUniqueDefaultFunctionName(string defaultFunctionName, Func<string, bool> functionExists)
+        {
+            if (!functionExists(defaultFunctionName))
+            {
+                return defaultFunctionName;
+            }
+
+            var index = 1;
+            string candidate;
+            do
+            {
+                candidate = $"{defaultFunctionName}{index}";
+                index++;
+            }
+            while (functionExists(candidate));
+
+            return candidate;
+        }
+
+        private static bool FunctionArtifactExists(string functionName, string fileName, Template template)
+        {
+            if (IsNodeV4Template(template))
+            {
+                return template.Files
+                    .Where(file => !file.Key.EndsWith(".dat"))
+                    .Select(file => fileName ?? file.Key.Replace("%functionName%", functionName))
+                    .Any(name => FileSystemHelpers.FileExists(
+                        Path.Combine(Environment.CurrentDirectory, "src", "functions", name)));
+            }
+
+            return FileSystemHelpers.DirectoryExists(Path.Combine(Environment.CurrentDirectory, functionName));
+        }
+
+        private static bool IsNodeV4Template(Template template)
+        {
+            return template.Id.EndsWith("JavaScript-4.x", StringComparison.OrdinalIgnoreCase) ||
+                template.Id.EndsWith("TypeScript-4.x", StringComparison.OrdinalIgnoreCase);
         }
 
         private bool InferAndUpdateLanguage(WorkerRuntime workerRuntime)

--- a/src/Cli/func/Actions/LocalActions/CreateFunctionAction.cs
+++ b/src/Cli/func/Actions/LocalActions/CreateFunctionAction.cs
@@ -153,9 +153,12 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                     ColoredConsole.WriteLine($"Template: {TemplateName}");
                 }
 
-                ColoredConsole.Write($"Function name: [{TemplateName}] ");
+                var defaultFunctionName = GetUniqueDefaultFunctionName(
+                    TemplateName,
+                    functionName => DotnetFunctionArtifactExists(functionName, Language));
+                ColoredConsole.Write($"Function name: [{defaultFunctionName}] ");
                 FunctionName = FunctionName ?? Console.ReadLine();
-                FunctionName = string.IsNullOrEmpty(FunctionName) ? TemplateName : FunctionName;
+                FunctionName = string.IsNullOrEmpty(FunctionName) ? defaultFunctionName : FunctionName;
                 ColoredConsole.WriteLine(FunctionName);
                 var namespaceStr = Path.GetFileName(Environment.CurrentDirectory);
                 await DotnetHelpers.DeployDotnetFunction(TemplateName.Replace(" ", string.Empty), Utilities.SanitizeClassName(FunctionName), Utilities.SanitizeNameSpace(namespaceStr), Language.Replace("-isolated", string.Empty), _workerRuntime, AuthorizationLevel);
@@ -219,9 +222,10 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 }
 
                 var templateJob = template.Jobs.Single(x => x.Type.Equals(jobName, StringComparison.OrdinalIgnoreCase));
+                var templateJobInputs = GetTemplateJobInputsWithUniquePythonV2Default(templateJob.Inputs, FileName);
 
                 var variables = new Dictionary<string, string>();
-                _userInputHandler.RunUserInputActions(providedInputs, templateJob.Inputs, variables);
+                _userInputHandler.RunUserInputActions(providedInputs, templateJobInputs, variables);
 
                 if (string.IsNullOrEmpty(FunctionName))
                 {
@@ -270,9 +274,11 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                         ConfigureAuthorizationLevel(template);
                     }
 
-                    var defaultFunctionName = GetUniqueDefaultFunctionName(
-                        template.Metadata.DefaultFunctionName,
-                        functionName => FunctionArtifactExists(functionName, FileName, template));
+                    var defaultFunctionName = ShouldUseUniqueDefaultFunctionName(FileName, template)
+                        ? GetUniqueDefaultFunctionName(
+                            template.Metadata.DefaultFunctionName,
+                            functionName => FunctionArtifactExists(functionName, FileName, template))
+                        : template.Metadata.DefaultFunctionName;
                     ColoredConsole.Write($"Function name: [{defaultFunctionName}] ");
                     FunctionName = FunctionName ?? Console.ReadLine();
                     FunctionName = string.IsNullOrEmpty(FunctionName) ? defaultFunctionName : FunctionName;
@@ -492,9 +498,74 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             return candidate;
         }
 
+        internal static bool ShouldUseUniqueDefaultFunctionName(string fileName, Template template)
+        {
+            return !TemplateHelpers.IsNodeV4Template(template) || string.IsNullOrEmpty(fileName);
+        }
+
+        internal static bool DotnetFunctionArtifactExists(string functionName, string language)
+        {
+            var fileExtension = language.Replace("-isolated", string.Empty).Equals(Languages.FSharp, StringComparison.OrdinalIgnoreCase)
+                ? ".fs"
+                : ".cs";
+            var fileName = $"{Utilities.SanitizeClassName(functionName)}{fileExtension}";
+
+            return FileSystemHelpers.FileExists(Path.Combine(Environment.CurrentDirectory, fileName));
+        }
+
+        internal static bool PythonV2FunctionArtifactExists(string functionName, string fileName)
+        {
+            var functionAppPath = Path.Combine(Environment.CurrentDirectory, string.IsNullOrEmpty(fileName) ? PySteinFunctionAppPy : fileName);
+            if (!FileSystemHelpers.FileExists(functionAppPath))
+            {
+                return false;
+            }
+
+            var fileContent = FileSystemHelpers.ReadAllTextFromFile(functionAppPath);
+            return Regex.IsMatch(fileContent, $@"^\s*def\s+{Regex.Escape(functionName)}\s*\(", RegexOptions.Multiline) ||
+                Regex.IsMatch(fileContent, $@"@(?:[\w]+\.)?function_name\(name\s*=\s*[""']{Regex.Escape(functionName)}[""']\)", RegexOptions.Multiline);
+        }
+
+        private IList<TemplateJobInput> GetTemplateJobInputsWithUniquePythonV2Default(IList<TemplateJobInput> inputs, string fileName)
+        {
+            if (!string.IsNullOrEmpty(FunctionName))
+            {
+                return inputs;
+            }
+
+            var functionNameInput = inputs.FirstOrDefault(input => string.Equals(input.ParamId, GetFunctionNameParamId, StringComparison.OrdinalIgnoreCase));
+            if (functionNameInput is null)
+            {
+                return inputs;
+            }
+
+            var defaultFunctionName = functionNameInput.DefaultValue ??
+                _userPrompts.FirstOrDefault(prompt => string.Equals(prompt.Id, GetFunctionNameParamId, StringComparison.OrdinalIgnoreCase))?.DefaultValue;
+            if (string.IsNullOrEmpty(defaultFunctionName))
+            {
+                return inputs;
+            }
+
+            var uniqueDefaultFunctionName = GetUniqueDefaultFunctionName(
+                defaultFunctionName,
+                functionName => PythonV2FunctionArtifactExists(functionName, fileName));
+
+            return inputs
+                .Select(input => string.Equals(input.ParamId, GetFunctionNameParamId, StringComparison.OrdinalIgnoreCase)
+                    ? new TemplateJobInput
+                    {
+                        AssignTo = input.AssignTo,
+                        ParamId = input.ParamId,
+                        DefaultValue = uniqueDefaultFunctionName,
+                        IsRequired = input.IsRequired
+                    }
+                    : input)
+                .ToList();
+        }
+
         private static bool FunctionArtifactExists(string functionName, string fileName, Template template)
         {
-            if (IsNodeV4Template(template))
+            if (TemplateHelpers.IsNodeV4Template(template))
             {
                 return template.Files
                     .Where(file => !file.Key.EndsWith(".dat"))
@@ -504,12 +575,6 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             }
 
             return FileSystemHelpers.DirectoryExists(Path.Combine(Environment.CurrentDirectory, functionName));
-        }
-
-        private static bool IsNodeV4Template(Template template)
-        {
-            return template.Id.EndsWith("JavaScript-4.x", StringComparison.OrdinalIgnoreCase) ||
-                template.Id.EndsWith("TypeScript-4.x", StringComparison.OrdinalIgnoreCase);
         }
 
         private bool InferAndUpdateLanguage(WorkerRuntime workerRuntime)

--- a/src/Cli/func/Common/Template.cs
+++ b/src/Cli/func/Common/Template.cs
@@ -21,6 +21,15 @@ namespace Azure.Functions.Cli.Common
         public Dictionary<string, string> Files { get; set; }
     }
 
+    internal static class TemplateHelpers
+    {
+        public static bool IsNodeV4Template(Template template)
+        {
+            return template.Id.EndsWith("JavaScript-4.x", StringComparison.OrdinalIgnoreCase) ||
+                template.Id.EndsWith("TypeScript-4.x", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
     internal class TemplateMetadata
     {
         [JsonProperty("name")]

--- a/src/Cli/func/Common/TemplatesManager.cs
+++ b/src/Cli/func/Common/TemplatesManager.cs
@@ -142,7 +142,7 @@ namespace Azure.Functions.Cli.Common
 
         public async Task Deploy(string name, string fileName, Template template)
         {
-            if (template.Id.EndsWith("JavaScript-4.x", StringComparison.OrdinalIgnoreCase) || template.Id.EndsWith("TypeScript-4.x", StringComparison.OrdinalIgnoreCase))
+            if (TemplateHelpers.IsNodeV4Template(template))
             {
                 await DeployNewNodeProgrammingModel(name, fileName, template);
             }

--- a/test/Cli/Func.UnitTests/ActionsTests/CreateFunctionActionTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/CreateFunctionActionTests.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Azure.Functions.Cli.Actions.LocalActions;
+using Xunit;
+
+namespace Azure.Functions.Cli.UnitTests.ActionsTests
+{
+    public class CreateFunctionActionTests
+    {
+        [Fact]
+        public void GetUniqueDefaultFunctionName_ReturnsDefault_WhenAvailable()
+        {
+            var result = CreateFunctionAction.GetUniqueDefaultFunctionName("HttpTrigger", _ => false);
+
+            Assert.Equal("HttpTrigger", result);
+        }
+
+        [Fact]
+        public void GetUniqueDefaultFunctionName_IncrementsUntilNameIsAvailable()
+        {
+            var existingNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "HttpTrigger",
+                "HttpTrigger1",
+                "HttpTrigger2"
+            };
+
+            var result = CreateFunctionAction.GetUniqueDefaultFunctionName("HttpTrigger", existingNames.Contains);
+
+            Assert.Equal("HttpTrigger3", result);
+        }
+    }
+}

--- a/test/Cli/Func.UnitTests/ActionsTests/CreateFunctionActionTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/CreateFunctionActionTests.cs
@@ -4,7 +4,10 @@
 using System;
 using System.Collections.Generic;
 using Azure.Functions.Cli.Actions.LocalActions;
+using Azure.Functions.Cli.Common;
+using NSubstitute;
 using Xunit;
+using static Azure.Functions.Cli.Common.Constants;
 
 namespace Azure.Functions.Cli.UnitTests.ActionsTests
 {
@@ -31,6 +34,64 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
             var result = CreateFunctionAction.GetUniqueDefaultFunctionName("HttpTrigger", existingNames.Contains);
 
             Assert.Equal("HttpTrigger3", result);
+        }
+
+        [Fact]
+        public void ShouldUseUniqueDefaultFunctionName_ReturnsFalse_ForNodeV4WithFixedFileName()
+        {
+            var template = new Template { Id = "HttpTrigger-JavaScript-4.x" };
+
+            var result = CreateFunctionAction.ShouldUseUniqueDefaultFunctionName("functions.js", template);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void ShouldUseUniqueDefaultFunctionName_ReturnsTrue_ForNodeV4WithoutFixedFileName()
+        {
+            var template = new Template { Id = "HttpTrigger-JavaScript-4.x" };
+
+            var result = CreateFunctionAction.ShouldUseUniqueDefaultFunctionName(null, template);
+
+            Assert.True(result);
+        }
+
+        [Theory]
+        [InlineData(Languages.CSharp, "HttpTrigger.cs")]
+        [InlineData(Languages.FSharp, "HttpTrigger.fs")]
+        public void DotnetFunctionArtifactExists_ChecksGeneratedFunctionFile(string language, string expectedFileName)
+        {
+            var fileSystem = Substitute.For<System.IO.Abstractions.IFileSystem>();
+            fileSystem.File.Exists(Arg.Is<string>(path => path.EndsWith(expectedFileName, StringComparison.Ordinal))).Returns(true);
+
+            using (FileSystemHelpers.Override(fileSystem))
+            {
+                var result = CreateFunctionAction.DotnetFunctionArtifactExists("HttpTrigger", language);
+
+                Assert.True(result);
+            }
+        }
+
+        [Fact]
+        public void PythonV2FunctionArtifactExists_ChecksExistingFunctionDefinition()
+        {
+            var fileSystem = Substitute.For<System.IO.Abstractions.IFileSystem>();
+            fileSystem.File.Exists(Arg.Any<string>()).Returns(true);
+            fileSystem.File.ReadAllText(Arg.Any<string>()).Returns(
+                "import azure.functions as func\n" +
+                "\n" +
+                "app = func.FunctionApp()\n" +
+                "\n" +
+                "@app.route(route=\"HttpTrigger\")\n" +
+                "def HttpTrigger(req: func.HttpRequest) -> func.HttpResponse:\n" +
+                "    pass\n");
+
+            using (FileSystemHelpers.Override(fileSystem))
+            {
+                var result = CreateFunctionAction.PythonV2FunctionArtifactExists("HttpTrigger", PySteinFunctionAppPy);
+
+                Assert.True(result);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #3262.

## Summary
- when `func new` offers a default function name, choose the first available name instead of defaulting to an existing artifact
- use `HttpTrigger`, `HttpTrigger1`, `HttpTrigger2`, ... style naming for classic folder templates and Node v4 file templates
- add unit coverage for the default-name increment helper

## Validation
- `git diff --check`
- Not run locally: this machine does not have the .NET SDK (`dotnet`, `csc`, and `msbuild` are unavailable).