### PR TITLE
Add bundles workload spec proposal

### DIFF
--- a/proposed/bundles-workload-spec.md
+++ b/proposed/bundles-workload-spec.md
@@ -45,7 +45,10 @@
   workload-build time by the workload's own MSBuild process.
 - **Custom bundles install root.** Bundle payloads live inside the
   workload install directory under `<workload-home>`. There is no
-  second on-disk root, no override env var, and no plan to add one.
+  second on-disk root, no bundles-specific override env var, and no
+  plan to add one. (`<workload-home>` itself is customizable via
+  `FUNC_CLI_WORKLOADS_HOME`, per Workload Spec §11; this naturally
+  relocates bundle installs along with everything else.)
 - **CT → host transport beyond today's env vars.** If a future
   CT-host workload introduces a different startup transport, that is
   out of scope for this spec.

--- a/proposed/bundles-workload-spec.md
+++ b/proposed/bundles-workload-spec.md
@@ -56,7 +56,7 @@
 | Term | Meaning |
 |------|---------|
 | **Bundle id** | The `host.json` `extensionBundle.id` value, e.g. `Microsoft.Azure.Functions.ExtensionBundle` or `Microsoft.Azure.Functions.ExtensionBundle.Preview`. |
-| **Bundle version** | A SemVer version of an extension bundle payload, e.g. `4.22.0` (stable) or `4.33.0-experimental.1` (prerelease). Prerelease tags carry preview / experimental builds. |
+| **Bundle version** | A SemVer version of an extension bundle payload, e.g. `4.22.0` (stable) or `4.33.0-experimental` (prerelease). Prerelease tags carry preview / experimental builds. |
 | **Bundles workload** | The single workload package id `Azure.Functions.Cli.Workloads.ExtensionBundles` (`kind: workload`). Each installed instance of this workload carries exactly **one** bundle version, packaged at workload-build time. The workload version is **always equal to the bundle version it packages**. |
 | **Bundle workload install dir** | The directory the workload subsystem extracts an installed bundles workload into, per Workload Spec §6.1: `<workload-home>/workloads/azure.functions.cli.workloads.extensionbundles/<bundle-version>/`. |
 | **Resolved bundle path** | The directory the provider returns to a consumer. It is a subdirectory of the bundle workload install dir whose contents match today's extension bundle zip layout exactly, so the Functions runtime host needs no changes to consume it. |
@@ -76,7 +76,7 @@ The workload version equals the bundle version it packages:
 | `func workload install …` | Bundle version delivered |
 |---------------------------|--------------------------|
 | `Azure.Functions.Cli.Workloads.ExtensionBundles@4.22.0` | `4.22.0` |
