### PR TITLE
Adds func pack and func publish 

### DIFF
--- a/eng/build/Minified.targets
+++ b/eng/build/Minified.targets
@@ -6,6 +6,7 @@
     <_LanguageWorkers Include="$(PublishDir)\workers\java" />
     <_LanguageWorkers Include="$(PublishDir)\workers\powershell" />
     <_LanguageWorkers Include="$(PublishDir)\workers\node" />
+    <_LanguageWorkers Include="$(PublishDir)\workers\native" />
   </ItemGroup>
 
   <!-- Remove worker directories from minified builds -->

--- a/eng/build/Workers.Golang.targets
+++ b/eng/build/Workers.Golang.targets
@@ -1,0 +1,15 @@
+<Project>
+
+  <!--
+    Ships the Go (native) worker config alongside the published CLI so the host
+    can discover the Go worker at workers/native/worker.config.json.
+  -->
+  <ItemGroup>
+    <Content Include="$(RepoRoot)src\Cli\func\StaticResources\nativeWorkerConfig.json">
+      <Link>workers\native\worker.config.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
+</Project>

--- a/eng/ci/templates/jobs/test-e2e-linux.yml
+++ b/eng/ci/templates/jobs/test-e2e-linux.yml
@@ -25,16 +25,12 @@ jobs:
       custom_linux_x64:
         languageWorker: 'Custom'
         runtime: 'linux-x64'
+      go_linux_x64:
+        languageWorker: 'Go'
+        runtime: 'linux-x64'
 
   steps:
   - template: /eng/ci/templates/steps/install-tools.yml@self
-
-  - bash: |
-      sudo apt-get update
-      sudo apt-get install -y npm golang
-      npm --version
-      go version
-    displayName: 'Install npm and Go'
 
   - pwsh: ./eng/scripts/start-emulators.ps1
     displayName: 'Start emulators (NoWait)'

--- a/eng/ci/templates/jobs/test-e2e-osx.yml
+++ b/eng/ci/templates/jobs/test-e2e-osx.yml
@@ -46,13 +46,19 @@ jobs:
   # arm64-native Go via Homebrew and prepend it so it wins over the cached
   # GoTool@0 path on macOS only. Linux/Windows pipelines continue to use
   # GoTool@0 from install-tools.yml unchanged.
+  #
+  # We pin to go@1.24 (keg-only) to match the version GoTool@0 installs on
+  # Linux/Windows; otherwise the unversioned 'go' formula floats to the
+  # latest brew release, drifting macOS away from the other OSes and (when
+  # GoTool@0's GOROOT is still set) producing toolchain mismatches like:
+  #   compile: version "go1.24.2" does not match go tool version "go1.26.2"
   - bash: |
       set -euo pipefail
-      brew install go
-      GO_BIN="$(brew --prefix go)/bin"
+      brew install go@1.24
+      GO_BIN="$(brew --prefix go@1.24)/bin"
       echo "##vso[task.prependpath]$GO_BIN"
       "$GO_BIN/go" version
-    displayName: 'Install Go (Homebrew, arm64-native)'
+    displayName: 'Install Go 1.24 (Homebrew, arm64-native)'
 
   - template: /eng/ci/templates/steps/restore-nuget.yml@self
 

--- a/eng/ci/templates/jobs/test-e2e-osx.yml
+++ b/eng/ci/templates/jobs/test-e2e-osx.yml
@@ -40,25 +40,16 @@ jobs:
 
   - template: /eng/ci/templates/steps/install-tools.yml@self
 
-  # GoTool@0 (in install-tools.yml) only ships an amd64 Go binary, which fails
-  # to execute on Apple Silicon (macOS-latest is arm64) without Rosetta 2 and
-  # surfaces as "Could not find a Go installation" inside func. Install an
-  # arm64-native Go via Homebrew and prepend it so it wins over the cached
-  # GoTool@0 path on macOS only. Linux/Windows pipelines continue to use
-  # GoTool@0 from install-tools.yml unchanged.
-  #
-  # We pin to go@1.24 (keg-only) to match the major.minor GoTool@0 installs
-  # on Linux/Windows. We also override GOROOT to brew's matching toolchain;
-  # GoTool@0 exports GOROOT pointing at its own 1.24.2 cache, and brew's go
-  # driver (1.24.x latest patch, e.g. 1.24.13) reads that env var and aborts:
-  #   compile: version "go1.24.2" does not match go tool version "go1.24.13"
+  # On macOS, GoTool@0 (in install-tools.yml) is skipped because it only
+  # ships an amd64 Go binary, which can't run on Apple Silicon agents.
+  # Install an arm64-native Go via Homebrew, pinned to the same major.minor
+  # (1.24) used by GoTool@0 on Linux/Windows, so all three OSes test against
+  # a consistent Go version.
   - bash: |
       set -euo pipefail
       brew install go@1.24
       GO_BIN="$(brew --prefix go@1.24)/bin"
-      BREW_GOROOT="$("$GO_BIN/go" env GOROOT)"
       echo "##vso[task.prependpath]$GO_BIN"
-      echo "##vso[task.setvariable variable=GOROOT]$BREW_GOROOT"
       "$GO_BIN/go" version
     displayName: 'Install Go 1.24 (Homebrew, arm64-native)'
 

--- a/eng/ci/templates/jobs/test-e2e-osx.yml
+++ b/eng/ci/templates/jobs/test-e2e-osx.yml
@@ -47,16 +47,18 @@ jobs:
   # GoTool@0 path on macOS only. Linux/Windows pipelines continue to use
   # GoTool@0 from install-tools.yml unchanged.
   #
-  # We pin to go@1.24 (keg-only) to match the version GoTool@0 installs on
-  # Linux/Windows; otherwise the unversioned 'go' formula floats to the
-  # latest brew release, drifting macOS away from the other OSes and (when
-  # GoTool@0's GOROOT is still set) producing toolchain mismatches like:
-  #   compile: version "go1.24.2" does not match go tool version "go1.26.2"
+  # We pin to go@1.24 (keg-only) to match the major.minor GoTool@0 installs
+  # on Linux/Windows. We also override GOROOT to brew's matching toolchain;
+  # GoTool@0 exports GOROOT pointing at its own 1.24.2 cache, and brew's go
+  # driver (1.24.x latest patch, e.g. 1.24.13) reads that env var and aborts:
+  #   compile: version "go1.24.2" does not match go tool version "go1.24.13"
   - bash: |
       set -euo pipefail
       brew install go@1.24
       GO_BIN="$(brew --prefix go@1.24)/bin"
+      BREW_GOROOT="$("$GO_BIN/go" env GOROOT)"
       echo "##vso[task.prependpath]$GO_BIN"
+      echo "##vso[task.setvariable variable=GOROOT]$BREW_GOROOT"
       "$GO_BIN/go" version
     displayName: 'Install Go 1.24 (Homebrew, arm64-native)'
 

--- a/eng/ci/templates/jobs/test-e2e-osx.yml
+++ b/eng/ci/templates/jobs/test-e2e-osx.yml
@@ -25,15 +25,13 @@ jobs:
       custom_osx_x64:
         languageWorker: 'Custom'
         runtime: 'osx-x64'
+      go_osx_x64:
+        languageWorker: 'Go'
+        runtime: 'osx-x64'
 
   steps:
   - pwsh: ./eng/scripts/start-emulators.ps1
     displayName: 'Start emulators (NoWait)'
-
-  - script: |
-      brew install go
-      go version
-    displayName: 'Install Go'
 
   - script: |
       sudo chown -R $(id -u):$(id -g) ~/.npm

--- a/eng/ci/templates/jobs/test-e2e-osx.yml
+++ b/eng/ci/templates/jobs/test-e2e-osx.yml
@@ -40,6 +40,20 @@ jobs:
 
   - template: /eng/ci/templates/steps/install-tools.yml@self
 
+  # GoTool@0 (in install-tools.yml) only ships an amd64 Go binary, which fails
+  # to execute on Apple Silicon (macOS-latest is arm64) without Rosetta 2 and
+  # surfaces as "Could not find a Go installation" inside func. Install an
+  # arm64-native Go via Homebrew and prepend it so it wins over the cached
+  # GoTool@0 path on macOS only. Linux/Windows pipelines continue to use
+  # GoTool@0 from install-tools.yml unchanged.
+  - bash: |
+      set -euo pipefail
+      brew install go
+      GO_BIN="$(brew --prefix go)/bin"
+      echo "##vso[task.prependpath]$GO_BIN"
+      "$GO_BIN/go" version
+    displayName: 'Install Go (Homebrew, arm64-native)'
+
   - template: /eng/ci/templates/steps/restore-nuget.yml@self
 
   - pwsh: |

--- a/eng/ci/templates/jobs/test-e2e-windows.yml
+++ b/eng/ci/templates/jobs/test-e2e-windows.yml
@@ -25,6 +25,9 @@ jobs:
       custom_win_x64:
         languageWorker: 'Custom'
         runtime: 'win-x64'
+      go_win_x64:
+        languageWorker: 'Go'
+        runtime: 'win-x64'
 
   steps:
   - pwsh: ./eng/scripts/start-emulators.ps1 -NoWait

--- a/eng/ci/templates/steps/install-tools.yml
+++ b/eng/ci/templates/steps/install-tools.yml
@@ -38,3 +38,8 @@ steps:
   inputs:
     packageType: sdk
     useGlobalJson: true
+
+- task: GoTool@0
+  inputs:
+    version: '1.24.2'
+  displayName: 'Install Go 1.24.2'

--- a/eng/ci/templates/steps/install-tools.yml
+++ b/eng/ci/templates/steps/install-tools.yml
@@ -43,3 +43,9 @@ steps:
   inputs:
     version: '1.24.2'
   displayName: 'Install Go 1.24.2'
+  # Skip on macOS: GoTool@0 only ships an amd64 Go binary, which fails to
+  # execute on Apple Silicon agents (macOS-latest is arm64). It also exports
+  # GOROOT pointing at its own toolchain, which conflicts with the brew
+  # Go we install in the macOS E2E job (test-e2e-osx.yml). Mac jobs that
+  # need Go install it via Homebrew themselves.
+  condition: ne(variables['Agent.OS'], 'Darwin')

--- a/src/Cli/func/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Cli/func/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -164,6 +164,27 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 throw new CliException($"--build {PublishBuildOption} is not supported for Windows Elastic Premium Function Apps.");
             }
 
