### PR TITLE
Trim env-var value before opt-out sentinel check

### DIFF
--- a/src/Func/Telemetry/CliTelemetry.cs
+++ b/src/Func/Telemetry/CliTelemetry.cs
@@ -121,7 +121,7 @@ internal static class CliTelemetry
         // Explicit "off" sentinels mean the user has not opted out;
         // anything else (including unrecognized values) is treated as
         // opt-out, so we fail safe toward not collecting telemetry.
-        return !_optOutFalseSentinels.Contains(value);
+        return !_optOutFalseSentinels.Contains(value.Trim());
     }
 
     private static string ResolveCliVersion()

--- a/test/Func.Tests/Telemetry/TelemetryTests.cs
+++ b/test/Func.Tests/Telemetry/TelemetryTests.cs
@@ -40,6 +40,8 @@ public class TelemetryTests
     [InlineData("n")]
     [InlineData("off")]
     [InlineData("OFF")]
+    [InlineData("  off  ")]
+    [InlineData("\tfalse\n")]
     public void TryGetConnectionString_OptOutFalseSentinels_DoNotOptOut(string value)
     {
         // The documented "off" sentinels must NOT be treated as opt-out.


### PR DESCRIPTION
Quick PR feedback follow up

Surrounding whitespace would otherwise cause '  off  ' or 'false\n' to miss the sentinel set and be treated as opt-out, the opposite of what the user intended.

