### PR TITLE
init UX: shorter auto-select hint, alias fallback search, display names

### DIFF
--- a/docs/building-a-workload.md
+++ b/docs/building-a-workload.md
@@ -210,6 +210,8 @@ internal sealed class NodeProjectInitializer : IProjectInitializer
 {
     public string Stack => "node";
 
+    public string DisplayName => "Node.js";
+
     public IReadOnlyList<string> SupportedLanguages => ["JavaScript", "TypeScript"];
 
     public bool CanHandle(string stack) =>

--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -212,7 +212,7 @@ The abstractions library exposes the surface workload authors program against:
 |------|------|
 | `IWorkload` | Entry point. Identity (`PackageId`, `PackageVersion`, `DisplayName`, `Description`) plus `Configure(FunctionsCliBuilder)`. |
 | `FunctionsCliBuilder` | The DI seam handed to a workload. Exposes `Services` for plain DI registrations and `RegisterCommand(...)` overloads (instance / type / factory) for contributing top-level commands. Abstract base so we can grow the surface without breaking workloads. |
-| `IProjectInitializer` | Owns `func init` for a stack. Declares `Stack`, `SupportedLanguages`, registers init options via `IInitOptionRegistry`, and runs `InitializeAsync(InitContext, ParseResult, CancellationToken)`. |
+| `IProjectInitializer` | Owns `func init` for a stack. Declares `Stack`, `DisplayName`, `SupportedLanguages`, registers init options via `IInitOptionRegistry`, and runs `InitializeAsync(InitContext, ParseResult, CancellationToken)`. |
 | `IInitOptionRegistry` / `CommonInitOptions` | The registry de-dupes options that multiple workloads contribute (e.g. `--no-bundles`) so each option appears once in `--help` and every workload reads the same parsed value. `CommonInitOptions` is a small factory of the shared options themselves (`NoBundle`, `BundlesChannel`). |
 | `WorkloadContext` / `InitContext` | Records carrying common + command-specific inputs to providers. |
 | `FuncCommand` | Parser-independent base for workload-contributed top-level commands. Describes `Name`, `Description`, `Options`, `Arguments`, `Subcommands`, and an `ExecuteAsync(FuncCommandInvocationContext, CancellationToken)`. |

--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -179,6 +179,9 @@ interaction.WriteLine(l => l
 | `PromptForInput(prompt, defaultValue)` | `string` | Returns `defaultValue` |
 | `ShowStatusAsync<T>(message, action)` | `T` | Runs action, prints status text |
 | `StatusAsync(message, action)` | — | Runs action, prints status text |
+| `RunWithProgressAsync<T>(initialDescription, action)` | `T` | Runs action; prints each description change as a line |
+
+`RunWithProgressAsync` exposes an `IProgressContext` to the action, which long-running operations can use to update the description, set/report numeric progress, or increment. The Spectre implementation renders a live progress bar; in non-interactive mode each description change is written as a separate line so logs remain readable.
 
 ### `IsInteractive` Property
 

--- a/src/Abstractions/Projects/IProjectInitializer.cs
+++ b/src/Abstractions/Projects/IProjectInitializer.cs
@@ -20,6 +20,12 @@ public interface IProjectInitializer
     /// <summary>The canonical stack id this initializer owns (e.g. "dotnet").</summary>
     public string Stack { get; }
 
+    /// <summary>
+    /// Human-friendly name for this stack shown in interactive prompts and help text
+    /// (e.g. ".NET", "Node.js"). Defaults to <see cref="Stack"/> when not overridden.
+    /// </summary>
+    public string DisplayName => Stack;
+
     /// <summary>Display labels for the languages this initializer supports (e.g. "C#", "F#").</summary>
     public IReadOnlyList<string> SupportedLanguages { get; }
 

--- a/src/Func/Commands/InitCommand.cs
+++ b/src/Func/Commands/InitCommand.cs
@@ -343,13 +343,17 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
             return null;
         }
 
-        // Multiple initializers, interactive: prompt.
-        var choices = _initializers.Select(i => i.Stack).ToList();
+        // Multiple initializers, interactive: prompt using display names,
+        // then map the selection back to its initializer.
+        var displayToInitializer = _initializers.ToDictionary(
+            i => i.DisplayName,
+            i => i,
+            StringComparer.Ordinal);
         string picked = await _interaction.PromptForSelectionAsync(
             "Select a stack:",
-            choices,
+            displayToInitializer.Keys,
             cancellationToken);
 
-        return _initializers.FirstOrDefault(i => i.Stack == picked);
+        return displayToInitializer.TryGetValue(picked, out IProjectInitializer? chosen) ? chosen : null;
     }
 }

--- a/src/Func/Commands/InitCommand.cs
+++ b/src/Func/Commands/InitCommand.cs
@@ -37,7 +37,7 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
 
     public Option<bool> ForceOption { get; } = new("--force")
     {
-        Description = "Force initialization even if the folder is not empty"
+        Description = "Re-initialize the directory: deletes its contents (except .git) before scaffolding the new project."
     };
 
     private readonly IInteractionService _interaction;
@@ -137,6 +137,17 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
 
         language = resolved;
 
+        if (force)
+        {
+            if (!await ConfirmClearDirectoryAsync(workingDirectory.Info, cancellationToken))
+            {
+                _interaction.WriteHint("Init cancelled. The directory was not modified.");
+                return 1;
+            }
+
+            ClearDirectory(workingDirectory.Info);
+        }
+
         WriteCliConfigurationFile(workingDirectory.Info, initializer.Stack, language, force);
         _interaction.WriteBlankLine();
 
@@ -174,6 +185,53 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
         return languages.Count == 0
             ? "The programming language. Install a stack workload (`func workload install <id>`) to see supported values."
             : "The programming language. Supported values: " + string.Join(", ", languages) + ".";
