### PR TITLE
Initial implementation of the Host workload

### DIFF
--- a/Azure.Functions.Cli.slnx
+++ b/Azure.Functions.Cli.slnx
@@ -31,7 +31,9 @@
     <Project Path="test/Fixtures/Workloads.Tests.Fixtures.WithCommand/Workloads.Tests.Fixtures.WithCommand.csproj" />
     <Project Path="test/Func.Tests/Func.Tests.csproj" />
   </Folder>
-  <Folder Name="/test/Workloads/" />
+  <Folder Name="/test/Workloads/">
+    <Project Path="test/Workloads/Host.Tests/Workloads.Host.Tests.csproj" />
+  </Folder>
   <Folder Name="/test/Workloads/Stacks/">
     <Project Path="test/Workloads/Stacks/DotNet.Tests/Workloads.DotNet.Tests.csproj" />
     <Project Path="test/Workloads/Stacks/Go.Tests/Workloads.Go.Tests.csproj" />

--- a/Azure.Functions.Cli.slnx
+++ b/Azure.Functions.Cli.slnx
@@ -8,7 +8,9 @@
     <Project Path="src/Abstractions/Abstractions.csproj" />
     <Project Path="src/Func/Func.csproj" />
   </Folder>
-  <Folder Name="/src/Workloads/" />
+  <Folder Name="/src/Workloads/">
+    <Project Path="src/Workloads/Host/Workloads.Host.csproj" />
+  </Folder>
   <Folder Name="/src/Workloads/Stacks/">
     <Project Path="src/Workloads/Stacks/DotNet/Workloads.DotNet.csproj" />
     <Project Path="src/Workloads/Stacks/Go/Workloads.Go.csproj" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -4,6 +4,9 @@
     <clear />
     <add key="infra" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/infra/nuget/v3/index.json" />
     <add key="AzureFunctionsRelease" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsRelease/nuget/v3/index.json" />
+    <add key="Microsoft.Azure.Functions.PowerShellWorker" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/Microsoft.Azure.Functions.PowerShellWorker/nuget/v3/index.json" />
+    <add key="AzureFunctions" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctions/nuget/v3/index.json" />
+    <add key="AzureFunctionsTempStaging" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/docs/repo-structure.md
+++ b/docs/repo-structure.md
@@ -14,7 +14,7 @@ azure-functions-core-tools/
 │   ├── Func/                          # Main CLI executable (assembly: func)
 │   └── Abstractions/                  # Shared types for workload authors (NuGet)
 |   └── Workloads/
-|       ├── <Name>/                    # Ungrouped workload projects
+|       ├── <Name>/                    # Ungrouped workload projects, e.g. Host
 |       └── <kind>/
 |           └── <Name>/                # Grouped workload projects, e.g. Stacks/Python
 ├── test/
@@ -34,6 +34,7 @@ azure-functions-core-tools/
 │       ├── abstractions-public-build.yml # Abstractions PR validation
 │       ├── abstractions-official-build.yml # Abstractions release + NuGet pack
 │       ├── code-mirror.yml               # Mirror to engineering repo
+│       ├── release/                      # Release pipelines for CLI, Abstractions, and workloads
 │       └── templates/                    # Shared pipeline templates
 ├── docs/                              # Developer documentation
 └── out/                               # Build artifacts (gitignored)
@@ -120,6 +121,7 @@ Each component has its own CI pipeline with **path-scoped triggers**, enabling i
 | CLI official build | `eng/ci/cli-official-build.yml` | Release branches |
 | Abstractions public | `eng/ci/abstractions-public-build.yml` | PRs touching `src/Abstractions/` |
 | Abstractions official | `eng/ci/abstractions-official-build.yml` | Release builds, NuGet pack |
+| Workload release | `eng/ci/release/official-release.workload.*.yml` | Manual workload package releases |
 | Code mirror | `eng/ci/code-mirror.yml` | Mirror to engineering repo |
 
 ## Test Patterns

--- a/eng/build/Packages.props
+++ b/eng/build/Packages.props
@@ -38,6 +38,7 @@
   <!-- host -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="4.1048.200" />
