### PR TITLE
Ignore Microsoft.ApplicationInsights major bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,11 @@ updates:
       - dependency-name: "Microsoft.Azure.Functions.PowerShellWorker.*"
       - dependency-name: "Microsoft.Azure.Functions.PythonWorker"
       - dependency-name: "Microsoft.Azure.WebJobs.Script.WebHost"
+      # We intentionally stay on Microsoft.ApplicationInsights 2.x and do
+      # not plan to move to v3.
+      - dependency-name: "Microsoft.ApplicationInsights"
+        update-types:
+          - "version-update:semver-major"
     groups:
       opentelemetry:
         patterns:


### PR DESCRIPTION
Adds a dependabot ignore rule for `Microsoft.ApplicationInsights` major-version bumps. We intentionally stay on 2.x and do not plan to move to v3 (closed #4986 manually for the same reason).

This stops dependabot from re-opening the v3 PR on its weekly cadence.