### PR TITLE
Add --bundles-channel option to Go init

### DIFF
--- a/src/Workloads/Stacks/Go/GoProjectInitializer.cs
+++ b/src/Workloads/Stacks/Go/GoProjectInitializer.cs
@@ -4,6 +4,7 @@
 using System.CommandLine;
 using System.Diagnostics;
 using System.Reflection;
+using System.Text.Json.Nodes;
 using Azure.Functions.Cli.Commands;
 using Azure.Functions.Cli.Projects;
 
@@ -33,7 +34,19 @@ internal sealed class GoProjectInitializer : IProjectInitializer
         DefaultValueFactory = _ => false,
     };
 
-    public IReadOnlyList<Option> GetInitOptions() => [SkipGoModTidyOption];
+    public Option<bool> NoBundleOption { get; } = new("--no-bundle")
+    {
+        Description = "Skip writing the default extensionBundle block in host.json.",
+        DefaultValueFactory = _ => false,
+    };
+
+    public Option<BundleChannel> BundlesChannelOption { get; } = new("--bundles-channel", "-c")
+    {
+        Description = "Extension bundle release channel: GA (default), Preview, or Experimental.",
+        DefaultValueFactory = _ => BundleChannel.GA,
+    };
+
+    public IReadOnlyList<Option> GetInitOptions() => [SkipGoModTidyOption, NoBundleOption, BundlesChannelOption];
 
     public async Task InitializeAsync(
         InitContext context,
@@ -46,12 +59,21 @@ internal sealed class GoProjectInitializer : IProjectInitializer
 
         string root = context.WorkingDirectory.Info.FullName;
         bool force = context.Force;
+        bool noBundle = parseResult.GetValue(NoBundleOption);
+        BundleChannel channel = parseResult.GetValue(BundlesChannelOption);
         string moduleName = ResolveModuleName(context);
 
         ProjectFiles.WriteIfMissing(
             Path.Combine(root, "host.json"),
             ProjectFiles.MinimalHostJson,
             force);
+
+        if (!noBundle)
+        {
+            ProjectFiles.MergeHostJson(
+                Path.Combine(root, "host.json"),
+                host => EnsureExtensionBundle(host, channel));
+        }
 
         ProjectFiles.WriteIfMissing(
             Path.Combine(root, "go.mod"),
@@ -100,6 +122,21 @@ internal sealed class GoProjectInitializer : IProjectInitializer
             .Where(c => char.IsLetterOrDigit(c) || c is '-' or '_');
         string sanitized = new([.. chars]);
         return string.IsNullOrEmpty(sanitized) ? DefaultModuleName : sanitized;
+    }
+
+    private static void EnsureExtensionBundle(JsonObject host, BundleChannel channel)
+    {
+        // Only fill in when missing so a user-customised bundle survives `--force`.
+        if (host.ContainsKey("extensionBundle"))
+        {
+            return;
+        }
+
+        host["extensionBundle"] = new JsonObject
+        {
+            ["id"] = ExtensionBundle.IdFor(channel),
+            ["version"] = ExtensionBundle.DefaultVersionRange,
+        };
     }
 
     private static async Task<(int ExitCode, string Stderr)> DefaultRunGoModTidy(string workingDirectory, CancellationToken cancellationToken)

--- a/test/Workloads/Stacks/Go.Tests/GoProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/Go.Tests/GoProjectInitializerTests.cs
@@ -44,8 +44,11 @@ public class GoProjectInitializerTests : IDisposable
     public void GetInitOptions_ContainsSkipGoModTidy()
     {
         IReadOnlyList<Option> options = new GoProjectInitializer().GetInitOptions();
-        Assert.Single(options);
-        Assert.Equal("--skip-go-mod-tidy", options[0].Name);
+        IReadOnlyList<string> names = [.. options.Select(o => o.Name)];
+
+        Assert.Contains("--skip-go-mod-tidy", names);
+        Assert.Contains("--no-bundle", names);
+        Assert.Contains("--bundles-channel", names);
     }
 
     [Fact]
@@ -79,18 +82,76 @@ public class GoProjectInitializerTests : IDisposable
     }
 
     [Fact]
