### PR TITLE
Wire installed workloads into host DI at startup

### DIFF
--- a/.github/instructions/dotnet.instructions.md
+++ b/.github/instructions/dotnet.instructions.md
@@ -113,6 +113,19 @@ fire:
 - Don't run `dotnet format` across unrelated files; no drive-by reformatting.
 - Don't disable analyzers to silence warnings, fix the underlying issue.
 
+## Code comments
+
+Comment to explain *why*, not *what*. XML doc summaries
+are one or two sentences; reach for `<remarks>` only when there's a single
+non-obvious clarification, and avoid stacking `<para>` blocks. Don't cite
+spec sections or document URLs from inside code (`§6.2`,
+`workload-package-layout §5.4`). Don't justify naming choices, list
+convention origins ("matches tsconfig.json…"), or narrate the alternative
+you didn't pick. Skip comments that restate the next line (DI registrations,
+obvious defaults, "Empty when no X" on a collection). Lead with the
+operative verb. Keep pointers to follow-up issues, cross-platform quirks,
+and rationale that isn't visible from the surrounding code.
+
 ## XML doc summaries
 
 `<summary>` and `</summary>` go on their own lines, even for one-liners:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,19 @@ the full CLI.
 - Keep changes minimal and surgical. User-visible behavior changes must be
   flagged explicitly in the PR description.
 
+### Code comments
+
+Comment to explain *why*, not *what*. XML doc summaries
+are one or two sentences; reach for `<remarks>` only when there's a single
+non-obvious clarification, and avoid stacking `<para>` blocks. Don't cite
+spec sections or document URLs from inside code (`§6.2`,
+`workload-package-layout §5.4`). Don't justify naming choices, list
+convention origins ("matches tsconfig.json…"), or narrate the alternative
+you didn't pick. Skip comments that restate the next line (DI registrations,
+obvious defaults, "Empty when no X" on a collection). Lead with the
+operative verb. Keep pointers to follow-up issues, cross-platform quirks,
+and rationale that isn't visible from the surrounding code.
+
 ## CLI Conventions
 
 This repo ships **one product**: the `func` CLI. Treat it as a CLI first and a

--- a/Azure.Functions.Cli.slnx
+++ b/Azure.Functions.Cli.slnx
@@ -12,5 +12,6 @@
     <Project Path="test/Func.Tests/Func.Tests.csproj" />
     <Project Path="test/Workload.Tests.Fixtures.Default/Workload.Tests.Fixtures.Default.csproj" />
     <Project Path="test/Workload.Tests.Fixtures.Sdk/Workload.Tests.Fixtures.Sdk.csproj" />
+    <Project Path="test/Workload.Tests.Fixtures.WithCommand/Workload.Tests.Fixtures.WithCommand.csproj" />
   </Folder>
 </Solution>

--- a/eng/build/Packages.props
+++ b/eng/build/Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.7.0" />
+    <PackageVersion Include="NuGet.Versioning" Version="6.12.1" />
   </ItemGroup>
   <!-- analyzers -->
   <ItemGroup>

--- a/src/Abstractions/Workloads/WorkloadKind.cs
+++ b/src/Abstractions/Workloads/WorkloadKind.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workloads;
+
+/// <summary>
+/// Discriminator for the three shapes a workload package can take, declared
+/// in <c>workload.json</c>'s <c>kind</c> field
+/// (workload-package-layout §5.4). Determines whether the loader activates
+/// the package, skips it, or treats it as install-time-only.
+/// </summary>
+public enum WorkloadKind
+{
+    /// <summary>
+    /// Default. Carries a runtime payload and a <see cref="Workload"/>
+    /// entry-point class; the loader activates it and calls
+    /// <see cref="Workload.Configure"/>.
+    /// </summary>
+    Workload = 0,
+
+    /// <summary>
+    /// Carries a payload but no entry-point class. The loader skips
+    /// activation; built-in commands resolve the install directory by
+    /// package id (e.g. the Functions host runtime).
+    /// </summary>
+    Content = 1,
+
+    /// <summary>
+    /// Carries no payload of its own. Bundles other workload-or-content
+    /// packages via the <c>.nuspec</c>'s <c>&lt;dependencies&gt;</c>. The
+    /// loader never activates it.
+    /// </summary>
+    Meta = 2,
+}

--- a/src/Abstractions/Workloads/WorkloadMetadata.cs
+++ b/src/Abstractions/Workloads/WorkloadMetadata.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Text.Json.Serialization;
+
 namespace Azure.Functions.Cli.Workloads;
 
 /// <summary>

--- a/src/Abstractions/Workloads/WorkloadMetadata.cs
+++ b/src/Abstractions/Workloads/WorkloadMetadata.cs
@@ -4,21 +4,27 @@
 namespace Azure.Functions.Cli.Workloads;
 
 /// <summary>
-/// Per-workload manifest authored alongside the <see cref="Workload"/>
-/// implementation and shipped at the root of the workload's NuGet package
-/// (<c>workload.json</c>). Required: a package without this file is not a
-/// valid workload.
-///
-/// Read at install time to discover the entry-point assembly and type, which
-/// the CLI then records in its global workload registry. Distinct from the
-/// global registry itself: this file describes a single workload as authored;
-/// the registry tracks every workload installed on the machine.
+/// Contents of a workload's <c>workload.json</c> manifest. Every workload
+/// package must ship one at its root; packages without it are not valid
+/// workloads and are rejected at install time.
 /// </summary>
 public sealed class WorkloadMetadata
 {
     /// <summary>
-    /// Where to find the <see cref="Workload"/> implementation inside the
-    /// package. Path is relative to the package root.
+    /// JSON Schema URL identifying the manifest format.
     /// </summary>
-    public required EntryPointSpec EntryPoint { get; init; }
+    [JsonPropertyName("$schema")]
+    [JsonPropertyOrder(-1)]
+    public required string Schema { get; init; }
+
+    /// <summary>
+    /// Package shape. Defaults to <see cref="WorkloadKind.Workload"/>.
+    /// </summary>
+    public WorkloadKind Kind { get; init; } = WorkloadKind.Workload;
+
+    /// <summary>
+    /// Entry-point assembly and type. Required for
+    /// <see cref="WorkloadKind.Workload"/>; otherwise null.
+    /// </summary>
+    public EntryPointSpec? EntryPoint { get; init; }
 }

--- a/src/Func/Commands/Workload/WorkloadListCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadListCommand.cs
@@ -8,11 +8,7 @@ using Azure.Functions.Cli.Workloads;
 namespace Azure.Functions.Cli.Commands.Workload;
 
 /// <summary>
-/// Lists workloads recorded in the global registry. Reads from the cached
-/// <see cref="WorkloadInfo"/> list materialized by
-/// <see cref="IWorkloadProvider"/> so display name and description come from
-/// each loaded <see cref="Workloads.Workload"/> instance and the file-backed
-/// registry isn't re-read on every invocation.
+/// Lists workloads from <see cref="IWorkloadProvider"/>.
 /// </summary>
 internal sealed class WorkloadListCommand(
     IInteractionService interaction,
@@ -24,14 +20,14 @@ internal sealed class WorkloadListCommand(
     private readonly IInteractionService _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
     private readonly IWorkloadProvider _workloads = workloads ?? throw new ArgumentNullException(nameof(workloads));
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
-        IReadOnlyList<WorkloadInfo> workloads = await _workloads.GetWorkloadsAsync(cancellationToken);
+        IReadOnlyList<WorkloadInfo> workloads = _workloads.GetWorkloads();
 
         if (workloads.Count == 0)
         {
             _interaction.WriteHint("No workloads installed.");
-            return 0;
+            return Task.FromResult(0);
         }
 
         IEnumerable<string[]> rows = workloads.Select(w => new[]
@@ -44,6 +40,6 @@ internal sealed class WorkloadListCommand(
         });
 
         _interaction.WriteTable(["ID", "Aliases", "Display Name", "Description", "Version"], rows);
-        return 0;
+        return Task.FromResult(0);
     }
 }

--- a/src/Func/Func.csproj
+++ b/src/Func/Func.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" />
+    <PackageReference Include="NuGet.Versioning" />
   </ItemGroup>
 
 </Project>

--- a/src/Func/Hosting/CliHostFactory.cs
+++ b/src/Func/Hosting/CliHostFactory.cs
@@ -1,0 +1,85 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Telemetry;
+using Azure.Monitor.OpenTelemetry.Exporter;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Azure.Functions.Cli.Hosting;
+
+/// <summary>
+/// Builds the CLI host with all services, configuration, and workloads wired in.
+/// </summary>
+internal static class CliHostFactory
+{
+    /// <summary>
+    /// Creates and starts the CLI host. Registers built-in commands and
+    /// workload storage, loads installed workloads, and invokes each
+    /// workload's <see cref="Workloads.Workload.Configure"/>. The returned
+    /// host is already started so OpenTelemetry listeners are subscribed and
+    /// hosted services are running before any command code executes.
+    /// </summary>
+    /// <param name="interaction">The interaction service used for warnings, errors, and prompts. Registered as a singleton in the host.</param>
+    /// <param name="configureConfiguration">Optional hook for tests to override configuration sources (e.g. point <c>Workloads:Home</c> at a temp directory).</param>
+    /// <param name="cancellationToken">Cancellation propagated to <see cref="IHost.StartAsync"/> and the workload registration step.</param>
+    public static async Task<IHost> CreateHostAsync(
+        IInteractionService interaction,
+        Action<IConfigurationBuilder>? configureConfiguration = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(interaction);
+
+        // Empty builder: skip the default config and logging providers a CLI
+        // doesn't need. The host owns shared lifetimes (currently just the
+        // OpenTelemetry pipeline) so flush + shutdown happen via host disposal.
+        HostApplicationBuilder hostBuilder = Host.CreateEmptyApplicationBuilder(null);
+        hostBuilder.Services.AddSingleton(interaction);
+
+        // Only wire OpenTelemetry when a connection string is available and the
+        // user hasn't opted out; otherwise ActivitySource / Meter calls no-op.
+        if (CliTelemetry.TryGetConnectionString(out string? connectionString))
+        {
+            hostBuilder.Services.AddOpenTelemetry()
+                .ConfigureResource(r => CliTelemetry.ConfigureResource(r))
+                .WithTracing(t => t
+                    .AddSource(CliTelemetry.SourceName)
+                    .AddAzureMonitorTraceExporter(o => o.ConnectionString = connectionString))
+                .WithMetrics(m => m
+                    .AddMeter(CliTelemetry.SourceName)
+                    .AddAzureMonitorMetricExporter(o => o.ConnectionString = connectionString));
+        }
+
+        hostBuilder.Services.AddBuiltInCommands();
+
+        // FUNC_CLI_ prefix is stripped and "__" maps to section nesting, so
+        // FUNC_CLI_Workloads__Home binds to WorkloadPathsOptions.Home.
+        hostBuilder.Configuration.AddEnvironmentVariables(prefix: Constants.EnvironmentVariablePrefix);
+        configureConfiguration?.Invoke(hostBuilder.Configuration);
+        hostBuilder.Services.AddWorkloadStorage();
+
+        // Runs before Build() so workloads can still mutate IServiceCollection.
+        // The boot duration is recorded after StartAsync below — OTel listeners
+        // aren't subscribed until the host starts, so emitting earlier drops it.
+        WorkloadRegistrationResult registration = await WorkloadRegistration.RegisterWorkloadsAsync(
+            hostBuilder.Services,
+            hostBuilder.Configuration,
+            interaction,
+            cancellationToken);
+
+        IHost host = hostBuilder.Build();
+
+        // Start before any command code emits telemetry so OTel listeners are
+        // subscribed.
+        await host.StartAsync(cancellationToken);
+
+        CliTelemetry.Metric.RecordWorkloadBoot(
+            registration.WorkloadCount,
+            registration.ElapsedMilliseconds);
+
+        return host;
+    }
+}

