### PR TITLE
Implement IProjectInitializer for the DotNet workload

### DIFF
--- a/src/Abstractions/Common/Constants.cs
+++ b/src/Abstractions/Common/Constants.cs
@@ -1,12 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Azure.Functions.Cli.Common;
+namespace Azure.Functions.Cli.Abstractions.Common;
 
 /// <summary>
 /// Common constants used across the Azure Functions CLI.
 /// </summary>
-public static class SharedConstants
+public static class Constants
 {
     /// <summary>
     /// Directory name (under the user profile) the func CLI persists state in.

--- a/src/Abstractions/Common/SharedConstants.cs
+++ b/src/Abstractions/Common/SharedConstants.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Common;
+
+/// <summary>
+/// Common constants used across the Azure Functions CLI.
+/// </summary>
+public static class SharedConstants
+{
+    /// <summary>
+    /// Directory name (under the user profile) the func CLI persists state in.
+    /// </summary>
+    public const string FuncHomeDirectoryName = ".azure-functions";
+}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,4 +8,8 @@
     <UpdateBuildNumber Condition="'$(IsReleaseCI)' == 'true'">true</UpdateBuildNumber>
   </PropertyGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+  </ItemGroup>
+
 </Project>

--- a/src/Func/Common/Constants.cs
+++ b/src/Func/Common/Constants.cs
@@ -34,7 +34,6 @@ internal static class Constants
 
     /// <summary>
     /// Prefix for the CLI environment variables, including those that bind into <c>IConfiguration</c>.
-    /// e.g. <c>FUNC_CLI_Workloads__Home</c> binds <c>Workloads:Home</c>.
     /// </summary>
     public const string EnvironmentVariablePrefix = "FUNC_CLI_";
 

--- a/src/Func/Common/Constants.cs
+++ b/src/Func/Common/Constants.cs
@@ -28,11 +28,6 @@ internal static class Constants
     public const string VersionCacheFileName = ".version-check";
 
     /// <summary>
-    /// Directory name (under the user profile) the func CLI persists state in.
-    /// </summary>
-    public const string FuncHomeDirectoryName = ".azure-functions";
-
-    /// <summary>
     /// Prefix for the CLI environment variables, including those that bind into <c>IConfiguration</c>.
     /// </summary>
     public const string EnvironmentVariablePrefix = "FUNC_CLI_";

--- a/src/Func/Common/Constants.cs
+++ b/src/Func/Common/Constants.cs
@@ -34,6 +34,7 @@ internal static class Constants
 
     /// <summary>
     /// Prefix for the CLI environment variables, including those that bind into <c>IConfiguration</c>.
+    /// e.g. <c>FUNC_CLI_Workloads__Home</c> binds <c>Workloads:Home</c>.
     /// </summary>
     public const string EnvironmentVariablePrefix = "FUNC_CLI_";
 

--- a/src/Func/Common/VersionChecker.cs
+++ b/src/Func/Common/VersionChecker.cs
@@ -4,6 +4,7 @@
 using System.Net.Http.Json;
 using System.Reflection;
 using System.Text.Json.Serialization;
+using AbstractionsConstants = Azure.Functions.Cli.Abstractions.Common.Constants;
 
 namespace Azure.Functions.Cli.Common;
 
@@ -129,7 +130,7 @@ internal static class VersionChecker
     {
         string cacheDir = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            SharedConstants.FuncHomeDirectoryName);
+            AbstractionsConstants.FuncHomeDirectoryName);
         return Path.Combine(cacheDir, Constants.VersionCacheFileName);
     }
 

--- a/src/Func/Common/VersionChecker.cs
+++ b/src/Func/Common/VersionChecker.cs
@@ -129,7 +129,7 @@ internal static class VersionChecker
     {
         string cacheDir = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            Constants.FuncHomeDirectoryName);
+            SharedConstants.FuncHomeDirectoryName);
         return Path.Combine(cacheDir, Constants.VersionCacheFileName);
     }
 

--- a/src/Func/Configuration/CliConfigurationSourceBuilder.cs
+++ b/src/Func/Configuration/CliConfigurationSourceBuilder.cs
@@ -33,7 +33,7 @@ internal sealed class CliConfigurationSourceBuilder(ILocalSettingsProvider local
     {
         string home = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            Constants.FuncHomeDirectoryName);
+            SharedConstants.FuncHomeDirectoryName);
 
         return Path.Combine(home, CliConfigurationNames.ConfigFileName);
     }

--- a/src/Func/Configuration/CliConfigurationSourceBuilder.cs
+++ b/src/Func/Configuration/CliConfigurationSourceBuilder.cs
@@ -3,6 +3,7 @@
 
 using Azure.Functions.Cli.Common;
 using Microsoft.Extensions.Configuration;
+using AbstractionsConstants = Azure.Functions.Cli.Abstractions.Common.Constants;
 
 namespace Azure.Functions.Cli.Configuration;
 
@@ -33,7 +34,7 @@ internal sealed class CliConfigurationSourceBuilder(ILocalSettingsProvider local
     {
         string home = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            SharedConstants.FuncHomeDirectoryName);
+            AbstractionsConstants.FuncHomeDirectoryName);
 
         return Path.Combine(home, CliConfigurationNames.ConfigFileName);
     }

--- a/src/Func/Workloads/Storage/WorkloadHomeResolver.cs
+++ b/src/Func/Workloads/Storage/WorkloadHomeResolver.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Common;
-
+using AbstractionsConstants = Azure.Functions.Cli.Abstractions.Common.Constants;
 namespace Azure.Functions.Cli.Workloads.Storage;
 
 /// <summary>
@@ -27,7 +27,7 @@ internal static class WorkloadHomeResolver
         string home = string.IsNullOrWhiteSpace(configured)
             ? Path.Combine(
                 System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile),
-                Constants.FuncHomeDirectoryName)
+                AbstractionsConstants.FuncHomeDirectoryName)
             : configured;
 
         return Path.GetFullPath(home);

--- a/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
@@ -139,12 +139,6 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli, ITemp
                 $"The dotnet CLI operation timed out after {OperationTimeout.TotalMinutes:0} minutes. Check your network connection and try again.",
                 isUserError: true);
         }
-        catch (Win32Exception ex)
-        {
-            throw new GracefulException(
-                $"Failed to terminate the dotnet process (Win32Exception: {ex.Message}). You may need to end it manually and retry.",
-                isUserError: true);
-        }
     }
 
     private bool IsHiveFresh()

--- a/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
@@ -19,7 +19,7 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli) : IPr
     internal const string TemplateShortName = "func";
     internal const string DefaultFramework = "net10.0";
 
-    internal static readonly TimeSpan HiveTtl = TimeSpan.FromDays(7);
+    internal static readonly TimeSpan HiveTtl = TimeSpan.FromDays(30);
 
     private static readonly string _hivePath = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),

--- a/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
@@ -18,10 +18,14 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli) : IPr
     internal const string TemplateShortName = "func";
     internal const string DefaultFramework = "net10.0";
 
+    internal static readonly TimeSpan HiveTtl = TimeSpan.FromDays(7);
+
     private static readonly string _hivePath = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
         "azure-functions-core-tools",
         "dotnet-template-hive");
+
+    private static readonly string _timestampPath = Path.Combine(_hivePath, ".installed");
 
     private readonly IDotnetCliRunner _dotnetCli = dotnetCli ?? throw new ArgumentNullException(nameof(dotnetCli));
 
@@ -60,22 +64,56 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli) : IPr
             "--language", language,
             "--Framework", framework,
             "--debug:custom-hive", _hivePath,
+            "--force", // CLI creates host.json before calling this so we need to pass force for the the template to overwrite it.
         ];
-
-        if (context.Force)
-        {
-            args.Add("--force");
-        }
 
         await _dotnetCli.RunAsync(args, projectPath, cancellationToken);
     }
 
     internal async Task EnsureTemplatesInstalledAsync(CancellationToken cancellationToken)
     {
+        if (IsHiveFresh())
+        {
+            return;
+        }
+
         await _dotnetCli.RunAsync(
             ["new", "install", TemplatesPackageName, "--debug:custom-hive", _hivePath],
             workingDirectory: null,
             cancellationToken);
+
+        WriteTimestamp();
+    }
+
+    private static bool IsHiveFresh()
+    {
+        try
+        {
+            if (!File.Exists(_timestampPath))
+            {
+                return false;
+            }
+
+            DateTime installedUtc = File.GetLastWriteTimeUtc(_timestampPath);
+            return DateTime.UtcNow - installedUtc < HiveTtl;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+    }
+
+    private static void WriteTimestamp()
+    {
+        try
+        {
+            Directory.CreateDirectory(_hivePath);
+            File.WriteAllText(_timestampPath, string.Empty);
+        }
+        catch (IOException)
+        {
+            // Non-fatal; next run will simply reinstall.
+        }
     }
 
     internal static string NormalizeLanguage(string? language)

--- a/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
@@ -3,8 +3,8 @@
 
 using System.CommandLine;
 using Azure.Functions.Cli.Commands;
-using Azure.Functions.Cli.Abstractions.Common;
 using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Common;
 
 namespace Azure.Functions.Cli.Workloads.DotNet;
 
@@ -13,28 +13,26 @@ namespace Azure.Functions.Cli.Workloads.DotNet;
 /// Uses the <c>Microsoft.Azure.Functions.Worker.ProjectTemplates</c> NuGet
 /// template package to scaffold projects via <c>dotnet new func</c>.
 /// </summary>
-internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli) : IProjectInitializer
+internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli, ITemplateHivePathProvider hivePathProvider) : IProjectInitializer
 {
     internal const string TemplatesPackageName = "Microsoft.Azure.Functions.Worker.ProjectTemplates";
     internal const string TemplateShortName = "func";
     internal const string DefaultFramework = "net10.0";
 
+    internal static readonly IReadOnlyList<string> SupportedFrameworks = ["net10.0"];
+
     internal static readonly TimeSpan HiveTtl = TimeSpan.FromDays(30);
-
-    private static readonly string _hivePath = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-        Constants.FuncHomeDirectoryName,
-        "dotnet-template-hive");
-
-    private static readonly string _timestampPath = Path.Combine(_hivePath, ".installed");
+    internal static readonly TimeSpan OperationTimeout = TimeSpan.FromMinutes(5);
 
     private readonly IDotnetCliRunner _dotnetCli = dotnetCli ?? throw new ArgumentNullException(nameof(dotnetCli));
