### PR TITLE
bug: dedup workload-contributed init options

### DIFF
--- a/.github/skills/create-workload/SKILL.md
+++ b/.github/skills/create-workload/SKILL.md
@@ -140,7 +140,7 @@ Create the following files:
   ```
   - Initializer must be `internal sealed` (per repo convention; tests reach it via `InternalsVisibleTo`).
   - For stubs, return `[]` from `GetInitOptions(IInitOptionRegistry)` and only throw from `InitializeAsync`. Throwing from `GetInitOptions` breaks any code path that enumerates options across workloads.
-  - For shared options that other stacks also contribute (`--no-bundle`, `--bundles-channel`), use the factories in `Azure.Functions.Cli.Projects.CommonInitOptions` so wording stays consistent. Register every option via `registry.GetOrAdd(...)` and stash the returned canonical instance for reads inside `InitializeAsync`.
+  - For shared options that other stacks also contribute (`--no-bundles`, `--bundles-channel`), use the factories in `Azure.Functions.Cli.Projects.CommonInitOptions` so wording stays consistent. Register every option via `registry.GetOrAdd(...)` and stash the returned canonical instance for reads inside `InitializeAsync`.
 
 ### 2. Test project
 

--- a/.github/skills/create-workload/SKILL.md
+++ b/.github/skills/create-workload/SKILL.md
@@ -126,7 +126,7 @@ Create the following files:
 
       public IReadOnlyList<string> SupportedLanguages { get; } = ["<Language>"];
 
-      public IReadOnlyList<Option> GetInitOptions() => [];
+      public IReadOnlyList<Option> GetInitOptions(IInitOptionRegistry registry) => [];
 
       public Task InitializeAsync(
           InitContext context,
@@ -139,7 +139,8 @@ Create the following files:
   }
   ```
   - Initializer must be `internal sealed` (per repo convention; tests reach it via `InternalsVisibleTo`).
-  - For stubs, return `[]` from `GetInitOptions()` and only throw from `InitializeAsync`. Throwing from `GetInitOptions` breaks any code path that enumerates options across workloads.
+  - For stubs, return `[]` from `GetInitOptions(IInitOptionRegistry)` and only throw from `InitializeAsync`. Throwing from `GetInitOptions` breaks any code path that enumerates options across workloads.
+  - For shared options that other stacks also contribute (`--no-bundle`, `--bundles-channel`), use the factories in `Azure.Functions.Cli.Projects.CommonInitOptions` so wording stays consistent. Register every option via `registry.GetOrAdd(...)` and stash the returned canonical instance for reads inside `InitializeAsync`.
 
 ### 2. Test project
 

--- a/docs/building-a-workload.md
+++ b/docs/building-a-workload.md
@@ -217,15 +217,23 @@ internal sealed class NodeProjectInitializer : IProjectInitializer
         stack.Equals("javascript", StringComparison.OrdinalIgnoreCase) ||
         stack.Equals("typescript", StringComparison.OrdinalIgnoreCase);
 
-    // Workload-specific options. Attached to `func init` during command construction
-    // and visible in --help. Read back inside InitializeAsync via the ParseResult.
-    public Option<string> PackageManagerOption { get; } = new("--package-manager")
-    {
-        Description = "The package manager to use (npm, yarn, pnpm)",
-        DefaultValueFactory = _ => "npm"
-    };
+    // Workload-specific options. Registered through the supplied IInitOptionRegistry,
+    // which is what lets options like `--no-bundle` that multiple stacks contribute
+    // appear once in --help and resolve to the same instance for every workload that
+    // reads them back. Stash the canonical instance returned by GetOrAdd and read
+    // values from it inside InitializeAsync.
+    public Option<string> PackageManagerOption { get; private set; } = default!;
 