--- a/src/Func/Hosting/WorkloadRegistration.cs
+++ b/src/Func/Hosting/WorkloadRegistration.cs
@@ -1,30 +1,150 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Diagnostics;
+using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Telemetry;
 using Azure.Functions.Cli.Workloads;
+using Azure.Functions.Cli.Workloads.Loading;
+using Azure.Functions.Cli.Workloads.Storage;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NuGet.Versioning;
 
 namespace Azure.Functions.Cli.Hosting;
 
 /// <summary>
-/// Bridges installed workloads into the host. In the final design this reads
-/// the global manifest at <c>~/.azure-functions/workloads.json</c>, loads
-/// each workload's entry-point assembly into its own
-/// <see cref="System.Runtime.Loader.AssemblyLoadContext"/>, instantiates the
-/// type identified by <c>[assembly: ExportCliWorkload&lt;T&gt;]</c>, and invokes
-/// <see cref="Workload.Configure"/>.
-///
-/// At this stage <see cref="RegisterWorkloads"/> is a no-op: the loaded-
-/// workloads list itself is published as a singleton by
-/// <see cref="WorkloadStorageRegistration.AddWorkloadStorage"/>, so commands
-/// that only need to enumerate installed workloads (e.g. <c>func workload
-/// list</c>) inject <c>IReadOnlyList&lt;WorkloadInfo&gt;</c> directly. This
-/// hook will grow to invoke <see cref="Workload.Configure"/> per loaded
-/// workload once the contribution surface lands.
+/// Bridges installed workloads into the host. Reads the global manifest at
+/// <c>~/.azure-functions/workloads.json</c>, loads each live workload's
+/// entry-point assembly into its own
+/// <see cref="System.Runtime.Loader.AssemblyLoadContext"/>, and invokes
+/// <see cref="Workload.Configure"/> so each workload can contribute
+/// services and commands.
 /// </summary>
+/// <remarks>
+/// Runs before <see cref="Microsoft.Extensions.Hosting.IHostBuilder.Build"/>
+/// so workloads can mutate the <see cref="IServiceCollection"/>. Per-workload
+/// failures (load or <see cref="Workload.Configure"/>) are isolated: a single
+/// throw becomes a stderr warning and the remaining workloads still load.
+/// Only the highest installed semver per <c>packageId</c> goes live; older
+/// versions stay in the on-disk registry for rollback but aren't loaded into
+/// the process. Content-only and meta entries are skipped.
+/// </remarks>
 internal static class WorkloadRegistration
 {
-    public static void RegisterWorkloads(FunctionsCliBuilder builder)
+    /// <summary>
+    /// Loads every live workload, publishes them via
+    /// <see cref="IWorkloadProvider"/>, and invokes
+    /// <see cref="Workload.Configure"/> on each. Returns boot duration and
+    /// loaded count so the caller can emit telemetry after the host is
+    /// started (emitting from here would fire before OTel listeners are
+    /// subscribed and the metric would be dropped).
+    /// </summary>
+    /// <param name="services">The host's service collection. Workload-contributed services are added here.</param>
+    /// <param name="configuration">The host's configuration. The <c>Workloads</c> section is read to locate the workload home directory.</param>
+    /// <param name="interaction">Used to surface per-workload load and Configure failures as warnings.</param>
+    /// <param name="cancellationToken">Cancellation propagated to manifest reads.</param>
+    /// <returns>The number of workloads loaded and the elapsed boot time.</returns>
+    public static async Task<WorkloadRegistrationResult> RegisterWorkloadsAsync(
+        IServiceCollection services,
+        IConfiguration configuration,
+        IInteractionService interaction,
+        CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(interaction);
+
+        var stopwatch = Stopwatch.StartNew();
+
+        // Bind WorkloadPathsOptions the same way the host's DI binding does,
+        // so FUNC_CLI_Workloads__Home and test overrides flow through.
+        var paths = new WorkloadPathsOptions();
+        configuration.GetSection(WorkloadStorageRegistration.ConfigurationSection).Bind(paths);
+
+        var store = new WorkloadStore(paths);
+        var loader = new WorkloadLoader(paths);
+
+        IReadOnlyList<WorkloadEntry> allEntries = await store.GetWorkloadsAsync(cancellationToken);
+        IReadOnlyList<WorkloadEntry> liveEntries = SelectLiveEntries(allEntries);
+
+        var workloads = new List<WorkloadInfo>(liveEntries.Count);
+        foreach (WorkloadEntry entry in liveEntries)
+        {
+            try
+            {
+                // Load per-entry so one failure becomes a warning instead of
+                // aborting discovery for the rest.
+                IReadOnlyList<WorkloadInfo> loaded = loader.Load([entry]);
+                workloads.Add(loaded[0]);
+            }
+            catch (Exception ex)
+            {
+                interaction.WriteWarning(
+                    $"Workload '{entry.PackageId}@{entry.PackageVersion}' could not be loaded: {ex.Message}");
+            }
+        }
+
+        // Register each WorkloadInfo individually so anything can contribute
+        // another via AddSingleton. Consumers depend on IWorkloadProvider,
+        // not IEnumerable<WorkloadInfo>, to name the domain concept and leave
+        // room for lookup behavior later.
+        foreach (WorkloadInfo workload in workloads)
+        {
+            services.AddSingleton(workload);
+        }
+
+        services.AddSingleton<IWorkloadProvider, WorkloadProvider>();
+
+        foreach (WorkloadInfo workload in workloads)
+        {
+            // Per-workload builder so RegisterCommand can tag the resulting
+            // ExternalCommand with its owning workload.
+            var builder = new DefaultFunctionsCliBuilder(services, workload);
+            try
+            {
+                workload.Instance.Configure(builder);
+            }
+            catch (Exception ex)
+            {
+                // A misbehaving workload must not brick the CLI — the user
+                // still needs `func workload uninstall` to remove it.
+                // Not transactional: services registered before the throw
+                // remain in the collection. Tracked in #4948.
+                interaction.WriteWarning(
+                    $"Workload '{workload.PackageId}@{workload.PackageVersion}' failed to initialize: {ex.Message}");
+            }
+        }
+
+        stopwatch.Stop();
+        return new WorkloadRegistrationResult(workloads.Count, stopwatch.ElapsedMilliseconds);
     }
+
+    /// <summary>
+    /// Skips non-workload entries (content-only, meta) and keeps only the
+    /// highest installed semver per <c>packageId</c>. Older versions stay on
+    /// disk for rollback but don't go live in the process.
+    /// </summary>
+    private static IReadOnlyList<WorkloadEntry> SelectLiveEntries(IReadOnlyList<WorkloadEntry> entries)
+    {
+        if (entries.Count == 0)
+        {
+            return [];
+        }
+
+        return [.. entries
+            .Where(e => e.Kind == WorkloadKind.Workload)
+            .GroupBy(e => e.PackageId, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group
+                .OrderByDescending(e => ParseVersionOrZero(e.PackageVersion))
+                .First())];
+    }
+
+    /// <summary>
+    /// Parses a registry version string, falling back to 0.0.0 on failure so
+    /// the "highest semver wins" sort stays deterministic instead of throwing
+    /// at boot. The malformed entry surfaces its own loader warning later.
+    /// </summary>
+    private static NuGetVersion ParseVersionOrZero(string version)
+        => NuGetVersion.TryParse(version, out NuGetVersion? parsed) ? parsed : new NuGetVersion(0, 0, 0);
 }

--- a/src/Func/Hosting/WorkloadRegistrationResult.cs
+++ b/src/Func/Hosting/WorkloadRegistrationResult.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Hosting;
+
+/// <summary>
+/// Boot count and duration returned by
+/// <see cref="WorkloadRegistration.RegisterWorkloadsAsync"/> so the caller
+/// can emit telemetry after <see cref="Microsoft.Extensions.Hosting.IHost.StartAsync"/>
+/// subscribes the OpenTelemetry pipeline.
+/// </summary>
+internal readonly record struct WorkloadRegistrationResult(int WorkloadCount, long ElapsedMilliseconds);

--- a/src/Func/Hosting/WorkloadStorageRegistration.cs
+++ b/src/Func/Hosting/WorkloadStorageRegistration.cs
@@ -11,8 +11,8 @@ using Microsoft.Extensions.Options;
 namespace Azure.Functions.Cli.Hosting;
 
 /// <summary>
-/// Wires the workload-storage subsystem (paths + manifest store + loader +
-/// provider) into DI. Binds <see cref="WorkloadPathsOptions"/> from the
+/// Wires the workload-storage subsystem (paths + manifest store + loader)
+/// into DI. Binds <see cref="WorkloadPathsOptions"/> from the
 /// <c>Workloads</c> configuration section so the
 /// <c>FUNC_CLI_Workloads__Home</c> env var (registered at host build) flows
 /// through, while tests can register their own options without touching
@@ -42,14 +42,6 @@ internal static class WorkloadStorageRegistration
         services.AddSingleton<IWorkloadStore, WorkloadStore>();
         services.AddSingleton<IWorkloadLoader, WorkloadLoader>();
         services.AddSingleton<IWorkloadMetadataReader, WorkloadMetadataReader>();
-
-        // The provider composes store + loader, lazily materializes the
-        // installed-workloads list, and caches it for the life of the
-        // process. Commands that need to enumerate live workloads (list,
-        // alias routing, command contribution) inject this rather than the
-        // store + loader directly. Singleton because the cache must be shared
-        // across resolutions.
-        services.AddSingleton<IWorkloadProvider, WorkloadProvider>();
 
         return services;
     }

--- a/src/Func/Program.cs
+++ b/src/Func/Program.cs
@@ -10,62 +10,10 @@ using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Console.Theme;
 using Azure.Functions.Cli.Hosting;
 using Azure.Functions.Cli.Telemetry;
-using Azure.Monitor.OpenTelemetry.Exporter;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using OpenTelemetry.Metrics;
-using OpenTelemetry.Trace;
 
 DefaultTheme theme = new();
 SpectreInteractionService interaction = new(theme);
