### PR TITLE
Enforce style rules via editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -152,10 +152,28 @@ dotnet_naming_style.pascal_case_and_prefix_with_I_style.capitalization          
 # Modifier preferences
 csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async:warning
 
-# Prefer "var" only when the type is apparent
-csharp_style_var_for_built_in_types = false:suggestion
-csharp_style_var_when_type_is_apparent = true:suggestion
-csharp_style_var_elsewhere = false:suggestion
+# Prefer "var" only when the type is apparent (IDE0007 / IDE0008).
+# Bumped to warning so the agent gets fast feedback instead of relying on review.
+csharp_style_var_for_built_in_types = false:warning
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = false:warning
+
+# Prefer target-typed `new()` when the LHS type is written explicitly (IDE0090).
+# Pairs with the var rules above: write the type once on the left, use `new()` on the right.
+csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
+
+# Prefer primary constructor syntax (IDE0290).
+csharp_style_prefer_primary_constructors = true:suggestion
+
+# Prefer method group conversion over trivial lambda wrappers (IDE0200).
+csharp_style_prefer_method_group_conversion = true:warning
+
+# Require file-scoped namespaces in new files (IDE0161).
+csharp_style_namespace_declarations = file_scoped:warning
+
+# Prefer collection expressions `[]` over `Array.Empty<T>()`, `new[] { ... }`,
+# `new List<T>()`, etc. (IDE0300 / IDE0301 / IDE0303 / IDE0305).
+dotnet_style_prefer_collection_expression = true:warning
 
 # Prefer method-like constructs to have a block body
 csharp_style_expression_bodied_methods = false:none

--- a/.github/instructions/dotnet.instructions.md
+++ b/.github/instructions/dotnet.instructions.md
@@ -13,7 +13,9 @@ here disagrees with `AGENTS.md`, **`AGENTS.md` wins**.
 ## DI and composition
 
 - Use **primary constructor syntax** for DI:
-  `internal sealed class Foo(IBar bar) : IFoo`.
+  `internal sealed class Foo(IBar bar) : IFoo`. The same applies to non-DI
+  classes (exceptions, builders) where a single ctor + field/property
+  initializers can be collapsed.
 - Validate non-nullable constructor dependencies with `ArgumentNullException`:
   `private readonly IBar _bar = bar ?? throw new ArgumentNullException(nameof(bar));`.
 - No service locators, no `IServiceProvider.GetService` outside the composition
@@ -84,15 +86,30 @@ the lightest option:
   interpolation.
 - For user-facing CLI output, use `IInteractionService`, not `ILogger`.
 
+## Modern C# constructs
+
+These are enforced by `.editorconfig` (see IDE0007/0008/0090/0161/0200/0290 and
+IDE0300-0305). Write them this way the first time so the linter never has to
+fire:
+
+- **Collection expressions**: `[]` not `Array.Empty<T>()`; `[a, b]` not
+  `new[] { a, b }`; `[]` not `new List<T>()`; `[.. source]` not
+  `source.ToArray()`.
+- **Target-typed `new()`** when the LHS type is written: `Grid grid = new();`
+  not `var grid = new Grid();` or `Grid grid = new Grid();`. Pairs with the
+  `var` rule below: write the type once on the left, infer it on the right.
+- **Method groups** over wrapper lambdas: `SetAction(ExecuteAsync)` not
+  `SetAction((p, ct) => ExecuteAsync(p, ct))`.
+- **File-scoped namespaces** in new files.
+- **`var`** only when the RHS makes the type obvious (`new T(...)`, a cast,
+  a literal). When the type is hidden behind a method or property call, write
+  the type explicitly. Tests opt out of this one in `.editorconfig` to reduce
+  rename churn.
+
 ## Style
 
-- **File-scoped namespaces** in new files.
 - Match the style of the file you're editing.
 - No unused `using` directives.
-- Use `var` only when the type is obvious from the right-hand side (e.g.
-  `new T(...)`, a cast, or a literal). When the type is hidden behind a method
-  or property call, write the type explicitly so readers don't have to chase
-  the API to know what they're holding.
 - Don't run `dotnet format` across unrelated files; no drive-by reformatting.
 - Don't disable analyzers to silence warnings, fix the underlying issue.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,16 +85,16 @@ the full CLI.
 ### Style
 
 - Match the style of the file you're editing.
