### PR TITLE
Revert "Remove --bundles-channel option from Node and Python init" (#5060)

### DIFF
--- a/src/Abstractions/Projects/ExtensionBundle.cs
+++ b/src/Abstractions/Projects/ExtensionBundle.cs
@@ -4,18 +4,34 @@
 namespace Azure.Functions.Cli.Projects;
 
 /// <summary>
+/// Release channel for the Functions extension bundle. Values map to the
+/// three published bundle ids (GA / Preview / Experimental).
+/// </summary>
+public enum BundleChannel
+{
+    GA,
+    Preview,
+    Experimental,
+}
+
+/// <summary>
 /// Shared metadata for the Functions extension bundle. Used by script-based
 /// workloads (Python, Node, ...) that don't compile in their own extensions.
 /// </summary>
 public static class ExtensionBundle
 {
     /// <summary>
-    /// NuGet id for the GA extension bundle written by <c>func init</c> templates.
-    /// </summary>
-    public const string DefaultId = "Microsoft.Azure.Functions.ExtensionBundle";
-
-    /// <summary>
     /// Default version range pulled by <c>func init</c> templates.
     /// </summary>
     public const string DefaultVersionRange = "[4.*, 5.0.0)";
+
+    /// <summary>
+    /// Returns the NuGet id for the bundle published under <paramref name="channel"/>.
+    /// </summary>
+    public static string IdFor(BundleChannel channel) => channel switch
+    {
+        BundleChannel.Preview => "Microsoft.Azure.Functions.ExtensionBundle.Preview",
+        BundleChannel.Experimental => "Microsoft.Azure.Functions.ExtensionBundle.Experimental",
+        _ => "Microsoft.Azure.Functions.ExtensionBundle",
+    };
 }

--- a/src/Workloads/Stacks/Node/NodeProjectInitializer.cs
+++ b/src/Workloads/Stacks/Node/NodeProjectInitializer.cs
@@ -34,13 +34,19 @@ internal sealed class NodeProjectInitializer : IProjectInitializer
         DefaultValueFactory = _ => false,
     };
 
+    public Option<BundleChannel> BundlesChannelOption { get; } = new("--bundles-channel", "-c")
+    {
+        Description = "Extension bundle release channel: GA (default), Preview, or Experimental.",
+        DefaultValueFactory = _ => BundleChannel.GA,
+    };
+
     public Option<bool> SkipNpmInstallOption { get; } = new("--skip-npm-install")
     {
         Description = "Skip running 'npm install' after Node project creation.",
         DefaultValueFactory = _ => false,
     };
 
-    public IReadOnlyList<Option> GetInitOptions() => [NoBundleOption, SkipNpmInstallOption];
+    public IReadOnlyList<Option> GetInitOptions() => [NoBundleOption, BundlesChannelOption, SkipNpmInstallOption];
 
     public async Task InitializeAsync(
         InitContext context,
@@ -55,6 +61,7 @@ internal sealed class NodeProjectInitializer : IProjectInitializer
         bool force = context.Force;
         bool isTypeScript = string.Equals(context.Language, "typescript", StringComparison.OrdinalIgnoreCase);
         bool noBundle = parseResult.GetValue(NoBundleOption);
+        BundleChannel channel = parseResult.GetValue(BundlesChannelOption);
         bool skipNpmInstall = parseResult.GetValue(SkipNpmInstallOption);
 
         string projectName = ResolveProjectName(context);
@@ -103,7 +110,7 @@ internal sealed class NodeProjectInitializer : IProjectInitializer
         {
             ProjectFiles.MergeHostJson(
                 Path.Combine(root, "host.json"),
-                EnsureExtensionBundle);
+                host => EnsureExtensionBundle(host, channel));
         }
 
         if (!skipNpmInstall)
@@ -127,7 +134,7 @@ internal sealed class NodeProjectInitializer : IProjectInitializer
         return string.IsNullOrEmpty(sanitized) ? "function-app" : sanitized;
     }
 
-    private static void EnsureExtensionBundle(JsonObject host)
+    private static void EnsureExtensionBundle(JsonObject host, BundleChannel channel)
     {
         if (host.ContainsKey("extensionBundle"))
         {
@@ -136,7 +143,7 @@ internal sealed class NodeProjectInitializer : IProjectInitializer
 
         host["extensionBundle"] = new JsonObject
         {
-            ["id"] = ExtensionBundle.DefaultId,
+            ["id"] = ExtensionBundle.IdFor(channel),
             ["version"] = ExtensionBundle.DefaultVersionRange,
         };
     }

--- a/src/Workloads/Stacks/Python/PythonProjectInitializer.cs
+++ b/src/Workloads/Stacks/Python/PythonProjectInitializer.cs
@@ -26,7 +26,13 @@ internal sealed class PythonProjectInitializer : IProjectInitializer
         DefaultValueFactory = _ => false,
     };
 
