### PR TITLE
Add profile list and show commands

### DIFF
--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -2,7 +2,7 @@
 
 This document explains the runtime architecture of the Azure Functions Core Tools v5 CLI — how commands are composed, how telemetry is wired, and how the console layer works.
 
-> **Status**: v5 is in active development. As of this PR, the workload abstractions, the DI host that loads workloads, and the `func workload install` / `uninstall` commands are wired into the CLI. Workloads are installed from a local `.nupkg` on disk; NuGet feed acquisition lands in a follow-up. Built-in commands that depend on workload contributions (e.g. `func init`) report "no workloads installed" and exit cleanly until at least one workload is installed.
+> **Status**: v5 is in active development. As of this PR, the workload abstractions, the DI host that loads workloads, profile inspection, and the `func workload install` / `uninstall` commands are wired into the CLI. Workloads are installed from a local `.nupkg` on disk; NuGet feed acquisition lands in a follow-up. Built-in commands that depend on workload contributions (e.g. `func init`) report "no workloads installed" and exit cleanly until at least one workload is installed.
 
 ## Startup Flow
 
@@ -27,7 +27,7 @@ Program.cs
   ├── Parser.CreateCommand(host.Services)
   │   ├── Build root command
   │   ├── Resolve every FuncCliCommand from DI:
-  │   │     ├── Built-in commands (IBuiltInCommand): init, new, start, version, help, workload
+  │   │     ├── Built-in commands (IBuiltInCommand): init, new, start, version, help, profile, workload
   │   │     └── ExternalCommand wrappers (each carries the WorkloadInfo for the
   │   │         workload that called RegisterCommand)
   │   ├── Skip workload commands that collide with built-ins or with each
@@ -60,6 +60,9 @@ func
 ├── init [path]           Initialize a new Functions project
 ├── new [path]            Create a new function from a template
 ├── start [path]          Start the Functions host (placeholder)
+├── profile
+│   ├── list [path]       List available profiles
+│   └── show <name> [path]  Show profile details
 ├── workload
 │   └── list              List installed workloads
 ├── version (hidden)      Print version info

--- a/src/Func/Commands/Profile/ProfileCommand.cs
+++ b/src/Func/Commands/Profile/ProfileCommand.cs
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Hosting;
+
+namespace Azure.Functions.Cli.Commands.Profile;
+
+/// <summary>
+/// Groups Azure Functions profile management commands.
+/// </summary>
+internal sealed class ProfileCommand : FuncCliCommand, IBuiltInCommand
+{
+    public ProfileCommand(ProfileListCommand listCommand, ProfileShowCommand showCommand)
+        : base("profile", "Inspect and manage Azure Functions CLI profiles.")
+    {
+        ArgumentNullException.ThrowIfNull(listCommand);
+        ArgumentNullException.ThrowIfNull(showCommand);
+
+        Subcommands.Add(listCommand);
+        Subcommands.Add(showCommand);
+    }
+}

--- a/src/Func/Commands/Profile/ProfileListCommand.cs
+++ b/src/Func/Commands/Profile/ProfileListCommand.cs
@@ -29,10 +29,7 @@ internal sealed class ProfileListCommand : FuncCliCommand
     private readonly IProfileCatalog _catalog;
     private readonly IOptionsMonitor<ProjectProfileOptions> _projectProfileOptions;
 
-    public ProfileListCommand(
-        IInteractionService interaction,
-        IProfileCatalog catalog,
-        IOptionsMonitor<ProjectProfileOptions> projectProfileOptions)
+    public ProfileListCommand(IInteractionService interaction, IProfileCatalog catalog, IOptionsMonitor<ProjectProfileOptions> projectProfileOptions)
         : base("list", "List available Azure Functions profiles.")
     {
         _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
@@ -74,15 +71,14 @@ internal sealed class ProfileListCommand : FuncCliCommand
     /// <exception cref="ProfileConfigurationException">
     /// Thrown when profile documents or inheritance are invalid.
     /// </exception>
-    private async Task<ProfileListResult> GetProfilesAsync(
-        DirectoryInfo workingDirectory,
-        string? sourceValue,
-        CancellationToken cancellationToken)
+    private async Task<ProfileListResult> GetProfilesAsync(DirectoryInfo workingDirectory, string? sourceValue, CancellationToken cancellationToken)
     {
         IReadOnlySet<ProfileSourceKind>? sourceKinds = ParseSourceFilter(sourceValue);
         var sourceContext = new ProfileSourceContext(workingDirectory);
+
         IReadOnlyList<ProfileSourceSnapshot> snapshots = await _catalog.LoadAsync(sourceContext, cancellationToken);
         IReadOnlyList<ProfileDefinitionEntry> entries = _catalog.ListEffectiveProfiles(snapshots, sourceKinds);
+
         List<ProfileListRow> rows = [];
         foreach (ProfileDefinitionEntry entry in entries)
         {
@@ -141,6 +137,7 @@ internal sealed class ProfileListCommand : FuncCliCommand
             },
             profiles = result.Profiles,
         };
+
         _interaction.WriteJson(value);
     }
 
@@ -190,10 +187,5 @@ internal sealed class ProfileListCommand : FuncCliCommand
 
     private sealed record ProfileListProject(IReadOnlyList<string> Profiles, string? DefaultProfile);
 
-    private sealed record ProfileListRow(
-        string Name,
-        string Source,
-        string HostVersion,
-        string ExtensionBundleVersion,
-        string Status);
+    private sealed record ProfileListRow(string Name, string Source, string HostVersion, string ExtensionBundleVersion, string Status);
 }

