### PR TITLE
Include native worker in minified builds

### DIFF
--- a/eng/build/Minified.targets
+++ b/eng/build/Minified.targets
@@ -6,6 +6,7 @@
     <_LanguageWorkers Include="$(PublishDir)\workers\java" />
     <_LanguageWorkers Include="$(PublishDir)\workers\powershell" />
     <_LanguageWorkers Include="$(PublishDir)\workers\node" />
+    <_LanguageWorkers Include="$(PublishDir)\workers\native" />
   </ItemGroup>
 
   <!-- Remove worker directories from minified builds -->


### PR DESCRIPTION
Adds `$(PublishDir)\workers\native` to the `_LanguageWorkers` item group in `eng/build/Minified.targets` so the native workers directory is removed from minified builds alongside the other language workers.

Base: `feature/go-support`