### PR TITLE
Add content workloads to provider inventory

### DIFF
--- a/src/Func/Commands/Workload/WorkloadListCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadListCommand.cs
@@ -96,12 +96,10 @@ internal sealed class WorkloadListCommand : FuncCliCommand
     {
         IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
 
-        // Cross-reference loaded info so we can surface DisplayName /
-        // Description for the version that's currently live; older
-        // side-by-side versions have no loaded instance, so we fall back
-        // to the placeholder in the table renderer.
-        Dictionary<(string PackageId, string Version), WorkloadInfo> loadedByKey = _workloads
-            .GetWorkloads()
+        // Cross-reference runtime info so loaded versions use presentation
+        // from their instances; older and content entries use registry data.
+        Dictionary<(string PackageId, string Version), RuntimeWorkloadInfo> loadedByKey = _workloads
+            .GetRuntimeWorkloads()
             .ToDictionary(
                 w => (w.PackageId, w.PackageVersion),
                 w => w,
@@ -112,15 +110,18 @@ internal sealed class WorkloadListCommand : FuncCliCommand
             .ThenByDescending(e => ParseVersion(e.PackageVersion))
             .Select(e =>
             {
-                loadedByKey.TryGetValue((e.PackageId, e.PackageVersion), out WorkloadInfo? info);
+                loadedByKey.TryGetValue((e.PackageId, e.PackageVersion), out RuntimeWorkloadInfo? info);
                 return new ListRow(
                     e.PackageId,
                     e.PackageVersion,
                     e.Aliases ?? [],
-                    info?.DisplayName ?? string.Empty,
-                    info?.Description ?? string.Empty);
+                    info?.DisplayName ?? GetDisplayName(e),
+                    info?.Description ?? (e.Description ?? string.Empty));
             })];
     }
+
+    private static string GetDisplayName(WorkloadEntry entry)
+        => string.IsNullOrWhiteSpace(entry.DisplayName) ? entry.PackageId : entry.DisplayName;
 
     private static NuGetVersion ParseVersion(string raw) =>
         NuGetVersion.TryParse(raw, out NuGetVersion? v) ? v : new NuGetVersion(0, 0, 0);

--- a/src/Func/Hosting/CliHostFactory.cs
+++ b/src/Func/Hosting/CliHostFactory.cs
@@ -83,7 +83,15 @@ internal static class CliHostFactory
         builder.Services.AddSingleton<IFunctionsProjectResolver, FunctionsProjectResolver>();
         builder.Services.AddSingleton<IStartInitializationRunner, DemoStartInitializationRunner>();
         builder.Services.AddSingleton(new WorkloadProjectFactoryRegistration(
-            new WorkloadInfo(new DotnetWorkload(), "test", "1.0", [], "test", "description"),
+            new RuntimeWorkloadInfo(
+                new DotnetWorkload(),
+                "test",
+                "1.0",
+                [],
+                AppContext.BaseDirectory,
+                AppContext.BaseDirectory,
+                "test",
+                "description"),
             new DemoProjectFactory()));
 
         builder.Services.AddSingleton<StartDashboardEventStreamFactory>();

--- a/src/Func/Hosting/DefaultFunctionsCliBuilder.cs
+++ b/src/Func/Hosting/DefaultFunctionsCliBuilder.cs
@@ -10,7 +10,7 @@ namespace Azure.Functions.Cli.Hosting;
 
 /// <summary>
 /// Default <see cref="FunctionsCliBuilder"/> implementation. Each workload
-/// gets its own instance scoped to its <see cref="WorkloadInfo"/>; the
+/// gets its own instance scoped to its <see cref="RuntimeWorkloadInfo"/>; the
 /// underlying <see cref="IServiceCollection"/> is the global container.
 /// </summary>
 /// <remarks>
@@ -18,9 +18,9 @@ namespace Azure.Functions.Cli.Hosting;
 /// calling <c>RegisterCommand</c> or <c>AddProjectFactory</c> on it
 /// throws so an untracked registration can never reach the parser.
 /// </remarks>