--- a/src/Func/Commands/Profile/ProfileListCommand.cs
+++ b/src/Func/Commands/Profile/ProfileListCommand.cs
@@ -1,0 +1,199 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Profiles;
+using Microsoft.Extensions.Options;
+using NuGet.Versioning;
+
+namespace Azure.Functions.Cli.Commands.Profile;
+
+/// <summary>
+/// Lists profiles available from project, user, and built-in sources.
+/// </summary>
+internal sealed class ProfileListCommand : FuncCliCommand
+{
+    public Option<string?> SourceOption { get; } = new("--source")
+    {
+        Description = "Comma-separated profile sources to include: project, user, built-in."
+    };
+
+    public Option<bool> JsonOption { get; } = new("--json")
+    {
+        Description = "Emit machine-readable JSON."
+    };
+
+    private readonly IInteractionService _interaction;
+    private readonly IProfileCatalog _catalog;
+    private readonly IOptionsMonitor<ProjectProfileOptions> _projectProfileOptions;
+
+    public ProfileListCommand(
+        IInteractionService interaction,
+        IProfileCatalog catalog,
+        IOptionsMonitor<ProjectProfileOptions> projectProfileOptions)
+        : base("list", "List available Azure Functions profiles.")
+    {
+        _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
+        _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
+        _projectProfileOptions = projectProfileOptions
+            ?? throw new ArgumentNullException(nameof(projectProfileOptions));
+
+        AddPathArgument();
+        Options.Add(SourceOption);
+        Options.Add(JsonOption);
+    }
+
+    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        WorkingDirectory workingDirectory = parseResult.GetValue(PathArgument!)!;
+        string? sourceValue = parseResult.GetValue(SourceOption);
+        bool json = parseResult.GetValue(JsonOption);
+
+        ProfileListResult result;
+        try
+        {
+            result = await GetProfilesAsync(workingDirectory.Info, sourceValue, cancellationToken);
+        }
+        catch (ProfileConfigurationException ex)
+        {
+            throw new GracefulException(ex.Message, isUserError: true, verboseMessage: ex.ToString());
+        }
+
+        if (json)
+        {
+            WriteJson(result);
+            return 0;
+        }
+
+        WriteTable(result);
+        return 0;
+    }
+
+    /// <exception cref="ProfileConfigurationException">
+    /// Thrown when profile documents or inheritance are invalid.
+    /// </exception>
+    private async Task<ProfileListResult> GetProfilesAsync(
+        DirectoryInfo workingDirectory,
+        string? sourceValue,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlySet<ProfileSourceKind>? sourceKinds = ParseSourceFilter(sourceValue);
+        var sourceContext = new ProfileSourceContext(workingDirectory);
+        IReadOnlyList<ProfileSourceSnapshot> snapshots = await _catalog.LoadAsync(sourceContext, cancellationToken);
+        IReadOnlyList<ProfileDefinitionEntry> entries = _catalog.ListEffectiveProfiles(snapshots, sourceKinds);
+        List<ProfileListRow> rows = [];
+        foreach (ProfileDefinitionEntry entry in entries)
+        {
+            ResolvedProfile profile = _catalog.ResolveProfile(entry, snapshots);
+            rows.Add(new ProfileListRow(
+                profile.Name,
+                profile.Source.KindDisplayName,
+                RangeText(profile.HostVersionRange),
+                RangeText(profile.ExtensionBundleVersionRange),
+                profile.Status.ToString().ToLowerInvariant()));
+        }
+
+        string projectDirectory = Path.GetFullPath(workingDirectory.FullName);
+        ProjectProfileOptions projectOptions = _projectProfileOptions.Get(projectDirectory);
+        var project = new ProfileListProject(projectOptions.Profiles, projectOptions.DefaultProfile);
+        return new ProfileListResult(project, rows);
+    }
+
+    private void WriteTable(ProfileListResult result)
+    {
+        if (result.Project.Profiles.Count > 0)
+        {
+            _interaction.WriteDefinitionList(
+            [
+                new DefinitionItem("Project profiles", FormatProjectProfiles(result.Project)),
+            ]);
+            _interaction.WriteBlankLine();
+        }
+
+        if (result.Profiles.Count == 0)
+        {
+            _interaction.WriteHint("No profiles found.");
+            return;
+        }
+
+        _interaction.WriteTable(
+            ["Name", "Source", "Host Version", "Extension Bundle", "Status"],
+            result.Profiles.Select(row => new[]
+            {
+                row.Name,
+                row.Source,
+                row.HostVersion,
+                row.ExtensionBundleVersion,
+                row.Status,
+            }));
+    }
+
+    private void WriteJson(ProfileListResult result)
+    {
+        var value = new
+        {
+            project = new
+            {
+                profiles = result.Project.Profiles,
+                defaultProfile = result.Project.DefaultProfile,
+            },
+            profiles = result.Profiles,
+        };
+        _interaction.WriteJson(value);
+    }
+
+    private static IReadOnlySet<ProfileSourceKind>? ParseSourceFilter(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        HashSet<ProfileSourceKind> kinds =
+        [
+            .. value
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(ParseSourceKind),
+        ];
+
+        if (kinds.Count == 0)
+        {
+            throw new ProfileConfigurationException(
+                "--source must include at least one source: project, user, built-in.");
+        }
+
+        return kinds;
+    }
+
+    private static ProfileSourceKind ParseSourceKind(string value)
+        => value.Trim().ToLowerInvariant() switch
+        {
+            "project" => ProfileSourceKind.Project,
+            "user" => ProfileSourceKind.User,
+            "built-in" or "builtin" => ProfileSourceKind.BuiltIn,
+            _ => throw new ProfileConfigurationException(
+                $"Unknown profile source '{value}'. Use one of: project, user, built-in."),
+        };
+
+    private static string FormatProjectProfiles(ProfileListProject project)
+        => string.Join(", ", project.Profiles.Select(profile =>
+            string.Equals(profile, project.DefaultProfile, StringComparison.OrdinalIgnoreCase)
+                ? $"{profile} (default)"
+                : profile));
+
+    private static string RangeText(VersionRange? range)
+        => range?.OriginalString ?? range?.ToString() ?? "-";
+
+    private sealed record ProfileListResult(ProfileListProject Project, IReadOnlyList<ProfileListRow> Profiles);
+
+    private sealed record ProfileListProject(IReadOnlyList<string> Profiles, string? DefaultProfile);
+
+    private sealed record ProfileListRow(
+        string Name,
+        string Source,
+        string HostVersion,
+        string ExtensionBundleVersion,
+        string Status);
+}

