### PR TITLE
Scaffold .func/config.json support

### DIFF
--- a/src/Func/Commands/InitCommand.cs
+++ b/src/Func/Commands/InitCommand.cs
@@ -119,6 +119,8 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
 
         await initializer.InitializeAsync(context, parseResult, cancellationToken);
 
+        WriteFuncProjectConfig(workingDirectory.Info, initializer.Stack, context.Language, context.Force);
+
         _interaction.WriteLine(l => l
             .Success("✓ ")
             .Muted("Project initialized for ")
@@ -126,6 +128,48 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
             .Muted("."));
 
         return 0;
+    }
+
+    private void WriteFuncProjectConfig(DirectoryInfo workingDirectory, string stack, string? language, bool force)
+    {
+        string folder = Path.Combine(workingDirectory.FullName, ".func");
+        string path = Path.Combine(folder, "config.json");
+
+        // Treat an existing file as user-owned unless --force was passed.
+        if (File.Exists(path) && !force)
+        {
+            return;
+        }
+
+        try
+        {
+            Directory.CreateDirectory(folder);
+
+            var payload = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["stack"] = stack,
+            };
+            if (!string.IsNullOrWhiteSpace(language))
+            {
+                payload["language"] = language;
+            }
+
+            string json = System.Text.Json.JsonSerializer.Serialize(payload, new System.Text.Json.JsonSerializerOptions
+            {
+                WriteIndented = true,
+            });
+            File.WriteAllText(path, json + Environment.NewLine);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Project files already scaffolded; only the stack-pinning metadata failed.
+            // Warn the user and let init succeed — they can create .func/config.json by hand.
+            _interaction.WriteLine(l => l
+                .Warning("! ")
+                .Muted("Could not write .func/config.json (")
+                .Code(ex.Message)
+                .Muted(")."));
+        }
     }
 
     private async Task<IProjectInitializer?> SelectInitializerAsync(string? stack, CancellationToken cancellationToken)

--- a/src/Func/Hosting/WorkloadRegistration.cs
+++ b/src/Func/Hosting/WorkloadRegistration.cs
@@ -121,6 +121,7 @@ internal static class WorkloadRegistration
         services.AddSingleton<IWorkloadProvider, WorkloadProvider>();
 
         services.AddSingleton<ILocalSettingsReader, LocalSettingsReader>();
+        services.AddSingleton<IFuncProjectConfigReader, FuncProjectConfigReader>();
         services.AddSingleton<IWorkloadResolver, WorkloadResolver>();
         services.AddSingleton<IWorkloadInvoker, WorkloadInvoker>();
 

--- a/src/Func/Workloads/Resolution/FuncProjectConfig.cs
+++ b/src/Func/Workloads/Resolution/FuncProjectConfig.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workloads.Resolution;
+
+/// <summary>
+/// Parsed shape of <c>.func/config.json</c>. Both fields are optional;
+/// callers treat null/whitespace as "not set" and fall through to the next
+/// resolution step.
+/// </summary>
+/// <param name="Stack">Workload alias (matched the same way as <c>--stack</c>).</param>
+/// <param name="Language">Programming language hint (e.g. "python", "typescript").</param>
+internal sealed record FuncProjectConfig(string? Stack, string? Language);

