### PR TITLE
Add language alias support for func init

### DIFF
--- a/src/Abstractions/Projects/IProjectInitializer.cs
+++ b/src/Abstractions/Projects/IProjectInitializer.cs
@@ -30,6 +30,11 @@ public interface IProjectInitializer
     public IReadOnlyList<string> SupportedLanguages { get; }
 
     /// <summary>
+    /// Maps each canonical language name to its accepted aliases (e.g. "C#" → ["csharp"]).
+    /// </summary>
+    public IReadOnlyDictionary<string, IReadOnlyList<string>> SupportedLanguageAliases { get; }
+
+    /// <summary>
     /// Registers the options this initializer contributes to <c>func init</c> via
     /// <paramref name="registry"/>, and returns the canonical instances to use when reading
     /// values back inside <see cref="InitializeAsync"/>. Options shared across workloads

--- a/src/Func/Commands/InitCommand.cs
+++ b/src/Func/Commands/InitCommand.cs
@@ -325,13 +325,23 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
 
         if (!string.IsNullOrWhiteSpace(requested))
         {
+            // First try direct match against canonical language names.
             string? match = supported.FirstOrDefault(l =>
                 string.Equals(l, requested, StringComparison.OrdinalIgnoreCase));
+
+            // If no direct match, try resolving as an alias.
             if (match is null)
             {
+                match = ResolveAlias(requested, initializer.SupportedLanguageAliases);
+            }
+
+            if (match is null)
+            {
+                IEnumerable<string> allAliases = initializer.SupportedLanguageAliases.Values.SelectMany(v => v);
                 _interaction.WriteError(
                     $"Language '{requested}' is not supported by the '{initializer.Stack}' stack. " +
-                    $"Supported values: {string.Join(", ", supported)}.");
+                    $"Supported values: {string.Join(", ", supported)}. " +
+                    $"Also accepted: {string.Join(", ", allAliases)}.");
                 return (null, 1);
             }
 
@@ -357,6 +367,19 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
             cancellationToken);
 
         return (picked.ToLowerInvariant(), null);
+    }
+
+    private static string? ResolveAlias(string requested, IReadOnlyDictionary<string, IReadOnlyList<string>> aliases)
+    {
+        foreach (KeyValuePair<string, IReadOnlyList<string>> entry in aliases)
+        {
+            if (entry.Value.Contains(requested, StringComparer.OrdinalIgnoreCase))
+            {
+                return entry.Key;
+            }
+        }
+
+        return null;
     }
 
     private async Task<IProjectInitializer?> SelectInitializerAsync(string? requestedStack, CancellationToken cancellationToken)

--- a/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.CommandLine;
-using System.ComponentModel;
 using Azure.Functions.Cli.Commands;
 using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Common;
@@ -32,7 +31,13 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli, ITemp
 
     public string DisplayName => ".NET";
 
-    public IReadOnlyList<string> SupportedLanguages => ["C#", "F#", "csharp", "fsharp"];
+    public IReadOnlyDictionary<string, IReadOnlyList<string>> SupportedLanguageAliases { get; } = new Dictionary<string, IReadOnlyList<string>>()
+    {
+        { "C#", ["csharp"] },
+        { "F#", ["fsharp"] }
+    };
+
+    public IReadOnlyList<string> SupportedLanguages => [.. SupportedLanguageAliases.Keys];
 
     public Option<string> FrameworkOption { get; private set; } = default!;
 
@@ -198,18 +203,28 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli, ITemp
         }
     }
 
-    internal static string NormalizeLanguage(string? language)
+    internal string NormalizeLanguage(string? language)
     {
         if (string.IsNullOrWhiteSpace(language))
         {
-            return "c#";
+            return "C#";
         }
 
-        return language.ToLowerInvariant() switch
+        // Check if it matches a canonical language name (case-insensitive).
+        foreach (KeyValuePair<string, IReadOnlyList<string>> entry in SupportedLanguageAliases)
         {
-            "csharp" or "c#" => "c#",
-            "fsharp" or "f#" => "f#",
-            _ => language
-        };
+            if (string.Equals(entry.Key, language, StringComparison.OrdinalIgnoreCase))
+            {
+                return entry.Key;
+            }
+
+            if (entry.Value.Contains(language, StringComparer.OrdinalIgnoreCase))
+            {
+                return entry.Key;
+            }
+        }
+
+        return language;
     }
