### PR TITLE
Add build-workloads skill

### DIFF
--- a/.claude/skills/build-workloads
+++ b/.claude/skills/build-workloads
@@ -1,0 +1,1 @@
+../../.github/skills/build-workloads

--- a/.github/skills/build-workloads/SKILL.md
+++ b/.github/skills/build-workloads/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: build-workloads
+description: 'Use when a user wants to build every workload in this repo and publish the resulting .nupkgs to a local NuGet feed for end-to-end testing of `func workload install` against a real v3 feed.'
+---
+
+# Build Workloads to a Local NuGet Feed
+
+End-to-end loop: pack every `PackageType=FuncCliWorkload` project, stand up a
+local NuGet v3 feed ([BaGet](https://github.com/loic-sharma/BaGet) in Docker),
+push the `.nupkg`s to it, and print the `func workload install` invocation that
+targets the feed.
+
+Use this skill when the user says things like:
+
+- "build all the workloads to a local feed"
+- "push the workloads to a local NuGet feed"
+- "set up a local feed for `func workload install` testing"
+
+Do **not** use it for shipping packages, for the `infra` feed, or to test the
+file-based `func workload install <path-to-nupkg>` flow. That works without a
+feed.
+
+## What the skill does
+
+1. Starts (or reuses) the local feed container via `assets/docker-compose.yml`.
+   Default endpoint: `http://localhost:5555/v3/index.json`. Default API key:
+   `NUGET-SERVER-API-KEY`. Packages persist in a named Docker volume so reruns
+   keep history.
+2. Packs every workload csproj listed in `Azure.Functions.Cli.slnx` under
+   `src/Workloads/**`, into a single output folder.
+3. Pushes each produced `.nupkg` to the feed, skipping duplicates so a rerun
+   without bumping `VersionPrefix` is idempotent.
+4. Echoes the install command the user runs from another shell:
+   ```
+   func workload install <name> --source http://localhost:5555/v3/index.json
+   ```
+
+## Running it
+
+From the repo root:
+
+```pwsh
+pwsh ./.github/skills/build-workloads/scripts/build-workloads.ps1
+```
+
+Flags worth knowing (see script header for the full list):
+
+- `-Port <int>` — host port for the local feed (default `5555`).
+- `-Configuration <Debug|Release>` — defaults to `Debug`.
+- `-VersionSuffix <string>` — appended to the package version so each run
+  produces a fresh `1.0.0-<suffix>` package without editing csproj files.
+  Defaults to a UTC timestamp; pass an empty string to use the version baked
+  into the csproj.
+- `-PackOnly` — pack the workloads but don't touch Docker or push.
+- `-NoBuild` — push existing `.nupkg`s from the output folder without
+  re-packing.
+- `-Down` — stop and remove the feed container, then exit.
+
+The script is the source of truth. If a flag is in the script but missing here,
+trust the script.
+
+## Verifying the feed
+
+```pwsh
+curl http://localhost:5555/v3/index.json
+curl 'http://localhost:5555/v3/search?q=PackageType:FuncCliWorkload'
+```
+
+A browser at `http://localhost:5555/` shows the feed UI listing every pushed
+workload.
+
+## Notes for the agent running this skill
+
+- The feed rejects republishing the same `id@version`. If a workload is already
+  pushed and you didn't change `VersionPrefix`, either use `-VersionSuffix`
+  (default) or `-Down` first to wipe the volume.
+- The script discovers workloads by parsing `Azure.Functions.Cli.slnx` for
+  projects under `src/Workloads/`, so new workloads added per the
+  `create-workload` skill are picked up automatically. Do **not** hardcode the
+  current eight workload paths.
+- This skill is local-loop tooling. Do not wire it into CI, do not commit
+  generated `.nupkg`s, and do not change the published feed configuration.

--- a/.github/skills/build-workloads/assets/docker-compose.yml
+++ b/.github/skills/build-workloads/assets/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  baget:
+    image: loicsharma/baget:latest
+    container_name: func-workloads-feed
+    ports:
+      - "${BAGET_PORT:-5555}:80"
+    environment:
+      ApiKey: ${BAGET_API_KEY:-NUGET-SERVER-API-KEY}
+      Storage__Type: FileSystem
+      Storage__Path: /var/baget/packages
+      Database__Type: Sqlite
+      Database__ConnectionString: Data Source=/var/baget/baget.db
+      Search__Type: Database
+    volumes:
+      - func-workloads-feed-data:/var/baget
+
+volumes:
+  func-workloads-feed-data:

--- a/.github/skills/build-workloads/scripts/build-workloads.ps1
+++ b/.github/skills/build-workloads/scripts/build-workloads.ps1
@@ -1,0 +1,162 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Pack every workload in src/Workloads and publish the resulting .nupkgs to
+    a local NuGet feed running in Docker.
+
+.DESCRIPTION
+    Local-loop tooling for end-to-end testing of `func workload install`
+    against a real NuGet v3 feed. See SKILL.md next to this script.
+
+.PARAMETER Port
+    Host port for the local feed. Default: 5555.
+
+.PARAMETER ApiKey
+    API key the feed requires for pushes. Default: NUGET-SERVER-API-KEY.
+
+.PARAMETER Configuration
+    Build configuration. Default: Debug.
+
+.PARAMETER VersionSuffix
+    Suffix appended to the package version. Default: a UTC timestamp so each
+    run produces a fresh prerelease. Pass '' to use the version baked into the
+    csproj.
+
+.PARAMETER PackOnly
+    Pack the workloads but don't touch Docker or push.
+
+.PARAMETER NoBuild
+    Push existing .nupkgs from the output folder without re-packing.
+
+.PARAMETER Down
+    Stop and remove the local feed container (and its data volume), then exit.
+#>
+[CmdletBinding()]
+param(
+    [int] $Port = 5555,
+    [string] $ApiKey = 'NUGET-SERVER-API-KEY',
+    [ValidateSet('Debug', 'Release')]
+    [string] $Configuration = 'Debug',
+    [string] $VersionSuffix = ("local." + (Get-Date -AsUTC -Format 'yyyyMMddHHmmss')),
+    [switch] $PackOnly,
+    [switch] $NoBuild,
+    [switch] $Down
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$skillRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+$repoRoot = (Resolve-Path (Join-Path $skillRoot '../..')).Path
+$composeFile = Join-Path $skillRoot 'assets/docker-compose.yml'
+$slnxFile = Join-Path $repoRoot 'Azure.Functions.Cli.slnx'
+$outputDir = Join-Path $repoRoot 'artifacts/workloads-feed'
+$feedUrl = "http://localhost:$Port/v3/index.json"
+
+function Invoke-Native {
+    param([Parameter(Mandatory)] [string] $File, [string[]] $Arguments)
+    & $File @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$File $($Arguments -join ' ') exited with code $LASTEXITCODE"
+    }
+}
+
+function Get-DockerComposeCommand {
+    $docker = Get-Command docker -ErrorAction SilentlyContinue
+    if (-not $docker) { throw "docker is not on PATH. Install Docker Desktop and retry." }
+    & docker compose version *> $null
+    if ($LASTEXITCODE -eq 0) { return @('docker', 'compose') }
+    $compose = Get-Command docker-compose -ErrorAction SilentlyContinue
+    if ($compose) { return @('docker-compose') }
+    throw "Neither 'docker compose' nor 'docker-compose' is available."
+}
+
+function Invoke-Compose {
+    param([string[]] $Arguments)
+    $cmd = Get-DockerComposeCommand
+    $env:BAGET_PORT = "$Port"
+    $env:BAGET_API_KEY = $ApiKey
+    Invoke-Native -File $cmd[0] -Arguments (@($cmd[1..($cmd.Length - 1)]) + @('-f', $composeFile) + $Arguments)
+}
+
+function Get-WorkloadProjects {
+    if (-not (Test-Path $slnxFile)) { throw "Solution file not found: $slnxFile" }
+    [xml] $slnx = Get-Content -Raw $slnxFile
+    $projects = $slnx.SelectNodes('//Project') |
+        ForEach-Object { $_.GetAttribute('Path') } |
+        Where-Object { $_ -and ($_ -replace '\\', '/').StartsWith('src/Workloads/') } |
+        Sort-Object -Unique
+    if (-not $projects) { throw "No workload projects found under src/Workloads/ in $slnxFile" }
+    $projects | ForEach-Object { Join-Path $repoRoot ($_ -replace '\\', '/') }
+}
+
+function Wait-ForFeed {
+    Write-Host "Waiting for local feed at $feedUrl ..." -ForegroundColor Cyan
+    for ($i = 0; $i -lt 60; $i++) {
+        try {
+            $r = Invoke-WebRequest -Uri $feedUrl -UseBasicParsing -TimeoutSec 2 -ErrorAction Stop
+            if ($r.StatusCode -eq 200) { Write-Host "Feed is ready." -ForegroundColor Green; return }
+        } catch {
+            Start-Sleep -Seconds 1
+        }
+    }
+    throw "Local feed did not become ready on $feedUrl within 60s."
+}
+
+if ($Down) {
+    Write-Host "Stopping the local feed and removing its data volume..." -ForegroundColor Cyan
+    Invoke-Compose -Arguments @('down', '-v')
+    return
+}
+
+if (-not $NoBuild) {
+    if (Test-Path $outputDir) { Remove-Item -Recurse -Force $outputDir }
+    New-Item -ItemType Directory -Path $outputDir | Out-Null
+
+    $projects = Get-WorkloadProjects
+    Write-Host "Packing $($projects.Count) workload project(s) into $outputDir" -ForegroundColor Cyan
+    foreach ($proj in $projects) {
+        Write-Host "  pack $proj" -ForegroundColor DarkCyan
+        $packArgs = @(
+            'pack', $proj,
+            '-c', $Configuration,
+            '-o', $outputDir,
+            '--nologo'
+        )
+        if ($VersionSuffix) { $packArgs += @('--version-suffix', $VersionSuffix) }
+        Invoke-Native -File 'dotnet' -Arguments $packArgs
+    }
+}
+
+$nupkgs = @(Get-ChildItem -Path $outputDir -Filter '*.nupkg' -File -ErrorAction SilentlyContinue)
+if (-not $nupkgs) { throw "No .nupkg files in $outputDir. Run without -NoBuild first." }
+
+if ($PackOnly) {
+    Write-Host "Packed $($nupkgs.Count) package(s) to $outputDir. Skipping Docker and push (-PackOnly)." -ForegroundColor Green
+    return
+}
+
+Write-Host "Starting local feed on port $Port ..." -ForegroundColor Cyan
+Invoke-Compose -Arguments @('up', '-d')
+Wait-ForFeed
+
+Write-Host "Pushing $($nupkgs.Count) package(s) to $feedUrl" -ForegroundColor Cyan
+foreach ($pkg in $nupkgs) {
+    Write-Host "  push $($pkg.Name)" -ForegroundColor DarkCyan
+    $pushArgs = @(
+        'nuget', 'push', $pkg.FullName,
+        '--source', $feedUrl,
+        '--api-key', $ApiKey,
+        '--skip-duplicate'
+    )
+    Invoke-Native -File 'dotnet' -Arguments $pushArgs
+}
+
+Write-Host ""
+Write-Host "Done. Feed UI:    http://localhost:$Port/" -ForegroundColor Green
+Write-Host "      v3 index:   $feedUrl" -ForegroundColor Green
+Write-Host ""
+Write-Host "Install a workload from this feed:" -ForegroundColor Yellow
+Write-Host "  func workload install <name> --source $feedUrl"
+Write-Host "Tear down with:" -ForegroundColor Yellow
+Write-Host "  pwsh $PSCommandPath -Down"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,6 +281,8 @@ task matches:
 - **Adding a new CLI command** → `add-command` skill.
 - **Creating a new workload** (Node, Python, Java, ...) → `create-workload`
   skill.
+- **Building all workloads and publishing to a local NuGet feed for testing** →
+  `build-workloads` skill.
 - **Reviewing a design** → `dotnet-design-pattern-review` skill.
 
 ## Build & Test Commands
@@ -331,6 +333,8 @@ via symlinks under `.claude/skills/`. Available skills:
 
 - `add-command` — adding a new CLI command.
 - `create-workload` — scaffolding a new workload (Node, Python, Java, ...).
+- `build-workloads` — pack every workload and publish to a local NuGet feed
+  (Docker) for end-to-end `func workload install` testing.
 - `dotnet-design-pattern-review` — design pattern review checklist.
 
 The **Design Principles**, **CLI Conventions**, and **.NET / C# Practices**


### PR DESCRIPTION
Adds a new agent skill, `build-workloads`, that packs every workload in `src/Workloads/**` and publishes the resulting `.nupkg`s to a local NuGet v3 feed (BaGet in Docker) so we can exercise `func workload install --source <feed>` end-to-end without a real feed.

### What's included
- `.github/skills/build-workloads/SKILL.md` (frontmatter + when-to-use + flag reference)
- `scripts/build-workloads.ps1` — discovers workload projects from `Azure.Functions.Cli.slnx` (no hardcoding, picks up new workloads added via `create-workload` automatically), `dotnet pack`s them, brings the feed up via Docker compose, waits for `/v3/index.json`, then `dotnet nuget push --skip-duplicate`.
- `assets/docker-compose.yml` — BaGet on port 5555, persistent named volume.
- `.claude/skills/build-workloads` symlink (per repo convention).
- `AGENTS.md` lists the new skill alongside `add-command` / `create-workload`.

### Usage
```pwsh
pwsh ./.github/skills/build-workloads/scripts/build-workloads.ps1
# then, from any shell:
func workload install <name> --source http://localhost:5555/v3/index.json
# tear down:
pwsh ./.github/skills/build-workloads/scripts/build-workloads.ps1 -Down
```

Flags: `-Port`, `-Configuration`, `-VersionSuffix` (defaults to a timestamp so reruns don't collide), `-PackOnly`, `-NoBuild`, `-Down`.

### Verified
- pwsh parses cleanly.
- Discovery finds all 8 workload csprojs under `src/Workloads/`.
- `docker compose config` validates the compose file.

Local-loop tooling only, not wired into CI.