### PR TITLE
Implement workload spec gaps: prune, --json, list --all-versions, install prompt

### DIFF
--- a/src/Func/Commands/Workload/WorkloadCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadCommand.cs
@@ -19,7 +19,8 @@ internal sealed class WorkloadCommand : FuncCliCommand, IBuiltInCommand
         WorkloadInstallCommand installCommand,
         WorkloadUninstallCommand uninstallCommand,
         WorkloadUpdateCommand updateCommand,
-        WorkloadSearchCommand searchCommand)
+        WorkloadSearchCommand searchCommand,
+        WorkloadPruneCommand pruneCommand)
         : base("workload", "Manage Func CLI workloads.")
     {
         ArgumentNullException.ThrowIfNull(listCommand);
@@ -27,11 +28,13 @@ internal sealed class WorkloadCommand : FuncCliCommand, IBuiltInCommand
         ArgumentNullException.ThrowIfNull(uninstallCommand);
         ArgumentNullException.ThrowIfNull(updateCommand);
         ArgumentNullException.ThrowIfNull(searchCommand);
+        ArgumentNullException.ThrowIfNull(pruneCommand);
 
         Subcommands.Add(listCommand);
         Subcommands.Add(installCommand);
         Subcommands.Add(uninstallCommand);
         Subcommands.Add(updateCommand);
         Subcommands.Add(searchCommand);
+        Subcommands.Add(pruneCommand);
     }
 }