+    private readonly string _hivePath = (hivePathProvider ?? throw new ArgumentNullException(nameof(hivePathProvider))).HivePath;
+    private readonly string _timestampPath = (hivePathProvider ?? throw new ArgumentNullException(nameof(hivePathProvider))).TimestampPath;
 
     public string Stack => "dotnet";
 
     public IReadOnlyList<string> SupportedLanguages => ["C#", "F#", "csharp", "fsharp"];
 
-    public Option<string> FrameworkOption { get; } = new("--target-framework")
+    public Option<string> FrameworkOption { get; } = new("--tfm")
     {
         Description = "The target framework for the project (e.g. net10.0).",
         DefaultValueFactory = _ => DefaultFramework
@@ -51,11 +49,25 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli) : IPr
         ArgumentNullException.ThrowIfNull(parseResult);
 
         string projectPath = context.WorkingDirectory.Info.FullName;
-        string? projectName = context.ProjectName ?? Path.GetFileName(projectPath);
+
         string language = NormalizeLanguage(context.Language);
+        if (!SupportedLanguages.Contains(language, StringComparer.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException($"Language '{context.Language}' is not supported. Supported languages: {string.Join(", ", SupportedLanguages)}.", nameof(context));
+        }
+
+        string projectName = context.ProjectName ?? Path.GetFileName(projectPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectName, nameof(context.ProjectName));
+
         string framework = parseResult.GetValue(FrameworkOption) ?? DefaultFramework;
+        if (!SupportedFrameworks.Contains(framework, StringComparer.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException($"Framework '{framework}' is not supported. Supported frameworks: {string.Join(", ", SupportedFrameworks)}.", nameof(framework));
+        }
 
         await EnsureTemplatesInstalledAsync(cancellationToken);
+
+        Directory.CreateDirectory(projectPath);
 
         List<string> args =
         [
@@ -63,12 +75,16 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli) : IPr
             "--name", projectName,
             "--output", projectPath,
             "--language", language,
-            "--Framework", framework,
+            "--framework", framework,
             "--debug:custom-hive", _hivePath,
-            "--force", // CLI creates host.json before calling this so we need to pass force for the the template to overwrite it.
         ];
 
-        await _dotnetCli.RunAsync(args, projectPath, cancellationToken);
+        if (context.Force)
+        {
+            args.Add("--force");
+        }
+
+        await RunWithTimeoutAsync(args, projectPath, cancellationToken);
     }
 
     internal async Task EnsureTemplatesInstalledAsync(CancellationToken cancellationToken)
@@ -78,7 +94,7 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli) : IPr
             return;
         }
 
-        await _dotnetCli.RunAsync(
+        await RunWithTimeoutAsync(
             ["new", "install", TemplatesPackageName, "--debug:custom-hive", _hivePath],
             workingDirectory: null,
             cancellationToken);
@@ -86,12 +102,39 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli) : IPr
         WriteTimestamp();
     }
 
-    private static bool IsHiveFresh()
+    private async Task RunWithTimeoutAsync(
+        IReadOnlyList<string> args,
+        string? workingDirectory,
+        CancellationToken cancellationToken)
+    {
+        using CancellationTokenSource timeoutCts = new(OperationTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken, timeoutCts.Token);
+
+        try
+        {
+            await _dotnetCli.RunAsync(args, workingDirectory, linkedCts.Token);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            throw new GracefulException(
+                $"The dotnet CLI operation timed out after {OperationTimeout.TotalMinutes:0} minutes. Check your network connection and try again.",
+                isUserError: true);
+        }
+    }
+
+    private bool IsHiveFresh()
     {
         try
         {
             if (!File.Exists(_timestampPath))
             {
+                return false;
+            }
+
+            if (!Directory.Exists(_hivePath) || !Directory.EnumerateFileSystemEntries(_hivePath).Skip(1).Any())
+            {
+                // Hive directory is missing or effectively empty; force reinstall.
                 return false;
             }
 
@@ -104,7 +147,7 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli) : IPr
         }
     }
 
-    private static void WriteTimestamp()
+    private void WriteTimestamp()
     {
         try
         {

--- a/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
@@ -18,6 +18,11 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli) : IPr
     internal const string TemplateShortName = "func";
     internal const string DefaultFramework = "net10.0";
 
+    private static readonly string _hivePath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "azure-functions-core-tools",
+        "dotnet-template-hive");
+
     private readonly IDotnetCliRunner _dotnetCli = dotnetCli ?? throw new ArgumentNullException(nameof(dotnetCli));
 
     public string Stack => "dotnet";
@@ -47,42 +52,28 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli) : IPr
 
         await EnsureTemplatesInstalledAsync(cancellationToken);
 
-        try
-        {
-            List<string> args =
-            [
-                "new", TemplateShortName,
-                "--name", projectName,
-                "--output", projectPath,
-                "--language", language,
-                "--Framework", framework,
-            ];
+        List<string> args =
+        [
+            "new", TemplateShortName,
+            "--name", projectName,
+            "--output", projectPath,
+            "--language", language,
+            "--Framework", framework,
+            "--debug:custom-hive", _hivePath,
+        ];
 
-            if (context.Force)
-            {
-                args.Add("--force");
-            }
-
-            await _dotnetCli.RunAsync(args, projectPath, cancellationToken);
-        }
-        finally
+        if (context.Force)
         {
-            await UninstallTemplatesAsync(cancellationToken);
+            args.Add("--force");
         }
+
+        await _dotnetCli.RunAsync(args, projectPath, cancellationToken);
     }
 
     internal async Task EnsureTemplatesInstalledAsync(CancellationToken cancellationToken)
     {
         await _dotnetCli.RunAsync(
-            ["new", "install", TemplatesPackageName],
-            workingDirectory: null,
-            cancellationToken);
-    }
-
-    internal async Task UninstallTemplatesAsync(CancellationToken cancellationToken)
-    {
-        await _dotnetCli.RunAsync(
-            ["new", "uninstall", TemplatesPackageName],
+            ["new", "install", TemplatesPackageName, "--debug:custom-hive", _hivePath],
             workingDirectory: null,
             cancellationToken);
     }

--- a/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
@@ -3,7 +3,7 @@
 
 using System.CommandLine;
 using Azure.Functions.Cli.Commands;
-using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Abstractions.Common;
 using Azure.Functions.Cli.Projects;
 
 namespace Azure.Functions.Cli.Workloads.DotNet;
@@ -23,7 +23,7 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli) : IPr
 
     private static readonly string _hivePath = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-        SharedConstants.FuncHomeDirectoryName,
+        Constants.FuncHomeDirectoryName,
         "dotnet-template-hive");
 
     private static readonly string _timestampPath = Path.Combine(_hivePath, ".installed");

--- a/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
@@ -15,7 +15,6 @@ namespace Azure.Functions.Cli.Workloads.DotNet;
 internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli) : IProjectInitializer
 {
     internal const string TemplatesPackageName = "Microsoft.Azure.Functions.Worker.ProjectTemplates";
-    internal const string TemplatesPackageVersion = "4.0.5544";
     internal const string TemplateShortName = "func";
     internal const string DefaultFramework = "net10.0";
 
@@ -48,27 +47,42 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli) : IPr
 
         await EnsureTemplatesInstalledAsync(cancellationToken);
 
-        List<string> args =
-        [
-            "new", TemplateShortName,
-            "--name", projectName,
-            "--output", projectPath,
-            "--language", language,
-            "--Framework", framework,
-        ];
-
-        if (context.Force)
+        try
         {
-            args.Add("--force");
-        }
+            List<string> args =
+            [
+                "new", TemplateShortName,
+                "--name", projectName,
+                "--output", projectPath,
+                "--language", language,
+                "--Framework", framework,
+            ];
 
-        await _dotnetCli.RunAsync(args, projectPath, cancellationToken);
+            if (context.Force)
+            {
+                args.Add("--force");
+            }
+
+            await _dotnetCli.RunAsync(args, projectPath, cancellationToken);
+        }
+        finally
+        {
+            await UninstallTemplatesAsync(cancellationToken);
+        }
     }
 
     internal async Task EnsureTemplatesInstalledAsync(CancellationToken cancellationToken)
     {
         await _dotnetCli.RunAsync(
-            ["new", "install", $"{TemplatesPackageName}@{TemplatesPackageVersion}"],
+            ["new", "install", TemplatesPackageName],
+            workingDirectory: null,
+            cancellationToken);
+    }
+
+    internal async Task UninstallTemplatesAsync(CancellationToken cancellationToken)
+    {
+        await _dotnetCli.RunAsync(
+            ["new", "uninstall", TemplatesPackageName],
             workingDirectory: null,
             cancellationToken);
     }
