### PR TITLE
Refactor func init to always write host skeleton, polish workload install UX

### DIFF
--- a/src/Func/Commands/InitCommand.cs
+++ b/src/Func/Commands/InitCommand.cs
@@ -24,7 +24,7 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
 
     public Option<string?> NameOption { get; } = new("--name", "-n")
     {
-        Description = "The name of the function app project"
+        Description = "The name of the Function App project"
     };
 
     public Option<string?> LanguageOption { get; } = new("--language", "-l")
@@ -55,6 +55,8 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
         _hintRenderer = hintRenderer;
         _initializers = initializers.ToList();
 
+        LanguageOption.Description = BuildLanguageOptionDescription(_initializers);
+
         AddPathArgument();
         Options.Add(StackOption);
         Options.Add(NameOption);
@@ -76,7 +78,7 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
-        // Two workloads claiming the same stack is unrecoverable — `--stack`
+        // Two workloads claiming the same stack is unrecoverable: `--stack`
         // would be ambiguous and auto-select would silently pick whichever
         // DI returned first. Validated lazily here (rather than in the ctor)
         // so an init-side conflict doesn't break unrelated commands like
@@ -95,42 +97,137 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
 
         WorkingDirectory workingDirectory = parseResult.GetValue(PathArgument!)!;
         workingDirectory.CreateIfNotExists();
-
-        string? stack = parseResult.GetValue(StackOption);
-
-        IProjectInitializer? initializer = await SelectInitializerAsync(stack, cancellationToken);
-        if (initializer is null)
+        bool force = parseResult.GetValue(ForceOption);
+        string? language = parseResult.GetValue(LanguageOption);
+        if (!string.IsNullOrWhiteSpace(language))
         {
-            string[] installed = [.. _initializers.Select(i => i.Stack)];
-            WorkloadHint hint = installed.Length == 0
-                ? new WorkloadHint(WorkloadHintKind.NoWorkloadsInstalled, "initialize a project", null, installed)
-                : stack is not null
-                    ? new WorkloadHint(WorkloadHintKind.NoMatchingStack, "initialize a project", stack, installed)
-                    : new WorkloadHint(WorkloadHintKind.AmbiguousStackChoice, "initialize a project", null, installed);
-            _hintRenderer.Render(hint);
+            language = language.Trim().ToLowerInvariant();
+        }
+        string? requestedStack = parseResult.GetValue(StackOption);
+
+        // Refuse to overwrite an existing Functions project. Either host.json
+        // or .func/config.json being present is enough to count: both are
+        // host-owned skeleton files we'd otherwise rewrite. --force opts in
+        // to a re-init.
+        if (!force && IsAlreadyInitialized(workingDirectory.Info, out string existingFile))
+        {
+            _interaction.WriteError(
+                $"This directory already contains a Functions project ('{existingFile}' is present). " +
+                "Pass --force to re-initialize.");
             return 1;
+        }
+
+        InitializerSelection selection = await SelectInitializerAsync(requestedStack, cancellationToken);
+
+        // Always lay down the host-owned skeleton so a folder is usable even
+        // when no initializer runs. Workload initializers layer their files
+        // on top after this point.
+        WriteHostJson(workingDirectory.Info, force);
+        WriteFuncProjectConfig(workingDirectory.Info, selection.Initializer?.Stack, language, force);
+        _interaction.WriteBlankLine();
+
+        if (selection.Initializer is null)
+        {
+            _hintRenderer.Render(selection.Hint!);
+            return 0;
+        }
+
+        if (selection.Hint is not null)
+        {
+            // Auto-select info line, rendered before initializer output so
+            // the user sees why this stack was chosen.
+            _hintRenderer.Render(selection.Hint);
         }
 
         var context = new InitContext(
             WorkingDirectory: workingDirectory,
             ProjectName: parseResult.GetValue(NameOption),
-            Language: parseResult.GetValue(LanguageOption),
-            Force: parseResult.GetValue(ForceOption));
+            Language: language,
+            Force: force);
 
-        await initializer.InitializeAsync(context, parseResult, cancellationToken);
-
-        WriteFuncProjectConfig(workingDirectory.Info, initializer.Stack, context.Language, context.Force);
+        await selection.Initializer.InitializeAsync(context, parseResult, cancellationToken);
 
         _interaction.WriteLine(l => l
             .Success("✓ ")
             .Muted("Project initialized for ")
-            .Code(initializer.Stack)
+            .Code(selection.Initializer.Stack)
             .Muted("."));
 
         return 0;
     }
 
-    private void WriteFuncProjectConfig(DirectoryInfo workingDirectory, string stack, string? language, bool force)
+    // Builds the help text for `--language`. Languages are pulled from
+    // installed initializers' SupportedLanguages, lowercased and sorted for
+    // a stable, consistent presentation. The `--language` value itself is
+    // normalized to lower case in ExecuteAsync, so matching is case-insensitive.
+    private static string BuildLanguageOptionDescription(IReadOnlyList<IProjectInitializer> initializers)
+    {
+        var languages = initializers
+            .SelectMany(i => i.SupportedLanguages)
+            .Where(l => !string.IsNullOrWhiteSpace(l))
+            .Select(l => l.Trim().ToLowerInvariant())
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(l => l, StringComparer.Ordinal)
+            .ToList();
+
+        return languages.Count == 0
+            ? "The programming language. Install a stack workload (`func workload install <id>`) to see supported values."
+            : "The programming language. Supported values: " + string.Join(", ", languages) + ".";
+    }
+
+    private static bool IsAlreadyInitialized(DirectoryInfo workingDirectory, out string existingFile)
+    {
+        string hostJson = Path.Combine(workingDirectory.FullName, "host.json");
+        if (File.Exists(hostJson))
+        {
+            existingFile = "host.json";
+            return true;
+        }
+
+        string config = Path.Combine(workingDirectory.FullName, ".func", "config.json");
+        if (File.Exists(config))
+        {
+            existingFile = Path.Combine(".func", "config.json");
+            return true;
+        }
+
+        existingFile = string.Empty;
+        return false;
+    }
+
+    private void WriteHostJson(DirectoryInfo workingDirectory, bool force)
+    {
+        string path = Path.Combine(workingDirectory.FullName, "host.json");
+
+        // Treat an existing file as user-owned unless --force was passed.
+        // Workloads that need extensionBundle / logging defaults will merge
+        // into the file we just wrote (or the user's existing one).
+        if (File.Exists(path) && !force)
+        {
+            return;
+        }
+
+        try
+        {
+            const string MinimalHostJson = "{\n  \"version\": \"2.0\"\n}\n";
+            File.WriteAllText(path, MinimalHostJson);
+
+            _interaction.WriteLine(l => l
+                .Muted("· Wrote ")
+                .Code("host.json")
+                .Muted("."));
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            _interaction.WriteLine(l => l
+                .Warning("! ")
+                .Muted("Could not write host.json (")
+                .Code(ex.Message)
+                .Muted(")."));
+        }
+    }
+
+    private void WriteFuncProjectConfig(DirectoryInfo workingDirectory, string? stack, string? language, bool force)
     {
         string folder = Path.Combine(workingDirectory.FullName, ".func");
         string path = Path.Combine(folder, "config.json");
@@ -145,10 +242,11 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
         {
             Directory.CreateDirectory(folder);
 
-            var payload = new Dictionary<string, string>(StringComparer.Ordinal)
+            var payload = new Dictionary<string, string>(StringComparer.Ordinal);
+            if (!string.IsNullOrWhiteSpace(stack))
             {
-                ["stack"] = stack,
-            };
+                payload["stack"] = stack;
+            }
             if (!string.IsNullOrWhiteSpace(language))
             {
                 payload["language"] = language;
@@ -159,11 +257,16 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
                 WriteIndented = true,
             });
             File.WriteAllText(path, json + Environment.NewLine);