-    public IReadOnlyList<Option> GetInitOptions() => [PackageManagerOption];
+    public IReadOnlyList<Option> GetInitOptions(IInitOptionRegistry registry)
+    {
+        PackageManagerOption = registry.GetOrAdd(new Option<string>("--package-manager")
+        {
+            Description = "The package manager to use (npm, yarn, pnpm)",
+            DefaultValueFactory = _ => "npm"
+        });
+
+        return [PackageManagerOption];
+    }
 
     public async Task InitializeAsync(
         InitContext context,
@@ -427,7 +435,7 @@ Use the Python pipelines (`eng/ci/workloads/python/{public,official}-build.yml`)
 - [ ] `workload.json` next to the csproj, listing the entry-point `assemblyPath` and `type`
 - [ ] Subclass of `Workload` with a parameterless constructor, overriding `DisplayName`, `Description`, and `Configure`
 - [ ] `Configure(FunctionsCliBuilder)` null-checks `builder` and registers an `IProjectInitializer` and/or top-level commands via `builder.RegisterCommand(...)`
-- [ ] `IProjectInitializer.GetInitOptions()` returns any extra options the initializer needs (return `[]` for stubs; only throw from `InitializeAsync`)
+- [ ] `IProjectInitializer.GetInitOptions(IInitOptionRegistry registry)` registers any extra options the initializer needs via `registry.GetOrAdd(...)` and returns the canonical instances (return `[]` for stubs; only throw from `InitializeAsync`)
 - [ ] Test project `test/Workloads/<kind>/<Name>.Tests/Workloads.<Name>.Tests.csproj`, assembly name `Azure.Functions.Cli.Workloads.<Name>.Tests` (matches the workload's `InternalsVisibleTo`)
 - [ ] Both projects added to `Azure.Functions.Cli.slnx` under solution folders that mirror their source and test paths
 - [ ] `eng/ci/workloads/<name>/{public,official}-build.yml` extending `eng/ci/templates/jobs/build-workload.yml` with `WorkloadProjectName: <Name>`

--- a/docs/building-a-workload.md
+++ b/docs/building-a-workload.md
@@ -218,7 +218,7 @@ internal sealed class NodeProjectInitializer : IProjectInitializer
         stack.Equals("typescript", StringComparison.OrdinalIgnoreCase);
 
     // Workload-specific options. Registered through the supplied IInitOptionRegistry,
-    // which is what lets options like `--no-bundle` that multiple stacks contribute
+    // which is what lets options like `--no-bundles` that multiple stacks contribute
     // appear once in --help and resolve to the same instance for every workload that
     // reads them back. Stash the canonical instance returned by GetOrAdd and read
     // values from it inside InitializeAsync.

--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -212,7 +212,8 @@ The abstractions library exposes the surface workload authors program against:
 |------|------|
 | `IWorkload` | Entry point. Identity (`PackageId`, `PackageVersion`, `DisplayName`, `Description`) plus `Configure(FunctionsCliBuilder)`. |
 | `FunctionsCliBuilder` | The DI seam handed to a workload. Exposes `Services` for plain DI registrations and `RegisterCommand(...)` overloads (instance / type / factory) for contributing top-level commands. Abstract base so we can grow the surface without breaking workloads. |
-| `IProjectInitializer` | Owns `func init` for a stack. Declares `Stack`, `SupportedLanguages`, contributes init options, and runs `InitializeAsync(InitContext, ParseResult, CancellationToken)`. |
+| `IProjectInitializer` | Owns `func init` for a stack. Declares `Stack`, `SupportedLanguages`, registers init options via `IInitOptionRegistry`, and runs `InitializeAsync(InitContext, ParseResult, CancellationToken)`. |
+| `IInitOptionRegistry` / `CommonInitOptions` | The registry de-dupes options that multiple workloads contribute (e.g. `--no-bundle`) so each option appears once in `--help` and every workload reads the same parsed value. `CommonInitOptions` is a small factory of the shared options themselves (`NoBundle`, `BundlesChannel`). |
 | `WorkloadContext` / `InitContext` | Records carrying common + command-specific inputs to providers. |
 | `FuncCommand` | Parser-independent base for workload-contributed top-level commands. Describes `Name`, `Description`, `Options`, `Arguments`, `Subcommands`, and an `ExecuteAsync(FuncCommandInvocationContext, CancellationToken)`. |
 | `FuncCommandOption` / `FuncCommandArgument` | Typed descriptors used by `FuncCommand`. Identity matters — pass the same descriptor instance to `context.GetValue(...)` to read parsed values. |
@@ -243,7 +244,9 @@ Build commands (Parser.CreateCommand):
   ├── Built-in collisions throw (CLI bug); workload commands that collide with
   │   built-ins or with each other are skipped with a warning that names the
   │   workload(s)
-  ├── InitCommand sees IEnumerable<IProjectInitializer>, attaches their options
+  ├── InitCommand sees IEnumerable<IProjectInitializer>, drives each one through an
+  │   IInitOptionRegistry to register init options (shared names — like --no-bundle —
+  │   collapse to a single canonical Option instance)
   ├── WorkloadListCommand depends on IWorkloadProvider
   └── HelpCommand built last with a back-reference to the constructed root
 
@@ -320,7 +323,7 @@ If a newer version is found, a notice is printed after the command completes.
 4. Delegate to IProjectInitializer.InitializeAsync(context, parseResult)
 ```
 
-Each registered initializer also contributes options to `func init` via `GetInitOptions()`; values are read back inside `InitializeAsync` via the `ParseResult`.
+Each registered initializer also contributes options to `func init` via `GetInitOptions(IInitOptionRegistry)`; values are read back inside `InitializeAsync` via the `ParseResult`. The registry collapses same-named contributions across workloads so shared options (e.g. `--no-bundle`) show up once in `--help` and every contributing workload reads the canonical instance.
 
 ### `func new`
 

--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -213,7 +213,7 @@ The abstractions library exposes the surface workload authors program against:
 | `IWorkload` | Entry point. Identity (`PackageId`, `PackageVersion`, `DisplayName`, `Description`) plus `Configure(FunctionsCliBuilder)`. |
 | `FunctionsCliBuilder` | The DI seam handed to a workload. Exposes `Services` for plain DI registrations and `RegisterCommand(...)` overloads (instance / type / factory) for contributing top-level commands. Abstract base so we can grow the surface without breaking workloads. |
 | `IProjectInitializer` | Owns `func init` for a stack. Declares `Stack`, `SupportedLanguages`, registers init options via `IInitOptionRegistry`, and runs `InitializeAsync(InitContext, ParseResult, CancellationToken)`. |
-| `IInitOptionRegistry` / `CommonInitOptions` | The registry de-dupes options that multiple workloads contribute (e.g. `--no-bundle`) so each option appears once in `--help` and every workload reads the same parsed value. `CommonInitOptions` is a small factory of the shared options themselves (`NoBundle`, `BundlesChannel`). |
+| `IInitOptionRegistry` / `CommonInitOptions` | The registry de-dupes options that multiple workloads contribute (e.g. `--no-bundles`) so each option appears once in `--help` and every workload reads the same parsed value. `CommonInitOptions` is a small factory of the shared options themselves (`NoBundle`, `BundlesChannel`). |
 | `WorkloadContext` / `InitContext` | Records carrying common + command-specific inputs to providers. |
 | `FuncCommand` | Parser-independent base for workload-contributed top-level commands. Describes `Name`, `Description`, `Options`, `Arguments`, `Subcommands`, and an `ExecuteAsync(FuncCommandInvocationContext, CancellationToken)`. |
 | `FuncCommandOption` / `FuncCommandArgument` | Typed descriptors used by `FuncCommand`. Identity matters — pass the same descriptor instance to `context.GetValue(...)` to read parsed values. |
@@ -245,7 +245,7 @@ Build commands (Parser.CreateCommand):
   │   built-ins or with each other are skipped with a warning that names the
   │   workload(s)
   ├── InitCommand sees IEnumerable<IProjectInitializer>, drives each one through an
-  │   IInitOptionRegistry to register init options (shared names — like --no-bundle —
+  │   IInitOptionRegistry to register init options (shared names — like --no-bundles —
   │   collapse to a single canonical Option instance)
   ├── WorkloadListCommand depends on IWorkloadProvider
   └── HelpCommand built last with a back-reference to the constructed root
@@ -323,7 +323,7 @@ If a newer version is found, a notice is printed after the command completes.
 4. Delegate to IProjectInitializer.InitializeAsync(context, parseResult)
 ```
 
-Each registered initializer also contributes options to `func init` via `GetInitOptions(IInitOptionRegistry)`; values are read back inside `InitializeAsync` via the `ParseResult`. The registry collapses same-named contributions across workloads so shared options (e.g. `--no-bundle`) show up once in `--help` and every contributing workload reads the canonical instance.
+Each registered initializer also contributes options to `func init` via `GetInitOptions(IInitOptionRegistry)`; values are read back inside `InitializeAsync` via the `ParseResult`. The registry collapses same-named contributions across workloads so shared options (e.g. `--no-bundles`) show up once in `--help` and every contributing workload reads the canonical instance.
 
 ### `func new`
 

--- a/src/Abstractions/Projects/CommonInitOptions.cs
+++ b/src/Abstractions/Projects/CommonInitOptions.cs
@@ -18,10 +18,10 @@ namespace Azure.Functions.Cli.Projects;
 public static class CommonInitOptions
 {
     /// <summary>
-    /// <c>--no-bundle</c>. Used by every stack that emits a default extension bundle entry
+    /// <c>--no-bundles</c>. Used by every stack that emits a default extension bundle entry
     /// in <c>host.json</c> (Node, Python, Go, ...).
     /// </summary>
-    public static Option<bool> NoBundle() => new("--no-bundle")
+    public static Option<bool> NoBundle() => new("--no-bundles")
     {
         Description = "Skip writing the default extensionBundle block in host.json.",
         DefaultValueFactory = _ => false,

--- a/src/Abstractions/Projects/CommonInitOptions.cs
+++ b/src/Abstractions/Projects/CommonInitOptions.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+
+namespace Azure.Functions.Cli.Projects;
+
+/// <summary>
+/// Factories for <see cref="Option"/>s that multiple workloads contribute to <c>func init</c>.
+/// Centralising the name, description, default, and alias here keeps wording consistent
+/// across stacks and lets <see cref="IInitOptionRegistry"/> share a single canonical instance
+/// per <c>InitCommand</c>.
+/// </summary>
+/// <remarks>
+/// Each method returns a fresh instance per call. The registry collapses duplicates so the
+/// option appears once in <c>--help</c> and every workload sees the same parsed value.
+/// </remarks>
+public static class CommonInitOptions
+{
+    /// <summary>
+    /// <c>--no-bundle</c>. Used by every stack that emits a default extension bundle entry
+    /// in <c>host.json</c> (Node, Python, Go, ...).
+    /// </summary>
+    public static Option<bool> NoBundle() => new("--no-bundle")
+    {
+        Description = "Skip writing the default extensionBundle block in host.json.",
+        DefaultValueFactory = _ => false,
+    };
+
+    /// <summary>
+    /// <c>--bundles-channel</c> / <c>-c</c>. Selects the extension bundle release channel
+    /// (<see cref="BundleChannel.GA"/> by default).
+    /// </summary>
+    public static Option<BundleChannel> BundlesChannel() => new("--bundles-channel", "-c")
+    {
+        Description = "Extension bundle release channel: GA (default), Preview, or Experimental.",
+        DefaultValueFactory = _ => BundleChannel.GA,
+    };
+}

--- a/src/Abstractions/Projects/IInitOptionRegistry.cs
+++ b/src/Abstractions/Projects/IInitOptionRegistry.cs
@@ -1,0 +1,27 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+
+namespace Azure.Functions.Cli.Projects;
+
+/// <summary>
+/// Coordinates the options that <see cref="IProjectInitializer"/> implementations contribute
+/// to <c>func init</c>. Two installed workloads may contribute an option with the same name
+/// (e.g. <c>--no-bundle</c>); the registry returns one shared canonical instance so the option
+/// is shown once in <c>--help</c> and every contributing workload reads the same parsed value.
+/// </summary>
+public interface IInitOptionRegistry
+{
+    /// <summary>
+    /// Returns the canonical option for <paramref name="option"/>'s name. If a same-named option
+    /// has already been registered, the supplied instance is discarded and the existing one is
+    /// returned (provided the types match). Otherwise, the supplied instance is registered and
+    /// returned as-is.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when two workloads register the same option name with mismatched types, or when the
+    /// supplied option's name or any alias collides with a different existing option.
+    /// </exception>
+    public Option<T> GetOrAdd<T>(Option<T> option);
+}

--- a/src/Abstractions/Projects/IInitOptionRegistry.cs
+++ b/src/Abstractions/Projects/IInitOptionRegistry.cs
@@ -8,7 +8,7 @@ namespace Azure.Functions.Cli.Projects;
 /// <summary>
 /// Coordinates the options that <see cref="IProjectInitializer"/> implementations contribute
 /// to <c>func init</c>. Two installed workloads may contribute an option with the same name
-/// (e.g. <c>--no-bundle</c>); the registry returns one shared canonical instance so the option
+/// (e.g. <c>--no-bundles</c>); the registry returns one shared canonical instance so the option
 /// is shown once in <c>--help</c> and every contributing workload reads the same parsed value.
 /// </summary>
 public interface IInitOptionRegistry

--- a/src/Abstractions/Projects/IProjectInitializer.cs
+++ b/src/Abstractions/Projects/IProjectInitializer.cs
@@ -24,10 +24,13 @@ public interface IProjectInitializer
     public IReadOnlyList<string> SupportedLanguages { get; }
 
     /// <summary>
-    /// Options this initializer contributes to the <c>func init</c> command.
-    /// Attached during command construction and visible in <c>--help</c>.
+    /// Registers the options this initializer contributes to <c>func init</c> via
+    /// <paramref name="registry"/>, and returns the canonical instances to use when reading
+    /// values back inside <see cref="InitializeAsync"/>. Options shared across workloads
+    /// (e.g. <c>--no-bundle</c>) appear once in <c>--help</c> and resolve to the same instance
+    /// for every contributing workload.
     /// </summary>
-    public IReadOnlyList<Option> GetInitOptions();
+    public IReadOnlyList<Option> GetInitOptions(IInitOptionRegistry registry);
 
     /// <summary>
     /// Scaffolds a new project at <see cref="WorkloadContext.WorkingDirectory"/>.

--- a/src/Abstractions/Projects/IProjectInitializer.cs
+++ b/src/Abstractions/Projects/IProjectInitializer.cs
@@ -27,7 +27,7 @@ public interface IProjectInitializer
     /// Registers the options this initializer contributes to <c>func init</c> via
     /// <paramref name="registry"/>, and returns the canonical instances to use when reading
     /// values back inside <see cref="InitializeAsync"/>. Options shared across workloads
-    /// (e.g. <c>--no-bundle</c>) appear once in <c>--help</c> and resolve to the same instance
+    /// (e.g. <c>--no-bundles</c>) appear once in <c>--help</c> and resolve to the same instance
     /// for every contributing workload.
     /// </summary>
     public IReadOnlyList<Option> GetInitOptions(IInitOptionRegistry registry);

--- a/src/Abstractions/Projects/InitOptionRegistry.cs
+++ b/src/Abstractions/Projects/InitOptionRegistry.cs
@@ -1,0 +1,75 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+
+namespace Azure.Functions.Cli.Projects;
+
+/// <summary>
+/// Default <see cref="IInitOptionRegistry"/> implementation. Adds each unique option to the
+/// supplied <see cref="Command"/> exactly once and shares the canonical instance across
+/// workloads that contribute the same name.
+/// </summary>
+/// <remarks>
+/// Public so workload test projects can drive <see cref="IProjectInitializer.GetInitOptions"/>
+/// without taking a dependency on the host's internals.
+/// </remarks>
+public sealed class InitOptionRegistry : IInitOptionRegistry
+{
+    private readonly Command _command;
+    private readonly Dictionary<string, Entry> _byName = new(StringComparer.Ordinal);
+    private string _activeStack = "?";
+
+    public InitOptionRegistry(Command command)
+    {
+        _command = command ?? throw new ArgumentNullException(nameof(command));
+    }
+
+    /// <summary>
+    /// Sets the workload id used when reporting collisions, so the error message can name both
+    /// the workload registering now and the one that owned the conflicting name first.
+    /// </summary>
+    public void SetActiveStack(string stack)
+    {
+        _activeStack = stack ?? "?";
+    }
+
+    public Option<T> GetOrAdd<T>(Option<T> option)
+    {
+        ArgumentNullException.ThrowIfNull(option);
+
+        if (_byName.TryGetValue(option.Name, out Entry existing))
+        {
+            if (existing.Option is not Option<T> typed)
+            {
+                throw new InvalidOperationException(
+                    $"Workload '{_activeStack}' contributes option '{option.Name}' as {typeof(T).Name}, " +
+                    $"but workload '{existing.OwningStack}' already registered it as {existing.Option.ValueType.Name}. " +
+                    "Same-named options across workloads must use the same value type.");
+            }
+
+            return typed;
+        }
+
+        foreach (string alias in option.Aliases)
+        {
+            if (_byName.TryGetValue(alias, out Entry existingByAlias))
+            {
+                throw new InvalidOperationException(
+                    $"Workload '{_activeStack}' contributes option '{option.Name}' with alias '{alias}', " +
+                    $"but workload '{existingByAlias.OwningStack}' already uses '{alias}' for option '{existingByAlias.Option.Name}'.");
+            }
+        }
+
+        _command.Options.Add(option);
+        _byName[option.Name] = new Entry(option, _activeStack);
+        foreach (string alias in option.Aliases)
+        {
+            _byName[alias] = new Entry(option, _activeStack);
+        }
+
+        return option;
+    }
+
+    private readonly record struct Entry(Option Option, string OwningStack);
+}

--- a/src/Func/Commands/InitCommand.cs
+++ b/src/Func/Commands/InitCommand.cs
@@ -67,15 +67,17 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
         Options.Add(ForceOption);
 
         // Workload-contributed options are attached after built-ins so they
-        // appear as a clearly-grouped block in --help output.
+        // appear as a clearly-grouped block in --help output. Multiple workloads
+        // may legitimately contribute the same option (e.g. --no-bundle for
+        // every stack that emits an extension bundle). The registry de-dupes
+        // by name and returns a single canonical instance to every workload,
+        // so the option appears once in --help and every workload that reads
+        // it back sees the same parsed value.
+        var registry = new InitOptionRegistry(this);
         foreach (IProjectInitializer initializer in _initializers)
         {
-            foreach (Option option in initializer.GetInitOptions())
-            {
-                // TODO: detect option-name collisions across workloads and surface
-                // a workload-named error.
-                Options.Add(option);
-            }
+            registry.SetActiveStack(initializer.Stack);
+            initializer.GetInitOptions(registry);
         }
     }
 

--- a/src/Func/Commands/InitCommand.cs
+++ b/src/Func/Commands/InitCommand.cs
@@ -68,7 +68,7 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
 
         // Workload-contributed options are attached after built-ins so they
         // appear as a clearly-grouped block in --help output. Multiple workloads
-        // may legitimately contribute the same option (e.g. --no-bundle for
+        // may legitimately contribute the same option (e.g. --no-bundles for
         // every stack that emits an extension bundle). The registry de-dupes
         // by name and returns a single canonical instance to every workload,
         // so the option appears once in --help and every workload that reads

--- a/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
@@ -32,13 +32,20 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli, ITemp
 
     public IReadOnlyList<string> SupportedLanguages => ["C#", "F#", "csharp", "fsharp"];
 
-    public Option<string> FrameworkOption { get; } = new("--target-framework", "-tfm")
-    {
-        Description = "The target framework for the project (e.g. net10.0).",
-        DefaultValueFactory = _ => DefaultFramework
-    };
+    public Option<string> FrameworkOption { get; private set; } = default!;
 
-    public IReadOnlyList<Option> GetInitOptions() => [FrameworkOption];
+    public IReadOnlyList<Option> GetInitOptions(IInitOptionRegistry registry)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+
+        FrameworkOption = registry.GetOrAdd(new Option<string>("--target-framework", "-tfm")
+        {
+            Description = "The target framework for the project (e.g. net10.0).",
+            DefaultValueFactory = _ => DefaultFramework
+        });
+
+        return [FrameworkOption];
+    }
 
     public async Task InitializeAsync(
         InitContext context,

--- a/src/Workloads/Stacks/Go/GoProjectInitializer.cs
+++ b/src/Workloads/Stacks/Go/GoProjectInitializer.cs
@@ -28,25 +28,28 @@ internal sealed class GoProjectInitializer : IProjectInitializer
 
     public IReadOnlyList<string> SupportedLanguages { get; } = ["Go"];
 
-    public Option<bool> SkipGoModTidyOption { get; } = new("--skip-go-mod-tidy")
-    {
-        Description = "Skip running 'go mod tidy' after Go project creation.",
-        DefaultValueFactory = _ => false,
-    };
+    public Option<bool> SkipGoModTidyOption { get; private set; } = default!;
 
-    public Option<bool> NoBundleOption { get; } = new("--no-bundle")
-    {
-        Description = "Skip writing the default extensionBundle block in host.json.",
-        DefaultValueFactory = _ => false,
-    };
+    public Option<bool> NoBundleOption { get; private set; } = default!;
 
-    public Option<BundleChannel> BundlesChannelOption { get; } = new("--bundles-channel", "-c")
-    {
-        Description = "Extension bundle release channel: GA (default), Preview, or Experimental.",
-        DefaultValueFactory = _ => BundleChannel.GA,
-    };
+    public Option<BundleChannel> BundlesChannelOption { get; private set; } = default!;
 
-    public IReadOnlyList<Option> GetInitOptions() => [SkipGoModTidyOption, NoBundleOption, BundlesChannelOption];
+    public IReadOnlyList<Option> GetInitOptions(IInitOptionRegistry registry)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+
+        SkipGoModTidyOption = registry.GetOrAdd(new Option<bool>("--skip-go-mod-tidy")
+        {
+            Description = "Skip running 'go mod tidy' after Go project creation.",
+            DefaultValueFactory = _ => false,
+        });
+
+        NoBundleOption = registry.GetOrAdd(CommonInitOptions.NoBundle());
+
+        BundlesChannelOption = registry.GetOrAdd(CommonInitOptions.BundlesChannel());
+
+        return [SkipGoModTidyOption, NoBundleOption, BundlesChannelOption];
+    }
 
     public async Task InitializeAsync(
         InitContext context,

--- a/src/Workloads/Stacks/Node/NodeProjectInitializer.cs
+++ b/src/Workloads/Stacks/Node/NodeProjectInitializer.cs
@@ -28,25 +28,28 @@ internal sealed class NodeProjectInitializer : IProjectInitializer
 
     public IReadOnlyList<string> SupportedLanguages { get; } = ["JavaScript", "TypeScript"];
 
-    public Option<bool> NoBundleOption { get; } = new("--no-bundle")
-    {
-        Description = "Skip writing the default extensionBundle block in host.json.",
-        DefaultValueFactory = _ => false,
-    };
+    public Option<bool> NoBundleOption { get; private set; } = default!;
 
-    public Option<BundleChannel> BundlesChannelOption { get; } = new("--bundles-channel", "-c")
-    {
-        Description = "Extension bundle release channel: GA (default), Preview, or Experimental.",
-        DefaultValueFactory = _ => BundleChannel.GA,
-    };
+    public Option<BundleChannel> BundlesChannelOption { get; private set; } = default!;
 
-    public Option<bool> SkipNpmInstallOption { get; } = new("--skip-npm-install")
-    {
-        Description = "Skip running 'npm install' after Node project creation.",
-        DefaultValueFactory = _ => false,
-    };
+    public Option<bool> SkipNpmInstallOption { get; private set; } = default!;
 
-    public IReadOnlyList<Option> GetInitOptions() => [NoBundleOption, BundlesChannelOption, SkipNpmInstallOption];
+    public IReadOnlyList<Option> GetInitOptions(IInitOptionRegistry registry)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+
+        NoBundleOption = registry.GetOrAdd(CommonInitOptions.NoBundle());
+
+        BundlesChannelOption = registry.GetOrAdd(CommonInitOptions.BundlesChannel());
+
+        SkipNpmInstallOption = registry.GetOrAdd(new Option<bool>("--skip-npm-install")
+        {
+            Description = "Skip running 'npm install' after Node project creation.",
+            DefaultValueFactory = _ => false,
+        });
+
+        return [NoBundleOption, BundlesChannelOption, SkipNpmInstallOption];
+    }
 
     public async Task InitializeAsync(
         InitContext context,

--- a/src/Workloads/Stacks/Node/NodeProjectInitializer.cs
+++ b/src/Workloads/Stacks/Node/NodeProjectInitializer.cs
@@ -103,7 +103,7 @@ internal sealed class NodeProjectInitializer : IProjectInitializer
         Directory.CreateDirectory(Path.Combine(root, "src", "functions"));
 
         // Always lay down the base host.json so the project is valid even
-        // with --no-bundle. MergeHostJson below layers extensionBundle on top.
+        // with --no-bundles. MergeHostJson below layers extensionBundle on top.
         ProjectFiles.WriteIfMissing(
             Path.Combine(root, "host.json"),
             ProjectFiles.MinimalHostJson,

--- a/src/Workloads/Stacks/Python/PythonProjectInitializer.cs
+++ b/src/Workloads/Stacks/Python/PythonProjectInitializer.cs
@@ -75,7 +75,7 @@ internal sealed class PythonProjectInitializer : IProjectInitializer
             force);
 
         // Always lay down the base host.json so the project is valid even
-        // with --no-bundle. MergeHostJson below layers extensionBundle on top.
+        // with --no-bundles. MergeHostJson below layers extensionBundle on top.
         ProjectFiles.WriteIfMissing(
             Path.Combine(root, "host.json"),
             ProjectFiles.MinimalHostJson,
@@ -106,4 +106,3 @@ internal sealed class PythonProjectInitializer : IProjectInitializer
         };
     }
 }
-

--- a/src/Workloads/Stacks/Python/PythonProjectInitializer.cs
+++ b/src/Workloads/Stacks/Python/PythonProjectInitializer.cs
@@ -20,19 +20,20 @@ internal sealed class PythonProjectInitializer : IProjectInitializer
 
     public IReadOnlyList<string> SupportedLanguages { get; } = ["Python"];
 
-    public Option<bool> NoBundleOption { get; } = new("--no-bundle")
-    {
-        Description = "Skip writing the default extensionBundle block in host.json.",
-        DefaultValueFactory = _ => false,
-    };
+    public Option<bool> NoBundleOption { get; private set; } = default!;
 
-    public Option<BundleChannel> BundlesChannelOption { get; } = new("--bundles-channel", "-c")
-    {
-        Description = "Extension bundle release channel: GA (default), Preview, or Experimental.",
-        DefaultValueFactory = _ => BundleChannel.GA,
-    };
+    public Option<BundleChannel> BundlesChannelOption { get; private set; } = default!;
 
-    public IReadOnlyList<Option> GetInitOptions() => [NoBundleOption, BundlesChannelOption];
+    public IReadOnlyList<Option> GetInitOptions(IInitOptionRegistry registry)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+
+        NoBundleOption = registry.GetOrAdd(CommonInitOptions.NoBundle());
+
+        BundlesChannelOption = registry.GetOrAdd(CommonInitOptions.BundlesChannel());
+
+        return [NoBundleOption, BundlesChannelOption];
+    }
 
     public Task InitializeAsync(
         InitContext context,

--- a/test/Func.Tests/Commands/InitCommandTests.cs
+++ b/test/Func.Tests/Commands/InitCommandTests.cs
@@ -483,18 +483,18 @@ public class InitCommandTests
     [Fact]
     public void InitCommand_DedupesContributedOptionsByName()
     {
-        // Two workloads contributing the same option name (e.g. --no-bundle) must
+        // Two workloads contributing the same option name (e.g. --no-bundles) must
         // appear once in --help and resolve to a single canonical Option instance.
         var first = new FakeProjectInitializer(
             "node",
-            optionFactory: r => [r.GetOrAdd(new Option<bool>("--no-bundle"))]);
+            optionFactory: r => [r.GetOrAdd(new Option<bool>("--no-bundles"))]);
         var second = new FakeProjectInitializer(
             "python",
-            optionFactory: r => [r.GetOrAdd(new Option<bool>("--no-bundle"))]);
+            optionFactory: r => [r.GetOrAdd(new Option<bool>("--no-bundles"))]);
 
         var cmd = new InitCommand(_interaction, _hintRenderer, [first, second]);
 