@@ -77,13 +91,13 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli) : IPr
     {
         if (string.IsNullOrWhiteSpace(language))
         {
-            return "C#";
+            return "c#";
         }
 
-        return language.ToUpperInvariant() switch
+        return language.ToLowerInvariant() switch
         {
-            "CSHARP" or "C#" => "C#",
-            "FSHARP" or "F#" => "F#",
+            "csharp" or "c#" => "c#",
+            "fsharp" or "f#" => "f#",
             _ => language
         };
     }

--- a/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
@@ -31,7 +31,7 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli) : IPr
 
     public Option<string> FrameworkOption { get; } = new("--target-framework")
     {
-        Description = "The target framework for the project (e.g. net8.0, net10.0).",
+        Description = "The target framework for the project (e.g. net10.0).",
         DefaultValueFactory = _ => DefaultFramework
     };
 

--- a/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine;
 using Azure.Functions.Cli.Commands;
+using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Projects;
 
 namespace Azure.Functions.Cli.Workloads.DotNet;
@@ -21,8 +22,8 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli) : IPr
     internal static readonly TimeSpan HiveTtl = TimeSpan.FromDays(7);
 
     private static readonly string _hivePath = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        "azure-functions-core-tools",
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        SharedConstants.FuncHomeDirectoryName,
         "dotnet-template-hive");
 
     private static readonly string _timestampPath = Path.Combine(_hivePath, ".installed");

--- a/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
@@ -9,21 +9,82 @@ namespace Azure.Functions.Cli.Workloads.DotNet;
 
 /// <summary>
 /// Project initializer for .NET (C# and F#) Azure Functions.
+/// Uses the <c>Microsoft.Azure.Functions.Worker.ProjectTemplates</c> NuGet
+/// template package to scaffold projects via <c>dotnet new func</c>.
 /// </summary>
-internal sealed class DotNetProjectInitializer : IProjectInitializer
+internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli) : IProjectInitializer
 {
+    internal const string TemplatesPackageName = "Microsoft.Azure.Functions.Worker.ProjectTemplates";
+    internal const string TemplatesPackageVersion = "4.0.5544";
+    internal const string TemplateShortName = "func";
+    internal const string DefaultFramework = "net10.0";
+
+    private readonly IDotnetCliRunner _dotnetCli = dotnetCli ?? throw new ArgumentNullException(nameof(dotnetCli));
+
     public string Stack => "dotnet";
 
     public IReadOnlyList<string> SupportedLanguages => ["C#", "F#", "csharp", "fsharp"];
 
-    public IReadOnlyList<Option> GetInitOptions() => [];
+    public Option<string> FrameworkOption { get; } = new("--target-framework")
+    {
+        Description = "The target framework for the project (e.g. net8.0, net10.0).",
+        DefaultValueFactory = _ => DefaultFramework
+    };
 
-    public Task InitializeAsync(
+    public IReadOnlyList<Option> GetInitOptions() => [FrameworkOption];
+
+    public async Task InitializeAsync(
         InitContext context,
         ParseResult parseResult,
         CancellationToken cancellationToken = default)
     {
-        throw new NotImplementedException(
-            ".NET project initialization is not implemented yet.");
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(parseResult);
+
+        string projectPath = context.WorkingDirectory.Info.FullName;
+        string? projectName = context.ProjectName ?? Path.GetFileName(projectPath);
+        string language = NormalizeLanguage(context.Language);
+        string framework = parseResult.GetValue(FrameworkOption) ?? DefaultFramework;
+
+        await EnsureTemplatesInstalledAsync(cancellationToken);
+
+        List<string> args =
+        [
+            "new", TemplateShortName,
+            "--name", projectName,
+            "--output", projectPath,
+            "--language", language,
+            "--Framework", framework,
+        ];
+
+        if (context.Force)
+        {
+            args.Add("--force");
+        }
+
+        await _dotnetCli.RunAsync(args, projectPath, cancellationToken);
+    }
+
+    internal async Task EnsureTemplatesInstalledAsync(CancellationToken cancellationToken)
+    {
+        await _dotnetCli.RunAsync(
+            ["new", "install", $"{TemplatesPackageName}@{TemplatesPackageVersion}"],
+            workingDirectory: null,
+            cancellationToken);
+    }
+
+    internal static string NormalizeLanguage(string? language)
+    {
+        if (string.IsNullOrWhiteSpace(language))
+        {
+            return "C#";
+        }
+
+        return language.ToUpperInvariant() switch
+        {
+            "CSHARP" or "C#" => "C#",
+            "FSHARP" or "F#" => "F#",
+            _ => language
+        };
     }
 }

--- a/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
@@ -32,7 +32,7 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli, ITemp
 
     public IReadOnlyList<string> SupportedLanguages => ["C#", "F#", "csharp", "fsharp"];
 
-    public Option<string> FrameworkOption { get; } = new("--tfm")
+    public Option<string> FrameworkOption { get; } = new("--tfm", "--target-framework")
     {
         Description = "The target framework for the project (e.g. net10.0).",
         DefaultValueFactory = _ => DefaultFramework

--- a/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.CommandLine;
+using System.ComponentModel;
 using Azure.Functions.Cli.Commands;
 using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Common;
@@ -25,14 +26,13 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli, ITemp
     internal static readonly TimeSpan OperationTimeout = TimeSpan.FromMinutes(5);
 
     private readonly IDotnetCliRunner _dotnetCli = dotnetCli ?? throw new ArgumentNullException(nameof(dotnetCli));
-    private readonly string _hivePath = (hivePathProvider ?? throw new ArgumentNullException(nameof(hivePathProvider))).HivePath;
-    private readonly string _timestampPath = (hivePathProvider ?? throw new ArgumentNullException(nameof(hivePathProvider))).TimestampPath;
+    private readonly ITemplateHivePathProvider _hivePathProvider = hivePathProvider ?? throw new ArgumentNullException(nameof(hivePathProvider));
 
     public string Stack => "dotnet";
 
     public IReadOnlyList<string> SupportedLanguages => ["C#", "F#", "csharp", "fsharp"];
 
-    public Option<string> FrameworkOption { get; } = new("--tfm", "--target-framework")
+    public Option<string> FrameworkOption { get; } = new("--target-framework", "-tfm")
     {
         Description = "The target framework for the project (e.g. net10.0).",
         DefaultValueFactory = _ => DefaultFramework
@@ -65,7 +65,16 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli, ITemp
             throw new ArgumentException($"Framework '{framework}' is not supported. Supported frameworks: {string.Join(", ", SupportedFrameworks)}.", nameof(framework));
         }
 
-        await EnsureTemplatesInstalledAsync(cancellationToken);
+        try
+        {
+            await EnsureTemplatesInstalledAsync(cancellationToken);
+        }
+        catch (DotnetCliException ex)
+        {
+            throw new GracefulException(
+                $"Failed to install project templates: {ex.Message}",
+                isUserError: true);
+        }
 
         Directory.CreateDirectory(projectPath);
 
@@ -76,7 +85,7 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli, ITemp
             "--output", projectPath,
             "--language", language,
             "--framework", framework,
-            "--debug:custom-hive", _hivePath,
+            "--debug:custom-hive", _hivePathProvider.HivePath,
         ];
 
         if (context.Force)
@@ -84,7 +93,16 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli, ITemp
             args.Add("--force");
         }
 
-        await RunWithTimeoutAsync(args, projectPath, cancellationToken);
+        try
+        {
+            await RunWithTimeoutAsync(args, projectPath, cancellationToken);
+        }
+        catch (DotnetCliException ex)
+        {
+            throw new GracefulException(
+                $"Failed to scaffold project: {ex.Message}",
+                isUserError: true);
+        }
     }
 
     internal async Task EnsureTemplatesInstalledAsync(CancellationToken cancellationToken)
@@ -95,7 +113,7 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli, ITemp
         }
 
         await RunWithTimeoutAsync(
-            ["new", "install", TemplatesPackageName, "--debug:custom-hive", _hivePath],
+            ["new", "install", TemplatesPackageName, "--debug:custom-hive", _hivePathProvider.HivePath],
             workingDirectory: null,
             cancellationToken);
 
@@ -121,24 +139,41 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli, ITemp
                 $"The dotnet CLI operation timed out after {OperationTimeout.TotalMinutes:0} minutes. Check your network connection and try again.",
                 isUserError: true);
         }