-
-// Build the host: a CLI process gets the empty variant so we skip the default
-// configuration and logging providers (they're not needed). The host owns
-// shared lifetimes — currently just the OpenTelemetry pipeline, which is
-// registered as hosted services so flush + shutdown happen via host disposal.
-HostApplicationBuilder hostBuilder = Host.CreateEmptyApplicationBuilder(null);
-hostBuilder.Services.AddSingleton(interaction);
-
-// Wire OpenTelemetry only when a real instrumentation key is baked in and
-// the user hasn't opted out. When it isn't, no listener is subscribed and
-// ActivitySource / Meter calls become no-ops.
-if (CliTelemetry.TryGetConnectionString(out string? connectionString))
-{
-    hostBuilder.Services.AddOpenTelemetry()
-        .ConfigureResource(r => CliTelemetry.ConfigureResource(r))
-        .WithTracing(t => t
-            .AddSource(CliTelemetry.SourceName)
-            .AddAzureMonitorTraceExporter(o => o.ConnectionString = connectionString))
-        .WithMetrics(m => m
-            .AddMeter(CliTelemetry.SourceName)
-            .AddAzureMonitorMetricExporter(o => o.ConnectionString = connectionString));
-}
-
-// Register built-in commands so they flow through DI alongside any
-// workload-contributed commands.
-hostBuilder.Services.AddBuiltInCommands();
-
-// Storage subsystem: bind WorkloadPathsOptions from the "Workloads" config
-// section so the FUNC_CLI_Workloads__Home env var flows through (the
-// FUNC_CLI_ prefix is stripped, "__" maps to section nesting).
-hostBuilder.Configuration.AddEnvironmentVariables(prefix: Constants.EnvironmentVariablePrefix);
-hostBuilder.Services.AddWorkloadStorage();
-
-// Let installed workloads contribute services. The builder exposes the same
-// IServiceCollection the host uses, so anything a workload registers is
-// resolvable when commands are built below.
-WorkloadRegistration.RegisterWorkloads(new DefaultFunctionsCliBuilder(hostBuilder.Services));
-
-using IHost host = hostBuilder.Build();
-
-// Start the host so hosted services (OTel providers) are running and
-// listeners are subscribed before any command code emits telemetry.
-await host.StartAsync();
-
-// Create the command tree, resolving built-ins (and any workload-contributed
-// services they depend on) from the host's service provider.
-FuncRootCommand rootCommand = Parser.CreateCommand(host.Services);
 
 // Wire cancellation to Ctrl+C / SIGTERM
 // First Ctrl+C: graceful shutdown. Second Ctrl+C: force exit.
@@ -98,6 +46,9 @@ using (Activity? activity = CliTelemetry.Trace.StartCommandActivity(commandName)
 {
     try
     {
+        using IHost host = await CliHostFactory.CreateHostAsync(interaction);
+        FuncRootCommand rootCommand = Parser.CreateCommand(host.Services);
+
         var config = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
         exitCode = await rootCommand.Parse(args).InvokeAsync(config, cts.Token);
     }

--- a/src/Func/Telemetry/MeterExtensions.cs
+++ b/src/Func/Telemetry/MeterExtensions.cs
@@ -29,6 +29,12 @@ internal static class MeterExtensions
             unit: "ms",
             description: "Duration of CLI command execution.");
 
+    private static readonly Histogram<double> _workloadBootDuration =
+        CliTelemetry.Metric.CreateHistogram<double>(
+            TelemetryConventions.WorkloadBootDurationInstrument,
+            unit: "ms",
+            description: "Duration of workload load + Configure at CLI startup.");
+
     extension(Meter meter)
     {
         /// <summary>
@@ -51,6 +57,20 @@ internal static class MeterExtensions
 
             _commandCount.Add(1, tags);
             _commandDuration.Record(durationMs, tags);
+        }
+
+        /// <summary>
+        /// Records the duration of CLI startup workload loading + Configure
+        /// invocation, tagged with the number of workloads processed.
+        /// </summary>
+        public void RecordWorkloadBoot(int workloadCount, long durationMs)
+        {
+            var tags = new TagList
+            {
+                { TelemetryConventions.CliWorkloadCount, workloadCount },
+            };
+
+            _workloadBootDuration.Record(durationMs, tags);
         }
     }
 }

--- a/src/Func/Telemetry/TelemetryConventions.cs
+++ b/src/Func/Telemetry/TelemetryConventions.cs
@@ -20,8 +20,10 @@ internal static class TelemetryConventions
     // Span / metric tag keys.
     public const string CliCommandName = "cli.command.name";
     public const string ProcessExitCode = "process.exit_code";
+    public const string CliWorkloadCount = "cli.workload.count";
 
     // Metric instrument names.
     public const string CommandCountInstrument = "cli.command.count";
     public const string CommandDurationInstrument = "cli.command.duration";
+    public const string WorkloadBootDurationInstrument = "cli.workload.boot_duration";
 }

--- a/src/Func/Workloads/Discovery/WorkloadMetadataReader.cs
+++ b/src/Func/Workloads/Discovery/WorkloadMetadataReader.cs
@@ -20,11 +20,9 @@ internal sealed class WorkloadMetadataReader : IWorkloadMetadataReader
     public const string MetadataFileName = "workload.json";
 
     /// <summary>
-    /// Conventional sub-directory inside a workload's package that holds
-    /// the workload's assemblies, dependencies, and runtime config. The
-    /// per-workload manifest (<see cref="MetadataFileName"/>) sits at the
-    /// package root and points into this directory. Mirrors the NuGet
-    /// <c>tools/</c> convention; <c>any</c> denotes a TFM-agnostic payload.
+    /// Sub-directory inside a workload's package that holds its assemblies,
+    /// dependencies, and runtime config. Mirrors NuGet's <c>tools/</c>
+    /// convention; <c>any</c> denotes a TFM-agnostic payload.
     /// </summary>
     public const string ContentDirectoryName = "tools/any";
 
@@ -67,11 +65,51 @@ internal sealed class WorkloadMetadataReader : IWorkloadMetadataReader
                 $"'{metadataPath}' deserialized to null.");
         }
 
-        // System.Text.Json honours `required` on init-only properties, so a
-        // missing entryPoint / assemblyPath / type already throws above. The
-        // remaining failure mode is a JSON object that parses but contains
-        // empty strings; surface that with the same exception type so callers
-        // only have to handle one.
+        // Reject unknown $schema values strictly rather than partially
+        // interpret a future schema.
+        if (!WorkloadManifestSchema.IsPackageManifestSupported(metadata.Schema))
+        {
+            string supported = string.Join(
+                ", ",
+                WorkloadManifestSchema.SupportedPackageManifestSchemas);
+            throw new InvalidWorkloadException(
+                $"'{metadataPath}' has unsupported or missing $schema '{metadata.Schema}'. " +
+                $"This CLI understands: {supported}. Update the CLI to read newer manifests.");
+        }
+
+        switch (metadata.Kind)
+        {
+            case WorkloadKind.Workload:
+                ValidateWorkloadEntryPoint(metadata, metadataPath);
+                return metadata;
+
+            case WorkloadKind.Content:
+            case WorkloadKind.Meta:
+                // entryPoint is meaningless for content/meta packages — reject
+                // it at author time instead of silently ignoring the field.
+                if (metadata.EntryPoint is not null)
+                {
+                    throw new InvalidWorkloadException(
+                        $"'{metadataPath}' declares kind '{metadata.Kind.ToString().ToLowerInvariant()}' " +
+                        "but also defines an entryPoint. Remove the entryPoint or change the kind to 'workload'.");
+                }
+
+                return metadata;
+
+            default:
+                throw new InvalidWorkloadException(
+                    $"'{metadataPath}' has unrecognized kind '{metadata.Kind}'.");
+        }
+    }
+
+    private static void ValidateWorkloadEntryPoint(WorkloadMetadata metadata, string metadataPath)
+    {
+        if (metadata.EntryPoint is null)
+        {
+            throw new InvalidWorkloadException(
+                $"'{metadataPath}' is missing entryPoint (required for kind 'workload').");
+        }
+
         if (string.IsNullOrWhiteSpace(metadata.EntryPoint.AssemblyPath))
         {
             throw new InvalidWorkloadException(
@@ -84,17 +122,13 @@ internal sealed class WorkloadMetadataReader : IWorkloadMetadataReader
                 $"'{metadataPath}' is missing entryPoint.type.");
         }
 
-        // entryPoint.assemblyPath is interpreted relative to the package's
-        // content root by the loader. Reject anything that would let a
-        // package escape that root: absolute paths, rooted UNC-style paths,
-        // or any segment of `..`. Defense-in-depth check also lives in the
-        // loader.
+        // Reject anything that would let a package escape its content root:
+        // absolute paths or `..` segments. Defense-in-depth — the loader
+        // also checks.
         ValidateRelativePathStaysWithinPackage(
             metadata.EntryPoint.AssemblyPath,
             metadataPath,
             "entryPoint.assemblyPath");
-
-        return metadata;
     }
 
     private static void ValidateRelativePathStaysWithinPackage(
@@ -108,9 +142,8 @@ internal sealed class WorkloadMetadataReader : IWorkloadMetadataReader
                 $"'{metadataPath}' has invalid {fieldName} '{value}': absolute paths are not allowed.");
         }
 
