### PR TITLE
Cancel in-progress PR validation runs on new commits

### DIFF
--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -10,6 +10,7 @@ schedules:
 trigger: none
 
 pr:
+  autoCancel: true
   branches:
     include:
     - main


### PR DESCRIPTION
Sets `autoCancel: true` on the `pr` trigger in `eng/ci/public-build.yml` so that pushing a new commit to a PR cancels the in-progress validation run for the prior commit instead of letting them stack and consume pool resources.

Companion PR for `main`: https://github.com/Azure/azure-functions-core-tools/pull/new/liliankasem/liliankasem-ci-autocancel-pr