### PR TITLE
Remove --bundles-channel option from Node and Python init

### DIFF
--- a/src/Abstractions/Projects/ExtensionBundle.cs
+++ b/src/Abstractions/Projects/ExtensionBundle.cs
@@ -4,34 +4,18 @@
 namespace Azure.Functions.Cli.Projects;
 
 /// <summary>
-/// Release channel for the Functions extension bundle. Values map to the
-/// three published bundle ids (GA / Preview / Experimental).
-/// </summary>
-public enum BundleChannel
-{
-    GA,
-    Preview,
-    Experimental,
-}
-
-/// <summary>
 /// Shared metadata for the Functions extension bundle. Used by script-based
 /// workloads (Python, Node, ...) that don't compile in their own extensions.
 /// </summary>
 public static class ExtensionBundle
 {
     /// <summary>
+    /// NuGet id for the GA extension bundle written by <c>func init</c> templates.
+    /// </summary>
+    public const string DefaultId = "Microsoft.Azure.Functions.ExtensionBundle";
+
+    /// <summary>
     /// Default version range pulled by <c>func init</c> templates.
     /// </summary>
     public const string DefaultVersionRange = "[4.*, 5.0.0)";
-
-    /// <summary>
-    /// Returns the NuGet id for the bundle published under <paramref name="channel"/>.
-    /// </summary>
-    public static string IdFor(BundleChannel channel) => channel switch
-    {
-        BundleChannel.Preview => "Microsoft.Azure.Functions.ExtensionBundle.Preview",
-        BundleChannel.Experimental => "Microsoft.Azure.Functions.ExtensionBundle.Experimental",
-        _ => "Microsoft.Azure.Functions.ExtensionBundle",
-    };
 }

--- a/src/Workloads/Stacks/Node/NodeProjectInitializer.cs
+++ b/src/Workloads/Stacks/Node/NodeProjectInitializer.cs
@@ -34,19 +34,13 @@ internal sealed class NodeProjectInitializer : IProjectInitializer
         DefaultValueFactory = _ => false,
     };
 
-    public Option<BundleChannel> BundlesChannelOption { get; } = new("--bundles-channel", "-c")
-    {
-        Description = "Extension bundle release channel: GA (default), Preview, or Experimental.",
-        DefaultValueFactory = _ => BundleChannel.GA,
-    };
-
     public Option<bool> SkipNpmInstallOption { get; } = new("--skip-npm-install")
     {
         Description = "Skip running 'npm install' after Node project creation.",
         DefaultValueFactory = _ => false,
     };
 
-    public IReadOnlyList<Option> GetInitOptions() => [NoBundleOption, BundlesChannelOption, SkipNpmInstallOption];
+    public IReadOnlyList<Option> GetInitOptions() => [NoBundleOption, SkipNpmInstallOption];
 
     public async Task InitializeAsync(
         InitContext context,
@@ -61,7 +55,6 @@ internal sealed class NodeProjectInitializer : IProjectInitializer
         bool force = context.Force;
         bool isTypeScript = string.Equals(context.Language, "typescript", StringComparison.OrdinalIgnoreCase);
         bool noBundle = parseResult.GetValue(NoBundleOption);
-        BundleChannel channel = parseResult.GetValue(BundlesChannelOption);
         bool skipNpmInstall = parseResult.GetValue(SkipNpmInstallOption);
 
         string projectName = ResolveProjectName(context);
@@ -110,7 +103,7 @@ internal sealed class NodeProjectInitializer : IProjectInitializer
         {
             ProjectFiles.MergeHostJson(
                 Path.Combine(root, "host.json"),
-                host => EnsureExtensionBundle(host, channel));
+                EnsureExtensionBundle);
         }
 
         if (!skipNpmInstall)
@@ -134,7 +127,7 @@ internal sealed class NodeProjectInitializer : IProjectInitializer
         return string.IsNullOrEmpty(sanitized) ? "function-app" : sanitized;
     }
 
-    private static void EnsureExtensionBundle(JsonObject host, BundleChannel channel)
+    private static void EnsureExtensionBundle(JsonObject host)
     {
         if (host.ContainsKey("extensionBundle"))
         {
@@ -143,7 +136,7 @@ internal sealed class NodeProjectInitializer : IProjectInitializer
 
         host["extensionBundle"] = new JsonObject
         {
-            ["id"] = ExtensionBundle.IdFor(channel),
+            ["id"] = ExtensionBundle.DefaultId,
             ["version"] = ExtensionBundle.DefaultVersionRange,
         };
     }

--- a/src/Workloads/Stacks/Python/PythonProjectInitializer.cs
+++ b/src/Workloads/Stacks/Python/PythonProjectInitializer.cs
@@ -26,13 +26,7 @@ internal sealed class PythonProjectInitializer : IProjectInitializer
         DefaultValueFactory = _ => false,
     };
 