-        // Path.GetFileName / DirectorySeparatorChar handle both '/' and '\\'
-        // on Windows, but workload.json is authored cross-platform and may
-        // contain forward slashes even when read on Windows. Split on both.
+        // workload.json is authored cross-platform, so a Windows host may
+        // see forward slashes. Split on both separators.
         string[] segments = value.Split(['/', '\\'], StringSplitOptions.RemoveEmptyEntries);
         foreach (string segment in segments)
         {

--- a/src/Func/Workloads/IWorkloadProvider.cs
+++ b/src/Func/Workloads/IWorkloadProvider.cs
@@ -4,19 +4,17 @@
 namespace Azure.Functions.Cli.Workloads;
 
 /// <summary>
-/// Hands out the currently-installed, hydrated workloads. Composes the
-/// registry (<see cref="Storage.IWorkloadStore"/>) with the assembly loader
-/// (<see cref="Loading.IWorkloadLoader"/>) and caches the result so repeated
-/// command invocations don't re-read <c>workloads.json</c> or re-activate
-/// already-loaded assemblies.
+/// Hands out the set of installed, hydrated workloads. The list is
+/// materialized once at host startup by
+/// <see cref="Hosting.WorkloadRegistration"/> and exposed through this
+/// abstraction so consumers depend on a named domain concept rather than a
+/// raw <see cref="IEnumerable{T}"/> of <see cref="WorkloadInfo"/>.
 /// </summary>
 internal interface IWorkloadProvider
 {
     /// <summary>
-    /// Returns the loaded workloads, materializing them on first access and
-    /// returning the cached list on subsequent calls. Safe to call
-    /// concurrently; loading happens at most once per provider instance.
+    /// Returns the workloads that were loaded at boot. The result is stable
+    /// for the lifetime of the host.
     /// </summary>
-    public ValueTask<IReadOnlyList<WorkloadInfo>> GetWorkloadsAsync(
-        CancellationToken cancellationToken = default);
+    public IReadOnlyList<WorkloadInfo> GetWorkloads();
 }

--- a/src/Func/Workloads/Loading/WorkloadLoader.cs
+++ b/src/Func/Workloads/Loading/WorkloadLoader.cs
@@ -33,42 +33,49 @@ internal sealed class WorkloadLoader(IWorkloadPaths paths) : IWorkloadLoader
 
     private WorkloadInfo LoadEntry(WorkloadEntry entry)
     {
+        // Non-workload entries are filtered upstream; reaching the loader
+        // without an EntryPoint is a CLI bug, not a user error.
+        EntryPointSpec entryPoint = entry.EntryPoint
+            ?? throw new InvalidOperationException(
+                $"[{entry.PackageId}] WorkloadLoader was invoked for a non-workload entry (kind={entry.Kind}, no EntryPoint). " +
+                "Only kind=workload entries should reach the loader. This is a CLI bug.");
+
         string installPath = _paths.GetInstallDirectory(entry.PackageId, entry.PackageVersion);
         string contentRoot = Path.GetFullPath(Path.Combine(installPath, "tools", "any"));
-        string assemblyPath = Path.GetFullPath(Path.Combine(contentRoot, entry.EntryPoint.AssemblyPath));
+        string assemblyPath = Path.GetFullPath(Path.Combine(contentRoot, entryPoint.AssemblyPath));
 
-        // Defense-in-depth: the metadata reader rejects rooted paths and `..`
-        // segments at parse time, but the registry stores the same value and
-        // could be tampered with on disk. Refuse to load anything resolved
-        // outside the content root.
+        // Defense-in-depth: the metadata reader already rejects rooted paths
+        // and `..` segments, but the on-disk registry stores the same value
+        // and could be tampered with. Refuse anything resolving outside
+        // the content root.
         string contentRootWithSeparator = contentRoot.EndsWith(Path.DirectorySeparatorChar)
             ? contentRoot
             : contentRoot + Path.DirectorySeparatorChar;
         if (!assemblyPath.StartsWith(contentRootWithSeparator, StringComparison.Ordinal))
         {
             throw new GracefulException(
-                $"[{entry.PackageId}] Could not load workload: assembly path '{entry.EntryPoint.AssemblyPath}' resolves outside the package content root '{contentRoot}'.",
+                $"[{entry.PackageId}] Could not load workload: assembly path '{entryPoint.AssemblyPath}' resolves outside the package content root '{contentRoot}'.",
                 isUserError: true);
         }
 
         if (!File.Exists(assemblyPath))
         {
             throw new GracefulException(
-                $"[{entry.PackageId}] Could not load workload: assembly '{entry.EntryPoint.AssemblyPath}' was not found at '{contentRoot}'.",
+                $"[{entry.PackageId}] Could not load workload: assembly '{entryPoint.AssemblyPath}' was not found at '{contentRoot}'.",
                 isUserError: true);
         }
 
         Assembly assembly = new WorkloadLoadContext(entry.PackageId, assemblyPath)
             .LoadFromAssemblyPath(assemblyPath);
 
-        Type? type = assembly.GetType(entry.EntryPoint.Type, throwOnError: false) ?? throw new GracefulException(
-                $"[{entry.PackageId}] Could not load workload: type '{entry.EntryPoint.Type}' was not found in '{entry.EntryPoint.AssemblyPath}' (install path: '{installPath}').",
+        Type? type = assembly.GetType(entryPoint.Type, throwOnError: false) ?? throw new GracefulException(
+                $"[{entry.PackageId}] Could not load workload: type '{entryPoint.Type}' was not found in '{entryPoint.AssemblyPath}' (install path: '{installPath}').",
                 isUserError: true);
 
         if (!typeof(Workload).IsAssignableFrom(type))
         {
             throw new GracefulException(
-                $"[{entry.PackageId}] Could not load workload: type '{entry.EntryPoint.Type}' does not derive from {nameof(Workload)} (install path: '{installPath}').",
+                $"[{entry.PackageId}] Could not load workload: type '{entryPoint.Type}' does not derive from {nameof(Workload)} (install path: '{installPath}').",
                 isUserError: true);
         }
 

--- a/src/Func/Workloads/Storage/WorkloadJsonContext.cs
+++ b/src/Func/Workloads/Storage/WorkloadJsonContext.cs
@@ -1,17 +1,26 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Text.Json;
 using System.Text.Json.Serialization;
+using Azure.Functions.Cli.Workloads;
 
 namespace Azure.Functions.Cli.Workloads.Storage;
 
 /// <summary>
-/// System.Text.Json source-generated serialization context for the workload
-/// storage shapes. Build-time generation keeps the JSON path reflection-free
-/// (AOT/trim-friendly) and centralizes naming policy so individual properties
-/// don't carry <c>[JsonPropertyName]</c> attributes.
+/// Source-generated <see cref="JsonSerializerContext"/> for workload storage
+/// shapes. Keeps the JSON path reflection-free (AOT/trim-friendly).
 /// </summary>
-[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    Converters = [typeof(WorkloadKindJsonConverter)])]
 [JsonSerializable(typeof(WorkloadRegistry))]
 [JsonSerializable(typeof(WorkloadMetadata))]
 internal sealed partial class WorkloadJsonContext : JsonSerializerContext;
+
+/// <summary>
+/// Serializes <see cref="WorkloadKind"/> as a lowercase string
+/// (<c>"workload"</c> / <c>"content"</c> / <c>"meta"</c>). The default
+/// <see cref="JsonStringEnumConverter{TEnum}"/> would emit PascalCase.
+/// </summary>
+internal sealed class WorkloadKindJsonConverter() : JsonStringEnumConverter<WorkloadKind>(JsonNamingPolicy.CamelCase);

--- a/src/Func/Workloads/Storage/WorkloadManifestSchema.cs
+++ b/src/Func/Workloads/Storage/WorkloadManifestSchema.cs
@@ -4,47 +4,59 @@
 namespace Azure.Functions.Cli.Workloads.Storage;
 
 /// <summary>
-/// Versioning for the on-disk workload manifest, using a JSON Schema URL
-/// rather than a numeric version field.
+/// Schema URLs used to version the workload subsystem's JSON manifests.
 /// </summary>
 /// <remarks>
-/// The manifest carries its schema identity in the top-level
-/// <c>$schema</c> property, the same convention used by widely-supported
-/// JSON config formats (e.g. <c>tsconfig.json</c>, <c>azure-pipelines.yml</c>,
-/// <c>dotnet/global.json</c>). Editors and validators can fetch the schema
-/// at the URL and validate the document; breaking changes ship under a
-/// new versioned URL (<c>/v2/</c>, <c>/v3/</c>, ...) so older and newer
-/// CLIs can coexist on disk without one silently corrupting the other.
-/// A manifest written by a future Func CLI with a schema URL this CLI
-/// doesn't recognize is rejected at load time with an actionable error.
+/// Each manifest carries its schema identity in the top-level <c>$schema</c>
+/// property. Breaking changes ship under a new versioned URL so older and
+/// newer CLIs can coexist on disk. The registry and per-package manifest
+/// version independently.
 /// </remarks>
 internal static class WorkloadManifestSchema
 {
     /// <summary>
-    /// v1 manifest schema URL. Pinned so tests and external tooling can
-    /// reference a stable identifier that does not move when
-    /// <see cref="CurrentSchema"/> is bumped.
+    /// v1 schema URL for the global workload registry (<c>workloads.json</c>).
     /// </summary>
-    public const string V1Schema = "https://aka.ms/func/workloads/v1/schema.json";
+    public const string RegistryV1Schema = "https://aka.ms/func/workloads/v1/schema.json";
 
     /// <summary>
-    /// Current schema URL written into newly-saved manifests. Bump the
-    /// version segment (<c>v1</c> → <c>v2</c>) when the manifest shape
-    /// changes in a way older CLIs cannot safely read.
+    /// v1 schema URL for the per-package manifest (<c>workload.json</c>).
     /// </summary>
-    public const string CurrentSchema = V1Schema;
+    public const string PackageManifestV1Schema = "https://aka.ms/func-workloads/package/v1/schema.json";
 
     /// <summary>
-    /// Schemas this CLI knows how to read.
+    /// Current schema URL written into newly-saved registries.
     /// </summary>
-    public static IReadOnlyList<string> SupportedSchemas { get; } = [V1Schema];
+    public const string CurrentRegistrySchema = RegistryV1Schema;
 
     /// <summary>
-    /// Returns <c>true</c> if this CLI understands the supplied schema URL.
-    /// <c>null</c> or empty is treated as legacy v1 so manifests written
-    /// before this field was introduced still load.
+    /// Current schema URL accepted in package manifests.
     /// </summary>
-    public static bool IsSupported(string? schema)
-        => string.IsNullOrEmpty(schema) || SupportedSchemas.Contains(schema, StringComparer.Ordinal);
+    public const string CurrentPackageManifestSchema = PackageManifestV1Schema;
+
+    /// <summary>
+    /// Registry schemas this CLI knows how to read.
+    /// </summary>
+    public static IReadOnlyList<string> SupportedRegistrySchemas { get; } = [RegistryV1Schema];
+
+    /// <summary>
+    /// Per-package manifest schemas this CLI knows how to read.
+    /// </summary>
+    public static IReadOnlyList<string> SupportedPackageManifestSchemas { get; } = [PackageManifestV1Schema];
+
+    /// <summary>
+    /// Returns <c>true</c> if this CLI understands the supplied registry schema URL.
+    /// <c>null</c> or empty is treated as legacy v1 so pre-<c>$schema</c> registries still load.
+    /// </summary>
+    public static bool IsRegistrySupported(string? schema)
+        => string.IsNullOrEmpty(schema) || SupportedRegistrySchemas.Contains(schema, StringComparer.Ordinal);
+
+    /// <summary>
+    /// Returns <c>true</c> if this CLI understands the supplied package manifest schema URL.
+    /// <c>$schema</c> is required in package manifests, so empty/null is rejected.
+    /// </summary>
+    public static bool IsPackageManifestSupported(string? schema)
+        => !string.IsNullOrEmpty(schema)
+           && SupportedPackageManifestSchemas.Contains(schema, StringComparer.Ordinal);
 }
 

--- a/src/Func/Workloads/Storage/WorkloadRegistry.cs
+++ b/src/Func/Workloads/Storage/WorkloadRegistry.cs
@@ -2,42 +2,45 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Text.Json.Serialization;
+using Azure.Functions.Cli.Workloads;
 
 namespace Azure.Functions.Cli.Workloads.Storage;
 
 /// <summary>
-/// On-disk shape of <c>~/.azure-functions/workloads.json</c>. Flat list of
-/// installed workloads keyed by (<see cref="WorkloadEntry.PackageId"/>,
-/// <see cref="WorkloadEntry.PackageVersion"/>); side-by-side installs are
-/// separate entries.
+/// On-disk shape of <c>~/.azure-functions/workloads.json</c>.
+/// Workload and content packages live in <see cref="Workloads"/> keyed by
+/// (<see cref="WorkloadEntry.PackageId"/>, <see cref="WorkloadEntry.PackageVersion"/>);
+/// meta packages live in <see cref="Metas"/>, one row per id (no side-by-side).
 /// </summary>
 internal sealed class WorkloadRegistry
 {
     /// <summary>
-    /// JSON Schema URL identifying the registry format. Doubles as a
-    /// version marker: a future CLI emitting a different URL signals a
-    /// schema this CLI may not understand, and is rejected at load.
-    /// Serialized as <c>$schema</c> to follow the JSON Schema convention
-    /// (matches tsconfig.json, azure-pipelines.yml, dotnet/global.json).
+    /// JSON Schema URL identifying the registry format. A URL this CLI doesn't
+    /// recognize is rejected at load.
     /// </summary>
     [JsonPropertyName("$schema")]
     [JsonPropertyOrder(-1)]
-    public string Schema { get; init; } = WorkloadManifestSchema.CurrentSchema;
+    public string Schema { get; init; } = WorkloadManifestSchema.CurrentRegistrySchema;
 
     /// <summary>
-    /// Installed workloads. Empty when no workload has been installed yet.
+    /// Installed workload and content packages.
     /// </summary>
     public IList<WorkloadEntry> Workloads { get; init; } = [];
+
+    /// <summary>
+    /// Installed meta packages. Bookkeeping only; the loader never activates them.
+    /// </summary>
+    public IList<MetaEntry> Metas { get; init; } = [];
 }
 
 /// <summary>
-/// One installed workload version recorded in the global workload registry.
+/// One installed workload-or-content package.
 /// </summary>
 internal sealed class WorkloadEntry
 {
     /// <summary>
     /// NuGet package id (e.g. <c>"Azure.Functions.Cli.Workload.Dotnet"</c>).
-    /// Matched case-insensitively (NuGet convention).
+    /// Matched case-insensitively.
     /// </summary>
     public required string PackageId { get; init; }
 
@@ -47,15 +50,79 @@ internal sealed class WorkloadEntry
     public required string PackageVersion { get; init; }
 
     /// <summary>
-    /// Short aliases the user can pass to <c>func workload install/uninstall</c>
-    /// instead of the full package id (e.g. <c>"dotnet"</c>).
+    /// Package shape stamped at install time. The loader only activates
+    /// <see cref="WorkloadKind.Workload"/>; <see cref="WorkloadKind.Content"/>
+    /// ships files only. Meta packages live in <see cref="WorkloadRegistry.Metas"/>.
+    /// </summary>
+    public WorkloadKind Kind { get; init; } = WorkloadKind.Workload;
+
+    /// <summary>
+    /// Short aliases accepted by <c>func workload install/uninstall</c>
+    /// (e.g. <c>"dotnet"</c>), captured from the package's <c>.nuspec</c>
+    /// <c>alias:&lt;name&gt;</c> tags.
     /// </summary>
     public IReadOnlyList<string> Aliases { get; init; } = [];
 
     /// <summary>
-    /// Where to find the <see cref="Workload"/> implementation. Copied from
-    /// the package's <see cref="WorkloadMetadata"/> at install time so the
-    /// CLI doesn't have to re-read the package on every load.
+    /// Catalog feed URL or local path the package was installed from.
     /// </summary>
-    public required EntryPointSpec EntryPoint { get; init; }
+    public string Source { get; init; } = string.Empty;
+
+    /// <summary>
+    /// True when installed directly via <c>func workload install &lt;id&gt;</c>;
+    /// false when pulled in as a meta-package member. Defaults to true for legacy entries.
+    /// </summary>
+    public bool InstalledExplicitly { get; init; } = true;
+
+    /// <summary>
+    /// Where to find the <see cref="Workload"/> implementation, copied from
+    /// the package's <see cref="WorkloadMetadata"/> at install time.
+    /// Required for <see cref="WorkloadKind.Workload"/>; <see langword="null"/>
+    /// for <see cref="WorkloadKind.Content"/>.
+    /// </summary>
+    public EntryPointSpec? EntryPoint { get; init; }
+}
+
+/// <summary>
+/// One installed meta package. Records which member packages were brought in
+/// together so uninstall can offer cascade; metas have no payload of their own.
+/// </summary>
+internal sealed class MetaEntry
+{
+    /// <summary>
+    /// NuGet package id of the meta. Unique within <see cref="WorkloadRegistry.Metas"/>.
+    /// </summary>
+    public required string PackageId { get; init; }
+
+    /// <summary>
+    /// Installed meta version.
+    /// </summary>
+    public required string PackageVersion { get; init; }
+
+    /// <summary>
+    /// Catalog feed URL or local path the meta was installed from.
+    /// </summary>
+    public string Source { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Member packages this meta brought in, copied from the meta's
+    /// <c>.nuspec</c> <c>&lt;dependencies&gt;</c> at install time.
+    /// </summary>
+    public IReadOnlyList<MetaMember> Members { get; init; } = [];
+}
+
+/// <summary>
+/// One member of a meta package.
+/// </summary>
+internal sealed class MetaMember
+{
+    /// <summary>
+    /// NuGet package id of the member.
+    /// </summary>
+    public required string PackageId { get; init; }
+
+    /// <summary>
+    /// Member version pinned by this meta version.
+    /// </summary>
+    public required string PackageVersion { get; init; }
 }

--- a/src/Func/Workloads/Storage/WorkloadStore.cs
+++ b/src/Func/Workloads/Storage/WorkloadStore.cs
@@ -105,11 +105,11 @@ internal class WorkloadStore(IWorkloadPaths paths) : IWorkloadStore
                 cancellationToken)
                 ?? new WorkloadRegistry();
 
-            if (!WorkloadManifestSchema.IsSupported(registry.Schema))
+            if (!WorkloadManifestSchema.IsRegistrySupported(registry.Schema))
             {
                 string supported = string.Join(
                     Environment.NewLine,
-                    WorkloadManifestSchema.SupportedSchemas.Select(s => $"  - {s}"));
+                    WorkloadManifestSchema.SupportedRegistrySchemas.Select(s => $"  - {s}"));
 
                 throw new GracefulException(
                     $"The schema '{registry.Schema}' declared by registry '{path}' is not supported."

--- a/src/Func/Workloads/WorkloadProvider.cs
+++ b/src/Func/Workloads/WorkloadProvider.cs
@@ -1,53 +1,17 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Azure.Functions.Cli.Workloads.Loading;
-using Azure.Functions.Cli.Workloads.Storage;
-
 namespace Azure.Functions.Cli.Workloads;
 
 /// <summary>
-/// Default <see cref="IWorkloadProvider"/>. Reads the registry through
-/// <see cref="IWorkloadStore"/>, hydrates each entry through
-/// <see cref="IWorkloadLoader"/>, and caches the resulting list for the
-/// lifetime of the provider (singleton in DI).
+/// Default <see cref="IWorkloadProvider"/>. Snapshots the
+/// <see cref="WorkloadInfo"/> singletons registered by
+/// <see cref="Hosting.WorkloadRegistration"/> into a stable list.
 /// </summary>
-internal sealed class WorkloadProvider(IWorkloadStore store, IWorkloadLoader loader) : IWorkloadProvider
+internal sealed class WorkloadProvider(IEnumerable<WorkloadInfo> workloads) : IWorkloadProvider
 {
-    private readonly IWorkloadStore _store = store ?? throw new ArgumentNullException(nameof(store));
-    private readonly IWorkloadLoader _loader = loader ?? throw new ArgumentNullException(nameof(loader));
-    private readonly SemaphoreSlim _gate = new(initialCount: 1, maxCount: 1);
+    private readonly IReadOnlyList<WorkloadInfo> _workloads =
+        (workloads ?? throw new ArgumentNullException(nameof(workloads))).ToList();
 
-    private IReadOnlyList<WorkloadInfo>? _cached;
-
-    /// <inheritdoc />
-    public async ValueTask<IReadOnlyList<WorkloadInfo>> GetWorkloadsAsync(
-        CancellationToken cancellationToken = default)
-    {
-        // Fast path: already materialized.
-        IReadOnlyList<WorkloadInfo>? snapshot = _cached;
-        if (snapshot is not null)
-        {
-            return snapshot;
-        }
-
-        await _gate.WaitAsync(cancellationToken);
-        try
-        {
-            // Double-checked: another caller may have populated the cache while
-            // we waited on the gate.
-            if (_cached is not null)
-            {
-                return _cached;
-            }
-
-            IReadOnlyList<WorkloadEntry> entries = await _store.GetWorkloadsAsync(cancellationToken);
-            _cached = _loader.Load(entries);
-            return _cached;
-        }
-        finally
-        {
-            _gate.Release();
-        }
-    }
+    public IReadOnlyList<WorkloadInfo> GetWorkloads() => _workloads;
 }

--- a/test/Func.Tests/Commands/Workload/WorkloadListCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadListCommandTests.cs
@@ -16,7 +16,7 @@ public class WorkloadListCommandTests
     [Fact]
     public async Task EmptyList_WritesNoWorkloadsHint_ReturnsZero()
     {
-        var cmd = new WorkloadListCommand(_interaction, ProviderReturning([]));
+        var cmd = new WorkloadListCommand(_interaction, Provider());
         int exit = await InvokeAsync(cmd);
 
         Assert.Equal(0, exit);
@@ -36,7 +36,7 @@ public class WorkloadListCommandTests
                 aliases: ["dotnet", "dotnet-isolated"]),
         };
 
-        var cmd = new WorkloadListCommand(_interaction, ProviderReturning(workloads));
+        var cmd = new WorkloadListCommand(_interaction, Provider(workloads));
         int exit = await InvokeAsync(cmd);
 
         Assert.Equal(0, exit);
@@ -58,7 +58,7 @@ public class WorkloadListCommandTests
                 aliases: []),
         };
 