-        int matches = cmd.Options.Count(o => o.Name == "--no-bundle");
+        int matches = cmd.Options.Count(o => o.Name == "--no-bundles");
         Assert.Equal(1, matches);
         Assert.Same(first.ContributedOptions[0], second.ContributedOptions[0]);
     }
@@ -503,17 +503,17 @@ public class InitCommandTests
     public async Task InitCommand_SharedOption_IsReadCorrectlyByLaterWorkload()
     {
         // When `python` is selected but `node` was registered first, python must still see
-        // the user-supplied value for the shared `--no-bundle` option.
+        // the user-supplied value for the shared `--no-bundles` option.
         var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
         try
         {
             bool? observed = null;
             var node = new FakeProjectInitializer(
                 "node",
-                optionFactory: r => [r.GetOrAdd(new Option<bool>("--no-bundle"))]);
+                optionFactory: r => [r.GetOrAdd(new Option<bool>("--no-bundles"))]);
             var python = new FakeProjectInitializer(
                 "python",
-                optionFactory: r => [r.GetOrAdd(new Option<bool>("--no-bundle"))],
+                optionFactory: r => [r.GetOrAdd(new Option<bool>("--no-bundles"))],
                 onInitialize: (init, parseResult) =>
                 {
                     var opt = (Option<bool>)init.ContributedOptions[0];
@@ -525,7 +525,7 @@ public class InitCommandTests
                 [node, python],
                 language: null,
                 stack: "python",
-                extraArgs: ["--no-bundle"]);
+                extraArgs: ["--no-bundles"]);
 
             Assert.Equal(0, exitCode);
             Assert.True(observed);
@@ -541,17 +541,17 @@ public class InitCommandTests
     {
         var first = new FakeProjectInitializer(
             "node",
-            optionFactory: r => [r.GetOrAdd(new Option<bool>("--no-bundle"))]);
+            optionFactory: r => [r.GetOrAdd(new Option<bool>("--no-bundles"))]);
         var second = new FakeProjectInitializer(
             "python",
-            optionFactory: r => [r.GetOrAdd(new Option<string>("--no-bundle"))]);
+            optionFactory: r => [r.GetOrAdd(new Option<string>("--no-bundles"))]);
 
         var ex = Assert.Throws<InvalidOperationException>(() =>
             new InitCommand(_interaction, _hintRenderer, [first, second]));
 
         Assert.Contains("python", ex.Message);
         Assert.Contains("node", ex.Message);
