### PR TITLE
Scaffold Node, Python, Go worker content workloads

### DIFF
--- a/Azure.Functions.Cli.slnx
+++ b/Azure.Functions.Cli.slnx
@@ -18,6 +18,11 @@
   <Folder Name="/src/Workloads/Tools/">
     <Project Path="src/Workloads/Tools/ExtensionBundles/Workloads.ExtensionBundles.csproj" />
   </Folder>
+  <Folder Name="/src/Workloads/Workers/">
+    <Project Path="src/Workloads/Workers/Go/Workloads.Workers.Go.csproj" />
+    <Project Path="src/Workloads/Workers/Node/Workloads.Workers.Node.csproj" />
+    <Project Path="src/Workloads/Workers/Python/Workloads.Workers.Python.csproj" />
+  </Folder>
   <Folder Name="/test/">
     <Project Path="test/Fixtures/Workloads.Tests.Fixtures.Default/Workloads.Tests.Fixtures.Default.csproj" />
     <Project Path="test/Fixtures/Workloads.Tests.Fixtures.Sdk/Workloads.Tests.Fixtures.Sdk.csproj" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -3,7 +3,7 @@
   <packageSources>
     <clear />
     <add key="infra" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/infra/nuget/v3/index.json" />
-    <add key="AzureFunctions" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctions/nuget/v3/index.json" />
+    <add key="AzureFunctionsRelease" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsRelease/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -3,6 +3,7 @@
   <packageSources>
     <clear />
     <add key="infra" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/infra/nuget/v3/index.json" />
+    <add key="AzureFunctions" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctions/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/eng/build/Packages.props
+++ b/eng/build/Packages.props
@@ -24,6 +24,11 @@
   <ItemGroup>
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
   </ItemGroup>
+  <!-- language workers -->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.13.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.PythonWorker" Version="4.43.0" />
+  </ItemGroup>
   <!-- test projects -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />

--- a/src/Workloads/Workers/Go/Directory.Version.props
+++ b/src/Workloads/Workers/Go/Directory.Version.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionSuffix>preview.1</VersionSuffix>
+  </PropertyGroup>
+</Project>

--- a/src/Workloads/Workers/Go/README.md
+++ b/src/Workloads/Workers/Go/README.md
@@ -1,0 +1,18 @@
+# Azure Functions CLI – Go worker workload
+
+Content workload that ships the Go worker assets (a static `worker.config.json`
+plus any supporting files) consumed by the Azure Functions CLI host.
+
+## Install
+
+```bash
+func workload install Azure.Functions.Cli.Workloads.Workers.Go
+# or by alias
+func workload install go-worker
+```
+
+## Status
+
+Preview. Go has no upstream worker NuGet; drop the static worker config and
+related assets into `content/` and they will be packed under `content/` in the
+resulting NuGet.

--- a/src/Workloads/Workers/Go/Workloads.Workers.Go.csproj
+++ b/src/Workloads/Workers/Go/Workloads.Workers.Go.csproj
@@ -5,7 +5,7 @@
     <Title>Azure Functions CLI Go Language Worker</Title>
     <Description>Azure Functions CLI content workload that ships the Go worker assets (static worker config).</Description>
     <PackageType>FuncCliWorkload</PackageType>
-    <PackageTags>kind:content alias:go-worker func-workload</PackageTags>
+    <PackageTags>kind:content alias:go-worker func-worker func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>

--- a/src/Workloads/Workers/Go/Workloads.Workers.Go.csproj
+++ b/src/Workloads/Workers/Go/Workloads.Workers.Go.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Title>Go worker</Title>
+    <Title>Azure Functions CLI Go Language Worker</Title>
     <Description>Azure Functions CLI content workload that ships the Go worker assets (static worker config).</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:content alias:go-worker func-workload</PackageTags>

--- a/src/Workloads/Workers/Go/Workloads.Workers.Go.csproj
+++ b/src/Workloads/Workers/Go/Workloads.Workers.Go.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Title>Go worker</Title>
+    <Description>Azure Functions CLI content workload that ships the Go worker assets (static worker config).</Description>
+    <PackageType>FuncCliWorkload</PackageType>
+    <PackageTags>kind:content alias:go-worker func-workload</PackageTags>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="workload.json" Pack="true" PackagePath="/" />
+    <Content Include="content/**" Pack="true" PackagePath="content/" />
+  </ItemGroup>
+
+</Project>

--- a/src/Workloads/Workers/Go/content/PLACEHOLDER.md
+++ b/src/Workloads/Workers/Go/content/PLACEHOLDER.md
@@ -1,0 +1,1 @@
+Placeholder so the `content/` folder is tracked in git. Worker assets land here.

