### PR TITLE
Worker workloads: two-axis version scheme mirroring upstream worker pkgs

### DIFF
--- a/eng/build/Packages.props
+++ b/eng/build/Packages.props
@@ -24,7 +24,12 @@
   <ItemGroup>
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
   </ItemGroup>
-  <!-- language workers -->
+  <!-- language workers
+       Authoritative source for each worker pkg version is the corresponding
+       workload's Directory.Version.props ($(WorkerVersion)), which both pins
+       the restored worker pkg (via VersionOverride) and drives the workload
+       pkg version. Keep these central pins in sync with those props as a
+       documentation aid. -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.13.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.PythonWorker" Version="4.43.0" />

--- a/src/Workloads/Workers/Go/Directory.Version.props
+++ b/src/Workloads/Workers/Go/Directory.Version.props
@@ -6,27 +6,14 @@
     it carries. Go has no upstream worker NuGet, so $(WorkerVersion) is
     maintained manually here and tracks the static worker.config.json
     payload shipped under content/workers/native/.
-      $(WorkerVersion)  - Go worker payload version. Bare three-part SemVer.
-      $(WorkerChannel)  - stable | preview | experimental. Selects the
-                          workload pkg's prerelease label.
+      $(WorkerVersion) - Go worker payload version. Bare three-part SemVer.
 
-    Derived $(VersionPrefix):
-      stable        -> 1.0.0
-      preview       -> 1.0.0-preview
-      experimental  -> 1.0.0-experimental
+    No channel axis: there are no preview/experimental Go worker SKUs.
   -->
 
   <PropertyGroup>
     <WorkerVersion>1.0.0</WorkerVersion>
-    <WorkerChannel>stable</WorkerChannel>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(WorkerChannel)' == 'stable'">
     <VersionPrefix>$(WorkerVersion)</VersionPrefix>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(WorkerChannel)' != 'stable'">
-    <VersionPrefix>$(WorkerVersion)-$(WorkerChannel)</VersionPrefix>
   </PropertyGroup>
 
 </Project>

--- a/src/Workloads/Workers/Go/Directory.Version.props
+++ b/src/Workloads/Workers/Go/Directory.Version.props
@@ -14,6 +14,7 @@
   <PropertyGroup>
     <WorkerVersion>1.0.0</WorkerVersion>
     <VersionPrefix>$(WorkerVersion)</VersionPrefix>
+    <VersionSuffix>preview.1</VersionSuffix>
   </PropertyGroup>
 
 </Project>

--- a/src/Workloads/Workers/Go/Directory.Version.props
+++ b/src/Workloads/Workers/Go/Directory.Version.props
@@ -1,6 +1,32 @@
 <Project>
+
+  <!--
+    Workload pkg versioning. This is a content-only workload (no workload
+    code or assemblies), so the pkg version is driven by the worker payload
+    it carries. Go has no upstream worker NuGet, so $(WorkerVersion) is
+    maintained manually here and tracks the static worker.config.json
+    payload shipped under content/workers/native/.
+      $(WorkerVersion)  - Go worker payload version. Bare three-part SemVer.
+      $(WorkerChannel)  - stable | preview | experimental. Selects the
+                          workload pkg's prerelease label.
+
+    Derived $(VersionPrefix):
+      stable        -> 1.0.0
+      preview       -> 1.0.0-preview
+      experimental  -> 1.0.0-experimental
+  -->
+
   <PropertyGroup>
-    <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>preview.1</VersionSuffix>
+    <WorkerVersion>1.0.0</WorkerVersion>
+    <WorkerChannel>stable</WorkerChannel>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(WorkerChannel)' == 'stable'">
+    <VersionPrefix>$(WorkerVersion)</VersionPrefix>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(WorkerChannel)' != 'stable'">
+    <VersionPrefix>$(WorkerVersion)-$(WorkerChannel)</VersionPrefix>
+  </PropertyGroup>
+
 </Project>

--- a/src/Workloads/Workers/Go/README.md
+++ b/src/Workloads/Workers/Go/README.md
@@ -13,21 +13,13 @@ func workload install go-worker
 
 ## Version scheme
 
