### PR TITLE
Drop Workload Name/Version, flatten DisplayName/Description onto WorkloadInfo

### DIFF
--- a/src/Abstractions/Workloads/Workload.cs
+++ b/src/Abstractions/Workloads/Workload.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Reflection;
-
 namespace Azure.Functions.Cli.Workloads;
 
 /// <summary>
@@ -18,53 +16,14 @@ namespace Azure.Functions.Cli.Workloads;
 /// Abstract class (rather than an interface) so we can grow the surface with
 /// new properties or virtual members without breaking existing workloads.
 /// </summary>
+/// <remarks>
+/// The workload's identity (package id, version, aliases) is supplied by the
+/// NuGet package's nuspec at install time and persisted in the global
+/// registry, so the type itself only needs to describe its CLI presentation
+/// and wire up its services.
+/// </remarks>
 public abstract class Workload
 {
-    /// <summary>
-    /// Globally unique workload identifier, typically the assembly / NuGet
-    /// package name (e.g. <c>"Azure.Functions.Cli.Workload.Dotnet"</c>).
-    /// </summary>
-    public abstract string Name { get; }
-
-    /// <summary>
-    /// Workload version. Defaults to the workload assembly's
-    /// <see cref="System.Reflection.AssemblyInformationalVersionAttribute"/>
-    /// (falling back to <see cref="System.Reflection.AssemblyFileVersionAttribute"/>
-    /// and then <see cref="System.Reflection.AssemblyName.Version"/>), so
-    /// most workloads can leave this alone and let the build supply the
-    /// version. Override to author the version on the workload itself when
-    /// the running code should be the source of truth. Should be a valid
-    /// SemVer 2.0 string (e.g. <c>"1.2.3"</c>, <c>"1.2.3-preview.1"</c>);
-    /// the CLI does not currently enforce or normalize the format.
-    /// </summary>
-    public virtual string Version
-    {
-        get
-        {
-            Assembly assembly = GetType().Assembly;
-
-            string? informational = assembly
-                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
-                ?.InformationalVersion;
-            if (!string.IsNullOrWhiteSpace(informational))
-            {
-                // Strip any +sha build metadata so callers see a clean SemVer string.
-                int plus = informational.IndexOf('+');
-                return plus >= 0 ? informational[..plus] : informational;
-            }
-
-            string? file = assembly
-                .GetCustomAttribute<AssemblyFileVersionAttribute>()
-                ?.Version;
-            if (!string.IsNullOrWhiteSpace(file))
-            {
-                return file;
-            }
-
-            return assembly.GetName().Version?.ToString() ?? "0.0.0";
-        }
-    }
-
     /// <summary>
     /// Human-readable name shown in <c>func workload list</c>.
     /// </summary>

--- a/src/Func/Commands/Workload/WorkloadListCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadListCommand.cs
@@ -38,12 +38,12 @@ internal sealed class WorkloadListCommand(
         {
             w.PackageId,
             w.Aliases.Count == 0 ? AliasesPlaceholder : string.Join(", ", w.Aliases),
-            w.Instance.DisplayName,
-            w.Instance.Description,
+            w.DisplayName,
+            w.Description,
             w.PackageVersion,
         });
 
-        _interaction.WriteTable(["Package", "Aliases", "Name", "Description", "Version"], rows);
+        _interaction.WriteTable(["ID", "Aliases", "Display Name", "Description", "Version"], rows);
         return 0;
     }
 }

--- a/src/Func/Workloads/Loading/WorkloadLoader.cs
+++ b/src/Func/Workloads/Loading/WorkloadLoader.cs
@@ -79,6 +79,8 @@ internal sealed class WorkloadLoader(IWorkloadPaths paths) : IWorkloadLoader
             Instance: instance,
             PackageId: entry.PackageId,
             PackageVersion: entry.PackageVersion,
-            Aliases: entry.Aliases);
+            Aliases: entry.Aliases,
+            DisplayName: instance.DisplayName,
+            Description: instance.Description);
     }
 }

--- a/src/Func/Workloads/WorkloadInfo.cs
+++ b/src/Func/Workloads/WorkloadInfo.cs
@@ -4,17 +4,25 @@
 namespace Azure.Functions.Cli.Workloads;
 
 /// <summary>
-/// CLI-side view of a loaded workload. Pairs the runtime <see cref="Workload"/>
-/// instance with the package identity recorded in the global registry. Internal
-/// — workload authors implement <see cref="Workload"/>; they don't see this
-/// type.
+/// CLI-side view of a loaded workload. Hides the fact that a workload's
+/// metadata comes from two sources: identity (<see cref="PackageId"/>,
+/// <see cref="PackageVersion"/>, <see cref="Aliases"/>) is sourced from the
+/// global registry (recorded at install time from the package's nuspec);
+/// presentation (<see cref="DisplayName"/>, <see cref="Description"/>) is
+/// sourced from the loaded <see cref="Workload"/> instance. Consumers see
+/// one cohesive record. Internal: workload authors implement
+/// <see cref="Workload"/>; they don't see this type.
 /// </summary>