+
 }

--- a/src/Workloads/Stacks/Go/GoProjectInitializer.cs
+++ b/src/Workloads/Stacks/Go/GoProjectInitializer.cs
@@ -28,7 +28,13 @@ internal sealed class GoProjectInitializer : IProjectInitializer
 
     public string DisplayName => "Go";
 
-    public IReadOnlyList<string> SupportedLanguages { get; } = ["Go"];
+    public IReadOnlyDictionary<string, IReadOnlyList<string>> SupportedLanguageAliases { get; } =
+        new Dictionary<string, IReadOnlyList<string>>()
+        {
+            { "Go", ["golang"] }
+        };
+
+    public IReadOnlyList<string> SupportedLanguages => [.. SupportedLanguageAliases.Keys];
 
     public Option<bool> SkipGoModTidyOption { get; private set; } = default!;
 

--- a/src/Workloads/Stacks/Node/NodeProjectInitializer.cs
+++ b/src/Workloads/Stacks/Node/NodeProjectInitializer.cs
@@ -20,6 +20,12 @@ internal sealed class NodeProjectInitializer : IProjectInitializer
     private const string ProjectNamePlaceholder = "__PROJECT_NAME__";
     private static readonly Assembly _assembly = typeof(NodeProjectInitializer).Assembly;
 
+    public IReadOnlyDictionary<string, IReadOnlyList<string>> SupportedLanguageAliases { get; } = new Dictionary<string, IReadOnlyList<string>>()
+    {
+        { "JavaScript", ["js"] },
+        { "TypeScript", ["ts"] }
+    };
+
     // Internal seam so tests can stub out the `npm install` invocation
     // without spawning real processes.
     internal Func<string, CancellationToken, Task<(int ExitCode, string Stderr)>> RunNpmInstall { get; set; } = DefaultRunNpmInstall;
@@ -28,7 +34,7 @@ internal sealed class NodeProjectInitializer : IProjectInitializer
 
     public string DisplayName => "Node.js";
 
-    public IReadOnlyList<string> SupportedLanguages { get; } = ["JavaScript", "TypeScript"];
+    public IReadOnlyList<string> SupportedLanguages => [.. SupportedLanguageAliases.Keys];
 
     public Option<bool> NoBundleOption { get; private set; } = default!;
 
@@ -64,7 +70,14 @@ internal sealed class NodeProjectInitializer : IProjectInitializer
 
         string root = context.WorkingDirectory.Info.FullName;
         bool force = context.Force;
-        bool isTypeScript = string.Equals(context.Language, "typescript", StringComparison.OrdinalIgnoreCase);
+
+        string language = NormalizeLanguage(context.Language);
+        if (!SupportedLanguages.Contains(language, StringComparer.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException($"Language '{context.Language}' is not supported. Supported languages: {string.Join(", ", SupportedLanguages)}.", nameof(context));
+        }
+
+        bool isTypeScript = string.Equals(language, "TypeScript", StringComparison.OrdinalIgnoreCase);
         bool noBundle = parseResult.GetValue(NoBundleOption);
         BundleChannel channel = parseResult.GetValue(BundlesChannelOption);
         bool skipNpmInstall = parseResult.GetValue(SkipNpmInstallOption);
@@ -187,5 +200,28 @@ internal sealed class NodeProjectInitializer : IProjectInitializer
             // 'npm' may not be installed; the scaffolded files are still valid.
             return (-1, ex.Message);
         }