--- a/src/Workloads/Workers/Go/release_notes.md
+++ b/src/Workloads/Workers/Go/release_notes.md
@@ -1,0 +1,5 @@
+# Azure.Functions.Cli.Workloads.Workers.Go
+
+## 1.0.0-preview.1
+
+- Initial scaffold of the Go worker content workload.

--- a/src/Workloads/Workers/Go/workload.json
+++ b/src/Workloads/Workers/Go/workload.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
+  "kind": "content"
+}

--- a/src/Workloads/Workers/Node/Directory.Version.props
+++ b/src/Workloads/Workers/Node/Directory.Version.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionSuffix>preview.1</VersionSuffix>
+  </PropertyGroup>
+</Project>

--- a/src/Workloads/Workers/Node/README.md
+++ b/src/Workloads/Workers/Node/README.md
@@ -1,0 +1,18 @@
+# Azure Functions CLI – Node.js worker workload
+
+Content workload that ships the Node.js language worker payload consumed by the
+Azure Functions CLI host.
+
+## Install
+
+```bash
+func workload install Azure.Functions.Cli.Workloads.Workers.Node
+# or by alias
+func workload install node-worker
+```
+
+## Status
+
+Preview. Worker assets are sourced from the
+`Microsoft.Azure.Functions.NodeJsWorker` NuGet package. The `content/` folder
+is the placeholder where the worker payload is staged before packing.

--- a/src/Workloads/Workers/Node/Workloads.Workers.Node.csproj
+++ b/src/Workloads/Workers/Node/Workloads.Workers.Node.csproj
@@ -5,7 +5,7 @@
     <Title>Azure Functions CLI Node.js Language Worker</Title>
     <Description>Azure Functions CLI content workload that ships the Node.js language worker.</Description>
     <PackageType>FuncCliWorkload</PackageType>
-    <PackageTags>kind:content alias:node-worker func-workload</PackageTags>
+    <PackageTags>kind:content alias:node-worker func-worker func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>

--- a/src/Workloads/Workers/Node/Workloads.Workers.Node.csproj
+++ b/src/Workloads/Workers/Node/Workloads.Workers.Node.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Title>Node.js worker</Title>
+    <Title>Azure Functions CLI Node.js Language Worker</Title>
     <Description>Azure Functions CLI content workload that ships the Node.js language worker.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:content alias:node-worker func-workload</PackageTags>

--- a/src/Workloads/Workers/Node/Workloads.Workers.Node.csproj
+++ b/src/Workloads/Workers/Node/Workloads.Workers.Node.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Title>Node.js worker</Title>
+    <Description>Azure Functions CLI content workload that ships the Node.js language worker.</Description>
+    <PackageType>FuncCliWorkload</PackageType>
+    <PackageTags>kind:content alias:node-worker func-workload</PackageTags>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker">
+      <PrivateAssets>all</PrivateAssets>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="workload.json" Pack="true" PackagePath="/" />
+    <Content Include="content/**" Pack="true" PackagePath="content/" />
+  </ItemGroup>
+
+</Project>

--- a/src/Workloads/Workers/Node/content/PLACEHOLDER.md
+++ b/src/Workloads/Workers/Node/content/PLACEHOLDER.md
@@ -1,0 +1,1 @@
+Placeholder so the `content/` folder is tracked in git. Worker assets land here.

--- a/src/Workloads/Workers/Node/release_notes.md
+++ b/src/Workloads/Workers/Node/release_notes.md
@@ -1,0 +1,5 @@
+# Azure.Functions.Cli.Workloads.Workers.Node
+
+## 1.0.0-preview.1
+
+- Initial scaffold of the Node worker content workload.

--- a/src/Workloads/Workers/Node/workload.json
+++ b/src/Workloads/Workers/Node/workload.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
+  "kind": "content"
+}

--- a/src/Workloads/Workers/Python/Directory.Version.props
+++ b/src/Workloads/Workers/Python/Directory.Version.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionSuffix>preview.1</VersionSuffix>
+  </PropertyGroup>
+</Project>

--- a/src/Workloads/Workers/Python/README.md
+++ b/src/Workloads/Workers/Python/README.md
@@ -1,0 +1,18 @@
+# Azure Functions CLI – Python worker workload
+
+Content workload that ships the Python language worker payload consumed by the
+Azure Functions CLI host.
+
+## Install
+
+```bash
+func workload install Azure.Functions.Cli.Workloads.Workers.Python
+# or by alias
+func workload install python-worker
+```
+
+## Status
+
+Preview. Worker assets are sourced from the
+`Microsoft.Azure.Functions.PythonWorker` NuGet package. The `content/` folder
+is the placeholder where the worker payload is staged before packing.