-Mirrors the Node and Python worker workloads: `$(WorkerVersion)` (three-part
-SemVer) + `$(WorkerChannel)` (`stable` \| `preview` \| `experimental`) drive
-`$(VersionPrefix)`. Go has no upstream worker NuGet, so `$(WorkerVersion)` is
-maintained manually in `Directory.Version.props` alongside any change to the
-static `worker.config.json` payload.
+Mirrors the Node and Python worker workloads: a single `$(WorkerVersion)`
+(three-part SemVer) drives `$(VersionPrefix)`. Go has no upstream worker
+NuGet, so `$(WorkerVersion)` is maintained manually in
+`Directory.Version.props` alongside any change to the static
+`worker.config.json` payload.
 
-| Channel      | Workload pkg version |
-|--------------|----------------------|
-| stable       | `1.0.0`              |
-| preview      | `1.0.0-preview`      |
-| experimental | `1.0.0-experimental` |
-
-```bash
-dotnet pack ... /p:WorkerChannel=preview
-```
+No channel axis: there are no preview/experimental Go worker SKUs.
 
 ## Status
 

--- a/src/Workloads/Workers/Go/README.md
+++ b/src/Workloads/Workers/Go/README.md
@@ -19,7 +19,9 @@ NuGet, so `$(WorkerVersion)` is maintained manually in
 `Directory.Version.props` alongside any change to the static
 `worker.config.json` payload.
 
-No channel axis: there are no preview/experimental Go worker SKUs.
+Ships as a NuGet prerelease (`1.0.0-preview.1`) via `$(VersionSuffix)`
+while the Go worker integration stabilises. `func workload install` won't
+pick up prereleases without an explicit version pin or `--prerelease`.
 
 ## Status
 