+    }
+
+    internal string NormalizeLanguage(string? language)
+    {
+        if (string.IsNullOrWhiteSpace(language))
+        {
+            return "JavaScript";
+        }
+
+        foreach (KeyValuePair<string, IReadOnlyList<string>> entry in SupportedLanguageAliases)
+        {
+            if (string.Equals(entry.Key, language, StringComparison.OrdinalIgnoreCase))
+            {
+                return entry.Key;
+            }
+
+            if (entry.Value.Contains(language, StringComparer.OrdinalIgnoreCase))
+            {
+                return entry.Key;
+            }
+        }
+
+        return language;
     }
 }

--- a/src/Workloads/Stacks/Python/PythonProjectInitializer.cs
+++ b/src/Workloads/Stacks/Python/PythonProjectInitializer.cs
@@ -16,11 +16,16 @@ internal sealed class PythonProjectInitializer : IProjectInitializer
 {
     private static readonly Assembly _assembly = typeof(PythonProjectInitializer).Assembly;
 
+    public IReadOnlyDictionary<string, IReadOnlyList<string>> SupportedLanguageAliases { get; } = new Dictionary<string, IReadOnlyList<string>>()
+    {
+        { "Python", ["py"] }
+    };
+
     public string Stack => "python";
 
     public string DisplayName => "Python";
 
-    public IReadOnlyList<string> SupportedLanguages { get; } = ["Python"];
+    public IReadOnlyList<string> SupportedLanguages => [.. SupportedLanguageAliases.Keys];
 
     public Option<bool> NoBundleOption { get; private set; } = default!;
 
@@ -45,6 +50,12 @@ internal sealed class PythonProjectInitializer : IProjectInitializer
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(parseResult);
         cancellationToken.ThrowIfCancellationRequested();
+
+        string language = NormalizeLanguage(context.Language);
+        if (!SupportedLanguages.Contains(language, StringComparer.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException($"Language '{context.Language}' is not supported. Supported languages: {string.Join(", ", SupportedLanguages)}.", nameof(context));
+        }
 
         string root = context.WorkingDirectory.Info.FullName;
         bool force = context.Force;
@@ -106,5 +117,28 @@ internal sealed class PythonProjectInitializer : IProjectInitializer
             ["id"] = ExtensionBundle.IdFor(channel),
             ["version"] = ExtensionBundle.DefaultVersionRange,
         };
+    }
+
+    internal string NormalizeLanguage(string? language)
+    {
+        if (string.IsNullOrWhiteSpace(language))
+        {
+            return "Python";
+        }
+
+        foreach (KeyValuePair<string, IReadOnlyList<string>> entry in SupportedLanguageAliases)
+        {
+            if (string.Equals(entry.Key, language, StringComparison.OrdinalIgnoreCase))
+            {
+                return entry.Key;
+            }
+
+            if (entry.Value.Contains(language, StringComparer.OrdinalIgnoreCase))
+            {
+                return entry.Key;
+            }
+        }
+
+        return language;
     }
 }

--- a/test/Func.Tests/Commands/InitCommandTests.cs
+++ b/test/Func.Tests/Commands/InitCommandTests.cs
@@ -629,12 +629,16 @@ public class InitCommandTests
     private sealed class FakeProjectInitializer(
         string stack,
         IReadOnlyList<string>? supportedLanguages = null,
+        IReadOnlyDictionary<string, IReadOnlyList<string>>? aliases = null,
         Func<IInitOptionRegistry, IReadOnlyList<Option>>? optionFactory = null,
         Action<FakeProjectInitializer, ParseResult>? onInitialize = null) : IProjectInitializer
     {
         public string Stack { get; } = stack;
 
         public IReadOnlyList<string> SupportedLanguages { get; } = supportedLanguages ?? [];
+
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> SupportedLanguageAliases { get; } =
+            aliases ?? new Dictionary<string, IReadOnlyList<string>>();
 
         public bool WasInvoked { get; private set; }
 

--- a/test/Workloads/Stacks/DotNet.Tests/DotNetProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/DotNet.Tests/DotNetProjectInitializerTests.cs
@@ -51,7 +51,7 @@ public class DotNetProjectInitializerTests : IDisposable
     [Fact]
     public void SupportedLanguages_ReturnsExpectedLanguages()
     {
-        Assert.Equal(["C#", "F#", "csharp", "fsharp"], CreateInitializer().SupportedLanguages);
+        Assert.Equal(["C#", "F#"], CreateInitializer().SupportedLanguages);
     }
 
     [Fact]
@@ -67,19 +67,19 @@ public class DotNetProjectInitializerTests : IDisposable
     }
 
     [Theory]