+
+            _interaction.WriteLine(l => l
+                .Muted("· Wrote ")
+                .Code(Path.Combine(".func", "config.json"))
+                .Muted("."));
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
-            // Project files already scaffolded; only the stack-pinning metadata failed.
-            // Warn the user and let init succeed — they can create .func/config.json by hand.
+            // Skeleton write failed; warn and let init succeed. The user can
+            // create .func/config.json by hand if they want stack pinning.
             _interaction.WriteLine(l => l
                 .Warning("! ")
                 .Muted("Could not write .func/config.json (")
@@ -172,40 +275,70 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
         }
     }
 
-    private async Task<IProjectInitializer?> SelectInitializerAsync(string? stack, CancellationToken cancellationToken)
+    private async Task<InitializerSelection> SelectInitializerAsync(string? requestedStack, CancellationToken cancellationToken)
     {
+        string[] installed = [.. _initializers.Select(i => i.Stack)];
+
         if (_initializers.Count == 0)
         {
-            return null;
+            return InitializerSelection.MissOnly(new WorkloadHint(
+                WorkloadHintKind.NoWorkloadsInstalled, "initialize a project", null, installed));
         }
 
-        if (!string.IsNullOrEmpty(stack))
+        if (!string.IsNullOrEmpty(requestedStack))
         {
-            return _initializers.FirstOrDefault(i =>
-                string.Equals(i.Stack, stack, StringComparison.OrdinalIgnoreCase));
+            IProjectInitializer? match = _initializers.FirstOrDefault(i =>
+                string.Equals(i.Stack, requestedStack, StringComparison.OrdinalIgnoreCase));
+            return match is not null
+                ? InitializerSelection.Picked(match)
+                : InitializerSelection.MissOnly(new WorkloadHint(
+                    WorkloadHintKind.NoMatchingStack, "initialize a project", requestedStack, installed));
         }
 
-        // No stack specified — auto-select if there's only one initializer
+        // No stack specified: auto-select if there's only one initializer
         // installed (the common case for engineers using a single language).
+        // Surface an info line so the user knows why this stack was picked.
         if (_initializers.Count == 1)
         {
-            return _initializers[0];
+            IProjectInitializer sole = _initializers[0];
+            return InitializerSelection.PickedWithHint(
+                sole,
+                new WorkloadHint(
+                    WorkloadHintKind.AutoSelectedSoleWorkload,
+                    "initialize a project",
+                    sole.Stack,
+                    installed));
         }
 
-        // Multiple initializers — prompt the user to pick. In non-interactive
-        // mode we fall back to the "no match" error so scripts get a clear
-        // failure instead of silently picking the first option.
+        // Multiple initializers, non-interactive: bootstrap the skeleton and
+        // tell the user to re-run with --stack. Scripts get a clear next-step
+        // hint instead of a silently-picked first option.
         if (!_interaction.IsInteractive)
         {
-            return null;
+            return InitializerSelection.MissOnly(new WorkloadHint(
+                WorkloadHintKind.AmbiguousStackChoice, "initialize a project", null, installed));
         }
 
+        // Multiple initializers, interactive: prompt.
         var choices = _initializers.Select(i => i.Stack).ToList();
         string picked = await _interaction.PromptForSelectionAsync(
             "Select a stack:",
             choices,
             cancellationToken);
 
-        return _initializers.FirstOrDefault(i => i.Stack == picked);
+        IProjectInitializer? promptedMatch = _initializers.FirstOrDefault(i => i.Stack == picked);
+        return promptedMatch is not null
+            ? InitializerSelection.Picked(promptedMatch)
+            : InitializerSelection.MissOnly(new WorkloadHint(
+                WorkloadHintKind.AmbiguousStackChoice, "initialize a project", null, installed));
+    }
+
+    private readonly record struct InitializerSelection(IProjectInitializer? Initializer, WorkloadHint? Hint)
+    {
+        public static InitializerSelection Picked(IProjectInitializer initializer) => new(initializer, null);
+
+        public static InitializerSelection PickedWithHint(IProjectInitializer initializer, WorkloadHint hint) => new(initializer, hint);
+
+        public static InitializerSelection MissOnly(WorkloadHint hint) => new(null, hint);
     }
 }

--- a/src/Func/Commands/Workload/WorkloadInstallCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadInstallCommand.cs
@@ -23,6 +23,7 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
     private readonly IInteractionService _interaction;
     private readonly IWorkloadInstaller _installer;
     private readonly IWorkloadStore _store;
