### PR TITLE
Address PR #4912 review feedback

### DIFF
--- a/docs/building-a-workload.md
+++ b/docs/building-a-workload.md
@@ -250,8 +250,8 @@ public sealed class DurableWorkload : IWorkload
     {
         // Pick the overload that fits how your command is constructed:
         //   builder.RegisterCommand(new DurableCommand());        // simple instance
-        //   builder.RegisterCommand<DurableCommand>();            // DI-constructed
-        //   builder.RegisterCommand(sp => new DurableCommand(...)); // custom factory
+        //   builder.RegisterCommand<DurableCommand>();            // DI-constructed (recommended)
+        //   builder.RegisterCommand(typeof(DurableCommand));      // by runtime Type
         builder.RegisterCommand<DurableCommand>();
     }
 }

--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -234,7 +234,7 @@ Configure (CLI startup):
             └── builder.Services.AddSingleton<IProjectInitializer, …>()
                 builder.RegisterCommand(new MyTopLevelCommand())     // optional
                 builder.RegisterCommand<MyDiCommand>()               // optional
-                builder.RegisterCommand(sp => new MyFactoryCommand(...)) // optional
+                builder.RegisterCommand(typeof(MyByTypeCommand))     // optional
 
 Build commands (Parser.CreateCommand):
   ├── Resolve every FuncCliCommand from DI:

--- a/src/Abstractions/Workloads/FunctionsCliBuilder.cs
+++ b/src/Abstractions/Workloads/FunctionsCliBuilder.cs
@@ -33,12 +33,15 @@ public abstract class FunctionsCliBuilder
     public void RegisterCommand(FuncCommand command)
     {
         ArgumentNullException.ThrowIfNull(command);
-        OnRegisterCommand(command);
+        OnRegisterCommand(_ => command);
     }
 
     /// <summary>
-    /// Registers a top-level command by type. The command is constructed by
-    /// the DI container, so it can request services through its constructor.
+    /// Registers a top-level command by type. The command is constructed
+    /// through <see cref="ActivatorUtilities.GetServiceOrCreateInstance(IServiceProvider, Type)"/>,
+    /// so it can request services through its constructor without the
+    /// workload needing to register the command type itself with
+    /// <see cref="Services"/>.
     /// </summary>
     /// <typeparam name="TCommand">A concrete <see cref="FuncCommand"/>.</typeparam>
     /// <exception cref="ArgumentException"><typeparamref name="TCommand"/> is abstract.</exception>
@@ -52,30 +55,49 @@ public abstract class FunctionsCliBuilder
                 nameof(TCommand));
         }
 
-        OnRegisterCommand<TCommand>();
+        OnRegisterCommand(sp => ActivatorUtilities.GetServiceOrCreateInstance<TCommand>(sp));
     }
 
     /// <summary>
-    /// Registers a top-level command produced by <paramref name="factory"/>.
-    /// Useful when the command needs services not registered through
-    /// <see cref="Services"/>, or when constructing the command requires
-    /// custom logic.
+    /// Registers a top-level command by runtime <see cref="Type"/>. Useful
+    /// when the command type is only known at runtime (e.g. discovered from
+    /// configuration). The type must be a concrete <see cref="FuncCommand"/>;
+    /// it is constructed through
+    /// <see cref="ActivatorUtilities.GetServiceOrCreateInstance(IServiceProvider, Type)"/>.
     /// </summary>
-    /// <exception cref="ArgumentNullException"><paramref name="factory"/> is <c>null</c>.</exception>
-    public void RegisterCommand(Func<IServiceProvider, FuncCommand> factory)
+    /// <param name="commandType">A concrete type assignable to <see cref="FuncCommand"/>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="commandType"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="commandType"/> is not assignable to <see cref="FuncCommand"/>, or it is abstract.
+    /// </exception>
+    public void RegisterCommand(Type commandType)
     {
-        ArgumentNullException.ThrowIfNull(factory);
-        OnRegisterCommand(factory);
+        ArgumentNullException.ThrowIfNull(commandType);
+
+        if (!typeof(FuncCommand).IsAssignableFrom(commandType))
+        {
+            throw new ArgumentException(
+                $"Type '{commandType}' is not assignable to {nameof(FuncCommand)}.",
+                nameof(commandType));
+        }
+
+        if (commandType.IsAbstract)
+        {
+            throw new ArgumentException(
+                $"Cannot register abstract command type '{commandType}'. Pass a concrete FuncCommand subclass.",
+                nameof(commandType));
+        }
+
+        OnRegisterCommand(sp => (FuncCommand)ActivatorUtilities.GetServiceOrCreateInstance(sp, commandType));
     }
 