--- a/src/Workloads/Workers/Go/README.md
+++ b/src/Workloads/Workers/Go/README.md
@@ -11,6 +11,24 @@ func workload install Azure.Functions.Cli.Workloads.Workers.Go
 func workload install go-worker
 ```
 
+## Version scheme
+
+Mirrors the Node and Python worker workloads: `$(WorkerVersion)` (three-part
+SemVer) + `$(WorkerChannel)` (`stable` \| `preview` \| `experimental`) drive
+`$(VersionPrefix)`. Go has no upstream worker NuGet, so `$(WorkerVersion)` is
+maintained manually in `Directory.Version.props` alongside any change to the
+static `worker.config.json` payload.
+
+| Channel      | Workload pkg version |
+|--------------|----------------------|
+| stable       | `1.0.0`              |
+| preview      | `1.0.0-preview`      |
+| experimental | `1.0.0-experimental` |
+
+```bash
+dotnet pack ... /p:WorkerChannel=preview
+```
+
 ## Status
 
 Preview. Go has no upstream worker NuGet; the workload ships a static native

--- a/src/Workloads/Workers/Go/release_notes.md
+++ b/src/Workloads/Workers/Go/release_notes.md
@@ -2,10 +2,9 @@
 
 ## 1.0.0
 
-- Adopt two-axis version scheme: manually maintained `$(WorkerVersion)` (no
-  upstream Go worker NuGet) plus `$(WorkerChannel)` (`stable` | `preview` |
-  `experimental`) drive the workload pkg version. Matches the Node and
-  Python worker workload version layout.
+- Adopt single-axis `$(WorkerVersion)` version scheme. Manually maintained
+  (no upstream Go worker NuGet) and drives the workload pkg version.
+  Matches the Node and Python worker workload version layout.
 
 ## 1.0.0-preview.1
 

--- a/src/Workloads/Workers/Go/release_notes.md
+++ b/src/Workloads/Workers/Go/release_notes.md
@@ -1,11 +1,8 @@
 # Azure.Functions.Cli.Workloads.Workers.Go
 
-## 1.0.0
+## 1.0.0-preview.1
 
 - Adopt single-axis `$(WorkerVersion)` version scheme. Manually maintained
   (no upstream Go worker NuGet) and drives the workload pkg version.
-  Matches the Node and Python worker workload version layout.
-
-## 1.0.0-preview.1
-
-- Initial scaffold of the Go worker content workload.
+  Matches the Node and Python worker workload version layout. Ships as a
+  preview while the Go worker integration stabilises.

--- a/src/Workloads/Workers/Go/release_notes.md
+++ b/src/Workloads/Workers/Go/release_notes.md
@@ -1,5 +1,12 @@
 # Azure.Functions.Cli.Workloads.Workers.Go
 
+## 1.0.0
+
+- Adopt two-axis version scheme: manually maintained `$(WorkerVersion)` (no
+  upstream Go worker NuGet) plus `$(WorkerChannel)` (`stable` | `preview` |
+  `experimental`) drive the workload pkg version. Matches the Node and
+  Python worker workload version layout.
+
 ## 1.0.0-preview.1
 
 - Initial scaffold of the Go worker content workload.

--- a/src/Workloads/Workers/Node/Directory.Version.props
+++ b/src/Workloads/Workers/Node/Directory.Version.props
@@ -1,6 +1,32 @@
 <Project>
+
+  <!--
+    Workload pkg versioning. This is a content-only workload (no workload
+    code or assemblies), so the pkg version maps 1:1 to the worker payload
+    version it carries:
+      $(WorkerVersion)  - the Node.js worker package version. Mirrors the
+                          Microsoft.Azure.Functions.NodeJsWorker version
+                          pulled in at pack time. Bare three-part SemVer.
+      $(WorkerChannel)  - stable | preview | experimental. Selects the
+                          workload pkg's prerelease label.
+
+    Derived $(VersionPrefix):
+      stable        -> 3.13.0
+      preview       -> 3.13.0-preview
+      experimental  -> 3.13.0-experimental
+  -->
+
   <PropertyGroup>
-    <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>preview.1</VersionSuffix>
+    <WorkerVersion>3.13.0</WorkerVersion>
+    <WorkerChannel>stable</WorkerChannel>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(WorkerChannel)' == 'stable'">
+    <VersionPrefix>$(WorkerVersion)</VersionPrefix>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(WorkerChannel)' != 'stable'">
+    <VersionPrefix>$(WorkerVersion)-$(WorkerChannel)</VersionPrefix>
+  </PropertyGroup>
+
 </Project>

--- a/src/Workloads/Workers/Node/Directory.Version.props
+++ b/src/Workloads/Workers/Node/Directory.Version.props
@@ -4,29 +4,18 @@
     Workload pkg versioning. This is a content-only workload (no workload
     code or assemblies), so the pkg version maps 1:1 to the worker payload
     version it carries:
-      $(WorkerVersion)  - the Node.js worker package version. Mirrors the
-                          Microsoft.Azure.Functions.NodeJsWorker version
-                          pulled in at pack time. Bare three-part SemVer.
-      $(WorkerChannel)  - stable | preview | experimental. Selects the
-                          workload pkg's prerelease label.
+      $(WorkerVersion) - the Node.js worker package version. Mirrors the
+                         Microsoft.Azure.Functions.NodeJsWorker version
+                         pulled in at pack time. Bare three-part SemVer.
 
-    Derived $(VersionPrefix):
-      stable        -> 3.13.0
-      preview       -> 3.13.0-preview
-      experimental  -> 3.13.0-experimental
+    Unlike the bundles workload, there is no channel axis: the upstream
+    NodeJsWorker NuGet doesn't ship preview/experimental SKUs, so the
+    workload pkg version is just $(WorkerVersion).
   -->
 
   <PropertyGroup>
     <WorkerVersion>3.13.0</WorkerVersion>
-    <WorkerChannel>stable</WorkerChannel>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(WorkerChannel)' == 'stable'">
     <VersionPrefix>$(WorkerVersion)</VersionPrefix>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(WorkerChannel)' != 'stable'">
-    <VersionPrefix>$(WorkerVersion)-$(WorkerChannel)</VersionPrefix>
   </PropertyGroup>
 
 </Project>

--- a/src/Workloads/Workers/Node/README.md
+++ b/src/Workloads/Workers/Node/README.md
@@ -11,6 +11,34 @@ func workload install Azure.Functions.Cli.Workloads.Workers.Node
 func workload install node-worker
 ```
 
