### PR TITLE
Bundles workload scaffolding

### DIFF
--- a/Azure.Functions.Cli.slnx
+++ b/Azure.Functions.Cli.slnx
@@ -14,6 +14,9 @@
     <Project Path="src/Workloads/Stacks/Node/Workloads.Node.csproj" />
     <Project Path="src/Workloads/Stacks/Python/Workloads.Python.csproj" />
   </Folder>
+  <Folder Name="/src/Workloads/Tools/">
+    <Project Path="src/Workloads/Tools/ExtensionBundles/Workloads.ExtensionBundles.csproj" />
+  </Folder>
   <Folder Name="/test/">
     <Project Path="test/Func.Tests/Func.Tests.csproj" />
     <Project Path="test/Workloads.Tests.Fixtures.Default/Workloads.Tests.Fixtures.Default.csproj" />
@@ -25,5 +28,8 @@
     <Project Path="test/Workloads/Stacks/Go.Tests/Workloads.Go.Tests.csproj" />
     <Project Path="test/Workloads/Stacks/Node.Tests/Workloads.Node.Tests.csproj" />
     <Project Path="test/Workloads/Stacks/Python.Tests/Workloads.Python.Tests.csproj" />
+  </Folder>
+  <Folder Name="/test/Workloads/Tools/">
+    <Project Path="test/Workloads/Tools/ExtensionBundles.Tests/Workloads.ExtensionBundles.Tests.csproj" />
   </Folder>
 </Solution>

--- a/eng/ci/release/official-release.workload.bundles.yml
+++ b/eng/ci/release/official-release.workload.bundles.yml
@@ -1,0 +1,18 @@
+parameters:
+- name: public
+  displayName: Publish to nuget.org?
+  type: boolean
+  default: false
+
+# Release has no triggers outside of pipeline
+trigger: none
+pr: none
+
+extends:
+  template: /eng/ci/templates/pipelines/release-packages.yml@self
+  parameters:
+    public: ${{ parameters.public }}
+    folder: workloads/bundles
+    projects: |
+      $(Build.SourcesDirectory)/src/Workloads/Tools/ExtensionBundles/Workloads.ExtensionBundles.csproj
+      $(Build.SourcesDirectory)/test/Workloads/Tools/ExtensionBundles.Tests/Workloads.ExtensionBundles.Tests.csproj

--- a/src/Workloads/Tools/ExtensionBundles/Directory.Version.props
+++ b/src/Workloads/Tools/ExtensionBundles/Directory.Version.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionSuffix>preview.1</VersionSuffix>
+  </PropertyGroup>
+</Project>

--- a/src/Workloads/Tools/ExtensionBundles/ExtensionBundlesWorkload.cs
+++ b/src/Workloads/Tools/ExtensionBundles/ExtensionBundlesWorkload.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads;
+
+namespace Azure.Functions.Cli.Workloads.ExtensionBundles;
+
+/// <summary>
+/// Entry point for the extension bundles workload. Resolves bundle payloads
+/// for <c>func start</c> and owns the on-disk bundle cache.
+/// </summary>
+/// <remarks>
+/// Scaffolding only in this release. <see cref="Configure"/> registers no
+/// services yet; the <c>IExtensionBundleProvider</c> contribution point and
+/// the resolver implementation land in a follow-up PR (see the
+/// <a href="https://github.com/Azure/azure-functions-core-tools/blob/docs/proposed/bundles-workload-spec.md">bundles
+/// workload spec</a>).
+/// </remarks>
+internal sealed class ExtensionBundlesWorkload : Workload
+{
+    public override string DisplayName => "Extension Bundles";
+
+    public override string Description =>
+        "Resolves and caches Azure Functions extension bundles for func start.";
+
+    public override void Configure(FunctionsCliBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        // TODO: register IExtensionBundleProvider once the abstraction lands
+        // (see proposed/bundles-workload-spec.md §4.2 and §5).
+    }
+}

--- a/src/Workloads/Tools/ExtensionBundles/ExtensionBundlesWorkload.cs
+++ b/src/Workloads/Tools/ExtensionBundles/ExtensionBundlesWorkload.cs
@@ -7,7 +7,9 @@ namespace Azure.Functions.Cli.Workloads.ExtensionBundles;
 
 /// <summary>
 /// Entry point for the extension bundles workload. Resolves bundle payloads
-/// for <c>func start</c> and owns the on-disk bundle cache.
+/// for the func CLI and owns the on-disk bundle cache. Today's primary
+/// consumer is <c>func start</c>; the contribution point is open to other
+/// commands.
 /// </summary>
 /// <remarks>
 /// Scaffolding only in this release. <see cref="Configure"/> registers no
