### PR TITLE
Update workload guide and skill to match new workload shape

### DIFF
--- a/.github/skills/create-workload/SKILL.md
+++ b/.github/skills/create-workload/SKILL.md
@@ -1,20 +1,19 @@
 ---
 name: create-workload
-description: 'Use when adding a new func CLI workload (e.g. Node, Python, Java). Scaffolds the source project, test project, solution entry, CI pipelines, base CLI registration, and docs.'
+description: 'Use when adding a new func CLI workload (e.g. Node, Python, Java). Scaffolds the source project, test project, solution entry, CI pipelines, and docs.'
 ---
 
 # Create a New Workload
 
-See `docs/building-a-workload.md` for the interface contracts. Below is the full
-checklist for scaffolding a new workload project. Use the dotnet workload as the
-reference implementation.
+See `docs/building-a-workload.md` for the full guide and rationale. Use the
+Python workload (`src/Workload/Python/`) as the canonical reference.
 
 ## Workload Project Checklist
 
 Replace `<Name>` with the workload name (e.g., `Node`, `Python`, `Java`).
 Replace `<name>` with the lowercase form (e.g., `node`, `python`, `java`).
 
-### 1. Source project — `src/Workload/<Name>/`
+### 1. Source project, `src/Workload/<Name>/`
 
 Create the following files:
 
@@ -23,20 +22,37 @@ Create the following files:
   <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
       <TargetFramework>net10.0</TargetFramework>
-      <Description>Azure Functions CLI <name> workload — ...</Description>
+      <Description>Azure Functions CLI <Name> workload.</Description>
+      <PackageType>FuncCliWorkload</PackageType>
+      <PackageTags>alias:<name> func-workload</PackageTags>
+      <IncludeBuildOutput>false</IncludeBuildOutput>
+      <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+      <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-      <InternalsVisibleTo Include="Azure.Functions.Workload.<Name>.Tests" />
+      <InternalsVisibleTo Include="Azure.Functions.Cli.Workload.<Name>.Tests" />
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="../../Abstractions/Abstractions.csproj" />
+      <ProjectReference Include="$(SrcRoot)Abstractions/Abstractions.csproj">
+        <PrivateAssets>all</PrivateAssets>
+        <ExcludeAssets>runtime</ExcludeAssets>
+      </ProjectReference>
     </ItemGroup>
 
+    <ItemGroup>
+      <None Include="workload.json" Pack="true" PackagePath="/" />
+      <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="tools/any/" Visible="false" />
+    </ItemGroup>
   </Project>
   ```
-- [ ] `Directory.Version.props` — workload version:
+  - `PackageType=FuncCliWorkload` is required for catalog discovery.
+  - `IncludeBuildOutput=false` plus the explicit `tools/any/` pack item is what makes the loader find the workload assembly.
+  - `SuppressDependenciesWhenPacking=true` plus `PrivateAssets=all` / `ExcludeAssets=runtime` on Abstractions keep the workload self-contained: the CLI provides Abstractions at runtime.
+  - Add additional aliases to `PackageTags` as needed (e.g., `alias:javascript alias:typescript`).
+  - Csproj/assembly name must be `Azure.Functions.Cli.Workload.<Name>` (set via the project filename and matched in the package id).
+- [ ] `Directory.Version.props`, the workload's version:
   ```xml
   <Project>
     <PropertyGroup>
@@ -45,31 +61,95 @@ Create the following files:
     </PropertyGroup>
   </Project>
   ```
-- [ ] `release_notes.md` — initial release notes
-- [ ] `<Name>Workload.cs` — class implementing `IWorkload`
-- [ ] At least one of: `IProjectInitializer`, `ITemplateProvider`, `IPackProvider` implementations
+- [ ] `release_notes.md`:
+  ```markdown
+  # Azure.Functions.Cli.Workload.<Name>
 
-### 2. Test project — `test/Workload/<Name>.Tests/`
+  ## 1.0.0-preview.1
 
