### PR TITLE
Add FUNCTIONS_CLI_GO_PREVIEW opt-in flag for Go CLI detection

### DIFF
--- a/src/Cli/func/Actions/LocalActions/InitAction/InitAction.cs
+++ b/src/Cli/func/Actions/LocalActions/InitAction/InitAction.cs
@@ -471,6 +471,13 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 : Constants.StorageEmulatorConnectionString;
             localSettingsJsonContent = localSettingsJsonContent.Replace($"{{{Constants.AzureWebJobsStorage}}}", azureWebJobsStorageValue);
 
+            // Add the explicit Go preview opt-in so the CLI doesn't have to fall back to scanning
+            // for go.mod on every command. See WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage.
+            if (workerRuntime == Helpers.WorkerRuntime.Go)
+            {
+                localSettingsJsonContent = AddLocalSetting(localSettingsJsonContent, Constants.FunctionsCliGoPreview, "true");
+            }
+
             if (workerRuntime == Helpers.WorkerRuntime.Powershell)
             {
                 localSettingsJsonContent = AddLocalSetting(localSettingsJsonContent, Constants.FunctionsWorkerRuntimeVersion, Constants.PowerShellWorkerDefaultVersion);

--- a/src/Cli/func/Common/Constants.cs
+++ b/src/Cli/func/Common/Constants.cs
@@ -21,6 +21,12 @@ namespace Azure.Functions.Cli.Common
         public const string GoZipFileName = "gozip";
         public const string FunctionsWorkerRuntime = "FUNCTIONS_WORKER_RUNTIME";
         public const string FunctionsWorkerRuntimeVersion = "FUNCTIONS_WORKER_RUNTIME_VERSION";
+
+        // CLI-only preview opt-in for the Go worker. Read from env first, then local.settings.json
+        // (Values). Never sent to the host or to Azure (the CLI strips local.settings on publish).
+        // Intentionally Go-specific and short-lived: when the platform exposes a first-class
+        // mapping for "native" → concrete language, this flag and its consumers should be removed.
+        public const string FunctionsCliGoPreview = "FUNCTIONS_CLI_GO_PREVIEW";
         public const string RequirementsTxt = "requirements.txt";
         public const string PythonGettingStarted = "getting_started.md";
         public const string PySteinFunctionAppPy = "function_app.py";

--- a/src/Cli/func/Helpers/WorkerRuntimeLanguageHelper.cs
+++ b/src/Cli/func/Helpers/WorkerRuntimeLanguageHelper.cs
@@ -193,6 +193,19 @@ namespace Azure.Functions.Cli.Helpers
 
         public static WorkerRuntime GetCurrentWorkerRuntimeLanguage(ISecretsManager secretsManager, bool refreshSecrets = false)
         {
+            // Preview opt-in: FUNCTIONS_CLI_GO_PREVIEW lets a project declare itself as Go
+            // without forcing the resolver to scan the working directory for go.mod. Env var
+            // wins; local.settings.json is the secondary source. See TryResolveGoPreviewFlag.
+            if (TryResolveGoPreviewFlag(secretsManager, refreshSecrets))
+            {
+                if (GlobalCoreToolsSettings.IsVerbose)
+                {
+                    ColoredConsole.WriteLine(VerboseColor($"Resolving worker runtime to 'go' ({Constants.FunctionsCliGoPreview} is set)."));
+                }
+
+                return WorkerRuntime.Go;
+            }
+
             string setting = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime);
 
             if (string.IsNullOrWhiteSpace(setting))
@@ -258,11 +271,13 @@ namespace Azure.Functions.Cli.Helpers
         /// <remarks>
         /// Marker -> runtime:
         /// <list type="bullet">
-        ///   <item><c>go.mod</c> → <see cref="WorkerRuntime.Go"/></item>
+        ///   <item><c>go.mod</c> -> <see cref="WorkerRuntime.Go"/></item>
         /// </list>
         /// Add new native languages here as they are introduced. Invoked exclusively from
         /// <see cref="GetCurrentWorkerRuntimeLanguage"/> so callers never have to special-case
-        /// the "native" literal.
+        /// the "native" literal. Preferred path is the explicit <see cref="Constants.FunctionsCliGoPreview"/>
+        /// opt-in checked earlier in the resolver; this fallback exists for projects that
+        /// predate the flag.
         /// </remarks>
         private static WorkerRuntime ResolveNativeFromProjectMarkers()
         {
@@ -270,7 +285,7 @@ namespace Azure.Functions.Cli.Helpers
             {
                 if (GlobalCoreToolsSettings.IsVerbose)
                 {
-                    ColoredConsole.WriteLine(VerboseColor($"Resolving native worker runtime to 'go' ({GoHelpers.GoModFileName} found)."));
+                    ColoredConsole.WriteLine(VerboseColor($"Resolving native worker runtime to 'go' ({GoHelpers.GoModFileName} found; consider setting {Constants.FunctionsCliGoPreview}=true in local.settings.json)."));
                 }
 
                 return WorkerRuntime.Go;
@@ -278,7 +293,43 @@ namespace Azure.Functions.Cli.Helpers
 
             throw new CliException(
                 $"FUNCTIONS_WORKER_RUNTIME is set to 'native' but no supported project marker was found in '{Environment.CurrentDirectory}'. " +
-                "Run 'func init' to initialize a supported function app in this directory.");
+                $"Set '{Constants.FunctionsCliGoPreview}=true' in local.settings.json, or run 'func init' to initialize a supported function app in this directory.");
+        }
+
+        /// <summary>
+        /// Returns <c>true</c> when the Go preview flag is set to a truthy value either in the
+        /// process environment or in <c>local.settings.json</c>. Env var wins; local.settings.json
+        /// access failures (e.g. command run from outside a project root) are treated as "not set".
+        /// </summary>
+        private static bool TryResolveGoPreviewFlag(ISecretsManager secretsManager, bool refreshSecrets = false)
+        {
+            if (EnvironmentHelper.GetEnvironmentVariableAsBool(Constants.FunctionsCliGoPreview))
+            {
+                return true;
+            }
+
+            if (secretsManager is null)
+            {
+                return false;
+            }
+
+            string fromSettings;
+            try
+            {
+                fromSettings = secretsManager.GetSecrets(refreshSecrets)?.FirstOrDefault(s => s.Key.Equals(Constants.FunctionsCliGoPreview, StringComparison.OrdinalIgnoreCase)).Value;
+            }
+            catch (CliException)
+            {
+                return false;
+            }
+
+            if (string.IsNullOrEmpty(fromSettings))
+            {
+                return false;
+            }
+
+            return fromSettings.Equals("1", StringComparison.Ordinal)
+                || fromSettings.Equals("true", StringComparison.OrdinalIgnoreCase);
         }
 
         public static string GetDefaultTemplateLanguageFromWorker(WorkerRuntime worker)

--- a/test/Cli/Func.E2ETests/Commands/FuncInit/GoInitTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncInit/GoInitTests.cs
@@ -21,7 +21,7 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncInit
             var testName = nameof(Init_WithGo_GeneratesExpectedFunctionProjectFiles);
             var funcInitCommand = new FuncInitCommand(FuncPath, testName, Log ?? throw new ArgumentNullException(nameof(Log)));
             var localSettingsPath = Path.Combine(workingDir, Common.Constants.LocalSettingsJsonFileName);
-            var expectedLocalSettingsContent = new[] { Common.Constants.FunctionsWorkerRuntime, "native" };
+            var expectedLocalSettingsContent = new[] { Common.Constants.FunctionsWorkerRuntime, "native", Common.Constants.FunctionsCliGoPreview, "true" };
             var hostJsonPath = Path.Combine(workingDir, "host.json");
             var expectedHostJsonContent = new[] { "extensionBundle" };
             var mainGoPath = Path.Combine(workingDir, "main.go");

--- a/test/Cli/Func.UnitTests/ActionsTests/InitActionGoTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/InitActionGoTests.cs
@@ -13,6 +13,7 @@ using Xunit;
 
 namespace Azure.Functions.Cli.UnitTests.ActionsTests
 {
+    [Collection("NativeWorkerRuntimeTests")]
     public class InitActionGoTests
     {
         private static InitAction CreateAction()
@@ -187,6 +188,134 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
             {
                 Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, previousEnv);
                 GlobalCoreToolsSettings.CurrentWorkerRuntime = previousRuntime;
+            }
+        }
+
+        [Theory]
+        [InlineData("true")]
+        [InlineData("True")]
+        [InlineData("TRUE")]
+        [InlineData("1")]
+        public void GetCurrentWorkerRuntimeLanguage_GoPreviewEnvVar_ResolvesToGo(string envValue)
+        {
+            // Env var takes precedence over local.settings.json and the go.mod fallback.
+            // Even with no project markers and no FUNCTIONS_WORKER_RUNTIME, the explicit
+            // preview opt-in is enough to select the Go runtime.
+            var secretsManager = Substitute.For<ISecretsManager>();
+            secretsManager.GetSecrets(Arg.Any<bool>()).Returns(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+
+            var previousFlag = Environment.GetEnvironmentVariable(Constants.FunctionsCliGoPreview);
+            var previousRuntime = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime);
+            try
+            {
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, envValue);
+                Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, null);
+
+                var resolved = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(secretsManager);
+
+                resolved.Should().Be(WorkerRuntime.Go);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, previousFlag);
+                Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, previousRuntime);
+            }
+        }
+
+        [Theory]
+        [InlineData("true")]
+        [InlineData("True")]
+        [InlineData("1")]
+        public void GetCurrentWorkerRuntimeLanguage_GoPreviewSetting_ResolvesToGo(string settingValue)
+        {
+            // local.settings.json wins when the env var isn't set, without any go.mod scan.
+            var secretsManager = Substitute.For<ISecretsManager>();
+            secretsManager.GetSecrets(Arg.Any<bool>()).Returns(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { Constants.FunctionsCliGoPreview, settingValue },
+                { Constants.FunctionsWorkerRuntime, "native" },
+            });
+
+            var previousFlag = Environment.GetEnvironmentVariable(Constants.FunctionsCliGoPreview);
+            var previousRuntime = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime);
+            try
+            {
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, null);
+                Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, null);
+
+                var resolved = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(secretsManager);
+
+                resolved.Should().Be(WorkerRuntime.Go);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, previousFlag);
+                Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, previousRuntime);
+            }
+        }
+
+        [Theory]
+        [InlineData("false")]
+        [InlineData("0")]
+        [InlineData("yes")]
+        [InlineData("")]
+        public void GetCurrentWorkerRuntimeLanguage_GoPreviewFalsy_FallsThroughToLegacyResolution(string flagValue)
+        {
+            // Falsy flag values must not short-circuit; the legacy native+go.mod path should still run.
+            var secretsManager = Substitute.For<ISecretsManager>();
+            secretsManager.GetSecrets(Arg.Any<bool>()).Returns(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { Constants.FunctionsCliGoPreview, flagValue },
+                { Constants.FunctionsWorkerRuntime, "native" },
+            });
+
+            var fileSystem = Substitute.For<IFileSystem>();
+            fileSystem.File.Exists(Arg.Is<string>(p => p.EndsWith("go.mod"))).Returns(true);
+
+            var previousFlag = Environment.GetEnvironmentVariable(Constants.FunctionsCliGoPreview);
+            var previousRuntime = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime);
+            try
+            {
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, null);
+                Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, null);
+
+                using (FileSystemHelpers.Override(fileSystem))
+                {
+                    var resolved = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(secretsManager);
+
+                    resolved.Should().Be(WorkerRuntime.Go);
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, previousFlag);
+                Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, previousRuntime);
+            }
+        }
+
+        [Fact]
+        public void GetCurrentWorkerRuntimeLanguage_GoPreviewEnvVar_BeatsSecretsManagerThrow()
+        {
+            // SecretsManager throwing (e.g. command run from outside a project root) must not
+            // mask an explicit env-var opt-in.
+            var secretsManager = Substitute.For<ISecretsManager>();
+            secretsManager.GetSecrets(Arg.Any<bool>()).Returns(_ => throw new CliException("no project"));
+
+            var previousFlag = Environment.GetEnvironmentVariable(Constants.FunctionsCliGoPreview);
+            var previousRuntime = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime);
+            try
+            {
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, "true");
+                Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, null);
+
+                var resolved = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(secretsManager);
+
+                resolved.Should().Be(WorkerRuntime.Go);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, previousFlag);
+                Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, previousRuntime);
             }
         }
     }