+    <PackageVersion Include="System.Diagnostics.EventLog" Version="10.0.0" />
   </ItemGroup>
   <!-- test projects -->
   <ItemGroup>

--- a/eng/build/Packages.props
+++ b/eng/build/Packages.props
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.7.0" />
     <PackageVersion Include="NuGet.Versioning" Version="6.13.2" />
   </ItemGroup>
@@ -33,6 +34,10 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.13.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.PythonWorker" Version="4.43.0" />
+  </ItemGroup>
+  <!-- host -->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="4.1048.200" />
   </ItemGroup>
   <!-- test projects -->
   <ItemGroup>

--- a/eng/ci/release/official-release.workload.host.yml
+++ b/eng/ci/release/official-release.workload.host.yml
@@ -1,0 +1,17 @@
+parameters:
+- name: public
+  displayName: Publish to nuget.org?
+  type: boolean
+  default: false
+
+# Release has no triggers outside of pipeline
+trigger: none
+pr: none
+
+extends:
+  template: /eng/ci/templates/pipelines/release-packages.yml@self
+  parameters:
+    public: ${{ parameters.public }}
+    folder: workloads/host
+    projects: |
+      $(Build.SourcesDirectory)/src/Workloads/Host/Workloads.Host.csproj

--- a/eng/ci/release/official-release.workload.host.yml
+++ b/eng/ci/release/official-release.workload.host.yml
@@ -15,3 +15,4 @@ extends:
     folder: workloads/host
     projects: |
       $(Build.SourcesDirectory)/src/Workloads/Host/Workloads.Host.csproj
+      $(Build.SourcesDirectory)/test/Workloads/Host.Tests/Workloads.Host.Tests.csproj

--- a/src/Workloads/Host/Directory.Version.props
+++ b/src/Workloads/Host/Directory.Version.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <VersionPrefix>4.1050.0</VersionPrefix>
+    <VersionSuffix>preview</VersionSuffix>
+  </PropertyGroup>
+</Project>

--- a/src/Workloads/Host/Directory.Version.props
+++ b/src/Workloads/Host/Directory.Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>4.1050.0</VersionPrefix>
+    <VersionPrefix>4.1048.200</VersionPrefix>
     <VersionSuffix>preview</VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/Workloads/Host/FunctionsHostAuthenticationHandler.cs