--- a/src/Func/Commands/Workload/WorkloadInstallCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadInstallCommand.cs
@@ -22,6 +22,7 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
 {
     private readonly IInteractionService _interaction;
     private readonly IWorkloadInstaller _installer;
+    private readonly IWorkloadStore _store;
 
     public Argument<string> WorkloadArgument { get; } = new("id")
     {
@@ -53,11 +54,15 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
         Description = "Disable alias matching. <id> must be the literal package id.",
     };
 
-    public WorkloadInstallCommand(IInteractionService interaction, IWorkloadInstaller installer)
+    public WorkloadInstallCommand(
+        IInteractionService interaction,
+        IWorkloadInstaller installer,
+        IWorkloadStore store)
         : base("install", "Install a workload.")
     {
         _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
         _installer = installer ?? throw new ArgumentNullException(nameof(installer));
+        _store = store ?? throw new ArgumentNullException(nameof(store));
 
         WorkloadArgument.AddRequiredIdValidator();
         VersionOption.AddSemVerValidator();
@@ -78,6 +83,20 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
         bool includePrerelease = parseResult.GetValue(IncludePrereleaseOption);
         bool exact = parseResult.GetValue(ExactOption);
         bool force = parseResult.GetValue(ForceOption);
+
+        if (!force && !LooksLikeLocalPackagePath(workload))
+        {
+            // Spec §4.1: when any version of <package> is already installed,
+            // prompt the user to use `update` instead. --force skips the
+            // prompt entirely. Non-interactive contexts treat the prompt as
+            // a decline and exit non-zero with the same hint. Local .nupkg
+            // installs bypass the check since the resolver path differs.
+            int? earlyExit = await CheckAlreadyInstalledAsync(workload, exact, cancellationToken);
+            if (earlyExit is { } code)
+            {
+                return code;
+            }
+        }
 
         try
         {
@@ -128,6 +147,54 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
     /// </summary>
     private static bool LooksLikeLocalPackagePath(string value)
         => value.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase) && File.Exists(value);
+
+    private async Task<int?> CheckAlreadyInstalledAsync(
+        string identifier,
+        bool exact,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
+        if (installed.Count == 0)
+        {
+            return null;
+        }
+
+        // Same matching rules as uninstall/update: by package id always,
+        // by alias unless --exact. We don't need to enforce uniqueness
+        // here; if any version matches we prompt.
+        WorkloadEntry? match = installed.FirstOrDefault(e =>
+            string.Equals(e.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
+            || (!exact && (e.Aliases?.Any(a => string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)) ?? false)));
+
+        if (match is null)
+        {
+            return null;
+        }
+
+        string canonicalId = match.PackageId;
+        string prompt =
+            $"'{canonicalId}' is already installed at {match.PackageVersion}. " +
+            $"Run 'func workload update {canonicalId}' instead?";
+
+        if (!_interaction.IsInteractive)
+        {
+            _interaction.WriteHint(
+                $"'{canonicalId}' is already installed at {match.PackageVersion}. " +
+                $"Run 'func workload update {canonicalId}' to upgrade, or pass --force to install side-by-side.");
+            return 1;
+        }
+
+        bool useUpdate = await _interaction.ConfirmAsync(prompt, defaultValue: true, cancellationToken);
+        if (useUpdate)
+        {
+            _interaction.WriteHint($"Run 'func workload update {canonicalId}' to upgrade.");
+            return 1;
+        }
+
+        // User declined the suggestion: fall through to a normal install,
+        // which will go side-by-side or no-op for the same version.
+        return null;
+    }
 
     private static string BuildSuccessMessage(WorkloadInstallResult result)
     {

--- a/src/Func/Commands/Workload/WorkloadListCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadListCommand.cs
@@ -4,42 +4,148 @@
 using System.CommandLine;
 using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Workloads;
+using Azure.Functions.Cli.Workloads.Storage;
+using NuGet.Versioning;
 
 namespace Azure.Functions.Cli.Commands.Workload;
 
 /// <summary>
-/// Lists workloads from <see cref="IWorkloadProvider"/>.
+/// <c>func workload list [--all-versions|-a] [--json]</c>. Lists installed
+/// workloads. Default: only the loaded version per workload (highest
+/// installed semver). Pass <c>--all-versions</c> to include every
+/// side-by-side install.
 /// </summary>
-internal sealed class WorkloadListCommand(
-    IInteractionService interaction,
-    IWorkloadProvider workloads)
-    : FuncCliCommand("list", "List installed workloads.")
+internal sealed class WorkloadListCommand : FuncCliCommand
 {
     private const string AliasesPlaceholder = "-";
 
-    private readonly IInteractionService _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
-    private readonly IWorkloadProvider _workloads = workloads ?? throw new ArgumentNullException(nameof(workloads));
+    private readonly IInteractionService _interaction;
+    private readonly IWorkloadProvider _workloads;
+    private readonly IWorkloadStore _store;
 
-    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    public Option<bool> AllVersionsOption { get; } = new("--all-versions", "-a")
     {
-        IReadOnlyList<WorkloadInfo> workloads = _workloads.GetWorkloads();
+        Description = "List every installed version of every workload. Default: loaded version only.",
+    };
 
-        if (workloads.Count == 0)
+    public Option<bool> JsonOption { get; } = new("--json")
+    {
+        Description = "Emit machine-readable JSON instead of a table.",
+    };
+
+    public WorkloadListCommand(
+        IInteractionService interaction,
+        IWorkloadProvider workloads,
+        IWorkloadStore store)
+        : base("list", "List installed workloads.")
+    {
+        _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
+        _workloads = workloads ?? throw new ArgumentNullException(nameof(workloads));
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+
+        Options.Add(AllVersionsOption);
+        Options.Add(JsonOption);
+    }
+
+    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        bool allVersions = parseResult.GetValue(AllVersionsOption);
+        bool json = parseResult.GetValue(JsonOption);
+
+        IReadOnlyList<ListRow> rows = allVersions
+            ? await BuildAllVersionsRowsAsync(cancellationToken)
+            : BuildLoadedRows();
+
+        if (json)
         {
-            _interaction.WriteHint("No workloads installed.");
-            return Task.FromResult(0);
+            _interaction.WriteJson(rows);
+            return 0;
         }
 
-        IEnumerable<string[]> rows = workloads.Select(w => new[]
+        if (rows.Count == 0)
         {
-            w.PackageId,
-            w.Aliases.Count == 0 ? AliasesPlaceholder : string.Join(", ", w.Aliases),
-            w.DisplayName,
-            w.Description,
-            w.PackageVersion,
+            _interaction.WriteHint("No workloads installed.");
+            return 0;
+        }
+
+        IEnumerable<string[]> tableRows = rows.Select(r => new[]
+        {
+            r.PackageId,
+            r.Aliases.Count == 0 ? AliasesPlaceholder : string.Join(", ", r.Aliases),
+            string.IsNullOrWhiteSpace(r.DisplayName) ? AliasesPlaceholder : r.DisplayName,
+            string.IsNullOrWhiteSpace(r.Description) ? AliasesPlaceholder : r.Description,
+            r.PackageVersion,
         });
 
-        _interaction.WriteTable(["ID", "Aliases", "Display Name", "Description", "Version"], rows);
-        return Task.FromResult(0);
+        _interaction.WriteTable(["ID", "Aliases", "Display Name", "Description", "Version"], tableRows);
+        return 0;
+    }
+
+    private IReadOnlyList<ListRow> BuildLoadedRows()
+    {
+        IReadOnlyList<WorkloadInfo> workloads = _workloads.GetWorkloads();
+        return [.. workloads.Select(w => new ListRow(
+            w.PackageId,
+            w.PackageVersion,
+            w.Aliases,
+            w.DisplayName,
+            w.Description))];
+    }
+
+    private async Task<IReadOnlyList<ListRow>> BuildAllVersionsRowsAsync(CancellationToken cancellationToken)
+    {
+        IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
+
+        // Cross-reference loaded info so we can surface DisplayName /
+        // Description for the version that's currently live; older
+        // side-by-side versions have no loaded instance, so we fall back
+        // to the placeholder in the table renderer.
+        Dictionary<(string PackageId, string Version), WorkloadInfo> loadedByKey = _workloads
+            .GetWorkloads()
+            .ToDictionary(
+                w => (w.PackageId, w.PackageVersion),
+                w => w,
+                new PackageVersionKeyComparer());
+
+        return [.. installed
+            .OrderBy(e => e.PackageId, StringComparer.OrdinalIgnoreCase)
+            .ThenByDescending(e => ParseVersion(e.PackageVersion))
+            .Select(e =>
+            {
+                loadedByKey.TryGetValue((e.PackageId, e.PackageVersion), out WorkloadInfo? info);
+                return new ListRow(
+                    e.PackageId,
+                    e.PackageVersion,
+                    e.Aliases ?? [],
+                    info?.DisplayName ?? string.Empty,
+                    info?.Description ?? string.Empty);
+            })];
+    }
+
+    private static NuGetVersion ParseVersion(string raw) =>
+        NuGetVersion.TryParse(raw, out NuGetVersion? v) ? v : new NuGetVersion(0, 0, 0);
+
+    /// <summary>
+    /// Row projection used for both the table and JSON output. Property
+    /// names are camelCased by the JSON serializer.
+    /// </summary>
+    internal sealed record ListRow(
+        string PackageId,
+        string PackageVersion,
+        IReadOnlyList<string> Aliases,
+        string DisplayName,
+        string Description);
+
+    private sealed class PackageVersionKeyComparer : IEqualityComparer<(string PackageId, string Version)>
+    {
+        public bool Equals((string PackageId, string Version) x, (string PackageId, string Version) y) =>
+            string.Equals(x.PackageId, y.PackageId, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(x.Version, y.Version, StringComparison.Ordinal);
+
+        public int GetHashCode((string PackageId, string Version) obj) =>
+            HashCode.Combine(
+                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.PackageId),
+                StringComparer.Ordinal.GetHashCode(obj.Version));
     }
 }
+

--- a/src/Func/Commands/Workload/WorkloadPruneCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadPruneCommand.cs
@@ -1,0 +1,127 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Workloads.Install;
+using Azure.Functions.Cli.Workloads.Storage;
+using NuGet.Versioning;
+
+namespace Azure.Functions.Cli.Commands.Workload;
+
+/// <summary>
+/// <c>func workload prune [&lt;id&gt;] [--exact|-e]</c>. Removes inactive
+/// side-by-side installs per spec §4.1: for each in-scope <c>packageId</c>,
+/// keeps the highest installed version and uninstalls every older
+/// version. Local-only; never touches the catalog.
+/// </summary>
+internal sealed class WorkloadPruneCommand : FuncCliCommand
+{
+    private readonly IInteractionService _interaction;
+    private readonly IWorkloadInstaller _installer;
+    private readonly IWorkloadStore _store;
+
+    public Argument<string?> WorkloadArgument { get; } = new("id")
+    {
+        Arity = ArgumentArity.ZeroOrOne,
+        Description = "Workload package id or alias to prune. Default: prune every installed workload.",
+    };
+
+    public Option<bool> ExactOption { get; } = new("--exact", "-e")
+    {
+        Description = "Disable alias matching. <id> must be the literal package id.",
+    };
+
+    public WorkloadPruneCommand(
+        IInteractionService interaction,
+        IWorkloadInstaller installer,
+        IWorkloadStore store)
+        : base("prune", "Remove inactive side-by-side workload installs.")
+    {
+        _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
+        _installer = installer ?? throw new ArgumentNullException(nameof(installer));
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+
+        WorkloadArgument.AddOptionalIdValidator();
+
+        Arguments.Add(WorkloadArgument);
+        Options.Add(ExactOption);
+    }
+
+    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        string? identifier = parseResult.GetValue(WorkloadArgument);
+        bool exact = parseResult.GetValue(ExactOption);
+
+        IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
+        if (installed.Count == 0)
+        {
+            _interaction.WriteHint("No workloads installed.");
+            return 0;
+        }
+
+        IReadOnlyList<WorkloadEntry> scoped = ScopeToTarget(installed, identifier, exact);
+        if (scoped.Count == 0)
+        {
+            _interaction.WriteWarning(
+                $"Workload '{identifier}' is not installed; nothing to prune.");
+            return 0;
+        }
+
+        // Group by canonical package id so an alias that maps to one
+        // package doesn't accidentally prune another. Within each group
+        // keep the highest installable semver and remove the rest.
+        IEnumerable<IGrouping<string, WorkloadEntry>> byPackageId = scoped
+            .GroupBy(e => e.PackageId, StringComparer.OrdinalIgnoreCase);
+
+        int removedCount = 0;
+        foreach (IGrouping<string, WorkloadEntry> group in byPackageId)
+        {
+            List<WorkloadEntry> ordered = [.. group.OrderByDescending(e => ParseVersion(e.PackageVersion))];
+            if (ordered.Count <= 1)
+            {
+                continue;
+            }
+
+            // Skip ordered[0] (the highest version), uninstall the rest.
+            for (int i = 1; i < ordered.Count; i++)
+            {
+                WorkloadEntry candidate = ordered[i];
+                bool removed = await _installer.UninstallAsync(
+                    candidate.PackageId, candidate.PackageVersion, cancellationToken);
+                if (removed)
+                {
+                    removedCount++;
+                    _interaction.WriteSuccess(
+                        $"Pruned workload '{candidate.PackageId}' version '{candidate.PackageVersion}'.");
+                }
+            }
+        }
+
+        if (removedCount == 0)
+        {
+            _interaction.WriteHint("Nothing to prune; only one version installed per workload.");
+        }
+
+        return 0;
+    }
+
+    private static IReadOnlyList<WorkloadEntry> ScopeToTarget(
+        IReadOnlyList<WorkloadEntry> installed,
+        string? identifier,
+        bool exact)
+    {
+        if (string.IsNullOrWhiteSpace(identifier))
+        {
+            return installed;
+        }
+
+        return [.. installed.Where(e =>
+            string.Equals(e.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
+            || (!exact && (e.Aliases?.Any(a => string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)) ?? false)))];
+    }
+
+    private static NuGetVersion ParseVersion(string raw) =>
+        NuGetVersion.TryParse(raw, out NuGetVersion? v) ? v : new NuGetVersion(0, 0, 0);
+}

--- a/src/Func/Commands/Workload/WorkloadSearchCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadSearchCommand.cs
@@ -37,6 +37,11 @@ internal sealed class WorkloadSearchCommand : FuncCliCommand
         Description = "Include prerelease versions in the results.",
     };
 
+    public Option<bool> JsonOption { get; } = new("--json")
+    {
+        Description = "Emit machine-readable JSON instead of a table.",
+    };
+
     public WorkloadSearchCommand(IInteractionService interaction, IWorkloadCatalog catalog)
         : base("search", "Search the workload catalog.")
     {
@@ -46,6 +51,7 @@ internal sealed class WorkloadSearchCommand : FuncCliCommand
         Arguments.Add(QueryArgument);
         Options.Add(SourceOption);
         Options.Add(IncludePrereleaseOption);
+        Options.Add(JsonOption);
     }
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
@@ -53,6 +59,7 @@ internal sealed class WorkloadSearchCommand : FuncCliCommand
         string? query = parseResult.GetValue(QueryArgument);
         string? source = parseResult.GetValue(SourceOption);
         bool includePrerelease = parseResult.GetValue(IncludePrereleaseOption);
+        bool json = parseResult.GetValue(JsonOption);
 
         // TODO: surface --skip and --take for paging once we have a UX
         // story for repeated queries (see workload spec §4.1).
@@ -72,6 +79,19 @@ internal sealed class WorkloadSearchCommand : FuncCliCommand
         catch (ArgumentException ex)
         {
             throw new GracefulException(ex.Message, isUserError: true);
+        }
+
+        if (json)
+        {
+            _interaction.WriteJson(results.Select(r => new
+            {
+                packageId = r.PackageId,
+                latestVersion = r.LatestVersion.ToNormalizedString(),
+                title = r.Title,
+                description = r.Description,
+                aliases = r.Aliases,
+            }));
+            return 0;
         }
 
         if (results.Count == 0)

--- a/src/Func/Console/IInteractionService.cs
+++ b/src/Func/Console/IInteractionService.cs
@@ -75,6 +75,14 @@ internal interface IInteractionService
     /// <summary>Writes a bordered data table.</summary>
     public void WriteTable(string[] columns, IEnumerable<string[]> rows);
 
+    /// <summary>
+    /// Serializes <paramref name="value"/> to indented JSON and writes it to
+    /// stdout as a single block. Intended for the <c>--json</c> flag on
+    /// commands that surface machine-readable output. Bypasses theming
+    /// because JSON is data, not styled text.
+    /// </summary>
+    public void WriteJson(object value);
+
     /// <summary>Displays a status spinner while executing an async operation.</summary>
     public Task<T> ShowStatusAsync<T>(string statusMessage, Func<CancellationToken, Task<T>> action, CancellationToken cancellationToken = default);
 

--- a/src/Func/Console/SpectreInteractionService.cs
+++ b/src/Func/Console/SpectreInteractionService.cs
@@ -117,6 +117,23 @@ internal class SpectreInteractionService : IInteractionService
         _stdout.Write(table);
     }
 