-- Prefer **file-scoped namespaces** in new files.
 - Don't leave unused `using` directives.
 - Don't run `dotnet format` across unrelated files or make drive-by formatting
   changes.
 - Follow the existing `stylecop.json` / analyzer rules. Don't disable analyzers
   to silence warnings, fix the underlying issue.
-- Use `var` only when the type is obvious from the right-hand side (e.g.
-  `new T(...)`, a cast, or a literal). When the type is hidden behind a method
-  or property call, write the type explicitly so readers don't have to chase
-  the API to know what they're holding.
+- Mechanical conventions (`var` discipline, target-typed `new()`, collection
+  expressions, method group conversions, file-scoped namespaces, primary
+  constructors) are enforced by `.editorconfig`. See the **Modern C#
+  constructs** section in `.github/instructions/dotnet.instructions.md` for
+  the short list of preferred forms.
 - Keep changes minimal and surgical. User-visible behavior changes must be
   flagged explicitly in the PR description.
 
@@ -102,6 +102,14 @@ the full CLI.
 
 This repo ships **one product**: the `func` CLI. Treat it as a CLI first and a
 .NET app second.
+
+### Branding
+
+The product name in user-facing strings, HTTP `User-Agent` headers, telemetry
+identifiers, and release notes is **"Azure Functions CLI"**. The legacy
+"Azure Functions Core Tools" branding (and the npm install hint that came with
+it) is being phased out of v5. Don't reintroduce either when adding new
+output, error messages, or version notices.
 
 ### Console I/O, never call it directly
 

--- a/src/Abstractions/Workloads/FunctionsCliBuilder.cs
+++ b/src/Abstractions/Workloads/FunctionsCliBuilder.cs
@@ -55,7 +55,7 @@ public abstract class FunctionsCliBuilder
                 nameof(TCommand));
         }
 
-        OnRegisterCommand(sp => ActivatorUtilities.GetServiceOrCreateInstance<TCommand>(sp));
+        OnRegisterCommand(ActivatorUtilities.GetServiceOrCreateInstance<TCommand>);
     }
 
     /// <summary>

