### PR TITLE
Resolve telemetry command name from ParseResult

### DIFF
--- a/src/Func/Program.cs
+++ b/src/Func/Program.cs
@@ -37,8 +37,9 @@ Console.CancelKeyPress += (_, e) =>
 // Fire background version check (non-blocking, best-effort)
 Task<string?> versionCheckTask = VersionChecker.CheckForUpdateAsync(cts.Token);
 
-// Parse and invoke asynchronously.
-string commandName = ResolveCommandName(args);
+ParseResult commandParseResult = rootCommand.Parse(args);
+string commandName = CommandNameResolver.ResolveCommandName(commandParseResult, rootCommand);
+
 var stopwatch = Stopwatch.StartNew();
 int exitCode = 0;
 
@@ -50,7 +51,7 @@ using (Activity? activity = CliTelemetry.Trace.StartCommandActivity(commandName)
         FuncRootCommand rootCommand = Parser.CreateCommand(host.Services);
 
         var config = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
-        exitCode = await rootCommand.Parse(args).InvokeAsync(config, cts.Token);
+        exitCode = await commandParseResult.InvokeAsync(config, cts.Token);
     }
     catch (OperationCanceledException)
     {
@@ -93,37 +94,6 @@ if (exitCode != 130)
 // disposes the OTel providers, which flushes pending telemetry. No explicit
 // flush needed here.
 return exitCode;
-
-/// <summary>
-/// Resolves the command name from args for telemetry.
-/// </summary>
-static string ResolveCommandName(string[] args)
-{
-    if (args.Length == 0)
-    {
-        return "help";
-    }
-
-    // Take command args (skip options starting with -)
-    var parts = new List<string>();
-    foreach (string arg in args)
-    {
-        if (arg.StartsWith('-'))
-        {
-            break;
-        }
-
-        parts.Add(arg);
-
-        // At most 2 levels (e.g., "workload install", "host start")
-        if (parts.Count >= 2)
-        {
-            break;
-        }
-    }
-
-    return parts.Count > 0 ? string.Join(" ", parts) : "unknown";
-}
 
 /// <summary>
 /// Prints a version update notice if a newer version is available.

--- a/src/Func/Program.cs
+++ b/src/Func/Program.cs
@@ -37,18 +37,25 @@ Console.CancelKeyPress += (_, e) =>
 // Fire background version check (non-blocking, best-effort)
 Task<string?> versionCheckTask = VersionChecker.CheckForUpdateAsync(cts.Token);
 
-ParseResult commandParseResult = rootCommand.Parse(args);
-string commandName = CommandNameResolver.ResolveCommandName(commandParseResult, rootCommand);
-
 var stopwatch = Stopwatch.StartNew();
 int exitCode = 0;
 
-using (Activity? activity = CliTelemetry.Trace.StartCommandActivity(commandName))
+// Best-effort fallback for the metric tag when we fail before the parse
+// resolves a command path (e.g. host startup blows up). The activity gets
+// no `cli.command.name` tag at all in that window, but the metric needs a
+// non-null value.
+string commandName = "unknown";
+
+using (Activity? activity = CliTelemetry.Trace.StartCommandActivity())
 {
     try
     {
         using IHost host = await CliHostFactory.CreateHostAsync(interaction);
         FuncRootCommand rootCommand = Parser.CreateCommand(host.Services);
+
+        ParseResult commandParseResult = rootCommand.Parse(args);
+        commandName = CommandNameResolver.ResolveCommandName(commandParseResult, rootCommand);
+        activity?.SetCommandName(commandName);
 
         var config = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
         exitCode = await commandParseResult.InvokeAsync(config, cts.Token);

--- a/src/Func/Telemetry/ActivityExtensions.cs
+++ b/src/Func/Telemetry/ActivityExtensions.cs
@@ -11,31 +11,52 @@ namespace Azure.Functions.Cli.Telemetry;
 /// </summary>
 /// <remarks>
 /// Naming and span shape follow the (experimental) OTel CLI semantic
-/// conventions: <see cref="ActivityKind.Internal"/> kind, span name set to
-/// the subcommand path, and the <c>cli.command.name</c> attribute.
-/// Resource-level attributes (<c>service.name</c>, <c>service.version</c>,
-/// <c>os.*</c>, <c>process.runtime.*</c>) are configured once on the
+/// conventions: <see cref="ActivityKind.Internal"/> kind, fixed operation
+/// name <c>"cli.command"</c>, and the <c>cli.command.name</c> attribute
+/// applied via <see cref="SetCommandName"/> once parsing resolves the
+/// invoked command path. Resource-level attributes
+/// (<c>service.name</c>, <c>service.version</c>, <c>os.*</c>,
+/// <c>process.runtime.*</c>) are configured once on the
 /// <see cref="OpenTelemetry.Resources.ResourceBuilder"/> and inherited by
 /// every span — they should not be set per span here.
 /// </remarks>
 internal static class ActivityExtensions
 {
+    /// <summary>
+    /// Fixed operation name for CLI command spans. The user-facing command
+    /// path is attached as a tag and (when known) as <c>DisplayName</c>.
+    /// </summary>
+    public const string CommandActivityName = "cli.command";
+
     extension(ActivitySource source)
     {
         /// <summary>
         /// Starts an <see cref="Activity"/> that represents the execution of
         /// a CLI command. Returns <c>null</c> when no listener is subscribed.
+        /// Call <see cref="SetCommandName"/> once parsing resolves the
+        /// invoked command path.
         /// </summary>
-        public Activity? StartCommandActivity(string commandName)
+        public Activity? StartCommandActivity()
         {
-            Activity? activity = source.StartActivity(commandName, ActivityKind.Internal);
-            activity?.SetTag(TelemetryConventions.CliCommandName, commandName);
-            return activity;
+            return source.StartActivity(CommandActivityName, ActivityKind.Internal);
         }
     }
 
     extension(Activity activity)
     {
+        /// <summary>
+        /// Tags the activity with the resolved CLI command path and sets the
+        /// display name so trace explorers show <c>"workload list"</c> rather
+        /// than the operation name <c>"cli.command"</c>. Safe to call
+        /// multiple times; the most recent value wins.
+        /// </summary>
+        public Activity SetCommandName(string commandName)
+        {
+            activity.DisplayName = commandName;
+            activity.SetTag(TelemetryConventions.CliCommandName, commandName);
+            return activity;
+        }
+
         /// <summary>
         /// Records the exception on the activity and marks its status as
         /// <see cref="ActivityStatusCode.Error"/>. Use this on the failure

--- a/src/Func/Telemetry/CommandNameResolver.cs
+++ b/src/Func/Telemetry/CommandNameResolver.cs
@@ -1,0 +1,54 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Commands;
+
+namespace Azure.Functions.Cli.Telemetry;
+
+/// <summary>
+/// Resolves a low-cardinality command name for telemetry from a parsed
+/// command line. The matched command path (e.g. <c>"workload list"</c>)
+/// is preferred so dashboards can group by command without exploding into
+/// per-invocation variants from raw <c>args</c>.
+/// </summary>
+internal static class CommandNameResolver
+{
+    /// <summary>
+    /// Resolves a telemetry-friendly command name from a parsed result.
+    /// Walks the matched command up to (but excluding) <paramref name="rootCommand"/>
+    /// and joins each segment with a space. When only the root matched and
+    /// no subcommand was given, returns:
+    /// <list type="bullet">
+    /// <item><description><c>"unknown"</c> when the parse produced errors (e.g. a typo),</description></item>
+    /// <item><description><c>"version"</c> when <see cref="FuncRootCommand.VerboseOption"/>
+    /// is set (the root action prints detailed version),</description></item>
+    /// <item><description><c>"help"</c> otherwise (the root action shows help).</description></item>
+    /// </list>
+    /// </summary>
+    public static string ResolveCommandName(ParseResult parseResult, FuncRootCommand rootCommand)
+    {
+        ArgumentNullException.ThrowIfNull(parseResult);
+        ArgumentNullException.ThrowIfNull(rootCommand);
+
+        var parts = new List<string>();
+        Command? current = parseResult.CommandResult.Command;
+        while (current is not null && current != rootCommand)
+        {
+            parts.Insert(0, current.Name);
+            current = current.Parents.OfType<Command>().FirstOrDefault();
+        }
+
+        if (parts.Count > 0)
+        {
+            return string.Join(' ', parts);
+        }
+
+        if (parseResult.Errors.Count > 0)
+        {
+            return "unknown";
+        }
+
+        return parseResult.GetValue(rootCommand.VerboseOption) ? "version" : "help";
+    }
+}

--- a/test/Func.Tests/Telemetry/CommandNameResolverTests.cs
+++ b/test/Func.Tests/Telemetry/CommandNameResolverTests.cs
@@ -1,0 +1,131 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Commands;
+using Azure.Functions.Cli.Telemetry;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Telemetry;
+
+public class CommandNameResolverTests
+{
+    [Fact]
+    public void ResolveCommandName_NullParseResult_Throws()
+    {
+        var rootCommand = new FuncRootCommand();
+
+        Assert.Throws<ArgumentNullException>(
+            () => CommandNameResolver.ResolveCommandName(null!, rootCommand));
+    }
+
+    [Fact]
+    public void ResolveCommandName_NullRootCommand_Throws()
+    {
+        var rootCommand = new FuncRootCommand();
+        ParseResult parseResult = rootCommand.Parse([]);
+
+        Assert.Throws<ArgumentNullException>(
+            () => CommandNameResolver.ResolveCommandName(parseResult, null!));
+    }
+
+    [Fact]
+    public void ResolveCommandName_NoArgs_ReturnsHelp()
+    {
+        // `func` alone → root action shows help.
+        var rootCommand = new FuncRootCommand();
+        ParseResult parseResult = rootCommand.Parse([]);
+
+        string name = CommandNameResolver.ResolveCommandName(parseResult, rootCommand);
+
+        Assert.Equal("help", name);
+    }
+
+    [Fact]
+    public void ResolveCommandName_VerboseFlagOnly_ReturnsVersion()
+    {
+        // `func --verbose` → root action runs detailed version output.
+        var rootCommand = new FuncRootCommand();
+        ParseResult parseResult = rootCommand.Parse(["--verbose"]);
+
+        string name = CommandNameResolver.ResolveCommandName(parseResult, rootCommand);
+
+        Assert.Equal("version", name);
+    }
+
+    [Fact]
+    public void ResolveCommandName_TopLevelSubcommand_ReturnsCommandName()
+    {
+        var rootCommand = new FuncRootCommand();
+        var initCommand = new Command("init", "init description");
+        rootCommand.Subcommands.Add(initCommand);
+        ParseResult parseResult = rootCommand.Parse(["init"]);
+
+        string name = CommandNameResolver.ResolveCommandName(parseResult, rootCommand);
+
+        Assert.Equal("init", name);
+    }
+
+    [Fact]
+    public void ResolveCommandName_NestedSubcommand_ReturnsJoinedPath()
+    {
+        var rootCommand = new FuncRootCommand();
+        var workloadCommand = new Command("workload", "workload description");
+        var listCommand = new Command("list", "list description");
+        workloadCommand.Subcommands.Add(listCommand);
+        rootCommand.Subcommands.Add(workloadCommand);
+        ParseResult parseResult = rootCommand.Parse(["workload", "list"]);
+
+        string name = CommandNameResolver.ResolveCommandName(parseResult, rootCommand);
+
+        Assert.Equal("workload list", name);
+    }
+
+    [Fact]
+    public void ResolveCommandName_DeeplyNestedSubcommand_ReturnsFullPath()
+    {
+        // Defensive: ensure the walk isn't artificially capped at two levels.
+        var rootCommand = new FuncRootCommand();
+        var workloadCommand = new Command("workload", "workload description");
+        var remoteCommand = new Command("remote", "remote description");
+        var addCommand = new Command("add", "add description");
+        remoteCommand.Subcommands.Add(addCommand);
+        workloadCommand.Subcommands.Add(remoteCommand);
+        rootCommand.Subcommands.Add(workloadCommand);
+        ParseResult parseResult = rootCommand.Parse(["workload", "remote", "add"]);
+
+        string name = CommandNameResolver.ResolveCommandName(parseResult, rootCommand);
+
+        Assert.Equal("workload remote add", name);
+    }
+
+    [Fact]
+    public void ResolveCommandName_VerboseAfterSubcommand_ReturnsSubcommandName()
+    {
+        // `func init --verbose` is still an `init` invocation; the recursive
+        // verbose flag must not promote the activity to "version".
+        var rootCommand = new FuncRootCommand();
+        var initCommand = new Command("init", "init description");
+        rootCommand.Subcommands.Add(initCommand);
+        ParseResult parseResult = rootCommand.Parse(["init", "--verbose"]);
+
+        string name = CommandNameResolver.ResolveCommandName(parseResult, rootCommand);
+
+        Assert.Equal("init", name);
+    }
+
+    [Fact]
+    public void ResolveCommandName_UnknownToken_ReturnsUnknown()
+    {
+        // `func badcommand` produces a parse error and stays at root —
+        // we should not telemeter typos as "help".
+        var rootCommand = new FuncRootCommand();
+        ParseResult parseResult = rootCommand.Parse(["badcommand"]);
+
+        Assert.NotEmpty(parseResult.Errors);
+
+        string name = CommandNameResolver.ResolveCommandName(parseResult, rootCommand);
+
+        Assert.Equal("unknown", name);
+    }
+}

--- a/test/Func.Tests/Telemetry/TelemetryTests.cs
+++ b/test/Func.Tests/Telemetry/TelemetryTests.cs
@@ -90,7 +90,7 @@ public class TelemetryTests
     {
         // Without an OTel listener subscribed, ActivitySource.StartActivity
         // returns null and the extension propagates that.
-        Assert.Null(CliTelemetry.Trace.StartCommandActivity("test"));
+        Assert.Null(CliTelemetry.Trace.StartCommandActivity());
     }
 
     [Fact]
@@ -102,15 +102,51 @@ public class TelemetryTests
     }
 
     [Fact]
-    public void StartCommandActivity_WithListener_AppliesCommandNameTag()
+    public void StartCommandActivity_WithListener_UsesFixedOperationName()
+    {
+        // The activity is started before the command path is known, so it
+        // gets a stable operation name and no cli.command.name tag yet.
+        using var listener = SubscribeListener();
+
+        using var activity = CliTelemetry.Trace.StartCommandActivity();
+        Assert.NotNull(activity);
+
+        Assert.Equal(ActivityExtensions.CommandActivityName, activity.OperationName);
+        Assert.Equal(ActivityKind.Internal, activity.Kind);
+        Assert.Null(activity.GetTagItem(TelemetryConventions.CliCommandName));
+    }
+
+    [Fact]
+    public void SetCommandName_AppliesDisplayNameAndTag()
     {
         using var listener = SubscribeListener();
 
-        using var activity = CliTelemetry.Trace.StartCommandActivity("workload install");
+        using var activity = CliTelemetry.Trace.StartCommandActivity();
         Assert.NotNull(activity);
 
-        Assert.Equal("workload install", activity.GetTagItem("cli.command.name"));
-        Assert.Equal(ActivityKind.Internal, activity.Kind);
+        activity.SetCommandName("workload install");
+
+        Assert.Equal("workload install", activity.DisplayName);
+        Assert.Equal("workload install", activity.GetTagItem(TelemetryConventions.CliCommandName));
+        // Operation name (fixed at creation) is left alone — only DisplayName moves.
+        Assert.Equal(ActivityExtensions.CommandActivityName, activity.OperationName);
+    }
+
+    [Fact]
+    public void SetCommandName_LastValueWins()
+    {
+        // Defensive: tag should reflect the most recent name in case a future
+        // caller resolves the command in stages.
+        using var listener = SubscribeListener();
+
+        using var activity = CliTelemetry.Trace.StartCommandActivity();
+        Assert.NotNull(activity);
+
+        activity.SetCommandName("workload");
+        activity.SetCommandName("workload install");
+
+        Assert.Equal("workload install", activity.DisplayName);
+        Assert.Equal("workload install", activity.GetTagItem(TelemetryConventions.CliCommandName));
     }
 
     [Fact]
@@ -118,7 +154,7 @@ public class TelemetryTests
     {
         using var listener = SubscribeListener();
 
-        using var activity = CliTelemetry.Trace.StartCommandActivity("test");
+        using var activity = CliTelemetry.Trace.StartCommandActivity();
         Assert.NotNull(activity);
 
         var ex = new InvalidOperationException("boom");


### PR DESCRIPTION
Replace the raw string[] walk in Program.cs with a dedicated CommandNameResolver that walks the matched command up the Parents chain on the ParseResult. The root command is now parsed once and the same ParseResult is reused for InvokeAsync, removing a parallel source of truth for "what command was invoked".

Behavior corrections (telemetry command name):
- `func`                       "unknown" -> "help"
- `func --verbose`             "unknown" -> "version"
- `func badcommand`            "badcommand" -> "unknown"
- `func workload remote add`   "workload remote" -> "workload remote add"
- `func --opt value init`      unchanged: "init" (no more skip-`-` heuristic)

Telemetry cardinality stays bounded: only command paths defined in the parse tree, plus the "unknown" / "version" / "help" sentinels, can be recorded.

Adds 9 xUnit tests covering null-arg guards, root-only fallbacks, top-level / nested / deeply nested subcommands, recursive verbose after a subcommand, and unknown-token parse errors.

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] I have added all required tests (Unit tests, E2E tests)