+        catch (Win32Exception ex)
+        {
+            throw new GracefulException(
+                $"Failed to terminate the dotnet process (Win32Exception: {ex.Message}). You may need to end it manually and retry.",
+                isUserError: true);
+        }
     }
 
     private bool IsHiveFresh()
     {
         try
         {
-            if (!File.Exists(_timestampPath))
+            string hivePath = _hivePathProvider.HivePath;
+            string timestampPath = _hivePathProvider.TimestampPath;
+
+            if (!File.Exists(timestampPath))
             {
                 return false;
             }
 
-            if (!Directory.Exists(_hivePath) || !Directory.EnumerateFileSystemEntries(_hivePath).Skip(1).Any())
+            if (!Directory.Exists(hivePath))
             {
-                // Hive directory is missing or effectively empty; force reinstall.
                 return false;
             }
 
-            DateTime installedUtc = File.GetLastWriteTimeUtc(_timestampPath);
+            bool hasTemplates = Directory
+                .EnumerateFileSystemEntries(hivePath)
+                .Any(e => !string.Equals(Path.GetFileName(e), ".installed", StringComparison.Ordinal));
+
+            if (!hasTemplates)
+            {
+                return false;
+            }
+
+            DateTime installedUtc = File.GetLastWriteTimeUtc(timestampPath);
             return DateTime.UtcNow - installedUtc < HiveTtl;
         }
         catch (IOException)
@@ -151,8 +186,8 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli, ITemp
     {
         try
         {
-            Directory.CreateDirectory(_hivePath);
-            File.WriteAllText(_timestampPath, string.Empty);
+            Directory.CreateDirectory(_hivePathProvider.HivePath);
+            File.WriteAllText(_hivePathProvider.TimestampPath, string.Empty);
         }
         catch (IOException)
         {

--- a/src/Workloads/Stacks/DotNet/DotNetWorkload.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetWorkload.cs
@@ -19,6 +19,7 @@ public sealed class DotNetWorkload : Workload
     {
         ArgumentNullException.ThrowIfNull(builder);
         builder.Services.AddSingleton<IDotnetCliRunner, DotnetCliRunner>();
+        builder.Services.AddSingleton<ITemplateHivePathProvider, TemplateHivePathProvider>();
         builder.Services.AddSingleton<IProjectInitializer, DotNetProjectInitializer>();
     }
 }

--- a/src/Workloads/Stacks/DotNet/DotNetWorkload.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetWorkload.cs
@@ -18,6 +18,7 @@ public sealed class DotNetWorkload : Workload
     public override void Configure(FunctionsCliBuilder builder)
     {
         ArgumentNullException.ThrowIfNull(builder);
+        builder.Services.AddSingleton<IDotnetPathResolver, DotnetPathResolver>();
         builder.Services.AddSingleton<IDotnetCliRunner, DotnetCliRunner>();
         builder.Services.AddSingleton<ITemplateHivePathProvider, TemplateHivePathProvider>();
         builder.Services.AddSingleton<IProjectInitializer, DotNetProjectInitializer>();

--- a/src/Workloads/Stacks/DotNet/DotNetWorkload.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetWorkload.cs
@@ -13,7 +13,7 @@ public sealed class DotNetWorkload : Workload
 {
     public override string DisplayName => ".NET";
 
-    public override string Description => "Azure Functions tooling for .NET (C#) projects.";
+    public override string Description => "Azure Functions CLI tooling for .NET (C#) projects.";
 
     public override void Configure(FunctionsCliBuilder builder)
     {

--- a/src/Workloads/Stacks/DotNet/DotNetWorkload.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetWorkload.cs
@@ -18,6 +18,7 @@ public sealed class DotNetWorkload : Workload
     public override void Configure(FunctionsCliBuilder builder)
     {
         ArgumentNullException.ThrowIfNull(builder);
+        builder.Services.AddSingleton<IDotnetCliRunner, DotnetCliRunner>();
         builder.Services.AddSingleton<IProjectInitializer, DotNetProjectInitializer>();
     }
 }

--- a/src/Workloads/Stacks/DotNet/DotnetCliException.cs
+++ b/src/Workloads/Stacks/DotNet/DotnetCliException.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workloads.DotNet;
+
+/// <summary>
+/// Thrown when a <c>dotnet</c> CLI child process exits with a non-zero exit code.
+/// </summary>
+internal sealed class DotnetCliException : Exception
+{
+    public int ExitCode { get; }
+
+    public string StandardError { get; }
+
+    public string StandardOutput { get; }
+
+    public string Command { get; }
+
+    public DotnetCliException(int exitCode, string standardError, string standardOutput, string command)
+        : base(BuildMessage(exitCode, standardError, standardOutput, command))
+    {
+        ExitCode = exitCode;
+        StandardError = standardError;
+        StandardOutput = standardOutput;
+        Command = command;
+    }
+
+    private static string BuildMessage(int exitCode, string stderr, string stdout, string command)
+    {
+        return $"'dotnet {command}' failed with exit code {exitCode}.{Environment.NewLine}{stderr}{stdout}";
+    }
+}

--- a/src/Workloads/Stacks/DotNet/DotnetCliRunner.cs
+++ b/src/Workloads/Stacks/DotNet/DotnetCliRunner.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace Azure.Functions.Cli.Workloads.DotNet;
 
@@ -10,6 +11,12 @@ namespace Azure.Functions.Cli.Workloads.DotNet;
 /// </summary>
 internal sealed class DotnetCliRunner : IDotnetCliRunner
 {
+    private static readonly string _dotnetExeName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+        ? "dotnet.exe"
+        : "dotnet";
+
+    private static readonly Lazy<string> _dotnetPath = new(ResolveDotnetPath);
+
     public async Task RunAsync(
         IReadOnlyList<string> arguments,
         string? workingDirectory,
@@ -19,7 +26,7 @@ internal sealed class DotnetCliRunner : IDotnetCliRunner
 
         ProcessStartInfo psi = new()
         {
-            FileName = "dotnet",
+            FileName = _dotnetPath.Value,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
@@ -58,15 +65,101 @@ internal sealed class DotnetCliRunner : IDotnetCliRunner
                     $"'dotnet {string.Join(' ', arguments)}' failed with exit code {process.ExitCode}.{Environment.NewLine}{stderr}{stdout}");
             }
         }
-        catch (OperationCanceledException)
+        finally
         {
-            // Ensure the child process does not outlive the caller.
             if (!process.HasExited)
             {
-                process.Kill(entireProcessTree: true);
+                try
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+                catch { }
             }
-
-            throw;
         }
+    }
+
+    /// <summary>
+    /// Resolves the full path to the <c>dotnet</c> muxer using well-known environment
+    /// variables and conventions, rather than relying on PATH resolution.
+    /// </summary>
+    private static string ResolveDotnetPath()
+    {
+        // 1. DOTNET_HOST_PATH – set by the SDK to the absolute path of the running dotnet host.
+        string? hostPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
+        if (!string.IsNullOrEmpty(hostPath) && File.Exists(hostPath))
+        {
+            return hostPath;
+        }
+
+        // 2. Current process – if this tool is launched via `dotnet func`, the process is the muxer.
+        string? processPath = Environment.ProcessPath;
+        if (processPath is not null
+            && Path.GetFileName(processPath).Equals(_dotnetExeName, StringComparison.OrdinalIgnoreCase)
+            && File.Exists(processPath))
+        {
+            return processPath;
+        }
+
+        // 3. DOTNET_ROOT (and architecture-specific variants) – standard variable pointing
+        //    to the dotnet installation directory.
+        foreach (string envVar in GetDotnetRootVariables())
+        {
+            string? dotnetRoot = Environment.GetEnvironmentVariable(envVar);
+            if (!string.IsNullOrEmpty(dotnetRoot))
+            {
+                string candidate = Path.Combine(dotnetRoot, _dotnetExeName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        // 4. Well-known default install locations (platform-specific).
+        foreach (string defaultPath in GetDefaultInstallPaths())
+        {
+            if (File.Exists(defaultPath))
+            {
+                return defaultPath;
+            }
+        }
+
+        // 5. Fallback – rely on PATH (best effort).
+        return _dotnetExeName;
+    }
+
+    private static IReadOnlyList<string> GetDotnetRootVariables()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return RuntimeInformation.OSArchitecture switch
+            {
+                Architecture.X86 => ["DOTNET_ROOT(x86)", "DOTNET_ROOT"],
+                Architecture.Arm64 => ["DOTNET_ROOT", "DOTNET_ROOT(ARM64)"],
+                _ => ["DOTNET_ROOT"]
+            };
+        }
+
+        return ["DOTNET_ROOT"];
+    }
+
+    private static IReadOnlyList<string> GetDefaultInstallPaths()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return [Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "dotnet", _dotnetExeName)];
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return
+            [
+                Path.Combine("/usr/local/share/dotnet", _dotnetExeName),
+                Path.Combine("/opt/homebrew/bin", _dotnetExeName),
+            ];
+        }
+
+        // Linux
+        return [Path.Combine("/usr/share/dotnet", _dotnetExeName)];
     }
 }