-    public Option<BundleChannel> BundlesChannelOption { get; } = new("--bundles-channel", "-c")
-    {
-        Description = "Extension bundle release channel: GA (default), Preview, or Experimental.",
-        DefaultValueFactory = _ => BundleChannel.GA,
-    };
-
-    public IReadOnlyList<Option> GetInitOptions() => [NoBundleOption, BundlesChannelOption];
+    public IReadOnlyList<Option> GetInitOptions() => [NoBundleOption];
 
     public Task InitializeAsync(
         InitContext context,
@@ -46,7 +40,6 @@ internal sealed class PythonProjectInitializer : IProjectInitializer
         string root = context.WorkingDirectory.Info.FullName;
         bool force = context.Force;
         bool noBundle = parseResult.GetValue(NoBundleOption);
-        BundleChannel channel = parseResult.GetValue(BundlesChannelOption);
 
         ProjectFiles.WriteIfMissing(
             Path.Combine(root, "function_app.py"),
@@ -84,13 +77,13 @@ internal sealed class PythonProjectInitializer : IProjectInitializer
         {
             ProjectFiles.MergeHostJson(
                 Path.Combine(root, "host.json"),
-                host => EnsureExtensionBundle(host, channel));
+                EnsureExtensionBundle);
         }
 
         return Task.CompletedTask;
     }
 
-    private static void EnsureExtensionBundle(JsonObject host, BundleChannel channel)
+    private static void EnsureExtensionBundle(JsonObject host)
     {
         // Only fill in when missing so a user-customised bundle survives `--force`.
         if (host.ContainsKey("extensionBundle"))
@@ -100,7 +93,7 @@ internal sealed class PythonProjectInitializer : IProjectInitializer
 
         host["extensionBundle"] = new JsonObject
         {
-            ["id"] = ExtensionBundle.IdFor(channel),
+            ["id"] = ExtensionBundle.DefaultId,
             ["version"] = ExtensionBundle.DefaultVersionRange,
         };
     }

--- a/test/Workloads/Stacks/Node.Tests/NodeProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/Node.Tests/NodeProjectInitializerTests.cs
@@ -47,8 +47,8 @@ public class NodeProjectInitializerTests : IDisposable
         IReadOnlyList<string> names = [.. options.Select(o => o.Name)];
 
         Assert.Contains("--no-bundle", names);
-        Assert.Contains("--bundles-channel", names);
         Assert.Contains("--skip-npm-install", names);
+        Assert.DoesNotContain("--bundles-channel", names);
     }
 
     [Fact]
@@ -140,15 +140,6 @@ public class NodeProjectInitializerTests : IDisposable
         string content = File.ReadAllText(hostJsonPath);
         Assert.Contains("\"version\"", content);
         Assert.DoesNotContain("extensionBundle", content);
-    }
-
-    [Fact]
-    public async Task InitializeAsync_BundlesChannel_Preview_WritesPreviewBundleId()
-    {
-        await RunAsync(language: null, force: false, args: ["--bundles-channel", "Preview"]);
-
-        JsonNode? bundle = JsonNode.Parse(File.ReadAllText(Path.Combine(_projectDir.FullName, "host.json")))!["extensionBundle"];
-        Assert.Equal("Microsoft.Azure.Functions.ExtensionBundle.Preview", bundle!["id"]!.GetValue<string>());
     }
 
     [Fact]

--- a/test/Workloads/Stacks/Python.Tests/PythonProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/Python.Tests/PythonProjectInitializerTests.cs
@@ -47,7 +47,7 @@ public class PythonProjectInitializerTests : IDisposable
         IReadOnlyList<string> names = [.. options.Select(o => o.Name)];
 
         Assert.Contains("--no-bundle", names);
-        Assert.Contains("--bundles-channel", names);
+        Assert.DoesNotContain("--bundles-channel", names);
     }
 
     [Fact]
@@ -134,30 +134,6 @@ public class PythonProjectInitializerTests : IDisposable
         string content = File.ReadAllText(hostJsonPath);
         Assert.Contains("\"version\"", content);
         Assert.DoesNotContain("extensionBundle", content);
-    }
-
-    [Fact]
-    public async Task InitializeAsync_BundlesChannel_Preview_WritesPreviewBundleId()
-    {
-        await RunAsync(force: false, args: ["--bundles-channel", "Preview"]);
-
-        string hostJsonPath = Path.Combine(_projectDir.FullName, "host.json");
-        var root = JsonNode.Parse(File.ReadAllText(hostJsonPath));
-        Assert.Equal(
-            "Microsoft.Azure.Functions.ExtensionBundle.Preview",
-            root!["extensionBundle"]!["id"]!.GetValue<string>());
-    }
-
-    [Fact]
-    public async Task InitializeAsync_BundlesChannel_Experimental_WritesExperimentalBundleId()
-    {
-        await RunAsync(force: false, args: ["--bundles-channel", "Experimental"]);
-
-        string hostJsonPath = Path.Combine(_projectDir.FullName, "host.json");
-        var root = JsonNode.Parse(File.ReadAllText(hostJsonPath));
-        Assert.Equal(
-            "Microsoft.Azure.Functions.ExtensionBundle.Experimental",
-            root!["extensionBundle"]!["id"]!.GetValue<string>());
     }
 
     private Task RunAsync(bool force, string[]? args = null)


### PR DESCRIPTION
Removes the `--bundles-channel` / `-c` option from `func init` for the Node and Python stacks. Both initializers now always write the GA extension bundle to `host.json`.

Also drops the `BundleChannel` enum and `ExtensionBundle.IdFor` helper, replacing them with a single `ExtensionBundle.DefaultId` constant.

Users who need the Preview or Experimental channel can edit `host.json` directly.

Replaces #5059 (auto-closed because the branch lacked shared history with `vnext`).