### PR TITLE
Pin Go toolchain to 1.25.9 for gozip

### DIFF
--- a/eng/ci/templates/official/jobs/test-consolidated-cli-artifacts.yml
+++ b/eng/ci/templates/official/jobs/test-consolidated-cli-artifacts.yml
@@ -51,7 +51,7 @@ jobs:
   - task: GoTool@0
     displayName: 'Install Go'
     inputs:
-      version: '1.20'
+      version: '1.25.9'
 
   - download: current
     displayName: 'Download artifact'

--- a/eng/ci/templates/public/jobs/test-unit-linux.yml
+++ b/eng/ci/templates/public/jobs/test-unit-linux.yml
@@ -21,7 +21,7 @@ jobs:
 
   - task: GoTool@0
     inputs:
-      version: '1.21'
+      version: '1.25.9'
     displayName: 'Install Go'
 
   - template: /eng/ci/templates/steps/install-tools.yml@self

--- a/eng/ci/templates/steps/install-tools.yml
+++ b/eng/ci/templates/steps/install-tools.yml
@@ -4,6 +4,11 @@ steps:
     versionSpec: '18.x'
   displayName: 'Install Node 18.x'
 
+- task: GoTool@0
+  inputs:
+    version: '1.25.9'
+  displayName: 'Install Go 1.25.9'
+
 - task: UsePythonVersion@0
   inputs:
     versionSpec: '3.10'


### PR DESCRIPTION
### Issue describing the changes in this PR

n/a

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

- Add GoTool@0 (1.25.9) to install-tools.yml so publish-cli.yml builds gozip with a patched Go (was inheriting the agent's 1.24.11).
- Bump pinned Go from 1.20 to 1.25.9 in test-consolidated-cli-artifacts.yml.
- Bump pinned Go from 1.21 to 1.25.9 in test-unit-linux.yml.