--- a/src/Workloads/Stacks/DotNet/DotnetCliRunner.cs
+++ b/src/Workloads/Stacks/DotNet/DotnetCliRunner.cs
@@ -1,0 +1,72 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Diagnostics;
+
+namespace Azure.Functions.Cli.Workload.DotNet;
+
+/// <summary>
+/// Executes <c>dotnet</c> CLI commands in a child process.
+/// </summary>
+internal sealed class DotnetCliRunner : IDotnetCliRunner
+{
+    public async Task RunAsync(
+        IReadOnlyList<string> arguments,
+        string? workingDirectory,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        ProcessStartInfo psi = new()
+        {
+            FileName = "dotnet",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        if (workingDirectory is not null)
+        {
+            psi.WorkingDirectory = workingDirectory;
+        }
+
+        foreach (string arg in arguments)
+        {
+            psi.ArgumentList.Add(arg);
+        }
+
+        using Process process = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start dotnet process.");
+
+        try
+        {
+            // Read both streams concurrently to avoid deadlock when either
+            // buffer fills while the other is being awaited.
+            Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+            Task<string> stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+
+            await Task.WhenAll(stdoutTask, stderrTask);
+            await process.WaitForExitAsync(cancellationToken);
+
+            string stdout = stdoutTask.Result;
+            string stderr = stderrTask.Result;
+
+            if (process.ExitCode != 0)
+            {
+                throw new InvalidOperationException(
+                    $"'dotnet {string.Join(' ', arguments)}' failed with exit code {process.ExitCode}.{Environment.NewLine}{stderr}{stdout}");
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Ensure the child process does not outlive the caller.
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+
+            throw;
+        }
+    }
+}

--- a/src/Workloads/Stacks/DotNet/DotnetCliRunner.cs
+++ b/src/Workloads/Stacks/DotNet/DotnetCliRunner.cs
@@ -3,7 +3,7 @@
 
 using System.Diagnostics;
 
-namespace Azure.Functions.Cli.Workload.DotNet;
+namespace Azure.Functions.Cli.Workloads.DotNet;
 
 /// <summary>
 /// Executes <c>dotnet</c> CLI commands in a child process.

--- a/src/Workloads/Stacks/DotNet/DotnetCliRunner.cs
+++ b/src/Workloads/Stacks/DotNet/DotnetCliRunner.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 
 namespace Azure.Functions.Cli.Workloads.DotNet;
 
@@ -11,11 +10,7 @@ namespace Azure.Functions.Cli.Workloads.DotNet;
 /// </summary>
 internal sealed class DotnetCliRunner : IDotnetCliRunner
 {
-    private static readonly string _dotnetExeName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-        ? "dotnet.exe"
-        : "dotnet";
-
-    private static readonly Lazy<string> _dotnetPath = new(ResolveDotnetPath);
+    private static readonly Lazy<string> _dotnetPath = new(DotnetPathResolver.Resolve);
 
     public async Task RunAsync(
         IReadOnlyList<string> arguments,
@@ -76,90 +71,5 @@ internal sealed class DotnetCliRunner : IDotnetCliRunner
                 catch { }
             }
         }
-    }
-
-    /// <summary>
-    /// Resolves the full path to the <c>dotnet</c> muxer using well-known environment
-    /// variables and conventions, rather than relying on PATH resolution.
-    /// </summary>
-    private static string ResolveDotnetPath()
-    {
-        // 1. DOTNET_HOST_PATH – set by the SDK to the absolute path of the running dotnet host.
-        string? hostPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
-        if (!string.IsNullOrEmpty(hostPath) && File.Exists(hostPath))
-        {
-            return hostPath;
-        }
-
-        // 2. Current process – if this tool is launched via `dotnet func`, the process is the muxer.
-        string? processPath = Environment.ProcessPath;
-        if (processPath is not null
-            && Path.GetFileName(processPath).Equals(_dotnetExeName, StringComparison.OrdinalIgnoreCase)
-            && File.Exists(processPath))
-        {
-            return processPath;
-        }
-
-        // 3. DOTNET_ROOT (and architecture-specific variants) – standard variable pointing
-        //    to the dotnet installation directory.
-        foreach (string envVar in GetDotnetRootVariables())
-        {
-            string? dotnetRoot = Environment.GetEnvironmentVariable(envVar);
-            if (!string.IsNullOrEmpty(dotnetRoot))
-            {
-                string candidate = Path.Combine(dotnetRoot, _dotnetExeName);
-                if (File.Exists(candidate))
-                {
-                    return candidate;
-                }
-            }
-        }
-
-        // 4. Well-known default install locations (platform-specific).
-        foreach (string defaultPath in GetDefaultInstallPaths())
-        {
-            if (File.Exists(defaultPath))
-            {
-                return defaultPath;
-            }
-        }
-
-        // 5. Fallback – rely on PATH (best effort).
-        return _dotnetExeName;
-    }
-
-    private static IReadOnlyList<string> GetDotnetRootVariables()
-    {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            return RuntimeInformation.OSArchitecture switch
-            {
-                Architecture.X86 => ["DOTNET_ROOT(x86)", "DOTNET_ROOT"],
-                Architecture.Arm64 => ["DOTNET_ROOT", "DOTNET_ROOT(ARM64)"],
-                _ => ["DOTNET_ROOT"]
-            };
-        }
-
-        return ["DOTNET_ROOT"];
-    }
-
-    private static IReadOnlyList<string> GetDefaultInstallPaths()
-    {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            return [Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "dotnet", _dotnetExeName)];
-        }
-
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-        {
-            return
-            [
-                Path.Combine("/usr/local/share/dotnet", _dotnetExeName),
-                Path.Combine("/opt/homebrew/bin", _dotnetExeName),
-            ];
-        }
-
-        // Linux
-        return [Path.Combine("/usr/share/dotnet", _dotnetExeName)];
     }
 }

--- a/src/Workloads/Stacks/DotNet/DotnetCliRunner.cs
+++ b/src/Workloads/Stacks/DotNet/DotnetCliRunner.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.ComponentModel;
 using System.Diagnostics;
 
 namespace Azure.Functions.Cli.Workloads.DotNet;
@@ -8,9 +9,9 @@ namespace Azure.Functions.Cli.Workloads.DotNet;
 /// <summary>
 /// Executes <c>dotnet</c> CLI commands in a child process.
 /// </summary>
-internal sealed class DotnetCliRunner : IDotnetCliRunner
+internal sealed class DotnetCliRunner(IDotnetPathResolver pathResolver) : IDotnetCliRunner
 {
-    private static readonly Lazy<string> _dotnetPath = new(DotnetPathResolver.Resolve);
+    private readonly IDotnetPathResolver _pathResolver = pathResolver ?? throw new ArgumentNullException(nameof(pathResolver));
 
     public async Task RunAsync(
         IReadOnlyList<string> arguments,
@@ -21,7 +22,7 @@ internal sealed class DotnetCliRunner : IDotnetCliRunner
 
         ProcessStartInfo psi = new()
         {
-            FileName = _dotnetPath.Value,
+            FileName = _pathResolver.Resolve(),
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
@@ -51,25 +52,47 @@ internal sealed class DotnetCliRunner : IDotnetCliRunner
             await Task.WhenAll(stdoutTask, stderrTask);
             await process.WaitForExitAsync(cancellationToken);
 
-            string stdout = stdoutTask.Result;
-            string stderr = stderrTask.Result;
+            string stdout = await stdoutTask;
+            string stderr = await stderrTask;
 
             if (process.ExitCode != 0)
             {
-                throw new InvalidOperationException(
-                    $"'dotnet {string.Join(' ', arguments)}' failed with exit code {process.ExitCode}.{Environment.NewLine}{stderr}{stdout}");
+                throw new DotnetCliException(
+                    process.ExitCode,
+                    stderr,
+                    stdout,
+                    string.Join(' ', arguments));
             }
         }
-        finally
+        catch (OperationCanceledException)
+        {
+            KillProcess(process);
+            throw;
+        }
+        catch (Exception) when (!process.HasExited)
+        {
+            KillProcess(process);
+        }
+    }
+
+    /// <summary>
+    /// Kills the process tree. Swallows <see cref="InvalidOperationException"/>
+    /// (race between HasExited check and kill — process already gone). Lets
+    /// <see cref="Win32Exception"/> propagate so the caller can surface it as
+    /// a user-facing error.
+    /// </summary>
+    private static void KillProcess(Process process)
+    {
+        try
         {
             if (!process.HasExited)
             {
-                try
-                {
-                    process.Kill(entireProcessTree: true);
-                }
-                catch { }
+                process.Kill(entireProcessTree: true);
             }
+        }
+        catch (InvalidOperationException)
+        {
+            // Process exited between HasExited check and Kill call — nothing to do.
         }
     }
 }

--- a/src/Workloads/Stacks/DotNet/DotnetCliRunner.cs
+++ b/src/Workloads/Stacks/DotNet/DotnetCliRunner.cs
@@ -64,23 +64,12 @@ internal sealed class DotnetCliRunner(IDotnetPathResolver pathResolver) : IDotne
                     string.Join(' ', arguments));
             }
         }
-        catch (OperationCanceledException)
-        {
-            KillProcess(process);
-            throw;
-        }
-        catch (Exception) when (!process.HasExited)
+        finally
         {
             KillProcess(process);
         }
     }
 
-    /// <summary>
-    /// Kills the process tree. Swallows <see cref="InvalidOperationException"/>
-    /// (race between HasExited check and kill — process already gone). Lets
-    /// <see cref="Win32Exception"/> propagate so the caller can surface it as
-    /// a user-facing error.
-    /// </summary>
     private static void KillProcess(Process process)
     {
         try
@@ -90,9 +79,9 @@ internal sealed class DotnetCliRunner(IDotnetPathResolver pathResolver) : IDotne
                 process.Kill(entireProcessTree: true);
             }
         }
-        catch (InvalidOperationException)
+        catch (Exception)
         {
-            // Process exited between HasExited check and Kill call — nothing to do.
+            // This is best effort and we don't want to mask the original exception if the process has already exited.
         }
     }
 }

--- a/src/Workloads/Stacks/DotNet/DotnetPathResolver.cs
+++ b/src/Workloads/Stacks/DotNet/DotnetPathResolver.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Runtime.InteropServices;
+using Azure.Functions.Cli.Common;
 
 namespace Azure.Functions.Cli.Workloads.DotNet;
 
@@ -9,16 +10,29 @@ namespace Azure.Functions.Cli.Workloads.DotNet;
 /// Resolves the full path to the <c>dotnet</c> muxer using well-known environment
 /// variables and conventions, rather than relying on PATH resolution.
 /// </summary>
-internal static class DotnetPathResolver
+internal sealed class DotnetPathResolver : IDotnetPathResolver
 {
     private static readonly string _dotnetExeName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
         ? "dotnet.exe"
         : "dotnet";
 
+    private string? _cachedPath;
+
     /// <summary>
     /// Returns the resolved path to the <c>dotnet</c> executable.
     /// </summary>
-    public static string Resolve()
+    public string Resolve()
+    {
+        if (_cachedPath is not null)
+        {
+            return _cachedPath;
+        }
+
+        _cachedPath = ResolveCore();
+        return _cachedPath;
+    }
+
+    private static string ResolveCore()
     {
         // 1. DOTNET_HOST_PATH – set by the SDK to the absolute path of the running dotnet host.
         string? hostPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
@@ -60,8 +74,9 @@ internal static class DotnetPathResolver
             }
         }
 