+++ b/src/Workloads/Host/FunctionsHostAuthenticationHandler.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Script.WebHost.Authentication;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Azure.Functions.Cli.Workloads.Host;
+
+internal sealed class FunctionsHostAuthenticationHandler<TOptions>(
+    IOptionsMonitor<TOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder)
+    : AuthenticationHandler<TOptions>(options, logger, encoder)
+    where TOptions : AuthenticationSchemeOptions, new()
+{
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        Claim[] claims =
+        [
+            new(SecurityConstants.AuthLevelClaimType, AuthorizationLevel.Admin.ToString()),
+        ];
+        ClaimsIdentity identity = new(claims, AuthLevelAuthenticationDefaults.AuthenticationScheme);
+        AuthenticationTicket ticket = new(new ClaimsPrincipal(identity), Scheme.Name);
+
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/src/Workloads/Host/FunctionsHostAuthorizationHandler.cs
+++ b/src/Workloads/Host/FunctionsHostAuthorizationHandler.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization;
+
+namespace Azure.Functions.Cli.Workloads.Host;
+
+internal sealed class FunctionsHostAuthorizationHandler
+    : AuthorizationHandler<FunctionAuthorizationRequirement, FunctionDescriptor>
+{
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        FunctionAuthorizationRequirement requirement,
+        FunctionDescriptor resource)
+    {
+        context.Succeed(requirement);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Workloads/Host/FunctionsHostRunner.cs
+++ b/src/Workloads/Host/FunctionsHostRunner.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using FunctionsHostProgram = Microsoft.Azure.WebJobs.Script.WebHost.Program;
+
+namespace Azure.Functions.Cli.Workloads.Host;
+
+internal sealed class FunctionsHostRunner : IFunctionsHostRunner
+{
+    public async Task RunAsync(string[] args, bool enableAuth, CancellationToken cancellationToken)
+    {
+        using IWebHost host = FunctionsHostProgram.CreateWebHostBuilder(args)
+            .UseSetting(WebHostDefaults.ApplicationKey, typeof(FunctionsHostStartup).Assembly.GetName().Name)
+            .ConfigureServices((context, services) =>
+            {
+                services.AddSingleton<IStartup>(new FunctionsHostStartup(context.Configuration, enableAuth));
+            })
+            .UseIIS()
+            .Build();
+
+        await host.RunAsync(cancellationToken);
+    }
+}

--- a/src/Workloads/Host/FunctionsHostStartup.cs
+++ b/src/Workloads/Host/FunctionsHostStartup.cs
@@ -1,0 +1,67 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Authentication;
+using Microsoft.Azure.WebJobs.Script.WebHost.Controllers;
+using Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Azure.Functions.Cli.Workloads.Host;
+
+internal sealed class FunctionsHostStartup(IConfiguration configuration, bool enableAuth) : IStartup
+{
+    private readonly IConfiguration _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+
+    public IServiceProvider ConfigureServices(IServiceCollection services)
+    {
+        if (enableAuth)
+        {
+            services.AddWebJobsScriptHostAuthentication();
+        }
+        else
+        {
+            services.AddAuthentication()
+                .AddScriptJwtBearer()
+                .AddScheme<AuthenticationLevelOptions, FunctionsHostAuthenticationHandler<AuthenticationLevelOptions>>(
+                    AuthLevelAuthenticationDefaults.AuthenticationScheme,
+                    configureOptions: _ => { });
+
+            services.AddSingleton<IAuthorizationHandler, FunctionsHostAuthorizationHandler>();
+        }
+
+        services.AddWebJobsScriptHostAuthorization();
+        services.AddMvc()
+            .AddApplicationPart(typeof(HostController).Assembly);
+
+        services.AddWebJobsScriptHost(_configuration);
+        services.AddSingleton<IDependencyValidator, ThrowingDependencyValidator>();
+
+        return services.BuildServiceProvider();
+    }
+
+    public void Configure(IApplicationBuilder app)
+        => app.UseWebJobsScriptHost();
+
+    private sealed class ThrowingDependencyValidator : DependencyValidator
+    {
+        public override void Validate(IServiceCollection services)
+        {
+            try
+            {
+                base.Validate(services);
+            }
+            catch (InvalidHostServicesException ex)
+            {
+                throw new InvalidOperationException("Invalid host services.", ex);
+            }
+        }
+    }
+}

--- a/src/Workloads/Host/HostShell.cs
+++ b/src/Workloads/Host/HostShell.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workloads.Host;
+
+internal sealed class HostShell(IFunctionsHostRunner hostRunner)
+{
+    public const string EnableAuthArgument = "--enable-auth";
+
+    private readonly IFunctionsHostRunner _hostRunner = hostRunner ?? throw new ArgumentNullException(nameof(hostRunner));
+
+    public async Task<int> RunAsync(string[] args, CancellationToken cancellationToken = default)
+    {
+        (bool enableAuth, string[] hostArgs) = ParseArguments(args);
+        await _hostRunner.RunAsync(hostArgs, enableAuth, cancellationToken);
+        return 0;
+    }
+
+    private static (bool EnableAuth, string[] HostArgs) ParseArguments(string[] args)
+    {
+        bool enableAuth = false;
+        List<string> hostArgs = [];
+
+        foreach (string arg in args)
+        {
+            if (string.Equals(arg, EnableAuthArgument, StringComparison.Ordinal))
+            {
+                enableAuth = true;
+                continue;
+            }
+
+            hostArgs.Add(arg);
+        }
+
+        return (enableAuth, [.. hostArgs]);
+    }
+}

--- a/src/Workloads/Host/IFunctionsHostRunner.cs
+++ b/src/Workloads/Host/IFunctionsHostRunner.cs
@@ -1,0 +1,9 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workloads.Host;
+
+internal interface IFunctionsHostRunner
+{
+    public Task RunAsync(string[] args, bool enableAuth, CancellationToken cancellationToken);
+}

--- a/src/Workloads/Host/PackHostWorkload.targets
+++ b/src/Workloads/Host/PackHostWorkload.targets
@@ -1,0 +1,46 @@
+<Project>
+
+  <PropertyGroup>
+    <_HostWorkloadExplicitRuntimeIdentifier>$(RuntimeIdentifier)</_HostWorkloadExplicitRuntimeIdentifier>
+    <PackRidSpecificHostWorkload>false</PackRidSpecificHostWorkload>
+    <PackageId Condition="'$(PackRidSpecificHostWorkload)' == 'true' And '$(_HostWorkloadExplicitRuntimeIdentifier)' != ''">$(AssemblyName).$(_HostWorkloadExplicitRuntimeIdentifier)</PackageId>
+    <PackageTags Condition="'$(PackRidSpecificHostWorkload)' == 'true' And '$(_HostWorkloadExplicitRuntimeIdentifier)' != ''">$(PackageTags) rid:$(_HostWorkloadExplicitRuntimeIdentifier)</PackageTags>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);StageHostWorkloadPayload</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
+  <Target Name="ValidateHostRidSpecificPackage" BeforeTargets="ResolvePackageAssets;GenerateNuspec" Condition="'$(PackRidSpecificHostWorkload)' == 'true'">
+    <Error
+      Condition="'$(_HostWorkloadExplicitRuntimeIdentifier)' == ''"
+      Text="PackRidSpecificHostWorkload requires RuntimeIdentifier. Pass -r &lt;rid&gt; when packing the host workload." />
+    <Error
+      Condition="'$(SelfContained)' != 'true'"
+      Text="PackRidSpecificHostWorkload requires SelfContained=true." />
+  </Target>
+
+  <Target Name="StageHostWorkloadPayload">
+    <PropertyGroup>
+      <HostWorkloadPayloadRoot>$(IntermediateOutputPath)workload-payload/</HostWorkloadPayloadRoot>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <HostWorkloadPayloadInput Include="$(OutputPath)**/*" Exclude="$(OutputPath)**/*.pdb" />
+    </ItemGroup>
+
+    <Error
+      Condition="'@(HostWorkloadPayloadInput)' == ''"
+      Text="Host workload build output was not found. Build the project before packing." />
+
+    <RemoveDir Directories="$(HostWorkloadPayloadRoot)" />
+    <Copy
+      SourceFiles="@(HostWorkloadPayloadInput)"
+      DestinationFiles="@(HostWorkloadPayloadInput->'$(HostWorkloadPayloadRoot)%(RecursiveDir)%(Filename)%(Extension)')" />
+
+    <ItemGroup>
+      <TfmSpecificPackageFile
+        Include="$(HostWorkloadPayloadRoot)**/*"
+        PackagePath="tools/any/%(RecursiveDir)%(Filename)%(Extension)"
+        Visible="false" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Workloads/Host/Program.cs
+++ b/src/Workloads/Host/Program.cs
@@ -1,0 +1,1 @@
+Console.WriteLine("Azure Functions Host");

--- a/src/Workloads/Host/Program.cs
+++ b/src/Workloads/Host/Program.cs
@@ -1,1 +1,31 @@
-Console.WriteLine("Azure Functions Host");
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using DotnetHost = Microsoft.Extensions.Hosting.Host;
+
+namespace Azure.Functions.Cli.Workloads.Host;
+
+internal static class Program
+{
+    public static async Task<int> Main(string[] args)
+    {
+        HostApplicationBuilder builder = DotnetHost.CreateEmptyApplicationBuilder(null);
+        builder.Services.AddSingleton<HostShell>();
+        builder.Services.AddSingleton<IFunctionsHostRunner, FunctionsHostRunner>();
+
+        using IHost shellHost = builder.Build();
+        await shellHost.StartAsync();
+
+        try
+        {
+            HostShell shell = shellHost.Services.GetRequiredService<HostShell>();
+            return await shell.RunAsync(args);
+        }
+        finally
+        {
+            await shellHost.StopAsync();
+        }
+    }
+}

--- a/src/Workloads/Host/README.md
+++ b/src/Workloads/Host/README.md
@@ -1,7 +1,7 @@
 # Azure Functions CLI - Host workload
 
-Content workload that ships the Azure Functions host payload consumed by the
-Azure Functions CLI when running function apps locally.
+Content workload that ships a small Azure Functions host shell and the host
+payload consumed by the Azure Functions CLI when running function apps locally.
 
 ## Install
 
@@ -13,5 +13,28 @@ func workload install host
 
 ## Status
 
-Preview. This package is a placeholder content workload; the host payload will
-be staged under `content/` before packing in a follow-up change.
+Preview. The shell expects the Azure Functions CLI to prepare the process
+environment and command-line arguments before launch. It does not translate
+private CLI configuration into host settings. The workload stages the shell
+build output under `content/` when the package is packed.
+
+## Launch contract
+
+The workload executable is a thin bootstrapper around the packaged Azure
+Functions Host. It supports one shell-specific command-line option; every other
+argument passed to the workload executable is forwarded unchanged to the host.
+
+The Azure Functions CLI is responsible for setting the process working
+directory, environment variables, and any host arguments before launching the
+workload process.
+
+| Argument | Owner | Description |
+| --- | --- | --- |
+| `--enable-auth` | Host workload shell | Enables the host's full authentication pipeline. When omitted, the shell starts the host with local auth bypassed, matching local Core Tools behavior. This argument is consumed by the shell and is not forwarded to the host. |
+| `--urls <value>` | Azure Functions Host / ASP.NET Core | Optional listener URL configuration forwarded to the host. The CLI may use this when it wants command-line URL binding instead of setting `ASPNETCORE_URLS`. |
+| Any other host-supported argument | Azure Functions Host | Forwarded unchanged. The workload shell does not validate, normalize, or translate host arguments. |
+
+The shell does not support private CLI options such as `--script-root`, `--port`,
+`--cors`, `--cors-credentials`, or `--functions`. The CLI should resolve those
+concepts before process launch and express them using the host's expected
+environment/configuration surface.

--- a/src/Workloads/Host/README.md
+++ b/src/Workloads/Host/README.md
@@ -10,13 +10,17 @@ func workload install Azure.Functions.Cli.Workloads.Host
 # or by alias
 func workload install host
 ```
+> Note: the actual package ID is `Microsoft.Azure.Functions.Workloads.Host.<rid>`. The format and workload specs will be updated to detail how this would be handled. The workload also supports installation by the shorter alias `host`.
 
 ## Status
 
 Preview. The shell expects the Azure Functions CLI to prepare the process
 environment and command-line arguments before launch. It does not translate
-private CLI configuration into host settings. The workload stages the shell
-build output under `content/` when the package is packed.
+private CLI configuration into host settings. Local builds are
+framework-dependent by default.
+
+Release packaging should be performed with a RID-specific self-contained payload under `tools/any/` by passing
+`-p:PackRidSpecificHostWorkload=true -r <rid> -p:SelfContained=true`, which also suffixes the package id with the RID.
 
 ## Launch contract
 

--- a/src/Workloads/Host/README.md
+++ b/src/Workloads/Host/README.md
@@ -1,0 +1,17 @@
+# Azure Functions CLI - Host workload
+
+Content workload that ships the Azure Functions host payload consumed by the
+Azure Functions CLI when running function apps locally.
+
+## Install
+
+```bash
+func workload install Azure.Functions.Cli.Workloads.Host
+# or by alias
+func workload install host
+```
+
+## Status
+
+Preview. This package is a placeholder content workload; the host payload will
+be staged under `content/` before packing in a follow-up change.

--- a/src/Workloads/Host/Workloads.Host.csproj
+++ b/src/Workloads/Host/Workloads.Host.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <Title>Azure Functions Host</Title>
+    <Description>Azure Functions Host CLI workload.</Description>
+    <PackageType>FuncCliWorkload</PackageType>
+    <PackageTags>kind:content alias:host func-workload</PackageTags>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="workload.json" Pack="true" PackagePath="/" />
+    <Content Include="content/**" Pack="true" PackagePath="content/" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+
+</Project>

--- a/src/Workloads/Host/Workloads.Host.csproj
+++ b/src/Workloads/Host/Workloads.Host.csproj
@@ -3,25 +3,61 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <Title>Azure Functions Host</Title>
-    <Description>Azure Functions Host CLI workload.</Description>
+    <Description>Azure Functions CLI content workload that ships the Azure Functions host.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:content alias:host func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>
+    <!-- The pinned WebHost package still exposes IWebHost; remove this when the package exposes the IHost-based entry point from dev. -->
+    <NoWarn>$(NoWarn);NU5128;NU5100;ASPDEPR008</NoWarn>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);StageHostWorkloadContent</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="workload.json" Pack="true" PackagePath="/" />
-    <Content Include="content/**" Pack="true" PackagePath="content/" />
+    <InternalsVisibleTo Include="Azure.Functions.Cli.Workloads.Host.Tests" />
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="Program.cs" />
+    <PackageReference Include="Microsoft.Extensions.Hosting">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
+
+  <ItemGroup>
+    <None Include="workload.json" Pack="true" PackagePath="/" />
+  </ItemGroup>
+
+  <Target Name="StageHostWorkloadContent">
+    <PropertyGroup>
+      <HostWorkloadContentRoot>$(IntermediateOutputPath)workload-content/</HostWorkloadContentRoot>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <HostWorkloadContentInput Include="$(OutputPath)**/*" Exclude="$(OutputPath)**/*.pdb" />
+    </ItemGroup>
+
+    <Error
+      Condition="'@(HostWorkloadContentInput)' == ''"
+      Text="Host workload build output was not found. Build the project before packing." />
+
+    <RemoveDir Directories="$(HostWorkloadContentRoot)" />
+    <Copy
+      SourceFiles="@(HostWorkloadContentInput)"
+      DestinationFiles="@(HostWorkloadContentInput->'$(HostWorkloadContentRoot)%(RecursiveDir)%(Filename)%(Extension)')" />
+
+    <ItemGroup>
+      <TfmSpecificPackageFile
+        Include="$(HostWorkloadContentRoot)**/*"
+        PackagePath="content/%(RecursiveDir)%(Filename)%(Extension)"
+        Visible="false" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/src/Workloads/Host/Workloads.Host.csproj
+++ b/src/Workloads/Host/Workloads.Host.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
+    <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
     <Title>Azure Functions Host</Title>
     <Description>Azure Functions CLI content workload that ships the Azure Functions host.</Description>
     <PackageType>FuncCliWorkload</PackageType>
@@ -11,7 +12,6 @@
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <!-- The pinned WebHost package still exposes IWebHost; remove this when the package exposes the IHost-based entry point from dev. -->
     <NoWarn>$(NoWarn);NU5128;NU5100;ASPDEPR008</NoWarn>
-    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);StageHostWorkloadContent</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
   <ItemGroup>
@@ -28,36 +28,15 @@
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="System.Diagnostics.EventLog">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
     <None Include="workload.json" Pack="true" PackagePath="/" />
   </ItemGroup>
 
-  <Target Name="StageHostWorkloadContent">
-    <PropertyGroup>
-      <HostWorkloadContentRoot>$(IntermediateOutputPath)workload-content/</HostWorkloadContentRoot>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <HostWorkloadContentInput Include="$(OutputPath)**/*" Exclude="$(OutputPath)**/*.pdb" />
-    </ItemGroup>
-
-    <Error
-      Condition="'@(HostWorkloadContentInput)' == ''"
-      Text="Host workload build output was not found. Build the project before packing." />
-
-    <RemoveDir Directories="$(HostWorkloadContentRoot)" />
-    <Copy
-      SourceFiles="@(HostWorkloadContentInput)"
-      DestinationFiles="@(HostWorkloadContentInput->'$(HostWorkloadContentRoot)%(RecursiveDir)%(Filename)%(Extension)')" />
-
-    <ItemGroup>
-      <TfmSpecificPackageFile
-        Include="$(HostWorkloadContentRoot)**/*"
-        PackagePath="content/%(RecursiveDir)%(Filename)%(Extension)"
-        Visible="false" />
-    </ItemGroup>
-  </Target>
+  <Import Project="PackHostWorkload.targets" />
 
 </Project>

--- a/src/Workloads/Host/content/placeholder.txt
+++ b/src/Workloads/Host/content/placeholder.txt
@@ -1,0 +1,1 @@
+Host payload assets will be staged in this folder before packing.

--- a/src/Workloads/Host/content/placeholder.txt
+++ b/src/Workloads/Host/content/placeholder.txt
@@ -1,1 +1,0 @@
-Host payload assets will be staged in this folder before packing.

--- a/src/Workloads/Host/release_notes.md
+++ b/src/Workloads/Host/release_notes.md
@@ -2,4 +2,4 @@
 
 ## 1.0.0-preview.1
 
-- Initial scaffold of the Host content workload.
+- Initial scaffold of the Host content workload with a minimal host shell.

--- a/src/Workloads/Host/release_notes.md
+++ b/src/Workloads/Host/release_notes.md
@@ -1,0 +1,5 @@
+# Azure.Functions.Cli.Workloads.Host
+
+## 1.0.0-preview.1
+
+- Initial scaffold of the Host content workload.

--- a/src/Workloads/Host/workload.json
+++ b/src/Workloads/Host/workload.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
+  "kind": "content"
+}

--- a/test/Workloads/Host.Tests/HostShellTests.cs
+++ b/test/Workloads/Host.Tests/HostShellTests.cs
@@ -1,0 +1,67 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Xunit;
+
+namespace Azure.Functions.Cli.Workloads.Host.Tests;
+
+public sealed class HostShellTests
+{
+    [Fact]
+    public async Task RunAsync_RunsHostWithProvidedArguments()
+    {
+        var hostRunner = new TestHostRunner();
+        var shell = new HostShell(hostRunner);
+
+        int exitCode = await shell.RunAsync(
+            ["--urls", "http://0.0.0.0:7072", "--hostid", "abc"],
+            CancellationToken.None);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(["--urls", "http://0.0.0.0:7072", "--hostid", "abc"], hostRunner.Args);
+        Assert.False(hostRunner.EnableAuth);
+    }
+
+    [Fact]
+    public async Task RunAsync_EnableAuth_RemovesShellArgumentAndEnablesHostAuth()
+    {
+        var hostRunner = new TestHostRunner();
+        var shell = new HostShell(hostRunner);
+
+        await shell.RunAsync(
+            ["--urls", "http://0.0.0.0:7072", "--enable-auth", "--hostid", "abc"],
+            CancellationToken.None);
+
+        Assert.Equal(["--urls", "http://0.0.0.0:7072", "--hostid", "abc"], hostRunner.Args);
+        Assert.True(hostRunner.EnableAuth);
+    }
+
+    [Fact]
+    public async Task RunAsync_PassesCancellationTokenToHost()
+    {
+        var hostRunner = new TestHostRunner();
+        var shell = new HostShell(hostRunner);
+        using CancellationTokenSource cancellationTokenSource = new();
+
+        await shell.RunAsync([], cancellationTokenSource.Token);
+
+        Assert.Equal(cancellationTokenSource.Token, hostRunner.CancellationToken);
+    }
+
+    private sealed class TestHostRunner : IFunctionsHostRunner
+    {
+        public IReadOnlyList<string> Args { get; private set; } = [];
+
+        public bool EnableAuth { get; private set; }
+
+        public CancellationToken CancellationToken { get; private set; }
+
+        public Task RunAsync(string[] args, bool enableAuth, CancellationToken cancellationToken)
+        {
+            Args = args;
+            EnableAuth = enableAuth;
+            CancellationToken = cancellationToken;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/Workloads/Host.Tests/Workloads.Host.Tests.csproj
+++ b/test/Workloads/Host.Tests/Workloads.Host.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyName>Azure.Functions.Cli.Workloads.Host.Tests</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(SrcRoot)Workloads/Host/Workloads.Host.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->
This pull request introduces a new "Host" content workload to the Azure Functions CLI, providing a minimal shell for running the Azure Functions host as a workload. 

The main changes include adding the new workload project, implementing the shell and host runner, integrating authentication/authorization options, and setting up the build, packaging, and release infrastructure for the workload. 

**The shell currently implements the Core Tools behavior for the host initialization. Changes to that are outside of the scope of this PR.**

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)