--- a/test/Cli/Func.UnitTests/ActionsTests/NativeWorkerRuntimeTestCollection.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/NativeWorkerRuntimeTestCollection.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Xunit;
+
+namespace Azure.Functions.Cli.UnitTests.ActionsTests
+{
+    // Tests that exercise WorkerRuntimeLanguageHelper.ResolveNativeWorkerRuntime mutate
+    // process-global state (FUNCTIONS_WORKER_RUNTIME, FUNCTIONS_CLI_GO_PREVIEW env vars,
+    // FileSystemHelpers.Override, GlobalCoreToolsSettings.CurrentWorkerRuntime). Disable
+    // cross-class parallelization so they don't race against each other.
+    [CollectionDefinition("NativeWorkerRuntimeTests", DisableParallelization = true)]
+    public class NativeWorkerRuntimeTestCollection
+    {
+    }
+}

--- a/test/Cli/Func.UnitTests/ActionsTests/StartHostActionTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/StartHostActionTests.cs
@@ -19,6 +19,7 @@ using Xunit;
 
 namespace Azure.Functions.Cli.UnitTests.ActionsTests
 {
+    [Collection("NativeWorkerRuntimeTests")]
     public class StartHostActionTests
     {
         [SkippableFact]


### PR DESCRIPTION
Stacked on #4943.

## What

Adds a CLI-only preview flag (`FUNCTIONS_CLI_GO_PREVIEW`) so Core Tools can identify Go projects without scanning the working directory for `go.mod`.

Today, when a user runs `func init --worker-runtime go`, the host registers Go under `language: native` and `local.settings.json` ends up with `FUNCTIONS_WORKER_RUNTIME=native`. To map `native` back to `WorkerRuntime.Go`, the resolver currently scans the cwd for `go.mod`. That works but is fragile (wrong cwd, monorepos, partial checkouts) and forces every consumer of the resolver to hit disk.

This flag lets `func init` declare "this is a Go project" up front so later commands (`func start`, `func pack`, `func publish`, ...) get a deterministic answer.

## Behavior

- New constant: `Constants.FunctionsCliGoPreview = "FUNCTIONS_CLI_GO_PREVIEW"`.
- `func init --worker-runtime go` now writes both `FUNCTIONS_WORKER_RUNTIME=native` **and** `FUNCTIONS_CLI_GO_PREVIEW=true` into `local.settings.json`.
- `WorkerRuntimeLanguageHelper.ResolveNativeWorkerRuntime` precedence:
  1. `FUNCTIONS_CLI_GO_PREVIEW` env var (truthy = `true`/`1`, case-insensitive) -> `WorkerRuntime.Go`
  2. `FUNCTIONS_CLI_GO_PREVIEW` in `local.settings.json` (same truthy rules) -> `WorkerRuntime.Go`
  3. Legacy fallback: `FUNCTIONS_WORKER_RUNTIME=native` + `go.mod` exists in cwd -> `WorkerRuntime.Go`
  4. Otherwise: `WorkerRuntime.None` (with an updated `CliException` message that mentions the new flag).

Existing Go projects keep working via fallback (3); the flag is purely opt-in.

## Removal plan

Short-lived. Once the platform exposes a proper `native -> language` mapping (or once the host registers Go under a non-native language id), this flag and the legacy `go.mod` scan should both be deleted.

## Tests

- `InitActionGoTests`: 4 new fixtures cover env-var truthy values, settings truthy values, falsy fallthrough to legacy, and the SecretsManager-throws case.
- `GoInitTests` (E2E): asserts `FUNCTIONS_CLI_GO_PREVIEW=true` is written to `local.settings.json`.
- New `NativeWorkerRuntimeTestCollection` (xUnit) puts `InitActionGoTests` and `StartHostActionTests` in the same serial collection, preventing env-var races between classes.

Combined filter (`ResolveNativeWorkerRuntime|StartHostActionTests|InitActionGoTests`): 64 passed, 0 failed, 3 skipped (platform-specific).