-        Assert.Contains("--no-bundle", ex.Message);
+        Assert.Contains("--no-bundles", ex.Message);
     }
 
     [Fact]

--- a/test/Func.Tests/Commands/InitCommandTests.cs
+++ b/test/Func.Tests/Commands/InitCommandTests.cs
@@ -180,7 +180,8 @@ public class InitCommandTests
         IReadOnlyList<IProjectInitializer> initializers,
         string? language = null,
         string? stack = null,
-        bool force = false)
+        bool force = false,
+        IReadOnlyList<string>? extraArgs = null)
     {
         var cmd = new InitCommand(_interaction, _hintRenderer, initializers);
         var root = new RootCommand { cmd };
@@ -198,6 +199,10 @@ public class InitCommandTests
         if (force)
         {
             args.Add("--force");
+        }
+        if (extraArgs is not null)
+        {
+            args.AddRange(extraArgs);
         }
         ParseResult result = root.Parse(args.ToArray());
         return await result.InvokeAsync();
@@ -475,7 +480,104 @@ public class InitCommandTests
         }
     }
 
-    private sealed class FakeProjectInitializer(string stack, IReadOnlyList<string>? supportedLanguages = null) : IProjectInitializer
+    [Fact]
+    public void InitCommand_DedupesContributedOptionsByName()
+    {
+        // Two workloads contributing the same option name (e.g. --no-bundle) must
+        // appear once in --help and resolve to a single canonical Option instance.
+        var first = new FakeProjectInitializer(
+            "node",
+            optionFactory: r => [r.GetOrAdd(new Option<bool>("--no-bundle"))]);
+        var second = new FakeProjectInitializer(
+            "python",
+            optionFactory: r => [r.GetOrAdd(new Option<bool>("--no-bundle"))]);
+
+        var cmd = new InitCommand(_interaction, _hintRenderer, [first, second]);
+
+        int matches = cmd.Options.Count(o => o.Name == "--no-bundle");
+        Assert.Equal(1, matches);
+        Assert.Same(first.ContributedOptions[0], second.ContributedOptions[0]);
+    }
+
+    [Fact]
+    public async Task InitCommand_SharedOption_IsReadCorrectlyByLaterWorkload()
+    {
+        // When `python` is selected but `node` was registered first, python must still see
+        // the user-supplied value for the shared `--no-bundle` option.
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+        try
+        {
+            bool? observed = null;
+            var node = new FakeProjectInitializer(
+                "node",
+                optionFactory: r => [r.GetOrAdd(new Option<bool>("--no-bundle"))]);
+            var python = new FakeProjectInitializer(
+                "python",
+                optionFactory: r => [r.GetOrAdd(new Option<bool>("--no-bundle"))],
+                onInitialize: (init, parseResult) =>
+                {
+                    var opt = (Option<bool>)init.ContributedOptions[0];
+                    observed = parseResult.GetValue(opt);
+                });
+
+            int exitCode = await RunInitAsync(
+                newDir,
+                [node, python],
+                language: null,
+                stack: "python",
+                extraArgs: ["--no-bundle"]);
+
+            Assert.Equal(0, exitCode);
+            Assert.True(observed);
+        }
+        finally
+        {
+            CleanupDirectory(newDir);
+        }
+    }
+
+    [Fact]
+    public void InitCommand_ThrowsWhenWorkloadsContributeSameNameDifferentType()
+    {
+        var first = new FakeProjectInitializer(
+            "node",
+            optionFactory: r => [r.GetOrAdd(new Option<bool>("--no-bundle"))]);
+        var second = new FakeProjectInitializer(
+            "python",
+            optionFactory: r => [r.GetOrAdd(new Option<string>("--no-bundle"))]);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new InitCommand(_interaction, _hintRenderer, [first, second]));
+
+        Assert.Contains("python", ex.Message);
+        Assert.Contains("node", ex.Message);
+        Assert.Contains("--no-bundle", ex.Message);
+    }
+
+    [Fact]
+    public void InitCommand_ThrowsWhenAliasCollidesAcrossWorkloads()
+    {
+        // Two workloads both want -c as an alias, but for different options.
+        var first = new FakeProjectInitializer(
+            "node",
+            optionFactory: r => [r.GetOrAdd(new Option<string>("--bundles-channel", "-c"))]);
+        var second = new FakeProjectInitializer(
+            "go",
+            optionFactory: r => [r.GetOrAdd(new Option<string>("--clean", "-c"))]);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new InitCommand(_interaction, _hintRenderer, [first, second]));
+
+        Assert.Contains("-c", ex.Message);
+        Assert.Contains("--clean", ex.Message);
+        Assert.Contains("--bundles-channel", ex.Message);
+    }
+
+    private sealed class FakeProjectInitializer(
+        string stack,
+        IReadOnlyList<string>? supportedLanguages = null,
+        Func<IInitOptionRegistry, IReadOnlyList<Option>>? optionFactory = null,
+        Action<FakeProjectInitializer, ParseResult>? onInitialize = null) : IProjectInitializer
     {
         public string Stack { get; } = stack;
 
@@ -483,11 +585,18 @@ public class InitCommandTests
 
         public bool WasInvoked { get; private set; }
 
-        public IReadOnlyList<Option> GetInitOptions() => [];
+        public IReadOnlyList<Option> ContributedOptions { get; private set; } = [];
+
+        public IReadOnlyList<Option> GetInitOptions(IInitOptionRegistry registry)
+        {
+            ContributedOptions = optionFactory?.Invoke(registry) ?? [];
+            return ContributedOptions;
+        }
 
         public Task InitializeAsync(InitContext context, ParseResult parseResult, CancellationToken cancellationToken = default)
         {
             WasInvoked = true;
+            onInitialize?.Invoke(this, parseResult);
             return Task.CompletedTask;
         }
     }