+            // Go is cross-compiled to linux/amd64 and currently only supported on Flex Consumption.
+            // Reject Windows targets, non-Flex SKUs, and unsupported build modes up front.
+            if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.Go)
+            {
+                if (!functionApp.IsLinux)
+                {
+                    throw new CliException("Golang is only supported for Linux Function Apps.");
+                }
+
+                if (!functionApp.IsFlex)
+                {
+                    throw new CliException("Golang is only supported on Flex Consumption Function Apps.");
+                }
+
+                if (PublishBuildOption == BuildOption.Remote || PublishBuildOption == BuildOption.Container)
+                {
+                    throw new CliException(
+                        $"--build {PublishBuildOption} is not supported for Go. Run 'func publish' without '--build {PublishBuildOption}'.");
+                }
+            }
+
             // Get the GitIgnoreParser from the functionApp root
             var functionAppRoot = ScriptHostHelpers.GetFunctionAppRootDirectory(Environment.CurrentDirectory);
             var ignoreParser = PublishHelper.GetIgnoreParser(functionAppRoot);
@@ -223,6 +244,26 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             if (isNonCsxDotnetRuntime && !NoBuild && PublishBuildOption != BuildOption.Remote)
             {
                 await DotnetHelpers.BuildAndChangeDirectory(Path.Combine("bin", "publish"), DotnetCliParameters);
+            }
+            else if (workerRuntime == WorkerRuntime.Go &&
+                     PublishBuildOption != BuildOption.Remote &&
+                     PublishBuildOption != BuildOption.Container)
+            {
+                // Go always builds locally — there is no remote/container path for Go publishes.
+                // The remote/container conditions are redundant given the up-front rejection above;
+                // keeping them documents intent and stays defensive against future changes to ResolveBuildOption.
+                GoHelpers.AssertGoFunctionAppLayout(functionAppRoot);
+
+                if (NoBuild)
+                {
+                    // Trust the user's pre-built binary, but verify it is actually a linux/amd64 ELF
+                    // so we don't silently upload a host-OS binary to a Linux Flex host.
+                    GoHelpers.AssertLinuxAmd64Binary(functionAppRoot);
+                }
+                else
+                {
+                    await GoHelpers.BuildForLinux(functionAppRoot);
+                }
             }
 
             if (!isNonCsxDotnetRuntime)
@@ -1317,6 +1358,13 @@ namespace Azure.Functions.Cli.Actions.AzureActions
 
         private static void InternalListIgnoredFiles(GitIgnoreParser ignoreParser)
         {
+            if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.Go)
+            {
+                // Go uses an explicit allowlist (see GoHelpers.GetPackFiles); funcignore is not consulted.
+                ColoredConsole.WriteLine("Go publishes only host.json and app; all other files are excluded.");
+                return;
+            }
+
             if (ignoreParser == null)
             {
                 ColoredConsole.Error.WriteLine("No .funcignore file");
@@ -1331,6 +1379,20 @@ namespace Azure.Functions.Cli.Actions.AzureActions
 
         private static void InternalListIncludedFiles(GitIgnoreParser ignoreParser)
         {
+            if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.Go)
+            {
+                // Go zip is built from the explicit allowlist in GoHelpers.GetPackFiles; print those
+                // files rooted at the function app root so output matches what is actually packaged
+                // even when 'func publish' is run from a subdirectory.
+                var functionAppRoot = ScriptHostHelpers.GetFunctionAppRootDirectory(Environment.CurrentDirectory);
+                foreach (var file in GoHelpers.GetPackFiles(functionAppRoot))
+                {
+                    ColoredConsole.WriteLine(file);
+                }
+
+                return;
+            }
+
             if (ignoreParser == null)
             {
                 ColoredConsole.Error.WriteLine("No .funcignore file");

--- a/src/Cli/func/Actions/HostActions/StartHostAction.cs
+++ b/src/Cli/func/Actions/HostActions/StartHostAction.cs
@@ -733,6 +733,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
 
         private async Task PreRunConditions()
         {
+            ResolveNativeWorkerRuntime();
             EnsureWorkerRuntimeIsSet();
 
             if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.Python)
@@ -749,6 +750,20 @@ namespace Azure.Functions.Cli.Actions.HostActions
             else if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.Powershell && !CommandChecker.CommandExists("dotnet"))
             {
                 throw new CliException("Dotnet is required for PowerShell Functions. Please install dotnet (.NET Core SDK) for your system from https://www.microsoft.com/net/download");
+            }
+            else if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.Go)
+            {
+                var goVersion = await GoHelpers.GetEnvironmentGoVersion();
+                GoHelpers.AssertGoVersion(goVersion);
+
+                if (NoBuild)
+                {
+                    GoHelpers.AssertBinaryExists();
+                }
+                else
+                {
+                    await GoHelpers.BuildProject();
+                }
             }
 
             if (!NetworkHelpers.IsPortAvailable(Port))
@@ -879,6 +894,37 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 ? await SecurityHelpers.GetOrCreateCertificate(CertPath, CertPassword)
                 : null;
             return (new Uri($"{protocol}://0.0.0.0:{Port}"), new Uri($"{protocol}://localhost:{Port}"), cert);
