### PR TITLE
Scaffold Python workload + shared workload CI templates

### DIFF
--- a/.github/skills/create-workload/SKILL.md
+++ b/.github/skills/create-workload/SKILL.md
@@ -74,6 +74,7 @@ Create the following files:
 
   - Initial scaffold of the <Name> workload (entry point + stub project initializer).
   ```
+- [ ] `README.md` next to the csproj. `Release.props` auto-includes it as `<PackageReadmeFile>` (and the Functions icon as `<PackageIcon>`), so both surface on NuGet feeds. Describe the workload's purpose, supported languages, and any prerequisites.
 - [ ] `workload.json`, the entry-point manifest packed at the package root. `assemblyPath` is relative to `tools/any/` (bare filename; no leading `/`, no `..`); `type` is the FQN of the `Workload` subclass:
   ```json
   {

--- a/Azure.Functions.Cli.slnx
+++ b/Azure.Functions.Cli.slnx
@@ -7,9 +7,11 @@
   <Folder Name="/src/">
     <Project Path="src/Abstractions/Abstractions.csproj" />
     <Project Path="src/Func/Func.csproj" />
+    <Project Path="src/Workload/Python/Workload.Python.csproj" />
   </Folder>
   <Folder Name="/test/">
     <Project Path="test/Func.Tests/Func.Tests.csproj" />
+    <Project Path="test/Workload/Python.Tests/Workload.Python.Tests.csproj" />
     <Project Path="test/Workload.Tests.Fixtures.Default/Workload.Tests.Fixtures.Default.csproj" />
     <Project Path="test/Workload.Tests.Fixtures.Sdk/Workload.Tests.Fixtures.Sdk.csproj" />
     <Project Path="test/Workload.Tests.Fixtures.WithCommand/Workload.Tests.Fixtures.WithCommand.csproj" />

--- a/docs/building-a-workload.md
+++ b/docs/building-a-workload.md
@@ -62,7 +62,8 @@ The shape mirrors WebJobs' `IWebJobsStartup`. `Configure(FunctionsCliBuilder)` i
 3. Subclass `Workload` and override `DisplayName`, `Description`, and `Configure`
 4. Inside `Configure`, register an `IProjectInitializer`, an `IProjectDetector` (so the resolver can claim directories owned by your workload), and/or top-level commands via `builder.RegisterCommand(...)` plus any supporting services
 5. Add a `workload.json` next to your csproj describing the entry-point assembly and type
-6. Build, package, and install with `func workload install <path-to-nupkg>`
+6. Add a `README.md` next to the csproj — `Release.props` auto-includes it as `<PackageReadmeFile>` so it surfaces on NuGet feeds and in `func workload list`
+7. Build, package, and install with `func workload install <path-to-nupkg>`
 
 ## Step 1: Create the Project
 
@@ -151,6 +152,8 @@ Add a `workload.json` that points at your entry-point type. `assemblyPath` is **
   }
 }
 ```
+
+Add a `README.md` next to the csproj. `Release.props` auto-wires it as `<PackageReadmeFile>` (and the Functions icon as `<PackageIcon>`), so both surface on NuGet feeds without extra packing config. Use it to describe the workload's purpose, the language(s) it supports, and any prerequisites.
 
 ## Step 2: Subclass `Workload`
 
@@ -394,6 +397,7 @@ Use the Python pipelines (`eng/ci/workloads/python/{public,official}-build.yml`)
 
 - [ ] New project `src/Workload/<Name>/Workload.<Name>.csproj`, packs as `PackageType=FuncCliWorkload`, references `Abstractions` with `PrivateAssets=all` / `ExcludeAssets=runtime`
 - [ ] `Directory.Version.props` and `release_notes.md` next to the csproj
+- [ ] `README.md` next to the csproj (auto-packed by `Release.props` as `<PackageReadmeFile>`)
 - [ ] `workload.json` next to the csproj, listing the entry-point `assemblyPath` and `type`
 - [ ] Subclass of `Workload` with a parameterless constructor, overriding `DisplayName`, `Description`, and `Configure`
 - [ ] `Configure(FunctionsCliBuilder)` null-checks `builder` and registers an `IProjectInitializer` and/or top-level commands via `builder.RegisterCommand(...)`

--- a/eng/ci/templates/jobs/build-workload.yml
+++ b/eng/ci/templates/jobs/build-workload.yml
@@ -1,0 +1,81 @@
+parameters:
+- name: WorkloadProjectName
+  type: string
+- name: sign
+  type: boolean
+  default: false
+
+jobs:
+- job: build_workload_${{ parameters.WorkloadProjectName }}
+  displayName: Build Workload.${{ parameters.WorkloadProjectName }}
+
+  variables:
+  - template: /eng/ci/templates/variables/build.yml@self
+  - name: workload_project
+    readonly: true
+    value: src/Workload/${{ parameters.WorkloadProjectName }}/Workload.${{ parameters.WorkloadProjectName }}.csproj
+  - name: workload_tests
+    readonly: true
+    value: test/Workload/${{ parameters.WorkloadProjectName }}.Tests/Workload.${{ parameters.WorkloadProjectName }}.Tests.csproj
+  - name: pack_dir
+    readonly: true
+    value: $(Build.ArtifactStagingDirectory)/pkg
+
+  templateContext:
+    outputParentDirectory: $(Build.ArtifactStagingDirectory)
+    outputs:
+    - output: pipelineArtifact
+      displayName: Publish Workload Package
+      path: $(pack_dir)
+      artifact: drop_workload_${{ parameters.WorkloadProjectName }}
+
+  steps:
+    - template: /eng/ci/templates/steps/install-dotnet.yml@self
+
+    - task: DotNetCoreCLI@2
+      displayName: Restore
+      inputs:
+        command: custom
+        custom: restore
+        projects: $(workload_tests)
+        arguments: -v m
+
+    - task: DotNetCoreCLI@2
+      displayName: Build
+      inputs:
+        command: build
+        projects: $(workload_tests)
+        arguments: -c $(configuration) -v m --no-restore
+
+    - task: DotNetCoreCLI@2
+      displayName: Unit tests
+      inputs:
+        command: test
+        projects: $(workload_tests)
+        arguments: -c $(configuration) --no-build
+
+    - ${{ if eq(parameters.sign, true) }}:
+      - template: ci/sign-files.yml@eng
+        parameters:
+          displayName: Sign workload assembly
+          minimatch: true
+          signType: dll-strong-name
+          folderPath: out/bin/Workload.${{ parameters.WorkloadProjectName }}
+          pattern: |
+            **/Azure.Functions.Cli.Workload.${{ parameters.WorkloadProjectName }}.dll
+
+    - task: DotNetCoreCLI@2
+      displayName: Pack
+      inputs:
+        command: custom
+        custom: pack
+        projects: $(workload_project)
+        arguments: -c $(configuration) -v m -o $(pack_dir) --no-build
+
+    - ${{ if eq(parameters.sign, true) }}:
+      - template: ci/sign-files.yml@eng
+        parameters:
+          displayName: Sign workload nupkg
+          signType: nuget
+          folderPath: $(pack_dir)
+          pattern: '*.nupkg'

--- a/eng/ci/workloads/python/official-build.yml
+++ b/eng/ci/workloads/python/official-build.yml
@@ -1,0 +1,69 @@
+parameters:
+- name: sign
+  type: boolean
+  default: false
+
+schedules:
+- cron: "0 8 * * *"
+  displayName: Nightly Build
+  branches:
+    include:
+      - main
+      - vnext
+  always: true
+
+pr: none
+
+trigger:
+  branches:
+    include:
+    - main
+    - vnext
+    - feature/*
+    - release/*
+  paths:
+    include:
+    - src/Abstractions/
+    - src/Workload/Python/
+    - test/Workload/Python.Tests/
+    - eng/
+
+resources:
+  repositories:
+  - repository: 1es
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+  - repository: eng
+    type: git
+    name: engineering
+    ref: refs/tags/release
+
+variables:
+- template: /ci/variables/cfs.yml@eng
+- name: sign
+  readonly: true
+  ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/release/') }}:
+    value: true
+  ${{ else }}:
+    value: ${{ parameters.sign }}
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1es
+  parameters:
+    pool:
+      name: 1es-pool-azfunc
+      image: 1es-ubuntu-24.04-min
+      os: linux
+
+    sdl:
+      codeql:
+         runSourceLanguagesInSourceAnalysis: true
+
+    stages:
+      - stage: Build
+        jobs:
+        - template: /eng/ci/templates/jobs/build-workload.yml@self
+          parameters:
+            WorkloadProjectName: Python
+            sign: ${{ variables.sign }}

--- a/eng/ci/workloads/python/public-build.yml
+++ b/eng/ci/workloads/python/public-build.yml
@@ -1,0 +1,57 @@
+schedules:
+- cron: "0 7 * * *"
+  displayName: Nightly Build
+  branches:
+    include:
+      - main
+      - vnext
+  always: true
+
+trigger: none
+
+pr:
+  branches:
+    include:
+    - main
+    - vnext
+    - feature/*
+    - release/*
+  paths:
+    include:
+    - src/Abstractions/
+    - src/Workload/Python/
+    - test/Workload/Python.Tests/
+    - eng/
+
+resources:
+  repositories:
+  - repository: 1es
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1es
+  parameters:
+    pool:
+      name: 1es-pool-azfunc-public
+      image: 1es-ubuntu-24.04-min
+      os: linux
+
+    sdl:
+      sourceAnalysisPool:
+        name: 1es-pool-azfunc-public
+        image: 1es-windows-2022
+        os: windows
+
+    settings:
+      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+      networkIsolationPolicy: Preferred, NuGet
+
+    stages:
+      - stage: Build
+        jobs:
+        - template: /eng/ci/templates/jobs/build-workload.yml@self
+          parameters:
+            WorkloadProjectName: Python
+            sign: false

--- a/src/Workload/Python/Directory.Version.props
+++ b/src/Workload/Python/Directory.Version.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionSuffix>preview.1</VersionSuffix>
+  </PropertyGroup>
+</Project>

--- a/src/Workload/Python/PythonProjectInitializer.cs
+++ b/src/Workload/Python/PythonProjectInitializer.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Workloads;
+
+namespace Azure.Functions.Cli.Workload.Python;
+
+/// <summary>
+/// Stub <see cref="IProjectInitializer"/> for Python. Scaffolding logic
+/// lands in a follow-up PR; this only claims the stack so the host can
+/// route <c>func init --stack python</c> here.
+/// </summary>
+internal sealed class PythonProjectInitializer : IProjectInitializer
+{
+    public string Stack => "python";
+
+    public IReadOnlyList<string> SupportedLanguages { get; } = ["Python"];
+
+    public IReadOnlyList<Option> GetInitOptions() => [];
+
+    public Task InitializeAsync(
+        InitContext context,
+        ParseResult parseResult,
+        CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException(
+            "Python project initialization is not implemented yet.");
+    }
+}

--- a/src/Workload/Python/PythonWorkload.cs
+++ b/src/Workload/Python/PythonWorkload.cs
@@ -14,7 +14,7 @@ public sealed class PythonWorkload : Workloads.Workload
 {
     public override string DisplayName => "Python";
 
-    public override string Description => "Azure Functions tooling for Python projects.";
+    public override string Description => "Azure Functions CLI tooling for Python projects.";
 
     public override void Configure(FunctionsCliBuilder builder)
     {

--- a/src/Workload/Python/PythonWorkload.cs
+++ b/src/Workload/Python/PythonWorkload.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Azure.Functions.Cli.Workload.Python;
+
+/// <summary>
+/// Entry-point for the Python workload. Registers Python-specific
+/// services (project initializer today; resolver / commands later).
+/// </summary>
+public sealed class PythonWorkload : Workloads.Workload
+{
+    public override string DisplayName => "Python";
+
+    public override string Description => "Azure Functions tooling for Python projects.";
+
+    public override void Configure(FunctionsCliBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        builder.Services.AddSingleton<IProjectInitializer, PythonProjectInitializer>();
+    }
+}

--- a/src/Workload/Python/README.md
+++ b/src/Workload/Python/README.md
@@ -1,0 +1,23 @@
+# Azure Functions CLI – Python workload
+
+This workload extends the Azure Functions CLI (`func`) with Python project
+support: `func init --stack python` scaffolding, language-specific options,
+and (via the workload model) any future Python-only commands.
+
+## Install
+
+```bash
+func workload install Azure.Functions.Cli.Workload.Python
+# or by alias
+func workload install python
+```
+
+## Status
+
+Preview. The project initializer is currently a stub; full scaffolding lands
+in a follow-up release.
+
+## Links
+
+- [Azure Functions CLI](https://github.com/Azure/azure-functions-core-tools)
+- [Workload spec](https://github.com/Azure/azure-functions-core-tools/blob/docs/proposed/workload-spec.md)

--- a/src/Workload/Python/Workload.Python.csproj
+++ b/src/Workload/Python/Workload.Python.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Title>Python</Title>
-    <Description>Azure Functions CLI Python workload.</Description>
+    <Description>Azure Functions CLI tooling for Python projects.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:workload alias:python func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workload/Python/Workload.Python.csproj
+++ b/src/Workload/Python/Workload.Python.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <Title>Python</Title>
     <Description>Azure Functions CLI Python workload.</Description>
     <PackageType>FuncCliWorkload</PackageType>
-    <PackageTags>alias:python func-workload</PackageTags>
+    <PackageTags>kind:workload alias:python func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>

--- a/src/Workload/Python/Workload.Python.csproj
+++ b/src/Workload/Python/Workload.Python.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Description>Azure Functions CLI Python workload.</Description>
+    <PackageType>FuncCliWorkload</PackageType>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Azure.Functions.Cli.Workload.Python.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(SrcRoot)Abstractions/Abstractions.csproj">
+      <PrivateAssets>all</PrivateAssets>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="workload.json" Pack="true" PackagePath="/" />
+    <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="tools/any/" Visible="false" />
+  </ItemGroup>
+
+</Project>

--- a/src/Workload/Python/Workload.Python.csproj
+++ b/src/Workload/Python/Workload.Python.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Description>Azure Functions CLI Python workload.</Description>
     <PackageType>FuncCliWorkload</PackageType>
+    <PackageTags>alias:python func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>

--- a/src/Workload/Python/release_notes.md
+++ b/src/Workload/Python/release_notes.md
@@ -1,0 +1,5 @@
+# Azure.Functions.Cli.Workload.Python
+
+## 1.0.0-preview.1
+
+- Initial scaffold of the Python workload (entry point + stub project initializer).

--- a/src/Workload/Python/workload.json
+++ b/src/Workload/Python/workload.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
+  "kind": "workload",
+  "entryPoint": {
+    "assemblyPath": "Azure.Functions.Cli.Workload.Python.dll",
+    "type": "Azure.Functions.Cli.Workload.Python.PythonWorkload"
+  }
+}

--- a/test/Workload/Python.Tests/PythonProjectInitializerTests.cs
+++ b/test/Workload/Python.Tests/PythonProjectInitializerTests.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Workloads;
+using Xunit;
+
+namespace Azure.Functions.Cli.Workload.Python.Tests;
+
+public class PythonProjectInitializerTests
+{
+    [Fact]
+    public async Task InitializeAsync_Throws_NotImplemented()
+    {
+        var initializer = new PythonProjectInitializer();
+        var context = new InitContext(
+            WorkingDirectory.FromExplicit(Path.GetTempPath()),
+            ProjectName: "test",
+            Language: null,
+            Force: false);
+
+        await Assert.ThrowsAsync<NotImplementedException>(
+            () => initializer.InitializeAsync(context, new RootCommand().Parse(string.Empty)));
+    }
+
+    [Fact]
+    public void Stack_IsPython()
+    {
+        Assert.Equal("python", new PythonProjectInitializer().Stack);
+    }
+
+    [Fact]
+    public void GetInitOptions_IsEmpty()
+    {
+        Assert.Empty(new PythonProjectInitializer().GetInitOptions());
+    }
+}

--- a/test/Workload/Python.Tests/PythonWorkloadTests.cs
+++ b/test/Workload/Python.Tests/PythonWorkloadTests.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Functions.Cli.Workload.Python.Tests;
+
+public class PythonWorkloadTests
+{
+    [Fact]
+    public void Configure_RegistersProjectInitializer()
+    {
+        ServiceCollection services = new();
+        FunctionsCliBuilder builder = Substitute.For<FunctionsCliBuilder>();
+        builder.Services.Returns(services);
+
+        new PythonWorkload().Configure(builder);
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        IProjectInitializer initializer = provider.GetRequiredService<IProjectInitializer>();
+        Assert.IsType<PythonProjectInitializer>(initializer);
+        Assert.Equal("python", initializer.Stack);
+        Assert.Equal("Python", Assert.Single(initializer.SupportedLanguages));
+    }
+
+    [Fact]
+    public void Configure_NullBuilder_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new PythonWorkload().Configure(null!));
+    }
+}

--- a/test/Workload/Python.Tests/Workload.Python.Tests.csproj
+++ b/test/Workload/Python.Tests/Workload.Python.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(SrcRoot)Workload/Python/Workload.Python.csproj" />
+    <ProjectReference Include="$(SrcRoot)Abstractions/Abstractions.csproj" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Adds scaffolding for the Python workload, plus the shared CI templates that the Node and Go workloads will reuse.

## Scope

- `src/Workload/Python/` — entry point (`PythonWorkload`) registering a stub `PythonProjectInitializer` that throws `NotImplementedException` in `InitializeAsync`. Real scaffolding lands in a follow-up PR.
- `test/Workload/Python.Tests/` — workload contract tests (initializer registered, stack/language metadata, init throws as expected).
- `eng/ci/templates/jobs/build-workload.yml` — shared pipeline job parameterised by `WorkloadProjectName`. Builds, tests, and packs a single workload project.
- `eng/ci/workloads/python/{public,official}-build.yml` — Python-specific pipelines that extend the 1ES template and pass `WorkloadProjectName: Python`. Path filters scope triggers to Abstractions, the workload, its tests, and `eng/`.
- `Azure.Functions.Cli.slnx` — registers the new projects.

## Verified locally

- `dotnet build` (full solution): 0 warnings, 0 errors.
- `dotnet test` on `Workload.Python.Tests`: 5/5 pass.
- `dotnet pack` produces `Azure.Functions.Cli.Workload.Python.<version>.nupkg` with `packageType=FuncCliWorkload`, `workload.json` at root, and the workload DLL at `tools/any/`.

## Follow-ups

- Node and Go workload PRs will reuse the same shape and the shared CI template added here.
- Real Python project scaffolding (templates, files, language host wiring) is a separate PR.