+    }
+
+    // Warns about the destructive side of --force and (in interactive mode)
+    // asks for confirmation. Non-interactive callers proceed without
+    // prompting, on the theory that --force is itself an explicit opt-in.
+    // Returns false only when the user declined the interactive prompt.
+    private async Task<bool> ConfirmClearDirectoryAsync(DirectoryInfo workingDirectory, CancellationToken cancellationToken)
+    {
+        bool hasContent = workingDirectory.EnumerateFiles().Any()
+            || workingDirectory.EnumerateDirectories().Any(d => !string.Equals(d.Name, ".git", StringComparison.Ordinal));
+        if (!hasContent)
+        {
+            return true;
+        }
+
+        _interaction.WriteWarning(
+            $"--force will delete all files in '{workingDirectory.FullName}' (except .git) before initializing.");
+
+        if (!_interaction.IsInteractive)
+        {
+            return true;
+        }
+
+        return await _interaction.ConfirmAsync("Continue?", defaultValue: false, cancellationToken);
+    }
+
+    // Wipes everything in the working directory before a --force re-init so
+    // leftover files from the prior stack (node_modules, requirements.txt,
+    // etc.) don't pollute the new project. Preserves .git so the user
+    // doesn't lose history.
+    private static void ClearDirectory(DirectoryInfo workingDirectory)
+    {
+        foreach (FileInfo file in workingDirectory.EnumerateFiles())
+        {
+            file.Attributes = FileAttributes.Normal;
+            file.Delete();
+        }
+
+        foreach (DirectoryInfo dir in workingDirectory.EnumerateDirectories())
+        {
+            if (string.Equals(dir.Name, ".git", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            dir.Delete(recursive: true);
+        }
     }
 
     private static bool IsAlreadyInitialized(DirectoryInfo workingDirectory, out string existingFile)

--- a/src/Func/Commands/Workload/WorkloadInstallCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadInstallCommand.cs
@@ -104,16 +104,27 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
 
         try
         {
-            WorkloadInstallResult result = LooksLikeLocalPackagePath(workload)
-                ? await _installer.InstallFromPackageAsync(workload, force, cancellationToken)
-                : await _installer.InstallFromCatalogAsync(
-                    workload,
-                    string.IsNullOrEmpty(versionText) ? null : NuGetVersion.Parse(versionText),
-                    source,
-                    includePrerelease,
-                    exact,
-                    force,
-                    cancellationToken);
+            WorkloadInstallResult result = await _interaction.RunWithProgressAsync(
+                LooksLikeLocalPackagePath(workload)
+                    ? $"Installing '{Path.GetFileName(workload)}'"
+                    : $"Installing workload '{workload}'",
+                async (ctx, ct) =>
+                {
+                    var progress = new ProgressAdapter(ctx);
+
+                    return LooksLikeLocalPackagePath(workload)
+                        ? await _installer.InstallFromPackageAsync(workload, force, progress, ct)
+                        : await _installer.InstallFromCatalogAsync(
+                            workload,
+                            string.IsNullOrEmpty(versionText) ? null : NuGetVersion.Parse(versionText),
+                            source,
+                            includePrerelease,
+                            exact,
+                            force,
+                            progress,
+                            ct);
+                },
+                cancellationToken);
 
             string message = BuildSuccessMessage(result);
             if (result.AlreadyInstalled)
@@ -249,5 +260,20 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
                 => $"{verb} (content at '{entry.Source}').",
             _ => $"{verb}.",
         };
+    }
+
+    /// <summary>
+    /// Bridges <see cref="IProgress{T}"/> calls from the installer onto the
+    /// <see cref="IProgressContext"/> backing the progress bar.
+    /// </summary>
+    private sealed class ProgressAdapter(IProgressContext context) : IProgress<WorkloadInstallProgress>
+    {
+        private readonly IProgressContext _context = context;
+
+        public void Report(WorkloadInstallProgress value)
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            _context.SetDescription(value.Description);
+        }
     }
 }