-        // 5. Fallback – rely on PATH (best effort).
-        return _dotnetExeName;
+        throw new GracefulException(
+            "Could not locate the dotnet host. Install the .NET SDK or set the DOTNET_HOST_PATH or DOTNET_ROOT environment variable.",
+            isUserError: true);
     }
 
     private static IReadOnlyList<string> GetDotnetRootVariables()
@@ -71,7 +86,7 @@ internal static class DotnetPathResolver
             return RuntimeInformation.OSArchitecture switch
             {
                 Architecture.X86 => ["DOTNET_ROOT(x86)", "DOTNET_ROOT"],
-                Architecture.Arm64 => ["DOTNET_ROOT", "DOTNET_ROOT(ARM64)"],
+                Architecture.Arm64 => ["DOTNET_ROOT_ARM64", "DOTNET_ROOT"],
                 _ => ["DOTNET_ROOT"]
             };
         }

--- a/src/Workloads/Stacks/DotNet/DotnetPathResolver.cs
+++ b/src/Workloads/Stacks/DotNet/DotnetPathResolver.cs
@@ -1,0 +1,101 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Runtime.InteropServices;
+
+namespace Azure.Functions.Cli.Workloads.DotNet;
+
+/// <summary>
+/// Resolves the full path to the <c>dotnet</c> muxer using well-known environment
+/// variables and conventions, rather than relying on PATH resolution.
+/// </summary>
+internal static class DotnetPathResolver
+{
+    private static readonly string _dotnetExeName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+        ? "dotnet.exe"
+        : "dotnet";
+
+    /// <summary>
+    /// Returns the resolved path to the <c>dotnet</c> executable.
+    /// </summary>
+    public static string Resolve()
+    {
+        // 1. DOTNET_HOST_PATH – set by the SDK to the absolute path of the running dotnet host.
+        string? hostPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
+        if (!string.IsNullOrEmpty(hostPath) && File.Exists(hostPath))
+        {
+            return hostPath;
+        }
+
+        // 2. Current process – if this tool is launched via `dotnet func`, the process is the muxer.
+        string? processPath = Environment.ProcessPath;
+        if (processPath is not null
+            && Path.GetFileName(processPath).Equals(_dotnetExeName, StringComparison.OrdinalIgnoreCase)
+            && File.Exists(processPath))
+        {
+            return processPath;
+        }
+
+        // 3. DOTNET_ROOT (and architecture-specific variants) – standard variable pointing
+        //    to the dotnet installation directory.
+        foreach (string envVar in GetDotnetRootVariables())
+        {
+            string? dotnetRoot = Environment.GetEnvironmentVariable(envVar);
+            if (!string.IsNullOrEmpty(dotnetRoot))
+            {
+                string candidate = Path.Combine(dotnetRoot, _dotnetExeName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        // 4. Well-known default install locations (platform-specific).
+        foreach (string defaultPath in GetDefaultInstallPaths())
+        {
+            if (File.Exists(defaultPath))
+            {
+                return defaultPath;
+            }
+        }
+
+        // 5. Fallback – rely on PATH (best effort).
+        return _dotnetExeName;
+    }
+
+    private static IReadOnlyList<string> GetDotnetRootVariables()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return RuntimeInformation.OSArchitecture switch
+            {
+                Architecture.X86 => ["DOTNET_ROOT(x86)", "DOTNET_ROOT"],
+                Architecture.Arm64 => ["DOTNET_ROOT", "DOTNET_ROOT(ARM64)"],
+                _ => ["DOTNET_ROOT"]
+            };
+        }
+
+        return ["DOTNET_ROOT"];
+    }
+
+    private static IReadOnlyList<string> GetDefaultInstallPaths()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return [Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "dotnet", _dotnetExeName)];
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return
+            [
+                Path.Combine("/usr/local/share/dotnet", _dotnetExeName),
+                Path.Combine("/opt/homebrew/bin", _dotnetExeName),
+            ];
+        }
+
+        // Linux
+        return [Path.Combine("/usr/share/dotnet", _dotnetExeName)];
+    }
+}

--- a/src/Workloads/Stacks/DotNet/IDotnetCliRunner.cs
+++ b/src/Workloads/Stacks/DotNet/IDotnetCliRunner.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workload.DotNet;
+
+/// <summary>
+/// Runs <c>dotnet</c> CLI commands in a child process.
+/// </summary>
+internal interface IDotnetCliRunner
+{
+    /// <summary>
+    /// Executes <c>dotnet</c> with the supplied arguments.
+    /// </summary>
+    /// <param name="arguments">The arguments to pass to <c>dotnet</c>.</param>
+    /// <param name="workingDirectory">Optional working directory for the process.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <exception cref="InvalidOperationException">The process could not start or exited with a non-zero code.</exception>
+    public Task RunAsync(IReadOnlyList<string> arguments, string? workingDirectory, CancellationToken cancellationToken);
+}

--- a/src/Workloads/Stacks/DotNet/IDotnetCliRunner.cs
+++ b/src/Workloads/Stacks/DotNet/IDotnetCliRunner.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Azure.Functions.Cli.Workload.DotNet;
+namespace Azure.Functions.Cli.Workloads.DotNet;
 
 /// <summary>
 /// Runs <c>dotnet</c> CLI commands in a child process.

--- a/src/Workloads/Stacks/DotNet/IDotnetCliRunner.cs
+++ b/src/Workloads/Stacks/DotNet/IDotnetCliRunner.cs
@@ -14,6 +14,7 @@ internal interface IDotnetCliRunner
     /// <param name="arguments">The arguments to pass to <c>dotnet</c>.</param>
     /// <param name="workingDirectory">Optional working directory for the process.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <exception cref="InvalidOperationException">The process could not start or exited with a non-zero code.</exception>
+    /// <exception cref="InvalidOperationException">The process could not be started.</exception>
+    /// <exception cref="DotnetCliException">The process exited with a non-zero exit code.</exception>
     public Task RunAsync(IReadOnlyList<string> arguments, string? workingDirectory, CancellationToken cancellationToken);
 }

--- a/src/Workloads/Stacks/DotNet/IDotnetPathResolver.cs
+++ b/src/Workloads/Stacks/DotNet/IDotnetPathResolver.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workloads.DotNet;
+
+/// <summary>
+/// Resolves the full path to the <c>dotnet</c> muxer executable.
+/// </summary>
+internal interface IDotnetPathResolver
+{
+    /// <summary>
+    /// Returns the absolute path to the <c>dotnet</c> executable.
+    /// </summary>
+    /// <exception cref="Azure.Functions.Cli.Common.GracefulException">
+    /// The dotnet host could not be located.
+    /// </exception>
+    public string Resolve();
+}

--- a/src/Workloads/Stacks/DotNet/ITemplateHivePathProvider.cs
+++ b/src/Workloads/Stacks/DotNet/ITemplateHivePathProvider.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workloads.DotNet;
+
+/// <summary>
+/// Provides the file-system paths for the dotnet template hive used by
+/// <see cref="DotNetProjectInitializer"/>.
+/// </summary>
+internal interface ITemplateHivePathProvider
+{
+    /// <summary>
+    /// Root directory of the custom template hive.
+    /// </summary>
+    public string HivePath { get; }
+
+    /// <summary>
+    /// Path to the timestamp file that records when templates were last installed.
+    /// </summary>
+    public string TimestampPath { get; }
+}

--- a/src/Workloads/Stacks/DotNet/TemplateHivePathProvider.cs
+++ b/src/Workloads/Stacks/DotNet/TemplateHivePathProvider.cs
@@ -20,6 +20,9 @@ internal sealed class TemplateHivePathProvider : ITemplateHivePathProvider
 
     public TemplateHivePathProvider()
     {
+        // Read directly from the process environment (not through IConfiguration) so the
+        // template hive cannot be redirected by host config, global config, or project
+        // .func/config.json. Only an explicit env var set by the user should control this.
         string? configured = Environment.GetEnvironmentVariable(HivePathEnvironmentVariable);
 
         string hivePath = string.IsNullOrWhiteSpace(configured)

--- a/src/Workloads/Stacks/DotNet/TemplateHivePathProvider.cs
+++ b/src/Workloads/Stacks/DotNet/TemplateHivePathProvider.cs
@@ -7,12 +7,12 @@ namespace Azure.Functions.Cli.Workloads.DotNet;
 
 /// <summary>
 /// Default implementation that resolves the template hive path, honoring the
-/// <c>FUNC_CLI_WORKLOADS_HOME</c> environment variable when set, and falling
-/// back to <c>~/.azure-functions/dotnet-template-hive</c>.
+/// <c>FUNC_CLI_DOTNET_TEMPLATE_HIVE</c> environment variable when set, and
+/// falling back to <c>~/.azure-functions/dotnet-template-hive</c>.
 /// </summary>
 internal sealed class TemplateHivePathProvider : ITemplateHivePathProvider
 {
-    private const string WorkloadsHomeEnvVar = "FUNC_CLI_WORKLOADS_HOME";
+    internal const string HivePathEnvironmentVariable = "FUNC_CLI_DOTNET_TEMPLATE_HIVE";
     private const string HiveDirectoryName = "dotnet-template-hive";
 
     public string HivePath { get; }
@@ -20,15 +20,16 @@ internal sealed class TemplateHivePathProvider : ITemplateHivePathProvider
 
     public TemplateHivePathProvider()
     {
-        string? workloadsHome = Environment.GetEnvironmentVariable(WorkloadsHomeEnvVar);
+        string? configured = Environment.GetEnvironmentVariable(HivePathEnvironmentVariable);
 
-        string basePath = !string.IsNullOrEmpty(workloadsHome)
-            ? workloadsHome
-            : Path.Combine(
+        string hivePath = string.IsNullOrWhiteSpace(configured)
+            ? Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-                Constants.FuncHomeDirectoryName);
+                Constants.FuncHomeDirectoryName,
+                HiveDirectoryName)
+            : configured;
 
-        HivePath = Path.Combine(basePath, HiveDirectoryName);
+        HivePath = Path.GetFullPath(hivePath);
         TimestampPath = Path.Combine(HivePath, ".installed");
     }
 }