--- a/src/Func/Commands/Profile/ProfileShowCommand.cs
+++ b/src/Func/Commands/Profile/ProfileShowCommand.cs
@@ -1,0 +1,152 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Profiles;
+using NuGet.Versioning;
+
+namespace Azure.Functions.Cli.Commands.Profile;
+
+/// <summary>
+/// Shows details for one Azure Functions profile.
+/// </summary>
+internal sealed class ProfileShowCommand : FuncCliCommand
+{
+    public Argument<string> NameArgument { get; } = new("name")
+    {
+        Description = "The profile name to inspect."
+    };
+
+    public Option<bool> RawOption { get; } = new("--raw")
+    {
+        Description = "Show the raw profile definition without inherited values."
+    };
+
+    private readonly IInteractionService _interaction;
+    private readonly IProfileCatalog _catalog;
+
+    public ProfileShowCommand(IInteractionService interaction, IProfileCatalog catalog)
+        : base("show", "Show details for an Azure Functions profile.")
+    {
+        _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
+        _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
+
+        Arguments.Add(NameArgument);
+        AddPathArgument();
+        Options.Add(RawOption);
+    }
+
+    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        WorkingDirectory workingDirectory = parseResult.GetValue(PathArgument!)!;
+        string name = parseResult.GetValue(NameArgument)!;
+        bool raw = parseResult.GetValue(RawOption);
+
+        try
+        {
+            var sourceContext = new ProfileSourceContext(workingDirectory.Info);
+            IReadOnlyList<ProfileSourceSnapshot> snapshots = await _catalog.LoadAsync(sourceContext, cancellationToken);
+            if (raw)
+            {
+                ProfileDefinitionEntry entry = _catalog.FindProfile(name, snapshots)
+                    ?? throw new ProfileConfigurationException($"Profile '{name}' was not found.");
+                WriteRawProfile(entry);
+            }
+            else
+            {
+                ResolvedProfile profile = _catalog.ResolveProfile(name, snapshots);
+                WriteResolvedProfile(profile);
+            }
+        }
+        catch (ProfileConfigurationException ex)
+        {
+            throw new GracefulException(ex.Message, isUserError: true, verboseMessage: ex.ToString());
+        }
+
+        return 0;
+    }
+
+    private void WriteResolvedProfile(ResolvedProfile profile)
+    {
+        List<DefinitionItem> items =
+        [
+            new("Name", profile.Name),
+            new("Source", profile.Source.KindDisplayName),
+            new("Status", profile.Status.ToString().ToLowerInvariant()),
+            new("Host version", RangeText(profile.HostVersionRange)),
+            new("Extension bundle", RangeText(profile.ExtensionBundleVersionRange)),
+            new("Workers", FormatWorkers(profile.WorkerVersionRanges)),
+            new("Supported runtimes", FormatList(profile.SupportedRuntimes, "not enforced")),
+        ];
+
+        AddIfNotEmpty(items, "SKU", profile.Sku);
+        AddIfNotEmpty(items, "Deprecation URL", profile.DeprecationUrl);
+        AddIfNotEmpty(items, "Notes", profile.Notes);
+
+        _interaction.WriteDefinitionList(items);
+    }
+
+    private void WriteRawProfile(ProfileDefinitionEntry entry)
+    {
+        ProfileDefinition definition = entry.Definition;
+        List<DefinitionItem> items =
+        [
+            new("Name", entry.Name),
+            new("Source", entry.Source.KindDisplayName),
+            new("Status", definition.Status ?? "stable"),
+            new("Extends", definition.Extends ?? "-"),
+            new("Host version", definition.Host?.Version ?? "-"),
+            new("Extension bundle", definition.ExtensionBundle?.Version ?? "-"),
+            new("Workers", FormatRawWorkers(definition.Workers)),
+            new("Supported runtimes", FormatList(definition.SupportedRuntimes, "-")),
+        ];
+
+        AddIfNotEmpty(items, "SKU", definition.Sku);
+        AddIfNotEmpty(items, "Deprecation URL", definition.DeprecationUrl);
+        AddIfNotEmpty(items, "Notes", definition.Notes);
+
+        _interaction.WriteDefinitionList(items);
+    }
+
+    private static void AddIfNotEmpty(List<DefinitionItem> items, string label, string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            items.Add(new DefinitionItem(label, value));
+        }
+    }
+
+    private static string FormatWorkers(IReadOnlyDictionary<string, VersionRange> workers)
+    {
+        if (workers.Count == 0)
+        {
+            return "none";
+        }
+
+        return string.Join(", ", workers
+            .OrderBy(w => w.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(w => $"{w.Key} {RangeText(w.Value)}"));
+    }
+
+    private static string FormatRawWorkers(IReadOnlyDictionary<string, ProfileWorkerConstraint?>? workers)
+    {
+        if (workers is null || workers.Count == 0)
+        {
+            return "-";
+        }
+
+        return string.Join(", ", workers
+            .OrderBy(w => w.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(w => w.Value is null ? $"{w.Key} <removed>" : $"{w.Key} {w.Value.Version}"));
+    }
+
+    private static string FormatList(IReadOnlyList<string>? values, string emptyText)
+        => values is null || values.Count == 0
+            ? emptyText
+            : string.Join(", ", values);
+
+    private static string RangeText(VersionRange? range)
+        => range?.OriginalString ?? range?.ToString() ?? "-";
+}

--- a/src/Func/Hosting/BuiltInCommands.cs
+++ b/src/Func/Hosting/BuiltInCommands.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Commands;
+using Azure.Functions.Cli.Commands.Profile;
 using Azure.Functions.Cli.Commands.Start.Initialization;
 using Azure.Functions.Cli.Commands.Workload;
 using Azure.Functions.Cli.Common;
@@ -36,6 +37,9 @@ internal static class BuiltInCommands
         services.AddSingleton<FuncCliCommand, InitCommand>();
         services.AddSingleton<FuncCliCommand, NewCommand>();
         services.AddSingleton<FuncCliCommand, StartCommand>();
+        services.AddSingleton<ProfileListCommand>();
+        services.AddSingleton<ProfileShowCommand>();
+        services.AddSingleton<FuncCliCommand, ProfileCommand>();
 
         // Shared dashboard primitives (renderers and per-invocation pipeline
         // are constructed inline by StartCommand so cancellation flows
@@ -56,4 +60,3 @@ internal static class BuiltInCommands
         return services;
     }
 }
-

--- a/src/Func/Hosting/ProfileRegistration.cs
+++ b/src/Func/Hosting/ProfileRegistration.cs
@@ -26,6 +26,7 @@ internal static class ProfileRegistration
         services.AddSingleton<IProfileSource, BuiltInProfileSource>();
         services.AddSingleton<IConfigureOptions<ProjectProfileOptions>, ProjectProfileOptionsSetup>();
         services.AddSingleton<IConfigureOptions<UserProfilePreferenceOptions>, UserProfilePreferenceOptionsSetup>();
+        services.AddSingleton<IProfileCatalog, ProfileCatalog>();
         services.AddSingleton<IProfileResolver, ProfileResolver>();
 
         return services;

--- a/src/Func/Profiles/IProfileCatalog.cs
+++ b/src/Func/Profiles/IProfileCatalog.cs
@@ -1,0 +1,47 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Profiles;
+
+/// <summary>
+/// Provides access to profile definitions and inherited profile resolution.
+/// </summary>
+internal interface IProfileCatalog
+{
+    /// <summary>
+    /// Loads all configured profile sources for a working directory.
+    /// </summary>
+    public Task<IReadOnlyList<ProfileSourceSnapshot>> LoadAsync(
+        ProfileSourceContext context,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Returns the first visible definition for each profile name from the supplied snapshots.
+    /// </summary>
+    public IReadOnlyList<ProfileDefinitionEntry> ListEffectiveProfiles(
+        IReadOnlyList<ProfileSourceSnapshot> snapshots,
+        IReadOnlySet<ProfileSourceKind>? sourceKinds = null);
+
+    /// <summary>
+    /// Finds the first profile definition matching the supplied name.
+    /// </summary>
+    public ProfileDefinitionEntry? FindProfile(string name, IReadOnlyList<ProfileSourceSnapshot> snapshots);
+
+    /// <summary>
+    /// Resolves a named profile from the supplied snapshots.
+    /// </summary>
+    /// <exception cref="ProfileConfigurationException">
+    /// Thrown when the profile cannot be found or its inherited definition is invalid.
+    /// </exception>
+    public ResolvedProfile ResolveProfile(string name, IReadOnlyList<ProfileSourceSnapshot> snapshots);
+
+    /// <summary>
+    /// Resolves a specific profile definition from the supplied snapshots.
+    /// </summary>
+    /// <exception cref="ProfileConfigurationException">
+    /// Thrown when the profile's inherited definition is invalid.
+    /// </exception>
+    public ResolvedProfile ResolveProfile(
+        ProfileDefinitionEntry entry,
+        IReadOnlyList<ProfileSourceSnapshot> snapshots);
+}

--- a/src/Func/Profiles/IProfileCatalog.cs
+++ b/src/Func/Profiles/IProfileCatalog.cs
@@ -11,16 +11,12 @@ internal interface IProfileCatalog
     /// <summary>
     /// Loads all configured profile sources for a working directory.
     /// </summary>
-    public Task<IReadOnlyList<ProfileSourceSnapshot>> LoadAsync(
-        ProfileSourceContext context,
-        CancellationToken cancellationToken);
+    public Task<IReadOnlyList<ProfileSourceSnapshot>> LoadAsync(ProfileSourceContext context, CancellationToken cancellationToken);
 
     /// <summary>
     /// Returns the first visible definition for each profile name from the supplied snapshots.
     /// </summary>
-    public IReadOnlyList<ProfileDefinitionEntry> ListEffectiveProfiles(
-        IReadOnlyList<ProfileSourceSnapshot> snapshots,
-        IReadOnlySet<ProfileSourceKind>? sourceKinds = null);
+    public IReadOnlyList<ProfileDefinitionEntry> ListEffectiveProfiles(IReadOnlyList<ProfileSourceSnapshot> snapshots, IReadOnlySet<ProfileSourceKind>? sourceKinds = null);
 
     /// <summary>
     /// Finds the first profile definition matching the supplied name.
@@ -41,7 +37,5 @@ internal interface IProfileCatalog
     /// <exception cref="ProfileConfigurationException">
     /// Thrown when the profile's inherited definition is invalid.
     /// </exception>
-    public ResolvedProfile ResolveProfile(
-        ProfileDefinitionEntry entry,
-        IReadOnlyList<ProfileSourceSnapshot> snapshots);
+    public ResolvedProfile ResolveProfile(ProfileDefinitionEntry entry, IReadOnlyList<ProfileSourceSnapshot> snapshots);
 }