--- a/src/Func/Commands/InitCommand.cs
+++ b/src/Func/Commands/InitCommand.cs
@@ -101,7 +101,7 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
         IProjectInitializer? initializer = await SelectInitializerAsync(stack, cancellationToken);
         if (initializer is null)
         {
-            string[] installed = _initializers.Select(i => i.Stack).ToArray();
+            string[] installed = [.. _initializers.Select(i => i.Stack)];
             WorkloadHint hint = installed.Length == 0
                 ? new WorkloadHint(WorkloadHintKind.NoWorkloadsInstalled, "initialize a project", null, installed)
                 : stack is not null

--- a/src/Func/Hosting/WorkloadStorageRegistration.cs
+++ b/src/Func/Hosting/WorkloadStorageRegistration.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Workloads;
 using Azure.Functions.Cli.Workloads.Discovery;
 using Azure.Functions.Cli.Workloads.Loading;
 using Azure.Functions.Cli.Workloads.Storage;

--- a/src/Func/Program.cs
+++ b/src/Func/Program.cs
@@ -17,20 +17,20 @@ using Microsoft.Extensions.Hosting;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 
-var theme = new DefaultTheme();
-var interaction = new SpectreInteractionService(theme);
+DefaultTheme theme = new();
+SpectreInteractionService interaction = new(theme);
 
 // Build the host: a CLI process gets the empty variant so we skip the default
 // configuration and logging providers (they're not needed). The host owns
 // shared lifetimes — currently just the OpenTelemetry pipeline, which is
 // registered as hosted services so flush + shutdown happen via host disposal.
-var hostBuilder = Host.CreateEmptyApplicationBuilder(null);
+HostApplicationBuilder hostBuilder = Host.CreateEmptyApplicationBuilder(null);
 hostBuilder.Services.AddSingleton(interaction);
 
 // Wire OpenTelemetry only when a real instrumentation key is baked in and
 // the user hasn't opted out. When it isn't, no listener is subscribed and
 // ActivitySource / Meter calls become no-ops.
-if (CliTelemetry.TryGetConnectionString(out var connectionString))
+if (CliTelemetry.TryGetConnectionString(out string? connectionString))
 {
     hostBuilder.Services.AddOpenTelemetry()
         .ConfigureResource(r => CliTelemetry.ConfigureResource(r))
@@ -57,7 +57,7 @@ hostBuilder.Services.AddWorkloadStorage();
 // resolvable when commands are built below.
 WorkloadRegistration.RegisterWorkloads(new DefaultFunctionsCliBuilder(hostBuilder.Services));
 
-using var host = hostBuilder.Build();
+using IHost host = hostBuilder.Build();
 
 // Start the host so hosted services (OTel providers) are running and
 // listeners are subscribed before any command code emits telemetry.

--- a/test/Func.Tests/Hosting/DefaultFunctionsCliBuilderTests.cs
+++ b/test/Func.Tests/Hosting/DefaultFunctionsCliBuilderTests.cs
@@ -78,7 +78,7 @@ public class DefaultFunctionsCliBuilderTests
         var services = new ServiceCollection();
         var builder = new DefaultFunctionsCliBuilder(services, TestWorkloads.CreateInfo());
 
-        var ex = Assert.Throws<ArgumentException>(() => builder.RegisterCommand<AbstractFuncCommand>());
+        var ex = Assert.Throws<ArgumentException>(builder.RegisterCommand<AbstractFuncCommand>);
         Assert.Contains("abstract command type", ex.Message);
         Assert.Contains(nameof(AbstractFuncCommand), ex.Message);
     }
@@ -163,7 +163,7 @@ public class DefaultFunctionsCliBuilderTests
     {
         var builder = new DefaultFunctionsCliBuilder(new ServiceCollection());
 
-        Assert.Throws<InvalidOperationException>(() => builder.RegisterCommand<GenericTestCommand>());
+        Assert.Throws<InvalidOperationException>(builder.RegisterCommand<GenericTestCommand>);
     }
 
     [Fact]

--- a/test/Func.Tests/Workloads/WorkloadProviderTests.cs
+++ b/test/Func.Tests/Workloads/WorkloadProviderTests.cs
@@ -75,9 +75,8 @@ public class WorkloadProviderTests
             .Returns([]);
         var provider = new WorkloadProvider(store, loader);
 
-        Task<IReadOnlyList<WorkloadInfo>>[] callers = Enumerable.Range(0, 10)
-            .Select(_ => Task.Run(async () => await provider.GetWorkloadsAsync()))
-            .ToArray();
+        Task<IReadOnlyList<WorkloadInfo>>[] callers = [.. Enumerable.Range(0, 10)
+            .Select(_ => Task.Run(async () => await provider.GetWorkloadsAsync()))];
 
         // Give the callers time to queue behind the gate before releasing.
         await Task.Delay(50);


### PR DESCRIPTION
Add IDE analyzer rules to `.editorconfig` so the linter enforces conventions the agent was previously expected to apply by hand. With `EnforceCodeStyleInBuild=true` (already set) and `TreatWarningsAsErrors=$(CI)`, violations show as warnings locally and fail CI.

### Rules added

| Rule | Analyzer | Severity |
|------|----------|----------|
| Collection expressions `[]` over `Array.Empty<T>()` / `new[]{}` / `new List<T>()` | IDE0300/0301/0303/0305 | warning |
| Target-typed `new()` when LHS type is apparent | IDE0090 | warning |
| Method group over trivial wrapper lambda | IDE0200 | warning |
| File-scoped namespaces | IDE0161 | warning |
| `var` discipline (only when type apparent) | IDE0007/0008 | bumped suggestion → warning |
| Primary constructors | IDE0290 | suggestion (judgment call) |

Test override block already permits `var` everywhere in tests; the new collection-expression and method-group rules still apply there, which is what we want.

### Fixes from new rule violations

- `Program.cs`: `var` → explicit types; `new DefaultTheme()` → `new()`.
- `FunctionsCliBuilder.cs`: trivial lambda → method group.
- `InitCommand.cs`: `.Select(...).ToArray()` → `[.. ...]`.
- `DefaultFunctionsCliBuilderTests.cs`: trivial lambdas → method groups.
- `WorkloadProviderTests.cs`: collection expression with spread.

### Pre-existing build fix

`WorkloadStorageRegistration.cs` was missing `using Azure.Functions.Cli.Workloads;` after the previous commit's using cleanup, breaking the `Func` build with CS0246. Restored the using.

### Validation

- `dotnet build` clean, 0 warnings under `CI=true` (warnings-as-errors).
- `dotnet test`: 164 / 164 passing.