-internal sealed class DefaultFunctionsCliBuilder(IServiceCollection services, WorkloadInfo? workload) : FunctionsCliBuilder
+internal sealed class DefaultFunctionsCliBuilder(IServiceCollection services, RuntimeWorkloadInfo? workload) : FunctionsCliBuilder
 {
-    private readonly WorkloadInfo? _workload = workload;
+    private readonly RuntimeWorkloadInfo? _workload = workload;
 
     public DefaultFunctionsCliBuilder(IServiceCollection services)
         : this(services, workload: null)
@@ -72,13 +72,13 @@ internal sealed class DefaultFunctionsCliBuilder(IServiceCollection services, Wo
     {
         ArgumentNullException.ThrowIfNull(factory);
 
-        WorkloadInfo workload = RequireWorkload();
+        RuntimeWorkloadInfo workload = RequireWorkload();
         Services.AddSingleton(new WorkloadProjectFactoryRegistration(workload, factory));
     }
 
     private void RegisterCommandFactory(Func<IServiceProvider, FuncCommand> factory)
     {
-        WorkloadInfo workload = RequireWorkload();
+        RuntimeWorkloadInfo workload = RequireWorkload();
         Services.AddSingleton<FuncCliCommand>(sp =>
         {
             FuncCommand command = factory(sp)
@@ -88,7 +88,7 @@ internal sealed class DefaultFunctionsCliBuilder(IServiceCollection services, Wo
         });
     }
 
-    private WorkloadInfo RequireWorkload()
+    private RuntimeWorkloadInfo RequireWorkload()
         => _workload ?? throw new InvalidOperationException(
             "Workload services can only be registered through a workload-scoped builder. " +
             "Calling builder registration methods on the host's global builder is a CLI bug.");

--- a/src/Func/Hosting/WorkloadRegistration.cs
+++ b/src/Func/Hosting/WorkloadRegistration.cs
@@ -15,7 +15,7 @@ namespace Azure.Functions.Cli.Hosting;
 
 /// <summary>
 /// Bridges installed workloads into the host. Reads the global manifest at
-/// <c>~/.azure-functions/workloads.json</c>, loads each live workload's
+/// <c>~/.azure-functions/workloads.json</c>, loads each live runtime workload's
 /// entry-point assembly into its own
 /// <see cref="System.Runtime.Loader.AssemblyLoadContext"/>, and invokes
 /// <see cref="Workload.Configure"/> so each workload can contribute
@@ -28,7 +28,8 @@ namespace Azure.Functions.Cli.Hosting;
 /// throw becomes a stderr warning and the remaining workloads still load.
 /// Only the highest installed semver per <c>packageId</c> goes live; older
 /// versions stay in the on-disk registry for rollback but aren't loaded into
-/// the process. Content-only and meta entries are skipped.
+/// the process. Content-only entries are added to the provider inventory;
+/// meta entries are skipped.
 /// <para>
 /// Boot duration is captured by the <c>cli.workload.boot</c> activity opened
 /// here; the <see cref="WorkloadBootMetricListener"/> translates that
@@ -83,17 +84,18 @@ internal static class WorkloadRegistration
         var loader = new WorkloadLoader(paths);
 
         IReadOnlyList<WorkloadEntry> allEntries = await store.GetWorkloadsAsync(cancellationToken);
-        IReadOnlyList<WorkloadEntry> liveEntries = SelectLiveEntries(allEntries);
+        IReadOnlyList<WorkloadEntry> liveEntries = SelectLiveRuntimeEntries(allEntries);
+        IReadOnlyList<ContentWorkloadInfo> contentWorkloads = CreateContentWorkloads(allEntries, paths);
 
-        var workloads = new List<WorkloadInfo>(liveEntries.Count);
+        var runtimeWorkloads = new List<RuntimeWorkloadInfo>(liveEntries.Count);
         foreach (WorkloadEntry entry in liveEntries)
         {
             try
             {
                 // Load per-entry so one failure becomes a warning instead of
                 // aborting discovery for the rest.
-                IReadOnlyList<WorkloadInfo> loaded = loader.Load([entry]);
-                workloads.Add(loaded[0]);
+                IReadOnlyList<RuntimeWorkloadInfo> loaded = loader.Load([entry]);
+                runtimeWorkloads.Add(loaded[0]);
             }
             catch (Exception ex)
             {
@@ -102,20 +104,21 @@ internal static class WorkloadRegistration
             }
         }
 
-        // Register each WorkloadInfo individually so anything can contribute
-        // another via AddSingleton. Consumers depend on IWorkloadProvider,
-        // not IEnumerable<WorkloadInfo>, to name the domain concept and leave
-        // room for lookup behavior later.
-        foreach (WorkloadInfo workload in workloads)
+        foreach (RuntimeWorkloadInfo workload in runtimeWorkloads)
         {
-            services.AddSingleton(workload);
+            services.AddSingleton<WorkloadInfo>(workload);
+        }
+
+        foreach (ContentWorkloadInfo workload in contentWorkloads)
+        {
+            services.AddSingleton<WorkloadInfo>(workload);
         }
 
         services.AddSingleton<IWorkloadProvider, WorkloadProvider>();
 
         services.AddSingleton<IWorkloadInvoker, WorkloadInvoker>();
 
-        foreach (WorkloadInfo workload in workloads)
+        foreach (RuntimeWorkloadInfo workload in runtimeWorkloads)
         {
             // Per-workload builder so RegisterCommand can tag the resulting
             // ExternalCommand with its owning workload.
@@ -135,15 +138,15 @@ internal static class WorkloadRegistration
             }
         }
 
-        return workloads.Count;
+        return runtimeWorkloads.Count;
     }
 
     /// <summary>
-    /// Skips non-workload entries (content-only, meta) and keeps only the
+    /// Skips non-runtime entries and keeps only the
     /// highest installed semver per <c>packageId</c>. Older versions stay on
     /// disk for rollback but don't go live in the process.
     /// </summary>
-    private static IReadOnlyList<WorkloadEntry> SelectLiveEntries(IReadOnlyList<WorkloadEntry> entries)
+    private static IReadOnlyList<WorkloadEntry> SelectLiveRuntimeEntries(IReadOnlyList<WorkloadEntry> entries)
     {
         if (entries.Count == 0)
         {
@@ -157,6 +160,29 @@ internal static class WorkloadRegistration
                 .OrderByDescending(e => ParseVersionOrZero(e.PackageVersion))
                 .First())];
     }
+
+    private static IReadOnlyList<ContentWorkloadInfo> CreateContentWorkloads(
+        IReadOnlyList<WorkloadEntry> entries,
+        IWorkloadPaths paths)
+    {
+        return [.. entries
+            .Where(e => e.Kind == WorkloadKind.Content)
+            .Select(e =>
+            {
+                string installDirectory = paths.GetInstallDirectory(e.PackageId, e.PackageVersion);
+                return new ContentWorkloadInfo(
+                    e.PackageId,
+                    e.PackageVersion,
+                    e.Aliases,
+                    installDirectory,
+                    Path.GetFullPath(Path.Combine(installDirectory, "tools", "any")),
+                    GetDisplayName(e),
+                    e.Description ?? string.Empty);
+            })];
+    }
+
+    private static string GetDisplayName(WorkloadEntry entry)
+        => string.IsNullOrWhiteSpace(entry.DisplayName) ? entry.PackageId : entry.DisplayName;
 
     /// <summary>
     /// Parses a registry version string, falling back to 0.0.0 on failure so

--- a/src/Func/Workloads/ExternalCommand.cs
+++ b/src/Func/Workloads/ExternalCommand.cs
@@ -34,7 +34,7 @@ internal sealed class ExternalCommand : FuncCliCommand
     private readonly Dictionary<FuncCommandOption, Option> _optionLookup;
     private readonly Dictionary<FuncCommandArgument, Argument> _argumentLookup;
 
-    public ExternalCommand(WorkloadInfo workload, FuncCommand source)
+    public ExternalCommand(RuntimeWorkloadInfo workload, FuncCommand source)
         : base(ValidateName(source), ValidateDescription(source))
     {
         ArgumentNullException.ThrowIfNull(workload);
@@ -50,10 +50,14 @@ internal sealed class ExternalCommand : FuncCliCommand
         AddSubcommands(source.Subcommands);
     }
 