+## Version scheme
+
+The workload pkg version maps 1:1 to the Node.js worker payload it carries.
+Two props in `Directory.Version.props` drive `$(VersionPrefix)`:
+
+| Prop               | Meaning                                                                                |
+|--------------------|----------------------------------------------------------------------------------------|
+| `$(WorkerVersion)` | `Microsoft.Azure.Functions.NodeJsWorker` version. Bare three-part SemVer.              |
+| `$(WorkerChannel)` | `stable` \| `preview` \| `experimental`. Selects the workload pkg's prerelease label.  |
+
+| Channel      | Workload pkg version |
+|--------------|----------------------|
+| stable       | `3.13.0`             |
+| preview      | `3.13.0-preview`     |
+| experimental | `3.13.0-experimental`|
+
+Bump `$(WorkerVersion)` whenever the upstream worker package is bumped.
+`$(WorkerVersion)` also pins the restored
+`Microsoft.Azure.Functions.NodeJsWorker` pkg via `VersionOverride`, so the
+two versions cannot drift.
+
+## Build-time channel selection
+
+```bash
+dotnet pack ... /p:WorkerChannel=preview
+dotnet pack ... /p:WorkerChannel=experimental
+```
+
 ## Status
 
 Preview. Worker assets are pulled at pack time from the restored

--- a/src/Workloads/Workers/Node/README.md
+++ b/src/Workloads/Workers/Node/README.md
@@ -14,30 +14,19 @@ func workload install node-worker
 ## Version scheme
 
 The workload pkg version maps 1:1 to the Node.js worker payload it carries.
-Two props in `Directory.Version.props` drive `$(VersionPrefix)`:
+One prop in `Directory.Version.props` drives `$(VersionPrefix)`:
 
-| Prop               | Meaning                                                                                |
-|--------------------|----------------------------------------------------------------------------------------|
-| `$(WorkerVersion)` | `Microsoft.Azure.Functions.NodeJsWorker` version. Bare three-part SemVer.              |
-| `$(WorkerChannel)` | `stable` \| `preview` \| `experimental`. Selects the workload pkg's prerelease label.  |
-
-| Channel      | Workload pkg version |
-|--------------|----------------------|
-| stable       | `3.13.0`             |
-| preview      | `3.13.0-preview`     |
-| experimental | `3.13.0-experimental`|
+| Prop               | Meaning                                                                   |
+|--------------------|---------------------------------------------------------------------------|
+| `$(WorkerVersion)` | `Microsoft.Azure.Functions.NodeJsWorker` version. Bare three-part SemVer. |
 
 Bump `$(WorkerVersion)` whenever the upstream worker package is bumped.
 `$(WorkerVersion)` also pins the restored
 `Microsoft.Azure.Functions.NodeJsWorker` pkg via `VersionOverride`, so the
 two versions cannot drift.
 
-## Build-time channel selection
-
-```bash
-dotnet pack ... /p:WorkerChannel=preview
-dotnet pack ... /p:WorkerChannel=experimental
-```
+Unlike the bundles workload, there is no channel axis: the upstream
+NodeJsWorker NuGet doesn't ship preview/experimental SKUs.
 
 ## Status
 

--- a/src/Workloads/Workers/Node/Workloads.Workers.Node.csproj
+++ b/src/Workloads/Workers/Node/Workloads.Workers.Node.csproj
@@ -25,7 +25,7 @@
       pointing at the restored package root. IncludeAssets=none keeps the
       package's build targets and contentFiles from affecting this project.
     -->
-    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" GeneratePathProperty="true">
+    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" GeneratePathProperty="true" VersionOverride="$(WorkerVersion)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>none</IncludeAssets>
     </PackageReference>