-    [InlineData(null, "c#")]
-    [InlineData("", "c#")]
-    [InlineData("  ", "c#")]
-    [InlineData("csharp", "c#")]
-    [InlineData("CSHARP", "c#")]
-    [InlineData("C#", "c#")]
-    [InlineData("fsharp", "f#")]
-    [InlineData("FSHARP", "f#")]
-    [InlineData("F#", "f#")]
+    [InlineData(null, "C#")]
+    [InlineData("", "C#")]
+    [InlineData("  ", "C#")]
+    [InlineData("csharp", "C#")]
+    [InlineData("CSHARP", "C#")]
+    [InlineData("C#", "C#")]
+    [InlineData("fsharp", "F#")]
+    [InlineData("FSHARP", "F#")]
+    [InlineData("F#", "F#")]
     [InlineData("unknown", "unknown")]
     public void NormalizeLanguage_ReturnsExpectedResult(string? input, string expected)
     {
-        Assert.Equal(expected, DotNetProjectInitializer.NormalizeLanguage(input));
+        Assert.Equal(expected, CreateInitializer().NormalizeLanguage(input));
     }
 
     [Fact]

--- a/test/Workloads/Stacks/DotNet.Tests/DotNetWorkloadTests.cs
+++ b/test/Workloads/Stacks/DotNet.Tests/DotNetWorkloadTests.cs
@@ -44,7 +44,7 @@ public class DotNetWorkloadTests
         IProjectInitializer initializer = provider.GetRequiredService<IProjectInitializer>();
         Assert.IsType<DotNetProjectInitializer>(initializer);
         Assert.Equal("dotnet", initializer.Stack);
-        Assert.Equal(["C#", "F#", "csharp", "fsharp"], initializer.SupportedLanguages);
+        Assert.Equal(["C#", "F#"], initializer.SupportedLanguages);
     }
 
     [Fact]

--- a/test/Workloads/Stacks/Node.Tests/NodeProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/Node.Tests/NodeProjectInitializerTests.cs
@@ -41,6 +41,47 @@ public class NodeProjectInitializerTests : IDisposable
         Assert.Equal("node", new NodeProjectInitializer().Stack);
     }
 