-- [ ] `Workload.<Name>.Tests.csproj`
+  - Initial scaffold of the <Name> workload (entry point + stub project initializer).
+  ```
+- [ ] `workload.json`, the entry-point manifest packed at the package root:
+  ```json
+  {
+    "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
+    "kind": "workload",
+    "entryPoint": {
+      "assemblyPath": "Azure.Functions.Cli.Workload.<Name>.dll",
+      "type": "Azure.Functions.Cli.Workload.<Name>.<Name>Workload"
+    }
+  }
+  ```
+- [ ] `<Name>Workload.cs`, subclass of `Workloads.Workload`:
+  ```csharp
+  using Azure.Functions.Cli.Workloads;
+  using Microsoft.Extensions.DependencyInjection;
+
+  namespace Azure.Functions.Cli.Workload.<Name>;
+
+  /// <summary>
+  /// Entry-point for the <Name> workload.
+  /// </summary>
+  public sealed class <Name>Workload : Workloads.Workload
+  {
+      public override string DisplayName => "<Name>";
+
+      public override string Description => "Azure Functions tooling for <Name> projects.";
+
+      public override void Configure(FunctionsCliBuilder builder)
+      {
+          ArgumentNullException.ThrowIfNull(builder);
+          builder.Services.AddSingleton<IProjectInitializer, <Name>ProjectInitializer>();
+      }
+  }
+  ```
+  - Must be `public sealed` and have a parameterless constructor (the loader activates it by reflection).
+  - Use expression-bodied `=>` overrides; do not redeclare package id or version on the class — the csproj and `Directory.Version.props` are the single source of truth.
+- [ ] At least one provider, typically `<Name>ProjectInitializer.cs` implementing `IProjectInitializer`:
+  ```csharp
+  internal sealed class <Name>ProjectInitializer : IProjectInitializer
+  {
+      public string Stack => "<name>";
+
+      public IReadOnlyList<string> SupportedLanguages { get; } = ["<Language>"];
+
+      public IReadOnlyList<Option> GetInitOptions() => [];
+
+      public Task InitializeAsync(
+          InitContext context,
+          ParseResult parseResult,
+          CancellationToken cancellationToken = default)
+      {
+          throw new NotImplementedException(
+              "<Name> project initialization is not implemented yet.");
+      }
+  }
+  ```
+  - Initializer must be `internal sealed` (per repo convention; tests reach it via `InternalsVisibleTo`).
+  - For stubs, return `[]` from `GetInitOptions()` and only throw from `InitializeAsync`. Throwing from `GetInitOptions` breaks any code path that enumerates options across workloads.
+
+### 2. Test project, `test/Workload/<Name>.Tests/`
+
+- [ ] `Workload.<Name>.Tests.csproj`, assembly name `Azure.Functions.Cli.Workload.<Name>.Tests`:
   ```xml
   <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
       <TargetFramework>net10.0</TargetFramework>
+      <AssemblyName>Azure.Functions.Cli.Workload.<Name>.Tests</AssemblyName>
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="$(SrcRoot)Workload/<Name>/$Workload.<Name>.csproj" />
+      <ProjectReference Include="$(SrcRoot)Workload/<Name>/Workload.<Name>.csproj" />
     </ItemGroup>
-
   </Project>
   ```
-- [ ] Contract tests for the `IWorkload` implementation
-- [ ] Unit tests for each provider (initializer, template, pack)
+  - Don't add a redundant `ProjectReference` to `Abstractions`; it flows through the workload reference.
+- [ ] `<Name>WorkloadTests.cs`, contract tests for the workload (initializer is registered via `Configure`, `DisplayName` / `Description` are set).
+- [ ] `<Name>ProjectInitializerTests.cs`, unit tests for the initializer (`Stack`, `SupportedLanguages`, `InitializeAsync` throws `NotImplementedException` for stubs).
 
-### 3. Solution file — `Azure.Functions.Cli.slnx`
+### 3. Solution file, `Azure.Functions.Cli.slnx`
 
-- [ ] Add both projects to the solution:
+- [ ] Add both projects to the solution under the `/src/Workload/` and `/test/Workload/` folders:
   ```
   dotnet sln add src/Workload/<Name>/Workload.<Name>.csproj
   dotnet sln add test/Workload/<Name>.Tests/Workload.<Name>.Tests.csproj
@@ -77,51 +157,44 @@ Create the following files:
 
 ### 4. CI pipelines
 
-Create two pipeline files in `eng/ci/`:
+All workloads share a single job template, `eng/ci/templates/jobs/build-workload.yml`, parameterised by `WorkloadProjectName`. Each workload only needs two thin pipeline files; do not introduce per-workload job/step templates.
 
-- [ ] `workload-<name>-public-build.yml` — 1ES Unofficial template
-  - Path filters: `src/Abstractions/**`, `src/Workload/<Name>/**`,
-    `test/Workload/<Name>.Tests/**`, plus CI template paths
-  - Build & test stage on Windows + Linux
+- [ ] `eng/ci/workloads/<name>/public-build.yml`, 1ES Unofficial template:
+  - Extends the 1ES unofficial template and references the shared job template:
+    ```yaml
+    extends:
+      template: ...1ESPipelineTemplates/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
+      parameters:
+        ...
+        stages:
+          - stage: BuildAndTest
+            jobs:
+              - template: /eng/ci/templates/jobs/build-workload.yml@self
+                parameters:
+                  WorkloadProjectName: <Name>
+    ```
+  - Path filters scope triggers to `src/Abstractions/**`, `src/Workload/<Name>/**`, `test/Workload/<Name>.Tests/**`, `eng/ci/templates/jobs/build-workload.yml`, and the pipeline file itself.
+- [ ] `eng/ci/workloads/<name>/official-build.yml`, 1ES Official template:
+  - Same shape, but extends the Official template, sets `pr: none`, and adds `release/*` to its branch triggers (and to path filters as needed). The shared template handles build + test + pack.
 