-    /// <summary>The workload that registered the underlying <see cref="FuncCommand"/>.</summary>
-    public WorkloadInfo Workload { get; }
+    /// <summary>
+    /// The workload that registered the underlying <see cref="FuncCommand"/>.
+    /// </summary>
+    public RuntimeWorkloadInfo Workload { get; }
 
-    /// <summary>The workload-supplied command this adapter is wrapping.</summary>
+    /// <summary>
+    /// The workload-supplied command this adapter is wrapping.
+    /// </summary>
     public FuncCommand Source { get; }
 
     protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)

--- a/src/Func/Workloads/IWorkloadProvider.cs
+++ b/src/Func/Workloads/IWorkloadProvider.cs
@@ -4,17 +4,24 @@
 namespace Azure.Functions.Cli.Workloads;
 
 /// <summary>
-/// Hands out the set of installed, hydrated workloads. The list is
-/// materialized once at host startup by
-/// <see cref="Hosting.WorkloadRegistration"/> and exposed through this
-/// abstraction so consumers depend on a named domain concept rather than a
-/// raw <see cref="IEnumerable{T}"/> of <see cref="WorkloadInfo"/>.
+/// Hands out the workload inventory materialized once at host startup by
+/// <see cref="Hosting.WorkloadRegistration"/>.
 /// </summary>
 internal interface IWorkloadProvider
 {
     /// <summary>
-    /// Returns the workloads that were loaded at boot. The result is stable
-    /// for the lifetime of the host.
+    /// Returns runtime and content workloads discovered at boot. The result
+    /// is stable for the lifetime of the host.
     /// </summary>
     public IReadOnlyList<WorkloadInfo> GetWorkloads();
+
+    /// <summary>
+    /// Returns runtime workloads that were loaded and configured at boot.
+    /// </summary>
+    public IReadOnlyList<RuntimeWorkloadInfo> GetRuntimeWorkloads();
+
+    /// <summary>
+    /// Returns installed content workloads discovered at boot.
+    /// </summary>
+    public IReadOnlyList<ContentWorkloadInfo> GetContentWorkloads();
 }

--- a/src/Func/Workloads/Install/WorkloadInstaller.cs
+++ b/src/Func/Workloads/Install/WorkloadInstaller.cs
@@ -120,6 +120,8 @@ internal sealed class WorkloadInstaller(
                 PackageId = packageId,
                 PackageVersion = version,
                 Aliases = aliases,
+                DisplayName = GetDisplayName(metadata, packageId),
+                Description = metadata.Description ?? string.Empty,
                 EntryPoint = metadata.EntryPoint,
                 Kind = metadata.Kind,
                 Source = Path.GetFullPath(nupkgPath),
@@ -409,6 +411,8 @@ internal sealed class WorkloadInstaller(
                 PackageId = newPackageId,
                 PackageVersion = newVersion,
                 Aliases = aliases,
+                DisplayName = GetDisplayName(metadata, newPackageId),
+                Description = metadata.Description ?? string.Empty,
                 EntryPoint = metadata.EntryPoint,
                 Kind = metadata.Kind,
                 Source = resolved.Source.Source,
@@ -537,4 +541,7 @@ internal sealed class WorkloadInstaller(
             // user can clean up manually.
         }
     }
+
+    private static string GetDisplayName(WorkloadMetadata metadata, string packageId)
+        => string.IsNullOrWhiteSpace(metadata.DisplayName) ? packageId : metadata.DisplayName;
 }

--- a/src/Func/Workloads/Invocation/IWorkloadInvoker.cs
+++ b/src/Func/Workloads/Invocation/IWorkloadInvoker.cs
@@ -11,7 +11,7 @@ namespace Azure.Functions.Cli.Workloads.Invocation;
 /// </summary>
 internal interface IWorkloadInvoker
 {
-    public Task InvokeAsync(WorkloadInfo workload, Func<CancellationToken, Task> operation, CancellationToken cancellationToken);
+    public Task InvokeAsync(RuntimeWorkloadInfo workload, Func<CancellationToken, Task> operation, CancellationToken cancellationToken);
 
-    public Task<TResult> InvokeAsync<TResult>(WorkloadInfo workload, Func<CancellationToken, Task<TResult>> operation, CancellationToken cancellationToken);
+    public Task<TResult> InvokeAsync<TResult>(RuntimeWorkloadInfo workload, Func<CancellationToken, Task<TResult>> operation, CancellationToken cancellationToken);
 }

--- a/src/Func/Workloads/Invocation/WorkloadInvoker.cs
+++ b/src/Func/Workloads/Invocation/WorkloadInvoker.cs
@@ -12,7 +12,7 @@ namespace Azure.Functions.Cli.Workloads.Invocation;
 /// </summary>
 internal sealed class WorkloadInvoker : IWorkloadInvoker
 {
-    public async Task InvokeAsync(WorkloadInfo workload, Func<CancellationToken, Task> operation, CancellationToken cancellationToken)
+    public async Task InvokeAsync(RuntimeWorkloadInfo workload, Func<CancellationToken, Task> operation, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(workload);
         ArgumentNullException.ThrowIfNull(operation);
@@ -35,7 +35,7 @@ internal sealed class WorkloadInvoker : IWorkloadInvoker
         }
     }
 
-    public async Task<TResult> InvokeAsync<TResult>(WorkloadInfo workload, Func<CancellationToken, Task<TResult>> operation, CancellationToken cancellationToken)
+    public async Task<TResult> InvokeAsync<TResult>(RuntimeWorkloadInfo workload, Func<CancellationToken, Task<TResult>> operation, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(workload);
         ArgumentNullException.ThrowIfNull(operation);
@@ -58,13 +58,13 @@ internal sealed class WorkloadInvoker : IWorkloadInvoker
         }
     }
 
-    private static GracefulException RewrapGraceful(WorkloadInfo workload, GracefulException original)
+    private static GracefulException RewrapGraceful(RuntimeWorkloadInfo workload, GracefulException original)
         => new(
             message: $"[{workload.PackageId}] {original.Message}",
             isUserError: original.IsUserError,
             verboseMessage: original.VerboseMessage);
 