-    /// <summary>Hook implemented by the host to wire a <see cref="FuncCommand"/> instance.</summary>
-    protected abstract void OnRegisterCommand(FuncCommand command);
-
-    /// <summary>Hook implemented by the host to wire a <see cref="FuncCommand"/> by type.</summary>
-    protected abstract void OnRegisterCommand<TCommand>()
-        where TCommand : FuncCommand;
-
-    /// <summary>Hook implemented by the host to wire a <see cref="FuncCommand"/> via a factory.</summary>
+    /// <summary>
+    /// Hook implemented by the host to wire a <see cref="FuncCommand"/>
+    /// produced by <paramref name="factory"/> into the parser. The factory
+    /// is invoked when the host resolves commands; it is given the host's
+    /// <see cref="IServiceProvider"/> so the command can request services.
+    /// </summary>
     protected abstract void OnRegisterCommand(Func<IServiceProvider, FuncCommand> factory);
 }
+
 

--- a/src/Func/Hosting/DefaultFunctionsCliBuilder.cs
+++ b/src/Func/Hosting/DefaultFunctionsCliBuilder.cs
@@ -43,20 +43,6 @@ internal sealed class DefaultFunctionsCliBuilder : FunctionsCliBuilder
 
     public override IServiceCollection Services { get; }
 
-    protected override void OnRegisterCommand(FuncCommand command)
-    {
-        var workload = RequireWorkload();
-        Services.AddSingleton<FuncCliCommand>(_ => new ExternalCommand(workload, command));
-    }
-
-    protected override void OnRegisterCommand<TCommand>()
-    {
-        var workload = RequireWorkload();
-        Services.AddSingleton<TCommand>();
-        Services.AddSingleton<FuncCliCommand>(sp =>
-            new ExternalCommand(workload, sp.GetRequiredService<TCommand>()));
-    }
-
     protected override void OnRegisterCommand(Func<IServiceProvider, FuncCommand> factory)
     {
         var workload = RequireWorkload();

--- a/src/Func/Workloads/ExternalCommand.cs
+++ b/src/Func/Workloads/ExternalCommand.cs
@@ -177,8 +177,8 @@ internal sealed class ExternalCommand : FuncCliCommand
         }
     }
 
-    private InvalidOperationException BuildSourceError(string message)
-        => new($"Workload '{Workload.PackageId}' {message}");
+    private WorkloadOperationException BuildSourceError(string message)
+        => new(Workload, message);
 
     private static Option<T> CreateTypedOption<T>(FuncCommandOption descriptor)
     {

--- a/src/Func/Workloads/WorkloadOperationException.cs
+++ b/src/Func/Workloads/WorkloadOperationException.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workloads;
+
+/// <summary>
+/// Raised when the host detects that a workload-supplied <see cref="FuncCommand"/>
+/// declares its options, arguments, or subcommands in a way the CLI cannot
+/// honor (duplicate names, null entries, missing metadata, etc.). Carrying the
+/// owning <see cref="WorkloadInfo"/> lets the top-level error handler attribute
+/// the failure to the workload that produced it instead of presenting a
+/// generic <see cref="InvalidOperationException"/>.
+///
+/// Internal because the throw sites all run inside <see cref="ExternalCommand"/>
+/// after the workload's <see cref="IWorkload.Configure"/> has already returned;
+/// workload code is never on the call stack and does not need to catch this.
+/// </summary>
+internal sealed class WorkloadOperationException : Exception
+{
+    public WorkloadOperationException(WorkloadInfo workload, string message)
+        : base(BuildMessage(workload, message))
+    {
+        Workload = workload;
+    }
+
+    public WorkloadOperationException(WorkloadInfo workload, string message, Exception innerException)
+        : base(BuildMessage(workload, message), innerException)
+    {
+        Workload = workload;
+    }
+
+    /// <summary>The workload whose contribution triggered the failure.</summary>
+    public WorkloadInfo Workload { get; }
+
+    private static string BuildMessage(WorkloadInfo workload, string message)
+    {
+        ArgumentNullException.ThrowIfNull(workload);
+        return $"Workload '{workload.PackageId}' {message}";
+    }
+}

--- a/test/Func.Tests/Hosting/DefaultFunctionsCliBuilderTests.cs
+++ b/test/Func.Tests/Hosting/DefaultFunctionsCliBuilderTests.cs
@@ -60,6 +60,19 @@ public class DefaultFunctionsCliBuilderTests
     }
 
     [Fact]
