### PR TITLE
Lift host.json gate into WorkloadResolver

### DIFF
--- a/src/Func/Workloads/Resolution/WorkloadResolver.cs
+++ b/src/Func/Workloads/Resolution/WorkloadResolver.cs
@@ -39,6 +39,17 @@ internal sealed class WorkloadResolver(
                 $"Installed: {FormatInstalled(installed)}.");
         }
 
+        // CLI-wide invariant: a directory without host.json is not a
+        // Functions project. Gate here so per-stack resolvers can focus
+        // on their fingerprints and we surface one consistent diagnostic.
+        if (!File.Exists(Path.Combine(context.Directory.FullName, "host.json")))
+        {
+            return new WorkloadResolution.None(
+                "This directory does not look like an Azure Functions project. " +
+                $"No 'host.json' was found in '{context.Directory.FullName}'. " +
+                "Run 'func init' to scaffold one, or change to a Functions project directory.");
+        }
+
         IReadOnlyList<ResolverClaim> claims = await CollectClaimsAsync(context.Directory, cancellationToken);
 
         // FUNCTIONS_WORKER_RUNTIME, when set, is treated as an explicit

--- a/test/Func.Tests/Workloads/Resolution/WorkloadResolverTests.cs
+++ b/test/Func.Tests/Workloads/Resolution/WorkloadResolverTests.cs
@@ -8,14 +8,33 @@ using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Workloads.Resolution;
 
-public sealed class WorkloadResolverTests
+public sealed class WorkloadResolverTests : IDisposable
 {
-    private readonly DirectoryInfo _dir = new(Path.Combine(Path.GetTempPath(), "resolver-tests"));
+    private readonly DirectoryInfo _dir;
     private readonly ILocalSettingsReader _settings = Substitute.For<ILocalSettingsReader>();
 
     public WorkloadResolverTests()
     {
+        _dir = new DirectoryInfo(Path.Combine(Path.GetTempPath(), "func-resolver-tests-" + Guid.NewGuid().ToString("N")));
+        _dir.Create();
+        File.WriteAllText(Path.Combine(_dir.FullName, "host.json"), "{}");
+
         _settings.ReadWorkerRuntime(Arg.Any<DirectoryInfo>()).Returns((string?)null);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (_dir.Exists)
+            {
+                _dir.Delete(recursive: true);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup; temp dirs are reclaimed by the OS.
+        }
     }
 
     [Fact]
@@ -241,6 +260,40 @@ public sealed class WorkloadResolverTests
             CancellationToken.None);
 
         Assert.IsType<WorkloadResolution.None>(result);
+    }
+
+    [Fact]
+    public async Task NoHostJson_ReturnsNoneWithoutInvokingResolvers()
+    {
+        // CLI-wide invariant: a directory without host.json is not a
+        // Functions project. The host gates this so per-stack resolvers
+        // don't have to repeat the check.
+        var emptyDir = new DirectoryInfo(Path.Combine(Path.GetTempPath(), "func-resolver-no-host-" + Guid.NewGuid().ToString("N")));
+        emptyDir.Create();
+        try
+        {
+            WorkloadInfo dotnet = NewWorkload("Pkg.Dotnet");
+            IProjectResolver resolverStub = NewProjectResolver(EvaluationResult.Match("would have matched"));
+
+            WorkloadResolver resolver = NewResolver(
+                workloads: [dotnet],
+                resolvers: [(dotnet, resolverStub)]);
+
+            WorkloadResolution result = await resolver.ResolveAsync(
+                new WorkloadResolutionContext(emptyDir, StackSelector: null),
+                CancellationToken.None);
+
+            var none = Assert.IsType<WorkloadResolution.None>(result);
+            Assert.Contains("does not look like an Azure Functions project", none.Message);
+            Assert.Contains("host.json", none.Message);
+            Assert.Contains(emptyDir.FullName, none.Message);
+            Assert.Contains("func init", none.Message);
+            await resolverStub.DidNotReceive().EvaluateAsync(Arg.Any<DirectoryInfo>(), Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            try { emptyDir.Delete(recursive: true); } catch { }
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Why

A directory without `host.json` is not a Functions project regardless of stack. That check is a CLI-wide invariant, not a per-stack concern, but PR #5008 currently duplicates it across every `IProjectResolver` (Python, Node, Go) and would force every future workload to do the same.

## What

- Add the `host.json` precondition to `WorkloadResolver.ResolveAsync`, placed after the `StackSelector` and `SkipDirectoryDetection` short-circuits and before `CollectClaimsAsync`. If `host.json` is missing, return `WorkloadResolution.None` immediately without invoking any resolver.
- One consistent host-level diagnostic:
  > "This directory does not look like an Azure Functions project. No 'host.json' was found in '<dir>'. Run 'func init' to scaffold one, or change to a Functions project directory."
- `WorkloadResolverTests` now seeds a real temp directory containing `host.json` (class is `IDisposable` for cleanup) so existing directory-inspection tests still exercise their intended paths. Adds one new test, `NoHostJson_ReturnsNoneWithoutInvokingResolvers`, that pins the gate.

## Notes

- Base is `vnext` (not `main`).
- PR #5008 (`liliankasem/feat/workload-resolvers`) will be rebased on top of this once it merges to drop its now-redundant per-resolver `host.json` check.
- No change to `IProjectResolver` / `EvaluationResult` shape.

## Validation

- `dotnet test test/Func.Tests/Func.Tests.csproj` -> 326 passed, 0 failed.