### PR TITLE
Add IProjectResolver implementations for Python, Node, and Go workloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ eng/tools/publish-tools/npm/bin/
 
 # MacOS related
 .DS_Store
+
+# Roslyn / C# language server incremental analysis caches
+*.lscache

--- a/src/Workload/Go/GoProjectResolver.cs
+++ b/src/Workload/Go/GoProjectResolver.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads;
+
+namespace Azure.Functions.Cli.Workload.Go;
+
+/// <summary>
+/// Resolves a directory as a Go Functions project when <c>host.json</c> is present
+/// alongside a <c>go.mod</c> or any <c>*.go</c> file at the project root.
+/// </summary>
+internal sealed class GoProjectResolver : IProjectResolver
+{
+    private const string WorkerRuntime = "go";
+
+    public Task<EvaluationResult> EvaluateAsync(DirectoryInfo workingDirectory, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(workingDirectory);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!workingDirectory.Exists || !File.Exists(Path.Combine(workingDirectory.FullName, "host.json")))
+        {
+            return Task.FromResult(EvaluationResult.NoMatch("no host.json"));
+        }
+
+        if (File.Exists(Path.Combine(workingDirectory.FullName, "go.mod")))
+        {
+            return Task.FromResult(EvaluationResult.Match("found go.mod", WorkerRuntime));
+        }
+
+        if (Directory.EnumerateFiles(workingDirectory.FullName, "*.go", SearchOption.TopDirectoryOnly).Any())
+        {
+            return Task.FromResult(EvaluationResult.Match("found *.go file", WorkerRuntime));
+        }
+
+        return Task.FromResult(EvaluationResult.NoMatch("host.json present but no Go fingerprint file"));
+    }
+}