+    public void RegisterCommand_Generic_DoesNotRegisterCommandTypeInDi()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new GenericTestPayload("from-di"));
+        var builder = new DefaultFunctionsCliBuilder(services, TestWorkloads.CreateInfo());
+
+        builder.RegisterCommand<GenericTestCommand>();
+
+        var sp = services.BuildServiceProvider();
+        Assert.Null(sp.GetService<GenericTestCommand>());
+    }
+
+    [Fact]
     public void RegisterCommand_Generic_AbstractType_Throws()
     {
         var services = new ServiceCollection();
@@ -71,40 +84,60 @@ public class DefaultFunctionsCliBuilderTests
     }
 
     [Fact]
-    public void RegisterCommand_Factory_InvokedPerResolution()
+    public void RegisterCommand_Type_ResolvesThroughDi()
     {
         var services = new ServiceCollection();
+        services.AddSingleton(new GenericTestPayload("from-di"));
         var workload = TestWorkloads.CreateInfo();
         var builder = new DefaultFunctionsCliBuilder(services, workload);
 
-        builder.RegisterCommand(_ => new TestWorkloads.StubFuncCommand("from-factory"));
+        builder.RegisterCommand(typeof(GenericTestCommand));
 
         var resolved = services.BuildServiceProvider().GetServices<FuncCliCommand>().ToList();
         var external = Assert.Single(resolved.OfType<ExternalCommand>());
-        Assert.Equal("from-factory", external.Name);
+        var source = Assert.IsType<GenericTestCommand>(external.Source);
+        Assert.Equal("from-di", source.Payload.Value);
     }
 
     [Fact]
-    public void RegisterCommand_Factory_Null_Throws()
+    public void RegisterCommand_Type_DoesNotRegisterCommandTypeInDi()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new GenericTestPayload("from-di"));
+        var builder = new DefaultFunctionsCliBuilder(services, TestWorkloads.CreateInfo());
+
+        builder.RegisterCommand(typeof(GenericTestCommand));
+
+        var sp = services.BuildServiceProvider();
+        Assert.Null(sp.GetService<GenericTestCommand>());
+    }
+
+    [Fact]
+    public void RegisterCommand_Type_NullType_Throws()
     {
         var builder = new DefaultFunctionsCliBuilder(new ServiceCollection(), TestWorkloads.CreateInfo());
 
-        Assert.Throws<ArgumentNullException>(
-            () => builder.RegisterCommand((Func<IServiceProvider, FuncCommand>)null!));
+        Assert.Throws<ArgumentNullException>(() => builder.RegisterCommand((Type)null!));
     }
 
     [Fact]
-    public void RegisterCommand_Factory_ReturnsNull_FailsAtResolutionTime()
+    public void RegisterCommand_Type_NotFuncCommand_Throws()
     {
-        var services = new ServiceCollection();
-        var workload = TestWorkloads.CreateInfo("Workload.With.NullFactory");
-        var builder = new DefaultFunctionsCliBuilder(services, workload);
+        var builder = new DefaultFunctionsCliBuilder(new ServiceCollection(), TestWorkloads.CreateInfo());
 
-        builder.RegisterCommand(_ => null!);
+        var ex = Assert.Throws<ArgumentException>(() => builder.RegisterCommand(typeof(string)));
+        Assert.Contains("not assignable", ex.Message);
+        Assert.Contains(nameof(FuncCommand), ex.Message);
+    }
 
-        var sp = services.BuildServiceProvider();
-        var ex = Assert.Throws<InvalidOperationException>(() => sp.GetServices<FuncCliCommand>().ToList());
-        Assert.Contains("Workload.With.NullFactory", ex.Message);
+    [Fact]
+    public void RegisterCommand_Type_AbstractType_Throws()
+    {
+        var builder = new DefaultFunctionsCliBuilder(new ServiceCollection(), TestWorkloads.CreateInfo());
+
+        var ex = Assert.Throws<ArgumentException>(() => builder.RegisterCommand(typeof(AbstractFuncCommand)));
+        Assert.Contains("abstract command type", ex.Message);
+        Assert.Contains(nameof(AbstractFuncCommand), ex.Message);
     }
 
     [Fact]
@@ -134,12 +167,11 @@ public class DefaultFunctionsCliBuilderTests
     }
 
     [Fact]