-- [ ] `workload-<name>-official-build.yml` — 1ES Official template
-  - Same path filters plus `release/*` branch and pack template path
-  - Build & test stage + NuGet pack stage
-  - `pr: none` (official builds only trigger on push)
+Use `eng/ci/workloads/python/{public,official}-build.yml` as the reference.
 
-Create CI templates:
+### 5. Documentation
 
-- [ ] `eng/ci/templates/jobs/test-workload-<name>.yml` — job template
-- [ ] `eng/ci/templates/steps/run-workload-<name>-tests.yml` — test step
-- [ ] `eng/ci/templates/official/jobs/pack-workload-<name>.yml` — NuGet pack job
+- [ ] `docs/repo-structure.md`, add the new project directories and CI pipeline entries.
+- [ ] `docs/building-a-workload.md`, update only if you introduce new patterns. The existing guide already covers the standard shape this skill scaffolds.
 
-Use the dotnet workload CI files as templates.
-
-### 5. Base CLI updates — `src/Func/`
-
-In `src/Func/Workloads/WorkloadManager.cs`:
-
-- [ ] Add short alias to `_wellKnownAliases` dictionary:
-  ```csharp
-  ["<name>"] = "Azure.Functions.Cli.Workload.<Name>",
-  ```
-- [ ] Add entry to `_workloadCatalog` array:
-  ```csharp
-  new("<name>", "Azure.Functions.Cli.Workload.<Name>", "<Display Name>", "<Languages>"),
-  ```
-
-If the workload has unique project files (e.g., `go.mod`, `Cargo.toml`):
-- [ ] Implement `IProjectDetector` and register it in `Workload.Configure` via `builder.RegisterDetector(...)`. Declare project markers (globs) and worker-runtime ids on the detector so the resolver's pre-filter and `FUNCTIONS_WORKER_RUNTIME` lookup can short-circuit to your workload.
-
-### 6. Documentation
-
-- [ ] `docs/repo-structure.md` — add new project directories, CI pipeline entries
-- [ ] `docs/building-a-workload.md` — update if new patterns are introduced
-
-### 7. Verify
+### 6. Verify
 
 ```bash
 dotnet restore
 dotnet build
 dotnet test
 ```
+
+A correctly built workload package should:
+
+- Have package id `Azure.Functions.Cli.Workload.<Name>` and `packageType=FuncCliWorkload`.
+- Contain `workload.json` at the package root.
+- Contain the workload assembly at `tools/any/Azure.Functions.Cli.Workload.<Name>.dll`.
+- Not contain Abstractions or any of its transitive dependencies.

--- a/.github/skills/create-workload/SKILL.md
+++ b/.github/skills/create-workload/SKILL.md
@@ -25,7 +25,7 @@ Create the following files:
     <PropertyGroup>
       <TargetFramework>net10.0</TargetFramework>
       <Title><Name></Title>
-      <Description>Azure Functions CLI <Name> workload.</Description>
+      <Description>Azure Functions CLI tooling for <Name> projects.</Description>
       <PackageType>FuncCliWorkload</PackageType>
       <PackageTags>kind:workload alias:<name> func-workload</PackageTags>
       <IncludeBuildOutput>false</IncludeBuildOutput>
