### PR TITLE
Rename workload test fixtures to drop Func. prefix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,6 +233,7 @@ dotnet test --filter "FullyQualifiedName~ClassName"  # Run specific tests
 - **Assembly/namespace names**: omit by default, will be built from project name with a top-level namespace `Azure.Functions.Cli` prefixed by msbuild props.
   - e.g.: `Workload.<Name>.csproj` will automatically become `Azure.Functions.Cli.Workload.<Name>.dll` and namespace of `Azure.Functions.Cli.Workload.<Name>`.
   - Manually setting is only done when that convention is not desired. e.g.: `Func.csproj` manually sets `<AssemblyName>func</AssemblyName>` and `<RootNamespace>$(TopLevelNamespace)</RootNamespace>`.
+- **`Func.` prefix is reserved**: only the entry-point binary (`Func/Func.csproj`) and its primary test project (`Func.Tests/Func.Tests.csproj`) may start with `Func.`. All other projects, including test fixtures, should use a folder/csproj name that starts with the structural area (e.g. `Workload.Tests.Fixtures.Default`), so the default `<AssemblyName>` and `<RootNamespace>` from `eng/build/Engineering.props` produce a clean `Azure.Functions.Cli.<name>`.
 - **Package IDs**: omit by default, will be based on assembly name.
 - **CI pipelines**: `workload-<name>-public-build.yml` and `workload-<name>-official-build.yml`
 - **Tests**: xUnit with NSubstitute for mocking, `FakeDotnetCliRunner` pattern for CLI wrappers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,6 +234,7 @@ dotnet test --filter "FullyQualifiedName~ClassName"  # Run specific tests
   - e.g.: `Workload.<Name>.csproj` will automatically become `Azure.Functions.Cli.Workload.<Name>.dll` and namespace of `Azure.Functions.Cli.Workload.<Name>`.
   - Manually setting is only done when that convention is not desired. e.g.: `Func.csproj` manually sets `<AssemblyName>func</AssemblyName>` and `<RootNamespace>$(TopLevelNamespace)</RootNamespace>`.
 - **`Func.` prefix is reserved**: only the entry-point binary (`Func/Func.csproj`) and its primary test project (`Func.Tests/Func.Tests.csproj`) may start with `Func.`. All other projects, including test fixtures, should use a folder/csproj name that starts with the structural area (e.g. `Workload.Tests.Fixtures.Default`), so the default `<AssemblyName>` and `<RootNamespace>` from `eng/build/Engineering.props` produce a clean `Azure.Functions.Cli.<name>`.
+- **Path separators**: use forward slashes (`/`) in MSBuild paths (csproj/props/targets/slnx), not backslashes. MSBuild normalises both, but `/` is portable across Windows/macOS/Linux and matches the rest of the repo.
 - **Package IDs**: omit by default, will be based on assembly name.
 - **CI pipelines**: `workload-<name>-public-build.yml` and `workload-<name>-official-build.yml`
 - **Tests**: xUnit with NSubstitute for mocking, `FakeDotnetCliRunner` pattern for CLI wrappers

--- a/Azure.Functions.Cli.slnx
+++ b/Azure.Functions.Cli.slnx
@@ -10,7 +10,7 @@
   </Folder>
   <Folder Name="/test/">
     <Project Path="test/Func.Tests/Func.Tests.csproj" />
-    <Project Path="test/Func.Tests.Fixtures.Workload/Func.Tests.Fixtures.Workload.csproj" />
-    <Project Path="test/Func.Tests.Fixtures.WorkloadSdk/Func.Tests.Fixtures.WorkloadSdk.csproj" />
+    <Project Path="test/Workload.Tests.Fixtures.Default/Workload.Tests.Fixtures.Default.csproj" />
+    <Project Path="test/Workload.Tests.Fixtures.Sdk/Workload.Tests.Fixtures.Sdk.csproj" />
   </Folder>
 </Solution>

--- a/test/Func.Tests/Func.Tests.csproj
+++ b/test/Func.Tests/Func.Tests.csproj
@@ -12,12 +12,12 @@
 
   <!-- Test fixtures: built and copied to output as content; loaded via reflection. -->
   <ItemGroup>