--- a/src/Func/Commands/Workload/WorkloadUpdateCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadUpdateCommand.cs
@@ -179,8 +179,13 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
     {
         try
         {
-            WorkloadUpdateResult result = await _installer.UpdateAsync(
-                packageId, targetVersion, source, includePrerelease, allowMajor, cancellationToken);
+            WorkloadUpdateResult result = await _interaction.RunWithProgressAsync(
+                $"Updating workload '{packageId}'",
+                async (ctx, ct) => await _installer.UpdateAsync(
+                    packageId, targetVersion, source, includePrerelease, allowMajor,
+                    new ProgressAdapter(ctx),
+                    ct),
+                cancellationToken);
 
             RenderSingle(result);
             return 0;
@@ -225,12 +230,16 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
         {
             try
             {
-                WorkloadUpdateResult result = await _installer.UpdateAsync(
-                    packageId,
-                    targetInstalledVersion: null,
-                    source,
-                    includePrerelease,
-                    allowMajor,
+                WorkloadUpdateResult result = await _interaction.RunWithProgressAsync(
+                    $"Updating workload '{packageId}'",
+                    async (ctx, ct) => await _installer.UpdateAsync(
+                        packageId,
+                        targetInstalledVersion: null,
+                        source,
+                        includePrerelease,
+                        allowMajor,
+                        new ProgressAdapter(ctx),
+                        ct),
                     cancellationToken);
                 RenderSingle(result);
             }
@@ -276,5 +285,20 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
 
         _interaction.WriteSuccess(
             $"Updated workload '{display}' from {result.PreviousVersion} to {result.Entry.PackageVersion}.");
+    }
+
+    /// <summary>
+    /// Bridges <see cref="IProgress{T}"/> reports from the installer onto
+    /// the live progress bar.
+    /// </summary>
+    private sealed class ProgressAdapter(IProgressContext context) : IProgress<WorkloadInstallProgress>
+    {
+        private readonly IProgressContext _context = context;
+
+        public void Report(WorkloadInstallProgress value)
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            _context.SetDescription(value.Description);
+        }
     }
 }

--- a/src/Func/Console/IInteractionService.cs
+++ b/src/Func/Console/IInteractionService.cs
@@ -90,6 +90,23 @@ internal interface IInteractionService
     public Task StatusAsync(string statusMessage, Func<CancellationToken, Task> action, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Displays a progress indicator (a bar in interactive contexts, plain
+    /// log lines elsewhere) and passes a mutable <see cref="IProgressContext"/>
+    /// to <paramref name="action"/> so the running operation can update its
+    /// description and report completion.
+    /// </summary>
+    /// <remarks>
+    /// Prefer this over <see cref="ShowStatusAsync{T}"/> when the operation
+    /// has distinct phases the user benefits from seeing (e.g. resolve →
+    /// download → extract). Phases with a known total surface as a real
+    /// percentage; phases without one render as indeterminate motion.
+    /// </remarks>
+    public Task<T> RunWithProgressAsync<T>(
+        string initialDescription,
+        Func<IProgressContext, CancellationToken, Task<T>> action,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Prompts the user with a yes/no confirmation. Returns <paramref name="defaultValue"/>
     /// in non-interactive mode. Throws <see cref="OperationCanceledException"/> on Ctrl+C.
     /// </summary>

--- a/src/Func/Console/IProgressContext.cs
+++ b/src/Func/Console/IProgressContext.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Console;
+
+/// <summary>
+/// Mutable handle on an in-flight progress display. Passed by
+/// <see cref="IInteractionService.RunWithProgressAsync{T}"/> to the action so
+/// long-running work can update its description and (optionally) report
+/// completion against a known total.
+/// </summary>
+/// <remarks>
+/// Implementations must be safe to call from the same logical flow that owns
+/// the running action; concurrent updates from background tasks are not
+/// required to be thread-safe. In non-interactive mode the implementation
+/// typically degrades to writing a single line per description change and
+/// ignores numeric updates.
+/// </remarks>
+internal interface IProgressContext
+{
+    /// <summary>
+    /// Updates the visible description for the in-flight task. Pass a short
+    /// present-tense phrase (e.g. <c>"Downloading workload..."</c>).
+    /// </summary>
+    public void SetDescription(string description);
+
+    /// <summary>
+    /// Sets the total expected work units. Pass <c>null</c> for indeterminate
+    /// progress (no percentage). Switching to a non-null value enables
+    /// percentage / "X of Y" display.
+    /// </summary>
+    public void SetTotal(double? total);
+
+    /// <summary>
+    /// Reports the absolute current value (between 0 and the configured
+    /// total). Ignored when no total has been set.
+    /// </summary>
+    public void Report(double value);
+
+    /// <summary>
+    /// Convenience: increments the current value by <paramref name="amount"/>.
+    /// </summary>
+    public void Increment(double amount);
+}

--- a/src/Func/Console/SpectreInteractionService.cs
+++ b/src/Func/Console/SpectreInteractionService.cs
@@ -159,6 +159,139 @@ internal class SpectreInteractionService : IInteractionService
         }, cancellationToken);
     }
 
+    public async Task<T> RunWithProgressAsync<T>(
+        string initialDescription,
+        Func<IProgressContext, CancellationToken, Task<T>> action,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(initialDescription);
+        ArgumentNullException.ThrowIfNull(action);
+
+        if (!IsInteractive)
+        {
+            // No live region in non-interactive output. Log the initial
+            // description plus every subsequent SetDescription so the user
+            // still sees phase transitions in CI logs.
+            _stderr.Write(new Paragraph($"{initialDescription}...", _theme.Muted).Append(Environment.NewLine));
+            var logging = new LoggingProgressContext(_stderr, _theme, initialDescription);
+            return await action(logging, cancellationToken);
+        }
+
+        T result = default!;
+        await _stderr.Progress()
+            .AutoRefresh(true)
+            .HideCompleted(false)
+            .Columns(
+                new TaskDescriptionColumn { Alignment = Justify.Left },
+                new ProgressBarColumn(),
+                new PercentageColumn(),
+                new SpinnerColumn(Spinner.Known.Dots))
+            .StartAsync(async ctx =>
+            {
+                ProgressTask task = ctx.AddTask(initialDescription, autoStart: true, maxValue: 1d);
+                task.IsIndeterminate = true;
+
+                var live = new SpectreProgressContext(task);
+                result = await action(live, cancellationToken);
+
+                // Snap to 100% on success so the bar doesn't linger as a
+                // half-filled fragment when the action finishes without
+                // having called Report.
+                if (task.IsIndeterminate)
+                {
+                    task.IsIndeterminate = false;
+                    task.MaxValue = 1d;
+                    task.Value = 1d;
+                }
+                else if (task.MaxValue > 0)
+                {
+                    task.Value = task.MaxValue;
+                }
+
+                task.StopTask();
+            });
+
+        return result;
+    }
+
+    private sealed class SpectreProgressContext(ProgressTask task) : IProgressContext
+    {
+        private readonly ProgressTask _task = task;
+
+        public void SetDescription(string description)
+        {
+            ArgumentNullException.ThrowIfNull(description);
+            _task.Description = description;
+        }
+
+        public void SetTotal(double? total)
+        {
+            if (total is null)
+            {
+                _task.IsIndeterminate = true;
+                return;
+            }
+
+            _task.IsIndeterminate = false;
+            _task.MaxValue = total.Value;
+            if (_task.Value > total.Value)
+            {
+                _task.Value = total.Value;
+            }
+        }
+
+        public void Report(double value)
+        {
+            if (_task.IsIndeterminate)
+            {
+                return;
+            }
+
+            _task.Value = value;
+        }
+
+        public void Increment(double amount)
+        {
+            if (_task.IsIndeterminate)
+            {
+                return;
+            }
+
+            _task.Increment(amount);
+        }
+    }
+
+    private sealed class LoggingProgressContext(IAnsiConsole console, ITheme theme, string initialDescription) : IProgressContext
+    {
+        private readonly IAnsiConsole _console = console;
+        private readonly ITheme _theme = theme;
+        private string _description = initialDescription;
+
+        public void SetDescription(string description)
+        {
+            ArgumentNullException.ThrowIfNull(description);
+            if (string.Equals(description, _description, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            _description = description;
+            _console.Write(new Paragraph($"{description}...", _theme.Muted).Append(Environment.NewLine));
+        }
+
+        public void SetTotal(double? total)
+        {
+        }
+
+        public void Report(double value)
+        {
+        }
+
+        public void Increment(double amount)
+        {
+        }
+    }
+
     public async Task<bool> ConfirmAsync(string prompt, bool defaultValue = false, CancellationToken cancellationToken = default)
     {
         if (!IsInteractive)

--- a/src/Func/Workloads/Install/IWorkloadInstaller.cs
+++ b/src/Func/Workloads/Install/IWorkloadInstaller.cs
@@ -40,6 +40,7 @@ internal interface IWorkloadInstaller
     public Task<WorkloadInstallResult> InstallFromPackageAsync(
         string nupkgPath,
         bool force = false,
+        IProgress<WorkloadInstallProgress>? progress = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -81,6 +82,7 @@ internal interface IWorkloadInstaller
         bool includePrerelease,
         bool exact,
         bool force,
+        IProgress<WorkloadInstallProgress>? progress = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -111,6 +113,7 @@ internal interface IWorkloadInstaller
         string? source,
         bool includePrerelease,
         bool allowMajor,
+        IProgress<WorkloadInstallProgress>? progress = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Func/Workloads/Install/WorkloadInstallProgress.cs
+++ b/src/Func/Workloads/Install/WorkloadInstallProgress.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workloads.Install;
+
+/// <summary>
+/// High-level stage of a workload install / update flow. Exposed so callers
+/// (e.g. <c>WorkloadInstallCommand</c>) can translate phase transitions into
+/// user-facing progress descriptions without duplicating phrasing across
+/// install entry points.
+/// </summary>
+internal enum WorkloadInstallPhase
+{
+    /// <summary>Resolving the alias or package id against the catalog.</summary>
+    Resolving,
+
+    /// <summary>Downloading the resolved <c>.nupkg</c> from the source.</summary>
+    Downloading,
+
+    /// <summary>Extracting the package onto disk.</summary>
+    Extracting,
+
+    /// <summary>Persisting the install to the global registry.</summary>
+    Registering,
+}
+
+/// <summary>
+/// Progress payload reported by <see cref="IWorkloadInstaller"/> entry points.
+/// </summary>
+/// <param name="Phase">Coarse phase the installer just entered.</param>
+/// <param name="Description">
+/// Human-readable description of the in-flight work. Suitable for use as a
+/// progress bar / spinner label. Already includes the package id where
+/// relevant.
+/// </param>
+internal sealed record WorkloadInstallProgress(WorkloadInstallPhase Phase, string Description);

--- a/src/Func/Workloads/Install/WorkloadInstaller.cs
+++ b/src/Func/Workloads/Install/WorkloadInstaller.cs
@@ -45,6 +45,7 @@ internal sealed class WorkloadInstaller(
     public async Task<WorkloadInstallResult> InstallFromPackageAsync(
         string nupkgPath,
         bool force = false,
+        IProgress<WorkloadInstallProgress>? progress = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(nupkgPath);
@@ -111,6 +112,10 @@ internal sealed class WorkloadInstaller(
         WorkloadEntry entry;
         try
         {
+            progress?.Report(new WorkloadInstallProgress(
+                WorkloadInstallPhase.Extracting,
+                $"Extracting workload '{packageId}' {version}"));
+
             await ExtractPackageAsync(reader, installPath, cancellationToken);
 
             WorkloadMetadata metadata = _metadataReader.Read(installPath);
@@ -125,6 +130,10 @@ internal sealed class WorkloadInstaller(
                 Source = Path.GetFullPath(nupkgPath),
                 InstallRefCount = 1,
             };
+
+            progress?.Report(new WorkloadInstallProgress(
+                WorkloadInstallPhase.Registering,
+                $"Registering workload '{packageId}' {version}"));
 
             await _store.SaveWorkloadAsync(entry, cancellationToken);
         }
@@ -145,9 +154,14 @@ internal sealed class WorkloadInstaller(
         bool includePrerelease,
         bool exact,
         bool force,
+        IProgress<WorkloadInstallProgress>? progress = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+
+        progress?.Report(new WorkloadInstallProgress(
+            WorkloadInstallPhase.Resolving,
+            $"Resolving workload '{packageId}'"));
 
         string resolvedId = exact
             ? packageId
@@ -162,13 +176,17 @@ internal sealed class WorkloadInstaller(
 
         try
         {
+            progress?.Report(new WorkloadInstallProgress(
+                WorkloadInstallPhase.Downloading,
+                $"Downloading '{resolved.PackageId}' {resolved.Version.ToNormalizedString()}"));
+
             await using (Stream packageStream = await _catalog.DownloadAsync(resolved, cancellationToken))
             await using (FileStream tempStream = File.Create(tempPath))
             {
                 await packageStream.CopyToAsync(tempStream, cancellationToken);
             }
 
-            return await InstallFromPackageAsync(tempPath, force, cancellationToken);
+            return await InstallFromPackageAsync(tempPath, force, progress, cancellationToken);
         }
         finally
         {
@@ -195,9 +213,14 @@ internal sealed class WorkloadInstaller(
         string? source,
         bool includePrerelease,
         bool allowMajor,
+        IProgress<WorkloadInstallProgress>? progress = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+
+        progress?.Report(new WorkloadInstallProgress(
+            WorkloadInstallPhase.Resolving,
+            $"Resolving update for '{packageId}'"));
 
         IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
         List<WorkloadEntry> matches = [.. installed
@@ -235,7 +258,7 @@ internal sealed class WorkloadInstaller(
         }
 
         WorkloadEntry newEntry = await StageAndSwapAsync(
-            currentEntry, resolved, cancellationToken);
+            currentEntry, resolved, progress, cancellationToken);
 
         return new WorkloadUpdateResult(newEntry, currentEntry.PackageVersion, NoUpdateAvailable: false);
     }
@@ -370,6 +393,7 @@ internal sealed class WorkloadInstaller(
     private async Task<WorkloadEntry> StageAndSwapAsync(
         WorkloadEntry currentEntry,
         ResolvedPackage resolved,
+        IProgress<WorkloadInstallProgress>? progress,
         CancellationToken cancellationToken)
     {
         string tempNupkg = Path.Combine(
@@ -382,6 +406,10 @@ internal sealed class WorkloadInstaller(
 
         try
         {
+            progress?.Report(new WorkloadInstallProgress(
+                WorkloadInstallPhase.Downloading,
+                $"Downloading '{resolved.PackageId}' {resolved.Version.ToNormalizedString()}"));
+
             await using (Stream packageStream = await _catalog.DownloadAsync(resolved, cancellationToken))
             await using (FileStream tempStream = File.Create(tempNupkg))
             {
@@ -416,6 +444,10 @@ internal sealed class WorkloadInstaller(
             Directory.CreateDirectory(Path.GetDirectoryName(stagingPath)!);
             Directory.CreateDirectory(stagingPath);
 
+            progress?.Report(new WorkloadInstallProgress(
+                WorkloadInstallPhase.Extracting,
+                $"Extracting workload '{newPackageId}' {newVersion}"));
+
             await ExtractPackageAsync(reader, stagingPath, cancellationToken);
             WorkloadMetadata metadata = _metadataReader.Read(stagingPath);
 
@@ -437,6 +469,10 @@ internal sealed class WorkloadInstaller(
             //      recoverable via `func workload prune`.
             //   3. Delete the previous install directory.
             Directory.Move(stagingPath, finalInstallPath);
+
+            progress?.Report(new WorkloadInstallProgress(
+                WorkloadInstallPhase.Registering,
+                $"Registering workload '{newPackageId}' {newVersion}"));
 
             await _store.ReplaceWorkloadAsync(
                 currentEntry.PackageId,

--- a/src/Func/Workloads/Install/WorkloadInstaller.cs
+++ b/src/Func/Workloads/Install/WorkloadInstaller.cs
@@ -282,11 +282,20 @@ internal sealed class WorkloadInstaller(
         };
 
         IReadOnlyList<CatalogSearchResult> hits = await _catalog.SearchAsync(query, cancellationToken);
+        IReadOnlyList<string> matchedIds = FilterByAlias(hits, aliasOrId);
 
-        IReadOnlyList<string> matchedIds = [.. hits
-            .Where(r => r.Aliases.Any(a => string.Equals(a, aliasOrId, StringComparison.OrdinalIgnoreCase)))
-            .Select(r => r.PackageId)
-            .Distinct(StringComparer.OrdinalIgnoreCase)];
+        // Some feeds (BaGet, older NuGet implementations) tokenize the `q=`
+        // term in ways that drop hyphenated aliases like `node-worker`. When
+        // the targeted query returns nothing, retry with an empty filter:
+        // the `packageType=FuncCliWorkload` constraint keeps the result set
+        // bounded to workload packages, which we then filter client-side.
+        if (matchedIds.Count == 0 && hits.Count == 0)
+        {
+            IReadOnlyList<CatalogSearchResult> all = await _catalog.SearchAsync(
+                query with { Filter = null },
+                cancellationToken);
+            matchedIds = FilterByAlias(all, aliasOrId);
+        }
 
         if (matchedIds.Count > 1)
         {
@@ -295,6 +304,12 @@ internal sealed class WorkloadInstaller(
 
         return matchedIds.Count == 1 ? matchedIds[0] : aliasOrId;
     }
+
+    private static IReadOnlyList<string> FilterByAlias(IReadOnlyList<CatalogSearchResult> hits, string alias) =>
+        [.. hits
+            .Where(r => r.Aliases.Any(a => string.Equals(a, alias, StringComparison.OrdinalIgnoreCase)))
+            .Select(r => r.PackageId)
+            .Distinct(StringComparer.OrdinalIgnoreCase)];
 
     private async Task<ResolvedPackage> ResolveCatalogPackageAsync(
         string packageId,

--- a/src/Func/Workloads/WorkloadHintRenderer.cs
+++ b/src/Func/Workloads/WorkloadHintRenderer.cs
@@ -72,20 +72,12 @@ internal sealed class WorkloadHintRenderer(IInteractionService interaction) : IW
     {
         _interaction.WriteHint(
             $"Auto-selecting '{hint.RequestedStack}' (the only installed workload).");
-
-        IEnumerable<DefinitionItem> others = KnownInstallableWorkloads.LanguageMap
-            .Where(kvp => !string.Equals(kvp.Key, hint.RequestedStack, StringComparison.OrdinalIgnoreCase))
-            .Select(kvp => new DefinitionItem(
-                $"func workload install {kvp.Key}",
-                string.Join(", ", kvp.Value)));
-
-        if (others.Any())
-        {
-            _interaction.WriteBlankLine();
-            _interaction.WriteHint("You can install more workloads via:");
-            _interaction.WriteBlankLine();
-            _interaction.WriteDefinitionList(others);
-        }
+        _interaction.WriteLine(l => l
+            .Muted("Install more with ")
+            .Command("func workload install")
+            .Muted(" or run ")
+            .Command("func workload search")
+            .Muted(" to discover available stacks."));
     }
 
     private void WriteInstalledStacks(IReadOnlyList<string> stacks)

--- a/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
@@ -30,6 +30,8 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli, ITemp
 
     public string Stack => "dotnet";
 
+    public string DisplayName => ".NET";
+
     public IReadOnlyList<string> SupportedLanguages => ["C#", "F#", "csharp", "fsharp"];
 
     public Option<string> FrameworkOption { get; private set; } = default!;

--- a/src/Workloads/Stacks/Go/GoProjectInitializer.cs
+++ b/src/Workloads/Stacks/Go/GoProjectInitializer.cs
@@ -26,6 +26,8 @@ internal sealed class GoProjectInitializer : IProjectInitializer
 
     public string Stack => "go";
 
+    public string DisplayName => "Go";
+
     public IReadOnlyList<string> SupportedLanguages { get; } = ["Go"];
 
     public Option<bool> SkipGoModTidyOption { get; private set; } = default!;

--- a/src/Workloads/Stacks/Node/NodeProjectInitializer.cs
+++ b/src/Workloads/Stacks/Node/NodeProjectInitializer.cs
@@ -26,6 +26,8 @@ internal sealed class NodeProjectInitializer : IProjectInitializer
 
     public string Stack => "node";
 
+    public string DisplayName => "Node.js";
+
     public IReadOnlyList<string> SupportedLanguages { get; } = ["JavaScript", "TypeScript"];
 
     public Option<bool> NoBundleOption { get; private set; } = default!;

--- a/src/Workloads/Stacks/Python/PythonProjectInitializer.cs
+++ b/src/Workloads/Stacks/Python/PythonProjectInitializer.cs
@@ -18,6 +18,8 @@ internal sealed class PythonProjectInitializer : IProjectInitializer
 
     public string Stack => "python";
 
+    public string DisplayName => "Python";
+
     public IReadOnlyList<string> SupportedLanguages { get; } = ["Python"];
 
     public Option<bool> NoBundleOption { get; private set; } = default!;

--- a/test/Func.Tests/Commands/InitCommandTests.cs
+++ b/test/Func.Tests/Commands/InitCommandTests.cs
@@ -389,6 +389,59 @@ public class InitCommandTests
         }
     }
 
+    [Fact]
+    public async Task InitCommand_Force_ClearsDirectoryButPreservesDotGit()
+    {
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(newDir);
+            // Pre-existing junk from a prior stack.
+            File.WriteAllText(Path.Combine(newDir, "package.json"), "{}");
+            File.WriteAllText(Path.Combine(newDir, "requirements.txt"), "azure-functions");
+            Directory.CreateDirectory(Path.Combine(newDir, "node_modules"));
+            File.WriteAllText(Path.Combine(newDir, "node_modules", "marker"), "x");
+
+            // .git must survive.
+            Directory.CreateDirectory(Path.Combine(newDir, ".git"));
+            File.WriteAllText(Path.Combine(newDir, ".git", "HEAD"), "ref: refs/heads/main");
+
+            var initializer = new FakeProjectInitializer("python");
+            int exitCode = await RunInitAsync(newDir, initializer, language: null, stack: "python", force: true);
+
+            Assert.Equal(0, exitCode);
+            Assert.False(File.Exists(Path.Combine(newDir, "package.json")));
+            Assert.False(File.Exists(Path.Combine(newDir, "requirements.txt")));
+            Assert.False(Directory.Exists(Path.Combine(newDir, "node_modules")));
+            Assert.True(File.Exists(Path.Combine(newDir, ".git", "HEAD")));
+        }
+        finally
+        {
+            CleanupDirectory(newDir);
+        }
+    }
+
+    [Fact]
+    public async Task InitCommand_Force_WritesWarningBeforeClearing()
+    {
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(newDir);
+            File.WriteAllText(Path.Combine(newDir, "leftover.txt"), "x");
+
+            var initializer = new FakeProjectInitializer("python");
+            int exitCode = await RunInitAsync(newDir, initializer, language: null, stack: "python", force: true);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(_interaction.Lines, l => l.StartsWith("WARNING:") && l.Contains("--force will delete"));
+        }
+        finally
+        {
+            CleanupDirectory(newDir);
+        }
+    }
+
     private static void AssertConfigJsonHasShape(string directory, string? expectedStack, string? expectedLanguage)
     {
         string configPath = Path.Combine(directory, ".func", "config.json");

--- a/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
@@ -49,7 +49,7 @@ public class WorkloadInstallCommandTests
 
         Assert.Equal(0, exit);
         await _installer.Received(1).InstallFromCatalogAsync(
-            "Test.Workload", null, null, false, false, false, Arg.Any<CancellationToken>());
+            "Test.Workload", null, null, false, false, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -75,6 +75,7 @@ public class WorkloadInstallCommandTests
             true,
             true,
             true,
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -94,6 +95,7 @@ public class WorkloadInstallCommandTests
             false,
             false,
             true,
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -107,7 +109,7 @@ public class WorkloadInstallCommandTests
 
         Assert.Equal(0, exit);
         await _installer.Received(1).InstallFromCatalogAsync(
-            "test.workload", null, null, false, true, false, Arg.Any<CancellationToken>());
+            "test.workload", null, null, false, true, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -122,7 +124,7 @@ public class WorkloadInstallCommandTests
 
         Assert.Equal(0, exit);
         await _installer.Received(1).InstallFromCatalogAsync(
-            "Test.Workload", null, "/tmp/local-feed", false, false, false, Arg.Any<CancellationToken>());
+            "Test.Workload", null, "/tmp/local-feed", false, false, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -184,7 +186,7 @@ public class WorkloadInstallCommandTests
     {
         _installer.InstallFromCatalogAsync(
                 Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Returns(new WorkloadInstallResult(
                 new WorkloadEntry
                 {
@@ -211,7 +213,7 @@ public class WorkloadInstallCommandTests
     {
         _installer.InstallFromCatalogAsync(
                 Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Throws(new AmbiguousPackageMatchException(
                 "myalias", new[] { "Pkg.A", "Pkg.B" }));
 
@@ -228,7 +230,7 @@ public class WorkloadInstallCommandTests
     {
         _installer.InstallFromCatalogAsync(
                 Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Throws(new WorkloadPackageNotFoundException("not on any source"));
 
         var cmd = NewInstall();
@@ -243,7 +245,7 @@ public class WorkloadInstallCommandTests
     {
         _installer.InstallFromCatalogAsync(
                 Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Throws(new InvalidWorkloadException("bad package"));
 
         var cmd = NewInstall();
@@ -258,7 +260,7 @@ public class WorkloadInstallCommandTests
     {
         _installer.InstallFromCatalogAsync(
                 Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Throws(new InvalidOperationException(
                 "Workload 'x' version '1' is already installed at '/p' but is missing from the registry."));
 
@@ -275,7 +277,7 @@ public class WorkloadInstallCommandTests
     {
         _installer.InstallFromCatalogAsync(
                 Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Throws(new NullReferenceException("oops"));
 
         var cmd = NewInstall();
@@ -290,7 +292,7 @@ public class WorkloadInstallCommandTests
         await File.WriteAllBytesAsync(tempPkg, [0x50, 0x4B]);
         try
         {
-            _installer.InstallFromPackageAsync(tempPkg, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            _installer.InstallFromPackageAsync(tempPkg, Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
                 .Returns(new WorkloadInstallResult(
                     new WorkloadEntry
                     {
@@ -305,7 +307,7 @@ public class WorkloadInstallCommandTests
 
             Assert.Equal(0, exit);
             await _installer.Received(1).InstallFromPackageAsync(
-                tempPkg, false, Arg.Any<CancellationToken>());
+                tempPkg, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
             await _installer.DidNotReceiveWithAnyArgs().InstallFromCatalogAsync(
                 default!, default, default, default, default, default, default);
         }
@@ -334,7 +336,7 @@ public class WorkloadInstallCommandTests
         Assert.Equal(1, exit);
         await _installer.DidNotReceive().InstallFromCatalogAsync(
             Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
         Assert.Contains(_interaction.Lines, l =>
             l.StartsWith("HINT:") && l.Contains("func workload update test"));
     }
@@ -400,7 +402,7 @@ public class WorkloadInstallCommandTests
 
         Assert.Equal(0, exit);
         await _installer.Received(1).InstallFromCatalogAsync(
-            "alias1", null, null, false, true, false, Arg.Any<CancellationToken>());
+            "alias1", null, null, false, true, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -422,14 +424,54 @@ public class WorkloadInstallCommandTests
 
         Assert.Equal(0, exit);
         await _installer.Received(1).InstallFromCatalogAsync(
-            "Test.Workload", null, null, false, false, true, Arg.Any<CancellationToken>());
+            "Test.Workload", null, null, false, false, true, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
         await _store.DidNotReceive().GetWorkloadsAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Install_PassesProgressReporter_AndRendersDescriptionUpdates()
+    {
+        // Drive the captured IProgress<...> as if the installer were emitting
+        // real phase reports; we should see the descriptions land on the
+        // recording progress context so the user sees them as bar labels.
+        IProgress<WorkloadInstallProgress>? captured = null;
+        _installer.InstallFromCatalogAsync(
+                Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(),
+                Arg.Do<IProgress<WorkloadInstallProgress>?>(p => captured = p),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                captured?.Report(new WorkloadInstallProgress(WorkloadInstallPhase.Resolving, "Resolving workload 'Test.Workload'"));
+                captured?.Report(new WorkloadInstallProgress(WorkloadInstallPhase.Downloading, "Downloading 'test.workload' 1.0.0"));
+                captured?.Report(new WorkloadInstallProgress(WorkloadInstallPhase.Extracting, "Extracting workload 'test.workload' 1.0.0"));
+                captured?.Report(new WorkloadInstallProgress(WorkloadInstallPhase.Registering, "Registering workload 'test.workload' 1.0.0"));
+                return new WorkloadInstallResult(
+                    new WorkloadEntry
+                    {
+                        PackageId = "test.workload",
+                        PackageVersion = "1.0.0",
+                        EntryPoint = new EntryPointSpec { AssemblyPath = "x.dll", Type = "T" },
+                    },
+                    AlreadyInstalled: false);
+            });
+
+        var cmd = NewInstall();
+        int exit = await InvokeAsync(cmd, "Test.Workload");
+
+        Assert.Equal(0, exit);
+        Assert.NotNull(captured);
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("PROGRESS:", StringComparison.Ordinal) && l.Contains("Installing workload 'Test.Workload'", StringComparison.Ordinal));
+        Assert.Contains(_interaction.Lines, l => l == "PROGRESS: Resolving workload 'Test.Workload'");
+        Assert.Contains(_interaction.Lines, l => l == "PROGRESS: Downloading 'test.workload' 1.0.0");
+        Assert.Contains(_interaction.Lines, l => l == "PROGRESS: Extracting workload 'test.workload' 1.0.0");
+        Assert.Contains(_interaction.Lines, l => l == "PROGRESS: Registering workload 'test.workload' 1.0.0");
     }
 
     private void StubCatalogResult(bool alreadyInstalled = false) =>
         _installer.InstallFromCatalogAsync(
                 Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Returns(new WorkloadInstallResult(
                 new WorkloadEntry
                 {

--- a/test/Func.Tests/Commands/Workload/WorkloadUpdateCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadUpdateCommandTests.cs
@@ -116,7 +116,7 @@ public class WorkloadUpdateCommandTests
         _installer.UpdateAsync(
                 "Test.Workload",
                 Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Returns(new WorkloadUpdateResult(
                 Entry: new WorkloadEntry { PackageId = "test.workload", PackageVersion = "1.1.0" },
                 PreviousVersion: "1.0.0",
@@ -140,7 +140,7 @@ public class WorkloadUpdateCommandTests
         _installer.UpdateAsync(
                 "Test.Workload",
                 Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Returns(new WorkloadUpdateResult(
                 Entry: new WorkloadEntry { PackageId = "test.workload", PackageVersion = "1.0.0" },
                 PreviousVersion: "1.0.0",
@@ -162,7 +162,7 @@ public class WorkloadUpdateCommandTests
     {
         _installer.UpdateAsync(
                 Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Returns(new WorkloadUpdateResult(
                 Entry: new WorkloadEntry { PackageId = "test.workload", PackageVersion = "2.0.0" },
                 PreviousVersion: "1.0.0",
@@ -184,6 +184,7 @@ public class WorkloadUpdateCommandTests
             "https://example/v3/index.json",
             true,
             true,
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -192,7 +193,7 @@ public class WorkloadUpdateCommandTests
     {
         _installer.UpdateAsync(
                 Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Throws(new InvalidOperationException("Workload 'test.workload' is not installed."));
 
         var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store);
@@ -208,7 +209,7 @@ public class WorkloadUpdateCommandTests
     {
         _installer.UpdateAsync(
                 Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Throws(new WorkloadPackageNotFoundException("nope"));
 
         var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store);
@@ -231,7 +232,7 @@ public class WorkloadUpdateCommandTests
         Assert.Contains(_interaction.Lines, l => l.StartsWith("HINT:") && l.Contains("No workloads installed"));
         await _installer.DidNotReceive().UpdateAsync(
             Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -246,7 +247,7 @@ public class WorkloadUpdateCommandTests
         _installer.UpdateAsync(
                 "a.workload",
                 Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Returns(new WorkloadUpdateResult(
                 new WorkloadEntry { PackageId = "a.workload", PackageVersion = "1.2.0" },
                 "1.1.0",
@@ -254,7 +255,7 @@ public class WorkloadUpdateCommandTests
         _installer.UpdateAsync(
                 "b.workload",
                 Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Returns(new WorkloadUpdateResult(
                 new WorkloadEntry { PackageId = "b.workload", PackageVersion = "2.0.0" },
                 "2.0.0",
@@ -266,10 +267,10 @@ public class WorkloadUpdateCommandTests
         Assert.Equal(0, exit);
         await _installer.Received(1).UpdateAsync(
             "a.workload", Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
         await _installer.Received(1).UpdateAsync(
             "b.workload", Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
         Assert.Contains(_interaction.Lines, l => l.StartsWith("SUCCESS:") && l.Contains("a.workload"));
         Assert.Contains(_interaction.Lines, l => l.StartsWith("WARNING:") && l.Contains("b.workload"));
     }
@@ -285,12 +286,12 @@ public class WorkloadUpdateCommandTests
         _installer.UpdateAsync(
                 "a.workload",
                 Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Throws(new WorkloadPackageNotFoundException("not on feed"));
         _installer.UpdateAsync(
                 "b.workload",
                 Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Returns(new WorkloadUpdateResult(
                 new WorkloadEntry { PackageId = "b.workload", PackageVersion = "2.1.0" },
                 "2.0.0",
@@ -310,7 +311,7 @@ public class WorkloadUpdateCommandTests
         _installer.UpdateAsync(
                 "Test.Workload",
                 Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Returns(new WorkloadUpdateResult(
                 Entry: new WorkloadEntry { PackageId = "test.workload", PackageVersion = "1.0.0" },
                 PreviousVersion: "1.0.0",
@@ -343,7 +344,7 @@ public class WorkloadUpdateCommandTests
         _installer.UpdateAsync(
                 "test.workload",
                 Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Returns(new WorkloadUpdateResult(
                 new WorkloadEntry { PackageId = "test.workload", PackageVersion = "1.1.0" },
                 "1.0.0",
@@ -356,7 +357,7 @@ public class WorkloadUpdateCommandTests
         await _installer.Received(1).UpdateAsync(
             "test.workload",
             Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -374,7 +375,7 @@ public class WorkloadUpdateCommandTests
         _installer.UpdateAsync(
                 "demo",
                 Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Throws(new InvalidOperationException("Workload 'demo' is not installed."));
 
         var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store);
@@ -385,7 +386,7 @@ public class WorkloadUpdateCommandTests
         await _installer.DidNotReceive().UpdateAsync(
             "test.workload",
             Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -407,7 +408,7 @@ public class WorkloadUpdateCommandTests
         Assert.True(ex.IsUserError);
         await _installer.DidNotReceive().UpdateAsync(
             Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
     }
 
     private static Task<int> InvokeAsync(WorkloadUpdateCommand cmd, params string[] args)

--- a/test/Func.Tests/TestInteractionService.cs
+++ b/test/Func.Tests/TestInteractionService.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Globalization;
 using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Console.Theme;
 using Spectre.Console.Rendering;
@@ -98,6 +99,30 @@ internal class TestInteractionService : IInteractionService
         cancellationToken.ThrowIfCancellationRequested();
         _lines.Add($"STATUS: {statusMessage}");
         await action(cancellationToken);
+    }
+
+    public async Task<T> RunWithProgressAsync<T>(
+        string initialDescription,
+        Func<IProgressContext, CancellationToken, Task<T>> action,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        _lines.Add($"PROGRESS: {initialDescription}");
+        var ctx = new RecordingProgressContext(_lines);
+        return await action(ctx, cancellationToken);
+    }
+
+    private sealed class RecordingProgressContext(List<string> lines) : IProgressContext
+    {
+        private readonly List<string> _lines = lines;
+
+        public void SetDescription(string description) => _lines.Add($"PROGRESS: {description}");
+
+        public void SetTotal(double? total) => _lines.Add(FormattableString.Invariant($"PROGRESS TOTAL: {(total is null ? "indeterminate" : total.Value.ToString("0.##", CultureInfo.InvariantCulture))}"));
+
+        public void Report(double value) => _lines.Add(FormattableString.Invariant($"PROGRESS REPORT: {value:0.##}"));
+
+        public void Increment(double amount) => _lines.Add(FormattableString.Invariant($"PROGRESS INCREMENT: {amount:0.##}"));
     }
 
     public Task<bool> ConfirmAsync(string prompt, bool defaultValue = false, CancellationToken cancellationToken = default)

--- a/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
+++ b/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
@@ -555,6 +555,29 @@ public sealed class WorkloadInstallerTests : IDisposable
             Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task InstallFromPackage_ReportsExtractAndRegisterPhases()
+    {
+        string nupkg = BuildNupkg();
+        var reports = new List<WorkloadInstallProgress>();
+        var progress = new RecordingProgress(reports);
+
+        WorkloadInstaller installer = NewInstaller();
+        await installer.InstallFromPackageAsync(nupkg, force: false, progress);
+
+        Assert.Collection(
+            reports,
+            r => Assert.Equal(WorkloadInstallPhase.Extracting, r.Phase),
+            r => Assert.Equal(WorkloadInstallPhase.Registering, r.Phase));
+        Assert.Contains("test.workload", reports[0].Description);
+        Assert.Contains("test.workload", reports[1].Description);
+    }
+
+    private sealed class RecordingProgress(List<WorkloadInstallProgress> sink) : IProgress<WorkloadInstallProgress>
+    {
+        public void Report(WorkloadInstallProgress value) => sink.Add(value);
+    }
+
     private static WorkloadEntry ExistingEntry(string id, string version) => new()
     {
         PackageId = id,

--- a/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
+++ b/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
@@ -483,6 +483,78 @@ public sealed class WorkloadInstallerTests : IDisposable
         Assert.Contains("not installed", ex.Message);
     }
 
+    [Fact]
+    public async Task InstallFromCatalog_AliasResolution_FallsBackToBroadSearchWhenTargetedReturnsZero()
+    {
+        // BaGet and older NuGet feeds tokenize the `q=` term in ways that drop
+        // hyphenated aliases (e.g. `node-worker`). When the targeted alias
+        // search returns nothing, the installer should retry with an empty
+        // filter and match by alias client-side.
+        string nupkg = BuildNupkg();
+        var resolved = NewResolved("real.workload.id", "1.0.0");
+        var source = new PackageSource("https://example/v3/index.json", "test");
+
+        _catalog.SearchAsync(
+                Arg.Is<CatalogSearchQuery>(q => q.Filter == "node-worker"),
+                Arg.Any<CancellationToken>())
+            .Returns([]);
+        _catalog.SearchAsync(
+                Arg.Is<CatalogSearchQuery>(q => q.Filter == null),
+                Arg.Any<CancellationToken>())
+            .Returns(new List<CatalogSearchResult>
+            {
+                new("other.workload", NuGetVersion.Parse("1.0.0"), Title: null, Description: null, Aliases: ["other"], Source: source),
+                new("real.workload.id", NuGetVersion.Parse("1.0.0"), Title: null, Description: null, Aliases: ["node-worker"], Source: source),
+            });
+        _catalog.ResolveLatestVersionAsync(
+                "real.workload.id", true, null, true, null, Arg.Any<CancellationToken>())
+            .Returns(resolved);
+        _catalog.DownloadAsync(resolved, Arg.Any<CancellationToken>())
+            .Returns(_ => File.OpenRead(nupkg));
+
+        WorkloadInstaller installer = NewInstaller();
+        WorkloadInstallResult result = await installer.InstallFromCatalogAsync(
+            "node-worker", version: null, source: null,
+            includePrerelease: true, exact: false, force: false);
+
+        Assert.Equal("test.workload", result.Entry.PackageId);
+        await _catalog.Received(1).SearchAsync(
+            Arg.Is<CatalogSearchQuery>(q => q.Filter == null),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InstallFromCatalog_AliasResolution_SkipsFallbackWhenTargetedHasHits()
+    {
+        // If the targeted search returns any results (even non-matching),
+        // we trust the server filter and don't pay for a second broad query.
+        string nupkg = BuildNupkg();
+        var resolved = NewResolved("node.pkg", "1.0.0");
+        var source = new PackageSource("https://example/v3/index.json", "test");
+
+        _catalog.SearchAsync(
+                Arg.Is<CatalogSearchQuery>(q => q.Filter == "node"),
+                Arg.Any<CancellationToken>())
+            .Returns(new List<CatalogSearchResult>
+            {
+                new("node.pkg", NuGetVersion.Parse("1.0.0"), Title: null, Description: null, Aliases: ["node"], Source: source),
+            });
+        _catalog.ResolveLatestVersionAsync(
+                "node.pkg", false, null, true, null, Arg.Any<CancellationToken>())
+            .Returns(resolved);
+        _catalog.DownloadAsync(resolved, Arg.Any<CancellationToken>())
+            .Returns(_ => File.OpenRead(nupkg));
+
+        WorkloadInstaller installer = NewInstaller();
+        _ = await installer.InstallFromCatalogAsync(
+            "node", version: null, source: null,
+            includePrerelease: false, exact: false, force: false);
+
+        await _catalog.DidNotReceive().SearchAsync(
+            Arg.Is<CatalogSearchQuery>(q => q.Filter == null),
+            Arg.Any<CancellationToken>());
+    }
+
     private static WorkloadEntry ExistingEntry(string id, string version) => new()
     {
         PackageId = id,


### PR DESCRIPTION
Three small `func init` / `func workload install` UX fixes against `vnext`.

### 1. Shorter auto-select hint

`WorkloadHintRenderer.RenderAutoSelectedSoleWorkload` no longer enumerates every other workload's install command. Before:

```
Auto-selecting 'node' (the only installed workload).

You can install more workloads via:

 func workload install dotnet C#, F#
 func workload install python Python
 func workload install java Java
 func workload install powershell PowerShell
```

After:

```
Auto-selecting 'node' (the only installed workload).
Install more with func workload install or run func workload search to discover available stacks.
```

### 2. Alias install for hyphenated aliases (e.g. `node-worker`)

`func workload install node-worker --source ... --prerelease` previously failed with "Could not resolve workload 'node-worker'". Root cause: BaGet (and older NuGet feeds) tokenize the `q=` term in ways that drop hyphenated tags like `alias:node-worker`, so the targeted alias search returns zero hits and we fall through to treating `node-worker` as a literal package id.

Fix: when the targeted search returns no hits at all, `ResolveAliasOrIdAsync` retries with an empty filter (still bounded by `packageType=FuncCliWorkload`) and matches by alias client-side. Verified end-to-end against the local BaGet feed.

### 3. Friendly stack names in the `func init` prompt

The interactive stack picker now shows the workload's `DisplayName` ("Node.js", ".NET", "Python", "Go") instead of the canonical short id ("node", "dotnet", ...). `IProjectInitializer` gains a `DisplayName` property with a default of `Stack`, so existing workload implementations stay source-compatible.

### Tests

- 2 new unit tests in `WorkloadInstallerTests` covering the alias fallback (fires when targeted returns zero, skipped when targeted has hits).
- All 586 existing tests pass.
- End-to-end verified locally for #1 and #2 against the local BaGet feed.

Docs updated: `building-a-workload.md` sample initializer and `cli-architecture.md` interface description now mention `DisplayName`.