--- a/src/Workloads/Workers/Node/release_notes.md
+++ b/src/Workloads/Workers/Node/release_notes.md
@@ -1,5 +1,12 @@
 # Azure.Functions.Cli.Workloads.Workers.Node
 
+## 3.13.0
+
+- Adopt two-axis version scheme: `$(WorkerVersion)` mirrors
+  `Microsoft.Azure.Functions.NodeJsWorker`, `$(WorkerChannel)` selects the
+  prerelease label (`stable` | `preview` | `experimental`). Workload pkg
+  version now tracks the worker payload version 1:1.
+
 ## 1.0.0-preview.1
 
 - Initial scaffold of the Node worker content workload.

--- a/src/Workloads/Workers/Node/release_notes.md
+++ b/src/Workloads/Workers/Node/release_notes.md
@@ -2,10 +2,9 @@
 
 ## 3.13.0
 
-- Adopt two-axis version scheme: `$(WorkerVersion)` mirrors
-  `Microsoft.Azure.Functions.NodeJsWorker`, `$(WorkerChannel)` selects the
-  prerelease label (`stable` | `preview` | `experimental`). Workload pkg
-  version now tracks the worker payload version 1:1.
+- Adopt single-axis version scheme: `$(WorkerVersion)` mirrors
+  `Microsoft.Azure.Functions.NodeJsWorker`. Workload pkg version tracks the
+  worker payload version 1:1.
 
 ## 1.0.0-preview.1
 

--- a/src/Workloads/Workers/Python/Directory.Version.props
+++ b/src/Workloads/Workers/Python/Directory.Version.props
@@ -1,6 +1,32 @@
 <Project>
+
+  <!--
+    Workload pkg versioning. This is a content-only workload (no workload
+    code or assemblies), so the pkg version maps 1:1 to the worker payload
+    version it carries:
+      $(WorkerVersion)  - the Python worker package version. Mirrors the
+                          Microsoft.Azure.Functions.PythonWorker version
+                          pulled in at pack time. Bare three-part SemVer.
+      $(WorkerChannel)  - stable | preview | experimental. Selects the
+                          workload pkg's prerelease label.
+
+    Derived $(VersionPrefix):
+      stable        -> 4.43.0
+      preview       -> 4.43.0-preview
+      experimental  -> 4.43.0-experimental
+  -->
+
   <PropertyGroup>
-    <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>preview.1</VersionSuffix>
+    <WorkerVersion>4.43.0</WorkerVersion>
+    <WorkerChannel>stable</WorkerChannel>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(WorkerChannel)' == 'stable'">
+    <VersionPrefix>$(WorkerVersion)</VersionPrefix>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(WorkerChannel)' != 'stable'">
+    <VersionPrefix>$(WorkerVersion)-$(WorkerChannel)</VersionPrefix>
+  </PropertyGroup>
+
 </Project>

--- a/src/Workloads/Workers/Python/Directory.Version.props
+++ b/src/Workloads/Workers/Python/Directory.Version.props
@@ -4,29 +4,18 @@
     Workload pkg versioning. This is a content-only workload (no workload
     code or assemblies), so the pkg version maps 1:1 to the worker payload
     version it carries:
-      $(WorkerVersion)  - the Python worker package version. Mirrors the
-                          Microsoft.Azure.Functions.PythonWorker version
-                          pulled in at pack time. Bare three-part SemVer.
-      $(WorkerChannel)  - stable | preview | experimental. Selects the
-                          workload pkg's prerelease label.
+      $(WorkerVersion) - the Python worker package version. Mirrors the
+                         Microsoft.Azure.Functions.PythonWorker version
+                         pulled in at pack time. Bare three-part SemVer.
 
-    Derived $(VersionPrefix):
-      stable        -> 4.43.0
-      preview       -> 4.43.0-preview
-      experimental  -> 4.43.0-experimental
+    Unlike the bundles workload, there is no channel axis: the upstream
+    PythonWorker NuGet doesn't ship preview/experimental SKUs, so the
+    workload pkg version is just $(WorkerVersion).
   -->
 
   <PropertyGroup>
     <WorkerVersion>4.43.0</WorkerVersion>
