### PR TITLE
Fix help usage path for nested subcommands

### DIFF
--- a/src/Func/Commands/HelpCommand.cs
+++ b/src/Func/Commands/HelpCommand.cs
@@ -119,8 +119,7 @@ internal class HelpCommand : FuncCliCommand
     /// </summary>
     internal void RenderCommandHelp(Command command)
     {
-        bool isRoot = command is RootCommand;
-        string commandPath = isRoot ? "func" : $"func {command.Name}";
+        string commandPath = BuildCommandPath(command);
 
         _interaction.WriteBlankLine();
         _interaction.WriteTitle(commandPath);
@@ -201,6 +200,29 @@ internal class HelpCommand : FuncCliCommand
                 line.Plain(" ").Muted("[options]");
             }
         });
+    }
+
+    /// <summary>
+    /// Builds the full command path from the root, e.g. <c>func workload install</c>
+    /// for a nested subcommand. Falls back to <c>func</c> for the root command.
+    /// </summary>
+    private static string BuildCommandPath(Command command)
+    {
+        if (command is RootCommand)
+        {
+            return "func";
+        }
+
+        var names = new List<string>();
+        Symbol? current = command;
+        while (current is not null and not RootCommand)
+        {
+            names.Add(current.Name);
+            current = current.Parents.FirstOrDefault();
+        }
+
+        names.Reverse();
+        return "func " + string.Join(' ', names);
     }
 
     private string FormatOptionName(Option option)

--- a/test/Func.Tests/Commands/HelpCommandTests.cs
+++ b/test/Func.Tests/Commands/HelpCommandTests.cs
@@ -57,4 +57,19 @@ public class HelpCommandTests
         Assert.Equal(1, exitCode);
         Assert.Contains("Unknown command", _interaction.AllOutput);
     }
+
+    [Fact]
+    public void RenderCommandHelp_WithNestedSubcommand_UsesFullPath()
+    {
+        var workloadCommand = _rootCommand.Subcommands
+            .First(c => c.Name == "workload");
+        var installCommand = workloadCommand.Subcommands
+            .First(c => c.Name == "install");
+
+        _helpCommand.RenderCommandHelp(installCommand);
+
+        var output = _interaction.AllOutput;
+        Assert.Contains("func workload install", output);
+        Assert.DoesNotContain("func install ", output);
+    }
 }


### PR DESCRIPTION
## Problem

Running a nested subcommand like \`func workload install\` without required args printed the wrong usage path:

\`\`\`
> func workload install
Required argument missing for command: 'install'.

func install

Install a workload.

── Usage ──
  func install <id> [options]
\`\`\`

The usage shows \`func install\` instead of \`func workload install\`.

## Cause

\`HelpCommand.RenderCommandHelp\` built the path as \`func {command.Name}\`, ignoring parent commands.

## Fix

Added \`BuildCommandPath\` which walks \`Symbol.Parents\` up to the \`RootCommand\` and joins names, so nested subcommands render with their full path.

## Verification

- New regression test in \`HelpCommandTests\` covering \`workload install\`.
- All 244 \`Func.Tests\` pass.
- Smoke-tested the built binary: now prints \`func workload install <id> [options]\`.