### PR TITLE
Expand Dependabot coverage across ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,35 @@ updates:
         patterns:
           - "Microsoft.Extensions.*"
           - "System.*"
+
+  # Publish-tooling npm package (eng/tools/publish-tools/npm).
+  - package-ecosystem: "npm"
+    directory: "/eng/tools/publish-tools/npm"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    open-pull-requests-limit: 5
+
+  # Publish-tooling Python requirements.
+  - package-ecosystem: "pip"
+    directory: "/eng/tools/publish-tools"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    open-pull-requests-limit: 5
+
+  # Container base image.
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    open-pull-requests-limit: 5
+
+  # GitHub Actions workflow versions.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,7 @@ updates:
         patterns:
           - "OpenTelemetry*"
           - "Azure.Monitor.OpenTelemetry.*"
-      microsoft-extensions:
+      microsoft-bcl:
         patterns:
           - "Microsoft.Extensions.*"
+          - "System.*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,24 @@ updates:
         update-types: 
           - "version-update:semver-major"
           - "version-update:semver-minor"
+
+  # NuGet packages (transitives included via central package management).
+  # Security advisories are surfaced through the Security tab regardless of schedule;
+  # the weekly cadence is for routine version drift PRs.
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    open-pull-requests-limit: 10
+    groups:
+      powershell-workers:
+        patterns:
+          - "Microsoft.Azure.Functions.PowerShellWorker.*"
+      opentelemetry:
+        patterns:
+          - "OpenTelemetry*"
+          - "Azure.Monitor.OpenTelemetry.*"
+      microsoft-extensions:
+        patterns:
+          - "Microsoft.Extensions.*"


### PR DESCRIPTION
## Why

We were missing a proactive feed for new advisories against our pinned dependencies. Dependabot already runs for `dotnet-sdk`; this expands coverage so:

- Security advisories surface under `Security > Dependabot alerts` (org-private until publicly disclosed).
- Dependabot can auto-open PRs to address them.
- Routine version drift gets a weekly PR per group instead of being silently ignored.

## Changes

`.github/dependabot.yml` adds the following ecosystems:

| Ecosystem | Path | Notes |
|-----------|------|-------|
| `nuget` | `/` | All NuGet (CPM transitives included). Grouped: `powershell-workers`, `opentelemetry`, `microsoft-bcl` (`Microsoft.Extensions.*` + `System.*`) |
| `npm` | `/eng/tools/publish-tools/npm` | The `azure-functions-core-tools` npm package |
| `pip` | `/eng/tools/publish-tools` | Publish tooling Python deps |
| `docker` | `/docker` | Container base image |
| `github-actions` | `/` | Workflow action versions |

All on a weekly Wednesday cadence with `open-pull-requests-limit` caps to keep noise down. Existing `dotnet-sdk` ecosystem entry untouched.

**Intentionally skipped:** `test/TestFunctionApps/*` (test fixtures, noisy churn) and `src/Cli/func/StaticResources/requirements.txt` (template embedded in CLI for end users, not our dep).

## Scope changes after review

Dropped from this PR per discussion:

- **Trivy artifact scan**: moved to `liliankasem/feat/trivy-artifact-scan` for a separate team conversation. Trivy scans inside shipped artifact contents; the existing tools (Dependency Review, NuGet audit, Component Governance, Dependabot) are primarily manifest-driven. Worth a broader call on whether to address that gap.
- **Promoting `NU1902` / `NU1903` to CI errors**: reverted. We don't want to halt CI on existing packages with newly-disclosed vulnerabilities. Dependabot will track those instead.
- **OpenTelemetry CPM transitive-pinning overrides**: never landed (would force host transitives to versions the host wasn't built against). Tracked separately at https://github.com/Azure/azure-functions-host/issues/11773.

## What this PR does *not* cover

Dependabot reads manifests we own at the repo level. It does not unzip another ecosystem's package to look at content inside it. Concretely, the following classes of finding will not be flagged:

- `commons-lang3-3.9.jar` packaged as content inside `Microsoft.Azure.Functions.JavaWorker.nupkg`. Dependabot's NuGet scanner sees `Microsoft.Azure.Functions.JavaWorker` and its `.nuspec` dependencies. It does not unzip the nupkg, find the JAR, and identify the Maven coordinates inside.
- `gozip` Go binary inside the NuGet package (well, was, that's gone now).
- Python wheels under `workers/python/.../site-packages/` inside `Microsoft.Azure.Functions.PythonWorker.nupkg`. Dependabot pip scanner only reads `requirements.txt` files we author. It does not reach into `.whl` METADATA inside a NuGet package.

Component Governance has the same shape: its language detectors (NuGet, Maven, Pip, Npm, etc.) are manifest-triggered, so a bare `.jar` or `.whl` shipped without a `pom.xml` / `requirements.txt` next to it is invisible to them. The empirical evidence is that `commons-lang3 3.9` sat unflagged inside the JavaWorker JAR for 7 months while CG was running.

CG does include a `Linux` detector backed by [syft](https://github.com/anchore/syft) that *can* read JAR and wheel contents directly, but it is primarily scoped to scanning container layers (deb/rpm/apk databases). Whether we can point it at our unzipped artifact tree to close the same gap that Trivy would close is worth investigating in the broader team conversation, alongside Trivy.

That investigation is what the parked Trivy branch is a backstop for.

## Out of scope / follow-ups

- Team discussion on artifact-content scanning (Trivy, CG syft path, or otherwise).
- Host package age gate.
- SBOM emission per release.