--- a/src/Workload/Go/GoProjectResolver.cs
+++ b/src/Workload/Go/GoProjectResolver.cs
@@ -11,7 +11,7 @@ namespace Azure.Functions.Cli.Workload.Go;
 /// </summary>
 internal sealed class GoProjectResolver : IProjectResolver
 {
-    private const string WorkerRuntime = "go";
+    private const string WorkerRuntime = "native";
 
     public Task<EvaluationResult> EvaluateAsync(DirectoryInfo workingDirectory, CancellationToken cancellationToken)
     {

--- a/src/Workload/Go/GoWorkload.cs
+++ b/src/Workload/Go/GoWorkload.cs
@@ -20,5 +20,6 @@ public sealed class GoWorkload : Workloads.Workload
     {
         ArgumentNullException.ThrowIfNull(builder);
         builder.Services.AddSingleton<IProjectInitializer, GoProjectInitializer>();
+        builder.RegisterProjectResolver(new GoProjectResolver());
     }
 }

--- a/src/Workload/Node/NodeProjectResolver.cs
+++ b/src/Workload/Node/NodeProjectResolver.cs
@@ -1,0 +1,90 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Text.Json;
+using Azure.Functions.Cli.Workloads;
+
+namespace Azure.Functions.Cli.Workload.Node;
+
+/// <summary>
+/// Resolves a directory as a Node Functions project when <c>host.json</c> is present
+/// alongside a <c>package.json</c>, <c>tsconfig.json</c>, or a <c>*.js</c>/<c>*.mjs</c>/<c>*.cjs</c>/<c>*.ts</c>
+/// file at the project root. A <c>package.json</c> declaring <c>@azure/functions</c> is the strongest signal.
+/// </summary>
+internal sealed class NodeProjectResolver : IProjectResolver
+{
+    private const string WorkerRuntime = "node";
+    private const string FunctionsPackage = "@azure/functions";
+
+    private static readonly string[] _sourceFilePatterns = ["*.js", "*.mjs", "*.cjs", "*.ts"];
+
+    public Task<EvaluationResult> EvaluateAsync(DirectoryInfo workingDirectory, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(workingDirectory);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!workingDirectory.Exists || !File.Exists(Path.Combine(workingDirectory.FullName, "host.json")))
+        {
+            return Task.FromResult(EvaluationResult.NoMatch("no host.json"));
+        }
+
+        string packageJsonPath = Path.Combine(workingDirectory.FullName, "package.json");
+        if (File.Exists(packageJsonPath))
+        {
+            string reason = DeclaresFunctionsPackage(packageJsonPath)
+                ? "package.json declares @azure/functions"
+                : "found package.json";
+            return Task.FromResult(EvaluationResult.Match(reason, WorkerRuntime));
+        }
+
+        if (File.Exists(Path.Combine(workingDirectory.FullName, "tsconfig.json")))
+        {
+            return Task.FromResult(EvaluationResult.Match("found tsconfig.json", WorkerRuntime));
+        }
+
+        foreach (string pattern in _sourceFilePatterns)
+        {
+            if (Directory.EnumerateFiles(workingDirectory.FullName, pattern, SearchOption.TopDirectoryOnly).Any())
+            {
+                return Task.FromResult(EvaluationResult.Match($"found {pattern} file", WorkerRuntime));
+            }
+        }
+
+        return Task.FromResult(EvaluationResult.NoMatch("host.json present but no Node fingerprint file"));
+    }
+
+    private static bool DeclaresFunctionsPackage(string packageJsonPath)
+    {
+        // Parse just enough of package.json to spot @azure/functions in
+        // dependencies or devDependencies. Malformed JSON falls through
+        // to the weaker "found package.json" signal rather than throwing.
+        try
+        {
+            using FileStream stream = File.OpenRead(packageJsonPath);
+            using var doc = JsonDocument.Parse(stream);
+
+            if (doc.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                return false;
+            }
+
+            return HasFunctionsDependency(doc.RootElement, "dependencies")
+                || HasFunctionsDependency(doc.RootElement, "devDependencies");
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+    }
+
+    private static bool HasFunctionsDependency(JsonElement root, string sectionName)
+    {
+        return root.TryGetProperty(sectionName, out JsonElement section)
+            && section.ValueKind == JsonValueKind.Object
+            && section.TryGetProperty(FunctionsPackage, out _);
+    }
+}

--- a/src/Workload/Node/NodeWorkload.cs
+++ b/src/Workload/Node/NodeWorkload.cs
@@ -20,5 +20,6 @@ public sealed class NodeWorkload : Workloads.Workload
     {
         ArgumentNullException.ThrowIfNull(builder);
         builder.Services.AddSingleton<IProjectInitializer, NodeProjectInitializer>();
+        builder.RegisterProjectResolver(new NodeProjectResolver());
     }
 }