-    <WorkerChannel>stable</WorkerChannel>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(WorkerChannel)' == 'stable'">
     <VersionPrefix>$(WorkerVersion)</VersionPrefix>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(WorkerChannel)' != 'stable'">
-    <VersionPrefix>$(WorkerVersion)-$(WorkerChannel)</VersionPrefix>
   </PropertyGroup>
 
 </Project>

--- a/src/Workloads/Workers/Python/README.md
+++ b/src/Workloads/Workers/Python/README.md
@@ -14,30 +14,19 @@ func workload install python-worker
 ## Version scheme
 
 The workload pkg version maps 1:1 to the Python worker payload it carries.
-Two props in `Directory.Version.props` drive `$(VersionPrefix)`:
+One prop in `Directory.Version.props` drives `$(VersionPrefix)`:
 
-| Prop               | Meaning                                                                                |
-|--------------------|----------------------------------------------------------------------------------------|
-| `$(WorkerVersion)` | `Microsoft.Azure.Functions.PythonWorker` version. Bare three-part SemVer.              |
-| `$(WorkerChannel)` | `stable` \| `preview` \| `experimental`. Selects the workload pkg's prerelease label.  |
-
-| Channel      | Workload pkg version |
-|--------------|----------------------|
-| stable       | `4.43.0`             |
-| preview      | `4.43.0-preview`     |
-| experimental | `4.43.0-experimental`|
+| Prop               | Meaning                                                                   |
+|--------------------|---------------------------------------------------------------------------|
+| `$(WorkerVersion)` | `Microsoft.Azure.Functions.PythonWorker` version. Bare three-part SemVer. |
 
 Bump `$(WorkerVersion)` whenever the upstream worker package is bumped.
 `$(WorkerVersion)` also pins the restored
 `Microsoft.Azure.Functions.PythonWorker` pkg via `VersionOverride`, so the
 two versions cannot drift.
 
-## Build-time channel selection
-
-```bash
-dotnet pack ... /p:WorkerChannel=preview
-dotnet pack ... /p:WorkerChannel=experimental
-```
+Unlike the bundles workload, there is no channel axis: the upstream
+PythonWorker NuGet doesn't ship preview/experimental SKUs.
 
 ## Status
 