--- a/src/Func/Workloads/Resolution/FuncProjectConfigReader.cs
+++ b/src/Func/Workloads/Resolution/FuncProjectConfigReader.cs
@@ -1,0 +1,76 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Text.Json;
+
+namespace Azure.Functions.Cli.Workloads.Resolution;
+
+/// <summary>
+/// Default <see cref="IFuncProjectConfigReader"/>. Tolerant of missing,
+/// malformed, or wrong-shape files so the resolver can fall through.
+/// Mirrors <see cref="LocalSettingsReader"/>'s shape.
+/// </summary>
+internal sealed class FuncProjectConfigReader : IFuncProjectConfigReader
+{
+    internal const string ConfigFolderName = ".func";
+    internal const string ConfigFileName = "config.json";
+
+    private const string StackProperty = "stack";
+    private const string LanguageProperty = "language";
+
+    public FuncProjectConfig? Read(DirectoryInfo directory)
+    {
+        ArgumentNullException.ThrowIfNull(directory);
+
+        string path = Path.Combine(directory.FullName, ConfigFolderName, ConfigFileName);
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            using FileStream stream = File.OpenRead(path);
+            using var document = JsonDocument.Parse(stream);
+
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            string? stack = ReadStringProperty(document.RootElement, StackProperty);
+            string? language = ReadStringProperty(document.RootElement, LanguageProperty);
+
+            if (stack is null && language is null)
+            {
+                return null;
+            }
+
+            return new FuncProjectConfig(stack, language);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    private static string? ReadStringProperty(JsonElement root, string name)
+    {
+        if (!root.TryGetProperty(name, out JsonElement value)
+            || value.ValueKind != JsonValueKind.String)
+        {
+            return null;
+        }
+
+        string? raw = value.GetString();
+        return string.IsNullOrWhiteSpace(raw) ? null : raw;
+    }
+}

--- a/src/Func/Workloads/Resolution/IFuncProjectConfigReader.cs
+++ b/src/Func/Workloads/Resolution/IFuncProjectConfigReader.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workloads.Resolution;
+
+/// <summary>
+/// Reads the per-project <c>.func/config.json</c> file.
+/// </summary>
+internal interface IFuncProjectConfigReader
+{
+    /// <summary>
+    /// Returns the parsed config, or <c>null</c> when the file is missing,
+    /// malformed, or empty. Never throws.
+    /// </summary>
+    public FuncProjectConfig? Read(DirectoryInfo directory);
+}

--- a/src/Func/Workloads/Resolution/IWorkloadResolver.cs
+++ b/src/Func/Workloads/Resolution/IWorkloadResolver.cs
@@ -5,9 +5,13 @@ namespace Azure.Functions.Cli.Workloads.Resolution;
 
 /// <summary>
 /// Decides which installed workload owns a given directory. Order:
-/// explicit <c>--stack</c> selector, then registered
-/// <see cref="IProjectResolver"/>s with <c>FUNCTIONS_WORKER_RUNTIME</c> in
-/// <c>local.settings.json</c> as a tie-breaker.
+/// explicit <c>--stack</c> selector, then <c>.func/config.json</c>'s
+/// <c>stack</c> as a project-pinned declaration, then a <c>host.json</c>
+/// gate that rejects directories which don't look like Functions projects,
+/// then <c>FUNCTIONS_WORKER_RUNTIME</c> in <c>local.settings.json</c>
+/// filtering registered <see cref="IProjectResolver"/> claims by worker
+/// runtime, then unfiltered <see cref="IProjectResolver"/> auto-detection
+/// as a fallback.
 /// </summary>
 internal interface IWorkloadResolver
 {

--- a/src/Func/Workloads/Resolution/WorkloadResolver.cs
+++ b/src/Func/Workloads/Resolution/WorkloadResolver.cs
@@ -11,12 +11,14 @@ namespace Azure.Functions.Cli.Workloads.Resolution;
 internal sealed class WorkloadResolver(
     IWorkloadProvider workloads,
     IEnumerable<WorkloadProjectResolverContribution> resolvers,
-    ILocalSettingsReader localSettings) : IWorkloadResolver
+    ILocalSettingsReader localSettings,
+    IFuncProjectConfigReader projectConfig) : IWorkloadResolver
 {
     private readonly IWorkloadProvider _workloads = workloads ?? throw new ArgumentNullException(nameof(workloads));
     private readonly IReadOnlyList<WorkloadProjectResolverContribution> _resolvers =
         (resolvers ?? throw new ArgumentNullException(nameof(resolvers))).ToList();
     private readonly ILocalSettingsReader _localSettings = localSettings ?? throw new ArgumentNullException(nameof(localSettings));
+    private readonly IFuncProjectConfigReader _projectConfig = projectConfig ?? throw new ArgumentNullException(nameof(projectConfig));
 
     public async Task<WorkloadResolution> ResolveAsync(WorkloadResolutionContext context, CancellationToken cancellationToken)
     {
@@ -27,7 +29,7 @@ internal sealed class WorkloadResolver(
         // 1. Explicit selector wins.
         if (!string.IsNullOrWhiteSpace(context.StackSelector))
         {
-            return ResolveBySelector(installed, context.StackSelector);
+            return ResolveBySelector(installed, context.StackSelector, $"--stack '{context.StackSelector}'");
         }
 
         // No project to inspect (e.g. `func init`).
@@ -37,6 +39,17 @@ internal sealed class WorkloadResolver(
                 "No --stack flag supplied. " +
                 "Pass --stack <id> to choose a workload. " +
                 $"Installed: {FormatInstalled(installed)}.");
+        }
+
+        // 2. .func/config.json is treated as an explicit project-pinned
+        // declaration: it wins over both FUNCTIONS_WORKER_RUNTIME and
+        // resolver auto-detection. It also bypasses the host.json gate
+        // below — if the user has pinned a stack explicitly, we trust
+        // them and don't require host.json to also be present.
+        FuncProjectConfig? config = _projectConfig.Read(context.Directory);
+        if (!string.IsNullOrWhiteSpace(config?.Stack))
+        {
+            return ResolveBySelector(installed, config.Stack, $".func/config.json declares stack '{config.Stack}'");
         }
 
         // CLI-wide invariant: a directory without host.json is not a
@@ -52,7 +65,7 @@ internal sealed class WorkloadResolver(
 
         IReadOnlyList<ResolverClaim> claims = await CollectClaimsAsync(context.Directory, cancellationToken);
 
-        // FUNCTIONS_WORKER_RUNTIME, when set, is treated as an explicit
+        // 3. FUNCTIONS_WORKER_RUNTIME, when set, is treated as an explicit
         // declaration: only claims with a matching WorkerRuntime count.
         string? runtime = _localSettings.ReadWorkerRuntime(context.Directory);
         if (!string.IsNullOrWhiteSpace(runtime))
@@ -60,6 +73,7 @@ internal sealed class WorkloadResolver(
             return ResolveByRuntime(installed, claims, runtime);
         }
 
+        // 4. Auto-detection from registered IProjectResolvers.
         return ResolveByClaims(claims);
     }
 
@@ -87,7 +101,7 @@ internal sealed class WorkloadResolver(
         return [.. claimsByWorkload.Values];
     }
 
-    private static WorkloadResolution ResolveBySelector(IReadOnlyList<WorkloadInfo> installed, string selector)
+    private static WorkloadResolution ResolveBySelector(IReadOnlyList<WorkloadInfo> installed, string selector, string source)
     {
         // Match against aliases; mirrors `func workload install <alias>`.
         List<WorkloadInfo> matches = [.. installed.Where(w =>
@@ -95,13 +109,13 @@ internal sealed class WorkloadResolver(
 
         return matches.Count switch
         {
-            1 => new WorkloadResolution.Resolved(matches[0], $"Selected by --stack '{selector}'."),
+            1 => new WorkloadResolution.Resolved(matches[0], $"Selected by {source}."),
             0 => new WorkloadResolution.None(
-                $"No installed workload claims stack '{selector}'. " +
+                $"No installed workload claims stack '{selector}' (from {source}). " +
                 $"Installed: {FormatInstalled(installed)}. " +
                 $"Run 'func workload install <package>' to add a workload."),
             _ => new WorkloadResolution.None(
-                $"Multiple installed workloads claim stack '{selector}': {FormatPackages(matches)}. " +
+                $"Multiple installed workloads claim stack '{selector}' (from {source}): {FormatPackages(matches)}. " +
                 $"Pass --stack with an exact package id to disambiguate."),
         };
     }

--- a/test/Func.Tests/Commands/InitCommandTests.cs
+++ b/test/Func.Tests/Commands/InitCommandTests.cs
@@ -1,7 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.CommandLine;
+using System.Text.Json;
 using Azure.Functions.Cli.Commands;
+using Azure.Functions.Cli.Workloads;
 using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands;
@@ -72,6 +75,116 @@ public class InitCommandTests
             {
                 Directory.Delete(newDir, recursive: true);
             }
+        }
+    }
+
+    [Fact]
+    public async Task InitCommand_ScaffoldsFuncProjectConfig_OnSuccess()
+    {
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+
+        try
+        {
+            var initializer = new FakeProjectInitializer("python");
+            int exitCode = await RunInitAsync(newDir, initializer, language: "python");
+
+            Assert.Equal(0, exitCode);
+            Assert.True(initializer.WasInvoked);
+
+            string configPath = Path.Combine(newDir, ".func", "config.json");
+            Assert.True(File.Exists(configPath), $"Expected .func/config.json at {configPath}.");
+
+            using var doc = JsonDocument.Parse(File.ReadAllText(configPath));
+            Assert.Equal("python", doc.RootElement.GetProperty("stack").GetString());
+            Assert.Equal("python", doc.RootElement.GetProperty("language").GetString());
+        }
+        finally
+        {
+            if (Directory.Exists(newDir))
+            {
+                Directory.Delete(newDir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task InitCommand_DoesNotOverwriteExistingFuncProjectConfig()
+    {
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(newDir, ".func"));
+            string configPath = Path.Combine(newDir, ".func", "config.json");
+            const string existingContent = """{"stack":"node","language":"typescript"}""";
+            File.WriteAllText(configPath, existingContent);
+
+            var initializer = new FakeProjectInitializer("python");
+            int exitCode = await RunInitAsync(newDir, initializer, language: "python");
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal(existingContent, File.ReadAllText(configPath));
+        }
+        finally
+        {
+            if (Directory.Exists(newDir))
+            {
+                Directory.Delete(newDir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task InitCommand_OmitsLanguageWhenNotSpecified()
+    {
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+
+        try
+        {
+            var initializer = new FakeProjectInitializer("dotnet");
+            int exitCode = await RunInitAsync(newDir, initializer, language: null);
+
+            Assert.Equal(0, exitCode);
+
+            string configPath = Path.Combine(newDir, ".func", "config.json");
+            using var doc = JsonDocument.Parse(File.ReadAllText(configPath));
+            Assert.Equal("dotnet", doc.RootElement.GetProperty("stack").GetString());
+            Assert.False(doc.RootElement.TryGetProperty("language", out _));
+        }
+        finally
+        {
+            if (Directory.Exists(newDir))
+            {
+                Directory.Delete(newDir, recursive: true);
+            }
+        }
+    }
+
+    private async Task<int> RunInitAsync(string path, IProjectInitializer initializer, string? language)
+    {
+        var cmd = new InitCommand(_interaction, _hintRenderer, [initializer]);
+        var root = new RootCommand { cmd };
+        string args = language is null
+            ? $"init \"{path}\""
+            : $"init \"{path}\" --language {language}";
+        ParseResult result = root.Parse(args);
+        return await result.InvokeAsync();
+    }
+
+    private sealed class FakeProjectInitializer(string stack) : IProjectInitializer
+    {
+        public string Stack { get; } = stack;
+
+        public IReadOnlyList<string> SupportedLanguages { get; } = [];
+
+        public bool WasInvoked { get; private set; }
+
+        public IReadOnlyList<Option> GetInitOptions() => [];
+
+        public Task InitializeAsync(InitContext context, ParseResult parseResult, CancellationToken cancellationToken = default)
+        {
+            WasInvoked = true;
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/Func.Tests/Workloads/Resolution/FuncProjectConfigReaderTests.cs
+++ b/test/Func.Tests/Workloads/Resolution/FuncProjectConfigReaderTests.cs
@@ -1,0 +1,125 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads.Resolution;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Workloads.Resolution;
+
+public sealed class FuncProjectConfigReaderTests : IDisposable
+{
+    private readonly DirectoryInfo _dir = Directory.CreateTempSubdirectory("func-project-config-reader-");
+    private readonly FuncProjectConfigReader _reader = new();
+
+    public void Dispose() => _dir.Delete(recursive: true);
+
+    [Fact]
+    public void Read_FolderMissing_ReturnsNull()
+    {
+        Assert.Null(_reader.Read(_dir));
+    }
+
+    [Fact]
+    public void Read_FileMissing_ReturnsNull()
+    {
+        Directory.CreateDirectory(Path.Combine(_dir.FullName, ".func"));
+
+        Assert.Null(_reader.Read(_dir));
+    }
+
+    [Fact]
+    public void Read_StackOnly_ReturnsConfigWithStack()
+    {
+        WriteConfig("""{"stack":"python"}""");
+
+        FuncProjectConfig? config = _reader.Read(_dir);
+
+        Assert.NotNull(config);
+        Assert.Equal("python", config!.Stack);
+        Assert.Null(config.Language);
+    }
+
+    [Fact]
+    public void Read_BothFields_ReturnsConfigWithBoth()
+    {
+        WriteConfig("""{"stack":"node","language":"typescript"}""");
+
+        FuncProjectConfig? config = _reader.Read(_dir);
+
+        Assert.NotNull(config);
+        Assert.Equal("node", config!.Stack);
+        Assert.Equal("typescript", config.Language);
+    }
+
+    [Fact]
+    public void Read_UnknownPropertiesIgnored()
+    {
+        WriteConfig("""{"$schema":"https://example.com/schema.json","stack":"dotnet","azurite":{"port":10000}}""");
+
+        FuncProjectConfig? config = _reader.Read(_dir);
+
+        Assert.NotNull(config);
+        Assert.Equal("dotnet", config!.Stack);
+    }
+
+    [Fact]
+    public void Read_EmptyStack_TreatsAsNotSet()
+    {
+        WriteConfig("""{"stack":"  ","language":"python"}""");
+
+        FuncProjectConfig? config = _reader.Read(_dir);
+
+        Assert.NotNull(config);
+        Assert.Null(config!.Stack);
+        Assert.Equal("python", config.Language);
+    }
+
+    [Fact]
+    public void Read_NeitherFieldSet_ReturnsNull()
+    {
+        WriteConfig("""{"$schema":"https://example.com/schema.json"}""");
+
+        Assert.Null(_reader.Read(_dir));
+    }
+
+    [Fact]
+    public void Read_NonStringStack_TreatsAsNotSet()
+    {
+        WriteConfig("""{"stack":42,"language":"python"}""");
+
+        FuncProjectConfig? config = _reader.Read(_dir);
+
+        Assert.NotNull(config);
+        Assert.Null(config!.Stack);
+        Assert.Equal("python", config.Language);
+    }
+
+    [Fact]
+    public void Read_RootIsArray_ReturnsNull()
+    {
+        WriteConfig("""["stack","python"]""");
+
+        Assert.Null(_reader.Read(_dir));
+    }
+
+    [Fact]
+    public void Read_MalformedJson_ReturnsNullDoesNotThrow()
+    {
+        WriteConfig("not json {");
+
+        Assert.Null(_reader.Read(_dir));
+    }
+
+    [Fact]
+    public void Read_NullDirectory_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => _reader.Read(null!));
+    }
+
+    private void WriteConfig(string contents)
+    {
+        string folder = Path.Combine(_dir.FullName, ".func");
+        Directory.CreateDirectory(folder);
+        File.WriteAllText(Path.Combine(folder, "config.json"), contents);
+    }
+}

--- a/test/Func.Tests/Workloads/Resolution/WorkloadResolverTests.cs
+++ b/test/Func.Tests/Workloads/Resolution/WorkloadResolverTests.cs
@@ -12,6 +12,7 @@ public sealed class WorkloadResolverTests : IDisposable
 {
     private readonly DirectoryInfo _dir;
     private readonly ILocalSettingsReader _settings = Substitute.For<ILocalSettingsReader>();
+    private readonly IFuncProjectConfigReader _projectConfig = Substitute.For<IFuncProjectConfigReader>();
 
     public WorkloadResolverTests()
     {
@@ -20,6 +21,7 @@ public sealed class WorkloadResolverTests : IDisposable
         File.WriteAllText(Path.Combine(_dir.FullName, "host.json"), "{}");
 
         _settings.ReadWorkerRuntime(Arg.Any<DirectoryInfo>()).Returns((string?)null);
+        _projectConfig.Read(Arg.Any<DirectoryInfo>()).Returns((FuncProjectConfig?)null);
     }
 
     public void Dispose()
@@ -330,13 +332,134 @@ public sealed class WorkloadResolverTests : IDisposable
         Assert.Same(dotnet, resolved.Workload);
     }
 
+    [Fact]
+    public async Task ProjectConfig_StackBeatsResolverClaims()
+    {
+        WorkloadInfo dotnet = NewWorkload("Pkg.Dotnet", aliases: ["dotnet"]);
+        WorkloadInfo python = NewWorkload("Pkg.Python", aliases: ["python"]);
+        IProjectResolver dotnetResolver = NewProjectResolver(EvaluationResult.Match("found .csproj"));
+        IProjectResolver pythonResolver = NewProjectResolver(EvaluationResult.NoMatch());
+        _projectConfig.Read(_dir).Returns(new FuncProjectConfig(Stack: "python", Language: null));
+
+        WorkloadResolver resolver = NewResolver(
+            workloads: [dotnet, python],
+            resolvers: [(dotnet, dotnetResolver), (python, pythonResolver)]);
+
+        WorkloadResolution result = await resolver.ResolveAsync(
+            new WorkloadResolutionContext(_dir, StackSelector: null),
+            CancellationToken.None);
+
+        var resolved = Assert.IsType<WorkloadResolution.Resolved>(result);
+        Assert.Same(python, resolved.Workload);
+        Assert.Contains(".func/config.json declares stack 'python'", resolved.Message);
+        // Resolver auto-detection must not run when config provides an explicit pin.
+        await dotnetResolver.DidNotReceive().EvaluateAsync(Arg.Any<DirectoryInfo>(), Arg.Any<CancellationToken>());
+        await pythonResolver.DidNotReceive().EvaluateAsync(Arg.Any<DirectoryInfo>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ProjectConfig_StackBeatsLocalSettingsRuntime()
+    {
+        WorkloadInfo dotnet = NewWorkload("Pkg.Dotnet", aliases: ["dotnet"]);
+        WorkloadInfo python = NewWorkload("Pkg.Python", aliases: ["python"]);
+        _settings.ReadWorkerRuntime(_dir).Returns("dotnet-isolated");
+        _projectConfig.Read(_dir).Returns(new FuncProjectConfig(Stack: "python", Language: null));
+
+        WorkloadResolver resolver = NewResolver(workloads: [dotnet, python]);
+
+        WorkloadResolution result = await resolver.ResolveAsync(
+            new WorkloadResolutionContext(_dir, StackSelector: null),
+            CancellationToken.None);
+
+        var resolved = Assert.IsType<WorkloadResolution.Resolved>(result);
+        Assert.Same(python, resolved.Workload);
+        Assert.Contains(".func/config.json declares stack 'python'", resolved.Message);
+    }
+
+    [Fact]
+    public async Task ProjectConfig_ExplicitStackSelectorBeatsConfig()
+    {
+        WorkloadInfo dotnet = NewWorkload("Pkg.Dotnet", aliases: ["dotnet"]);
+        WorkloadInfo python = NewWorkload("Pkg.Python", aliases: ["python"]);
+        _projectConfig.Read(Arg.Any<DirectoryInfo>()).Returns(new FuncProjectConfig(Stack: "python", Language: null));
+
+        WorkloadResolver resolver = NewResolver(workloads: [dotnet, python]);
+
+        WorkloadResolution result = await resolver.ResolveAsync(
+            new WorkloadResolutionContext(_dir, StackSelector: "dotnet"),
+            CancellationToken.None);
+
+        var resolved = Assert.IsType<WorkloadResolution.Resolved>(result);
+        Assert.Same(dotnet, resolved.Workload);
+        Assert.Contains("--stack 'dotnet'", resolved.Message);
+        // Config is not consulted when --stack wins outright.
+        _projectConfig.DidNotReceive().Read(Arg.Any<DirectoryInfo>());
+    }
+
+    [Fact]
+    public async Task ProjectConfig_StackUninstalled_ReturnsNoneWithConfigSource()
+    {
+        WorkloadInfo dotnet = NewWorkload("Pkg.Dotnet", aliases: ["dotnet"]);
+        _projectConfig.Read(_dir).Returns(new FuncProjectConfig(Stack: "python", Language: null));
+
+        WorkloadResolver resolver = NewResolver(workloads: [dotnet]);
+
+        WorkloadResolution result = await resolver.ResolveAsync(
+            new WorkloadResolutionContext(_dir, StackSelector: null),
+            CancellationToken.None);
+
+        var none = Assert.IsType<WorkloadResolution.None>(result);
+        Assert.Contains(".func/config.json declares stack 'python'", none.Message);
+        Assert.Contains("Pkg.Dotnet", none.Message);
+    }
+
+    [Fact]
+    public async Task ProjectConfig_LanguageOnlyFallsThroughToClaims()
+    {
+        WorkloadInfo python = NewWorkload("Pkg.Python", aliases: ["python"]);
+        IProjectResolver pythonResolver = NewProjectResolver(EvaluationResult.Match("found requirements.txt"));
+        _projectConfig.Read(_dir).Returns(new FuncProjectConfig(Stack: null, Language: "python"));
+
+        WorkloadResolver resolver = NewResolver(
+            workloads: [python],
+            resolvers: [(python, pythonResolver)]);
+
+        WorkloadResolution result = await resolver.ResolveAsync(
+            new WorkloadResolutionContext(_dir, StackSelector: null),
+            CancellationToken.None);
+
+        var resolved = Assert.IsType<WorkloadResolution.Resolved>(result);
+        Assert.Same(python, resolved.Workload);
+        Assert.Contains("found requirements.txt", resolved.Message);
+    }
+
+    [Fact]
+    public async Task ProjectConfig_WhitespaceStackFallsThroughToClaims()
+    {
+        WorkloadInfo dotnet = NewWorkload("Pkg.Dotnet", aliases: ["dotnet"]);
+        IProjectResolver dotnetResolver = NewProjectResolver(EvaluationResult.Match("found .csproj"));
+        _projectConfig.Read(_dir).Returns(new FuncProjectConfig(Stack: "   ", Language: null));
+
+        WorkloadResolver resolver = NewResolver(
+            workloads: [dotnet],
+            resolvers: [(dotnet, dotnetResolver)]);
+
+        WorkloadResolution result = await resolver.ResolveAsync(
+            new WorkloadResolutionContext(_dir, StackSelector: null),
+            CancellationToken.None);
+
+        var resolved = Assert.IsType<WorkloadResolution.Resolved>(result);
+        Assert.Same(dotnet, resolved.Workload);
+    }
+
     private WorkloadResolver NewResolver(
         IReadOnlyList<WorkloadInfo>? workloads = null,
         IReadOnlyList<(WorkloadInfo Workload, IProjectResolver Resolver)>? resolvers = null)
         => new(
             new StubWorkloadProvider(workloads ?? []),
             (resolvers ?? []).Select(d => new WorkloadProjectResolverContribution(d.Workload, d.Resolver)).ToList(),
-            _settings);
+            _settings,
+            _projectConfig);
 
     private static WorkloadInfo NewWorkload(string packageId, IReadOnlyList<string>? aliases = null)
         => TestWorkloads.CreateInfo(packageId) with { Aliases = aliases ?? [] };


### PR DESCRIPTION
Adds a per-project `.func/config.json` that pins the workload stack and language. Resolution order in `WorkloadResolver` becomes:

```
--stack > .func/config.json > FUNCTIONS_WORKER_RUNTIME > resolver claims
```

`func init` writes the file after a successful init, never overwriting an existing one. The reader is tolerant of missing/malformed files.

### Deferred (intentionally out of scope)

- Mismatch warning when \`.func/config.json\` disagrees with resolver auto-detection.
- \`InitCommand\` reading config to seed selection.
- \`\$schema\` URL + JSON schema file.
- \`.gitignore\` template change.
- README / \`docs/\` updates.
- Standalone E2E covering full precedence chain.
- Per-workload extension area, walk-up discovery, mirroring to \`main\`/\`in-proc\`.