### PR TITLE
Bump dotnet templates version to 4.0.5569

### DIFF
--- a/eng/build/Templates.targets
+++ b/eng/build/Templates.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <TemplatesVersion>4.0.5544</TemplatesVersion>
+    <TemplatesVersion>4.0.5569</TemplatesVersion>
     <TemplatesJsonVersion>3.1.1648</TemplatesJsonVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Bumps `TemplatesVersion` in `eng/build/Templates.targets` from `4.0.5544` to `4.0.5569` to pick up the latest released [azure-functions-templates](https://github.com/Azure/azure-functions-templates) NuGet packages.

Replaces #5034 (same commit, moved off fork to upstream branch).