+    public void WriteJson(object value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        // Bypass _stdout (which would re-render via Spectre) and write the
+        // raw JSON directly so consumers piping `--json` get clean output.
+        string json = System.Text.Json.JsonSerializer.Serialize(value, _jsonOptions);
+        System.Console.Out.WriteLine(json);
+    }
+
+    private static readonly System.Text.Json.JsonSerializerOptions _jsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
     public async Task<T> ShowStatusAsync<T>(string statusMessage, Func<CancellationToken, Task<T>> action, CancellationToken cancellationToken = default)
     {
         if (!IsInteractive)

--- a/src/Func/Hosting/BuiltInCommands.cs
+++ b/src/Func/Hosting/BuiltInCommands.cs
@@ -42,6 +42,7 @@ internal static class BuiltInCommands
         services.AddSingleton<WorkloadUninstallCommand>();
         services.AddSingleton<WorkloadUpdateCommand>();
         services.AddSingleton<WorkloadSearchCommand>();
+        services.AddSingleton<WorkloadPruneCommand>();
         services.AddSingleton<FuncCliCommand, WorkloadCommand>();
 
         return services;

--- a/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
@@ -20,11 +20,12 @@ public class WorkloadInstallCommandTests
 {
     private readonly TestInteractionService _interaction = new();
     private readonly IWorkloadInstaller _installer = Substitute.For<IWorkloadInstaller>();
+    private readonly IWorkloadStore _store = Substitute.For<IWorkloadStore>();
 
     [Fact]
     public void Install_HasExpectedArgsAndOptions()
     {
-        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
         Assert.Single(cmd.Arguments, a => a.Name == "id");
         Assert.Contains(cmd.Options, o => o.Name == "--force");
         Assert.Contains(cmd.Options, o => o.Name == "--version");
@@ -37,7 +38,7 @@ public class WorkloadInstallCommandTests
     {
         StubCatalogResult();
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
         int exit = await InvokeAsync(cmd, "Test.Workload");
 
         Assert.Equal(0, exit);
@@ -50,7 +51,7 @@ public class WorkloadInstallCommandTests
     {
         StubCatalogResult();
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
         int exit = await InvokeAsync(
             cmd,
             "Test.Workload",
@@ -76,7 +77,7 @@ public class WorkloadInstallCommandTests
     {
         StubCatalogResult();
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
         int exit = await InvokeAsync(cmd, "Test.Workload", "-v", "1.2.3", "-f");
 
         Assert.Equal(0, exit);
@@ -95,7 +96,7 @@ public class WorkloadInstallCommandTests
     {
         StubCatalogResult();
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
         int exit = await InvokeAsync(cmd, "test.workload", "-e");
 
         Assert.Equal(0, exit);
@@ -110,7 +111,7 @@ public class WorkloadInstallCommandTests
         // handles it. The CLI does not special-case paths.
         StubCatalogResult();
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
         int exit = await InvokeAsync(cmd, "Test.Workload", "--source", "/tmp/local-feed");
 
         Assert.Equal(0, exit);
@@ -121,7 +122,7 @@ public class WorkloadInstallCommandTests
     [Fact]
     public void Install_InvalidVersion_FailsValidation()
     {
-        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
         var root = new RootCommand();
         root.Subcommands.Add(cmd);
 
@@ -134,7 +135,7 @@ public class WorkloadInstallCommandTests
     [Fact]
     public void Install_MissingPackageArg_FailsValidation()
     {
-        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
         var root = new RootCommand();
         root.Subcommands.Add(cmd);
 
@@ -146,7 +147,7 @@ public class WorkloadInstallCommandTests
     [Fact]
     public void Install_WhitespaceArg_FailsValidation()
     {
-        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
         var root = new RootCommand();
         root.Subcommands.Add(cmd);
 
@@ -161,7 +162,7 @@ public class WorkloadInstallCommandTests
     {
         StubCatalogResult(alreadyInstalled: true);
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
         int exit = await InvokeAsync(cmd, "Test.Workload");
 
         Assert.Equal(0, exit);
@@ -188,7 +189,7 @@ public class WorkloadInstallCommandTests
                 },
                 AlreadyInstalled: false));
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
         int exit = await InvokeAsync(cmd, "test.content");
 
         Assert.Equal(0, exit);
@@ -208,7 +209,7 @@ public class WorkloadInstallCommandTests
             .Throws(new AmbiguousPackageMatchException(
                 "myalias", new[] { "Pkg.A", "Pkg.B" }));
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
         GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
             () => InvokeAsync(cmd, "myalias"));
         Assert.Contains("myalias", ex.Message);
@@ -224,7 +225,7 @@ public class WorkloadInstallCommandTests
                 Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Throws(new WorkloadPackageNotFoundException("not on any source"));
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
         GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
             () => InvokeAsync(cmd, "Test.Workload"));
         Assert.Contains("not on any source", ex.Message);
@@ -239,7 +240,7 @@ public class WorkloadInstallCommandTests
                 Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Throws(new InvalidWorkloadException("bad package"));
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
         GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
             () => InvokeAsync(cmd, "Test.Workload"));
         Assert.Equal("bad package", ex.Message);
@@ -255,7 +256,7 @@ public class WorkloadInstallCommandTests
             .Throws(new InvalidOperationException(
                 "Workload 'x' version '1' is already installed at '/p' but is missing from the registry."));
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
         GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
             () => InvokeAsync(cmd, "Test.Workload"));
         Assert.Contains("missing from the registry", ex.Message);
@@ -271,7 +272,7 @@ public class WorkloadInstallCommandTests
                 Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Throws(new NullReferenceException("oops"));
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer);
+        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
         await Assert.ThrowsAsync<NullReferenceException>(
             () => InvokeAsync(cmd, "Test.Workload"));
     }
@@ -293,7 +294,7 @@ public class WorkloadInstallCommandTests
                     },
                     AlreadyInstalled: false));
 