-    private static WorkloadProtocolException WrapProtocol(WorkloadInfo workload, Exception original)
+    private static WorkloadProtocolException WrapProtocol(RuntimeWorkloadInfo workload, Exception original)
         => new(
             workload,
             message: $"[{workload.PackageId}] error: {original.Message} " +

--- a/src/Func/Workloads/Invocation/WorkloadProtocolException.cs
+++ b/src/Func/Workloads/Invocation/WorkloadProtocolException.cs
@@ -12,7 +12,7 @@ namespace Azure.Functions.Cli.Workloads.Invocation;
 /// </summary>
 internal sealed class WorkloadProtocolException : GracefulException
 {
-    public WorkloadProtocolException(WorkloadInfo workload, string message, Exception innerException)
+    public WorkloadProtocolException(RuntimeWorkloadInfo workload, string message, Exception innerException)
         : base(message, isUserError: false, verboseMessage: innerException?.ToString())
     {
         ArgumentNullException.ThrowIfNull(workload);
@@ -20,7 +20,7 @@ internal sealed class WorkloadProtocolException : GracefulException
         OriginalException = innerException ?? throw new ArgumentNullException(nameof(innerException));
     }
 
-    public WorkloadInfo Workload { get; }
+    public RuntimeWorkloadInfo Workload { get; }
 
     public Exception OriginalException { get; }
 }

--- a/src/Func/Workloads/Loading/IWorkloadLoader.cs
+++ b/src/Func/Workloads/Loading/IWorkloadLoader.cs
@@ -6,24 +6,22 @@ using Azure.Functions.Cli.Workloads.Storage;
 namespace Azure.Functions.Cli.Workloads.Loading;
 
 /// <summary>
-/// Hydrates workload registry entries into runnable <see cref="WorkloadInfo"/>
-/// instances. Pure: takes registry entries in, returns loaded workloads out.
-/// The composition root reads the entries from <see cref="IWorkloadStore"/>
-/// and hands them here, keeping the storage and assembly-loading concerns
-/// independently testable.
+/// Hydrates runtime workload registry entries into runnable
+/// <see cref="RuntimeWorkloadInfo"/> instances.
 /// </summary>
 internal interface IWorkloadLoader
 {
     /// <summary>
-    /// Loads each entry into its own <see cref="System.Runtime.Loader.AssemblyLoadContext"/>
-    /// and activates the declared <see cref="Workload"/> type.
+    /// Loads each runtime entry into its own
+    /// <see cref="System.Runtime.Loader.AssemblyLoadContext"/> and activates
+    /// the declared <see cref="Workload"/> type.
     /// </summary>
     /// <param name="entries">The registry entries to hydrate.</param>
-    /// <returns>One <see cref="WorkloadInfo"/> per input, in the same order.</returns>
+    /// <returns>One <see cref="RuntimeWorkloadInfo"/> per input, in the same order.</returns>
     /// <exception cref="Common.GracefulException">
     /// Thrown when an entry's assembly is missing, the declared type cannot be
     /// found, or the type does not derive from <see cref="Workload"/>. Other
     /// entries are not partially loaded, the operation is all-or-nothing.
     /// </exception>
-    public IReadOnlyList<WorkloadInfo> Load(IReadOnlyList<WorkloadEntry> entries);
+    public IReadOnlyList<RuntimeWorkloadInfo> Load(IReadOnlyList<WorkloadEntry> entries);
 }

--- a/src/Func/Workloads/Loading/WorkloadLoader.cs
+++ b/src/Func/Workloads/Loading/WorkloadLoader.cs
@@ -18,11 +18,11 @@ internal sealed class WorkloadLoader(IWorkloadPaths paths) : IWorkloadLoader
         ?? throw new ArgumentNullException(nameof(paths));
 
     /// <inheritdoc />
-    public IReadOnlyList<WorkloadInfo> Load(IReadOnlyList<WorkloadEntry> entries)
+    public IReadOnlyList<RuntimeWorkloadInfo> Load(IReadOnlyList<WorkloadEntry> entries)
     {
         ArgumentNullException.ThrowIfNull(entries);
 
-        var results = new List<WorkloadInfo>(entries.Count);
+        var results = new List<RuntimeWorkloadInfo>(entries.Count);
         foreach (WorkloadEntry entry in entries)
         {
             results.Add(LoadEntry(entry));
@@ -31,13 +31,18 @@ internal sealed class WorkloadLoader(IWorkloadPaths paths) : IWorkloadLoader
         return results;
     }
 
-    private WorkloadInfo LoadEntry(WorkloadEntry entry)
+    private RuntimeWorkloadInfo LoadEntry(WorkloadEntry entry)
     {
-        // Non-workload entries are filtered upstream; reaching the loader
-        // without an EntryPoint is a CLI bug, not a user error.
+        if (entry.Kind != WorkloadKind.Workload)
+        {
+            throw new InvalidOperationException(
+                $"[{entry.PackageId}] WorkloadLoader was invoked for a non-runtime entry (kind={entry.Kind}). " +
+                "Only kind=workload entries should reach the loader. This is a CLI bug.");
+        }
+
         EntryPointSpec entryPoint = entry.EntryPoint
             ?? throw new InvalidOperationException(
-                $"[{entry.PackageId}] WorkloadLoader was invoked for a non-workload entry (kind={entry.Kind}, no EntryPoint). " +
+                $"[{entry.PackageId}] WorkloadLoader was invoked for a runtime entry without an EntryPoint. " +
                 "Only kind=workload entries should reach the loader. This is a CLI bug.");
 
         string installPath = _paths.GetInstallDirectory(entry.PackageId, entry.PackageVersion);
@@ -77,11 +82,13 @@ internal sealed class WorkloadLoader(IWorkloadPaths paths) : IWorkloadLoader
 
         var instance = (Workload)Activator.CreateInstance(type)!;
 
-        return new WorkloadInfo(
+        return new RuntimeWorkloadInfo(
             Instance: instance,
             PackageId: entry.PackageId,
             PackageVersion: entry.PackageVersion,
             Aliases: entry.Aliases,
+            InstallDirectory: installPath,
+            ContentRoot: contentRoot,
             DisplayName: instance.DisplayName,
             Description: instance.Description);
     }

--- a/src/Func/Workloads/Storage/WorkloadRegistry.cs
+++ b/src/Func/Workloads/Storage/WorkloadRegistry.cs
@@ -63,6 +63,16 @@ internal sealed class WorkloadEntry
     public IReadOnlyList<string> Aliases { get; init; } = [];
 
     /// <summary>
+    /// Human-readable name captured from the package manifest at install time.
+    /// </summary>
+    public string DisplayName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// One-line description captured from the package manifest at install time.
+    /// </summary>
+    public string Description { get; init; } = string.Empty;
+
+    /// <summary>
     /// Catalog feed URL or local path the package was installed from.
     /// </summary>
     public string Source { get; init; } = string.Empty;

--- a/src/Func/Workloads/WorkloadInfo.cs
+++ b/src/Func/Workloads/WorkloadInfo.cs
@@ -4,25 +4,64 @@
 namespace Azure.Functions.Cli.Workloads;
 
 /// <summary>
-/// CLI-side view of a loaded workload. Hides the fact that a workload's
-/// metadata comes from two sources: identity (<see cref="PackageId"/>,
-/// <see cref="PackageVersion"/>, <see cref="Aliases"/>) is sourced from the
-/// global registry (recorded at install time from the package's nuspec);
-/// presentation (<see cref="DisplayName"/>, <see cref="Description"/>) is
-/// sourced from the loaded <see cref="Workload"/> instance. Consumers see
-/// one cohesive record. Internal: workload authors implement
-/// <see cref="Workload"/>; they don't see this type.
+/// CLI-side view of an installed workload package.
 /// </summary>
-/// <param name="Instance">The loaded workload's runtime instance. Use this for behaviour (e.g. <see cref="Workload.Configure"/>); read presentation through <see cref="DisplayName"/> / <see cref="Description"/>.</param>
-/// <param name="PackageId">NuGet package id from the registry entry (e.g. <c>"Azure.Functions.Cli.Workloads.Dotnet"</c>).</param>
+/// <param name="Kind">Installed package shape.</param>
+/// <param name="PackageId">NuGet package id from the registry entry.</param>
 /// <param name="PackageVersion">Installed package version from the registry entry.</param>
-/// <param name="Aliases">User-facing tokens accepted by <c>-s</c> (e.g. <c>["dotnet", "dotnet-isolated"]</c>).</param>
-/// <param name="DisplayName">Human-readable name for <c>func workload list</c>; sourced from <see cref="Workload.DisplayName"/>.</param>
-/// <param name="Description">One-line workload description; sourced from <see cref="Workload.Description"/>.</param>
-internal sealed record WorkloadInfo(
+/// <param name="Aliases">User-facing tokens accepted by workload commands.</param>
+/// <param name="InstallDirectory">Package install directory under the workload home.</param>
+/// <param name="ContentRoot">Directory containing package payload files.</param>
+/// <param name="DisplayName">Human-readable name for <c>func workload list</c>.</param>
+/// <param name="Description">One-line workload description.</param>
+internal abstract record WorkloadInfo(
+    WorkloadKind Kind,
+    string PackageId,
+    string PackageVersion,
+    IReadOnlyList<string> Aliases,
+    string InstallDirectory,
+    string ContentRoot,
+    string DisplayName,
+    string Description);
+
+/// <summary>
+/// CLI-side view of a loaded runtime workload.
+/// </summary>
+/// <param name="Instance">The loaded workload's runtime instance.</param>
+/// <param name="PackageId">NuGet package id from the registry entry.</param>
+/// <param name="PackageVersion">Installed package version from the registry entry.</param>
+/// <param name="Aliases">User-facing tokens accepted by workload commands.</param>
+/// <param name="InstallDirectory">Package install directory under the workload home.</param>
+/// <param name="ContentRoot">Directory containing package payload files.</param>
+/// <param name="DisplayName">Human-readable name for <c>func workload list</c>.</param>
+/// <param name="Description">One-line workload description.</param>
+internal sealed record RuntimeWorkloadInfo(
     Workload Instance,
     string PackageId,
     string PackageVersion,
     IReadOnlyList<string> Aliases,
+    string InstallDirectory,
+    string ContentRoot,
     string DisplayName,
-    string Description);
+    string Description)
+    : WorkloadInfo(WorkloadKind.Workload, PackageId, PackageVersion, Aliases, InstallDirectory, ContentRoot, DisplayName, Description);
+
+/// <summary>
+/// CLI-side view of an installed content workload.
+/// </summary>
+/// <param name="PackageId">NuGet package id from the registry entry.</param>
+/// <param name="PackageVersion">Installed package version from the registry entry.</param>
+/// <param name="Aliases">User-facing tokens accepted by workload commands.</param>
+/// <param name="InstallDirectory">Package install directory under the workload home.</param>
+/// <param name="ContentRoot">Directory containing package payload files.</param>
+/// <param name="DisplayName">Human-readable name for <c>func workload list</c>.</param>
+/// <param name="Description">One-line workload description.</param>
+internal sealed record ContentWorkloadInfo(
+    string PackageId,
+    string PackageVersion,
+    IReadOnlyList<string> Aliases,
+    string InstallDirectory,
+    string ContentRoot,
+    string DisplayName,
+    string Description)
+    : WorkloadInfo(WorkloadKind.Content, PackageId, PackageVersion, Aliases, InstallDirectory, ContentRoot, DisplayName, Description);

--- a/src/Func/Workloads/WorkloadMetadata.cs
+++ b/src/Func/Workloads/WorkloadMetadata.cs
@@ -29,4 +29,14 @@ internal sealed class WorkloadMetadata
     /// <see cref="WorkloadKind.Workload"/>; otherwise null.
     /// </summary>
     public EntryPointSpec? EntryPoint { get; init; }
+
+    /// <summary>
+    /// Human-readable name for inventory and list output.
+    /// </summary>
+    public string DisplayName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// One-line workload description for inventory and list output.
+    /// </summary>
+    public string Description { get; init; } = string.Empty;
 }

--- a/src/Func/Workloads/WorkloadProjectFactoryRegistration.cs
+++ b/src/Func/Workloads/WorkloadProjectFactoryRegistration.cs
@@ -6,6 +6,7 @@ using Azure.Functions.Cli.Projects;
 namespace Azure.Functions.Cli.Workloads;
 
 /// <summary>
-/// Pairs an <see cref="IFunctionsProjectFactory"/> with the workload that registered it.
+/// Pairs an <see cref="IFunctionsProjectFactory"/> with the workload that
+/// registered it.
 /// </summary>
-internal sealed record WorkloadProjectFactoryRegistration(WorkloadInfo Workload, IFunctionsProjectFactory Factory);
+internal sealed record WorkloadProjectFactoryRegistration(RuntimeWorkloadInfo Workload, IFunctionsProjectFactory Factory);

--- a/src/Func/Workloads/WorkloadProvider.cs
+++ b/src/Func/Workloads/WorkloadProvider.cs
@@ -4,14 +4,32 @@
 namespace Azure.Functions.Cli.Workloads;
 
 /// <summary>
-/// Default <see cref="IWorkloadProvider"/>. Snapshots the
-/// <see cref="WorkloadInfo"/> singletons registered by
-/// <see cref="Hosting.WorkloadRegistration"/> into a stable list.
+/// Default <see cref="IWorkloadProvider"/>. Snapshots the workload inventory
+/// registered by <see cref="Hosting.WorkloadRegistration"/> into stable lists.
 /// </summary>
 internal sealed class WorkloadProvider(IEnumerable<WorkloadInfo> workloads) : IWorkloadProvider
 {
-    private readonly IReadOnlyList<WorkloadInfo> _workloads =
-        (workloads ?? throw new ArgumentNullException(nameof(workloads))).ToList();
+    private readonly Snapshot _snapshot = CreateSnapshot(workloads);
 
-    public IReadOnlyList<WorkloadInfo> GetWorkloads() => _workloads;
+    public IReadOnlyList<WorkloadInfo> GetWorkloads() => _snapshot.Workloads;
+
+    public IReadOnlyList<RuntimeWorkloadInfo> GetRuntimeWorkloads() => _snapshot.RuntimeWorkloads;
+
+    public IReadOnlyList<ContentWorkloadInfo> GetContentWorkloads() => _snapshot.ContentWorkloads;
+
+    private static Snapshot CreateSnapshot(IEnumerable<WorkloadInfo> workloads)
+    {
+        ArgumentNullException.ThrowIfNull(workloads);
+
+        IReadOnlyList<WorkloadInfo> all = [.. workloads];
+        return new Snapshot(
+            all,
+            [.. all.OfType<RuntimeWorkloadInfo>()],
+            [.. all.OfType<ContentWorkloadInfo>()]);
+    }
+
+    private sealed record Snapshot(
+        IReadOnlyList<WorkloadInfo> Workloads,
+        IReadOnlyList<RuntimeWorkloadInfo> RuntimeWorkloads,
+        IReadOnlyList<ContentWorkloadInfo> ContentWorkloads);
 }

--- a/test/Func.Tests/Commands/Workload/WorkloadListCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadListCommandTests.cs
@@ -48,6 +48,25 @@ public class WorkloadListCommandTests
     }
 
     [Fact]
+    public async Task ContentEntry_WritesTableWithRegistryDisplayMetadata()
+    {
+        WorkloadInfo[] workloads =
+        [
+            TestWorkloads.CreateContentInfo(
+                packageId: "Azure.Functions.Cli.Workloads.Host",
+                version: "4.0.0"),
+        ];
+
+        var cmd = new WorkloadListCommand(_interaction, Provider(workloads), Substitute.For<IWorkloadStore>());
+        int exit = await InvokeAsync(cmd);
+
+        Assert.Equal(0, exit);
+        Assert.Contains(
+            "  ROW: [Azure.Functions.Cli.Workloads.Host, -, Azure.Functions.Cli.Workloads.Host, -, 4.0.0]",
+            _interaction.Lines);
+    }
+
+    [Fact]
     public async Task MissingAliases_RendersDashPlaceholder()
     {
         var workloads = new[]
@@ -147,8 +166,8 @@ public class WorkloadListCommandTests
         Assert.Contains("2.0.0", rows[0]);
         Assert.Contains(".NET", rows[0]);
         Assert.Contains("1.0.0", rows[1]);
-        // Older side-by-side has no loaded info; placeholder used.
-        Assert.Contains(", -, -, ", rows[1]);
+        // Older side-by-side has no loaded info, so registry display metadata is used.
+        Assert.Equal("  ROW: [Pkg.A, a, Pkg.A, -, 1.0.0]", rows[1]);
     }
 
     [Fact]
@@ -164,15 +183,25 @@ public class WorkloadListCommandTests
     {
         var provider = Substitute.For<IWorkloadProvider>();
         provider.GetWorkloads().Returns(workloads);
+        provider.GetRuntimeWorkloads().Returns([.. workloads.OfType<RuntimeWorkloadInfo>()]);
+        provider.GetContentWorkloads().Returns([.. workloads.OfType<ContentWorkloadInfo>()]);
         return provider;
     }
 
-    private static WorkloadInfo NewInfo(
+    private static RuntimeWorkloadInfo NewInfo(
         FakeWorkload instance,
         string packageId,
         string packageVersion,
         IReadOnlyList<string> aliases)
-        => new(instance, packageId, packageVersion, aliases, instance.DisplayName, instance.Description);
+        => new(
+            instance,
+            packageId,
+            packageVersion,
+            aliases,
+            AppContext.BaseDirectory,
+            AppContext.BaseDirectory,
+            instance.DisplayName,
+            instance.Description);
 
     private static Task<int> InvokeAsync(WorkloadListCommand cmd, params string[] args)
     {

--- a/test/Func.Tests/Hosting/CliHostFactoryTests.cs
+++ b/test/Func.Tests/Hosting/CliHostFactoryTests.cs
@@ -59,6 +59,26 @@ public sealed class CliHostFactoryTests : IDisposable
     }
 
     [Fact]
+    public async Task CreateHostAsync_ContentWorkloads_AreIncludedInProviderInventory()
+    {
+        StageFixtureWorkload("withcommand.fixture", "1.0.0", CommandWorkloadType);
+        WriteRegistry(
+            ("withcommand.fixture", "1.0.0", CommandWorkloadType, WorkloadKind.Workload),
+            ("host.content", "4.0.0", null, WorkloadKind.Content),
+            ("host.content", "4.1.0", null, WorkloadKind.Content));
+
+        var interaction = new TestInteractionService();
+
+        using IHost host = await StartHostAsync(interaction);
+
+        IWorkloadProvider provider = host.Services.GetRequiredService<IWorkloadProvider>();
+        Assert.Single(provider.GetRuntimeWorkloads());
+        Assert.Equal(2, provider.GetContentWorkloads().Count);
+        Assert.Equal(3, provider.GetWorkloads().Count);
+        Assert.All(provider.GetContentWorkloads(), w => Assert.Equal(w.PackageId, w.DisplayName));
+    }
+
+    [Fact]
     public async Task CreateHostAsync_WhenWorkloadConfigureThrows_WarnsAndContinues()
     {
         StageFixtureWorkload("throwing.fixture", "1.0.0", ThrowingWorkloadType);
@@ -202,33 +222,34 @@ public sealed class CliHostFactoryTests : IDisposable
     }
 
     private void WriteRegistry(params (string PackageId, string Version, string TypeName)[] entries)
+        => WriteRegistry([.. entries.Select(e => (
+            e.PackageId,
+            e.Version,
+            TypeName: (string?)e.TypeName,
+            Kind: WorkloadKind.Workload))]);
+
+    private void WriteRegistry(params (string PackageId, string Version, string? TypeName, WorkloadKind Kind)[] entries)
     {
-        var registry = new
+        WorkloadRegistry registry = new()
         {
-            Schema = WorkloadManifestSchema.CurrentRegistrySchema,
-            Workloads = entries.Select(e => new
+            Workloads = [.. entries.Select(e => new WorkloadEntry
             {
                 PackageId = e.PackageId,
                 PackageVersion = e.Version,
-                Aliases = Array.Empty<string>(),
-                EntryPoint = new
+                Aliases = [],
+                Kind = e.Kind,
+                EntryPoint = e.TypeName is null
+                    ? null
+                    : new EntryPointSpec
                 {
                     AssemblyPath = FixtureAssembly,
                     Type = e.TypeName,
                 },
-            }).ToArray(),
+            })],
         };
 
         Directory.CreateDirectory(_home);
-        var json = JsonSerializer.Serialize(registry, new JsonSerializerOptions
-        {
-            WriteIndented = true,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        });
-
-        // Match the on-disk shape WorkloadRegistry uses: $schema property name.
-        json = json.Replace("\"schema\":", "\"$schema\":", StringComparison.Ordinal);
-
+        string json = JsonSerializer.Serialize(registry, WorkloadJsonContext.Default.WorkloadRegistry);
         File.WriteAllText(Path.Combine(_home, WorkloadPathsOptions.WorkloadRegistryFileName), json);
     }
 }