--- a/src/Workloads/Workers/Python/README.md
+++ b/src/Workloads/Workers/Python/README.md
@@ -11,6 +11,34 @@ func workload install Azure.Functions.Cli.Workloads.Workers.Python
 func workload install python-worker
 ```
 
+## Version scheme
+
+The workload pkg version maps 1:1 to the Python worker payload it carries.
+Two props in `Directory.Version.props` drive `$(VersionPrefix)`:
+
+| Prop               | Meaning                                                                                |
+|--------------------|----------------------------------------------------------------------------------------|
+| `$(WorkerVersion)` | `Microsoft.Azure.Functions.PythonWorker` version. Bare three-part SemVer.              |
+| `$(WorkerChannel)` | `stable` \| `preview` \| `experimental`. Selects the workload pkg's prerelease label.  |
+
+| Channel      | Workload pkg version |
+|--------------|----------------------|
+| stable       | `4.43.0`             |
+| preview      | `4.43.0-preview`     |
+| experimental | `4.43.0-experimental`|
+
+Bump `$(WorkerVersion)` whenever the upstream worker package is bumped.
+`$(WorkerVersion)` also pins the restored
+`Microsoft.Azure.Functions.PythonWorker` pkg via `VersionOverride`, so the
+two versions cannot drift.
+
+## Build-time channel selection
+
+```bash
+dotnet pack ... /p:WorkerChannel=preview
+dotnet pack ... /p:WorkerChannel=experimental
+```
+
 ## Status
 
 Preview. Worker assets are pulled at pack time from the restored

--- a/src/Workloads/Workers/Python/Workloads.Workers.Python.csproj
+++ b/src/Workloads/Workers/Python/Workloads.Workers.Python.csproj
@@ -25,7 +25,7 @@
       pointing at the restored package root. IncludeAssets=none keeps the
       package's build targets and tools/ files from affecting this project.
     -->
-    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" GeneratePathProperty="true">
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" GeneratePathProperty="true" VersionOverride="$(WorkerVersion)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>none</IncludeAssets>
     </PackageReference>

--- a/src/Workloads/Workers/Python/release_notes.md
+++ b/src/Workloads/Workers/Python/release_notes.md
@@ -1,5 +1,12 @@
 # Azure.Functions.Cli.Workloads.Workers.Python
 
+## 4.43.0
+
+- Adopt two-axis version scheme: `$(WorkerVersion)` mirrors
+  `Microsoft.Azure.Functions.PythonWorker`, `$(WorkerChannel)` selects the
+  prerelease label (`stable` | `preview` | `experimental`). Workload pkg
+  version now tracks the worker payload version 1:1.
+
 ## 1.0.0-preview.1
 
 - Initial scaffold of the Python worker content workload.

--- a/src/Workloads/Workers/Python/release_notes.md
+++ b/src/Workloads/Workers/Python/release_notes.md
@@ -2,10 +2,9 @@
 
 ## 4.43.0
 
-- Adopt two-axis version scheme: `$(WorkerVersion)` mirrors
-  `Microsoft.Azure.Functions.PythonWorker`, `$(WorkerChannel)` selects the
-  prerelease label (`stable` | `preview` | `experimental`). Workload pkg
-  version now tracks the worker payload version 1:1.
+- Adopt single-axis version scheme: `$(WorkerVersion)` mirrors
+  `Microsoft.Azure.Functions.PythonWorker`. Workload pkg version tracks the
+  worker payload version 1:1.
 
 ## 1.0.0-preview.1
 


### PR DESCRIPTION
Mirrors the bundles workload version coupling from #5055, scoped down for the worker workloads: the workload pkg version tracks the worker payload it ships 1:1. There is **no channel axis** for workers (the upstream `NodeJsWorker` / `PythonWorker` NuGets don't ship preview/experimental SKUs, and Go has no upstream worker pkg at all).

Each workload's `Directory.Version.props` now has a single driver:

| Prop               | Meaning                                       |
|--------------------|-----------------------------------------------|
| `$(WorkerVersion)` | Worker payload version. Bare three-part SemVer. Drives `$(VersionPrefix)` directly. |

### Coupling to upstream worker NuGets

For **Node** (`Microsoft.Azure.Functions.NodeJsWorker`) and **Python** (`Microsoft.Azure.Functions.PythonWorker`), `$(WorkerVersion)` is also applied as `VersionOverride` on the `PackageReference` so the restored worker pkg and the workload pkg cannot drift. The workload pkg version literally is the worker payload version it ships.

For **Go**, there's no upstream worker NuGet, so `$(WorkerVersion)` is maintained manually alongside the static `worker.config.json` payload. Same single-axis layout for consistency.

### Default starting versions

| Workload | `$(WorkerVersion)` | Upstream pkg version |
|----------|--------------------|----------------------|
| Node     | `3.13.0`           | `3.13.0`             |
| Python   | `4.43.0`           | `4.43.0`             |
| Go       | `1.0.0`            | n/a (static content) |

Central pins for the worker NuGets in `eng/build/Packages.props` are kept (matched to `$(WorkerVersion)`) as a documentation aid; the workload props are the authoritative source.

### Verification

```
CI=true dotnet build -c Release src/Workloads/Workers/{Node,Python,Go}/Workloads.Workers.*.csproj
```
0 warnings, 0 errors across all three.

`dotnet pack` for each project produces:
- `Azure.Functions.Cli.Workloads.Workers.Node.3.13.0.nupkg`
- `Azure.Functions.Cli.Workloads.Workers.Python.4.43.0.nupkg`
- `Azure.Functions.Cli.Workloads.Workers.Go.1.0.0.nupkg`

### Notes

- Targets the `vnext` orphan branch, same as #5055.
- READMEs and `release_notes.md` in each workload updated.
- No host or core CLI version changes.