+    private readonly WorkloadUpdateCommand _updateCommand;
 
     public Argument<string> WorkloadArgument { get; } = new("id")
     {
@@ -57,12 +58,14 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
     public WorkloadInstallCommand(
         IInteractionService interaction,
         IWorkloadInstaller installer,
-        IWorkloadStore store)
+        IWorkloadStore store,
+        WorkloadUpdateCommand updateCommand)
         : base("install", "Install a workload.")
     {
         _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
         _installer = installer ?? throw new ArgumentNullException(nameof(installer));
         _store = store ?? throw new ArgumentNullException(nameof(store));
+        _updateCommand = updateCommand ?? throw new ArgumentNullException(nameof(updateCommand));
 
         WorkloadArgument.AddRequiredIdValidator();
         VersionOption.AddSemVerValidator();
@@ -203,55 +206,32 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
             return null;
         }
 
-        return await RunUpdateAsync(match.PackageId, source, includePrerelease, cancellationToken);
+        return await DispatchToUpdateAsync(match.PackageId, source, includePrerelease, cancellationToken);
     }
 
-    private async Task<int> RunUpdateAsync(
+    // Delegate to the `func workload update` command (Parse + InvokeAsync) so
+    // confirm-yes goes through exactly the same flow the user would hit if they
+    // had run `func workload update <id>` themselves: same options, same
+    // validators, same output. Avoids forking the rendering or the underlying
+    // installer call between install and update.
+    private async Task<int> DispatchToUpdateAsync(
         string packageId,
         string? source,
         bool includePrerelease,
         CancellationToken cancellationToken)
     {
-        try
+        var args = new List<string> { packageId };
+        if (!string.IsNullOrEmpty(source))
         {
-            WorkloadUpdateResult result = await _installer.UpdateAsync(
-                packageId,
-                targetInstalledVersion: null,
-                source,
-                includePrerelease,
-                allowMajor: false,
-                cancellationToken);
-
-            if (result.NoCandidateOnSource)
-            {
-                _interaction.WriteHint(
-                    $"No version of '{result.Entry.PackageId}' was found on the configured source. " +
-                    "Pass --source to point at the feed that publishes it.");
-                return 1;
-            }
-
-            if (result.NoUpdateAvailable)
-            {
-                string display = result.Entry.Aliases.Count > 0 ? result.Entry.Aliases[0] : result.Entry.PackageId;
-                _interaction.WriteWarning(
-                    $"Workload '{display}' is already at the latest available version " +
-                    $"({result.Entry.PackageVersion}).");
-                return 0;
-            }
-
-            string displayName = result.Entry.Aliases.Count > 0 ? result.Entry.Aliases[0] : result.Entry.PackageId;
-            _interaction.WriteSuccess(
-                $"Updated workload '{displayName}' from {result.PreviousVersion} to {result.Entry.PackageVersion}.");
-            return 0;
+            args.Add("--source");
+            args.Add(source);
         }
-        catch (Exception ex) when (
-            ex is WorkloadPackageNotFoundException
-            or FileNotFoundException
-            or InvalidWorkloadException
-            or InvalidOperationException)
+        if (includePrerelease)
         {
-            throw new GracefulException(ex.Message, isUserError: true);
+            args.Add("--prerelease");
         }
+
+        return await _updateCommand.Parse(args.ToArray()).InvokeAsync(configuration: null, cancellationToken);
     }
 
     private static string BuildSuccessMessage(WorkloadInstallResult result)

--- a/src/Func/Commands/Workload/WorkloadInstallCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadInstallCommand.cs
@@ -91,7 +91,8 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
             // prompt entirely. Non-interactive contexts treat the prompt as
             // a decline and exit non-zero with the same hint. Local .nupkg
             // installs bypass the check since the resolver path differs.
-            int? earlyExit = await CheckAlreadyInstalledAsync(workload, exact, cancellationToken);
+            int? earlyExit = await HandleAlreadyInstalledAsync(
+                workload, exact, source, includePrerelease, cancellationToken);
             if (earlyExit is { } code)
             {
                 return code;
@@ -111,7 +112,15 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
                     force,
                     cancellationToken);
 
-            _interaction.WriteSuccess(BuildSuccessMessage(result));
+            string message = BuildSuccessMessage(result);
+            if (result.AlreadyInstalled)
+            {
+                _interaction.WriteWarning(message);
+            }
+            else
+            {
+                _interaction.WriteSuccess(message);
+            }
             return 0;
         }
         catch (WorkloadPackageNotFoundException ex)
@@ -148,9 +157,11 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
     private static bool LooksLikeLocalPackagePath(string value)
         => value.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase) && File.Exists(value);
 
-    private async Task<int?> CheckAlreadyInstalledAsync(
+    private async Task<int?> HandleAlreadyInstalledAsync(
         string identifier,
         bool exact,
+        string? source,
+        bool includePrerelease,
         CancellationToken cancellationToken)
     {
         IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
@@ -171,29 +182,76 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
             return null;
         }
 
-        string canonicalId = match.PackageId;
-        string prompt =
-            $"'{canonicalId}' is already installed at {match.PackageVersion}. " +
-            $"Run 'func workload update {canonicalId}' instead?";
+        // Prefer the first alias for user-facing messages; fall back to the
+        // canonical package id when no alias is published.
+        string display = match.Aliases.Count > 0 ? match.Aliases[0] : match.PackageId;
+        string prompt = $"'{display}' is already installed at {match.PackageVersion}. Update instead?";
 
         if (!_interaction.IsInteractive)
         {
             _interaction.WriteHint(
-                $"'{canonicalId}' is already installed at {match.PackageVersion}. " +
-                $"Run 'func workload update {canonicalId}' to upgrade, or pass --force to install side-by-side.");
+                $"'{display}' is already installed at {match.PackageVersion}. " +
+                $"Run 'func workload update {display}' to upgrade, or pass --force to install side-by-side.");
             return 1;
         }
 
-        bool useUpdate = await _interaction.ConfirmAsync(prompt, defaultValue: true, cancellationToken);
-        if (useUpdate)
+        bool runUpdate = await _interaction.ConfirmAsync(prompt, defaultValue: true, cancellationToken);
+        if (!runUpdate)
         {
-            _interaction.WriteHint($"Run 'func workload update {canonicalId}' to upgrade.");
-            return 1;
+            // User declined: fall through to a normal install, which will
+            // go side-by-side or no-op for the same version.
+            return null;
         }
 
