### PR TITLE
Scaffold Go workload

### DIFF
--- a/Azure.Functions.Cli.slnx
+++ b/Azure.Functions.Cli.slnx
@@ -7,11 +7,13 @@
   <Folder Name="/src/">
     <Project Path="src/Abstractions/Abstractions.csproj" />
     <Project Path="src/Func/Func.csproj" />
+    <Project Path="src/Workload/Go/Workload.Go.csproj" />
     <Project Path="src/Workload/Node/Workload.Node.csproj" />
     <Project Path="src/Workload/Python/Workload.Python.csproj" />
   </Folder>
   <Folder Name="/test/">
     <Project Path="test/Func.Tests/Func.Tests.csproj" />
+    <Project Path="test/Workload/Go.Tests/Workload.Go.Tests.csproj" />
     <Project Path="test/Workload/Node.Tests/Workload.Node.Tests.csproj" />
     <Project Path="test/Workload/Python.Tests/Workload.Python.Tests.csproj" />
     <Project Path="test/Workload.Tests.Fixtures.Default/Workload.Tests.Fixtures.Default.csproj" />

--- a/eng/ci/workloads/go/official-build.yml
+++ b/eng/ci/workloads/go/official-build.yml
@@ -1,0 +1,69 @@
+parameters:
+- name: sign
+  type: boolean
+  default: false
+
+schedules:
+- cron: "0 8 * * *"
+  displayName: Nightly Build
+  branches:
+    include:
+      - main
+      - vnext
+  always: true
+
+pr: none
+
+trigger:
+  branches:
+    include:
+    - main
+    - vnext
+    - feature/*
+    - release/*
+  paths:
+    include:
+    - src/Abstractions/
+    - src/Workload/Go/
+    - test/Workload/Go.Tests/
+    - eng/
+
+resources:
+  repositories:
+  - repository: 1es
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+  - repository: eng
+    type: git
+    name: engineering
+    ref: refs/tags/release
+
+variables:
+- template: /ci/variables/cfs.yml@eng
+- name: sign
+  readonly: true
+  ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/release/') }}:
+    value: true
+  ${{ else }}:
+    value: ${{ parameters.sign }}
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1es
+  parameters:
+    pool:
+      name: 1es-pool-azfunc
+      image: 1es-ubuntu-24.04-min
+      os: linux
+
+    sdl:
+      codeql:
+         runSourceLanguagesInSourceAnalysis: true
+
+    stages:
+      - stage: Build
+        jobs:
+        - template: /eng/ci/templates/jobs/build-workload.yml@self
+          parameters:
+            WorkloadProjectName: Go
+            sign: ${{ variables.sign }}

--- a/eng/ci/workloads/go/public-build.yml
+++ b/eng/ci/workloads/go/public-build.yml
@@ -1,0 +1,57 @@
+schedules:
+- cron: "0 7 * * *"
+  displayName: Nightly Build
+  branches:
+    include:
+      - main
+      - vnext
+  always: true
+
+trigger: none
+
+pr:
+  branches:
+    include:
+    - main
+    - vnext
+    - feature/*
+    - release/*
+  paths:
+    include:
+    - src/Abstractions/
+    - src/Workload/Go/
+    - test/Workload/Go.Tests/
+    - eng/
+
+resources:
+  repositories:
+  - repository: 1es
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1es
+  parameters:
+    pool:
+      name: 1es-pool-azfunc-public
+      image: 1es-ubuntu-24.04-min
+      os: linux
+
+    sdl:
+      sourceAnalysisPool:
+        name: 1es-pool-azfunc-public
+        image: 1es-windows-2022
+        os: windows
+
+    settings:
+      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+      networkIsolationPolicy: Preferred, NuGet
+
+    stages:
+      - stage: Build
+        jobs:
+        - template: /eng/ci/templates/jobs/build-workload.yml@self
+          parameters:
+            WorkloadProjectName: Go
+            sign: false

--- a/src/Workload/Go/Directory.Version.props
+++ b/src/Workload/Go/Directory.Version.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionSuffix>preview.1</VersionSuffix>
+  </PropertyGroup>
+</Project>

--- a/src/Workload/Go/GoProjectInitializer.cs
+++ b/src/Workload/Go/GoProjectInitializer.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Workloads;
+
+namespace Azure.Functions.Cli.Workload.Go;
+
+/// <summary>
+/// Stub <see cref="IProjectInitializer"/> for Go. Scaffolding logic
+/// lands in a follow-up PR; this only claims the stack so the host can
+/// route <c>func init --stack go</c> here.
+/// </summary>
+internal sealed class GoProjectInitializer : IProjectInitializer
+{
+    public string Stack => "go";
+
+    public IReadOnlyList<string> SupportedLanguages { get; } = ["Go"];
+
+    public IReadOnlyList<Option> GetInitOptions() => [];
+
+    public Task InitializeAsync(
+        InitContext context,
+        ParseResult parseResult,
+        CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException(
+            "Go project initialization is not implemented yet.");
+    }
+}

--- a/src/Workload/Go/GoWorkload.cs
+++ b/src/Workload/Go/GoWorkload.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Azure.Functions.Cli.Workload.Go;
+
+/// <summary>
+/// Entry-point for the Go workload. Registers Go-specific
+/// services (project initializer today; resolver / commands later).
+/// </summary>
+public sealed class GoWorkload : Workloads.Workload
+{
+    public override string DisplayName => "Go";
+
+    public override string Description => "Azure Functions tooling for Go projects.";
+
+    public override void Configure(FunctionsCliBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        builder.Services.AddSingleton<IProjectInitializer, GoProjectInitializer>();
+    }
+}

--- a/src/Workload/Go/GoWorkload.cs
+++ b/src/Workload/Go/GoWorkload.cs
@@ -14,7 +14,7 @@ public sealed class GoWorkload : Workloads.Workload
 {
     public override string DisplayName => "Go";
 
-    public override string Description => "Azure Functions tooling for Go projects.";
+    public override string Description => "Azure Functions CLI tooling for Go projects.";
 
     public override void Configure(FunctionsCliBuilder builder)
     {

--- a/src/Workload/Go/README.md
+++ b/src/Workload/Go/README.md
@@ -1,0 +1,23 @@
+# Azure Functions CLI – Go workload
+
+This workload extends the Azure Functions CLI (`func`) with Go project
+support: `func init --stack go` scaffolding, language-specific options,
+and (via the workload model) any future Go-only commands.
+
+## Install
+
+```bash
+func workload install Azure.Functions.Cli.Workload.Go
+# or by alias
+func workload install go
+```
+
+## Status
+
+Preview. The project initializer is currently a stub; full scaffolding lands
+in a follow-up release.
+
+## Links
+
+- [Azure Functions CLI](https://github.com/Azure/azure-functions-core-tools)
+- [Workload spec](https://github.com/Azure/azure-functions-core-tools/blob/docs/proposed/workload-spec.md)

--- a/src/Workload/Go/Workload.Go.csproj
+++ b/src/Workload/Go/Workload.Go.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <Title>Go</Title>
     <Description>Azure Functions CLI Go workload.</Description>
     <PackageType>FuncCliWorkload</PackageType>
-    <PackageTags>alias:go func-workload</PackageTags>
+    <PackageTags>kind:workload alias:go func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>

--- a/src/Workload/Go/Workload.Go.csproj
+++ b/src/Workload/Go/Workload.Go.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Description>Azure Functions CLI Go workload.</Description>
+    <PackageType>FuncCliWorkload</PackageType>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Azure.Functions.Cli.Workload.Go.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(SrcRoot)Abstractions/Abstractions.csproj">
+      <PrivateAssets>all</PrivateAssets>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="workload.json" Pack="true" PackagePath="/" />
+    <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="tools/any/" Visible="false" />
+  </ItemGroup>
+
+</Project>

--- a/src/Workload/Go/Workload.Go.csproj
+++ b/src/Workload/Go/Workload.Go.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Description>Azure Functions CLI Go workload.</Description>
     <PackageType>FuncCliWorkload</PackageType>
+    <PackageTags>alias:go func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>

--- a/src/Workload/Go/Workload.Go.csproj
+++ b/src/Workload/Go/Workload.Go.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Title>Go</Title>
-    <Description>Azure Functions CLI Go workload.</Description>
+    <Description>Azure Functions CLI tooling for Go projects.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:workload alias:go func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workload/Go/release_notes.md
+++ b/src/Workload/Go/release_notes.md
@@ -1,0 +1,5 @@
+# Azure.Functions.Cli.Workload.Go
+
+## 1.0.0-preview.1
+
+- Initial scaffold of the Go workload (entry point + stub project initializer).

--- a/src/Workload/Go/workload.json
+++ b/src/Workload/Go/workload.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
+  "kind": "workload",
+  "entryPoint": {
+    "assemblyPath": "Azure.Functions.Cli.Workload.Go.dll",
+    "type": "Azure.Functions.Cli.Workload.Go.GoWorkload"
+  }
+}

--- a/test/Workload/Go.Tests/GoProjectInitializerTests.cs
+++ b/test/Workload/Go.Tests/GoProjectInitializerTests.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Workloads;
+using Xunit;
+
+namespace Azure.Functions.Cli.Workload.Go.Tests;
+
+public class GoProjectInitializerTests
+{
+    [Fact]
+    public async Task InitializeAsync_Throws_NotImplemented()
+    {
+        GoProjectInitializer initializer = new();
+        InitContext context = new(
+            WorkingDirectory.FromExplicit(Path.GetTempPath()),
+            ProjectName: "test",
+            Language: null,
+            Force: false);
+
+        await Assert.ThrowsAsync<NotImplementedException>(
+            () => initializer.InitializeAsync(context, new RootCommand().Parse(string.Empty)));
+    }
+
+    [Fact]
+    public void Stack_IsGo()
+    {
+        Assert.Equal("go", new GoProjectInitializer().Stack);
+    }
+
+    [Fact]
+    public void GetInitOptions_IsEmpty()
+    {
+        Assert.Empty(new GoProjectInitializer().GetInitOptions());
+    }
+}

--- a/test/Workload/Go.Tests/GoWorkloadTests.cs
+++ b/test/Workload/Go.Tests/GoWorkloadTests.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Functions.Cli.Workload.Go.Tests;
+
+public class GoWorkloadTests
+{
+    [Fact]
+    public void Configure_RegistersProjectInitializer()
+    {
+        ServiceCollection services = new();
+        FunctionsCliBuilder builder = Substitute.For<FunctionsCliBuilder>();
+        builder.Services.Returns(services);
+
+        new GoWorkload().Configure(builder);
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        IProjectInitializer initializer = provider.GetRequiredService<IProjectInitializer>();
+        Assert.IsType<GoProjectInitializer>(initializer);
+        Assert.Equal("go", initializer.Stack);
+        Assert.Equal("Go", Assert.Single(initializer.SupportedLanguages));
+    }
+
+    [Fact]
+    public void Configure_NullBuilder_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new GoWorkload().Configure(null!));
+    }
+}

--- a/test/Workload/Go.Tests/Workload.Go.Tests.csproj
+++ b/test/Workload/Go.Tests/Workload.Go.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(SrcRoot)Workload/Go/Workload.Go.csproj" />
+    <ProjectReference Include="$(SrcRoot)Abstractions/Abstractions.csproj" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Adds scaffolding for the Go workload, alongside the Python and Node siblings.

**Stacks on #4998 (Python).** That PR adds the shared `eng/ci/templates/jobs/build-workload.yml` template this pipeline reuses. Rebase onto `vnext` after #4998 merges.

## Scope

- `src/Workload/Go/` — entry point (`GoWorkload`) registering a stub `GoProjectInitializer` that throws `NotImplementedException` in `InitializeAsync`. Real scaffolding lands in a follow-up PR.
- `test/Workload/Go.Tests/` — workload contract tests.
- `eng/ci/workloads/go/{public,official}-build.yml` — Go-specific pipelines that pass `WorkloadProjectName: Go` to the shared workload template.
- `Azure.Functions.Cli.slnx` — registers the new projects.

## Verified locally

- `dotnet test` on `Workload.Go.Tests`: 5/5 pass.
- `dotnet pack` produces `Azure.Functions.Cli.Workload.Go.<version>.nupkg` with `packageType=FuncCliWorkload`, `workload.json` at root, and the workload DLL at `tools/any/`.

## Follow-ups

- Real Go project scaffolding (templates, files, language host wiring) is a separate PR.