--- a/src/Func/Profiles/ProfileCatalog.cs
+++ b/src/Func/Profiles/ProfileCatalog.cs
@@ -1,0 +1,233 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using NuGet.Versioning;
+
+namespace Azure.Functions.Cli.Profiles;
+
+/// <summary>
+/// Default profile catalog over project, user, and built-in profile sources.
+/// </summary>
+internal sealed class ProfileCatalog(IEnumerable<IProfileSource> sources) : IProfileCatalog
+{
+    private const int MaxInheritanceDepth = 5;
+
+    private readonly IReadOnlyList<IProfileSource> _sources =
+        (sources ?? throw new ArgumentNullException(nameof(sources))).ToList();
+
+    public async Task<IReadOnlyList<ProfileSourceSnapshot>> LoadAsync(
+        ProfileSourceContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        List<ProfileSourceSnapshot> snapshots = [];
+        foreach (IProfileSource source in _sources)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            snapshots.Add(await source.LoadAsync(context, cancellationToken));
+        }
+
+        return snapshots;
+    }
+
+    public IReadOnlyList<ProfileDefinitionEntry> ListEffectiveProfiles(
+        IReadOnlyList<ProfileSourceSnapshot> snapshots,
+        IReadOnlySet<ProfileSourceKind>? sourceKinds = null)
+    {
+        ArgumentNullException.ThrowIfNull(snapshots);
+
+        List<ProfileDefinitionEntry> entries = [];
+        HashSet<string> seen = new(StringComparer.OrdinalIgnoreCase);
+        foreach (ProfileSourceSnapshot snapshot in snapshots)
+        {
+            if (sourceKinds is not null && !sourceKinds.Contains(snapshot.Source.Kind))
+            {
+                continue;
+            }
+
+            foreach ((string name, ProfileDefinition definition) in snapshot.Profiles
+                .OrderBy(p => p.Key, StringComparer.OrdinalIgnoreCase))
+            {
+                if (seen.Add(name))
+                {
+                    entries.Add(new ProfileDefinitionEntry(name, definition, snapshot.Source));
+                }
+            }
+        }
+
+        return [.. entries.OrderBy(e => e.Name, StringComparer.OrdinalIgnoreCase)];
+    }
+
+    public ProfileDefinitionEntry? FindProfile(string name, IReadOnlyList<ProfileSourceSnapshot> snapshots)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(snapshots);
+
+        return FindProfileCore(name, snapshots);
+    }
+
+    public ResolvedProfile ResolveProfile(string name, IReadOnlyList<ProfileSourceSnapshot> snapshots)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(snapshots);
+
+        ProfileDefinitionEntry entry = FindProfileCore(name, snapshots)
+            ?? throw new ProfileConfigurationException($"Profile '{name}' was not found.");
+
+        return ResolveProfile(entry, snapshots);
+    }
+
+    public ResolvedProfile ResolveProfile(
+        ProfileDefinitionEntry entry,
+        IReadOnlyList<ProfileSourceSnapshot> snapshots)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        ArgumentNullException.ThrowIfNull(snapshots);
+
+        ProfileDefinitionEntry resolvedEntry = ResolveDefinitionEntry(entry, snapshots, []);
+        VersionRange hostVersionRange = ParseRequiredRange(
+            resolvedEntry.Definition.Host?.Version,
+            resolvedEntry.Name,
+            "host.version");
+        Dictionary<string, VersionRange> workerRanges = new(StringComparer.OrdinalIgnoreCase);
+        if (resolvedEntry.Definition.Workers is { } workers)
+        {
+            foreach ((string runtime, ProfileWorkerConstraint? constraint) in workers)
+            {
+                if (constraint is null)
+                {
+                    continue;
+                }
+
+                workerRanges[runtime] = ParseRequiredRange(
+                    constraint.Version,
+                    resolvedEntry.Name,
+                    $"workers.{runtime}.version");
+            }
+        }
+
+        VersionRange? bundleRange = resolvedEntry.Definition.ExtensionBundle?.Version is { } extensionBundleVersion
+            ? ParseRequiredRange(extensionBundleVersion, resolvedEntry.Name, "extensionBundle.version")
+            : null;
+
+        ProfileStatus status = resolvedEntry.Definition.Status is null
+            ? ProfileStatus.Stable
+            : ProfileDocumentParser.ParseStatus(
+                resolvedEntry.Definition.Status,
+                resolvedEntry.Name,
+                resolvedEntry.Source.DisplayName);
+
+        return new ResolvedProfile(
+            resolvedEntry.Name,
+            resolvedEntry.Source,
+            resolvedEntry.Definition.Sku,
+            status,
+            resolvedEntry.Definition.DeprecationUrl,
+            hostVersionRange,
+            workerRanges,
+            bundleRange,
+            resolvedEntry.Definition.SupportedRuntimes,
+            resolvedEntry.Definition.Notes);
+    }
+
+    private ProfileDefinitionEntry ResolveDefinitionEntry(
+        ProfileDefinitionEntry entry,
+        IReadOnlyList<ProfileSourceSnapshot> snapshots,
+        IReadOnlyList<string> chain)
+    {
+        if (chain.Count > MaxInheritanceDepth)
+        {
+            throw new ProfileConfigurationException($"Profile inheritance chain exceeds maximum depth of {MaxInheritanceDepth}.");
+        }
+
+        string? repeated = chain.FirstOrDefault(p => string.Equals(p, entry.Name, StringComparison.OrdinalIgnoreCase));
+        if (repeated is not null)
+        {
+            string cycle = string.Join(" -> ", [.. chain, entry.Name]);
+            throw new ProfileConfigurationException($"Circular profile inheritance detected: {cycle}.");
+        }
+
+        if (NullIfWhiteSpace(entry.Definition.Extends) is not { } parentName)
+        {
+            return entry;
+        }
+
+        ProfileDefinitionEntry parent = FindProfileCore(parentName, snapshots)
+            ?? throw new ProfileConfigurationException($"Profile '{parentName}' was not found.");
+        ProfileDefinitionEntry resolvedParent = ResolveDefinitionEntry(parent, snapshots, [.. chain, entry.Name]);
+        ProfileDefinition merged = Merge(resolvedParent.Definition, entry.Definition);
+        return entry with { Definition = merged };
+    }
+
+    private static ProfileDefinitionEntry? FindProfileCore(string name, IReadOnlyList<ProfileSourceSnapshot> snapshots)
+    {
+        foreach (ProfileSourceSnapshot snapshot in snapshots)
+        {
+            if (snapshot.Profiles.TryGetValue(name, out ProfileDefinition? definition))
+            {
+                return new ProfileDefinitionEntry(name, definition, snapshot.Source);
+            }
+        }
+
+        return null;
+    }
+
+    private static ProfileDefinition Merge(ProfileDefinition parent, ProfileDefinition child)
+        => new()
+        {
+            Sku = child.Sku ?? parent.Sku,
+            Status = child.Status ?? parent.Status,
+            DeprecationUrl = child.DeprecationUrl ?? parent.DeprecationUrl,
+            Host = child.Host ?? parent.Host,
+            Workers = MergeWorkers(parent.Workers, child.Workers),
+            ExtensionBundle = child.ExtensionBundle ?? parent.ExtensionBundle,
+            SupportedRuntimes = child.SupportedRuntimes ?? parent.SupportedRuntimes,
+            Notes = child.Notes ?? parent.Notes,
+        };
+
+    private static Dictionary<string, ProfileWorkerConstraint?>? MergeWorkers(
+        Dictionary<string, ProfileWorkerConstraint?>? parent,
+        Dictionary<string, ProfileWorkerConstraint?>? child)
+    {
+        if (parent is null && child is null)
+        {
+            return null;
+        }
+
+        Dictionary<string, ProfileWorkerConstraint?> merged = parent is null
+            ? new(StringComparer.OrdinalIgnoreCase)
+            : new(parent, StringComparer.OrdinalIgnoreCase);
+
+        if (child is not null)
+        {
+            foreach ((string runtime, ProfileWorkerConstraint? constraint) in child)
+            {
+                if (constraint is null)
+                {
+                    merged.Remove(runtime);
+                }
+                else
+                {
+                    merged[runtime] = constraint;
+                }
+            }
+        }
+
+        return merged;
+    }
+
+    private static VersionRange ParseRequiredRange(string? value, string profileName, string propertyName)
+    {
+        if (string.IsNullOrWhiteSpace(value) || !VersionRange.TryParse(value, out VersionRange? range))
+        {
+            throw new ProfileConfigurationException(
+                $"Profile '{profileName}' has invalid NuGet version range for '{propertyName}'.");
+        }
+
+        return range;
+    }
+
+    private static string? NullIfWhiteSpace(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/src/Func/Profiles/ProfileCatalog.cs
+++ b/src/Func/Profiles/ProfileCatalog.cs
@@ -15,9 +15,7 @@ internal sealed class ProfileCatalog(IEnumerable<IProfileSource> sources) : IPro
     private readonly IReadOnlyList<IProfileSource> _sources =
         (sources ?? throw new ArgumentNullException(nameof(sources))).ToList();
 
-    public async Task<IReadOnlyList<ProfileSourceSnapshot>> LoadAsync(
-        ProfileSourceContext context,
-        CancellationToken cancellationToken)
+    public async Task<IReadOnlyList<ProfileSourceSnapshot>> LoadAsync(ProfileSourceContext context, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(context);
 
@@ -31,9 +29,7 @@ internal sealed class ProfileCatalog(IEnumerable<IProfileSource> sources) : IPro
         return snapshots;
     }
 
-    public IReadOnlyList<ProfileDefinitionEntry> ListEffectiveProfiles(
-        IReadOnlyList<ProfileSourceSnapshot> snapshots,
-        IReadOnlySet<ProfileSourceKind>? sourceKinds = null)
+    public IReadOnlyList<ProfileDefinitionEntry> ListEffectiveProfiles(IReadOnlyList<ProfileSourceSnapshot> snapshots, IReadOnlySet<ProfileSourceKind>? sourceKinds = null)
     {
         ArgumentNullException.ThrowIfNull(snapshots);
 
@@ -78,18 +74,14 @@ internal sealed class ProfileCatalog(IEnumerable<IProfileSource> sources) : IPro
         return ResolveProfile(entry, snapshots);
     }
 
-    public ResolvedProfile ResolveProfile(
-        ProfileDefinitionEntry entry,
-        IReadOnlyList<ProfileSourceSnapshot> snapshots)
+    public ResolvedProfile ResolveProfile(ProfileDefinitionEntry entry, IReadOnlyList<ProfileSourceSnapshot> snapshots)
     {
         ArgumentNullException.ThrowIfNull(entry);
         ArgumentNullException.ThrowIfNull(snapshots);
 
         ProfileDefinitionEntry resolvedEntry = ResolveDefinitionEntry(entry, snapshots, []);
-        VersionRange hostVersionRange = ParseRequiredRange(
-            resolvedEntry.Definition.Host?.Version,
-            resolvedEntry.Name,
-            "host.version");
+        VersionRange hostVersionRange = ParseRequiredRange(resolvedEntry.Definition.Host?.Version, resolvedEntry.Name, "host.version");
+
         Dictionary<string, VersionRange> workerRanges = new(StringComparer.OrdinalIgnoreCase);
         if (resolvedEntry.Definition.Workers is { } workers)
         {
@@ -113,10 +105,7 @@ internal sealed class ProfileCatalog(IEnumerable<IProfileSource> sources) : IPro
 
         ProfileStatus status = resolvedEntry.Definition.Status is null
             ? ProfileStatus.Stable
-            : ProfileDocumentParser.ParseStatus(
-                resolvedEntry.Definition.Status,
-                resolvedEntry.Name,
-                resolvedEntry.Source.DisplayName);
+            : ProfileDocumentParser.ParseStatus(resolvedEntry.Definition.Status, resolvedEntry.Name, resolvedEntry.Source.DisplayName);
 
         return new ResolvedProfile(
             resolvedEntry.Name,
@@ -131,10 +120,7 @@ internal sealed class ProfileCatalog(IEnumerable<IProfileSource> sources) : IPro
             resolvedEntry.Definition.Notes);
     }
 
-    private ProfileDefinitionEntry ResolveDefinitionEntry(
-        ProfileDefinitionEntry entry,
-        IReadOnlyList<ProfileSourceSnapshot> snapshots,
-        IReadOnlyList<string> chain)
+    private ProfileDefinitionEntry ResolveDefinitionEntry(ProfileDefinitionEntry entry, IReadOnlyList<ProfileSourceSnapshot> snapshots, IReadOnlyList<string> chain)
     {
         if (chain.Count > MaxInheritanceDepth)
         {
@@ -157,6 +143,7 @@ internal sealed class ProfileCatalog(IEnumerable<IProfileSource> sources) : IPro
             ?? throw new ProfileConfigurationException($"Profile '{parentName}' was not found.");
         ProfileDefinitionEntry resolvedParent = ResolveDefinitionEntry(parent, snapshots, [.. chain, entry.Name]);
         ProfileDefinition merged = Merge(resolvedParent.Definition, entry.Definition);
+
         return entry with { Definition = merged };
     }
 
@@ -186,9 +173,7 @@ internal sealed class ProfileCatalog(IEnumerable<IProfileSource> sources) : IPro
             Notes = child.Notes ?? parent.Notes,
         };
 
-    private static Dictionary<string, ProfileWorkerConstraint?>? MergeWorkers(
-        Dictionary<string, ProfileWorkerConstraint?>? parent,
-        Dictionary<string, ProfileWorkerConstraint?>? child)
+    private static Dictionary<string, ProfileWorkerConstraint?>? MergeWorkers(Dictionary<string, ProfileWorkerConstraint?>? parent, Dictionary<string, ProfileWorkerConstraint?>? child)
     {
         if (parent is null && child is null)
         {

--- a/src/Func/Profiles/ProfileResolver.cs
+++ b/src/Func/Profiles/ProfileResolver.cs
@@ -3,19 +3,19 @@
 
 using Azure.Functions.Cli.Console;
 using Microsoft.Extensions.Options;
-using NuGet.Versioning;
 
 namespace Azure.Functions.Cli.Profiles;
 
 /// <summary>
 /// Default active profile resolver.
 /// </summary>
-internal sealed class ProfileResolver(IEnumerable<IProfileSource> sources, IOptionsMonitor<ProjectProfileOptions> projectProfileOptions,
-    IOptionsMonitor<UserProfilePreferenceOptions> userProfilePreferenceOptions, IInteractionService interaction) : IProfileResolver
+internal sealed class ProfileResolver(
+    IProfileCatalog catalog,
+    IOptionsMonitor<ProjectProfileOptions> projectProfileOptions,
+    IOptionsMonitor<UserProfilePreferenceOptions> userProfilePreferenceOptions,
+    IInteractionService interaction) : IProfileResolver
 {
-    private const int MaxInheritanceDepth = 5;
-
-    private readonly IReadOnlyList<IProfileSource> _sources = (sources ?? throw new ArgumentNullException(nameof(sources))).ToList();
+    private readonly IProfileCatalog _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
     private readonly IOptionsMonitor<ProjectProfileOptions> _projectProfileOptions =
         projectProfileOptions ?? throw new ArgumentNullException(nameof(projectProfileOptions));
     private readonly IOptionsMonitor<UserProfilePreferenceOptions> _userProfilePreferenceOptions =
@@ -37,8 +37,9 @@ internal sealed class ProfileResolver(IEnumerable<IProfileSource> sources, IOpti
             return new ProfileResolution.None(diagnostics);
         }
 
-        IReadOnlyList<ProfileSourceSnapshot> snapshots = await LoadSourcesAsync(context, cancellationToken);
-        ResolvedProfile profile = ResolveProfile(profileName, snapshots);
+        var sourceContext = new ProfileSourceContext(context.WorkingDirectory);
+        IReadOnlyList<ProfileSourceSnapshot> snapshots = await _catalog.LoadAsync(sourceContext, cancellationToken);
+        ResolvedProfile profile = _catalog.ResolveProfile(profileName, snapshots);
 
         if (profile.Status == ProfileStatus.Deprecated)
         {
@@ -119,158 +120,6 @@ internal sealed class ProfileResolver(IEnumerable<IProfileSource> sources, IOpti
 
     private static bool IsDeclaredProfile(ProjectProfileOptions projectConfig, string profile)
         => projectConfig.Profiles.Any(p => string.Equals(p, profile, StringComparison.OrdinalIgnoreCase));
-
-    private async Task<IReadOnlyList<ProfileSourceSnapshot>> LoadSourcesAsync(
-        ProfileResolutionContext context,
-        CancellationToken cancellationToken)
-    {
-        var sourceContext = new ProfileSourceContext(context.WorkingDirectory);
-        List<ProfileSourceSnapshot> snapshots = [];
-        foreach (IProfileSource source in _sources)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            snapshots.Add(await source.LoadAsync(sourceContext, cancellationToken));
-        }
-
-        return snapshots;
-    }
-
-    private ResolvedProfile ResolveProfile(string name, IReadOnlyList<ProfileSourceSnapshot> snapshots)
-    {
-        ProfileDefinitionEntry entry = ResolveDefinitionEntry(name, snapshots, []);
-        VersionRange hostVersionRange = ParseRequiredRange(entry.Definition.Host?.Version, entry.Name, "host.version");
-        Dictionary<string, VersionRange> workerRanges = new(StringComparer.OrdinalIgnoreCase);
-        if (entry.Definition.Workers is { } workers)
-        {
-            foreach ((string runtime, ProfileWorkerConstraint? constraint) in workers)
-            {
-                if (constraint is null)
-                {
-                    continue;
-                }
-
-                workerRanges[runtime] = ParseRequiredRange(constraint.Version, entry.Name, $"workers.{runtime}.version");
-            }
-        }
-
-        VersionRange? bundleRange = entry.Definition.ExtensionBundle?.Version is { } extensionBundleVersion
-            ? ParseRequiredRange(extensionBundleVersion, entry.Name, "extensionBundle.version")
-            : null;
-
-        ProfileStatus status = entry.Definition.Status is null
-            ? ProfileStatus.Stable
-            : ProfileDocumentParser.ParseStatus(entry.Definition.Status, entry.Name, entry.Source.DisplayName);
-
-        return new ResolvedProfile(
-            entry.Name,
-            entry.Source,
-            entry.Definition.Sku,
-            status,
-            entry.Definition.DeprecationUrl,
-            hostVersionRange,
-            workerRanges,
-            bundleRange,
-            entry.Definition.SupportedRuntimes,
-            entry.Definition.Notes);
-    }
-
-    private ProfileDefinitionEntry ResolveDefinitionEntry(
-        string name,
-        IReadOnlyList<ProfileSourceSnapshot> snapshots,
-        IReadOnlyList<string> chain)
-    {
-        if (chain.Count > MaxInheritanceDepth)
-        {
-            throw new ProfileConfigurationException($"Profile inheritance chain exceeds maximum depth of {MaxInheritanceDepth}.");
-        }
-
-        string? repeated = chain.FirstOrDefault(p => string.Equals(p, name, StringComparison.OrdinalIgnoreCase));
-        if (repeated is not null)
-        {
-            string cycle = string.Join(" -> ", [.. chain, name]);
-            throw new ProfileConfigurationException($"Circular profile inheritance detected: {cycle}.");
-        }
-
-        ProfileDefinitionEntry own = FindProfile(name, snapshots)
-            ?? throw new ProfileConfigurationException($"Profile '{name}' was not found.");
-
-        if (NullIfWhiteSpace(own.Definition.Extends) is not { } parentName)
-        {
-            return own;
-        }
-
-        ProfileDefinitionEntry parent = ResolveDefinitionEntry(parentName, snapshots, [.. chain, name]);
-        ProfileDefinition merged = Merge(parent.Definition, own.Definition);
-        return own with { Definition = merged };
-    }
-
-    private static ProfileDefinitionEntry? FindProfile(string name, IReadOnlyList<ProfileSourceSnapshot> snapshots)
-    {
-        foreach (ProfileSourceSnapshot snapshot in snapshots)
-        {
-            if (snapshot.Profiles.TryGetValue(name, out ProfileDefinition? definition))
-            {
-                return new ProfileDefinitionEntry(name, definition, snapshot.Source);
-            }
-        }
-
-        return null;
-    }
-
-    private static ProfileDefinition Merge(ProfileDefinition parent, ProfileDefinition child)
-        => new()
-        {
-            Sku = child.Sku ?? parent.Sku,
-            Status = child.Status ?? parent.Status,
-            DeprecationUrl = child.DeprecationUrl ?? parent.DeprecationUrl,
-            Host = child.Host ?? parent.Host,
-            Workers = MergeWorkers(parent.Workers, child.Workers),
-            ExtensionBundle = child.ExtensionBundle ?? parent.ExtensionBundle,
-            SupportedRuntimes = child.SupportedRuntimes ?? parent.SupportedRuntimes,
-            Notes = child.Notes ?? parent.Notes,
-        };
-
-    private static Dictionary<string, ProfileWorkerConstraint?>? MergeWorkers(
-        Dictionary<string, ProfileWorkerConstraint?>? parent,
-        Dictionary<string, ProfileWorkerConstraint?>? child)
-    {
-        if (parent is null && child is null)
-        {
-            return null;
-        }
-
-        Dictionary<string, ProfileWorkerConstraint?> merged = parent is null
-            ? new(StringComparer.OrdinalIgnoreCase)
-            : new(parent, StringComparer.OrdinalIgnoreCase);
-
-        if (child is not null)
-        {
-            foreach ((string runtime, ProfileWorkerConstraint? constraint) in child)
-            {
-                if (constraint is null)
-                {
-                    merged.Remove(runtime);
-                }
-                else
-                {
-                    merged[runtime] = constraint;
-                }
-            }
-        }
-
-        return merged;
-    }
-
-    private static VersionRange ParseRequiredRange(string? value, string profileName, string propertyName)
-    {
-        if (string.IsNullOrWhiteSpace(value) || !VersionRange.TryParse(value, out VersionRange? range))
-        {
-            throw new ProfileConfigurationException(
-                $"Profile '{profileName}' has invalid NuGet version range for '{propertyName}'.");
-        }
-
-        return range;
-    }
 
     private static string? NullIfWhiteSpace(string? value)
         => string.IsNullOrWhiteSpace(value) ? null : value.Trim();

--- a/src/Func/Profiles/ProfileSourceSnapshot.cs
+++ b/src/Func/Profiles/ProfileSourceSnapshot.cs
@@ -6,10 +6,7 @@ namespace Azure.Functions.Cli.Profiles;
 /// <summary>
 /// Profiles loaded from one source.
 /// </summary>
-internal sealed record ProfileSourceSnapshot(
-    ProfileSourceInfo Source,
-    IReadOnlyDictionary<string, ProfileDefinition> Profiles,
-    DateTimeOffset? GeneratedAt = null)
+internal sealed record ProfileSourceSnapshot(ProfileSourceInfo Source, IReadOnlyDictionary<string, ProfileDefinition> Profiles, DateTimeOffset? GeneratedAt = null)
 {
     public static ProfileSourceSnapshot Empty(ProfileSourceInfo source) =>
         new(source, new Dictionary<string, ProfileDefinition>(StringComparer.OrdinalIgnoreCase));

--- a/test/Func.Tests/Commands/Profile/ProfileCommandTests.cs
+++ b/test/Func.Tests/Commands/Profile/ProfileCommandTests.cs
@@ -1,0 +1,247 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using Azure.Functions.Cli.Commands;
+using Azure.Functions.Cli.Commands.Profile;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Profiles;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Commands.Profile;
+
+public sealed class ProfileCommandTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly TestInteractionService _interaction = new();
+
+    public ProfileCommandTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"func-profile-command-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ProfileCommand_RegisteredInParser()
+    {
+        var root = TestParser.CreateRoot(_interaction);
+        Command? profileCommand = root.Subcommands.SingleOrDefault(c => c.Name == "profile");
+
+        Assert.NotNull(profileCommand);
+        Assert.Contains(profileCommand!.Subcommands, c => c.Name == "list");
+        Assert.Contains(profileCommand.Subcommands, c => c.Name == "show");
+    }
+
+    [Fact]
+    public async Task List_WritesProfilesWithProjectSelection()
+    {
+        ProfileListCommand command = CreateListCommand(
+            ProjectOptions(["my-preview", "flex"], defaultProfile: "my-preview"),
+            Source(ProfileSourceKind.Project, Profile("staging", extends: "flex", hostRange: null)),
+            Source(ProfileSourceKind.User, Profile("my-preview", hostRange: "[4.1.0, 5.0.0)")),
+            Source(ProfileSourceKind.BuiltIn, Profile("flex", hostRange: "[4.0.0, 5.0.0)", bundleRange: "[3.0.0, 5.0.0)")));
+
+        int exit = await InvokeAsync(command, _tempDir);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("  Project profiles    my-preview (default), flex", _interaction.Lines);
+        Assert.Contains("TABLE: [Name, Source, Host Version, Extension Bundle, Status]", _interaction.Lines);
+        Assert.Contains("  ROW: [flex, built-in, [4.0.0, 5.0.0), [3.0.0, 5.0.0), stable]", _interaction.Lines);
+        Assert.Contains("  ROW: [my-preview, user, [4.1.0, 5.0.0), -, stable]", _interaction.Lines);
+        Assert.Contains("  ROW: [staging, project, [4.0.0, 5.0.0), [3.0.0, 5.0.0), stable]", _interaction.Lines);
+    }
+
+    [Fact]
+    public async Task List_SourceFilter_UsesFilteredSourceWhenProfileNamesOverlap()
+    {
+        ProfileListCommand command = CreateListCommand(
+            ProjectOptions(),
+            Source(ProfileSourceKind.Project, Profile("flex", hostRange: "[9.0.0, 10.0.0)")),
+            Source(ProfileSourceKind.BuiltIn, Profile("flex", hostRange: "[4.0.0, 5.0.0)")));
+
+        int exit = await InvokeAsync(command, "--source", "built-in", _tempDir);
+
+        Assert.Equal(0, exit);
+        string row = Assert.Single(_interaction.Lines, l => l.StartsWith("  ROW:"));
+        Assert.Equal("  ROW: [flex, built-in, [4.0.0, 5.0.0), -, stable]", row);
+    }
+
+    [Fact]
+    public async Task List_Json_WritesStructuredProfiles()
+    {
+        ProfileListCommand command = CreateListCommand(
+            ProjectOptions(["flex"], defaultProfile: "flex"),
+            Source(ProfileSourceKind.BuiltIn, Profile("flex", hostRange: "[4.0.0, 5.0.0)")));
+
+        int exit = await InvokeAsync(command, "--json", _tempDir);
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain(_interaction.Lines, l => l.StartsWith("TABLE:"));
+        string json = _interaction.Lines.Single(l => l.StartsWith("JSON:"));
+        Assert.Contains("\"defaultProfile\":\"flex\"", json);
+        Assert.Contains("\"name\":\"flex\"", json);
+        Assert.Contains("\"source\":\"built-in\"", json);
+    }
+
+    [Fact]
+    public async Task Show_WritesResolvedProfile()
+    {
+        ProfileShowCommand command = CreateShowCommand(
+            Source(ProfileSourceKind.Project, Profile(
+                "staging",
+                extends: "flex",
+                hostRange: null,
+                workers: Workers(("node", "[4.0.0]")))),
+            Source(ProfileSourceKind.BuiltIn, Profile(
+                "flex",
+                hostRange: "[4.0.0, 5.0.0)",
+                bundleRange: "[3.0.0, 5.0.0)",
+                supportedRuntimes: ["node"])));
+
+        int exit = await InvokeAsync(command, "staging", _tempDir);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("  Name    staging", _interaction.Lines);
+        Assert.Contains("  Source    project", _interaction.Lines);
+        Assert.Contains("  Host version    [4.0.0, 5.0.0)", _interaction.Lines);
+        Assert.Contains("  Extension bundle    [3.0.0, 5.0.0)", _interaction.Lines);
+        Assert.Contains("  Workers    node [4.0.0]", _interaction.Lines);
+        Assert.Contains("  Supported runtimes    node", _interaction.Lines);
+    }
+
+    [Fact]
+    public async Task Show_Raw_WritesDefinitionWithoutInheritance()
+    {
+        ProfileShowCommand command = CreateShowCommand(
+            Source(ProfileSourceKind.Project, Profile("staging", extends: "flex", hostRange: null)),
+            Source(ProfileSourceKind.BuiltIn, Profile("flex", hostRange: "[4.0.0, 5.0.0)")));
+
+        int exit = await InvokeAsync(command, "staging", "--raw", _tempDir);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("  Name    staging", _interaction.Lines);
+        Assert.Contains("  Extends    flex", _interaction.Lines);
+        Assert.Contains("  Host version    -", _interaction.Lines);
+    }
+
+    [Fact]
+    public async Task Show_MissingProfile_ThrowsGracefulException()
+    {
+        ProfileShowCommand command = CreateShowCommand(
+            Source(ProfileSourceKind.BuiltIn, Profile("flex", hostRange: "[4.0.0, 5.0.0)")));
+
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => InvokeAsync(command, "missing", _tempDir));
+
+        Assert.Contains("Profile 'missing' was not found.", ex.Message);
+    }
+
+    private ProfileListCommand CreateListCommand(ProjectProfileOptions options, params IProfileSource[] sources)
+    {
+        var catalog = new ProfileCatalog(sources);
+        var optionsMonitor = new TestOptionsMonitor<ProjectProfileOptions>(options);
+        return new ProfileListCommand(_interaction, catalog, optionsMonitor);
+    }
+
+    private ProfileShowCommand CreateShowCommand(params IProfileSource[] sources)
+    {
+        var catalog = new ProfileCatalog(sources);
+        return new ProfileShowCommand(_interaction, catalog);
+    }
+
+    private static Task<int> InvokeAsync(FuncCliCommand command, params string[] args)
+    {
+        var root = new RootCommand();
+        root.Subcommands.Add(command);
+        ParseResult result = root.Parse(new[] { command.Name }.Concat(args).ToArray());
+        var config = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
+        return result.InvokeAsync(config);
+    }
+
+    private static ProjectProfileOptions ProjectOptions(IReadOnlyList<string>? profiles = null, string? defaultProfile = null)
+        => new()
+        {
+            Profiles = profiles?.ToList() ?? [],
+            DefaultProfile = defaultProfile,
+        };
+
+    private static IProfileSource Source(ProfileSourceKind kind, params KeyValuePair<string, ProfileDefinition>[] profiles)
+        => new FakeProfileSource(new ProfileSourceInfo(kind, $"{kind} profiles"), profiles);
+
+    private static KeyValuePair<string, ProfileDefinition> Profile(
+        string name,
+        string? hostRange = "[1.0.0, 2.0.0)",
+        string? bundleRange = null,
+        string? status = null,
+        string? deprecationUrl = null,
+        string? extends = null,
+        Dictionary<string, ProfileWorkerConstraint?>? workers = null,
+        List<string>? supportedRuntimes = null)
+        => new(name, new ProfileDefinition
+        {
+            Status = status,
+            DeprecationUrl = deprecationUrl,
+            Extends = extends,
+            Host = hostRange is null ? null : new ProfileVersionConstraint { Version = hostRange },
+            ExtensionBundle = bundleRange is null ? null : new ProfileVersionConstraint { Version = bundleRange },
+            Workers = workers,
+            SupportedRuntimes = supportedRuntimes,
+        });
+
+    private static Dictionary<string, ProfileWorkerConstraint?> Workers(params (string Runtime, string Range)[] workers)
+        => workers.ToDictionary(
+            worker => worker.Runtime,
+            worker => (ProfileWorkerConstraint?)new ProfileWorkerConstraint { Version = worker.Range },
+            StringComparer.OrdinalIgnoreCase);
+
+    private sealed class FakeProfileSource(
+        ProfileSourceInfo source,
+        IReadOnlyList<KeyValuePair<string, ProfileDefinition>> profiles) : IProfileSource
+    {
+        private readonly ProfileSourceInfo _source = source;
+        private readonly IReadOnlyList<KeyValuePair<string, ProfileDefinition>> _profiles = profiles;
+
+        public Task<ProfileSourceSnapshot> LoadAsync(ProfileSourceContext context, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Dictionary<string, ProfileDefinition> profiles = new(StringComparer.OrdinalIgnoreCase);
+            foreach ((string name, ProfileDefinition definition) in _profiles)
+            {
+                profiles.Add(name, definition);
+            }
+
+            var snapshot = new ProfileSourceSnapshot(_source, profiles);
+            return Task.FromResult(snapshot);
+        }
+    }
+
+    private sealed class TestOptionsMonitor<TOptions>(TOptions value) : IOptionsMonitor<TOptions>
+    {
+        private readonly TOptions _value = value;
+
+        public TOptions CurrentValue => _value;
+
+        public TOptions Get(string? name) => _value;
+
+        public IDisposable OnChange(Action<TOptions, string?> listener) => NoopDisposable.Instance;
+    }
+
+    private sealed class NoopDisposable : IDisposable
+    {
+        public static NoopDisposable Instance { get; } = new();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/test/Func.Tests/Profiles/ProfileResolverTests.cs
+++ b/test/Func.Tests/Profiles/ProfileResolverTests.cs
@@ -278,9 +278,10 @@ public class ProfileResolverTests
 
     private ProfileResolver CreateResolver(params IProfileSource[] sources)
     {
+        var catalog = new ProfileCatalog(sources);
         var projectOptionsMonitor = new TestOptionsMonitor<ProjectProfileOptions>(_projectProfileOptions);
         var userOptionsMonitor = new TestOptionsMonitor<UserProfilePreferenceOptions>(_userProfilePreferenceOptions);
-        return new ProfileResolver(sources, projectOptionsMonitor, userOptionsMonitor, _interaction);
+        return new ProfileResolver(catalog, projectOptionsMonitor, userOptionsMonitor, _interaction);
     }
 
     private async Task<ProfileResolution.Resolved> ResolveProfileAsync(

--- a/test/Func.Tests/TestParser.cs
+++ b/test/Func.Tests/TestParser.cs
@@ -9,6 +9,7 @@ using Azure.Functions.Cli.Hosting;
 using Azure.Functions.Cli.Workloads;
 using Azure.Functions.Cli.Workloads.Loading;
 using Azure.Functions.Cli.Workloads.Storage;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 
@@ -63,9 +64,11 @@ internal static class TestParser
     {
         var services = new ServiceCollection();
         services.AddSingleton(interaction);
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         services.AddOptions<StackOptions>();
         services.AddOptions<HostStartupOptions>();
         services.AddBuiltInCommands();
+        services.AddProfiles();
         services.AddSingleton(Substitute.For<IStartInitializationRunner>());
 
         // Stub the workload subsystem so commands that depend on it (e.g.


### PR DESCRIPTION
## Summary
- add `func profile list` and `func profile show` read-only inspection commands
- extract shared profile loading/resolution into `IProfileCatalog`
- register profile commands and update command architecture docs