--- a/test/Func.Tests/ParserTests.cs
+++ b/test/Func.Tests/ParserTests.cs
@@ -72,7 +72,7 @@ public class ParserTests
     [Fact]
     public void CreateCommand_WorkloadRegisteredCommand_AppearsAsRootSubcommand()
     {
-        WorkloadInfo workload = TestWorkloads.CreateInfo("My.Workload");
+        RuntimeWorkloadInfo workload = TestWorkloads.CreateInfo("My.Workload");
         FuncRootCommand root = TestParser.CreateRootWithWorkload(
             _interaction,
             workload,
@@ -87,7 +87,7 @@ public class ParserTests
     [Fact]
     public void CreateCommand_WorkloadCommandCollidesWithBuiltIn_IsSkippedWithNamedWarning()
     {
-        WorkloadInfo workload = TestWorkloads.CreateInfo("Wl.Bar");
+        RuntimeWorkloadInfo workload = TestWorkloads.CreateInfo("Wl.Bar");
         FuncRootCommand root = TestParser.CreateRootWithWorkload(
             _interaction,
             workload,
@@ -104,8 +104,8 @@ public class ParserTests
     [Fact]
     public void CreateCommand_TwoWorkloadCommandsSameName_BothSkippedWithNamedWarning()
     {
-        WorkloadInfo workloadA = TestWorkloads.CreateInfo("Wl.A");
-        WorkloadInfo workloadB = TestWorkloads.CreateInfo("Wl.B");
+        RuntimeWorkloadInfo workloadA = TestWorkloads.CreateInfo("Wl.A");
+        RuntimeWorkloadInfo workloadB = TestWorkloads.CreateInfo("Wl.B");
 
         IServiceProvider services = TestParser.BuildServiceProviderWith(_interaction, s =>
         {

--- a/test/Func.Tests/TestParser.cs
+++ b/test/Func.Tests/TestParser.cs
@@ -35,7 +35,7 @@ internal static class TestParser
     /// </summary>
     public static FuncRootCommand CreateRootWithWorkload(
         IInteractionService interaction,
-        WorkloadInfo workload,
+        RuntimeWorkloadInfo workload,
         Action<FunctionsCliBuilder> configure)
     {
         ServiceCollection services = BuildBaseServices(interaction);
@@ -83,6 +83,8 @@ internal static class TestParser
         // returns no workloads. Tests that need a populated set replace it.
         IWorkloadProvider emptyProvider = Substitute.For<IWorkloadProvider>();
         emptyProvider.GetWorkloads().Returns([]);
+        emptyProvider.GetRuntimeWorkloads().Returns([]);
+        emptyProvider.GetContentWorkloads().Returns([]);
         services.AddSingleton(emptyProvider);
 
         // Workload install pipeline: substitute the installer so commands

--- a/test/Func.Tests/TestWorkloads.cs
+++ b/test/Func.Tests/TestWorkloads.cs
@@ -12,19 +12,33 @@ namespace Azure.Functions.Cli.Tests;
 /// </summary>
 internal static class TestWorkloads
 {
-    public static WorkloadInfo CreateInfo(
+    public static RuntimeWorkloadInfo CreateInfo(
         string packageId = "Test.Workload.A",
         string version = "1.0.0")
     {
         var instance = new TestWorkload(packageId);
-        return new WorkloadInfo(
+        return new RuntimeWorkloadInfo(
             Instance: instance,
             PackageId: packageId,
             PackageVersion: version,
             Aliases: [],
+            InstallDirectory: AppContext.BaseDirectory,
+            ContentRoot: AppContext.BaseDirectory,
             DisplayName: instance.DisplayName,
             Description: instance.Description);
     }
+
+    public static ContentWorkloadInfo CreateContentInfo(
+        string packageId = "Test.Content.A",
+        string version = "1.0.0")
+        => new(
+            PackageId: packageId,
+            PackageVersion: version,
+            Aliases: [],
+            InstallDirectory: AppContext.BaseDirectory,
+            ContentRoot: AppContext.BaseDirectory,
+            DisplayName: packageId,
+            Description: string.Empty);
 
     /// <summary>
     /// Minimal <see cref="Workloads.Workload"/> used by tests that need a

--- a/test/Func.Tests/Workloads/Discovery/WorkloadMetadataReaderTests.cs
+++ b/test/Func.Tests/Workloads/Discovery/WorkloadMetadataReaderTests.cs
@@ -93,6 +93,25 @@ public class WorkloadMetadataReaderTests : IDisposable
     }
 
     [Fact]
+    public void Read_ReturnsDisplayMetadata()
+    {
+        WriteMetadata(
+            $$"""
+            {
+              "$schema": "{{SchemaUrl}}",
+              "kind": "content",
+              "displayName": "Functions Host",
+              "description": "Azure Functions host payload."
+            }
+            """);
+
+        WorkloadMetadata metadata = _reader.Read(_tempDir);
+
+        Assert.Equal("Functions Host", metadata.DisplayName);
+        Assert.Equal("Azure Functions host payload.", metadata.Description);
+    }
+
+    [Fact]
     public void Read_ReturnsMetaMetadata_WhenKindIsMeta()
     {
         WriteMetadata(

--- a/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
+++ b/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
@@ -64,6 +64,8 @@ public sealed class WorkloadInstallerTests : IDisposable
                 e.PackageId == "test.workload" &&
                 e.PackageVersion == "1.0.0" &&
                 e.EntryPoint!.AssemblyPath == "Test.dll" &&
+                e.DisplayName == "test.workload" &&
+                e.Description == string.Empty &&
                 e.Source == Path.GetFullPath(nupkg) &&
                 e.InstallRefCount == 1 &&
                 e.Aliases.SequenceEqual(new[] { "test", "stub" })),
@@ -250,9 +252,15 @@ public sealed class WorkloadInstallerTests : IDisposable
 
         Assert.Equal(WorkloadKind.Content, result.Entry.Kind);
         Assert.Null(result.Entry.EntryPoint);
+        Assert.Equal("test.workload", result.Entry.DisplayName);
+        Assert.Equal(string.Empty, result.Entry.Description);
 
         await _store.Received(1).SaveWorkloadAsync(
-            Arg.Is<WorkloadEntry>(e => e.Kind == WorkloadKind.Content && e.EntryPoint == null),
+            Arg.Is<WorkloadEntry>(e =>
+                e.Kind == WorkloadKind.Content &&
+                e.EntryPoint == null &&
+                e.DisplayName == "test.workload" &&
+                e.Description == string.Empty),
             Arg.Any<CancellationToken>());
     }
 

--- a/test/Func.Tests/Workloads/Invocation/WorkloadInvokerTests.cs
+++ b/test/Func.Tests/Workloads/Invocation/WorkloadInvokerTests.cs
@@ -11,7 +11,7 @@ namespace Azure.Functions.Cli.Tests.Workloads.Invocation;
 public sealed class WorkloadInvokerTests
 {
     private readonly WorkloadInvoker _invoker = new();
-    private readonly WorkloadInfo _workload = TestWorkloads.CreateInfo("Pkg.Acme");
+    private readonly RuntimeWorkloadInfo _workload = TestWorkloads.CreateInfo("Pkg.Acme");
 
     [Fact]
     public async Task InvokeAsync_Success_RunsAndReturns()

--- a/test/Func.Tests/Workloads/WorkloadProviderTests.cs
+++ b/test/Func.Tests/Workloads/WorkloadProviderTests.cs
@@ -12,7 +12,7 @@ public class WorkloadProviderTests
     public void GetWorkloads_ReturnsInjectedSet_AsStableList()
     {
         WorkloadInfo a = TestWorkloads.CreateInfo("Pkg.A");
-        WorkloadInfo b = TestWorkloads.CreateInfo("Pkg.B");
+        WorkloadInfo b = TestWorkloads.CreateContentInfo("Pkg.B");
 
         var provider = new WorkloadProvider([a, b]);
 
@@ -25,6 +25,23 @@ public class WorkloadProviderTests
         Assert.Equal(2, first.Count);
         Assert.Same(a, first[0]);
         Assert.Same(b, first[1]);
+    }
+
+    [Fact]
+    public void TypedViews_ReturnMatchingKinds_AsStableLists()
+    {
+        RuntimeWorkloadInfo runtime = TestWorkloads.CreateInfo("Pkg.Runtime");
+        ContentWorkloadInfo content = TestWorkloads.CreateContentInfo("Pkg.Content");
+
+        var provider = new WorkloadProvider([runtime, content]);
+
+        IReadOnlyList<RuntimeWorkloadInfo> runtimeWorkloads = provider.GetRuntimeWorkloads();
+        IReadOnlyList<ContentWorkloadInfo> contentWorkloads = provider.GetContentWorkloads();
+
+        Assert.Same(runtimeWorkloads, provider.GetRuntimeWorkloads());
+        Assert.Same(contentWorkloads, provider.GetContentWorkloads());
+        Assert.Same(runtime, Assert.Single(runtimeWorkloads));
+        Assert.Same(content, Assert.Single(contentWorkloads));
     }
 
     [Fact]


### PR DESCRIPTION
Split workload info into runtime and content models, snapshot content workloads during startup, and include registry-backed display metadata in workload list output.