-        // User declined the suggestion: fall through to a normal install,
-        // which will go side-by-side or no-op for the same version.
-        return null;
+        return await RunUpdateAsync(match.PackageId, source, includePrerelease, cancellationToken);
+    }
+
+    private async Task<int> RunUpdateAsync(
+        string packageId,
+        string? source,
+        bool includePrerelease,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            WorkloadUpdateResult result = await _installer.UpdateAsync(
+                packageId,
+                targetInstalledVersion: null,
+                source,
+                includePrerelease,
+                allowMajor: false,
+                cancellationToken);
+
+            if (result.NoCandidateOnSource)
+            {
+                _interaction.WriteHint(
+                    $"No version of '{result.Entry.PackageId}' was found on the configured source. " +
+                    "Pass --source to point at the feed that publishes it.");
+                return 1;
+            }
+
+            if (result.NoUpdateAvailable)
+            {
+                string display = result.Entry.Aliases.Count > 0 ? result.Entry.Aliases[0] : result.Entry.PackageId;
+                _interaction.WriteWarning(
+                    $"Workload '{display}' is already at the latest available version " +
+                    $"({result.Entry.PackageVersion}).");
+                return 0;
+            }
+
+            string displayName = result.Entry.Aliases.Count > 0 ? result.Entry.Aliases[0] : result.Entry.PackageId;
+            _interaction.WriteSuccess(
+                $"Updated workload '{displayName}' from {result.PreviousVersion} to {result.Entry.PackageVersion}.");
+            return 0;
+        }
+        catch (Exception ex) when (
+            ex is WorkloadPackageNotFoundException
+            or FileNotFoundException
+            or InvalidWorkloadException
+            or InvalidOperationException)
+        {
+            throw new GracefulException(ex.Message, isUserError: true);
+        }
     }
 
     private static string BuildSuccessMessage(WorkloadInstallResult result)
@@ -205,8 +263,8 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
 
         return entry.Kind switch
         {
-            WorkloadKind.Workload when entry.EntryPoint is not null
-                => $"{verb} (entry point: {entry.EntryPoint.Type}).",
+            WorkloadKind.Workload when entry.Aliases.Count > 0
+                => $"{verb} (aliases: {string.Join(", ", entry.Aliases)}).",
             WorkloadKind.Content
                 => $"{verb} (content at '{entry.Source}').",
             _ => $"{verb}.",

--- a/src/Func/Commands/Workload/WorkloadUpdateCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadUpdateCommand.cs
@@ -263,7 +263,7 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
 
         if (result.NoUpdateAvailable)
         {
-            _interaction.WriteHint(
+            _interaction.WriteWarning(
                 $"Workload '{result.Entry.PackageId}' is already at the latest available version " +
                 $"({result.Entry.PackageVersion}).");
             return;

--- a/src/Func/Commands/Workload/WorkloadUpdateCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadUpdateCommand.cs
@@ -253,10 +253,15 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
 
     private void RenderSingle(WorkloadUpdateResult result)
     {
+        // Prefer the published alias for user-facing messages so the output
+        // matches the token the user typed; fall back to the package id when
+        // no alias is published.
+        string display = result.Entry.Aliases.Count > 0 ? result.Entry.Aliases[0] : result.Entry.PackageId;
+
         if (result.NoCandidateOnSource)
         {
             _interaction.WriteHint(
-                $"No version of '{result.Entry.PackageId}' was found on the configured source. " +
+                $"No version of '{display}' was found on the configured source. " +
                 "Pass --source to point at the feed that publishes it.");
             return;
         }
@@ -264,12 +269,12 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
         if (result.NoUpdateAvailable)
         {
             _interaction.WriteWarning(
-                $"Workload '{result.Entry.PackageId}' is already at the latest available version " +
+                $"Workload '{display}' is already at the latest available version " +
                 $"({result.Entry.PackageVersion}).");
             return;
         }
 
         _interaction.WriteSuccess(
-            $"Updated workload '{result.Entry.PackageId}' from {result.PreviousVersion} to {result.Entry.PackageVersion}.");
+            $"Updated workload '{display}' from {result.PreviousVersion} to {result.Entry.PackageVersion}.");
     }
 }

--- a/src/Func/Workloads/WorkloadHint.cs
+++ b/src/Func/Workloads/WorkloadHint.cs
@@ -18,6 +18,12 @@ internal enum WorkloadHintKind
 
     /// <summary>Multiple stacks are installed and the user did not specify <c>--stack</c>.</summary>
     AmbiguousStackChoice,
+
+    /// <summary>
+    /// Exactly one workload is installed and was auto-picked because the user did
+    /// not specify <c>--stack</c>. Informational; the action proceeds.
+    /// </summary>
+    AutoSelectedSoleWorkload,
 }
 
 /// <summary>
@@ -28,7 +34,7 @@ internal enum WorkloadHintKind
 /// </summary>
 /// <param name="Kind">Which situation is being described; controls layout.</param>
 /// <param name="ActionDescription">What the user was trying to do (e.g. "initialize a project"). Used in the install prompt.</param>
-/// <param name="RequestedStack">The <c>--stack</c> value the user passed, when applicable.</param>
+/// <param name="RequestedStack">The relevant stack id: the <c>--stack</c> value the user passed, or the auto-selected stack for <see cref="WorkloadHintKind.AutoSelectedSoleWorkload"/>.</param>
 /// <param name="InstalledStacks">Stack identifiers currently registered, when applicable.</param>
 internal sealed record WorkloadHint(
     WorkloadHintKind Kind,

--- a/src/Func/Workloads/WorkloadHintRenderer.cs
+++ b/src/Func/Workloads/WorkloadHintRenderer.cs
@@ -30,6 +30,9 @@ internal sealed class WorkloadHintRenderer(IInteractionService interaction) : IW
             case WorkloadHintKind.AmbiguousStackChoice:
                 RenderAmbiguousStackChoice(hint);
                 break;
+            case WorkloadHintKind.AutoSelectedSoleWorkload:
+                RenderAutoSelectedSoleWorkload(hint);
+                break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(hint), hint.Kind, "Unknown workload hint kind.");
         }