-    public IReadOnlyList<Option> GetInitOptions() => [NoBundleOption];
+    public Option<BundleChannel> BundlesChannelOption { get; } = new("--bundles-channel", "-c")
+    {
+        Description = "Extension bundle release channel: GA (default), Preview, or Experimental.",
+        DefaultValueFactory = _ => BundleChannel.GA,
+    };
+
+    public IReadOnlyList<Option> GetInitOptions() => [NoBundleOption, BundlesChannelOption];
 
     public Task InitializeAsync(
         InitContext context,
@@ -40,6 +46,7 @@ internal sealed class PythonProjectInitializer : IProjectInitializer
         string root = context.WorkingDirectory.Info.FullName;
         bool force = context.Force;
         bool noBundle = parseResult.GetValue(NoBundleOption);
+        BundleChannel channel = parseResult.GetValue(BundlesChannelOption);
 
         ProjectFiles.WriteIfMissing(
             Path.Combine(root, "function_app.py"),
@@ -77,13 +84,13 @@ internal sealed class PythonProjectInitializer : IProjectInitializer
         {
             ProjectFiles.MergeHostJson(
                 Path.Combine(root, "host.json"),
-                EnsureExtensionBundle);
+                host => EnsureExtensionBundle(host, channel));
         }
 
         return Task.CompletedTask;
     }
 
-    private static void EnsureExtensionBundle(JsonObject host)
+    private static void EnsureExtensionBundle(JsonObject host, BundleChannel channel)
     {
         // Only fill in when missing so a user-customised bundle survives `--force`.
         if (host.ContainsKey("extensionBundle"))
@@ -93,7 +100,7 @@ internal sealed class PythonProjectInitializer : IProjectInitializer
 
         host["extensionBundle"] = new JsonObject
         {
-            ["id"] = ExtensionBundle.DefaultId,
+            ["id"] = ExtensionBundle.IdFor(channel),
             ["version"] = ExtensionBundle.DefaultVersionRange,
         };
     }

--- a/test/Workloads/Stacks/Node.Tests/NodeProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/Node.Tests/NodeProjectInitializerTests.cs
@@ -47,8 +47,8 @@ public class NodeProjectInitializerTests : IDisposable
         IReadOnlyList<string> names = [.. options.Select(o => o.Name)];
 
         Assert.Contains("--no-bundle", names);
+        Assert.Contains("--bundles-channel", names);
         Assert.Contains("--skip-npm-install", names);
-        Assert.DoesNotContain("--bundles-channel", names);
     }
 
     [Fact]
@@ -140,6 +140,15 @@ public class NodeProjectInitializerTests : IDisposable
         string content = File.ReadAllText(hostJsonPath);
         Assert.Contains("\"version\"", content);
         Assert.DoesNotContain("extensionBundle", content);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_BundlesChannel_Preview_WritesPreviewBundleId()
+    {
+        await RunAsync(language: null, force: false, args: ["--bundles-channel", "Preview"]);
+
+        JsonNode? bundle = JsonNode.Parse(File.ReadAllText(Path.Combine(_projectDir.FullName, "host.json")))!["extensionBundle"];
+        Assert.Equal("Microsoft.Azure.Functions.ExtensionBundle.Preview", bundle!["id"]!.GetValue<string>());
     }
 
     [Fact]

--- a/test/Workloads/Stacks/Python.Tests/PythonProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/Python.Tests/PythonProjectInitializerTests.cs
@@ -47,7 +47,7 @@ public class PythonProjectInitializerTests : IDisposable
         IReadOnlyList<string> names = [.. options.Select(o => o.Name)];
 
         Assert.Contains("--no-bundle", names);
-        Assert.DoesNotContain("--bundles-channel", names);
+        Assert.Contains("--bundles-channel", names);
     }
 
     [Fact]
@@ -134,6 +134,30 @@ public class PythonProjectInitializerTests : IDisposable
         string content = File.ReadAllText(hostJsonPath);
         Assert.Contains("\"version\"", content);
         Assert.DoesNotContain("extensionBundle", content);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_BundlesChannel_Preview_WritesPreviewBundleId()
+    {
+        await RunAsync(force: false, args: ["--bundles-channel", "Preview"]);
+
+        string hostJsonPath = Path.Combine(_projectDir.FullName, "host.json");
+        var root = JsonNode.Parse(File.ReadAllText(hostJsonPath));
+        Assert.Equal(
+            "Microsoft.Azure.Functions.ExtensionBundle.Preview",
+            root!["extensionBundle"]!["id"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task InitializeAsync_BundlesChannel_Experimental_WritesExperimentalBundleId()
+    {
+        await RunAsync(force: false, args: ["--bundles-channel", "Experimental"]);
+
+        string hostJsonPath = Path.Combine(_projectDir.FullName, "host.json");
+        var root = JsonNode.Parse(File.ReadAllText(hostJsonPath));
+        Assert.Equal(
+            "Microsoft.Azure.Functions.ExtensionBundle.Experimental",
+            root!["extensionBundle"]!["id"]!.GetValue<string>());
     }
 
     private Task RunAsync(bool force, string[]? args = null)


### PR DESCRIPTION
Reverts #5060.

Restores `--bundles-channel` (`-c`) on `func init` for Node and Python so users can still select the GA, Preview, or Experimental extension bundle id written into `host.json`.

Build green; Node (37) and Python (33) init tests pass.