--- a/test/Workloads/Stacks/DotNet.Tests/DotNetProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/DotNet.Tests/DotNetProjectInitializerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.CommandLine;
+using Azure.Functions.Cli.Projects;
 using NSubstitute;
 using Xunit;
 
@@ -40,7 +41,8 @@ public class DotNetProjectInitializerTests : IDisposable
     public void GetInitOptions_ContainsFrameworkOption()
     {
         DotNetProjectInitializer initializer = CreateInitializer();
-        IReadOnlyList<Option> options = initializer.GetInitOptions();
+        RootCommand root = [];
+        IReadOnlyList<Option> options = initializer.GetInitOptions(new InitOptionRegistry(root));
 
         Assert.Single(options);
         Assert.Same(initializer.FrameworkOption, options[0]);

--- a/test/Workloads/Stacks/Go.Tests/GoProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/Go.Tests/GoProjectInitializerTests.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Commands;
+using Azure.Functions.Cli.Projects;
 using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.Go.Tests;
@@ -43,7 +44,8 @@ public class GoProjectInitializerTests : IDisposable
     [Fact]
     public void GetInitOptions_ContainsSkipGoModTidy()
     {
-        IReadOnlyList<Option> options = new GoProjectInitializer().GetInitOptions();
+        RootCommand root = [];
+        IReadOnlyList<Option> options = new GoProjectInitializer().GetInitOptions(new InitOptionRegistry(root));
         IReadOnlyList<string> names = [.. options.Select(o => o.Name)];
 
         Assert.Contains("--skip-go-mod-tidy", names);
@@ -190,10 +192,7 @@ public class GoProjectInitializerTests : IDisposable
             Language: null,
             Force: false);
         var root = new RootCommand();
-        foreach (Option opt in initializer.GetInitOptions())
-        {
-            root.Options.Add(opt);
-        }
+        initializer.GetInitOptions(new InitOptionRegistry(root));
 
         await initializer.InitializeAsync(context, root.Parse("--skip-go-mod-tidy"));
         Assert.Equal(0, calls);
@@ -212,10 +211,7 @@ public class GoProjectInitializerTests : IDisposable
             Language: null,
             Force: false);
         var root = new RootCommand();