@@ -37,9 +40,9 @@ internal sealed class WorkloadHintRenderer(IInteractionService interaction) : IW
 
     private void RenderNoWorkloadsInstalled(WorkloadHint hint)
     {
-        _interaction.WriteError("No stacks installed.");
+        _interaction.WriteWarning("No stacks installed.");
         _interaction.WriteBlankLine();
-        _interaction.WriteHint($"Install a stack to {hint.ActionDescription}:");
+        _interaction.WriteHint($"Install a stack workload to {hint.ActionDescription}:");
         _interaction.WriteBlankLine();
 
         IEnumerable<DefinitionItem> items = KnownInstallableWorkloads.LanguageMap.Select(static kvp =>
@@ -63,6 +66,26 @@ internal sealed class WorkloadHintRenderer(IInteractionService interaction) : IW
     {
         _interaction.WriteHint("Multiple stacks installed; pass --stack <name> to choose.");
         WriteInstalledStacks(hint.InstalledStacks);
+    }
+
+    private void RenderAutoSelectedSoleWorkload(WorkloadHint hint)
+    {
+        _interaction.WriteHint(
+            $"Auto-selecting '{hint.RequestedStack}' (the only installed workload).");
+
+        IEnumerable<DefinitionItem> others = KnownInstallableWorkloads.LanguageMap
+            .Where(kvp => !string.Equals(kvp.Key, hint.RequestedStack, StringComparison.OrdinalIgnoreCase))
+            .Select(kvp => new DefinitionItem(
+                $"func workload install {kvp.Key}",
+                string.Join(", ", kvp.Value)));
+
+        if (others.Any())
+        {
+            _interaction.WriteBlankLine();
+            _interaction.WriteHint("You can install more workloads via:");
+            _interaction.WriteBlankLine();
+            _interaction.WriteDefinitionList(others);
+        }
     }
 
     private void WriteInstalledStacks(IReadOnlyList<string> stacks)

--- a/test/Func.Tests/Commands/InitCommandTests.cs
+++ b/test/Func.Tests/Commands/InitCommandTests.cs
@@ -52,10 +52,9 @@ public class InitCommandTests
     [Fact]
     public async Task InitCommand_CreatesMissingDirectoryBeforeDispatch()
     {
-        // No workloads installed → InitCommand short-circuits to a hint, but it
-        // must still have created the [path] directory by then. This guards the
-        // post-ApplyPath refactor: previously `ApplyPath(parseResult, createIfNotExists: true)`
-        // did this; now `WorkingDirectory.CreateIfNotExists()` does.
+        // No workloads installed: InitCommand bootstraps the host skeleton and
+        // renders a NoWorkloadsInstalled hint. It must still have created the
+        // [path] directory by then.
         var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
         Assert.False(Directory.Exists(newDir));
 
@@ -66,7 +65,7 @@ public class InitCommandTests
 
             var exitCode = await result.InvokeAsync();
 
-            Assert.Equal(1, exitCode); // no workloads installed
+            Assert.Equal(0, exitCode);
             Assert.True(Directory.Exists(newDir));
         }
         finally
@@ -122,7 +121,10 @@ public class InitCommandTests
             var initializer = new FakeProjectInitializer("python");
             int exitCode = await RunInitAsync(newDir, initializer, language: "python");
 
-            Assert.Equal(0, exitCode);
+            // Folder is already a Functions project (.func/config.json present);
+            // command refuses without --force, initializer never runs.
+            Assert.Equal(1, exitCode);
+            Assert.False(initializer.WasInvoked);
             Assert.Equal(existingContent, File.ReadAllText(configPath));
         }
         finally
@@ -160,15 +162,271 @@ public class InitCommandTests
         }
     }
 