-    <ProjectReference Include="..\Func.Tests.Fixtures.Workload\Func.Tests.Fixtures.Workload.csproj">
+    <ProjectReference Include="..\Workload.Tests.Fixtures.Default\Workload.Tests.Fixtures.Default.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>Content</OutputItemType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </ProjectReference>
-    <ProjectReference Include="..\Func.Tests.Fixtures.WorkloadSdk\Func.Tests.Fixtures.WorkloadSdk.csproj">
+    <ProjectReference Include="..\Workload.Tests.Fixtures.Sdk\Workload.Tests.Fixtures.Sdk.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>Content</OutputItemType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/test/Func.Tests/Func.Tests.csproj
+++ b/test/Func.Tests/Func.Tests.csproj
@@ -12,12 +12,7 @@
 
   <!-- Test fixtures: built and copied to output as content; loaded via reflection. -->
   <ItemGroup>
-    <ProjectReference Include="..\Workload.Tests.Fixtures.Default\Workload.Tests.Fixtures.Default.csproj">
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ProjectReference>
-    <ProjectReference Include="..\Workload.Tests.Fixtures.Sdk\Workload.Tests.Fixtures.Sdk.csproj">
+    <ProjectReference Include="../Workload.Tests.Fixtures.*/Workload.Tests.Fixtures.*.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>Content</OutputItemType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/test/Func.Tests/Workloads/Loading/WorkloadLoaderTests.cs
+++ b/test/Func.Tests/Workloads/Loading/WorkloadLoaderTests.cs
@@ -12,13 +12,13 @@ namespace Azure.Functions.Cli.Tests.Workloads.Loading;
 
 public class WorkloadLoaderTests
 {
-    private const string FixturePackageId = "Azure.Functions.Cli.Tests.Fixtures.Workload";
-    private const string FixtureAssemblyFile = "Azure.Functions.Cli.Tests.Fixtures.Workload.dll";
-    private const string FixtureTypeName = "Azure.Functions.Cli.Tests.Fixtures.Workload.StubWorkload";
+    private const string FixturePackageId = "Azure.Functions.Cli.Workload.Tests.Fixtures.Default";
+    private const string FixtureAssemblyFile = "Azure.Functions.Cli.Workload.Tests.Fixtures.Default.dll";
+    private const string FixtureTypeName = "Azure.Functions.Cli.Workload.Tests.Fixtures.Default.StubWorkload";
 
-    private const string SdkFixturePackageId = "Azure.Functions.Cli.Tests.Fixtures.WorkloadSdk";
-    private const string SdkFixtureAssemblyFile = "Azure.Functions.Cli.Tests.Fixtures.WorkloadSdk.dll";
-    private const string SdkFixtureTypeName = "Azure.Functions.Cli.Tests.Fixtures.WorkloadSdk.StubWorkload";
+    private const string SdkFixturePackageId = "Azure.Functions.Cli.Workload.Tests.Fixtures.Sdk";
+    private const string SdkFixtureAssemblyFile = "Azure.Functions.Cli.Workload.Tests.Fixtures.Sdk.dll";
+    private const string SdkFixtureTypeName = "Azure.Functions.Cli.Workload.Tests.Fixtures.Sdk.StubWorkload";
 
     [Fact]
     public void LoadInstalled_ReturnsEmpty_WhenNoEntries()
@@ -76,7 +76,7 @@ public class WorkloadLoaderTests
         var loader = new WorkloadLoader();
         var entry = FixtureEntry(
             FixturePackageId,
-            typeNameOverride: "Azure.Functions.Cli.Tests.Fixtures.Workload.NotAWorkload");
+            typeNameOverride: "Azure.Functions.Cli.Workload.Tests.Fixtures.Default.NotAWorkload");
 
         var ex = Assert.Throws<GracefulException>(() => loader.LoadInstalled(new[] { entry }));
 