-    public void RegisterCommand_Factory_WithoutWorkloadContext_Throws()
+    public void RegisterCommand_Type_WithoutWorkloadContext_Throws()
     {
         var builder = new DefaultFunctionsCliBuilder(new ServiceCollection());
 
-        Assert.Throws<InvalidOperationException>(
-            () => builder.RegisterCommand(_ => new TestWorkloads.StubFuncCommand("oops")));
+        Assert.Throws<InvalidOperationException>(() => builder.RegisterCommand(typeof(GenericTestCommand)));
     }
 
     private sealed class GenericTestPayload(string value)

--- a/test/Func.Tests/Workloads/ExternalCommandTests.cs
+++ b/test/Func.Tests/Workloads/ExternalCommandTests.cs
@@ -85,7 +85,7 @@ public class ExternalCommandTests
         var b = new FuncCommandOption<string>("--name", null, "second");
         var source = new TestWorkloads.StubFuncCommand("deploy", options: [a, b]);
 
-        var ex = Assert.Throws<InvalidOperationException>(
+        var ex = Assert.Throws<WorkloadOperationException>(
             () => new ExternalCommand(TestWorkloads.CreateInfo("Workload.A"), source));
         Assert.Contains("Workload.A", ex.Message);
         Assert.Contains("--name", ex.Message);
@@ -98,7 +98,7 @@ public class ExternalCommandTests
         var b = new FuncCommandOption<string>("--second", "-x", "second");
         var source = new TestWorkloads.StubFuncCommand("deploy", options: [a, b]);
 
-        var ex = Assert.Throws<InvalidOperationException>(
+        var ex = Assert.Throws<WorkloadOperationException>(
             () => new ExternalCommand(TestWorkloads.CreateInfo(), source));
         Assert.Contains("-x", ex.Message);
     }
@@ -110,7 +110,7 @@ public class ExternalCommandTests
         var b = new FuncCommandArgument<string>("path", "second");
         var source = new TestWorkloads.StubFuncCommand("deploy", arguments: [a, b]);
 
-        var ex = Assert.Throws<InvalidOperationException>(
+        var ex = Assert.Throws<WorkloadOperationException>(
             () => new ExternalCommand(TestWorkloads.CreateInfo(), source));
         Assert.Contains("path", ex.Message);
     }
@@ -122,9 +122,22 @@ public class ExternalCommandTests
         var b = new TestWorkloads.StubFuncCommand("dup");
         var source = new TestWorkloads.StubFuncCommand("parent", subcommands: [a, b]);
 
-        var ex = Assert.Throws<InvalidOperationException>(
+        var ex = Assert.Throws<WorkloadOperationException>(
             () => new ExternalCommand(TestWorkloads.CreateInfo(), source));
         Assert.Contains("dup", ex.Message);
+    }
+
+    [Fact]
+    public void Ctor_WorkloadOperationException_CarriesWorkloadInfo()
+    {
+        var a = new FuncCommandOption<string>("--name", null, "first");
+        var b = new FuncCommandOption<string>("--name", null, "second");
+        var source = new TestWorkloads.StubFuncCommand("deploy", options: [a, b]);
+        var workload = TestWorkloads.CreateInfo("Workload.B");
+
+        var ex = Assert.Throws<WorkloadOperationException>(
+            () => new ExternalCommand(workload, source));
+        Assert.Same(workload, ex.Workload);
     }
 
     [Fact]


### PR DESCRIPTION
Follow up based on PR feedback.

- Drop public RegisterCommand(Func<IServiceProvider, FuncCommand>) overload and collapse three protected hooks into a single OnRegisterCommand(Func<IServiceProvider, FuncCommand>).
- Add public RegisterCommand(Type) overload mirroring the generic one, for callers that only know the command type at runtime.
- Switch RegisterCommand<TCommand>() to ActivatorUtilities so registering a command type does not pollute the workload's IServiceCollection with a TCommand singleton as a side effect.
- Introduce internal WorkloadOperationException carrying the WorkloadInfo and replace the InvalidOperationException thrown by ExternalCommand when a workload-supplied FuncCommand declares an invalid options / arguments / subcommands shape.
- Add tests for the new RegisterCommand(Type) overload, the no-DI side-effect contract on the generic and Type overloads, and update ExternalCommandTests to assert the new exception type.
- Update docs/building-a-workload.md and docs/cli-architecture.md for the new RegisterCommand surface.


### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
