### PR TITLE
Update worker package layout

### DIFF
--- a/src/Func/Workers/DefaultFunctionsWorkerResolver.cs
+++ b/src/Func/Workers/DefaultFunctionsWorkerResolver.cs
@@ -81,11 +81,13 @@ internal sealed class DefaultFunctionsWorkerResolver(
 
     private static string GetWorkerPackageId(FunctionsWorkerId workerId) => WorkerPackageIdPrefix + workerId.Value;
 
+    private static string GetWorkerInstallAlias(FunctionsWorkerId workerId) => workerId.Value + "-worker";
+
     private static FunctionsWorkerResolutionResult NotInstalled(FunctionsWorkerId workerId)
         => NotInstalledResult(
             workerId,
             $"No installed Azure Functions worker was found for '{workerId.Value}'. "
-            + $"Run 'func workload install {workerId.Value}' to install it.");
+            + $"Run 'func workload install {GetWorkerInstallAlias(workerId)}' to install it.");
 
     private static FunctionsWorkerResolutionResult NotInstalledResult(FunctionsWorkerId workerId, string message)
     {
@@ -104,7 +106,7 @@ internal sealed class DefaultFunctionsWorkerResolver(
                     workerId,
                     versionConstraint: null,
                     $"Installed Azure Functions worker workloads for '{workerId.Value}' do not include a valid package version. "
-                    + $"Run 'func workload install {workerId.Value} --force' to repair the install.");
+                    + $"Run 'func workload install {GetWorkerInstallAlias(workerId)} --force' to repair the install.");
 
             return FunctionsWorkerResolutionResults.NotResolved(invalidVersionFailure);
         }
@@ -114,7 +116,7 @@ internal sealed class DefaultFunctionsWorkerResolver(
             workerId,
             rangeText,
             $"Installed Azure Functions worker workloads for '{workerId.Value}' do not satisfy version range '{rangeText}'. "
-            + $"Run 'func workload install {workerId.Value}' to install a compatible worker.");
+            + $"Run 'func workload install {GetWorkerInstallAlias(workerId)}' to install a compatible worker.");
 
         return FunctionsWorkerResolutionResults.NotResolved(failure);
     }
@@ -131,7 +133,7 @@ internal sealed class DefaultFunctionsWorkerResolver(
             workerConfigPath,
             $"Installed Azure Functions worker '{workerId.Value}' package '{selected.Workload.PackageId}' "
             + $"{selected.Version.ToNormalizedString()} is missing '{workerConfigPath}'. "
-            + $"Run 'func workload install {workerId.Value} --force' to repair the install.");
+            + $"Run 'func workload install {GetWorkerInstallAlias(workerId)} --force' to repair the install.");
 
         return FunctionsWorkerResolutionResults.NotResolved(failure);
     }

--- a/src/Workloads/Workers/Go/Directory.Version.props
+++ b/src/Workloads/Workers/Go/Directory.Version.props
@@ -5,7 +5,7 @@
     code or assemblies), so the pkg version is driven by the worker payload
     it carries. Go has no upstream worker NuGet, so $(WorkerVersion) is
     maintained manually here and tracks the static worker.config.json
-    payload shipped under content/workers/native/.
+    payload packaged under tools/any/.
       $(WorkerVersion) - Go worker payload version. Bare three-part SemVer.
 
     No channel axis: there are no preview/experimental Go worker SKUs.

--- a/src/Workloads/Workers/Go/README.md
+++ b/src/Workloads/Workers/Go/README.md
@@ -26,7 +26,5 @@ pick up prereleases without an explicit version pin or `--prerelease`.
 ## Status
 
 Preview. Go has no upstream worker NuGet; the workload ships a static native
-`worker.config.json` from `content/workers/native/` that points the host at a
-user-built Go executable (`bin/app`). The host discovers the Go worker via
-the `workers/native/` path, which matches the layout used by
-`feature/go-support`.
+`worker.config.json` under `tools/any/` that points the host at a user-built Go
+executable (`bin/app`).

--- a/src/Workloads/Workers/Go/Workloads.Workers.Go.csproj
+++ b/src/Workloads/Workers/Go/Workloads.Workers.Go.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <None Include="workload.json" Pack="true" PackagePath="/" />
-    <Content Include="content/**/*" Pack="true" PackagePath="content/" />
+    <Content Include="content/workers/native/worker.config.json" Pack="true" PackagePath="tools/any/" />
   </ItemGroup>
 
 </Project>

