### PR TITLE
Make 'run' the canonical host command, alias 'start'

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ func <command> [path] [options]
 |---------|-------------|
 | `func init [path]` | Initialize a new Azure Functions project |
 | `func new [path]` | Create a new function from a template |
-| `func start [path]` | Start the Functions host locally |
+| `func run [path]` | Start the Functions host locally (alias: `func start`) |
 | `func workload install <id>` | Install a language workload |
 | `func workload list` | List installed workloads |
 | `func version` | Display version information |

--- a/src/Func/Commands/Start/StartCommand.cs
+++ b/src/Func/Commands/Start/StartCommand.cs
@@ -17,7 +17,8 @@ using Microsoft.Extensions.Options;
 namespace Azure.Functions.Cli.Commands;
 
 /// <summary>
-/// Launches the Azure Functions host runtime via 'func start'.
+/// Launches the Azure Functions host runtime via 'func run' (also aliased
+/// as 'func start' for backward compatibility).
 /// </summary>
 /// <remarks>
 /// v1 prototype: real host integration is not yet implemented, so the
@@ -103,9 +104,15 @@ internal sealed class StartCommand : FuncCliCommand, IBuiltInCommand
         IStartInitializationRunner initializationRunner,
         IOptionsMonitor<HostStartupOptions> hostStartupOptions,
         StartDashboardEventStreamFactory? eventStreamFactory = null)
-        : base("start", "Launch the Azure Functions host runtime.")
+        : base("run", "Launch the Azure Functions host runtime.")
     {
         ArgumentNullException.ThrowIfNull(interaction);
+
+        // 'start' is the legacy name from Core Tools v4 and earlier. Kept as
+        // an alias so existing scripts, package.json entries, and muscle
+        // memory continue to work after the canonical rename to 'run'.
+        Aliases.Add("start");
+
         ArgumentNullException.ThrowIfNull(palette);
         ArgumentNullException.ThrowIfNull(versionProvider);
         ArgumentNullException.ThrowIfNull(initializationRunner);

--- a/test/Func.Tests/Commands/StartCommandTests.cs
+++ b/test/Func.Tests/Commands/StartCommandTests.cs
@@ -68,9 +68,22 @@ public class StartCommandTests : IDisposable
     public void StartCommand_RegisteredInParser()
     {
         var root = TestParser.CreateRoot(_interaction);
-        var names = root.Subcommands.Select(c => c.Name).ToList();
+        var runCommand = root.Subcommands.SingleOrDefault(c => c.Name == "run");
 
-        Assert.Contains("start", names);
+        Assert.NotNull(runCommand);
+        Assert.Contains("start", runCommand!.Aliases);
+    }
+
+    [Fact]
+    public async Task StartCommand_InvokableByRunName()
+    {
+        var nonExistent = Path.Combine(_tempDir, "does-not-exist");
+        var root = TestParser.CreateRoot(_interaction);
+        var result = root.Parse($"run \"{nonExistent}\"");
+
+        var config = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
+        var ex = await Assert.ThrowsAsync<GracefulException>(() => result.InvokeAsync(config));
+        Assert.Contains("does not exist", ex.Message);
     }
 
     [Fact]


### PR DESCRIPTION
Renames the func host launch command from `start` to `run` and keeps `start` as an alias so existing scripts and muscle memory continue to work.

## Changes

- `StartCommand` is now registered as `run`, with `start` added to `Aliases`.
- README command table updated to list `func run [path]` and note the `start` alias.
- Test coverage:
  - `StartCommand_RegisteredInParser` asserts the command is registered as `run` with `start` in its aliases.
  - New `StartCommand_InvokableByRunName` exercises invocation under the canonical name.
  - Existing tests continue to parse with `start ...`, validating the alias.

## Verification

- `dotnet build src/Func/Func.csproj`: succeeded.
- `dotnet test test/Func.Tests/Func.Tests.csproj`: 478/478 passed.
- Manual smoke test: both `func run /nonexistent` and `func start /nonexistent` produce the same `GracefulException` from `StartCommand`.

## Notes

- File and class names (`StartCommand.cs`, `Commands/Start/`, `StartInitializationRunner`, etc.) are left in place. Renaming the full namespace tree was out of scope for this PR and would balloon the diff; happy to follow up if desired.
- `package.json` templates still use `"start": "func start"` (npm convention dictates the script key, and `func start` continues to work via the alias).