-        foreach (Option opt in initializer.GetInitOptions())
-        {
-            root.Options.Add(opt);
-        }
+        initializer.GetInitOptions(new InitOptionRegistry(root));
 
         await initializer.InitializeAsync(context, root.Parse(string.Empty));
         Assert.Equal(1, calls);
@@ -232,10 +228,7 @@ public class GoProjectInitializerTests : IDisposable
             Language: null,
             Force: force);
         var root = new RootCommand();
-        foreach (Option opt in initializer.GetInitOptions())
-        {
-            root.Options.Add(opt);
-        }
+        initializer.GetInitOptions(new InitOptionRegistry(root));
 
         return initializer.InitializeAsync(context, root.Parse(args ?? []));
     }

--- a/test/Workloads/Stacks/Go.Tests/GoProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/Go.Tests/GoProjectInitializerTests.cs
@@ -49,7 +49,7 @@ public class GoProjectInitializerTests : IDisposable
         IReadOnlyList<string> names = [.. options.Select(o => o.Name)];
 
         Assert.Contains("--skip-go-mod-tidy", names);
-        Assert.Contains("--no-bundle", names);
+        Assert.Contains("--no-bundles", names);
         Assert.Contains("--bundles-channel", names);
     }
 
@@ -147,10 +147,10 @@ public class GoProjectInitializerTests : IDisposable
     [Fact]
     public async Task InitializeAsync_NoBundle_WritesMinimalHostJsonWithoutExtensionBundle()
     {
-        await RunAsync(projectName: "my-go-app", force: false, args: ["--no-bundle"]);
+        await RunAsync(projectName: "my-go-app", force: false, args: ["--no-bundles"]);
 
         string hostJsonPath = Path.Combine(_projectDir.FullName, "host.json");
-        Assert.True(File.Exists(hostJsonPath), "host.json should be created even with --no-bundle");
+        Assert.True(File.Exists(hostJsonPath), "host.json should be created even with --no-bundles");
         string content = File.ReadAllText(hostJsonPath);
         Assert.Contains("\"version\"", content);
         Assert.DoesNotContain("extensionBundle", content);

--- a/test/Workloads/Stacks/Node.Tests/NodeProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/Node.Tests/NodeProjectInitializerTests.cs
@@ -48,7 +48,7 @@ public class NodeProjectInitializerTests : IDisposable
         IReadOnlyList<Option> options = new NodeProjectInitializer().GetInitOptions(new InitOptionRegistry(root));
         IReadOnlyList<string> names = [.. options.Select(o => o.Name)];
 
-        Assert.Contains("--no-bundle", names);
+        Assert.Contains("--no-bundles", names);
         Assert.Contains("--bundles-channel", names);
         Assert.Contains("--skip-npm-install", names);
     }