-    public async Task InitializeAsync_DoesNotTouchHostJson()
+    public async Task InitializeAsync_AppendsExtensionBundle_IntoExistingHostJson()
     {
-        const string baseHost = "{\n  \"version\": \"2.0\"\n}";
-        File.WriteAllText(Path.Combine(_projectDir.FullName, "host.json"), baseHost);
+        File.WriteAllText(Path.Combine(_projectDir.FullName, "host.json"), "{ \"version\": \"2.0\" }");
 
         await RunAsync(projectName: "my-go-app", force: false);
 
-        string after = File.ReadAllText(Path.Combine(_projectDir.FullName, "host.json"));
-        Assert.Equal(baseHost, after);
-        var root = JsonNode.Parse(after) as JsonObject;
+        var root = JsonNode.Parse(File.ReadAllText(Path.Combine(_projectDir.FullName, "host.json")));
         Assert.NotNull(root);
-        Assert.False(root!.ContainsKey("customHandler"));
+        Assert.Equal("2.0", root!["version"]!.GetValue<string>());
+        JsonNode? bundle = root["extensionBundle"];
+        Assert.NotNull(bundle);
+        Assert.Equal("Microsoft.Azure.Functions.ExtensionBundle", bundle!["id"]!.GetValue<string>());
+        Assert.Equal("[4.*, 5.0.0)", bundle["version"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task InitializeAsync_LeavesExistingExtensionBundleUntouched()
+    {
+        const string custom = "{\"version\":\"2.0\",\"extensionBundle\":{\"id\":\"custom\",\"version\":\"1.0.0\"}}";
+        File.WriteAllText(Path.Combine(_projectDir.FullName, "host.json"), custom);
+
+        await RunAsync(projectName: "my-go-app", force: false);
+
+        JsonNode? bundle = JsonNode.Parse(File.ReadAllText(Path.Combine(_projectDir.FullName, "host.json")))!["extensionBundle"];
+        Assert.Equal("custom", bundle!["id"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task InitializeAsync_BundlesChannel_Default_WritesDefaultBundleId()
+    {
+        await RunAsync(projectName: "my-go-app", force: false);
+
+        var root = JsonNode.Parse(File.ReadAllText(Path.Combine(_projectDir.FullName, "host.json")));
+        Assert.Equal(
+            "Microsoft.Azure.Functions.ExtensionBundle",
+            root!["extensionBundle"]!["id"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task InitializeAsync_BundlesChannel_Preview_WritesPreviewBundleId()
+    {
+        await RunAsync(projectName: "my-go-app", force: false, args: ["--bundles-channel", "Preview"]);
+
+        var root = JsonNode.Parse(File.ReadAllText(Path.Combine(_projectDir.FullName, "host.json")));
+        Assert.Equal(
+            "Microsoft.Azure.Functions.ExtensionBundle.Preview",
+            root!["extensionBundle"]!["id"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task InitializeAsync_BundlesChannel_Experimental_WritesExperimentalBundleId()
+    {
+        await RunAsync(projectName: "my-go-app", force: false, args: ["--bundles-channel", "Experimental"]);
+
+        var root = JsonNode.Parse(File.ReadAllText(Path.Combine(_projectDir.FullName, "host.json")));
+        Assert.Equal(
+            "Microsoft.Azure.Functions.ExtensionBundle.Experimental",
+            root!["extensionBundle"]!["id"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task InitializeAsync_NoBundle_WritesMinimalHostJsonWithoutExtensionBundle()
+    {
+        await RunAsync(projectName: "my-go-app", force: false, args: ["--no-bundle"]);
+
+        string hostJsonPath = Path.Combine(_projectDir.FullName, "host.json");
+        Assert.True(File.Exists(hostJsonPath), "host.json should be created even with --no-bundle");
+        string content = File.ReadAllText(hostJsonPath);
+        Assert.Contains("\"version\"", content);
+        Assert.DoesNotContain("extensionBundle", content);
     }
 
     [Fact]
@@ -160,7 +221,7 @@ public class GoProjectInitializerTests : IDisposable
         Assert.Equal(1, calls);
     }
 
-    private Task RunAsync(string? projectName, bool force)
+    private Task RunAsync(string? projectName, bool force, string[]? args = null)
     {
         var initializer = new GoProjectInitializer();
         // Skip the real `go mod tidy` invocation in tests by stubbing the seam.
@@ -170,6 +231,12 @@ public class GoProjectInitializerTests : IDisposable
             ProjectName: projectName,
             Language: null,
             Force: force);
-        return initializer.InitializeAsync(context, new RootCommand().Parse(string.Empty));
+        var root = new RootCommand();
+        foreach (Option opt in initializer.GetInitOptions())
+        {
+            root.Options.Add(opt);
+        }
+
+        return initializer.InitializeAsync(context, root.Parse(args ?? []));
     }
 }


### PR DESCRIPTION
Mirrors the Node and Python initializers for the Go workload:

- `--bundles-channel` / `-c`: selects the extension bundle id written into `host.json` (GA, Preview, or Experimental). Defaults to GA.
- `--no-bundle`: skips writing the `extensionBundle` block.

Reuses the existing `BundleChannel` enum and `ExtensionBundle.IdFor(channel)` helper from `Azure.Functions.Cli.Projects`. Depends on #5063 (already merged into `vnext`), which restored the `BundleChannel` enum.