--- a/src/Workloads/Workers/Python/Workloads.Workers.Python.csproj
+++ b/src/Workloads/Workers/Python/Workloads.Workers.Python.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Title>Python worker</Title>
+    <Title>Azure Functions CLI Python Language Worker</Title>
     <Description>Azure Functions CLI content workload that ships the Python language worker.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:content alias:python-worker func-workload</PackageTags>

--- a/src/Workloads/Workers/Python/Workloads.Workers.Python.csproj
+++ b/src/Workloads/Workers/Python/Workloads.Workers.Python.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Title>Python worker</Title>
+    <Description>Azure Functions CLI content workload that ships the Python language worker.</Description>
+    <PackageType>FuncCliWorkload</PackageType>
+    <PackageTags>kind:content alias:python-worker func-workload</PackageTags>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker">
+      <PrivateAssets>all</PrivateAssets>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="workload.json" Pack="true" PackagePath="/" />
+    <Content Include="content/**" Pack="true" PackagePath="content/" />
+  </ItemGroup>
+
+</Project>

--- a/src/Workloads/Workers/Python/Workloads.Workers.Python.csproj
+++ b/src/Workloads/Workers/Python/Workloads.Workers.Python.csproj
@@ -5,7 +5,7 @@
     <Title>Azure Functions CLI Python Language Worker</Title>
     <Description>Azure Functions CLI content workload that ships the Python language worker.</Description>
     <PackageType>FuncCliWorkload</PackageType>
-    <PackageTags>kind:content alias:python-worker func-workload</PackageTags>
+    <PackageTags>kind:content alias:python-worker func-worker func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>

--- a/src/Workloads/Workers/Python/content/PLACEHOLDER.md
+++ b/src/Workloads/Workers/Python/content/PLACEHOLDER.md
@@ -1,0 +1,1 @@
+Placeholder so the `content/` folder is tracked in git. Worker assets land here.

--- a/src/Workloads/Workers/Python/release_notes.md
+++ b/src/Workloads/Workers/Python/release_notes.md
@@ -1,0 +1,5 @@
+# Azure.Functions.Cli.Workloads.Workers.Python
+
+## 1.0.0-preview.1
+
+- Initial scaffold of the Python worker content workload.

--- a/src/Workloads/Workers/Python/workload.json
+++ b/src/Workloads/Workers/Python/workload.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
+  "kind": "content"
+}


### PR DESCRIPTION
Scaffolds three worker content workloads under `src/Workloads/Workers/`, following the existing `src/Workloads/Stacks/` and `src/Workloads/Tools/` pattern:

| Project | Assembly / PackageId | Worker source |
| --- | --- | --- |
| `Workers/Node` | `Azure.Functions.Cli.Workloads.Workers.Node` | `Microsoft.Azure.Functions.NodeJsWorker` PackageReference |
| `Workers/Python` | `Azure.Functions.Cli.Workloads.Workers.Python` | `Microsoft.Azure.Functions.PythonWorker` PackageReference |
| `Workers/Go` | `Azure.Functions.Cli.Workloads.Workers.Go` | Empty `content/` folder, ready for the static `worker.config.json` and supporting assets |

Each project mirrors the existing workload conventions:

- `Workloads.Workers.<Stack>.csproj` with `PackageType=FuncCliWorkload`, `PackageTags="kind:content alias:<stack>-worker func-workload"`, `IncludeBuildOutput=false`, `SuppressDependenciesWhenPacking=true`.
- `workload.json` with `"kind": "content"` (no entry-point, no code).
- `Directory.Version.props` (`1.0.0-preview.1`).
- `release_notes.md` and `README.md` placeholders.
- `content/` folder packed to `content/` in the resulting `.nupkg`.

Also:

- Adds `Microsoft.Azure.Functions.NodeJsWorker` (`3.13.0`) and `Microsoft.Azure.Functions.PythonWorker` (`4.43.0`) to `eng/build/Packages.props`.
- Wires the three projects into `Azure.Functions.Cli.slnx` under a new `/src/Workloads/Workers/` solution folder.

Dotnet is intentionally omitted, isolated .NET ships the worker as part of the user's compiled app and in-proc is hosted by the Functions host directly, so there's no separate worker payload to package.

Verified `dotnet build` and `dotnet pack` succeed locally for all three projects; the Go `.nupkg` packs `workload.json` and `README.md` at the root and is ready to receive content under `content/`.