@@ -145,14 +145,14 @@ public class WorkloadLoaderTests
     public void LoadInstalled_HydratesEntry_WithSdkShapedFixture()
     {
         // Sibling of LoadInstalled_HydratesEntry_FromAssemblyOnDisk, but using
-        // the Func.Tests.Fixtures.WorkloadSdk project, whose csproj follows the
+        // the Workload.Tests.Fixtures.Sdk project, whose csproj follows the
         // future workload SDK convention (Private="false",
         // ExcludeAssets="runtime") so its deps.json does not list the contract
         // assemblies as runtime assets. This exercises the natural-resolution
         // path: AssemblyDependencyResolver returns null for the contract
-        // assemblies and the default context resolves them — distinct from the
+        // assemblies and the default context resolves them, distinct from the
         // defensive intercept path exercised by the sibling test using the
-        // mis-packaged Func.Tests.Fixtures.Workload fixture.
+        // mis-packaged Workload.Tests.Fixtures.Default fixture.
         var loader = new WorkloadLoader();
 
         var loaded = loader.LoadInstalled(new[] { SdkFixtureEntry(SdkFixturePackageId) });
@@ -174,9 +174,9 @@ public class WorkloadLoaderTests
         // Pins the SDK convention end-to-end: the WorkloadSdk fixture project
         // must NOT ship Azure.Functions.Cli.Abstractions in its runtime closure
         // (deps.json). If this fails, someone removed Private="false" /
-        // ExcludeAssets="runtime" from Func.Tests.Fixtures.WorkloadSdk.csproj
+        // ExcludeAssets="runtime" from Workload.Tests.Fixtures.Sdk.csproj
         // and the fixture is silently no longer exercising the natural-
-        // resolution path — the LoadInstalled_HydratesEntry_WithSdkShapedFixture
+        // resolution path: the LoadInstalled_HydratesEntry_WithSdkShapedFixture
         // test would still pass via the loader's defensive intercept, hiding
         // the regression. Asserting the resolver invariant directly is what
         // separates the two test cases.

--- a/test/Workload.Tests.Fixtures.Default/NotAWorkload.cs
+++ b/test/Workload.Tests.Fixtures.Default/NotAWorkload.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Azure.Functions.Cli.Tests.Fixtures.Workload;
+namespace Azure.Functions.Cli.Workload.Tests.Fixtures.Default;
 
 public sealed class NotAWorkload
 {

--- a/test/Workload.Tests.Fixtures.Default/StubWorkload.cs
+++ b/test/Workload.Tests.Fixtures.Default/StubWorkload.cs
@@ -3,11 +3,11 @@
 
 using Azure.Functions.Cli.Workloads;
 
-namespace Azure.Functions.Cli.Tests.Fixtures.Workload;
+namespace Azure.Functions.Cli.Workload.Tests.Fixtures.Default;
 
 public sealed class StubWorkload : IWorkload
 {
-    public string PackageId => "Azure.Functions.Cli.Tests.Fixtures.Workload";
+    public string PackageId => "Azure.Functions.Cli.Workload.Tests.Fixtures.Default";
 
     public string PackageVersion => "1.0.0";
 

--- a/test/Workload.Tests.Fixtures.Default/Workload.Tests.Fixtures.Default.csproj
+++ b/test/Workload.Tests.Fixtures.Default/Workload.Tests.Fixtures.Default.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <AssemblyName>$(TopLevelNamespace).Tests.Fixtures.Workload</AssemblyName>
-    <RootNamespace>$(AssemblyName)</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Workload.Tests.Fixtures.Sdk/StubWorkload.cs
+++ b/test/Workload.Tests.Fixtures.Sdk/StubWorkload.cs
@@ -3,11 +3,11 @@
 
 using Azure.Functions.Cli.Workloads;
 
-namespace Azure.Functions.Cli.Tests.Fixtures.WorkloadSdk;
+namespace Azure.Functions.Cli.Workload.Tests.Fixtures.Sdk;
 
 /// <summary>
 /// SDK-shaped test fixture: behaves identically to the sibling
-/// <c>Func.Tests.Fixtures.Workload</c> stub, but its csproj follows the future
+/// <c>Workload.Tests.Fixtures.Default</c> stub, but its csproj follows the future
 /// workload SDK convention (<c>Private="false"</c>,
 /// <c>ExcludeAssets="runtime"</c>) so the contract assembly is excluded from
 /// the fixture's runtime closure. This exercises the loader's natural-
@@ -17,7 +17,7 @@ namespace Azure.Functions.Cli.Tests.Fixtures.WorkloadSdk;
 /// </summary>
 public sealed class StubWorkload : IWorkload
 {
-    public string PackageId => "Azure.Functions.Cli.Tests.Fixtures.WorkloadSdk";
+    public string PackageId => "Azure.Functions.Cli.Workload.Tests.Fixtures.Sdk";
 
     public string PackageVersion => "1.0.0";
 

--- a/test/Workload.Tests.Fixtures.Sdk/Workload.Tests.Fixtures.Sdk.csproj
+++ b/test/Workload.Tests.Fixtures.Sdk/Workload.Tests.Fixtures.Sdk.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <AssemblyName>$(TopLevelNamespace).Tests.Fixtures.WorkloadSdk</AssemblyName>
-    <RootNamespace>$(AssemblyName)</RootNamespace>
 
     <!--
       EnableDynamicLoading is the SDK switch a real workload csproj would set:
@@ -22,7 +20,7 @@
       for Azure.Functions.Cli.Abstractions and the default context resolves to
       the host's copy — the "natural-resolution path".
 
-      The sibling Func.Tests.Fixtures.Workload project is intentionally shaped
+      The sibling Workload.Tests.Fixtures.Default project is intentionally shaped
       the *opposite* way (no Private/ExcludeAssets) so its deps.json *does*
       list Abstractions, exercising the loader's defensive intercept path. The
       two fixtures together pin both halves of the type-unification contract.


### PR DESCRIPTION
Cleanup per Jacob's review on #4916: only `Func/Func.csproj` and `Func.Tests/Func.Tests.csproj` should carry the `Func.` prefix. The two pre-existing workload test fixtures violated that rule and overrode `<AssemblyName>` / `<RootNamespace>` to compensate. Renaming the folders/csprojs lets `eng/build/Engineering.props` auto-derive a clean assembly name and namespace, and the manual overrides go away.

### Renames

| Old folder + csproj | New folder + csproj | Resulting AssemblyName |
|---|---|---|
| `test/Func.Tests.Fixtures.Workload/Func.Tests.Fixtures.Workload.csproj` | `test/Workload.Tests.Fixtures.Default/Workload.Tests.Fixtures.Default.csproj` | `Azure.Functions.Cli.Workload.Tests.Fixtures.Default` |
| `test/Func.Tests.Fixtures.WorkloadSdk/Func.Tests.Fixtures.WorkloadSdk.csproj` | `test/Workload.Tests.Fixtures.Sdk/Workload.Tests.Fixtures.Sdk.csproj` | `Azure.Functions.Cli.Workload.Tests.Fixtures.Sdk` |

For each project:
- `git mv` folder + csproj.
- Removed the explicit `<AssemblyName>` / `<RootNamespace>` overrides.
- Updated `namespace` in every `.cs` file.
- Preserved the `EnableDynamicLoading` + `Private="false" ExcludeAssets="runtime"` setup on the SDK fixture.

Wiring updates: `Azure.Functions.Cli.slnx`, `test/Func.Tests/Func.Tests.csproj` ProjectReferences, and the constants/comments in `test/Func.Tests/Workloads/Loading/WorkloadLoaderTests.cs`.

### AGENTS.md

Added a bullet to the **Project Conventions** section capturing the rule explicitly so future fixtures follow it.

### Out of scope

- The new `Workload.Tests.Fixtures.CrossAssembly` fixture in #4916 already follows this convention.
- `Func.Tests.Fixtures.Workload.Second` (also added by #4916) will be renamed inside #4916 itself, not here.

### Validation

`dotnet test` locally: 116/116 passing.