-            var cmd = new WorkloadInstallCommand(_interaction, _installer);
+            var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
             int exit = await InvokeAsync(cmd, tempPkg);
 
             Assert.Equal(0, exit);
@@ -306,6 +307,96 @@ public class WorkloadInstallCommandTests
         {
             File.Delete(tempPkg);
         }
+    }
+
+    [Fact]
+    public async Task Install_AlreadyInstalled_NonInteractive_ReturnsOneAndDoesNotInstall()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(new[]
+        {
+            new WorkloadEntry
+            {
+                PackageId = "Test.Workload",
+                PackageVersion = "1.0.0",
+                Aliases = ["test"],
+            },
+        });
+
+        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
+        int exit = await InvokeAsync(cmd, "Test.Workload");
+
+        Assert.Equal(1, exit);
+        await _installer.DidNotReceive().InstallFromCatalogAsync(
+            Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
+            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        Assert.Contains(_interaction.Lines, l =>
+            l.StartsWith("HINT:") && l.Contains("func workload update Test.Workload"));
+    }
+
+    [Fact]
+    public async Task Install_AlreadyInstalled_AliasMatch_NonInteractive_HintsCanonicalId()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(new[]
+        {
+            new WorkloadEntry
+            {
+                PackageId = "Test.Workload",
+                PackageVersion = "1.2.3",
+                Aliases = ["alias1"],
+            },
+        });
+
+        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
+        int exit = await InvokeAsync(cmd, "alias1");
+
+        Assert.Equal(1, exit);
+        Assert.Contains(_interaction.Lines, l =>
+            l.StartsWith("HINT:") && l.Contains("Test.Workload") && l.Contains("1.2.3"));
+    }
+
+    [Fact]
+    public async Task Install_AlreadyInstalled_ExactSkipsAliasMatch_ProceedsToInstall()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(new[]
+        {
+            new WorkloadEntry
+            {
+                PackageId = "Test.Workload",
+                PackageVersion = "1.0.0",
+                Aliases = ["alias1"],
+            },
+        });
+        StubCatalogResult();
+
+        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
+        int exit = await InvokeAsync(cmd, "alias1", "--exact");
+
+        Assert.Equal(0, exit);
+        await _installer.Received(1).InstallFromCatalogAsync(
+            "alias1", null, null, false, true, false, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Install_AlreadyInstalled_ForceSkipsPromptAndInstalls()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(new[]
+        {
+            new WorkloadEntry
+            {
+                PackageId = "Test.Workload",
+                PackageVersion = "1.0.0",
+                Aliases = ["test"],
+            },
+        });
+        StubCatalogResult();
+
+        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
+        int exit = await InvokeAsync(cmd, "Test.Workload", "--force");
+
+        Assert.Equal(0, exit);
+        await _installer.Received(1).InstallFromCatalogAsync(
+            "Test.Workload", null, null, false, false, true, Arg.Any<CancellationToken>());
+        await _store.DidNotReceive().GetWorkloadsAsync(Arg.Any<CancellationToken>());
     }
 
     private void StubCatalogResult(bool alreadyInstalled = false) =>

