### PR TITLE
[in-proc] Update extensions.csproj template to net8.0

### DIFF
--- a/src/Azure.Functions.Cli/StaticResources/ExtensionsProj.csproj.template
+++ b/src/Azure.Functions.Cli/StaticResources/ExtensionsProj.csproj.template
@@ -1,10 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-	<WarningsAsErrors></WarningsAsErrors>
-	<DefaultItemExcludes>**</DefaultItemExcludes>
+    <TargetFramework>net8.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.3" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.6.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Mirrors #4788 for the `in-proc` branch.

### Issue
When Core Tools generates the bundled extensions project (e.g. for csharp-script or `func extensions install`), the .NET SDK emits:

> .NET 6 is no longer supported. Please consider migrating to a supported version...

The actual cause is that `StaticResources/ExtensionsProj.csproj.template` still targets `netcoreapp3.1` (and was being retargeted by the SDK to a newer TFM with the warning). #4788 fixed this on `main`; this PR applies the same fix to `in-proc`.

### Change
Retarget the template to `net8.0` and switch to `Microsoft.NET.Sdk.Functions 4.6.0`, matching what #4788 did on `main`.

### Pull request checklist
- [x] My changes **do not** require documentation changes
- [x] My changes **do not** need to be backported to a previous version
- [x] My changes **should not** be added to the release notes for the next release
- [ ] I have added all required tests (Unit tests, E2E tests) - template-only change, covered by existing extensions install/sync flows