--- a/src/Workload/Python/PythonProjectResolver.cs
+++ b/src/Workload/Python/PythonProjectResolver.cs
@@ -1,0 +1,63 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads;
+
+namespace Azure.Functions.Cli.Workload.Python;
+
+/// <summary>
+/// Resolves a directory as a Python Functions project when <c>host.json</c> is present
+/// alongside <c>function_app.py</c>, a known dependency manifest (<c>requirements.txt</c>,
+/// <c>pyproject.toml</c>, <c>uv.lock</c>, <c>poetry.lock</c>), or any <c>*.py</c> file at the project root.
+/// </summary>
+internal sealed class PythonProjectResolver : IProjectResolver
+{
+    private const string WorkerRuntime = "python";
+
+    public Task<EvaluationResult> EvaluateAsync(DirectoryInfo workingDirectory, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(workingDirectory);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!workingDirectory.Exists || !File.Exists(Path.Combine(workingDirectory.FullName, "host.json")))
+        {
+            return Task.FromResult(EvaluationResult.NoMatch("no host.json"));
+        }
+
+        // v2 programming model entry point: strongest signal.
+        if (File.Exists(Path.Combine(workingDirectory.FullName, "function_app.py")))
+        {
+            return Task.FromResult(EvaluationResult.Match("found function_app.py", WorkerRuntime));
+        }
+
+        // Dependency-manager manifests. Lock files are checked alongside
+        // pyproject.toml so a uv- or poetry-managed project without
+        // requirements.txt is still claimed.
+        string? manifest = FirstExisting(workingDirectory, "requirements.txt", "pyproject.toml", "uv.lock", "poetry.lock");
+        if (manifest is not null)
+        {
+            return Task.FromResult(EvaluationResult.Match($"found {manifest}", WorkerRuntime));
+        }
+
+        // Fallback: any *.py at the project root.
+        if (Directory.EnumerateFiles(workingDirectory.FullName, "*.py", SearchOption.TopDirectoryOnly).Any())
+        {
+            return Task.FromResult(EvaluationResult.Match("found *.py file", WorkerRuntime));
+        }
+
+        return Task.FromResult(EvaluationResult.NoMatch("host.json present but no Python fingerprint file"));
+    }
+
+    private static string? FirstExisting(DirectoryInfo directory, params string[] fileNames)
+    {
+        foreach (string name in fileNames)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, name)))
+            {
+                return name;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Workload/Python/PythonWorkload.cs
+++ b/src/Workload/Python/PythonWorkload.cs
@@ -20,5 +20,6 @@ public sealed class PythonWorkload : Workloads.Workload
     {
         ArgumentNullException.ThrowIfNull(builder);
         builder.Services.AddSingleton<IProjectInitializer, PythonProjectInitializer>();
+        builder.RegisterProjectResolver(new PythonProjectResolver());
     }
 }

--- a/test/Workload/Go.Tests/GoProjectResolverTests.cs
+++ b/test/Workload/Go.Tests/GoProjectResolverTests.cs
@@ -1,0 +1,122 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads;
+using Xunit;
+
+namespace Azure.Functions.Cli.Workload.Go.Tests;
+
+public class GoProjectResolverTests : IDisposable
+{
+    private readonly DirectoryInfo _projectDir;
+
+    public GoProjectResolverTests()
+    {
+        _projectDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "func-go-resolver-" + Guid.NewGuid().ToString("N")));
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (_projectDir.Exists)
+            {
+                _projectDir.Delete(recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    [Fact]
+    public async Task Empty_directory_does_not_match()
+    {
+        EvaluationResult result = await new GoProjectResolver().EvaluateAsync(_projectDir, default);
+
+        Assert.False(result.IsMatch);
+        Assert.Equal("no host.json", result.Reason);
+    }
+
+    [Theory]
+    [InlineData("go.mod", "module example")]
+    [InlineData("main.go", "package main")]
+    public async Task Fingerprint_without_host_json_does_not_match(string fileName, string contents)
+    {
+        WriteFile(fileName, contents);
+
+        EvaluationResult result = await new GoProjectResolver().EvaluateAsync(_projectDir, default);
+
+        Assert.False(result.IsMatch);
+    }
+
+    [Fact]
+    public async Task Foreign_python_directory_does_not_match()
+    {
+        WriteFile("host.json", "{}");
+        WriteFile("requirements.txt", string.Empty);
+
+        EvaluationResult result = await new GoProjectResolver().EvaluateAsync(_projectDir, default);
+
+        Assert.False(result.IsMatch);
+    }
+
+    [Fact]
+    public async Task Foreign_node_directory_does_not_match()
+    {
+        WriteFile("host.json", "{}");
+        WriteFile("package.json", "{}");
+
+        EvaluationResult result = await new GoProjectResolver().EvaluateAsync(_projectDir, default);
+
+        Assert.False(result.IsMatch);
+    }
+
+    [Theory]
+    [InlineData("go.mod", "module example")]
+    [InlineData("main.go", "package main")]
+    public async Task Match_for_each_fingerprint(string fileName, string contents)
+    {
+        WriteFile("host.json", "{}");
+        WriteFile(fileName, contents);
+
+        EvaluationResult result = await new GoProjectResolver().EvaluateAsync(_projectDir, default);
+
+        Assert.True(result.IsMatch);
+        Assert.Equal("go", result.WorkerRuntime);
+        Assert.NotNull(result.Reason);
+    }
+
+    [Fact]
+    public async Task GoMod_takes_precedence_over_loose_go_files()
+    {
+        WriteFile("host.json", "{}");
+        WriteFile("go.mod", "module example");
+        WriteFile("main.go", "package main");
+
+        EvaluationResult result = await new GoProjectResolver().EvaluateAsync(_projectDir, default);
+
+        Assert.True(result.IsMatch);
+        Assert.Equal("found go.mod", result.Reason);
+    }
+
+    [Fact]
+    public async Task Host_json_only_does_not_match()
+    {
+        WriteFile("host.json", "{}");
+
+        EvaluationResult result = await new GoProjectResolver().EvaluateAsync(_projectDir, default);
+
+        Assert.False(result.IsMatch);
+    }
+
+    [Fact]
+    public async Task NullDirectory_throws()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => new GoProjectResolver().EvaluateAsync(null!, default));
+    }
+
+    private void WriteFile(string name, string contents)
+        => File.WriteAllText(Path.Combine(_projectDir.FullName, name), contents);
+}

