### PR TITLE
Add workload catalog consumers: install-by-id, update, search

### DIFF
--- a/src/Func/Commands/Workload/WorkloadCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadCommand.cs
@@ -17,15 +17,21 @@ internal sealed class WorkloadCommand : FuncCliCommand, IBuiltInCommand
     public WorkloadCommand(
         WorkloadListCommand listCommand,
         WorkloadInstallCommand installCommand,
-        WorkloadUninstallCommand uninstallCommand)
+        WorkloadUninstallCommand uninstallCommand,
+        WorkloadUpdateCommand updateCommand,
+        WorkloadSearchCommand searchCommand)
         : base("workload", "Manage Func CLI workloads.")
     {
         ArgumentNullException.ThrowIfNull(listCommand);
         ArgumentNullException.ThrowIfNull(installCommand);
         ArgumentNullException.ThrowIfNull(uninstallCommand);
+        ArgumentNullException.ThrowIfNull(updateCommand);
+        ArgumentNullException.ThrowIfNull(searchCommand);
 
         Subcommands.Add(listCommand);
         Subcommands.Add(installCommand);
         Subcommands.Add(uninstallCommand);
+        Subcommands.Add(updateCommand);
+        Subcommands.Add(searchCommand);
     }
 }

--- a/src/Func/Commands/Workload/WorkloadInstallCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadInstallCommand.cs
@@ -25,7 +25,7 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
 
     public Argument<string> WorkloadArgument { get; } = new("id")
     {
-        Description = "Workload package id or alias to install.",
+        Description = "Workload package id, alias, or path to a local .nupkg.",
     };
 
     public Option<string?> VersionOption { get; } = new("--version", "-v")
@@ -38,9 +38,9 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
         Description = "Catalog source URL or local directory to resolve from. Default: the configured catalog.",
     };
 
-    public Option<bool> IncludePrereleasesOption { get; } = new("--include-prereleases")
+    public Option<bool> IncludePrereleaseOption { get; } = new("--prerelease")
     {
-        Description = "Allow prerelease versions when resolving from the catalog.",
+        Description = "Allow prerelease versions when resolving from the catalog. Default: stable only.",
     };
 
     public Option<bool> ForceOption { get; } = new("--force", "-f")
@@ -59,28 +59,13 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
         _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
         _installer = installer ?? throw new ArgumentNullException(nameof(installer));
 
-        WorkloadArgument.Validators.Add(result =>
-        {
-            string? value = result.GetValue(WorkloadArgument);
-            if (string.IsNullOrWhiteSpace(value))
-            {
-                result.AddError("A workload id is required.");
-            }
-        });
-
-        VersionOption.Validators.Add(result =>
-        {
-            string? value = result.GetValue(VersionOption);
-            if (!string.IsNullOrWhiteSpace(value) && !NuGetVersion.TryParse(value, out _))
-            {
-                result.AddError($"'{value}' is not a valid semver version.");
-            }
-        });
+        WorkloadArgument.AddRequiredIdValidator();
+        VersionOption.AddSemVerValidator();
 
         Arguments.Add(WorkloadArgument);
         Options.Add(VersionOption);
         Options.Add(SourceOption);
-        Options.Add(IncludePrereleasesOption);
+        Options.Add(IncludePrereleaseOption);
         Options.Add(ExactOption);
         Options.Add(ForceOption);
     }
@@ -90,20 +75,22 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
         string workload = parseResult.GetValue(WorkloadArgument)!;
         string? versionText = parseResult.GetValue(VersionOption);
         string? source = parseResult.GetValue(SourceOption);
-        bool includePrereleases = parseResult.GetValue(IncludePrereleasesOption);
+        bool includePrerelease = parseResult.GetValue(IncludePrereleaseOption);
         bool exact = parseResult.GetValue(ExactOption);
         bool force = parseResult.GetValue(ForceOption);
 
         try
         {
-            WorkloadInstallResult result = await _installer.InstallFromCatalogAsync(
-                workload,
-                string.IsNullOrEmpty(versionText) ? null : NuGetVersion.Parse(versionText),
-                source,
-                includePrereleases,
-                exact,
-                force,
-                cancellationToken);
+            WorkloadInstallResult result = LooksLikeLocalPackagePath(workload)
+                ? await _installer.InstallFromPackageAsync(workload, force, cancellationToken)
+                : await _installer.InstallFromCatalogAsync(
+                    workload,
+                    string.IsNullOrEmpty(versionText) ? null : NuGetVersion.Parse(versionText),
+                    source,
+                    includePrerelease,
+                    exact,
+                    force,
+                    cancellationToken);
 
             _interaction.WriteSuccess(BuildSuccessMessage(result));
             return 0;
@@ -112,11 +99,15 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
         {
             throw new GracefulException(ex.Message, isUserError: true);
         }
-        catch (AmbiguousAliasException ex)
+        catch (AmbiguousPackageMatchException ex)
         {
             throw new GracefulException(ex.Message, isUserError: true);
         }
         catch (InvalidWorkloadException ex)
+        {
+            throw new GracefulException(ex.Message, isUserError: true);
+        }
+        catch (FileNotFoundException ex)
         {
             throw new GracefulException(ex.Message, isUserError: true);
         }
@@ -127,6 +118,16 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
                 isUserError: true);
         }
     }
+
+    /// <summary>
+    /// Returns <c>true</c> when the positional argument looks like a path
+    /// to a <c>.nupkg</c> on disk (i.e. ends in <c>.nupkg</c> and points to
+    /// an existing file). Lets the user install a local package without
+    /// going through the catalog. NuGet package ids cannot legally end in
+    /// <c>.nupkg</c>, so this is unambiguous.
+    /// </summary>
+    private static bool LooksLikeLocalPackagePath(string value)
+        => value.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase) && File.Exists(value);
 
     private static string BuildSuccessMessage(WorkloadInstallResult result)
     {

--- a/src/Func/Commands/Workload/WorkloadInstallCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadInstallCommand.cs
@@ -5,31 +5,52 @@ using System.CommandLine;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Workloads;
+using Azure.Functions.Cli.Workloads.Catalog;
 using Azure.Functions.Cli.Workloads.Discovery;
 using Azure.Functions.Cli.Workloads.Install;
 using Azure.Functions.Cli.Workloads.Storage;
+using NuGet.Versioning;
 
 namespace Azure.Functions.Cli.Commands.Workload;
 
 /// <summary>
-/// <c>func workload install &lt;package&gt;</c>. Installs a workload from a
-/// <c>.nupkg</c> on disk. Feed-based acquisition is not yet supported.
+/// <c>func workload install &lt;package&gt;</c>. Resolves a workload package
+/// id (or alias) through the configured catalog and installs it. Use
+/// <c>--source</c> to point at a local folder or alternate feed.
 /// </summary>
 internal sealed class WorkloadInstallCommand : FuncCliCommand
 {
-    private const string NupkgExtension = ".nupkg";
-
     private readonly IInteractionService _interaction;
     private readonly IWorkloadInstaller _installer;
 
     public Argument<string> WorkloadArgument { get; } = new("id")
     {
-        Description = "Workload to install. Currently must be a path to a .nupkg on disk.",
+        Description = "Workload package id or alias to install.",
+    };
+
+    public Option<string?> VersionOption { get; } = new("--version", "-v")
+    {
+        Description = "Specific semver version to install. Default: the latest stable version in the catalog.",
+    };
+
+    public Option<string?> SourceOption { get; } = new("--source")
+    {
+        Description = "Catalog source URL or local directory to resolve from. Default: the configured catalog.",
+    };
+
+    public Option<bool> IncludePrereleasesOption { get; } = new("--include-prereleases")
+    {
+        Description = "Allow prerelease versions when resolving from the catalog.",
     };
 
     public Option<bool> ForceOption { get; } = new("--force", "-f")
     {
         Description = "Overwrite an existing install of the same id and version.",
+    };
+
+    public Option<bool> ExactOption { get; } = new("--exact", "-e")
+    {
+        Description = "Disable alias matching. <id> must be the literal package id.",
     };
 
     public WorkloadInstallCommand(IInteractionService interaction, IWorkloadInstaller installer)
@@ -44,33 +65,54 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
             if (string.IsNullOrWhiteSpace(value))
             {
                 result.AddError("A workload id is required.");
-                return;
             }
+        });
 
-            if (!value.EndsWith(NupkgExtension, StringComparison.OrdinalIgnoreCase))
+        VersionOption.Validators.Add(result =>
+        {
+            string? value = result.GetValue(VersionOption);
+            if (!string.IsNullOrWhiteSpace(value) && !NuGetVersion.TryParse(value, out _))
             {
-                result.AddError(
-                    $"Resolving '{value}' against a NuGet feed is not yet supported. " +
-                    "Pass a path to a .nupkg on disk.");
+                result.AddError($"'{value}' is not a valid semver version.");
             }
         });
 
         Arguments.Add(WorkloadArgument);
+        Options.Add(VersionOption);
+        Options.Add(SourceOption);
+        Options.Add(IncludePrereleasesOption);
+        Options.Add(ExactOption);
         Options.Add(ForceOption);
     }
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         string workload = parseResult.GetValue(WorkloadArgument)!;
+        string? versionText = parseResult.GetValue(VersionOption);
+        string? source = parseResult.GetValue(SourceOption);
+        bool includePrereleases = parseResult.GetValue(IncludePrereleasesOption);
+        bool exact = parseResult.GetValue(ExactOption);
         bool force = parseResult.GetValue(ForceOption);
 
         try
         {
-            WorkloadInstallResult result = await _installer.InstallFromPackageAsync(workload, force, cancellationToken);
+            WorkloadInstallResult result = await _installer.InstallFromCatalogAsync(
+                workload,
+                string.IsNullOrEmpty(versionText) ? null : NuGetVersion.Parse(versionText),
+                source,
+                includePrereleases,
+                exact,
+                force,
+                cancellationToken);
+
             _interaction.WriteSuccess(BuildSuccessMessage(result));
             return 0;
         }
-        catch (FileNotFoundException ex)
+        catch (WorkloadPackageNotFoundException ex)
+        {
+            throw new GracefulException(ex.Message, isUserError: true);
+        }
+        catch (AmbiguousAliasException ex)
         {
             throw new GracefulException(ex.Message, isUserError: true);
         }

--- a/src/Func/Commands/Workload/WorkloadOptionValidators.cs
+++ b/src/Func/Commands/Workload/WorkloadOptionValidators.cs
@@ -1,0 +1,71 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using NuGet.Versioning;
+
+namespace Azure.Functions.Cli.Commands.Workload;
+
+/// <summary>
+/// Shared parse-time validators for <c>func workload</c> options and
+/// arguments. Centralized so message wording and parsing rules stay
+/// consistent across install/uninstall/update/search.
+/// </summary>
+internal static class WorkloadOptionValidators
+{
+    /// <summary>
+    /// Rejects an option value that is non-empty and is not a valid
+    /// <see cref="NuGetVersion"/> string. Empty / null values pass (the
+    /// option is optional).
+    /// </summary>
+    public static void AddSemVerValidator(this Option<string?> option)
+    {
+        ArgumentNullException.ThrowIfNull(option);
+
+        option.Validators.Add(result =>
+        {
+            string? value = result.GetValue(option);
+            if (!string.IsNullOrWhiteSpace(value) && !NuGetVersion.TryParse(value, out _))
+            {
+                result.AddError($"'{value}' is not a valid semver version.");
+            }
+        });
+    }
+
+    /// <summary>
+    /// Rejects a required workload-id argument that is null or whitespace.
+    /// </summary>
+    public static void AddRequiredIdValidator(this Argument<string> argument)
+    {
+        ArgumentNullException.ThrowIfNull(argument);
+
+        argument.Validators.Add(result =>
+        {
+            string? value = result.GetValue(argument);
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                result.AddError("A workload id is required.");
+            }
+        });
+    }
+
+    /// <summary>
+    /// Rejects an optional workload-id argument that was supplied but is
+    /// only whitespace. A genuinely omitted argument still passes.
+    /// </summary>
+    public static void AddOptionalIdValidator(this Argument<string?> argument)
+    {
+        ArgumentNullException.ThrowIfNull(argument);
+
+        argument.Validators.Add(result =>
+        {
+            // An omitted optional argument parses to null and stays valid;
+            // only reject explicit whitespace-only input.
+            string? value = result.GetValue(argument);
+            if (value is not null && string.IsNullOrWhiteSpace(value))
+            {
+                result.AddError("A workload id is required.");
+            }
+        });
+    }
+}

--- a/src/Func/Commands/Workload/WorkloadSearchCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadSearchCommand.cs
@@ -29,10 +29,10 @@ internal sealed class WorkloadSearchCommand : FuncCliCommand
 
     public Option<string?> SourceOption { get; } = new("--source")
     {
-        Description = "Catalog source URL or local directory to search.",
+        Description = "NuGet feed URI to search.",
     };
 
-    public Option<bool> IncludePrereleasesOption { get; } = new("--include-prereleases")
+    public Option<bool> IncludePrereleaseOption { get; } = new("--prerelease")
     {
         Description = "Include prerelease versions in the results.",
     };
@@ -45,19 +45,21 @@ internal sealed class WorkloadSearchCommand : FuncCliCommand
 
         Arguments.Add(QueryArgument);
         Options.Add(SourceOption);
-        Options.Add(IncludePrereleasesOption);
+        Options.Add(IncludePrereleaseOption);
     }
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         string? query = parseResult.GetValue(QueryArgument);
         string? source = parseResult.GetValue(SourceOption);
-        bool includePrereleases = parseResult.GetValue(IncludePrereleasesOption);
+        bool includePrerelease = parseResult.GetValue(IncludePrereleaseOption);
 
+        // TODO: surface --skip and --take for paging once we have a UX
+        // story for repeated queries (see workload spec §4.1).
         var searchQuery = new CatalogSearchQuery
         {
             Filter = query,
-            IncludePrerelease = includePrereleases,
+            IncludePrerelease = includePrerelease,
             Take = DefaultTake,
             Source = source,
         };

--- a/src/Func/Commands/Workload/WorkloadSearchCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadSearchCommand.cs
@@ -1,0 +1,106 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Workloads.Catalog;
+
+namespace Azure.Functions.Cli.Commands.Workload;
+
+/// <summary>
+/// <c>func workload search [&lt;query&gt;]</c>. Renders matching workload
+/// packages from the configured catalog as a table.
+/// </summary>
+internal sealed class WorkloadSearchCommand : FuncCliCommand
+{
+    private const int DefaultTake = 20;
+    private const int DescriptionMaxLength = 80;
+    private const string Placeholder = "-";
+
+    private readonly IInteractionService _interaction;
+    private readonly IWorkloadCatalog _catalog;
+
+    public Argument<string?> QueryArgument { get; } = new("query")
+    {
+        Arity = ArgumentArity.ZeroOrOne,
+        Description = "Optional free-form query. Omit to list all workloads.",
+    };
+
+    public Option<string?> SourceOption { get; } = new("--source")
+    {
+        Description = "Catalog source URL or local directory to search.",
+    };
+
+    public Option<bool> IncludePrereleasesOption { get; } = new("--include-prereleases")
+    {
+        Description = "Include prerelease versions in the results.",
+    };
+
+    public WorkloadSearchCommand(IInteractionService interaction, IWorkloadCatalog catalog)
+        : base("search", "Search the workload catalog.")
+    {
+        _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
+        _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
+
+        Arguments.Add(QueryArgument);
+        Options.Add(SourceOption);
+        Options.Add(IncludePrereleasesOption);
+    }
+
+    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        string? query = parseResult.GetValue(QueryArgument);
+        string? source = parseResult.GetValue(SourceOption);
+        bool includePrereleases = parseResult.GetValue(IncludePrereleasesOption);
+
+        var searchQuery = new CatalogSearchQuery
+        {
+            Filter = query,
+            IncludePrerelease = includePrereleases,
+            Take = DefaultTake,
+            Source = source,
+        };
+
+        IReadOnlyList<CatalogSearchResult> results;
+        try
+        {
+            results = await _catalog.SearchAsync(searchQuery, cancellationToken);
+        }
+        catch (ArgumentException ex)
+        {
+            throw new GracefulException(ex.Message, isUserError: true);
+        }
+
+        if (results.Count == 0)
+        {
+            _interaction.WriteWarning("No workloads found.");
+            return 0;
+        }
+
+        IEnumerable<string[]> rows = results.Select(r => new[]
+        {
+            r.PackageId,
+            r.Aliases.Count == 0 ? Placeholder : string.Join(", ", r.Aliases),
+            string.IsNullOrWhiteSpace(r.Title) ? Placeholder : r.Title!,
+            TruncateDescription(r.Description),
+            r.LatestVersion.ToNormalizedString(),
+        });
+
+        _interaction.WriteTable(["ID", "Aliases", "Display Name", "Description", "Latest"], rows);
+        return 0;
+    }
+
+    private static string TruncateDescription(string? description)
+    {
+        if (string.IsNullOrWhiteSpace(description))
+        {
+            return Placeholder;
+        }
+
+        string trimmed = description.Trim();
+        return trimmed.Length <= DescriptionMaxLength
+            ? trimmed
+            : string.Concat(trimmed.AsSpan(0, DescriptionMaxLength - 3), "...");
+    }
+}