--- a/src/Workloads/Stacks/DotNet/TemplateHivePathProvider.cs
+++ b/src/Workloads/Stacks/DotNet/TemplateHivePathProvider.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Abstractions.Common;
+
+namespace Azure.Functions.Cli.Workloads.DotNet;
+
+/// <summary>
+/// Default implementation that resolves the template hive path, honoring the
+/// <c>FUNC_CLI_WORKLOADS_HOME</c> environment variable when set, and falling
+/// back to <c>~/.azure-functions/dotnet-template-hive</c>.
+/// </summary>
+internal sealed class TemplateHivePathProvider : ITemplateHivePathProvider
+{
+    private const string WorkloadsHomeEnvVar = "FUNC_CLI_WORKLOADS_HOME";
+    private const string HiveDirectoryName = "dotnet-template-hive";
+
+    public string HivePath { get; }
+    public string TimestampPath { get; }
+
+    public TemplateHivePathProvider()
+    {
+        string? workloadsHome = Environment.GetEnvironmentVariable(WorkloadsHomeEnvVar);
+
+        string basePath = !string.IsNullOrEmpty(workloadsHome)
+            ? workloadsHome
+            : Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                Constants.FuncHomeDirectoryName);
+
+        HivePath = Path.Combine(basePath, HiveDirectoryName);
+        TimestampPath = Path.Combine(HivePath, ".installed");
+    }
+}