--- a/src/Workloads/Workers/Node/README.md
+++ b/src/Workloads/Workers/Node/README.md
@@ -32,4 +32,4 @@ NodeJsWorker NuGet doesn't ship preview/experimental SKUs.
 
 Preview. Worker assets are pulled at pack time from the restored
 `Microsoft.Azure.Functions.NodeJsWorker` NuGet package and packed under
-`content/workers/node/` in the resulting workload NuGet.
+`tools/any/` in the resulting workload NuGet.

--- a/src/Workloads/Workers/Node/Workloads.Workers.Node.csproj
+++ b/src/Workloads/Workers/Node/Workloads.Workers.Node.csproj
@@ -17,7 +17,7 @@
       TODO: Decouple from the upstream worker's precise package layout.
       The plan is to include the NodeJsWorker package's assets normally (let
       it wire up its content/None items via its build targets), then have a
-      target here transform those items and repack them under content/. For
+      target here transform those items and repack them under tools/any/. For
       now we glob the restored package payload directly, which is brittle if
       the upstream layout changes.
 
@@ -43,7 +43,7 @@
       <None Include="@(_NodeWorkerFile)"
             TargetPath="%(RecursiveDir)%(Filename)%(Extension)"
             Pack="true"
-            PackagePath="content/workers/node/" />
+            PackagePath="tools/any/" />
     </ItemGroup>
   </Target>
 

--- a/src/Workloads/Workers/Python/README.md
+++ b/src/Workloads/Workers/Python/README.md
@@ -32,4 +32,4 @@ PythonWorker NuGet doesn't ship preview/experimental SKUs.
 
 Preview. Worker assets are pulled at pack time from the restored
 `Microsoft.Azure.Functions.PythonWorker` NuGet package (its `tools/` payload)
-and packed under `content/workers/python/` in the resulting workload NuGet.
+and packed under `tools/any/` in the resulting workload NuGet.

--- a/src/Workloads/Workers/Python/Workloads.Workers.Python.csproj
+++ b/src/Workloads/Workers/Python/Workloads.Workers.Python.csproj
@@ -17,7 +17,7 @@
       TODO: Decouple from the upstream worker's precise package layout.
       The plan is to include the PythonWorker package's assets normally (let
       it wire up its content/None items via its build targets), then have a
-      target here transform those items and repack them under content/. For
+      target here transform those items and repack them under tools/any/. For
       now we glob the restored package payload directly, which is brittle if
       the upstream layout changes.
 
@@ -43,7 +43,7 @@
       <None Include="@(_PythonWorkerFile)"
             TargetPath="%(RecursiveDir)%(Filename)%(Extension)"
             Pack="true"
-            PackagePath="content/workers/python/" />
+            PackagePath="tools/any/" />
     </ItemGroup>
   </Target>
 

--- a/test/Func.Tests/Workers/DefaultFunctionsWorkerResolverTests.cs
+++ b/test/Func.Tests/Workers/DefaultFunctionsWorkerResolverTests.cs
@@ -123,8 +123,7 @@ public class DefaultFunctionsWorkerResolverTests
         FunctionsWorkerResolutionFailure.NotInstalled failure =
             Assert.IsType<FunctionsWorkerResolutionFailure.NotInstalled>(notResolved.Failure);
         Assert.Equal("ruby", failure.WorkerId.Value);
-        Assert.Contains("func workload install ruby", failure.Message);
-        Assert.DoesNotContain("ruby-worker", failure.Message);
+        Assert.Contains("func workload install ruby-worker", failure.Message);
     }
 
     [Fact]
@@ -142,6 +141,7 @@ public class DefaultFunctionsWorkerResolverTests
             Assert.IsType<FunctionsWorkerResolutionFailure.MissingCompatibleVersion>(notResolved.Failure);
         Assert.Equal("node", failure.WorkerId.Value);
         Assert.Null(failure.VersionConstraint);
+        Assert.Contains("func workload install node-worker --force", failure.Message);
         _fileSystem.DidNotReceive().FileExists(Arg.Any<string>());
     }
 
@@ -181,6 +181,7 @@ public class DefaultFunctionsWorkerResolverTests
         Assert.Equal(PythonWorkerPackageId, failure.PackageId);
         Assert.Equal("4.43.0", failure.PackageVersion);
         Assert.Equal(workerConfigPath, failure.WorkerConfigPath);
+        Assert.Contains("func workload install python-worker --force", failure.Message);
     }
 
     [Fact]


### PR DESCRIPTION
<!-- Please provide all the information below.  -->
This pull request standardizes the packaging and installation instructions for Azure Functions worker workloads. The main focus is on unifying the directory structure for worker assets across Go, Node, and Python workers, and updating user-facing installation messages to use a consistent alias format. 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

