### PR TITLE
Prep release 4.12.0-preview.1

### DIFF
--- a/eng/ci/templates/jobs/test-e2e-linux.yml
+++ b/eng/ci/templates/jobs/test-e2e-linux.yml
@@ -32,6 +32,16 @@ jobs:
   steps:
   - template: /eng/ci/templates/steps/install-tools.yml@self
 
+  # The 1es-ubuntu-24.04-min image doesn't ship npm. NodeTool@0 in install-tools.yml
+  # installs Node into the agent user's tool cache, but start-emulators.ps1 runs
+  # `sudo npm install -g azurite` and sudo's PATH doesn't include the tool cache.
+  # Install npm system-wide via apt so azurite can be installed and launched as root.
+  - bash: |
+      sudo apt-get update
+      sudo apt-get install -y npm
+      npm --version
+    displayName: 'Install npm'
+
   - pwsh: ./eng/scripts/start-emulators.ps1
     displayName: 'Start emulators (NoWait)'
 

--- a/eng/ci/templates/public/jobs/test-unit-linux.yml
+++ b/eng/ci/templates/public/jobs/test-unit-linux.yml
@@ -19,9 +19,15 @@ jobs:
       sudo apt-get -y install fuse-zip
     displayName: 'Install fuse-zip'
 
-  - task: GoTool@0
-    inputs:
-      version: '1.24.2'
+  - script: |
+      set -e
+      VERSION=1.24.2
+      ARCHIVE=go${VERSION}.linux-amd64.tar.gz
+      DEST="$AGENT_TOOLSDIRECTORY/go-${VERSION}"
+      mkdir -p "$DEST"
+      curl -fsSL "https://go.dev/dl/${ARCHIVE}" -o "$AGENT_TEMPDIRECTORY/${ARCHIVE}"
+      tar -C "$DEST" -xzf "$AGENT_TEMPDIRECTORY/${ARCHIVE}"
+      echo "##vso[task.prependpath]$DEST/go/bin"
     displayName: 'Install Go 1.24.2'
 
   - template: /eng/ci/templates/steps/install-tools.yml@self

--- a/eng/ci/templates/steps/install-tools.yml
+++ b/eng/ci/templates/steps/install-tools.yml
@@ -39,13 +39,31 @@ steps:
     packageType: sdk
     useGlobalJson: true
 
-- task: GoTool@0
-  inputs:
-    version: '1.24.2'
+- pwsh: |
+    $version = '1.24.2'
+    $isWindows = $IsWindows
+    if ($isWindows) {
+      $archive = "go$version.windows-amd64.zip"
+      $url = "https://go.dev/dl/$archive"
+      $dest = Join-Path $env:AGENT_TOOLSDIRECTORY "go-$version"
+      New-Item -ItemType Directory -Force -Path $dest | Out-Null
+      $zipPath = Join-Path $env:AGENT_TEMPDIRECTORY $archive
+      Invoke-WebRequest -Uri $url -OutFile $zipPath
+      Expand-Archive -Path $zipPath -DestinationPath $dest -Force
+      $goBin = Join-Path $dest 'go\bin'
+    } else {
+      $archive = "go$version.linux-amd64.tar.gz"
+      $url = "https://go.dev/dl/$archive"
+      $dest = Join-Path $env:AGENT_TOOLSDIRECTORY "go-$version"
+      New-Item -ItemType Directory -Force -Path $dest | Out-Null
+      $tarPath = Join-Path $env:AGENT_TEMPDIRECTORY $archive
+      Invoke-WebRequest -Uri $url -OutFile $tarPath
+      & tar -C $dest -xzf $tarPath
+      $goBin = Join-Path $dest 'go/bin'
+    }
+    Write-Host "##vso[task.prependpath]$goBin"
+    Write-Host "Installed Go $version to $goBin"
   displayName: 'Install Go 1.24.2'