--- a/test/Func.Tests/Commands/Workload/WorkloadListCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadListCommandTests.cs
@@ -4,6 +4,7 @@
 using System.CommandLine;
 using Azure.Functions.Cli.Commands.Workload;
 using Azure.Functions.Cli.Workloads;
+using Azure.Functions.Cli.Workloads.Storage;
 using NSubstitute;
 using Xunit;
 
@@ -16,7 +17,7 @@ public class WorkloadListCommandTests
     [Fact]
     public async Task EmptyList_WritesNoWorkloadsHint_ReturnsZero()
     {
-        var cmd = new WorkloadListCommand(_interaction, Provider());
+        var cmd = new WorkloadListCommand(_interaction, Provider(), Substitute.For<IWorkloadStore>());
         int exit = await InvokeAsync(cmd);
 
         Assert.Equal(0, exit);
@@ -36,7 +37,7 @@ public class WorkloadListCommandTests
                 aliases: ["dotnet", "dotnet-isolated"]),
         };
 
-        var cmd = new WorkloadListCommand(_interaction, Provider(workloads));
+        var cmd = new WorkloadListCommand(_interaction, Provider(workloads), Substitute.For<IWorkloadStore>());
         int exit = await InvokeAsync(cmd);
 
         Assert.Equal(0, exit);
