### PR TITLE
Group dependabot updates by ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,15 @@
 version: 2
+
+# Grouping strategy:
+# - Each ecosystem produces ONE PR for all minor + patch updates per week.
+# - Major version bumps stay as individual PRs so they can be reviewed and
+#   merged on their own (they often require code changes or coordination).
+# - A few NuGet sub-groups stay separate (workers, microsoft-bcl,
+#   opentelemetry) because they want to be bumped together regardless of
+#   semver level.
+# - Security updates are surfaced via the Security tab regardless of
+#   grouping; the weekly cadence here is for routine version drift PRs.
+
 updates:
   - package-ecosystem: "dotnet-sdk"
     directory: "/"
@@ -7,13 +18,10 @@ updates:
       day: "wednesday"
     ignore:
       - dependency-name: "*"
-        update-types: 
+        update-types:
           - "version-update:semver-major"
           - "version-update:semver-minor"
 
-  # NuGet packages (transitives included via central package management).
-  # Security advisories are surfaced through the Security tab regardless of schedule;
-  # the weekly cadence is for routine version drift PRs.
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:
@@ -21,46 +29,85 @@ updates:
       day: "wednesday"
     open-pull-requests-limit: 10
     groups:
-      powershell-workers:
+      # Workers are bumped together (and tied to host bumps); group all
+      # semver levels here.
+      workers:
         patterns:
+          - "Microsoft.Azure.Functions.JavaWorker"
+          - "Microsoft.Azure.Functions.NodeJsWorker"
           - "Microsoft.Azure.Functions.PowerShellWorker.*"
+          - "Microsoft.Azure.Functions.PythonWorker"
       opentelemetry:
         patterns:
           - "OpenTelemetry*"
           - "Azure.Monitor.OpenTelemetry.*"
+      # BCL/runtime packages are versioned together (e.g. .NET 9 -> 10);
+      # group all semver levels.
       microsoft-bcl:
         patterns:
           - "Microsoft.Extensions.*"
           - "System.*"
+      # Catch-all: every remaining NuGet package, minor + patch only.
+      # Major bumps fall through and get individual PRs.
+      nuget-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
-  # Publish-tooling npm package (eng/tools/publish-tools/npm).
   - package-ecosystem: "npm"
     directory: "/eng/tools/publish-tools/npm"
     schedule:
       interval: "weekly"
       day: "wednesday"
     open-pull-requests-limit: 5
+    groups:
+      npm-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
-  # Publish-tooling Python requirements.
   - package-ecosystem: "pip"
     directory: "/eng/tools/publish-tools"
     schedule:
       interval: "weekly"
       day: "wednesday"
     open-pull-requests-limit: 5
+    groups:
+      pip-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
-  # Container base image.
   - package-ecosystem: "docker"
     directory: "/docker"
     schedule:
       interval: "weekly"
       day: "wednesday"
     open-pull-requests-limit: 5
+    groups:
+      docker-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
-  # GitHub Actions workflow versions.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "wednesday"
     open-pull-requests-limit: 5
+    groups:
+      github-actions-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Cuts down the per-week dependabot PR volume by grouping minor + patch updates into a single PR per ecosystem. Major version bumps still get their own PRs so they can be reviewed and merged independently (they often need code changes or coordination with other repos, e.g. host).

### What changes

- **NuGet**: existing topical groups (`workers`, `microsoft-bcl`, `opentelemetry`) are kept and `workers` is widened to cover all worker packages (Java, NodeJs, PowerShell, Python). A new `nuget-minor-and-patch` catch-all groups every other NuGet package's minor + patch updates into one PR. Majors fall through to individual PRs.
- **npm** (`eng/tools/publish-tools/npm`): new `npm-minor-and-patch` group.
- **pip** (`eng/tools/publish-tools`): new `pip-minor-and-patch` group.
- **docker** (`/docker`): new `docker-minor-and-patch` group.
- **github-actions** (`/`): new `github-actions-minor-and-patch` group.

### Effect on weekly PR volume

This week we had 20 individual dependabot PRs. Under this config that would have been roughly:
- 1 NuGet minor/patch PR
- 1 NuGet `workers` PR (covering NodeJsWorker + PowerShell workers)
- 1 NuGet `microsoft-bcl` PR
- ~4 NuGet major PRs (Autofac, FluentAssertions, ApplicationInsights, AspNetCore.DataProtection)
- 1 npm minor/patch PR + 1-2 npm major PRs
- 1 pip PR
- 1 github-actions PR (5 actions in one)

So roughly ~10 PRs instead of 20, with the high-risk majors still surfaced individually.

### Notes

- Security advisories are surfaced via the Security tab regardless of grouping; this only affects the routine version-drift cadence.
- `dotnet-sdk` updates remain ungrouped (only patch updates ever pass its `ignore` filter, so grouping adds no value).