+    [Theory]
+    [InlineData(null, "JavaScript")]
+    [InlineData("", "JavaScript")]
+    [InlineData("js", "JavaScript")]
+    [InlineData("JS", "JavaScript")]
+    [InlineData("JavaScript", "JavaScript")]
+    [InlineData("ts", "TypeScript")]
+    [InlineData("TS", "TypeScript")]
+    [InlineData("TypeScript", "TypeScript")]
+    [InlineData("unknown", "unknown")]
+    public void NormalizeLanguage_ReturnsExpectedResult(string? input, string expected)
+    {
+        Assert.Equal(expected, new NodeProjectInitializer().NormalizeLanguage(input));
+    }
+
+    [Fact]
+    public async Task InitializeAsync_UnsupportedLanguage_Throws()
+    {
+        ArgumentException ex = await Assert.ThrowsAsync<ArgumentException>(
+            () => RunAsync(language: "ruby", force: false));
+
+        Assert.Contains("ruby", ex.Message);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_AliasTs_ScaffoldsTypeScript()
+    {
+        await RunAsync(language: "ts", force: false);
+
+        Assert.True(File.Exists(Path.Combine(_projectDir.FullName, "tsconfig.json")));
+    }
+
+    [Fact]
+    public async Task InitializeAsync_AliasJs_ScaffoldsJavaScript()
+    {
+        await RunAsync(language: "js", force: false);
+
+        Assert.True(File.Exists(Path.Combine(_projectDir.FullName, "package.json")));
+        Assert.False(File.Exists(Path.Combine(_projectDir.FullName, "tsconfig.json")));
+    }
+
     [Fact]
     public void GetInitOptions_RegistersBundleAndNpmOptions()
     {

--- a/test/Workloads/Stacks/Python.Tests/PythonProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/Python.Tests/PythonProjectInitializerTests.cs
@@ -41,6 +41,36 @@ public class PythonProjectInitializerTests : IDisposable
         Assert.Equal("python", new PythonProjectInitializer().Stack);
     }
 
+    [Theory]
+    [InlineData(null, "Python")]
+    [InlineData("", "Python")]
+    [InlineData("py", "Python")]
+    [InlineData("PY", "Python")]
+    [InlineData("Python", "Python")]
+    [InlineData("PYTHON", "Python")]
+    [InlineData("unknown", "unknown")]
+    public void NormalizeLanguage_ReturnsExpectedResult(string? input, string expected)
+    {
+        Assert.Equal(expected, new PythonProjectInitializer().NormalizeLanguage(input));
+    }
+
+    [Fact]
+    public async Task InitializeAsync_UnsupportedLanguage_Throws()
+    {
+        ArgumentException ex = await Assert.ThrowsAsync<ArgumentException>(
+            () => RunAsync(force: false, language: "ruby"));
+
+        Assert.Contains("ruby", ex.Message);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_AliasPy_Succeeds()
+    {
+        await RunAsync(force: false, language: "py");
+
+        Assert.True(File.Exists(Path.Combine(_projectDir.FullName, "function_app.py")));
+    }
+
     [Fact]
     public void GetInitOptions_RegistersBundleOptions()
     {
@@ -162,13 +192,13 @@ public class PythonProjectInitializerTests : IDisposable
             root!["extensionBundle"]!["id"]!.GetValue<string>());
     }
 
-    private Task RunAsync(bool force, string[]? args = null)
+    private Task RunAsync(bool force, string[]? args = null, string? language = null)
     {
         PythonProjectInitializer initializer = new();
         InitContext context = new(
             WorkingDirectory.FromExplicit(_projectDir.FullName),
             ProjectName: "test",
-            Language: null,
+            Language: language,
             Force: force);
 
         RootCommand root = [];


### PR DESCRIPTION
## Add language alias support to workload project initializers

### Summary

Adds a `SupportedLanguageAliases` property to `IProjectInitializer` and implements it in all workloads (DotNet, Node, Python, Go). This allows `func init --language` to accept common shorthand aliases (e.g. `js`, `ts`, `py`, `csharp`, `golang`) in addition to the canonical display names.

### Design

- `SupportedLanguages` remains the display-only list (derived from `SupportedLanguageAliases.Keys`).
- `SupportedLanguageAliases` is the single source of truth mapping canonical names to their aliases.
- `InitCommand.ResolveLanguageAsync` resolves aliases before validating, so users can pass either canonical names or aliases via `--language`.
- Error messages show supported languages with a hint about accepted aliases.

### Changes

- **`IProjectInitializer`**: Added `SupportedLanguageAliases` to the interface contract.
- **`InitCommand.ResolveLanguageAsync`**: Now resolves aliases before rejecting unknown languages. Adds a `ResolveAlias` helper.
- **DotNet**: `C#` -> [`csharp`], `F#` -> [`fsharp`]
- **Node**: `JavaScript` -> [`js`], `TypeScript` -> [`ts`]
- **Python**: `Python` -> [`py`]
- **Go**: `Go` -> [`golang`]
- `NormalizeLanguage` is now an instance method (uses the alias dictionary directly).
- Updated test fakes and added `NormalizeLanguage` theory tests + unsupported language + alias end-to-end tests for Node and Python.

### Validation

- All tests pass: DotNet (23), Node (49), Python (42), Go (28), InitCommand (18).
- Zero build warnings.