### PR TITLE
Add profile set command

### DIFF
--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -62,7 +62,8 @@ func
 ├── start [path]          Start the Functions host (placeholder)
 ├── profile
 │   ├── list [path]       List available profiles
-│   └── show <name> [path]  Show profile details
+│   ├── show <name> [path]  Show profile details
+│   └── set <name> [path]   Set the project default profile
 ├── workload
 │   └── list              List installed workloads
 ├── version (hidden)      Print version info

--- a/src/Func/Commands/InitCommand.cs
+++ b/src/Func/Commands/InitCommand.cs
@@ -243,10 +243,7 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
             return true;
         }
 
-        string config = Path.Combine(
-            workingDirectory.FullName,
-            CliConfigurationNames.ProjectConfigFolderName,
-            CliConfigurationNames.ConfigFileName);
+        string config = CliConfigurationPathsOptions.GetProjectConfigPath(workingDirectory);
         if (File.Exists(config))
         {
             existingFile = Path.GetRelativePath(workingDirectory.FullName, config);
@@ -259,8 +256,8 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
 
     private void WriteCliConfigurationFile(DirectoryInfo workingDirectory, string? stack, string? language, bool force)
     {
-        string folder = Path.Combine(workingDirectory.FullName, CliConfigurationNames.ProjectConfigFolderName);
-        string path = Path.Combine(folder, CliConfigurationNames.ConfigFileName);
+        string folder = CliConfigurationPathsOptions.GetProjectConfigFolderPath(workingDirectory);
+        string path = CliConfigurationPathsOptions.GetProjectConfigPath(workingDirectory);
 
         // Treat an existing file as user-owned unless --force was passed.
         if (File.Exists(path) && !force)
@@ -297,7 +294,7 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
 
             _interaction.WriteLine(l => l
                 .Muted("· Wrote ")
-                .Code(Path.Combine(CliConfigurationNames.ProjectConfigFolderName, CliConfigurationNames.ConfigFileName))
+                .Code(CliConfigurationPathsOptions.ProjectConfigDisplayPath)
                 .Muted("."));
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
@@ -306,7 +303,7 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
             // create .func/config.json by hand if they want stack pinning.
             _interaction.WriteLine(l => l
                 .Warning("! ")
-                .Muted("Could not write .func/config.json (")
+                .Muted($"Could not write {CliConfigurationPathsOptions.ProjectConfigDisplayPath} (")
                 .Code(ex.Message)
                 .Muted(")."));
         }

--- a/src/Func/Commands/Profile/ProfileCommand.cs
+++ b/src/Func/Commands/Profile/ProfileCommand.cs
@@ -10,13 +10,15 @@ namespace Azure.Functions.Cli.Commands.Profile;
 /// </summary>
 internal sealed class ProfileCommand : FuncCliCommand, IBuiltInCommand
 {
-    public ProfileCommand(ProfileListCommand listCommand, ProfileShowCommand showCommand)
+    public ProfileCommand(ProfileListCommand listCommand, ProfileShowCommand showCommand, ProfileSetCommand setCommand)
         : base("profile", "Inspect and manage Azure Functions CLI profiles.")
     {
         ArgumentNullException.ThrowIfNull(listCommand);
         ArgumentNullException.ThrowIfNull(showCommand);
+        ArgumentNullException.ThrowIfNull(setCommand);
 
         Subcommands.Add(listCommand);
         Subcommands.Add(showCommand);
+        Subcommands.Add(setCommand);
     }
 }

--- a/src/Func/Commands/Profile/ProfileSetCommand.cs
+++ b/src/Func/Commands/Profile/ProfileSetCommand.cs
@@ -1,0 +1,83 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Configuration;
+using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Profiles;
+
+namespace Azure.Functions.Cli.Commands.Profile;
+
+/// <summary>
+/// Sets the default profile for a Functions project.
+/// </summary>
+internal sealed class ProfileSetCommand : FuncCliCommand
+{
+    public Argument<string> NameArgument { get; } = new("name")
+    {
+        Description = "The profile name to set as the project default."
+    };
+
+    private readonly IInteractionService _interaction;
+    private readonly IProfileCatalog _catalog;
+    private readonly IProjectProfileConfigStore _projectConfigStore;
+
+    public ProfileSetCommand(IInteractionService interaction, IProfileCatalog catalog, IProjectProfileConfigStore projectConfigStore)
+        : base("set", "Set the default profile for a Functions project.")
+    {
+        _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
+        _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
+        _projectConfigStore = projectConfigStore ?? throw new ArgumentNullException(nameof(projectConfigStore));
+
+        Arguments.Add(NameArgument);
+        AddPathArgument();
+    }
+
+    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        WorkingDirectory workingDirectory = parseResult.GetValue(PathArgument!)!;
+        if (!workingDirectory.Exists)
+        {
+            string displayPath = workingDirectory.OriginalPath ?? workingDirectory.Info.FullName;
+            throw new GracefulException($"The specified path does not exist: '{displayPath}'", isUserError: true);
+        }
+
+        string name = parseResult.GetValue(NameArgument)!;
+        ProjectProfileConfigUpdateResult result;
+        try
+        {
+            result = await SetProfileAsync(workingDirectory.Info, name, cancellationToken);
+        }
+        catch (ProfileConfigurationException ex)
+        {
+            throw new GracefulException(ex.Message, isUserError: true, verboseMessage: ex.ToString());
+        }
+
+        WriteResult(result);
+        return 0;
+    }
+
+    /// <exception cref="ProfileConfigurationException">
+    /// Thrown when the profile cannot be resolved or the project config cannot be written.
+    /// </exception>
+    private async Task<ProjectProfileConfigUpdateResult> SetProfileAsync(DirectoryInfo workingDirectory, string name, CancellationToken cancellationToken)
+    {
+        var sourceContext = new ProfileSourceContext(workingDirectory);
+        IReadOnlyList<ProfileSourceSnapshot> snapshots = await _catalog.LoadAsync(sourceContext, cancellationToken);
+        ResolvedProfile profile = _catalog.ResolveProfile(name, snapshots);
+
+        return await _projectConfigStore.SetDefaultProfileAsync(workingDirectory, profile.Name, cancellationToken);
+    }
+
+    private void WriteResult(ProjectProfileConfigUpdateResult result)
+    {
+        _interaction.WriteSuccess($"Profile '{result.Profile}' set as this project's default.");
+        if (result.AddedProfile)
+        {
+            _interaction.WriteHint($"Added '{result.Profile}' to this project's profiles list.");
+        }
+
+        _interaction.WriteLine(l => l.Muted("Wrote ").Code(CliConfigurationPathsOptions.ProjectConfigDisplayPath).Muted("."));
+    }
+}

