### PR TITLE
Scaffold Node workload

### DIFF
--- a/Azure.Functions.Cli.slnx
+++ b/Azure.Functions.Cli.slnx
@@ -7,10 +7,12 @@
   <Folder Name="/src/">
     <Project Path="src/Abstractions/Abstractions.csproj" />
     <Project Path="src/Func/Func.csproj" />
+    <Project Path="src/Workload/Node/Workload.Node.csproj" />
     <Project Path="src/Workload/Python/Workload.Python.csproj" />
   </Folder>
   <Folder Name="/test/">
     <Project Path="test/Func.Tests/Func.Tests.csproj" />
+    <Project Path="test/Workload/Node.Tests/Workload.Node.Tests.csproj" />
     <Project Path="test/Workload/Python.Tests/Workload.Python.Tests.csproj" />
     <Project Path="test/Workload.Tests.Fixtures.Default/Workload.Tests.Fixtures.Default.csproj" />
     <Project Path="test/Workload.Tests.Fixtures.Sdk/Workload.Tests.Fixtures.Sdk.csproj" />

--- a/eng/ci/workloads/node/official-build.yml
+++ b/eng/ci/workloads/node/official-build.yml
@@ -1,0 +1,69 @@
+parameters:
+- name: sign
+  type: boolean
+  default: false
+
+schedules:
+- cron: "0 8 * * *"
+  displayName: Nightly Build
+  branches:
+    include:
+      - main
+      - vnext
+  always: true
+
+pr: none
+
+trigger:
+  branches:
+    include:
+    - main
+    - vnext
+    - feature/*
+    - release/*
+  paths:
+    include:
+    - src/Abstractions/
+    - src/Workload/Node/
+    - test/Workload/Node.Tests/
+    - eng/
+
+resources:
+  repositories:
+  - repository: 1es
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+  - repository: eng
+    type: git
+    name: engineering
+    ref: refs/tags/release
+
+variables:
+- template: /ci/variables/cfs.yml@eng
+- name: sign
+  readonly: true
+  ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/release/') }}:
+    value: true
+  ${{ else }}:
+    value: ${{ parameters.sign }}
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1es
+  parameters:
+    pool:
+      name: 1es-pool-azfunc
+      image: 1es-ubuntu-24.04-min
+      os: linux
+
+    sdl:
+      codeql:
+         runSourceLanguagesInSourceAnalysis: true
+
+    stages:
+      - stage: Build
+        jobs:
+        - template: /eng/ci/templates/jobs/build-workload.yml@self
+          parameters:
+            WorkloadProjectName: Node
+            sign: ${{ variables.sign }}

--- a/eng/ci/workloads/node/public-build.yml
+++ b/eng/ci/workloads/node/public-build.yml
@@ -1,0 +1,57 @@
+schedules:
+- cron: "0 7 * * *"
+  displayName: Nightly Build
+  branches:
+    include:
+      - main
+      - vnext
+  always: true
+
+trigger: none
+
+pr:
+  branches:
+    include:
+    - main
+    - vnext
+    - feature/*
+    - release/*
+  paths:
+    include:
+    - src/Abstractions/
+    - src/Workload/Node/
+    - test/Workload/Node.Tests/
+    - eng/
+
+resources:
+  repositories:
+  - repository: 1es
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1es
+  parameters:
+    pool:
+      name: 1es-pool-azfunc-public
+      image: 1es-ubuntu-24.04-min
+      os: linux
+
+    sdl:
+      sourceAnalysisPool:
+        name: 1es-pool-azfunc-public
+        image: 1es-windows-2022
+        os: windows
+
+    settings:
+      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+      networkIsolationPolicy: Preferred, NuGet
+
+    stages:
+      - stage: Build
+        jobs:
+        - template: /eng/ci/templates/jobs/build-workload.yml@self
+          parameters:
+            WorkloadProjectName: Node
+            sign: false

--- a/src/Workload/Node/Directory.Version.props
+++ b/src/Workload/Node/Directory.Version.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionSuffix>preview.1</VersionSuffix>
+  </PropertyGroup>
+</Project>

--- a/src/Workload/Node/NodeProjectInitializer.cs
+++ b/src/Workload/Node/NodeProjectInitializer.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Workloads;
+
+namespace Azure.Functions.Cli.Workload.Node;
+
+/// <summary>
+/// Stub <see cref="IProjectInitializer"/> for Node. Scaffolding logic
+/// lands in a follow-up PR; this only claims the stack so the host can
+/// route <c>func init --stack node</c> here.
+/// </summary>
+internal sealed class NodeProjectInitializer : IProjectInitializer
+{
+    public string Stack => "node";
+
+    public IReadOnlyList<string> SupportedLanguages { get; } = ["JavaScript", "TypeScript"];
+
+    public IReadOnlyList<Option> GetInitOptions() => [];
+
+    public Task InitializeAsync(
+        InitContext context,
+        ParseResult parseResult,
+        CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException(
+            "Node project initialization is not implemented yet.");
+    }
+}

--- a/src/Workload/Node/NodeWorkload.cs
+++ b/src/Workload/Node/NodeWorkload.cs
@@ -14,7 +14,7 @@ public sealed class NodeWorkload : Workloads.Workload
 {
     public override string DisplayName => "Node";
 
-    public override string Description => "Azure Functions CLI tooling for JavaScript and TypeScript projects.";
+    public override string Description => "Azure Functions CLI tooling for Node.js projects.";
 
     public override void Configure(FunctionsCliBuilder builder)
     {

--- a/src/Workload/Node/NodeWorkload.cs
+++ b/src/Workload/Node/NodeWorkload.cs
@@ -14,7 +14,7 @@ public sealed class NodeWorkload : Workloads.Workload
 {
     public override string DisplayName => "Node";
 
-    public override string Description => "Azure Functions tooling for JavaScript and TypeScript projects.";
+    public override string Description => "Azure Functions CLI tooling for JavaScript and TypeScript projects.";
 
     public override void Configure(FunctionsCliBuilder builder)
     {

--- a/src/Workload/Node/NodeWorkload.cs
+++ b/src/Workload/Node/NodeWorkload.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Azure.Functions.Cli.Workload.Node;
+
+/// <summary>
+/// Entry-point for the Node workload. Registers Node-specific
+/// services (project initializer today; resolver / commands later).
+/// </summary>
+public sealed class NodeWorkload : Workloads.Workload
+{
+    public override string DisplayName => "Node";
+
+    public override string Description => "Azure Functions tooling for JavaScript and TypeScript projects.";
+
+    public override void Configure(FunctionsCliBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        builder.Services.AddSingleton<IProjectInitializer, NodeProjectInitializer>();
+    }
+}

--- a/src/Workload/Node/README.md
+++ b/src/Workload/Node/README.md
@@ -1,0 +1,24 @@
+# Azure Functions CLI – Node workload
+
+This workload extends the Azure Functions CLI (`func`) with Node.js project
+support (JavaScript and TypeScript): `func init --stack node` scaffolding,
+language-specific options, and (via the workload model) any future Node-only
+commands.
+
+## Install
+
+```bash
+func workload install Azure.Functions.Cli.Workload.Node
+# or by alias
+func workload install node
+```
+
+## Status
+
+Preview. The project initializer is currently a stub; full scaffolding lands
+in a follow-up release.
+
+## Links
+
+- [Azure Functions CLI](https://github.com/Azure/azure-functions-core-tools)
+- [Workload spec](https://github.com/Azure/azure-functions-core-tools/blob/docs/proposed/workload-spec.md)

--- a/src/Workload/Node/Workload.Node.csproj
+++ b/src/Workload/Node/Workload.Node.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Title>Node.js</Title>
-    <Description>Azure Functions CLI Node workload.</Description>
+    <Description>Azure Functions CLI tooling for JavaScript and TypeScript projects.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:workload alias:node func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workload/Node/Workload.Node.csproj
+++ b/src/Workload/Node/Workload.Node.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Description>Azure Functions CLI Node workload.</Description>
     <PackageType>FuncCliWorkload</PackageType>
+    <PackageTags>alias:node func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>

--- a/src/Workload/Node/Workload.Node.csproj
+++ b/src/Workload/Node/Workload.Node.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Description>Azure Functions CLI Node workload.</Description>
+    <PackageType>FuncCliWorkload</PackageType>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Azure.Functions.Cli.Workload.Node.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(SrcRoot)Abstractions/Abstractions.csproj">
+      <PrivateAssets>all</PrivateAssets>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="workload.json" Pack="true" PackagePath="/" />
+    <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="tools/any/" Visible="false" />
+  </ItemGroup>
+
+</Project>

--- a/src/Workload/Node/Workload.Node.csproj
+++ b/src/Workload/Node/Workload.Node.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <Title>Node.js</Title>
     <Description>Azure Functions CLI Node workload.</Description>
     <PackageType>FuncCliWorkload</PackageType>
-    <PackageTags>alias:node func-workload</PackageTags>
+    <PackageTags>kind:workload alias:node func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>

--- a/src/Workload/Node/Workload.Node.csproj
+++ b/src/Workload/Node/Workload.Node.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Title>Node.js</Title>
-    <Description>Azure Functions CLI tooling for JavaScript and TypeScript projects.</Description>
+    <Description>Azure Functions CLI tooling for Node.js projects.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:workload alias:node func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workload/Node/release_notes.md
+++ b/src/Workload/Node/release_notes.md
@@ -1,0 +1,5 @@
+# Azure.Functions.Cli.Workload.Node
+
+## 1.0.0-preview.1
+
+- Initial scaffold of the Node workload (entry point + stub project initializer).

--- a/src/Workload/Node/workload.json
+++ b/src/Workload/Node/workload.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
+  "kind": "workload",
+  "entryPoint": {
+    "assemblyPath": "Azure.Functions.Cli.Workload.Node.dll",
+    "type": "Azure.Functions.Cli.Workload.Node.NodeWorkload"
+  }
+}

--- a/test/Workload/Node.Tests/NodeProjectInitializerTests.cs
+++ b/test/Workload/Node.Tests/NodeProjectInitializerTests.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Workloads;
+using Xunit;
+
+namespace Azure.Functions.Cli.Workload.Node.Tests;
+
+public class NodeProjectInitializerTests
+{
+    [Fact]
+    public async Task InitializeAsync_Throws_NotImplemented()
+    {
+        NodeProjectInitializer initializer = new();
+        InitContext context = new(
+            WorkingDirectory.FromExplicit(Path.GetTempPath()),
+            ProjectName: "test",
+            Language: null,
+            Force: false);
+
+        await Assert.ThrowsAsync<NotImplementedException>(
+            () => initializer.InitializeAsync(context, new RootCommand().Parse(string.Empty)));
+    }
+
+    [Fact]
+    public void Stack_IsNode()
+    {
+        Assert.Equal("node", new NodeProjectInitializer().Stack);
+    }
+
+    [Fact]
+    public void GetInitOptions_IsEmpty()
+    {
+        Assert.Empty(new NodeProjectInitializer().GetInitOptions());
+    }
+}

--- a/test/Workload/Node.Tests/NodeWorkloadTests.cs
+++ b/test/Workload/Node.Tests/NodeWorkloadTests.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Functions.Cli.Workload.Node.Tests;
+
+public class NodeWorkloadTests
+{
+    [Fact]
+    public void Configure_RegistersProjectInitializer()
+    {
+        ServiceCollection services = new();
+        FunctionsCliBuilder builder = Substitute.For<FunctionsCliBuilder>();
+        builder.Services.Returns(services);
+
+        new NodeWorkload().Configure(builder);
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        IProjectInitializer initializer = provider.GetRequiredService<IProjectInitializer>();
+        Assert.IsType<NodeProjectInitializer>(initializer);
+        Assert.Equal("node", initializer.Stack);
+        Assert.Equal(["JavaScript", "TypeScript"], initializer.SupportedLanguages);
+    }
+
+    [Fact]
+    public void Configure_NullBuilder_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new NodeWorkload().Configure(null!));
+    }
+}

--- a/test/Workload/Node.Tests/Workload.Node.Tests.csproj
+++ b/test/Workload/Node.Tests/Workload.Node.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(SrcRoot)Workload/Node/Workload.Node.csproj" />
+    <ProjectReference Include="$(SrcRoot)Abstractions/Abstractions.csproj" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Adds scaffolding for the Node workload, alongside the Python and Go siblings.

**Stacks on #4998 (Python).** That PR adds the shared `eng/ci/templates/jobs/build-workload.yml` template this pipeline reuses. Rebase onto `vnext` after #4998 merges.

## Scope

- `src/Workload/Node/` — entry point (`NodeWorkload`) registering a stub `NodeProjectInitializer` that throws `NotImplementedException` in `InitializeAsync`. Real scaffolding lands in a follow-up PR.
- `test/Workload/Node.Tests/` — workload contract tests (initializer registered, stack/language metadata, init throws as expected).
- `eng/ci/workloads/node/{public,official}-build.yml` — Node-specific pipelines that pass `WorkloadProjectName: Node` to the shared workload template.
- `Azure.Functions.Cli.slnx` — registers the new projects.

## Verified locally

- `dotnet test` on `Workload.Node.Tests`: 5/5 pass.
- `dotnet pack` produces `Azure.Functions.Cli.Workload.Node.<version>.nupkg` with `packageType=FuncCliWorkload`, `workload.json` at root, and the workload DLL at `tools/any/`.

## Follow-ups

- Real Node project scaffolding (templates, files, language host wiring) is a separate PR.