@@ -58,7 +59,7 @@ public class WorkloadListCommandTests
                 aliases: []),
         };
 
-        var cmd = new WorkloadListCommand(_interaction, Provider(workloads));
+        var cmd = new WorkloadListCommand(_interaction, Provider(workloads), Substitute.For<IWorkloadStore>());
         await InvokeAsync(cmd);
 
         string rowLine = _interaction.Lines.Single(l => l.StartsWith("  ROW:"));
@@ -76,11 +77,87 @@ public class WorkloadListCommandTests
             NewInfo(new FakeWorkload(), "Pkg.A", "1.1.0", []),
         };
 
-        var cmd = new WorkloadListCommand(_interaction, Provider(workloads));
+        var cmd = new WorkloadListCommand(_interaction, Provider(workloads), Substitute.For<IWorkloadStore>());
         await InvokeAsync(cmd);
 
         var rows = _interaction.Lines.Where(l => l.StartsWith("  ROW:")).ToList();
         Assert.Equal(3, rows.Count);
+    }
+
+    [Fact]
+    public async Task List_Json_EmitsLoadedRowsAsJson()
+    {
+        var workloads = new[]
+        {
+            NewInfo(
+                instance: new FakeWorkload(displayName: ".NET", description: "C#"),
+                packageId: "Azure.Functions.Cli.Workload.Dotnet",
+                packageVersion: "1.0.0",
+                aliases: ["dotnet"]),
+        };
+
+        var cmd = new WorkloadListCommand(_interaction, Provider(workloads), Substitute.For<IWorkloadStore>());
+        int exit = await InvokeAsync(cmd, "--json");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain(_interaction.Lines, l => l.StartsWith("TABLE:"));
+        string jsonLine = _interaction.Lines.Single(l => l.StartsWith("JSON:"));
+        Assert.Contains("\"packageId\":\"Azure.Functions.Cli.Workload.Dotnet\"", jsonLine);
+        Assert.Contains("\"packageVersion\":\"1.0.0\"", jsonLine);
+    }
+
+    [Fact]
+    public async Task List_AllVersions_PullsFromStoreAndSortsDescending()
+    {
+        var loaded = new[]
+        {
+            NewInfo(
+                instance: new FakeWorkload(displayName: ".NET", description: "C#"),
+                packageId: "Pkg.A",
+                packageVersion: "2.0.0",
+                aliases: ["a"]),
+        };
+
+        var entries = new[]
+        {
+            new global::Azure.Functions.Cli.Workloads.Storage.WorkloadEntry
+            {
+                PackageId = "Pkg.A",
+                PackageVersion = "1.0.0",
+                Aliases = ["a"],
+            },
+            new global::Azure.Functions.Cli.Workloads.Storage.WorkloadEntry
+            {
+                PackageId = "Pkg.A",
+                PackageVersion = "2.0.0",
+                Aliases = ["a"],
+            },
+        };
+
+        var store = Substitute.For<global::Azure.Functions.Cli.Workloads.Storage.IWorkloadStore>();
+        store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(entries);
+
+        var cmd = new WorkloadListCommand(_interaction, Provider(loaded), store);
+        int exit = await InvokeAsync(cmd, "--all-versions");
+
+        Assert.Equal(0, exit);
+        var rows = _interaction.Lines.Where(l => l.StartsWith("  ROW:")).ToList();
+        Assert.Equal(2, rows.Count);
+        // Highest version first; loaded info populates DisplayName/Description.
+        Assert.Contains("2.0.0", rows[0]);
+        Assert.Contains(".NET", rows[0]);
+        Assert.Contains("1.0.0", rows[1]);
+        // Older side-by-side has no loaded info; placeholder used.
+        Assert.Contains(", -, -, ", rows[1]);
+    }
+
+    [Fact]
+    public async Task List_HasJsonAndAllVersionsOptions()
+    {
+        var cmd = new WorkloadListCommand(_interaction, Provider(), Substitute.For<IWorkloadStore>());
+        Assert.Contains(cmd.Options, o => o.Name == "--json");
+        Assert.Contains(cmd.Options, o => o.Name == "--all-versions");
+        await Task.CompletedTask;
     }
 
     private static IWorkloadProvider Provider(params WorkloadInfo[] workloads)