--- a/test/Workload/Go.Tests/GoProjectResolverTests.cs
+++ b/test/Workload/Go.Tests/GoProjectResolverTests.cs
@@ -83,7 +83,7 @@ public class GoProjectResolverTests : IDisposable
         EvaluationResult result = await new GoProjectResolver().EvaluateAsync(_projectDir, default);
 
         Assert.True(result.IsMatch);
-        Assert.Equal("go", result.WorkerRuntime);
+        Assert.Equal("native", result.WorkerRuntime);
         Assert.NotNull(result.Reason);
     }
 

--- a/test/Workload/Go.Tests/GoWorkloadTests.cs
+++ b/test/Workload/Go.Tests/GoWorkloadTests.cs
@@ -31,4 +31,16 @@ public class GoWorkloadTests
     {
         Assert.Throws<ArgumentNullException>(() => new GoWorkload().Configure(null!));
     }
+
+    [Fact]
+    public void Configure_RegistersProjectResolver()
+    {
+        ServiceCollection services = new();
+        FunctionsCliBuilder builder = Substitute.For<FunctionsCliBuilder>();
+        builder.Services.Returns(services);
+
+        new GoWorkload().Configure(builder);
+
+        builder.Received(1).RegisterProjectResolver(Arg.Any<GoProjectResolver>());
+    }
 }