@@ -99,7 +99,7 @@ Create the following files:
   {
       public override string DisplayName => "<Name>";
 
-      public override string Description => "Azure Functions tooling for <Name> projects.";
+      public override string Description => "Azure Functions CLI tooling for <Name> projects.";
 
       public override void Configure(FunctionsCliBuilder builder)
       {

--- a/.github/skills/create-workload/SKILL.md
+++ b/.github/skills/create-workload/SKILL.md
@@ -5,7 +5,9 @@ description: 'Use when adding a new func CLI workload (e.g. Node, Python, Java).
 
 # Create a New Workload
 
-See `docs/building-a-workload.md` for the full guide and rationale. Use the
+See `docs/building-a-workload.md` for the authoring guide and rationale, and
+`docs/proposed/workload-package-layout.md` for the package-layout spec
+(`workload.json` schema, `kind` discriminator, install pipeline). Use the
 Python workload (`src/Workload/Python/`) as the canonical reference.
 
 ## Workload Project Checklist
@@ -22,9 +24,10 @@ Create the following files:
   <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
       <TargetFramework>net10.0</TargetFramework>
+      <Title><Name></Title>
       <Description>Azure Functions CLI <Name> workload.</Description>
       <PackageType>FuncCliWorkload</PackageType>
-      <PackageTags>alias:<name> func-workload</PackageTags>
+      <PackageTags>kind:workload alias:<name> func-workload</PackageTags>
       <IncludeBuildOutput>false</IncludeBuildOutput>
       <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
       <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>
@@ -48,9 +51,11 @@ Create the following files:
   </Project>
   ```
   - `PackageType=FuncCliWorkload` is required for catalog discovery.
+  - `Title` is the feed-UI display name; `Description` is the one-line summary. The `Workload` class's `DisplayName` / `Description` overrides serve the same purpose for the running CLI.
+  - `PackageTags` should include exactly one `kind:<workload|content|meta>` tag matching `workload.json`'s `kind` field, plus one or more `alias:<name>` tags so users can install by short name. `func-workload` is recommended for generic feed UI discoverability.
   - `IncludeBuildOutput=false` plus the explicit `tools/any/` pack item is what makes the loader find the workload assembly.
-  - `SuppressDependenciesWhenPacking=true` plus `PrivateAssets=all` / `ExcludeAssets=runtime` on Abstractions keep the workload self-contained: the CLI provides Abstractions at runtime.
-  - Add additional aliases to `PackageTags` as needed (e.g., `alias:javascript alias:typescript`).
+  - `SuppressDependenciesWhenPacking=true` plus `PrivateAssets=all` / `ExcludeAssets=runtime` on Abstractions keep the workload self-contained: the CLI provides Abstractions (and the other host-shared contract assemblies) at runtime. Apply the same `PrivateAssets=all` rule to **every** future `<PackageReference>`.
+  - The csproj above only packs the workload's own assembly. As soon as the workload pulls in transitive managed dependencies, you'll need to pack the `dotnet publish` output (workload `.dll`, `.deps.json`, transitive deps, optional `runtimes/`). The upcoming `Workload.Sdk` package will provide that pack target. See `docs/proposed/workload-package-layout.md` §5 and §9.
   - Csproj/assembly name must be `Azure.Functions.Cli.Workload.<Name>` (set via the project filename and matched in the package id).
 - [ ] `Directory.Version.props`, the workload's version:
   ```xml
@@ -69,7 +74,7 @@ Create the following files:
 
   - Initial scaffold of the <Name> workload (entry point + stub project initializer).
   ```
-- [ ] `workload.json`, the entry-point manifest packed at the package root:
+- [ ] `workload.json`, the entry-point manifest packed at the package root. `assemblyPath` is relative to `tools/any/` (bare filename; no leading `/`, no `..`); `type` is the FQN of the `Workload` subclass:
   ```json
   {
     "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
@@ -195,6 +200,8 @@ dotnet test
 A correctly built workload package should:
 
 - Have package id `Azure.Functions.Cli.Workload.<Name>` and `packageType=FuncCliWorkload`.
+- Carry tags `kind:workload alias:<name>` (plus optional extra `alias:` entries and `func-workload`).
 - Contain `workload.json` at the package root.
 - Contain the workload assembly at `tools/any/Azure.Functions.Cli.Workload.<Name>.dll`.
-- Not contain Abstractions or any of its transitive dependencies.
+- Have an empty `<dependencies>` element in its `.nuspec`.
+- Not contain Abstractions or any of the other host-shared contract assemblies.

--- a/docs/building-a-workload.md
+++ b/docs/building-a-workload.md
@@ -1,8 +1,10 @@
 # Building a New Workload
 
-This guide walks through building a workload for the Azure Functions Core Tools v5 CLI. A workload is a NuGet package that the CLI loads at runtime to extend its behavior — most commonly to provide `func init` / `func new` support for a specific language stack (e.g. Node.js, Python, Java), but a workload can also contribute brand-new subcommands.
+This guide walks through building a workload for the Azure Functions Core Tools v5 CLI. A workload is a NuGet package that the CLI loads at runtime to extend its behavior, most commonly to provide `func init` / `func new` support for a specific language stack (e.g. Node.js, Python, Java), but a workload can also contribute brand-new subcommands.
 
 > **Status**: the abstractions, DI host, and `func workload install` / `uninstall` commands described below are in the tree as of this PR. Workloads are installed from a local `.nupkg` on disk; NuGet feed acquisition lands in a follow-up.
+>
+> **Spec**: this guide is the authoring view. The on-disk and on-feed layout, the `workload.json` schema, the `kind` discriminator (`workload` / `content` / `meta`), and the install pipeline are specified in [`docs/proposed/workload-package-layout.md`](./proposed/workload-package-layout.md). Consult that doc for the contract; this guide stays focused on the happy-path authoring experience for `kind: workload`.
 
 ## Architecture
 
@@ -76,9 +78,10 @@ Create the `Workload.Node.csproj`. The csproj is the single source of truth for 
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <Title>Node.js</Title>
     <Description>Azure Functions CLI Node.js workload.</Description>
     <PackageType>FuncCliWorkload</PackageType>
-    <PackageTags>alias:node alias:javascript alias:typescript func-workload</PackageTags>
+    <PackageTags>kind:workload alias:node alias:javascript alias:typescript func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>
@@ -105,11 +108,15 @@ Create the `Workload.Node.csproj`. The csproj is the single source of truth for 
 
 What each piece does:
 
-- `PackageType=FuncCliWorkload` is how the CLI's catalog discovers workload packages.
+- `PackageType=FuncCliWorkload` is how the CLI's catalog discovers workload packages (see `docs/proposed/workload-package-layout.md` §5, §7).
+- `Title` is the display name surfaced by NuGet feed UIs; `Description` is the one-line summary. The `Workload` class's `DisplayName` / `Description` overrides serve the same purpose for `func workload list` (no duplication: feed metadata vs. running CLI).
+- `PackageTags` should include exactly one `kind:<workload|content|meta>` tag matching `workload.json`'s `kind`, plus one or more `alias:<name>` tags so `func workload install <alias>` resolves. `func-workload` is recommended for generic feed UI discoverability.
 - `IncludeBuildOutput=false` + the explicit `<None Include="$(OutputPath)$(AssemblyName).dll" ... PackagePath="tools/any/" />` puts the workload assembly under `tools/any/` instead of `lib/`, which is where the loader looks.
 - `<None Include="workload.json" ... PackagePath="/" />` ships the manifest at the package root.
-- `SuppressDependenciesWhenPacking=true` plus `PrivateAssets=all` / `ExcludeAssets=runtime` on the `Abstractions` reference keep the workload self-contained: the CLI provides Abstractions at runtime.
+- `SuppressDependenciesWhenPacking=true` plus `PrivateAssets=all` / `ExcludeAssets=runtime` on the `Abstractions` reference keep the workload self-contained: the CLI provides Abstractions (and the other host-shared contract assemblies, see §9.2 of the layout spec) at runtime. The same `PrivateAssets=all` rule applies to **every** `<PackageReference>` you add later, not just `Abstractions`.
 - `NU5128`/`NU5100` are suppressed because we deliberately ship without `lib/` and place files under `tools/any/`.
+
+> **Pack scope today.** The csproj above packs only the workload assembly itself. That works for stubs and for workloads whose runtime closure is just the host-shared contracts. As soon as a workload pulls in a transitive managed dependency (e.g., `Newtonsoft.Json`), the long-term shape from the package-layout spec applies: the package must contain the publish output (workload `.dll`, `.deps.json`, optional `.pdb`, every transitive managed dep, and any `runtimes/<rid>/` assets the deps ship). The upcoming `Workload.Sdk` package will provide the publish-into-`tools/any/` target; until then, workloads with transitive deps need to wire that step manually. See `docs/proposed/workload-package-layout.md` §5 and §9.
 
 Add a sibling `Directory.Version.props` for the workload version:
 
@@ -132,7 +139,7 @@ And a `release_notes.md`:
 - Initial scaffold of the Node.js workload (entry point + stub project initializer).
 ```
 
-Add a `workload.json` that points at your entry-point type:
+Add a `workload.json` that points at your entry-point type. `assemblyPath` is **relative to `tools/any/`**, conventionally a bare filename (no leading `/`, no `..`); `type` is the FQN of your `Workload` subclass.
 
 ```json
 {

--- a/docs/building-a-workload.md
+++ b/docs/building-a-workload.md
@@ -16,8 +16,9 @@ This guide walks through building a workload for the Azure Functions Core Tools 
            ▼
 ┌─────────────────────────────────┐
 │  Abstractions                   │
-│  NuGet package with interfaces  │
-│  IWorkload, FunctionsCliBuilder │
+│  NuGet package with the         │
+│  Workload base class,           │
+│  FunctionsCliBuilder,           │
 │  IProjectInitializer, …         │
 └──────────┬──────────────────────┘
            │ referenced by (compile-time)
@@ -40,7 +41,7 @@ The CLI builds a `HostApplicationBuilder` at startup. Each installed workload is
 1. CLI builds the host (HostApplicationBuilder)
 2. For each entry in ~/.azure-functions/workloads.json:
      ├── Load the workload assembly into an isolated AssemblyLoadContext
-     ├── Activate the IWorkload type
+     ├── Activate the Workload type named in the package's workload.json
      └── Call workload.Configure(builder)        ← workload registers services here
 3. CLI builds the root command tree from DI
      ├── Built-in commands resolve workload-contributed services they consume
@@ -50,15 +51,16 @@ The CLI builds a `HostApplicationBuilder` at startup. Each installed workload is
 4. Command dispatch
 ```
 
-The shape mirrors WebJobs' `IWebJobsStartup` — `Configure(FunctionsCliBuilder)` is the workload's only seam, and everything beyond it is plain .NET DI.
+The shape mirrors WebJobs' `IWebJobsStartup`. `Configure(FunctionsCliBuilder)` is the workload's only seam, and everything beyond it is plain .NET DI.
 
 ## Quick Start
 
-1. Create a class library project that targets `net10.0`
-2. Reference `Azure.Functions.Cli.Abstractions`
-3. Implement `IWorkload`
+1. Create a class library project under `src/Workload/<Name>/` that targets `net10.0` and packs as `PackageType=FuncCliWorkload`
+2. Reference `Azure.Functions.Cli.Abstractions` (with `PrivateAssets=all` and `ExcludeAssets=runtime` so it isn't shipped inside your package)
+3. Subclass `Workload` and override `DisplayName`, `Description`, and `Configure`
 4. Inside `Configure`, register an `IProjectInitializer`, an `IProjectDetector` (so the resolver can claim directories owned by your workload), and/or top-level commands via `builder.RegisterCommand(...)` plus any supporting services
-5. Build, package, and install with `func workload install <path-to-nupkg>`
+5. Add a `workload.json` next to your csproj describing the entry-point assembly and type
+6. Build, package, and install with `func workload install <path-to-nupkg>`
 
 ## Step 1: Create the Project
 
@@ -67,31 +69,85 @@ mkdir src/Workload/Node
 cd src/Workload/Node
 ```
 
-Create the `Workload.Node.csproj`:
+Create the `Workload.Node.csproj`. The csproj is the single source of truth for packaging; there are no per-folder `Directory.Build.props` for workloads.
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <Description>Azure Functions CLI Node.js workload.</Description>
+    <PackageType>FuncCliWorkload</PackageType>
+    <PackageTags>alias:node alias:javascript alias:typescript func-workload</PackageTags>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="../../Abstractions/Abstractions.csproj" />
-  </ItemGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Azure.Functions.Cli.Workload.Node.Tests" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="$(SrcRoot)Abstractions/Abstractions.csproj">
+      <PrivateAssets>all</PrivateAssets>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="workload.json" Pack="true" PackagePath="/" />
+    <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="tools/any/" Visible="false" />
+  </ItemGroup>
+
 </Project>
 ```
 
-Add the standard build files (copy from an existing project): `Directory.Version.props`.
+What each piece does:
 
-## Step 2: Implement IWorkload
+- `PackageType=FuncCliWorkload` is how the CLI's catalog discovers workload packages.
+- `IncludeBuildOutput=false` + the explicit `<None Include="$(OutputPath)$(AssemblyName).dll" ... PackagePath="tools/any/" />` puts the workload assembly under `tools/any/` instead of `lib/`, which is where the loader looks.
+- `<None Include="workload.json" ... PackagePath="/" />` ships the manifest at the package root.
+- `SuppressDependenciesWhenPacking=true` plus `PrivateAssets=all` / `ExcludeAssets=runtime` on the `Abstractions` reference keep the workload self-contained: the CLI provides Abstractions at runtime.
+- `NU5128`/`NU5100` are suppressed because we deliberately ship without `lib/` and place files under `tools/any/`.
 
-`IWorkload` is the entry point the CLI activates. **It must have a parameterless constructor.**
+Add a sibling `Directory.Version.props` for the workload version:
+
+```xml
+<Project>
+  <PropertyGroup>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionSuffix>preview.1</VersionSuffix>
+  </PropertyGroup>
+</Project>
+```
+
+And a `release_notes.md`:
+
+```markdown
+# Azure.Functions.Cli.Workload.Node
+
+## 1.0.0-preview.1
+
+- Initial scaffold of the Node.js workload (entry point + stub project initializer).
+```
+
+Add a `workload.json` that points at your entry-point type:
+
+```json
+{
+  "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
+  "kind": "workload",
+  "entryPoint": {
+    "assemblyPath": "Azure.Functions.Cli.Workload.Node.dll",
+    "type": "Azure.Functions.Cli.Workload.Node.NodeWorkload"
+  }
+}
+```
+
+## Step 2: Subclass `Workload`
+
+`Workload` is an abstract class in `Azure.Functions.Cli.Abstractions` (under `Azure.Functions.Cli.Workloads`). The CLI loader instantiates the type named in `workload.json` and calls `Configure`. **It must have a parameterless constructor.**
 
 ```csharp
 // NodeWorkload.cs
@@ -100,23 +156,27 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Azure.Functions.Cli.Workload.Node;
 
-public sealed class NodeWorkload : IWorkload
+/// <summary>
+/// Entry-point for the Node.js workload. Registers the project initializer
+/// and any Node-specific services.
+/// </summary>
+public sealed class NodeWorkload : Workloads.Workload
 {
-    public string PackageId      => "Azure.Functions.Cli.Workload.Node";
-    public string PackageVersion => "1.0.0";   // typically read from assembly metadata
-    public string DisplayName    => "Node.js";
-    public string Description    => "func init / func new support for Node.js and TypeScript.";
+    public override string DisplayName => "Node.js";
 
-    public void Configure(FunctionsCliBuilder builder)
+    public override string Description => "Azure Functions tooling for Node.js and TypeScript projects.";
+
+    public override void Configure(FunctionsCliBuilder builder)
     {
+        ArgumentNullException.ThrowIfNull(builder);
         builder.Services.AddSingleton<IProjectInitializer, NodeProjectInitializer>();
-        // builder.RegisterCommand(new NodeTopLevelCommand());
+        // builder.RegisterCommand<NodeTopLevelCommand>();
         // …any other services your providers depend on
     }
 }
 ```
 
-The properties surface in `func workload list`.
+`DisplayName` and `Description` surface in `func workload list`. Package id and version aren't on the class: they come from the csproj/`Directory.Version.props` (single source of truth) and are persisted in the global registry at install time.
 
 ## Step 3: Implement IProjectInitializer
 
@@ -239,15 +299,16 @@ internal sealed class DurableCommand : FuncCommand
     }
 }
 
-public sealed class DurableWorkload : IWorkload
+public sealed class DurableWorkload : Workloads.Workload
 {
-    public string PackageId      => "Azure.Functions.Cli.Workload.Durable";
-    public string PackageVersion => "1.0.0";
-    public string DisplayName    => "Durable Functions";
-    public string Description    => "Durable Functions management commands.";
+    public override string DisplayName => "Durable Functions";
 
-    public void Configure(FunctionsCliBuilder builder)
+    public override string Description => "Durable Functions management commands.";
+
+    public override void Configure(FunctionsCliBuilder builder)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+
         // Pick the overload that fits how your command is constructed:
         //   builder.RegisterCommand(new DurableCommand());        // simple instance
         //   builder.RegisterCommand<DurableCommand>();            // DI-constructed (recommended)
@@ -307,16 +368,30 @@ dotnet sln add src/Workload/Node/Workload.Node.csproj
 dotnet sln add test/Workload/Node.Tests/Workload.Node.Tests.csproj
 ```
 
-Add path-scoped public + official CI pipelines in `eng/ci/` (mirror the abstractions pipelines as a starting point — workload-specific templates will land alongside the loader in a follow-up PR).
+Workloads share a single CI job template, `eng/ci/templates/jobs/build-workload.yml`, parameterised by `WorkloadProjectName`. Each workload owns two thin pipeline files that extend the 1ES template and pass that parameter:
+
+- `eng/ci/workloads/<name>/public-build.yml` — 1ES Unofficial template (PR + branch builds).
+- `eng/ci/workloads/<name>/official-build.yml` — 1ES Official template (push + release branches, with the pack stage).
+
+Both should set path filters to scope triggers to:
+
+- `src/Abstractions/**`
+- `src/Workload/<Name>/**`
+- `test/Workload/<Name>.Tests/**`
+- `eng/ci/templates/jobs/build-workload.yml`
+- The pipeline file itself
+
+Use the Python pipelines (`eng/ci/workloads/python/{public,official}-build.yml`) as the reference. New workloads should not introduce per-workload job/step templates: `build-workload.yml` already covers build, test, and pack.
 
 ## Checklist
 
-- [ ] New project `src/Workload/<Name>/Workload.<Name>.csproj`, references `Abstractions` only
-- [ ] `IWorkload` with parameterless constructor and the five identity properties (`PackageId`, `PackageVersion`, `Type`, `DisplayName`, `Description`)
-- [ ] `Configure(FunctionsCliBuilder)` registers an `IProjectInitializer` and/or top-level commands via `builder.RegisterCommand(...)`
-- [ ] `IProjectInitializer.GetInitOptions()` returns any extra options the initializer needs
-- [ ] Test project `test/Workload/<Name>.Tests/Workload.<Name>.Tests.csproj`
-- [ ] `Directory.Version.props` created
-- [ ] Added to the solution
-- [ ] Public + official CI pipelines in `eng/ci/`
+- [ ] New project `src/Workload/<Name>/Workload.<Name>.csproj`, packs as `PackageType=FuncCliWorkload`, references `Abstractions` with `PrivateAssets=all` / `ExcludeAssets=runtime`
+- [ ] `Directory.Version.props` and `release_notes.md` next to the csproj
+- [ ] `workload.json` next to the csproj, listing the entry-point `assemblyPath` and `type`
+- [ ] Subclass of `Workload` with a parameterless constructor, overriding `DisplayName`, `Description`, and `Configure`
+- [ ] `Configure(FunctionsCliBuilder)` null-checks `builder` and registers an `IProjectInitializer` and/or top-level commands via `builder.RegisterCommand(...)`
+- [ ] `IProjectInitializer.GetInitOptions()` returns any extra options the initializer needs (return `[]` for stubs; only throw from `InitializeAsync`)
+- [ ] Test project `test/Workload/<Name>.Tests/Workload.<Name>.Tests.csproj`, assembly name `Azure.Functions.Cli.Workload.<Name>.Tests` (matches the workload's `InternalsVisibleTo`)
+- [ ] Both projects added to `Azure.Functions.Cli.slnx`
+- [ ] `eng/ci/workloads/<name>/{public,official}-build.yml` extending `eng/ci/templates/jobs/build-workload.yml` with `WorkloadProjectName: <Name>`
 - [ ] `dotnet build` and `dotnet test` pass

--- a/docs/building-a-workload.md
+++ b/docs/building-a-workload.md
@@ -79,7 +79,7 @@ Create the `Workload.Node.csproj`. The csproj is the single source of truth for 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Title>Node.js</Title>
-    <Description>Azure Functions CLI Node.js workload.</Description>
+    <Description>Azure Functions CLI tooling for Node.js projects.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:workload alias:node alias:javascript alias:typescript func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>
@@ -171,7 +171,7 @@ public sealed class NodeWorkload : Workloads.Workload
 {
     public override string DisplayName => "Node.js";
 
-    public override string Description => "Azure Functions tooling for Node.js and TypeScript projects.";
+    public override string Description => "Azure Functions CLI tooling for Node.js projects.";
 
     public override void Configure(FunctionsCliBuilder builder)
     {


### PR DESCRIPTION
Brings `docs/building-a-workload.md` and the `create-workload` skill in line with the workload structure used by the Python workload (#4998), so anyone scaffolding a new workload (or following the skill checklist) ends up with the same layout we're settling on.

## What changed

- **Workload type**: docs no longer reference `IWorkload`. Workloads subclass the abstract `Workloads.Workload` class and override `DisplayName`, `Description`, and `Configure`. Removed the bogus `PackageId` / `PackageVersion` / `Type` properties; package id and version live in the csproj + `Directory.Version.props`.
- **csproj template**: now carries everything needed to ship a real workload package (`PackageType=FuncCliWorkload`, `IncludeBuildOutput=false`, explicit pack of the assembly under `tools/any/`, `SuppressDependenciesWhenPacking`, Abstractions `ProjectReference` with `PrivateAssets=all` / `ExcludeAssets=runtime`, `NU5128`/`NU5100` suppression, and the `<None>` items for `workload.json` and the dll). No reliance on a per-folder `Directory.Build.*`.
- **Per-workload layout**: documents the standard files under `src/Workload/<Name>/`, namely `Workload.<Name>.csproj`, `Directory.Version.props`, `release_notes.md`, `workload.json`, the `Workload` subclass, and the project initializer.
- **Initializer guidance**: `internal sealed`, `GetInitOptions()` returns `[]` for stubs, `InitializeAsync` is the only method that throws `NotImplementedException` until real scaffolding lands.
- **CI section**: replaces the "mirror the abstractions pipelines" placeholder with the actual pattern. Workloads share a single job template `eng/ci/templates/jobs/build-workload.yml` parameterised by `WorkloadProjectName`, and each workload owns thin `eng/ci/workloads/<name>/{public,official}-build.yml` files that extend the 1ES templates and pass that parameter. No more per-workload job/step templates.
- **Tests**: assembly name `Azure.Functions.Cli.Workload.<Name>.Tests` (matches `InternalsVisibleTo`), drops the redundant Abstractions `ProjectReference`.

The skill (`.github/skills/create-workload/SKILL.md`, also surfaced as `.claude/skills/create-workload` via symlink) is rewritten end-to-end so the checklist now produces a workload that builds and packs correctly without any follow-up cleanup.

## Verified

- `docs/building-a-workload.md` and `.github/skills/create-workload/SKILL.md` describe the same layout used in #4998.
- No code changes; nothing to build/test.