--- a/test/Func.Tests/Commands/Workload/WorkloadPruneCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadPruneCommandTests.cs
@@ -1,0 +1,154 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Commands.Workload;
+using Azure.Functions.Cli.Workloads.Install;
+using Azure.Functions.Cli.Workloads.Storage;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Commands.Workload;
+
+public class WorkloadPruneCommandTests
+{
+    private readonly TestInteractionService _interaction = new();
+    private readonly IWorkloadInstaller _installer = Substitute.For<IWorkloadInstaller>();
+    private readonly IWorkloadStore _store = Substitute.For<IWorkloadStore>();
+
+    [Fact]
+    public void Prune_HasExpectedArgsAndOptions()
+    {
+        var cmd = new WorkloadPruneCommand(_interaction, _installer, _store);
+        Assert.Single(cmd.Arguments, a => a.Name == "id");
+        Assert.Contains(cmd.Options, o => o.Name == "--exact");
+    }
+
+    [Fact]
+    public async Task Prune_EmptyStore_HintsAndReturnsZero()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(Array.Empty<WorkloadEntry>());
+
+        var cmd = new WorkloadPruneCommand(_interaction, _installer, _store);
+        int exit = await InvokeAsync(cmd);
+
+        Assert.Equal(0, exit);
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("HINT:") && l.Contains("No workloads installed"));
+        await _installer.DidNotReceive().UninstallAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Prune_SingleVersionPerPackage_NoOpHint()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(new[]
+        {
+            new WorkloadEntry { PackageId = "Pkg.A", PackageVersion = "1.0.0" },
+            new WorkloadEntry { PackageId = "Pkg.B", PackageVersion = "2.0.0" },
+        });
+
+        var cmd = new WorkloadPruneCommand(_interaction, _installer, _store);
+        int exit = await InvokeAsync(cmd);
+
+        Assert.Equal(0, exit);
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("HINT:") && l.Contains("Nothing to prune"));
+        await _installer.DidNotReceive().UninstallAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Prune_KeepsHighestVersion_RemovesOlderSideBySide()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(new[]
+        {
+            new WorkloadEntry { PackageId = "Pkg.A", PackageVersion = "1.0.0" },
+            new WorkloadEntry { PackageId = "Pkg.A", PackageVersion = "2.0.0" },
+            new WorkloadEntry { PackageId = "Pkg.A", PackageVersion = "1.5.0" },
+        });
+        _installer.UninstallAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var cmd = new WorkloadPruneCommand(_interaction, _installer, _store);
+        int exit = await InvokeAsync(cmd);
+
+        Assert.Equal(0, exit);
+        await _installer.Received(1).UninstallAsync("Pkg.A", "1.5.0", Arg.Any<CancellationToken>());
+        await _installer.Received(1).UninstallAsync("Pkg.A", "1.0.0", Arg.Any<CancellationToken>());
+        await _installer.DidNotReceive().UninstallAsync("Pkg.A", "2.0.0", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Prune_ScopedById_OnlyTouchesThatPackage()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(new[]
+        {
+            new WorkloadEntry { PackageId = "Pkg.A", PackageVersion = "1.0.0" },
+            new WorkloadEntry { PackageId = "Pkg.A", PackageVersion = "2.0.0" },
+            new WorkloadEntry { PackageId = "Pkg.B", PackageVersion = "1.0.0" },
+            new WorkloadEntry { PackageId = "Pkg.B", PackageVersion = "2.0.0" },
+        });
+        _installer.UninstallAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var cmd = new WorkloadPruneCommand(_interaction, _installer, _store);
+        int exit = await InvokeAsync(cmd, "Pkg.A");
+
+        Assert.Equal(0, exit);
+        await _installer.Received(1).UninstallAsync("Pkg.A", "1.0.0", Arg.Any<CancellationToken>());
+        await _installer.DidNotReceive().UninstallAsync("Pkg.B", Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Prune_ScopedByAlias_MatchesAlias()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(new[]
+        {
+            new WorkloadEntry { PackageId = "Pkg.A", PackageVersion = "1.0.0", Aliases = ["a"] },
+            new WorkloadEntry { PackageId = "Pkg.A", PackageVersion = "2.0.0", Aliases = ["a"] },
+        });
+        _installer.UninstallAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var cmd = new WorkloadPruneCommand(_interaction, _installer, _store);
+        int exit = await InvokeAsync(cmd, "a");
+
+        Assert.Equal(0, exit);
+        await _installer.Received(1).UninstallAsync("Pkg.A", "1.0.0", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Prune_Exact_DoesNotMatchAlias()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(new[]
+        {
+            new WorkloadEntry { PackageId = "Pkg.A", PackageVersion = "1.0.0", Aliases = ["a"] },
+            new WorkloadEntry { PackageId = "Pkg.A", PackageVersion = "2.0.0", Aliases = ["a"] },
+        });
+
+        var cmd = new WorkloadPruneCommand(_interaction, _installer, _store);
+        int exit = await InvokeAsync(cmd, "a", "--exact");
+
+        Assert.Equal(0, exit);
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("WARNING:") && l.Contains("'a' is not installed"));
+        await _installer.DidNotReceive().UninstallAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Prune_WhitespaceArg_FailsValidation()
+    {
+        var cmd = new WorkloadPruneCommand(_interaction, _installer, _store);
+        int exit = await InvokeAsync(cmd, "   ");
+
+        Assert.NotEqual(0, exit);
+        await _store.DidNotReceive().GetWorkloadsAsync(Arg.Any<CancellationToken>());
+    }
+
+    private static Task<int> InvokeAsync(WorkloadPruneCommand cmd, params string[] args)
+    {
+        var root = new RootCommand();
+        root.Subcommands.Add(cmd);
+        var config = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
+        return root.Parse(new[] { cmd.Name }.Concat(args).ToArray()).InvokeAsync(config);
+    }
+}

--- a/test/Func.Tests/Commands/Workload/WorkloadSearchCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadSearchCommandTests.cs
@@ -151,6 +151,30 @@ public class WorkloadSearchCommandTests
         Assert.DoesNotContain(_interaction.Lines, l => l.Contains(longDesc));
     }
 