--- a/test/Workload/Node.Tests/NodeProjectResolverTests.cs
+++ b/test/Workload/Node.Tests/NodeProjectResolverTests.cs
@@ -1,0 +1,164 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads;
+using Xunit;
+
+namespace Azure.Functions.Cli.Workload.Node.Tests;
+
+public class NodeProjectResolverTests : IDisposable
+{
+    private readonly DirectoryInfo _projectDir;
+
+    public NodeProjectResolverTests()
+    {
+        _projectDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "func-node-resolver-" + Guid.NewGuid().ToString("N")));
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (_projectDir.Exists)
+            {
+                _projectDir.Delete(recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    [Fact]
+    public async Task Empty_directory_does_not_match()
+    {
+        EvaluationResult result = await new NodeProjectResolver().EvaluateAsync(_projectDir, default);
+
+        Assert.False(result.IsMatch);
+        Assert.Equal("no host.json", result.Reason);
+    }
+
+    [Theory]
+    [InlineData("package.json")]
+    [InlineData("tsconfig.json")]
+    [InlineData("index.js")]
+    [InlineData("index.ts")]
+    public async Task Fingerprint_without_host_json_does_not_match(string fileName)
+    {
+        WriteFile(fileName, "{}");
+
+        EvaluationResult result = await new NodeProjectResolver().EvaluateAsync(_projectDir, default);
+
+        Assert.False(result.IsMatch);
+    }
+
+    [Fact]
+    public async Task Foreign_python_directory_does_not_match()
+    {
+        WriteFile("host.json", "{}");
+        WriteFile("requirements.txt", string.Empty);
+
+        EvaluationResult result = await new NodeProjectResolver().EvaluateAsync(_projectDir, default);
+
+        Assert.False(result.IsMatch);
+    }
+
+    [Fact]
+    public async Task Foreign_go_directory_does_not_match()
+    {
+        WriteFile("host.json", "{}");
+        WriteFile("go.mod", "module example");
+
+        EvaluationResult result = await new NodeProjectResolver().EvaluateAsync(_projectDir, default);
+
+        Assert.False(result.IsMatch);
+    }
+
+    [Theory]
+    [InlineData("package.json", "{}")]
+    [InlineData("tsconfig.json", "{}")]
+    [InlineData("index.js", "module.exports = {};")]
+    [InlineData("index.mjs", "export default {};")]
+    [InlineData("index.cjs", "module.exports = {};")]
+    [InlineData("index.ts", "export const x = 1;")]
+    public async Task Match_for_each_fingerprint(string fileName, string contents)
+    {
+        WriteFile("host.json", "{}");
+        WriteFile(fileName, contents);
+
+        EvaluationResult result = await new NodeProjectResolver().EvaluateAsync(_projectDir, default);
+
+        Assert.True(result.IsMatch);
+        Assert.Equal("node", result.WorkerRuntime);
+        Assert.NotNull(result.Reason);
+    }
+
+    [Fact]
+    public async Task PackageJson_with_azure_functions_dep_uses_specific_reason()
+    {
+        WriteFile("host.json", "{}");
+        WriteFile("package.json", """{ "dependencies": { "@azure/functions": "^4.0.0" } }""");
+
+        EvaluationResult result = await new NodeProjectResolver().EvaluateAsync(_projectDir, default);
+
+        Assert.True(result.IsMatch);
+        Assert.Equal("node", result.WorkerRuntime);
+        Assert.Equal("package.json declares @azure/functions", result.Reason);
+    }
+
+    [Fact]
+    public async Task PackageJson_with_azure_functions_dev_dep_uses_specific_reason()
+    {
+        WriteFile("host.json", "{}");
+        WriteFile("package.json", """{ "devDependencies": { "@azure/functions": "^4.0.0" } }""");
+
+        EvaluationResult result = await new NodeProjectResolver().EvaluateAsync(_projectDir, default);
+
+        Assert.True(result.IsMatch);
+        Assert.Equal("package.json declares @azure/functions", result.Reason);
+    }
+
+    [Fact]
+    public async Task PackageJson_without_azure_functions_dep_uses_generic_reason()
+    {
+        WriteFile("host.json", "{}");
+        WriteFile("package.json", """{ "dependencies": { "lodash": "^4.0.0" } }""");
+
+        EvaluationResult result = await new NodeProjectResolver().EvaluateAsync(_projectDir, default);
+
+        Assert.True(result.IsMatch);
+        Assert.Equal("found package.json", result.Reason);
+    }
+
+    [Fact]
+    public async Task Malformed_package_json_falls_back_to_generic_reason()
+    {
+        WriteFile("host.json", "{}");
+        WriteFile("package.json", "{ this is not valid json");
+
+        EvaluationResult result = await new NodeProjectResolver().EvaluateAsync(_projectDir, default);
+
+        Assert.True(result.IsMatch);
+        Assert.Equal("found package.json", result.Reason);
+    }
+
+    [Fact]
+    public async Task Host_json_only_does_not_match()
+    {
+        WriteFile("host.json", "{}");
+
+        EvaluationResult result = await new NodeProjectResolver().EvaluateAsync(_projectDir, default);
+
+        Assert.False(result.IsMatch);
+    }
+
+    [Fact]
+    public async Task NullDirectory_throws()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => new NodeProjectResolver().EvaluateAsync(null!, default));
+    }
+
+    private void WriteFile(string name, string contents)
+        => File.WriteAllText(Path.Combine(_projectDir.FullName, name), contents);
+}