-    private async Task<int> RunInitAsync(string path, IProjectInitializer initializer, string? language)
+    private async Task<int> RunInitAsync(
+        string path,
+        IProjectInitializer initializer,
+        string? language,
+        string? stack = null,
+        bool force = false)
     {
-        var cmd = new InitCommand(_interaction, _hintRenderer, [initializer]);
+        return await RunInitAsync(path, [initializer], language, stack, force);
+    }
+
+    private async Task<int> RunInitAsync(
+        string path,
+        IReadOnlyList<IProjectInitializer> initializers,
+        string? language = null,
+        string? stack = null,
+        bool force = false)
+    {
+        var cmd = new InitCommand(_interaction, _hintRenderer, initializers);
         var root = new RootCommand { cmd };
-        string args = language is null
-            ? $"init \"{path}\""
-            : $"init \"{path}\" --language {language}";
-        ParseResult result = root.Parse(args);
+        var args = new List<string> { "init", path };
+        if (stack is not null)
+        {
+            args.Add("--stack");
+            args.Add(stack);
+        }
+        if (language is not null)
+        {
+            args.Add("--language");
+            args.Add(language);
+        }
+        if (force)
+        {
+            args.Add("--force");
+        }
+        ParseResult result = root.Parse(args.ToArray());
         return await result.InvokeAsync();
+    }
+
+    [Fact]
+    public async Task InitCommand_NoWorkloadsInstalled_BootstrapsSkeletonAndExitsZero()
+    {
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+        try
+        {
+            int exitCode = await RunInitAsync(newDir, initializers: []);
+
+            Assert.Equal(0, exitCode);
+            AssertHostJsonWritten(newDir);
+            AssertConfigJsonHasShape(newDir, expectedStack: null, expectedLanguage: null);
+
+            WorkloadHint hint = Assert.Single(_hintRenderer.Hints);
+            Assert.Equal(WorkloadHintKind.NoWorkloadsInstalled, hint.Kind);
+        }
+        finally
+        {
+            CleanupDirectory(newDir);
+        }
+    }
+
+    [Fact]
+    public async Task InitCommand_StackProvidedButNoMatch_BootstrapsSkeletonAndExitsZero()
+    {
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+        try
+        {
+            var initializer = new FakeProjectInitializer("python");
+            int exitCode = await RunInitAsync(newDir, initializer, language: null, stack: "ruby");
+
+            Assert.Equal(0, exitCode);
+            Assert.False(initializer.WasInvoked);
+            AssertHostJsonWritten(newDir);
+            AssertConfigJsonHasShape(newDir, expectedStack: null, expectedLanguage: null);
+
+            WorkloadHint hint = Assert.Single(_hintRenderer.Hints);
+            Assert.Equal(WorkloadHintKind.NoMatchingStack, hint.Kind);
+            Assert.Equal("ruby", hint.RequestedStack);
+        }
+        finally
+        {
+            CleanupDirectory(newDir);
+        }
+    }
+
+    [Fact]
+    public async Task InitCommand_MultipleWorkloads_NonInteractive_BootstrapsSkeletonAndExitsZero()
+    {
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+        try
+        {
+            var python = new FakeProjectInitializer("python");
+            var node = new FakeProjectInitializer("node");
+            int exitCode = await RunInitAsync(newDir, [python, node]);
+
+            Assert.Equal(0, exitCode);
+            Assert.False(python.WasInvoked);
+            Assert.False(node.WasInvoked);
+            AssertHostJsonWritten(newDir);
+            AssertConfigJsonHasShape(newDir, expectedStack: null, expectedLanguage: null);
+
+            WorkloadHint hint = Assert.Single(_hintRenderer.Hints);
+            Assert.Equal(WorkloadHintKind.AmbiguousStackChoice, hint.Kind);
+        }
+        finally
+        {
+            CleanupDirectory(newDir);
+        }
+    }
+
+    [Fact]
+    public async Task InitCommand_SingleWorkload_AutoSelectsAndRendersInfoHint()
+    {
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+        try
+        {
+            var initializer = new FakeProjectInitializer("python");
+            int exitCode = await RunInitAsync(newDir, initializer, language: null);
+
+            Assert.Equal(0, exitCode);
+            Assert.True(initializer.WasInvoked);
+            AssertHostJsonWritten(newDir);
+            AssertConfigJsonHasShape(newDir, expectedStack: "python", expectedLanguage: null);
+
+            WorkloadHint hint = Assert.Single(_hintRenderer.Hints);
+            Assert.Equal(WorkloadHintKind.AutoSelectedSoleWorkload, hint.Kind);
+            Assert.Equal("python", hint.RequestedStack);
+        }
+        finally
+        {
+            CleanupDirectory(newDir);
+        }
+    }
+
+    [Fact]
+    public async Task InitCommand_StackProvided_WritesHostJsonAndConfig()
+    {
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+        try
+        {
+            var initializer = new FakeProjectInitializer("python");
+            int exitCode = await RunInitAsync(newDir, initializer, language: "python", stack: "python");
+
+            Assert.Equal(0, exitCode);
+            Assert.True(initializer.WasInvoked);
+            AssertHostJsonWritten(newDir);
+            AssertConfigJsonHasShape(newDir, expectedStack: "python", expectedLanguage: "python");
+
+            // --stack matched directly, no hint.
+            Assert.Empty(_hintRenderer.Hints);
+        }
+        finally
+        {
+            CleanupDirectory(newDir);
+        }
+    }
+
+    [Fact]
+    public async Task InitCommand_PreservesExistingHostJson_WhenForceIsNotSet()
+    {
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(newDir);
+            string hostPath = Path.Combine(newDir, "host.json");
+            const string existingContent = "{\"version\":\"2.0\",\"customMarker\":true}";
+            File.WriteAllText(hostPath, existingContent);
+
+            var initializer = new FakeProjectInitializer("python");
+            int exitCode = await RunInitAsync(newDir, initializer, language: null, stack: "python");
+
+            // host.json present means the folder is already a Functions project;
+            // command refuses without --force, initializer never runs.
+            Assert.Equal(1, exitCode);
+            Assert.False(initializer.WasInvoked);
+            Assert.Equal(existingContent, File.ReadAllText(hostPath));
+        }
+        finally
+        {
+            CleanupDirectory(newDir);
+        }
+    }
+
+    [Fact]
+    public async Task InitCommand_RefusesEarly_BeforeWorkloadSelection_WhenAlreadyInitialized()
+    {
+        // Even with zero workloads installed, a directory that already has a
+        // host.json is treated as initialized: no skeleton write, no hint, exit 1.
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(newDir);
+            File.WriteAllText(Path.Combine(newDir, "host.json"), "{\"version\":\"2.0\"}");
+
+            int exitCode = await RunInitAsync(newDir, initializers: []);
+
+            Assert.Equal(1, exitCode);
+            Assert.Empty(_hintRenderer.Hints);
+            // No .func/config.json written either.
+            Assert.False(File.Exists(Path.Combine(newDir, ".func", "config.json")));
+        }
+        finally
+        {
+            CleanupDirectory(newDir);
+        }
+    }
+
+    [Fact]
+    public async Task InitCommand_OverwritesExistingHostJson_WhenForceIsSet()
+    {
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(newDir);
+            string hostPath = Path.Combine(newDir, "host.json");
+            File.WriteAllText(hostPath, "{\"version\":\"2.0\",\"customMarker\":true}");
+
+            var initializer = new FakeProjectInitializer("python");
+            int exitCode = await RunInitAsync(newDir, initializer, language: null, stack: "python", force: true);
+
+            Assert.Equal(0, exitCode);
+            AssertHostJsonWritten(newDir);
+        }
+        finally
+        {
+            CleanupDirectory(newDir);
+        }
+    }
+
+    private static void AssertHostJsonWritten(string directory)
+    {
+        string path = Path.Combine(directory, "host.json");
+        Assert.True(File.Exists(path), $"Expected host.json at {path}.");
+        using var doc = JsonDocument.Parse(File.ReadAllText(path));
+        Assert.Equal("2.0", doc.RootElement.GetProperty("version").GetString());
+    }
+
+    private static void AssertConfigJsonHasShape(string directory, string? expectedStack, string? expectedLanguage)
+    {
+        string configPath = Path.Combine(directory, ".func", "config.json");
+        Assert.True(File.Exists(configPath), $"Expected .func/config.json at {configPath}.");
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(configPath));
+        if (expectedStack is null)
+        {
+            Assert.False(doc.RootElement.TryGetProperty("stack", out _));
+        }
+        else
+        {
+            Assert.Equal(expectedStack, doc.RootElement.GetProperty("stack").GetString());
+        }
+        if (expectedLanguage is null)
+        {
+            Assert.False(doc.RootElement.TryGetProperty("language", out _));
+        }
+        else
+        {
+            Assert.Equal(expectedLanguage, doc.RootElement.GetProperty("language").GetString());
+        }
+    }
+
+    private static void CleanupDirectory(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
     }
 
     private sealed class FakeProjectInitializer(string stack) : IProjectInitializer