+    [Fact]
+    public async Task Search_JsonOption_EmitsJsonAndSkipsTable()
+    {
+        StubSearch(
+            new CatalogSearchResult(
+                "func.workload.python",
+                NuGetVersion.Parse("1.2.3"),
+                Title: "Python",
+                Description: "Python workload",
+                Aliases: ["python"],
+                Source: _stubSource));
+
+        var cmd = new WorkloadSearchCommand(_interaction, _catalog);
+        int exit = await InvokeAsync(cmd, "--json");
+
+        Assert.Equal(0, exit);
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("JSON:"));
+        Assert.DoesNotContain(_interaction.Lines, l => l.StartsWith("TABLE:"));
+        string jsonLine = _interaction.Lines.Single(l => l.StartsWith("JSON:"));
+        Assert.Contains("\"packageId\":\"func.workload.python\"", jsonLine);
+        Assert.Contains("\"latestVersion\":\"1.2.3\"", jsonLine);
+        Assert.Contains("\"aliases\":[\"python\"]", jsonLine);
+    }
+
     private void StubSearch(params CatalogSearchResult[] results)
     {
         _catalog.SearchAsync(Arg.Any<CatalogSearchQuery>(), Arg.Any<CancellationToken>())

--- a/test/Func.Tests/TestInteractionService.cs
+++ b/test/Func.Tests/TestInteractionService.cs
@@ -71,6 +71,19 @@ internal class TestInteractionService : IInteractionService
         }
     }
 
+    public void WriteJson(object value)
+    {
+        // Capture a normalized JSON projection so tests can assert structure
+        // without being sensitive to indentation.
+        string json = System.Text.Json.JsonSerializer.Serialize(value, new System.Text.Json.JsonSerializerOptions
+        {
+            WriteIndented = false,
+            PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        });
+        _lines.Add($"JSON: {json}");
+    }
+
     // --- Interactive ---
 
     public async Task<T> ShowStatusAsync<T>(string statusMessage, Func<CancellationToken, Task<T>> action, CancellationToken cancellationToken = default)


### PR DESCRIPTION
Stacked on top of #4954 (`liliankasem/feat/workload-catalog-consumers`). Closes the spec §4.1 gaps that the validation audit flagged as out of scope.

## Changes

### `func workload prune` (new command)
For each in-scope `packageId`, keeps the highest installed semver and uninstalls every older side-by-side version. Local-only, never touches the catalog.

```
func workload prune [<id>] [--exact|-e]
```

### `--json` on `list` and `search`
Bypasses Spectre and writes raw JSON via a new `IInteractionService.WriteJson(object)` method so output piped to `jq` isn't decorated. Camel-cased property names; nulls omitted.

### `list --all-versions|-a` plus loaded-only default
- Default `list` now shows only the loaded version per workload (highest installed semver).
- `--all-versions` pulls every entry from `IWorkloadStore`, sorted by package id ascending then version descending. Older side-by-side rows fall back to `-` for Display Name / Description (no loaded info).

### `install` "already installed" prompt
Per spec §4.1: when any version of `<package>` is already installed and `--force` is not passed, prompt the user to use `update` instead.

- **Interactive**: prompt with default `yes` (use update). On confirm: exit 1 with hint. On decline: fall through to install (may go side-by-side).
- **Non-interactive** (CI / pipes): exit 1 with the same hint, no prompt.
- `--force` skips the check entirely; `--exact` scopes the lookup to the literal package id.

### Tests
16 new tests under `test/Func.Tests/Commands/Workload/`. Full suite: 301/301 pass.

## Notes on AGENTS.md exception policy
The broad `InvalidOperationException` catches in `install`/`update` were re-evaluated against AGENTS.md and judged acceptable: each call site's xmldoc documents the exception as a user-facing failure mode, satisfying the "narrow `try` + documented" rule. No catches were widened or narrowed in this PR.
