### PR TITLE
Drop brittle StartCommandActivity_NoListener test

### DIFF
--- a/test/Func.Tests/Telemetry/TelemetryTests.cs
+++ b/test/Func.Tests/Telemetry/TelemetryTests.cs
@@ -86,14 +86,6 @@ public class TelemetryTests
     }
 
     [Fact]
-    public void StartCommandActivity_NoListener_ReturnsNull()
-    {
-        // Without an OTel listener subscribed, ActivitySource.StartActivity
-        // returns null and the extension propagates that.
-        Assert.Null(CliTelemetry.Trace.StartCommandActivity());
-    }
-
-    [Fact]
     public void RecordCommand_NoListener_DoesNotThrow()
     {
         // Metric instruments record nothing when no MeterListener is wired up.


### PR DESCRIPTION
## Why

`StartCommandActivity_NoListener_ReturnsNull` is order-dependent and flakes on CI.

The assertion (`StartActivity` returns null without a listener) relies on the global `ActivitySource` state being clean. `WorkloadBootMetricListener.EnsureRegistered()` installs a process-global `ActivityListener` and never disposes it. Any test that constructs the host (e.g. `CliHostFactoryTests`) triggers that registration and leaves the listener active for the rest of the test run. When xUnit's parallel scheduling runs `CliHostFactoryTests` before this one, the assertion fails.

## Fix

Delete the test. It was checking a property of `System.Diagnostics.ActivitySource` (`StartActivity` returns null without a listener), not behaviour of our wrapper. The wrapper is exercised by the four `StartCommandActivity_WithListener_*`, `SetCommandName_*` and `Fail_*` tests, which all subscribe a listener via `SubscribeListener()`.

## Repro

CI run on PR #4954 hit this with the same scheduling. Locally:

```
dotnet test test/Func.Tests/Func.Tests.csproj
```

passes 243/243 with the test removed.