-  # Skip on macOS: GoTool@0 only ships an amd64 Go binary, which fails to
-  # execute on Apple Silicon agents (macOS-latest is arm64). It also exports
-  # GOROOT pointing at its own toolchain, which conflicts with the brew
-  # Go we install in the macOS E2E job (test-e2e-osx.yml). Mac jobs that
-  # need Go install it via Homebrew themselves.
+  # Skip on macOS: macOS-latest is arm64 (Apple Silicon). Mac jobs that need
+  # Go install it via Homebrew themselves (see test-e2e-osx.yml).
   condition: ne(variables['Agent.OS'], 'Darwin')

--- a/eng/ci/templates/steps/install-tools.yml
+++ b/eng/ci/templates/steps/install-tools.yml
@@ -41,8 +41,7 @@ steps:
 
 - pwsh: |
     $version = '1.24.2'
-    $isWindows = $IsWindows
-    if ($isWindows) {
+    if ($IsWindows) {
       $archive = "go$version.windows-amd64.zip"
       $url = "https://go.dev/dl/$archive"
       $dest = Join-Path $env:AGENT_TOOLSDIRECTORY "go-$version"

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,4 +1,4 @@
-# Azure Functions CLI 4.10.0
+# Azure Functions CLI 4.12.0-preview.1
 
 #### Host Version
 
@@ -9,10 +9,4 @@
 
 #### Changes
 
-- Fix `func pack` throwing cryptic `Unsupported runtime: None` when `local.settings.json` is absent and `FUNCTIONS_WORKER_RUNTIME` is not set (#4829)
-- Mark Node.js 24 as GA in stacks.json (add Flex Consumption SKU) (#4867)
-- Surface SSL/TLS certificate errors clearly when SSL inspection proxies intercept connections (#4857)
-- Fix `func kubernetes deploy` race condition where `kubectl rollout status` ran before the Deployment was registered (#4919)
-- Fix `func kubernetes delete` to honor `--no-docker` instead of failing on registry auth (#4919)
-- Add `McpPromptTrigger` template for dotnet-isolated `func new` (#4891)
-- Fix func azure storage fetch-connection-string failing with "Cannot find storage account" due to ARM eventual consistency (#4884)
+- Add Go language support to `func init`, `func start`, `func pack`, and `func publish` (#4875, #4892, #4943)

--- a/src/Cli/func/Directory.Version.props
+++ b/src/Cli/func/Directory.Version.props
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>4.10.0</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
+    <VersionPrefix>4.12.0</VersionPrefix>
+    <VersionSuffix>preview.1</VersionSuffix>
     <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>
 

--- a/test/Cli/Func.E2ETests/Commands/FuncInit/GoInitTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncInit/GoInitTests.cs
@@ -1,11 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using AwesomeAssertions;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.E2ETests.Traits;
 using Azure.Functions.Cli.TestFramework.Assertions;
 using Azure.Functions.Cli.TestFramework.Commands;
-using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/Cli/Func.E2ETests/Commands/FuncNew/GoFuncNewTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncNew/GoFuncNewTests.cs
@@ -1,10 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using AwesomeAssertions;
 using Azure.Functions.Cli.E2ETests.Traits;
 using Azure.Functions.Cli.TestFramework.Assertions;
 using Azure.Functions.Cli.TestFramework.Commands;
-using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/Cli/Func.UnitTests/ActionsTests/InitActionGoTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/InitActionGoTests.cs
@@ -2,12 +2,12 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.IO.Abstractions;
+using AwesomeAssertions;
 using Azure.Functions.Cli.Actions.LocalActions;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.ConfigurationProfiles;
 using Azure.Functions.Cli.Helpers;
 using Azure.Functions.Cli.Interfaces;
-using FluentAssertions;
 using NSubstitute;
 using Xunit;
 

--- a/test/Cli/Func.UnitTests/ActionsTests/PackAction/GoPackResolveOutputPathTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/PackAction/GoPackResolveOutputPathTests.cs
@@ -1,9 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using AwesomeAssertions;
 using Azure.Functions.Cli.Actions.LocalActions.PackAction;
 using Azure.Functions.Cli.Common;
-using FluentAssertions;
 using Xunit;
 
 namespace Azure.Functions.Cli.UnitTests.ActionsTests.PackAction

--- a/test/Cli/Func.UnitTests/ActionsTests/PackAction/GoPackSubcommandActionTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/PackAction/GoPackSubcommandActionTests.cs
@@ -1,9 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using AwesomeAssertions;
 using Azure.Functions.Cli.Actions.LocalActions.PackAction;
 using Azure.Functions.Cli.Common;
-using FluentAssertions;
 using Xunit;
 
 namespace Azure.Functions.Cli.UnitTests.ActionsTests.PackAction

--- a/test/Cli/Func.UnitTests/CommonTests/ExecutableTests.cs
+++ b/test/Cli/Func.UnitTests/CommonTests/ExecutableTests.cs
@@ -3,8 +3,8 @@
 
 using System.Runtime.InteropServices;
 using System.Text;
+using AwesomeAssertions;
 using Azure.Functions.Cli.Common;
-using FluentAssertions;
 using Xunit;
 
 namespace Azure.Functions.Cli.UnitTests.CommonTests

--- a/test/Cli/Func.UnitTests/HelperTests/GoHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/GoHelperTests.cs
@@ -3,9 +3,9 @@
 
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using AwesomeAssertions;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Helpers;
-using FluentAssertions;
 using Xunit;
 
 namespace Azure.Functions.Cli.UnitTests.HelperTests
@@ -27,7 +27,7 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
             WorkerLanguageVersionInfo worker = await GoHelpers.GetEnvironmentGoVersion();
 
             worker.Should().NotBeNull();
-            worker.Major.Should().BeGreaterOrEqualTo(1, "Go major version should be at least 1");
+            worker.Major.Should().BeGreaterThanOrEqualTo(1, "Go major version should be at least 1");
         }
 
         [SkipIfGoNonExistFact]

--- a/test/Cli/Func.UnitTests/HelperTests/ZipHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/ZipHelperTests.cs
@@ -36,8 +36,10 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
             {
                 if (_isCI)
                 {
-                    // copy the windows-built linux zip so we can include it in ci artifacts for validation on linux
-                    File.Copy(linuxZip, Path.Combine(Directory.GetCurrentDirectory(), "ZippedOnWindows.zip"), true);
+                    // Copy the windows-built linux zip so we can include it in CI artifacts for
+                    // validation on Linux. Use a deterministic repo-relative path because the
+                    // VSTest runner's working directory varies across SDK versions.
+                    File.Copy(linuxZip, Path.Combine(GetUnitTestsOutputDir(), "ZippedOnWindows.zip"), true);
                 }
 
                 VerifyWindowsZip(windowsZip);
@@ -60,6 +62,18 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
             {
                 throw new Exception("Unsupported OS");
             }
+        }
+
+        private static string GetUnitTestsOutputDir()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Azure.Functions.Cli.sln")))
+            {
+                dir = dir.Parent;
+            }
+
+            Assert.True(dir is not null, "Could not find repo root (Azure.Functions.Cli.sln).");
+            return Path.Combine(dir!.FullName, "out", "bin", "Azure.Functions.Cli.UnitTests", "debug");
         }
 
         private async Task<string> BuildAndCopyFileToZipAsync(string rid)


### PR DESCRIPTION
Bumps Core Tools to `4.11.0-preview.1` for the `feature/go-support` branch.

### Changes
- `VersionPrefix` → `4.11.0`, `VersionSuffix` → `preview.1` in `src/Cli/func/Directory.Version.props`
- Reset `release_notes.md` for the preview, listing Go support for `func init`, `func start`, `func pack`, and `func publish`

Host version is unchanged from 4.10.0, so no worker version updates are required.