--- a/src/Func/Commands/Workload/WorkloadUninstallCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadUninstallCommand.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.CommandLine;
-using System.CommandLine.Parsing;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Workloads.Install;
@@ -22,12 +21,12 @@ internal sealed class WorkloadUninstallCommand : FuncCliCommand
 
     public Argument<string> WorkloadArgument { get; } = new("id")
     {
-        Description = "ID or alias of the workload to uninstall.",
+        Description = "Workload package id or alias to uninstall.",
     };
 
     public Option<string?> VersionOption { get; } = new("--version", "-v")
     {
-        Description = "Specific version to uninstall. Omit when only one version is installed.",
+        Description = "Specific version to uninstall. Default: the only installed version.",
     };
 
     public Option<bool> AllVersionsOption { get; } = new("--all-versions", "-a")
@@ -37,7 +36,7 @@ internal sealed class WorkloadUninstallCommand : FuncCliCommand
 
     public Option<bool> ExactOption { get; } = new("--exact", "-e")
     {
-        Description = "Match the argument as a literal package id; do not look up aliases.",
+        Description = "Disable alias matching. <id> must be the literal package id.",
     };
 
     public WorkloadUninstallCommand(
@@ -50,14 +49,7 @@ internal sealed class WorkloadUninstallCommand : FuncCliCommand
         _installer = installer ?? throw new ArgumentNullException(nameof(installer));
         _store = store ?? throw new ArgumentNullException(nameof(store));
 
-        WorkloadArgument.Validators.Add(result =>
-        {
-            string? value = result.GetValue(WorkloadArgument);
-            if (string.IsNullOrWhiteSpace(value))
-            {
-                result.AddError("A workload id is required.");
-            }
-        });
+        WorkloadArgument.AddRequiredIdValidator();
 
         Arguments.Add(WorkloadArgument);
         Options.Add(VersionOption);
@@ -66,11 +58,13 @@ internal sealed class WorkloadUninstallCommand : FuncCliCommand
 
         Validators.Add(result =>
         {
-            int specified = result.Children
-                .OfType<OptionResult>()
-                .Count(or => or.Option == VersionOption || or.Option == AllVersionsOption);
+            // --version names a single version; --all-versions wipes them
+            // all. They contradict each other, so reject the combination
+            // at parse time rather than picking a precedence at runtime.
+            bool versionSpecified = result.GetResult(VersionOption) is not null;
+            bool allSpecified = result.GetResult(AllVersionsOption) is not null;
 
-            if (specified > 1)
+            if (versionSpecified && allSpecified)
             {
                 result.AddError("--all-versions and --version cannot be combined.");
             }

--- a/src/Func/Commands/Workload/WorkloadUpdateCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadUpdateCommand.cs
@@ -26,12 +26,12 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
     public Argument<string?> WorkloadArgument { get; } = new("id")
     {
         Arity = ArgumentArity.ZeroOrOne,
-        Description = "ID or alias of the installed workload to update. Mutually exclusive with --all.",
+        Description = "Workload package id or alias to update. Mutually exclusive with --all.",
     };
 
     public Option<string?> VersionOption { get; } = new("--version", "-v")
     {
-        Description = "Installed version to replace. Defaults to the highest installed semver.",
+        Description = "Installed version to replace. Default: the highest installed semver.",
     };
 
     public Option<bool> AllOption { get; } = new("--all")
@@ -46,17 +46,17 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
 
     public Option<string?> SourceOption { get; } = new("--source")
     {
-        Description = "Catalog source URL or local directory to resolve from.",
+        Description = "Catalog source URL or local directory to resolve from. Default: the configured catalog.",
     };
 
-    public Option<bool> IncludePrereleasesOption { get; } = new("--include-prereleases")
+    public Option<bool> IncludePrereleaseOption { get; } = new("--prerelease")
     {
-        Description = "Allow prerelease versions when resolving the new version.",
+        Description = "Allow prerelease versions when resolving from the catalog. Default: stable only.",
     };
 
     public Option<bool> ExactOption { get; } = new("--exact", "-e")
     {
-        Description = "Match the argument as a literal package id; do not look up aliases.",
+        Description = "Disable alias matching. <id> must be the literal package id.",
     };
 
     public WorkloadUpdateCommand(
@@ -69,21 +69,15 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
         _installer = installer ?? throw new ArgumentNullException(nameof(installer));
         _store = store ?? throw new ArgumentNullException(nameof(store));
 
-        VersionOption.Validators.Add(result =>
-        {
-            string? value = result.GetValue(VersionOption);
-            if (!string.IsNullOrWhiteSpace(value) && !NuGetVersion.TryParse(value, out _))
-            {
-                result.AddError($"'{value}' is not a valid semver version.");
-            }
-        });
+        WorkloadArgument.AddOptionalIdValidator();
+        VersionOption.AddSemVerValidator();
 
         Arguments.Add(WorkloadArgument);
         Options.Add(VersionOption);
         Options.Add(AllOption);
         Options.Add(MajorOption);
         Options.Add(SourceOption);
-        Options.Add(IncludePrereleasesOption);
+        Options.Add(IncludePrereleaseOption);
         Options.Add(ExactOption);
 
         Validators.Add(result =>
@@ -103,9 +97,17 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
                 return;
             }
 
-            if (all && !string.IsNullOrWhiteSpace(result.GetValue(VersionOption)))
+            if (all && result.GetResult(VersionOption) is not null)
             {
                 result.AddError("--version cannot be combined with --all.");
+            }
+
+            if (all && result.GetResult(ExactOption) is not null && result.GetValue(ExactOption))
+            {
+                // --exact only narrows alias resolution for a single id, so
+                // it's meaningless without one. Reject explicitly so the
+                // user doesn't think it filtered the --all set somehow.
+                result.AddError("--exact cannot be combined with --all.");
             }
         });
     }
@@ -117,12 +119,12 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
         string? versionText = parseResult.GetValue(VersionOption);
         bool allowMajor = parseResult.GetValue(MajorOption);
         string? source = parseResult.GetValue(SourceOption);
-        bool includePrereleases = parseResult.GetValue(IncludePrereleasesOption);
+        bool includePrerelease = parseResult.GetValue(IncludePrereleaseOption);
         bool exact = parseResult.GetValue(ExactOption);
 
         if (all)
         {
-            return await UpdateAllAsync(source, includePrereleases, allowMajor, cancellationToken);
+            return await UpdateAllAsync(source, includePrerelease, allowMajor, cancellationToken);
         }
 
         string packageId = await ResolveInstalledPackageIdAsync(identifier!, exact, cancellationToken);
@@ -131,7 +133,7 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
             packageId,
             string.IsNullOrEmpty(versionText) ? null : NuGetVersion.Parse(versionText),
             source,
-            includePrereleases,
+            includePrerelease,
             allowMajor,
             cancellationToken);
     }
@@ -171,14 +173,14 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
         string packageId,
         NuGetVersion? targetVersion,
         string? source,
-        bool includePrereleases,
+        bool includePrerelease,
         bool allowMajor,
         CancellationToken cancellationToken)
     {
         try
         {
             WorkloadUpdateResult result = await _installer.UpdateAsync(
-                packageId, targetVersion, source, includePrereleases, allowMajor, cancellationToken);
+                packageId, targetVersion, source, includePrerelease, allowMajor, cancellationToken);
 
             RenderSingle(result);
             return 0;
@@ -203,7 +205,7 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
 
     private async Task<int> UpdateAllAsync(
         string? source,
-        bool includePrereleases,
+        bool includePrerelease,
         bool allowMajor,
         CancellationToken cancellationToken)
     {
@@ -218,7 +220,7 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
             return 0;
         }
 
-        int failed = 0;
+        bool anyFailed = false;
         foreach (string packageId in packageIds)
         {
             try
@@ -227,7 +229,7 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
                     packageId,
                     targetInstalledVersion: null,
                     source,
-                    includePrereleases,
+                    includePrerelease,
                     allowMajor,
                     cancellationToken);
                 RenderSingle(result);
@@ -241,12 +243,12 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
                 // Per-id failure must not block other workloads. Surface
                 // the message and keep going; the final exit code reflects
                 // whether any failed.
-                failed++;
+                anyFailed = true;
                 _interaction.WriteError($"Update failed for '{packageId}': {ex.Message}");
             }
         }
 
-        return failed == 0 ? 0 : 1;
+        return anyFailed ? 1 : 0;
     }
 
     private void RenderSingle(WorkloadUpdateResult result)

--- a/src/Func/Commands/Workload/WorkloadUpdateCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadUpdateCommand.cs
@@ -1,0 +1,273 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Workloads.Catalog;
+using Azure.Functions.Cli.Workloads.Discovery;
+using Azure.Functions.Cli.Workloads.Install;
+using Azure.Functions.Cli.Workloads.Storage;
+using NuGet.Versioning;
+
+namespace Azure.Functions.Cli.Commands.Workload;
+
+/// <summary>
+/// <c>func workload update [&lt;id&gt;]</c>. In-place atomic version
+/// swap per spec §6.4. Not side-by-side: use <c>install --force</c> for
+/// SxS. Pass <c>--all</c> to update every installed workload.
+/// </summary>
+internal sealed class WorkloadUpdateCommand : FuncCliCommand
+{
+    private readonly IInteractionService _interaction;
+    private readonly IWorkloadInstaller _installer;
+    private readonly IWorkloadStore _store;
+
+    public Argument<string?> WorkloadArgument { get; } = new("id")
+    {
+        Arity = ArgumentArity.ZeroOrOne,
+        Description = "ID or alias of the installed workload to update. Mutually exclusive with --all.",
+    };
+
+    public Option<string?> VersionOption { get; } = new("--version", "-v")
+    {
+        Description = "Installed version to replace. Defaults to the highest installed semver.",
+    };
+
+    public Option<bool> AllOption { get; } = new("--all")
+    {
+        Description = "Update every installed workload. Mutually exclusive with <id>.",
+    };
+
+    public Option<bool> MajorOption { get; } = new("--major")
+    {
+        Description = "Allow crossing a major-version boundary. Default: same major only.",
+    };
+
+    public Option<string?> SourceOption { get; } = new("--source")
+    {
+        Description = "Catalog source URL or local directory to resolve from.",
+    };
+
+    public Option<bool> IncludePrereleasesOption { get; } = new("--include-prereleases")
+    {
+        Description = "Allow prerelease versions when resolving the new version.",
+    };
+
+    public Option<bool> ExactOption { get; } = new("--exact", "-e")
+    {
+        Description = "Match the argument as a literal package id; do not look up aliases.",
+    };
+
+    public WorkloadUpdateCommand(
+        IInteractionService interaction,
+        IWorkloadInstaller installer,
+        IWorkloadStore store)
+        : base("update", "Update an installed workload in place.")
+    {
+        _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
+        _installer = installer ?? throw new ArgumentNullException(nameof(installer));
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+
+        VersionOption.Validators.Add(result =>
+        {
+            string? value = result.GetValue(VersionOption);
+            if (!string.IsNullOrWhiteSpace(value) && !NuGetVersion.TryParse(value, out _))
+            {
+                result.AddError($"'{value}' is not a valid semver version.");
+            }
+        });
+
+        Arguments.Add(WorkloadArgument);
+        Options.Add(VersionOption);
+        Options.Add(AllOption);
+        Options.Add(MajorOption);
+        Options.Add(SourceOption);
+        Options.Add(IncludePrereleasesOption);
+        Options.Add(ExactOption);
+
+        Validators.Add(result =>
+        {
+            string? id = result.GetValue(WorkloadArgument);
+            bool all = result.GetValue(AllOption);
+
+            if (string.IsNullOrWhiteSpace(id) && !all)
+            {
+                result.AddError("Specify a workload <id> or pass --all.");
+                return;
+            }
+
+            if (!string.IsNullOrWhiteSpace(id) && all)
+            {
+                result.AddError("<id> and --all are mutually exclusive.");
+                return;
+            }
+
+            if (all && !string.IsNullOrWhiteSpace(result.GetValue(VersionOption)))
+            {
+                result.AddError("--version cannot be combined with --all.");
+            }
+        });
+    }
+
+    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        string? identifier = parseResult.GetValue(WorkloadArgument);
+        bool all = parseResult.GetValue(AllOption);
+        string? versionText = parseResult.GetValue(VersionOption);
+        bool allowMajor = parseResult.GetValue(MajorOption);
+        string? source = parseResult.GetValue(SourceOption);
+        bool includePrereleases = parseResult.GetValue(IncludePrereleasesOption);
+        bool exact = parseResult.GetValue(ExactOption);
+
+        if (all)
+        {
+            return await UpdateAllAsync(source, includePrereleases, allowMajor, cancellationToken);
+        }
+
+        string packageId = await ResolveInstalledPackageIdAsync(identifier!, exact, cancellationToken);
+
+        return await UpdateOneAsync(
+            packageId,
+            string.IsNullOrEmpty(versionText) ? null : NuGetVersion.Parse(versionText),
+            source,
+            includePrereleases,
+            allowMajor,
+            cancellationToken);
+    }
+
+    private async Task<string> ResolveInstalledPackageIdAsync(
+        string identifier,
+        bool exact,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
+
+        bool MatchesId(WorkloadEntry e) =>
+            string.Equals(e.PackageId, identifier, StringComparison.OrdinalIgnoreCase);
+
+        bool MatchesAlias(WorkloadEntry e) =>
+            !exact && (e.Aliases?.Any(a => string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)) ?? false);
+
+        string[] matchedIds = [.. installed
+            .Where(e => MatchesId(e) || MatchesAlias(e))
+            .Select(e => e.PackageId)
+            .Distinct(StringComparer.OrdinalIgnoreCase)];
+
+        if (matchedIds.Length > 1)
+        {
+            throw new GracefulException(
+                $"Alias '{identifier}' matches multiple installed workloads ({string.Join(", ", matchedIds)}). " +
+                "Pass the workload ID instead.",
+                isUserError: true);
+        }
+
+        // Defer the "not installed" error to UpdateAsync so messaging stays
+        // consistent with the --version path that's also resolved there.
+        return matchedIds.Length == 1 ? matchedIds[0] : identifier;
+    }
+
+    private async Task<int> UpdateOneAsync(
+        string packageId,
+        NuGetVersion? targetVersion,
+        string? source,
+        bool includePrereleases,
+        bool allowMajor,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            WorkloadUpdateResult result = await _installer.UpdateAsync(
+                packageId, targetVersion, source, includePrereleases, allowMajor, cancellationToken);
+
+            RenderSingle(result);
+            return 0;
+        }
+        catch (WorkloadPackageNotFoundException ex)
+        {
+            throw new GracefulException(ex.Message, isUserError: true);
+        }
+        catch (FileNotFoundException ex)
+        {
+            throw new GracefulException(ex.Message, isUserError: true);
+        }
+        catch (InvalidWorkloadException ex)
+        {
+            throw new GracefulException(ex.Message, isUserError: true);
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw new GracefulException(ex.Message, isUserError: true);
+        }
+    }
+
+    private async Task<int> UpdateAllAsync(
+        string? source,
+        bool includePrereleases,
+        bool allowMajor,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
+        IReadOnlyList<string> packageIds = [.. installed
+            .Select(e => e.PackageId)
+            .Distinct(StringComparer.OrdinalIgnoreCase)];
+
+        if (packageIds.Count == 0)
+        {
+            _interaction.WriteHint("No workloads installed.");
+            return 0;
+        }
+
+        int failed = 0;
+        foreach (string packageId in packageIds)
+        {
+            try
+            {
+                WorkloadUpdateResult result = await _installer.UpdateAsync(
+                    packageId,
+                    targetInstalledVersion: null,
+                    source,
+                    includePrereleases,
+                    allowMajor,
+                    cancellationToken);
+                RenderSingle(result);
+            }
+            catch (Exception ex) when (
+                ex is WorkloadPackageNotFoundException
+                or FileNotFoundException
+                or InvalidWorkloadException
+                or InvalidOperationException)
+            {
+                // Per-id failure must not block other workloads. Surface
+                // the message and keep going; the final exit code reflects
+                // whether any failed.
+                failed++;
+                _interaction.WriteError($"Update failed for '{packageId}': {ex.Message}");
+            }
+        }
+
+        return failed == 0 ? 0 : 1;
+    }
+
+    private void RenderSingle(WorkloadUpdateResult result)
+    {
+        if (result.NoCandidateOnSource)
+        {
+            _interaction.WriteHint(
+                $"No version of '{result.Entry.PackageId}' was found on the configured source. " +
+                "Pass --source to point at the feed that publishes it.");
+            return;
+        }
+
+        if (result.NoUpdateAvailable)
+        {
+            _interaction.WriteHint(
+                $"Workload '{result.Entry.PackageId}' is already at the latest available version " +
+                $"({result.Entry.PackageVersion}).");
+            return;
+        }
+
+        _interaction.WriteSuccess(
+            $"Updated workload '{result.Entry.PackageId}' from {result.PreviousVersion} to {result.Entry.PackageVersion}.");
+    }
+}