@@ -21,7 +23,7 @@ internal sealed class ExtensionBundlesWorkload : Workload
     public override string DisplayName => "Extension Bundles";
 
     public override string Description =>
-        "Resolves and caches Azure Functions extension bundles for func start.";
+        "Resolves and caches Azure Functions extension bundles for the func CLI.";
 
     public override void Configure(FunctionsCliBuilder builder)
     {

--- a/src/Workloads/Tools/ExtensionBundles/README.md
+++ b/src/Workloads/Tools/ExtensionBundles/README.md
@@ -1,0 +1,25 @@
+# Azure Functions CLI – Extension Bundles workload
+
+This workload resolves Azure Functions extension bundles for `func start` and
+owns the on-disk bundle payload cache. It is the single acquisition mechanism
+for extension bundles in v5.
+
+## Install
+
+```bash
+func workload install Azure.Functions.Cli.Workloads.ExtensionBundles
+# or by alias
+func workload install bundles
+```
+
+## Status
+
+Preview, scaffolding only. The resolver, on-disk cache, and `func start`
+integration land in a follow-up PR. See the
+[bundles workload spec](https://github.com/Azure/azure-functions-core-tools/blob/docs/proposed/bundles-workload-spec.md).
+
+## Links
+
+- [Azure Functions CLI](https://github.com/Azure/azure-functions-core-tools)
+- [Workload spec](https://github.com/Azure/azure-functions-core-tools/blob/docs/proposed/workload-spec.md)
+- [Bundles workload spec](https://github.com/Azure/azure-functions-core-tools/blob/docs/proposed/bundles-workload-spec.md)

--- a/src/Workloads/Tools/ExtensionBundles/README.md
+++ b/src/Workloads/Tools/ExtensionBundles/README.md
@@ -1,8 +1,10 @@
 # Azure Functions CLI – Extension Bundles workload
 
-This workload resolves Azure Functions extension bundles for `func start` and
-owns the on-disk bundle payload cache. It is the single acquisition mechanism
-for extension bundles in v5.
+This workload resolves Azure Functions extension bundles for the `func` CLI
+and owns the on-disk bundle payload cache. It is the single bundle
+acquisition mechanism in v5. Today's primary consumer is `func start`; the
+contribution point is open to any other command that needs a resolved bundle
+path.
 
 ## Install
 

--- a/src/Workloads/Tools/ExtensionBundles/Workloads.ExtensionBundles.csproj
+++ b/src/Workloads/Tools/ExtensionBundles/Workloads.ExtensionBundles.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Title>Extension Bundles</Title>
+    <Description>Resolves and caches Azure Functions extension bundles for func start.</Description>
+    <PackageType>FuncCliWorkload</PackageType>
+    <PackageTags>kind:workload alias:bundles func-workload</PackageTags>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Azure.Functions.Cli.Workloads.ExtensionBundles.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(SrcRoot)Abstractions/Abstractions.csproj">
+      <PrivateAssets>all</PrivateAssets>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="workload.json" Pack="true" PackagePath="/" />
+    <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="tools/any/" Visible="false" />
+  </ItemGroup>
+
+</Project>

--- a/src/Workloads/Tools/ExtensionBundles/Workloads.ExtensionBundles.csproj
+++ b/src/Workloads/Tools/ExtensionBundles/Workloads.ExtensionBundles.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Title>Extension Bundles</Title>
-    <Description>Resolves and caches Azure Functions extension bundles for func start.</Description>
+    <Description>Resolves and caches Azure Functions extension bundles for the func CLI.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:workload alias:bundles func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workloads/Tools/ExtensionBundles/release_notes.md
+++ b/src/Workloads/Tools/ExtensionBundles/release_notes.md
@@ -1,0 +1,5 @@
+# Azure.Functions.Cli.Workloads.ExtensionBundles
+
+## 1.0.0-preview.1
+
+- Initial scaffold of the extension bundles workload (entry point only; resolver and cache land in a follow-up release).

--- a/src/Workloads/Tools/ExtensionBundles/workload.json
+++ b/src/Workloads/Tools/ExtensionBundles/workload.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
+  "kind": "workload",
+  "entryPoint": {
+    "assemblyPath": "Azure.Functions.Cli.Workloads.ExtensionBundles.dll",
+    "type": "Azure.Functions.Cli.Workloads.ExtensionBundles.ExtensionBundlesWorkload"
+  }
+}

--- a/test/Workloads/Tools/ExtensionBundles.Tests/ExtensionBundlesWorkloadTests.cs
+++ b/test/Workloads/Tools/ExtensionBundles.Tests/ExtensionBundlesWorkloadTests.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Functions.Cli.Workloads.ExtensionBundles.Tests;
+
+public class ExtensionBundlesWorkloadTests
+{
+    [Fact]
+    public void DisplayName_IsSet()
+    {
+        Assert.False(string.IsNullOrWhiteSpace(new ExtensionBundlesWorkload().DisplayName));
+    }
+
+    [Fact]
+    public void Description_IsSet()
+    {
+        Assert.False(string.IsNullOrWhiteSpace(new ExtensionBundlesWorkload().Description));
+    }
+
+    [Fact]
+    public void Configure_NullBuilder_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new ExtensionBundlesWorkload().Configure(null!));
+    }
+
+    [Fact]
+    public void Configure_RegistersNoServicesYet()
+    {
+        // Scaffolding-only: Configure is intentionally a no-op until the
+        // IExtensionBundleProvider abstraction lands in the follow-up PR.
+        ServiceCollection services = new();
+        FunctionsCliBuilder builder = Substitute.For<FunctionsCliBuilder>();
+        builder.Services.Returns(services);
+
+        new ExtensionBundlesWorkload().Configure(builder);
+
+        Assert.Empty(services);
+    }
+}

--- a/test/Workloads/Tools/ExtensionBundles.Tests/Workloads.ExtensionBundles.Tests.csproj
+++ b/test/Workloads/Tools/ExtensionBundles.Tests/Workloads.ExtensionBundles.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(SrcRoot)Workloads/Tools/ExtensionBundles/Workloads.ExtensionBundles.csproj" />
+    <ProjectReference Include="$(SrcRoot)Abstractions/Abstractions.csproj" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
> **Scaffolding only.** No logic, no abstractions, no `func start` changes — those land in a follow-up PR. Opening as **draft** for early visibility.

Stands up the `Azure.Functions.Cli.Workloads.ExtensionBundles` workload project so the resolver/cache implementation (PR 2) has a place to land.

Spec: [`proposed/bundles-workload-spec.md` (PR #5033)](https://github.com/Azure/azure-functions-core-tools/pull/5033). Base: `vnext` (where the workload subsystem lives).

## What's here

- `src/Workloads/Tools/ExtensionBundles/` — new project mirroring `Workloads.Node`:
  - `Workloads.ExtensionBundles.csproj` (`PackageType=FuncCliWorkload`, alias `bundles`, `1.0.0-preview.1` via `Directory.Version.props`)
  - `workload.json` (`kind: workload`, entry-point `ExtensionBundlesWorkload`)
  - `ExtensionBundlesWorkload.cs` — `Workload` subclass with empty `Configure()` and a `TODO` pointing at PR 2
  - `README.md`, `release_notes.md`
- `test/Workloads/Tools/ExtensionBundles.Tests/` — new project with sanity tests (instantiation + `Configure` null/no-op contract). Matches the Node tests layout the CI YAML expects.
- `Azure.Functions.Cli.slnx` — adds both projects under new `Tools/` folders.
- `eng/ci/release/official-release.workload.bundles.yml` — mirror of `...workload.node.yml`; pipeline folder `workloads/bundles`. Pipeline is wired but not triggered until there's something to publish.

## What's deliberately **not** here (lands in PR 2)

- `IExtensionBundleProvider` and the result/context records in `Func.Cli.Abstractions`
- Resolution algorithm (NuGet-style range intersection, installed-payload pick, on-demand fetch fallback)
- On-disk layout under `<bundles-home>` and the `FUNC_CLI_Bundles__Home` override
- CDN download (will be **stubbed** in PR 2, not real)
- Telemetry event wiring (event shape only in PR 2)
- `ValidateExtensionBundleInitializationStep` rewrite and `host.json` parsing
- Hint copy for `EmptyIntersection` / `NoCompatiblePayload`

## Verification

- `dotnet restore && dotnet build` — clean, no warnings.
- `dotnet test` — 4 new + 516 existing tests pass.
- `dotnet pack` produces a valid `.nupkg`:
  ```
  workload.json          ← package root
  tools/any/Azure.Functions.Cli.Workloads.ExtensionBundles.dll
  ```

## Notes

- No `main`-targeted removal PR needed: the legacy `ExtensionBundleHelper`, `DownloadBundleAction`, `BundleActionHelper`, `ExtensionBundleConfigurationBuilder`, and `func extensions install` don't exist on `vnext` (only on `main`).
- The new YAML had to be added with `git add -f` because the repo's `.gitignore` has a `[Rr]elease/` rule (VS template) that matches `eng/ci/release/`. Existing release YAMLs are tracked the same way.
