### PR TITLE
Fix build-workloads skill: repo root path and HTTP push

### DIFF
--- a/.github/skills/build-workloads/scripts/build-workloads.ps1
+++ b/.github/skills/build-workloads/scripts/build-workloads.ps1
@@ -47,7 +47,7 @@ $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
 $skillRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
-$repoRoot = (Resolve-Path (Join-Path $skillRoot '../..')).Path
+$repoRoot = (Resolve-Path (Join-Path $skillRoot '../../..')).Path
 $composeFile = Join-Path $skillRoot 'assets/docker-compose.yml'
 $slnxFile = Join-Path $repoRoot 'Azure.Functions.Cli.slnx'
 $outputDir = Join-Path $repoRoot 'artifacts/workloads-feed'
@@ -141,13 +141,29 @@ Invoke-Compose -Arguments @('up', '-d')
 Wait-ForFeed
 
 Write-Host "Pushing $($nupkgs.Count) package(s) to $feedUrl" -ForegroundColor Cyan
+
+# dotnet nuget push refuses HTTP sources unless the source is declared with
+# allowInsecureConnections="true". Write a throwaway NuGet.Config alongside the
+# packages so the push uses it without affecting the repo's NuGet.Config.
+$pushConfig = Join-Path $outputDir 'NuGet.Config'
+@"
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="local" value="$feedUrl" allowInsecureConnections="true" />
+  </packageSources>
+</configuration>
+"@ | Set-Content -Path $pushConfig -Encoding UTF8
+
 foreach ($pkg in $nupkgs) {
     Write-Host "  push $($pkg.Name)" -ForegroundColor DarkCyan
     $pushArgs = @(
         'nuget', 'push', $pkg.FullName,
-        '--source', $feedUrl,
+        '--source', 'local',
         '--api-key', $ApiKey,
-        '--skip-duplicate'
+        '--skip-duplicate',
+        '--configfile', $pushConfig
     )
     Invoke-Native -File 'dotnet' -Arguments $pushArgs
 }


### PR DESCRIPTION
Two bugs found while running `/build-workloads` end-to-end:

1. **`$repoRoot` resolved to `.github/`.** The script lives at
   `.github/skills/build-workloads/scripts/build-workloads.ps1`, so
   walking up two parents from the script's directory lands in
   `.github/`, not the repo root. Bumped to three `..` segments so
   `Azure.Functions.Cli.slnx` and `artifacts/workloads-feed` resolve
   correctly.

2. **`dotnet nuget push` rejected the HTTP feed.** Modern NuGet refuses
   HTTP sources unless the source is declared with
   `allowInsecureConnections="true"`. Write a throwaway `NuGet.Config`
   into the output folder and push through it with `--configfile`, so
   the repo's `NuGet.Config` is untouched.

Verified locally: all 8 workloads pack and push to BaGet at
`http://localhost:5555/v3/index.json`.