+        }
+
+        internal void ResolveNativeWorkerRuntime()
+        {
+            // 'native' is the host's runtime identifier for any worker registered with
+            // language="native" (today: Go via workers/native/worker.config.json).
+            // Resolve it here by inspecting project markers; add new arms as additional native
+            // workers (e.g. Rust) are onboarded.
+            var setting = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime)
+                          ?? _secretsManager.GetSecrets().FirstOrDefault(s => s.Key.Equals(Constants.FunctionsWorkerRuntime, StringComparison.OrdinalIgnoreCase)).Value;
+
+            if (string.IsNullOrWhiteSpace(setting)
+                || !string.Equals(setting, "native", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            if (FileSystemHelpers.FileExists(Path.Combine(Environment.CurrentDirectory, "go.mod")))
+            {
+                if (VerboseLogging == true)
+                {
+                    ColoredConsole.WriteLine(VerboseColor("Resolving native worker runtime to 'go' (go.mod found)."));
+                }
+
+                GlobalCoreToolsSettings.CurrentWorkerRuntime = WorkerRuntime.Go;
+                return;
+            }
+
+            throw new CliException(
+                $"Could not determine the worker language for the project at '{Environment.CurrentDirectory}'. " +
+                "Run 'func init' to initialize a supported function app in this directory.");
         }
 
         private void EnsureWorkerRuntimeIsSet()

--- a/src/Cli/func/Actions/LocalActions/InitAction/InitAction.cs
+++ b/src/Cli/func/Actions/LocalActions/InitAction/InitAction.cs
@@ -71,6 +71,8 @@ namespace Azure.Functions.Cli.Actions.LocalActions
 
         public bool SkipNpmInstall { get; set; } = false;
 
+        public bool SkipGoModTidy { get; set; } = false;
+
         public WorkerRuntime ResolvedWorkerRuntime { get; set; }
 
         public string ResolvedLanguage { get; set; }
@@ -139,13 +141,17 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 .Callback(tf => TargetFramework = tf);
 
             Parser
-                .Setup<string>("language")
+                .Setup<string>('l', "language")
                 .SetDefault(null)
                 .Callback(l => Language = l);
 
             Parser
                 .Setup<bool>("skip-npm-install")
                 .Callback(skip => SkipNpmInstall = skip);
+
+            Parser
+                .Setup<bool>("skip-go-mod-tidy")
+                .Callback(skip => SkipGoModTidy = skip);
 
             Parser
                 .Setup<string>('m', "model")
@@ -209,6 +215,8 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             {
                 (ResolvedWorkerRuntime, ResolvedLanguage) = ResolveWorkerRuntimeAndLanguage(WorkerRuntime, Language);
 
+                Utilities.WarnIfGoWorkerRuntime(ResolvedWorkerRuntime);
+
                 // Order here is important: each language may have multiple runtimes, and each unique (language, worker-runtime) pair
                 // may have its own programming model. Thus, we assume that ResolvedLanguage and ResolvedWorkerRuntime are properly set
                 // before attempting to resolve the programming model.
@@ -229,6 +237,11 @@ namespace Azure.Functions.Cli.Actions.LocalActions
 
             TelemetryHelpers.AddCommandEventToDictionary(TelemetryCommandEvents, "WorkerRuntime", ResolvedWorkerRuntime.ToString());
 
+            if (ResolvedWorkerRuntime == Helpers.WorkerRuntime.Go && InitDocker)
+            {
+                throw new CliException("Docker support for the Go worker runtime is not yet available.");
+            }
+
             ValidateTargetFramework();
             if (WorkerRuntimeLanguageHelper.IsDotnet(ResolvedWorkerRuntime) && !Csx)
             {
@@ -238,7 +251,18 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             else
             {
                 bool managedDependenciesOption = ResolveManagedDependencies(ResolvedWorkerRuntime, ManagedDependencies);
-                await InitLanguageSpecificArtifacts(ResolvedWorkerRuntime, ResolvedLanguage, ResolvedProgrammingModel, managedDependenciesOption, GeneratePythonDocumentation);
+
+                if (ResolvedWorkerRuntime == Helpers.WorkerRuntime.Go)
+                {
+                    await GoHelpers.SetupProject(
+                        Utilities.SanitizeLiteral(Path.GetFileName(Environment.CurrentDirectory), allowed: "-_"),
+                        SkipGoModTidy);
+                }
+                else
+                {
+                    await InitLanguageSpecificArtifacts(ResolvedWorkerRuntime, ResolvedLanguage, ResolvedProgrammingModel, managedDependenciesOption, GeneratePythonDocumentation);
+                }
+
                 await WriteFiles();
 
                 await WriteHostJson(ResolvedWorkerRuntime, managedDependenciesOption, ExtensionBundle);
@@ -274,9 +298,27 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             if (!string.IsNullOrEmpty(workerRuntimeString))
             {
                 workerRuntime = WorkerRuntimeLanguageHelper.NormalizeWorkerRuntime(workerRuntimeString);
-                language = !string.IsNullOrEmpty(languageString)
-                    ? WorkerRuntimeLanguageHelper.NormalizeLanguage(languageString)
-                    : WorkerRuntimeLanguageHelper.NormalizeLanguage(workerRuntimeString);
+                if (workerRuntime == Helpers.WorkerRuntime.Go)
+                {
+                    return (workerRuntime, string.Empty);
+                }
+
+                if (!string.IsNullOrEmpty(languageString))
+                {
+                    language = WorkerRuntimeLanguageHelper.NormalizeLanguage(languageString);
+                }
+                else if (WorkerRuntimeLanguageHelper.TryNormalizeLanguage(workerRuntimeString, out var inferredLanguage))
+                {
+                    language = inferredLanguage;
+                }
+                else
+                {
+                    language = LanguageSelectionIfRelevant(workerRuntime);
+                    if (string.IsNullOrEmpty(language))
+                    {
+                        language = WorkerRuntimeLanguageHelper.GetDefaultTemplateLanguageFromWorker(workerRuntime);
+                    }
+                }
             }
             else if (GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone == Helpers.WorkerRuntime.None)
             {
@@ -292,6 +334,11 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             else
             {
                 workerRuntime = GlobalCoreToolsSettings.CurrentWorkerRuntime;
+                if (workerRuntime == Helpers.WorkerRuntime.Go)
+                {
+                    return (workerRuntime, string.Empty);
+                }
+
                 language = GlobalCoreToolsSettings.CurrentLanguageOrNull
                     ?? (!string.IsNullOrEmpty(languageString) ? WorkerRuntimeLanguageHelper.NormalizeLanguage(languageString) : null)
                     ?? WorkerRuntimeLanguageHelper.NormalizeLanguage(WorkerRuntimeLanguageHelper.GetRuntimeMoniker(workerRuntime));
@@ -407,7 +454,14 @@ namespace Azure.Functions.Cli.Actions.LocalActions
         private static async Task WriteLocalSettingsJson(WorkerRuntime workerRuntime, ProgrammingModel programmingModel)
         {
             string localSettingsJsonContent = await StaticResources.LocalSettingsJson;
-            localSettingsJsonContent = localSettingsJsonContent.Replace($"{{{Constants.FunctionsWorkerRuntime}}}", WorkerRuntimeLanguageHelper.GetRuntimeMoniker(workerRuntime));
+
+            // The Go worker is registered with the host under the "native" runtime identifier,
+            // so FUNCTIONS_WORKER_RUNTIME in local.settings.json must be "native" even though
+            // the CLI exposes the runtime as "go" everywhere else.
+            string workerRuntimeSetting = workerRuntime == Helpers.WorkerRuntime.Go
+                ? "native"
+                : WorkerRuntimeLanguageHelper.GetRuntimeMoniker(workerRuntime);
+            localSettingsJsonContent = localSettingsJsonContent.Replace($"{{{Constants.FunctionsWorkerRuntime}}}", workerRuntimeSetting);
             localSettingsJsonContent = localSettingsJsonContent.Replace($"{{{Constants.AzureWebJobsStorage}}}", Constants.StorageEmulatorConnectionString);
 
             if (workerRuntime == Helpers.WorkerRuntime.Powershell)
@@ -489,6 +543,11 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             else if (workerRuntime == Helpers.WorkerRuntime.Custom)
             {
                 await FileSystemHelpers.WriteFileIfNotExists("Dockerfile", await StaticResources.DockerfileCustom);
+            }
+            else if (workerRuntime == Helpers.WorkerRuntime.Go)
+            {
+                // Docker support for Go is validated up-front in RunAsync; this branch is unreachable in practice.
+                throw new CliException("Docker support for the Go worker runtime is not yet available.");
             }
             else if (workerRuntime == Helpers.WorkerRuntime.None)
             {

--- a/src/Cli/func/Actions/LocalActions/InitAction/InitGoSubcommandAction.cs
+++ b/src/Cli/func/Actions/LocalActions/InitAction/InitGoSubcommandAction.cs
@@ -1,0 +1,27 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Fclp;
+
+namespace Azure.Functions.Cli.Actions.LocalActions
+{
+    [Action(Name = "init go", ParentCommandName = "init", ShowInHelp = true, HelpText = "Options specific to Go runtime apps when running func init")]
+    internal class InitGoSubcommandAction : BaseAction
+    {
+        public override ICommandLineParserResult ParseArgs(string[] args)
+        {
+            Parser
+                .Setup<bool>("skip-go-mod-tidy")
+                .WithDescription("Skip running 'go mod tidy' after Go project creation.")
+                .Callback(_ => { });
+
+            return base.ParseArgs(args);
+        }
+
+        public override Task RunAsync()
+        {
+            // This method is never called - the main InitAction handles execution
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Cli/func/Actions/LocalActions/PackAction/GoPackSubcommandAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/GoPackSubcommandAction.cs
@@ -1,0 +1,61 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Helpers;
+using Azure.Functions.Cli.Interfaces;
+using Fclp;
+
+namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
+{
+    [Action(Name = "pack go", ParentCommandName = "pack", ShowInHelp = false, HelpText = "Arguments specific to Go apps when running func pack")]
+    internal class GoPackSubcommandAction : PackSubcommandAction
+    {
+        public override ICommandLineParserResult ParseArgs(string[] args)
+        {
+            return base.ParseArgs(args);
+        }
+
+        public async Task RunAsync(PackOptions packOptions)
+        {
+            await ExecuteAsync(packOptions);
+        }
+
+        protected internal override void ValidateFunctionApp(string functionAppRoot, PackOptions options)
+        {
+            // RunValidations runs the standard host.json check plus our Go-specific checks.
+            var validations = new List<Action<string>>
+            {
+                dir => PackValidationHelper.RunRequiredFilesValidation(dir, new[] { GoHelpers.GoModFileName }, "Validate go.mod"),
+            };
+            PackValidationHelper.RunValidations(functionAppRoot, validations);
+        }
+
+        protected override Task<string> GetPackingRootAsync(string functionAppRoot, PackOptions options)
+        {
+            // Go packs from the function app root without a separate staging dir.
+            return Task.FromResult(functionAppRoot);
+        }
+
+        protected override async Task PerformBuildBeforePackingAsync(string packingRoot, string functionAppRoot, PackOptions options)
+        {
+            if (options.NoBuild)
+            {
+                // --no-build: trust the user's pre-built binary, but verify it is actually a linux/amd64 ELF.
+                GoHelpers.AssertLinuxAmd64Binary(functionAppRoot);
+                return;
+            }
+
+            await GoHelpers.BuildForLinux(functionAppRoot);
+        }
+
+        // No PackFunctionAsync override — the default flow goes through
+        // PackHelpers.CreatePackage → ZipHelper.GetAppZipFile, which has a Go branch
+        // that emits the explicit allowlist (host.json + app).
+        public override Task RunAsync()
+        {
+            // Subcommand is dispatched via PackAction.RunRuntimeSpecificPackAsync; not invoked directly.
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Cli/func/Actions/LocalActions/PackAction/PackAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/PackAction.cs
@@ -129,6 +129,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
                 WorkerRuntime.Node => new NodePackSubcommandAction(_secretsManager).RunAsync(packOptions, Args),
                 WorkerRuntime.Powershell => new PowershellPackSubcommandAction().RunAsync(packOptions),
                 WorkerRuntime.Custom => new CustomPackSubcommandAction().RunAsync(packOptions),
+                WorkerRuntime.Go => new GoPackSubcommandAction().RunAsync(packOptions),
                 _ => throw new CliException($"Unsupported runtime: {runtime}")
             });
     }

--- a/src/Cli/func/Common/Executable.cs
+++ b/src/Cli/func/Common/Executable.cs
@@ -122,11 +122,32 @@ namespace Azure.Functions.Cli.Common
 
                 if (timeout is null)
                 {
-                    return await exitCodeTask.ConfigureAwait(false);
+                    var exitCode = await exitCodeTask.ConfigureAwait(false);
+
+                    if (_streamOutput)
+                    {
+                        // Process exit and async output delivery are independent: the Exited event
+                        // can fire before OutputDataReceived/ErrorDataReceived have drained the OS
+                        // pipe buffers. For short-lived commands (e.g. `go version`) this leaves
+                        // callers reading an empty StringBuilder. The parameterless WaitForExit()
+                        // is the documented way to flush the async event pump after the process
+                        // has already exited.
+                        Process.WaitForExit();
+                    }
+
+                    return exitCode;
                 }
                 else
                 {
-                    return await exitCodeTask.WaitAsync(timeout.Value).ConfigureAwait(false);
+                    var exitCode = await exitCodeTask.WaitAsync(timeout.Value).ConfigureAwait(false);
+
+                    if (_streamOutput)
+                    {
+                        // See comment above: drain async output handlers before returning.
+                        Process.WaitForExit();
+                    }
+
+                    return exitCode;
                 }
             }
             catch (TimeoutException)

--- a/src/Cli/func/Common/Utilities.cs
+++ b/src/Cli/func/Common/Utilities.cs
@@ -64,6 +64,19 @@ namespace Azure.Functions.Cli
             ColoredConsole.WriteLine();
         }
 
+        internal static void WarnIfGoWorkerRuntime(Helpers.WorkerRuntime workerRuntime)
+        {
+            if (workerRuntime != Helpers.WorkerRuntime.Go)
+            {
+                return;
+            }
+
+            ColoredConsole
+                .WriteLine("The Go worker runtime is currently in preview. Features and behavior may change in future releases.".DarkYellow());
+
+            ColoredConsole.WriteLine();
+        }
+
         internal static void PrintSupportInformation()
         {
             Architecture arch = RuntimeInformation.ProcessArchitecture;

--- a/src/Cli/func/Directory.Build.targets
+++ b/src/Cli/func/Directory.Build.targets
@@ -6,6 +6,7 @@
   <Import Project="$(EngBuildRoot)Templates.targets" Condition="'$(SkipTemplates)' != 'true'" />
 
   <Import Project="$(EngBuildRoot)Workers.Powershell.targets" />
+  <Import Project="$(EngBuildRoot)Workers.Golang.targets" />
   <Import Project="$(EngBuildRoot)Workers.Python.Workaround.targets" Condition="'$(RuntimeIdentifier)' == 'win-arm64'" />
 
 </Project>

--- a/src/Cli/func/Helpers/GoHelpers.cs
+++ b/src/Cli/func/Helpers/GoHelpers.cs
@@ -202,6 +202,7 @@ namespace Azure.Functions.Cli.Helpers
                             "Re-run 'func pack' without '--no-build' to produce a linux/amd64 binary.");
                     }
                 }
+
                 return header;
             }
 

--- a/src/Cli/func/Helpers/GoHelpers.cs
+++ b/src/Cli/func/Helpers/GoHelpers.cs
@@ -1,0 +1,153 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Text;
+using System.Text.RegularExpressions;
+using Azure.Functions.Cli.Common;
+using Colors.Net;
+using static Azure.Functions.Cli.Common.OutputTheme;
+
+namespace Azure.Functions.Cli.Helpers
+{
+    public static class GoHelpers
+    {
+        private const int MinimumGoMajorVersion = 1;
+        private const int MinimumGoMinorVersion = 24;
+
+        public static async Task<WorkerLanguageVersionInfo> GetEnvironmentGoVersion()
+        {
+            return await GetVersion("go");
+        }
+
+        public static void AssertGoVersion(WorkerLanguageVersionInfo goVersion)
+        {
+            if (goVersion?.Version == null)
+            {
+                throw new CliException(
+                    $"Could not find a Go installation. Go {MinimumGoMajorVersion}.{MinimumGoMinorVersion} or later is required. " +
+                    "Please install Go from https://go.dev/dl/");
+            }
+
+            if (GlobalCoreToolsSettings.IsVerbose)
+            {
+                ColoredConsole.WriteLine(VerboseColor($"Found Go version {goVersion.Version} ({goVersion.ExecutablePath})."));
+            }
+
+            if (goVersion.Major == null || goVersion.Minor == null)
+            {
+                throw new CliException(
+                    $"Unable to parse Go version '{goVersion.Version}'. " +
+                    $"Go {MinimumGoMajorVersion}.{MinimumGoMinorVersion} or later is required.");
+            }
+
+            // Accept any major version > 1, or major == 1 with minor >= 24
+            if (goVersion.Major > MinimumGoMajorVersion)
+            {
+                return;
+            }
+
+            if (goVersion.Major == MinimumGoMajorVersion && goVersion.Minor >= MinimumGoMinorVersion)
+            {
+                return;
+            }
+
+            throw new CliException(
+                $"Go version {goVersion.Version} is not supported. " +
+                $"Go {MinimumGoMajorVersion}.{MinimumGoMinorVersion} or later is required. " +
+                "Please update Go from https://go.dev/dl/");
+        }
+
+        public static async Task SetupProject(string moduleName, bool skipGoModTidy)
+        {
+            var goVersion = await GetEnvironmentGoVersion();
+            AssertGoVersion(goVersion);
+
+            // Scaffold go.mod, main.go, and .funcignore from embedded templates.
+            // The SDK version is pinned inside go.mod.template so that contributors
+            // bumping the SDK only touch template files (no C# change required) and
+            // `go mod tidy` resolves the pinned version deterministically.
+            var goModContent = (await StaticResources.GoMod).Replace("{ModuleName}", moduleName);
+            await FileSystemHelpers.WriteFileIfNotExists("go.mod", goModContent);
+            await FileSystemHelpers.WriteFileIfNotExists("main.go", await StaticResources.MainGo);
+            await FileSystemHelpers.WriteFileIfNotExists(Constants.FuncIgnoreFile, await StaticResources.FuncIgnore);
+
+            if (!skipGoModTidy)
+            {
+                await RunGoCommandAsync("mod tidy", null, throwOnFailure: false);
+            }
+            else
+            {
+                ColoredConsole.WriteLine(AdditionalInfoColor("Skipped \"go mod tidy\". You must run \"go mod tidy\" manually."));
+            }
+        }
+
+        private static async Task RunGoCommandAsync(string arguments, string errorMessage, bool throwOnFailure = true)
+        {
+            var exe = new Executable("go", arguments);
+            var stderr = new StringBuilder();
+            var exitCode = await exe.RunAsync(
+                l =>
+                {
+                    if (GlobalCoreToolsSettings.IsVerbose)
+                    {
+                        ColoredConsole.WriteLine(VerboseColor(l));
+                    }
+                },
+                e =>
+                {
+                    stderr.AppendLine(e);
+                    if (GlobalCoreToolsSettings.IsVerbose)
+                    {
+                        ColoredConsole.WriteLine(VerboseColor(e));
+                    }
+                });
+
+            if (exitCode != 0)
+            {
+                var stderrOutput = stderr.ToString().Trim();
+                if (throwOnFailure)
+                {
+                    var detail = string.IsNullOrEmpty(stderrOutput) ? string.Empty : $" {stderrOutput}";
+                    throw new CliException($"{errorMessage}{detail}");
+                }
+
+                ColoredConsole.WriteLine(WarningColor($"Warning: 'go {arguments}' exited with a non-zero code. You may need to run it manually."));
+                if (!string.IsNullOrEmpty(stderrOutput))
+                {
+                    ColoredConsole.WriteLine(WarningColor(stderrOutput));
+                }
+            }
+        }
+
+        private static async Task<WorkerLanguageVersionInfo> GetVersion(string goExe)
+        {
+            try
+            {
+                var exe = new Executable(goExe, "version");
+                var sb = new StringBuilder();
+                var exitCode = await exe.RunAsync(l => sb.AppendLine(l), e => sb.AppendLine(e));
+
+                if (exitCode == 0)
+                {
+                    var output = sb.ToString().Trim();
+
+                    // Parse "go version go1.24.2 linux/amd64" format
+                    var match = Regex.Match(output, @"go(\d+\.\d+(?:\.\d+)?)");
+                    if (match.Success)
+                    {
+                        return new WorkerLanguageVersionInfo(WorkerRuntime.Go, match.Groups[1].Value, goExe);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                if (GlobalCoreToolsSettings.IsVerbose)
+                {
+                    ColoredConsole.WriteLine(VerboseColor($"Unable to detect Go version: {ex.Message}"));
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Cli/func/Helpers/GoHelpers.cs
+++ b/src/Cli/func/Helpers/GoHelpers.cs
@@ -13,7 +13,8 @@ namespace Azure.Functions.Cli.Helpers
     {
         private const int MinimumGoMajorVersion = 1;
         private const int MinimumGoMinorVersion = 24;
-        private const string GoBinaryName = "app";
+        internal const string GoBinaryName = "app";
+        internal const string GoModFileName = "go.mod";
 
         public static async Task<WorkerLanguageVersionInfo> GetEnvironmentGoVersion()
         {
@@ -121,6 +122,172 @@ namespace Azure.Functions.Cli.Helpers
                 throw new CliException(
                     $"Could not find a built Go binary '{binaryName}' in '{workingDirectory}'. " +
                     $"Run 'func start' without '--no-build' to compile, or run 'go build -o {binaryName} .' manually.");
+            }
+        }
+
+        /// <summary>
+        /// Cross-compiles the user's Go project into a linux/amd64 binary named
+        /// <see cref="GoBinaryName"/> in <paramref name="workingDirectory"/>. Used
+        /// by <c>func pack</c> and <c>func publish</c> — the produced binary is the
+        /// one that runs on the Linux Functions host, regardless of the dev OS.
+        /// </summary>
+        public static async Task BuildForLinux(string workingDirectory = null)
+        {
+            workingDirectory ??= Environment.CurrentDirectory;
+
+            var goVersion = await GetEnvironmentGoVersion();
+            AssertGoVersion(goVersion);
+
+            ColoredConsole.WriteLine($"Building Go worker binary '{GoBinaryName}' for linux/amd64...");
+
+            var env = new Dictionary<string, string>
+            {
+                ["CGO_ENABLED"] = "0",
+                ["GOOS"] = "linux",
+                ["GOARCH"] = "amd64",
+            };
+
+            var exe = new Executable("go", $"build -o \"{GoBinaryName}\" .", workingDirectory: workingDirectory, environmentVariables: env);
+            var stderr = new StringBuilder();
+            var exitCode = await exe.RunAsync(
+                l => ColoredConsole.WriteLine(l),
+                e =>
+                {
+                    stderr.AppendLine(e);
+                    ColoredConsole.Error.WriteLine(ErrorColor(e));
+                });
+
+            if (exitCode != 0)
+            {
+                var detail = stderr.Length == 0 ? string.Empty : $" {stderr.ToString().Trim()}";
+                throw new CliException($"Go build for linux/amd64 failed with exit code {exitCode}.{detail}");
+            }
+        }
+
+        /// <summary>
+        /// Ensures the Go binary in <paramref name="workingDirectory"/> is a valid
+        /// Linux x86_64 executable suitable for the Azure Functions Linux host.
+        /// Validates the binary's structure by checking its ELF header format.
+        /// Called by <c>func pack --no-build</c> to confirm the binary was properly
+        /// cross-compiled before packaging for deployment.
+        /// </summary>
+        public static void AssertLinuxAmd64Binary(string workingDirectory = null)
+        {
+            workingDirectory ??= Environment.CurrentDirectory;
+            var binaryPath = Path.Combine(workingDirectory, GoBinaryName);
+
+            void ValidateBinaryExists()
+            {
+                if (!FileSystemHelpers.FileExists(binaryPath))
+                {
+                    throw new CliException(
+                        $"Could not find a built Go binary '{GoBinaryName}' in '{workingDirectory}'. " +
+                        $"Run 'func pack' without '--no-build' to cross-compile, or run " +
+                        $"'CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o {GoBinaryName} .' manually.");
+                }
+            }
+
+            byte[] ReadElfHeader()
+            {
+                // Read the first 20 bytes of the ELF header so we can validate magic, class, data, and machine.
+                // Layout reference: https://refspecs.linuxfoundation.org/elf/gabi4+/ch4.eheader.html
+                var header = new byte[20];
+                using (var fs = new FileStream(binaryPath, FileMode.Open, FileAccess.Read))
+                {
+                    int read = fs.Read(header, 0, header.Length);
+                    if (read < header.Length)
+                    {
+                        throw new CliException(
+                            $"'{binaryPath}' is too small to be an ELF binary. " +
+                            "Re-run 'func pack' without '--no-build' to produce a linux/amd64 binary.");
+                    }
+                }
+                return header;
+            }
+
+            // ELF magic is the file signature that identifies an ELF (Executable and Linkable Format) binary
+            void ValidateElfMagic(byte[] header)
+            {
+                // ELF magic: 0x7F 'E' 'L' 'F'
+                bool isElf = header[0] == 0x7F && header[1] == (byte)'E' && header[2] == (byte)'L' && header[3] == (byte)'F';
+                if (!isElf)
+                {
+                    throw new CliException(
+                        $"'{binaryPath}' is not an ELF binary. The Functions Linux host requires a linux/amd64 ELF binary. " +
+                        "Re-run 'func pack' without '--no-build', or build with 'CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o app .'");
+                }
+            }
+
+            void ValidateElfFormat(byte[] header)
+            {
+                // EI_CLASS == 2 (64-bit), EI_DATA == 1 (little endian)
+                if (header[4] != 2 || header[5] != 1)
+                {
+                    throw new CliException(
+                        $"'{binaryPath}' is not a 64-bit little-endian ELF binary. The Functions Linux host requires a linux/amd64 binary. " +
+                        "Re-run 'func pack' without '--no-build', or build with 'CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o app .'");
+                }
+            }
+
+            void ValidateElfMachine(byte[] header)
+            {
+                // e_machine is at offset 18, 2 bytes little-endian. 0x3E == EM_X86_64.
+                ushort eMachine = (ushort)(header[18] | (header[19] << 8));
+                if (eMachine != 0x3E)
+                {
+                    throw new CliException(
+                        $"'{binaryPath}' targets machine 0x{eMachine:X4}, not x86_64. The Functions Linux host requires a linux/amd64 binary. " +
+                        "Re-run 'func pack' without '--no-build', or build with 'CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o app .'");
+                }
+            }
+
+            // Execute validations in order
+            ValidateBinaryExists();
+            var header = ReadElfHeader();
+            ValidateElfMagic(header);
+            ValidateElfFormat(header);
+            ValidateElfMachine(header);
+        }
+
+        /// <summary>
+        /// Returns the explicit allowlist of files that should be included in the
+        /// Go deployment zip. Centralizes the list so that <see cref="ZipHelper"/>
+        /// (zip composition) and <c>func publish --list-included-files</c> stay in sync.
+        /// </summary>
+        public static IEnumerable<string> GetPackFiles(string functionAppRoot)
+        {
+            functionAppRoot ??= Environment.CurrentDirectory;
+            return new[]
+            {
+                Path.Combine(functionAppRoot, Constants.HostJsonFileName),
+                Path.Combine(functionAppRoot, GoBinaryName),
+            };
+        }
+
+        /// <summary>
+        /// Verifies the function app root has the files required to build/publish a Go app:
+        /// <c>host.json</c> and <c>go.mod</c>. Throws <see cref="CliException"/> with an
+        /// actionable message on failure. Used by <c>func publish</c>; <c>func pack</c>
+        /// performs the equivalent checks via <see cref="PackValidationHelper"/>.
+        /// </summary>
+        public static void AssertGoFunctionAppLayout(string functionAppRoot)
+        {
+            functionAppRoot ??= Environment.CurrentDirectory;
+
+            var hostJsonPath = Path.Combine(functionAppRoot, Constants.HostJsonFileName);
+            if (!FileSystemHelpers.FileExists(hostJsonPath))
+            {
+                throw new CliException(
+                    $"Could not find '{Constants.HostJsonFileName}' in '{functionAppRoot}'. " +
+                    "Run 'func publish' from the root of a Go function app.");
+            }
+
+            var goModPath = Path.Combine(functionAppRoot, GoModFileName);
+            if (!FileSystemHelpers.FileExists(goModPath))
+            {
+                throw new CliException(
+                    $"Could not find '{GoModFileName}' in '{functionAppRoot}'. " +
+                    "Run 'func publish' from the root of a Go function app.");
             }
         }
 

--- a/src/Cli/func/Helpers/GoHelpers.cs
+++ b/src/Cli/func/Helpers/GoHelpers.cs
@@ -9,10 +9,11 @@ using static Azure.Functions.Cli.Common.OutputTheme;
 
 namespace Azure.Functions.Cli.Helpers
 {
-    public static class GoHelpers
+    internal static class GoHelpers
     {
         private const int MinimumGoMajorVersion = 1;
         private const int MinimumGoMinorVersion = 24;
+        private const string GoBinaryName = "app";
 
         public static async Task<WorkerLanguageVersionInfo> GetEnvironmentGoVersion()
         {
@@ -78,6 +79,48 @@ namespace Azure.Functions.Cli.Helpers
             else
             {
                 ColoredConsole.WriteLine(AdditionalInfoColor("Skipped \"go mod tidy\". You must run \"go mod tidy\" manually."));
+            }
+        }
+
+        /// <summary>
+        /// Compiles the user's Go project into a binary named <see cref="GoBinaryName"/>
+        /// in <paramref name="workingDirectory"/>. The host resolves this binary via
+        /// <c>defaultExecutablePath</c> in <c>workers/native/worker.config.json</c>
+        /// (the host appends <c>.exe</c> on Windows automatically).
+        /// </summary>
+        public static async Task BuildProject(string workingDirectory = null)
+        {
+            workingDirectory ??= Environment.CurrentDirectory;
+            var outputName = OperatingSystem.IsWindows() ? $"{GoBinaryName}.exe" : GoBinaryName;
+            ColoredConsole.WriteLine($"Building Go worker binary '{outputName}'...");
+
+            var exe = new Executable("go", $"build -o \"{outputName}\" .", workingDirectory: workingDirectory);
+            var exitCode = await exe.RunAsync(
+                l => ColoredConsole.WriteLine(l),
+                e => ColoredConsole.Error.WriteLine(ErrorColor(e)));
+
+            if (exitCode != 0)
+            {
+                throw new CliException($"Go build failed with exit code {exitCode}. See output above for details.");
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the compiled Go worker binary exists in
+        /// <paramref name="workingDirectory"/>. Throws a <see cref="CliException"/>
+        /// with an actionable message when missing — used by <c>func start --no-build</c>.
+        /// </summary>
+        public static void AssertBinaryExists(string workingDirectory = null)
+        {
+            workingDirectory ??= Environment.CurrentDirectory;
+            var binaryName = OperatingSystem.IsWindows() ? $"{GoBinaryName}.exe" : GoBinaryName;
+            var binaryPath = Path.Combine(workingDirectory, binaryName);
+
+            if (!FileSystemHelpers.FileExists(binaryPath))
+            {
+                throw new CliException(
+                    $"Could not find a built Go binary '{binaryName}' in '{workingDirectory}'. " +
+                    $"Run 'func start' without '--no-build' to compile, or run 'go build -o {binaryName} .' manually.");
             }
         }
 

--- a/src/Cli/func/Helpers/LanguageWorkerHelper.cs
+++ b/src/Cli/func/Helpers/LanguageWorkerHelper.cs
@@ -15,6 +15,7 @@ namespace Azure.Functions.Cli.Helpers
             { WorkerRuntime.Powershell, "languageWorkers:powershell:arguments" },
             { WorkerRuntime.Dotnet, string.Empty },
             { WorkerRuntime.Custom, string.Empty },
+            { WorkerRuntime.Go, string.Empty },
             { WorkerRuntime.None, string.Empty }
         }
         .Select(p => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)

--- a/src/Cli/func/Helpers/WorkerRuntimeLanguageHelper.cs
+++ b/src/Cli/func/Helpers/WorkerRuntimeLanguageHelper.cs
@@ -38,10 +38,10 @@ namespace Azure.Functions.Cli.Helpers
             { WorkerRuntime.Dotnet, new[] { "c#", "csharp", "f#", "fsharp" } },
             { WorkerRuntime.Node, new[] { "js", "javascript", "typescript", "ts" } },
             { WorkerRuntime.Python, new[] { "py" } },
+            { WorkerRuntime.Go, new[] { "golang" } },
             { WorkerRuntime.Java, new string[] { } },
             { WorkerRuntime.Powershell, new[] { "pwsh" } },
             { WorkerRuntime.Custom, new string[] { } },
-            { WorkerRuntime.Go, new[] { "golang" } }
         };
 
         private static readonly IDictionary<string, WorkerRuntime> _normalizeMap = _availableWorkersRuntime

--- a/src/Cli/func/Helpers/WorkerRuntimeLanguageHelper.cs
+++ b/src/Cli/func/Helpers/WorkerRuntimeLanguageHelper.cs
@@ -25,7 +25,9 @@ namespace Azure.Functions.Cli.Helpers
         [DisplayString("powershell")]
         Powershell,
         [DisplayString("custom")]
-        Custom
+        Custom,
+        [DisplayString("go")]
+        Go
     }
 
     public static class WorkerRuntimeLanguageHelper
@@ -38,7 +40,8 @@ namespace Azure.Functions.Cli.Helpers
             { WorkerRuntime.Python, new[] { "py" } },
             { WorkerRuntime.Java, new string[] { } },
             { WorkerRuntime.Powershell, new[] { "pwsh" } },
-            { WorkerRuntime.Custom, new string[] { } }
+            { WorkerRuntime.Custom, new string[] { } },
+            { WorkerRuntime.Go, new[] { "golang" } }
         };
 
         private static readonly IDictionary<string, WorkerRuntime> _normalizeMap = _availableWorkersRuntime
@@ -67,7 +70,7 @@ namespace Azure.Functions.Cli.Helpers
             { Constants.Languages.CSharp, new[] { "csharp", "dotnet", "dotnet-isolated", "dotnetIsolated" } },
             { Constants.Languages.FSharp, new[] { "fsharp" } },
             { Constants.Languages.Java, new string[] { } },
-            { Constants.Languages.Custom, new string[] { } }
+            { Constants.Languages.Custom, new string[] { } },
         };
 
         public static readonly IDictionary<string, string> WorkerRuntimeStringToLanguage = _languageToAlias
@@ -79,7 +82,7 @@ namespace Azure.Functions.Cli.Helpers
         {
             { WorkerRuntime.Node, new[] { Constants.Languages.JavaScript, Constants.Languages.TypeScript } },
             { WorkerRuntime.Dotnet, new[] { Constants.Languages.CSharp, Constants.Languages.FSharp } },
-            { WorkerRuntime.DotnetIsolated, new[] { Constants.Languages.CSharp, Constants.Languages.FSharp } }
+            { WorkerRuntime.DotnetIsolated, new[] { Constants.Languages.CSharp, Constants.Languages.FSharp } },
         };
 
         public static IEnumerable<WorkerRuntime> AvailableWorkersList => _availableWorkersRuntime.Keys
@@ -110,6 +113,8 @@ namespace Azure.Functions.Cli.Helpers
                     return "powershell";
                 case WorkerRuntime.Custom:
                     return "custom";
+                case WorkerRuntime.Go:
+                    return "go";
                 default:
                     return "None";
             }
@@ -159,7 +164,7 @@ namespace Azure.Functions.Cli.Helpers
             {
                 throw new ArgumentNullException(nameof(languageString), "language can't be empty");
             }
-            else if (_normalizeMap.ContainsKey(languageString))
+            else if (WorkerRuntimeStringToLanguage.ContainsKey(languageString))
             {
                 return WorkerRuntimeStringToLanguage[languageString];
             }
@@ -167,6 +172,18 @@ namespace Azure.Functions.Cli.Helpers
             {
                 throw new ArgumentException($"Language '{languageString}' is not available. Available language strings are {WorkerRuntimeStringToLanguage.Keys}");
             }
+        }
+
+        public static bool TryNormalizeLanguage(string languageString, out string normalized)
+        {
+            if (!string.IsNullOrWhiteSpace(languageString) && WorkerRuntimeStringToLanguage.ContainsKey(languageString))
+            {
+                normalized = WorkerRuntimeStringToLanguage[languageString];
+                return true;
+            }
+
+            normalized = null;
+            return false;
         }
 
         public static IEnumerable<string> LanguagesForWorker(WorkerRuntime worker)

--- a/src/Cli/func/Helpers/ZipHelper.cs
+++ b/src/Cli/func/Helpers/ZipHelper.cs
@@ -42,6 +42,13 @@ namespace Azure.Functions.Cli.Helpers
                 // Remote build for dotnet does not require bin and obj folders. They will be generated during the oryx build
                 return await CreateZip(FileSystemHelpers.GetLocalFiles(functionAppRoot, ignoreParser, false, new string[] { "bin", "obj" }), functionAppRoot, Array.Empty<string>());
             }
+            else if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.Go)
+            {
+                // Go publishes an explicit allowlist (host.json + the cross-compiled 'app' binary),
+                // The 'app' binary needs the executable bit set
+                // when extracted on Linux. Shared by both `func pack` and `func publish`.
+                return await CreateZip(GoHelpers.GetPackFiles(functionAppRoot), functionAppRoot, new[] { GoHelpers.GoBinaryName });
+            }
             else
             {
                 var customHandler = await HostHelpers.GetCustomHandlerExecutable(functionAppRoot);

--- a/src/Cli/func/Services/RuntimeEolChecker.cs
+++ b/src/Cli/func/Services/RuntimeEolChecker.cs
@@ -180,6 +180,7 @@ namespace Azure.Functions.Cli.Services
                 WorkerRuntime.Powershell => "POWERSHELL",
                 WorkerRuntime.Dotnet => "DOTNET",
                 WorkerRuntime.DotnetIsolated => "DOTNET-ISOLATED",
+                WorkerRuntime.Go => "GO",
                 _ => null
             };
 

--- a/src/Cli/func/StaticResources/StaticResources.cs
+++ b/src/Cli/func/StaticResources/StaticResources.cs
@@ -84,6 +84,10 @@ namespace Azure.Functions.Cli
 
         public static Task<string> FuncIgnore => GetValue("funcignore");
 
+        public static Task<string> MainGo => GetValue("main.go");
+
+        public static Task<string> GoMod => GetValue("go.mod");
+
         public static Task<string> PackageJsonJsV4 => GetValue("package-js-v4.json");
 
         public static Task<string> PackageJsonJs => GetValue("package-js.json");

--- a/src/Cli/func/StaticResources/StaticResources.props
+++ b/src/Cli/func/StaticResources/StaticResources.props
@@ -1,6 +1,12 @@
 <Project>
   <!-- Static resources embedded into the assembly -->
   <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)main.go">
+      <LogicalName>$(AssemblyName).main.go</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)go.mod.template">
+      <LogicalName>$(AssemblyName).go.mod</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)stacks.json">
       <LogicalName>$(AssemblyName).stacks.json</LogicalName>
     </EmbeddedResource>

--- a/src/Cli/func/StaticResources/go.mod.template
+++ b/src/Cli/func/StaticResources/go.mod.template
@@ -1,0 +1,5 @@
+module {ModuleName}
+
+go 1.24
+
+require github.com/azure/azure-functions-golang-worker v0.2.0-preview

--- a/src/Cli/func/StaticResources/main.go
+++ b/src/Cli/func/StaticResources/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/azure/azure-functions-golang-worker/sdk"
+	"github.com/azure/azure-functions-golang-worker/worker"
+)
+
+// HTTPTriggerHandler handles standard HTTP requests
+func HTTPTriggerHandler(w http.ResponseWriter, r *http.Request) {
+	log.Printf("Processing HTTP Trigger for %s", r.URL.Path)
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("Hello from Go Worker!"))
+}
+
+func main() {
+	app := sdk.FunctionApp()
+	app.HTTP("hello", HTTPTriggerHandler,
+		sdk.WithMethods("GET", "POST"),
+		sdk.WithAuth("anonymous"),
+	)
+	worker.Start(app)
+}

--- a/src/Cli/func/StaticResources/nativeWorkerConfig.json
+++ b/src/Cli/func/StaticResources/nativeWorkerConfig.json
@@ -1,0 +1,11 @@
+{
+    "description": {
+        "language": "native",
+        "defaultExecutablePath": "app",
+        "workerIndexing": "true"
+    },
+    "processOptions": {
+        "initializationTimeout": "00:02:00",
+        "environmentReloadTimeout": "00:02:00"
+    }
+}

--- a/test/Cli/Func.E2ETests/Commands/FuncInit/GoInitTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncInit/GoInitTests.cs
@@ -1,0 +1,112 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.E2ETests.Traits;
+using Azure.Functions.Cli.TestFramework.Assertions;
+using Azure.Functions.Cli.TestFramework.Commands;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Azure.Functions.Cli.E2ETests.Commands.FuncInit
+{
+    [Trait(WorkerRuntimeTraits.WorkerRuntime, WorkerRuntimeTraits.Go)]
+    public class GoInitTests(ITestOutputHelper log) : BaseE2ETests(log)
+    {
+        [Fact]
+        public void Init_WithGo_GeneratesExpectedFunctionProjectFiles()
+        {
+            var workingDir = WorkingDirectory;
+            var testName = nameof(Init_WithGo_GeneratesExpectedFunctionProjectFiles);
+            var funcInitCommand = new FuncInitCommand(FuncPath, testName, Log ?? throw new ArgumentNullException(nameof(Log)));
+            var localSettingsPath = Path.Combine(workingDir, Common.Constants.LocalSettingsJsonFileName);
+            var expectedLocalSettingsContent = new[] { Common.Constants.FunctionsWorkerRuntime, "native" };
+            var hostJsonPath = Path.Combine(workingDir, "host.json");
+            var expectedHostJsonContent = new[] { "extensionBundle" };
+            var mainGoPath = Path.Combine(workingDir, "main.go");
+            var expectedMainGoContent = new[] { "package main" };
+            var funcIgnorePath = Path.Combine(workingDir, ".funcignore");
+
+            var filesToValidate = new List<(string FilePath, string[] ExpectedContent)>
+            {
+                (localSettingsPath, expectedLocalSettingsContent),
+                (hostJsonPath, expectedHostJsonContent),
+                (mainGoPath, expectedMainGoContent)
+            };
+
+            var funcInitResult = funcInitCommand
+                .WithWorkingDirectory(workingDir)
+                .Execute(["--worker-runtime", "go"]);
+
+            funcInitResult.Should().WriteVsCodeExtensionsJsonAndExitWithZero(workingDir);
+            funcInitResult.Should().FilesExistsWithExpectContent(filesToValidate);
+            File.Exists(funcIgnorePath).Should().BeTrue("Expected .funcignore to exist");
+            File.Exists(Path.Combine(workingDir, "go.mod")).Should().BeTrue("Expected go.mod to exist");
+        }
+
+        [Fact]
+        public void Init_WithSkipGoModTidy_SkipsTidyStep()
+        {
+            var workingDir = WorkingDirectory;
+            var testName = nameof(Init_WithSkipGoModTidy_SkipsTidyStep);
+            var funcInitCommand = new FuncInitCommand(FuncPath, testName, Log ?? throw new ArgumentNullException(nameof(Log)));
+
+            var funcInitResult = funcInitCommand
+                .WithWorkingDirectory(workingDir)
+                .Execute(["--worker-runtime", "go", "--skip-go-mod-tidy"]);
+
+            funcInitResult.Should().ExitWith(0);
+            funcInitResult.Should().HaveStdOutContaining("Skipped \"go mod tidy\"");
+        }
+
+        [Fact]
+        public void Init_WithForceFlag_InNonEmptyDirectory()
+        {
+            var workingDir = WorkingDirectory;
+            File.WriteAllText(Path.Combine(workingDir, "existing.txt"), "test");
+
+            var testName = nameof(Init_WithForceFlag_InNonEmptyDirectory);
+            var funcInitCommand = new FuncInitCommand(FuncPath, testName, Log ?? throw new ArgumentNullException(nameof(Log)));
+
+            var funcInitResult = funcInitCommand
+                .WithWorkingDirectory(workingDir)
+                .Execute(["--worker-runtime", "go", "--force"]);
+
+            funcInitResult.Should().ExitWith(0);
+            File.Exists(Path.Combine(workingDir, "main.go")).Should().BeTrue("Expected main.go to exist");
+        }
+
+        [Fact]
+        public void Init_WithDockerFlag_FailsLoudly()
+        {
+            var workingDir = WorkingDirectory;
+            var testName = nameof(Init_WithDockerFlag_FailsLoudly);
+            var funcInitCommand = new FuncInitCommand(FuncPath, testName, Log ?? throw new ArgumentNullException(nameof(Log)));
+
+            var funcInitResult = funcInitCommand
+                .WithWorkingDirectory(workingDir)
+                .Execute(["--worker-runtime", "go", "--docker"]);
+
+            funcInitResult.Should().ExitWith(1);
+            funcInitResult.Should().HaveStdErrContaining("Docker support for the Go worker runtime is not yet available");
+            File.Exists(Path.Combine(workingDir, "Dockerfile")).Should().BeFalse("Expected no Dockerfile for Go runtime");
+        }
+
+        [Fact]
+        public void Init_WithGolangAlias_ResolvesToGo()
+        {
+            var workingDir = WorkingDirectory;
+            var testName = nameof(Init_WithGolangAlias_ResolvesToGo);
+            var funcInitCommand = new FuncInitCommand(FuncPath, testName, Log ?? throw new ArgumentNullException(nameof(Log)));
+
+            var funcInitResult = funcInitCommand
+                .WithWorkingDirectory(workingDir)
+                .Execute(["--worker-runtime", "golang"]);
+
+            funcInitResult.Should().ExitWith(0);
+            File.Exists(Path.Combine(workingDir, "main.go")).Should().BeTrue("Expected main.go to exist");
+            File.Exists(Path.Combine(workingDir, "go.mod")).Should().BeTrue("Expected go.mod to exist");
+        }
+    }
+}

--- a/test/Cli/Func.E2ETests/Traits/WorkerRuntimeTraits.cs
+++ b/test/Cli/Func.E2ETests/Traits/WorkerRuntimeTraits.cs
@@ -49,5 +49,10 @@ namespace Azure.Functions.Cli.E2ETests.Traits
         /// Indicates tests that target the Custom runtime.
         /// </summary>
         public const string Custom = "Custom";
+
+        /// <summary>
+        /// Indicates tests that target the Go runtime.
+        /// </summary>
+        public const string Go = "Go";
     }
 }

--- a/test/Cli/Func.UnitTests/ActionsTests/InitActionGoTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/InitActionGoTests.cs
@@ -1,0 +1,85 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Actions.LocalActions;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.ConfigurationProfiles;
+using Azure.Functions.Cli.Helpers;
+using Azure.Functions.Cli.Interfaces;
+using FluentAssertions;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Functions.Cli.UnitTests.ActionsTests
+{
+    public class InitActionGoTests
+    {
+        private static InitAction CreateAction()
+        {
+            var templatesManager = Substitute.For<ITemplatesManager>();
+            var secretsManager = Substitute.For<ISecretsManager>();
+            var configProfiles = new List<IConfigurationProfile>();
+            return new InitAction(templatesManager, secretsManager, configProfiles);
+        }
+
+        [Fact]
+        public void ParseArgs_SkipGoModTidy_DefaultsToFalse()
+        {
+            var action = CreateAction();
+
+            action.ParseArgs(Array.Empty<string>());
+
+            action.SkipGoModTidy.Should().BeFalse();
+        }
+
+        [Fact]
+        public void ParseArgs_WithSkipGoModTidyFlag_SetsTrue()
+        {
+            var action = CreateAction();
+
+            action.ParseArgs(new[] { "--skip-go-mod-tidy" });
+
+            action.SkipGoModTidy.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ParseArgs_WorkerRuntimeGo_Parses()
+        {
+            var action = CreateAction();
+
+            action.ParseArgs(new[] { "--worker-runtime", "go" });
+
+            action.WorkerRuntime.Should().Be("go");
+        }
+
+        [Theory]
+        [InlineData("go")]
+        [InlineData("golang")]
+        [InlineData("Go")]
+        [InlineData("Golang")]
+        public void NormalizeWorkerRuntime_GoAliases_ResolveToGo(string input)
+        {
+            var result = WorkerRuntimeLanguageHelper.NormalizeWorkerRuntime(input);
+
+            result.Should().Be(WorkerRuntime.Go);
+        }
+
+        [Fact]
+        public void GetRuntimeMoniker_Go_ReturnsGo()
+        {
+            var result = WorkerRuntimeLanguageHelper.GetRuntimeMoniker(WorkerRuntime.Go);
+
+            result.Should().Be("go");
+        }
+
+        [Fact]
+        public void ProgrammingModelHelper_Go_DefaultsToV1()
+        {
+            var supportedModels = ProgrammingModelHelper.GetSupportedProgrammingModels(WorkerRuntime.Go);
+            supportedModels.Should().Contain(ProgrammingModel.V1);
+
+            var resolved = ProgrammingModelHelper.ResolveProgrammingModel(null, WorkerRuntime.Go, string.Empty);
+            resolved.Should().Be(ProgrammingModel.V1);
+        }
+    }
+}

--- a/test/Cli/Func.UnitTests/ActionsTests/PackAction/GoPackSubcommandActionTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/PackAction/GoPackSubcommandActionTests.cs
@@ -1,0 +1,66 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Actions.LocalActions.PackAction;
+using Azure.Functions.Cli.Common;
+using Xunit;
+
+namespace Azure.Functions.Cli.UnitTests.ActionsTests.PackAction
+{
+    public class GoPackSubcommandActionTests : System.IDisposable
+    {
+        private readonly string _tempDirectory;
+
+        public GoPackSubcommandActionTests()
+        {
+            _tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(_tempDirectory);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_tempDirectory))
+            {
+                Directory.Delete(_tempDirectory, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void ValidateFunctionApp_ValidStructure_PassesValidation()
+        {
+            File.WriteAllText(Path.Combine(_tempDirectory, "host.json"), "{}");
+            File.WriteAllText(Path.Combine(_tempDirectory, "go.mod"), "module example.com/test\n\ngo 1.24\n");
+
+            var action = new GoPackSubcommandAction();
+            var ex = Record.Exception(() => action.ValidateFunctionApp(_tempDirectory, new PackOptions()));
+
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void ValidateFunctionApp_MissingHostJson_ThrowsCliException()
+        {
+            File.WriteAllText(Path.Combine(_tempDirectory, "go.mod"), "module example.com/test\n\ngo 1.24\n");
+
+            var action = new GoPackSubcommandAction();
+            var ex = Record.Exception(() => action.ValidateFunctionApp(_tempDirectory, new PackOptions()));
+
+            Assert.NotNull(ex);
+            Assert.IsType<CliException>(ex);
+            Assert.Contains("host.json", ex.Message);
+        }
+
+        [Fact]
+        public void ValidateFunctionApp_MissingGoMod_ThrowsCliException()
+        {
+            File.WriteAllText(Path.Combine(_tempDirectory, "host.json"), "{}");
+
+            var action = new GoPackSubcommandAction();
+            var ex = Record.Exception(() => action.ValidateFunctionApp(_tempDirectory, new PackOptions()));
+
+            Assert.NotNull(ex);
+            Assert.IsType<CliException>(ex);
+            Assert.Contains("go.mod", ex.Message);
+        }
+    }
+}

--- a/test/Cli/Func.UnitTests/ActionsTests/StartHostActionTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/StartHostActionTests.cs
@@ -511,5 +511,98 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
                 Environment.SetEnvironmentVariable(pythonEnvVar, originalValue);
             }
         }
+
+        [Fact]
+        public void ResolveNativeWorkerRuntime_NativeWithGoMod_ResolvesToGo()
+        {
+            string envVar = Constants.FunctionsWorkerRuntime;
+            string original = Environment.GetEnvironmentVariable(envVar);
+            Environment.SetEnvironmentVariable(envVar, "native");
+
+            var fileSystem = Substitute.For<IFileSystem>();
+            fileSystem.File.Exists(Arg.Is<string>(p => p.EndsWith("go.mod"))).Returns(true);
+
+            var secretsManager = new Mock<ISecretsManager>();
+            secretsManager.Setup(s => s.GetSecrets()).Returns(new Dictionary<string, string>());
+
+            var previous = GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone;
+
+            try
+            {
+                using (FileSystemHelpers.Override(fileSystem))
+                {
+                    GlobalCoreToolsSettings.CurrentWorkerRuntime = WorkerRuntime.None;
+                    var action = new StartHostAction(secretsManager.Object, Mock.Of<IProcessManager>());
+
+                    action.ResolveNativeWorkerRuntime();
+
+                    GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone.Should().Be(WorkerRuntime.Go);
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(envVar, original);
+                GlobalCoreToolsSettings.CurrentWorkerRuntime = previous;
+            }
+        }
+
+        [Fact]
+        public void ResolveNativeWorkerRuntime_NativeWithoutGoMod_Throws()
+        {
+            string envVar = Constants.FunctionsWorkerRuntime;
+            string original = Environment.GetEnvironmentVariable(envVar);
+            Environment.SetEnvironmentVariable(envVar, "native");
+
+            var fileSystem = Substitute.For<IFileSystem>();
+            fileSystem.File.Exists(Arg.Any<string>()).Returns(false);
+
+            var secretsManager = new Mock<ISecretsManager>();
+            secretsManager.Setup(s => s.GetSecrets()).Returns(new Dictionary<string, string>());
+
+            try
+            {
+                using (FileSystemHelpers.Override(fileSystem))
+                {
+                    var action = new StartHostAction(secretsManager.Object, Mock.Of<IProcessManager>());
+
+                    Action act = () => action.ResolveNativeWorkerRuntime();
+
+                    act.Should().Throw<CliException>()
+                        .Which.Message.Should().Contain("Run 'func init'");
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(envVar, original);
+            }
+        }
+
+        [Fact]
+        public void ResolveNativeWorkerRuntime_NonNativeRuntime_NoOp()
+        {
+            string envVar = Constants.FunctionsWorkerRuntime;
+            string original = Environment.GetEnvironmentVariable(envVar);
+            Environment.SetEnvironmentVariable(envVar, "python");
+
+            var secretsManager = new Mock<ISecretsManager>();
+            secretsManager.Setup(s => s.GetSecrets()).Returns(new Dictionary<string, string>());
+
+            var previous = GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone;
+
+            try
+            {
+                GlobalCoreToolsSettings.CurrentWorkerRuntime = WorkerRuntime.Python;
+                var action = new StartHostAction(secretsManager.Object, Mock.Of<IProcessManager>());
+
+                action.ResolveNativeWorkerRuntime();
+
+                GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone.Should().Be(WorkerRuntime.Python);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(envVar, original);
+                GlobalCoreToolsSettings.CurrentWorkerRuntime = previous;
+            }
+        }
     }
 }

--- a/test/Cli/Func.UnitTests/CommonTests/ExecutableTests.cs
+++ b/test/Cli/Func.UnitTests/CommonTests/ExecutableTests.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Runtime.InteropServices;
+using System.Text;
+using Azure.Functions.Cli.Common;
+using FluentAssertions;
+using Xunit;
+
+namespace Azure.Functions.Cli.UnitTests.CommonTests
+{
+    public class ExecutableTests
+    {
+        [Fact]
+        public async Task RunAsync_CapturesFullStdout_ForShortLivedProcess()
+        {
+            (string exe, string args) = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? ("cmd.exe", "/c echo hello-from-test")
+                : ("/bin/sh", "-c \"echo hello-from-test\"");
+
+            var sb = new StringBuilder();
+            var executable = new Executable(exe, args);
+
+            int exitCode = await executable.RunAsync(o => sb.AppendLine(o), e => sb.AppendLine(e));
+
+            exitCode.Should().Be(0);
+            sb.ToString().Should().Contain("hello-from-test");
+        }
+    }
+}

--- a/test/Cli/Func.UnitTests/HelperTests/GoHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/GoHelperTests.cs
@@ -1,0 +1,130 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Runtime.InteropServices;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Helpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Azure.Functions.Cli.UnitTests.HelperTests
+{
+    public class GoHelperTests
+    {
+        [SkipIfGoNonExistFact]
+        public async Task InterpreterShouldHaveExecutablePath()
+        {
+            WorkerLanguageVersionInfo worker = await GoHelpers.GetEnvironmentGoVersion();
+
+            worker.Should().NotBeNull();
+            worker.ExecutablePath.Should().NotBeNullOrEmpty("Go executable path should not be empty");
+        }
+
+        [SkipIfGoNonExistFact]
+        public async Task InterpreterShouldHaveMajorVersion()
+        {
+            WorkerLanguageVersionInfo worker = await GoHelpers.GetEnvironmentGoVersion();
+
+            worker.Should().NotBeNull();
+            worker.Major.Should().BeGreaterOrEqualTo(1, "Go major version should be at least 1");
+        }
+
+        [SkipIfGoNonExistFact]
+        public async Task WorkerInfoRuntimeShouldBeGo()
+        {
+            WorkerLanguageVersionInfo worker = await GoHelpers.GetEnvironmentGoVersion();
+
+            worker.Should().NotBeNull();
+            worker.Runtime.Should().Be(WorkerRuntime.Go, "Worker runtime should be Go");
+        }
+
+        [Theory]
+        [InlineData("1.24.0", false)]
+        [InlineData("1.24.2", false)]
+        [InlineData("1.25.0", false)]
+        [InlineData("1.23.0", true)]
+        [InlineData("1.22.5", true)]
+        [InlineData("1.20.0", true)]
+        [InlineData("2.0.0", false)]
+        public void AssertGoVersion_ValidatesMinimumVersion(string goVersion, bool expectException)
+        {
+            var worker = new WorkerLanguageVersionInfo(WorkerRuntime.Go, goVersion, "go");
+
+            if (!expectException)
+            {
+                GoHelpers.AssertGoVersion(worker);
+            }
+            else
+            {
+                var action = () => GoHelpers.AssertGoVersion(worker);
+                action.Should().Throw<CliException>();
+            }
+        }
+
+        [Fact]
+        public void AssertGoVersion_NullVersion_ThrowsCliException()
+        {
+            var action = () => GoHelpers.AssertGoVersion(null);
+            action.Should().Throw<CliException>().Which.Message.Should().Contain("Could not find a Go installation");
+        }
+
+        [Theory]
+        [InlineData("beta1")]
+        [InlineData("notaversion")]
+        public void AssertGoVersion_UnparseableVersion_ThrowsCliException(string version)
+        {
+            var worker = new WorkerLanguageVersionInfo(WorkerRuntime.Go, version, "go");
+
+            var action = () => GoHelpers.AssertGoVersion(worker);
+            action.Should().Throw<CliException>().Which.Message.Should().Contain("Unable to parse Go version");
+        }
+
+        [Theory]
+        [InlineData("1.24.2.1")]
+        [InlineData("1.25.0-rc1")]
+        public void AssertGoVersion_ExtraVersionParts_DoesNotThrow(string version)
+        {
+            var worker = new WorkerLanguageVersionInfo(WorkerRuntime.Go, version, "go");
+
+            GoHelpers.AssertGoVersion(worker);
+        }
+    }
+
+    public sealed class SkipIfGoNonExistFact : FactAttribute
+    {
+        public SkipIfGoNonExistFact()
+        {
+            string goExe;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                goExe = "go.exe";
+            }
+            else
+            {
+                goExe = "go";
+            }
+
+            if (!CheckIfGoExists(goExe))
+            {
+                Skip = "go does not exist";
+            }
+        }
+
+        private bool CheckIfGoExists(string goExe)
+        {
+            string path = Environment.GetEnvironmentVariable("PATH");
+            if (!string.IsNullOrEmpty(path))
+            {
+                foreach (string p in path.Split(Path.PathSeparator))
+                {
+                    if (File.Exists(Path.Combine(p, goExe)))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/test/Cli/Func.UnitTests/HelperTests/GoHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/GoHelperTests.cs
@@ -88,6 +88,90 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
 
             GoHelpers.AssertGoVersion(worker);
         }
+
+        [Fact]
+        public void AssertBinaryExists_BinaryPresent_DoesNotThrow()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "func-go-test-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                var binaryName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    ? "app.exe"
+                    : "app";
+                File.WriteAllText(Path.Combine(dir, binaryName), "stub");
+
+                var action = () => GoHelpers.AssertBinaryExists(dir);
+                action.Should().NotThrow();
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void AssertBinaryExists_BinaryMissing_ThrowsActionableCliException()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "func-go-test-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                var action = () => GoHelpers.AssertBinaryExists(dir);
+
+                action.Should().Throw<CliException>()
+                    .Which.Message.Should().Contain("Could not find a built Go binary")
+                                  .And.Contain("--no-build")
+                                  .And.Contain("go build");
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [SkipIfGoNonExistFact]
+        public async Task BuildProject_ValidProject_ProducesBinary()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "func-go-build-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                File.WriteAllText(Path.Combine(dir, "go.mod"), "module example.com/test\n\ngo 1.24\n");
+                File.WriteAllText(Path.Combine(dir, "main.go"), "package main\n\nfunc main() {}\n");
+
+                await GoHelpers.BuildProject(dir);
+
+                var binaryName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    ? "app.exe"
+                    : "app";
+                File.Exists(Path.Combine(dir, binaryName)).Should().BeTrue("BuildProject should produce the worker binary");
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [SkipIfGoNonExistFact]
+        public async Task BuildProject_InvalidProject_ThrowsCliException()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "func-go-build-fail-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                File.WriteAllText(Path.Combine(dir, "go.mod"), "module example.com/test\n\ngo 1.24\n");
+                File.WriteAllText(Path.Combine(dir, "main.go"), "package main\n\nthis is not valid go\n");
+
+                Func<Task> act = () => GoHelpers.BuildProject(dir);
+                var ex = await Assert.ThrowsAsync<CliException>(act);
+                ex.Message.Should().Contain("Go build failed");
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
     }
 
     public sealed class SkipIfGoNonExistFact : FactAttribute

--- a/test/Cli/Func.UnitTests/HelperTests/GoHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/GoHelperTests.cs
@@ -172,6 +172,162 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
                 Directory.Delete(dir, recursive: true);
             }
         }
+
+        [SkipIfGoNonExistFact]
+        public async Task BuildForLinux_ValidProject_ProducesLinuxAmd64Binary()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "func-go-buildlinux-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                File.WriteAllText(Path.Combine(dir, "go.mod"), "module example.com/test\n\ngo 1.24\n");
+                File.WriteAllText(Path.Combine(dir, "main.go"), "package main\n\nfunc main() {}\n");
+
+                await GoHelpers.BuildForLinux(dir);
+
+                var binary = Path.Combine(dir, GoHelpers.GoBinaryName);
+                File.Exists(binary).Should().BeTrue("BuildForLinux should produce the linux/amd64 worker binary");
+
+                // The produced binary is itself a linux/amd64 ELF, so AssertLinuxAmd64Binary should accept it.
+                var assert = () => GoHelpers.AssertLinuxAmd64Binary(dir);
+                assert.Should().NotThrow();
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void AssertLinuxAmd64Binary_BinaryMissing_ThrowsActionableCliException()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "func-go-elf-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                var action = () => GoHelpers.AssertLinuxAmd64Binary(dir);
+
+                action.Should().Throw<CliException>()
+                    .Which.Message.Should().Contain("Could not find a built Go binary")
+                                  .And.Contain("linux")
+                                  .And.Contain("amd64");
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void AssertLinuxAmd64Binary_NotElf_Throws()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "func-go-elf-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                // 32 bytes of non-ELF garbage so the size check passes but the magic check fails.
+                File.WriteAllBytes(Path.Combine(dir, GoHelpers.GoBinaryName), new byte[32]);
+
+                var action = () => GoHelpers.AssertLinuxAmd64Binary(dir);
+                action.Should().Throw<CliException>()
+                    .Which.Message.Should().Contain("not an ELF binary");
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void AssertLinuxAmd64Binary_ElfButWrongArch_Throws()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "func-go-elf-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                // Synthesize an ELF64 LE header but with e_machine = EM_AARCH64 (0xB7) instead of EM_X86_64.
+                var header = BuildElfHeader(machine: 0xB7);
+                File.WriteAllBytes(Path.Combine(dir, GoHelpers.GoBinaryName), header);
+
+                var action = () => GoHelpers.AssertLinuxAmd64Binary(dir);
+                action.Should().Throw<CliException>()
+                    .Which.Message.Should().Contain("0x00B7")
+                                  .And.Contain("not x86_64");
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void AssertLinuxAmd64Binary_ValidHeader_DoesNotThrow()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "func-go-elf-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                File.WriteAllBytes(Path.Combine(dir, GoHelpers.GoBinaryName), BuildElfHeader(machine: 0x3E));
+
+                var action = () => GoHelpers.AssertLinuxAmd64Binary(dir);
+                action.Should().NotThrow();
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void AssertLinuxAmd64Binary_Elf32_Throws()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "func-go-elf-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                // Override EI_CLASS (offset 4) to 1 (ELFCLASS32) — should be rejected even if e_machine is x86_64.
+                var header = BuildElfHeader(machine: 0x3E);
+                header[4] = 1;
+                File.WriteAllBytes(Path.Combine(dir, GoHelpers.GoBinaryName), header);
+
+                var action = () => GoHelpers.AssertLinuxAmd64Binary(dir);
+                action.Should().Throw<CliException>()
+                    .Which.Message.Should().Contain("not a 64-bit little-endian ELF binary");
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void GetPackFiles_ReturnsHostJsonAndAppBinary()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "func-go-files-" + Guid.NewGuid().ToString("N"));
+
+            var files = GoHelpers.GetPackFiles(root).ToArray();
+
+            files.Should().HaveCount(2);
+            files.Should().Contain(Path.Combine(root, "host.json"));
+            files.Should().Contain(Path.Combine(root, GoHelpers.GoBinaryName));
+        }
+
+        // Builds a minimal 20-byte ELF identification region with EI_CLASS=64-bit, EI_DATA=little-endian
+        // and an arbitrary e_machine value. AssertLinuxAmd64Binary only inspects the first 20 bytes, so
+        // this is enough to exercise its checks without producing a valid runnable binary.
+        private static byte[] BuildElfHeader(ushort machine)
+        {
+            var header = new byte[20];
+            header[0] = 0x7F;
+            header[1] = (byte)'E';
+            header[2] = (byte)'L';
+            header[3] = (byte)'F';
+            header[4] = 2; // EI_CLASS = ELFCLASS64
+            header[5] = 1; // EI_DATA  = ELFDATA2LSB
+            header[18] = (byte)(machine & 0xFF);
+            header[19] = (byte)((machine >> 8) & 0xFF);
+            return header;
+        }
     }
 
     public sealed class SkipIfGoNonExistFact : FactAttribute