--- a/test/Workload/Node.Tests/NodeWorkloadTests.cs
+++ b/test/Workload/Node.Tests/NodeWorkloadTests.cs
@@ -31,4 +31,16 @@ public class NodeWorkloadTests
     {
         Assert.Throws<ArgumentNullException>(() => new NodeWorkload().Configure(null!));
     }
+
+    [Fact]
+    public void Configure_RegistersProjectResolver()
+    {
+        ServiceCollection services = new();
+        FunctionsCliBuilder builder = Substitute.For<FunctionsCliBuilder>();
+        builder.Services.Returns(services);
+
+        new NodeWorkload().Configure(builder);
+
+        builder.Received(1).RegisterProjectResolver(Arg.Any<NodeProjectResolver>());
+    }
 }

--- a/test/Workload/Python.Tests/PythonProjectResolverTests.cs
+++ b/test/Workload/Python.Tests/PythonProjectResolverTests.cs
@@ -1,0 +1,168 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads;
+using Xunit;
+
+namespace Azure.Functions.Cli.Workload.Python.Tests;
+
+public class PythonProjectResolverTests : IDisposable
+{
+    private readonly DirectoryInfo _projectDir;
+
+    public PythonProjectResolverTests()
+    {
+        _projectDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "func-python-resolver-" + Guid.NewGuid().ToString("N")));
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (_projectDir.Exists)
+            {
+                _projectDir.Delete(recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup; CI runners may hold file handles briefly.
+        }
+    }
+
+    [Fact]
+    public async Task Empty_directory_does_not_match()
+    {
+        EvaluationResult result = await new PythonProjectResolver().EvaluateAsync(_projectDir, default);
+
+        Assert.False(result.IsMatch);
+        Assert.Equal("no host.json", result.Reason);
+    }
+
+    [Fact]
+    public async Task NonExistent_directory_does_not_match()
+    {
+        var missing = new DirectoryInfo(Path.Combine(_projectDir.FullName, "does-not-exist"));
+
+        EvaluationResult result = await new PythonProjectResolver().EvaluateAsync(missing, default);
+
+        Assert.False(result.IsMatch);
+    }
+
+    [Theory]
+    [InlineData("requirements.txt")]
+    [InlineData("pyproject.toml")]
+    [InlineData("function_app.py")]
+    [InlineData("uv.lock")]
+    [InlineData("poetry.lock")]
+    public async Task Fingerprint_without_host_json_does_not_match(string fileName)
+    {
+        WriteFile(fileName, string.Empty);
+
+        EvaluationResult result = await new PythonProjectResolver().EvaluateAsync(_projectDir, default);
+
+        Assert.False(result.IsMatch);
+    }
+
+    [Fact]
+    public async Task Foreign_stack_directory_does_not_match()
+    {
+        // host.json + Node fingerprint should not be claimed by the Python resolver.
+        WriteFile("host.json", "{}");
+        WriteFile("package.json", "{}");
+
+        EvaluationResult result = await new PythonProjectResolver().EvaluateAsync(_projectDir, default);
+
+        Assert.False(result.IsMatch);
+    }
+
+    [Fact]
+    public async Task Foreign_go_directory_does_not_match()
+    {
+        WriteFile("host.json", "{}");
+        WriteFile("go.mod", "module example");
+
+        EvaluationResult result = await new PythonProjectResolver().EvaluateAsync(_projectDir, default);
+
+        Assert.False(result.IsMatch);
+    }
+
+    [Theory]
+    [InlineData("function_app.py")]
+    [InlineData("requirements.txt")]
+    [InlineData("pyproject.toml")]
+    [InlineData("uv.lock")]
+    [InlineData("poetry.lock")]
+    public async Task Match_for_each_fingerprint(string fileName)
+    {
+        WriteFile("host.json", "{}");
+        WriteFile(fileName, string.Empty);
+
+        EvaluationResult result = await new PythonProjectResolver().EvaluateAsync(_projectDir, default);
+
+        Assert.True(result.IsMatch);
+        Assert.Equal("python", result.WorkerRuntime);
+        Assert.NotNull(result.Reason);
+    }
+
+    [Fact]
+    public async Task Uv_managed_project_matches_via_pyproject_and_lock()
+    {
+        // Reproduces the uv layout from issue #4676 / #4705: no requirements.txt,
+        // pyproject.toml + uv.lock instead.
+        WriteFile("host.json", "{}");
+        WriteFile("pyproject.toml", "[project]\nname = \"x\"\n");
+        WriteFile("uv.lock", string.Empty);
+
+        EvaluationResult result = await new PythonProjectResolver().EvaluateAsync(_projectDir, default);
+
+        Assert.True(result.IsMatch);
+        Assert.Equal("python", result.WorkerRuntime);
+    }
+
+    [Fact]
+    public async Task Poetry_managed_project_matches_via_pyproject_and_lock()
+    {
+        WriteFile("host.json", "{}");
+        WriteFile("pyproject.toml", "[tool.poetry]\nname = \"x\"\n");
+        WriteFile("poetry.lock", string.Empty);
+
+        EvaluationResult result = await new PythonProjectResolver().EvaluateAsync(_projectDir, default);
+
+        Assert.True(result.IsMatch);
+        Assert.Equal("python", result.WorkerRuntime);
+    }
+
+    [Fact]
+    public async Task Bare_py_file_with_host_json_matches()
+    {
+        WriteFile("host.json", "{}");
+        WriteFile("loose.py", "print('hi')");
+
+        EvaluationResult result = await new PythonProjectResolver().EvaluateAsync(_projectDir, default);
+
+        Assert.True(result.IsMatch);
+        Assert.Equal("python", result.WorkerRuntime);
+        Assert.Contains("*.py", result.Reason);
+    }
+
+    [Fact]
+    public async Task Host_json_only_does_not_match()
+    {
+        WriteFile("host.json", "{}");
+
+        EvaluationResult result = await new PythonProjectResolver().EvaluateAsync(_projectDir, default);
+
+        Assert.False(result.IsMatch);
+    }
+
+    [Fact]
+    public async Task NullDirectory_throws()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => new PythonProjectResolver().EvaluateAsync(null!, default));
+    }
+
+    private void WriteFile(string name, string contents)
+        => File.WriteAllText(Path.Combine(_projectDir.FullName, name), contents);
+}