--- a/src/Func/Hosting/BuiltInCommands.cs
+++ b/src/Func/Hosting/BuiltInCommands.cs
@@ -40,6 +40,8 @@ internal static class BuiltInCommands
         services.AddSingleton<WorkloadListCommand>();
         services.AddSingleton<WorkloadInstallCommand>();
         services.AddSingleton<WorkloadUninstallCommand>();
+        services.AddSingleton<WorkloadUpdateCommand>();
+        services.AddSingleton<WorkloadSearchCommand>();
         services.AddSingleton<FuncCliCommand, WorkloadCommand>();
 
         return services;

--- a/src/Func/Hosting/CliHostFactory.cs
+++ b/src/Func/Hosting/CliHostFactory.cs
@@ -72,6 +72,7 @@ internal static class CliHostFactory
 
         builder.Services.AddBuiltInCommands();
         builder.Services.AddWorkloadStorage();
+        builder.Services.AddWorkloadCatalog();
         builder.Services.AddWorkloadInstaller();
 
         return builder;

--- a/src/Func/Workloads/Catalog/NuGetProtocolSourceClient.cs
+++ b/src/Func/Workloads/Catalog/NuGetProtocolSourceClient.cs
@@ -1,7 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Globalization;
+using Azure.Functions.Cli.Workloads.Install;
+using Newtonsoft.Json.Linq;
 using NuGet.Common;
+using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 using PackageSource = NuGet.Configuration.PackageSource;
@@ -9,16 +13,23 @@ using PackageSource = NuGet.Configuration.PackageSource;
 namespace Azure.Functions.Cli.Workloads.Catalog;
 
 /// <summary>
-/// HTTP- or file-backed client built on <c>NuGet.Protocol</c>. Drives
-/// <see cref="PackageSearchResource"/> and <see cref="FindPackageByIdResource"/>
-/// against the v3 service index (remote) or the on-disk feed layout (local)
-/// of the supplied <see cref="SourceRepository"/>, restricting search to the
-/// <c>FuncCliWorkload</c> package type.
+/// V3 NuGet feed client built on <c>NuGet.Protocol</c>. Drives search via
+/// the source's <c>SearchQueryService</c> entry (with the <c>packageType=</c>
+/// filter) and version/download via <see cref="FindPackageByIdResource"/>,
+/// restricting search to the <c>FuncCliWorkload</c> package type.
 /// </summary>
-internal sealed class NuGetProtocolSourceClient(SourceRepository repository)
+internal class NuGetProtocolSourceClient(SourceRepository repository)
 {
-    private const string PackageType = "FuncCliWorkload";
-    private const string AliasTagPrefix = "alias:";
+    private const string FuncCliWorkloadPackageType = "FuncCliWorkload";
+
+    // SearchFilter.PackageTypes is serialised by NuGet.Client as
+    // 'packageTypeFilter=', which nuget.org silently ignores (verified via
+    // probe-nuget-package-type-filter.ps1). The wiki-spec parameter
+    // 'packageType=' (singular, query-string) is the one nuget.org honours,
+    // and no typed NuGet.Client API exposes it. So we hand-build the search
+    // request against the V3 service index and trust the server-side filter.
+    // Wiki: https://github.com/NuGet/Home/wiki/Search-by-Package-Type-and-Query-Language-Surfacing
+    private const string PackageTypeQueryParam = "packageType";
 
     private readonly SourceRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
 
@@ -30,31 +41,17 @@ internal sealed class NuGetProtocolSourceClient(SourceRepository repository)
     {
         ArgumentNullException.ThrowIfNull(query);
 
-        PackageSearchResource searchResource = await _repository.GetResourceAsync<PackageSearchResource>(cancellationToken);
-        SearchFilter filter = new(query.IncludePrerelease)
-        {
-            PackageTypes = [PackageType],
-        };
+        int take = query.Take ?? CatalogSearchQuery.DefaultTake;
+        Uri? searchUri = await TryBuildV3SearchUriAsync(query, take, cancellationToken);
 
-        IEnumerable<IPackageSearchMetadata> hits = await searchResource.SearchAsync(
-            query.Filter ?? string.Empty,
-            filter,
-            query.Skip,
-            query.Take ?? CatalogSearchQuery.DefaultTake,
-            NullLogger.Instance,
-            cancellationToken);
-
-        var results = new List<CatalogSearchResult>();
-        foreach (IPackageSearchMetadata hit in hits)
+        if (searchUri is null)
         {
-            CatalogSearchResult? result = ToResult(hit, Source);
-            if (result is not null)
-            {
-                results.Add(result);
-            }
+            throw new InvalidOperationException(
+                $"Source '{Source.Source}' does not advertise a SearchQueryService entry. Workload search requires a V3 NuGet feed.");
         }
 
-        return results;
+        JObject? raw = await FetchSearchResponseAsync(searchUri, cancellationToken);
+        return raw is null ? [] : ParseV3Hits(raw, Source);
     }
 
     public async Task<IReadOnlyList<NuGetVersion>> ListVersionsAsync(
@@ -115,20 +112,121 @@ internal sealed class NuGetProtocolSourceClient(SourceRepository repository)
         }
     }
 
