### PR TITLE
Require a stack workload to run `init`

### DIFF
--- a/src/Abstractions/Projects/ProjectFiles.cs
+++ b/src/Abstractions/Projects/ProjectFiles.cs
@@ -12,6 +12,11 @@ namespace Azure.Functions.Cli.Projects;
 /// </summary>
 public static class ProjectFiles
 {
+    /// <summary>
+    /// The minimal host.json content written during project initialization.
+    /// </summary>
+    public const string MinimalHostJson = "{\n  \"version\": \"2.0\"\n}\n";
+
     private static readonly JsonSerializerOptions _writeOptions = new()
     {
         WriteIndented = true,

--- a/src/Func/Commands/InitCommand.cs
+++ b/src/Func/Commands/InitCommand.cs
@@ -120,38 +120,23 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
             return 1;
         }
 
-        InitializerSelection selection = await SelectInitializerAsync(requestedStack, cancellationToken);
+        IProjectInitializer? initializer = await SelectInitializerAsync(requestedStack, cancellationToken);
 
-        if (selection.Initializer is not null)
+        if (initializer is null)
         {
-            (string? resolved, int? errorCode) = await ResolveLanguageAsync(language, selection.Initializer, cancellationToken);
-            if (errorCode is int code)
-            {
-                return code;
-            }
-
-            language = resolved;
+            return 1;
         }
 
-        // Always lay down the host-owned skeleton so a folder is usable even
-        // when no initializer runs. Workload initializers layer their files
-        // on top after this point.
-        WriteHostJson(workingDirectory.Info, force);
-        WriteCliConfigurationFile(workingDirectory.Info, selection.Initializer?.Stack, language, force);
+        (string? resolved, int? errorCode) = await ResolveLanguageAsync(language, initializer, cancellationToken);
+        if (errorCode is int code)
+        {
+            return code;
+        }
+
+        language = resolved;
+
+        WriteCliConfigurationFile(workingDirectory.Info, initializer.Stack, language, force);
         _interaction.WriteBlankLine();
-
-        if (selection.Initializer is null)
-        {
-            _hintRenderer.Render(selection.Hint!);
-            return 0;
-        }
-
-        if (selection.Hint is not null)
-        {
-            // Auto-select info line, rendered before initializer output so
-            // the user sees why this stack was chosen.
-            _hintRenderer.Render(selection.Hint);
-        }
 
         var context = new InitContext(
             WorkingDirectory: workingDirectory,
@@ -159,12 +144,12 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
             Language: language,
             Force: force);
 
-        await selection.Initializer.InitializeAsync(context, parseResult, cancellationToken);
+        await initializer.InitializeAsync(context, parseResult, cancellationToken);
 
         _interaction.WriteLine(l => l
             .Success("✓ ")
             .Muted("Project initialized for ")
-            .Code(selection.Initializer.Stack)
+            .Code(initializer.Stack)
             .Muted("."));
 
         return 0;
@@ -210,38 +195,6 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
 
         existingFile = string.Empty;
         return false;
-    }
-
-    private void WriteHostJson(DirectoryInfo workingDirectory, bool force)
-    {
-        string path = Path.Combine(workingDirectory.FullName, "host.json");
-
-        // Treat an existing file as user-owned unless --force was passed.
-        // Workloads that need extensionBundle / logging defaults will merge
-        // into the file we just wrote (or the user's existing one).
-        if (File.Exists(path) && !force)
-        {
-            return;
-        }
-
-        try
-        {
-            const string MinimalHostJson = "{\n  \"version\": \"2.0\"\n}\n";
-            File.WriteAllText(path, MinimalHostJson);
-
-            _interaction.WriteLine(l => l
-                .Muted("· Wrote ")
-                .Code("host.json")
-                .Muted("."));
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-        {
-            _interaction.WriteLine(l => l
-                .Warning("! ")
-                .Muted("Could not write host.json (")
-                .Code(ex.Message)
-                .Muted(")."));
-        }
     }
 
     private void WriteCliConfigurationFile(DirectoryInfo workingDirectory, string? stack, string? language, bool force)
@@ -346,48 +299,46 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
         return (picked.ToLowerInvariant(), null);
     }
 