--- a/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
@@ -22,10 +22,16 @@ public class WorkloadInstallCommandTests
     private readonly IWorkloadInstaller _installer = Substitute.For<IWorkloadInstaller>();
     private readonly IWorkloadStore _store = Substitute.For<IWorkloadStore>();
 
+    // Real command (not a substitute) — install confirms-yes by Parse+Invoke
+    // through this instance, so the same _installer / _store mocks back it.
+    private WorkloadUpdateCommand UpdateCommand() => new(_interaction, _installer, _store);
+
+    private WorkloadInstallCommand NewInstall() => new(_interaction, _installer, _store, UpdateCommand());
+
     [Fact]
     public void Install_HasExpectedArgsAndOptions()
     {
-        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
+        var cmd = NewInstall();
         Assert.Single(cmd.Arguments, a => a.Name == "id");
         Assert.Contains(cmd.Options, o => o.Name == "--force");
         Assert.Contains(cmd.Options, o => o.Name == "--version");
@@ -38,7 +44,7 @@ public class WorkloadInstallCommandTests
     {
         StubCatalogResult();
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
+        var cmd = NewInstall();
         int exit = await InvokeAsync(cmd, "Test.Workload");
 
         Assert.Equal(0, exit);
@@ -51,7 +57,7 @@ public class WorkloadInstallCommandTests
     {
         StubCatalogResult();
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
+        var cmd = NewInstall();
         int exit = await InvokeAsync(
             cmd,
             "Test.Workload",
@@ -77,7 +83,7 @@ public class WorkloadInstallCommandTests
     {
         StubCatalogResult();
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
+        var cmd = NewInstall();
         int exit = await InvokeAsync(cmd, "Test.Workload", "-v", "1.2.3", "-f");
 
         Assert.Equal(0, exit);
@@ -96,7 +102,7 @@ public class WorkloadInstallCommandTests
     {
         StubCatalogResult();
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
+        var cmd = NewInstall();
         int exit = await InvokeAsync(cmd, "test.workload", "-e");
 
         Assert.Equal(0, exit);
@@ -111,7 +117,7 @@ public class WorkloadInstallCommandTests
         // handles it. The CLI does not special-case paths.
         StubCatalogResult();
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
+        var cmd = NewInstall();
         int exit = await InvokeAsync(cmd, "Test.Workload", "--source", "/tmp/local-feed");
 
         Assert.Equal(0, exit);
@@ -122,7 +128,7 @@ public class WorkloadInstallCommandTests
     [Fact]
     public void Install_InvalidVersion_FailsValidation()
     {
-        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
+        var cmd = NewInstall();
         var root = new RootCommand();
         root.Subcommands.Add(cmd);
 
@@ -135,7 +141,7 @@ public class WorkloadInstallCommandTests
     [Fact]
     public void Install_MissingPackageArg_FailsValidation()
     {
-        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
+        var cmd = NewInstall();
         var root = new RootCommand();
         root.Subcommands.Add(cmd);
 
@@ -147,7 +153,7 @@ public class WorkloadInstallCommandTests
     [Fact]
     public void Install_WhitespaceArg_FailsValidation()
     {
-        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
+        var cmd = NewInstall();
         var root = new RootCommand();
         root.Subcommands.Add(cmd);
 
@@ -162,7 +168,7 @@ public class WorkloadInstallCommandTests
     {
         StubCatalogResult(alreadyInstalled: true);
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
+        var cmd = NewInstall();
         int exit = await InvokeAsync(cmd, "Test.Workload");
 
         Assert.Equal(0, exit);
@@ -189,7 +195,7 @@ public class WorkloadInstallCommandTests
                 },
                 AlreadyInstalled: false));
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
+        var cmd = NewInstall();
         int exit = await InvokeAsync(cmd, "test.content");
 
         Assert.Equal(0, exit);
@@ -209,7 +215,7 @@ public class WorkloadInstallCommandTests
             .Throws(new AmbiguousPackageMatchException(
                 "myalias", new[] { "Pkg.A", "Pkg.B" }));
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
+        var cmd = NewInstall();
         GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
             () => InvokeAsync(cmd, "myalias"));
         Assert.Contains("myalias", ex.Message);
@@ -225,7 +231,7 @@ public class WorkloadInstallCommandTests
                 Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Throws(new WorkloadPackageNotFoundException("not on any source"));
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
+        var cmd = NewInstall();
         GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
             () => InvokeAsync(cmd, "Test.Workload"));
         Assert.Contains("not on any source", ex.Message);
@@ -240,7 +246,7 @@ public class WorkloadInstallCommandTests
                 Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Throws(new InvalidWorkloadException("bad package"));
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
+        var cmd = NewInstall();
         GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
             () => InvokeAsync(cmd, "Test.Workload"));
         Assert.Equal("bad package", ex.Message);
@@ -256,7 +262,7 @@ public class WorkloadInstallCommandTests
             .Throws(new InvalidOperationException(
                 "Workload 'x' version '1' is already installed at '/p' but is missing from the registry."));
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
+        var cmd = NewInstall();
         GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
             () => InvokeAsync(cmd, "Test.Workload"));
         Assert.Contains("missing from the registry", ex.Message);
@@ -272,7 +278,7 @@ public class WorkloadInstallCommandTests
                 Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Throws(new NullReferenceException("oops"));
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
+        var cmd = NewInstall();
         await Assert.ThrowsAsync<NullReferenceException>(
             () => InvokeAsync(cmd, "Test.Workload"));
     }
@@ -294,7 +300,7 @@ public class WorkloadInstallCommandTests
                     },
                     AlreadyInstalled: false));
 
-            var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
+            var cmd = NewInstall();
             int exit = await InvokeAsync(cmd, tempPkg);
 
             Assert.Equal(0, exit);