@@ -135,10 +135,10 @@ public class NodeProjectInitializerTests : IDisposable
     [Fact]
     public async Task InitializeAsync_NoBundle_WritesMinimalHostJsonWithoutExtensionBundle()
     {
-        await RunAsync(language: null, force: false, args: ["--no-bundle"]);
+        await RunAsync(language: null, force: false, args: ["--no-bundles"]);
 
         string hostJsonPath = Path.Combine(_projectDir.FullName, "host.json");
-        Assert.True(File.Exists(hostJsonPath), "host.json should be created even with --no-bundle");
+        Assert.True(File.Exists(hostJsonPath), "host.json should be created even with --no-bundles");
         string content = File.ReadAllText(hostJsonPath);
         Assert.Contains("\"version\"", content);
         Assert.DoesNotContain("extensionBundle", content);

--- a/test/Workloads/Stacks/Node.Tests/NodeProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/Node.Tests/NodeProjectInitializerTests.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Commands;
+using Azure.Functions.Cli.Projects;
 using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.Node.Tests;
@@ -43,7 +44,8 @@ public class NodeProjectInitializerTests : IDisposable
     [Fact]
     public void GetInitOptions_RegistersBundleAndNpmOptions()
     {
-        IReadOnlyList<Option> options = new NodeProjectInitializer().GetInitOptions();
+        RootCommand root = [];
+        IReadOnlyList<Option> options = new NodeProjectInitializer().GetInitOptions(new InitOptionRegistry(root));
         IReadOnlyList<string> names = [.. options.Select(o => o.Name)];
 
         Assert.Contains("--no-bundle", names);
@@ -215,10 +217,8 @@ public class NodeProjectInitializerTests : IDisposable
             Force: force);
 
         RootCommand root = [];
-        foreach (Option option in initializer.GetInitOptions())
-        {
-            root.Options.Add(option);
-        }
+        var registry = new InitOptionRegistry(root);
+        initializer.GetInitOptions(registry);
 
         ParseResult parseResult = root.Parse(args ?? []);
         return initializer.InitializeAsync(context, parseResult);

--- a/test/Workloads/Stacks/Python.Tests/PythonProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/Python.Tests/PythonProjectInitializerTests.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Commands;
+using Azure.Functions.Cli.Projects;
 using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.Python.Tests;
@@ -43,7 +44,8 @@ public class PythonProjectInitializerTests : IDisposable
     [Fact]
     public void GetInitOptions_RegistersBundleOptions()
     {
-        IReadOnlyList<Option> options = new PythonProjectInitializer().GetInitOptions();
+        RootCommand root = [];
+        IReadOnlyList<Option> options = new PythonProjectInitializer().GetInitOptions(new InitOptionRegistry(root));
         IReadOnlyList<string> names = [.. options.Select(o => o.Name)];
 
         Assert.Contains("--no-bundle", names);
@@ -170,10 +172,7 @@ public class PythonProjectInitializerTests : IDisposable
             Force: force);
 
         RootCommand root = [];
-        foreach (Option option in initializer.GetInitOptions())
-        {
-            root.Options.Add(option);
-        }
+        initializer.GetInitOptions(new InitOptionRegistry(root));
 
         ParseResult parseResult = root.Parse(args ?? []);
         return initializer.InitializeAsync(context, parseResult);

--- a/test/Workloads/Stacks/Python.Tests/PythonProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/Python.Tests/PythonProjectInitializerTests.cs
@@ -48,7 +48,7 @@ public class PythonProjectInitializerTests : IDisposable
         IReadOnlyList<Option> options = new PythonProjectInitializer().GetInitOptions(new InitOptionRegistry(root));
         IReadOnlyList<string> names = [.. options.Select(o => o.Name)];
 
-        Assert.Contains("--no-bundle", names);
+        Assert.Contains("--no-bundles", names);
         Assert.Contains("--bundles-channel", names);
     }
 