-| `Azure.Functions.Cli.Workloads.ExtensionBundles@4.33.0-experimental.1` | `4.33.0-experimental.1` |
+| `Azure.Functions.Cli.Workloads.ExtensionBundles@4.33.0-experimental` | `4.33.0-experimental` |
 
 Multiple bundle versions coexist on disk by installing the workload
 multiple times with `func workload install --force` (Workload Spec
@@ -98,9 +98,12 @@ Rationale:
 
 Preview and experimental bundles do **not** get a separate workload
 package id. They are expressed as SemVer prerelease versions of the
-same package, e.g. `4.33.0-preview.1`, `4.33.0-experimental.2`. This
-matches NuGet's own prerelease convention and lets the workload
-subsystem manage them with no new code paths.
+same package: `4.33.0-preview`, `4.33.0-experimental`. The
+prerelease label is a bare channel name with **no** numeric
+disambiguator; a republished preview/experimental drop for the same
+`<major>.<minor>.<patch>` overwrites its predecessor in the workload
+catalog. This matches NuGet's prerelease convention while keeping
+the version strings short and obvious.
 
 `host.json` continues to support both bundle ids
 (`Microsoft.Azure.Functions.ExtensionBundle` and

--- a/proposed/bundles-workload-spec.md
+++ b/proposed/bundles-workload-spec.md
@@ -69,15 +69,16 @@
 
 | Term | Meaning |
 |------|---------|
-| **Bundle id** | The `host.json` `extensionBundle.id` value, e.g. `Microsoft.Azure.Functions.ExtensionBundle` or `Microsoft.Azure.Functions.ExtensionBundle.Preview`. |
-| **Bundle version** | A SemVer version of an extension bundle payload, e.g. `4.22.0` (stable) or `4.33.0-experimental` (prerelease). Prerelease tags carry preview / experimental builds. |
-| **Bundles workload** | The single `kind: content` workload package id `Azure.Functions.Cli.Workloads.ExtensionBundles`. Each installed instance carries exactly **one** bundle version, packaged at workload-build time. The workload version is **always equal to the bundle version it packages**. |
-| **Bundle workload install dir** | The directory the workload subsystem extracts an installed bundles workload into, per Workload Spec §6.1: `<workload-home>/workloads/azure.functions.cli.workloads.extensionbundles/<bundle-version>/`. |
+| **Bundle id** | The `host.json` `extensionBundle.id` value. Three ids exist in v5: `Microsoft.Azure.Functions.ExtensionBundle` (stable), `Microsoft.Azure.Functions.ExtensionBundle.Preview`, and `Microsoft.Azure.Functions.ExtensionBundle.Experimental`. Each id is its own channel; experimental is **not** a label on the Preview id. |
+| **Bundle payload version** | The 3-part SemVer version of the extension bundle payload zip (e.g. `4.35.0`). This is the version the Functions runtime knows about and the version the user sees in `func` logs. It carries **no** prerelease label, even for the preview / experimental channels. |
+| **Workload pkg version** | The 4-part version of the bundles workload `.nupkg`, of the form `BundleVersion.WorkloadIteration[-Channel]` (e.g. `4.35.0.1`, `4.35.0.1-preview`, `4.35.0.1-experimental`). See §4.1 for the version scheme. |
+| **Bundles workload** | The single `kind: content` workload package id `Azure.Functions.Cli.Workloads.ExtensionBundles`. Each installed instance carries exactly **one** bundle payload, packaged at workload-build time. |
+| **Bundle workload install dir** | The directory the workload subsystem extracts an installed bundles workload into, per Workload Spec §6.1: `<workload-home>/workloads/azure.functions.cli.workloads.extensionbundles/<workload-pkg-version>/`. |
 | **Resolved bundle path** | The directory the CLI core returns to its bundle consumer (today: `func start`). It is a subdirectory of the bundle workload install dir whose contents match today's extension bundle zip layout exactly, so the Functions runtime host needs no changes to consume it. |
 
 ## 4. Architecture
 
-### 4.1 Content workload, one bundle version per install
+### 4.1 Content workload, one bundle payload per install
 
 There is **one** workload package id:
 
@@ -89,29 +90,68 @@ It is `kind: content` (Workload Spec §3, §5.3): the package ships
 the bundle payload under `tools/any/` with no `entryPoint`. The
 workload subsystem records its registry row but does not load it
 (Workload Spec §6.2 step 3, §5.1 "non-`workload` kinds"). The CLI
-core resolves the install directory by package id and version, in
-the same way `func start` resolves the host-runtime workload today
-(Workload Spec §4.6).
+core resolves the install directory by package id and workload pkg
+version, in the same way `func start` resolves the host-runtime
+workload today (Workload Spec §4.6).
 
-The workload version equals the bundle version it packages:
+#### 4.1.1 Two-axis version scheme
 
-| `func workload install …` | Bundle version delivered |
-|---------------------------|--------------------------|
-| `Azure.Functions.Cli.Workloads.ExtensionBundles@4.22.0` | `4.22.0` |
-| `Azure.Functions.Cli.Workloads.ExtensionBundles@4.33.0-preview` | `4.33.0-preview` |
-| `Azure.Functions.Cli.Workloads.ExtensionBundles@4.33.0-experimental` | `4.33.0-experimental` |
+The workload pkg version is **not** a 1:1 mirror of the bundle
+payload version. It has the form:
+
+```
+BundleVersion.WorkloadIteration[-Channel]
+```
+
+Three MSBuild props in `Directory.Version.props` drive
+`<VersionPrefix>`:
+
+- `$(BundleVersion)` (e.g. `4.35.0`): the 3-part SemVer version of
+  the bundle payload. Drives the CDN URL (§5.3.2) and the
+  user-facing version in `func` logs.
+- `$(WorkloadIteration)` (e.g. `1`): per-bundle iteration counter
+  for the workload pkg itself, always occupying the 4th segment
+  regardless of channel. Bump when republishing the same bundle
+  payload with a workload-only fix.
+- `$(BundleChannel)` (`stable` | `preview` | `experimental`):
+  selects the CDN bundle id at pack time (§5.3.1) and the
+  prerelease label on the workload pkg version.
+
+The resulting workload pkg versions per channel:
+
+| Channel | host.json `extensionBundle.id` | Workload pkg version | Bundle payload version |
+|---|---|---|---|
+| stable | `Microsoft.Azure.Functions.ExtensionBundle` | `4.35.0.1` | `4.35.0` |
+| preview | `Microsoft.Azure.Functions.ExtensionBundle.Preview` | `4.35.0.1-preview` | `4.35.0` |
+| experimental | `Microsoft.Azure.Functions.ExtensionBundle.Experimental` | `4.35.0.1-experimental` | `4.35.0` |
+
+Each installed workload pkg version still ships **exactly one**
+bundle payload version; the 1:1 contract holds at the user-facing
+surface. The 4th segment and prerelease label are CLI-internal
+plumbing.
+
+Rationale for splitting the two axes:
+
+- The workload pkg can be re-released with a fix (catalog metadata,
+  packaging bug, signing, etc.) without bumping the bundle payload
+  version. Workload-only fixes get `.2`, `.3`, ... in the 4th
+  segment.
+- The prerelease label is NuGet's built-in "this is preview"
+  signal: `func workload install` won't pick up preview /
+  experimental rows without an explicit pin or `--prerelease`.
+- The iteration counter is always in the same slot across
+  channels, so `WorkloadIteration` increments cleanly regardless
+  of channel.
 
 Multiple bundle versions coexist on disk by installing the workload
 multiple times with `func workload install --force` (Workload Spec
 §4.6 already specifies this side-by-side model for the host-runtime
 workload; bundles use the same mechanism). Each install is a
-distinct row in the workload registry.
+distinct row in the workload registry, keyed by workload pkg
+version.
 
-Rationale:
+Other rationale:
 
-- A 1:1 mapping between workload version and bundle version makes
-  every install reproducible and auditable: the version in
-  `workloads.json` is the bundle version on disk, full stop.
 - Side-by-side coexistence via `--force` is already part of the
   workload subsystem; bundles don't need a separate cache layer.
 - Keeping the workload payload-only (no assembly, no
@@ -121,27 +161,27 @@ Rationale:
 - Eliminating a second on-disk root removes an entire class of
   override / migration concerns.
 
-### 4.2 SemVer prerelease tags for preview / experimental
+### 4.2 Three-channel id model and resolver filter
 
-Preview and experimental bundles do **not** get a separate workload
-package id. They are expressed as SemVer prerelease versions of the
-same package: `4.33.0-preview`, `4.33.0-experimental`. The
-prerelease label is a bare channel name with **no** numeric
-disambiguator; a republished preview/experimental drop for the same
-`<major>.<minor>.<patch>` overwrites its predecessor in the workload
-catalog. This matches NuGet's prerelease convention while keeping
-the version strings short and obvious.
+`host.json` `extensionBundle.id` selects the **channel**. Each of
+the three v5 ids maps to the same workload package
+(`Azure.Functions.Cli.Workloads.ExtensionBundles`); the CLI core
+resolver picks installed rows by matching the workload pkg
+version's prerelease label against the requested id:
 
-`host.json` continues to support both bundle ids
-(`Microsoft.Azure.Functions.ExtensionBundle` and
-`...ExtensionBundle.Preview`). Both ids map to the **same** workload
-package; the chosen `extensionBundle.id` plus the requested version
-range selects candidates from the installed registry rows. The
-exact mapping rules between an `id=...Preview` host.json and which
-installed workload versions are considered candidates are captured
-as an open question in §9 (the simplest rule is "Preview id selects
-only prerelease-tagged versions; stable id selects only
-stable-tagged versions").
+| host.json `extensionBundle.id` | Matching workload pkg versions |
+|---|---|
+| `Microsoft.Azure.Functions.ExtensionBundle` | versions with **no** prerelease label (e.g. `4.35.0.1`) |
+| `Microsoft.Azure.Functions.ExtensionBundle.Preview` | versions whose prerelease label is **exactly `preview`** (e.g. `4.35.0.1-preview`) |
+| `Microsoft.Azure.Functions.ExtensionBundle.Experimental` | versions whose prerelease label is **exactly `experimental`** (e.g. `4.35.0.1-experimental`) |
+
+The match is exact: a workload version's prerelease label is the
+encoded channel. Preview does not match experimental versions and
+vice versa.
+
+The version-range intersection (§5.1) is then evaluated against
+the **bundle payload version** (3-part `$(BundleVersion)`) of each
+matching candidate.
 
 ### 4.3 CLI core ownership
 
@@ -251,15 +291,18 @@ workload`-style package) later without touching the rest of CT.
      ```
      This project requires an extension bundle but no bundles
      workload is installed. Install a version with:
-       func workload install Azure.Functions.Cli.Workloads.ExtensionBundles@<version>
+       func workload install Azure.Functions.Cli.Workloads.ExtensionBundles@<workload-pkg-version>
      ```
-     Exit non-zero.
+     e.g. `...@4.35.0.1` for stable or `...@4.35.0.1-preview` for
+     preview. Exit non-zero.
 4. On `Resolved`: set
    `AzureFunctionsJobHost__extensionBundle__downloadPath` to the
    returned path and launch the host. Log at Information:
    ```
-   Using extension bundle <id> <version> from <path>
+   Using extension bundle <id> <bundle-payload-version> from <path>
    ```
+   where `<bundle-payload-version>` is the 3-part bundle version
+   (e.g. `4.35.0`), not the workload pkg version.
 5. On `EmptyIntersection` or `NoCompatibleInstall`: print the
    structured install hint (§5.4) and exit non-zero. Do not start
    the host.
@@ -282,26 +325,34 @@ worker runtime, active profile), the CLI core:
    - the `host.json` `extensionBundle.version` range, and
    - the active profile's `extensionBundle.version` range (if
      declared; otherwise the constraint equals the host.json range).
-2. Enumerates **installed bundle workload versions** by reading the
+2. Enumerates **installed bundle workload rows** by reading the
    workload registry (`workloads.json`, Workload Spec §10.1) for
    rows whose `packageId` is
-   `azure.functions.cli.workloads.extensionbundles`.
-3. Filters that set by host.json `extensionBundle.id` per §4.2
-   (stable id → stable-tagged versions; Preview id →
-   prerelease-tagged versions; final rule per §9 open question).
-4. Selects the **highest** filtered version that satisfies the
-   constraint range.
+   `azure.functions.cli.workloads.extensionbundles`. Each row's
+   identity is its full workload pkg version (e.g. `4.35.0.1`,
+   `4.35.0.1-preview`).
+3. Filters those rows by host.json `extensionBundle.id` per the
+   §4.2 channel rule (stable id → no prerelease label; Preview id
+   → prerelease label exactly `preview`; Experimental id →
+   prerelease label exactly `experimental`).
+4. Projects each surviving row to its **bundle payload version**
+   (3-part `$(BundleVersion)`) and selects the **highest** that
+   satisfies the constraint range.
 5. Produces one of:
    - **Resolved**: the absolute path inside that workload's install
-     dir whose layout matches the extension bundle zip (§5.2).
+     dir whose layout matches the extension bundle zip (§5.2). The
+     resolution carries the **3-part bundle payload version** as
+     its user-facing version, not the full workload pkg version.
    - **WorkloadMissing**: no rows for the bundles package id exist
      at any version.
    - **EmptyIntersection**: the host.json range and the profile
-     range do not overlap. Carries the highest version that would
-     satisfy host.json alone (for the install hint).
+     range do not overlap. Carries the highest bundle payload
+     version that would satisfy host.json alone (for the install
+     hint).
    - **NoCompatibleInstall**: the constraint range and a list of
-     installed bundle workload versions are non-empty but none
-     match. Carries the install hint for a satisfying version.
+     filtered installed bundle workload rows are non-empty but
+     none match. Carries the install hint for a satisfying
+     version.
 6. If the active profile declares `supportedRuntimes` and the
    project's worker runtime is not listed, the result includes a
    non-fatal warning. `func start` logs it and proceeds; mismatch
@@ -315,8 +366,12 @@ The bundles workload `.nupkg` ships its payload under `tools/any/`,
 which the workload subsystem extracts into:
 
 ```
-<workload-home>/workloads/azure.functions.cli.workloads.extensionbundles/<bundle-version>/
+<workload-home>/workloads/azure.functions.cli.workloads.extensionbundles/<workload-pkg-version>/
 ```
+
+The directory is keyed by the full workload pkg version (e.g.
+`4.35.0.1`, `4.35.0.1-preview`), so stable and preview installs of
+the same bundle payload coexist as distinct directories.
 
 The actual bundle content (the layout the Functions runtime host
 already knows how to read: `bin/`, `extensions.json`, etc.) lives
@@ -403,7 +458,9 @@ Tracking this transition is open question §9.Q5.
 
 ### 5.4 Install hints
 
-The CLI core owns hint copy for the failure variants of §5.1:
+The CLI core owns hint copy for the failure variants of §5.1.
+Suggested pin versions in hints use the **full workload pkg
+version** (4-part, with channel label as applicable):
 
 - `EmptyIntersection`:
   ```
@@ -418,8 +475,10 @@ The CLI core owns hint copy for the failure variants of §5.1:
   (id=<bundle-id>).
   Installed versions: <v1>, <v2>, ...
   Install a satisfying version with:
-    func workload install Azure.Functions.Cli.Workloads.ExtensionBundles@<suggested-version> --force
+    func workload install Azure.Functions.Cli.Workloads.ExtensionBundles@<workload-pkg-version> --force
   ```
+  e.g. `...@4.35.0.1` for stable, `...@4.35.0.1-preview` for
+  preview.
 - `WorkloadMissing` hint: see §4.4 step 3.
 
 ## 6. Logging and verbosity
@@ -434,8 +493,9 @@ The CLI core owns hint copy for the failure variants of §5.1:
   [bundle-resolve] host.json range = <host-range>
   [bundle-resolve] profile '<profile>' range = <profile-range>
   [bundle-resolve] constraint = <intersection>
-  [bundle-resolve] installed versions (filtered) = <v1>, <v2>, ...
-  [bundle-resolve] selected = <version>
+  [bundle-resolve] installed workload pkg versions (filtered) = <wpv1>, <wpv2>, ...
+  [bundle-resolve] installed bundle payload versions = <bpv1>, <bpv2>, ...
+  [bundle-resolve] selected bundle payload version = <bundle-payload-version>
   [bundle-resolve] path = <resolved-path>
   ```
 
@@ -447,7 +507,7 @@ single `bundle-resolve` event:
 | Field | Value |
 |-------|-------|
 | `bundleId` | `host.json` `extensionBundle.id` |
-| `resolvedVersion` | Selected bundle version, or `null` on failure |
+| `resolvedVersion` | Selected 3-part **bundle payload version** (e.g. `4.35.0`) on success, or `null` on failure. The full 4-part workload pkg version is CLI-internal and is not emitted. |
 | `profileName` | Active profile name, or `null` if no profile |
 | `succeeded` | `true` if the host was launched with a resolved bundle |
 | `reason` | `ok` \| `no-host-json-bundle` \| `workload-missing` \| `empty-intersection` \| `no-compatible-install` |
@@ -479,27 +539,14 @@ none there.
 
 ## 9. Open questions
 
-1. **Bundle id mapping rule.** When host.json declares
-   `id=Microsoft.Azure.Functions.ExtensionBundle.Preview`, which
-   installed workload versions are candidates? Proposed: only
-   versions carrying a prerelease tag whose label is `preview` or
-   `experimental` (case-insensitive). Confirm the exact rule and
-   whether `.Preview` is still the only "preview-y" id in v5.
-2. **Payload subpath inside `tools/any/`.** What's the canonical
-   relative path the CLI core appends to the install dir to reach
-   the host-consumable bundle layout? Whatever it is, it should be
-   documented next to the workload package and treated as part of
-   the content-workload contract (Workload Spec §5.1 "the contract
-   between the consumer and the content workload is owned by the
-   consumer").
-3. Should `bundle-resolve` telemetry include constraint range
+1. Should `bundle-resolve` telemetry include constraint range
    strings (potentially high cardinality) or just the outcome
    enum?
-4. **Catalog feed.** Do bundle workload `.nupkg`s ship to the same
+2. **Catalog feed.** Do bundle workload `.nupkg`s ship to the same
    workload catalog as host-runtime workloads, or a dedicated
    bundles feed? Most likely the same feed; verify with the
    Extension Bundle publishing pipeline owners.
-5. **Payload-source pivot (CDN → build artifacts).** The first
+3. **Payload-source pivot (CDN → build artifacts).** The first
    cut pulls the bundle payload from the public bundle CDN via
    MSBuild `DownloadFile` (§5.3.2) because the bundles workload
    lives in this repo and not in the bundles repo. The target
@@ -511,3 +558,14 @@ none there.
    stay here and consume the artifact cross-pipeline? Either
    option resolves this question. Until it is resolved, refreshing
    the pinned bundle payload is a manual artifact download.
+
+### Resolved
+
+- **Bundle id mapping rule** (previously Q1). Resolved by §4.2:
+  three host.json ids (stable / Preview / Experimental), each
+  mapping to workload pkg versions whose prerelease label exactly
+  matches the channel. Implemented in PR #5036.
+- **Payload subpath inside `tools/any/`** (previously Q2). The
+  bundle content lives directly under `tools/any/`; the CLI core
+  appends that subpath as part of the content-workload contract.
+  Implemented in PR #5036 (`InstalledBundleScanner`).

--- a/proposed/bundles-workload-spec.md
+++ b/proposed/bundles-workload-spec.md
@@ -41,7 +41,9 @@
   the host-workload rule (Workload Spec §4.5): a missing or
   unsatisfying installed workload set causes `func start` to print
   an install hint and exit non-zero. CT never installs workloads
-  implicitly.
+  implicitly. Auto-install gated on profile opt-in is a separate
+  cross-cutting concern (will apply to host runtime, bundles, and
+  any other content workload) and is out of scope for this spec.
 - **Bundle CDN access from CT at runtime.** Neither the CLI nor the
   bundles workload contacts the bundle CDN at run time. The bundle
   payload is part of the workload `.nupkg`, fetched from the CDN

--- a/proposed/bundles-workload-spec.md
+++ b/proposed/bundles-workload-spec.md
@@ -160,6 +160,46 @@ The bundles workload contains **only** the bundle payload and the
 build-time `DownloadFile` plumbing that fetched it from the bundle
 CDN (§5.3). It has no runtime code.
 
+#### 4.3.1 Component shape
+
+The CLI-side implementation is factored into three pieces, all
+living in CT (not in the workload):
+
+| Component | Layer | Responsibility |
+|-----------|-------|----------------|
+| `IInstalledBundleWorkloads` | `Func.Cli.Abstractions` | Enumerates installed rows of the bundles content workload from the workload registry. Returns `(version, installDir)` pairs. Implementation wraps the existing workload subsystem (`IWorkloadStore` + `IWorkloadPaths`). |
+| `IExtensionBundleResolver` | `Func.Cli.Abstractions` | Runs the algorithm in §5.1. Pure function over `(ProjectContext, IInstalledBundleWorkloads)`; returns an `ExtensionBundleResolution` discriminated union. |
+| `ValidateExtensionBundleInitializationStep` | `Azure.Functions.Cli` (`func start` pipeline) | Sole consumer in v1. Calls the resolver, sets the env vars on success, prints the hint and exits non-zero on failure. Also unconditionally sets `AzureFunctionsJobHost__extensionBundle__ensureLatest=false` (see §4.4 step 6). |
+
+`ExtensionBundleResolution` is a closed discriminated union with
+four cases matching the outcomes in §5.1: `Resolved`,
+`WorkloadMissing`, `EmptyIntersection`, `NoCompatibleInstall`. Each
+failure case carries enough structured data for the consumer to
+emit the hint copy in §5.4 without re-deriving anything.
+
+The package id constant used by both the CT resolver and the
+workload `.csproj` to agree on the bundles package name lives in
+`Func.Cli.Abstractions` (e.g. on `IInstalledBundleWorkloads`) so
+there is exactly one source of truth.
+
+#### 4.3.2 Why these abstractions live in `Func.Cli.Abstractions`
+
+Even though the bundles workload itself ships no runtime assembly
+(content-only), the **resolver** and the **installed-workloads
+enumerator** are written against `Func.Cli.Abstractions` rather
+than CT's internals. This keeps two doors open:
+
+- A future non-content bundles delivery model could provide its
+  own `IInstalledBundleWorkloads` implementation without touching
+  CT.
+- An alternative consumer (e.g. `func pack` validation) can reuse
+  `IExtensionBundleResolver` without depending on `func start`
+  pipeline internals.
+
+Neither door is exercised in v1; the abstractions cost is small
+and keeps the layering consistent with the rest of the workload
+ecosystem.
+
 ### 4.4 `func start` responsibilities
 
 `func start` is the only v1 consumer. Its responsibilities:

--- a/proposed/bundles-workload-spec.md
+++ b/proposed/bundles-workload-spec.md
@@ -87,10 +87,11 @@ Azure.Functions.Cli.Workloads.ExtensionBundles
 ```
 
 It is `kind: content` (Workload Spec §3, §5.3): the package ships
-the bundle payload under `tools/any/` with no `entryPoint`. The
-workload subsystem records its registry row but does not load it
-(Workload Spec §6.2 step 3, §5.1 "non-`workload` kinds"). The CLI
-core resolves the install directory by package id and workload pkg
+the bundle payload under `tools/any/<BundleVersion>/` (see §5.2 for
+the version-nest contract) with no `entryPoint`. The workload
+subsystem records its registry row but does not load it (Workload
+Spec §6.2 step 3, §5.1 "non-`workload` kinds"). The CLI core
+resolves the install directory by package id and workload pkg
 version, in the same way `func start` resolves the host-runtime
 workload today (Workload Spec §4.6).
 
@@ -356,25 +357,49 @@ worker runtime, active profile), the CLI core:
 
 The CLI core performs **no** network I/O.
 
-### 5.2 Where bundle content lives
+### 5.2 On-disk layout
 
-The bundles workload `.nupkg` ships its payload under `tools/any/`,
-which the workload subsystem extracts into:
+The bundles workload `.nupkg` ships its payload under
+`tools/any/<BundleVersion>/`, which the workload subsystem extracts
+into:
 
 ```
 <workload-home>/workloads/azure.functions.cli.workloads.extensionbundles/<workload-pkg-version>/
+  tools/any/
+    <bundle-version>/          ← extension bundle root (bin/, extensions.json, ...)
+  workload.json
 ```
 
-The directory is keyed by the workload pkg version (e.g.
-`4.35.0`, `4.35.0-preview`), so stable and preview installs of
-the same bundle payload coexist as distinct directories.
+The install dir is keyed by the workload pkg version (e.g. `4.35.0`,
+`4.35.0-preview`), so stable and preview installs of the same
+bundle payload coexist as distinct directories. Inside, the bundle
+content (the layout the Functions runtime host already knows how
+to read: `bin/`, `extensions.json`, etc.) lives one level deeper
+in a directory named after the 3-part bundle payload version.
 
-The actual bundle content (the layout the Functions runtime host
-already knows how to read: `bin/`, `extensions.json`, etc.) lives
-under that directory at a fixed subpath chosen by the workload
-package. The CLI core knows that subpath (it is part of the
-content-workload contract, documented alongside the package) and
-returns the absolute path to it.
+#### 5.2.1 Resolved path and host probe contract
+
+The CLI core's bundle resolver returns the **parent** of the bundle
+version directory: `<install>/tools/any/`. The `func start` step
+then sets:
+
+```
+AzureFunctionsJobHost__extensionBundle__downloadPath = <install>/tools/any
+AzureFunctionsJobHost__extensionBundle__ensureLatest = false
+```
+
+The Functions runtime host's `ExtensionBundleManager` probes
+`<downloadPath>/<bundle-version>/...` for the bundle root, which
+lands on the version directory we just shipped. The version segment
+in the layout is what makes the host happy without CT having to set
+custom env vars or patch the host probe path.
+
+A practical consequence: a bundles workload `.nupkg` could in
+principle ship more than one bundle version under `tools/any/`
+(e.g. `tools/any/4.35.0/` and `tools/any/4.36.0/`) and the host
+would still probe correctly. Today each workload pkg carries
+exactly one bundle version per the 1:1 rule in §4.1.1, but the
+layout leaves that door open.
 
 No copy or relocation step is performed at install time, and there
 is no second on-disk root.
@@ -385,7 +410,13 @@ The bundles workload `.csproj` is a packaging-only project (no
 runtime assembly). At workload-build time, MSBuild fetches the
 bundle payload zip for the target version, unpacks the bundle into
 the workload output, and packs the result into the `.nupkg` under
-`tools/any/`.
+`tools/any/<BundleVersion>/` (see §5.2 for why the version nest is
+required).
+
+Other `kind: content` workloads can still pack flat at `tools/any/`
+if the consumer doesn't impose a version-probing contract; the
+nested layout is specific to bundles because the consumer is the
+host's `ExtensionBundleManager`.
 
 #### 5.3.1 Payload source: bundle pipeline build artifacts
 
@@ -561,7 +592,10 @@ none there.
   three host.json ids (stable / Preview / Experimental), each
   mapping to workload pkg versions whose prerelease label exactly
   matches the channel. Implemented in PR #5036.
-- **Payload subpath inside `tools/any/`** (previously Q2). The
-  bundle content lives directly under `tools/any/`; the CLI core
-  appends that subpath as part of the content-workload contract.
-  Implemented in PR #5036 (`InstalledBundleScanner`).
+- **Payload subpath inside `tools/any/`** (previously Q2).
+  Resolved by §5.2: the bundle payload lives under
+  `tools/any/<bundle-version>/`, and the CLI core returns the
+  parent (`tools/any/`) so the host's `ExtensionBundleManager`
+  can append the version segment in its probe. Implemented in
+  PR #5055 (packaging) and PR #5036 (resolver
+  `BundlePayloadSubpath = "tools/any"`).

--- a/proposed/bundles-workload-spec.md
+++ b/proposed/bundles-workload-spec.md
@@ -190,21 +190,43 @@ read with no code changes.
 
 ### 5.3 Payload acquisition
 
-The bundles workload acquires bundle payloads from the bundle CDN in
-two situations:
+The bundles workload acquires bundle payloads from one of three
+sources:
 
-1. **Eagerly**, when the workload subsystem gains a post-install /
-   first-run hook. The Workload Spec does not define one today (see
-   Workload Spec §12 #5, an open question). If/when such a hook is
-   added, the bundles workload uses it to populate the bundles home
-   with a **default payload set** (e.g. the latest stable bundle id +
-   version known to the workload manifest at publish time).
-2. **On demand at `func start`**, used unconditionally in v1 because
-   no post-install hook exists. Also used in the future as a fallback
-   whenever a project requires a version that wasn't in the
-   eagerly-populated default set (e.g. a profile-pinned older
-   version, or a brand-new version published after the workload's
-   default set was curated).
+1. **In-package, at workload build time.** The bundles workload's
+   own `.csproj` uses the MSBuild `DownloadFile` task to fetch a
+   curated set of **stable** bundle payloads from the bundle CDN at
+   workload-build time and packs them into the workload `.nupkg`
+   under e.g. `tools/any/bundles/<bundle-id>/<bundle-version>/`.
+   On workload install, these payloads are copied (or hard-linked)
+   into the bundles home. This is the **preferred** path for stable
+   bundles because it gives every fresh workload install a usable
+   offline-resolvable payload set with no post-install hook required
+   and no first-run network hit. The trade-off is workload package
+   size; the curated set should be small (e.g. the latest stable
+   `Microsoft.Azure.Functions.ExtensionBundle` major + minor).
+2. **Eagerly, via a post-install / first-run hook.** The Workload
+   Spec does not define such a hook today (see Workload Spec §12 #5,
+   an open question). If/when one is added, the bundles workload may
+   use it to grow the default payload set without rebuilding the
+   workload itself.
+3. **On demand at `func start`.** Used whenever a project requires a
+   version that isn't already in the bundles home (e.g. a
+   profile-pinned older version, a brand-new stable version
+   published after the workload was packaged, or any **preview /
+   experimental** bundle id such as
+   `Microsoft.Azure.Functions.ExtensionBundle.Preview`). Preview /
+   experimental payloads are explicitly **not** shipped inside the
+   workload package so that:
+   - workload package size doesn't churn with every preview drop,
+     and
+   - opting into a preview bundle is always an explicit network
+     event with a log line, never a silent "you already had it
+     locally" because the workload happened to ship it.
+
+In other words: the workload package eagerly carries **stable**
+bundle payloads it was built against; **preview / experimental**
+bundles are CDN-on-demand only.
 
 On-demand fetch at `func start`:
 
@@ -285,7 +307,7 @@ single `bundle-resolve` event:
 | `resolvedVersion` | Selected bundle version, or `null` on failure |
 | `profileName` | Active profile name, or `null` if no profile |
 | `succeeded` | `true` if the host was launched with a resolved bundle |
-| `reason` | `ok-cached` \| `ok-downloaded` \| `no-host-json-bundle` \| `workload-missing` \| `empty-intersection` \| `download-failed` |
+| `reason` | `ok-in-package` \| `ok-cached` \| `ok-downloaded` \| `no-host-json-bundle` \| `workload-missing` \| `empty-intersection` \| `download-failed` |
 
 Workload install / update / uninstall telemetry is covered by the
 generic workload subsystem (Workload Spec §11); this spec adds none
@@ -321,10 +343,11 @@ there.
    (`func bundles install <version>`), so users can prefetch
    bundles for offline scenarios without waiting for the on-demand
    path at `func start`?
-2. If the workload subsystem grows a post-install hook (Workload
-   Spec §12 #5), what is the default payload set policy on a fresh
-   install? Latest stable for both `ExtensionBundle` and
-   `ExtensionBundle.Preview`, or only the non-preview id?
+2. **In-package curated set policy.** Which stable bundle versions
+   ship inside the workload `.nupkg` via `DownloadFile` at workload
+   build time? Latest stable major.minor only, or latest two minors,
+   or every minor in a supported range? This trades workload package
+   size against how often a fresh install needs an on-demand fetch.
 3. Should the workload retain old payloads on update, or prune them?
    If prune, what's the retention policy (last N versions, anything
    referenced by an installed profile, etc.)?

--- a/proposed/bundles-workload-spec.md
+++ b/proposed/bundles-workload-spec.md
@@ -75,6 +75,7 @@ The workload version equals the bundle version it packages:
 | `func workload install …` | Bundle version delivered |
 |---------------------------|--------------------------|
 | `Azure.Functions.Cli.Workloads.ExtensionBundles@4.22.0` | `4.22.0` |
+| `Azure.Functions.Cli.Workloads.ExtensionBundles@4.33.0-preview` | `4.33.0-preview` |
 | `Azure.Functions.Cli.Workloads.ExtensionBundles@4.33.0-experimental` | `4.33.0-experimental` |
 
 Multiple bundle versions coexist on disk by installing the workload

--- a/proposed/bundles-workload-spec.md
+++ b/proposed/bundles-workload-spec.md
@@ -1,0 +1,335 @@
+# Bundles Workload Spec
+
+> **Status:** Draft. This spec defines how Azure Functions **extension
+> bundles** are resolved and delivered in v5 (vnext) Core Tools. It
+> layers on top of the [Workload Spec](workload-spec.md) and the
+> [Profile-Based Local Development design](cli-profiles.md). It does
+> **not** redefine the bundle on-disk format consumed by the Functions
+> runtime host; that contract is unchanged.
+
+## 1. Goals
+
+- Move all bundle acquisition, version selection, and on-disk
+  layout out of the `func` CLI binary and into a single first-class
+  workload, so bundles can ship and version independently of Core
+  Tools.
+- Expose a stable contribution point that any CLI command (today:
+  `func start`) can call to obtain a resolved bundle path for a
+  project + active profile.
+- Make `func start` resolution deterministic. When a satisfying
+  bundle payload is already cached locally, `func start` resolves
+  fully offline. When it isn't, the bundles workload may fetch it
+  on demand at start time (see §5.3).
+- Eliminate Core Tools' bespoke bundle download path
+  (`ExtensionBundleHelper`, `DownloadBundleAction`, `func extensions
+  install`). The bundles workload is the only acquisition mechanism
+  in v5.
+- Require no changes in the Functions runtime host. CT keeps using the
+  existing `AzureFunctionsJobHost__extensionBundle__downloadPath` env
+  var to point the host at the resolved bundle and to suppress its
+  built-in probe.
+
+## 2. Non-goals (v1)
+
+- **Project-level bundle pin.** No `--bundle-version` flag, no
+  `bundle.version` field in `.func/config.json`. Pinning is done by
+  authoring a custom profile (`cli-profiles.md` §5.2) that sets
+  `extensionBundle.version` to an exact range.
+- **Auto-install of the bundles workload on `func start`.** Follows
+  the host-workload rule (Workload Spec §4.5): a missing workload
+  causes `func start` to print an install hint and exit non-zero. CT
+  never installs workloads implicitly.
+- **CT → host transport beyond today's env vars.** If a future
+  CT-host workload introduces a different startup transport, that is
+  out of scope for this spec.
+
+## 3. Definitions
+
+| Term | Meaning |
+|------|---------|
+| **Bundle id** | The `host.json` `extensionBundle.id` value, e.g. `Microsoft.Azure.Functions.ExtensionBundle` or `Microsoft.Azure.Functions.ExtensionBundle.Preview`. |
+| **Bundle version** | A SemVer version of an extension bundle payload, e.g. `4.22.0`. |
+| **Bundles workload** | The single workload package `Azure.Functions.Cli.Workloads.ExtensionBundles` (`kind: workload`) that provides bundle resolution and owns the on-disk payload cache. |
+| **Bundles home** | The on-disk root the bundles workload uses for payloads. Defaults to `<workload-home>/bundles` (i.e. `~/.azure-functions/bundles`). Override via `FUNC_CLI_Bundles__Home`. |
+| **Resolved bundle path** | A directory path returned by the bundles workload to a consumer (e.g. `func start`). Its layout matches today's bundle zip layout exactly so the Functions runtime host needs no changes to consume it. |
+
+## 4. Architecture
+
+### 4.1 Single workload, not per-version packages
+
+There is **one** workload package:
+
+```
+Azure.Functions.Cli.Workloads.ExtensionBundles
+```
+
+Its package id does **not** encode a bundle version. Multiple bundle
+versions and both the stable and preview bundle ids are handled
+inside the workload's payload cache (§5), not as separate workload
+registry rows.
+
+Rationale:
+
+- The set of bundle versions a developer might need is open-ended; one
+  workload registry row per bundle version would balloon the workload
+  manifest and complicate version selection across the profile +
+  host.json constraint.
+- Bundle payloads have a stable shape the Functions runtime host
+  already understands. There is no per-version CLI-side code; the
+  only CLI-side code is the resolver. One workload assembly with a
+  payload cache is the simplest viable factoring.
+
+### 4.2 `IExtensionBundleProvider` contribution point
+
+Core Tools adds a new contribution point to `Func.Cli.Abstractions`
+(Workload Spec §5.1):
+
+| Service registered | The workload can... | Used by |
+|--------------------|---------------------|---------|
+| `IExtensionBundleProvider` | Resolve a bundle path for a project + active profile, and manage the on-disk bundle payload cache. | `func start` |
+
+The contract returns a resolved bundle path (or a structured failure
+with enough information for CT to print an actionable install/update
+hint). The bundles workload is the v1 implementer; the abstraction
+is open to alternative implementations.
+
+Exact interface signature lives in
+[`building-a-workload.md`](./building-a-workload.md). Out of scope
+for this spec.
+
+### 4.3 Consumer responsibilities (`func start`)
+
+`func start` is the only v1 consumer. Its responsibilities are
+intentionally minimal:
+
+1. Detect whether the project's `host.json` declares an
+   `extensionBundle` section. If not, **skip** resolution entirely
+   (do not load the bundles workload, do not set any env var).
+2. Resolve the active profile (cli-profiles `§6`).
+3. Look up an `IExtensionBundleProvider` from the loaded workloads.
+   - If none is registered, print the install hint:
+     ```
+     This project requires an extension bundle but no bundles
+     workload is installed. Install it with:
+       func workload install Azure.Functions.Cli.Workloads.ExtensionBundles
+     ```
+     Exit non-zero.
+4. Invoke the provider, passing the project context (parsed
+   `host.json` `extensionBundle` block, worker runtime, active
+   profile).
+5. On success: set
+   `AzureFunctionsJobHost__extensionBundle__downloadPath` to the
+   returned path and launch the host. Log at Information:
+   ```
+   Using extension bundle <id> <version> from <path>
+   ```
+6. On failure: surface the provider's structured error message
+   (which includes the install/update hint, see §5.4) and exit
+   non-zero. Do not start the host.
+7. **Always** set `AzureFunctionsJobHost__extensionBundle__ensureLatest=false`
+   when launching the host, whether or not a bundle was resolved.
+   In v5 the bundles workload owns freshness; the host runtime
+   must never reach out for a newer bundle behind CT's back.
+
+`func start` does **not** know about the bundles home, the bundle
+CDN, or per-version payload layout. That is entirely the workload's
+concern.
+
+## 5. Bundles workload behavior
+
+### 5.1 Resolution algorithm
+
+Given the consumer-supplied context (host.json `extensionBundle`
+block, worker runtime, active profile), the provider:
+
+1. Computes the **constraint range** as the NuGet-style intersection of:
+   - the `host.json` `extensionBundle.version` range, and
+   - the active profile's `extensionBundle.version` range (if
+     declared; otherwise the constraint equals the host.json range).
+2. Enumerates installed bundle payloads under the bundles home whose
+   bundle id matches `host.json` `extensionBundle.id`.
+3. Selects the **highest installed version** that satisfies the
+   constraint range.
+4. If no installed version satisfies the constraint, the provider
+   **may** fetch a satisfying version from the bundle CDN on demand
+   (see §5.3). If the fetch succeeds, the new payload is added to
+   the cache and selected.
+5. Returns either:
+   - **Resolved**: the absolute path
+     `<bundles-home>/<bundle-id>/<version>/`, or
+   - **EmptyIntersection**: the host.json range, the profile range,
+     and the highest version that would satisfy host.json alone (for
+     the install hint), or
+   - **NoCompatiblePayload**: the constraint range, a list of
+     installed versions for the same bundle id, and (if the on-demand
+     fetch was attempted and failed) the failure reason.
+6. If the active profile declares `supportedRuntimes` and the
+   project's worker runtime is not listed, the provider includes a
+   non-fatal warning in its successful result. `func start` logs it
+   and proceeds; mismatch is informational for bundles and **must
+   not** block start.
+
+### 5.2 On-disk layout (bundles home)
+
+The bundles workload manages payloads under:
+
+```
+<bundles-home>/<bundle-id>/<bundle-version>/
+```
+
+Default `<bundles-home>` is `<workload-home>/bundles`, i.e.
+`~/.azure-functions/bundles`. Override via the
+`FUNC_CLI_Bundles__Home` environment variable (same convention as
+`FUNC_CLI_Workloads__Home`, Workload Spec §11). The bundles workload
+**must** honor this override.
+
+The contents under `<bundle-version>/` mirror today's extension
+bundle zip layout exactly. Returning this directory to a consumer
+gives the Functions runtime host a directory it already knows how to
+read with no code changes.
+
+### 5.3 Payload acquisition
+
+The bundles workload acquires bundle payloads from the bundle CDN in
+two situations:
+
+1. **Eagerly**, when the workload subsystem gains a post-install /
+   first-run hook. The Workload Spec does not define one today (see
+   Workload Spec §12 #5, an open question). If/when such a hook is
+   added, the bundles workload uses it to populate the bundles home
+   with a **default payload set** (e.g. the latest stable bundle id +
+   version known to the workload manifest at publish time).
+2. **On demand at `func start`**, used unconditionally in v1 because
+   no post-install hook exists. Also used in the future as a fallback
+   whenever a project requires a version that wasn't in the
+   eagerly-populated default set (e.g. a profile-pinned older
+   version, or a brand-new version published after the workload's
+   default set was curated).
+
+On-demand fetch at `func start`:
+
+- The provider **must** print an Information log line before
+  initiating download, e.g. `Downloading extension bundle <id>
+  <version>…`, and a completion line on success.
+- The provider **must** apply a bounded timeout (workload-defined,
+  not specified here) and fail fast with a clear hint if the network
+  is unavailable, the version cannot be located, or integrity
+  verification fails.
+- A successful on-demand fetch is observationally identical to a
+  pre-cached resolution from `func start`'s perspective: same return
+  contract, same env var handling. Telemetry distinguishes the two
+  via the `reason` field (§7).
+
+Whether the workload also surfaces a `func bundles install <version>`
+subcommand (via `IExternalCommand`, Workload Spec §5.1) for ad-hoc
+prefetching is **deferred** (see §9 open questions).
+
+The bundles workload is responsible for verifying download integrity
+(checksum/signature) and for atomic extraction under `<bundles-home>`
+in both acquisition paths.
+
+### 5.4 Install / update hints
+
+When the provider returns `EmptyIntersection` or
+`NoCompatiblePayload`, it includes a fully-formed hint string the
+consumer prints verbatim. Example hints:
+
+- `EmptyIntersection`:
+  ```
+  Profile '<profile>' constrains extensionBundle.version to
+  '<profile-range>', which does not intersect host.json's
+  '<host-range>'. There is no bundle version that satisfies both.
+  Either widen host.json or pick a different profile.
+  ```
+- `NoCompatiblePayload` (after on-demand fetch was attempted and
+  failed, or was not possible offline):
+  ```
+  No <id> bundle satisfies <constraint-range>.
+  Installed versions: <v1>, <v2>, ...
+  On-demand download failed: <reason>.
+  Try again when online, or update bundles with:
+    func workload update Azure.Functions.Cli.Workloads.ExtensionBundles
+  ```
+
+The bundles workload owns the wording; CT does not duplicate this
+copy.
+
+## 6. Logging and verbosity
+
+- **Default verbosity**: on resolution success, a single Information
+  line: `Using extension bundle <id> <version> from <path>`. On
+  failure, the provider's hint and a non-zero exit. Nothing else.
+- **`--verbose`**: in addition to the above, log the resolution
+  trace at Debug:
+  ```
+  [bundle-resolve] id=<id>
+  [bundle-resolve] host.json range = <host-range>
+  [bundle-resolve] profile '<profile>' range = <profile-range>
+  [bundle-resolve] constraint = <intersection>
+  [bundle-resolve] installed versions = <v1>, <v2>, ...
+  [bundle-resolve] selected = <version>
+  [bundle-resolve] path = <resolved-path>
+  ```
+- The Debug trace is produced by the bundles workload (it has the
+  data) and emitted through CT's standard logger; CT does not
+  re-derive any of it.
+
+## 7. Telemetry
+
+On every `func start` that performs bundle resolution, CT emits a
+single `bundle-resolve` event:
+
+| Field | Value |
+|-------|-------|
+| `bundleId` | `host.json` `extensionBundle.id` |
+| `resolvedVersion` | Selected bundle version, or `null` on failure |
+| `profileName` | Active profile name, or `null` if no profile |
+| `succeeded` | `true` if the host was launched with a resolved bundle |
+| `reason` | `ok-cached` \| `ok-downloaded` \| `no-host-json-bundle` \| `workload-missing` \| `empty-intersection` \| `download-failed` |
+
+Workload install / update / uninstall telemetry is covered by the
+generic workload subsystem (Workload Spec §11); this spec adds none
+there.
+
+## 8. Compatibility & migration
+
+- **v4 → v5 projects.** Existing projects whose `host.json` declares
+  `extensionBundle` work unchanged in v5, **provided** the bundles
+  workload is installed and has a payload satisfying the project's
+  host.json range and the active profile.
+- **`func extensions install`.** Removed in v5. Added to the v4→v5
+  migration map (Workload Spec §4.7):
+  ```
+  'extensions install' is no longer supported. Extension bundles are
+  delivered as a workload. Install it with:
+    func workload install Azure.Functions.Cli.Workloads.ExtensionBundles
+  ```
+- **In-CLI bundle download code.** `ExtensionBundleHelper`,
+  `DownloadBundleAction`, `ExtensionBundleConfigurationBuilder`, and
+  the related code paths in `Startup` are removed from the `func`
+  binary in v5.
+- **Profiles.** Built-in profiles (cli-profiles §6.1) carry
+  `extensionBundle.version` ranges the bundle CDN is guaranteed to
+  satisfy at publication time. The bundles workload's default payload
+  set is curated so that the workload-installed-by-default scenario
+  works for those ranges out of the box.
+
+## 9. Open questions
+
+1. Does the bundles workload expose a `func bundles ...` subcommand
+   (via `IExternalCommand`) for ad-hoc per-version pulls
+   (`func bundles install <version>`), so users can prefetch
+   bundles for offline scenarios without waiting for the on-demand
+   path at `func start`?
+2. If the workload subsystem grows a post-install hook (Workload
+   Spec §12 #5), what is the default payload set policy on a fresh
+   install? Latest stable for both `ExtensionBundle` and
+   `ExtensionBundle.Preview`, or only the non-preview id?
+3. Should the workload retain old payloads on update, or prune them?
+   If prune, what's the retention policy (last N versions, anything
+   referenced by an installed profile, etc.)?
+4. Should `bundle-resolve` telemetry include constraint range strings
+   (potentially high cardinality) or just an outcome enum?
+5. Do we want an explicit "offline mode" flag/env var on `func start`
+   that suppresses the on-demand fetch even when network is
+   available (for reproducible CI builds, etc.)?

--- a/proposed/bundles-workload-spec.md
+++ b/proposed/bundles-workload-spec.md
@@ -43,10 +43,9 @@
   workload never downloads bundles. The bundle payload is part of
   the workload `.nupkg`, fetched from the CDN exactly once at
   workload-build time by the workload's own MSBuild process.
-- **Separate bundles home / `FUNC_CLI_BUNDLES_HOME` override.**
-  Bundle payloads live inside the workload install directory under
-  `<workload-home>`. There is no second on-disk root and no separate
-  override env var.
+- **Custom bundles install root.** Bundle payloads live inside the
+  workload install directory under `<workload-home>`. There is no
+  second on-disk root, no override env var, and no plan to add one.
 - **CT → host transport beyond today's env vars.** If a future
   CT-host workload introduces a different startup transport, that is
   out of scope for this spec.
@@ -91,8 +90,8 @@ Rationale:
   `workloads.json` is the bundle version on disk, full stop.
 - Side-by-side coexistence via `--force` is already part of the
   workload subsystem; bundles don't need a separate cache layer.
-- Eliminating a second on-disk root (the previous "bundles home")
-  removes an entire class of override / migration concerns.
+- Eliminating a second on-disk root removes an entire class of
+  override / migration concerns.
 
 ### 4.2 SemVer prerelease tags for preview / experimental
 
@@ -227,7 +226,7 @@ package. The provider returns the absolute path to that subpath; CT
 treats it as opaque.
 
 No copy or relocation step is performed at install time, and there
-is no separate "bundles home" root.
+is no second on-disk root.
 
 ### 5.3 Packaging (workload build time)
 

--- a/proposed/bundles-workload-spec.md
+++ b/proposed/bundles-workload-spec.md
@@ -50,7 +50,7 @@
 | **Bundle id** | The `host.json` `extensionBundle.id` value, e.g. `Microsoft.Azure.Functions.ExtensionBundle` or `Microsoft.Azure.Functions.ExtensionBundle.Preview`. |
 | **Bundle version** | A SemVer version of an extension bundle payload, e.g. `4.22.0`. |
 | **Bundles workload** | The single workload package `Azure.Functions.Cli.Workloads.ExtensionBundles` (`kind: workload`) that provides bundle resolution and owns the on-disk payload cache. |
-| **Bundles home** | The on-disk root the bundles workload uses for payloads. Defaults to `<workload-home>/bundles` (i.e. `~/.azure-functions/bundles`). Override via `FUNC_CLI_Bundles__Home`. |
+| **Bundles home** | The on-disk root the bundles workload uses for payloads. Defaults to `<workload-home>/bundles` (i.e. `~/.azure-functions/bundles`). Override via `FUNC_CLI_BUNDLES_HOME`. |
 | **Resolved bundle path** | A directory path returned by the bundles workload to a consumer (e.g. `func start`). Its layout matches today's bundle zip layout exactly so the Functions runtime host needs no changes to consume it. |
 
 ## 4. Architecture
@@ -179,9 +179,11 @@ The bundles workload manages payloads under:
 
 Default `<bundles-home>` is `<workload-home>/bundles`, i.e.
 `~/.azure-functions/bundles`. Override via the
-`FUNC_CLI_Bundles__Home` environment variable (same convention as
-`FUNC_CLI_Workloads__Home`, Workload Spec §11). The bundles workload
-**must** honor this override.
+`FUNC_CLI_BUNDLES_HOME` environment variable (same convention as
+`FUNC_CLI_WORKLOADS_HOME`, Workload Spec §11). Resolution mirrors
+`WorkloadHomeResolver` exactly: explicit env var wins, otherwise
+nest under the workload home (which itself honors
+`FUNC_CLI_WORKLOADS_HOME`).
 
 The contents under `<bundle-version>/` mirror today's extension
 bundle zip layout exactly. Returning this directory to a consumer

--- a/proposed/bundles-workload-spec.md
+++ b/proposed/bundles-workload-spec.md
@@ -1,57 +1,66 @@
 # Bundles Workload Spec
 
 > **Status:** Draft. This spec defines how Azure Functions **extension
-> bundles** are resolved and delivered in v5 (vnext) Core Tools. It
-> layers on top of the [Workload Spec](workload-spec.md) and the
+> bundles** are delivered as a content workload in v5 (vnext) Core
+> Tools, and how the CLI core resolves the correct version per
+> project + active profile. It layers on top of the
+> [Workload Spec](workload-spec.md) and the
 > [Profile-Based Local Development design](cli-profiles.md). It does
-> **not** redefine the bundle on-disk format consumed by the Functions
-> runtime host; that contract is unchanged.
+> **not** redefine the bundle on-disk format consumed by the
+> Functions runtime host; that contract is unchanged.
 
 ## 1. Goals
 
-- Move all bundle acquisition, version selection, and on-disk
-  layout out of the `func` CLI binary and into a workload, so bundles
-  can ship and version independently of Core Tools.
-- Expose a stable contribution point (`IExtensionBundleProvider`)
-  that any CLI command (today: `func start`) can call to obtain a
-  resolved bundle path for a project + active profile.
+- Move all bundle acquisition and on-disk layout out of the `func`
+  CLI binary and into a `kind: content` workload, mirroring how the
+  host runtime ships today (Workload Spec §4.6).
+- Keep version selection (host.json ∩ profile intersection,
+  highest-installed-wins) inside the CLI core. The bundles workload
+  ships **only the bundle payload**; it contains no resolution code
+  and registers no DI services.
 - Make `func start` resolution **deterministic and fully offline**.
-  The bundles workload performs no network I/O. All bundle payloads
+  The CLI performs no network I/O for bundles. All bundle payloads
   are obtained at workload **install** time (the payload ships
   inside the workload `.nupkg`).
 - Eliminate Core Tools' bespoke bundle download path
   (`ExtensionBundleHelper`, `DownloadBundleAction`, `func extensions
   install`). The bundles workload is the only acquisition mechanism
   in v5, and acquisition is `func workload install` + nothing else.
-- Require no changes in the Functions runtime host. CT keeps using the
-  existing `AzureFunctionsJobHost__extensionBundle__downloadPath` env
-  var to point the host at the resolved bundle and to suppress its
-  built-in probe.
+- Require no changes in the Functions runtime host. CT keeps using
+  the existing `AzureFunctionsJobHost__extensionBundle__downloadPath`
+  env var to point the host at the resolved bundle and to suppress
+  its built-in probe.
 
 ## 2. Non-goals (v1)
 
 - **Project-level bundle pin.** No `--bundle-version` flag, no
   `bundle.version` field in `.func/config.json`. Pinning is done by
-  authoring a custom profile (`cli-profiles.md` §5.2) that sets
+  authoring a custom profile (cli-profiles §5.2) that sets
   `extensionBundle.version` to an exact range.
 - **Auto-install of the bundles workload on `func start`.** Follows
   the host-workload rule (Workload Spec §4.5): a missing or
   unsatisfying installed workload set causes `func start` to print
   an install hint and exit non-zero. CT never installs workloads
   implicitly.
-- **Bundle CDN access from the bundles workload at runtime.** The
-  workload never downloads bundles. The bundle payload is part of
-  the workload `.nupkg`, fetched from the CDN exactly once at
-  workload-build time by the workload's own MSBuild process.
+- **Bundle CDN access from CT at runtime.** Neither the CLI nor the
+  bundles workload contacts the bundle CDN at run time. The bundle
+  payload is part of the workload `.nupkg`, fetched from the CDN
+  exactly once at workload-build time by the workload's own MSBuild
+  process.
 - **Custom bundles install root.** Bundle payloads live inside the
   workload install directory under `<workload-home>`. There is no
   second on-disk root, no bundles-specific override env var, and no
   plan to add one. (`<workload-home>` itself is customizable via
   `FUNC_CLI_WORKLOADS_HOME`, per Workload Spec §11; this naturally
   relocates bundle installs along with everything else.)
+- **Contribution points for bundles.** The bundles workload is
+  `kind: content` (Workload Spec §3, §5.3); content workloads
+  register no services and contribute no commands. There is **no**
+  `IExtensionBundleProvider` interface, no bundles-workload
+  assembly load. Resolution is a CLI-core concern.
 - **CT → host transport beyond today's env vars.** If a future
-  CT-host workload introduces a different startup transport, that is
-  out of scope for this spec.
+  CT-host workload introduces a different startup transport, that
+  is out of scope for this spec.
 
 ## 3. Definitions
 
@@ -59,19 +68,27 @@
 |------|---------|
 | **Bundle id** | The `host.json` `extensionBundle.id` value, e.g. `Microsoft.Azure.Functions.ExtensionBundle` or `Microsoft.Azure.Functions.ExtensionBundle.Preview`. |
 | **Bundle version** | A SemVer version of an extension bundle payload, e.g. `4.22.0` (stable) or `4.33.0-experimental` (prerelease). Prerelease tags carry preview / experimental builds. |
-| **Bundles workload** | The single workload package id `Azure.Functions.Cli.Workloads.ExtensionBundles` (`kind: workload`). Each installed instance of this workload carries exactly **one** bundle version, packaged at workload-build time. The workload version is **always equal to the bundle version it packages**. |
+| **Bundles workload** | The single `kind: content` workload package id `Azure.Functions.Cli.Workloads.ExtensionBundles`. Each installed instance carries exactly **one** bundle version, packaged at workload-build time. The workload version is **always equal to the bundle version it packages**. |
 | **Bundle workload install dir** | The directory the workload subsystem extracts an installed bundles workload into, per Workload Spec §6.1: `<workload-home>/workloads/azure.functions.cli.workloads.extensionbundles/<bundle-version>/`. |
-| **Resolved bundle path** | The directory the provider returns to a consumer. It is a subdirectory of the bundle workload install dir whose contents match today's extension bundle zip layout exactly, so the Functions runtime host needs no changes to consume it. |
+| **Resolved bundle path** | The directory the CLI core returns to its bundle consumer (today: `func start`). It is a subdirectory of the bundle workload install dir whose contents match today's extension bundle zip layout exactly, so the Functions runtime host needs no changes to consume it. |
 
 ## 4. Architecture
 
-### 4.1 One workload package, one bundle version per install
+### 4.1 Content workload, one bundle version per install
 
 There is **one** workload package id:
 
 ```
 Azure.Functions.Cli.Workloads.ExtensionBundles
 ```
+
+It is `kind: content` (Workload Spec §3, §5.3): the package ships
+the bundle payload under `tools/any/` with no `entryPoint`. The
+workload subsystem records its registry row but does not load it
+(Workload Spec §6.2 step 3, §5.1 "non-`workload` kinds"). The CLI
+core resolves the install directory by package id and version, in
+the same way `func start` resolves the host-runtime workload today
+(Workload Spec §4.6).
 
 The workload version equals the bundle version it packages:
 
@@ -94,6 +111,10 @@ Rationale:
   `workloads.json` is the bundle version on disk, full stop.
 - Side-by-side coexistence via `--force` is already part of the
   workload subsystem; bundles don't need a separate cache layer.
+- Keeping the workload payload-only (no assembly, no
+  contribution points) keeps the per-version `.nupkg` small,
+  AOT-friendly for the host CLI, and free of code-signing /
+  loading concerns.
 - Eliminating a second on-disk root removes an entire class of
   override / migration concerns.
 
@@ -119,70 +140,66 @@ as an open question in §9 (the simplest rule is "Preview id selects
 only prerelease-tagged versions; stable id selects only
 stable-tagged versions").
 
-### 4.3 `IExtensionBundleProvider` contribution point
+### 4.3 CLI core ownership
 
-Core Tools adds a new contribution point to `Func.Cli.Abstractions`
-(Workload Spec §5.1):
+Because the bundles workload is content-only, **all** of the
+following live in the `func` CLI core (concretely: in
+`Azure.Functions.Cli` against `Func.Cli.Abstractions`):
 
-| Service registered | The workload can... | Used by |
-|--------------------|---------------------|---------|
-| `IExtensionBundleProvider` | Resolve a bundle path for a project + active profile from the set of installed bundles workloads. | `func start` |
+- Reading the workload registry to enumerate installed bundle
+  versions (Workload Spec §10.1).
+- Computing the host.json ∩ profile intersection (§5.1).
+- Filtering candidates by host.json `extensionBundle.id` (§4.2).
+- Picking the highest compatible installed version.
+- Resolving the on-disk path (§5.2) and handing it to the host
+  via `AzureFunctionsJobHost__extensionBundle__downloadPath`.
+- Owning the user-facing log lines, install hints, and telemetry
+  events (§6, §5.4, §7).
 
-The contract returns a resolved bundle path (or a structured
-failure with enough information for CT to print an actionable
-install hint). The bundles workload is the v1 implementer; the
-abstraction is open to alternative implementations.
+The bundles workload contains **only** the bundle payload and the
+build-time `DownloadFile` plumbing that fetched it from the bundle
+CDN (§5.3). It has no runtime code.
 
-Exact interface signature lives in
-[`building-a-workload.md`](./building-a-workload.md). Out of scope
-for this spec.
+### 4.4 `func start` responsibilities
 
-### 4.4 Consumer responsibilities (`func start`)
-
-`func start` is the only v1 consumer. Its responsibilities are
-intentionally minimal:
+`func start` is the only v1 consumer. Its responsibilities:
 
 1. Detect whether the project's `host.json` declares an
-   `extensionBundle` section. If not, **skip** resolution entirely
-   (do not load the bundles workload, do not set any env var).
+   `extensionBundle` section. If not, **skip** bundle resolution
+   entirely (do not read the workload registry, do not set any env
+   var).
 2. Resolve the active profile (cli-profiles §6).
-3. Look up an `IExtensionBundleProvider` from the loaded workloads.
-   - If none is registered (i.e. **no** bundles workload installed
-     at any version), print the install hint:
+3. Run the resolution algorithm (§5.1).
+   - On `WorkloadMissing` (no rows for the bundles package at any
+     version), print the install hint:
      ```
      This project requires an extension bundle but no bundles
      workload is installed. Install a version with:
        func workload install Azure.Functions.Cli.Workloads.ExtensionBundles@<version>
      ```
      Exit non-zero.
-4. Invoke the provider, passing the project context (parsed
-   `host.json` `extensionBundle` block, worker runtime, active
-   profile).
-5. On success: set
+4. On `Resolved`: set
    `AzureFunctionsJobHost__extensionBundle__downloadPath` to the
    returned path and launch the host. Log at Information:
    ```
    Using extension bundle <id> <version> from <path>
    ```
-6. On failure: surface the provider's structured error message
-   (which includes the install hint, see §5.3) and exit non-zero.
-   Do not start the host.
-7. **Always** set `AzureFunctionsJobHost__extensionBundle__ensureLatest=false`
+5. On `EmptyIntersection` or `NoCompatibleInstall`: print the
+   structured install hint (§5.4) and exit non-zero. Do not start
+   the host.
+6. **Always** set
+   `AzureFunctionsJobHost__extensionBundle__ensureLatest=false`
    when launching the host, whether or not a bundle was resolved.
    In v5 the bundles workload owns the bundle on disk; the host
    runtime must never reach out for a newer bundle behind CT's
    back.
 
-`func start` does **not** know about workload install paths,
-per-version layout, or the bundle CDN. That is entirely the
-workload's concern.
-
-## 5. Bundles workload behavior
+## 5. Resolution and on-disk layout (CLI core)
 
 ### 5.1 Resolution algorithm
 
-Given the consumer-supplied context (host.json `extensionBundle`
-block, worker runtime, active profile), the provider:
+Given the project context (host.json `extensionBundle` block,
+worker runtime, active profile), the CLI core:
 
 1. Computes the **constraint range** as the NuGet-style intersection
    of:
@@ -190,34 +207,36 @@ block, worker runtime, active profile), the provider:
    - the active profile's `extensionBundle.version` range (if
      declared; otherwise the constraint equals the host.json range).
 2. Enumerates **installed bundle workload versions** by reading the
-   workload registry (`workloads.json`, Workload Spec §6.1) for
-   rows whose `packageId` is `azure.functions.cli.workloads.extensionbundles`.
+   workload registry (`workloads.json`, Workload Spec §10.1) for
+   rows whose `packageId` is
+   `azure.functions.cli.workloads.extensionbundles`.
 3. Filters that set by host.json `extensionBundle.id` per §4.2
-   (stable id → stable-tagged versions; Preview id → prerelease-
-   tagged versions; final rule per §9 open question).
+   (stable id → stable-tagged versions; Preview id →
+   prerelease-tagged versions; final rule per §9 open question).
 4. Selects the **highest** filtered version that satisfies the
    constraint range.
-5. Returns either:
+5. Produces one of:
    - **Resolved**: the absolute path inside that workload's install
-     dir whose layout matches the extension bundle zip (§5.2), or
-   - **EmptyIntersection**: the host.json range, the profile range,
-     and the highest version that would satisfy host.json alone
-     (for the install hint), or
+     dir whose layout matches the extension bundle zip (§5.2).
+   - **WorkloadMissing**: no rows for the bundles package id exist
+     at any version.
+   - **EmptyIntersection**: the host.json range and the profile
+     range do not overlap. Carries the highest version that would
+     satisfy host.json alone (for the install hint).
    - **NoCompatibleInstall**: the constraint range and a list of
-     installed bundle workload versions, plus the install hint for
-     a satisfying version.
+     installed bundle workload versions are non-empty but none
+     match. Carries the install hint for a satisfying version.
 6. If the active profile declares `supportedRuntimes` and the
-   project's worker runtime is not listed, the provider includes a
-   non-fatal warning in its successful result. `func start` logs it
-   and proceeds; mismatch is informational for bundles and **must
-   not** block start.
+   project's worker runtime is not listed, the result includes a
+   non-fatal warning. `func start` logs it and proceeds; mismatch
+   is informational for bundles and **must not** block start.
 
-The provider performs **no** network I/O.
+The CLI core performs **no** network I/O.
 
 ### 5.2 Where bundle content lives
 
-A bundles workload install puts the bundle payload inside its
-standard workload install dir (Workload Spec §6.1 step 6):
+The bundles workload `.nupkg` ships its payload under `tools/any/`,
+which the workload subsystem extracts into:
 
 ```
 <workload-home>/workloads/azure.functions.cli.workloads.extensionbundles/<bundle-version>/
@@ -225,39 +244,39 @@ standard workload install dir (Workload Spec §6.1 step 6):
 
 The actual bundle content (the layout the Functions runtime host
 already knows how to read: `bin/`, `extensions.json`, etc.) lives
-under that directory in a fixed subpath chosen by the workload
-package. The provider returns the absolute path to that subpath; CT
-treats it as opaque.
+under that directory at a fixed subpath chosen by the workload
+package. The CLI core knows that subpath (it is part of the
+content-workload contract, documented alongside the package) and
+returns the absolute path to it.
 
 No copy or relocation step is performed at install time, and there
 is no second on-disk root.
 
 ### 5.3 Packaging (workload build time)
 
-The bundles workload `.csproj` uses the MSBuild `DownloadFile` task
-to fetch the bundle payload for the target version from the bundle
-CDN once, at workload-build time, and packs it into the workload
-`.nupkg`. Practical consequences:
+The bundles workload `.csproj` is a packaging-only project (no
+runtime assembly). It uses the MSBuild `DownloadFile` task to
+fetch the bundle payload for the target version from the bundle
+CDN once, at workload-build time, and packs it into the `.nupkg`
+under `tools/any/`. Practical consequences:
 
 - The CDN is contacted by the **build pipeline that publishes the
   workload**, not by any user machine running `func`.
 - A user's machine acquires the bundle through the normal
   `func workload install` flow, which downloads the workload
   `.nupkg` from its catalog feed (Workload Spec §6.1).
-- Reproducibility: an installed workload version always carries the
-  exact bundle payload that was packed at build time. There is no
-  drift between "what the workload version says" and "what's on
-  disk."
+- Reproducibility: an installed workload version always carries
+  the exact bundle payload that was packed at build time. There
+  is no drift between "what the workload version says" and
+  "what's on disk."
 - Preview / experimental versions are produced the same way; the
   only difference is the SemVer prerelease tag on the workload
-  version and the corresponding URL the `DownloadFile` task pulls
-  from.
+  version and the corresponding URL the `DownloadFile` task
+  pulls from.
 
 ### 5.4 Install hints
 
-When the provider returns `EmptyIntersection` or
-`NoCompatibleInstall`, it includes a fully-formed hint string the
-consumer prints verbatim. Example hints:
+The CLI core owns hint copy for the failure variants of §5.1:
 
 - `EmptyIntersection`:
   ```
@@ -274,15 +293,13 @@ consumer prints verbatim. Example hints:
   Install a satisfying version with:
     func workload install Azure.Functions.Cli.Workloads.ExtensionBundles@<suggested-version> --force
   ```
-
-The bundles workload owns the wording; CT does not duplicate this
-copy.
+- `WorkloadMissing` hint: see §4.4 step 3.
 
 ## 6. Logging and verbosity
 
-- **Default verbosity**: on resolution success, a single Information
-  line: `Using extension bundle <id> <version> from <path>`. On
-  failure, the provider's hint and a non-zero exit. Nothing else.
+- **Default verbosity**: on resolution success, a single
+  Information line: `Using extension bundle <id> <version> from
+  <path>`. On failure, the hint and a non-zero exit. Nothing else.
 - **`--verbose`**: in addition to the above, log the resolution
   trace at Debug:
   ```
@@ -294,9 +311,6 @@ copy.
   [bundle-resolve] selected = <version>
   [bundle-resolve] path = <resolved-path>
   ```
-- The Debug trace is produced by the bundles workload (it has the
-  data) and emitted through CT's standard logger; CT does not
-  re-derive any of it.
 
 ## 7. Telemetry
 
@@ -312,44 +326,49 @@ single `bundle-resolve` event:
 | `reason` | `ok` \| `no-host-json-bundle` \| `workload-missing` \| `empty-intersection` \| `no-compatible-install` |
 
 Workload install / update / uninstall telemetry is covered by the
-generic workload subsystem (Workload Spec §11); this spec adds none
-there.
+generic workload subsystem (Workload Spec §11); this spec adds
+none there.
 
 ## 8. Compatibility & migration
 
-- **v4 → v5 projects.** Existing projects whose `host.json` declares
-  `extensionBundle` work unchanged in v5, **provided** an installed
-  bundles workload version satisfies the project's host.json range
-  and the active profile.
-- **`func extensions install`.** Removed in v5. Added to the v4→v5
-  migration map (Workload Spec §4.7):
+- **v4 → v5 projects.** Existing projects whose `host.json`
+  declares `extensionBundle` work unchanged in v5, **provided** an
+  installed bundles workload version satisfies the project's
+  host.json range and the active profile.
+- **`func extensions install`.** Removed in v5. Added to the
+  v4→v5 migration map (Workload Spec §4.7):
   ```
-  'extensions install' is no longer supported. Extension bundles are
-  delivered as a workload. Install a version with:
+  'extensions install' is no longer supported. Extension bundles
+  are delivered as a workload. Install a version with:
     func workload install Azure.Functions.Cli.Workloads.ExtensionBundles@<version>
   ```
 - **In-CLI bundle download code.** `ExtensionBundleHelper`,
-  `DownloadBundleAction`, `ExtensionBundleConfigurationBuilder`, and
-  the related code paths in `Startup` are removed from the `func`
-  binary in v5.
+  `DownloadBundleAction`, `ExtensionBundleConfigurationBuilder`,
+  and the related code paths in `Startup` are removed from the
+  `func` binary in v5.
 - **Profiles.** Built-in profiles (cli-profiles §6.1) carry
   `extensionBundle.version` ranges the bundles workload catalog is
   guaranteed to satisfy at publication time.
 
 ## 9. Open questions
 
-1. Does the bundles workload expose a `func bundles ...` subcommand
-   (via `IExternalCommand`) for ergonomic install / list of
-   bundles, or is the bare `func workload install` sufficient?
-2. **Bundle id mapping rule.** When host.json declares
+1. **Bundle id mapping rule.** When host.json declares
    `id=Microsoft.Azure.Functions.ExtensionBundle.Preview`, which
    installed workload versions are candidates? Proposed: only
-   versions carrying a prerelease tag whose label set intersects
-   `{preview, experimental}` (or similar). Confirm the exact rule
-   and whether `.Preview` is still the only "preview-y" id in v5.
+   versions carrying a prerelease tag whose label is `preview` or
+   `experimental` (case-insensitive). Confirm the exact rule and
+   whether `.Preview` is still the only "preview-y" id in v5.
+2. **Payload subpath inside `tools/any/`.** What's the canonical
+   relative path the CLI core appends to the install dir to reach
+   the host-consumable bundle layout? Whatever it is, it should be
+   documented next to the workload package and treated as part of
+   the content-workload contract (Workload Spec §5.1 "the contract
+   between the consumer and the content workload is owned by the
+   consumer").
 3. Should `bundle-resolve` telemetry include constraint range
-   strings (potentially high cardinality) or just the outcome enum?
-4. Catalog feed: do bundle workload `.nupkg`s ship to the same
+   strings (potentially high cardinality) or just the outcome
+   enum?
+4. **Catalog feed.** Do bundle workload `.nupkg`s ship to the same
    workload catalog as host-runtime workloads, or a dedicated
-   bundles feed? (Most likely the same feed; verify with the
-   Extension Bundle publishing pipeline owners.)
+   bundles feed? Most likely the same feed; verify with the
+   Extension Bundle publishing pipeline owners.

--- a/proposed/bundles-workload-spec.md
+++ b/proposed/bundles-workload-spec.md
@@ -71,7 +71,7 @@
 |------|---------|
 | **Bundle id** | The `host.json` `extensionBundle.id` value. Three ids exist in v5: `Microsoft.Azure.Functions.ExtensionBundle` (stable), `Microsoft.Azure.Functions.ExtensionBundle.Preview`, and `Microsoft.Azure.Functions.ExtensionBundle.Experimental`. Each id is its own channel; experimental is **not** a label on the Preview id. |
 | **Bundle payload version** | The 3-part SemVer version of the extension bundle payload zip (e.g. `4.35.0`). This is the version the Functions runtime knows about and the version the user sees in `func` logs. It carries **no** prerelease label, even for the preview / experimental channels. |
-| **Workload pkg version** | The 4-part version of the bundles workload `.nupkg`, of the form `BundleVersion.WorkloadIteration[-Channel]` (e.g. `4.35.0.1`, `4.35.0.1-preview`, `4.35.0.1-experimental`). See §4.1 for the version scheme. |
+| **Workload pkg version** | The version of the bundles workload `.nupkg`. Maps **1:1** to the bundle payload version: stable channel uses the bare 3-part version (e.g. `4.35.0`); preview / experimental channels use the bare 3-part version with a channel prerelease label (e.g. `4.35.0-preview`, `4.35.0-experimental`). See §4.1.1. |
 | **Bundles workload** | The single `kind: content` workload package id `Azure.Functions.Cli.Workloads.ExtensionBundles`. Each installed instance carries exactly **one** bundle payload, packaged at workload-build time. |
 | **Bundle workload install dir** | The directory the workload subsystem extracts an installed bundles workload into, per Workload Spec §6.1: `<workload-home>/workloads/azure.functions.cli.workloads.extensionbundles/<workload-pkg-version>/`. |
 | **Resolved bundle path** | The directory the CLI core returns to its bundle consumer (today: `func start`). It is a subdirectory of the bundle workload install dir whose contents match today's extension bundle zip layout exactly, so the Functions runtime host needs no changes to consume it. |
@@ -94,54 +94,46 @@ core resolves the install directory by package id and workload pkg
 version, in the same way `func start` resolves the host-runtime
 workload today (Workload Spec §4.6).
 
-#### 4.1.1 Two-axis version scheme
+#### 4.1.1 Version scheme
 
-The workload pkg version is **not** a 1:1 mirror of the bundle
-payload version. It has the form:
+The workload pkg version maps **1:1** to the bundle payload
+version. Because the workload pkg is content-only (no workload
+code), there is no reason to version it independently of the
+payload it carries.
 
-```
-BundleVersion.WorkloadIteration[-Channel]
-```
-
-Three MSBuild props in `Directory.Version.props` drive
+Two MSBuild props in `Directory.Version.props` drive
 `<VersionPrefix>`:
 
 - `$(BundleVersion)` (e.g. `4.35.0`): the 3-part SemVer version of
   the bundle payload. Drives the CDN URL (§5.3.2) and the
   user-facing version in `func` logs.
-- `$(WorkloadIteration)` (e.g. `1`): per-bundle iteration counter
-  for the workload pkg itself, always occupying the 4th segment
-  regardless of channel. Bump when republishing the same bundle
-  payload with a workload-only fix.
 - `$(BundleChannel)` (`stable` | `preview` | `experimental`):
-  selects the CDN bundle id at pack time (§5.3.1) and the
-  prerelease label on the workload pkg version.
+  selects the CDN bundle id at pack time (§5.3.1) and, for
+  non-stable channels, the prerelease label appended to the
+  workload pkg version.
 
 The resulting workload pkg versions per channel:
 
 | Channel | host.json `extensionBundle.id` | Workload pkg version | Bundle payload version |
 |---|---|---|---|
-| stable | `Microsoft.Azure.Functions.ExtensionBundle` | `4.35.0.1` | `4.35.0` |
-| preview | `Microsoft.Azure.Functions.ExtensionBundle.Preview` | `4.35.0.1-preview` | `4.35.0` |
-| experimental | `Microsoft.Azure.Functions.ExtensionBundle.Experimental` | `4.35.0.1-experimental` | `4.35.0` |
+| stable | `Microsoft.Azure.Functions.ExtensionBundle` | `4.35.0` | `4.35.0` |
+| preview | `Microsoft.Azure.Functions.ExtensionBundle.Preview` | `4.35.0-preview` | `4.35.0` |
+| experimental | `Microsoft.Azure.Functions.ExtensionBundle.Experimental` | `4.35.0-experimental` | `4.35.0` |
 
-Each installed workload pkg version still ships **exactly one**
-bundle payload version; the 1:1 contract holds at the user-facing
-surface. The 4th segment and prerelease label are CLI-internal
-plumbing.
+Each installed workload pkg version ships **exactly one** bundle
+payload version; the 1:1 contract holds at every level.
 
-Rationale for splitting the two axes:
+Rationale:
 
-- The workload pkg can be re-released with a fix (catalog metadata,
-  packaging bug, signing, etc.) without bumping the bundle payload
-  version. Workload-only fixes get `.2`, `.3`, ... in the 4th
-  segment.
+- Content-only pkg: no workload code to revision separately, so a
+  4th-segment iteration counter would be cognitive cost with no
+  payoff.
 - The prerelease label is NuGet's built-in "this is preview"
   signal: `func workload install` won't pick up preview /
   experimental rows without an explicit pin or `--prerelease`.
-- The iteration counter is always in the same slot across
-  channels, so `WorkloadIteration` increments cleanly regardless
-  of channel.
+- A workload-only republish (build pipeline change, packaging fix,
+  etc.) bumps the bundle payload's patch version. If that case
+  ever becomes common, we can introduce an iteration knob then.
 
 Multiple bundle versions coexist on disk by installing the workload
 multiple times with `func workload install --force` (Workload Spec
@@ -171,17 +163,19 @@ version's prerelease label against the requested id:
 
 | host.json `extensionBundle.id` | Matching workload pkg versions |
 |---|---|
-| `Microsoft.Azure.Functions.ExtensionBundle` | versions with **no** prerelease label (e.g. `4.35.0.1`) |
-| `Microsoft.Azure.Functions.ExtensionBundle.Preview` | versions whose prerelease label is **exactly `preview`** (e.g. `4.35.0.1-preview`) |
-| `Microsoft.Azure.Functions.ExtensionBundle.Experimental` | versions whose prerelease label is **exactly `experimental`** (e.g. `4.35.0.1-experimental`) |
+| `Microsoft.Azure.Functions.ExtensionBundle` | versions with **no** prerelease label (e.g. `4.35.0`) |
+| `Microsoft.Azure.Functions.ExtensionBundle.Preview` | versions whose prerelease label is **exactly `preview`** (e.g. `4.35.0-preview`) |
+| `Microsoft.Azure.Functions.ExtensionBundle.Experimental` | versions whose prerelease label is **exactly `experimental`** (e.g. `4.35.0-experimental`) |
 
 The match is exact: a workload version's prerelease label is the
 encoded channel. Preview does not match experimental versions and
 vice versa.
 
 The version-range intersection (§5.1) is then evaluated against
-the **bundle payload version** (3-part `$(BundleVersion)`) of each
-matching candidate.
+the **bundle payload version** (3-part `$(BundleVersion)`, which
+for stable channel is the workload pkg version itself, and for
+non-stable channels is the workload pkg version with the
+prerelease label stripped) of each matching candidate.
 
 ### 4.3 CLI core ownership
 
@@ -293,7 +287,7 @@ workload`-style package) later without touching the rest of CT.
      workload is installed. Install a version with:
        func workload install Azure.Functions.Cli.Workloads.ExtensionBundles@<workload-pkg-version>
      ```
-     e.g. `...@4.35.0.1` for stable or `...@4.35.0.1-preview` for
+     e.g. `...@4.35.0` for stable or `...@4.35.0-preview` for
      preview. Exit non-zero.
 4. On `Resolved`: set
    `AzureFunctionsJobHost__extensionBundle__downloadPath` to the
@@ -329,8 +323,8 @@ worker runtime, active profile), the CLI core:
    workload registry (`workloads.json`, Workload Spec §10.1) for
    rows whose `packageId` is
    `azure.functions.cli.workloads.extensionbundles`. Each row's
-   identity is its full workload pkg version (e.g. `4.35.0.1`,
-   `4.35.0.1-preview`).
+   identity is its workload pkg version (e.g. `4.35.0`,
+   `4.35.0-preview`).
 3. Filters those rows by host.json `extensionBundle.id` per the
    §4.2 channel rule (stable id → no prerelease label; Preview id
    → prerelease label exactly `preview`; Experimental id →
@@ -342,7 +336,9 @@ worker runtime, active profile), the CLI core:
    - **Resolved**: the absolute path inside that workload's install
      dir whose layout matches the extension bundle zip (§5.2). The
      resolution carries the **3-part bundle payload version** as
-     its user-facing version, not the full workload pkg version.
+     its user-facing version, not the workload pkg version (the
+     two differ only by the prerelease label on non-stable
+     channels).
    - **WorkloadMissing**: no rows for the bundles package id exist
      at any version.
    - **EmptyIntersection**: the host.json range and the profile
@@ -369,8 +365,8 @@ which the workload subsystem extracts into:
 <workload-home>/workloads/azure.functions.cli.workloads.extensionbundles/<workload-pkg-version>/
 ```
 
-The directory is keyed by the full workload pkg version (e.g.
-`4.35.0.1`, `4.35.0.1-preview`), so stable and preview installs of
+The directory is keyed by the workload pkg version (e.g.
+`4.35.0`, `4.35.0-preview`), so stable and preview installs of
 the same bundle payload coexist as distinct directories.
 
 The actual bundle content (the layout the Functions runtime host
@@ -459,8 +455,8 @@ Tracking this transition is open question §9.Q5.
 ### 5.4 Install hints
 
 The CLI core owns hint copy for the failure variants of §5.1.
-Suggested pin versions in hints use the **full workload pkg
-version** (4-part, with channel label as applicable):
+Suggested pin versions in hints use the **workload pkg version**
+(with channel prerelease label as applicable):
 
 - `EmptyIntersection`:
   ```
@@ -477,7 +473,7 @@ version** (4-part, with channel label as applicable):
   Install a satisfying version with:
     func workload install Azure.Functions.Cli.Workloads.ExtensionBundles@<workload-pkg-version> --force
   ```
-  e.g. `...@4.35.0.1` for stable, `...@4.35.0.1-preview` for
+  e.g. `...@4.35.0` for stable, `...@4.35.0-preview` for
   preview.
 - `WorkloadMissing` hint: see §4.4 step 3.
 
@@ -507,7 +503,7 @@ single `bundle-resolve` event:
 | Field | Value |
 |-------|-------|
 | `bundleId` | `host.json` `extensionBundle.id` |
-| `resolvedVersion` | Selected 3-part **bundle payload version** (e.g. `4.35.0`) on success, or `null` on failure. The full 4-part workload pkg version is CLI-internal and is not emitted. |
+| `resolvedVersion` | Selected 3-part **bundle payload version** (e.g. `4.35.0`) on success, or `null` on failure. The workload pkg version (which adds only a channel prerelease label on non-stable channels) is CLI-internal and is not emitted. |
 | `profileName` | Active profile name, or `null` if no profile |
 | `succeeded` | `true` if the host was launched with a resolved bundle |
 | `reason` | `ok` \| `no-host-json-bundle` \| `workload-missing` \| `empty-intersection` \| `no-compatible-install` |

--- a/proposed/bundles-workload-spec.md
+++ b/proposed/bundles-workload-spec.md
@@ -10,20 +10,19 @@
 ## 1. Goals
 
 - Move all bundle acquisition, version selection, and on-disk
-  layout out of the `func` CLI binary and into a single first-class
-  workload, so bundles can ship and version independently of Core
-  Tools.
-- Expose a stable contribution point that any CLI command (today:
-  `func start`) can call to obtain a resolved bundle path for a
-  project + active profile.
-- Make `func start` resolution deterministic. When a satisfying
-  bundle payload is already cached locally, `func start` resolves
-  fully offline. When it isn't, the bundles workload may fetch it
-  on demand at start time (see §5.3).
+  layout out of the `func` CLI binary and into a workload, so bundles
+  can ship and version independently of Core Tools.
+- Expose a stable contribution point (`IExtensionBundleProvider`)
+  that any CLI command (today: `func start`) can call to obtain a
+  resolved bundle path for a project + active profile.
+- Make `func start` resolution **deterministic and fully offline**.
+  The bundles workload performs no network I/O. All bundle payloads
+  are obtained at workload **install** time (the payload ships
+  inside the workload `.nupkg`).
 - Eliminate Core Tools' bespoke bundle download path
   (`ExtensionBundleHelper`, `DownloadBundleAction`, `func extensions
   install`). The bundles workload is the only acquisition mechanism
-  in v5.
+  in v5, and acquisition is `func workload install` + nothing else.
 - Require no changes in the Functions runtime host. CT keeps using the
   existing `AzureFunctionsJobHost__extensionBundle__downloadPath` env
   var to point the host at the resolved bundle and to suppress its
@@ -36,9 +35,18 @@
   authoring a custom profile (`cli-profiles.md` §5.2) that sets
   `extensionBundle.version` to an exact range.
 - **Auto-install of the bundles workload on `func start`.** Follows
-  the host-workload rule (Workload Spec §4.5): a missing workload
-  causes `func start` to print an install hint and exit non-zero. CT
-  never installs workloads implicitly.
+  the host-workload rule (Workload Spec §4.5): a missing or
+  unsatisfying installed workload set causes `func start` to print
+  an install hint and exit non-zero. CT never installs workloads
+  implicitly.
+- **Bundle CDN access from the bundles workload at runtime.** The
+  workload never downloads bundles. The bundle payload is part of
+  the workload `.nupkg`, fetched from the CDN exactly once at
+  workload-build time by the workload's own MSBuild process.
+- **Separate bundles home / `FUNC_CLI_BUNDLES_HOME` override.**
+  Bundle payloads live inside the workload install directory under
+  `<workload-home>`. There is no second on-disk root and no separate
+  override env var.
 - **CT → host transport beyond today's env vars.** If a future
   CT-host workload introduces a different startup transport, that is
   out of scope for this spec.
@@ -48,56 +56,82 @@
 | Term | Meaning |
 |------|---------|
 | **Bundle id** | The `host.json` `extensionBundle.id` value, e.g. `Microsoft.Azure.Functions.ExtensionBundle` or `Microsoft.Azure.Functions.ExtensionBundle.Preview`. |
-| **Bundle version** | A SemVer version of an extension bundle payload, e.g. `4.22.0`. |
-| **Bundles workload** | The single workload package `Azure.Functions.Cli.Workloads.ExtensionBundles` (`kind: workload`) that provides bundle resolution and owns the on-disk payload cache. |
-| **Bundles home** | The on-disk root the bundles workload uses for payloads. Defaults to `<workload-home>/bundles` (i.e. `~/.azure-functions/bundles`). Override via `FUNC_CLI_BUNDLES_HOME`. |
-| **Resolved bundle path** | A directory path returned by the bundles workload to a consumer (e.g. `func start`). Its layout matches today's bundle zip layout exactly so the Functions runtime host needs no changes to consume it. |
+| **Bundle version** | A SemVer version of an extension bundle payload, e.g. `4.22.0` (stable) or `4.33.0-experimental.1` (prerelease). Prerelease tags carry preview / experimental builds. |
+| **Bundles workload** | The single workload package id `Azure.Functions.Cli.Workloads.ExtensionBundles` (`kind: workload`). Each installed instance of this workload carries exactly **one** bundle version, packaged at workload-build time. The workload version is **always equal to the bundle version it packages**. |
+| **Bundle workload install dir** | The directory the workload subsystem extracts an installed bundles workload into, per Workload Spec §6.1: `<workload-home>/workloads/azure.functions.cli.workloads.extensionbundles/<bundle-version>/`. |
+| **Resolved bundle path** | The directory the provider returns to a consumer. It is a subdirectory of the bundle workload install dir whose contents match today's extension bundle zip layout exactly, so the Functions runtime host needs no changes to consume it. |
 
 ## 4. Architecture
 
-### 4.1 Single workload, not per-version packages
+### 4.1 One workload package, one bundle version per install
 
-There is **one** workload package:
+There is **one** workload package id:
 
 ```
 Azure.Functions.Cli.Workloads.ExtensionBundles
 ```
 
-Its package id does **not** encode a bundle version. Multiple bundle
-versions and both the stable and preview bundle ids are handled
-inside the workload's payload cache (§5), not as separate workload
-registry rows.
+The workload version equals the bundle version it packages:
+
+| `func workload install …` | Bundle version delivered |
+|---------------------------|--------------------------|
+| `Azure.Functions.Cli.Workloads.ExtensionBundles@4.22.0` | `4.22.0` |
+| `Azure.Functions.Cli.Workloads.ExtensionBundles@4.33.0-experimental.1` | `4.33.0-experimental.1` |
+
+Multiple bundle versions coexist on disk by installing the workload
+multiple times with `func workload install --force` (Workload Spec
+§4.6 already specifies this side-by-side model for the host-runtime
+workload; bundles use the same mechanism). Each install is a
+distinct row in the workload registry.
 
 Rationale:
 
-- The set of bundle versions a developer might need is open-ended; one
-  workload registry row per bundle version would balloon the workload
-  manifest and complicate version selection across the profile +
-  host.json constraint.
-- Bundle payloads have a stable shape the Functions runtime host
-  already understands. There is no per-version CLI-side code; the
-  only CLI-side code is the resolver. One workload assembly with a
-  payload cache is the simplest viable factoring.
+- A 1:1 mapping between workload version and bundle version makes
+  every install reproducible and auditable: the version in
+  `workloads.json` is the bundle version on disk, full stop.
+- Side-by-side coexistence via `--force` is already part of the
+  workload subsystem; bundles don't need a separate cache layer.
+- Eliminating a second on-disk root (the previous "bundles home")
+  removes an entire class of override / migration concerns.
 
-### 4.2 `IExtensionBundleProvider` contribution point
+### 4.2 SemVer prerelease tags for preview / experimental
+
+Preview and experimental bundles do **not** get a separate workload
+package id. They are expressed as SemVer prerelease versions of the
+same package, e.g. `4.33.0-preview.1`, `4.33.0-experimental.2`. This
+matches NuGet's own prerelease convention and lets the workload
+subsystem manage them with no new code paths.
+
+`host.json` continues to support both bundle ids
+(`Microsoft.Azure.Functions.ExtensionBundle` and
+`...ExtensionBundle.Preview`). Both ids map to the **same** workload
+package; the chosen `extensionBundle.id` plus the requested version
+range selects candidates from the installed registry rows. The
+exact mapping rules between an `id=...Preview` host.json and which
+installed workload versions are considered candidates are captured
+as an open question in §9 (the simplest rule is "Preview id selects
+only prerelease-tagged versions; stable id selects only
+stable-tagged versions").
+
+### 4.3 `IExtensionBundleProvider` contribution point
 
 Core Tools adds a new contribution point to `Func.Cli.Abstractions`
 (Workload Spec §5.1):
 
 | Service registered | The workload can... | Used by |
 |--------------------|---------------------|---------|
-| `IExtensionBundleProvider` | Resolve a bundle path for a project + active profile, and manage the on-disk bundle payload cache. | `func start` |
+| `IExtensionBundleProvider` | Resolve a bundle path for a project + active profile from the set of installed bundles workloads. | `func start` |
 
-The contract returns a resolved bundle path (or a structured failure
-with enough information for CT to print an actionable install/update
-hint). The bundles workload is the v1 implementer; the abstraction
-is open to alternative implementations.
+The contract returns a resolved bundle path (or a structured
+failure with enough information for CT to print an actionable
+install hint). The bundles workload is the v1 implementer; the
+abstraction is open to alternative implementations.
 
 Exact interface signature lives in
 [`building-a-workload.md`](./building-a-workload.md). Out of scope
 for this spec.
 
-### 4.3 Consumer responsibilities (`func start`)
+### 4.4 Consumer responsibilities (`func start`)
 
 `func start` is the only v1 consumer. Its responsibilities are
 intentionally minimal:
@@ -105,13 +139,14 @@ intentionally minimal:
 1. Detect whether the project's `host.json` declares an
    `extensionBundle` section. If not, **skip** resolution entirely
    (do not load the bundles workload, do not set any env var).
-2. Resolve the active profile (cli-profiles `§6`).
+2. Resolve the active profile (cli-profiles §6).
 3. Look up an `IExtensionBundleProvider` from the loaded workloads.
-   - If none is registered, print the install hint:
+   - If none is registered (i.e. **no** bundles workload installed
+     at any version), print the install hint:
      ```
      This project requires an extension bundle but no bundles
-     workload is installed. Install it with:
-       func workload install Azure.Functions.Cli.Workloads.ExtensionBundles
+     workload is installed. Install a version with:
+       func workload install Azure.Functions.Cli.Workloads.ExtensionBundles@<version>
      ```
      Exit non-zero.
 4. Invoke the provider, passing the project context (parsed
@@ -124,16 +159,17 @@ intentionally minimal:
    Using extension bundle <id> <version> from <path>
    ```
 6. On failure: surface the provider's structured error message
-   (which includes the install/update hint, see §5.4) and exit
-   non-zero. Do not start the host.
+   (which includes the install hint, see §5.3) and exit non-zero.
+   Do not start the host.
 7. **Always** set `AzureFunctionsJobHost__extensionBundle__ensureLatest=false`
    when launching the host, whether or not a bundle was resolved.
-   In v5 the bundles workload owns freshness; the host runtime
-   must never reach out for a newer bundle behind CT's back.
+   In v5 the bundles workload owns the bundle on disk; the host
+   runtime must never reach out for a newer bundle behind CT's
+   back.
 
-`func start` does **not** know about the bundles home, the bundle
-CDN, or per-version payload layout. That is entirely the workload's
-concern.
+`func start` does **not** know about workload install paths,
+per-version layout, or the bundle CDN. That is entirely the
+workload's concern.
 
 ## 5. Bundles workload behavior
 
@@ -142,120 +178,79 @@ concern.
 Given the consumer-supplied context (host.json `extensionBundle`
 block, worker runtime, active profile), the provider:
 
-1. Computes the **constraint range** as the NuGet-style intersection of:
+1. Computes the **constraint range** as the NuGet-style intersection
+   of:
    - the `host.json` `extensionBundle.version` range, and
    - the active profile's `extensionBundle.version` range (if
      declared; otherwise the constraint equals the host.json range).
-2. Enumerates installed bundle payloads under the bundles home whose
-   bundle id matches `host.json` `extensionBundle.id`.
-3. Selects the **highest installed version** that satisfies the
+2. Enumerates **installed bundle workload versions** by reading the
+   workload registry (`workloads.json`, Workload Spec §6.1) for
+   rows whose `packageId` is `azure.functions.cli.workloads.extensionbundles`.
+3. Filters that set by host.json `extensionBundle.id` per §4.2
+   (stable id → stable-tagged versions; Preview id → prerelease-
+   tagged versions; final rule per §9 open question).
+4. Selects the **highest** filtered version that satisfies the
    constraint range.
-4. If no installed version satisfies the constraint, the provider
-   **may** fetch a satisfying version from the bundle CDN on demand
-   (see §5.3). If the fetch succeeds, the new payload is added to
-   the cache and selected.
 5. Returns either:
-   - **Resolved**: the absolute path
-     `<bundles-home>/<bundle-id>/<version>/`, or
+   - **Resolved**: the absolute path inside that workload's install
+     dir whose layout matches the extension bundle zip (§5.2), or
    - **EmptyIntersection**: the host.json range, the profile range,
-     and the highest version that would satisfy host.json alone (for
-     the install hint), or
-   - **NoCompatiblePayload**: the constraint range, a list of
-     installed versions for the same bundle id, and (if the on-demand
-     fetch was attempted and failed) the failure reason.
+     and the highest version that would satisfy host.json alone
+     (for the install hint), or
+   - **NoCompatibleInstall**: the constraint range and a list of
+     installed bundle workload versions, plus the install hint for
+     a satisfying version.
 6. If the active profile declares `supportedRuntimes` and the
    project's worker runtime is not listed, the provider includes a
    non-fatal warning in its successful result. `func start` logs it
    and proceeds; mismatch is informational for bundles and **must
    not** block start.
 
-### 5.2 On-disk layout (bundles home)
+The provider performs **no** network I/O.
 
-The bundles workload manages payloads under:
+### 5.2 Where bundle content lives
+
+A bundles workload install puts the bundle payload inside its
+standard workload install dir (Workload Spec §6.1 step 6):
 
 ```
-<bundles-home>/<bundle-id>/<bundle-version>/
+<workload-home>/workloads/azure.functions.cli.workloads.extensionbundles/<bundle-version>/
 ```
 
-Default `<bundles-home>` is `<workload-home>/bundles`, i.e.
-`~/.azure-functions/bundles`. Override via the
-`FUNC_CLI_BUNDLES_HOME` environment variable (same convention as
-`FUNC_CLI_WORKLOADS_HOME`, Workload Spec §11). Resolution mirrors
-`WorkloadHomeResolver` exactly: explicit env var wins, otherwise
-nest under the workload home (which itself honors
-`FUNC_CLI_WORKLOADS_HOME`).
+The actual bundle content (the layout the Functions runtime host
+already knows how to read: `bin/`, `extensions.json`, etc.) lives
+under that directory in a fixed subpath chosen by the workload
+package. The provider returns the absolute path to that subpath; CT
+treats it as opaque.
 
-The contents under `<bundle-version>/` mirror today's extension
-bundle zip layout exactly. Returning this directory to a consumer
-gives the Functions runtime host a directory it already knows how to
-read with no code changes.
+No copy or relocation step is performed at install time, and there
+is no separate "bundles home" root.
 
-### 5.3 Payload acquisition
+### 5.3 Packaging (workload build time)
 
-The bundles workload acquires bundle payloads from one of three
-sources:
+The bundles workload `.csproj` uses the MSBuild `DownloadFile` task
+to fetch the bundle payload for the target version from the bundle
+CDN once, at workload-build time, and packs it into the workload
+`.nupkg`. Practical consequences:
 
-1. **In-package, at workload build time.** The bundles workload's
-   own `.csproj` uses the MSBuild `DownloadFile` task to fetch a
-   curated set of **stable** bundle payloads from the bundle CDN at
-   workload-build time and packs them into the workload `.nupkg`
-   under e.g. `tools/any/bundles/<bundle-id>/<bundle-version>/`.
-   On workload install, these payloads are copied (or hard-linked)
-   into the bundles home. This is the **preferred** path for stable
-   bundles because it gives every fresh workload install a usable
-   offline-resolvable payload set with no post-install hook required
-   and no first-run network hit. The trade-off is workload package
-   size; the curated set should be small (e.g. the latest stable
-   `Microsoft.Azure.Functions.ExtensionBundle` major + minor).
-2. **Eagerly, via a post-install / first-run hook.** The Workload
-   Spec does not define such a hook today (see Workload Spec §12 #5,
-   an open question). If/when one is added, the bundles workload may
-   use it to grow the default payload set without rebuilding the
-   workload itself.
-3. **On demand at `func start`.** Used whenever a project requires a
-   version that isn't already in the bundles home (e.g. a
-   profile-pinned older version, a brand-new stable version
-   published after the workload was packaged, or any **preview /
-   experimental** bundle id such as
-   `Microsoft.Azure.Functions.ExtensionBundle.Preview`). Preview /
-   experimental payloads are explicitly **not** shipped inside the
-   workload package so that:
-   - workload package size doesn't churn with every preview drop,
-     and
-   - opting into a preview bundle is always an explicit network
-     event with a log line, never a silent "you already had it
-     locally" because the workload happened to ship it.
+- The CDN is contacted by the **build pipeline that publishes the
+  workload**, not by any user machine running `func`.
+- A user's machine acquires the bundle through the normal
+  `func workload install` flow, which downloads the workload
+  `.nupkg` from its catalog feed (Workload Spec §6.1).
+- Reproducibility: an installed workload version always carries the
+  exact bundle payload that was packed at build time. There is no
+  drift between "what the workload version says" and "what's on
+  disk."
+- Preview / experimental versions are produced the same way; the
+  only difference is the SemVer prerelease tag on the workload
+  version and the corresponding URL the `DownloadFile` task pulls
+  from.
 
-In other words: the workload package eagerly carries **stable**
-bundle payloads it was built against; **preview / experimental**
-bundles are CDN-on-demand only.
-
-On-demand fetch at `func start`:
-
-- The provider **must** print an Information log line before
-  initiating download, e.g. `Downloading extension bundle <id>
-  <version>…`, and a completion line on success.
-- The provider **must** apply a bounded timeout (workload-defined,
-  not specified here) and fail fast with a clear hint if the network
-  is unavailable, the version cannot be located, or integrity
-  verification fails.
-- A successful on-demand fetch is observationally identical to a
-  pre-cached resolution from `func start`'s perspective: same return
-  contract, same env var handling. Telemetry distinguishes the two
-  via the `reason` field (§7).
-
-Whether the workload also surfaces a `func bundles install <version>`
-subcommand (via `IExternalCommand`, Workload Spec §5.1) for ad-hoc
-prefetching is **deferred** (see §9 open questions).
-
-The bundles workload is responsible for verifying download integrity
-(checksum/signature) and for atomic extraction under `<bundles-home>`
-in both acquisition paths.
-
-### 5.4 Install / update hints
+### 5.4 Install hints
 
 When the provider returns `EmptyIntersection` or
-`NoCompatiblePayload`, it includes a fully-formed hint string the
+`NoCompatibleInstall`, it includes a fully-formed hint string the
 consumer prints verbatim. Example hints:
 
 - `EmptyIntersection`:
@@ -265,14 +260,13 @@ consumer prints verbatim. Example hints:
   '<host-range>'. There is no bundle version that satisfies both.
   Either widen host.json or pick a different profile.
   ```
-- `NoCompatiblePayload` (after on-demand fetch was attempted and
-  failed, or was not possible offline):
+- `NoCompatibleInstall`:
   ```
-  No <id> bundle satisfies <constraint-range>.
+  No installed bundles workload satisfies <constraint-range>
+  (id=<bundle-id>).
   Installed versions: <v1>, <v2>, ...
-  On-demand download failed: <reason>.
-  Try again when online, or update bundles with:
-    func workload update Azure.Functions.Cli.Workloads.ExtensionBundles
+  Install a satisfying version with:
+    func workload install Azure.Functions.Cli.Workloads.ExtensionBundles@<suggested-version> --force
   ```
 
 The bundles workload owns the wording; CT does not duplicate this
@@ -290,7 +284,7 @@ copy.
   [bundle-resolve] host.json range = <host-range>
   [bundle-resolve] profile '<profile>' range = <profile-range>
   [bundle-resolve] constraint = <intersection>
-  [bundle-resolve] installed versions = <v1>, <v2>, ...
+  [bundle-resolve] installed versions (filtered) = <v1>, <v2>, ...
   [bundle-resolve] selected = <version>
   [bundle-resolve] path = <resolved-path>
   ```
@@ -309,7 +303,7 @@ single `bundle-resolve` event:
 | `resolvedVersion` | Selected bundle version, or `null` on failure |
 | `profileName` | Active profile name, or `null` if no profile |
 | `succeeded` | `true` if the host was launched with a resolved bundle |
-| `reason` | `ok-in-package` \| `ok-cached` \| `ok-downloaded` \| `no-host-json-bundle` \| `workload-missing` \| `empty-intersection` \| `download-failed` |
+| `reason` | `ok` \| `no-host-json-bundle` \| `workload-missing` \| `empty-intersection` \| `no-compatible-install` |
 
 Workload install / update / uninstall telemetry is covered by the
 generic workload subsystem (Workload Spec §11); this spec adds none
@@ -318,43 +312,38 @@ there.
 ## 8. Compatibility & migration
 
 - **v4 → v5 projects.** Existing projects whose `host.json` declares
-  `extensionBundle` work unchanged in v5, **provided** the bundles
-  workload is installed and has a payload satisfying the project's
-  host.json range and the active profile.
+  `extensionBundle` work unchanged in v5, **provided** an installed
+  bundles workload version satisfies the project's host.json range
+  and the active profile.
 - **`func extensions install`.** Removed in v5. Added to the v4→v5
   migration map (Workload Spec §4.7):
   ```
   'extensions install' is no longer supported. Extension bundles are
-  delivered as a workload. Install it with:
-    func workload install Azure.Functions.Cli.Workloads.ExtensionBundles
+  delivered as a workload. Install a version with:
+    func workload install Azure.Functions.Cli.Workloads.ExtensionBundles@<version>
   ```
 - **In-CLI bundle download code.** `ExtensionBundleHelper`,
   `DownloadBundleAction`, `ExtensionBundleConfigurationBuilder`, and
   the related code paths in `Startup` are removed from the `func`
   binary in v5.
 - **Profiles.** Built-in profiles (cli-profiles §6.1) carry
-  `extensionBundle.version` ranges the bundle CDN is guaranteed to
-  satisfy at publication time. The bundles workload's default payload
-  set is curated so that the workload-installed-by-default scenario
-  works for those ranges out of the box.
+  `extensionBundle.version` ranges the bundles workload catalog is
+  guaranteed to satisfy at publication time.
 
 ## 9. Open questions
 
 1. Does the bundles workload expose a `func bundles ...` subcommand
-   (via `IExternalCommand`) for ad-hoc per-version pulls
-   (`func bundles install <version>`), so users can prefetch
-   bundles for offline scenarios without waiting for the on-demand
-   path at `func start`?
-2. **In-package curated set policy.** Which stable bundle versions
-   ship inside the workload `.nupkg` via `DownloadFile` at workload
-   build time? Latest stable major.minor only, or latest two minors,
-   or every minor in a supported range? This trades workload package
-   size against how often a fresh install needs an on-demand fetch.
-3. Should the workload retain old payloads on update, or prune them?
-   If prune, what's the retention policy (last N versions, anything
-   referenced by an installed profile, etc.)?
-4. Should `bundle-resolve` telemetry include constraint range strings
-   (potentially high cardinality) or just an outcome enum?
-5. Do we want an explicit "offline mode" flag/env var on `func start`
-   that suppresses the on-demand fetch even when network is
-   available (for reproducible CI builds, etc.)?
+   (via `IExternalCommand`) for ergonomic install / list of
+   bundles, or is the bare `func workload install` sufficient?
+2. **Bundle id mapping rule.** When host.json declares
+   `id=Microsoft.Azure.Functions.ExtensionBundle.Preview`, which
+   installed workload versions are candidates? Proposed: only
+   versions carrying a prerelease tag whose label set intersects
+   `{preview, experimental}` (or similar). Confirm the exact rule
+   and whether `.Preview` is still the only "preview-y" id in v5.
+3. Should `bundle-resolve` telemetry include constraint range
+   strings (potentially high cardinality) or just the outcome enum?
+4. Catalog feed: do bundle workload `.nupkg`s ship to the same
+   workload catalog as host-runtime workloads, or a dedicated
+   bundles feed? (Most likely the same feed; verify with the
+   Extension Bundle publishing pipeline owners.)

--- a/proposed/bundles-workload-spec.md
+++ b/proposed/bundles-workload-spec.md
@@ -46,9 +46,10 @@
   any other content workload) and is out of scope for this spec.
 - **Bundle CDN access from CT at runtime.** Neither the CLI nor the
   bundles workload contacts the bundle CDN at run time. The bundle
-  payload is part of the workload `.nupkg`, fetched from the CDN
-  exactly once at workload-build time by the workload's own MSBuild
-  process.
+  payload is part of the workload `.nupkg`, fetched from the bundle
+  build pipeline's artifacts (or, interim, the CDN) exactly once at
+  workload-build time by the workload's own MSBuild process. See
+  §5.3 for the payload-source pivot.
 - **Custom bundles install root.** Bundle payloads live inside the
   workload install directory under `<workload-home>`. There is no
   second on-disk root, no bundles-specific override env var, and no
@@ -159,8 +160,8 @@ following live in the `func` CLI core (concretely: in
   events (§6, §5.4, §7).
 
 The bundles workload contains **only** the bundle payload and the
-build-time `DownloadFile` plumbing that fetched it from the bundle
-CDN (§5.3). It has no runtime code.
+build-time plumbing that fetched it from the bundle build pipeline
+(or, interim, the CDN: §5.3). It has no runtime code.
 
 #### 4.3.1 Component shape
 
@@ -330,24 +331,75 @@ is no second on-disk root.
 ### 5.3 Packaging (workload build time)
 
 The bundles workload `.csproj` is a packaging-only project (no
-runtime assembly). It uses the MSBuild `DownloadFile` task to
-fetch the bundle payload for the target version from the bundle
-CDN once, at workload-build time, and packs it into the `.nupkg`
-under `tools/any/`. Practical consequences:
+runtime assembly). At workload-build time, MSBuild fetches the
+bundle payload zip for the target version, unpacks the bundle into
+the workload output, and packs the result into the `.nupkg` under
+`tools/any/`.
 
-- The CDN is contacted by the **build pipeline that publishes the
-  workload**, not by any user machine running `func`.
+#### 5.3.1 Payload source: bundle pipeline build artifacts
+
+The canonical payload source is the **bundle build pipeline's
+artifacts feed** in Azure DevOps, not the public bundle CDN.
+
+- The bundles repo publishes a pipeline build per branch. The
+  three branches that matter for this spec are:
+  - `main` → stable bundle versions.
+  - `main-preview` → preview bundle versions.
+  - `main-experimental` → experimental bundle versions.
+- Each successful build publishes an artifact named `zip` that
+  contains, among other things, files of the shape:
+  `Microsoft.Azure.Functions.ExtensionBundle.<version>_any-any.zip`
+  (one per platform; bundles ship a platform-neutral `any-any`
+  variant which is the one this workload uses).
+- The bundles-workload build pipeline downloads exactly that file
+  for the target `<version>` from the build matching the SemVer
+  prerelease channel (stable / preview / experimental).
+
+This gives the bundles workload the same payload that has been
+signed and validated by the bundles release process, with no
+dependency on the public CDN at workload-build time and no
+dependency on the CDN at user-run time.
+
+#### 5.3.2 Interim: temporary CDN fetch
+
+For the first cut, while the workload still lives in
+`Azure/azure-functions-core-tools` and is decoupled from the
+bundles release schedule, MSBuild uses `DownloadFile` against the
+**public bundle CDN** as a quick-setup payload source. This is an
+implementation detail of the workload build and has no effect on
+the on-disk shape or on `func` runtime behavior.
+
+The pivot to build artifacts happens when:
+
+- The bundles workload moves into the bundles repo (or is wired
+  into the bundles release pipeline from this repo), so the
+  workload `.nupkg` and the bundle `.zip` are produced by the same
+  build and the artifact handle is naturally available; or
+- The bundle release process exposes a stable cross-pipeline
+  artifact download URL the workload build can target without
+  manual handling.
+
+Until then, refreshing the pinned bundle payload requires manually
+downloading the artifact zip from the bundle pipeline run and
+updating the `DownloadFile` URL + checksum in the workload csproj.
+Tracking this transition is open question §9.Q5.
+
+#### 5.3.3 Consequences (shared between both payload sources)
+
+- The payload source is contacted by the **build pipeline that
+  publishes the workload**, not by any user machine running
+  `func`.
 - A user's machine acquires the bundle through the normal
   `func workload install` flow, which downloads the workload
   `.nupkg` from its catalog feed (Workload Spec §6.1).
 - Reproducibility: an installed workload version always carries
   the exact bundle payload that was packed at build time. There
-  is no drift between "what the workload version says" and
-  "what's on disk."
+  is no drift between "what the workload version says" and "what's
+  on disk."
 - Preview / experimental versions are produced the same way; the
   only difference is the SemVer prerelease tag on the workload
-  version and the corresponding URL the `DownloadFile` task
-  pulls from.
+  version and the corresponding bundle artifact branch
+  (`main-preview` / `main-experimental`) the build pulls from.
 
 ### 5.4 Install hints
 
@@ -447,3 +499,15 @@ none there.
    workload catalog as host-runtime workloads, or a dedicated
    bundles feed? Most likely the same feed; verify with the
    Extension Bundle publishing pipeline owners.
+5. **Payload-source pivot (CDN → build artifacts).** The first
+   cut pulls the bundle payload from the public bundle CDN via
+   MSBuild `DownloadFile` (§5.3.2) because the bundles workload
+   lives in this repo and not in the bundles repo. The target
+   state is to consume the bundle build pipeline's `zip` artifact
+   per branch (`main` / `main-preview` / `main-experimental`,
+   §5.3.1) so the workload version always packs a payload that
+   was produced and signed by the same pipeline run. Decide:
+   does the bundles workload move into the bundles repo, or
+   stay here and consume the artifact cross-pipeline? Either
+   option resolves this question. Until it is resolved, refreshing
+   the pinned bundle payload is a manual artifact download.

--- a/proposed/bundles-workload-spec.md
+++ b/proposed/bundles-workload-spec.md
@@ -200,6 +200,39 @@ Neither door is exercised in v1; the abstractions cost is small
 and keeps the layering consistent with the rest of the workload
 ecosystem.
 
+#### 4.3.3 Folder isolation in CT
+
+All bundles-specific code in `Azure.Functions.Cli` lives under a
+single top-level folder (`Bundles/`), and the abstractions in
+`Func.Cli.Abstractions` live under a matching `Bundles/`
+sub-namespace. Concretely:
+
+```
+src/Cli/func/
+  Bundles/
+    IExtensionBundleResolver.cs       # (abstraction re-exported)
+    ExtensionBundleResolver.cs
+    InstalledBundleWorkloads.cs       # IInstalledBundleWorkloads impl
+    ExtensionBundleResolution.cs      # result union
+    BundleHintBuilder.cs              # §5.4 copy
+    BundleTelemetry.cs                # §7 event shape
+src/Cli/Abstractions/
+  Bundles/
+    IInstalledBundleWorkloads.cs
+    IExtensionBundleResolver.cs
+```
+
+The only file outside `Bundles/` that knows about bundles is
+`ValidateExtensionBundleInitializationStep` in the `func start`
+pipeline, and it talks to the resolver purely through
+`IExtensionBundleResolver`. No other CT subsystem references types
+under `Bundles/` directly.
+
+This isolation is a soft guarantee that the bundles resolver can
+be lifted into a separate assembly (e.g. an
+`Azure.Functions.Cli.Bundles` library, or back into a `kind:
+workload`-style package) later without touching the rest of CT.
+
 ### 4.4 `func start` responsibilities
 
 `func start` is the only v1 consumer. Its responsibilities:

--- a/proposed/bundles-workload-spec.md
+++ b/proposed/bundles-workload-spec.md
@@ -210,23 +210,23 @@ sub-namespace. Concretely:
 ```
 src/Cli/func/
   Bundles/
-    IExtensionBundleResolver.cs       # (abstraction re-exported)
     ExtensionBundleResolver.cs
     InstalledBundleWorkloads.cs       # IInstalledBundleWorkloads impl
     ExtensionBundleResolution.cs      # result union
     BundleHintBuilder.cs              # §5.4 copy
     BundleTelemetry.cs                # §7 event shape
+    ValidateExtensionBundleInitializationStep.cs  # func start consumer
 src/Cli/Abstractions/
   Bundles/
     IInstalledBundleWorkloads.cs
     IExtensionBundleResolver.cs
 ```
 
-The only file outside `Bundles/` that knows about bundles is
-`ValidateExtensionBundleInitializationStep` in the `func start`
-pipeline, and it talks to the resolver purely through
-`IExtensionBundleResolver`. No other CT subsystem references types
-under `Bundles/` directly.
+`ValidateExtensionBundleInitializationStep` is registered into the
+`func start` initialization pipeline from its usual composition
+root, but the type itself lives under `Bundles/` so the whole
+feature is colocated. No other CT subsystem references types under
+`Bundles/` directly.
 
 This isolation is a soft guarantee that the bundles resolver can
 be lifted into a separate assembly (e.g. an


### PR DESCRIPTION
Adds `proposed/bundles-workload-spec.md`, layered on top of [`workload-spec.md`](./workload-spec.md) and [`cli-profiles.md`](./cli-profiles.md).

## Summary

Defines how Azure Functions extension bundles are resolved and delivered in v5 (vnext) Core Tools.

- **One** workload package, `Azure.Functions.Cli.Workloads.ExtensionBundles` (`kind: workload`). No per-version packages.
- New contribution point `IExtensionBundleProvider` in `Func.Cli.Abstractions`, sibling of `IProjectInitializer`. `func start` is the v1 consumer.
- Resolution = intersection of host.json `extensionBundle.version` and the active profile's range, pick highest installed payload. Offline at start time; CDN only during `func workload install/update`.
- Bundles home: `<workload-home>/bundles` (default `~/.azure-functions/bundles`), override `FUNC_CLI_Bundles__Home` (matches `FUNC_CLI_Workloads__Home` convention).
- `func start` always sets `AzureFunctionsJobHost__extensionBundle__ensureLatest=false` and sets `downloadPath` to the resolved path. No Functions runtime host changes.
- Removes `ExtensionBundleHelper`, `DownloadBundleAction`, `ExtensionBundleConfigurationBuilder`, and the in-CLI bundle download path. `func extensions install` enters the v4→v5 migration map.

## Open questions

Captured in §9 of the spec: whether to expose `func bundles install <version>` via `IExternalCommand`, default payload set policy on fresh install, payload retention/prune policy on update, and telemetry cardinality for constraint range strings.

Targeting the `docs` branch alongside the other proposals.