-    internal static CatalogSearchResult? ToResult(IPackageSearchMetadata hit, PackageSource source)
+    /// <summary>
+    /// Issues the V3 search request through NuGet's <see cref="HttpSource"/>
+    /// so credential providers, retries, proxy, and HTTP cache configured
+    /// for the source all apply. Virtual so tests can stub the JSON
+    /// response without standing up an HTTP server.
+    /// </summary>
+    internal virtual async Task<JObject?> FetchSearchResponseAsync(
+        Uri searchUri,
+        CancellationToken cancellationToken)
     {
-        if (hit.Identity?.Id is null || hit.Identity.Version is null)
+        HttpSourceResource httpSourceResource = await _repository.GetResourceAsync<HttpSourceResource>(cancellationToken);
+        return await httpSourceResource.HttpSource.GetJObjectAsync(
+            new HttpSourceRequest(searchUri, NullLogger.Instance),
+            NullLogger.Instance,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Resolves the source's <c>SearchQueryService</c> entry from its V3
+    /// service index and builds a request URL with the
+    /// <c>packageType=FuncCliWorkload</c> filter. Returns null when the
+    /// source has no V3 service index (e.g. local file feeds).
+    /// </summary>
+    private async Task<Uri?> TryBuildV3SearchUriAsync(
+        CatalogSearchQuery query,
+        int take,
+        CancellationToken cancellationToken)
+    {
+        ServiceIndexResourceV3? serviceIndex = await _repository.GetResourceAsync<ServiceIndexResourceV3>(cancellationToken);
+        if (serviceIndex is null)
         {
             return null;
         }
 
-        return new CatalogSearchResult(
-            PackageId: hit.Identity.Id.ToLowerInvariant(),
-            LatestVersion: hit.Identity.Version,
-            Title: hit.Title,
-            Description: hit.Description,
-            Aliases: ParseAliases(hit.Tags),
-            Source: source);
+        // GetServiceEntryUri picks the best match in priority order across
+        // the V3 service index versions; pass the unversioned key first.
+        string? baseUrl = serviceIndex.GetServiceEntryUri(
+            "SearchQueryService",
+            "SearchQueryService/3.5.0",
+            "SearchQueryService/3.0.0-rc",
+            "SearchQueryService/3.0.0-beta")?.AbsoluteUri;
+
+        if (string.IsNullOrEmpty(baseUrl))
+        {
+            return null;
+        }
+
+        var qs = new List<string>
+        {
+            "q=" + Uri.EscapeDataString(query.Filter ?? string.Empty),
+            "skip=" + query.Skip.ToString(CultureInfo.InvariantCulture),
+            "take=" + take.ToString(CultureInfo.InvariantCulture),
+            "prerelease=" + query.IncludePrerelease.ToString(CultureInfo.InvariantCulture).ToLowerInvariant(),
+            "semVerLevel=2.0.0",
+            $"{PackageTypeQueryParam}=" + Uri.EscapeDataString(FuncCliWorkloadPackageType),
+        };
+
+        return new Uri(baseUrl + (baseUrl.Contains('?') ? "&" : "?") + string.Join("&", qs));
+    }
+
+    /// <summary>
+    /// Parses the V3 search response and applies a defensive client-side
+    /// filter on each hit's <c>packageTypes</c> array. Feeds that honour
+    /// <c>packageType=</c> server-side return a pre-filtered set; feeds that
+    /// don't (older or non-conforming implementations) get filtered here.
+    /// Hits that omit <c>packageTypes</c> are kept, since the server filter
+    /// already had its chance.
+    /// </summary>
+    internal static IReadOnlyList<CatalogSearchResult> ParseV3Hits(JObject response, PackageSource source)
+    {
+        if (response["data"] is not JArray data)
+        {
+            return [];
+        }
+
+        var results = new List<CatalogSearchResult>(data.Count);
+        foreach (JToken hit in data)
+        {
+            string? id = (string?)hit["id"];
+            string? versionString = (string?)hit["version"];
+            if (string.IsNullOrEmpty(id) || string.IsNullOrEmpty(versionString) ||
+                !NuGetVersion.TryParse(versionString, out NuGetVersion? version))
+            {
+                continue;
+            }
+
+            results.Add(new CatalogSearchResult(
+                PackageId: id.ToLowerInvariant(),
+                LatestVersion: version,
+                Title: (string?)hit["title"],
+                Description: (string?)hit["description"],
+                Aliases: ParseAliases(GetTagsString(hit["tags"])),
+                Source: source));
+        }
+
+        return results;
+    }
+
+    private static string? GetTagsString(JToken? tags)
+    {
+        // V3 search responses represent tags either as a space-delimited
+        // string or as a JSON array of individual tag strings, depending
+        // on the source implementation. Normalise both to the
+        // space-delimited form ParseAliases expects.
+        if (tags is JArray array)
+        {
+            return string.Join(' ', array.Select(t => (string?)t).Where(t => !string.IsNullOrWhiteSpace(t)));
+        }
+
+        if (tags is JValue { Value: string s })
+        {
+            return s;
+        }
+
+        return null;
     }
 
     private static IReadOnlyList<string> ParseAliases(string? tags)
@@ -141,9 +239,9 @@ internal sealed class NuGetProtocolSourceClient(SourceRepository repository)
         var aliases = new List<string>();
         foreach (string token in tags.Split([' ', ','], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
         {
-            if (token.StartsWith(AliasTagPrefix, StringComparison.OrdinalIgnoreCase))
+            if (token.StartsWith(WorkloadInstaller.AliasTagPrefix, StringComparison.OrdinalIgnoreCase))
             {
-                string alias = token[AliasTagPrefix.Length..].Trim();
+                string alias = token[WorkloadInstaller.AliasTagPrefix.Length..].Trim();
                 if (alias.Length > 0)
                 {
                     aliases.Add(alias.ToLowerInvariant());

--- a/src/Func/Workloads/Catalog/PackageSourceProvider.cs
+++ b/src/Func/Workloads/Catalog/PackageSourceProvider.cs
@@ -39,35 +39,17 @@ internal sealed class PackageSourceProvider(IOptions<WorkloadCatalogOptions> opt
 
     private static PackageSource Build(string value)
     {
-        // Remote v3 feeds: trust the URL as-is; NuGet validates on first use.
+        // Only http(s) V3 NuGet feeds are supported as workload sources.
+        // To install from a local .nupkg, pass the file path positionally to
+        // 'func workload install' instead of pointing --source at a folder.
         if (Uri.TryCreate(value, UriKind.Absolute, out Uri? uri)
             && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
         {
             return new PackageSource(value, value);
         }
 
-        // Local directories: resolve to an absolute path and verify it exists
-        // so misconfigurations surface eagerly rather than as "no results".
-        string fullPath;
-        try
-        {
-            fullPath = Path.GetFullPath(value);
-        }
-        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
-        {
-            throw new ArgumentException(
-                $"Source '{value}' is neither an absolute http(s) URL nor a valid local directory path.",
-                nameof(value),
-                ex);
-        }
-
-        if (!Directory.Exists(fullPath))
-        {
-            throw new ArgumentException(
-                $"Local source '{value}' does not exist or is not a directory.",
-                nameof(value));
-        }
-
-        return new PackageSource(fullPath, value);
+        throw new ArgumentException(
+            $"Source '{value}' is not a supported NuGet feed. Workload sources must be an absolute http(s) URL pointing at a V3 service index.",
+            nameof(value));
     }
 }

--- a/src/Func/Workloads/Install/AmbiguousAliasException.cs
+++ b/src/Func/Workloads/Install/AmbiguousAliasException.cs
@@ -1,0 +1,27 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workloads.Install;
+
+/// <summary>
+/// Thrown when an alias provided to <c>func workload install</c> matches
+/// more than one package id in the catalog (spec §6.1 step 2). The user
+/// must re-run with <c>--exact</c> and a specific package id.
+/// </summary>
+internal sealed class AmbiguousAliasException : Exception
+{
+    public AmbiguousAliasException(string alias, IReadOnlyList<string> packageIds)
+        : base(BuildMessage(alias, packageIds))
+    {
+        Alias = alias;
+        PackageIds = packageIds;
+    }
+
+    public string Alias { get; }
+
+    public IReadOnlyList<string> PackageIds { get; }
+
+    private static string BuildMessage(string alias, IReadOnlyList<string> packageIds)
+        => $"Alias '{alias}' matches multiple packages: {string.Join(", ", packageIds)}. "
+            + "Re-run with --exact <packageId>.";
+}

--- a/src/Func/Workloads/Install/AmbiguousPackageMatchException.cs
+++ b/src/Func/Workloads/Install/AmbiguousPackageMatchException.cs
@@ -8,9 +8,9 @@ namespace Azure.Functions.Cli.Workloads.Install;
 /// more than one package id in the catalog (spec §6.1 step 2). The user
 /// must re-run with <c>--exact</c> and a specific package id.
 /// </summary>
-internal sealed class AmbiguousAliasException : Exception
+internal sealed class AmbiguousPackageMatchException : Exception
 {
-    public AmbiguousAliasException(string alias, IReadOnlyList<string> packageIds)
+    public AmbiguousPackageMatchException(string alias, IReadOnlyList<string> packageIds)
         : base(BuildMessage(alias, packageIds))
     {
         Alias = alias;

--- a/src/Func/Workloads/Install/IWorkloadInstaller.cs
+++ b/src/Func/Workloads/Install/IWorkloadInstaller.cs
@@ -70,7 +70,7 @@ internal interface IWorkloadInstaller
     /// <exception cref="WorkloadPackageNotFoundException">
     /// No version matched on any configured source.
     /// </exception>
-    /// <exception cref="AmbiguousAliasException">
+    /// <exception cref="AmbiguousPackageMatchException">
     /// The alias matches multiple packages and <paramref name="exact"/> is
     /// <c>false</c>.
     /// </exception>

--- a/src/Func/Workloads/Install/IWorkloadInstaller.cs
+++ b/src/Func/Workloads/Install/IWorkloadInstaller.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Workloads.Catalog;
 using Azure.Functions.Cli.Workloads.Storage;
+using NuGet.Versioning;
 
 namespace Azure.Functions.Cli.Workloads.Install;
 
@@ -38,6 +40,77 @@ internal interface IWorkloadInstaller
     public Task<WorkloadInstallResult> InstallFromPackageAsync(
         string nupkgPath,
         bool force = false,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Resolves <paramref name="packageId"/> against the configured catalog,
+    /// downloads the matching <c>.nupkg</c> to a temp file, and routes it
+    /// through <see cref="InstallFromPackageAsync"/> so disk + registry
+    /// behaviour matches local installs exactly.
+    /// </summary>
+    /// <param name="packageId">
+    /// User-supplied package id or alias; case-insensitive. Treated as a
+    /// literal package id when <paramref name="exact"/> is <c>true</c>;
+    /// otherwise the catalog's <c>alias:&lt;name&gt;</c> tag is consulted
+    /// first (spec §6.1 step 2).
+    /// </param>
+    /// <param name="version">
+    /// Optional explicit version. When non-null the catalog must have an
+    /// exact match; when null the highest available version under
+    /// <paramref name="includePrerelease"/> is selected.
+    /// </param>
+    /// <param name="source">Optional <c>--source</c> override forwarded to the catalog.</param>
+    /// <param name="includePrerelease"><c>true</c> to allow prerelease versions when resolving.</param>
+    /// <param name="exact">
+    /// <c>true</c> to disable alias matching and treat
+    /// <paramref name="packageId"/> as a literal package id.
+    /// </param>
+    /// <param name="force">Forwarded to <see cref="InstallFromPackageAsync"/>.</param>
+    /// <param name="cancellationToken">Token to cancel resolve, download, and install.</param>
+    /// <exception cref="WorkloadPackageNotFoundException">
+    /// No version matched on any configured source.
+    /// </exception>
+    /// <exception cref="AmbiguousAliasException">
+    /// The alias matches multiple packages and <paramref name="exact"/> is
+    /// <c>false</c>.
+    /// </exception>
+    public Task<WorkloadInstallResult> InstallFromCatalogAsync(
+        string packageId,
+        NuGetVersion? version,
+        string? source,
+        bool includePrerelease,
+        bool exact,
+        bool force,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// In-place version swap for an installed workload (spec §6.4). Stages
+    /// and validates a new version before touching the existing install;
+    /// on failure the existing version remains live.
+    /// </summary>
+    /// <param name="packageId">Installed workload id; case-insensitive.</param>
+    /// <param name="targetInstalledVersion">
+    /// Optional installed version to replace. When null the highest
+    /// installed semver is targeted.
+    /// </param>
+    /// <param name="source">Optional <c>--source</c> override.</param>
+    /// <param name="includePrerelease"><c>true</c> to allow prerelease candidates.</param>
+    /// <param name="allowMajor">
+    /// <c>true</c> to allow the new version to cross a major boundary.
+    /// Default is <c>false</c> per spec; <c>--major</c> on the command sets
+    /// it to <c>true</c>.
+    /// </param>
+    /// <param name="cancellationToken">Token propagated to catalog + I/O.</param>
+    /// <exception cref="InvalidOperationException">
+    /// <paramref name="packageId"/> is not installed, or
+    /// <paramref name="targetInstalledVersion"/> is not present.
+    /// </exception>
+    public Task<WorkloadUpdateResult> UpdateAsync(
+        string packageId,
+        NuGetVersion? targetInstalledVersion,
+        string? source,
+        bool includePrerelease,
+        bool allowMajor,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Func/Workloads/Install/WorkloadInstaller.cs
+++ b/src/Func/Workloads/Install/WorkloadInstaller.cs
@@ -290,7 +290,7 @@ internal sealed class WorkloadInstaller(
 
         if (matchedIds.Count > 1)
         {
-            throw new AmbiguousAliasException(aliasOrId, matchedIds);
+            throw new AmbiguousPackageMatchException(aliasOrId, matchedIds);
         }
 
         return matchedIds.Count == 1 ? matchedIds[0] : aliasOrId;
@@ -316,7 +316,7 @@ internal sealed class WorkloadInstaller(
 
             string hint = includePrerelease
                 ? string.Empty
-                : " Pass --include-prereleases if it is a prerelease.";
+                : " Pass --prerelease if it is a prerelease.";
 
             throw new Catalog.WorkloadPackageNotFoundException(
                 $"Could not resolve workload '{packageId}'. {detail}{hint}");

--- a/src/Func/Workloads/Install/WorkloadInstaller.cs
+++ b/src/Func/Workloads/Install/WorkloadInstaller.cs
@@ -1,10 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Workloads.Catalog;
 using Azure.Functions.Cli.Workloads.Discovery;
 using Azure.Functions.Cli.Workloads.Storage;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
+using NuGet.Versioning;
 
 namespace Azure.Functions.Cli.Workloads.Install;
 
@@ -17,7 +19,8 @@ namespace Azure.Functions.Cli.Workloads.Install;
 internal sealed class WorkloadInstaller(
     IWorkloadPaths paths,
     IWorkloadStore store,
-    IWorkloadMetadataReader metadataReader) : IWorkloadInstaller
+    IWorkloadMetadataReader metadataReader,
+    IWorkloadCatalog catalog) : IWorkloadInstaller
 {
     /// <summary>
     /// Prefix on nuspec tags that marks the tag as a CLI-facing alias, so
@@ -36,6 +39,7 @@ internal sealed class WorkloadInstaller(
     private readonly IWorkloadPaths _paths = paths ?? throw new ArgumentNullException(nameof(paths));
     private readonly IWorkloadStore _store = store ?? throw new ArgumentNullException(nameof(store));
     private readonly IWorkloadMetadataReader _metadataReader = metadataReader ?? throw new ArgumentNullException(nameof(metadataReader));
+    private readonly IWorkloadCatalog _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
 
     /// <inheritdoc />
     public async Task<WorkloadInstallResult> InstallFromPackageAsync(
@@ -134,6 +138,109 @@ internal sealed class WorkloadInstaller(
     }
 
     /// <inheritdoc />
+    public async Task<WorkloadInstallResult> InstallFromCatalogAsync(
+        string packageId,
+        NuGetVersion? version,
+        string? source,
+        bool includePrerelease,
+        bool exact,
+        bool force,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+
+        string resolvedId = exact
+            ? packageId
+            : await ResolveAliasOrIdAsync(packageId, source, includePrerelease, cancellationToken);
+
+        ResolvedPackage resolved = await ResolveCatalogPackageAsync(
+            resolvedId, version, source, includePrerelease, cancellationToken);
+
+        string tempPath = Path.Combine(
+            Path.GetTempPath(),
+            $"func-workload-{Guid.NewGuid():N}.nupkg");
+
+        try
+        {
+            await using (Stream packageStream = await _catalog.DownloadAsync(resolved, cancellationToken))
+            await using (FileStream tempStream = File.Create(tempPath))
+            {
+                await packageStream.CopyToAsync(tempStream, cancellationToken);
+            }
+
+            return await InstallFromPackageAsync(tempPath, force, cancellationToken);
+        }
+        finally
+        {
+            try
+            {
+                if (File.Exists(tempPath))
+                {
+                    File.Delete(tempPath);
+                }
+            }
+            catch
+            {
+                // Best-effort cleanup of the temp .nupkg; the OS reaps the
+                // temp dir periodically and the registry / install dir are
+                // already consistent at this point.
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<WorkloadUpdateResult> UpdateAsync(
+        string packageId,
+        NuGetVersion? targetInstalledVersion,
+        string? source,
+        bool includePrerelease,
+        bool allowMajor,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+
+        IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
+        List<WorkloadEntry> matches = [.. installed
+            .Where(e => string.Equals(e.PackageId, packageId, StringComparison.OrdinalIgnoreCase))];
+
+        if (matches.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"Workload '{packageId}' is not installed.");
+        }
+
+        WorkloadEntry currentEntry = ResolveUpdateTarget(packageId, targetInstalledVersion, matches);
+        var currentVersion = NuGetVersion.Parse(currentEntry.PackageVersion);
+
+        ResolvedPackage? resolved = await _catalog.ResolveLatestVersionAsync(
+            currentEntry.PackageId,
+            includePrerelease,
+            currentVersion,
+            allowMajor,
+            source,
+            cancellationToken);
+
+        if (resolved is null)
+        {
+            return new WorkloadUpdateResult(
+                currentEntry,
+                currentEntry.PackageVersion,
+                NoUpdateAvailable: true,
+                NoCandidateOnSource: true);
+        }
+
+        if (resolved.Version <= currentVersion)
+        {
+            return new WorkloadUpdateResult(currentEntry, currentEntry.PackageVersion, NoUpdateAvailable: true);
+        }
+
+        WorkloadEntry newEntry = await StageAndSwapAsync(
+            currentEntry, resolved, cancellationToken);
+
+        return new WorkloadUpdateResult(newEntry, currentEntry.PackageVersion, NoUpdateAvailable: false);
+    }
+
+    /// <inheritdoc />
     public async Task<bool> UninstallAsync(
         string packageId,
         string version,
@@ -151,6 +258,206 @@ internal sealed class WorkloadInstaller(
         string installPath = _paths.GetInstallDirectory(packageId, version);
         TryDeleteDirectory(installPath);
         return true;
+    }
+
+    private async Task<string> ResolveAliasOrIdAsync(
+        string aliasOrId,
+        string? source,
+        bool includePrerelease,
+        CancellationToken cancellationToken)
+    {
+        // Spec §6.1 step 2 (default flow): query the catalog for packages
+        // declaring `alias:<aliasOrId>` and pick the unique match. Zero
+        // matches falls back to treating the input as a literal package id.
+        // Multiple distinct package ids is an error; the user must re-run
+        // with --exact <packageId>.
+        const int aliasSearchTake = 50;
+
+        var query = new CatalogSearchQuery
+        {
+            Filter = aliasOrId,
+            IncludePrerelease = includePrerelease,
+            Take = aliasSearchTake,
+            Source = source,
+        };
+
+        IReadOnlyList<CatalogSearchResult> hits = await _catalog.SearchAsync(query, cancellationToken);
+
+        IReadOnlyList<string> matchedIds = [.. hits
+            .Where(r => r.Aliases.Any(a => string.Equals(a, aliasOrId, StringComparison.OrdinalIgnoreCase)))
+            .Select(r => r.PackageId)
+            .Distinct(StringComparer.OrdinalIgnoreCase)];
+
+        if (matchedIds.Count > 1)
+        {
+            throw new AmbiguousAliasException(aliasOrId, matchedIds);
+        }
+
+        return matchedIds.Count == 1 ? matchedIds[0] : aliasOrId;
+    }
+
+    private async Task<ResolvedPackage> ResolveCatalogPackageAsync(
+        string packageId,
+        NuGetVersion? version,
+        string? source,
+        bool includePrerelease,
+        CancellationToken cancellationToken)
+    {
+        ResolvedPackage? resolved = version is null
+            ? await _catalog.ResolveLatestVersionAsync(
+                packageId, includePrerelease, currentVersion: null, allowMajor: true, source: source, cancellationToken)
+            : await _catalog.ResolveVersionAsync(packageId, version, source, cancellationToken);
+
+        if (resolved is null)
+        {
+            string detail = version is null
+                ? "No matching version was found on any configured source."
+                : $"Version '{version.ToNormalizedString()}' was not found on any configured source.";
+
+            string hint = includePrerelease
+                ? string.Empty
+                : " Pass --include-prereleases if it is a prerelease.";
+
+            throw new Catalog.WorkloadPackageNotFoundException(
+                $"Could not resolve workload '{packageId}'. {detail}{hint}");
+        }
+
+        return resolved;
+    }
+
+    private static WorkloadEntry ResolveUpdateTarget(
+        string packageId,
+        NuGetVersion? targetInstalledVersion,
+        IReadOnlyList<WorkloadEntry> matches)
+    {
+        if (targetInstalledVersion is null)
+        {
+            return matches
+                .OrderByDescending(e => NuGetVersion.Parse(e.PackageVersion))
+                .First();
+        }
+
+        string requested = targetInstalledVersion.ToNormalizedString();
+        WorkloadEntry? exact = matches.FirstOrDefault(e =>
+            string.Equals(e.PackageVersion, requested, StringComparison.Ordinal));
+
+        if (exact is null)
+        {
+            string available = string.Join(", ", matches.Select(m => m.PackageVersion));
+            throw new InvalidOperationException(
+                $"Workload '{packageId}' version '{requested}' is not installed. " +
+                $"Installed versions: {available}.");
+        }
+
+        return exact;
+    }
+
+    private async Task<WorkloadEntry> StageAndSwapAsync(
+        WorkloadEntry currentEntry,
+        ResolvedPackage resolved,
+        CancellationToken cancellationToken)
+    {
+        string tempNupkg = Path.Combine(
+            Path.GetTempPath(),
+            $"func-workload-{Guid.NewGuid():N}.nupkg");
+
+        string finalInstallPath = _paths.GetInstallDirectory(
+            resolved.PackageId, resolved.Version.ToNormalizedString());
+        string stagingPath = finalInstallPath + ".staging-" + Guid.NewGuid().ToString("N");
+
+        try
+        {
+            await using (Stream packageStream = await _catalog.DownloadAsync(resolved, cancellationToken))
+            await using (FileStream tempStream = File.Create(tempNupkg))
+            {
+                await packageStream.CopyToAsync(tempStream, cancellationToken);
+            }
+
+            using PackageArchiveReader reader = OpenPackage(tempNupkg);
+            NuspecReader nuspec = reader.NuspecReader;
+
+            string newPackageId = nuspec.GetId().ToLowerInvariant();
+            string newVersion = nuspec.GetVersion().ToNormalizedString();
+            IReadOnlyList<string> aliases = ParseAliases(nuspec.GetTags());
+
+            if (!nuspec.GetPackageTypes().Any(t => string.Equals(t.Name, FuncCliWorkloadPackageType, StringComparison.OrdinalIgnoreCase)))
+            {
+                throw new InvalidWorkloadException(
+                    $"Package '{newPackageId}' is not a func CLI workload " +
+                    $"(missing package type '{FuncCliWorkloadPackageType}' in its .nuspec).");
+            }
+
+            // Sanity check: the resolved id+version should match the package
+            // we actually downloaded. If not, the source returned a wrong
+            // bundle and we abort before touching the existing install.
+            if (!string.Equals(newPackageId, resolved.PackageId, StringComparison.OrdinalIgnoreCase) ||
+                !string.Equals(newVersion, resolved.Version.ToNormalizedString(), StringComparison.Ordinal))
+            {
+                throw new InvalidWorkloadException(
+                    $"Resolved package '{resolved.PackageId}' {resolved.Version.ToNormalizedString()} but the source returned " +
+                    $"'{newPackageId}' {newVersion}.");
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(stagingPath)!);
+            Directory.CreateDirectory(stagingPath);
+
+            await ExtractPackageAsync(reader, stagingPath, cancellationToken);
+            WorkloadMetadata metadata = _metadataReader.Read(stagingPath);
+
+            WorkloadEntry newEntry = new()
+            {
+                PackageId = newPackageId,
+                PackageVersion = newVersion,
+                Aliases = aliases,
+                EntryPoint = metadata.EntryPoint,
+                Kind = metadata.Kind,
+                Source = resolved.Source.Source,
+                InstallRefCount = currentEntry.InstallRefCount,
+            };
+
+            // Atomic swap (spec §6.4 step 4):
+            //   1. Move staged dir into final location.
+            //   2. Replace registry row in a single write (old removed,
+            //      new added). The orphaned-dir case in §6.4 step 5 is
+            //      recoverable via `func workload prune`.
+            //   3. Delete the previous install directory.
+            Directory.Move(stagingPath, finalInstallPath);
+
+            await _store.ReplaceWorkloadAsync(
+                currentEntry.PackageId,
+                currentEntry.PackageVersion,
+                newEntry,
+                cancellationToken);
+
+            string oldInstallPath = _paths.GetInstallDirectory(currentEntry.PackageId, currentEntry.PackageVersion);
+            if (!string.Equals(oldInstallPath, finalInstallPath, StringComparison.Ordinal))
+            {
+                // Spec §6.4 step 5: a delete failure here leaves an orphan
+                // directory, which `func workload prune` cleans up later.
+                TryDeleteDirectory(oldInstallPath);
+            }
+
+            return newEntry;
+        }
+        catch
+        {
+            TryDeleteDirectory(stagingPath);
+            throw;
+        }
+        finally
+        {
+            try
+            {
+                if (File.Exists(tempNupkg))
+                {
+                    File.Delete(tempNupkg);
+                }
+            }
+            catch
+            {
+                // Best-effort temp cleanup.
+            }
+        }
     }
 
     private static PackageArchiveReader OpenPackage(string nupkgPath)

--- a/src/Func/Workloads/Install/WorkloadUpdateResult.cs
+++ b/src/Func/Workloads/Install/WorkloadUpdateResult.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads.Storage;
+
+namespace Azure.Functions.Cli.Workloads.Install;
+
+/// <summary>
+/// Outcome of <see cref="IWorkloadInstaller.UpdateAsync"/>.
+/// </summary>
+/// <param name="Entry">
+/// Registry entry now in place for the workload. When
+/// <see cref="NoUpdateAvailable"/> is <c>true</c>, this is the existing
+/// entry (untouched); otherwise it is the freshly written entry for the
+/// new version.
+/// </param>
+/// <param name="PreviousVersion">
+/// The version that was installed before the update. Equal to
+/// <see cref="WorkloadEntry.PackageVersion"/> on <see cref="Entry"/> when
+/// <see cref="NoUpdateAvailable"/> is <c>true</c>.
+/// </param>
+/// <param name="NoUpdateAvailable">
+/// <see langword="true"/> when the catalog had no candidate higher than
+/// the currently installed version under the requested policy; the call
+/// was a no-op.
+/// </param>
+/// <param name="NoCandidateOnSource">
+/// <see langword="true"/> when the configured source returned no version
+/// at all for the package (typically because the package isn't published
+/// there). Implies <see cref="NoUpdateAvailable"/>; lets the command
+/// distinguish "package missing on source" from "found but not newer".
+/// </param>
+internal sealed record WorkloadUpdateResult(
+    WorkloadEntry Entry,
+    string PreviousVersion,
+    bool NoUpdateAvailable,
+    bool NoCandidateOnSource = false);

--- a/src/Func/Workloads/Storage/IWorkloadStore.cs
+++ b/src/Func/Workloads/Storage/IWorkloadStore.cs
@@ -41,4 +41,17 @@ internal interface IWorkloadStore
         string packageId,
         string version,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Atomically removes the entry for (<paramref name="oldPackageId"/>,
+    /// <paramref name="oldVersion"/>) and inserts <paramref name="newEntry"/>
+    /// in a single registry write. Used by <c>func workload update</c>
+    /// (spec §6.4 step 4) to avoid leaving the registry in a half-swapped
+    /// state if the process dies mid-write.
+    /// </summary>
+    public Task ReplaceWorkloadAsync(
+        string oldPackageId,
+        string oldVersion,
+        WorkloadEntry newEntry,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Func/Workloads/Storage/WorkloadStore.cs
+++ b/src/Func/Workloads/Storage/WorkloadStore.cs
@@ -66,6 +66,39 @@ internal class WorkloadStore(IWorkloadPaths paths) : IWorkloadStore
         return true;
     }
 
+    public async Task ReplaceWorkloadAsync(
+        string oldPackageId,
+        string oldVersion,
+        WorkloadEntry newEntry,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(oldPackageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(oldVersion);
+        ArgumentNullException.ThrowIfNull(newEntry);
+        ArgumentException.ThrowIfNullOrWhiteSpace(newEntry.PackageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(newEntry.PackageVersion);
+
+        WorkloadRegistry registry = await ReadRegistryAsync(cancellationToken);
+
+        int oldIndex = FindIndex(registry, oldPackageId, oldVersion);
+        if (oldIndex >= 0)
+        {
+            registry.Workloads.RemoveAt(oldIndex);
+        }
+
+        int newIndex = FindIndex(registry, newEntry.PackageId, newEntry.PackageVersion);
+        if (newIndex >= 0)
+        {
+            registry.Workloads[newIndex] = newEntry;
+        }
+        else
+        {
+            registry.Workloads.Add(newEntry);
+        }
+
+        await WriteRegistryAsync(registry, cancellationToken);
+    }
+
     private static int FindIndex(WorkloadRegistry registry, string packageId, string version)
     {
         for (int i = 0; i < registry.Workloads.Count; i++)

--- a/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
@@ -29,7 +29,7 @@ public class WorkloadInstallCommandTests
         Assert.Contains(cmd.Options, o => o.Name == "--force");
         Assert.Contains(cmd.Options, o => o.Name == "--version");
         Assert.Contains(cmd.Options, o => o.Name == "--source");
-        Assert.Contains(cmd.Options, o => o.Name == "--include-prereleases");
+        Assert.Contains(cmd.Options, o => o.Name == "--prerelease");
     }
 
     [Fact]
@@ -56,7 +56,7 @@ public class WorkloadInstallCommandTests
             "Test.Workload",
             "--version", "2.0.0-beta.1",
             "--source", "https://example/v3/index.json",
-            "--include-prereleases",
+            "--prerelease",
             "--exact",
             "--force");
 
@@ -144,6 +144,19 @@ public class WorkloadInstallCommandTests
     }
 
     [Fact]
+    public void Install_WhitespaceArg_FailsValidation()
+    {
+        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        var root = new RootCommand();
+        root.Subcommands.Add(cmd);
+
+        ParseResult parse = root.Parse([cmd.Name, "   "]);
+
+        Assert.NotEmpty(parse.Errors);
+        Assert.Contains(parse.Errors, e => e.Message.Contains("workload id is required"));
+    }
+
+    [Fact]
     public async Task Install_AlreadyInstalled_WritesIdempotentMessage()
     {
         StubCatalogResult(alreadyInstalled: true);
@@ -192,7 +205,7 @@ public class WorkloadInstallCommandTests
         _installer.InstallFromCatalogAsync(
                 Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
                 Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
-            .Throws(new AmbiguousAliasException(
+            .Throws(new AmbiguousPackageMatchException(
                 "myalias", new[] { "Pkg.A", "Pkg.B" }));
 
         var cmd = new WorkloadInstallCommand(_interaction, _installer);
@@ -261,6 +274,38 @@ public class WorkloadInstallCommandTests
         var cmd = new WorkloadInstallCommand(_interaction, _installer);
         await Assert.ThrowsAsync<NullReferenceException>(
             () => InvokeAsync(cmd, "Test.Workload"));
+    }
+
+    [Fact]
+    public async Task Install_LocalNupkgPath_RoutesToLocalInstaller()
+    {
+        string tempPkg = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.nupkg");
+        await File.WriteAllBytesAsync(tempPkg, [0x50, 0x4B]);
+        try
+        {
+            _installer.InstallFromPackageAsync(tempPkg, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                .Returns(new WorkloadInstallResult(
+                    new WorkloadEntry
+                    {
+                        PackageId = "test.workload",
+                        PackageVersion = "1.0.0",
+                        EntryPoint = new EntryPointSpec { AssemblyPath = "x.dll", Type = "T" },
+                    },
+                    AlreadyInstalled: false));
+
+            var cmd = new WorkloadInstallCommand(_interaction, _installer);
+            int exit = await InvokeAsync(cmd, tempPkg);
+
+            Assert.Equal(0, exit);
+            await _installer.Received(1).InstallFromPackageAsync(
+                tempPkg, false, Arg.Any<CancellationToken>());
+            await _installer.DidNotReceiveWithAnyArgs().InstallFromCatalogAsync(
+                default!, default, default, default, default, default, default);
+        }
+        finally
+        {
+            File.Delete(tempPkg);
+        }
     }
 
     private void StubCatalogResult(bool alreadyInstalled = false) =>

--- a/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
@@ -5,11 +5,13 @@ using System.CommandLine;
 using Azure.Functions.Cli.Commands.Workload;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Workloads;
+using Azure.Functions.Cli.Workloads.Catalog;
 using Azure.Functions.Cli.Workloads.Discovery;
 using Azure.Functions.Cli.Workloads.Install;
 using Azure.Functions.Cli.Workloads.Storage;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
+using NuGet.Versioning;
 using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands.Workload;
@@ -20,52 +22,134 @@ public class WorkloadInstallCommandTests
     private readonly IWorkloadInstaller _installer = Substitute.For<IWorkloadInstaller>();
 
     [Fact]
-    public void Install_HasWorkloadArgumentAndForceOption()
+    public void Install_HasExpectedArgsAndOptions()
     {
         var cmd = new WorkloadInstallCommand(_interaction, _installer);
         Assert.Single(cmd.Arguments, a => a.Name == "id");
-        Assert.Single(cmd.Options, o => o.Name == "--force");
+        Assert.Contains(cmd.Options, o => o.Name == "--force");
+        Assert.Contains(cmd.Options, o => o.Name == "--version");
+        Assert.Contains(cmd.Options, o => o.Name == "--source");
+        Assert.Contains(cmd.Options, o => o.Name == "--include-prereleases");
     }
 
     [Fact]
-    public void Install_NonNupkgArgument_FailsValidation()
+    public async Task Install_PackageId_RoutesToCatalogInstaller()
+    {
+        StubCatalogResult();
+
+        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        int exit = await InvokeAsync(cmd, "Test.Workload");
+
+        Assert.Equal(0, exit);
+        await _installer.Received(1).InstallFromCatalogAsync(
+            "Test.Workload", null, null, false, false, false, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Install_AllOptionsForwarded()
+    {
+        StubCatalogResult();
+
+        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        int exit = await InvokeAsync(
+            cmd,
+            "Test.Workload",
+            "--version", "2.0.0-beta.1",
+            "--source", "https://example/v3/index.json",
+            "--include-prereleases",
+            "--exact",
+            "--force");
+
+        Assert.Equal(0, exit);
+        await _installer.Received(1).InstallFromCatalogAsync(
+            "Test.Workload",
+            Arg.Is<NuGetVersion>(v => v != null && v.ToNormalizedString() == "2.0.0-beta.1"),
+            "https://example/v3/index.json",
+            true,
+            true,
+            true,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Install_ShortAliases_VAndF_Forward()
+    {
+        StubCatalogResult();
+
+        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        int exit = await InvokeAsync(cmd, "Test.Workload", "-v", "1.2.3", "-f");
+
+        Assert.Equal(0, exit);
+        await _installer.Received(1).InstallFromCatalogAsync(
+            "Test.Workload",
+            Arg.Is<NuGetVersion>(v => v != null && v.ToNormalizedString() == "1.2.3"),
+            null,
+            false,
+            false,
+            true,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Install_ExactShortAlias_E_Forwards()
+    {
+        StubCatalogResult();
+
+        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        int exit = await InvokeAsync(cmd, "test.workload", "-e");
+
+        Assert.Equal(0, exit);
+        await _installer.Received(1).InstallFromCatalogAsync(
+            "test.workload", null, null, false, true, false, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Install_LocalFolderSource_TreatedAsCatalogSource()
+    {
+        // --source can be a folder path; the catalog (LocalFolderSourceClient)
+        // handles it. The CLI does not special-case paths.
+        StubCatalogResult();
+
+        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        int exit = await InvokeAsync(cmd, "Test.Workload", "--source", "/tmp/local-feed");
+
+        Assert.Equal(0, exit);
+        await _installer.Received(1).InstallFromCatalogAsync(
+            "Test.Workload", null, "/tmp/local-feed", false, false, false, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void Install_InvalidVersion_FailsValidation()
     {
         var cmd = new WorkloadInstallCommand(_interaction, _installer);
         var root = new RootCommand();
         root.Subcommands.Add(cmd);
 
-        ParseResult parse = root.Parse([cmd.Name, "Test.Workload"]);
+        ParseResult parse = root.Parse([cmd.Name, "Test.Workload", "--version", "not-semver"]);
 
         Assert.NotEmpty(parse.Errors);
-        Assert.Contains(parse.Errors, e => e.Message.Contains("not yet supported") && e.Message.Contains(".nupkg"));
+        Assert.Contains(parse.Errors, e => e.Message.Contains("not a valid semver"));
     }
 
     [Fact]
-    public async Task Install_NupkgArgument_DelegatesToInstaller_WritesSuccess()
+    public void Install_MissingPackageArg_FailsValidation()
     {
-        StubResult(alreadyInstalled: false);
-
         var cmd = new WorkloadInstallCommand(_interaction, _installer);
-        int exit = await InvokeAsync(cmd, "Test.Workload.1.0.0.nupkg");
+        var root = new RootCommand();
+        root.Subcommands.Add(cmd);
 
-        Assert.Equal(0, exit);
-        await _installer.Received(1).InstallFromPackageAsync("Test.Workload.1.0.0.nupkg", false, Arg.Any<CancellationToken>());
-        Assert.Contains(
-            _interaction.Lines,
-            l => l.StartsWith("SUCCESS:")
-                && l.Contains("Installed workload")
-                && l.Contains("test.workload")
-                && l.Contains("1.0.0")
-                && l.Contains("entry point: T"));
+        ParseResult parse = root.Parse([cmd.Name]);
+
+        Assert.NotEmpty(parse.Errors);
     }
 
     [Fact]
     public async Task Install_AlreadyInstalled_WritesIdempotentMessage()
     {
-        StubResult(alreadyInstalled: true);
+        StubCatalogResult(alreadyInstalled: true);
 
         var cmd = new WorkloadInstallCommand(_interaction, _installer);
-        int exit = await InvokeAsync(cmd, "Test.Workload.1.0.0.nupkg");
+        int exit = await InvokeAsync(cmd, "Test.Workload");
 
         Assert.Equal(0, exit);
         Assert.Contains(
@@ -78,97 +162,111 @@ public class WorkloadInstallCommandTests
     [Fact]
     public async Task Install_ContentKind_MessageMentionsContentPath()
     {
-        _installer.InstallFromPackageAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+        _installer.InstallFromCatalogAsync(
+                Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(new WorkloadInstallResult(
                 new WorkloadEntry
                 {
                     PackageId = "test.content",
                     PackageVersion = "1.0.0",
                     Kind = WorkloadKind.Content,
-                    Source = "/abs/path/to/test.content.1.0.0.nupkg",
+                    Source = "https://api.nuget.org/v3/index.json",
                 },
                 AlreadyInstalled: false));
 
         var cmd = new WorkloadInstallCommand(_interaction, _installer);
-        int exit = await InvokeAsync(cmd, "test.content.1.0.0.nupkg");
+        int exit = await InvokeAsync(cmd, "test.content");
 
         Assert.Equal(0, exit);
         Assert.Contains(
             _interaction.Lines,
             l => l.StartsWith("SUCCESS:")
                 && l.Contains("content at")
-                && l.Contains("/abs/path/to/test.content.1.0.0.nupkg"));
+                && l.Contains("api.nuget.org"));
     }
 
     [Fact]
-    public async Task Install_ForceFlag_PassesForceToInstaller()
+    public async Task Install_AmbiguousAlias_GracefulException()
     {
-        StubResult(alreadyInstalled: false);
-
-        var cmd = new WorkloadInstallCommand(_interaction, _installer);
-        int exit = await InvokeAsync(cmd, "Test.Workload.1.0.0.nupkg", "--force");
-
-        Assert.Equal(0, exit);
-        await _installer.Received(1).InstallFromPackageAsync("Test.Workload.1.0.0.nupkg", true, Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task Install_ForceShortAlias_PassesForceToInstaller()
-    {
-        StubResult(alreadyInstalled: false);
-
-        var cmd = new WorkloadInstallCommand(_interaction, _installer);
-        int exit = await InvokeAsync(cmd, "Test.Workload.1.0.0.nupkg", "-f");
-
-        Assert.Equal(0, exit);
-        await _installer.Received(1).InstallFromPackageAsync("Test.Workload.1.0.0.nupkg", true, Arg.Any<CancellationToken>());
-    }
-
-    [Theory]
-    [InlineData(typeof(FileNotFoundException), "missing nupkg")]
-    [InlineData(typeof(InvalidWorkloadException), "bad package")]
-    public async Task Install_InstallerThrowsExpectedFailure_WrappedInGracefulException(Type exceptionType, string message)
-    {
-        var inner = (Exception)Activator.CreateInstance(exceptionType, message)!;
-        _installer.InstallFromPackageAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
-            .Throws(inner);
+        _installer.InstallFromCatalogAsync(
+                Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Throws(new AmbiguousAliasException(
+                "myalias", new[] { "Pkg.A", "Pkg.B" }));
 
         var cmd = new WorkloadInstallCommand(_interaction, _installer);
         GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => InvokeAsync(cmd, "Test.Workload.1.0.0.nupkg"));
-        Assert.Equal(message, ex.Message);
+            () => InvokeAsync(cmd, "myalias"));
+        Assert.Contains("myalias", ex.Message);
+        Assert.Contains("--exact", ex.Message);
         Assert.True(ex.IsUserError);
     }
 
     [Fact]
-    public async Task Install_InstallerThrowsBrokenInstall_AppendsForceHint()
+    public async Task Install_PackageNotFound_GracefulException()
     {
-        _installer.InstallFromPackageAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
-            .Throws(new InvalidOperationException("Workload 'x' version '1' is already installed at '/p' but is missing from the registry."));
+        _installer.InstallFromCatalogAsync(
+                Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Throws(new WorkloadPackageNotFoundException("not on any source"));
 
         var cmd = new WorkloadInstallCommand(_interaction, _installer);
         GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => InvokeAsync(cmd, "Test.Workload.1.0.0.nupkg"));
+            () => InvokeAsync(cmd, "Test.Workload"));
+        Assert.Contains("not on any source", ex.Message);
+        Assert.True(ex.IsUserError);
+    }
+
+    [Fact]
+    public async Task Install_InvalidWorkload_GracefulException()
+    {
+        _installer.InstallFromCatalogAsync(
+                Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Throws(new InvalidWorkloadException("bad package"));
+
+        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => InvokeAsync(cmd, "Test.Workload"));
+        Assert.Equal("bad package", ex.Message);
+        Assert.True(ex.IsUserError);
+    }
+
+    [Fact]
+    public async Task Install_BrokenInstall_AppendsForceHint()
+    {
+        _installer.InstallFromCatalogAsync(
+                Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Throws(new InvalidOperationException(
+                "Workload 'x' version '1' is already installed at '/p' but is missing from the registry."));
+
+        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => InvokeAsync(cmd, "Test.Workload"));
         Assert.Contains("missing from the registry", ex.Message);
         Assert.Contains("--force", ex.Message);
         Assert.True(ex.IsUserError);
     }
 
     [Fact]
-    public async Task Install_InstallerThrowsUnexpected_PropagatesUnchanged()
+    public async Task Install_UnexpectedException_PropagatesUnchanged()
     {
-        // Anything outside the catch list is treated as a runtime bug and
-        // surfaces unwrapped so Program.cs prints a stack trace.
-        _installer.InstallFromPackageAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+        _installer.InstallFromCatalogAsync(
+                Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Throws(new NullReferenceException("oops"));
 
         var cmd = new WorkloadInstallCommand(_interaction, _installer);
         await Assert.ThrowsAsync<NullReferenceException>(
-            () => InvokeAsync(cmd, "Test.Workload.1.0.0.nupkg"));
+            () => InvokeAsync(cmd, "Test.Workload"));
     }
 
-    private void StubResult(bool alreadyInstalled) =>
-        _installer.InstallFromPackageAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+    private void StubCatalogResult(bool alreadyInstalled = false) =>
+        _installer.InstallFromCatalogAsync(
+                Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(new WorkloadInstallResult(
                 new WorkloadEntry
                 {

--- a/test/Func.Tests/Commands/Workload/WorkloadSearchCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadSearchCommandTests.cs
@@ -1,0 +1,167 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Commands.Workload;
+using Azure.Functions.Cli.Workloads.Catalog;
+using NSubstitute;
+using NuGet.Versioning;
+using Xunit;
+using PackageSource = NuGet.Configuration.PackageSource;
+
+namespace Azure.Functions.Cli.Tests.Commands.Workload;
+
+public class WorkloadSearchCommandTests
+{
+    private readonly TestInteractionService _interaction = new();
+    private readonly IWorkloadCatalog _catalog = Substitute.For<IWorkloadCatalog>();
+
+    private static readonly PackageSource _stubSource = new("https://example/v3/index.json", "test");
+
+    [Fact]
+    public void Search_HasExpectedArgsAndOptions()
+    {
+        var cmd = new WorkloadSearchCommand(_interaction, _catalog);
+        Assert.Single(cmd.Arguments, a => a.Name == "query");
+        Assert.Contains(cmd.Options, o => o.Name == "--source");
+        Assert.Contains(cmd.Options, o => o.Name == "--include-prereleases");
+    }
+
+    [Fact]
+    public async Task Search_NoResults_WritesWarning()
+    {
+        StubSearch();
+
+        var cmd = new WorkloadSearchCommand(_interaction, _catalog);
+        int exit = await InvokeAsync(cmd);
+
+        Assert.Equal(0, exit);
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("WARNING:") && l.Contains("No workloads found"));
+    }
+
+    [Fact]
+    public async Task Search_Results_WritesTableRows()
+    {
+        StubSearch(
+            new CatalogSearchResult(
+                "func.workload.python",
+                NuGetVersion.Parse("1.2.3"),
+                Title: "Python",
+                Description: "Python workload",
+                Aliases: ["python"],
+                Source: _stubSource));
+
+        var cmd = new WorkloadSearchCommand(_interaction, _catalog);
+        int exit = await InvokeAsync(cmd);
+
+        Assert.Equal(0, exit);
+        Assert.Contains(_interaction.Lines, l =>
+            l.Contains("func.workload.python")
+            && l.Contains("python")
+            && l.Contains("Python")
+            && l.Contains("Python workload")
+            && l.Contains("1.2.3"));
+
+        Assert.Contains(_interaction.Lines, l =>
+            l.Contains("ID")
+            && l.Contains("Aliases")
+            && l.Contains("Display Name")
+            && l.Contains("Description")
+            && l.Contains("Latest"));
+    }
+
+    [Fact]
+    public async Task Search_NoAliases_RendersPlaceholder()
+    {
+        StubSearch(
+            new CatalogSearchResult(
+                "no.alias.pkg",
+                NuGetVersion.Parse("1.0.0"),
+                Title: null,
+                Description: null,
+                Aliases: [],
+                Source: _stubSource));
+
+        var cmd = new WorkloadSearchCommand(_interaction, _catalog);
+        await InvokeAsync(cmd);
+
+        Assert.Contains(_interaction.Lines, l =>
+            l.Contains("no.alias.pkg") && l.Contains(", -, -, -, "));
+    }
+
+    [Fact]
+    public async Task Search_ForwardsQuerySourceAndPrerelease()
+    {
+        CatalogSearchQuery? captured = null;
+        _catalog.SearchAsync(Arg.Do<CatalogSearchQuery>(q => captured = q), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<CatalogSearchResult>());
+
+        var cmd = new WorkloadSearchCommand(_interaction, _catalog);
+        int exit = await InvokeAsync(
+            cmd,
+            "python",
+            "--source", "https://example/v3/index.json",
+            "--include-prereleases");
+
+        Assert.Equal(0, exit);
+        Assert.NotNull(captured);
+        Assert.Equal("python", captured!.Filter);
+        Assert.True(captured.IncludePrerelease);
+        Assert.Equal("https://example/v3/index.json", captured.Source);
+        Assert.Equal(20, captured.Take);
+    }
+
+    [Fact]
+    public async Task Search_DefaultsPageSize20()
+    {
+        // Per spec §4.1 the CLI surface has no pagination flags; the
+        // command always asks the catalog for a page of 20.
+        CatalogSearchQuery? captured = null;
+        _catalog.SearchAsync(Arg.Do<CatalogSearchQuery>(q => captured = q), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<CatalogSearchResult>());
+
+        var cmd = new WorkloadSearchCommand(_interaction, _catalog);
+        int exit = await InvokeAsync(cmd);
+
+        Assert.Equal(0, exit);
+        Assert.NotNull(captured);
+        Assert.Null(captured!.Filter);
+        Assert.False(captured.IncludePrerelease);
+        Assert.Null(captured.Source);
+        Assert.Equal(20, captured.Take);
+    }
+
+    [Fact]
+    public async Task Search_LongDescription_TruncatedWithEllipsis()
+    {
+        string longDesc = new('x', 500);
+        StubSearch(
+            new CatalogSearchResult(
+                "test.workload",
+                NuGetVersion.Parse("1.0.0"),
+                Title: null,
+                Description: longDesc,
+                Aliases: [],
+                Source: _stubSource));
+
+        var cmd = new WorkloadSearchCommand(_interaction, _catalog);
+        await InvokeAsync(cmd);
+
+        Assert.Contains(_interaction.Lines, l => l.Contains("..."));
+        Assert.DoesNotContain(_interaction.Lines, l => l.Contains(longDesc));
+    }
+
+    private void StubSearch(params CatalogSearchResult[] results)
+    {
+        _catalog.SearchAsync(Arg.Any<CatalogSearchQuery>(), Arg.Any<CancellationToken>())
+            .Returns(results);
+    }
+
+    private static Task<int> InvokeAsync(WorkloadSearchCommand cmd, params string[] args)
+    {
+        var root = new RootCommand();
+        root.Subcommands.Add(cmd);
+        var config = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
+        return root.Parse(new[] { cmd.Name }.Concat(args).ToArray()).InvokeAsync(config);
+    }
+}

--- a/test/Func.Tests/Commands/Workload/WorkloadSearchCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadSearchCommandTests.cs
@@ -24,7 +24,7 @@ public class WorkloadSearchCommandTests
         var cmd = new WorkloadSearchCommand(_interaction, _catalog);
         Assert.Single(cmd.Arguments, a => a.Name == "query");
         Assert.Contains(cmd.Options, o => o.Name == "--source");
-        Assert.Contains(cmd.Options, o => o.Name == "--include-prereleases");
+        Assert.Contains(cmd.Options, o => o.Name == "--prerelease");
     }
 
     [Fact]
@@ -101,7 +101,7 @@ public class WorkloadSearchCommandTests
             cmd,
             "python",
             "--source", "https://example/v3/index.json",
-            "--include-prereleases");
+            "--prerelease");
 
         Assert.Equal(0, exit);
         Assert.NotNull(captured);

--- a/test/Func.Tests/Commands/Workload/WorkloadUninstallCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadUninstallCommandTests.cs
@@ -143,6 +143,19 @@ public class WorkloadUninstallCommandTests
     }
 
     [Fact]
+    public void Uninstall_WhitespaceArg_FailsValidation()
+    {
+        var cmd = NewCommand();
+        var root = new RootCommand();
+        root.Subcommands.Add(cmd);
+
+        ParseResult parse = root.Parse([cmd.Name, "   "]);
+
+        Assert.NotEmpty(parse.Errors);
+        Assert.Contains(parse.Errors, e => e.Message.Contains("workload id is required"));
+    }
+
+    [Fact]
     public async Task Uninstall_PackageIdMatchIsCaseInsensitive()
     {
         StubInstalled(("Test.Workload", "1.0.0"));

--- a/test/Func.Tests/Commands/Workload/WorkloadUpdateCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadUpdateCommandTests.cs
@@ -31,7 +31,7 @@ public class WorkloadUpdateCommandTests
         Assert.Contains(cmd.Options, o => o.Name == "--all");
         Assert.Contains(cmd.Options, o => o.Name == "--major");
         Assert.Contains(cmd.Options, o => o.Name == "--source");
-        Assert.Contains(cmd.Options, o => o.Name == "--include-prereleases");
+        Assert.Contains(cmd.Options, o => o.Name == "--prerelease");
         Assert.Contains(cmd.Options, o => o.Name == "--exact");
     }
 
@@ -57,6 +57,57 @@ public class WorkloadUpdateCommandTests
         ParseResult parse = root.Parse([cmd.Name, "test.workload", "--all"]);
 
         Assert.NotEmpty(parse.Errors);
+    }
+
+    [Fact]
+    public void Update_AllAndVersion_FailsValidation()
+    {
+        var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store);
+        var root = new RootCommand();
+        root.Subcommands.Add(cmd);
+
+        ParseResult parse = root.Parse([cmd.Name, "--all", "--version", "1.0.0"]);
+
+        Assert.NotEmpty(parse.Errors);
+        Assert.Contains(parse.Errors, e => e.Message.Contains("--version cannot be combined with --all"));
+    }
+
+    [Fact]
+    public void Update_AllAndExact_FailsValidation()
+    {
+        var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store);
+        var root = new RootCommand();
+        root.Subcommands.Add(cmd);
+
+        ParseResult parse = root.Parse([cmd.Name, "--all", "--exact"]);
+
+        Assert.NotEmpty(parse.Errors);
+        Assert.Contains(parse.Errors, e => e.Message.Contains("--exact cannot be combined with --all"));
+    }
+
+    [Fact]
+    public void Update_WhitespaceArg_FailsValidation()
+    {
+        var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store);
+        var root = new RootCommand();
+        root.Subcommands.Add(cmd);
+
+        ParseResult parse = root.Parse([cmd.Name, "   "]);
+
+        Assert.NotEmpty(parse.Errors);
+    }
+
+    [Fact]
+    public void Update_InvalidVersion_FailsValidation()
+    {
+        var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store);
+        var root = new RootCommand();
+        root.Subcommands.Add(cmd);
+
+        ParseResult parse = root.Parse([cmd.Name, "Test.Workload", "--version", "not-semver"]);
+
+        Assert.NotEmpty(parse.Errors);
+        Assert.Contains(parse.Errors, e => e.Message.Contains("not a valid semver"));
     }
 
     [Fact]
@@ -124,7 +175,7 @@ public class WorkloadUpdateCommandTests
             "--version", "1.0.0",
             "--major",
             "--source", "https://example/v3/index.json",
-            "--include-prereleases");
+            "--prerelease");
 
         Assert.Equal(0, exit);
         await _installer.Received(1).UpdateAsync(

--- a/test/Func.Tests/Commands/Workload/WorkloadUpdateCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadUpdateCommandTests.cs
@@ -1,0 +1,369 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Commands.Workload;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Workloads;
+using Azure.Functions.Cli.Workloads.Catalog;
+using Azure.Functions.Cli.Workloads.Discovery;
+using Azure.Functions.Cli.Workloads.Install;
+using Azure.Functions.Cli.Workloads.Storage;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using NuGet.Versioning;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Commands.Workload;
+
+public class WorkloadUpdateCommandTests
+{
+    private readonly TestInteractionService _interaction = new();
+    private readonly IWorkloadInstaller _installer = Substitute.For<IWorkloadInstaller>();
+    private readonly IWorkloadStore _store = Substitute.For<IWorkloadStore>();
+
+    [Fact]
+    public void Update_HasExpectedArgsAndOptions()
+    {
+        var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store);
+        Assert.Single(cmd.Arguments, a => a.Name == "id");
+        Assert.Contains(cmd.Options, o => o.Name == "--version");
+        Assert.Contains(cmd.Options, o => o.Name == "--all");
+        Assert.Contains(cmd.Options, o => o.Name == "--major");
+        Assert.Contains(cmd.Options, o => o.Name == "--source");
+        Assert.Contains(cmd.Options, o => o.Name == "--include-prereleases");
+        Assert.Contains(cmd.Options, o => o.Name == "--exact");
+    }
+
+    [Fact]
+    public void Update_MissingPackageAndAll_FailsValidation()
+    {
+        var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store);
+        var root = new RootCommand();
+        root.Subcommands.Add(cmd);
+
+        ParseResult parse = root.Parse([cmd.Name]);
+
+        Assert.NotEmpty(parse.Errors);
+    }
+
+    [Fact]
+    public void Update_BothIdAndAll_FailsValidation()
+    {
+        var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store);
+        var root = new RootCommand();
+        root.Subcommands.Add(cmd);
+
+        ParseResult parse = root.Parse([cmd.Name, "test.workload", "--all"]);
+
+        Assert.NotEmpty(parse.Errors);
+    }
+
+    [Fact]
+    public async Task Update_HappyPath_WritesSuccessWithOldAndNewVersion()
+    {
+        _installer.UpdateAsync(
+                "Test.Workload",
+                Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(new WorkloadUpdateResult(
+                Entry: new WorkloadEntry { PackageId = "test.workload", PackageVersion = "1.1.0" },
+                PreviousVersion: "1.0.0",
+                NoUpdateAvailable: false));
+
+        var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store);
+        int exit = await InvokeAsync(cmd, "Test.Workload");
+
+        Assert.Equal(0, exit);
+        Assert.Contains(
+            _interaction.Lines,
+            l => l.StartsWith("SUCCESS:")
+                && l.Contains("Updated workload")
+                && l.Contains("test.workload")
+                && l.Contains("from 1.0.0 to 1.1.0"));
+    }
+
+    [Fact]
+    public async Task Update_NoUpdateAvailable_WritesHint_ExitsZero()
+    {
+        _installer.UpdateAsync(
+                "Test.Workload",
+                Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(new WorkloadUpdateResult(
+                Entry: new WorkloadEntry { PackageId = "test.workload", PackageVersion = "1.0.0" },
+                PreviousVersion: "1.0.0",
+                NoUpdateAvailable: true));
+
+        var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store);
+        int exit = await InvokeAsync(cmd, "Test.Workload");
+
+        Assert.Equal(0, exit);
+        Assert.Contains(
+            _interaction.Lines,
+            l => l.Contains("already at the latest")
+                && l.Contains("test.workload")
+                && l.Contains("1.0.0"));
+    }
+
+    [Fact]
+    public async Task Update_ForwardsAllowMajorAndPrereleaseAndSource()
+    {
+        _installer.UpdateAsync(
+                Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(new WorkloadUpdateResult(
+                Entry: new WorkloadEntry { PackageId = "test.workload", PackageVersion = "2.0.0" },
+                PreviousVersion: "1.0.0",
+                NoUpdateAvailable: false));
+
+        var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store);
+        int exit = await InvokeAsync(
+            cmd,
+            "Test.Workload",
+            "--version", "1.0.0",
+            "--major",
+            "--source", "https://example/v3/index.json",
+            "--include-prereleases");
+
+        Assert.Equal(0, exit);
+        await _installer.Received(1).UpdateAsync(
+            "Test.Workload",
+            Arg.Is<NuGetVersion>(v => v != null && v.ToNormalizedString() == "1.0.0"),
+            "https://example/v3/index.json",
+            true,
+            true,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Update_NotInstalled_GracefulException()
+    {
+        _installer.UpdateAsync(
+                Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Throws(new InvalidOperationException("Workload 'test.workload' is not installed."));
+
+        var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store);
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => InvokeAsync(cmd, "Test.Workload"));
+
+        Assert.Contains("not installed", ex.Message);
+        Assert.True(ex.IsUserError);
+    }
+
+    [Fact]
+    public async Task Update_PackageNotFoundOnSource_GracefulException()
+    {
+        _installer.UpdateAsync(
+                Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Throws(new WorkloadPackageNotFoundException("nope"));
+
+        var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store);
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => InvokeAsync(cmd, "Test.Workload"));
+
+        Assert.True(ex.IsUserError);
+    }
+
+    [Fact]
+    public async Task Update_All_NoInstalled_WritesHint_ExitsZero()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<WorkloadEntry>());
+
+        var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store);
+        int exit = await InvokeAsync(cmd, "--all");
+
+        Assert.Equal(0, exit);
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("HINT:") && l.Contains("No workloads installed"));
+        await _installer.DidNotReceive().UpdateAsync(
+            Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
+            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Update_All_IteratesDistinctPackageIds()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(new WorkloadEntry[]
+        {
+            new() { PackageId = "a.workload", PackageVersion = "1.0.0" },
+            new() { PackageId = "A.Workload", PackageVersion = "1.1.0" },
+            new() { PackageId = "b.workload", PackageVersion = "2.0.0" },
+        });
+        _installer.UpdateAsync(
+                "a.workload",
+                Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(new WorkloadUpdateResult(
+                new WorkloadEntry { PackageId = "a.workload", PackageVersion = "1.2.0" },
+                "1.1.0",
+                NoUpdateAvailable: false));
+        _installer.UpdateAsync(
+                "b.workload",
+                Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(new WorkloadUpdateResult(
+                new WorkloadEntry { PackageId = "b.workload", PackageVersion = "2.0.0" },
+                "2.0.0",
+                NoUpdateAvailable: true));
+
+        var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store);
+        int exit = await InvokeAsync(cmd, "--all");
+
+        Assert.Equal(0, exit);
+        await _installer.Received(1).UpdateAsync(
+            "a.workload", Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
+            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        await _installer.Received(1).UpdateAsync(
+            "b.workload", Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
+            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("SUCCESS:") && l.Contains("a.workload"));
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("HINT:") && l.Contains("b.workload"));
+    }
+
+    [Fact]
+    public async Task Update_All_PerIdFailureDoesNotStopOthers_ReturnsNonZero()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(new WorkloadEntry[]
+        {
+            new() { PackageId = "a.workload", PackageVersion = "1.0.0" },
+            new() { PackageId = "b.workload", PackageVersion = "2.0.0" },
+        });
+        _installer.UpdateAsync(
+                "a.workload",
+                Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Throws(new WorkloadPackageNotFoundException("not on feed"));
+        _installer.UpdateAsync(
+                "b.workload",
+                Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(new WorkloadUpdateResult(
+                new WorkloadEntry { PackageId = "b.workload", PackageVersion = "2.1.0" },
+                "2.0.0",
+                NoUpdateAvailable: false));
+
+        var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store);
+        int exit = await InvokeAsync(cmd, "--all");
+
+        Assert.Equal(1, exit);
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("ERROR:") && l.Contains("a.workload"));
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("SUCCESS:") && l.Contains("b.workload"));
+    }
+
+    [Fact]
+    public async Task Update_NoCandidateOnSource_HintsAboutSource()
+    {
+        _installer.UpdateAsync(
+                "Test.Workload",
+                Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(new WorkloadUpdateResult(
+                Entry: new WorkloadEntry { PackageId = "test.workload", PackageVersion = "1.0.0" },
+                PreviousVersion: "1.0.0",
+                NoUpdateAvailable: true,
+                NoCandidateOnSource: true));
+
+        var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store);
+        int exit = await InvokeAsync(cmd, "Test.Workload");
+
+        Assert.Equal(0, exit);
+        Assert.Contains(
+            _interaction.Lines,
+            l => l.StartsWith("HINT:")
+                && l.Contains("No version of 'test.workload'")
+                && l.Contains("--source"));
+    }
+
+    [Fact]
+    public async Task Update_AliasMatchesInstalledEntry_ResolvesToPackageId()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(new WorkloadEntry[]
+        {
+            new()
+            {
+                PackageId = "test.workload",
+                PackageVersion = "1.0.0",
+                Aliases = ["demo"],
+            },
+        });
+        _installer.UpdateAsync(
+                "test.workload",
+                Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(new WorkloadUpdateResult(
+                new WorkloadEntry { PackageId = "test.workload", PackageVersion = "1.1.0" },
+                "1.0.0",
+                NoUpdateAvailable: false));
+
+        var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store);
+        int exit = await InvokeAsync(cmd, "demo");
+
+        Assert.Equal(0, exit);
+        await _installer.Received(1).UpdateAsync(
+            "test.workload",
+            Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
+            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Update_ExactSkipsAliasLookup_PassesArgumentThrough()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(new WorkloadEntry[]
+        {
+            new()
+            {
+                PackageId = "test.workload",
+                PackageVersion = "1.0.0",
+                Aliases = ["demo"],
+            },
+        });
+        _installer.UpdateAsync(
+                "demo",
+                Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Throws(new InvalidOperationException("Workload 'demo' is not installed."));
+
+        var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store);
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => InvokeAsync(cmd, "demo", "--exact"));
+
+        Assert.Contains("not installed", ex.Message);
+        await _installer.DidNotReceive().UpdateAsync(
+            "test.workload",
+            Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
+            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Update_AmbiguousAlias_GracefulException()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(new WorkloadEntry[]
+        {
+            new() { PackageId = "a.workload", PackageVersion = "1.0.0", Aliases = ["shared"] },
+            new() { PackageId = "b.workload", PackageVersion = "2.0.0", Aliases = ["shared"] },
+        });
+
+        var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store);
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => InvokeAsync(cmd, "shared"));
+
+        Assert.Contains("matches multiple installed workloads", ex.Message);
+        Assert.Contains("a.workload", ex.Message);
+        Assert.Contains("b.workload", ex.Message);
+        Assert.True(ex.IsUserError);
+        await _installer.DidNotReceive().UpdateAsync(
+            Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
+            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    private static Task<int> InvokeAsync(WorkloadUpdateCommand cmd, params string[] args)
+    {
+        var root = new RootCommand();
+        root.Subcommands.Add(cmd);
+        var config = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
+        return root.Parse(new[] { cmd.Name }.Concat(args).ToArray()).InvokeAsync(config);
+    }
+}

--- a/test/Func.Tests/TestParser.cs
+++ b/test/Func.Tests/TestParser.cs
@@ -83,6 +83,7 @@ internal static class TestParser
         // Workload install pipeline: substitute the installer so commands
         // resolve without standing up the real install/uninstall side effects.
         services.AddSingleton(Substitute.For<Cli.Workloads.Install.IWorkloadInstaller>());
+        services.AddSingleton(Substitute.For<Cli.Workloads.Catalog.IWorkloadCatalog>());
 
         return services;
     }

--- a/test/Func.Tests/Workloads/Catalog/NuGetProtocolSourceClientTests.cs
+++ b/test/Func.Tests/Workloads/Catalog/NuGetProtocolSourceClientTests.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Workloads.Catalog;
+using Newtonsoft.Json.Linq;
 using NSubstitute;
 using NuGet.Common;
-using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 using Xunit;
@@ -19,102 +19,68 @@ public sealed class NuGetProtocolSourceClientTests
         "test");
 
     [Fact]
-    public async Task SearchAsync_PassesPackageTypeFilterPrereleaseAndSkipTake()
+    public void ParseV3Hits_ParsesIdVersionAndAliasesFromTagsString()
     {
-        IPackageSearchMetadata[] hits = [Metadata("Workload.Python", "1.2.3", title: "Python", description: "py", tags: "alias:python language:python")];
-        PackageSearchResource search = Substitute.For<PackageSearchResource>();
-        SearchFilter? captured = null;
-        search.SearchAsync(
-                Arg.Any<string>(),
-                Arg.Do<SearchFilter>(f => captured = f),
-                Arg.Any<int>(),
-                Arg.Any<int>(),
-                Arg.Any<ILogger>(),
-                Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IEnumerable<IPackageSearchMetadata>>(hits));
-
-        NuGetProtocolSourceClient client = NewClient(searchResource: search);
-
-        IReadOnlyList<CatalogSearchResult> results = await client.SearchAsync(
-            new CatalogSearchQuery
+        var response = JObject.Parse("""
             {
-                Filter = "python",
-                IncludePrerelease = true,
-                Skip = 10,
-                Take = 20,
-            },
-            CancellationToken.None);
+              "data": [
+                {
+                  "id": "Workload.Python",
+                  "version": "1.2.3",
+                  "tags": "alias:python language:python"
+                }
+              ]
+            }
+            """);
 
-        Assert.NotNull(captured);
-        Assert.True(captured!.IncludePrerelease);
-        Assert.Equal(["FuncCliWorkload"], captured.PackageTypes);
-
-        await search.Received(1).SearchAsync(
-            "python",
-            Arg.Any<SearchFilter>(),
-            10,
-            20,
-            Arg.Any<ILogger>(),
-            Arg.Any<CancellationToken>());
-
-        CatalogSearchResult only = Assert.Single(results);
+        CatalogSearchResult only = Assert.Single(NuGetProtocolSourceClient.ParseV3Hits(response, _source));
         Assert.Equal("workload.python", only.PackageId);
-        Assert.Equal(NuGetVersion.Parse("1.2.3"), only.LatestVersion);
-        Assert.Equal("Python", only.Title);
         Assert.Equal(["python"], only.Aliases);
-        Assert.Same(_source, only.Source);
     }
 
     [Fact]
-    public async Task SearchAsync_DefaultsApplyForNullFilterAndTake()
+    public void ParseV3Hits_ParsesTagsArrayInAdditionToString()
     {
-        PackageSearchResource search = Substitute.For<PackageSearchResource>();
-        search.SearchAsync(Arg.Any<string>(), Arg.Any<SearchFilter>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<ILogger>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IEnumerable<IPackageSearchMetadata>>([]));
+        var response = JObject.Parse("""
+            {
+              "data": [
+                {
+                  "id": "Workload.Node",
+                  "version": "1.0.0",
+                  "tags": [ "alias:node", "language:javascript", "alias:nodejs" ]
+                }
+              ]
+            }
+            """);
 
-        NuGetProtocolSourceClient client = NewClient(searchResource: search);
-        await client.SearchAsync(new CatalogSearchQuery(), CancellationToken.None);
-
-        await search.Received(1).SearchAsync(
-            string.Empty,
-            Arg.Any<SearchFilter>(),
-            0,
-            CatalogSearchQuery.DefaultTake,
-            Arg.Any<ILogger>(),
-            Arg.Any<CancellationToken>());
+        CatalogSearchResult only = Assert.Single(NuGetProtocolSourceClient.ParseV3Hits(response, _source));
+        Assert.Equal(["node", "nodejs"], only.Aliases);
     }
 
     [Fact]
-    public async Task SearchAsync_SkipsEntriesMissingIdentity()
+    public void ParseV3Hits_SkipsEntriesMissingIdOrVersion()
     {
-        IPackageSearchMetadata good = Metadata("Workload.A", "1.0.0");
-        IPackageSearchMetadata bad = Substitute.For<IPackageSearchMetadata>();
-        bad.Identity.Returns((PackageIdentity?)null);
-        IPackageSearchMetadata[] hits = [good, bad];
+        var response = JObject.Parse("""
+            {
+              "data": [
+                { "version": "1.0.0" },
+                { "id": "A" },
+                { "id": "B", "version": "not-a-version" }
+              ]
+            }
+            """);
 
-        PackageSearchResource search = Substitute.For<PackageSearchResource>();
-        search.SearchAsync(Arg.Any<string>(), Arg.Any<SearchFilter>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<ILogger>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IEnumerable<IPackageSearchMetadata>>(hits));
-
-        NuGetProtocolSourceClient client = NewClient(searchResource: search);
-        IReadOnlyList<CatalogSearchResult> results = await client.SearchAsync(new CatalogSearchQuery(), CancellationToken.None);
-
-        Assert.Equal("workload.a", Assert.Single(results).PackageId);
+        Assert.Empty(NuGetProtocolSourceClient.ParseV3Hits(response, _source));
     }
 
     [Fact]
-    public async Task SearchAsync_ParsesAliasesFromTagsString()
+    public void ParseV3Hits_ReturnsEmptyWhenDataMissing()
     {
-        IPackageSearchMetadata[] hits = [Metadata("Workload.Node", "1.0.0", tags: "alias:node language:javascript alias:nodejs")];
-        PackageSearchResource search = Substitute.For<PackageSearchResource>();
-        search.SearchAsync(Arg.Any<string>(), Arg.Any<SearchFilter>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<ILogger>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IEnumerable<IPackageSearchMetadata>>(hits));
+        var response = JObject.Parse("""{ "totalHits": 0 }""");
 
-        NuGetProtocolSourceClient client = NewClient(searchResource: search);
-        IReadOnlyList<CatalogSearchResult> results = await client.SearchAsync(new CatalogSearchQuery(), CancellationToken.None);
-
-        Assert.Equal(["node", "nodejs"], Assert.Single(results).Aliases);
+        Assert.Empty(NuGetProtocolSourceClient.ParseV3Hits(response, _source));
     }
+
 
     [Fact]
     public async Task ListVersionsAsync_ReturnsResolvedVersions()
@@ -202,25 +168,9 @@ public sealed class NuGetProtocolSourceClientTests
     }
 
     private static NuGetProtocolSourceClient NewClient(
-        PackageSearchResource? searchResource = null,
         FindPackageByIdResource? findResource = null)
     {
-        SourceRepository repo = TestRepository.Build(_source, searchResource, findResource);
+        SourceRepository repo = TestRepository.Build(_source, findResource);
         return new NuGetProtocolSourceClient(repo);
-    }
-
-    private static IPackageSearchMetadata Metadata(
-        string id,
-        string version,
-        string? title = null,
-        string? description = null,
-        string? tags = null)
-    {
-        var meta = Substitute.For<IPackageSearchMetadata>();
-        meta.Identity.Returns(new PackageIdentity(id, NuGetVersion.Parse(version)));
-        meta.Title.Returns(title);
-        meta.Description.Returns(description);
-        meta.Tags.Returns(tags);
-        return meta;
     }
 }

--- a/test/Func.Tests/Workloads/Catalog/PackageSourceProviderTests.cs
+++ b/test/Func.Tests/Workloads/Catalog/PackageSourceProviderTests.cs
@@ -8,12 +8,8 @@ using PackageSource = NuGet.Configuration.PackageSource;
 
 namespace Azure.Functions.Cli.Tests.Workloads.Catalog;
 
-public sealed class PackageSourceProviderTests : IDisposable
+public sealed class PackageSourceProviderTests
 {
-    private readonly string _tempRoot = Directory.CreateTempSubdirectory("workload-source-provider-").FullName;
-
-    public void Dispose() => Directory.Delete(_tempRoot, recursive: true);
-
     [Fact]
     public void GetSource_OverrideUrl_ReturnsRemoteSource()
     {
@@ -23,19 +19,6 @@ public sealed class PackageSourceProviderTests : IDisposable
 
         Assert.False(source.IsLocal);
         Assert.Equal("https://example.test/v3/index.json", source.Source);
-    }
-
-    [Fact]
-    public void GetSource_OverrideLocalDir_ReturnsLocalSource()
-    {
-        string folder = Path.Combine(_tempRoot, "feed");
-        Directory.CreateDirectory(folder);
-        PackageSourceProvider provider = NewProvider();
-
-        PackageSource source = provider.GetSource(folder);
-
-        Assert.True(source.IsLocal);
-        Assert.Equal(Path.GetFullPath(folder), source.Source);
     }
 
     [Fact]
@@ -69,18 +52,21 @@ public sealed class PackageSourceProviderTests : IDisposable
         Assert.Equal(PackageSourceProvider.DefaultSourceUrl, source.Source);
     }
 
-    [Fact]
-    public void GetSource_OverrideMissingDirectory_Throws()
+    [Theory]
+    [InlineData("/some/local/folder")]
+    [InlineData("./relative")]
+    [InlineData("file:///tmp/feed")]
+    [InlineData("ftp://unsupported.example/feed")]
+    public void GetSource_NonHttpSource_Throws(string value)
     {
         PackageSourceProvider provider = NewProvider();
 
-        ArgumentException ex = Assert.Throws<ArgumentException>(
-            () => provider.GetSource(Path.Combine(_tempRoot, "does-not-exist")));
-        Assert.Contains("does not exist", ex.Message, StringComparison.OrdinalIgnoreCase);
+        ArgumentException ex = Assert.Throws<ArgumentException>(() => provider.GetSource(value));
+        Assert.Contains("not a supported NuGet feed", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public void GetSource_ConfiguredInvalidEntry_Throws()
+    public void GetSource_ConfiguredNonHttp_Throws()
     {
         PackageSourceProvider provider = NewProvider("ftp://unsupported.example/feed");
 

--- a/test/Func.Tests/Workloads/Catalog/WorkloadCatalogTests.cs
+++ b/test/Func.Tests/Workloads/Catalog/WorkloadCatalogTests.cs
@@ -2,9 +2,10 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Workloads.Catalog;
+using Newtonsoft.Json.Linq;
 using NSubstitute;
 using NuGet.Common;
-using NuGet.Packaging.Core;
+using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 using Xunit;
@@ -20,7 +21,7 @@ public sealed class WorkloadCatalogTests
     [Fact]
     public async Task SearchAsync_DelegatesToConfiguredSource()
     {
-        NuGetProtocolSourceClient client = BuildClient(_defaultSource, search: [Metadata("alpha", "1.0.0")]);
+        NuGetProtocolSourceClient client = BuildClient(_defaultSource, search: [("alpha", "1.0.0")]);
         WorkloadCatalog catalog = NewCatalog((_defaultSource, client));
 
         IReadOnlyList<CatalogSearchResult> results = await catalog.SearchAsync(new CatalogSearchQuery());
@@ -33,8 +34,8 @@ public sealed class WorkloadCatalogTests
     [Fact]
     public async Task SearchAsync_Source_ConsultsOnlyOverride()
     {
-        NuGetProtocolSourceClient defaultClient = BuildClient(_defaultSource, search: [Metadata("default-pkg", "1.0.0")]);
-        NuGetProtocolSourceClient overrideClient = BuildClient(_altSource, search: [Metadata("override-pkg", "1.0.0")]);
+        NuGetProtocolSourceClient defaultClient = BuildClient(_defaultSource, search: [("default-pkg", "1.0.0")]);
+        NuGetProtocolSourceClient overrideClient = BuildClient(_altSource, search: [("override-pkg", "1.0.0")]);
 
         var sourceProvider = Substitute.For<IPackageSourceProvider>();
         sourceProvider.GetSource(null).Returns(_defaultSource);
@@ -173,27 +174,49 @@ public sealed class WorkloadCatalogTests
 
     private static NuGetVersion V(string v) => NuGetVersion.Parse(v);
 
-    private static IPackageSearchMetadata Metadata(string id, string version, string? tags = null)
+    private sealed class FakeClient(SourceRepository repo, JObject? response) : NuGetProtocolSourceClient(repo)
     {
-        IPackageSearchMetadata m = Substitute.For<IPackageSearchMetadata>();
-        m.Identity.Returns(new PackageIdentity(id, NuGetVersion.Parse(version)));
-        m.Tags.Returns(tags);
-        return m;
+        internal override Task<JObject?> FetchSearchResponseAsync(Uri searchUri, CancellationToken cancellationToken)
+            => Task.FromResult(response);
+    }
+
+    private static JObject SearchResponse(params (string Id, string Version)[] hits)
+    {
+        var data = new JArray();
+        foreach ((string id, string version) in hits)
+        {
+            data.Add(new JObject
+            {
+                ["id"] = id,
+                ["version"] = version,
+            });
+        }
+
+        return new JObject { ["data"] = data, ["totalHits"] = hits.Length };
+    }
+
+    private static ServiceIndexResourceV3 NewServiceIndex()
+    {
+        // Minimal V3 service index that advertises a SearchQueryService URL.
+        // The URL itself is irrelevant since FakeClient short-circuits the
+        // actual HTTP fetch; what matters is that TryBuildV3SearchUriAsync
+        // resolves a non-null URI and routes through FetchSearchResponseAsync.
+        var json = JObject.Parse("""
+            {
+              "version": "3.0.0",
+              "resources": [
+                { "@id": "https://search.test/query", "@type": "SearchQueryService" }
+              ]
+            }
+            """);
+        return new ServiceIndexResourceV3(json, DateTime.UtcNow);
     }
 
     private static NuGetProtocolSourceClient BuildClient(
         PackageSource source,
-        IPackageSearchMetadata[]? search = null,
+        (string Id, string Version)[]? search = null,
         IEnumerable<NuGetVersion>? versions = null)
     {
-        PackageSearchResource? searchResource = null;
-        if (search is not null)
-        {
-            searchResource = Substitute.For<PackageSearchResource>();
-            searchResource.SearchAsync(Arg.Any<string>(), Arg.Any<SearchFilter>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<ILogger>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult<IEnumerable<IPackageSearchMetadata>>(search));
-        }
-
         FindPackageByIdResource? findResource = null;
         if (versions is not null)
         {
@@ -202,7 +225,8 @@ public sealed class WorkloadCatalogTests
                 .Returns(Task.FromResult(versions));
         }
 
-        return new NuGetProtocolSourceClient(TestRepository.Build(source, searchResource, findResource));
+        SourceRepository repo = TestRepository.Build(source, NewServiceIndex(), findResource);
+        return new FakeClient(repo, search is null ? null : SearchResponse(search));
     }
 
     private static WorkloadCatalog NewCatalog(params (PackageSource Source, NuGetProtocolSourceClient Client)[] entries)

--- a/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
+++ b/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
@@ -293,7 +293,7 @@ public sealed class WorkloadInstallerTests : IDisposable
                 includePrerelease: false, exact: true, force: false));
 
         Assert.Contains("test.workload", ex.Message);
-        Assert.Contains("--include-prereleases", ex.Message);
+        Assert.Contains("--prerelease", ex.Message);
         await _catalog.DidNotReceive().DownloadAsync(Arg.Any<ResolvedPackage>(), Arg.Any<CancellationToken>());
     }
 

--- a/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
+++ b/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
@@ -2,15 +2,18 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Workloads;
+using Azure.Functions.Cli.Workloads.Catalog;
 using Azure.Functions.Cli.Workloads.Discovery;
 using Azure.Functions.Cli.Workloads.Install;
 using Azure.Functions.Cli.Workloads.Storage;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using Xunit;
+using PackageSource = NuGet.Configuration.PackageSource;
 
 namespace Azure.Functions.Cli.Tests.Workloads.Install;
 
@@ -19,6 +22,7 @@ public sealed class WorkloadInstallerTests : IDisposable
     private readonly string _root = Directory.CreateTempSubdirectory("workload-installer-").FullName;
     private readonly IWorkloadStore _store = Substitute.For<IWorkloadStore>();
     private readonly IWorkloadMetadataReader _metadataReader = Substitute.For<IWorkloadMetadataReader>();
+    private readonly IWorkloadCatalog _catalog = Substitute.For<IWorkloadCatalog>();
     private readonly IWorkloadPaths _paths;
 
     public WorkloadInstallerTests()
@@ -252,9 +256,224 @@ public sealed class WorkloadInstallerTests : IDisposable
             Arg.Any<CancellationToken>());
     }
 
-    private WorkloadInstaller NewInstaller() => new(_paths, _store, _metadataReader);
+    [Fact]
+    public async Task InstallFromCatalog_ResolvesAndInstalls()
+    {
+        string nupkg = BuildNupkg();
+        var resolved = NewResolved("test.workload", "1.0.0");
+        _catalog.ResolveLatestVersionAsync(
+                "test.workload", false, null, true, null, Arg.Any<CancellationToken>())
+            .Returns(resolved);
+        _catalog.DownloadAsync(resolved, Arg.Any<CancellationToken>())
+            .Returns(_ => File.OpenRead(nupkg));
 
-    private string BuildNupkg(string? tags = null, bool includeFuncCliWorkloadType = true)
+        WorkloadInstaller installer = NewInstaller();
+        WorkloadInstallResult result = await installer.InstallFromCatalogAsync(
+            "test.workload", version: null, source: null,
+            includePrerelease: false, exact: true, force: false);
+
+        Assert.False(result.AlreadyInstalled);
+        Assert.Equal("test.workload", result.Entry.PackageId);
+        Assert.Equal("1.0.0", result.Entry.PackageVersion);
+        Assert.True(Directory.Exists(_paths.GetInstallDirectory("test.workload", "1.0.0")));
+        await _store.Received(1).SaveWorkloadAsync(Arg.Any<WorkloadEntry>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InstallFromCatalog_NoCandidate_Throws()
+    {
+        _catalog.ResolveLatestVersionAsync(
+                "test.workload", false, null, true, null, Arg.Any<CancellationToken>())
+            .Returns((ResolvedPackage?)null);
+
+        WorkloadInstaller installer = NewInstaller();
+        WorkloadPackageNotFoundException ex = await Assert.ThrowsAsync<WorkloadPackageNotFoundException>(
+            () => installer.InstallFromCatalogAsync(
+                "test.workload", version: null, source: null,
+                includePrerelease: false, exact: true, force: false));
+
+        Assert.Contains("test.workload", ex.Message);
+        Assert.Contains("--include-prereleases", ex.Message);
+        await _catalog.DidNotReceive().DownloadAsync(Arg.Any<ResolvedPackage>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InstallFromCatalog_ExplicitVersion_RoutesToExactResolution()
+    {
+        string nupkg = BuildNupkg();
+        var requested = NuGetVersion.Parse("1.0.0");
+        var resolved = NewResolved("test.workload", "1.0.0");
+
+        // Explicit version path uses the catalog's exact-version lookup.
+        _catalog.ResolveVersionAsync(
+                "test.workload", requested, null, Arg.Any<CancellationToken>())
+            .Returns(resolved);
+        _catalog.DownloadAsync(resolved, Arg.Any<CancellationToken>())
+            .Returns(_ => File.OpenRead(nupkg));
+
+        WorkloadInstaller installer = NewInstaller();
+        WorkloadInstallResult result = await installer.InstallFromCatalogAsync(
+            "test.workload", requested, source: null,
+            includePrerelease: false, exact: true, force: false);
+
+        Assert.Equal("1.0.0", result.Entry.PackageVersion);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_NotInstalled_Throws()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns([]);
+
+        WorkloadInstaller installer = NewInstaller();
+        InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => installer.UpdateAsync(
+                "test.workload", null, null, false, allowMajor: false));
+
+        Assert.Contains("not installed", ex.Message);
+        await _catalog.DidNotReceive().ResolveLatestVersionAsync(
+            Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<NuGetVersion?>(),
+            Arg.Any<bool>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateAsync_NoUpdateAvailable_ReturnsFlag_RegistryUntouched()
+    {
+        WorkloadEntry current = ExistingEntry("test.workload", "1.0.0");
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns([current]);
+        _catalog.ResolveLatestVersionAsync(
+                "test.workload", false, Arg.Any<NuGetVersion?>(), false, null, Arg.Any<CancellationToken>())
+            .Returns((ResolvedPackage?)null);
+
+        WorkloadInstaller installer = NewInstaller();
+        WorkloadUpdateResult result = await installer.UpdateAsync(
+            "test.workload", null, null, false, allowMajor: false);
+
+        Assert.True(result.NoUpdateAvailable);
+        Assert.True(result.NoCandidateOnSource);
+        Assert.Equal("1.0.0", result.PreviousVersion);
+        Assert.Same(current, result.Entry);
+        await _store.DidNotReceive().SaveWorkloadAsync(Arg.Any<WorkloadEntry>(), Arg.Any<CancellationToken>());
+        await _store.DidNotReceive().RemoveWorkloadAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateAsync_CatalogReturnsOlderVersion_NoUpdateButNotMissing()
+    {
+        WorkloadEntry current = ExistingEntry("test.workload", "1.5.0");
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns([current]);
+        _catalog.ResolveLatestVersionAsync(
+                "test.workload", false, Arg.Any<NuGetVersion?>(), false, null, Arg.Any<CancellationToken>())
+            .Returns(NewResolved("test.workload", "1.5.0"));
+
+        WorkloadInstaller installer = NewInstaller();
+        WorkloadUpdateResult result = await installer.UpdateAsync(
+            "test.workload", null, null, false, allowMajor: false);
+
+        Assert.True(result.NoUpdateAvailable);
+        Assert.False(result.NoCandidateOnSource);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_HappyPath_SwapsRegistryAndDeletesOldDir()
+    {
+        WorkloadEntry current = ExistingEntry("test.workload", "1.0.0");
+        string oldDir = _paths.GetInstallDirectory("test.workload", "1.0.0");
+        Directory.CreateDirectory(oldDir);
+        File.WriteAllText(Path.Combine(oldDir, "marker.txt"), "old");
+
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns([current]);
+
+        string newNupkg = BuildNupkg(version: "1.1.0");
+        var resolved = NewResolved("test.workload", "1.1.0");
+        _catalog.ResolveLatestVersionAsync(
+                "test.workload", false, Arg.Any<NuGetVersion?>(), false, null, Arg.Any<CancellationToken>())
+            .Returns(resolved);
+        _catalog.DownloadAsync(resolved, Arg.Any<CancellationToken>())
+            .Returns(_ => File.OpenRead(newNupkg));
+
+        WorkloadInstaller installer = NewInstaller();
+        WorkloadUpdateResult result = await installer.UpdateAsync(
+            "test.workload", null, null, false, allowMajor: false);
+
+        Assert.False(result.NoUpdateAvailable);
+        Assert.Equal("1.0.0", result.PreviousVersion);
+        Assert.Equal("1.1.0", result.Entry.PackageVersion);
+
+        string newDir = _paths.GetInstallDirectory("test.workload", "1.1.0");
+        Assert.True(Directory.Exists(newDir));
+        Assert.False(Directory.Exists(oldDir), "old install dir must be deleted after swap");
+
+        Received.InOrder(() =>
+        {
+            _store.ReplaceWorkloadAsync(
+                "test.workload",
+                "1.0.0",
+                Arg.Is<WorkloadEntry>(e => e.PackageId == "test.workload" && e.PackageVersion == "1.1.0"),
+                Arg.Any<CancellationToken>());
+        });
+    }
+
+    [Fact]
+    public async Task UpdateAsync_StagingFails_LeavesExistingInstallIntact()
+    {
+        WorkloadEntry current = ExistingEntry("test.workload", "1.0.0");
+        string oldDir = _paths.GetInstallDirectory("test.workload", "1.0.0");
+        Directory.CreateDirectory(oldDir);
+        File.WriteAllText(Path.Combine(oldDir, "marker.txt"), "old");
+
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns([current]);
+
+        var resolved = NewResolved("test.workload", "1.1.0");
+        _catalog.ResolveLatestVersionAsync(
+                "test.workload", false, Arg.Any<NuGetVersion?>(), false, null, Arg.Any<CancellationToken>())
+            .Returns(resolved);
+        _catalog.DownloadAsync(resolved, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new IOException("network glitch"));
+
+        WorkloadInstaller installer = NewInstaller();
+        await Assert.ThrowsAsync<IOException>(() => installer.UpdateAsync(
+            "test.workload", null, null, false, allowMajor: false));
+
+        Assert.True(Directory.Exists(oldDir), "existing install must remain after staging failure");
+        Assert.True(File.Exists(Path.Combine(oldDir, "marker.txt")));
+        await _store.DidNotReceive().ReplaceWorkloadAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<WorkloadEntry>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateAsync_RequestedVersionNotInstalled_Throws()
+    {
+        WorkloadEntry current = ExistingEntry("test.workload", "1.0.0");
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns([current]);
+
+        WorkloadInstaller installer = NewInstaller();
+        InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => installer.UpdateAsync(
+                "test.workload", NuGetVersion.Parse("0.9.0"), null, false, allowMajor: false));
+
+        Assert.Contains("0.9.0", ex.Message);
+        Assert.Contains("not installed", ex.Message);
+    }
+
+    private static WorkloadEntry ExistingEntry(string id, string version) => new()
+    {
+        PackageId = id,
+        PackageVersion = version,
+        Aliases = [],
+        Kind = WorkloadKind.Workload,
+        EntryPoint = new EntryPointSpec { AssemblyPath = "Test.dll", Type = "Test.Type" },
+        InstallRefCount = 1,
+    };
+
+    private static ResolvedPackage NewResolved(string id, string version) => new(
+        id,
+        NuGetVersion.Parse(version),
+        new PackageSource("https://example/v3/index.json", "test"));
+
+    private WorkloadInstaller NewInstaller() => new(_paths, _store, _metadataReader, _catalog);
+
+    private string BuildNupkg(string? tags = null, bool includeFuncCliWorkloadType = true, string version = "1.0.0")
     {
         string stubAssembly = Path.Combine(_root, $"stub-{Guid.NewGuid():N}.dll");
         File.WriteAllBytes(stubAssembly, [0x4D, 0x5A]);
@@ -262,7 +481,7 @@ public sealed class WorkloadInstallerTests : IDisposable
         var builder = new PackageBuilder
         {
             Id = "Test.Workload",
-            Version = NuGetVersion.Parse("1.0.0"),
+            Version = NuGetVersion.Parse(version),
             Description = "For tests.",
         };
         builder.Authors.Add("test");


### PR DESCRIPTION
Stacks on #4952. **Base branch: `liliankasem/feat/workload-nuget-catalog`.** Rebase to `vnext` once #4952 merges.

## What

Wires the catalog plumbing into three user-facing commands:

1. **`func workload install <package-id>`** now accepts a NuGet package id in addition to a local `.nupkg` path. Dispatch is by extension: `.nupkg` then existing local pipeline, otherwise catalog. New options: `--version|-v`, `--source`, `--include-prereleases` (rejected on local `.nupkg` installs via cross-validator).
2. **`func workload update <package-id>`** (new). Implements the in-place atomic swap from spec §6.4: resolve installed row, resolve new version (catalog), stage + validate, atomic `Directory.Move`, registry remove-old + save-new, delete old install. Failure during staging leaves the existing install untouched. `--major` opts in to crossing major versions; `--version` selects which installed row to update when multiple are present. Per scope, `--all` is omitted (follow-up).
3. **`func workload search [query]`** (new). Renders catalog results as a table (Id, Latest, Description) with `--skip`/`--take` pagination, `--source`, `--include-prereleases`.

## How

- All orchestration lives in `IWorkloadInstaller`. Two new methods: `InstallFromCatalogAsync` (resolve, download, reuse `InstallFromPackageAsync`) and `UpdateAsync` (returns `WorkloadUpdateResult` carrying the new entry, previous version, and a `NoUpdateAvailable` flag for the "already latest" case).
- `WorkloadInstaller` gains an `IWorkloadCatalog` constructor dep.
- Centralized `WorkloadInstaller.AliasTagPrefix`; removed the duplicate `private const` from `LocalFolderSourceClient` and `NuGetProtocolSourceClient`.
- DI: `CliHostFactory` now calls `AddWorkloadCatalog()`; `BuiltInCommands` registers the two new commands; `WorkloadCommand` lists them as subcommands.

## Out of scope (called out in the task)

- `--exact` (alias resolution) on install: separate PR.
- `update --all`: separate PR.
- `--json` output across commands: separate cross-cutting concern.
- `prune`, background staleness, project detection.
- Single-write registry transaction. §6.4 step 5 documents the orphaned-directory case as recoverable via `prune`; an inline comment notes this in `UpdateAsync`.

## Tests

`dotnet test test/Func.Tests/Func.Tests.csproj` -> 267 passed, 0 failed.

New coverage:
- `WorkloadInstallerTests`: catalog resolve+delegate, no-candidate throw, explicit-version download, download-failure cleanup, update happy path / no-update / not-installed / staging-failure rollback / orphaned-old-dir tolerance.
- `WorkloadInstallCommandTests`: dispatch by extension, options forwarding, cross-validator rejection on local installs, package-not-found to `GracefulException`.
- `WorkloadUpdateCommandTests`: arg/option shape, success rendering, "already latest" hint, not-installed graceful exception, missing-arg validation.
- `WorkloadSearchCommandTests`: arg/option shape, empty-results warning, table rendering, option forwarding, default skip/take, description truncation.

## Worker versions

No host dependency change.