@@ -322,7 +328,7 @@ public class WorkloadInstallCommandTests
             },
         });
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
+        var cmd = NewInstall();
         int exit = await InvokeAsync(cmd, "Test.Workload");
 
         Assert.Equal(1, exit);
@@ -346,7 +352,7 @@ public class WorkloadInstallCommandTests
             },
         });
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
+        var cmd = NewInstall();
         int exit = await InvokeAsync(cmd, "alias1");
 
         Assert.Equal(1, exit);
@@ -367,7 +373,7 @@ public class WorkloadInstallCommandTests
             },
         });
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
+        var cmd = NewInstall();
         int exit = await InvokeAsync(cmd, "Test.Workload");
 
         Assert.Equal(1, exit);
@@ -389,7 +395,7 @@ public class WorkloadInstallCommandTests
         });
         StubCatalogResult();
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
+        var cmd = NewInstall();
         int exit = await InvokeAsync(cmd, "alias1", "--exact");
 
         Assert.Equal(0, exit);
@@ -411,7 +417,7 @@ public class WorkloadInstallCommandTests
         });
         StubCatalogResult();
 
-        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
+        var cmd = NewInstall();
         int exit = await InvokeAsync(cmd, "Test.Workload", "--force");
 
         Assert.Equal(0, exit);

--- a/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
@@ -168,7 +168,7 @@ public class WorkloadInstallCommandTests
         Assert.Equal(0, exit);
         Assert.Contains(
             _interaction.Lines,
-            l => l.StartsWith("SUCCESS:")
+            l => l.StartsWith("WARNING:")
                 && l.Contains("already installed")
                 && l.Contains("test.workload"));
     }
@@ -330,7 +330,7 @@ public class WorkloadInstallCommandTests
             Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
             Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         Assert.Contains(_interaction.Lines, l =>
-            l.StartsWith("HINT:") && l.Contains("func workload update Test.Workload"));
+            l.StartsWith("HINT:") && l.Contains("func workload update test"));
     }
 
     [Fact]
@@ -348,6 +348,27 @@ public class WorkloadInstallCommandTests
 
         var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
         int exit = await InvokeAsync(cmd, "alias1");
+
+        Assert.Equal(1, exit);
+        Assert.Contains(_interaction.Lines, l =>
+            l.StartsWith("HINT:") && l.Contains("alias1") && l.Contains("1.2.3"));
+    }
+
+    [Fact]
+    public async Task Install_AlreadyInstalled_AliasMatch_NonInteractive_HintsCanonicalIdWhenNoAlias()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(new[]
+        {
+            new WorkloadEntry
+            {
+                PackageId = "Test.Workload",
+                PackageVersion = "1.2.3",
+                Aliases = [],
+            },
+        });
+
+        var cmd = new WorkloadInstallCommand(_interaction, _installer, _store);
+        int exit = await InvokeAsync(cmd, "Test.Workload");
 
         Assert.Equal(1, exit);
         Assert.Contains(_interaction.Lines, l =>

--- a/test/Func.Tests/Commands/Workload/WorkloadUpdateCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadUpdateCommandTests.cs
@@ -271,7 +271,7 @@ public class WorkloadUpdateCommandTests
             "b.workload", Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
             Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         Assert.Contains(_interaction.Lines, l => l.StartsWith("SUCCESS:") && l.Contains("a.workload"));
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("HINT:") && l.Contains("b.workload"));
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("WARNING:") && l.Contains("b.workload"));
     }
 
     [Fact]


### PR DESCRIPTION
Targets `vnext`. Two commits, two scopes.

## 1. `func init` always lays down the host-owned skeleton

Refuses to overwrite an existing project (`host.json` or `.func/config.json` present) unless `--force`. When it does run, always writes the host-owned skeleton (`host.json`, `.func/config.json`) before delegating to the workload initializer, so a folder is left in a usable state in every branch:

| Case | Behaviour |
|---|---|
| Already initialized + no `--force` | Error, exit 1, nothing written, initializer not invoked |
| `--force` | Overrides the refusal |
| No workloads installed | Skeleton written, 'no stacks installed' warning + install hints, exit 0 |
| `--stack <id>` matches | Skeleton written, initializer invoked, exit 0 |
| `--stack <id>` no match | Skeleton written, hint listing installed stacks, exit 0 |
| No `--stack`, single workload, non-interactive | Auto-select with info hint listing other installable workloads, skeleton written, initializer invoked |
| No `--stack`, multiple workloads, non-interactive | Skeleton written, ambiguous-stack hint, exit 0 |
| Initializer throws (e.g. stub) | Skeleton already written, error surfaces normally |

Other UX in the same flow:

- New \`WorkloadHintKind.AutoSelectedSoleWorkload\` renders auto-select reason plus \`func workload install <id>\` suggestions for the other known stacks (sourced from \`KnownInstallableWorkloads.LanguageMap\`).
- \`--language\` help text is built dynamically from installed workloads' \`SupportedLanguages\` (sorted, lowercased, deduped). The parsed value is normalized via \`Trim().ToLowerInvariant()\` before being passed downstream so matching is case-insensitive at the boundary.
- \`--name\` help wording corrected to \`Function App\`.
- 'No stacks installed' downgraded from error to warning.
- Each skeleton write logs a muted \`· Wrote <file>.\` line so the user can see what happened even when the initializer then throws.

15 init tests cover the matrix.

## 2. Polish \`func workload install\` / \`update\` UX

- \`func workload install <id>\` on an already-installed package now actually runs the update when the user confirms \`y\` at the prompt, instead of just printing \`Run 'func workload update <id>'\`.
- User-facing messages (install hints, success / no-op lines) prefer the published alias (\`python\`) over the canonical package id (\`azure.functions.cli.workload.python\`) when one is available.
- Post-install 'already installed' line is a warning, not success, since nothing was written.
- 'No update available' (both in the install confirm path and the explicit \`update\` command) is a warning for the same reason: it's a no-op outcome, not a tip.
- Workload install success message switched from \`(entry point: <type>)\` to \`(aliases: <list>)\` since the type name is internal noise; aliases are what the user types next.

## Tests

355/355 in \`Func.Tests\` pass.