-/// <param name="Instance">The loaded workload's runtime instance.</param>
+/// <param name="Instance">The loaded workload's runtime instance. Use this for behaviour (e.g. <see cref="Workload.Configure"/>); read presentation through <see cref="DisplayName"/> / <see cref="Description"/>.</param>
 /// <param name="PackageId">NuGet package id from the registry entry (e.g. <c>"Azure.Functions.Cli.Workload.Dotnet"</c>).</param>
 /// <param name="PackageVersion">Installed package version from the registry entry.</param>
 /// <param name="Aliases">User-facing tokens accepted by <c>-s</c> (e.g. <c>["dotnet", "dotnet-isolated"]</c>).</param>
+/// <param name="DisplayName">Human-readable name for <c>func workload list</c>; sourced from <see cref="Workload.DisplayName"/>.</param>
+/// <param name="Description">One-line workload description; sourced from <see cref="Workload.Description"/>.</param>
 internal sealed record WorkloadInfo(
     Workload Instance,
     string PackageId,
     string PackageVersion,
-    IReadOnlyList<string> Aliases);
+    IReadOnlyList<string> Aliases,
+    string DisplayName,
+    string Description);

--- a/test/Func.Tests/Commands/Workload/WorkloadListCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadListCommandTests.cs
@@ -30,18 +30,18 @@ public class WorkloadListCommandTests
     {
         var workloads = new[]
         {
-            new WorkloadInfo(
-                Instance: new FakeWorkload(displayName: ".NET", description: "C# / F# workload."),
-                PackageId: "Azure.Functions.Cli.Workload.Dotnet",
-                PackageVersion: "1.0.0",
-                Aliases: new[] { "dotnet", "dotnet-isolated" }),
+            NewInfo(
+                instance: new FakeWorkload(displayName: ".NET", description: "C# / F# workload."),
+                packageId: "Azure.Functions.Cli.Workload.Dotnet",
+                packageVersion: "1.0.0",
+                aliases: new[] { "dotnet", "dotnet-isolated" }),
         };
 
         var cmd = new WorkloadListCommand(_interaction, ProviderReturning(workloads));
         int exit = await InvokeAsync(cmd);
 
         Assert.Equal(0, exit);
-        Assert.Contains("TABLE: [Package, Aliases, Name, Description, Version]", _interaction.Lines);
+        Assert.Contains("TABLE: [ID, Aliases, Display Name, Description, Version]", _interaction.Lines);
         Assert.Contains(
             "  ROW: [Azure.Functions.Cli.Workload.Dotnet, dotnet, dotnet-isolated, .NET, C# / F# workload., 1.0.0]",
             _interaction.Lines);
@@ -52,11 +52,11 @@ public class WorkloadListCommandTests
     {
         var workloads = new[]
         {
-            new WorkloadInfo(
-                Instance: new FakeWorkload(),
-                PackageId: "Azure.Functions.Cli.Workload.Custom",
-                PackageVersion: "0.1.0",
-                Aliases: Array.Empty<string>()),
+            NewInfo(
+                instance: new FakeWorkload(),
+                packageId: "Azure.Functions.Cli.Workload.Custom",
+                packageVersion: "0.1.0",
+                aliases: Array.Empty<string>()),
         };
 
         var cmd = new WorkloadListCommand(_interaction, ProviderReturning(workloads));
@@ -72,9 +72,9 @@ public class WorkloadListCommandTests
     {
         var workloads = new[]
         {
-            new WorkloadInfo(new FakeWorkload(), "Pkg.A", "1.0.0", Array.Empty<string>()),
-            new WorkloadInfo(new FakeWorkload(), "Pkg.B", "2.0.0", Array.Empty<string>()),
-            new WorkloadInfo(new FakeWorkload(), "Pkg.A", "1.1.0", Array.Empty<string>()),
+            NewInfo(new FakeWorkload(), "Pkg.A", "1.0.0", Array.Empty<string>()),
+            NewInfo(new FakeWorkload(), "Pkg.B", "2.0.0", Array.Empty<string>()),
+            NewInfo(new FakeWorkload(), "Pkg.A", "1.1.0", Array.Empty<string>()),
         };
 
         var cmd = new WorkloadListCommand(_interaction, ProviderReturning(workloads));
@@ -92,6 +92,13 @@ public class WorkloadListCommandTests
         return provider;
     }
 
+    private static WorkloadInfo NewInfo(
+        FakeWorkload instance,
+        string packageId,
+        string packageVersion,
+        IReadOnlyList<string> aliases)
+        => new(instance, packageId, packageVersion, aliases, instance.DisplayName, instance.Description);
+
     private static Task<int> InvokeAsync(WorkloadListCommand cmd, params string[] args)
     {
         var root = new RootCommand();
@@ -103,10 +110,6 @@ public class WorkloadListCommandTests
         string displayName = "Test Workload",
         string description = "A workload for tests.") : global::Azure.Functions.Cli.Workloads.Workload
     {
-        public override string Name => "Fake";
-
-        public override string Version => "0.0.0";
-
         public override string DisplayName { get; } = displayName;
 
         public override string Description { get; } = description;

--- a/test/Func.Tests/TestWorkloads.cs
+++ b/test/Func.Tests/TestWorkloads.cs
@@ -14,25 +14,26 @@ internal static class TestWorkloads
     public static WorkloadInfo CreateInfo(
         string packageId = "Test.Workload.A",
         string version = "1.0.0")
-        => new(
-            Instance: new TestWorkload(packageId, version),
+    {
+        var instance = new TestWorkload(packageId);
+        return new WorkloadInfo(
+            Instance: instance,
             PackageId: packageId,
             PackageVersion: version,
-            Aliases: Array.Empty<string>());
+            Aliases: Array.Empty<string>(),
+            DisplayName: instance.DisplayName,
+            Description: instance.Description);
+    }
 
     /// <summary>
     /// Minimal <see cref="Workloads.Workload"/> used by tests that need a
     /// runtime instance to back a <see cref="WorkloadInfo"/>.
     /// </summary>
-    private sealed class TestWorkload(string name, string version) : global::Azure.Functions.Cli.Workloads.Workload
+    private sealed class TestWorkload(string name) : global::Azure.Functions.Cli.Workloads.Workload
     {
-        public override string Name { get; } = name;
+        public override string DisplayName { get; } = name;
 
-        public override string Version { get; } = version;
-
-        public override string DisplayName => Name;
-
-        public override string Description => $"{Name} for tests";
+        public override string Description => $"{DisplayName} for tests";
 
         public override void Configure(FunctionsCliBuilder builder)
         {

--- a/test/Func.Tests/Workloads/WorkloadProviderTests.cs
+++ b/test/Func.Tests/Workloads/WorkloadProviderTests.cs
@@ -23,9 +23,10 @@ public class WorkloadProviderTests
                 EntryPoint = new EntryPointSpec { AssemblyPath = "A.dll", Type = "A.T" },
             },
         };
+        var instance = new TestWorkload();
         var loaded = new[]
         {
-            new WorkloadInfo(new TestWorkload(), "Pkg.A", "1.0.0", Array.Empty<string>()),
+            new WorkloadInfo(instance, "Pkg.A", "1.0.0", Array.Empty<string>(), instance.DisplayName, instance.Description),
         };
         IWorkloadStore store = Substitute.For<IWorkloadStore>();
         store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(entries);
@@ -121,8 +122,6 @@ public class WorkloadProviderTests
 
     private sealed class TestWorkload : global::Azure.Functions.Cli.Workloads.Workload
     {
-        public override string Name => "test";
-
         public override string DisplayName => "Test";
 
         public override string Description => "Test workload.";

--- a/test/Workload.Tests.Fixtures.Default/StubWorkload.cs
+++ b/test/Workload.Tests.Fixtures.Default/StubWorkload.cs
@@ -7,10 +7,6 @@ namespace Azure.Functions.Cli.Workload.Tests.Fixtures.Default;
 
 public sealed class StubWorkload : Workloads.Workload
 {
-    public override string Name => "Azure.Functions.Cli.Workload.Tests.Fixtures.Default";
-
-    public override string Version => "1.0.0";
-
     public override string DisplayName => "Stub";
 
     public override string Description => "Test fixture workload.";

--- a/test/Workload.Tests.Fixtures.Sdk/StubWorkload.cs
+++ b/test/Workload.Tests.Fixtures.Sdk/StubWorkload.cs
@@ -17,10 +17,6 @@ namespace Azure.Functions.Cli.Workload.Tests.Fixtures.Sdk;
 /// </summary>
 public sealed class StubWorkload : Workloads.Workload
 {
-    public override string Name => "Azure.Functions.Cli.Workload.Tests.Fixtures.Sdk";
-
-    public override string Version => "1.0.0";
-
     public override string DisplayName => "Stub (SDK-shaped)";
 
     public override string Description => "SDK-convention test fixture workload.";


### PR DESCRIPTION
Two changes to the workload model that stand on their own as improvements to existing code, independent of install/uninstall.

Drop Workload.Name and Workload.Version — workload identity (id, version) comes from the registry entry (sourced from the package nuspec at install time), not the loaded type. Two sources for the same value drift; the customer-facing values are what's in the package. Remove the redundant properties from the abstract base.

Flatten DisplayName / Description onto WorkloadInfo — presentation still belongs on the Workload type, but consumers shouldn't have to reach into .Instance.X. WorkloadListCommand straddled two sources (identity from the registry, presentation from the loaded type). Project the presentation onto WorkloadInfo at load time so consumers see one record. Instance stays on the record because behaviour (Configure, command registration) still needs it.

Also renames the list command's columns from Package / Name to ID / Display Name to match the new identity model.