### PR TITLE
Initial implementation of func setup orchestration

### DIFF
--- a/src/Func/Commands/Setup/SetupCommand.cs
+++ b/src/Func/Commands/Setup/SetupCommand.cs
@@ -1,0 +1,169 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Hosting;
+
+namespace Azure.Functions.Cli.Commands.Setup;
+
+/// <summary>
+/// Prepares the local machine for running Azure Functions projects.
+/// </summary>
+internal sealed class SetupCommand : FuncCliCommand, IBuiltInCommand
+{
+    public Option<string[]?> FeaturesOption { get; } = new("--features")
+    {
+        Description = "Setup features to install or check. Examples: host, runtime, node, python, dotnet-isolated.",
+        Arity = ArgumentArity.OneOrMore,
+    };
+
+    public Option<string[]?> ProfileOption { get; } = new("--profile")
+    {
+        Description = "Azure Functions profile to use for version constraints. May be specified multiple times.",
+        Arity = ArgumentArity.OneOrMore,
+    };
+
+    public Option<string?> ProfilesOption { get; } = new("--profiles")
+    {
+        Description = "Comma-separated Azure Functions profiles to use for version constraints.",
+    };
+
+    public Option<string?> InstallPolicyOption { get; } = new("--install-policy")
+    {
+        Description = "Install policy: latest-compatible or if-needed. Default: latest-compatible.",
+    };
+
+    public Option<string?> SourceOption { get; } = new("--source")
+    {
+        Description = "NuGet package source to use for workload resolution and installation.",
+    };
+
+    public Option<bool> PrereleaseOption { get; } = new("--prerelease")
+    {
+        Description = "Allow prerelease workload versions when resolving from the catalog.",
+    };
+
+    public Option<bool> NonInteractiveOption { get; } = new("--non-interactive")
+    {
+        Description = "Do not prompt for input.",
+    };
+
+    public Option<bool> YesOption { get; } = new("--yes", "-y")
+    {
+        Description = "Answer yes to setup prompts.",
+    };
+
+    public Option<bool> CheckOption { get; } = new("--check")
+    {
+        Description = "Check whether the selected dependencies are installed without making changes.",
+    };
+
+    public Option<string?> OutputOption { get; } = new("--output")
+    {
+        Description = "Output mode: plain or json (NDJSON). Default: plain.",
+    };
+
+    private readonly ISetupRunner _runner;
+
+    public SetupCommand(ISetupRunner runner)
+        : base("setup", "Prepare local Azure Functions dependencies.")
+    {
+        _runner = runner ?? throw new ArgumentNullException(nameof(runner));
+
+        AddPathArgument();
+        Options.Add(FeaturesOption);
+        Options.Add(ProfileOption);
+        Options.Add(ProfilesOption);
+        Options.Add(InstallPolicyOption);
+        Options.Add(SourceOption);
+        Options.Add(PrereleaseOption);
+        Options.Add(NonInteractiveOption);
+        Options.Add(YesOption);
+        Options.Add(CheckOption);
+        Options.Add(OutputOption);
+    }
+
+    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        WorkingDirectory workingDirectory = parseResult.GetValue(PathArgument!)!;
+        if (!workingDirectory.Exists)
+        {
+            string displayPath = workingDirectory.OriginalPath ?? workingDirectory.Info.FullName;
+            throw new GracefulException($"The specified path does not exist: '{displayPath}'", isUserError: true);
+        }
+
+        SetupCommandOptions options = new(
+            workingDirectory.Info,
+            SplitList(parseResult.GetValue(FeaturesOption)),
+            SplitList(parseResult.GetValue(ProfileOption)).Concat(SplitList(parseResult.GetValue(ProfilesOption))).ToArray(),
+            NullIfWhiteSpace(parseResult.GetValue(SourceOption)),
+            ResolveInstallPolicy(parseResult.GetValue(InstallPolicyOption)),
+            parseResult.GetValue(PrereleaseOption),
+            parseResult.GetValue(NonInteractiveOption),
+            parseResult.GetValue(YesOption),
+            parseResult.GetValue(CheckOption),
+            ResolveOutputMode(parseResult.GetValue(OutputOption)));
+
+        SetupRunResult result = await _runner.RunAsync(options, cancellationToken);
+        return result.ExitCode;
+    }
+
+    private static SetupInstallPolicy ResolveInstallPolicy(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return SetupInstallPolicy.LatestCompatible;
+        }
+
+        return raw.Trim().ToLowerInvariant() switch
+        {
+            "latest-compatible" => SetupInstallPolicy.LatestCompatible,
+            "if-needed" => SetupInstallPolicy.IfNeeded,
+            _ => throw new GracefulException(
+                $"--install-policy must be one of: latest-compatible, if-needed. Got '{raw}'.",
+                isUserError: true),
+        };
+    }
+
+    private static SetupOutputMode ResolveOutputMode(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return SetupOutputMode.Plain;
+        }
+
+        return raw.Trim().ToLowerInvariant() switch
+        {
+            "plain" => SetupOutputMode.Plain,
+            "json" => SetupOutputMode.Json,
+            _ => throw new GracefulException("--output must be one of: plain, json. Got '" + raw + "'.", isUserError: true),
+        };
+    }
+
+    private static IReadOnlyList<string> SplitList(string[]? values)
+        => values is null ? [] : SplitList(values.AsEnumerable());
+
+    private static IReadOnlyList<string> SplitList(string? value)
+        => string.IsNullOrWhiteSpace(value) ? [] : SplitList([value]);
+
+    private static IReadOnlyList<string> SplitList(IEnumerable<string> values)
+    {
+        List<string> result = [];
+        foreach (string value in values)
+        {
+            foreach (string part in value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (!string.IsNullOrWhiteSpace(part))
+                {
+                    result.Add(part);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static string? NullIfWhiteSpace(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/src/Func/Commands/Setup/SetupCommandOptions.cs
+++ b/src/Func/Commands/Setup/SetupCommandOptions.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Commands.Setup;
+
+internal sealed record SetupCommandOptions(
+    DirectoryInfo WorkingDirectory,
+    IReadOnlyList<string> Features,
+    IReadOnlyList<string> ProfileNames,
+    string? Source,
+    SetupInstallPolicy InstallPolicy,
+    bool IncludePrerelease,
+    bool NonInteractive,
+    bool AssumeYes,
+    bool Check,
+    SetupOutputMode OutputMode);
+
+internal enum SetupInstallPolicy
+{
+    LatestCompatible,
+    IfNeeded,
+}
+
+internal enum SetupOutputMode
+{
+    Plain,
+    Json,
+}
+
+internal sealed record SetupRunResult(int ExitCode);
+
+internal interface ISetupRunner
+{
+    public Task<SetupRunResult> RunAsync(SetupCommandOptions options, CancellationToken cancellationToken);
+}

--- a/src/Func/Commands/Setup/SetupRenderer.cs
+++ b/src/Func/Commands/Setup/SetupRenderer.cs
@@ -1,0 +1,217 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Azure.Functions.Cli.Console;
+
+namespace Azure.Functions.Cli.Commands.Setup;
+
+internal sealed class SetupRenderer(IInteractionService interaction, SetupOutputMode outputMode)
+{
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private readonly IInteractionService _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
+    private readonly SetupOutputMode _outputMode = outputMode;
+
+    public void SetupStarted(
+        SetupCommandOptions options,
+        SetupFeaturePlan featurePlan,
+        IReadOnlyList<SetupProfileScope> profileScopes)
+    {
+        if (_outputMode == SetupOutputMode.Json)
+        {
+            WriteEvent("setup.started", new Dictionary<string, object?>
+            {
+                ["features"] = featurePlan.Features,
+                ["worker_runtimes"] = featurePlan.WorkerRuntimes,
+                ["profiles"] = profileScopes.Select(scope => scope.Profile?.Name).Where(name => name is not null).ToArray(),
+                ["source"] = options.Source,
+                ["install_policy"] = ToPolicyText(options.InstallPolicy),
+                ["check"] = options.Check,
+                ["prerelease"] = options.IncludePrerelease,
+            });
+            return;
+        }
+
+        _interaction.WriteTitle(options.Check ? "Checking Azure Functions setup" : "Setting up Azure Functions");
+    }
+
+    public void ProfileStarted(SetupProfileScope profileScope)
+    {
+        if (_outputMode == SetupOutputMode.Json)
+        {
+            WriteEvent("profile.started", new Dictionary<string, object?>
+            {
+                ["profile"] = profileScope.Profile?.Name,
+            });
+            return;
+        }
+
+        if (profileScope.Profile is not null)
+        {
+            _interaction.WriteSectionHeader($"Profile {profileScope.Profile.Name}");
+        }
+    }
+
+    public void DependencyDetected(SetupProfileScope profileScope, SetupDependency dependency)
+    {
+        if (_outputMode != SetupOutputMode.Json)
+        {
+            return;
+        }
+
+        WriteEvent("dependency.detected", DependencyPayload(profileScope, dependency));
+    }
+
+    public void DependencyResult(SetupProfileScope profileScope, SetupDependency dependency, SetupDependencyResult result)
+    {
+        if (_outputMode == SetupOutputMode.Json)
+        {
+            Dictionary<string, object?> payload = DependencyPayload(profileScope, dependency);
+            payload["status"] = ToStatusText(result.Status);
+            payload["package_id"] = result.PackageId ?? dependency.ResolvedPackageId ?? dependency.PackageId;
+            payload["version"] = result.Version;
+            payload["message"] = result.Message;
+            WriteEvent("dependency.result", payload);
+            return;
+        }
+
+        switch (result.Status)
+        {
+            case SetupDependencyStatus.Satisfied:
+                _interaction.WriteSuccess(result.Message);
+                break;
+
+            case SetupDependencyStatus.Installed:
+                _interaction.WriteSuccess(result.Message);
+                break;
+
+            case SetupDependencyStatus.SatisfiedFallback:
+                _interaction.WriteWarning(result.Message);
+                break;
+
+            case SetupDependencyStatus.Failed:
+                _interaction.WriteError(result.Message);
+                break;
+        }
+    }
+
+    public void ProfileCompleted(SetupProfileScope profileScope, ProfileSetupOutcome outcome)
+    {
+        if (_outputMode == SetupOutputMode.Json)
+        {
+            WriteEvent("profile.completed", new Dictionary<string, object?>
+            {
+                ["profile"] = profileScope.Profile?.Name,
+                ["success"] = outcome.FailureCount == 0,
+                ["failure_count"] = outcome.FailureCount,
+            });
+        }
+    }
+
+    public void SetupCompleted()
+    {
+        if (_outputMode == SetupOutputMode.Json)
+        {
+            WriteEvent("setup.completed", new Dictionary<string, object?>
+            {
+                ["success"] = true,
+            });
+            return;
+        }
+
+        _interaction.WriteSuccess("Azure Functions setup is complete.");
+    }
+
+    public void SetupFailed(int failureCount)
+    {
+        if (_outputMode == SetupOutputMode.Json)
+        {
+            WriteEvent("setup.failed", new Dictionary<string, object?>
+            {
+                ["failure_count"] = failureCount,
+            });
+            return;
+        }
+
+        _interaction.WriteError(failureCount == 1
+            ? "Azure Functions setup failed with 1 issue."
+            : $"Azure Functions setup failed with {failureCount} issues.");
+    }
+
+    public void SetupFailed(string message)
+    {
+        if (_outputMode == SetupOutputMode.Json)
+        {
+            WriteEvent("setup.failed", new Dictionary<string, object?>
+            {
+                ["message"] = message,
+            });
+            return;
+        }
+
+        _interaction.WriteError(message);
+    }
+
+    public void Warning(string message)
+    {
+        if (_outputMode == SetupOutputMode.Json)
+        {
+            WriteEvent("setup.warning", new Dictionary<string, object?>
+            {
+                ["message"] = message,
+            });
+            return;
+        }
+
+        _interaction.WriteWarning(message);
+    }
+
+    private void WriteEvent(string eventType, Dictionary<string, object?> payload)
+    {
+        payload["type"] = eventType;
+        payload["timestamp"] = DateTimeOffset.UtcNow;
+        _interaction.WriteLine(JsonSerializer.Serialize(payload, _jsonOptions));
+    }
+
+    private static Dictionary<string, object?> DependencyPayload(SetupProfileScope profileScope, SetupDependency dependency)
+        => new()
+        {
+            ["profile"] = profileScope.Profile?.Name,
+            ["dependency_type"] = ToDependencyKindText(dependency.Kind),
+            ["name"] = dependency.Name,
+            ["package_id"] = dependency.ResolvedPackageId ?? dependency.PackageId,
+            ["version_range"] = dependency.RangeText,
+        };
+
+    private static string ToDependencyKindText(SetupDependencyKind kind)
+        => kind switch
+        {
+            SetupDependencyKind.Host => "host",
+            SetupDependencyKind.Worker => "worker",
+            SetupDependencyKind.ExtensionBundle => "extension-bundle",
+            _ => kind.ToString(),
+        };
+
+    private static string ToPolicyText(SetupInstallPolicy policy)
+        => policy switch
+        {
+            SetupInstallPolicy.LatestCompatible => "latest-compatible",
+            SetupInstallPolicy.IfNeeded => "if-needed",
+            _ => policy.ToString(),
+        };
+
+    private static string ToStatusText(SetupDependencyStatus status)
+        => status switch
+        {
+            SetupDependencyStatus.Satisfied => "satisfied",
+            SetupDependencyStatus.Installed => "installed",
+            SetupDependencyStatus.SatisfiedFallback => "satisfied-fallback",
+            SetupDependencyStatus.Failed => "failed",
+            _ => status.ToString(),
+        };
+}

--- a/src/Func/Commands/Setup/SetupRunner.cs
+++ b/src/Func/Commands/Setup/SetupRunner.cs
@@ -1,0 +1,685 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Bundles;
+using Azure.Functions.Cli.Configuration;
+using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Profiles;
+using Azure.Functions.Cli.Workloads;
+using Azure.Functions.Cli.Workloads.Catalog;
+using Azure.Functions.Cli.Workloads.Discovery;
+using Azure.Functions.Cli.Workloads.Install;
+using Azure.Functions.Cli.Workloads.Storage;
+using Microsoft.Extensions.Options;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+
+namespace Azure.Functions.Cli.Commands.Setup;
+
+internal sealed class SetupRunner(
+    IInteractionService interaction,
+    IWorkloadStore workloadStore,
+    IWorkloadCatalog workloadCatalog,
+    IWorkloadInstaller workloadInstaller,
+    IProfileCatalog profileCatalog,
+    IOptionsMonitor<ProjectProfileOptions> projectProfileOptions,
+    IOptionsMonitor<UserProfilePreferenceOptions> userProfilePreferenceOptions,
+    ICliConfigurationProvider configurationProvider,
+    IHostJsonBundleSectionReader hostJsonBundleSectionReader) : ISetupRunner
+{
+    private readonly IInteractionService _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
+    private readonly IWorkloadStore _workloadStore = workloadStore ?? throw new ArgumentNullException(nameof(workloadStore));
+    private readonly IWorkloadCatalog _workloadCatalog = workloadCatalog ?? throw new ArgumentNullException(nameof(workloadCatalog));
+    private readonly IWorkloadInstaller _workloadInstaller = workloadInstaller ?? throw new ArgumentNullException(nameof(workloadInstaller));
+    private readonly IProfileCatalog _profileCatalog = profileCatalog ?? throw new ArgumentNullException(nameof(profileCatalog));
+    private readonly IOptionsMonitor<ProjectProfileOptions> _projectProfileOptions = projectProfileOptions ?? throw new ArgumentNullException(nameof(projectProfileOptions));
+    private readonly IOptionsMonitor<UserProfilePreferenceOptions> _userProfilePreferenceOptions = userProfilePreferenceOptions ?? throw new ArgumentNullException(nameof(userProfilePreferenceOptions));
+    private readonly ICliConfigurationProvider _configurationProvider = configurationProvider ?? throw new ArgumentNullException(nameof(configurationProvider));
+    private readonly IHostJsonBundleSectionReader _hostJsonBundleSectionReader = hostJsonBundleSectionReader ?? throw new ArgumentNullException(nameof(hostJsonBundleSectionReader));
+
+    public async Task<SetupRunResult> RunAsync(SetupCommandOptions options, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var renderer = new SetupRenderer(_interaction, options.OutputMode);
+        try
+        {
+            SetupFeaturePlan featurePlan = ResolveFeatures(options);
+            IReadOnlyList<SetupProfileScope> profileScopes = await ResolveProfileScopesAsync(options, renderer, cancellationToken);
+
+            renderer.SetupStarted(options, featurePlan, profileScopes);
+
+            int failureCount = 0;
+            foreach (SetupProfileScope profileScope in profileScopes)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                renderer.ProfileStarted(profileScope);
+
+                ProfileSetupOutcome outcome = await RunProfileAsync(options, featurePlan, profileScope, renderer, cancellationToken);
+                failureCount += outcome.FailureCount;
+                renderer.ProfileCompleted(profileScope, outcome);
+
+                if (outcome.FailureCount > 0 && !options.Check)
+                {
+                    renderer.SetupFailed(failureCount);
+                    return new SetupRunResult(1);
+                }
+            }
+
+            if (failureCount > 0)
+            {
+                renderer.SetupFailed(failureCount);
+                return new SetupRunResult(1);
+            }
+
+            renderer.SetupCompleted();
+            return new SetupRunResult(0);
+        }
+        catch (SetupConfigurationException ex)
+        {
+            renderer.SetupFailed(ex.Message);
+            return new SetupRunResult(1);
+        }
+        catch (ProfileConfigurationException ex)
+        {
+            renderer.SetupFailed(ex.Message);
+            return new SetupRunResult(1);
+        }
+        catch (ExtensionBundleConfigurationException ex)
+        {
+            renderer.SetupFailed(ex.Message);
+            return new SetupRunResult(1);
+        }
+    }
+
+    private async Task<ProfileSetupOutcome> RunProfileAsync(
+        SetupCommandOptions options,
+        SetupFeaturePlan featurePlan,
+        SetupProfileScope profileScope,
+        SetupRenderer renderer,
+        CancellationToken cancellationToken)
+    {
+        SetupDependencyPlan plan = await BuildDependencyPlanAsync(options.WorkingDirectory, featurePlan, profileScope, cancellationToken);
+        int failures = 0;
+
+        foreach (SetupDependency dependency in plan.Dependencies)
+        {
+            renderer.DependencyDetected(profileScope, dependency);
+            SetupDependencyResult result = await EnsureDependencyAsync(options, dependency, cancellationToken);
+            renderer.DependencyResult(profileScope, dependency, result);
+
+            if (result.Status == SetupDependencyStatus.Failed)
+            {
+                failures++;
+                if (!options.Check)
+                {
+                    return new ProfileSetupOutcome(failures);
+                }
+            }
+        }
+
+        foreach (SetupDependencyResult failure in plan.Failures)
+        {
+            renderer.DependencyResult(profileScope, failure.Dependency, failure);
+            failures++;
+            if (!options.Check)
+            {
+                return new ProfileSetupOutcome(failures);
+            }
+        }
+
+        return new ProfileSetupOutcome(failures);
+    }
+
+    private SetupFeaturePlan ResolveFeatures(SetupCommandOptions options)
+    {
+        IReadOnlyList<string> requestedFeatures = options.Features.Count == 0
+            ? GetDefaultFeatures(options.WorkingDirectory)
+            : options.Features;
+
+        if (requestedFeatures.Count == 0)
+        {
+            throw new SetupConfigurationException("At least one setup feature is required.");
+        }
+
+        HashSet<string> normalizedFeatures = new(StringComparer.OrdinalIgnoreCase);
+        HashSet<string> workerRuntimes = new(StringComparer.OrdinalIgnoreCase);
+        bool includeExtensionBundle = false;
+
+        foreach (string rawFeature in requestedFeatures)
+        {
+            string feature = NormalizeFeature(rawFeature);
+            if (!normalizedFeatures.Add(feature))
+            {
+                continue;
+            }
+
+            switch (feature)
+            {
+                case "host":
+                    break;
+
+                case "runtime":
+                    includeExtensionBundle = true;
+                    break;
+
+                case "dotnet":
+                case ".net":
+                case "dotnet-inprocess":
+                    throw new SetupConfigurationException("The 'dotnet' feature is not supported. Use 'dotnet-isolated'.");
+
+                default:
+                    workerRuntimes.Add(feature);
+                    if (GetBundlePolicy(feature) == SetupBundlePolicy.DefaultStable)
+                    {
+                        includeExtensionBundle = true;
+                    }
+
+                    break;
+            }
+        }
+
+        return new SetupFeaturePlan(
+            [.. normalizedFeatures],
+            [.. workerRuntimes.OrderBy(static runtime => runtime, StringComparer.OrdinalIgnoreCase)],
+            includeExtensionBundle);
+    }
+
+    private IReadOnlyList<string> GetDefaultFeatures(DirectoryInfo workingDirectory)
+    {
+        string? configuredStack = _configurationProvider
+            .GetProjectConfiguration(workingDirectory)
+            [$"{StackOptions.SectionName}:{nameof(StackOptions.Runtime)}"];
+
+        return string.IsNullOrWhiteSpace(configuredStack)
+            ? ["runtime"]
+            : [configuredStack.Trim()];
+    }
+
+    private async Task<IReadOnlyList<SetupProfileScope>> ResolveProfileScopesAsync(
+        SetupCommandOptions options,
+        SetupRenderer renderer,
+        CancellationToken cancellationToken)
+    {
+        string projectDirectory = Path.GetFullPath(options.WorkingDirectory.FullName);
+        ProjectProfileOptions projectOptions = _projectProfileOptions.Get(projectDirectory);
+        IReadOnlyList<string> explicitProfiles = NormalizeDistinct(options.ProfileNames);
+
+        if (explicitProfiles.Count > 0)
+        {
+            IReadOnlyList<ProfileSourceSnapshot> snapshots = await _profileCatalog.LoadAsync(new ProfileSourceContext(options.WorkingDirectory), cancellationToken);
+            List<SetupProfileScope> scopes = [];
+            foreach (string profileName in explicitProfiles)
+            {
+                if (projectOptions.Profiles.Count > 0 && !IsDeclaredProfile(projectOptions, profileName))
+                {
+                    renderer.Warning($"Profile '{profileName}' is not declared in this project's .func/config.json.");
+                }
+
+                scopes.Add(CreateProfileScope(profileName, snapshots, renderer));
+            }
+
+            return scopes;
+        }
+
+        if (projectOptions.Profiles.Count > 0)
+        {
+            IReadOnlyList<ProfileSourceSnapshot> snapshots = await _profileCatalog.LoadAsync(new ProfileSourceContext(options.WorkingDirectory), cancellationToken);
+            return [.. projectOptions.Profiles.Select(profileName => CreateProfileScope(profileName, snapshots, renderer))];
+        }
+
+        string? userDefaultProfile = NullIfWhiteSpace(_userProfilePreferenceOptions.CurrentValue.DefaultProfile);
+        if (userDefaultProfile is not null)
+        {
+            IReadOnlyList<ProfileSourceSnapshot> snapshots = await _profileCatalog.LoadAsync(new ProfileSourceContext(options.WorkingDirectory), cancellationToken);
+            return [CreateProfileScope(userDefaultProfile, snapshots, renderer)];
+        }
+
+        return [SetupProfileScope.Unconstrained];
+    }
+
+    private SetupProfileScope CreateProfileScope(
+        string profileName,
+        IReadOnlyList<ProfileSourceSnapshot> snapshots,
+        SetupRenderer renderer)
+    {
+        ResolvedProfile profile = _profileCatalog.ResolveProfile(profileName, snapshots);
+        if (profile.Status == ProfileStatus.Deprecated)
+        {
+            string suffix = string.IsNullOrWhiteSpace(profile.DeprecationUrl)
+                ? string.Empty
+                : $" See {profile.DeprecationUrl}.";
+            renderer.Warning($"Profile '{profile.Name}' is deprecated.{suffix}");
+        }
+
+        return new SetupProfileScope(profile);
+    }
+
+    private async Task<SetupDependencyPlan> BuildDependencyPlanAsync(
+        DirectoryInfo workingDirectory,
+        SetupFeaturePlan featurePlan,
+        SetupProfileScope profileScope,
+        CancellationToken cancellationToken)
+    {
+        List<SetupDependency> dependencies = [];
+        List<SetupDependencyResult> failures = [];
+
+        dependencies.Add(SetupDependency.Host(profileScope.Profile?.HostVersionRange));
+
+        foreach (string workerRuntime in featurePlan.WorkerRuntimes)
+        {
+            if (profileScope.Profile?.SupportedRuntimes is { } supportedRuntimes
+                && !supportedRuntimes.Any(runtime => string.Equals(runtime, workerRuntime, StringComparison.OrdinalIgnoreCase)))
+            {
+                var dependency = SetupDependency.Worker(workerRuntime, versionRange: null);
+                string message = $"Profile '{profileScope.Profile.Name}' does not support runtime '{workerRuntime}'. "
+                    + $"Supported runtimes: {string.Join(", ", supportedRuntimes)}.";
+                failures.Add(SetupDependencyResult.Failed(dependency, message));
+                continue;
+            }
+
+            VersionRange? workerRange = null;
+            profileScope.Profile?.WorkerVersionRanges.TryGetValue(workerRuntime, out workerRange);
+            dependencies.Add(SetupDependency.Worker(workerRuntime, workerRange));
+        }
+
+        if (featurePlan.IncludeExtensionBundle)
+        {
+            SetupDependencyResult? failure = null;
+            SetupDependency? bundleDependency = await TryCreateBundleDependencyAsync(workingDirectory, profileScope, cancellationToken);
+            if (bundleDependency is null)
+            {
+                var dependency = SetupDependency.Bundle(
+                    InstalledBundleScanner.StableBundleId,
+                    versionRange: null,
+                    rangeText: null);
+                failure = SetupDependencyResult.Failed(
+                    dependency,
+                    "The host.json extensionBundle range and profile extensionBundle range do not overlap.");
+            }
+            else
+            {
+                dependencies.Add(bundleDependency);
+            }
+
+            if (failure is not null)
+            {
+                failures.Add(failure);
+            }
+        }
+
+        return new SetupDependencyPlan(dependencies, failures);
+    }
+
+    private async Task<SetupDependency?> TryCreateBundleDependencyAsync(
+        DirectoryInfo workingDirectory,
+        SetupProfileScope profileScope,
+        CancellationToken cancellationToken)
+    {
+        HostJsonBundleSection? hostJsonBundle = await _hostJsonBundleSectionReader.ReadAsync(workingDirectory, cancellationToken);
+        VersionRange? profileRange = profileScope.Profile?.ExtensionBundleVersionRange;
+        string? profileRangeText = RangeText(profileRange);
+
+        if (hostJsonBundle is null)
+        {
+            return SetupDependency.Bundle(
+                InstalledBundleScanner.StableBundleId,
+                profileRange,
+                profileRangeText);
+        }
+
+        VersionRange? effectiveRange = VersionRangeIntersection.Intersect(hostJsonBundle.Version, profileRangeText);
+        return effectiveRange is null
+            ? null
+            : SetupDependency.Bundle(hostJsonBundle.Id, effectiveRange, RangeText(effectiveRange));
+    }
+
+    private async Task<SetupDependencyResult> EnsureDependencyAsync(
+        SetupCommandOptions options,
+        SetupDependency dependency,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<WorkloadEntry> installed = await _workloadStore.GetWorkloadsAsync(cancellationToken);
+        IReadOnlyList<InstalledCandidate> compatibleInstalled = GetInstalledCandidates(installed, dependency, options.IncludePrerelease)
+            .Where(candidate => dependency.VersionRange is null || dependency.VersionRange.Satisfies(candidate.Version))
+            .OrderByDescending(static candidate => candidate.Version)
+            .ToArray();
+
+        if (options.InstallPolicy == SetupInstallPolicy.IfNeeded && compatibleInstalled.Count > 0)
+        {
+            InstalledCandidate selected = compatibleInstalled[0];
+            return SetupDependencyResult.Satisfied(
+                dependency,
+                selected.Entry.PackageId,
+                selected.Version.ToNormalizedString(),
+                $"{dependency.DisplayName} is already installed.");
+        }
+
+        CatalogResolution resolution = await ResolveLatestFromCatalogAsync(dependency, options.Source, options.IncludePrerelease, cancellationToken);
+        if (resolution.FailureMessage is not null)
+        {
+            if (compatibleInstalled.Count > 0)
+            {
+                InstalledCandidate selected = compatibleInstalled[0];
+                return SetupDependencyResult.SatisfiedFallback(
+                    dependency,
+                    selected.Entry.PackageId,
+                    selected.Version.ToNormalizedString(),
+                    $"{dependency.DisplayName} is satisfied by installed version {selected.Version.ToNormalizedString()} because catalog resolution failed: {resolution.FailureMessage}");
+            }
+
+            return SetupDependencyResult.Failed(dependency, resolution.FailureMessage);
+        }
+
+        ResolvedPackage package = resolution.Package!;
+        dependency = dependency with { ResolvedPackageId = package.PackageId };
+        InstalledCandidate? exactInstalled = GetInstalledCandidates(installed, dependency, options.IncludePrerelease)
+            .FirstOrDefault(candidate => candidate.Version.Equals(package.Version));
+
+        string targetVersion = package.Version.ToNormalizedString();
+        if (exactInstalled is not null)
+        {
+            return SetupDependencyResult.Satisfied(
+                dependency,
+                package.PackageId,
+                targetVersion,
+                $"{dependency.DisplayName} {targetVersion} is already installed.");
+        }
+
+        if (options.Check)
+        {
+            return SetupDependencyResult.Failed(
+                dependency,
+                $"{dependency.DisplayName} {targetVersion} is not installed.");
+        }
+
+        try
+        {
+            WorkloadInstallResult installResult = await _workloadInstaller.InstallFromCatalogAsync(
+                package.PackageId,
+                package.Version,
+                options.Source,
+                includePrerelease: options.IncludePrerelease,
+                exact: true,
+                force: false,
+                progress: null,
+                cancellationToken);
+
+            string installedVersion = installResult.Entry.PackageVersion;
+            return installResult.AlreadyInstalled
+                ? SetupDependencyResult.Satisfied(
+                    dependency,
+                    installResult.Entry.PackageId,
+                    installedVersion,
+                    $"{dependency.DisplayName} {installedVersion} is already installed.")
+                : SetupDependencyResult.Installed(
+                    dependency,
+                    installResult.Entry.PackageId,
+                    installedVersion,
+                    $"Installed {dependency.DisplayName} {installedVersion}.");
+        }
+        catch (WorkloadPackageNotFoundException ex)
+        {
+            return SetupDependencyResult.Failed(dependency, ex.Message);
+        }
+        catch (AmbiguousPackageMatchException ex)
+        {
+            return SetupDependencyResult.Failed(dependency, ex.Message);
+        }
+        catch (InvalidWorkloadException ex)
+        {
+            return SetupDependencyResult.Failed(dependency, ex.Message);
+        }
+        catch (FileNotFoundException ex)
+        {
+            return SetupDependencyResult.Failed(dependency, ex.Message);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return SetupDependencyResult.Failed(dependency, ex.Message);
+        }
+    }
+
+    private async Task<CatalogResolution> ResolveLatestFromCatalogAsync(
+        SetupDependency dependency,
+        string? source,
+        bool includePrerelease,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            ResolvedPackage? package = dependency.VersionRange is null
+                ? await _workloadCatalog.ResolveLatestVersionAsync(
+                    dependency.PackageId,
+                    includePrerelease,
+                    currentVersion: null,
+                    allowMajor: true,
+                    source,
+                    cancellationToken)
+                : await _workloadCatalog.ResolveLatestVersionInRangeAsync(
+                    dependency.PackageId,
+                    dependency.VersionRange,
+                    includePrerelease,
+                    source,
+                    cancellationToken);
+
+            if (package is null)
+            {
+                string range = dependency.RangeText is null ? string.Empty : $" in range '{dependency.RangeText}'";
+                return CatalogResolution.Failed($"No {dependency.DisplayName} workload version{range} is available from the configured workload catalog.");
+            }
+
+            return CatalogResolution.Resolved(package);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex) when (
+            ex is SetupConfigurationException
+            or ArgumentException
+            or InvalidOperationException
+            or IOException
+            or HttpRequestException
+            or FatalProtocolException)
+        {
+            return CatalogResolution.Failed(ex.Message);
+        }
+    }
+
+    private static IReadOnlyList<InstalledCandidate> GetInstalledCandidates(
+        IReadOnlyList<WorkloadEntry> installed,
+        SetupDependency dependency,
+        bool includePrerelease)
+    {
+        List<InstalledCandidate> candidates = [];
+        foreach (WorkloadEntry entry in installed)
+        {
+            if (!MatchesDependency(entry, dependency)
+                || !NuGetVersion.TryParse(entry.PackageVersion, out NuGetVersion? version)
+                || (!includePrerelease && version.IsPrerelease))
+            {
+                continue;
+            }
+
+            candidates.Add(new InstalledCandidate(entry, version));
+        }
+
+        return candidates;
+    }
+
+    private static bool MatchesDependency(WorkloadEntry entry, SetupDependency dependency)
+    {
+        if (dependency.ResolvedPackageId is { } resolvedPackageId
+            && string.Equals(entry.PackageId, resolvedPackageId, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (string.Equals(entry.PackageId, dependency.PackageId, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsDeclaredProfile(ProjectProfileOptions projectOptions, string profile)
+        => projectOptions.Profiles.Any(candidate => string.Equals(candidate, profile, StringComparison.OrdinalIgnoreCase));
+
+    private static IReadOnlyList<string> NormalizeDistinct(IReadOnlyList<string> values)
+    {
+        List<string> result = [];
+        HashSet<string> seen = new(StringComparer.OrdinalIgnoreCase);
+        foreach (string value in values)
+        {
+            string? normalized = NullIfWhiteSpace(value);
+            if (normalized is not null && seen.Add(normalized))
+            {
+                result.Add(normalized);
+            }
+        }
+
+        return result;
+    }
+
+    private static string NormalizeFeature(string value)
+    {
+        string? normalized = NullIfWhiteSpace(value);
+        if (normalized is null)
+        {
+            throw new SetupConfigurationException("Setup feature names cannot be empty.");
+        }
+
+        return normalized.ToLowerInvariant();
+    }
+
+    private static string? NullIfWhiteSpace(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string? RangeText(VersionRange? range)
+        => range is null ? null : range.OriginalString ?? range.ToString();
+
+    private static SetupBundlePolicy GetBundlePolicy(string workerRuntime)
+        => string.Equals(workerRuntime, "dotnet-isolated", StringComparison.OrdinalIgnoreCase)
+            ? SetupBundlePolicy.NotSupported
+            : SetupBundlePolicy.DefaultStable;
+
+    private sealed record CatalogResolution(ResolvedPackage? Package, string? FailureMessage)
+    {
+        public static CatalogResolution Resolved(ResolvedPackage package) => new(package, FailureMessage: null);
+
+        public static CatalogResolution Failed(string failureMessage) => new(Package: null, failureMessage);
+    }
+
+    private sealed record InstalledCandidate(WorkloadEntry Entry, NuGetVersion Version);
+}
+
+internal sealed record SetupFeaturePlan(
+    IReadOnlyList<string> Features,
+    IReadOnlyList<string> WorkerRuntimes,
+    bool IncludeExtensionBundle);
+
+internal sealed record SetupProfileScope(ResolvedProfile? Profile)
+{
+    public static SetupProfileScope Unconstrained { get; } = new(Profile: null);
+
+    public string Name => Profile?.Name ?? "unconstrained";
+}
+
+internal sealed record SetupDependencyPlan(
+    IReadOnlyList<SetupDependency> Dependencies,
+    IReadOnlyList<SetupDependencyResult> Failures);
+
+internal sealed record SetupDependency(
+    SetupDependencyKind Kind,
+    string Name,
+    string DisplayName,
+    string PackageId,
+    VersionRange? VersionRange,
+    string? RangeText,
+    string? ResolvedPackageId)
+{
+    private const string WorkerPackagePrefix = "Azure.Functions.Cli.Workloads.Workers.";
+
+    public static SetupDependency Host(VersionRange? versionRange)
+        => new(
+            SetupDependencyKind.Host,
+            "host",
+            "host",
+            HostWorkloadPackage.CurrentPackageId,
+            versionRange,
+            SetupRunnerRangeText(versionRange),
+            ResolvedPackageId: null);
+
+    public static SetupDependency Worker(string runtime, VersionRange? versionRange)
+        => new(
+            SetupDependencyKind.Worker,
+            runtime,
+            $"{runtime} worker",
+            SetupRunnerWorkerPackageId(runtime),
+            versionRange,
+            SetupRunnerRangeText(versionRange),
+            ResolvedPackageId: null);
+
+    public static SetupDependency Bundle(string bundleId, VersionRange? versionRange, string? rangeText)
+        => new(
+            SetupDependencyKind.ExtensionBundle,
+            bundleId,
+            $"extension bundle {bundleId}",
+            IInstalledBundleWorkloads.BundleWorkloadPackageId,
+            versionRange,
+            rangeText,
+            ResolvedPackageId: null);
+
+    private static string SetupRunnerWorkerPackageId(string runtime) => WorkerPackagePrefix + runtime;
+
+    private static string? SetupRunnerRangeText(VersionRange? range)
+        => range is null ? null : range.OriginalString ?? range.ToString();
+
+}
+
+internal enum SetupDependencyKind
+{
+    Host,
+    Worker,
+    ExtensionBundle,
+}
+
+internal enum SetupDependencyStatus
+{
+    Satisfied,
+    Installed,
+    SatisfiedFallback,
+    Failed,
+}
+
+internal sealed record SetupDependencyResult(
+    SetupDependency Dependency,
+    SetupDependencyStatus Status,
+    string? PackageId,
+    string? Version,
+    string Message)
+{
+    public static SetupDependencyResult Satisfied(SetupDependency dependency, string packageId, string version, string message)
+        => new(dependency, SetupDependencyStatus.Satisfied, packageId, version, message);
+
+    public static SetupDependencyResult Installed(SetupDependency dependency, string packageId, string version, string message)
+        => new(dependency, SetupDependencyStatus.Installed, packageId, version, message);
+
+    public static SetupDependencyResult SatisfiedFallback(SetupDependency dependency, string packageId, string version, string message)
+        => new(dependency, SetupDependencyStatus.SatisfiedFallback, packageId, version, message);
+
+    public static SetupDependencyResult Failed(SetupDependency dependency, string message)
+        => new(dependency, SetupDependencyStatus.Failed, dependency.PackageId, Version: null, message);
+}
+
+internal sealed record ProfileSetupOutcome(int FailureCount);
+
+internal enum SetupBundlePolicy
+{
+    NotSupported,
+    DefaultStable,
+}
+
+internal sealed class SetupConfigurationException(string message) : Exception(message);

--- a/src/Func/Commands/Start/Initialization/HostWorkloads/DefaultHostWorkloadResolver.cs
+++ b/src/Func/Commands/Start/Initialization/HostWorkloads/DefaultHostWorkloadResolver.cs
@@ -16,9 +16,6 @@ internal sealed class DefaultHostWorkloadResolver(
     IWorkloadProvider workloadProvider,
     IWorkloadCatalog workloadCatalog) : IHostWorkloadResolver
 {
-    private const string HostAlias = "host";
-    private const int AliasSearchTake = 50;
-
     private readonly IWorkloadProvider _workloadProvider = workloadProvider ?? throw new ArgumentNullException(nameof(workloadProvider));
     private readonly IWorkloadCatalog _workloadCatalog = workloadCatalog ?? throw new ArgumentNullException(nameof(workloadCatalog));
 
@@ -94,7 +91,7 @@ internal sealed class DefaultHostWorkloadResolver(
         List<InstalledHostCandidate> candidates = [];
         foreach (ContentWorkloadInfo workload in _workloadProvider.GetContentWorkloads())
         {
-            if (!workload.Aliases.Any(static alias => string.Equals(alias, HostAlias, StringComparison.OrdinalIgnoreCase))
+            if (!string.Equals(workload.PackageId, HostWorkloadPackage.CurrentPackageId, StringComparison.OrdinalIgnoreCase)
                 || !NuGetVersion.TryParse(workload.PackageVersion, out NuGetVersion? version))
             {
                 continue;
@@ -115,7 +112,7 @@ internal sealed class DefaultHostWorkloadResolver(
         VersionRange? range,
         CancellationToken cancellationToken)
     {
-        string packageId = await ResolveHostPackageIdAsync(cancellationToken);
+        string packageId = HostWorkloadPackage.CurrentPackageId;
         ResolvedPackage? package = range is null
             ? await _workloadCatalog.ResolveLatestVersionAsync(
                 packageId, includePrerelease: false, currentVersion: null, allowMajor: true, source: null, cancellationToken)
@@ -133,38 +130,6 @@ internal sealed class DefaultHostWorkloadResolver(
         throw new HostWorkloadResolutionException(message);
     }
 
-    private async Task<string> ResolveHostPackageIdAsync(CancellationToken cancellationToken)
-    {
-        var query = new CatalogSearchQuery
-        {
-            Filter = HostAlias,
-            IncludePrerelease = false,
-            Take = AliasSearchTake,
-        };
-
-        IReadOnlyList<CatalogSearchResult> hits = await _workloadCatalog.SearchAsync(query, cancellationToken);
-        IReadOnlyList<string> matchedIds = FilterByAlias(hits, HostAlias);
-
-        if (matchedIds.Count == 0)
-        {
-            IReadOnlyList<CatalogSearchResult> all = await _workloadCatalog.SearchAsync(query with { Filter = null }, cancellationToken);
-            matchedIds = FilterByAlias(all, HostAlias);
-        }
-
-        if (matchedIds.Count == 0)
-        {
-            throw new HostWorkloadResolutionException("No host workload package was found in the configured workload catalog.");
-        }
-
-        if (matchedIds.Count > 1)
-        {
-            string matches = string.Join(", ", matchedIds);
-            throw new HostWorkloadResolutionException($"Multiple host workload packages were found: {matches}.");
-        }
-
-        return matchedIds[0];
-    }
-
     private static HostWorkloadResolution CreateOfflineInstallRequired(VersionRange? range)
     {
         string version = range is null ? "latest" : RangeText(range);
@@ -174,12 +139,6 @@ internal sealed class DefaultHostWorkloadResolver(
 
         return new HostWorkloadResolution.InstallRequired(version, message);
     }
-
-    private static IReadOnlyList<string> FilterByAlias(IReadOnlyList<CatalogSearchResult> hits, string alias)
-        => [.. hits
-            .Where(result => result.Aliases.Any(candidate => string.Equals(candidate, alias, StringComparison.OrdinalIgnoreCase)))
-            .Select(result => result.PackageId)
-            .Distinct(StringComparer.OrdinalIgnoreCase)];
 
     private static bool VersionEquals(NuGetVersion left, NuGetVersion right)
         => left.Equals(right);

--- a/src/Func/Commands/Start/Initialization/Steps/InstallHostWorkloadInitializationStep.cs
+++ b/src/Func/Commands/Start/Initialization/Steps/InstallHostWorkloadInitializationStep.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Workloads;
 using Azure.Functions.Cli.Workloads.Catalog;
 using Azure.Functions.Cli.Workloads.Discovery;
 using Azure.Functions.Cli.Workloads.Install;
@@ -17,8 +18,6 @@ internal sealed class InstallHostWorkloadInitializationStep(
     string hostVersion) : DemoInitializationStep
 {
     public const string StepId = "install_host_workload";
-
-    private const string HostAlias = "host";
 
     private readonly IWorkloadInstaller _installer = installer ?? throw new ArgumentNullException(nameof(installer));
 
@@ -46,11 +45,11 @@ internal sealed class InstallHostWorkloadInitializationStep(
         try
         {
             result = await _installer.InstallFromCatalogAsync(
-                HostAlias,
+                HostWorkloadPackage.CurrentPackageId,
                 _hostVersion,
                 source: null,
                 includePrerelease: false,
-                exact: false,
+                exact: true,
                 force: false,
                 progress: null,
                 cancellationToken);
@@ -73,7 +72,7 @@ internal sealed class InstallHostWorkloadInitializationStep(
         }
         catch (InvalidOperationException ex)
         {
-            string message = $"{ex.Message} Run 'func workload install {HostAlias} --force' to repair the install.";
+            string message = $"{ex.Message} Run 'func workload install {HostWorkloadPackage.CurrentPackageId} --exact --force' to repair the install.";
             throw new GracefulException(message, isUserError: true, verboseMessage: ex.ToString());
         }
 

--- a/src/Func/Hosting/BuiltInCommands.cs
+++ b/src/Func/Hosting/BuiltInCommands.cs
@@ -3,6 +3,7 @@
 
 using Azure.Functions.Cli.Commands;
 using Azure.Functions.Cli.Commands.Profile;
+using Azure.Functions.Cli.Commands.Setup;
 using Azure.Functions.Cli.Commands.Start.Initialization;
 using Azure.Functions.Cli.Commands.Workload;
 using Azure.Functions.Cli.Common;
@@ -40,6 +41,10 @@ internal static class BuiltInCommands
         services.AddSingleton<ProfileListCommand>();
         services.AddSingleton<ProfileShowCommand>();
         services.AddSingleton<FuncCliCommand, ProfileCommand>();
+
+        // Setup command and dependencies
+        services.AddSingleton<ISetupRunner, SetupRunner>();
+        services.AddSingleton<FuncCliCommand, SetupCommand>();
 
         // Shared dashboard primitives (renderers and per-invocation pipeline
         // are constructed inline by StartCommand so cancellation flows

--- a/src/Func/Workloads/HostWorkloadPackage.cs
+++ b/src/Func/Workloads/HostWorkloadPackage.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Runtime.InteropServices;
+
+namespace Azure.Functions.Cli.Workloads;
+
+internal static class HostWorkloadPackage
+{
+    private const string PackageIdPrefix = "Azure.Functions.Cli.Workloads.Host.";
+
+    public static string CurrentPackageId => FromRuntimeIdentifier(CurrentRuntimeIdentifier);
+
+    public static string CurrentRuntimeIdentifier
+    {
+        get
+        {
+            string runtimeIdentifier = RuntimeInformation.RuntimeIdentifier;
+            if (string.IsNullOrWhiteSpace(runtimeIdentifier))
+            {
+                throw new InvalidOperationException("Unable to determine the current runtime identifier for the host workload package.");
+            }
+
+            return runtimeIdentifier.Trim();
+        }
+    }
+
+    public static string FromRuntimeIdentifier(string runtimeIdentifier)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(runtimeIdentifier);
+        return PackageIdPrefix + runtimeIdentifier.Trim().ToLowerInvariant();
+    }
+}

--- a/test/Func.Tests/Commands/HostWorkloadResolverTests.cs
+++ b/test/Func.Tests/Commands/HostWorkloadResolverTests.cs
@@ -18,6 +18,8 @@ namespace Azure.Functions.Cli.Tests.Commands;
 
 public class HostWorkloadResolverTests
 {
+    private static readonly string _hostPackageId = HostWorkloadPackage.CurrentPackageId;
+
     private readonly IWorkloadProvider _workloadProvider = Substitute.For<IWorkloadProvider>();
     private readonly IWorkloadCatalog _workloadCatalog = Substitute.For<IWorkloadCatalog>();
     private readonly PackageSource _source = new("https://example.test/v3/index.json", "test");
@@ -25,8 +27,6 @@ public class HostWorkloadResolverTests
     public HostWorkloadResolverTests()
     {
         _workloadProvider.GetContentWorkloads().Returns([]);
-        _workloadCatalog.SearchAsync(Arg.Any<CatalogSearchQuery>(), Arg.Any<CancellationToken>())
-            .Returns([CreateCatalogResult("Azure.Functions.Cli.Workloads.Host", "5.0.0")]);
     }
 
     [Fact]
@@ -51,17 +51,18 @@ public class HostWorkloadResolverTests
     }
 
     [Fact]
-    public async Task ResolveAsync_UsesHostAliasInsteadOfFixedPackageId()
+    public async Task ResolveAsync_IgnoresHostAliasOnDifferentPackageId()
     {
-        ContentWorkloadInfo host = CreateHostWorkload("4.1000.0", packageId: "custom.host.package");
-        UseContentWorkloads(host);
+        ContentWorkloadInfo wrongRidHost = CreateHostWorkload("4.1000.0", packageId: "custom.host.package");
+        ContentWorkloadInfo selectedHost = CreateHostWorkload("4.900.0", packageId: _hostPackageId);
+        UseContentWorkloads(wrongRidHost, selectedHost);
         DefaultHostWorkloadResolver resolver = NewResolver();
         var context = new HostWorkloadResolutionContext(null, VersionRange.Parse("[4.0.0, 5.0.0)"), Offline: false);
 
         HostWorkloadResolution result = await resolver.ResolveAsync(context, CancellationToken.None);
 
         HostWorkloadResolution.Installed installed = Assert.IsType<HostWorkloadResolution.Installed>(result);
-        Assert.Same(host, installed.Workload);
+        Assert.Same(selectedHost, installed.Workload);
     }
 
     [Fact]
@@ -100,9 +101,9 @@ public class HostWorkloadResolverTests
     [Fact]
     public async Task ResolveAsync_NoInstalledHost_ReturnsInstallRequired()
     {
-        ResolvedPackage resolved = CreateResolvedPackage("Azure.Functions.Cli.Workloads.Host", "4.1048.199");
+        ResolvedPackage resolved = CreateResolvedPackage(_hostPackageId, "4.1048.199");
         _workloadCatalog.ResolveLatestVersionInRangeAsync(
-                "Azure.Functions.Cli.Workloads.Host",
+                _hostPackageId,
                 Arg.Any<VersionRange>(),
                 false,
                 null,
@@ -198,11 +199,11 @@ public class HostWorkloadResolverTests
         Assert.Equal("Installed host 4.1000.0", result.Message);
         Assert.Equal("4.1000.0", context.State.HostVersion);
         await installer.Received(1).InstallFromCatalogAsync(
-            packageId: "host",
+            packageId: _hostPackageId,
             version: Arg.Is<NuGetVersion?>(version => version != null && version.ToNormalizedString() == "4.1000.0"),
             source: null,
             includePrerelease: false,
-            exact: false,
+            exact: true,
             force: false,
             progress: null,
             cancellationToken: Arg.Any<CancellationToken>());
@@ -238,14 +239,12 @@ public class HostWorkloadResolverTests
     private DefaultHostWorkloadResolver NewResolver()
         => new(_workloadProvider, _workloadCatalog);
 
-    private CatalogSearchResult CreateCatalogResult(string packageId, string packageVersion)
-        => new(packageId, NuGetVersion.Parse(packageVersion), Title: null, Description: null, Aliases: ["host"], _source);
-
     private ResolvedPackage CreateResolvedPackage(string packageId, string packageVersion)
         => new(packageId, NuGetVersion.Parse(packageVersion), _source);
 
-    private static ContentWorkloadInfo CreateHostWorkload(string packageVersion, string packageId = "Azure.Functions.Cli.Workloads.Host")
+    private static ContentWorkloadInfo CreateHostWorkload(string packageVersion, string? packageId = null)
     {
+        packageId ??= _hostPackageId;
         string installDirectory = Path.Combine(Path.GetTempPath(), "workloads", packageId, packageVersion);
         return new ContentWorkloadInfo(
             packageId,
@@ -260,7 +259,7 @@ public class HostWorkloadResolverTests
     private static WorkloadEntry CreateHostEntry(string packageVersion)
         => new()
         {
-            PackageId = "Azure.Functions.Cli.Workloads.Host",
+            PackageId = _hostPackageId,
             PackageVersion = packageVersion,
             Kind = WorkloadKind.Content,
             Aliases = ["host"],

--- a/test/Func.Tests/Commands/Setup/SetupCommandTests.cs
+++ b/test/Func.Tests/Commands/Setup/SetupCommandTests.cs
@@ -1,0 +1,108 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using Azure.Functions.Cli;
+using Azure.Functions.Cli.Commands;
+using Azure.Functions.Cli.Commands.Setup;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Commands.Setup;
+
+public sealed class SetupCommandTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly TestInteractionService _interaction = new();
+
+    public SetupCommandTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"func-setup-command-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SetupCommand_HasExpectedOptions()
+    {
+        var cmd = new SetupCommand(Substitute.For<ISetupRunner>());
+        IReadOnlyList<string> optionNames = cmd.Options.Select(o => o.Name).ToArray();
+
+        Assert.Contains("--features", optionNames);
+        Assert.Contains("--profile", optionNames);
+        Assert.Contains("--profiles", optionNames);
+        Assert.Contains("--install-policy", optionNames);
+        Assert.Contains("--source", optionNames);
+        Assert.Contains("--prerelease", optionNames);
+        Assert.Contains("--non-interactive", optionNames);
+        Assert.Contains("--yes", optionNames);
+        Assert.Contains("--check", optionNames);
+        Assert.Contains("--output", optionNames);
+    }
+
+    [Fact]
+    public void SetupCommand_RegisteredInParser()
+    {
+        var root = TestParser.CreateRoot(_interaction);
+
+        Assert.Contains(root.Subcommands, command => command.Name == "setup");
+    }
+
+    [Fact]
+    public async Task SetupCommand_InvokesRunnerWithParsedOptions()
+    {
+        ISetupRunner setupRunner = Substitute.For<ISetupRunner>();
+        setupRunner.RunAsync(Arg.Any<SetupCommandOptions>(), Arg.Any<CancellationToken>())
+            .Returns(new SetupRunResult(0));
+
+        IServiceProvider services = TestParser.BuildServiceProviderWith(_interaction, serviceCollection =>
+        {
+            serviceCollection.AddSingleton(setupRunner);
+        });
+        FuncRootCommand root = Parser.CreateCommand(services);
+        ParseResult result = root.Parse(
+            $"setup \"{_tempDir}\" --features node,python --profile flex --profile premium --profiles staging,prod "
+            + "--source https://example.test/v3/index.json --install-policy if-needed --prerelease --non-interactive --yes --check --output json");
+
+        int exitCode = await result.InvokeAsync(new InvocationConfiguration { EnableDefaultExceptionHandler = false });
+
+        Assert.Equal(0, exitCode);
+        await setupRunner.Received(1).RunAsync(
+            Arg.Is<SetupCommandOptions>(options =>
+                options.WorkingDirectory.FullName == new DirectoryInfo(_tempDir).FullName
+                && options.Features.SequenceEqual(new[] { "node", "python" })
+                && options.ProfileNames.SequenceEqual(new[] { "flex", "premium", "staging", "prod" })
+                && options.Source == "https://example.test/v3/index.json"
+                && options.InstallPolicy == SetupInstallPolicy.IfNeeded
+                && options.IncludePrerelease
+                && options.NonInteractive
+                && options.AssumeYes
+                && options.Check
+                && options.OutputMode == SetupOutputMode.Json),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SetupCommand_InvalidInstallPolicy_ThrowsGracefulException()
+    {
+        var root = TestParser.CreateRoot(_interaction);
+        ParseResult result = root.Parse($"setup \"{_tempDir}\" --install-policy always");
+
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => result.InvokeAsync(new InvocationConfiguration { EnableDefaultExceptionHandler = false }));
+
+        Assert.Contains("--install-policy", ex.Message);
+        Assert.Contains("always", ex.Message);
+    }
+}

--- a/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
+++ b/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
@@ -1,0 +1,466 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Text.Json;
+using Azure.Functions.Cli.Bundles;
+using Azure.Functions.Cli.Commands.Setup;
+using Azure.Functions.Cli.Configuration;
+using Azure.Functions.Cli.Profiles;
+using Azure.Functions.Cli.Workloads;
+using Azure.Functions.Cli.Workloads.Catalog;
+using Azure.Functions.Cli.Workloads.Install;
+using Azure.Functions.Cli.Workloads.Storage;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NuGet.Configuration;
+using NuGet.Versioning;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Commands.Setup;
+
+public sealed class SetupRunnerTests : IDisposable
+{
+    private static readonly string _hostPackageId = HostWorkloadPackage.CurrentPackageId;
+
+    private readonly string _tempDir;
+    private readonly TestInteractionService _interaction = new();
+    private readonly IWorkloadStore _store = Substitute.For<IWorkloadStore>();
+    private readonly IWorkloadInstaller _installer = Substitute.For<IWorkloadInstaller>();
+    private readonly IProfileCatalog _profileCatalog = Substitute.For<IProfileCatalog>();
+    private readonly IHostJsonBundleSectionReader _bundleReader = Substitute.For<IHostJsonBundleSectionReader>();
+
+    public SetupRunnerTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"func-setup-runner-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns([]);
+        _bundleReader.ReadAsync(Arg.Any<DirectoryInfo>(), Arg.Any<CancellationToken>())
+            .Returns((HostJsonBundleSection?)null);
+        _installer.InstallFromCatalogAsync(
+                Arg.Any<string>(),
+                Arg.Any<NuGetVersion?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                string packageId = (string)callInfo[0]!;
+                var version = (NuGetVersion)callInfo[1]!;
+                return new WorkloadInstallResult(Entry(packageId, version.ToNormalizedString()), AlreadyInstalled: false);
+            });
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_DefaultsToRuntime_InstallsHostAndBundle()
+    {
+        FakeCatalog catalog = Catalog()
+            .WithLatest(_hostPackageId, "4.1.0")
+            .WithLatest(IInstalledBundleWorkloads.BundleWorkloadPackageId, "4.10.0");
+        SetupRunner runner = CreateRunner(catalog);
+
+        SetupRunResult result = await runner.RunAsync(Options(), CancellationToken.None);
+
+        Assert.Equal(0, result.ExitCode);
+        await _installer.Received(1).InstallFromCatalogAsync(
+            Arg.Is<string>(id => string.Equals(id, _hostPackageId, StringComparison.OrdinalIgnoreCase)),
+            Arg.Is<NuGetVersion>(version => version.ToNormalizedString() == "4.1.0"),
+            Arg.Any<string?>(),
+            Arg.Is(false),
+            Arg.Is(true),
+            Arg.Is(false),
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+        await _installer.Received(1).InstallFromCatalogAsync(
+            Arg.Is<string>(id => string.Equals(id, IInstalledBundleWorkloads.BundleWorkloadPackageId, StringComparison.OrdinalIgnoreCase)),
+            Arg.Is<NuGetVersion>(version => version.ToNormalizedString() == "4.10.0"),
+            Arg.Any<string?>(),
+            Arg.Is(false),
+            Arg.Is(true),
+            Arg.Is(false),
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunAsync_ConfiguredDotnetIsolated_InstallsWorkerAndSkipsBundle()
+    {
+        string workerPackageId = WorkerPackage("dotnet-isolated");
+        FakeCatalog catalog = Catalog()
+            .WithLatest(_hostPackageId, "4.1.0")
+            .WithLatest(workerPackageId, "1.2.3");
+        SetupRunner runner = CreateRunner(catalog, projectConfig: new Dictionary<string, string?>
+        {
+            [$"{StackOptions.SectionName}:{nameof(StackOptions.Runtime)}"] = "dotnet-isolated",
+        });
+
+        SetupRunResult result = await runner.RunAsync(Options(), CancellationToken.None);
+
+        Assert.Equal(0, result.ExitCode);
+        await _installer.Received(1).InstallFromCatalogAsync(
+            Arg.Is<string>(id => string.Equals(id, workerPackageId, StringComparison.OrdinalIgnoreCase)),
+            Arg.Is<NuGetVersion>(version => version.ToNormalizedString() == "1.2.3"),
+            Arg.Any<string?>(),
+            Arg.Is(false),
+            Arg.Is(true),
+            Arg.Is(false),
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+        await _installer.DidNotReceive().InstallFromCatalogAsync(
+            Arg.Is<string>(id => id.Contains("ExtensionBundles", StringComparison.OrdinalIgnoreCase)),
+            Arg.Any<NuGetVersion?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunAsync_Source_PassesSourceToCatalogAndInstaller()
+    {
+        const string source = "https://example.test/custom/index.json";
+        FakeCatalog catalog = Catalog().WithLatest(_hostPackageId, "4.1.0");
+        SetupRunner runner = CreateRunner(catalog);
+
+        SetupRunResult result = await runner.RunAsync(Options(features: ["host"], source: source), CancellationToken.None);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(catalog.SearchSources);
+        Assert.NotEmpty(catalog.ResolveSources);
+        Assert.All(catalog.ResolveSources, actual => Assert.Equal(source, actual));
+        await _installer.Received(1).InstallFromCatalogAsync(
+            Arg.Is<string>(id => string.Equals(id, _hostPackageId, StringComparison.OrdinalIgnoreCase)),
+            Arg.Is<NuGetVersion>(version => version.ToNormalizedString() == "4.1.0"),
+            Arg.Is<string?>(actual => actual == source),
+            Arg.Is(false),
+            Arg.Is(true),
+            Arg.Is(false),
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunAsync_HostFeature_UsesRidPackageIdWithoutAliasSearch()
+    {
+        FakeCatalog catalog = Catalog()
+            .WithAlias("host", "rogue.host.package", "9.9.9")
+            .WithLatest(_hostPackageId, "4.1.0");
+        SetupRunner runner = CreateRunner(catalog);
+
+        SetupRunResult result = await runner.RunAsync(Options(features: ["host"]), CancellationToken.None);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(catalog.SearchSources);
+        await _installer.Received(1).InstallFromCatalogAsync(
+            Arg.Is<string>(id => string.Equals(id, _hostPackageId, StringComparison.OrdinalIgnoreCase)),
+            Arg.Is<NuGetVersion>(version => version.ToNormalizedString() == "4.1.0"),
+            Arg.Any<string?>(),
+            Arg.Is(false),
+            Arg.Is(true),
+            Arg.Is(false),
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunAsync_IfNeeded_SkipsCatalogWhenCompatibleVersionInstalled()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>())
+            .Returns([Entry(_hostPackageId, "4.0.0", aliases: ["host"], kind: WorkloadKind.Content)]);
+        FakeCatalog catalog = Catalog();
+        SetupRunner runner = CreateRunner(catalog);
+
+        SetupRunResult result = await runner.RunAsync(Options(features: ["host"], installPolicy: SetupInstallPolicy.IfNeeded), CancellationToken.None);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(0, catalog.ResolveLatestCallCount);
+        await _installer.DidNotReceive().InstallFromCatalogAsync(
+            Arg.Any<string>(),
+            Arg.Any<NuGetVersion?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunAsync_LatestCompatibleCheck_FailsWhenLatestCompatibleIsMissing()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>())
+            .Returns([Entry(_hostPackageId, "4.0.0", aliases: ["host"], kind: WorkloadKind.Content)]);
+        FakeCatalog catalog = Catalog().WithLatest(_hostPackageId, "4.1.0");
+        SetupRunner runner = CreateRunner(catalog);
+
+        SetupRunResult result = await runner.RunAsync(Options(features: ["host"], check: true), CancellationToken.None);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains(_interaction.Lines, line => line.Contains("4.1.0") && line.Contains("not installed"));
+        await _installer.DidNotReceive().InstallFromCatalogAsync(
+            Arg.Any<string>(),
+            Arg.Any<NuGetVersion?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunAsync_JsonOutput_WritesNdjsonEvents()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>())
+            .Returns([Entry(_hostPackageId, "4.0.0", aliases: ["host"], kind: WorkloadKind.Content)]);
+        SetupRunner runner = CreateRunner(Catalog());
+
+        SetupRunResult result = await runner.RunAsync(
+            Options(
+                features: ["host"],
+                installPolicy: SetupInstallPolicy.IfNeeded,
+                check: true,
+                outputMode: SetupOutputMode.Json),
+            CancellationToken.None);
+
+        Assert.Equal(0, result.ExitCode);
+        string[] eventTypes = [.. _interaction.Lines
+            .Select(line => JsonDocument.Parse(line).RootElement.GetProperty("type").GetString()!)
+        ];
+
+        Assert.Equal(
+            ["setup.started", "profile.started", "dependency.detected", "dependency.result", "profile.completed", "setup.completed"],
+            eventTypes);
+    }
+
+    [Fact]
+    public async Task RunAsync_ProfileUnsupportedWorker_Fails()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>())
+            .Returns([
+                Entry(_hostPackageId, "4.0.0", aliases: ["host"], kind: WorkloadKind.Content),
+                Entry(IInstalledBundleWorkloads.BundleWorkloadPackageId, "4.0.0", kind: WorkloadKind.Content),
+            ]);
+        SetupRunner runner = CreateRunner(
+            Catalog(),
+            profileCatalog: new ProfileCatalog([
+                new FakeProfileSource(new ProfileSourceInfo(ProfileSourceKind.BuiltIn, "built-in"), [
+                    new("flex", new ProfileDefinition
+                    {
+                        Host = new ProfileVersionConstraint { Version = "[4.0.0, 5.0.0)" },
+                        ExtensionBundle = new ProfileVersionConstraint { Version = "[4.0.0, 5.0.0)" },
+                        SupportedRuntimes = ["python"],
+                    }),
+                ]),
+            ]));
+
+        SetupRunResult result = await runner.RunAsync(
+            Options(
+                features: ["node"],
+                profiles: ["flex"],
+                installPolicy: SetupInstallPolicy.IfNeeded,
+                check: true),
+            CancellationToken.None);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains(_interaction.Lines, line => line.Contains("does not support runtime 'node'"));
+    }
+
+    private SetupRunner CreateRunner(
+        IWorkloadCatalog catalog,
+        IReadOnlyDictionary<string, string?>? projectConfig = null,
+        IProfileCatalog? profileCatalog = null)
+        => new(
+            _interaction,
+            _store,
+            catalog,
+            _installer,
+            profileCatalog ?? _profileCatalog,
+            new TestOptionsMonitor<ProjectProfileOptions>(new ProjectProfileOptions()),
+            new TestOptionsMonitor<UserProfilePreferenceOptions>(new UserProfilePreferenceOptions()),
+            new FakeCliConfigurationProvider(projectConfig ?? new Dictionary<string, string?>()),
+            _bundleReader);
+
+    private SetupCommandOptions Options(
+        IReadOnlyList<string>? features = null,
+        IReadOnlyList<string>? profiles = null,
+        string? source = null,
+        SetupInstallPolicy installPolicy = SetupInstallPolicy.LatestCompatible,
+        bool check = false,
+        SetupOutputMode outputMode = SetupOutputMode.Plain)
+        => new(
+            new DirectoryInfo(_tempDir),
+            features ?? [],
+            profiles ?? [],
+            source,
+            installPolicy,
+            IncludePrerelease: false,
+            NonInteractive: true,
+            AssumeYes: true,
+            check,
+            outputMode);
+
+    private static FakeCatalog Catalog() => new();
+
+    private static string WorkerPackage(string runtime)
+        => "Azure.Functions.Cli.Workloads.Workers." + runtime;
+
+    private static WorkloadEntry Entry(
+        string packageId,
+        string version,
+        IReadOnlyList<string>? aliases = null,
+        WorkloadKind kind = WorkloadKind.Workload)
+        => new()
+        {
+            PackageId = packageId.ToLowerInvariant(),
+            PackageVersion = version,
+            Aliases = aliases ?? [],
+            Kind = kind,
+        };
+
+    private sealed class FakeCatalog : IWorkloadCatalog
+    {
+        private readonly PackageSource _source = new("https://example.test/v3/index.json");
+        private readonly Dictionary<string, CatalogSearchResult> _aliases = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, NuGetVersion> _latest = new(StringComparer.OrdinalIgnoreCase);
+
+        public int ResolveLatestCallCount { get; private set; }
+
+        public List<string?> SearchSources { get; } = [];
+
+        public List<string?> ResolveSources { get; } = [];
+
+        public FakeCatalog WithAlias(string alias, string packageId, string version)
+        {
+            var parsed = NuGetVersion.Parse(version);
+            var result = new CatalogSearchResult(
+                packageId.ToLowerInvariant(),
+                parsed,
+                Title: packageId,
+                Description: null,
+                Aliases: [alias],
+                _source);
+            _aliases[alias] = result;
+            _latest[packageId] = parsed;
+            return this;
+        }
+
+        public FakeCatalog WithLatest(string packageId, string version)
+        {
+            _latest[packageId] = NuGetVersion.Parse(version);
+            return this;
+        }
+
+        public Task<IReadOnlyList<CatalogSearchResult>> SearchAsync(CatalogSearchQuery query, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            SearchSources.Add(query.Source);
+            if (!string.IsNullOrWhiteSpace(query.Filter) && _aliases.TryGetValue(query.Filter, out CatalogSearchResult? result))
+            {
+                return Task.FromResult<IReadOnlyList<CatalogSearchResult>>([result]);
+            }
+
+            return Task.FromResult<IReadOnlyList<CatalogSearchResult>>([.. _aliases.Values]);
+        }
+
+        public Task<ResolvedPackage?> ResolveLatestVersionAsync(
+            string packageId,
+            bool includePrerelease,
+            NuGetVersion? currentVersion = null,
+            bool allowMajor = true,
+            string? source = null,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ResolveLatestCallCount++;
+            ResolveSources.Add(source);
+            return Task.FromResult(CreateResolved(packageId, _latest.TryGetValue(packageId, out NuGetVersion? version) ? version : null));
+        }
+
+        public Task<ResolvedPackage?> ResolveLatestVersionInRangeAsync(
+            string packageId,
+            VersionRange versionRange,
+            bool includePrerelease,
+            string? source = null,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ResolveLatestCallCount++;
+            ResolveSources.Add(source);
+            NuGetVersion? version = _latest.TryGetValue(packageId, out NuGetVersion? candidate) && versionRange.Satisfies(candidate)
+                ? candidate
+                : null;
+            return Task.FromResult(CreateResolved(packageId, version));
+        }
+
+        public Task<ResolvedPackage?> ResolveVersionAsync(
+            string packageId,
+            NuGetVersion version,
+            string? source = null,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(CreateResolved(packageId, version));
+        }
+
+        public Task<Stream> DownloadAsync(ResolvedPackage package, CancellationToken cancellationToken = default)
+            => Task.FromResult<Stream>(new MemoryStream());
+
+        private ResolvedPackage? CreateResolved(string packageId, NuGetVersion? version)
+            => version is null ? null : new ResolvedPackage(packageId.ToLowerInvariant(), version, _source);
+    }
+
+    private sealed class FakeCliConfigurationProvider(IReadOnlyDictionary<string, string?> projectValues) : ICliConfigurationProvider
+    {
+        private readonly IConfiguration _projectConfiguration = new ConfigurationBuilder()
+            .AddInMemoryCollection(projectValues)
+            .Build();
+
+        private readonly IConfiguration _userConfiguration = new ConfigurationBuilder().Build();
+
+        public IConfiguration GetUserConfiguration() => _userConfiguration;
+
+        public IConfiguration GetProjectConfiguration(DirectoryInfo projectDirectory) => _projectConfiguration;
+
+        public IConfiguration GetEffectiveConfiguration(DirectoryInfo projectDirectory) => _projectConfiguration;
+    }
+
+    private sealed class TestOptionsMonitor<TOptions>(TOptions value) : IOptionsMonitor<TOptions>
+    {
+        public TOptions CurrentValue => value;
+
+        public TOptions Get(string? name) => value;
+
+        public IDisposable? OnChange(Action<TOptions, string?> listener) => null;
+    }
+
+    private sealed class FakeProfileSource(
+        ProfileSourceInfo source,
+        IReadOnlyList<KeyValuePair<string, ProfileDefinition>> profiles) : IProfileSource
+    {
+        public Task<ProfileSourceSnapshot> LoadAsync(ProfileSourceContext context, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Dictionary<string, ProfileDefinition> definitions = new(StringComparer.OrdinalIgnoreCase);
+            foreach ((string name, ProfileDefinition definition) in profiles)
+            {
+                definitions.Add(name, definition);
+            }
+
+            return Task.FromResult(new ProfileSourceSnapshot(source, definitions));
+        }
+    }
+}

--- a/test/Func.Tests/Commands/StartInitializationTests.cs
+++ b/test/Func.Tests/Commands/StartInitializationTests.cs
@@ -574,7 +574,7 @@ public class StartInitializationTests : IDisposable
     private static WorkloadEntry CreateHostEntry(string packageVersion)
         => new()
         {
-            PackageId = "Azure.Functions.Cli.Workloads.Host",
+            PackageId = HostWorkloadPackage.CurrentPackageId,
             PackageVersion = packageVersion,
             Kind = WorkloadKind.Content,
             Aliases = ["host"],
@@ -584,11 +584,11 @@ public class StartInitializationTests : IDisposable
 
     private static ContentWorkloadInfo CreateHostWorkload(string packageVersion)
         => new(
-            PackageId: "Azure.Functions.Cli.Workloads.Host",
+            PackageId: HostWorkloadPackage.CurrentPackageId,
             PackageVersion: packageVersion,
             Aliases: ["host"],
-            InstallDirectory: Path.Combine(Path.GetTempPath(), "workloads", "host", packageVersion),
-            ContentRoot: Path.Combine(Path.GetTempPath(), "workloads", "host", packageVersion, "tools", "any"),
+            InstallDirectory: Path.Combine(Path.GetTempPath(), "workloads", HostWorkloadPackage.CurrentPackageId, packageVersion),
+            ContentRoot: Path.Combine(Path.GetTempPath(), "workloads", HostWorkloadPackage.CurrentPackageId, packageVersion, "tools", "any"),
             DisplayName: "Azure Functions host",
             Description: string.Empty);
 

--- a/test/Func.Tests/TestParser.cs
+++ b/test/Func.Tests/TestParser.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Commands;
+using Azure.Functions.Cli.Commands.Setup;
 using Azure.Functions.Cli.Commands.Start.Initialization;
 using Azure.Functions.Cli.Configuration;
 using Azure.Functions.Cli.Console;
@@ -70,6 +71,10 @@ internal static class TestParser
         services.AddBuiltInCommands();
         services.AddProfiles();
         services.AddSingleton(Substitute.For<IStartInitializationRunner>());
+        ISetupRunner setupRunner = Substitute.For<ISetupRunner>();
+        setupRunner.RunAsync(Arg.Any<SetupCommandOptions>(), Arg.Any<CancellationToken>())
+            .Returns(new SetupRunResult(0));
+        services.AddSingleton(setupRunner);
 
         // Stub the workload subsystem so commands that depend on it (e.g.
         // WorkloadListCommand) resolve without booting real storage / loading.


### PR DESCRIPTION
## Summary
- Add `func setup` with feature expansion, profile-aware dependency reconciliation, source overrides, check mode, and NDJSON output.
- Install host workloads by RID-specific package ID instead of host alias lookup.
- Add focused parser, setup runner, and host workload tests.