--- a/test/Workload/Python.Tests/PythonWorkloadTests.cs
+++ b/test/Workload/Python.Tests/PythonWorkloadTests.cs
@@ -31,4 +31,16 @@ public class PythonWorkloadTests
     {
         Assert.Throws<ArgumentNullException>(() => new PythonWorkload().Configure(null!));
     }
+
+    [Fact]
+    public void Configure_RegistersProjectResolver()
+    {
+        ServiceCollection services = new();
+        FunctionsCliBuilder builder = Substitute.For<FunctionsCliBuilder>();
+        builder.Services.Returns(services);
+
+        new PythonWorkload().Configure(builder);
+
+        builder.Received(1).RegisterProjectResolver(Arg.Any<PythonProjectResolver>());
+    }
 }


### PR DESCRIPTION
Adds an `IProjectResolver` per workload so the host's `WorkloadResolver` can claim Python / Node / Go Functions projects from a working directory. Until now each of these workloads only registered an `IProjectInitializer`, so any directory with `host.json` resolved as "no installed workload claims this directory".

## Detection rules

All three resolvers share the same shape: gate on `host.json` (universal Functions marker), then look for stack-specific fingerprints. Any one fingerprint is sufficient. `func init` sets `SkipDirectoryDetection`, so the empty-dir-being-scaffolded path doesn't go through resolvers.