--- a/src/Workloads/Stacks/DotNet/Workloads.DotNet.csproj
+++ b/src/Workloads/Stacks/DotNet/Workloads.DotNet.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Title>DotNet</Title>
-    <Description>Azure Functions tooling for .NET (C#, F#) projects.</Description>
+    <Description>Azure Functions CLI tooling for .NET (C#, F#) projects.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:workload alias:dotnet func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workloads/Stacks/DotNet/Workloads.DotNet.csproj
+++ b/src/Workloads/Stacks/DotNet/Workloads.DotNet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Title>Azure Functions CLI .NET Workload</Title>
+    <Title>DotNet</Title>
     <Description>Azure Functions tooling for .NET (C#, F#) projects.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:workload alias:dotnet func-workload</PackageTags>
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Azure.Functions.Cli.Workloads.DotNet.Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Workloads/Stacks/DotNet/Workloads.DotNet.csproj
+++ b/src/Workloads/Stacks/DotNet/Workloads.DotNet.csproj
@@ -13,7 +13,6 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Azure.Functions.Cli.Workloads.DotNet.Tests" />
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Workloads/Stacks/DotNet.Tests/DotNetProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/DotNet.Tests/DotNetProjectInitializerTests.cs
@@ -7,11 +7,28 @@ using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.DotNet.Tests;
 
-public class DotNetProjectInitializerTests
+public class DotNetProjectInitializerTests : IDisposable
 {
     private readonly IDotnetCliRunner _dotnetCli = Substitute.For<IDotnetCliRunner>();
+    private readonly ITemplateHivePathProvider _hivePathProvider = Substitute.For<ITemplateHivePathProvider>();
+    private readonly string _hivePath;
 
-    private DotNetProjectInitializer CreateInitializer() => new(_dotnetCli);
+    public DotNetProjectInitializerTests()
+    {
+        _hivePath = Path.Combine(Path.GetTempPath(), "func-test-hive-" + Guid.NewGuid().ToString("N"));
+        _hivePathProvider.HivePath.Returns(_hivePath);
+        _hivePathProvider.TimestampPath.Returns(Path.Combine(_hivePath, ".installed"));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_hivePath))
+        {
+            Directory.Delete(_hivePath, recursive: true);
+        }
+    }
+
+    private DotNetProjectInitializer CreateInitializer() => new(_dotnetCli, _hivePathProvider);
 
     [Fact]
     public void Stack_IsDotNet()
@@ -66,7 +83,7 @@ public class DotNetProjectInitializerTests
     [Fact]
     public void Constructor_ThrowsOnNullRunner()
     {
-        Assert.Throws<ArgumentNullException>(() => new DotNetProjectInitializer(null!));
+        Assert.Throws<ArgumentNullException>(() => new DotNetProjectInitializer(null!, _hivePathProvider));
     }
 
     [Fact]
@@ -74,16 +91,7 @@ public class DotNetProjectInitializerTests
     {
         DotNetProjectInitializer initializer = CreateInitializer();
 
-        string hivePath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            ".azure-functions",
-            "dotnet-template-hive");
-        string timestampPath = Path.Combine(hivePath, ".installed");
-        if (File.Exists(timestampPath))
-        {
-            File.Delete(timestampPath);
-        }
-
+        // Timestamp doesn't exist (temp path with unique GUID), so install should run.
         await initializer.EnsureTemplatesInstalledAsync(CancellationToken.None);
 
         await _dotnetCli.Received(1).RunAsync(
@@ -96,29 +104,17 @@ public class DotNetProjectInitializerTests
     [Fact]
     public async Task EnsureTemplatesInstalledAsync_SkipsInstallWhenTimestampIsFresh()
     {
-        string hivePath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            ".azure-functions",
-            "dotnet-template-hive");
-        string timestampPath = Path.Combine(hivePath, ".installed");
+        Directory.CreateDirectory(_hivePath);
+        File.WriteAllText(_hivePathProvider.TimestampPath, string.Empty);
+        File.WriteAllText(Path.Combine(_hivePath, "dummy-package"), string.Empty);
 
-        Directory.CreateDirectory(hivePath);
-        File.WriteAllText(timestampPath, string.Empty);
+        DotNetProjectInitializer initializer = CreateInitializer();
 
-        try
-        {
-            DotNetProjectInitializer initializer = CreateInitializer();
+        await initializer.EnsureTemplatesInstalledAsync(CancellationToken.None);
 
-            await initializer.EnsureTemplatesInstalledAsync(CancellationToken.None);
-
-            await _dotnetCli.DidNotReceive().RunAsync(
-                Arg.Any<IReadOnlyList<string>>(),
-                Arg.Any<string?>(),
-                Arg.Any<CancellationToken>());
-        }
-        finally
-        {
-            File.Delete(timestampPath);
-        }
+        await _dotnetCli.DidNotReceive().RunAsync(
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
     }
 }

--- a/test/Workloads/Stacks/DotNet.Tests/DotNetProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/DotNet.Tests/DotNetProjectInitializerTests.cs
@@ -87,6 +87,12 @@ public class DotNetProjectInitializerTests : IDisposable
     }
 
     [Fact]
+    public void Constructor_ThrowsOnNullHivePathProvider()
+    {
+        Assert.Throws<ArgumentNullException>(() => new DotNetProjectInitializer(_dotnetCli, null!));
+    }
+
+    [Fact]
     public async Task EnsureTemplatesInstalledAsync_CallsInstallWhenTimestampMissing()
     {
         DotNetProjectInitializer initializer = CreateInitializer();
@@ -106,6 +112,7 @@ public class DotNetProjectInitializerTests : IDisposable
     {
         Directory.CreateDirectory(_hivePath);
         File.WriteAllText(_hivePathProvider.TimestampPath, string.Empty);
+        // Create a real template entry (not just .installed) to satisfy the freshness check.
         File.WriteAllText(Path.Combine(_hivePath, "dummy-package"), string.Empty);
 
         DotNetProjectInitializer initializer = CreateInitializer();

--- a/test/Workloads/Stacks/DotNet.Tests/DotNetProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/DotNet.Tests/DotNetProjectInitializerTests.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.CommandLine;
-using Azure.Functions.Cli.Commands;
-using Azure.Functions.Cli.Common;
 using NSubstitute;
 using Xunit;
 
@@ -77,8 +75,8 @@ public class DotNetProjectInitializerTests
         DotNetProjectInitializer initializer = CreateInitializer();
 
         string hivePath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "azure-functions-core-tools",
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".azure-functions",
             "dotnet-template-hive");
         string timestampPath = Path.Combine(hivePath, ".installed");
         if (File.Exists(timestampPath))
@@ -99,8 +97,8 @@ public class DotNetProjectInitializerTests
     public async Task EnsureTemplatesInstalledAsync_SkipsInstallWhenTimestampIsFresh()
     {
         string hivePath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "azure-functions-core-tools",
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".azure-functions",
             "dotnet-template-hive");
         string timestampPath = Path.Combine(hivePath, ".installed");
 

--- a/test/Workloads/Stacks/DotNet.Tests/DotNetProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/DotNet.Tests/DotNetProjectInitializerTests.cs
@@ -4,43 +4,76 @@
 using System.CommandLine;
 using Azure.Functions.Cli.Commands;
 using Azure.Functions.Cli.Common;
+using NSubstitute;
 using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.DotNet.Tests;
 
 public class DotNetProjectInitializerTests
 {
-    [Fact]
-    public async Task InitializeAsync_Throws_NotImplemented()
-    {
-        var initializer = new DotNetProjectInitializer();
-        var context = new InitContext(
-            WorkingDirectory.FromExplicit(Path.GetTempPath()),
-            ProjectName: "test",
-            Language: null,
-            Force: false);
+    private readonly IDotnetCliRunner _dotnetCli = Substitute.For<IDotnetCliRunner>();
 
-        NotImplementedException exception = await Assert.ThrowsAsync<NotImplementedException>(
-            () => initializer.InitializeAsync(context, new RootCommand().Parse(string.Empty)));
-
-        Assert.Equal(".NET project initialization is not implemented yet.", exception.Message);
-    }
+    private DotNetProjectInitializer CreateInitializer() => new(_dotnetCli);
 
     [Fact]
     public void Stack_IsDotNet()
     {
-        Assert.Equal("dotnet", new DotNetProjectInitializer().Stack);
+        Assert.Equal("dotnet", CreateInitializer().Stack);
     }
 
     [Fact]
-    public void GetInitOptions_IsEmpty()
+    public void GetInitOptions_ContainsFrameworkOption()
     {
-        Assert.Empty(new DotNetProjectInitializer().GetInitOptions());
+        DotNetProjectInitializer initializer = CreateInitializer();
+        IReadOnlyList<Option> options = initializer.GetInitOptions();
+
+        Assert.Single(options);
+        Assert.Same(initializer.FrameworkOption, options[0]);
     }
 
     [Fact]
     public void SupportedLanguages_ReturnsExpectedLanguages()
     {
-        Assert.Equal(["C#", "F#", "csharp", "fsharp"], new DotNetProjectInitializer().SupportedLanguages);
+        Assert.Equal(["C#", "F#", "csharp", "fsharp"], CreateInitializer().SupportedLanguages);
+    }
+
+    [Fact]
+    public void TemplatesPackageName_IsCorrect()
+    {
+        Assert.Equal("Microsoft.Azure.Functions.Worker.ProjectTemplates", DotNetProjectInitializer.TemplatesPackageName);
+    }
+
+    [Fact]
+    public void TemplatesPackageVersion_IsCorrect()
+    {
+        Assert.Equal("4.0.5544", DotNetProjectInitializer.TemplatesPackageVersion);
+    }
+
+    [Fact]
+    public void DefaultFramework_IsNet10()
+    {
+        Assert.Equal("net10.0", DotNetProjectInitializer.DefaultFramework);
+    }
+
+    [Theory]
+    [InlineData(null, "C#")]
+    [InlineData("", "C#")]
+    [InlineData("  ", "C#")]
+    [InlineData("csharp", "C#")]
+    [InlineData("CSHARP", "C#")]
+    [InlineData("C#", "C#")]
+    [InlineData("fsharp", "F#")]
+    [InlineData("FSHARP", "F#")]
+    [InlineData("F#", "F#")]
+    [InlineData("unknown", "unknown")]
+    public void NormalizeLanguage_ReturnsExpectedResult(string? input, string expected)
+    {
+        Assert.Equal(expected, DotNetProjectInitializer.NormalizeLanguage(input));
+    }
+
+    [Fact]
+    public void Constructor_ThrowsOnNullRunner()
+    {
+        Assert.Throws<ArgumentNullException>(() => new DotNetProjectInitializer(null!));
     }
 }

--- a/test/Workloads/Stacks/DotNet.Tests/DotNetProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/DotNet.Tests/DotNetProjectInitializerTests.cs
@@ -44,27 +44,21 @@ public class DotNetProjectInitializerTests
     }
 
     [Fact]
-    public void TemplatesPackageVersion_IsCorrect()
-    {
-        Assert.Equal("4.0.5544", DotNetProjectInitializer.TemplatesPackageVersion);
-    }
-
-    [Fact]
     public void DefaultFramework_IsNet10()
     {
         Assert.Equal("net10.0", DotNetProjectInitializer.DefaultFramework);
     }
 
     [Theory]
-    [InlineData(null, "C#")]
-    [InlineData("", "C#")]
-    [InlineData("  ", "C#")]
-    [InlineData("csharp", "C#")]
-    [InlineData("CSHARP", "C#")]
-    [InlineData("C#", "C#")]
-    [InlineData("fsharp", "F#")]
-    [InlineData("FSHARP", "F#")]
-    [InlineData("F#", "F#")]
+    [InlineData(null, "c#")]
+    [InlineData("", "c#")]
+    [InlineData("  ", "c#")]
+    [InlineData("csharp", "c#")]
+    [InlineData("CSHARP", "c#")]
+    [InlineData("C#", "c#")]
+    [InlineData("fsharp", "f#")]
+    [InlineData("FSHARP", "f#")]
+    [InlineData("F#", "f#")]
     [InlineData("unknown", "unknown")]
     public void NormalizeLanguage_ReturnsExpectedResult(string? input, string expected)
     {

--- a/test/Workloads/Stacks/DotNet.Tests/DotNetProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/DotNet.Tests/DotNetProjectInitializerTests.cs
@@ -70,4 +70,57 @@ public class DotNetProjectInitializerTests
     {
         Assert.Throws<ArgumentNullException>(() => new DotNetProjectInitializer(null!));
     }
+
+    [Fact]
+    public async Task EnsureTemplatesInstalledAsync_CallsInstallWhenTimestampMissing()
+    {
+        DotNetProjectInitializer initializer = CreateInitializer();
+
+        string hivePath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "azure-functions-core-tools",
+            "dotnet-template-hive");
+        string timestampPath = Path.Combine(hivePath, ".installed");
+        if (File.Exists(timestampPath))
+        {
+            File.Delete(timestampPath);
+        }
+
+        await initializer.EnsureTemplatesInstalledAsync(CancellationToken.None);
+
+        await _dotnetCli.Received(1).RunAsync(
+            Arg.Is<IReadOnlyList<string>>(args =>
+                args.Contains(DotNetProjectInitializer.TemplatesPackageName)),
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task EnsureTemplatesInstalledAsync_SkipsInstallWhenTimestampIsFresh()
+    {
+        string hivePath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "azure-functions-core-tools",
+            "dotnet-template-hive");
+        string timestampPath = Path.Combine(hivePath, ".installed");
+
+        Directory.CreateDirectory(hivePath);
+        File.WriteAllText(timestampPath, string.Empty);
+
+        try
+        {
+            DotNetProjectInitializer initializer = CreateInitializer();
+
+            await initializer.EnsureTemplatesInstalledAsync(CancellationToken.None);
+
+            await _dotnetCli.DidNotReceive().RunAsync(
+                Arg.Any<IReadOnlyList<string>>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            File.Delete(timestampPath);
+        }
+    }
 }

--- a/test/Workloads/Stacks/DotNet.Tests/DotNetWorkloadTests.cs
+++ b/test/Workloads/Stacks/DotNet.Tests/DotNetWorkloadTests.cs
@@ -28,7 +28,7 @@ public class DotNetWorkloadTests
         var workload = new DotNetWorkload();
 
         // Act & Assert
-        Assert.Equal("Azure Functions tooling for .NET (C#) projects.", workload.Description);
+        Assert.Equal("Azure Functions CLI tooling for .NET (C#) projects.", workload.Description);
     }
 
     [Fact]


### PR DESCRIPTION
Simple `func init` functionality. Does not include everything from legacy [InitAction](https://github.com/Azure/azure-functions-core-tools/blob/main/src/Cli/func/Actions/LocalActions/InitAction/InitAction.cs) and is missing support for Docker (which likely needs a broader design across workloads/CLI project). CLI abstraction added based on instructions from [AGENTS.md](https://github.com/Azure/azure-functions-core-tools/blob/vnext/AGENTS.md).

## Implement .NET project initialization via `dotnet new` templates

### Summary

Implements the previously-stubbed `DotNetProjectInitializer.InitializeAsync` to scaffold .NET Azure Functions projects using `dotnet new func` from the `Microsoft.Azure.Functions.Worker.ProjectTemplates` NuGet package. Introduces an `IDotnetCliRunner` abstraction for testable process execution.

### Changes

**New files:**
| File | Description |
|------|-------------|
| `IDotnetCliRunner.cs` | Interface wrapping `dotnet` CLI execution |
| `DotnetCliRunner.cs` | Production implementation with concurrent stdout/stderr reads and process-tree cleanup on cancellation |

**Modified files:**
| File | Description |
|------|-------------|
| `DotNetProjectInitializer.cs` | Replaces `NotImplementedException` stub with full implementation: installs templates, runs `dotnet new func` with language/framework/force options, accepts `IDotnetCliRunner` via primary constructor |
| `DotNetWorkload.cs` | Registers `IDotnetCliRunner` singleton |
| `Workload.DotNet.csproj` | Adds `InternalsVisibleTo` for `DynamicProxyGenAssembly2` (NSubstitute proxy support) |
| `DotNetProjectInitializerTests.cs` | Rewrites tests to use NSubstitute mock; adds `--target-framework` option test, `NormalizeLanguage` theory (10 cases), constructor null-guard test |

### Key design decisions

- **`IDotnetCliRunner`** — process I/O behind an interface per repo conventions (AGENTS.md). Kept internal to the DotNet workload since only this stack needs it.
- **`--force` is conditional** — only passed to `dotnet new` when `context.Force` is true (the stub had no logic; the legacy `InitAction` always passed `--force`).
- **Concurrent stream reads** — `DotnetCliRunner` uses `Task.WhenAll` for stdout/stderr to prevent deadlock on large output.
- **Cancellation safety** — kills the entire process tree on `OperationCanceledException` to avoid orphaned `dotnet` processes.

### Testing

- 21 tests pass, 0 warnings
- All tests use `Substitute.For<IDotnetCliRunner>()` — no real `dotnet` process needed
- Manually tested CLI and created project as expected, hive and workload are created at expected locations.