-        var cmd = new WorkloadListCommand(_interaction, ProviderReturning(workloads));
+        var cmd = new WorkloadListCommand(_interaction, Provider(workloads));
         await InvokeAsync(cmd);
 
         string rowLine = _interaction.Lines.Single(l => l.StartsWith("  ROW:"));
@@ -76,18 +76,17 @@ public class WorkloadListCommandTests
             NewInfo(new FakeWorkload(), "Pkg.A", "1.1.0", []),
         };
 
-        var cmd = new WorkloadListCommand(_interaction, ProviderReturning(workloads));
+        var cmd = new WorkloadListCommand(_interaction, Provider(workloads));
         await InvokeAsync(cmd);
 
         var rows = _interaction.Lines.Where(l => l.StartsWith("  ROW:")).ToList();
         Assert.Equal(3, rows.Count);
     }
 
-    private static IWorkloadProvider ProviderReturning(IReadOnlyList<WorkloadInfo> workloads)
+    private static IWorkloadProvider Provider(params WorkloadInfo[] workloads)
     {
-        IWorkloadProvider provider = Substitute.For<IWorkloadProvider>();
-        provider.GetWorkloadsAsync(Arg.Any<CancellationToken>())
-            .Returns(new ValueTask<IReadOnlyList<WorkloadInfo>>(workloads));
+        var provider = Substitute.For<IWorkloadProvider>();
+        provider.GetWorkloads().Returns(workloads);
         return provider;
     }
 