| Workload | Fingerprints                                                                                                          | `WorkerRuntime` |
| -------- | --------------------------------------------------------------------------------------------------------------------- | --------------- |
| Python   | `function_app.py`, `requirements.txt`, `pyproject.toml`, `uv.lock`, `poetry.lock`, or any `*.py`                       | `python`        |
| Node     | `package.json` (parsed for `@azure/functions` dep), `tsconfig.json`, or any `*.js` / `*.mjs` / `*.cjs` / `*.ts`        | `node`          |
| Go       | `go.mod`, or any `*.go`                                                                                               | `go`            |

A few notes on the choices:

- **Python** explicitly accepts `pyproject.toml` + `uv.lock` (uv layout) and `pyproject.toml` + `poetry.lock` (poetry layout) so a Functions project without `requirements.txt` is still claimed. This is the resolver-side prerequisite for the `func publish` / `func pack` behaviours requested in #4676 and #4705; the command-level fixes themselves live in v4 and stay out of scope here.
- **Node** parses `package.json` lightly with `System.Text.Json` to look for `@azure/functions` in `dependencies` / `devDependencies`. Match yields a more specific `Reason` ("package.json declares @azure/functions") so the host's disambiguation message is useful when more than one workload claims the directory. Malformed JSON falls back to the generic "found package.json" signal rather than throwing.
- **Go** reports `WorkerRuntime = "go"`. The host is expected to map that to `native` for `FUNCTIONS_WORKER_RUNTIME` matching (Functions ships Go via the native worker today). Keeping the workload-side label honest lets the mapping live in one place in the host.
- Detection is shallow (top-level only, `SearchOption.TopDirectoryOnly`), and short-circuits on the first hit so non-matching directories return quickly.

## Wiring

Each `<Stack>Workload.Configure` now calls `builder.RegisterProjectResolver(new XxxProjectResolver())` alongside the existing `AddSingleton<IProjectInitializer, …>` line. Resolvers are stateless so a single shared instance is fine.

## Tests

New `<Name>ProjectResolverTests.cs` per workload using xUnit and a per-test temp directory (no shared filesystem state):

- empty / non-existent directory → no match
- fingerprint without `host.json` → no match
- foreign-stack directory (e.g. `PythonProjectResolver` against `host.json + package.json`) → no match
- positive match per fingerprint family with the expected `WorkerRuntime`
- Python: dedicated uv-managed and poetry-managed cases
- Node: `@azure/functions` dep variants (regular + dev), malformed `package.json` fallback
- Go: `go.mod` precedence over loose `*.go` files
- null-arg validation

`<Name>WorkloadTests` get one extra assertion that `Configure` calls `RegisterProjectResolver` with the right concrete type (verified through NSubstitute on the abstract `FunctionsCliBuilder`, so the workload test projects don't need to reference Func internals).

Test counts: Python 25/25, Node 25/25, Go 16/16. `Func.Tests` 325/325 still green (host-side `WorkloadResolver` tests already cover cross-resolver tie-breaking; resolver-level tests verify each resolver scopes itself).

## Out of scope

- Any change to `IProjectResolver` / `EvaluationResult` / `FunctionsCliBuilder`.
- `IProjectInitializer` scaffolding (still `NotImplementedException`).
- v4 (`main`) launcher / detector code.
- `func publish` / `func pack` behaviour fixes from #4676 / #4705 — command-level, will land in their own PRs.
- `.func/config.json` (CLI Profiles spec, `cli-profiles.md` §6.4): only carries `profiles` + `defaultProfile`, no stack/language fields, and not implemented in this branch. If project-level CLI config ever grows a stack hint, the right consumer is the host's `WorkloadResolver` (a new resolution tier between `--stack` and `FUNCTIONS_WORKER_RUNTIME`), not each workload's resolver.

Also includes a small follow-up commit adding `*.lscache` (Roslyn / C# language-server incremental analysis caches) to `.gitignore`.

Refs: #4676, #4705