@@ -129,10 +129,10 @@ public class PythonProjectInitializerTests : IDisposable
     [Fact]
     public async Task InitializeAsync_NoBundle_WritesMinimalHostJsonWithoutExtensionBundle()
     {
-        await RunAsync(force: false, args: ["--no-bundle"]);
+        await RunAsync(force: false, args: ["--no-bundles"]);
 
         string hostJsonPath = Path.Combine(_projectDir.FullName, "host.json");
-        Assert.True(File.Exists(hostJsonPath), "host.json should be created even with --no-bundle");
+        Assert.True(File.Exists(hostJsonPath), "host.json should be created even with --no-bundles");
         string content = File.ReadAllText(hostJsonPath);
         Assert.Contains("\"version\"", content);
         Assert.DoesNotContain("extensionBundle", content);


### PR DESCRIPTION
Closes the `// TODO: detect option-name collisions across workloads` in `InitCommand`.

## Why
Multiple workloads can legitimately contribute the same init option, today every extension-bundle stack (Node, Python, Go) defines both `--no-bundle` and `--bundles-channel`/`-c`. Before this change `InitCommand` naively added each duplicate to its `Options` list. That had two user-visible problems:

1. `func init --help` listed `--no-bundle` once per installed stack.
2. `parseResult.GetValue(option)` is identity-based in System.CommandLine 2.x. Only the **first** registered instance binds to the parsed value, so a workload that "lost" the registration race silently read `default(T)` even when the user passed the flag. Whether `func init --stack python --no-bundle` actually skipped the bundle depended on registration order across workloads.

## What
- New `IInitOptionRegistry` (abstraction) + `InitOptionRegistry` (concrete) in `src/Abstractions/Projects/`. Workloads register options through `registry.GetOrAdd(...)` and stash the returned canonical instance. Same-named contributions across workloads collapse to one instance; type mismatches and alias collisions throw with both workload ids in the message.
- `IProjectInitializer.GetInitOptions()` becomes `GetInitOptions(IInitOptionRegistry registry)` so the registry is the single place options enter the command.
- New `CommonInitOptions` factory (`NoBundle()`, `BundlesChannel()`) so the wording and defaults of cross-stack options live in one file.
- Node / Python / Go / DotNet initializers updated to use the registry and (where applicable) `CommonInitOptions`. Workload tests updated to drive `GetInitOptions` through an `InitOptionRegistry`.
- New `InitCommand` tests cover the four interesting cases: dedup-by-name, correct reads from the "loser" workload, type-mismatch error, alias collision error.
- Docs (`docs/cli-architecture.md`, `docs/building-a-workload.md`, `.github/skills/create-workload/SKILL.md`) updated to match the new signature and call out `CommonInitOptions`.

## Verification
- `dotnet build -c Release`: 0 warnings, 0 errors.
- `dotnet test -c Release`: 603 / 603 passing across Func.Tests + four workload test projects.

## Follow-up (out of scope)
Dynamic per-stack option visibility, hide a stack's options on workload-aware commands once `.func/config.json` pins a stack. Tracked separately in #TBD (will open after this lands).