-    private async Task<InitializerSelection> SelectInitializerAsync(string? requestedStack, CancellationToken cancellationToken)
+    private async Task<IProjectInitializer?> SelectInitializerAsync(string? requestedStack, CancellationToken cancellationToken)
     {
         string[] installed = [.. _initializers.Select(i => i.Stack)];
 
         if (_initializers.Count == 0)
         {
-            return InitializerSelection.MissOnly(new WorkloadHint(
+            _hintRenderer.Render(new WorkloadHint(
                 WorkloadHintKind.NoWorkloadsInstalled, "initialize a project", null, installed));
+            return null;
         }
 
         if (!string.IsNullOrEmpty(requestedStack))
         {
             IProjectInitializer? match = _initializers.FirstOrDefault(i =>
                 string.Equals(i.Stack, requestedStack, StringComparison.OrdinalIgnoreCase));
-            return match is not null
-                ? InitializerSelection.Picked(match)
-                : InitializerSelection.MissOnly(new WorkloadHint(
-                    WorkloadHintKind.NoMatchingStack, "initialize a project", requestedStack, installed));
+            if (match is not null)
+            {
+                return match;
+            }
+
+            _hintRenderer.Render(new WorkloadHint(
+                WorkloadHintKind.NoMatchingStack, "initialize a project", requestedStack, installed));
+            return null;
         }
 
-        // No stack specified: auto-select if there's only one initializer
-        // installed (the common case for engineers using a single language).
-        // Surface an info line so the user knows why this stack was picked.
+        // No --stack specified: auto-select when there's only one initializer.
         if (_initializers.Count == 1)
         {
             IProjectInitializer sole = _initializers[0];
-            return InitializerSelection.PickedWithHint(
-                sole,
-                new WorkloadHint(
-                    WorkloadHintKind.AutoSelectedSoleWorkload,
-                    "initialize a project",
-                    sole.Stack,
-                    installed));
+            _hintRenderer.Render(new WorkloadHint(
+                WorkloadHintKind.AutoSelectedSoleWorkload, "initialize a project", sole.Stack, installed));
+            return sole;
         }
 
-        // Multiple initializers, non-interactive: bootstrap the skeleton and
-        // tell the user to re-run with --stack. Scripts get a clear next-step
-        // hint instead of a silently-picked first option.
+        // Multiple initializers, non-interactive: tell the user to re-run with --stack.
         if (!_interaction.IsInteractive)
         {
-            return InitializerSelection.MissOnly(new WorkloadHint(
+            _hintRenderer.Render(new WorkloadHint(
                 WorkloadHintKind.AmbiguousStackChoice, "initialize a project", null, installed));
+            return null;
         }
 
         // Multiple initializers, interactive: prompt.
@@ -397,19 +348,6 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
             choices,
             cancellationToken);
 
-        IProjectInitializer? promptedMatch = _initializers.FirstOrDefault(i => i.Stack == picked);
-        return promptedMatch is not null
-            ? InitializerSelection.Picked(promptedMatch)
-            : InitializerSelection.MissOnly(new WorkloadHint(
-                WorkloadHintKind.AmbiguousStackChoice, "initialize a project", null, installed));
-    }
-
-    private readonly record struct InitializerSelection(IProjectInitializer? Initializer, WorkloadHint? Hint)
-    {
-        public static InitializerSelection Picked(IProjectInitializer initializer) => new(initializer, null);
-
-        public static InitializerSelection PickedWithHint(IProjectInitializer initializer, WorkloadHint hint) => new(initializer, hint);
-
-        public static InitializerSelection MissOnly(WorkloadHint hint) => new(null, hint);
+        return _initializers.FirstOrDefault(i => i.Stack == picked);
     }
 }

--- a/src/Workloads/Stacks/Go/GoProjectInitializer.cs
+++ b/src/Workloads/Stacks/Go/GoProjectInitializer.cs
@@ -49,6 +49,11 @@ internal sealed class GoProjectInitializer : IProjectInitializer
         string moduleName = ResolveModuleName(context);
 
         ProjectFiles.WriteIfMissing(
+            Path.Combine(root, "host.json"),
+            ProjectFiles.MinimalHostJson,
+            force);
+
+        ProjectFiles.WriteIfMissing(
             Path.Combine(root, "go.mod"),
             // TODO: revisit how the Go worker version is pinned. Go modules
             // don't support relaxed ranges (e.g. `1.x`), so today we hard-pin

--- a/src/Workloads/Stacks/Node/NodeProjectInitializer.cs
+++ b/src/Workloads/Stacks/Node/NodeProjectInitializer.cs
@@ -99,6 +99,13 @@ internal sealed class NodeProjectInitializer : IProjectInitializer
 
         Directory.CreateDirectory(Path.Combine(root, "src", "functions"));
 
+        // Always lay down the base host.json so the project is valid even
+        // with --no-bundle. MergeHostJson below layers extensionBundle on top.
+        ProjectFiles.WriteIfMissing(
+            Path.Combine(root, "host.json"),
+            ProjectFiles.MinimalHostJson,
+            force);
+
         if (!noBundle)
         {
             ProjectFiles.MergeHostJson(

--- a/src/Workloads/Stacks/Python/PythonProjectInitializer.cs
+++ b/src/Workloads/Stacks/Python/PythonProjectInitializer.cs
@@ -73,6 +73,13 @@ internal sealed class PythonProjectInitializer : IProjectInitializer
             ProjectFiles.ReadTemplate(_assembly, "local.settings.json"),
             force);
 
+        // Always lay down the base host.json so the project is valid even
+        // with --no-bundle. MergeHostJson below layers extensionBundle on top.
+        ProjectFiles.WriteIfMissing(
+            Path.Combine(root, "host.json"),
+            ProjectFiles.MinimalHostJson,
+            force);
+
         if (!noBundle)
         {
             ProjectFiles.MergeHostJson(

--- a/test/Func.Tests/Commands/InitCommandTests.cs
+++ b/test/Func.Tests/Commands/InitCommandTests.cs
@@ -53,9 +53,8 @@ public class InitCommandTests
     [Fact]
     public async Task InitCommand_CreatesMissingDirectoryBeforeDispatch()
     {
-        // No workloads installed: InitCommand bootstraps the host skeleton and
-        // renders a NoWorkloadsInstalled hint. It must still have created the
-        // [path] directory by then.
+        // Even when --stack is missing, InitCommand creates the target
+        // directory before validating (directory creation is unconditional).
         var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
         Assert.False(Directory.Exists(newDir));
 
@@ -66,7 +65,8 @@ public class InitCommandTests
 
             var exitCode = await result.InvokeAsync();
 
-            Assert.Equal(0, exitCode);
+            // No --stack provided → exit 1, but directory was still created.
+            Assert.Equal(1, exitCode);
             Assert.True(Directory.Exists(newDir));
         }
         finally
@@ -86,7 +86,7 @@ public class InitCommandTests
         try
         {
             var initializer = new FakeProjectInitializer("python");
-            int exitCode = await RunInitAsync(newDir, initializer, language: "python");
+            int exitCode = await RunInitAsync(newDir, initializer, language: "python", stack: "python");
 
             Assert.Equal(0, exitCode);
             Assert.True(initializer.WasInvoked);
@@ -121,7 +121,7 @@ public class InitCommandTests
             File.WriteAllText(configPath, existingContent);
 
             var initializer = new FakeProjectInitializer("python");
-            int exitCode = await RunInitAsync(newDir, initializer, language: "python");
+            int exitCode = await RunInitAsync(newDir, initializer, language: "python", stack: "python");
 
             // Folder is already a Functions project (.func/config.json present);
             // command refuses without --force, initializer never runs.
@@ -146,7 +146,7 @@ public class InitCommandTests
         try
         {
             var initializer = new FakeProjectInitializer("dotnet");
-            int exitCode = await RunInitAsync(newDir, initializer, language: null);
+            int exitCode = await RunInitAsync(newDir, initializer, language: null, stack: "dotnet");
 
             Assert.Equal(0, exitCode);
 
@@ -204,16 +204,14 @@ public class InitCommandTests
     }
 
     [Fact]
-    public async Task InitCommand_NoWorkloadsInstalled_BootstrapsSkeletonAndExitsZero()
+    public async Task InitCommand_NoWorkloadsInstalled_ExitsWithHint()
     {
         var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
         try
         {
             int exitCode = await RunInitAsync(newDir, initializers: []);
 
-            Assert.Equal(0, exitCode);
-            AssertHostJsonWritten(newDir);
-            AssertConfigJsonHasShape(newDir, expectedStack: null, expectedLanguage: null);
+            Assert.Equal(1, exitCode);
 
             WorkloadHint hint = Assert.Single(_hintRenderer.Hints);
             Assert.Equal(WorkloadHintKind.NoWorkloadsInstalled, hint.Kind);
@@ -225,7 +223,7 @@ public class InitCommandTests
     }
 
     [Fact]
-    public async Task InitCommand_StackProvidedButNoMatch_BootstrapsSkeletonAndExitsZero()
+    public async Task InitCommand_StackProvidedButNoMatch_ExitsWithHint()
     {
         var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
         try
@@ -233,10 +231,8 @@ public class InitCommandTests
             var initializer = new FakeProjectInitializer("python");
             int exitCode = await RunInitAsync(newDir, initializer, language: null, stack: "ruby");
 
-            Assert.Equal(0, exitCode);
+            Assert.Equal(1, exitCode);
             Assert.False(initializer.WasInvoked);
-            AssertHostJsonWritten(newDir);
-            AssertConfigJsonHasShape(newDir, expectedStack: null, expectedLanguage: null);
 
             WorkloadHint hint = Assert.Single(_hintRenderer.Hints);
             Assert.Equal(WorkloadHintKind.NoMatchingStack, hint.Kind);
@@ -249,7 +245,7 @@ public class InitCommandTests
     }
 
     [Fact]
-    public async Task InitCommand_MultipleWorkloads_NonInteractive_BootstrapsSkeletonAndExitsZero()
+    public async Task InitCommand_MultipleWorkloads_NoStack_NonInteractive_ExitsWithHint()
     {
         var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
         try
@@ -258,11 +254,9 @@ public class InitCommandTests
             var node = new FakeProjectInitializer("node");
             int exitCode = await RunInitAsync(newDir, [python, node]);
 
-            Assert.Equal(0, exitCode);
+            Assert.Equal(1, exitCode);
             Assert.False(python.WasInvoked);
             Assert.False(node.WasInvoked);
-            AssertHostJsonWritten(newDir);
-            AssertConfigJsonHasShape(newDir, expectedStack: null, expectedLanguage: null);
 
             WorkloadHint hint = Assert.Single(_hintRenderer.Hints);
             Assert.Equal(WorkloadHintKind.AmbiguousStackChoice, hint.Kind);
@@ -274,7 +268,7 @@ public class InitCommandTests
     }
 
     [Fact]
-    public async Task InitCommand_SingleWorkload_AutoSelectsAndRendersInfoHint()
+    public async Task InitCommand_SingleWorkload_NoStack_AutoSelectsAndRuns()
     {
         var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
         try
@@ -284,7 +278,6 @@ public class InitCommandTests
 
             Assert.Equal(0, exitCode);
             Assert.True(initializer.WasInvoked);
-            AssertHostJsonWritten(newDir);
             AssertConfigJsonHasShape(newDir, expectedStack: "python", expectedLanguage: null);
 
             WorkloadHint hint = Assert.Single(_hintRenderer.Hints);
@@ -298,7 +291,7 @@ public class InitCommandTests
     }
 
     [Fact]
-    public async Task InitCommand_StackProvided_WritesHostJsonAndConfig()
+    public async Task InitCommand_StackProvided_WritesConfigAndInvokesInitializer()
     {
         var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
         try
@@ -308,10 +301,9 @@ public class InitCommandTests
 
             Assert.Equal(0, exitCode);
             Assert.True(initializer.WasInvoked);
-            AssertHostJsonWritten(newDir);
             AssertConfigJsonHasShape(newDir, expectedStack: "python", expectedLanguage: "python");
 
-            // --stack matched directly, no hint.
+            // No hint rendered when --stack matched directly.
             Assert.Empty(_hintRenderer.Hints);
         }
         finally
@@ -347,21 +339,21 @@ public class InitCommandTests
     }
 
     [Fact]
-    public async Task InitCommand_RefusesEarly_BeforeWorkloadSelection_WhenAlreadyInitialized()
+    public async Task InitCommand_RefusesEarly_WhenAlreadyInitialized()
     {
-        // Even with zero workloads installed, a directory that already has a
-        // host.json is treated as initialized: no skeleton write, no hint, exit 1.
+        // A directory that already has a host.json is treated as initialized:
+        // no config write, exit 1.
         var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
         try
         {
             Directory.CreateDirectory(newDir);
             File.WriteAllText(Path.Combine(newDir, "host.json"), "{\"version\":\"2.0\"}");
 
-            int exitCode = await RunInitAsync(newDir, initializers: []);
+            var initializer = new FakeProjectInitializer("python");
+            int exitCode = await RunInitAsync(newDir, initializer, language: null, stack: "python");
 
             Assert.Equal(1, exitCode);
-            Assert.Empty(_hintRenderer.Hints);
-            // No .func/config.json written either.
+            Assert.False(initializer.WasInvoked);
             Assert.False(File.Exists(Path.Combine(newDir, ".func", "config.json")));
         }
         finally
@@ -371,7 +363,7 @@ public class InitCommandTests
     }
 
     [Fact]
-    public async Task InitCommand_OverwritesExistingHostJson_WhenForceIsSet()
+    public async Task InitCommand_OverwritesExistingProject_WhenForceIsSet()
     {
         var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
         try
@@ -384,20 +376,12 @@ public class InitCommandTests
             int exitCode = await RunInitAsync(newDir, initializer, language: null, stack: "python", force: true);
 
             Assert.Equal(0, exitCode);
-            AssertHostJsonWritten(newDir);
+            Assert.True(initializer.WasInvoked);
         }
         finally
         {
             CleanupDirectory(newDir);
         }
-    }
-
-    private static void AssertHostJsonWritten(string directory)
-    {
-        string path = Path.Combine(directory, "host.json");
-        Assert.True(File.Exists(path), $"Expected host.json at {path}.");
-        using var doc = JsonDocument.Parse(File.ReadAllText(path));
-        Assert.Equal("2.0", doc.RootElement.GetProperty("version").GetString());
     }
 
     private static void AssertConfigJsonHasShape(string directory, string? expectedStack, string? expectedLanguage)

--- a/test/Workloads/Stacks/Node.Tests/NodeProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/Node.Tests/NodeProjectInitializerTests.cs
@@ -131,12 +131,15 @@ public class NodeProjectInitializerTests : IDisposable
     }
 
     [Fact]
-    public async Task InitializeAsync_NoBundle_SkipsExtensionBundleMerge()
+    public async Task InitializeAsync_NoBundle_WritesMinimalHostJsonWithoutExtensionBundle()
     {
         await RunAsync(language: null, force: false, args: ["--no-bundle"]);
 
         string hostJsonPath = Path.Combine(_projectDir.FullName, "host.json");
-        Assert.False(File.Exists(hostJsonPath), "host.json should not be touched when --no-bundle is set");
+        Assert.True(File.Exists(hostJsonPath), "host.json should be created even with --no-bundle");
+        string content = File.ReadAllText(hostJsonPath);
+        Assert.Contains("\"version\"", content);
+        Assert.DoesNotContain("extensionBundle", content);
     }
 
     [Fact]

--- a/test/Workloads/Stacks/Python.Tests/PythonProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/Python.Tests/PythonProjectInitializerTests.cs
@@ -72,9 +72,9 @@ public class PythonProjectInitializerTests : IDisposable
     [Fact]
     public async Task InitializeAsync_AppendsExtensionBundle_IntoExistingHostJson()
     {
-        // Mimic what InitCommand wrote before delegating: minimal host.json
-        // with version only. Initializer must add extensionBundle without
-        // dropping version.
+        // Pre-existing host.json with version only. WriteIfMissing won't
+        // overwrite (force=false), and MergeHostJson adds extensionBundle
+        // without dropping version.
         File.WriteAllText(Path.Combine(_projectDir.FullName, "host.json"), "{ \"version\": \"2.0\" }");
 
         await RunAsync(force: false);
@@ -125,12 +125,15 @@ public class PythonProjectInitializerTests : IDisposable
     }
 
     [Fact]
-    public async Task InitializeAsync_NoBundle_SkipsExtensionBundleMerge()
+    public async Task InitializeAsync_NoBundle_WritesMinimalHostJsonWithoutExtensionBundle()
     {
         await RunAsync(force: false, args: ["--no-bundle"]);
 
         string hostJsonPath = Path.Combine(_projectDir.FullName, "host.json");
-        Assert.False(File.Exists(hostJsonPath), "host.json should not be touched when --no-bundle is set");
+        Assert.True(File.Exists(hostJsonPath), "host.json should be created even with --no-bundle");
+        string content = File.ReadAllText(hostJsonPath);
+        Assert.Contains("\"version\"", content);
+        Assert.DoesNotContain("extensionBundle", content);
     }
 
     [Fact]


### PR DESCRIPTION
## Make a resolved stack workload required for `func init` and move `host.json` writing to workload initializers

### Motivation

`func init` previously wrote a skeleton `host.json` itself and allowed running without `--stack`, bootstrapping an incomplete project. This shifts responsibility so that:

1. A resolved stack is **required** before any project files are written — no more half-initialized directories.
2. Each workload owns its own `host.json` creation, making the init command a thin orchestrator.

### Changes

**`InitCommand`**
- Removed `WriteHostJson` — the command no longer writes `host.json` directly.
- Removed `InitializerSelection` record struct; `SelectInitializerAsync` now returns `IProjectInitializer?` (null = failure, exit 1).
- Miss paths (no workloads, no match, ambiguous choice in non-interactive mode) render the existing workload hints and exit 1 instead of bootstrapping a skeleton and exiting 0.
- Auto-select (single installed workload) and interactive prompt (multiple workloads) still work — they resolve a stack before proceeding.

**Workload initializers (Go, Node, Python)**
- Each now calls `ProjectFiles.WriteIfMissing(host.json, ProjectFiles.MinimalHostJson, force)` to create the base `host.json`.
- Node/Python: `host.json` is always created regardless of `--no-bundle`; that flag only skips the `extensionBundle` merge.

**`ProjectFiles`**
- Added `public const string MinimalHostJson` to centralize the content and avoid drift across initializers.

### Behavioral changes

| Scenario | Before | After |
|----------|--------|-------|
| No `--stack`, no workloads | Exit 0, writes skeleton | Exit 1, renders hint |
| No `--stack`, single workload | Exit 0, auto-selects | Exit 0, auto-selects (unchanged) |
| No `--stack`, multiple workloads (non-interactive) | Exit 0, writes skeleton | Exit 1, renders hint |
| `--stack` provided, no match | Exit 0, writes skeleton | Exit 1, renders hint |
| `--no-bundle` (Node/Python) | No `host.json` created | Minimal `host.json` created (no extensionBundle) |

### Testing

- All 441 `Func.Tests` pass
- Go, Node, Python workload initializer tests updated and passing
- Updated `--no-bundle` tests to assert `host.json` exists with version only (no extensionBundle)