--- a/test/Cli/Func.UnitTests/HelperTests/ZipHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/ZipHelperTests.cs
@@ -214,5 +214,39 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
         {
             _output.WriteLine(output);
         }
+
+        [Fact]
+        public async Task GetAppZipFile_GoRuntime_ContainsOnlyHostJsonAndApp()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(dir);
+
+            var previousRuntime = GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone;
+            try
+            {
+                File.WriteAllText(Path.Combine(dir, "host.json"), "{}");
+                File.WriteAllBytes(Path.Combine(dir, GoHelpers.GoBinaryName), new byte[] { 0x7F, (byte)'E', (byte)'L', (byte)'F', 2, 1 });
+
+                // Files that must NOT be picked up — Go uses an explicit allowlist, not funcignore.
+                File.WriteAllText(Path.Combine(dir, "main.go"), "package main\nfunc main() {}\n");
+                File.WriteAllText(Path.Combine(dir, "go.mod"), "module example.com/test\n");
+                File.WriteAllText(Path.Combine(dir, "local.settings.json"), "{}");
+
+                GlobalCoreToolsSettings.CurrentWorkerRuntime = WorkerRuntime.Go;
+
+                var stream = await ZipHelper.GetAppZipFile(dir, buildNativeDeps: false, BuildOption.Default, noBuild: false);
+
+                Assert.NotNull(stream);
+                using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
+                var entries = archive.Entries.Select(e => e.FullName).OrderBy(n => n).ToArray();
+
+                Assert.Equal(new[] { "app", "host.json" }, entries);
+            }
+            finally
+            {
+                GlobalCoreToolsSettings.CurrentWorkerRuntime = previousRuntime;
+                Directory.Delete(dir, recursive: true);
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds `func pack` and `func publish` support for Go (a first-class language in
 Core Tools), plus follow-up fixes uncovered while testing the end-to-end flow.
 
 **`func pack` / `func publish` for Go**
 - New Go-aware code path that builds the project via `go build`, stages the
   resulting binary alongside `host.json` / function metadata, and produces the
   deployable zip / publish payload.
 - Honors `GOOS` / `GOARCH` so users can cross-compile from any dev machine to
   the target Function App's OS/architecture.
 
 **macOS E2E pipeline fixes**
 - Switched the macOS agent over to Homebrew Go instead of the `GoTool@0` task,
   which ships amd64 binaries that don't run on Apple Silicon agents.
 - Pinned `go@1.24` and overrode `GOROOT` so the brew toolchain is the sole Go
   on PATH during the run.
 
 **Shared `Executable` reliability fix**
 - `Executable.RunAsync` could return before the async stdout/stderr pumps had
   drained for very short-lived processes (e.g. `go version`), causing
   intermittent "Could not find a Go installation" failures on WSL and CI.
   Added a `Process.WaitForExit()` drain after the exit task completes, with a
   regression test in `ExecutableTests`.
 
 **Misc**
 - Re-ordered the language list so Go appears after Python in the `func init`
   / `func new` wizard.