--- a/src/Func/Common/VersionChecker.cs
+++ b/src/Func/Common/VersionChecker.cs
@@ -24,11 +24,11 @@ internal static class VersionChecker
     /// </summary>
     public static Task<string?> CheckForUpdateAsync(CancellationToken cancellationToken = default)
     {
-        UserConfigurationPathsOptions userConfigurationPaths = new();
+        CliConfigurationPathsOptions userConfigurationPaths = new();
         return CheckForUpdateAsync(userConfigurationPaths, cancellationToken);
     }
 
-    internal static async Task<string?> CheckForUpdateAsync(UserConfigurationPathsOptions userConfigurationPaths, CancellationToken cancellationToken = default)
+    internal static async Task<string?> CheckForUpdateAsync(CliConfigurationPathsOptions userConfigurationPaths, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(userConfigurationPaths);
 
@@ -134,7 +134,7 @@ internal static class VersionChecker
     private static bool IsNewer(Version latest, Version current)
         => latest > current;
 
-    private static Version? ReadCache(UserConfigurationPathsOptions userConfigurationPaths)
+    private static Version? ReadCache(CliConfigurationPathsOptions userConfigurationPaths)
     {
         try
         {
@@ -159,7 +159,7 @@ internal static class VersionChecker
         }
     }
 
-    private static void WriteCache(UserConfigurationPathsOptions userConfigurationPaths, Version version)
+    private static void WriteCache(CliConfigurationPathsOptions userConfigurationPaths, Version version)
     {
         try
         {

--- a/src/Func/Configuration/CliConfigurationPathsOptions.cs
+++ b/src/Func/Configuration/CliConfigurationPathsOptions.cs
@@ -6,21 +6,21 @@ using AbstractionsConstants = Azure.Functions.Cli.Abstractions.Common.Constants;
 namespace Azure.Functions.Cli.Configuration;
 
 /// <summary>
-/// Computed filesystem layout for user-scoped CLI configuration.
+/// Computed filesystem layout for CLI configuration.
 /// </summary>
-internal sealed class UserConfigurationPathsOptions
+internal sealed class CliConfigurationPathsOptions
 {
     public const string VersionCacheFileName = ".version-check";
     public const string ProfilesFileName = "profiles.json";
 
-    public UserConfigurationPathsOptions()
+    public CliConfigurationPathsOptions()
         : this(Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
             AbstractionsConstants.FuncHomeDirectoryName))
     {
     }
 
-    internal UserConfigurationPathsOptions(string home)
+    internal CliConfigurationPathsOptions(string home)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(home);
         Home = Path.GetFullPath(home);
@@ -33,4 +33,18 @@ internal sealed class UserConfigurationPathsOptions
     public string ProfilesPath => Path.Combine(Home, ProfilesFileName);
 
     public string VersionCachePath => Path.Combine(Home, VersionCacheFileName);
+
+    public static string ProjectConfigDisplayPath => Path.Combine(CliConfigurationNames.ProjectConfigFolderName, CliConfigurationNames.ConfigFileName);
+
+    public static string GetProjectConfigFolderPath(DirectoryInfo projectDirectory)
+    {
+        ArgumentNullException.ThrowIfNull(projectDirectory);
+        return Path.Combine(projectDirectory.FullName, CliConfigurationNames.ProjectConfigFolderName);
+    }
+
+    public static string GetProjectConfigPath(DirectoryInfo projectDirectory)
+    {
+        ArgumentNullException.ThrowIfNull(projectDirectory);
+        return Path.Combine(projectDirectory.FullName, ProjectConfigDisplayPath);
+    }
 }

--- a/src/Func/Configuration/CliConfigurationProvider.cs
+++ b/src/Func/Configuration/CliConfigurationProvider.cs
@@ -10,23 +10,23 @@ namespace Azure.Functions.Cli.Configuration;
 /// <summary>
 /// Builds and caches scoped CLI configuration roots.
 /// </summary>
-internal sealed class CliConfigurationProvider(ILocalSettingsProvider localSettingsProvider, UserConfigurationPathsOptions userConfigurationPaths)
+internal sealed class CliConfigurationProvider(ILocalSettingsProvider localSettingsProvider, CliConfigurationPathsOptions configurationPaths)
     : ICliConfigurationProvider
 {
     private readonly ILocalSettingsProvider _localSettingsProvider = localSettingsProvider ?? throw new ArgumentNullException(nameof(localSettingsProvider));
-    private readonly UserConfigurationPathsOptions _userConfigurationPaths = userConfigurationPaths ?? throw new ArgumentNullException(nameof(userConfigurationPaths));
+    private readonly CliConfigurationPathsOptions _configurationPaths = configurationPaths ?? throw new ArgumentNullException(nameof(configurationPaths));
     private readonly ConcurrentDictionary<string, IConfigurationRoot> _projectConfigurations = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, IConfigurationRoot> _effectiveConfigurations = new(StringComparer.OrdinalIgnoreCase);
     private IConfigurationRoot? _userConfiguration;
     private readonly Lock _userConfigurationLock = new();
 
     public CliConfigurationProvider(ILocalSettingsProvider localSettingsProvider)
-        : this(localSettingsProvider, new UserConfigurationPathsOptions())
+        : this(localSettingsProvider, new CliConfigurationPathsOptions())
     {
     }
 
     internal CliConfigurationProvider(ILocalSettingsProvider localSettingsProvider, DirectoryInfo userConfigurationDirectory)
-        : this(localSettingsProvider, CreateUserConfigurationPaths(userConfigurationDirectory))
+        : this(localSettingsProvider, CreateConfigurationPaths(userConfigurationDirectory))
     {
     }
 
@@ -39,7 +39,7 @@ internal sealed class CliConfigurationProvider(ILocalSettingsProvider localSetti
 
         lock (_userConfigurationLock)
         {
-            _userConfiguration ??= BuildUserConfiguration(_userConfigurationPaths);
+            _userConfiguration ??= BuildUserConfiguration(_configurationPaths);
 
             return _userConfiguration;
         }
@@ -67,11 +67,11 @@ internal sealed class CliConfigurationProvider(ILocalSettingsProvider localSetti
         return _effectiveConfigurations.GetOrAdd(key, static (_, state) => state.Provider.BuildEffectiveConfiguration(state.ProjectDirectory), state);
     }
 
-    private static IConfigurationRoot BuildUserConfiguration(UserConfigurationPathsOptions userConfigurationPaths)
+    private static IConfigurationRoot BuildUserConfiguration(CliConfigurationPathsOptions configurationPaths)
     {
         var builder = new ConfigurationBuilder();
         builder.AddEnvironmentVariables(prefix: Constants.EnvironmentVariablePrefix);
-        builder.AddJsonFile(userConfigurationPaths.ConfigPath, optional: true, reloadOnChange: false);
+        builder.AddJsonFile(configurationPaths.ConfigPath, optional: true, reloadOnChange: false);
 
         return builder.Build();
     }
@@ -80,7 +80,7 @@ internal sealed class CliConfigurationProvider(ILocalSettingsProvider localSetti
     {
         var builder = new ConfigurationBuilder();
         builder.Add(new LocalSettingsConfigurationSource(projectDirectory, _localSettingsProvider));
-        builder.AddJsonFile(GetProjectConfigPath(projectDirectory), optional: true, reloadOnChange: false);
+        builder.AddJsonFile(CliConfigurationPathsOptions.GetProjectConfigPath(projectDirectory), optional: true, reloadOnChange: false);
 
         return builder.Build();
     }
@@ -94,16 +94,10 @@ internal sealed class CliConfigurationProvider(ILocalSettingsProvider localSetti
         return builder.Build();
     }
 
-    private static string GetProjectConfigPath(DirectoryInfo projectDirectory)
-        => Path.Combine(
-            projectDirectory.FullName,
-            CliConfigurationNames.ProjectConfigFolderName,
-            CliConfigurationNames.ConfigFileName);
-
-    private static UserConfigurationPathsOptions CreateUserConfigurationPaths(DirectoryInfo userConfigurationDirectory)
+    private static CliConfigurationPathsOptions CreateConfigurationPaths(DirectoryInfo userConfigurationDirectory)
     {
         ArgumentNullException.ThrowIfNull(userConfigurationDirectory);
-        return new UserConfigurationPathsOptions(userConfigurationDirectory.FullName);
+        return new CliConfigurationPathsOptions(userConfigurationDirectory.FullName);
     }
 
     private static string NormalizeProjectDirectory(DirectoryInfo projectDirectory)

--- a/src/Func/Hosting/BuiltInCommands.cs
+++ b/src/Func/Hosting/BuiltInCommands.cs
@@ -39,6 +39,7 @@ internal static class BuiltInCommands
         services.AddSingleton<FuncCliCommand, StartCommand>();
         services.AddSingleton<ProfileListCommand>();
         services.AddSingleton<ProfileShowCommand>();
+        services.AddSingleton<ProfileSetCommand>();
         services.AddSingleton<FuncCliCommand, ProfileCommand>();
 
         // Shared dashboard primitives (renderers and per-invocation pipeline

--- a/src/Func/Hosting/CliHostFactory.cs
+++ b/src/Func/Hosting/CliHostFactory.cs
@@ -59,11 +59,11 @@ internal static class CliHostFactory
 
         var workingDirectory = new DirectoryInfo(Environment.CurrentDirectory);
         var localSettingsProvider = new LocalSettingsProvider();
-        var userConfigurationPaths = new UserConfigurationPathsOptions();
-        var configurationProvider = new CliConfigurationProvider(localSettingsProvider, userConfigurationPaths);
+        var configurationPaths = new CliConfigurationPathsOptions();
+        var configurationProvider = new CliConfigurationProvider(localSettingsProvider, configurationPaths);
         builder.Services.AddSingleton(localSettingsProvider);
         builder.Services.AddSingleton<ILocalSettingsProvider>(localSettingsProvider);
-        builder.Services.AddSingleton(userConfigurationPaths);
+        builder.Services.AddSingleton(configurationPaths);
         builder.Services.AddSingleton(configurationProvider);
         builder.Services.AddSingleton<ICliConfigurationProvider>(configurationProvider);
 

--- a/src/Func/Hosting/ProfileRegistration.cs
+++ b/src/Func/Hosting/ProfileRegistration.cs
@@ -18,7 +18,7 @@ internal static class ProfileRegistration
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        services.TryAddSingleton<UserConfigurationPathsOptions>();
+        services.TryAddSingleton<CliConfigurationPathsOptions>();
         services.AddSingleton<ProfileDocumentParser>();
         services.AddSingleton<IProfileFileSystem, ProfileFileSystem>();
         services.AddSingleton<IProfileSource, ProjectProfileSource>();
@@ -26,6 +26,7 @@ internal static class ProfileRegistration
         services.AddSingleton<IProfileSource, BuiltInProfileSource>();
         services.AddSingleton<IConfigureOptions<ProjectProfileOptions>, ProjectProfileOptionsSetup>();
         services.AddSingleton<IConfigureOptions<UserProfilePreferenceOptions>, UserProfilePreferenceOptionsSetup>();
+        services.AddSingleton<IProjectProfileConfigStore, ProjectProfileConfigStore>();
         services.AddSingleton<IProfileCatalog, ProfileCatalog>();
         services.AddSingleton<IProfileResolver, ProfileResolver>();
 

--- a/src/Func/Profiles/IProfileFileSystem.cs
+++ b/src/Func/Profiles/IProfileFileSystem.cs
@@ -8,5 +8,14 @@ namespace Azure.Functions.Cli.Profiles;
 /// </summary>
 internal interface IProfileFileSystem
 {
+    /// <summary>
+    /// Reads a text file if it exists.
+    /// </summary>
     public Task<string?> ReadAllTextIfExistsAsync(string path, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Writes a text file.
+    /// </summary>
+    public Task WriteAllTextAsync(string path, string contents, CancellationToken cancellationToken);
+
 }

--- a/src/Func/Profiles/IProjectProfileConfigStore.cs
+++ b/src/Func/Profiles/IProjectProfileConfigStore.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Profiles;
+
+/// <summary>
+/// Persists project-owned profile selection settings.
+/// </summary>
+internal interface IProjectProfileConfigStore
+{
+    /// <summary>
+    /// Sets the project's default profile, adding it to the declared profile list when needed.
+    /// </summary>
+    /// <exception cref="ProfileConfigurationException">
+    /// Thrown when the project config cannot be parsed or written.
+    /// </exception>
+    public Task<ProjectProfileConfigUpdateResult> SetDefaultProfileAsync(DirectoryInfo projectDirectory, string profileName, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Describes the project profile config update.
+/// </summary>
+internal sealed record ProjectProfileConfigUpdateResult(string Profile, string ConfigPath, bool AddedProfile, IReadOnlyList<string> Profiles);

--- a/src/Func/Profiles/ProfileFileSystem.cs
+++ b/src/Func/Profiles/ProfileFileSystem.cs
@@ -19,4 +19,13 @@ internal sealed class ProfileFileSystem : IProfileFileSystem
 
         return await File.ReadAllTextAsync(path, cancellationToken);
     }
+
+    public Task WriteAllTextAsync(string path, string contents, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentNullException.ThrowIfNull(contents);
+
+        return File.WriteAllTextAsync(path, contents, cancellationToken);
+    }
+
 }

--- a/src/Func/Profiles/ProjectProfileConfigStore.cs
+++ b/src/Func/Profiles/ProjectProfileConfigStore.cs
@@ -1,0 +1,170 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Azure.Functions.Cli.Configuration;
+
+namespace Azure.Functions.Cli.Profiles;
+
+/// <summary>
+/// Default project profile config store.
+/// </summary>
+internal sealed class ProjectProfileConfigStore(IProfileFileSystem fileSystem) : IProjectProfileConfigStore
+{
+    private static readonly string _projectConfigDisplayName = CliConfigurationPathsOptions.ProjectConfigDisplayPath;
+
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        WriteIndented = true,
+    };
+
+    private readonly IProfileFileSystem _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
+
+    public async Task<ProjectProfileConfigUpdateResult> SetDefaultProfileAsync(DirectoryInfo projectDirectory, string profileName, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(projectDirectory);
+        string normalizedProfileName = NormalizeProfileName(profileName);
+        string configPath = CliConfigurationPathsOptions.GetProjectConfigPath(projectDirectory);
+
+        string? json = await _fileSystem.ReadAllTextIfExistsAsync(configPath, cancellationToken);
+        JsonObject root = ParseProjectConfig(json);
+        List<string> profiles = ReadProfiles(root);
+        string selectedProfile = EnsureProfile(profiles, normalizedProfileName, out bool addedProfile);
+
+        root["profiles"] = CreateProfilesArray(profiles);
+        root["defaultProfile"] = selectedProfile;
+
+        string updatedJson = root.ToJsonString(_jsonOptions) + Environment.NewLine;
+        await WriteProjectConfigAsync(configPath, updatedJson, cancellationToken);
+
+        return new ProjectProfileConfigUpdateResult(selectedProfile, configPath, addedProfile, profiles);
+    }
+
+    private async Task WriteProjectConfigAsync(string configPath, string contents, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _fileSystem.WriteAllTextAsync(configPath, contents, cancellationToken);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            throw new ProfileConfigurationException($"Could not write project config '{_projectConfigDisplayName}': {ex.Message}", ex);
+        }
+    }
+
+    private static JsonObject ParseProjectConfig(string? json)
+    {
+        if (json is null)
+        {
+            throw new ProfileConfigurationException(
+                $"Project not initialized. Run 'func init' to create a Functions project before setting a profile.");
+        }
+
+        try
+        {
+            var node = JsonNode.Parse(json);
+            if (node is JsonObject root)
+            {
+                ValidateSchema(root);
+                return root;
+            }
+        }
+        catch (JsonException ex)
+        {
+            throw new ProfileConfigurationException($"Project config '{_projectConfigDisplayName}' contains invalid JSON.", ex);
+        }
+
+        throw new ProfileConfigurationException($"Project config '{_projectConfigDisplayName}' must contain a JSON object.");
+    }
+
+    private static void ValidateSchema(JsonObject root)
+    {
+        if (root["$schema"] is null)
+        {
+            return;
+        }
+
+        if (root["$schema"] is JsonValue schemaValue
+            && schemaValue.TryGetValue(out string? schema)
+            && !string.IsNullOrWhiteSpace(schema))
+        {
+            if (!string.Equals(schema, ProfileSchemas.ProjectConfigV1, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ProfileConfigurationException(
+                    $"Project config '{_projectConfigDisplayName}' uses unsupported schema '{schema}'. "
+                    + $"Expected '{ProfileSchemas.ProjectConfigV1}'.");
+            }
+
+            return;
+        }
+
+        throw new ProfileConfigurationException($"Project config '{_projectConfigDisplayName}' has an invalid '$schema' value.");
+    }
+
+    private static List<string> ReadProfiles(JsonObject root)
+    {
+        if (root["profiles"] is null)
+        {
+            return [];
+        }
+
+        if (root["profiles"] is not JsonArray profilesArray)
+        {
+            throw new ProfileConfigurationException($"Project config '{_projectConfigDisplayName}' property 'profiles' must be an array.");
+        }
+
+        List<string> profiles = [];
+        HashSet<string> seen = new(StringComparer.OrdinalIgnoreCase);
+        foreach (JsonNode? item in profilesArray)
+        {
+            if (item is not JsonValue profileValue
+                || !profileValue.TryGetValue(out string? profile)
+                || string.IsNullOrWhiteSpace(profile))
+            {
+                throw new ProfileConfigurationException($"Project config '{_projectConfigDisplayName}' contains an invalid profile name.");
+            }
+
+            string normalized = profile.Trim();
+            if (!seen.Add(normalized))
+            {
+                throw new ProfileConfigurationException($"Project config '{_projectConfigDisplayName}' declares profile '{normalized}' more than once.");
+            }
+
+            profiles.Add(normalized);
+        }
+
+        return profiles;
+    }
+
+    private static string EnsureProfile(List<string> profiles, string profileName, out bool addedProfile)
+    {
+        string? existingProfile = profiles.FirstOrDefault(p => string.Equals(p, profileName, StringComparison.OrdinalIgnoreCase));
+        if (existingProfile is not null)
+        {
+            addedProfile = false;
+            return existingProfile;
+        }
+
+        profiles.Add(profileName);
+        addedProfile = true;
+        return profileName;
+    }
+
+    private static JsonArray CreateProfilesArray(IEnumerable<string> profiles)
+    {
+        JsonArray array = [];
+        foreach (string profile in profiles)
+        {
+            array.Add(profile);
+        }
+
+        return array;
+    }
+
+    private static string NormalizeProfileName(string profileName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(profileName);
+        return profileName.Trim();
+    }
+}

--- a/src/Func/Profiles/ProjectProfileOptionsSetup.cs
+++ b/src/Func/Profiles/ProjectProfileOptionsSetup.cs
@@ -13,9 +13,7 @@ namespace Azure.Functions.Cli.Profiles;
 internal sealed class ProjectProfileOptionsSetup(IConfiguration configuration, ICliConfigurationProvider? configurationProvider = null)
     : IConfigureNamedOptions<ProjectProfileOptions>
 {
-    private static readonly string _projectConfigDisplayName = Path.Combine(
-        CliConfigurationNames.ProjectConfigFolderName,
-        CliConfigurationNames.ConfigFileName);
+    private static readonly string _projectConfigDisplayName = CliConfigurationPathsOptions.ProjectConfigDisplayPath;
 
     private readonly IConfiguration _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
     private readonly ICliConfigurationProvider? _configurationProvider = configurationProvider;

--- a/src/Func/Profiles/UserProfileSource.cs
+++ b/src/Func/Profiles/UserProfileSource.cs
@@ -8,19 +8,19 @@ namespace Azure.Functions.Cli.Profiles;
 /// <summary>
 /// Loads user-level profiles from the Azure Functions CLI home directory.
 /// </summary>
-internal sealed class UserProfileSource(ProfileDocumentParser parser, IProfileFileSystem fileSystem, UserConfigurationPathsOptions userConfigurationPaths)
+internal sealed class UserProfileSource(ProfileDocumentParser parser, IProfileFileSystem fileSystem, CliConfigurationPathsOptions configurationPaths)
     : IProfileSource
 {
     private readonly ProfileDocumentParser _parser = parser ?? throw new ArgumentNullException(nameof(parser));
     private readonly IProfileFileSystem _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
-    private readonly UserConfigurationPathsOptions _userConfigurationPaths =
-        userConfigurationPaths ?? throw new ArgumentNullException(nameof(userConfigurationPaths));
+    private readonly CliConfigurationPathsOptions _configurationPaths =
+        configurationPaths ?? throw new ArgumentNullException(nameof(configurationPaths));
 
     public async Task<ProfileSourceSnapshot> LoadAsync(ProfileSourceContext context, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        string path = _userConfigurationPaths.ProfilesPath;
+        string path = _configurationPaths.ProfilesPath;
         ProfileSourceInfo source = new(ProfileSourceKind.User, "~/.azure-functions/profiles.json", path);
         string? json = await _fileSystem.ReadAllTextIfExistsAsync(path, cancellationToken);
 

--- a/src/Func/Program.cs
+++ b/src/Func/Program.cs
@@ -62,14 +62,16 @@ string commandName = "unknown";
 
 using (Activity? activity = CliTelemetry.Trace.StartCommandActivity())
 {
+    FuncRootCommand? rootCommand = null;
+    ParseResult? commandParseResult = null;
     try
     {
         using IHost host = await CliHostFactory.CreateHostAsync(interaction, cts.Token);
         await host.StartAsync(cts.Token);
 
-        FuncRootCommand rootCommand = Parser.CreateCommand(host.Services);
+        rootCommand = Parser.CreateCommand(host.Services);
 
-        ParseResult commandParseResult = rootCommand.Parse(args);
+        commandParseResult = rootCommand.Parse(args);
         commandName = CommandNameResolver.ResolveCommandName(commandParseResult, rootCommand);
         activity?.SetCommandName(commandName);
 
@@ -86,7 +88,9 @@ using (Activity? activity = CliTelemetry.Trace.StartCommandActivity())
         activity?.Fail(ex);
         interaction.WriteError(ex.Message);
 
-        if (ex.VerboseMessage is not null)
+        if (ex.VerboseMessage is not null
+            && rootCommand is not null
+            && commandParseResult?.GetValue(rootCommand.VerboseOption) is true)
         {
             interaction.WriteHint(ex.VerboseMessage);
         }

--- a/test/Func.Tests/Commands/Profile/ProfileCommandTests.cs
+++ b/test/Func.Tests/Commands/Profile/ProfileCommandTests.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine;
 using System.CommandLine.Invocation;
+using System.Text.Json;
 using Azure.Functions.Cli.Commands;
 using Azure.Functions.Cli.Commands.Profile;
 using Azure.Functions.Cli.Common;
@@ -15,6 +16,7 @@ namespace Azure.Functions.Cli.Tests.Commands.Profile;
 public sealed class ProfileCommandTests : IDisposable
 {
     private readonly string _tempDir;
+    private readonly FakeProfileFileSystem _fileSystem = new();
     private readonly TestInteractionService _interaction = new();
 
     public ProfileCommandTests()
@@ -40,6 +42,7 @@ public sealed class ProfileCommandTests : IDisposable
         Assert.NotNull(profileCommand);
         Assert.Contains(profileCommand!.Subcommands, c => c.Name == "list");
         Assert.Contains(profileCommand.Subcommands, c => c.Name == "show");
+        Assert.Contains(profileCommand.Subcommands, c => c.Name == "set");
     }
 
     [Fact]
@@ -146,6 +149,111 @@ public sealed class ProfileCommandTests : IDisposable
         Assert.Contains("Profile 'missing' was not found.", ex.Message);
     }
 
+    [Fact]
+    public async Task Set_AddsProfileToExistingProjectConfigAndSetsDefault()
+    {
+        WriteProjectConfig("{}");
+        ProfileSetCommand command = CreateSetCommand(
+            Source(ProfileSourceKind.BuiltIn, Profile("flex", hostRange: "[4.0.0, 5.0.0)")));
+
+        int exit = await InvokeAsync(command, "flex", _tempDir);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("SUCCESS: Profile 'flex' set as this project's default.", _interaction.Lines);
+        Assert.Contains("HINT: Added 'flex' to this project's profiles list.", _interaction.Lines);
+        using JsonDocument document = ReadProjectConfig();
+        JsonElement root = document.RootElement;
+        Assert.Equal("flex", root.GetProperty("defaultProfile").GetString());
+        JsonElement profile = Assert.Single(root.GetProperty("profiles").EnumerateArray());
+        Assert.Equal("flex", profile.GetString());
+    }
+
+    [Fact]
+    public async Task Set_PreservesExistingProjectConfigAndAddsProfile()
+    {
+        WriteProjectConfig(
+            """
+            {
+              "Stack": {
+                "Runtime": "node"
+              },
+              "profiles": [ "flex" ],
+              "defaultProfile": "flex"
+            }
+            """);
+        ProfileSetCommand command = CreateSetCommand(
+            Source(ProfileSourceKind.BuiltIn, Profile("flex"), Profile("staging")));
+
+        int exit = await InvokeAsync(command, "staging", _tempDir);
+
+        Assert.Equal(0, exit);
+        using JsonDocument document = ReadProjectConfig();
+        JsonElement root = document.RootElement;
+        Assert.Equal("node", root.GetProperty("Stack").GetProperty("Runtime").GetString());
+        Assert.Equal("staging", root.GetProperty("defaultProfile").GetString());
+        string?[] profiles = [.. root.GetProperty("profiles").EnumerateArray().Select(p => p.GetString())];
+        string?[] expectedProfiles = ["flex", "staging"];
+        Assert.Equal(expectedProfiles, profiles);
+    }
+
+    [Fact]
+    public async Task Set_ExistingProfile_DoesNotDuplicateProfile()
+    {
+        WriteProjectConfig("""{"profiles":["FLEX"],"defaultProfile":"FLEX"}""");
+        ProfileSetCommand command = CreateSetCommand(
+            Source(ProfileSourceKind.BuiltIn, Profile("flex")));
+
+        int exit = await InvokeAsync(command, "flex", _tempDir);
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain(_interaction.Lines, l => l.StartsWith("HINT: Added", StringComparison.Ordinal));
+        using JsonDocument document = ReadProjectConfig();
+        JsonElement root = document.RootElement;
+        JsonElement profile = Assert.Single(root.GetProperty("profiles").EnumerateArray());
+        Assert.Equal("FLEX", profile.GetString());
+        Assert.Equal("FLEX", root.GetProperty("defaultProfile").GetString());
+    }
+
+    [Fact]
+    public async Task Set_MissingProfile_ThrowsGracefulException()
+    {
+        ProfileSetCommand command = CreateSetCommand(
+            Source(ProfileSourceKind.BuiltIn, Profile("flex")));
+
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => InvokeAsync(command, "missing", _tempDir));
+
+        Assert.Contains("Profile 'missing' was not found.", ex.Message);
+        Assert.False(_fileSystem.Exists(ProjectConfigPath()));
+    }
+
+    [Fact]
+    public async Task Set_MissingProjectConfig_ThrowsGracefulException()
+    {
+        ProfileSetCommand command = CreateSetCommand(
+            Source(ProfileSourceKind.BuiltIn, Profile("flex")));
+
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => InvokeAsync(command, "flex", _tempDir));
+
+        Assert.Contains("Project config '.func", ex.Message);
+        Assert.Contains("Run 'func init'", ex.Message);
+        Assert.False(_fileSystem.Exists(ProjectConfigPath()));
+    }
+
+    [Fact]
+    public async Task Set_InvalidProjectConfig_ThrowsGracefulException()
+    {
+        WriteProjectConfig("{ not valid json");
+        ProfileSetCommand command = CreateSetCommand(
+            Source(ProfileSourceKind.BuiltIn, Profile("flex")));
+
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => InvokeAsync(command, "flex", _tempDir));
+
+        Assert.Contains("contains invalid JSON", ex.Message);
+    }
+
     private ProfileListCommand CreateListCommand(ProjectProfileOptions options, params IProfileSource[] sources)
     {
         var catalog = new ProfileCatalog(sources);
@@ -157,6 +265,13 @@ public sealed class ProfileCommandTests : IDisposable
     {
         var catalog = new ProfileCatalog(sources);
         return new ProfileShowCommand(_interaction, catalog);
+    }
+
+    private ProfileSetCommand CreateSetCommand(params IProfileSource[] sources)
+    {
+        var catalog = new ProfileCatalog(sources);
+        var store = new ProjectProfileConfigStore(_fileSystem);
+        return new ProfileSetCommand(_interaction, catalog, store);
     }
 
     private static Task<int> InvokeAsync(FuncCliCommand command, params string[] args)
@@ -203,6 +318,43 @@ public sealed class ProfileCommandTests : IDisposable
             worker => worker.Runtime,
             worker => (ProfileWorkerConstraint?)new ProfileWorkerConstraint { Version = worker.Range },
             StringComparer.OrdinalIgnoreCase);
+
+    private void WriteProjectConfig(string contents)
+        => _fileSystem.WriteAllText(ProjectConfigPath(), contents);
+
+    private JsonDocument ReadProjectConfig()
+        => JsonDocument.Parse(_fileSystem.ReadAllText(ProjectConfigPath()));
+
+    private string ProjectConfigPath()
+        => Path.Combine(_tempDir, ".func", "config.json");
+
+    private sealed class FakeProfileFileSystem : IProfileFileSystem
+    {
+        private readonly Dictionary<string, string> _files = new(StringComparer.OrdinalIgnoreCase);
+
+        public Task<string?> ReadAllTextIfExistsAsync(string path, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            _files.TryGetValue(path, out string? contents);
+            return Task.FromResult(contents);
+        }
+
+        public Task WriteAllTextAsync(string path, string contents, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            WriteAllText(path, contents);
+            return Task.CompletedTask;
+        }
+
+        public void WriteAllText(string path, string contents)
+            => _files[path] = contents;
+
+        public string ReadAllText(string path)
+            => _files[path];
+
+        public bool Exists(string path)
+            => _files.ContainsKey(path);
+    }
 
     private sealed class FakeProfileSource(
         ProfileSourceInfo source,

--- a/test/Func.Tests/Commands/Profile/ProfileCommandTests.cs
+++ b/test/Func.Tests/Commands/Profile/ProfileCommandTests.cs
@@ -236,7 +236,7 @@ public sealed class ProfileCommandTests : IDisposable
         GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
             () => InvokeAsync(command, "flex", _tempDir));
 
-        Assert.Contains("Project config '.func", ex.Message);
+        Assert.Contains("Project not initialized.", ex.Message);
         Assert.Contains("Run 'func init'", ex.Message);
         Assert.False(_fileSystem.Exists(ProjectConfigPath()));
     }

--- a/test/Func.Tests/Commands/VersionCheckerTests.cs
+++ b/test/Func.Tests/Commands/VersionCheckerTests.cs
@@ -37,7 +37,7 @@ public class VersionCheckerTests
     public async Task CheckForUpdateAsync_UsesUserConfigurationPathsForCache()
     {
         string userHome = Path.Combine(Path.GetTempPath(), "func-cli-tests", Guid.NewGuid().ToString("N"));
-        var paths = new UserConfigurationPathsOptions(userHome);
+        var paths = new CliConfigurationPathsOptions(userHome);
 
         try
         {

--- a/test/Func.Tests/Profiles/UserProfileSourceTests.cs
+++ b/test/Func.Tests/Profiles/UserProfileSourceTests.cs
@@ -14,8 +14,8 @@ public class UserProfileSourceTests
     public async Task LoadAsync_ReadsProfilesFromUserConfigurationHome()
     {
         string userHome = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-        string expectedPath = Path.Combine(userHome, UserConfigurationPathsOptions.ProfilesFileName);
-        var paths = new UserConfigurationPathsOptions(userHome);
+        string expectedPath = Path.Combine(userHome, CliConfigurationPathsOptions.ProfilesFileName);
+        var paths = new CliConfigurationPathsOptions(userHome);
         IProfileFileSystem fileSystem = Substitute.For<IProfileFileSystem>();
         fileSystem.ReadAllTextIfExistsAsync(expectedPath, CancellationToken.None).Returns(Task.FromResult<string?>(null));
         var source = new UserProfileSource(new ProfileDocumentParser(), fileSystem, paths);


### PR DESCRIPTION
## Summary
- Add `func profile set <name> [path]` and register it under `func profile`.
- Write project-owned `.func\config.json` through a testable profile config store, preserving unrelated config and requiring `func init` first.
- Centralize CLI/user/project configuration paths under `CliConfigurationPathsOptions`.

## Validation
- `dotnet test .\test\Func.Tests\Func.Tests.csproj --no-restore --verbosity minimal`
- `$env:CI='true'; dotnet build .\test\Func.Tests\Func.Tests.csproj -c Release --no-restore --verbosity minimal`