### PR TITLE
Bump pip publish-tools dependencies

### DIFF
--- a/eng/tools/publish-tools/requirements.txt
+++ b/eng/tools/publish-tools/requirements.txt
@@ -1,3 +1,3 @@
 distro~=1.6.0
-requests~=2.33.0
+requests~=2.34.2
 wget~=3.2

--- a/eng/tools/publish-tools/requirements.txt
+++ b/eng/tools/publish-tools/requirements.txt
@@ -1,3 +1,3 @@
-distro~=1.6.0
+distro~=1.9.0
 requests~=2.33.0
 wget~=3.2


### PR DESCRIPTION
Consolidates 2 dependabot PRs (pip requirements under `eng/tools/publish-tools/`).

- distro: ~=1.6.0 -> ~=1.9.0 (#4969)
- requests: ~=2.33.0 -> ~=2.34.2 (#4968)

Closes #4969, #4968.