### PR TITLE
Release prep 4.11.0

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,4 +1,4 @@
-# Azure Functions CLI 4.10.0
+# Azure Functions CLI 4.11.0
 
 #### Host Version
 

--- a/src/Cli/func/Directory.Version.props
+++ b/src/Cli/func/Directory.Version.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>4.10.0</VersionPrefix>
+    <VersionPrefix>4.11.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>


### PR DESCRIPTION
Bumps Core Tools version to `4.11.0`.

### Changes
- `src/Cli/func/Directory.Version.props`: `4.10.0` → `4.11.0`
- `release_notes.md`: header updated to `4.11.0`

Host version is unchanged.