### PR TITLE
Workloads install: only extract workload.json and tools/

### DIFF
--- a/src/Func/Workloads/Install/WorkloadInstaller.cs
+++ b/src/Func/Workloads/Install/WorkloadInstaller.cs
@@ -480,10 +480,19 @@ internal sealed class WorkloadInstaller(
         CancellationToken cancellationToken)
     {
         // PackageArchiveReader already filters OPC metadata and rejects
-        // path-escape entries, so we don't re-filter here.
+        // path-escape entries. We additionally restrict the on-disk layout
+        // to the workload contract: workload.json at the root and the
+        // tools/ payload. Other package-level files (the .nuspec, NuGet's
+        // package icon, etc.) are pack-time artifacts the host never reads
+        // and would just bloat the install directory.
         foreach (string packageFile in await reader.GetFilesAsync(cancellationToken))
         {
             cancellationToken.ThrowIfCancellationRequested();
+
+            if (!IsInstallablePackageFile(packageFile))
+            {
+                continue;
+            }
 
             string targetPath = Path.Combine(destination, packageFile.Replace('/', Path.DirectorySeparatorChar));
             Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
@@ -492,6 +501,22 @@ internal sealed class WorkloadInstaller(
             using FileStream output = File.Create(targetPath);
             await entryStream.CopyToAsync(output, cancellationToken);
         }
+    }
+
+    /// <summary>
+    /// Whether a file inside the .nupkg is part of the workload's on-disk
+    /// contract. Only <c>workload.json</c> at the package root and entries
+    /// under <c>tools/</c> are extracted; everything else (.nuspec, package
+    /// icon, etc.) is pack-time metadata and stays inside the .nupkg.
+    /// </summary>
+    private static bool IsInstallablePackageFile(string packageFile)
+    {
+        if (string.Equals(packageFile, WorkloadMetadataReader.MetadataFileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return packageFile.StartsWith("tools/", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
+++ b/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
@@ -82,6 +82,33 @@ public sealed class WorkloadInstallerTests : IDisposable
     }
 
     [Fact]
+    public async Task InstallFromPackage_OnlyExtractsWorkloadJsonAndTools()
+    {
+        // Real workload packages also carry pack-time metadata (the .nuspec,
+        // icons, docs) that has no business landing in the install dir.
+        string nupkg = BuildNupkg(extraFiles:
+        [
+            (WriteTempFile("workload.json", "{}"), "workload.json"),
+            (WriteTempFile("readme.md", "# readme"), "readme.md"),
+            (WriteTempFile("icon.png", "png"), "icon.png"),
+            (WriteTempFile("notes.txt", "notes"), "docs/notes.txt"),
+        ]);
+
+        WorkloadInstaller installer = NewInstaller();
+        await installer.InstallFromPackageAsync(nupkg);
+
+        string installDir = _paths.GetInstallDirectory("test.workload", "1.0.0");
+        string[] entries = [.. Directory
+            .EnumerateFileSystemEntries(installDir, "*", SearchOption.AllDirectories)
+            .Select(p => Path.GetRelativePath(installDir, p).Replace(Path.DirectorySeparatorChar, '/'))
+            .OrderBy(p => p, StringComparer.Ordinal)];
+
+        Assert.Equal(
+            new[] { "tools", "tools/any", "tools/any/Test.dll", "workload.json" },
+            entries);
+    }
+
+    [Fact]
     public async Task InstallFromPackage_InvalidWorkloadJson_Throws_RollsBack()
     {
         string nupkg = BuildNupkg();
@@ -473,7 +500,11 @@ public sealed class WorkloadInstallerTests : IDisposable
 
     private WorkloadInstaller NewInstaller() => new(_paths, _store, _metadataReader, _catalog);
 
-    private string BuildNupkg(string? tags = null, bool includeFuncCliWorkloadType = true, string version = "1.0.0")
+    private string BuildNupkg(
+        string? tags = null,
+        bool includeFuncCliWorkloadType = true,
+        string version = "1.0.0",
+        IEnumerable<(string SourcePath, string TargetPath)>? extraFiles = null)
     {
         string stubAssembly = Path.Combine(_root, $"stub-{Guid.NewGuid():N}.dll");
         File.WriteAllBytes(stubAssembly, [0x4D, 0x5A]);
@@ -504,12 +535,27 @@ public sealed class WorkloadInstallerTests : IDisposable
             TargetPath = $"tools/{NuGetFramework.Parse("any").GetShortFolderName()}/Test.dll",
         });
 
+        if (extraFiles is not null)
+        {
+            foreach ((string source, string target) in extraFiles)
+            {
+                builder.Files.Add(new PhysicalPackageFile { SourcePath = source, TargetPath = target });
+            }
+        }
+
         string path = Path.Combine(_root, $"Test.Workload.{Guid.NewGuid():N}.nupkg");
         using (FileStream stream = File.Create(path))
         {
             builder.Save(stream);
         }
 
+        return path;
+    }
+
+    private string WriteTempFile(string name, string contents)
+    {
+        string path = Path.Combine(_root, $"{Guid.NewGuid():N}-{name}");
+        File.WriteAllText(path, contents);
         return path;
     }
 }


### PR DESCRIPTION
NuGet's `PackageArchiveReader.GetFiles()` returns everything except OPC metadata, so the .nuspec (and other root-level files in the .nupkg like icons or readmes) was landing in the workload install directory next to `workload.json` and `tools/`, even though the host never reads them.

Example before:
```
~/.azure-functions/workloads/azure.functions.cli.workloads.extensionbundles/4.35.0/
├── workload.json
├── tools/
├── Azure.Functions.Cli.Workloads.ExtensionBundles.nuspec   # not wanted
└── ...                                                     # not wanted
```

Filter `ExtractPackageAsync` to the workload on-disk contract: `workload.json` at the root plus the `tools/` payload. Everything else stays inside the .nupkg.

### Changes
- `WorkloadInstaller.ExtractPackageAsync`: skip entries that aren't `workload.json` or under `tools/`.
- New test `InstallFromPackage_OnlyExtractsWorkloadJsonAndTools` packs extra junk (readme, icon, `docs/notes.txt`) and asserts the install dir contains exactly `workload.json` + `tools/any/Test.dll`.