--- a/test/Func.Tests/Hosting/CliHostFactoryTests.cs
+++ b/test/Func.Tests/Hosting/CliHostFactoryTests.cs
@@ -1,0 +1,169 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Text.Json;
+using Azure.Functions.Cli.Hosting;
+using Azure.Functions.Cli.Workloads;
+using Azure.Functions.Cli.Workloads.Storage;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Hosting;
+
+/// <summary>
+/// Integration tests for the host-startup wiring: build the same host
+/// production uses, point it at a temp <c>Workloads:Home</c>, and assert the
+/// loaded workloads contributed (or failed to contribute) commands as
+/// expected. Each test sets up its own temp directory with the on-disk
+/// layout the loader expects:
+/// <c>&lt;Home&gt;/workloads.json</c> + <c>&lt;Home&gt;/workloads/&lt;pkg&gt;/&lt;ver&gt;/tools/any/&lt;asm&gt;.dll</c>.
+/// </summary>
+public sealed class CliHostFactoryTests : IDisposable
+{
+    private const string FixtureAssembly = "Azure.Functions.Cli.Workload.Tests.Fixtures.WithCommand.dll";
+    private const string CommandWorkloadType = "Azure.Functions.Cli.Workload.Tests.Fixtures.WithCommand.StubWorkload";
+    private const string ThrowingWorkloadType = "Azure.Functions.Cli.Workload.Tests.Fixtures.WithCommand.ThrowingWorkload";
+
+    private readonly string _home = Path.Combine(Path.GetTempPath(), "func-cli-tests", Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_home))
+        {
+            try
+            {
+                Directory.Delete(_home, recursive: true);
+            }
+            catch
+            {
+                // Best-effort cleanup; the OS will reap %TEMP% eventually.
+            }
+        }
+    }
+
+    [Fact]
+    public async Task CreateHostAsync_LoadsInstalledWorkloads_AndAddsTheirCommandsToRoot()
+    {
+        StageFixtureWorkload("withcommand.fixture", "1.0.0", CommandWorkloadType);
+        WriteRegistry(("withcommand.fixture", "1.0.0", CommandWorkloadType));
+
+        var interaction = new TestInteractionService();
+
+        using var host = await CliHostFactory.CreateHostAsync(
+            interaction,
+            cfg => cfg.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Workloads:Home"] = _home,
+            }));
+
+        var rootCommand = Parser.CreateCommand(host.Services);
+
+        Assert.Contains(rootCommand.Subcommands, c => string.Equals(c.Name, "hello-from-workload", StringComparison.Ordinal));
+        Assert.DoesNotContain(interaction.Lines, l => l.StartsWith("WARNING:", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task CreateHostAsync_WhenWorkloadConfigureThrows_WarnsAndContinues()
+    {
+        StageFixtureWorkload("throwing.fixture", "1.0.0", ThrowingWorkloadType);
+        WriteRegistry(("throwing.fixture", "1.0.0", ThrowingWorkloadType));
+
+        var interaction = new TestInteractionService();
+
+        using var host = await CliHostFactory.CreateHostAsync(
+            interaction,
+            cfg => cfg.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Workloads:Home"] = _home,
+            }));
+
+        var rootCommand = Parser.CreateCommand(host.Services);
+
+        Assert.Contains(
+            interaction.Lines,
+            l => l.StartsWith("WARNING:", StringComparison.Ordinal)
+                 && l.Contains("throwing.fixture@1.0.0", StringComparison.Ordinal)
+                 && l.Contains("Boom from ThrowingWorkload", StringComparison.Ordinal));
+
+        // Built-ins must still be there: a single misbehaving workload cannot brick the CLI.
+        Assert.Contains(rootCommand.Subcommands, c => string.Equals(c.Name, "version", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task CreateHostAsync_WithEmptyHome_LoadsHostWithoutWorkloadCommands()
+    {
+        Directory.CreateDirectory(_home);
+        // No workloads.json written: WorkloadStore returns an empty list.
+
+        var interaction = new TestInteractionService();
+
+        using var host = await CliHostFactory.CreateHostAsync(
+            interaction,
+            cfg => cfg.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Workloads:Home"] = _home,
+            }));
+
+        var rootCommand = Parser.CreateCommand(host.Services);
+
+        var workloads = host.Services.GetRequiredService<IWorkloadProvider>().GetWorkloads();
+        Assert.Empty(workloads);
+        Assert.DoesNotContain(rootCommand.Subcommands, c => string.Equals(c.Name, "hello-from-workload", StringComparison.Ordinal));
+        Assert.DoesNotContain(interaction.Lines, l => l.StartsWith("WARNING:", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Lays out one workload's runtime payload at the path the loader expects:
+    /// <c>&lt;Home&gt;/workloads/&lt;pkg&gt;/&lt;ver&gt;/tools/any/</c>, copying the
+    /// fixture's DLL/deps/runtimeconfig from where the test build's
+    /// <c>LayoutFixtureWorkloadsForTests</c> target staged them.
+    /// </summary>
+    private void StageFixtureWorkload(string packageId, string version, string typeName)
+    {
+        // typeName is unused at the filesystem layer; it lives in the registry entry
+        // (see WriteRegistry). It's a method parameter purely for callsite readability.
+        _ = typeName;
+        var installDir = Path.Combine(_home, "workloads", packageId, version, "tools", "any");
+        Directory.CreateDirectory(installDir);
+
+        var stagedFixtureRoot = Path.Combine(AppContext.BaseDirectory, "tools", "any");
+        foreach (var file in Directory.EnumerateFiles(stagedFixtureRoot))
+        {
+            var dest = Path.Combine(installDir, Path.GetFileName(file));
+            File.Copy(file, dest, overwrite: true);
+        }
+    }
+
+    private void WriteRegistry(params (string PackageId, string Version, string TypeName)[] entries)
+    {
+        var registry = new
+        {
+            Schema = WorkloadManifestSchema.CurrentRegistrySchema,
+            Workloads = entries.Select(e => new
+            {
+                PackageId = e.PackageId,
+                PackageVersion = e.Version,
+                Aliases = Array.Empty<string>(),
+                EntryPoint = new
+                {
+                    AssemblyPath = FixtureAssembly,
+                    Type = e.TypeName,
+                },
+            }).ToArray(),
+        };
+
+        Directory.CreateDirectory(_home);
+        var json = JsonSerializer.Serialize(registry, new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        });
+
+        // Match the on-disk shape WorkloadRegistry uses: $schema property name.
+        json = json.Replace("\"schema\":", "\"$schema\":", StringComparison.Ordinal);
+
+        File.WriteAllText(Path.Combine(_home, WorkloadPathsOptions.WorkloadRegistryFileName), json);
+    }
+}

--- a/test/Func.Tests/TestParser.cs
+++ b/test/Func.Tests/TestParser.cs
@@ -72,9 +72,12 @@ internal static class TestParser
         services.AddSingleton(emptyStore);
         services.AddSingleton(Substitute.For<IWorkloadLoader>());
 
+        // Loaded workloads are registered individually as singletons at host
+        // startup by WorkloadRegistration and surfaced via IWorkloadProvider.
+        // Tests don't go through that path, so register a stub provider that
+        // returns no workloads. Tests that need a populated set replace it.
         IWorkloadProvider emptyProvider = Substitute.For<IWorkloadProvider>();
-        emptyProvider.GetWorkloadsAsync(Arg.Any<CancellationToken>())
-            .Returns(new ValueTask<IReadOnlyList<WorkloadInfo>>([]));
+        emptyProvider.GetWorkloads().Returns([]);
         services.AddSingleton(emptyProvider);
 
         return services;

--- a/test/Func.Tests/Workloads/Discovery/WorkloadMetadataReaderTests.cs
+++ b/test/Func.Tests/Workloads/Discovery/WorkloadMetadataReaderTests.cs
@@ -3,12 +3,15 @@
 
 using Azure.Functions.Cli.Workloads;
 using Azure.Functions.Cli.Workloads.Discovery;
+using Azure.Functions.Cli.Workloads.Storage;
 using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Workloads.Discovery;
 
 public class WorkloadMetadataReaderTests : IDisposable
 {
+    private const string SchemaUrl = WorkloadManifestSchema.PackageManifestV1Schema;
+
     private readonly string _tempDir;
     private readonly WorkloadMetadataReader _reader = new();
 
@@ -30,8 +33,10 @@ public class WorkloadMetadataReaderTests : IDisposable
     public void Read_ReturnsMetadata_WhenManifestIsValid()
     {
         WriteMetadata(
-            """
+            $$"""
             {
+              "$schema": "{{SchemaUrl}}",
+              "kind": "workload",
               "entryPoint": {
                 "assemblyPath": "Foo.dll",
                 "type": "Foo.MyWorkload"
@@ -41,8 +46,114 @@ public class WorkloadMetadataReaderTests : IDisposable
 
         WorkloadMetadata metadata = _reader.Read(_tempDir);
 
-        Assert.Equal("Foo.dll", metadata.EntryPoint.AssemblyPath);
+        Assert.Equal(SchemaUrl, metadata.Schema);
+        Assert.Equal(WorkloadKind.Workload, metadata.Kind);
+        Assert.Equal("Foo.dll", metadata.EntryPoint!.AssemblyPath);
         Assert.Equal("Foo.MyWorkload", metadata.EntryPoint.Type);
+    }
+
+    [Fact]
+    public void Read_DefaultsKindToWorkload_WhenKindOmitted()
+    {
+        // workload-package-layout §5.4: kind defaults to "workload" when
+        // omitted, matching the authoring default for normal workloads.
+        WriteMetadata(
+            $$"""
+            {
+              "$schema": "{{SchemaUrl}}",
+              "entryPoint": {
+                "assemblyPath": "Foo.dll",
+                "type": "Foo.MyWorkload"
+              }
+            }
+            """);
+
+        WorkloadMetadata metadata = _reader.Read(_tempDir);
+
+        Assert.Equal(WorkloadKind.Workload, metadata.Kind);
+    }
+
+    [Fact]
+    public void Read_ReturnsContentMetadata_WhenKindIsContent()
+    {
+        // workload-package-layout §5.4: content packages declare "kind":
+        // "content" and omit entryPoint entirely.
+        WriteMetadata(
+            $$"""
+            {
+              "$schema": "{{SchemaUrl}}",
+              "kind": "content"
+            }
+            """);
+
+        WorkloadMetadata metadata = _reader.Read(_tempDir);
+
+        Assert.Equal(WorkloadKind.Content, metadata.Kind);
+        Assert.Null(metadata.EntryPoint);
+    }
+
+    [Fact]
+    public void Read_ReturnsMetaMetadata_WhenKindIsMeta()
+    {
+        WriteMetadata(
+            $$"""
+            {
+              "$schema": "{{SchemaUrl}}",
+              "kind": "meta"
+            }
+            """);
+
+        WorkloadMetadata metadata = _reader.Read(_tempDir);
+
+        Assert.Equal(WorkloadKind.Meta, metadata.Kind);
+        Assert.Null(metadata.EntryPoint);
+    }
+
+    [Theory]
+    [InlineData("content")]
+    [InlineData("meta")]
+    public void Read_Throws_WhenNonWorkloadKindDeclaresEntryPoint(string kind)
+    {
+        // workload-package-layout §5.4: entryPoint is forbidden for content
+        // and meta. The author should remove it (or set kind to workload).
+        WriteMetadata(
+            $$"""
+            {
+              "$schema": "{{SchemaUrl}}",
+              "kind": "{{kind}}",
+              "entryPoint": {
+                "assemblyPath": "Foo.dll",
+                "type": "Foo.MyWorkload"
+              }
+            }
+            """);
+
+        InvalidWorkloadException ex = Assert.Throws<InvalidWorkloadException>(
+            () => _reader.Read(_tempDir));
+
+        Assert.Contains(kind, ex.Message);
+        Assert.Contains("entryPoint", ex.Message);
+    }
+
+    [Fact]
+    public void Read_Throws_WhenSchemaUnknown()
+    {
+        WriteMetadata(
+            """
+            {
+              "$schema": "https://aka.ms/func-workloads/package/v999/schema.json",
+              "kind": "workload",
+              "entryPoint": {
+                "assemblyPath": "Foo.dll",
+                "type": "Foo.MyWorkload"
+              }
+            }
+            """);
+
+        InvalidWorkloadException ex = Assert.Throws<InvalidWorkloadException>(
+            () => _reader.Read(_tempDir));
+
+        Assert.Contains("$schema", ex.Message);
     }
 
     [Fact]
@@ -68,22 +179,31 @@ public class WorkloadMetadataReaderTests : IDisposable
     }
 
     [Fact]
-    public void Read_Throws_WhenEntryPointMissing()
+    public void Read_Throws_WhenWorkloadKindMissingEntryPoint()
     {
-        WriteMetadata("{}");
+        // kind=workload requires entryPoint.
+        WriteMetadata(
+            $$"""
+            {
+              "$schema": "{{SchemaUrl}}",
+              "kind": "workload"
+            }
+            """);
 
-        // `required` on init-only properties surfaces as a JsonException;
-        // the reader wraps it as an InvalidWorkloadException so callers only
-        // handle one type.
-        Assert.Throws<InvalidWorkloadException>(() => _reader.Read(_tempDir));
+        InvalidWorkloadException ex = Assert.Throws<InvalidWorkloadException>(
+            () => _reader.Read(_tempDir));
+
+        Assert.Contains("entryPoint", ex.Message);
     }
 
     [Fact]
     public void Read_Throws_WhenAssemblyPathBlank()
     {
         WriteMetadata(
-            """
+            $$"""
             {
+              "$schema": "{{SchemaUrl}}",
+              "kind": "workload",
               "entryPoint": {
                 "assemblyPath": "   ",
                 "type": "Foo.MyWorkload"
@@ -101,8 +221,10 @@ public class WorkloadMetadataReaderTests : IDisposable
     public void Read_Throws_WhenTypeBlank()
     {
         WriteMetadata(
-            """
+            $$"""
             {
+              "$schema": "{{SchemaUrl}}",
+              "kind": "workload",
               "entryPoint": {
                 "assemblyPath": "Foo.dll",
                 "type": ""
@@ -135,6 +257,8 @@ public class WorkloadMetadataReaderTests : IDisposable
         WriteMetadata(
             $$"""
             {
+              "$schema": "{{SchemaUrl}}",
+              "kind": "workload",
               "entryPoint": {
                 "assemblyPath": "{{assemblyPath}}",
                 "type": "Foo.MyWorkload"
@@ -158,6 +282,8 @@ public class WorkloadMetadataReaderTests : IDisposable
         WriteMetadata(
             $$"""
             {
+              "$schema": "{{SchemaUrl}}",
+              "kind": "workload",
               "entryPoint": {
                 "assemblyPath": "{{assemblyPath}}",
                 "type": "Foo.MyWorkload"
@@ -182,9 +308,10 @@ public class WorkloadMetadataReaderTests : IDisposable
         // surfaces here.
         WorkloadMetadata metadata = _reader.Read(AppContext.BaseDirectory);
 
+        Assert.Equal(WorkloadKind.Workload, metadata.Kind);
         Assert.Equal(
             "Azure.Functions.Cli.Workload.Tests.Fixtures.Default.dll",
-            metadata.EntryPoint.AssemblyPath);
+            metadata.EntryPoint!.AssemblyPath);
         Assert.Equal(
             "Azure.Functions.Cli.Workload.Tests.Fixtures.Default.StubWorkload",
             metadata.EntryPoint.Type);

--- a/test/Func.Tests/Workloads/Storage/WorkloadManifestSchemaTests.cs
+++ b/test/Func.Tests/Workloads/Storage/WorkloadManifestSchemaTests.cs
@@ -10,7 +10,7 @@ namespace Azure.Functions.Cli.Tests.Workloads.Storage;
 
 public class WorkloadManifestSchemaTests : IDisposable
 {
-    private const string V1Schema = WorkloadManifestSchema.V1Schema;
+    private const string V1Schema = WorkloadManifestSchema.RegistryV1Schema;
 
     private readonly string _tempHome;
     private readonly WorkloadStore _store;
@@ -35,7 +35,7 @@ public class WorkloadManifestSchemaTests : IDisposable
     [Fact]
     public void CurrentSchema_IsV1Url()
     {
-        Assert.Equal(V1Schema, WorkloadManifestSchema.CurrentSchema);
+        Assert.Equal(V1Schema, WorkloadManifestSchema.CurrentRegistrySchema);
     }
 
     [Fact]
@@ -104,7 +104,7 @@ public class WorkloadManifestSchemaTests : IDisposable
         Assert.Contains("v999", ex.Message);
         Assert.Contains("not supported", ex.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Supported schemas", ex.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains(WorkloadManifestSchema.V1Schema, ex.Message);
+        Assert.Contains(WorkloadManifestSchema.RegistryV1Schema, ex.Message);
         Assert.Contains("updating the CLI", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 

--- a/test/Func.Tests/Workloads/Storage/WorkloadStoreTests.cs
+++ b/test/Func.Tests/Workloads/Storage/WorkloadStoreTests.cs
@@ -69,7 +69,7 @@ public class WorkloadStoreTests : IDisposable
 
         var workloads = await _store.GetWorkloadsAsync();
         var installed = Assert.Single(workloads);
-        Assert.Equal("second.dll", installed.EntryPoint.AssemblyPath);
+        Assert.Equal("second.dll", installed.EntryPoint!.AssemblyPath);
     }
 
     [Fact]
@@ -80,7 +80,7 @@ public class WorkloadStoreTests : IDisposable
 
         var workloads = await _store.GetWorkloadsAsync();
         var installed = Assert.Single(workloads);
-        Assert.Equal("lower.dll", installed.EntryPoint.AssemblyPath);
+        Assert.Equal("lower.dll", installed.EntryPoint!.AssemblyPath);
     }
 
     [Fact]
@@ -126,7 +126,7 @@ public class WorkloadStoreTests : IDisposable
         Assert.Equal(entry.PackageId, actual.PackageId);
         Assert.Equal(entry.PackageVersion, actual.PackageVersion);
         Assert.Equal(entry.Aliases, actual.Aliases);
-        Assert.Equal(entry.EntryPoint.AssemblyPath, actual.EntryPoint.AssemblyPath);
+        Assert.Equal(entry.EntryPoint!.AssemblyPath, actual.EntryPoint!.AssemblyPath);
         Assert.Equal(entry.EntryPoint.Type, actual.EntryPoint.Type);
     }
 

--- a/test/Func.Tests/Workloads/WorkloadProviderTests.cs
+++ b/test/Func.Tests/Workloads/WorkloadProviderTests.cs
@@ -2,9 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Workloads;
-using Azure.Functions.Cli.Workloads.Loading;
-using Azure.Functions.Cli.Workloads.Storage;
-using NSubstitute;
 using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Workloads;
@@ -12,121 +9,27 @@ namespace Azure.Functions.Cli.Tests.Workloads;
 public class WorkloadProviderTests
 {
     [Fact]
-    public async Task GetWorkloadsAsync_ReturnsLoadedWorkloads_FromStoreEntries()
+    public void GetWorkloads_ReturnsInjectedSet_AsStableList()
     {
-        var entries = new[]
-        {
-            new WorkloadEntry
-            {
-                PackageId = "Pkg.A",
-                PackageVersion = "1.0.0",
-                EntryPoint = new EntryPointSpec { AssemblyPath = "A.dll", Type = "A.T" },
-            },
-        };
-        var instance = new TestWorkload();
-        var loaded = new[]
-        {
-            new WorkloadInfo(instance, "Pkg.A", "1.0.0", [], instance.DisplayName, instance.Description),
-        };
-        IWorkloadStore store = Substitute.For<IWorkloadStore>();
-        store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(entries);
-        IWorkloadLoader loader = Substitute.For<IWorkloadLoader>();
-        loader.Load(entries).Returns(loaded);
+        WorkloadInfo a = TestWorkloads.CreateInfo("Pkg.A");
+        WorkloadInfo b = TestWorkloads.CreateInfo("Pkg.B");
 
-        var provider = new WorkloadProvider(store, loader);
+        var provider = new WorkloadProvider([a, b]);
 
-        IReadOnlyList<WorkloadInfo> result = await provider.GetWorkloadsAsync();
+        IReadOnlyList<WorkloadInfo> first = provider.GetWorkloads();
+        IReadOnlyList<WorkloadInfo> second = provider.GetWorkloads();
 
-        Assert.Same(loaded, result);
-    }
-
-    [Fact]
-    public async Task GetWorkloadsAsync_CachesResult_AcrossCalls()
-    {
-        IWorkloadStore store = Substitute.For<IWorkloadStore>();
-        store.GetWorkloadsAsync(Arg.Any<CancellationToken>())
-            .Returns([]);
-        IWorkloadLoader loader = Substitute.For<IWorkloadLoader>();
-        loader.Load(Arg.Any<IReadOnlyList<WorkloadEntry>>())
-            .Returns([]);
-        var provider = new WorkloadProvider(store, loader);
-
-        IReadOnlyList<WorkloadInfo> first = await provider.GetWorkloadsAsync();
-        IReadOnlyList<WorkloadInfo> second = await provider.GetWorkloadsAsync();
-        IReadOnlyList<WorkloadInfo> third = await provider.GetWorkloadsAsync();
-
+        // Materialized once at construction, so repeated calls return the
+        // same list instance and never re-enumerate the source.
         Assert.Same(first, second);
-        Assert.Same(second, third);
-        await store.Received(1).GetWorkloadsAsync(Arg.Any<CancellationToken>());
-        loader.Received(1).Load(Arg.Any<IReadOnlyList<WorkloadEntry>>());
+        Assert.Equal(2, first.Count);
+        Assert.Same(a, first[0]);
+        Assert.Same(b, first[1]);
     }
 
     [Fact]
-    public async Task GetWorkloadsAsync_ConcurrentCallers_LoadOnlyOnce()
+    public void Ctor_NullWorkloads_Throws()
     {
-        // Have the store block until released so multiple callers all queue
-        // behind the gate, then assert the loader is still only invoked once.
-        var release = new TaskCompletionSource<IReadOnlyList<WorkloadEntry>>(
-            TaskCreationOptions.RunContinuationsAsynchronously);
-        IWorkloadStore store = Substitute.For<IWorkloadStore>();
-        store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(release.Task);
-        IWorkloadLoader loader = Substitute.For<IWorkloadLoader>();
-        loader.Load(Arg.Any<IReadOnlyList<WorkloadEntry>>())
-            .Returns([]);
-        var provider = new WorkloadProvider(store, loader);
-
-        Task<IReadOnlyList<WorkloadInfo>>[] callers = [.. Enumerable.Range(0, 10)
-            .Select(_ => Task.Run(async () => await provider.GetWorkloadsAsync()))];
-
-        // Give the callers time to queue behind the gate before releasing.
-        await Task.Delay(50);
-        release.SetResult([]);
-
-        IReadOnlyList<WorkloadInfo>[] results = await Task.WhenAll(callers);
-
-        Assert.All(results, r => Assert.Same(results[0], r));
-        loader.Received(1).Load(Arg.Any<IReadOnlyList<WorkloadEntry>>());
-    }
-
-    [Fact]
-    public async Task GetWorkloadsAsync_PassesCancellationToken_ToStore()
-    {
-        IWorkloadStore store = Substitute.For<IWorkloadStore>();
-        store.GetWorkloadsAsync(Arg.Any<CancellationToken>())
-            .Returns([]);
-        IWorkloadLoader loader = Substitute.For<IWorkloadLoader>();
-        loader.Load(Arg.Any<IReadOnlyList<WorkloadEntry>>())
-            .Returns([]);
-        var provider = new WorkloadProvider(store, loader);
-        using var cts = new CancellationTokenSource();
-
-        await provider.GetWorkloadsAsync(cts.Token);
-
-        await store.Received(1).GetWorkloadsAsync(cts.Token);
-    }
-
-    [Fact]
-    public void Ctor_NullStore_Throws()
-    {
-        IWorkloadLoader loader = Substitute.For<IWorkloadLoader>();
-        Assert.Throws<ArgumentNullException>(() => new WorkloadProvider(null!, loader));
-    }
-
-    [Fact]
-    public void Ctor_NullLoader_Throws()
-    {
-        IWorkloadStore store = Substitute.For<IWorkloadStore>();
-        Assert.Throws<ArgumentNullException>(() => new WorkloadProvider(store, null!));
-    }
-
-    private sealed class TestWorkload : global::Azure.Functions.Cli.Workloads.Workload
-    {
-        public override string DisplayName => "Test";
-
-        public override string Description => "Test workload.";
-
-        public override void Configure(FunctionsCliBuilder builder)
-        {
-        }
+        Assert.Throws<ArgumentNullException>(() => new WorkloadProvider(null!));
     }
 }

--- a/test/Workload.Tests.Fixtures.Default/workload.json
+++ b/test/Workload.Tests.Fixtures.Default/workload.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
+  "kind": "workload",
   "entryPoint": {
     "assemblyPath": "Azure.Functions.Cli.Workload.Tests.Fixtures.Default.dll",
     "type": "Azure.Functions.Cli.Workload.Tests.Fixtures.Default.StubWorkload"

--- a/test/Workload.Tests.Fixtures.Sdk/workload.json
+++ b/test/Workload.Tests.Fixtures.Sdk/workload.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
+  "kind": "workload",
   "entryPoint": {
     "assemblyPath": "Azure.Functions.Cli.Workload.Tests.Fixtures.Sdk.dll",
     "type": "Azure.Functions.Cli.Workload.Tests.Fixtures.Sdk.StubWorkload"

--- a/test/Workload.Tests.Fixtures.WithCommand/StubWorkload.cs
+++ b/test/Workload.Tests.Fixtures.WithCommand/StubWorkload.cs
@@ -1,0 +1,54 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads;
+
+namespace Azure.Functions.Cli.Workload.Tests.Fixtures.WithCommand;
+
+/// <summary>
+/// Test fixture whose <see cref="Workloads.Workload.Configure"/> registers a
+/// trivial command so integration tests can assert the command shows up on
+/// the constructed root.
+/// </summary>
+public sealed class StubWorkload : Workloads.Workload
+{
+    public override string DisplayName => "With Command";
+
+    public override string Description => "Fixture that contributes a single hello command.";
+
+    public override void Configure(FunctionsCliBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        builder.RegisterCommand(new HelloFromWorkloadCommand());
+    }
+}
+
+/// <summary>
+/// Test fixture whose <see cref="Workloads.Workload.Configure"/> throws, used
+/// to verify the host isolates per-workload Configure failures with a warning
+/// instead of bricking startup.
+/// </summary>
+public sealed class ThrowingWorkload : Workloads.Workload
+{
+    public override string DisplayName => "Throwing";
+
+    public override string Description => "Fixture whose Configure throws to exercise the warn-and-skip path.";
+
+    public override void Configure(FunctionsCliBuilder builder)
+        => throw new InvalidOperationException("Boom from ThrowingWorkload.");
+}
+
+/// <summary>
+/// Trivial workload-contributed command used by the host-startup smoke test.
+/// Public because the loader instantiates it across the workload ALC
+/// boundary; the test only asserts its presence on the root command tree.
+/// </summary>
+public sealed class HelloFromWorkloadCommand : FuncCommand
+{
+    public override string Name => "hello-from-workload";
+
+    public override string Description => "Test command contributed by a fixture workload.";
+
+    public override Task<int> ExecuteAsync(FuncCommandInvocationContext context, CancellationToken cancellationToken)
+        => Task.FromResult(0);
+}

--- a/test/Workload.Tests.Fixtures.WithCommand/Workload.Tests.Fixtures.WithCommand.csproj
+++ b/test/Workload.Tests.Fixtures.WithCommand/Workload.Tests.Fixtures.WithCommand.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(SrcRoot)Abstractions/Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Workload.Tests.Fixtures.WithCommand/workload.json
+++ b/test/Workload.Tests.Fixtures.WithCommand/workload.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
+  "kind": "workload",
+  "entryPoint": {
+    "assemblyPath": "Azure.Functions.Cli.Workload.Tests.Fixtures.WithCommand.dll",
+    "type": "Azure.Functions.Cli.Workload.Tests.Fixtures.WithCommand.StubWorkload"
+  }
+}


### PR DESCRIPTION
Resolves #4902.

Replaces the no-op `WorkloadRegistration` stub with the real load+Configure flow so installed workloads' commands and services actually show up in the running CLI.

## Boot pipeline

1. `Program.cs` → `CliHostFactory.CreateHostAsync` (single composition path, also used by tests with a config-override hook for `Workloads:Home`).
2. `WorkloadRegistration.RegisterWorkloadsAsync`:
   - Reads `~/.azure-functions/workloads.json` via `WorkloadStore`.
   - **Skips content-only entries** (workload-spec §6.2 step 3).
   - **Picks highest semver per `packageId`** via `NuGet.Versioning` (workload-spec §6.2 step 2).
   - **Loads each entry one-at-a-time** with try/catch + `IInteractionService.WriteWarning`, so a single bad workload cannot brick the CLI (workload-spec §6.2 "Failure isolation"). The `IWorkloadLoader.Load` contract stays all-or-nothing per call; per-entry isolation lives in this layer.
   - Publishes `IReadOnlyList<WorkloadInfo>` as a singleton.
   - Calls each `Workload.Configure(builder)` with the same per-workload isolation.
   - Records boot duration to telemetry as `func.workload.boot_duration_ms` (histogram tagged with `func.workload.count`).

## Schema changes (foundation for content-only / install)

- `WorkloadEntry.EntryPoint` and `WorkloadMetadata.EntryPoint` are now nullable.
- Both gain `bool ContentOnly { get; init; }`.
- `WorkloadMetadataReader` short-circuits validation when `contentOnly: true`; any declared `entryPoint` is silently ignored, not an error.

JSON shapes the loader now accepts:

**Per-package `workload.json` (normal):**
```json
{
  "entryPoint": {
    "assemblyPath": "Foo.Workload.dll",
    "type": "Foo.Workload.MyWorkload"
  }
}
```

**Per-package `workload.json` (content-only):**
```json
{ "contentOnly": true }
```

**Global `workloads.json`:**
```json
{
  "$schema": "https://aka.ms/func/workloads/v1/schema.json",
  "workloads": [
    { "packageId": "Foo.Workload", "packageVersion": "1.0.0", "aliases": ["foo"],
      "entryPoint": { "assemblyPath": "Foo.Workload.dll", "type": "Foo.Workload.MyWorkload" } },
    { "packageId": "Azure.Functions.Cli.Workload.Host", "packageVersion": "2.0.0", "aliases": ["host"],
      "contentOnly": true }
  ]
}
```

`assemblyPath` is always a bare filename; the loader resolves `<workloadHome>/workloads/<pkgId>/<pkgVer>/tools/any/<assemblyPath>`.

## Cleanup

`IWorkloadProvider`, `WorkloadProvider`, and `WorkloadProviderTests` are removed (~150 LOC). Eager loading at boot replaces the lazy provider abstraction; `WorkloadListCommand` consumes the singleton list directly.

`Program.cs` slimmed from ~140 lines to ~85: theme/interaction → `CliHostFactory` → `Parser.CreateCommand` → Ctrl+C → `RunAsync`.

## Foundation for install/uninstall (next)

Install/uninstall (#4901 follow-ups) get this for free:
- `WorkloadStore.SaveAsync` / `GetWorkloadsAsync` already exist.
- `ContentOnly` field on both `WorkloadEntry` and `WorkloadMetadata` means install can stamp content-only host-runtime packages with no further schema work.
- "Highest semver per packageId at boot" lives in the runtime, so install can blindly write side-by-side rows and uninstall can blindly delete a row, no "active version" pointer needed.
- Per-entry load-failure isolation means `func workload uninstall <bad>` keeps working even if `<bad>` itself can't load.

## Tests

- New `CliHostFactoryTests` (3 integration tests): happy path, Configure-throws warn-and-skip, empty home.
- New fixture project `Workload.Tests.Fixtures.WithCommand` with a command-registering and a Configure-throwing workload.
- `WorkloadStoreTests` and `WorkloadMetadataReaderTests` updated for nullable `EntryPoint`.

161/161 tests pass; `CI=true` build is warning-clean.
