### PR TITLE
Cancel in-progress PR validation runs on new commits

### DIFF
--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -9,6 +9,7 @@ schedules:
 trigger: none
 
 pr:
+  autoCancel: true
   branches:
     include:
     - release_4.0


### PR DESCRIPTION
Sets `autoCancel: true` on the `pr` trigger in `eng/ci/public-build.yml` so that pushing a new commit to a PR cancels the in-progress validation run for the prior commit instead of letting them stack and consume pool resources.

Companion PR targets `vnext` with the same change.