### PR TITLE
Add go support (preview)

### DIFF
--- a/eng/build/Minified.targets
+++ b/eng/build/Minified.targets
@@ -6,6 +6,7 @@
     <_LanguageWorkers Include="$(PublishDir)\workers\java" />
     <_LanguageWorkers Include="$(PublishDir)\workers\powershell" />
     <_LanguageWorkers Include="$(PublishDir)\workers\node" />
+    <_LanguageWorkers Include="$(PublishDir)\workers\native" />
   </ItemGroup>
 
   <!-- Remove worker directories from minified builds -->

--- a/eng/build/Minified.targets
+++ b/eng/build/Minified.targets
@@ -6,7 +6,6 @@
     <_LanguageWorkers Include="$(PublishDir)\workers\java" />
     <_LanguageWorkers Include="$(PublishDir)\workers\powershell" />
     <_LanguageWorkers Include="$(PublishDir)\workers\node" />
-    <_LanguageWorkers Include="$(PublishDir)\workers\native" />
   </ItemGroup>
 
   <!-- Remove worker directories from minified builds -->

--- a/eng/build/Workers.Golang.targets
+++ b/eng/build/Workers.Golang.targets
@@ -1,0 +1,15 @@
+<Project>
+
+  <!--
+    Ships the Go (native) worker config alongside the published CLI so the host
+    can discover the Go worker at workers/native/worker.config.json.
+  -->
+  <ItemGroup>
+    <Content Include="$(RepoRoot)src\Cli\func\StaticResources\nativeWorkerConfig.json">
+      <Link>workers\native\worker.config.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
+</Project>

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -37,6 +37,13 @@ variables:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1es
   parameters:
+    # Route 'go' CLI traffic through the centralized internal Go module proxy
+    # so GoZipTool builds can resolve modules in network-isolated CI agents.
+    # See https://aka.ms/goproxy_for_how_to_onboard
+    featureFlags:
+      golang:
+        internalModuleProxy:
+          enabled: true
     pool:
       name: 1es-pool-azfunc
       image: 1es-windows-2022

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -32,6 +32,13 @@ variables:
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1es
   parameters:
+    # Route 'go' CLI traffic through the centralized internal Go module proxy
+    # so unit tests / E2E tests / GoZipTool builds can resolve modules in
+    # network-isolated CI agents. See https://aka.ms/goproxy_for_how_to_onboard
+    featureFlags:
+      golang:
+        internalModuleProxy:
+          enabled: true
     pool:
       name: 1es-pool-azfunc-public
       image: 1es-windows-2022

--- a/eng/ci/templates/jobs/test-e2e-linux.yml
+++ b/eng/ci/templates/jobs/test-e2e-linux.yml
@@ -25,16 +25,12 @@ jobs:
       custom_linux_x64:
         languageWorker: 'Custom'
         runtime: 'linux-x64'
+      go_linux_x64:
+        languageWorker: 'Go'
+        runtime: 'linux-x64'
 
   steps:
   - template: /eng/ci/templates/steps/install-tools.yml@self
-
-  - bash: |
-      sudo apt-get update
-      sudo apt-get install -y npm golang
-      npm --version
-      go version
-    displayName: 'Install npm and Go'
 
   - pwsh: ./eng/scripts/start-emulators.ps1
     displayName: 'Start emulators (NoWait)'

--- a/eng/ci/templates/jobs/test-e2e-linux.yml
+++ b/eng/ci/templates/jobs/test-e2e-linux.yml
@@ -32,6 +32,16 @@ jobs:
   steps:
   - template: /eng/ci/templates/steps/install-tools.yml@self
 
+  # The 1es-ubuntu-24.04-min image doesn't ship npm. NodeTool@0 in install-tools.yml
+  # installs Node into the agent user's tool cache, but start-emulators.ps1 runs
+  # `sudo npm install -g azurite` and sudo's PATH doesn't include the tool cache.
+  # Install npm system-wide via apt so azurite can be installed and launched as root.
+  - bash: |
+      sudo apt-get update
+      sudo apt-get install -y npm
+      npm --version
+    displayName: 'Install npm'
+
   - pwsh: ./eng/scripts/start-emulators.ps1
     displayName: 'Start emulators (NoWait)'
 

--- a/eng/ci/templates/jobs/test-e2e-osx.yml
+++ b/eng/ci/templates/jobs/test-e2e-osx.yml
@@ -25,15 +25,13 @@ jobs:
       custom_osx_x64:
         languageWorker: 'Custom'
         runtime: 'osx-x64'
+      go_osx_x64:
+        languageWorker: 'Go'
+        runtime: 'osx-x64'
 
   steps:
   - pwsh: ./eng/scripts/start-emulators.ps1
     displayName: 'Start emulators (NoWait)'
-
-  - script: |
-      brew install go
-      go version
-    displayName: 'Install Go'
 
   - script: |
       sudo chown -R $(id -u):$(id -g) ~/.npm

--- a/eng/ci/templates/jobs/test-e2e-osx.yml
+++ b/eng/ci/templates/jobs/test-e2e-osx.yml
@@ -40,6 +40,25 @@ jobs:
 
   - template: /eng/ci/templates/steps/install-tools.yml@self
 
+  # On macOS, GoTool@0 (in install-tools.yml) is skipped because it only
+  # ships an amd64 Go binary, which can't run on Apple Silicon agents.
+  # Install an arm64-native Go via Homebrew, pinned to the same major.minor
+  # (1.24) used by GoTool@0 on Linux/Windows, so all three OSes test against
+  # a consistent Go version.
+  - bash: |
+      set -euo pipefail
+      brew install go@1.24
+      GO_PREFIX="$(brew --prefix go@1.24)"
+      GO_BIN="$GO_PREFIX/bin"
+      GO_ROOT="$GO_PREFIX/libexec"
+      # Pin GOROOT to the Homebrew install so the `go` binary doesn't pick up a
+      # stale GOROOT inherited from the hosted agent image (which can point at a
+      # different Go install and cause "package std not found" / version skew).
+      echo "##vso[task.prependpath]$GO_BIN"
+      echo "##vso[task.setvariable variable=GOROOT]$GO_ROOT"
+      GOROOT="$GO_ROOT" "$GO_BIN/go" version
+    displayName: 'Install Go 1.24 (Homebrew, arm64-native)'
+
   - template: /eng/ci/templates/steps/restore-nuget.yml@self
 
   - pwsh: |

--- a/eng/ci/templates/jobs/test-e2e-windows.yml
+++ b/eng/ci/templates/jobs/test-e2e-windows.yml
@@ -25,6 +25,9 @@ jobs:
       custom_win_x64:
         languageWorker: 'Custom'
         runtime: 'win-x64'
+      go_win_x64:
+        languageWorker: 'Go'
+        runtime: 'win-x64'
 
   steps:
   - pwsh: ./eng/scripts/start-emulators.ps1 -NoWait

--- a/eng/ci/templates/public/jobs/test-unit-linux.yml
+++ b/eng/ci/templates/public/jobs/test-unit-linux.yml
@@ -19,6 +19,11 @@ jobs:
       sudo apt-get -y install fuse-zip
     displayName: 'Install fuse-zip'
 
+  - task: GoTool@0
+    inputs:
+      version: '1.24.2'
+    displayName: 'Install Go 1.24.2'
+
   - template: /eng/ci/templates/steps/install-tools.yml@self
 
   - template: /eng/ci/templates/steps/restore-nuget.yml@self

--- a/eng/ci/templates/public/jobs/test-unit-linux.yml
+++ b/eng/ci/templates/public/jobs/test-unit-linux.yml
@@ -19,9 +19,15 @@ jobs:
       sudo apt-get -y install fuse-zip
     displayName: 'Install fuse-zip'
 
-  - task: GoTool@0
-    inputs:
-      version: '1.24.2'
+  - script: |
+      set -e
+      VERSION=1.24.2
+      ARCHIVE=go${VERSION}.linux-amd64.tar.gz
+      DEST="$AGENT_TOOLSDIRECTORY/go-${VERSION}"
+      mkdir -p "$DEST"
+      curl -fsSL "https://go.dev/dl/${ARCHIVE}" -o "$AGENT_TEMPDIRECTORY/${ARCHIVE}"
+      tar -C "$DEST" -xzf "$AGENT_TEMPDIRECTORY/${ARCHIVE}"
+      echo "##vso[task.prependpath]$DEST/go/bin"
     displayName: 'Install Go 1.24.2'
 
   - template: /eng/ci/templates/steps/install-tools.yml@self

--- a/eng/ci/templates/steps/install-tools.yml
+++ b/eng/ci/templates/steps/install-tools.yml
@@ -38,3 +38,8 @@ steps:
   inputs:
     packageType: sdk
     useGlobalJson: true
+
+- task: GoTool@0
+  inputs:
+    version: '1.24.2'
+  displayName: 'Install Go 1.24.2'

--- a/eng/ci/templates/steps/install-tools.yml
+++ b/eng/ci/templates/steps/install-tools.yml
@@ -43,3 +43,9 @@ steps:
   inputs:
     version: '1.24.2'
   displayName: 'Install Go 1.24.2'
+  # Skip on macOS: GoTool@0 only ships an amd64 Go binary, which fails to
+  # execute on Apple Silicon agents (macOS-latest is arm64). It also exports
+  # GOROOT pointing at its own toolchain, which conflicts with the brew
+  # Go we install in the macOS E2E job (test-e2e-osx.yml). Mac jobs that
+  # need Go install it via Homebrew themselves.
+  condition: ne(variables['Agent.OS'], 'Darwin')

--- a/eng/ci/templates/steps/install-tools.yml
+++ b/eng/ci/templates/steps/install-tools.yml
@@ -39,13 +39,30 @@ steps:
     packageType: sdk
     useGlobalJson: true
 
-- task: GoTool@0
-  inputs:
-    version: '1.24.2'
+- pwsh: |
+    $version = '1.24.2'
+    if ($IsWindows) {
+      $archive = "go$version.windows-amd64.zip"
+      $url = "https://go.dev/dl/$archive"
+      $dest = Join-Path $env:AGENT_TOOLSDIRECTORY "go-$version"
+      New-Item -ItemType Directory -Force -Path $dest | Out-Null
+      $zipPath = Join-Path $env:AGENT_TEMPDIRECTORY $archive
+      Invoke-WebRequest -Uri $url -OutFile $zipPath
+      Expand-Archive -Path $zipPath -DestinationPath $dest -Force
+      $goBin = Join-Path $dest 'go\bin'
+    } else {
+      $archive = "go$version.linux-amd64.tar.gz"
+      $url = "https://go.dev/dl/$archive"
+      $dest = Join-Path $env:AGENT_TOOLSDIRECTORY "go-$version"
+      New-Item -ItemType Directory -Force -Path $dest | Out-Null
+      $tarPath = Join-Path $env:AGENT_TEMPDIRECTORY $archive
+      Invoke-WebRequest -Uri $url -OutFile $tarPath
+      & tar -C $dest -xzf $tarPath
+      $goBin = Join-Path $dest 'go/bin'
+    }
+    Write-Host "##vso[task.prependpath]$goBin"
+    Write-Host "Installed Go $version to $goBin"
   displayName: 'Install Go 1.24.2'
-  # Skip on macOS: GoTool@0 only ships an amd64 Go binary, which fails to
-  # execute on Apple Silicon agents (macOS-latest is arm64). It also exports
-  # GOROOT pointing at its own toolchain, which conflicts with the brew
-  # Go we install in the macOS E2E job (test-e2e-osx.yml). Mac jobs that
-  # need Go install it via Homebrew themselves.
+  # Skip on macOS: macOS-latest is arm64 (Apple Silicon). Mac jobs that need
+  # Go install it via Homebrew themselves (see test-e2e-osx.yml).
   condition: ne(variables['Agent.OS'], 'Darwin')

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,6 +1,4 @@
-# Azure Functions CLI 4.11.1
-# Azure Functions CLI 4.11.0
-# Azure Functions CLI 4.12.0-preview.1
+# Azure Functions CLI 4.12.0
 
 #### Host Version
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,4 +1,6 @@
 # Azure Functions CLI 4.11.1
+# Azure Functions CLI 4.11.0
+# Azure Functions CLI 4.12.0-preview.1
 
 #### Host Version
 
@@ -11,3 +13,4 @@
 
 - Fix `HttpsProxyAgent is not a constructor` error in `install.js` when installing behind a proxy (https-proxy-agent v9 requires a named import).
 - Remove `azure-functions-core-tools` from the `devDependencies` of generated function app templates (`package-js.json`, `package-js-v4.json`, `package-ts.json`, `package-ts-v4.json`). Users get the CLI from their system install; pulling it in again via `npm install` doubled disk usage and made every project's install fragile to Core Tools postinstall regressions.
+- Add Go language support to `func init`, `func start`, `func pack`, and `func publish` (#4875, #4892, #4943)

--- a/release_notes.md
+++ b/release_notes.md
@@ -11,4 +11,4 @@
 
 - Fix `HttpsProxyAgent is not a constructor` error in `install.js` when installing behind a proxy (https-proxy-agent v9 requires a named import).
 - Remove `azure-functions-core-tools` from the `devDependencies` of generated function app templates (`package-js.json`, `package-js-v4.json`, `package-ts.json`, `package-ts-v4.json`). Users get the CLI from their system install; pulling it in again via `npm install` doubled disk usage and made every project's install fragile to Core Tools postinstall regressions.
-- Add Go language support to `func init`, `func start`, `func pack`, and `func publish` (#4875, #4892, #4943)
+- Add **preview** Go language support to `func init`, `func start`, `func pack`, and `func publish` (#4875, #4892, #4943). Behaviour, build/publish flags, and deployment layout may change before GA.

--- a/src/Cli/func/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Cli/func/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -164,12 +164,49 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 throw new CliException($"--build {PublishBuildOption} is not supported for Windows Elastic Premium Function Apps.");
             }
 
+            // Get the WorkerRuntime
+            var workerRuntime = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(_secretsManager, refreshSecrets: true);
+            if (workerRuntime != WorkerRuntime.None)
+            {
+                GlobalCoreToolsSettings.CurrentWorkerRuntime = workerRuntime;
+            }
+            else
+            {
+                workerRuntime = GlobalCoreToolsSettings.CurrentWorkerRuntime;
+            }
+
+            // Go is cross-compiled to linux/amd64 and currently only supported on Flex Consumption.
+            // Reject Windows targets, non-Flex SKUs, and unsupported build modes up front.
+            if (workerRuntime == WorkerRuntime.Go)
+            {
+                if (!functionApp.IsLinux)
+                {
+                    throw new CliException("Go is only supported for Linux Function Apps.");
+                }
+
+                if (!functionApp.IsFlex)
+                {
+                    throw new CliException("Go is only supported on Flex Consumption Function Apps.");
+                }
+
+                if (PublishBuildOption == BuildOption.Remote || PublishBuildOption == BuildOption.Container)
+                {
+                    throw new CliException(
+                        $"--build {PublishBuildOption} is not supported for Go. Run 'func publish' without '--build {PublishBuildOption}'.");
+                }
+
+                // BuildNativeDeps is checked separately because ResolveBuildOption (called later) flips
+                // PublishBuildOption to BuildOption.Container when --build-native-deps is set, which would
+                // bypass the Go build branch and ship a zip with a missing or stale 'app' binary.
+                if (BuildNativeDeps)
+                {
+                    throw new CliException("--build-native-deps is not supported for Go. Run 'func publish' without '--build-native-deps'.");
+                }
+            }
+
             // Get the GitIgnoreParser from the functionApp root
             var functionAppRoot = ScriptHostHelpers.GetFunctionAppRootDirectory(Environment.CurrentDirectory);
             var ignoreParser = PublishHelper.GetIgnoreParser(functionAppRoot);
-
-            // Get the WorkerRuntime
-            var workerRuntime = GlobalCoreToolsSettings.CurrentWorkerRuntime;
 
             // Get Stacks once for both .NET version determination and EOL checking
             var stacks = await AzureHelper.GetFunctionsStacks(AccessToken, ManagementURL);
@@ -223,6 +260,26 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             if (isNonCsxDotnetRuntime && !NoBuild && PublishBuildOption != BuildOption.Remote)
             {
                 await DotnetHelpers.BuildAndChangeDirectory(Path.Combine("bin", "publish"), DotnetCliParameters);
+            }
+            else if (workerRuntime == WorkerRuntime.Go &&
+                     PublishBuildOption != BuildOption.Remote &&
+                     PublishBuildOption != BuildOption.Container)
+            {
+                // Go always builds locally — there is no remote/container path for Go publishes.
+                // The remote/container conditions are redundant given the up-front rejection above;
+                // keeping them documents intent and stays defensive against future changes to ResolveBuildOption.
+                GoHelpers.AssertGoFunctionAppLayout(functionAppRoot);
+
+                if (NoBuild)
+                {
+                    // Trust the user's pre-built binary, but verify it is actually a linux/amd64 ELF
+                    // so we don't silently upload a host-OS binary to a Linux Flex host.
+                    GoHelpers.AssertLinuxAmd64Binary(functionAppRoot);
+                }
+                else
+                {
+                    await GoHelpers.BuildForLinux(functionAppRoot);
+                }
             }
 
             if (!isNonCsxDotnetRuntime)
@@ -1314,6 +1371,13 @@ namespace Azure.Functions.Cli.Actions.AzureActions
 
         private static void InternalListIgnoredFiles(GitIgnoreParser ignoreParser)
         {
+            if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.Go)
+            {
+                // Go uses an explicit allowlist (see GoHelpers.GetPackFiles); funcignore is not consulted.
+                ColoredConsole.WriteLine($"Go publishes only {Constants.HostJsonFileName} and {GoHelpers.GoBinaryName}; all other files are excluded.");
+                return;
+            }
+
             if (ignoreParser == null)
             {
                 ColoredConsole.Error.WriteLine("No .funcignore file");
@@ -1328,6 +1392,29 @@ namespace Azure.Functions.Cli.Actions.AzureActions
 
         private static void InternalListIncludedFiles(GitIgnoreParser ignoreParser)
         {
+            if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.Go)
+            {
+                // Go zip is built from the explicit allowlist in GoHelpers.GetPackFiles; print those
+                // files rooted at the function app root so output matches what is actually packaged
+                // even when 'func publish' is run from a subdirectory. The Go binary ('app') may
+                // not exist yet when --list-included-files is run before a build, so annotate it
+                // rather than printing a misleading path that doesn't exist on disk.
+                var functionAppRoot = ScriptHostHelpers.GetFunctionAppRootDirectory(Environment.CurrentDirectory);
+                foreach (var file in GoHelpers.GetPackFiles(functionAppRoot))
+                {
+                    if (FileSystemHelpers.FileExists(file))
+                    {
+                        ColoredConsole.WriteLine(file);
+                    }
+                    else
+                    {
+                        ColoredConsole.WriteLine($"{file} (will be built during publish)");
+                    }
+                }
+
+                return;
+            }
+
             if (ignoreParser == null)
             {
                 ColoredConsole.Error.WriteLine("No .funcignore file");

--- a/src/Cli/func/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Cli/func/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -164,16 +164,21 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 throw new CliException($"--build {PublishBuildOption} is not supported for Windows Elastic Premium Function Apps.");
             }
 
-            // Get the WorkerRuntime
-            var workerRuntime = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(_secretsManager, refreshSecrets: true);
-            if (workerRuntime != WorkerRuntime.None)
+            // Get the WorkerRuntime. Only re-resolve from local.settings.json when the Init-time
+            // value was None. This preserves the original behavior for Python/.NET/Node/PowerShell
+            // (single global read set during Init), while allowing Go's "native" → Go resolution
+            // when func publish is invoked without a prior func init.
+            var workerRuntime = GlobalCoreToolsSettings.CurrentWorkerRuntime;
+            if (workerRuntime == WorkerRuntime.None)
             {
-                GlobalCoreToolsSettings.CurrentWorkerRuntime = workerRuntime;
+                workerRuntime = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(_secretsManager, refreshSecrets: true);
+                if (workerRuntime != WorkerRuntime.None)
+                {
+                    GlobalCoreToolsSettings.CurrentWorkerRuntime = workerRuntime;
+                }
             }
-            else
-            {
-                workerRuntime = GlobalCoreToolsSettings.CurrentWorkerRuntime;
-            }
+
+            Utilities.WarnIfGoWorkerRuntime(workerRuntime);
 
             // Go is cross-compiled to linux/amd64 and currently only supported on Flex Consumption.
             // Reject Windows targets, non-Flex SKUs, and unsupported build modes up front.
@@ -307,7 +312,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                     }
                     else
                     {
-                        await PublishFunctionApp(functionApp, ignoreParser, additionalAppSettings);
+                        await PublishFunctionApp(functionApp, ignoreParser, additionalAppSettings, workerRuntime);
                     }
                 }
                 catch (HttpRequestException ex)
@@ -672,7 +677,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             }
         }
 
-        private async Task PublishFunctionApp(Site functionApp, GitIgnoreParser ignoreParser, IDictionary<string, string> additionalAppSettings)
+        private async Task PublishFunctionApp(Site functionApp, GitIgnoreParser ignoreParser, IDictionary<string, string> additionalAppSettings, WorkerRuntime workerRuntime)
         {
             ColoredConsole.WriteLine("Getting site publishing info...");
             var functionAppRoot = ScriptHostHelpers.GetFunctionAppRootDirectory(Environment.CurrentDirectory);
@@ -692,7 +697,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             }
 
             ColoredConsole.WriteLine(GetLogMessage("Starting the function app deployment..."));
-            Func<Task<Stream>> zipStreamFactory = () => ZipHelper.GetAppZipFile(functionAppRoot, BuildNativeDeps, PublishBuildOption, NoBuild, ignoreParser, AdditionalPackages);
+            Func<Task<Stream>> zipStreamFactory = () => ZipHelper.GetAppZipFile(functionAppRoot, BuildNativeDeps, PublishBuildOption, NoBuild, workerRuntime, ignoreParser, AdditionalPackages);
 
             bool shouldSyncTriggers = true;
             bool shouldDeferPublishZipDeploy = false;

--- a/src/Cli/func/Actions/HostActions/StartHostAction.cs
+++ b/src/Cli/func/Actions/HostActions/StartHostAction.cs
@@ -734,14 +734,21 @@ namespace Azure.Functions.Cli.Actions.HostActions
         private async Task PreRunConditions()
         {
             // GetCurrentWorkerRuntimeLanguage transparently resolves FUNCTIONS_WORKER_RUNTIME=native
-            // to a concrete runtime (e.g. Go via go.mod). Mirror the result into the global so
-            // downstream code that reads GlobalCoreToolsSettings.CurrentWorkerRuntime sees Go
-            // rather than None for Go projects.
-            var resolved = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(_secretsManager, refreshSecrets: true);
-            if (resolved != WorkerRuntime.None)
+            // to a concrete runtime (e.g. Go via go.mod). Only re-resolve when the Init-time value
+            // was None; otherwise use the global set during Init. Mirror resolved value into the
+            // global so downstream code that reads GlobalCoreToolsSettings.CurrentWorkerRuntime
+            // sees Go rather than None for Go projects.
+            var resolved = GlobalCoreToolsSettings.CurrentWorkerRuntime;
+            if (resolved == WorkerRuntime.None)
             {
-                GlobalCoreToolsSettings.CurrentWorkerRuntime = resolved;
+                resolved = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(_secretsManager, refreshSecrets: true);
+                if (resolved != WorkerRuntime.None)
+                {
+                    GlobalCoreToolsSettings.CurrentWorkerRuntime = resolved;
+                }
             }
+
+            Utilities.WarnIfGoWorkerRuntime(resolved);
 
             EnsureWorkerRuntimeIsSet();
 

--- a/src/Cli/func/Actions/HostActions/StartHostAction.cs
+++ b/src/Cli/func/Actions/HostActions/StartHostAction.cs
@@ -733,7 +733,16 @@ namespace Azure.Functions.Cli.Actions.HostActions
 
         private async Task PreRunConditions()
         {
-            ResolveNativeWorkerRuntime();
+            // GetCurrentWorkerRuntimeLanguage transparently resolves FUNCTIONS_WORKER_RUNTIME=native
+            // to a concrete runtime (e.g. Go via go.mod). Mirror the result into the global so
+            // downstream code that reads GlobalCoreToolsSettings.CurrentWorkerRuntime sees Go
+            // rather than None for Go projects.
+            var resolved = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(_secretsManager, refreshSecrets: true);
+            if (resolved != WorkerRuntime.None)
+            {
+                GlobalCoreToolsSettings.CurrentWorkerRuntime = resolved;
+            }
+
             EnsureWorkerRuntimeIsSet();
 
             if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.Python)
@@ -902,37 +911,6 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 ? await SecurityHelpers.GetOrCreateCertificate(CertPath, CertPassword)
                 : null;
             return (new Uri($"{protocol}://0.0.0.0:{Port}"), new Uri($"{protocol}://localhost:{Port}"), cert);
-        }
-
-        internal void ResolveNativeWorkerRuntime()
-        {
-            // 'native' is the host's runtime identifier for any worker registered with
-            // language="native" (today: Go via workers/native/worker.config.json).
-            // Resolve it here by inspecting project markers; add new arms as additional native
-            // workers (e.g. Rust) are onboarded.
-            var setting = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime)
-                          ?? _secretsManager.GetSecrets().FirstOrDefault(s => s.Key.Equals(Constants.FunctionsWorkerRuntime, StringComparison.OrdinalIgnoreCase)).Value;
-
-            if (string.IsNullOrWhiteSpace(setting)
-                || !string.Equals(setting, "native", StringComparison.OrdinalIgnoreCase))
-            {
-                return;
-            }
-
-            if (FileSystemHelpers.FileExists(Path.Combine(Environment.CurrentDirectory, "go.mod")))
-            {
-                if (VerboseLogging == true)
-                {
-                    ColoredConsole.WriteLine(VerboseColor("Resolving native worker runtime to 'go' (go.mod found)."));
-                }
-
-                GlobalCoreToolsSettings.CurrentWorkerRuntime = WorkerRuntime.Go;
-                return;
-            }
-
-            throw new CliException(
-                $"Could not determine the worker language for the project at '{Environment.CurrentDirectory}'. " +
-                "Run 'func init' to initialize a supported function app in this directory.");
         }
 
         private void EnsureWorkerRuntimeIsSet()

--- a/src/Cli/func/Actions/HostActions/StartHostAction.cs
+++ b/src/Cli/func/Actions/HostActions/StartHostAction.cs
@@ -733,6 +733,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
 
         private async Task PreRunConditions()
         {
+            ResolveNativeWorkerRuntime();
             EnsureWorkerRuntimeIsSet();
 
             if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.Python)
@@ -757,6 +758,20 @@ namespace Azure.Functions.Cli.Actions.HostActions
             else if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.Powershell && !CommandChecker.CommandExists("dotnet"))
             {
                 throw new CliException("Dotnet is required for PowerShell Functions. Please install dotnet (.NET Core SDK) for your system from https://www.microsoft.com/net/download");
+            }
+            else if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.Go)
+            {
+                var goVersion = await GoHelpers.GetEnvironmentGoVersion();
+                GoHelpers.AssertGoVersion(goVersion);
+
+                if (NoBuild)
+                {
+                    GoHelpers.AssertBinaryExists();
+                }
+                else
+                {
+                    await GoHelpers.BuildProject();
+                }
             }
 
             if (!NetworkHelpers.IsPortAvailable(Port))
@@ -887,6 +902,37 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 ? await SecurityHelpers.GetOrCreateCertificate(CertPath, CertPassword)
                 : null;
             return (new Uri($"{protocol}://0.0.0.0:{Port}"), new Uri($"{protocol}://localhost:{Port}"), cert);
+        }
+
+        internal void ResolveNativeWorkerRuntime()
+        {
+            // 'native' is the host's runtime identifier for any worker registered with
+            // language="native" (today: Go via workers/native/worker.config.json).
+            // Resolve it here by inspecting project markers; add new arms as additional native
+            // workers (e.g. Rust) are onboarded.
+            var setting = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime)
+                          ?? _secretsManager.GetSecrets().FirstOrDefault(s => s.Key.Equals(Constants.FunctionsWorkerRuntime, StringComparison.OrdinalIgnoreCase)).Value;
+
+            if (string.IsNullOrWhiteSpace(setting)
+                || !string.Equals(setting, "native", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            if (FileSystemHelpers.FileExists(Path.Combine(Environment.CurrentDirectory, "go.mod")))
+            {
+                if (VerboseLogging == true)
+                {
+                    ColoredConsole.WriteLine(VerboseColor("Resolving native worker runtime to 'go' (go.mod found)."));
+                }
+
+                GlobalCoreToolsSettings.CurrentWorkerRuntime = WorkerRuntime.Go;
+                return;
+            }
+
+            throw new CliException(
+                $"Could not determine the worker language for the project at '{Environment.CurrentDirectory}'. " +
+                "Run 'func init' to initialize a supported function app in this directory.");
         }
 
         private void EnsureWorkerRuntimeIsSet()

--- a/src/Cli/func/Actions/LocalActions/CreateFunctionAction.cs
+++ b/src/Cli/func/Actions/LocalActions/CreateFunctionAction.cs
@@ -127,6 +127,18 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 return;
             }
 
+            // Go uses programmatic registration in main.go (app.HTTP, app.Timer, ...);
+            // there are no per-function templates to scaffold, so 'func new' is intentionally not wired up.
+            if (_workerRuntime == WorkerRuntime.Go)
+            {
+                ColoredConsole
+                    .Error
+                    .WriteLine(ErrorColor("The 'func new' command is not yet supported for the Go runtime."))
+                    .WriteLine(ErrorColor("Go uses programmatic registration — add functions by editing 'main.go' (app.HTTP(...), app.Timer(...), etc.)."))
+                    .WriteLine(ErrorColor("For more information, visit: https://github.com/Azure/azure-functions-golang-worker"));
+                return;
+            }
+
             // Load templates and resolve language
             if (NeedsToLoadExtensionTemplates(_workerRuntime, Csx))
             {
@@ -350,6 +362,15 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 await _initAction.RunAsync();
                 Language = _initAction.ResolvedLanguage;
                 return _initAction.ResolvedWorkerRuntime;
+            }
+
+            // GetCurrentWorkerRuntimeLanguage handles FUNCTIONS_WORKER_RUNTIME=native
+            // (mapping to Go via go.mod, etc.) so 'func new' can short-circuit on unsupported
+            // runtimes before running language/template prompts that would mutate local.settings.json.
+            var resolved = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(_secretsManager, refreshSecrets: true);
+            if (resolved != WorkerRuntime.None)
+            {
+                return resolved;
             }
 
             return GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone;

--- a/src/Cli/func/Actions/LocalActions/InitAction/InitAction.cs
+++ b/src/Cli/func/Actions/LocalActions/InitAction/InitAction.cs
@@ -71,6 +71,8 @@ namespace Azure.Functions.Cli.Actions.LocalActions
 
         public bool SkipNpmInstall { get; set; } = false;
 
+        public bool SkipGoModTidy { get; set; } = false;
+
         public WorkerRuntime ResolvedWorkerRuntime { get; set; }
 
         public string ResolvedLanguage { get; set; }
@@ -139,13 +141,17 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 .Callback(tf => TargetFramework = tf);
 
             Parser
-                .Setup<string>("language")
+                .Setup<string>('l', "language")
                 .SetDefault(null)
                 .Callback(l => Language = l);
 
             Parser
                 .Setup<bool>("skip-npm-install")
                 .Callback(skip => SkipNpmInstall = skip);
+
+            Parser
+                .Setup<bool>("skip-go-mod-tidy")
+                .Callback(skip => SkipGoModTidy = skip);
 
             Parser
                 .Setup<string>('m', "model")
@@ -209,6 +215,8 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             {
                 (ResolvedWorkerRuntime, ResolvedLanguage) = ResolveWorkerRuntimeAndLanguage(WorkerRuntime, Language);
 
+                Utilities.WarnIfGoWorkerRuntime(ResolvedWorkerRuntime);
+
                 // Order here is important: each language may have multiple runtimes, and each unique (language, worker-runtime) pair
                 // may have its own programming model. Thus, we assume that ResolvedLanguage and ResolvedWorkerRuntime are properly set
                 // before attempting to resolve the programming model.
@@ -229,6 +237,11 @@ namespace Azure.Functions.Cli.Actions.LocalActions
 
             TelemetryHelpers.AddCommandEventToDictionary(TelemetryCommandEvents, "WorkerRuntime", ResolvedWorkerRuntime.ToString());
 
+            if (ResolvedWorkerRuntime == Helpers.WorkerRuntime.Go && InitDocker)
+            {
+                throw new CliException("Docker support for the Go worker runtime is not yet available.");
+            }
+
             ValidateTargetFramework();
             if (WorkerRuntimeLanguageHelper.IsDotnet(ResolvedWorkerRuntime) && !Csx)
             {
@@ -238,7 +251,18 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             else
             {
                 bool managedDependenciesOption = ResolveManagedDependencies(ResolvedWorkerRuntime, ManagedDependencies);
-                await InitLanguageSpecificArtifacts(ResolvedWorkerRuntime, ResolvedLanguage, ResolvedProgrammingModel, managedDependenciesOption, GeneratePythonDocumentation);
+
+                if (ResolvedWorkerRuntime == Helpers.WorkerRuntime.Go)
+                {
+                    await GoHelpers.SetupProject(
+                        Utilities.SanitizeLiteral(Path.GetFileName(Environment.CurrentDirectory), allowed: "-_"),
+                        SkipGoModTidy);
+                }
+                else
+                {
+                    await InitLanguageSpecificArtifacts(ResolvedWorkerRuntime, ResolvedLanguage, ResolvedProgrammingModel, managedDependenciesOption, GeneratePythonDocumentation);
+                }
+
                 await WriteFiles();
 
                 await WriteHostJson(ResolvedWorkerRuntime, managedDependenciesOption, ExtensionBundle);
@@ -274,9 +298,27 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             if (!string.IsNullOrEmpty(workerRuntimeString))
             {
                 workerRuntime = WorkerRuntimeLanguageHelper.NormalizeWorkerRuntime(workerRuntimeString);
-                language = !string.IsNullOrEmpty(languageString)
-                    ? WorkerRuntimeLanguageHelper.NormalizeLanguage(languageString)
-                    : WorkerRuntimeLanguageHelper.NormalizeLanguage(workerRuntimeString);
+                if (workerRuntime == Helpers.WorkerRuntime.Go)
+                {
+                    return (workerRuntime, string.Empty);
+                }
+
+                if (!string.IsNullOrEmpty(languageString))
+                {
+                    language = WorkerRuntimeLanguageHelper.NormalizeLanguage(languageString);
+                }
+                else if (WorkerRuntimeLanguageHelper.TryNormalizeLanguage(workerRuntimeString, out var inferredLanguage))
+                {
+                    language = inferredLanguage;
+                }
+                else
+                {
+                    language = LanguageSelectionIfRelevant(workerRuntime);
+                    if (string.IsNullOrEmpty(language))
+                    {
+                        language = WorkerRuntimeLanguageHelper.GetDefaultTemplateLanguageFromWorker(workerRuntime);
+                    }
+                }
             }
             else if (GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone == Helpers.WorkerRuntime.None)
             {
@@ -292,6 +334,11 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             else
             {
                 workerRuntime = GlobalCoreToolsSettings.CurrentWorkerRuntime;
+                if (workerRuntime == Helpers.WorkerRuntime.Go)
+                {
+                    return (workerRuntime, string.Empty);
+                }
+
                 language = GlobalCoreToolsSettings.CurrentLanguageOrNull
                     ?? (!string.IsNullOrEmpty(languageString) ? WorkerRuntimeLanguageHelper.NormalizeLanguage(languageString) : null)
                     ?? WorkerRuntimeLanguageHelper.NormalizeLanguage(WorkerRuntimeLanguageHelper.GetRuntimeMoniker(workerRuntime));
@@ -407,7 +454,14 @@ namespace Azure.Functions.Cli.Actions.LocalActions
         private static async Task WriteLocalSettingsJson(WorkerRuntime workerRuntime, ProgrammingModel programmingModel)
         {
             string localSettingsJsonContent = await StaticResources.LocalSettingsJson;
-            localSettingsJsonContent = localSettingsJsonContent.Replace($"{{{Constants.FunctionsWorkerRuntime}}}", WorkerRuntimeLanguageHelper.GetRuntimeMoniker(workerRuntime));
+
+            // The Go worker is registered with the host under the "native" runtime identifier,
+            // so FUNCTIONS_WORKER_RUNTIME in local.settings.json must be "native" even though
+            // the CLI exposes the runtime as "go" everywhere else.
+            string workerRuntimeSetting = workerRuntime == Helpers.WorkerRuntime.Go
+                ? "native"
+                : WorkerRuntimeLanguageHelper.GetRuntimeMoniker(workerRuntime);
+            localSettingsJsonContent = localSettingsJsonContent.Replace($"{{{Constants.FunctionsWorkerRuntime}}}", workerRuntimeSetting);
             localSettingsJsonContent = localSettingsJsonContent.Replace($"{{{Constants.AzureWebJobsStorage}}}", Constants.StorageEmulatorConnectionString);
 
             if (workerRuntime == Helpers.WorkerRuntime.Powershell)
@@ -489,6 +543,11 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             else if (workerRuntime == Helpers.WorkerRuntime.Custom)
             {
                 await FileSystemHelpers.WriteFileIfNotExists("Dockerfile", await StaticResources.DockerfileCustom);
+            }
+            else if (workerRuntime == Helpers.WorkerRuntime.Go)
+            {
+                // Docker support for Go is validated up-front in RunAsync; this branch is unreachable in practice.
+                throw new CliException("Docker support for the Go worker runtime is not yet available.");
             }
             else if (workerRuntime == Helpers.WorkerRuntime.None)
             {

--- a/src/Cli/func/Actions/LocalActions/InitAction/InitAction.cs
+++ b/src/Cli/func/Actions/LocalActions/InitAction/InitAction.cs
@@ -475,7 +475,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             // for go.mod on every command. See WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage.
             if (workerRuntime == Helpers.WorkerRuntime.Go)
             {
-                localSettingsJsonContent = AddLocalSetting(localSettingsJsonContent, Constants.FunctionsCliGoPreview, "true");
+                localSettingsJsonContent = AddLocalSetting(localSettingsJsonContent, Constants.FunctionsCliNativeLanguage, "go");
             }
 
             if (workerRuntime == Helpers.WorkerRuntime.Powershell)

--- a/src/Cli/func/Actions/LocalActions/InitAction/InitAction.cs
+++ b/src/Cli/func/Actions/LocalActions/InitAction/InitAction.cs
@@ -471,6 +471,13 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 : Constants.StorageEmulatorConnectionString;
             localSettingsJsonContent = localSettingsJsonContent.Replace($"{{{Constants.AzureWebJobsStorage}}}", azureWebJobsStorageValue);
 
+            // Add the explicit Go preview opt-in so the CLI doesn't have to fall back to scanning
+            // for go.mod on every command. See WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage.
+            if (workerRuntime == Helpers.WorkerRuntime.Go)
+            {
+                localSettingsJsonContent = AddLocalSetting(localSettingsJsonContent, Constants.FunctionsCliGoPreview, "true");
+            }
+
             if (workerRuntime == Helpers.WorkerRuntime.Powershell)
             {
                 localSettingsJsonContent = AddLocalSetting(localSettingsJsonContent, Constants.FunctionsWorkerRuntimeVersion, Constants.PowerShellWorkerDefaultVersion);

--- a/src/Cli/func/Actions/LocalActions/InitAction/InitAction.cs
+++ b/src/Cli/func/Actions/LocalActions/InitAction/InitAction.cs
@@ -462,7 +462,14 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 ? "native"
                 : WorkerRuntimeLanguageHelper.GetRuntimeMoniker(workerRuntime);
             localSettingsJsonContent = localSettingsJsonContent.Replace($"{{{Constants.FunctionsWorkerRuntime}}}", workerRuntimeSetting);
-            localSettingsJsonContent = localSettingsJsonContent.Replace($"{{{Constants.AzureWebJobsStorage}}}", Constants.StorageEmulatorConnectionString);
+
+            // For Go (preview) we leave AzureWebJobsStorage empty rather than seeding the storage
+            // emulator connection string. This avoids 'func azure functionapp publish -i -y' silently
+            // overwriting a production app's AzureWebJobsStorage with 'UseDevelopmentStorage=true'.
+            string azureWebJobsStorageValue = workerRuntime == Helpers.WorkerRuntime.Go
+                ? string.Empty
+                : Constants.StorageEmulatorConnectionString;
+            localSettingsJsonContent = localSettingsJsonContent.Replace($"{{{Constants.AzureWebJobsStorage}}}", azureWebJobsStorageValue);
 
             if (workerRuntime == Helpers.WorkerRuntime.Powershell)
             {

--- a/src/Cli/func/Actions/LocalActions/InitAction/InitGoSubcommandAction.cs
+++ b/src/Cli/func/Actions/LocalActions/InitAction/InitGoSubcommandAction.cs
@@ -1,0 +1,27 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Fclp;
+
+namespace Azure.Functions.Cli.Actions.LocalActions
+{
+    [Action(Name = "init go", ParentCommandName = "init", ShowInHelp = true, HelpText = "Options specific to Go runtime apps when running func init")]
+    internal class InitGoSubcommandAction : BaseAction
+    {
+        public override ICommandLineParserResult ParseArgs(string[] args)
+        {
+            Parser
+                .Setup<bool>("skip-go-mod-tidy")
+                .WithDescription("Skip running 'go mod tidy' after Go project creation.")
+                .Callback(_ => { });
+
+            return base.ParseArgs(args);
+        }
+
+        public override Task RunAsync()
+        {
+            // This method is never called - the main InitAction handles execution
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Cli/func/Actions/LocalActions/PackAction/CustomPackSubcommandAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/CustomPackSubcommandAction.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Helpers;
 using Azure.Functions.Cli.Interfaces;
 using Fclp;
 using Newtonsoft.Json;
@@ -12,6 +13,11 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
     [Action(Name = "pack custom", ParentCommandName = "pack", ShowInHelp = false, HelpText = "Arguments specific to custom worker runtime apps when running func pack")]
     internal class CustomPackSubcommandAction : PackSubcommandAction
     {
+        public CustomPackSubcommandAction()
+            : base(WorkerRuntime.Custom)
+        {
+        }
+
         public override ICommandLineParserResult ParseArgs(string[] args)
         {
             return base.ParseArgs(args);

--- a/src/Cli/func/Actions/LocalActions/PackAction/DotnetPackSubcommandAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/DotnetPackSubcommandAction.cs
@@ -15,6 +15,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
         private readonly bool _isDotnetIsolated;
 
         public DotnetPackSubcommandAction(bool isDotnetIsolated)
+            : base(isDotnetIsolated ? WorkerRuntime.DotnetIsolated : WorkerRuntime.Dotnet)
         {
             _isDotnetIsolated = isDotnetIsolated;
         }

--- a/src/Cli/func/Actions/LocalActions/PackAction/GoPackSubcommandAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/GoPackSubcommandAction.cs
@@ -1,0 +1,66 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Helpers;
+
+namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
+{
+    [Action(Name = "pack go", ParentCommandName = "pack", ShowInHelp = false, HelpText = "Arguments specific to Go apps when running func pack")]
+    internal class GoPackSubcommandAction : PackSubcommandAction
+    {
+        public async Task RunAsync(PackOptions packOptions)
+        {
+            await ExecuteAsync(packOptions);
+        }
+
+        protected internal override void ValidateFunctionApp(string functionAppRoot, PackOptions options)
+        {
+            GoHelpers.AssertGoFunctionAppLayout(functionAppRoot);
+        }
+
+        protected override Task<string> GetPackingRootAsync(string functionAppRoot, PackOptions options)
+        {
+            // Go packs from the function app root without a separate staging dir.
+            return Task.FromResult(functionAppRoot);
+        }
+
+        protected override async Task PerformBuildBeforePackingAsync(string packingRoot, string functionAppRoot, PackOptions options)
+        {
+            if (options.NoBuild)
+            {
+                // --no-build: trust the user's pre-built binary, but verify it is actually a linux/amd64 ELF.
+                GoHelpers.AssertLinuxAmd64Binary(functionAppRoot);
+                return;
+            }
+
+            await GoHelpers.BuildForLinux(functionAppRoot);
+        }
+
+        protected override string ResolveOutputPath(string functionAppRoot, string outputPath)
+        {
+            // If the user pointed --output at something that already exists as a file (not a
+            // directory), surface a clear error rather than letting Directory.CreateDirectory
+            // fail with an opaque IOException ("Cannot create ... because a file ... exists").
+            if (!string.IsNullOrEmpty(outputPath)
+                && File.Exists(Path.Combine(Environment.CurrentDirectory, outputPath)))
+            {
+                throw new CliException(
+                    $"--output '{outputPath}' refers to an existing file. " +
+                    "Pass an existing or new directory path instead.");
+            }
+
+            return base.ResolveOutputPath(functionAppRoot, outputPath);
+        }
+
+        // PackFunctionAsync intentionally not overridden — the default flow goes through
+        // PackHelpers.CreatePackage → ZipHelper.GetAppZipFile, which has a Go branch
+        // that emits the explicit allowlist (host.json + app).
+        public override Task RunAsync()
+        {
+            throw new NotSupportedException(
+                $"{nameof(GoPackSubcommandAction)} is not meant to be invoked directly. " +
+                $"Dispatch happens via {nameof(PackAction)}.RunRuntimeSpecificPackAsync, which calls {nameof(RunAsync)}({nameof(PackOptions)}).");
+        }
+    }
+}

--- a/src/Cli/func/Actions/LocalActions/PackAction/GoPackSubcommandAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/GoPackSubcommandAction.cs
@@ -9,6 +9,11 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
     [Action(Name = "pack go", ParentCommandName = "pack", ShowInHelp = false, HelpText = "Arguments specific to Go apps when running func pack")]
     internal class GoPackSubcommandAction : PackSubcommandAction
     {
+        public GoPackSubcommandAction()
+            : base(WorkerRuntime.Go)
+        {
+        }
+
         public async Task RunAsync(PackOptions packOptions)
         {
             await ExecuteAsync(packOptions);

--- a/src/Cli/func/Actions/LocalActions/PackAction/NodePackSubcommandAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/NodePackSubcommandAction.cs
@@ -18,6 +18,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
         private readonly ISecretsManager _secretsManager;
 
         public NodePackSubcommandAction(ISecretsManager secretsManager)
+            : base(WorkerRuntime.Node)
         {
             _secretsManager = secretsManager;
         }
@@ -67,7 +68,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
 
         protected override Task PackFunctionAsync(string packingRoot, string outputPath, PackOptions options)
         {
-            return PackHelpers.CreatePackage(packingRoot, outputPath, options.NoBuild, TelemetryCommandEvents);
+            return PackHelpers.CreatePackage(packingRoot, outputPath, options.NoBuild, Runtime, TelemetryCommandEvents);
         }
 
         private async Task RunNodeJsBuildProcess(string functionAppRoot)

--- a/src/Cli/func/Actions/LocalActions/PackAction/PackAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/PackAction.cs
@@ -85,8 +85,11 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
                 Environment.CurrentDirectory = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, FolderPath));
             }
 
-            // Detect the runtime from environment variable or local.settings.json
-            var workerRuntime = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(_secretsManager, refreshSecrets: true);
+            // Detect the runtime from environment variable or local.settings.json.
+            // GetCurrentWorkerRuntimeLanguage transparently maps FUNCTIONS_WORKER_RUNTIME=native
+            // to a concrete runtime (e.g. Go via go.mod), and throws an actionable CliException
+            // when "native" is set without a supported project marker.
+            WorkerRuntime workerRuntime = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(_secretsManager, refreshSecrets: true);
 
             if (workerRuntime == WorkerRuntime.None && NoBuild)
             {
@@ -129,6 +132,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
                 WorkerRuntime.Node => new NodePackSubcommandAction(_secretsManager).RunAsync(packOptions, Args),
                 WorkerRuntime.Powershell => new PowershellPackSubcommandAction().RunAsync(packOptions),
                 WorkerRuntime.Custom => new CustomPackSubcommandAction().RunAsync(packOptions),
+                WorkerRuntime.Go => new GoPackSubcommandAction().RunAsync(packOptions),
                 _ => throw new CliException($"Unsupported runtime: {runtime}")
             });
     }

--- a/src/Cli/func/Actions/LocalActions/PackAction/PackAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/PackAction.cs
@@ -91,6 +91,8 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
             // when "native" is set without a supported project marker.
             WorkerRuntime workerRuntime = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(_secretsManager, refreshSecrets: true);
 
+            Utilities.WarnIfGoWorkerRuntime(workerRuntime);
+
             if (workerRuntime == WorkerRuntime.None && NoBuild)
             {
                 // Narrow to top-level only to avoid false positives in node_modules/, venvs, etc.

--- a/src/Cli/func/Actions/LocalActions/PackAction/PackHelpers.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/PackHelpers.cs
@@ -21,6 +21,9 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
 
         public static string ResolveOutputPath(string functionAppRoot, string outputPath)
         {
+            // Default behavior shared by non-Go runtimes: outputPath (when provided) is always
+            // treated as a directory; the produced archive is named after the function app folder.
+            // Go overrides this in GoPackSubcommandAction to also accept an explicit .zip file path.
             string resolvedPath;
             if (string.IsNullOrEmpty(outputPath))
             {
@@ -29,8 +32,6 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
             else
             {
                 resolvedPath = Path.Combine(Environment.CurrentDirectory, outputPath);
-
-                // Create directory if it doesn't exist
                 Directory.CreateDirectory(resolvedPath);
                 resolvedPath = Path.Combine(resolvedPath, $"{Path.GetFileName(functionAppRoot)}");
             }

--- a/src/Cli/func/Actions/LocalActions/PackAction/PackHelpers.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/PackHelpers.cs
@@ -63,9 +63,9 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
             }
         }
 
-        public static async Task CreatePackage(string packingRoot, string outputPath, bool noBuild, IDictionary<string, string> telemetryCommandEvents, bool buildNativeDeps = false)
+        public static async Task CreatePackage(string packingRoot, string outputPath, bool noBuild, WorkerRuntime workerRuntime, IDictionary<string, string> telemetryCommandEvents, bool buildNativeDeps = false)
         {
-            var stream = await ZipHelper.GetAppZipFile(packingRoot, buildNativeDeps, BuildOption.Default, noBuild: noBuild);
+            var stream = await ZipHelper.GetAppZipFile(packingRoot, buildNativeDeps, BuildOption.Default, noBuild: noBuild, workerRuntime);
 
             ColoredConsole.WriteLine($"Creating a new package {outputPath}");
             await FileSystemHelpers.WriteToFile(outputPath, stream);

--- a/src/Cli/func/Actions/LocalActions/PackAction/PackSubcommandAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/PackSubcommandAction.cs
@@ -21,7 +21,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
 
             var packingRoot = await GetPackingRootAsync(functionAppRoot, options);
 
-            var outputPath = PackHelpers.ResolveOutputPath(functionAppRoot, options.OutputPath);
+            var outputPath = ResolveOutputPath(functionAppRoot, options.OutputPath);
             PackHelpers.CleanupExistingPackage(outputPath);
 
             await PerformBuildBeforePackingAsync(packingRoot, functionAppRoot, options);
@@ -50,6 +50,11 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
 
         // Hook: must return the root folder to package (can trigger build/publish as needed)
         protected abstract Task<string> GetPackingRootAsync(string functionAppRoot, PackOptions options);
+
+        // Hook: resolve the destination archive path. Default delegates to PackHelpers; runtimes
+        // that want different conventions (e.g. Go accepting an explicit .zip path) can override.
+        protected virtual string ResolveOutputPath(string functionAppRoot, string outputPath)
+            => PackHelpers.ResolveOutputPath(functionAppRoot, outputPath);
 
         // Hook: optional step to run right before packaging (e.g., Node build)
         protected virtual Task PerformBuildBeforePackingAsync(string packingRoot, string functionAppRoot, PackOptions options) => Task.CompletedTask;

--- a/src/Cli/func/Actions/LocalActions/PackAction/PackSubcommandAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/PackSubcommandAction.cs
@@ -2,12 +2,22 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Helpers;
 
 namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
 {
     // Base class for pack subcommands to reduce duplication using a template method.
     internal abstract class PackSubcommandAction : BaseAction
     {
+        protected PackSubcommandAction(WorkerRuntime workerRuntime)
+        {
+            Runtime = workerRuntime;
+        }
+
+        // The worker runtime this subcommand packs for. Set once at construction so the
+        // pack flow never has to read GlobalCoreToolsSettings.CurrentWorkerRuntime.
+        protected WorkerRuntime Runtime { get; }
+
         // Orchestrates the pack flow for subcommands that don't need extra args
         protected async Task ExecuteAsync(PackOptions options)
         {
@@ -61,7 +71,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
 
         // Hook: actual packaging operation (default zip from packingRoot)
         protected virtual Task PackFunctionAsync(string packingRoot, string outputPath, PackOptions options)
-            => PackHelpers.CreatePackage(packingRoot, outputPath, options.NoBuild, TelemetryCommandEvents);
+            => PackHelpers.CreatePackage(packingRoot, outputPath, options.NoBuild, Runtime, TelemetryCommandEvents);
 
         // Hook: optional cleanup after packaging
         protected virtual Task PerformCleanupAfterPackingAsync(string packingRoot, string functionAppRoot, PackOptions options) => Task.CompletedTask;

--- a/src/Cli/func/Actions/LocalActions/PackAction/PowershellPackSubcommandAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/PowershellPackSubcommandAction.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Helpers;
 using Azure.Functions.Cli.Interfaces;
 using Fclp;
 
@@ -11,6 +12,11 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
     [Action(Name = "pack powershell", ParentCommandName = "pack", ShowInHelp = false, HelpText = "Arguments specific to PowerShell apps when running func pack")]
     internal class PowershellPackSubcommandAction : PackSubcommandAction
     {
+        public PowershellPackSubcommandAction()
+            : base(WorkerRuntime.Powershell)
+        {
+        }
+
         public override ICommandLineParserResult ParseArgs(string[] args)
         {
             return base.ParseArgs(args);

--- a/src/Cli/func/Actions/LocalActions/PackAction/PythonPackSubcommandAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/PythonPackSubcommandAction.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Helpers;
 using Colors.Net;
 using Fclp;
 using Newtonsoft.Json.Linq;
@@ -12,6 +13,11 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
     [Action(Name = "pack python", ParentCommandName = "pack", ShowInHelp = true, HelpText = "Arguments specific to Python apps when running func pack")]
     internal class PythonPackSubcommandAction : PackSubcommandAction
     {
+        public PythonPackSubcommandAction()
+            : base(WorkerRuntime.Python)
+        {
+        }
+
         public bool BuildNativeDeps { get; set; }
 
         public override ICommandLineParserResult ParseArgs(string[] args)
@@ -78,7 +84,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
         protected override Task PackFunctionAsync(string packingRoot, string outputPath, PackOptions options)
         {
             // Include BuildNativeDeps in packaging call
-            return PackHelpers.CreatePackage(packingRoot, outputPath, options.NoBuild, TelemetryCommandEvents, BuildNativeDeps);
+            return PackHelpers.CreatePackage(packingRoot, outputPath, options.NoBuild, Runtime, TelemetryCommandEvents, BuildNativeDeps);
         }
 
         public override Task RunAsync()

--- a/src/Cli/func/Common/Constants.cs
+++ b/src/Cli/func/Common/Constants.cs
@@ -21,11 +21,11 @@ namespace Azure.Functions.Cli.Common
         public const string FunctionsWorkerRuntime = "FUNCTIONS_WORKER_RUNTIME";
         public const string FunctionsWorkerRuntimeVersion = "FUNCTIONS_WORKER_RUNTIME_VERSION";
 
-        // CLI-only preview opt-in for the Go worker. Read from env first, then local.settings.json
-        // (Values). Never sent to the host or to Azure (the CLI strips local.settings on publish).
-        // Intentionally Go-specific and short-lived: when the platform exposes a first-class
-        // mapping for "native" → concrete language, this flag and its consumers should be removed.
-        public const string FunctionsCliGoPreview = "FUNCTIONS_CLI_GO_PREVIEW";
+        // CLI-only disambiguator for FUNCTIONS_WORKER_RUNTIME=native projects. Read from env
+        // first, then local.settings.json (Values). Never sent to the host or to Azure (the CLI
+        // strips local.settings on publish). Today only "go" is recognized; new native languages
+        // (rust, c++, etc.) extend this same value space rather than introducing parallel flags.
+        public const string FunctionsCliNativeLanguage = "FUNCTIONS_CLI_NATIVE_LANGUAGE";
         public const string RequirementsTxt = "requirements.txt";
         public const string PythonGettingStarted = "getting_started.md";
         public const string PySteinFunctionAppPy = "function_app.py";

--- a/src/Cli/func/Common/Constants.cs
+++ b/src/Cli/func/Common/Constants.cs
@@ -20,6 +20,12 @@ namespace Azure.Functions.Cli.Common
         public const string FuncIgnoreFile = ".funcignore";
         public const string FunctionsWorkerRuntime = "FUNCTIONS_WORKER_RUNTIME";
         public const string FunctionsWorkerRuntimeVersion = "FUNCTIONS_WORKER_RUNTIME_VERSION";
+
+        // CLI-only preview opt-in for the Go worker. Read from env first, then local.settings.json
+        // (Values). Never sent to the host or to Azure (the CLI strips local.settings on publish).
+        // Intentionally Go-specific and short-lived: when the platform exposes a first-class
+        // mapping for "native" → concrete language, this flag and its consumers should be removed.
+        public const string FunctionsCliGoPreview = "FUNCTIONS_CLI_GO_PREVIEW";
         public const string RequirementsTxt = "requirements.txt";
         public const string PythonGettingStarted = "getting_started.md";
         public const string PySteinFunctionAppPy = "function_app.py";

--- a/src/Cli/func/Common/Executable.cs
+++ b/src/Cli/func/Common/Executable.cs
@@ -5,12 +5,18 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Azure.Functions.Cli.Extensions;
+using Azure.Functions.Cli.Helpers;
 using static Azure.Functions.Cli.Common.OutputTheme;
 
 namespace Azure.Functions.Cli.Common
 {
     internal class Executable : IAsyncDisposable
     {
+        // Cap the post-exit drain (see RunAsync) so a stuck async output handler can never
+        // hold up the caller indefinitely. The drain only flushes already-buffered stdout/stderr
+        // bytes, which normally completes in milliseconds; 5s is a defensive safety net.
+        private const int OutputDrainTimeoutMs = 5000;
+
         private readonly string _arguments;
         private readonly string _exeName;
         private readonly bool _shareConsole;
@@ -122,11 +128,32 @@ namespace Azure.Functions.Cli.Common
 
                 if (timeout is null)
                 {
-                    return await exitCodeTask.ConfigureAwait(false);
+                    var exitCode = await exitCodeTask.ConfigureAwait(false);
+
+                    if (_streamOutput)
+                    {
+                        // Process exit and async output delivery are independent: the Exited event
+                        // can fire before OutputDataReceived/ErrorDataReceived have drained the OS
+                        // pipe buffers. For short-lived commands (e.g. `go version`) this leaves
+                        // callers reading an empty StringBuilder. WaitForExit(int) flushes the async
+                        // event pump after the process has already exited, bounded so a hung handler
+                        // can never block forever.
+                        DrainAsyncOutput();
+                    }
+
+                    return exitCode;
                 }
                 else
                 {
-                    return await exitCodeTask.WaitAsync(timeout.Value).ConfigureAwait(false);
+                    var exitCode = await exitCodeTask.WaitAsync(timeout.Value).ConfigureAwait(false);
+
+                    if (_streamOutput)
+                    {
+                        // See comment above: drain async output handlers before returning.
+                        DrainAsyncOutput();
+                    }
+
+                    return exitCode;
                 }
             }
             catch (TimeoutException)
@@ -136,6 +163,39 @@ namespace Azure.Functions.Cli.Common
             catch (Win32Exception ex) when (ex.Message.Contains("cannot find the file specified"))
             {
                 throw new FileNotFoundException(ex.Message, ex);
+            }
+        }
+
+        private void DrainAsyncOutput()
+        {
+            try
+            {
+                if (!Process.WaitForExit(OutputDrainTimeoutMs))
+                {
+                    if (GlobalCoreToolsSettings.IsVerbose)
+                    {
+                        Colors.Net.ColoredConsole.WriteLine(VerboseColor(
+                            $"Output drain for '{_exeName}' did not complete within {OutputDrainTimeoutMs}ms; returning exit code with possibly truncated output."));
+                    }
+
+                    return;
+                }
+
+                // Process exited within timeout; the no-arg overload flushes the async
+                // stdout/stderr event handlers that WaitForExit(int) does not drain.
+                Process.WaitForExit();
+            }
+            catch (Exception ex) when (ex is InvalidOperationException || ex is System.ComponentModel.Win32Exception)
+            {
+                // The drain is a best-effort flush after process exit. If Process has already
+                // been disposed (InvalidOperationException) or the OS handle is no longer
+                // accessible (Win32Exception), swallow and return the captured exit code
+                // rather than masking it with an unrelated exception.
+                if (GlobalCoreToolsSettings.IsVerbose)
+                {
+                    Colors.Net.ColoredConsole.WriteLine(VerboseColor(
+                        $"Output drain for '{_exeName}' failed: {ex.Message}. Returning captured exit code."));
+                }
             }
         }
 

--- a/src/Cli/func/Common/Executable.cs
+++ b/src/Cli/func/Common/Executable.cs
@@ -15,7 +15,7 @@ namespace Azure.Functions.Cli.Common
         // Cap the post-exit drain (see RunAsync) so a stuck async output handler can never
         // hold up the caller indefinitely. The drain only flushes already-buffered stdout/stderr
         // bytes, which normally completes in milliseconds; 5s is a defensive safety net.
-        private const int OutputDrainTimeoutMs = 5000;
+        private static readonly TimeSpan _outputDrainTimeout = TimeSpan.FromMilliseconds(5000);
 
         private readonly string _arguments;
         private readonly string _exeName;
@@ -135,10 +135,10 @@ namespace Azure.Functions.Cli.Common
                         // Process exit and async output delivery are independent: the Exited event
                         // can fire before OutputDataReceived/ErrorDataReceived have drained the OS
                         // pipe buffers. For short-lived commands (e.g. `go version`) this leaves
-                        // callers reading an empty StringBuilder. WaitForExit(int) flushes the async
+                        // callers reading an empty StringBuilder. WaitForExitAsync drains the async
                         // event pump after the process has already exited, bounded so a hung handler
                         // can never block forever.
-                        DrainAsyncOutput();
+                        await DrainAsyncOutputAsync().ConfigureAwait(false);
                     }
 
                     return exitCode;
@@ -150,7 +150,7 @@ namespace Azure.Functions.Cli.Common
                     if (_streamOutput)
                     {
                         // See comment above: drain async output handlers before returning.
-                        DrainAsyncOutput();
+                        await DrainAsyncOutputAsync().ConfigureAwait(false);
                     }
 
                     return exitCode;
@@ -166,24 +166,20 @@ namespace Azure.Functions.Cli.Common
             }
         }
 
-        private void DrainAsyncOutput()
+        private async Task DrainAsyncOutputAsync()
         {
             try
             {
-                if (!Process.WaitForExit(OutputDrainTimeoutMs))
+                using var cts = new CancellationTokenSource(_outputDrainTimeout);
+                await Process.WaitForExitAsync(cts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                if (GlobalCoreToolsSettings.IsVerbose)
                 {
-                    if (GlobalCoreToolsSettings.IsVerbose)
-                    {
-                        Colors.Net.ColoredConsole.WriteLine(VerboseColor(
-                            $"Output drain for '{_exeName}' did not complete within {OutputDrainTimeoutMs}ms; returning exit code with possibly truncated output."));
-                    }
-
-                    return;
+                    Colors.Net.ColoredConsole.WriteLine(VerboseColor(
+                        $"Output drain for '{_exeName}' did not complete within {_outputDrainTimeout.TotalMilliseconds}ms; returning exit code with possibly truncated output."));
                 }
-
-                // Process exited within timeout; the no-arg overload flushes the async
-                // stdout/stderr event handlers that WaitForExit(int) does not drain.
-                Process.WaitForExit();
             }
             catch (Exception ex) when (ex is InvalidOperationException || ex is System.ComponentModel.Win32Exception)
             {

--- a/src/Cli/func/Common/Utilities.cs
+++ b/src/Cli/func/Common/Utilities.cs
@@ -64,6 +64,19 @@ namespace Azure.Functions.Cli
             ColoredConsole.WriteLine();
         }
 
+        internal static void WarnIfGoWorkerRuntime(Helpers.WorkerRuntime workerRuntime)
+        {
+            if (workerRuntime != Helpers.WorkerRuntime.Go)
+            {
+                return;
+            }
+
+            ColoredConsole
+                .WriteLine("The Go worker runtime is currently in preview. Features and behavior may change in future releases.".DarkYellow());
+
+            ColoredConsole.WriteLine();
+        }
+
         internal static void PrintSupportInformation()
         {
             Architecture arch = RuntimeInformation.ProcessArchitecture;

--- a/src/Cli/func/Common/Utilities.cs
+++ b/src/Cli/func/Common/Utilities.cs
@@ -72,7 +72,7 @@ namespace Azure.Functions.Cli
             }
 
             ColoredConsole
-                .WriteLine("The Go worker runtime is currently in preview. Features and behavior may change in future releases.".DarkYellow());
+                .WriteLine("Go support is in preview. The build/publish behavior and deployment layout may change before GA.".DarkYellow());
 
             ColoredConsole.WriteLine();
         }

--- a/src/Cli/func/Directory.Build.targets
+++ b/src/Cli/func/Directory.Build.targets
@@ -6,6 +6,7 @@
   <Import Project="$(EngBuildRoot)Templates.targets" Condition="'$(SkipTemplates)' != 'true'" />
 
   <Import Project="$(EngBuildRoot)Workers.Powershell.targets" />
+  <Import Project="$(EngBuildRoot)Workers.Golang.targets" />
   <Import Project="$(EngBuildRoot)Workers.Python.Workaround.targets" Condition="'$(RuntimeIdentifier)' == 'win-arm64'" />
 
 </Project>

--- a/src/Cli/func/Directory.Version.props
+++ b/src/Cli/func/Directory.Version.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>4.12.0</VersionPrefix>
-    <VersionSuffix>preview.1</VersionSuffix>
+    <VersionSuffix></VersionSuffix>
     <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>
 

--- a/src/Cli/func/Directory.Version.props
+++ b/src/Cli/func/Directory.Version.props
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>4.11.1</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
+    <VersionPrefix>4.12.0</VersionPrefix>
+    <VersionSuffix>preview.1</VersionSuffix>
     <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>
 

--- a/src/Cli/func/Helpers/GlobalCoreToolsSettings.cs
+++ b/src/Cli/func/Helpers/GlobalCoreToolsSettings.cs
@@ -45,7 +45,7 @@ namespace Azure.Functions.Cli.Helpers
             {
                 if (_currentWorkerRuntime == WorkerRuntime.None)
                 {
-                    ColoredConsole.Error.WriteLine(QuietWarningColor("Can't determine project language from files. Please use one of [--dotnet-isolated, --dotnet, --javascript, --typescript, --python, --powershell, --custom, --go]"));
+                    ColoredConsole.Error.WriteLine(QuietWarningColor("Can't determine project language from files. Please use one of [--dotnet-isolated, --dotnet, --javascript, --typescript, --python, --powershell, --custom, --go (preview)]"));
                     throw new CliException($"Worker runtime cannot be '{WorkerRuntime.None}'. Please set a valid runtime.");
                 }
 

--- a/src/Cli/func/Helpers/GlobalCoreToolsSettings.cs
+++ b/src/Cli/func/Helpers/GlobalCoreToolsSettings.cs
@@ -45,7 +45,7 @@ namespace Azure.Functions.Cli.Helpers
             {
                 if (_currentWorkerRuntime == WorkerRuntime.None)
                 {
-                    ColoredConsole.Error.WriteLine(QuietWarningColor("Can't determine project language from files. Please use one of [--dotnet-isolated, --dotnet, --javascript, --typescript, --python, --powershell, --custom]"));
+                    ColoredConsole.Error.WriteLine(QuietWarningColor("Can't determine project language from files. Please use one of [--dotnet-isolated, --dotnet, --javascript, --typescript, --python, --powershell, --custom, --go]"));
                     throw new CliException($"Worker runtime cannot be '{WorkerRuntime.None}'. Please set a valid runtime.");
                 }
 
@@ -142,6 +142,10 @@ namespace Azure.Functions.Cli.Helpers
                 else if (args.Contains("--custom"))
                 {
                     _currentWorkerRuntime = WorkerRuntime.Custom;
+                }
+                else if (args.Contains("--go") || args.Contains("--golang"))
+                {
+                    _currentWorkerRuntime = WorkerRuntime.Go;
                 }
                 else
                 {

--- a/src/Cli/func/Helpers/GoHelpers.cs
+++ b/src/Cli/func/Helpers/GoHelpers.cs
@@ -1,0 +1,153 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Text;
+using System.Text.RegularExpressions;
+using Azure.Functions.Cli.Common;
+using Colors.Net;
+using static Azure.Functions.Cli.Common.OutputTheme;
+
+namespace Azure.Functions.Cli.Helpers
+{
+    public static class GoHelpers
+    {
+        private const int MinimumGoMajorVersion = 1;
+        private const int MinimumGoMinorVersion = 24;
+
+        public static async Task<WorkerLanguageVersionInfo> GetEnvironmentGoVersion()
+        {
+            return await GetVersion("go");
+        }
+
+        public static void AssertGoVersion(WorkerLanguageVersionInfo goVersion)
+        {
+            if (goVersion?.Version == null)
+            {
+                throw new CliException(
+                    $"Could not find a Go installation. Go {MinimumGoMajorVersion}.{MinimumGoMinorVersion} or later is required. " +
+                    "Please install Go from https://go.dev/dl/");
+            }
+
+            if (GlobalCoreToolsSettings.IsVerbose)
+            {
+                ColoredConsole.WriteLine(VerboseColor($"Found Go version {goVersion.Version} ({goVersion.ExecutablePath})."));
+            }
+
+            if (goVersion.Major == null || goVersion.Minor == null)
+            {
+                throw new CliException(
+                    $"Unable to parse Go version '{goVersion.Version}'. " +
+                    $"Go {MinimumGoMajorVersion}.{MinimumGoMinorVersion} or later is required.");
+            }
+
+            // Accept any major version > 1, or major == 1 with minor >= 24
+            if (goVersion.Major > MinimumGoMajorVersion)
+            {
+                return;
+            }
+
+            if (goVersion.Major == MinimumGoMajorVersion && goVersion.Minor >= MinimumGoMinorVersion)
+            {
+                return;
+            }
+
+            throw new CliException(
+                $"Go version {goVersion.Version} is not supported. " +
+                $"Go {MinimumGoMajorVersion}.{MinimumGoMinorVersion} or later is required. " +
+                "Please update Go from https://go.dev/dl/");
+        }
+
+        public static async Task SetupProject(string moduleName, bool skipGoModTidy)
+        {
+            var goVersion = await GetEnvironmentGoVersion();
+            AssertGoVersion(goVersion);
+
+            // Scaffold go.mod, main.go, and .funcignore from embedded templates.
+            // The SDK version is pinned inside go.mod.template so that contributors
+            // bumping the SDK only touch template files (no C# change required) and
+            // `go mod tidy` resolves the pinned version deterministically.
+            var goModContent = (await StaticResources.GoMod).Replace("{ModuleName}", moduleName);
+            await FileSystemHelpers.WriteFileIfNotExists("go.mod", goModContent);
+            await FileSystemHelpers.WriteFileIfNotExists("main.go", await StaticResources.MainGo);
+            await FileSystemHelpers.WriteFileIfNotExists(Constants.FuncIgnoreFile, await StaticResources.FuncIgnore);
+
+            if (!skipGoModTidy)
+            {
+                await RunGoCommandAsync("mod tidy", null, throwOnFailure: false);
+            }
+            else
+            {
+                ColoredConsole.WriteLine(AdditionalInfoColor("Skipped \"go mod tidy\". You must run \"go mod tidy\" manually."));
+            }
+        }
+
+        private static async Task RunGoCommandAsync(string arguments, string errorMessage, bool throwOnFailure = true)
+        {
+            var exe = new Executable("go", arguments);
+            var stderr = new StringBuilder();
+            var exitCode = await exe.RunAsync(
+                l =>
+                {
+                    if (GlobalCoreToolsSettings.IsVerbose)
+                    {
+                        ColoredConsole.WriteLine(VerboseColor(l));
+                    }
+                },
+                e =>
+                {
+                    stderr.AppendLine(e);
+                    if (GlobalCoreToolsSettings.IsVerbose)
+                    {
+                        ColoredConsole.WriteLine(VerboseColor(e));
+                    }
+                });
+
+            if (exitCode != 0)
+            {
+                var stderrOutput = stderr.ToString().Trim();
+                if (throwOnFailure)
+                {
+                    var detail = string.IsNullOrEmpty(stderrOutput) ? string.Empty : $" {stderrOutput}";
+                    throw new CliException($"{errorMessage}{detail}");
+                }
+
+                ColoredConsole.WriteLine(WarningColor($"Warning: 'go {arguments}' exited with a non-zero code. You may need to run it manually."));
+                if (!string.IsNullOrEmpty(stderrOutput))
+                {
+                    ColoredConsole.WriteLine(WarningColor(stderrOutput));
+                }
+            }
+        }
+
+        private static async Task<WorkerLanguageVersionInfo> GetVersion(string goExe)
+        {
+            try
+            {
+                var exe = new Executable(goExe, "version");
+                var sb = new StringBuilder();
+                var exitCode = await exe.RunAsync(l => sb.AppendLine(l), e => sb.AppendLine(e));
+
+                if (exitCode == 0)
+                {
+                    var output = sb.ToString().Trim();
+
+                    // Parse "go version go1.24.2 linux/amd64" format
+                    var match = Regex.Match(output, @"go(\d+\.\d+(?:\.\d+)?)");
+                    if (match.Success)
+                    {
+                        return new WorkerLanguageVersionInfo(WorkerRuntime.Go, match.Groups[1].Value, goExe);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                if (GlobalCoreToolsSettings.IsVerbose)
+                {
+                    ColoredConsole.WriteLine(VerboseColor($"Unable to detect Go version: {ex.Message}"));
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Cli/func/Helpers/GoHelpers.cs
+++ b/src/Cli/func/Helpers/GoHelpers.cs
@@ -9,10 +9,11 @@ using static Azure.Functions.Cli.Common.OutputTheme;
 
 namespace Azure.Functions.Cli.Helpers
 {
-    public static class GoHelpers
+    internal static class GoHelpers
     {
         private const int MinimumGoMajorVersion = 1;
         private const int MinimumGoMinorVersion = 24;
+        private const string GoBinaryName = "app";
 
         public static async Task<WorkerLanguageVersionInfo> GetEnvironmentGoVersion()
         {
@@ -78,6 +79,48 @@ namespace Azure.Functions.Cli.Helpers
             else
             {
                 ColoredConsole.WriteLine(AdditionalInfoColor("Skipped \"go mod tidy\". You must run \"go mod tidy\" manually."));
+            }
+        }
+
+        /// <summary>
+        /// Compiles the user's Go project into a binary named <see cref="GoBinaryName"/>
+        /// in <paramref name="workingDirectory"/>. The host resolves this binary via
+        /// <c>defaultExecutablePath</c> in <c>workers/native/worker.config.json</c>
+        /// (the host appends <c>.exe</c> on Windows automatically).
+        /// </summary>
+        public static async Task BuildProject(string workingDirectory = null)
+        {
+            workingDirectory ??= Environment.CurrentDirectory;
+            var outputName = OperatingSystem.IsWindows() ? $"{GoBinaryName}.exe" : GoBinaryName;
+            ColoredConsole.WriteLine($"Building Go worker binary '{outputName}'...");
+
+            var exe = new Executable("go", $"build -o \"{outputName}\" .", workingDirectory: workingDirectory);
+            var exitCode = await exe.RunAsync(
+                l => ColoredConsole.WriteLine(l),
+                e => ColoredConsole.Error.WriteLine(ErrorColor(e)));
+
+            if (exitCode != 0)
+            {
+                throw new CliException($"Go build failed with exit code {exitCode}. See output above for details.");
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the compiled Go worker binary exists in
+        /// <paramref name="workingDirectory"/>. Throws a <see cref="CliException"/>
+        /// with an actionable message when missing — used by <c>func start --no-build</c>.
+        /// </summary>
+        public static void AssertBinaryExists(string workingDirectory = null)
+        {
+            workingDirectory ??= Environment.CurrentDirectory;
+            var binaryName = OperatingSystem.IsWindows() ? $"{GoBinaryName}.exe" : GoBinaryName;
+            var binaryPath = Path.Combine(workingDirectory, binaryName);
+
+            if (!FileSystemHelpers.FileExists(binaryPath))
+            {
+                throw new CliException(
+                    $"Could not find a built Go binary '{binaryName}' in '{workingDirectory}'. " +
+                    $"Run 'func start' without '--no-build' to compile, or run 'go build -o {binaryName} .' manually.");
             }
         }
 

--- a/src/Cli/func/Helpers/GoHelpers.cs
+++ b/src/Cli/func/Helpers/GoHelpers.cs
@@ -1,8 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
+using Azure.Functions.Cli.Actions.LocalActions.PackAction;
 using Azure.Functions.Cli.Common;
 using Colors.Net;
 using static Azure.Functions.Cli.Common.OutputTheme;
@@ -13,7 +15,10 @@ namespace Azure.Functions.Cli.Helpers
     {
         private const int MinimumGoMajorVersion = 1;
         private const int MinimumGoMinorVersion = 24;
-        private const string GoBinaryName = "app";
+        private const int GoVersionTimeoutMs = 5000;
+        internal const string GoBinaryName = "app";
+        internal const string GoBinDir = "bin";
+        internal const string GoModFileName = "go.mod";
 
         public static async Task<WorkerLanguageVersionInfo> GetEnvironmentGoVersion()
         {
@@ -64,9 +69,10 @@ namespace Azure.Functions.Cli.Helpers
             AssertGoVersion(goVersion);
 
             // Scaffold go.mod, main.go, and .funcignore from embedded templates.
-            // The SDK version is pinned inside go.mod.template so that contributors
-            // bumping the SDK only touch template files (no C# change required) and
-            // `go mod tidy` resolves the pinned version deterministically.
+            // go.mod intentionally omits a require line for azure-functions-golang-worker —
+            // `go mod tidy` resolves the latest available tag from the imports in main.go,
+            // so users always pick up the newest SDK without contributors having to bump
+            // a pinned version here.
             var goModContent = (await StaticResources.GoMod).Replace("{ModuleName}", moduleName);
             await FileSystemHelpers.WriteFileIfNotExists("go.mod", goModContent);
             await FileSystemHelpers.WriteFileIfNotExists("main.go", await StaticResources.MainGo);
@@ -84,25 +90,53 @@ namespace Azure.Functions.Cli.Helpers
 
         /// <summary>
         /// Compiles the user's Go project into a binary named <see cref="GoBinaryName"/>
-        /// in <paramref name="workingDirectory"/>. The host resolves this binary via
-        /// <c>defaultExecutablePath</c> in <c>workers/native/worker.config.json</c>
-        /// (the host appends <c>.exe</c> on Windows automatically).
+        /// under <c><see cref="GoBinDir"/>/</c> in <paramref name="workingDirectory"/>.
+        /// The host resolves this binary via <c>defaultExecutablePath</c> in
+        /// <c>workers/native/worker.config.json</c> (the host appends <c>.exe</c> on
+        /// Windows automatically).
         /// </summary>
         public static async Task BuildProject(string workingDirectory = null)
         {
             workingDirectory ??= Environment.CurrentDirectory;
             var outputName = OperatingSystem.IsWindows() ? $"{GoBinaryName}.exe" : GoBinaryName;
-            ColoredConsole.WriteLine($"Building Go worker binary '{outputName}'...");
+            var outputPath = Path.Combine(GoBinDir, outputName);
 
-            var exe = new Executable("go", $"build -o \"{outputName}\" .", workingDirectory: workingDirectory);
+            ColoredConsole.WriteLine($"Building Go worker binary '{outputPath}'...");
+
+            // Ensure bin/ exists so `go build -o bin/app` doesn't fail.
+            Directory.CreateDirectory(Path.Combine(workingDirectory, GoBinDir));
+
+            var stderrBuffer = new StringBuilder();
+            var exe = new Executable("go", $"build -o \"{outputPath}\" .", workingDirectory: workingDirectory);
             var exitCode = await exe.RunAsync(
                 l => ColoredConsole.WriteLine(l),
-                e => ColoredConsole.Error.WriteLine(ErrorColor(e)));
+                e =>
+                {
+                    stderrBuffer.AppendLine(e);
+                    ColoredConsole.Error.WriteLine(ErrorColor(e));
+                });
 
             if (exitCode != 0)
             {
+                if (LooksLikeStaleModules(stderrBuffer.ToString()))
+                {
+                    ColoredConsole.WriteLine(AdditionalInfoColor("Hint: run \"go mod tidy\" to update module dependencies, then re-run \"func start\"."));
+                }
+
                 throw new CliException($"Go build failed with exit code {exitCode}. See output above for details.");
             }
+        }
+
+        private static bool LooksLikeStaleModules(string stderr)
+        {
+            if (string.IsNullOrEmpty(stderr))
+            {
+                return false;
+            }
+
+            return stderr.Contains("missing go.sum entry", StringComparison.OrdinalIgnoreCase)
+                || stderr.Contains("no required module provides package", StringComparison.OrdinalIgnoreCase)
+                || stderr.Contains("inconsistent vendoring", StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -114,14 +148,175 @@ namespace Azure.Functions.Cli.Helpers
         {
             workingDirectory ??= Environment.CurrentDirectory;
             var binaryName = OperatingSystem.IsWindows() ? $"{GoBinaryName}.exe" : GoBinaryName;
-            var binaryPath = Path.Combine(workingDirectory, binaryName);
+            var binaryPath = Path.Combine(workingDirectory, GoBinDir, binaryName);
 
             if (!FileSystemHelpers.FileExists(binaryPath))
             {
                 throw new CliException(
-                    $"Could not find a built Go binary '{binaryName}' in '{workingDirectory}'. " +
-                    $"Run 'func start' without '--no-build' to compile, or run 'go build -o {binaryName} .' manually.");
+                    $"Could not find a built Go binary '{Path.Combine(GoBinDir, binaryName)}' in '{workingDirectory}'. " +
+                    $"Run 'func start' without '--no-build' to compile, or run 'go build -o {Path.Combine(GoBinDir, binaryName)} .' manually.");
             }
+        }
+
+        /// <summary>
+        /// Cross-compiles the user's Go project into a linux/amd64 binary named
+        /// <see cref="GoBinaryName"/> in <paramref name="workingDirectory"/>. Used
+        /// by <c>func pack</c> and <c>func publish</c> — the produced binary is the
+        /// one that runs on the Linux Functions host, regardless of the dev OS.
+        /// Targets linux/amd64 only.
+        /// </summary>
+        internal static async Task BuildForLinux(string workingDirectory = null)
+        {
+            workingDirectory ??= Environment.CurrentDirectory;
+
+            var goVersion = await GetEnvironmentGoVersion();
+            AssertGoVersion(goVersion);
+
+            var outputPath = Path.Combine(GoBinDir, GoBinaryName);
+            ColoredConsole.WriteLine($"Building Go worker binary '{outputPath}' for linux/amd64...");
+
+            // Ensure bin/ exists so `go build -o bin/app` doesn't fail.
+            Directory.CreateDirectory(Path.Combine(workingDirectory, GoBinDir));
+
+            var env = new Dictionary<string, string>
+            {
+                ["CGO_ENABLED"] = "0",
+                ["GOOS"] = "linux",
+                ["GOARCH"] = "amd64",
+            };
+
+            var exe = new Executable("go", $"build -o \"{outputPath}\" .", workingDirectory: workingDirectory, environmentVariables: env);
+
+            // Stream stderr inline (red) and let the thrown exception summarize on failure
+            // rather than re-printing the captured output, so users don't see compiler errors twice.
+            var exitCode = await exe.RunAsync(
+                l => ColoredConsole.WriteLine(l),
+                e => ColoredConsole.Error.WriteLine(ErrorColor(e)));
+
+            if (exitCode != 0)
+            {
+                throw new CliException(
+                    $"Go build for linux/amd64 failed with exit code {exitCode}. See output above for details.");
+            }
+        }
+
+        /// <summary>
+        /// Ensures the Go binary in <paramref name="workingDirectory"/> is a valid
+        /// Linux x86_64 executable suitable for the Azure Functions Linux host.
+        /// Validates the binary's structure by checking its ELF header format.
+        /// Called by <c>func pack --no-build</c> to confirm the binary was properly
+        /// cross-compiled before packaging for deployment.
+        /// </summary>
+        internal static void AssertLinuxAmd64Binary(string workingDirectory = null)
+        {
+            workingDirectory ??= Environment.CurrentDirectory;
+            var binaryPath = Path.Combine(workingDirectory, GoBinDir, GoBinaryName);
+            var displayPath = Path.Combine(GoBinDir, GoBinaryName);
+
+            void ValidateBinaryExists()
+            {
+                if (!FileSystemHelpers.FileExists(binaryPath))
+                {
+                    throw new CliException(
+                        $"Could not find a built Go binary '{displayPath}' in '{workingDirectory}'. " +
+                        $"Run 'func pack' without '--no-build' to cross-compile, or run " +
+                        $"'CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o {displayPath} .' manually.");
+                }
+            }
+
+            byte[] ReadElfHeader()
+            {
+                // Read the first 20 bytes of the ELF header so we can validate magic, class, data, and machine.
+                // Layout reference: https://refspecs.linuxfoundation.org/elf/gabi4+/ch4.eheader.html
+                var header = new byte[20];
+                using (var fs = new FileStream(binaryPath, FileMode.Open, FileAccess.Read))
+                {
+                    int read = fs.Read(header, 0, header.Length);
+                    if (read < header.Length)
+                    {
+                        throw new CliException(
+                            $"'{binaryPath}' is too small to be an ELF binary. " +
+                            "Re-run 'func pack' without '--no-build' to produce a linux/amd64 binary.");
+                    }
+                }
+
+                return header;
+            }
+
+            // ELF magic is the file signature that identifies an ELF (Executable and Linkable Format) binary
+            void ValidateElfMagic(byte[] header)
+            {
+                // ELF magic: 0x7F 'E' 'L' 'F'
+                bool isElf = header[0] == 0x7F && header[1] == (byte)'E' && header[2] == (byte)'L' && header[3] == (byte)'F';
+                if (!isElf)
+                {
+                    throw new CliException(
+                        $"'{binaryPath}' is not an ELF binary. Core Tools currently only supports linux/amd64 Go targets. " +
+                        $"Re-run 'func pack' without '--no-build', or build with 'CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o {displayPath} .'");
+                }
+            }
+
+            void ValidateElfFormat(byte[] header)
+            {
+                // EI_CLASS == 2 (64-bit), EI_DATA == 1 (little endian)
+                if (header[4] != 2 || header[5] != 1)
+                {
+                    throw new CliException(
+                        $"'{binaryPath}' is not a 64-bit little-endian ELF binary. Core Tools currently only supports linux/amd64 Go targets. " +
+                        $"Re-run 'func pack' without '--no-build', or build with 'CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o {displayPath} .'");
+                }
+            }
+
+            void ValidateElfMachine(byte[] header)
+            {
+                // e_machine is at offset 18, 2 bytes little-endian. 0x3E == EM_X86_64.
+                ushort eMachine = (ushort)(header[18] | (header[19] << 8));
+                if (eMachine != 0x3E)
+                {
+                    throw new CliException(
+                        $"'{binaryPath}' targets machine 0x{eMachine:X4}, not x86_64. Core Tools currently only supports linux/amd64 Go targets. " +
+                        $"Re-run 'func pack' without '--no-build', or build with 'CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o {displayPath} .'");
+                }
+            }
+
+            // Execute validations in order
+            ValidateBinaryExists();
+            var header = ReadElfHeader();
+            ValidateElfMagic(header);
+            ValidateElfFormat(header);
+            ValidateElfMachine(header);
+        }
+
+        /// <summary>
+        /// Returns the explicit allowlist of files that should be included in the
+        /// Go deployment zip. Centralizes the list so that <see cref="ZipHelper"/>
+        /// (zip composition) and <c>func publish --list-included-files</c> stay in sync.
+        /// </summary>
+        internal static IEnumerable<string> GetPackFiles(string functionAppRoot)
+        {
+            functionAppRoot ??= Environment.CurrentDirectory;
+            return new[]
+            {
+                Path.Combine(functionAppRoot, Constants.HostJsonFileName),
+                Path.Combine(functionAppRoot, GoBinDir, GoBinaryName),
+            };
+        }
+
+        /// <summary>
+        /// Verifies the function app root has the files required to build/publish a Go app
+        /// (<c>host.json</c> and <c>go.mod</c>) by routing through <see cref="PackValidationHelper"/>
+        /// so <c>func pack</c> and <c>func publish</c> share the same validation flow and messages.
+        /// Throws <see cref="CliException"/> on failure.
+        /// </summary>
+        internal static void AssertGoFunctionAppLayout(string functionAppRoot)
+        {
+            functionAppRoot ??= Environment.CurrentDirectory;
+
+            var validations = new List<Action<string>>
+            {
+                dir => PackValidationHelper.RunRequiredFilesValidation(dir, new[] { GoModFileName }, "Validate go.mod"),
+            };
+            PackValidationHelper.RunValidations(functionAppRoot, validations);
         }
 
         private static async Task RunGoCommandAsync(string arguments, string errorMessage, bool throwOnFailure = true)
@@ -162,35 +357,69 @@ namespace Azure.Functions.Cli.Helpers
             }
         }
 
-        private static async Task<WorkerLanguageVersionInfo> GetVersion(string goExe)
+        private static Task<WorkerLanguageVersionInfo> GetVersion(string goExe)
         {
+            // Synchronous Process I/O for reliability — async I/O (ReadToEndAsync /
+            // WaitForExitAsync) intermittently returned null on Linux CI agents for
+            // sub-second commands like 'go version', producing confusing
+            // "Could not find a Go installation" errors. Surface failure reasons to
+            // stderr rather than returning null silently so CI logs are diagnosable.
+            void Warn(string message) => ColoredConsole.Error.WriteLine(WarningColor($"Warning: {message}"));
+
             try
             {
-                var exe = new Executable(goExe, "version");
-                var sb = new StringBuilder();
-                var exitCode = await exe.RunAsync(l => sb.AppendLine(l), e => sb.AppendLine(e));
-
-                if (exitCode == 0)
+                using var process = new Process
                 {
-                    var output = sb.ToString().Trim();
-
-                    // Parse "go version go1.24.2 linux/amd64" format
-                    var match = Regex.Match(output, @"go(\d+\.\d+(?:\.\d+)?)");
-                    if (match.Success)
+                    StartInfo = new ProcessStartInfo
                     {
-                        return new WorkerLanguageVersionInfo(WorkerRuntime.Go, match.Groups[1].Value, goExe);
+                        FileName = goExe,
+                        Arguments = "version",
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true,
+                        UseShellExecute = false,
+                        CreateNoWindow = true,
+                    },
+                };
+
+                process.Start();
+                string output = process.StandardOutput.ReadToEnd().Trim();
+
+                if (!process.WaitForExit(GoVersionTimeoutMs))
+                {
+                    try
+                    {
+                        process.Kill();
                     }
+                    catch (InvalidOperationException)
+                    {
+                        // Process exited between WaitForExit returning and Kill — benign.
+                    }
+
+                    Warn($"'{goExe} version' did not complete within {GoVersionTimeoutMs}ms.");
+                    return Task.FromResult<WorkerLanguageVersionInfo>(null);
                 }
+
+                if (process.ExitCode != 0)
+                {
+                    Warn($"'{goExe} version' exited with code {process.ExitCode}.");
+                    return Task.FromResult<WorkerLanguageVersionInfo>(null);
+                }
+
+                // Parse "go version go1.24.2 linux/amd64" format.
+                var match = Regex.Match(output, @"go(\d+\.\d+(?:\.\d+)?)");
+                if (match.Success)
+                {
+                    return Task.FromResult(new WorkerLanguageVersionInfo(WorkerRuntime.Go, match.Groups[1].Value, goExe));
+                }
+
+                Warn($"'{goExe} version' returned unparseable output: '{output}'.");
             }
             catch (Exception ex)
             {
-                if (GlobalCoreToolsSettings.IsVerbose)
-                {
-                    ColoredConsole.WriteLine(VerboseColor($"Unable to detect Go version: {ex.Message}"));
-                }
+                Warn($"unable to detect Go version: {ex.GetType().Name}: {ex.Message}");
             }
 
-            return null;
+            return Task.FromResult<WorkerLanguageVersionInfo>(null);
         }
     }
 }

--- a/src/Cli/func/Helpers/LanguageWorkerHelper.cs
+++ b/src/Cli/func/Helpers/LanguageWorkerHelper.cs
@@ -15,6 +15,7 @@ namespace Azure.Functions.Cli.Helpers
             { WorkerRuntime.Powershell, "languageWorkers:powershell:arguments" },
             { WorkerRuntime.Dotnet, string.Empty },
             { WorkerRuntime.Custom, string.Empty },
+            { WorkerRuntime.Go, string.Empty },
             { WorkerRuntime.None, string.Empty }
         }
         .Select(p => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)

--- a/src/Cli/func/Helpers/PythonHelpers.cs
+++ b/src/Cli/func/Helpers/PythonHelpers.cs
@@ -330,15 +330,6 @@ namespace Azure.Functions.Cli.Helpers
 
             if (exitCode == 0)
             {
-                var trials = 0;
-
-                // this delay to make sure the output
-                while (string.IsNullOrWhiteSpace(sb.ToString()) && trials < 5)
-                {
-                    trials++;
-                    await Task.Delay(TimeSpan.FromMilliseconds(200));
-                }
-
                 return sb.ToString().Trim();
             }
             else

--- a/src/Cli/func/Helpers/WorkerRuntimeLanguageHelper.cs
+++ b/src/Cli/func/Helpers/WorkerRuntimeLanguageHelper.cs
@@ -25,7 +25,9 @@ namespace Azure.Functions.Cli.Helpers
         [DisplayString("powershell")]
         Powershell,
         [DisplayString("custom")]
-        Custom
+        Custom,
+        [DisplayString("go")]
+        Go
     }
 
     public static class WorkerRuntimeLanguageHelper
@@ -38,7 +40,8 @@ namespace Azure.Functions.Cli.Helpers
             { WorkerRuntime.Python, new[] { "py" } },
             { WorkerRuntime.Java, new string[] { } },
             { WorkerRuntime.Powershell, new[] { "pwsh" } },
-            { WorkerRuntime.Custom, new string[] { } }
+            { WorkerRuntime.Custom, new string[] { } },
+            { WorkerRuntime.Go, new[] { "golang" } }
         };
 
         private static readonly IDictionary<string, WorkerRuntime> _normalizeMap = _availableWorkersRuntime
@@ -67,7 +70,7 @@ namespace Azure.Functions.Cli.Helpers
             { Constants.Languages.CSharp, new[] { "csharp", "dotnet", "dotnet-isolated", "dotnetIsolated" } },
             { Constants.Languages.FSharp, new[] { "fsharp" } },
             { Constants.Languages.Java, new string[] { } },
-            { Constants.Languages.Custom, new string[] { } }
+            { Constants.Languages.Custom, new string[] { } },
         };
 
         public static readonly IDictionary<string, string> WorkerRuntimeStringToLanguage = _languageToAlias
@@ -79,7 +82,7 @@ namespace Azure.Functions.Cli.Helpers
         {
             { WorkerRuntime.Node, new[] { Constants.Languages.JavaScript, Constants.Languages.TypeScript } },
             { WorkerRuntime.Dotnet, new[] { Constants.Languages.CSharp, Constants.Languages.FSharp } },
-            { WorkerRuntime.DotnetIsolated, new[] { Constants.Languages.CSharp, Constants.Languages.FSharp } }
+            { WorkerRuntime.DotnetIsolated, new[] { Constants.Languages.CSharp, Constants.Languages.FSharp } },
         };
 
         public static IEnumerable<WorkerRuntime> AvailableWorkersList => _availableWorkersRuntime.Keys
@@ -110,6 +113,8 @@ namespace Azure.Functions.Cli.Helpers
                     return "powershell";
                 case WorkerRuntime.Custom:
                     return "custom";
+                case WorkerRuntime.Go:
+                    return "go";
                 default:
                     return "None";
             }
@@ -159,7 +164,7 @@ namespace Azure.Functions.Cli.Helpers
             {
                 throw new ArgumentNullException(nameof(languageString), "language can't be empty");
             }
-            else if (_normalizeMap.ContainsKey(languageString))
+            else if (WorkerRuntimeStringToLanguage.ContainsKey(languageString))
             {
                 return WorkerRuntimeStringToLanguage[languageString];
             }
@@ -167,6 +172,18 @@ namespace Azure.Functions.Cli.Helpers
             {
                 throw new ArgumentException($"Language '{languageString}' is not available. Available language strings are {WorkerRuntimeStringToLanguage.Keys}");
             }
+        }
+
+        public static bool TryNormalizeLanguage(string languageString, out string normalized)
+        {
+            if (!string.IsNullOrWhiteSpace(languageString) && WorkerRuntimeStringToLanguage.ContainsKey(languageString))
+            {
+                normalized = WorkerRuntimeStringToLanguage[languageString];
+                return true;
+            }
+
+            normalized = null;
+            return false;
         }
 
         public static IEnumerable<string> LanguagesForWorker(WorkerRuntime worker)

--- a/src/Cli/func/Helpers/WorkerRuntimeLanguageHelper.cs
+++ b/src/Cli/func/Helpers/WorkerRuntimeLanguageHelper.cs
@@ -38,10 +38,10 @@ namespace Azure.Functions.Cli.Helpers
             { WorkerRuntime.Dotnet, new[] { "c#", "csharp", "f#", "fsharp" } },
             { WorkerRuntime.Node, new[] { "js", "javascript", "typescript", "ts" } },
             { WorkerRuntime.Python, new[] { "py" } },
+            { WorkerRuntime.Go, new[] { "golang" } },
             { WorkerRuntime.Java, new string[] { } },
             { WorkerRuntime.Powershell, new[] { "pwsh" } },
             { WorkerRuntime.Custom, new string[] { } },
-            { WorkerRuntime.Go, new[] { "golang" } }
         };
 
         private static readonly IDictionary<string, WorkerRuntime> _normalizeMap = _availableWorkersRuntime
@@ -193,8 +193,32 @@ namespace Azure.Functions.Cli.Helpers
 
         public static WorkerRuntime GetCurrentWorkerRuntimeLanguage(ISecretsManager secretsManager, bool refreshSecrets = false)
         {
-            var setting = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime)
-                          ?? secretsManager.GetSecrets(refreshSecrets)?.FirstOrDefault(s => s.Key.Equals(Constants.FunctionsWorkerRuntime, StringComparison.OrdinalIgnoreCase)).Value;
+            string setting = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime);
+
+            if (string.IsNullOrWhiteSpace(setting))
+            {
+                // SecretsManager.GetSecrets throws CliException when there is no project root
+                // (e.g. 'func pack' invoked from a parent directory before cwd is changed).
+                // Treat that as "no setting found" so callers can decide what to do.
+                try
+                {
+                    setting = secretsManager?.GetSecrets(refreshSecrets)?.FirstOrDefault(s => s.Key.Equals(Constants.FunctionsWorkerRuntime, StringComparison.OrdinalIgnoreCase)).Value;
+                }
+                catch (CliException)
+                {
+                    return WorkerRuntime.None;
+                }
+            }
+
+            // The Functions host registers some workers under the literal "native" language
+            // identifier (see workers/native/worker.config.json). Map "native" back to a
+            // concrete WorkerRuntime using well-known project markers in the current directory.
+            // Throws CliException with an actionable message when the setting is "native" but
+            // no supported marker is found — callers that want a silent None should catch.
+            if (string.Equals(setting, "native", StringComparison.OrdinalIgnoreCase))
+            {
+                return ResolveNativeFromProjectMarkers();
+            }
 
             try
             {
@@ -224,6 +248,37 @@ namespace Azure.Functions.Cli.Helpers
                 .WriteLine(WarningColor($"Worker runtime '{runtimeMoniker}' has been set in '{SecretsManager.AppSettingsFilePath}'."));
 
             return workerRuntime;
+        }
+
+        /// <summary>
+        /// Maps <c>FUNCTIONS_WORKER_RUNTIME=native</c> to a concrete <see cref="WorkerRuntime"/>
+        /// by inspecting well-known project-marker files in the current directory. Throws
+        /// <see cref="CliException"/> when no supported marker is found.
+        /// </summary>
+        /// <remarks>
+        /// Marker -> runtime:
+        /// <list type="bullet">
+        ///   <item><c>go.mod</c> → <see cref="WorkerRuntime.Go"/></item>
+        /// </list>
+        /// Add new native languages here as they are introduced. Invoked exclusively from
+        /// <see cref="GetCurrentWorkerRuntimeLanguage"/> so callers never have to special-case
+        /// the "native" literal.
+        /// </remarks>
+        private static WorkerRuntime ResolveNativeFromProjectMarkers()
+        {
+            if (FileSystemHelpers.FileExists(Path.Combine(Environment.CurrentDirectory, GoHelpers.GoModFileName)))
+            {
+                if (GlobalCoreToolsSettings.IsVerbose)
+                {
+                    ColoredConsole.WriteLine(VerboseColor($"Resolving native worker runtime to 'go' ({GoHelpers.GoModFileName} found)."));
+                }
+
+                return WorkerRuntime.Go;
+            }
+
+            throw new CliException(
+                $"FUNCTIONS_WORKER_RUNTIME is set to 'native' but no supported project marker was found in '{Environment.CurrentDirectory}'. " +
+                "Run 'func init' to initialize a supported function app in this directory.");
         }
 
         public static string GetDefaultTemplateLanguageFromWorker(WorkerRuntime worker)

--- a/src/Cli/func/Helpers/WorkerRuntimeLanguageHelper.cs
+++ b/src/Cli/func/Helpers/WorkerRuntimeLanguageHelper.cs
@@ -26,7 +26,7 @@ namespace Azure.Functions.Cli.Helpers
         Powershell,
         [DisplayString("custom")]
         Custom,
-        [DisplayString("go")]
+        [DisplayString("go (preview)")]
         Go
     }
 
@@ -193,14 +193,14 @@ namespace Azure.Functions.Cli.Helpers
 
         public static WorkerRuntime GetCurrentWorkerRuntimeLanguage(ISecretsManager secretsManager, bool refreshSecrets = false)
         {
-            // Preview opt-in: FUNCTIONS_CLI_GO_PREVIEW lets a project declare itself as Go
-            // without forcing the resolver to scan the working directory for go.mod. Env var
-            // wins; local.settings.json is the secondary source. See TryResolveGoPreviewFlag.
-            if (TryResolveGoPreviewFlag(secretsManager, refreshSecrets))
+            // FUNCTIONS_CLI_NATIVE_LANGUAGE lets a project declare its native language without
+            // forcing the resolver to scan the working directory for go.mod. Env var wins;
+            // local.settings.json is the secondary source. See TryResolveNativeLanguageAsGo.
+            if (TryResolveNativeLanguageAsGo(secretsManager, refreshSecrets))
             {
                 if (GlobalCoreToolsSettings.IsVerbose)
                 {
-                    ColoredConsole.WriteLine(VerboseColor($"Resolving worker runtime to 'go' ({Constants.FunctionsCliGoPreview} is set)."));
+                    ColoredConsole.WriteLine(VerboseColor($"Resolving worker runtime to 'go' ({Constants.FunctionsCliNativeLanguage} is set)."));
                 }
 
                 return WorkerRuntime.Go;
@@ -210,17 +210,11 @@ namespace Azure.Functions.Cli.Helpers
 
             if (string.IsNullOrWhiteSpace(setting))
             {
-                // SecretsManager.GetSecrets throws CliException when there is no project root
-                // (e.g. 'func pack' invoked from a parent directory before cwd is changed).
-                // Treat that as "no setting found" so callers can decide what to do.
-                try
-                {
-                    setting = secretsManager?.GetSecrets(refreshSecrets)?.FirstOrDefault(s => s.Key.Equals(Constants.FunctionsWorkerRuntime, StringComparison.OrdinalIgnoreCase)).Value;
-                }
-                catch (CliException)
-                {
-                    return WorkerRuntime.None;
-                }
+                // When FUNCTIONS_WORKER_RUNTIME isn't in the environment, check local.settings.json.
+                // If secrets cannot be loaded (e.g. 'func pack' invoked from a parent directory
+                // before cwd is changed), the GetSecrets exceptions will propagate to the caller.
+                // Callers that want a silent None on missing secrets should catch CliException.
+                setting = secretsManager?.GetSecrets(refreshSecrets)?.FirstOrDefault(s => s.Key.Equals(Constants.FunctionsWorkerRuntime, StringComparison.OrdinalIgnoreCase)).Value;
             }
 
             // The Functions host registers some workers under the literal "native" language
@@ -275,7 +269,7 @@ namespace Azure.Functions.Cli.Helpers
         /// </list>
         /// Add new native languages here as they are introduced. Invoked exclusively from
         /// <see cref="GetCurrentWorkerRuntimeLanguage"/> so callers never have to special-case
-        /// the "native" literal. Preferred path is the explicit <see cref="Constants.FunctionsCliGoPreview"/>
+        /// the "native" literal. Preferred path is the explicit <see cref="Constants.FunctionsCliNativeLanguage"/>
         /// opt-in checked earlier in the resolver; this fallback exists for projects that
         /// predate the flag.
         /// </remarks>
@@ -285,7 +279,7 @@ namespace Azure.Functions.Cli.Helpers
             {
                 if (GlobalCoreToolsSettings.IsVerbose)
                 {
-                    ColoredConsole.WriteLine(VerboseColor($"Resolving native worker runtime to 'go' ({GoHelpers.GoModFileName} found; consider setting {Constants.FunctionsCliGoPreview}=true in local.settings.json)."));
+                    ColoredConsole.WriteLine(VerboseColor($"Resolving native worker runtime to 'go' ({GoHelpers.GoModFileName} found; consider setting {Constants.FunctionsCliNativeLanguage}=go in local.settings.json)."));
                 }
 
                 return WorkerRuntime.Go;
@@ -293,17 +287,18 @@ namespace Azure.Functions.Cli.Helpers
 
             throw new CliException(
                 $"FUNCTIONS_WORKER_RUNTIME is set to 'native' but no supported project marker was found in '{Environment.CurrentDirectory}'. " +
-                $"Set '{Constants.FunctionsCliGoPreview}=true' in local.settings.json, or run 'func init' to initialize a supported function app in this directory.");
+                $"Set '{Constants.FunctionsCliNativeLanguage}=go' in local.settings.json, or run 'func init' to initialize a supported function app in this directory.");
         }
 
         /// <summary>
-        /// Returns <c>true</c> when the Go preview flag is set to a truthy value either in the
+        /// Returns <c>true</c> when FUNCTIONS_CLI_NATIVE_LANGUAGE is set to "go" either in the
         /// process environment or in <c>local.settings.json</c>. Env var wins; local.settings.json
         /// access failures (e.g. command run from outside a project root) are treated as "not set".
         /// </summary>
-        private static bool TryResolveGoPreviewFlag(ISecretsManager secretsManager, bool refreshSecrets = false)
+        private static bool TryResolveNativeLanguageAsGo(ISecretsManager secretsManager, bool refreshSecrets = false)
         {
-            if (EnvironmentHelper.GetEnvironmentVariableAsBool(Constants.FunctionsCliGoPreview))
+            var envValue = Environment.GetEnvironmentVariable(Constants.FunctionsCliNativeLanguage);
+            if (!string.IsNullOrEmpty(envValue) && envValue.Equals("go", StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
@@ -316,7 +311,7 @@ namespace Azure.Functions.Cli.Helpers
             string fromSettings;
             try
             {
-                fromSettings = secretsManager.GetSecrets(refreshSecrets)?.FirstOrDefault(s => s.Key.Equals(Constants.FunctionsCliGoPreview, StringComparison.OrdinalIgnoreCase)).Value;
+                fromSettings = secretsManager.GetSecrets(refreshSecrets)?.FirstOrDefault(s => s.Key.Equals(Constants.FunctionsCliNativeLanguage, StringComparison.OrdinalIgnoreCase)).Value;
             }
             catch (CliException)
             {
@@ -328,8 +323,7 @@ namespace Azure.Functions.Cli.Helpers
                 return false;
             }
 
-            return fromSettings.Equals("1", StringComparison.Ordinal)
-                || fromSettings.Equals("true", StringComparison.OrdinalIgnoreCase);
+            return fromSettings.Equals("go", StringComparison.OrdinalIgnoreCase);
         }
 
         public static string GetDefaultTemplateLanguageFromWorker(WorkerRuntime worker)

--- a/src/Cli/func/Helpers/WorkerRuntimeLanguageHelper.cs
+++ b/src/Cli/func/Helpers/WorkerRuntimeLanguageHelper.cs
@@ -193,6 +193,19 @@ namespace Azure.Functions.Cli.Helpers
 
         public static WorkerRuntime GetCurrentWorkerRuntimeLanguage(ISecretsManager secretsManager, bool refreshSecrets = false)
         {
+            // Preview opt-in: FUNCTIONS_CLI_GO_PREVIEW lets a project declare itself as Go
+            // without forcing the resolver to scan the working directory for go.mod. Env var
+            // wins; local.settings.json is the secondary source. See TryResolveGoPreviewFlag.
+            if (TryResolveGoPreviewFlag(secretsManager, refreshSecrets))
+            {
+                if (GlobalCoreToolsSettings.IsVerbose)
+                {
+                    ColoredConsole.WriteLine(VerboseColor($"Resolving worker runtime to 'go' ({Constants.FunctionsCliGoPreview} is set)."));
+                }
+
+                return WorkerRuntime.Go;
+            }
+
             string setting = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime);
 
             if (string.IsNullOrWhiteSpace(setting))
@@ -258,11 +271,13 @@ namespace Azure.Functions.Cli.Helpers
         /// <remarks>
         /// Marker -> runtime:
         /// <list type="bullet">
-        ///   <item><c>go.mod</c> → <see cref="WorkerRuntime.Go"/></item>
+        ///   <item><c>go.mod</c> -> <see cref="WorkerRuntime.Go"/></item>
         /// </list>
         /// Add new native languages here as they are introduced. Invoked exclusively from
         /// <see cref="GetCurrentWorkerRuntimeLanguage"/> so callers never have to special-case
-        /// the "native" literal.
+        /// the "native" literal. Preferred path is the explicit <see cref="Constants.FunctionsCliGoPreview"/>
+        /// opt-in checked earlier in the resolver; this fallback exists for projects that
+        /// predate the flag.
         /// </remarks>
         private static WorkerRuntime ResolveNativeFromProjectMarkers()
         {
@@ -270,7 +285,7 @@ namespace Azure.Functions.Cli.Helpers
             {
                 if (GlobalCoreToolsSettings.IsVerbose)
                 {
-                    ColoredConsole.WriteLine(VerboseColor($"Resolving native worker runtime to 'go' ({GoHelpers.GoModFileName} found)."));
+                    ColoredConsole.WriteLine(VerboseColor($"Resolving native worker runtime to 'go' ({GoHelpers.GoModFileName} found; consider setting {Constants.FunctionsCliGoPreview}=true in local.settings.json)."));
                 }
 
                 return WorkerRuntime.Go;
@@ -278,7 +293,43 @@ namespace Azure.Functions.Cli.Helpers
 
             throw new CliException(
                 $"FUNCTIONS_WORKER_RUNTIME is set to 'native' but no supported project marker was found in '{Environment.CurrentDirectory}'. " +
-                "Run 'func init' to initialize a supported function app in this directory.");
+                $"Set '{Constants.FunctionsCliGoPreview}=true' in local.settings.json, or run 'func init' to initialize a supported function app in this directory.");
+        }
+
+        /// <summary>
+        /// Returns <c>true</c> when the Go preview flag is set to a truthy value either in the
+        /// process environment or in <c>local.settings.json</c>. Env var wins; local.settings.json
+        /// access failures (e.g. command run from outside a project root) are treated as "not set".
+        /// </summary>
+        private static bool TryResolveGoPreviewFlag(ISecretsManager secretsManager, bool refreshSecrets = false)
+        {
+            if (EnvironmentHelper.GetEnvironmentVariableAsBool(Constants.FunctionsCliGoPreview))
+            {
+                return true;
+            }
+
+            if (secretsManager is null)
+            {
+                return false;
+            }
+
+            string fromSettings;
+            try
+            {
+                fromSettings = secretsManager.GetSecrets(refreshSecrets)?.FirstOrDefault(s => s.Key.Equals(Constants.FunctionsCliGoPreview, StringComparison.OrdinalIgnoreCase)).Value;
+            }
+            catch (CliException)
+            {
+                return false;
+            }
+
+            if (string.IsNullOrEmpty(fromSettings))
+            {
+                return false;
+            }
+
+            return fromSettings.Equals("1", StringComparison.Ordinal)
+                || fromSettings.Equals("true", StringComparison.OrdinalIgnoreCase);
         }
 
         public static string GetDefaultTemplateLanguageFromWorker(WorkerRuntime worker)

--- a/src/Cli/func/Helpers/ZipHelper.cs
+++ b/src/Cli/func/Helpers/ZipHelper.cs
@@ -40,6 +40,13 @@ namespace Azure.Functions.Cli.Helpers
                 // Remote build for dotnet does not require bin and obj folders. They will be generated during the oryx build
                 return await CreateZip(FileSystemHelpers.GetLocalFiles(functionAppRoot, ignoreParser, false, new string[] { "bin", "obj" }), functionAppRoot, Array.Empty<string>());
             }
+            else if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.Go)
+            {
+                // Go deploys an explicit allowlist: host.json + the cross-compiled binary.
+                // The binary lives under bin/ locally (for .gitignore) but must appear at
+                // the zip root as 'app' because the Azure host expects it there.
+                return CreateGoZipPackage(functionAppRoot);
+            }
             else
             {
                 var customHandler = await HostHelpers.GetCustomHandlerExecutable(functionAppRoot);
@@ -98,7 +105,49 @@ namespace Azure.Functions.Cli.Helpers
             return Task.FromResult<Stream>(memStream);
         }
 
-        // Assumes all bytes of signatureToFind are non zero.
+        /// <summary>
+        /// Creates a zip for Go deployments where the binary is placed at the zip root
+        /// (not under <c>bin/</c>) because the Azure host expects <c>app</c> at the root.
+        /// Locally the binary is built to <c>bin/app</c> for .gitignore convenience.
+        /// </summary>
+        private static Stream CreateGoZipPackage(string functionAppRoot)
+        {
+            const byte CreatedByUnix = 3;
+            const uint centralDirectorySignature = 0x02014B50;
+
+            int unixExecutablePermissions = Convert.ToInt32("100777", 8) << 16;
+            int unixReadWritePermissions = Convert.ToInt32("100666", 8) << 16;
+
+            var hostJsonPath = Path.Combine(functionAppRoot, Constants.HostJsonFileName);
+            var binaryPath = Path.Combine(functionAppRoot, GoHelpers.GoBinDir, GoHelpers.GoBinaryName);
+
+            var memStream = new MemoryStream();
+
+            using (var zip = new ZipArchive(memStream, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                var hostEntry = zip.CreateEntryFromFile(hostJsonPath, Constants.HostJsonFileName);
+                hostEntry.ExternalAttributes = unixReadWritePermissions;
+
+                // Place binary at root as 'app', not 'bin/app'
+                var appEntry = zip.CreateEntryFromFile(binaryPath, GoHelpers.GoBinaryName);
+                appEntry.ExternalAttributes = unixExecutablePermissions;
+            }
+
+            if (OperatingSystem.IsWindows())
+            {
+                memStream.Seek(0, SeekOrigin.End);
+                while (SeekBackwardsToSignature(memStream, centralDirectorySignature))
+                {
+                    memStream.Seek(5, SeekOrigin.Current);
+                    memStream.WriteByte(CreatedByUnix);
+                    memStream.Seek(-6, SeekOrigin.Current);
+                }
+            }
+
+            memStream.Seek(0, SeekOrigin.Begin);
+            return memStream;
+        }
+
         // If the signature is found then returns true and positions stream at first byte of signature
         // If the signature is not found, returns false
         private static bool SeekBackwardsToSignature(Stream stream, uint signatureToFind)

--- a/src/Cli/func/Helpers/ZipHelper.cs
+++ b/src/Cli/func/Helpers/ZipHelper.cs
@@ -10,7 +10,7 @@ namespace Azure.Functions.Cli.Helpers
 {
     public static class ZipHelper
     {
-        public static async Task<Stream> GetAppZipFile(string functionAppRoot, bool buildNativeDeps, BuildOption buildOption, bool noBuild, GitIgnoreParser ignoreParser = null, string additionalPackages = null)
+        public static async Task<Stream> GetAppZipFile(string functionAppRoot, bool buildNativeDeps, BuildOption buildOption, bool noBuild, WorkerRuntime workerRuntime, GitIgnoreParser ignoreParser = null, string additionalPackages = null)
         {
             var gitIgnorePath = Path.Combine(functionAppRoot, Constants.FuncIgnoreFile);
             if (ignoreParser == null && FileSystemHelpers.FileExists(gitIgnorePath))
@@ -31,16 +31,16 @@ namespace Azure.Functions.Cli.Helpers
                 ColoredConsole.WriteLine(DarkYellow("Performing local build for functions project."));
             }
 
-            if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.Python && !noBuild)
+            if (workerRuntime == WorkerRuntime.Python && !noBuild)
             {
                 return await PythonHelpers.GetPythonDeploymentPackage(FileSystemHelpers.GetLocalFiles(functionAppRoot, ignoreParser), functionAppRoot, buildNativeDeps, buildOption, additionalPackages);
             }
-            else if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.Dotnet && buildOption == BuildOption.Remote)
+            else if (workerRuntime == WorkerRuntime.Dotnet && buildOption == BuildOption.Remote)
             {
                 // Remote build for dotnet does not require bin and obj folders. They will be generated during the oryx build
                 return await CreateZip(FileSystemHelpers.GetLocalFiles(functionAppRoot, ignoreParser, false, new string[] { "bin", "obj" }), functionAppRoot, Array.Empty<string>());
             }
-            else if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.Go)
+            else if (workerRuntime == WorkerRuntime.Go)
             {
                 // Go deploys an explicit allowlist: host.json + the cross-compiled binary.
                 // The binary lives under bin/ locally (for .gitignore) but must appear at

--- a/src/Cli/func/Services/RuntimeEolChecker.cs
+++ b/src/Cli/func/Services/RuntimeEolChecker.cs
@@ -180,6 +180,7 @@ namespace Azure.Functions.Cli.Services
                 WorkerRuntime.Powershell => "POWERSHELL",
                 WorkerRuntime.Dotnet => "DOTNET",
                 WorkerRuntime.DotnetIsolated => "DOTNET-ISOLATED",
+                WorkerRuntime.Go => "GO",
                 _ => null
             };
 

--- a/src/Cli/func/StaticResources/StaticResources.cs
+++ b/src/Cli/func/StaticResources/StaticResources.cs
@@ -84,6 +84,10 @@ namespace Azure.Functions.Cli
 
         public static Task<string> FuncIgnore => GetValue("funcignore");
 
+        public static Task<string> MainGo => GetValue("main.go");
+
+        public static Task<string> GoMod => GetValue("go.mod");
+
         public static Task<string> PackageJsonJsV4 => GetValue("package-js-v4.json");
 
         public static Task<string> PackageJsonJs => GetValue("package-js.json");

--- a/src/Cli/func/StaticResources/StaticResources.props
+++ b/src/Cli/func/StaticResources/StaticResources.props
@@ -1,6 +1,12 @@
 <Project>
   <!-- Static resources embedded into the assembly -->
   <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)main.go">
+      <LogicalName>$(AssemblyName).main.go</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)go.mod.template">
+      <LogicalName>$(AssemblyName).go.mod</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)stacks.json">
       <LogicalName>$(AssemblyName).stacks.json</LogicalName>
     </EmbeddedResource>

--- a/src/Cli/func/StaticResources/go.mod.template
+++ b/src/Cli/func/StaticResources/go.mod.template
@@ -1,0 +1,5 @@
+module {ModuleName}
+
+go 1.24
+
+require github.com/azure/azure-functions-golang-worker v0.2.0-preview

--- a/src/Cli/func/StaticResources/go.mod.template
+++ b/src/Cli/func/StaticResources/go.mod.template
@@ -1,5 +1,3 @@
 module {ModuleName}
 
 go 1.24
-
-require github.com/azure/azure-functions-golang-worker v0.2.0-preview

--- a/src/Cli/func/StaticResources/main.go
+++ b/src/Cli/func/StaticResources/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/azure/azure-functions-golang-worker/sdk"
+	"github.com/azure/azure-functions-golang-worker/worker"
+)
+
+// HTTPTriggerHandler handles standard HTTP requests
+func HTTPTriggerHandler(w http.ResponseWriter, r *http.Request) {
+	log.Printf("Processing HTTP Trigger for %s", r.URL.Path)
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("Hello from Go Worker!"))
+}
+
+func main() {
+	app := sdk.FunctionApp()
+	app.HTTP("hello", HTTPTriggerHandler,
+		sdk.WithMethods("GET", "POST"),
+		sdk.WithAuth("anonymous"),
+	)
+	worker.Start(app)
+}

--- a/src/Cli/func/StaticResources/nativeWorkerConfig.json
+++ b/src/Cli/func/StaticResources/nativeWorkerConfig.json
@@ -1,0 +1,11 @@
+{
+    "description": {
+        "language": "native",
+        "defaultExecutablePath": "app",
+        "workerIndexing": "true"
+    },
+    "processOptions": {
+        "initializationTimeout": "00:02:00",
+        "environmentReloadTimeout": "00:02:00"
+    }
+}

--- a/src/Cli/func/StaticResources/nativeWorkerConfig.json
+++ b/src/Cli/func/StaticResources/nativeWorkerConfig.json
@@ -1,7 +1,7 @@
 {
     "description": {
         "language": "native",
-        "defaultExecutablePath": "app",
+        "defaultExecutablePath": "bin/app",
         "workerIndexing": "true"
     },
     "processOptions": {

--- a/test/Cli/Func.E2ETests/Commands/FuncInit/GoInitTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncInit/GoInitTests.cs
@@ -1,0 +1,112 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.E2ETests.Traits;
+using Azure.Functions.Cli.TestFramework.Assertions;
+using Azure.Functions.Cli.TestFramework.Commands;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Azure.Functions.Cli.E2ETests.Commands.FuncInit
+{
+    [Trait(WorkerRuntimeTraits.WorkerRuntime, WorkerRuntimeTraits.Go)]
+    public class GoInitTests(ITestOutputHelper log) : BaseE2ETests(log)
+    {
+        [Fact]
+        public void Init_WithGo_GeneratesExpectedFunctionProjectFiles()
+        {
+            var workingDir = WorkingDirectory;
+            var testName = nameof(Init_WithGo_GeneratesExpectedFunctionProjectFiles);
+            var funcInitCommand = new FuncInitCommand(FuncPath, testName, Log ?? throw new ArgumentNullException(nameof(Log)));
+            var localSettingsPath = Path.Combine(workingDir, Common.Constants.LocalSettingsJsonFileName);
+            var expectedLocalSettingsContent = new[] { Common.Constants.FunctionsWorkerRuntime, "native" };
+            var hostJsonPath = Path.Combine(workingDir, "host.json");
+            var expectedHostJsonContent = new[] { "extensionBundle" };
+            var mainGoPath = Path.Combine(workingDir, "main.go");
+            var expectedMainGoContent = new[] { "package main" };
+            var funcIgnorePath = Path.Combine(workingDir, ".funcignore");
+
+            var filesToValidate = new List<(string FilePath, string[] ExpectedContent)>
+            {
+                (localSettingsPath, expectedLocalSettingsContent),
+                (hostJsonPath, expectedHostJsonContent),
+                (mainGoPath, expectedMainGoContent)
+            };
+
+            var funcInitResult = funcInitCommand
+                .WithWorkingDirectory(workingDir)
+                .Execute(["--worker-runtime", "go"]);
+
+            funcInitResult.Should().WriteVsCodeExtensionsJsonAndExitWithZero(workingDir);
+            funcInitResult.Should().FilesExistsWithExpectContent(filesToValidate);
+            File.Exists(funcIgnorePath).Should().BeTrue("Expected .funcignore to exist");
+            File.Exists(Path.Combine(workingDir, "go.mod")).Should().BeTrue("Expected go.mod to exist");
+        }
+
+        [Fact]
+        public void Init_WithSkipGoModTidy_SkipsTidyStep()
+        {
+            var workingDir = WorkingDirectory;
+            var testName = nameof(Init_WithSkipGoModTidy_SkipsTidyStep);
+            var funcInitCommand = new FuncInitCommand(FuncPath, testName, Log ?? throw new ArgumentNullException(nameof(Log)));
+
+            var funcInitResult = funcInitCommand
+                .WithWorkingDirectory(workingDir)
+                .Execute(["--worker-runtime", "go", "--skip-go-mod-tidy"]);
+
+            funcInitResult.Should().ExitWith(0);
+            funcInitResult.Should().HaveStdOutContaining("Skipped \"go mod tidy\"");
+        }
+
+        [Fact]
+        public void Init_WithForceFlag_InNonEmptyDirectory()
+        {
+            var workingDir = WorkingDirectory;
+            File.WriteAllText(Path.Combine(workingDir, "existing.txt"), "test");
+
+            var testName = nameof(Init_WithForceFlag_InNonEmptyDirectory);
+            var funcInitCommand = new FuncInitCommand(FuncPath, testName, Log ?? throw new ArgumentNullException(nameof(Log)));
+
+            var funcInitResult = funcInitCommand
+                .WithWorkingDirectory(workingDir)
+                .Execute(["--worker-runtime", "go", "--force"]);
+
+            funcInitResult.Should().ExitWith(0);
+            File.Exists(Path.Combine(workingDir, "main.go")).Should().BeTrue("Expected main.go to exist");
+        }
+
+        [Fact]
+        public void Init_WithDockerFlag_FailsLoudly()
+        {
+            var workingDir = WorkingDirectory;
+            var testName = nameof(Init_WithDockerFlag_FailsLoudly);
+            var funcInitCommand = new FuncInitCommand(FuncPath, testName, Log ?? throw new ArgumentNullException(nameof(Log)));
+
+            var funcInitResult = funcInitCommand
+                .WithWorkingDirectory(workingDir)
+                .Execute(["--worker-runtime", "go", "--docker"]);
+
+            funcInitResult.Should().ExitWith(1);
+            funcInitResult.Should().HaveStdErrContaining("Docker support for the Go worker runtime is not yet available");
+            File.Exists(Path.Combine(workingDir, "Dockerfile")).Should().BeFalse("Expected no Dockerfile for Go runtime");
+        }
+
+        [Fact]
+        public void Init_WithGolangAlias_ResolvesToGo()
+        {
+            var workingDir = WorkingDirectory;
+            var testName = nameof(Init_WithGolangAlias_ResolvesToGo);
+            var funcInitCommand = new FuncInitCommand(FuncPath, testName, Log ?? throw new ArgumentNullException(nameof(Log)));
+
+            var funcInitResult = funcInitCommand
+                .WithWorkingDirectory(workingDir)
+                .Execute(["--worker-runtime", "golang"]);
+
+            funcInitResult.Should().ExitWith(0);
+            File.Exists(Path.Combine(workingDir, "main.go")).Should().BeTrue("Expected main.go to exist");
+            File.Exists(Path.Combine(workingDir, "go.mod")).Should().BeTrue("Expected go.mod to exist");
+        }
+    }
+}

--- a/test/Cli/Func.E2ETests/Commands/FuncInit/GoInitTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncInit/GoInitTests.cs
@@ -1,11 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using AwesomeAssertions;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.E2ETests.Traits;
 using Azure.Functions.Cli.TestFramework.Assertions;
 using Azure.Functions.Cli.TestFramework.Commands;
-using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/Cli/Func.E2ETests/Commands/FuncInit/GoInitTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncInit/GoInitTests.cs
@@ -21,7 +21,7 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncInit
             var testName = nameof(Init_WithGo_GeneratesExpectedFunctionProjectFiles);
             var funcInitCommand = new FuncInitCommand(FuncPath, testName, Log ?? throw new ArgumentNullException(nameof(Log)));
             var localSettingsPath = Path.Combine(workingDir, Common.Constants.LocalSettingsJsonFileName);
-            var expectedLocalSettingsContent = new[] { Common.Constants.FunctionsWorkerRuntime, "native" };
+            var expectedLocalSettingsContent = new[] { Common.Constants.FunctionsWorkerRuntime, "native", Common.Constants.FunctionsCliGoPreview, "true" };
             var hostJsonPath = Path.Combine(workingDir, "host.json");
             var expectedHostJsonContent = new[] { "extensionBundle" };
             var mainGoPath = Path.Combine(workingDir, "main.go");

--- a/test/Cli/Func.E2ETests/Commands/FuncInit/GoInitTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncInit/GoInitTests.cs
@@ -21,7 +21,7 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncInit
             var testName = nameof(Init_WithGo_GeneratesExpectedFunctionProjectFiles);
             var funcInitCommand = new FuncInitCommand(FuncPath, testName, Log ?? throw new ArgumentNullException(nameof(Log)));
             var localSettingsPath = Path.Combine(workingDir, Common.Constants.LocalSettingsJsonFileName);
-            var expectedLocalSettingsContent = new[] { Common.Constants.FunctionsWorkerRuntime, "native", Common.Constants.FunctionsCliGoPreview, "true" };
+            var expectedLocalSettingsContent = new[] { Common.Constants.FunctionsWorkerRuntime, "native", Common.Constants.FunctionsCliNativeLanguage, "go" };
             var hostJsonPath = Path.Combine(workingDir, "host.json");
             var expectedHostJsonContent = new[] { "extensionBundle" };
             var mainGoPath = Path.Combine(workingDir, "main.go");

--- a/test/Cli/Func.E2ETests/Commands/FuncNew/GoFuncNewTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncNew/GoFuncNewTests.cs
@@ -1,10 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using AwesomeAssertions;
 using Azure.Functions.Cli.E2ETests.Traits;
 using Azure.Functions.Cli.TestFramework.Assertions;
 using Azure.Functions.Cli.TestFramework.Commands;
-using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/Cli/Func.E2ETests/Commands/FuncNew/GoFuncNewTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncNew/GoFuncNewTests.cs
@@ -1,0 +1,61 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.E2ETests.Traits;
+using Azure.Functions.Cli.TestFramework.Assertions;
+using Azure.Functions.Cli.TestFramework.Commands;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Azure.Functions.Cli.E2ETests.Commands.FuncNew
+{
+    [Trait(WorkerRuntimeTraits.WorkerRuntime, WorkerRuntimeTraits.Go)]
+    public class GoFuncNewTests(ITestOutputHelper log) : BaseE2ETests(log)
+    {
+        [Fact]
+        public void FuncNew_InGoWorkspace_FailsWithNotSupportedMessage_AndDoesNotMutateLocalSettings()
+        {
+            var workingDir = WorkingDirectory;
+            var testName = nameof(FuncNew_InGoWorkspace_FailsWithNotSupportedMessage_AndDoesNotMutateLocalSettings);
+
+            // Arrange: scaffold a Go workspace. local.settings.json must end up with FUNCTIONS_WORKER_RUNTIME=native.
+            var initResult = new FuncInitCommand(FuncPath, testName, Log)
+                .WithWorkingDirectory(workingDir)
+                .Execute(["--worker-runtime", "go", "--skip-go-mod-tidy"]);
+            initResult.Should().ExitWith(0);
+
+            var localSettingsPath = Path.Combine(workingDir, Common.Constants.LocalSettingsJsonFileName);
+            string before = File.ReadAllText(localSettingsPath);
+            before.Should().Contain("\"native\"", "init writes FUNCTIONS_WORKER_RUNTIME=native for Go projects");
+
+            // Act: 'func new' in a Go workspace previously hung at the language/template prompt and could
+            // overwrite FUNCTIONS_WORKER_RUNTIME from "native" to "go". It should now bail with a clear message.
+            var newResult = new FuncNewCommand(FuncPath, testName, Log)
+                .WithWorkingDirectory(workingDir)
+                .Execute([".", "--template", "HttpTrigger", "--name", "MyFunc"]);
+
+            // Assert: friendly error surfaces and local.settings.json is untouched.
+            newResult.Should().HaveStdErrContaining("The 'func new' command is not yet supported for the Go runtime.");
+            string after = File.ReadAllText(localSettingsPath);
+            after.Should().Be(before, "func new must not mutate local.settings.json for unsupported runtimes");
+        }
+
+        [Fact]
+        public void FuncNew_WithWorkerRuntimeGoFlag_InEmptyDir_FailsWithNotSupportedMessage()
+        {
+            var workingDir = WorkingDirectory;
+            var testName = nameof(FuncNew_WithWorkerRuntimeGoFlag_InEmptyDir_FailsWithNotSupportedMessage);
+
+            // 'func new --worker-runtime go' in an empty dir would normally trigger an implicit
+            // 'func init' before scaffolding the function. The Go guard should fire after init resolves
+            // the runtime to Go, before any function-template work runs.
+            var result = new FuncNewCommand(FuncPath, testName, Log)
+                .WithWorkingDirectory(workingDir)
+                .Execute([".", "--worker-runtime", "go", "--template", "HttpTrigger", "--name", "MyFunc", "--skip-go-mod-tidy"]);
+
+            result.Should().HaveStdErrContaining("The 'func new' command is not yet supported for the Go runtime.");
+            File.Exists(Path.Combine(workingDir, "MyFunc")).Should().BeFalse("no function directory should be created");
+        }
+    }
+}

--- a/test/Cli/Func.E2ETests/Traits/WorkerRuntimeTraits.cs
+++ b/test/Cli/Func.E2ETests/Traits/WorkerRuntimeTraits.cs
@@ -49,5 +49,10 @@ namespace Azure.Functions.Cli.E2ETests.Traits
         /// Indicates tests that target the Custom runtime.
         /// </summary>
         public const string Custom = "Custom";
+
+        /// <summary>
+        /// Indicates tests that target the Go runtime.
+        /// </summary>
+        public const string Go = "Go";
     }
 }

--- a/test/Cli/Func.UnitTests/ActionsTests/InitActionGoTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/InitActionGoTests.cs
@@ -1,0 +1,85 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Actions.LocalActions;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.ConfigurationProfiles;
+using Azure.Functions.Cli.Helpers;
+using Azure.Functions.Cli.Interfaces;
+using FluentAssertions;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Functions.Cli.UnitTests.ActionsTests
+{
+    public class InitActionGoTests
+    {
+        private static InitAction CreateAction()
+        {
+            var templatesManager = Substitute.For<ITemplatesManager>();
+            var secretsManager = Substitute.For<ISecretsManager>();
+            var configProfiles = new List<IConfigurationProfile>();
+            return new InitAction(templatesManager, secretsManager, configProfiles);
+        }
+
+        [Fact]
+        public void ParseArgs_SkipGoModTidy_DefaultsToFalse()
+        {
+            var action = CreateAction();
+
+            action.ParseArgs(Array.Empty<string>());
+
+            action.SkipGoModTidy.Should().BeFalse();
+        }
+
+        [Fact]
+        public void ParseArgs_WithSkipGoModTidyFlag_SetsTrue()
+        {
+            var action = CreateAction();
+
+            action.ParseArgs(new[] { "--skip-go-mod-tidy" });
+
+            action.SkipGoModTidy.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ParseArgs_WorkerRuntimeGo_Parses()
+        {
+            var action = CreateAction();
+
+            action.ParseArgs(new[] { "--worker-runtime", "go" });
+
+            action.WorkerRuntime.Should().Be("go");
+        }
+
+        [Theory]
+        [InlineData("go")]
+        [InlineData("golang")]
+        [InlineData("Go")]
+        [InlineData("Golang")]
+        public void NormalizeWorkerRuntime_GoAliases_ResolveToGo(string input)
+        {
+            var result = WorkerRuntimeLanguageHelper.NormalizeWorkerRuntime(input);
+
+            result.Should().Be(WorkerRuntime.Go);
+        }
+
+        [Fact]
+        public void GetRuntimeMoniker_Go_ReturnsGo()
+        {
+            var result = WorkerRuntimeLanguageHelper.GetRuntimeMoniker(WorkerRuntime.Go);
+
+            result.Should().Be("go");
+        }
+
+        [Fact]
+        public void ProgrammingModelHelper_Go_DefaultsToV1()
+        {
+            var supportedModels = ProgrammingModelHelper.GetSupportedProgrammingModels(WorkerRuntime.Go);
+            supportedModels.Should().Contain(ProgrammingModel.V1);
+
+            var resolved = ProgrammingModelHelper.ResolveProgrammingModel(null, WorkerRuntime.Go, string.Empty);
+            resolved.Should().Be(ProgrammingModel.V1);
+        }
+    }
+}

--- a/test/Cli/Func.UnitTests/ActionsTests/InitActionGoTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/InitActionGoTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.IO.Abstractions;
 using Azure.Functions.Cli.Actions.LocalActions;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.ConfigurationProfiles;
@@ -80,6 +81,113 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
 
             var resolved = ProgrammingModelHelper.ResolveProgrammingModel(null, WorkerRuntime.Go, string.Empty);
             resolved.Should().Be(ProgrammingModel.V1);
+        }
+
+        [Theory]
+        [InlineData("native")]
+        [InlineData("Native")]
+        [InlineData("NATIVE")]
+        public void GetCurrentWorkerRuntimeLanguage_NativeWithGoMod_ResolvesToGo(string settingValue)
+        {
+            var secretsManager = Substitute.For<ISecretsManager>();
+            secretsManager.GetSecrets(Arg.Any<bool>()).Returns(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { Constants.FunctionsWorkerRuntime, settingValue },
+            });
+
+            var fileSystem = Substitute.For<IFileSystem>();
+            fileSystem.File.Exists(Arg.Is<string>(p => p.EndsWith("go.mod"))).Returns(true);
+
+            var previousEnv = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime);
+            try
+            {
+                Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, null);
+
+                using (FileSystemHelpers.Override(fileSystem))
+                {
+                    var resolved = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(secretsManager);
+
+                    resolved.Should().Be(WorkerRuntime.Go);
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, previousEnv);
+            }
+        }
+
+        [Fact]
+        public void GetCurrentWorkerRuntimeLanguage_NativeWithoutGoMod_Throws()
+        {
+            var secretsManager = Substitute.For<ISecretsManager>();
+            secretsManager.GetSecrets(Arg.Any<bool>()).Returns(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { Constants.FunctionsWorkerRuntime, "native" },
+            });
+
+            var fileSystem = Substitute.For<IFileSystem>();
+            fileSystem.File.Exists(Arg.Any<string>()).Returns(false);
+
+            var previousEnv = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime);
+            try
+            {
+                Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, null);
+
+                using (FileSystemHelpers.Override(fileSystem))
+                {
+                    Action act = () => WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(secretsManager);
+
+                    act.Should().Throw<CliException>().WithMessage("*native*");
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, previousEnv);
+            }
+        }
+
+        [Fact]
+        public void GetCurrentWorkerRuntimeLanguage_NonNativeSetting_NormalizesAndReturns()
+        {
+            var secretsManager = Substitute.For<ISecretsManager>();
+            secretsManager.GetSecrets(Arg.Any<bool>()).Returns(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { Constants.FunctionsWorkerRuntime, "node" },
+            });
+
+            var previousEnv = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime);
+            Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, null);
+            try
+            {
+                var resolved = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(secretsManager);
+
+                resolved.Should().Be(WorkerRuntime.Node);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, previousEnv);
+            }
+        }
+
+        [Theory]
+        [InlineData("--go")]
+        [InlineData("--golang")]
+        public void GlobalCoreToolsSettings_Init_GoShortcutFlag_SetsCurrentWorkerRuntimeToGo(string flag)
+        {
+            var previousRuntime = GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone;
+            var previousEnv = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime);
+            Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, null);
+            try
+            {
+                GlobalCoreToolsSettings.Init(secretsManager: null, args: new[] { flag });
+
+                GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone.Should().Be(WorkerRuntime.Go);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, previousEnv);
+                GlobalCoreToolsSettings.CurrentWorkerRuntime = previousRuntime;
+            }
         }
     }
 }

--- a/test/Cli/Func.UnitTests/ActionsTests/InitActionGoTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/InitActionGoTests.cs
@@ -13,6 +13,7 @@ using Xunit;
 
 namespace Azure.Functions.Cli.UnitTests.ActionsTests
 {
+    [Collection("NativeWorkerRuntimeTests")]
     public class InitActionGoTests
     {
         private static InitAction CreateAction()
@@ -187,6 +188,134 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
             {
                 Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, previousEnv);
                 GlobalCoreToolsSettings.CurrentWorkerRuntime = previousRuntime;
+            }
+        }
+
+        [Theory]
+        [InlineData("true")]
+        [InlineData("True")]
+        [InlineData("TRUE")]
+        [InlineData("1")]
+        public void GetCurrentWorkerRuntimeLanguage_GoPreviewEnvVar_ResolvesToGo(string envValue)
+        {
+            // Env var takes precedence over local.settings.json and the go.mod fallback.
+            // Even with no project markers and no FUNCTIONS_WORKER_RUNTIME, the explicit
+            // preview opt-in is enough to select the Go runtime.
+            var secretsManager = Substitute.For<ISecretsManager>();
+            secretsManager.GetSecrets(Arg.Any<bool>()).Returns(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+
+            var previousFlag = Environment.GetEnvironmentVariable(Constants.FunctionsCliGoPreview);
+            var previousRuntime = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime);
+            try
+            {
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, envValue);
+                Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, null);
+
+                var resolved = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(secretsManager);
+
+                resolved.Should().Be(WorkerRuntime.Go);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, previousFlag);
+                Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, previousRuntime);
+            }
+        }
+
+        [Theory]
+        [InlineData("true")]
+        [InlineData("True")]
+        [InlineData("1")]
+        public void GetCurrentWorkerRuntimeLanguage_GoPreviewSetting_ResolvesToGo(string settingValue)
+        {
+            // local.settings.json wins when the env var isn't set, without any go.mod scan.
+            var secretsManager = Substitute.For<ISecretsManager>();
+            secretsManager.GetSecrets(Arg.Any<bool>()).Returns(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { Constants.FunctionsCliGoPreview, settingValue },
+                { Constants.FunctionsWorkerRuntime, "native" },
+            });
+
+            var previousFlag = Environment.GetEnvironmentVariable(Constants.FunctionsCliGoPreview);
+            var previousRuntime = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime);
+            try
+            {
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, null);
+                Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, null);
+
+                var resolved = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(secretsManager);
+
+                resolved.Should().Be(WorkerRuntime.Go);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, previousFlag);
+                Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, previousRuntime);
+            }
+        }
+
+        [Theory]
+        [InlineData("false")]
+        [InlineData("0")]
+        [InlineData("yes")]
+        [InlineData("")]
+        public void GetCurrentWorkerRuntimeLanguage_GoPreviewFalsy_FallsThroughToLegacyResolution(string flagValue)
+        {
+            // Falsy flag values must not short-circuit; the legacy native+go.mod path should still run.
+            var secretsManager = Substitute.For<ISecretsManager>();
+            secretsManager.GetSecrets(Arg.Any<bool>()).Returns(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { Constants.FunctionsCliGoPreview, flagValue },
+                { Constants.FunctionsWorkerRuntime, "native" },
+            });
+
+            var fileSystem = Substitute.For<IFileSystem>();
+            fileSystem.File.Exists(Arg.Is<string>(p => p.EndsWith("go.mod"))).Returns(true);
+
+            var previousFlag = Environment.GetEnvironmentVariable(Constants.FunctionsCliGoPreview);
+            var previousRuntime = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime);
+            try
+            {
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, null);
+                Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, null);
+
+                using (FileSystemHelpers.Override(fileSystem))
+                {
+                    var resolved = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(secretsManager);
+
+                    resolved.Should().Be(WorkerRuntime.Go);
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, previousFlag);
+                Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, previousRuntime);
+            }
+        }
+
+        [Fact]
+        public void GetCurrentWorkerRuntimeLanguage_GoPreviewEnvVar_BeatsSecretsManagerThrow()
+        {
+            // SecretsManager throwing (e.g. command run from outside a project root) must not
+            // mask an explicit env-var opt-in.
+            var secretsManager = Substitute.For<ISecretsManager>();
+            secretsManager.GetSecrets(Arg.Any<bool>()).Returns(_ => throw new CliException("no project"));
+
+            var previousFlag = Environment.GetEnvironmentVariable(Constants.FunctionsCliGoPreview);
+            var previousRuntime = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime);
+            try
+            {
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, "true");
+                Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, null);
+
+                var resolved = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(secretsManager);
+
+                resolved.Should().Be(WorkerRuntime.Go);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, previousFlag);
+                Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, previousRuntime);
             }
         }
     }

--- a/test/Cli/Func.UnitTests/ActionsTests/InitActionGoTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/InitActionGoTests.cs
@@ -192,10 +192,9 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
         }
 
         [Theory]
-        [InlineData("true")]
-        [InlineData("True")]
-        [InlineData("TRUE")]
-        [InlineData("1")]
+        [InlineData("go")]
+        [InlineData("Go")]
+        [InlineData("GO")]
         public void GetCurrentWorkerRuntimeLanguage_GoPreviewEnvVar_ResolvesToGo(string envValue)
         {
             // Env var takes precedence over local.settings.json and the go.mod fallback.
@@ -204,11 +203,11 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
             var secretsManager = Substitute.For<ISecretsManager>();
             secretsManager.GetSecrets(Arg.Any<bool>()).Returns(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
 
-            var previousFlag = Environment.GetEnvironmentVariable(Constants.FunctionsCliGoPreview);
+            var previousFlag = Environment.GetEnvironmentVariable(Constants.FunctionsCliNativeLanguage);
             var previousRuntime = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime);
             try
             {
-                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, envValue);
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliNativeLanguage, envValue);
                 Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, null);
 
                 var resolved = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(secretsManager);
@@ -217,30 +216,30 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
             }
             finally
             {
-                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, previousFlag);
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliNativeLanguage, previousFlag);
                 Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, previousRuntime);
             }
         }
 
         [Theory]
-        [InlineData("true")]
-        [InlineData("True")]
-        [InlineData("1")]
+        [InlineData("go")]
+        [InlineData("Go")]
+        [InlineData("GO")]
         public void GetCurrentWorkerRuntimeLanguage_GoPreviewSetting_ResolvesToGo(string settingValue)
         {
             // local.settings.json wins when the env var isn't set, without any go.mod scan.
             var secretsManager = Substitute.For<ISecretsManager>();
             secretsManager.GetSecrets(Arg.Any<bool>()).Returns(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
-                { Constants.FunctionsCliGoPreview, settingValue },
+                { Constants.FunctionsCliNativeLanguage, settingValue },
                 { Constants.FunctionsWorkerRuntime, "native" },
             });
 
-            var previousFlag = Environment.GetEnvironmentVariable(Constants.FunctionsCliGoPreview);
+            var previousFlag = Environment.GetEnvironmentVariable(Constants.FunctionsCliNativeLanguage);
             var previousRuntime = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime);
             try
             {
-                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, null);
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliNativeLanguage, null);
                 Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, null);
 
                 var resolved = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(secretsManager);
@@ -249,34 +248,33 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
             }
             finally
             {
-                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, previousFlag);
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliNativeLanguage, previousFlag);
                 Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, previousRuntime);
             }
         }
 
         [Theory]
-        [InlineData("false")]
-        [InlineData("0")]
-        [InlineData("yes")]
+        [InlineData("python")]
+        [InlineData("rust")]
         [InlineData("")]
         public void GetCurrentWorkerRuntimeLanguage_GoPreviewFalsy_FallsThroughToLegacyResolution(string flagValue)
         {
-            // Falsy flag values must not short-circuit; the legacy native+go.mod path should still run.
+            // Non-"go" flag values must not short-circuit; the legacy native+go.mod path should still run.
             var secretsManager = Substitute.For<ISecretsManager>();
             secretsManager.GetSecrets(Arg.Any<bool>()).Returns(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
-                { Constants.FunctionsCliGoPreview, flagValue },
+                { Constants.FunctionsCliNativeLanguage, flagValue },
                 { Constants.FunctionsWorkerRuntime, "native" },
             });
 
             var fileSystem = Substitute.For<IFileSystem>();
             fileSystem.File.Exists(Arg.Is<string>(p => p.EndsWith("go.mod"))).Returns(true);
 
-            var previousFlag = Environment.GetEnvironmentVariable(Constants.FunctionsCliGoPreview);
+            var previousFlag = Environment.GetEnvironmentVariable(Constants.FunctionsCliNativeLanguage);
             var previousRuntime = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime);
             try
             {
-                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, null);
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliNativeLanguage, null);
                 Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, null);
 
                 using (FileSystemHelpers.Override(fileSystem))
@@ -288,7 +286,7 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
             }
             finally
             {
-                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, previousFlag);
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliNativeLanguage, previousFlag);
                 Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, previousRuntime);
             }
         }
@@ -301,11 +299,11 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
             var secretsManager = Substitute.For<ISecretsManager>();
             secretsManager.GetSecrets(Arg.Any<bool>()).Returns(_ => throw new CliException("no project"));
 
-            var previousFlag = Environment.GetEnvironmentVariable(Constants.FunctionsCliGoPreview);
+            var previousFlag = Environment.GetEnvironmentVariable(Constants.FunctionsCliNativeLanguage);
             var previousRuntime = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime);
             try
             {
-                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, "true");
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliNativeLanguage, "go");
                 Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, null);
 
                 var resolved = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(secretsManager);
@@ -314,7 +312,7 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
             }
             finally
             {
-                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, previousFlag);
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliNativeLanguage, previousFlag);
                 Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, previousRuntime);
             }
         }

--- a/test/Cli/Func.UnitTests/ActionsTests/InitActionGoTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/InitActionGoTests.cs
@@ -2,12 +2,12 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.IO.Abstractions;
+using AwesomeAssertions;
 using Azure.Functions.Cli.Actions.LocalActions;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.ConfigurationProfiles;
 using Azure.Functions.Cli.Helpers;
 using Azure.Functions.Cli.Interfaces;
-using FluentAssertions;
 using NSubstitute;
 using Xunit;
 

--- a/test/Cli/Func.UnitTests/ActionsTests/NativeWorkerRuntimeTestCollection.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/NativeWorkerRuntimeTestCollection.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Xunit;
+
+namespace Azure.Functions.Cli.UnitTests.ActionsTests
+{
+    // Tests that exercise WorkerRuntimeLanguageHelper.ResolveNativeWorkerRuntime mutate
+    // process-global state (FUNCTIONS_WORKER_RUNTIME, FUNCTIONS_CLI_GO_PREVIEW env vars,
+    // FileSystemHelpers.Override, GlobalCoreToolsSettings.CurrentWorkerRuntime). Disable
+    // cross-class parallelization so they don't race against each other.
+    [CollectionDefinition("NativeWorkerRuntimeTests", DisableParallelization = true)]
+    public class NativeWorkerRuntimeTestCollection
+    {
+    }
+}

--- a/test/Cli/Func.UnitTests/ActionsTests/PackAction/GoPackResolveOutputPathTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/PackAction/GoPackResolveOutputPathTests.cs
@@ -1,9 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using AwesomeAssertions;
 using Azure.Functions.Cli.Actions.LocalActions.PackAction;
 using Azure.Functions.Cli.Common;
-using FluentAssertions;
 using Xunit;
 
 namespace Azure.Functions.Cli.UnitTests.ActionsTests.PackAction

--- a/test/Cli/Func.UnitTests/ActionsTests/PackAction/GoPackResolveOutputPathTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/PackAction/GoPackResolveOutputPathTests.cs
@@ -1,0 +1,77 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Actions.LocalActions.PackAction;
+using Azure.Functions.Cli.Common;
+using FluentAssertions;
+using Xunit;
+
+namespace Azure.Functions.Cli.UnitTests.ActionsTests.PackAction
+{
+    public class GoPackResolveOutputPathTests : IDisposable
+    {
+        private readonly string _tempDirectory;
+
+        public GoPackResolveOutputPathTests()
+        {
+            _tempDirectory = Path.Combine(Path.GetTempPath(), "func-pack-go-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(_tempDirectory);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_tempDirectory))
+            {
+                Directory.Delete(_tempDirectory, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void ResolveOutputPath_NoOutputProvided_UsesFunctionAppRootName()
+        {
+            var action = new TestGoPackSubcommandAction();
+            var functionAppRoot = Path.Combine(_tempDirectory, "myapp");
+
+            var result = action.InvokeResolveOutputPath(functionAppRoot, outputPath: null);
+
+            result.Should().Be(Path.Combine(Environment.CurrentDirectory, "myapp.zip"));
+        }
+
+        [Fact]
+        public void ResolveOutputPath_OutputIsDirectory_PlacesZipInside()
+        {
+            var action = new TestGoPackSubcommandAction();
+            var functionAppRoot = Path.Combine(_tempDirectory, "myapp");
+            var outputPath = Path.Combine(_tempDirectory, "pkg");
+
+            var result = action.InvokeResolveOutputPath(functionAppRoot, outputPath);
+
+            result.Should().Be(Path.Combine(outputPath, "myapp.zip"));
+            Directory.Exists(outputPath).Should().BeTrue();
+        }
+
+        [Fact]
+        public void ResolveOutputPath_OutputIsExistingFile_ThrowsClearError()
+        {
+            var action = new TestGoPackSubcommandAction();
+            var functionAppRoot = Path.Combine(_tempDirectory, "myapp");
+            var existingFile = Path.Combine(_tempDirectory, "already-a-file");
+            File.WriteAllText(existingFile, "marker");
+
+            Action act = () => action.InvokeResolveOutputPath(functionAppRoot, existingFile);
+
+            act.Should().Throw<CliException>()
+                .WithMessage("*existing file*")
+                .WithMessage("*directory*");
+        }
+
+        // Test subclass exposes the protected ResolveOutputPath override defined on
+        // GoPackSubcommandAction so the Go-specific existing-file guardrail can be
+        // exercised without invoking the full pack pipeline.
+        private sealed class TestGoPackSubcommandAction : GoPackSubcommandAction
+        {
+            public string InvokeResolveOutputPath(string functionAppRoot, string outputPath)
+                => ResolveOutputPath(functionAppRoot, outputPath);
+        }
+    }
+}

--- a/test/Cli/Func.UnitTests/ActionsTests/PackAction/GoPackSubcommandActionTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/PackAction/GoPackSubcommandActionTests.cs
@@ -1,9 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using AwesomeAssertions;
 using Azure.Functions.Cli.Actions.LocalActions.PackAction;
 using Azure.Functions.Cli.Common;
-using FluentAssertions;
 using Xunit;
 
 namespace Azure.Functions.Cli.UnitTests.ActionsTests.PackAction

--- a/test/Cli/Func.UnitTests/ActionsTests/PackAction/GoPackSubcommandActionTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/PackAction/GoPackSubcommandActionTests.cs
@@ -1,0 +1,65 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Actions.LocalActions.PackAction;
+using Azure.Functions.Cli.Common;
+using FluentAssertions;
+using Xunit;
+
+namespace Azure.Functions.Cli.UnitTests.ActionsTests.PackAction
+{
+    public class GoPackSubcommandActionTests : System.IDisposable
+    {
+        private readonly string _tempDirectory;
+
+        public GoPackSubcommandActionTests()
+        {
+            _tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(_tempDirectory);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_tempDirectory))
+            {
+                Directory.Delete(_tempDirectory, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void ValidateFunctionApp_ValidStructure_PassesValidation()
+        {
+            File.WriteAllText(Path.Combine(_tempDirectory, "host.json"), "{}");
+            File.WriteAllText(Path.Combine(_tempDirectory, "go.mod"), "module example.com/test\n\ngo 1.24\n");
+
+            var action = new GoPackSubcommandAction();
+            var validate = () => action.ValidateFunctionApp(_tempDirectory, new PackOptions());
+
+            validate.Should().NotThrow();
+        }
+
+        [Fact]
+        public void ValidateFunctionApp_MissingHostJson_ThrowsCliException()
+        {
+            File.WriteAllText(Path.Combine(_tempDirectory, "go.mod"), "module example.com/test\n\ngo 1.24\n");
+
+            var action = new GoPackSubcommandAction();
+            var validate = () => action.ValidateFunctionApp(_tempDirectory, new PackOptions());
+
+            validate.Should().Throw<CliException>()
+                .Which.Message.Should().Contain("host.json");
+        }
+
+        [Fact]
+        public void ValidateFunctionApp_MissingGoMod_ThrowsCliException()
+        {
+            File.WriteAllText(Path.Combine(_tempDirectory, "host.json"), "{}");
+
+            var action = new GoPackSubcommandAction();
+            var validate = () => action.ValidateFunctionApp(_tempDirectory, new PackOptions());
+
+            validate.Should().Throw<CliException>()
+                .Which.Message.Should().Contain("go.mod");
+        }
+    }
+}

--- a/test/Cli/Func.UnitTests/ActionsTests/PackAction/PackActionRuntimeDetectionTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/PackAction/PackActionRuntimeDetectionTests.cs
@@ -133,5 +133,37 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests.PackAction
             var ex = await Assert.ThrowsAsync<CliException>(() => action.RunAsync());
             ex.Message.Should().NotContain("Unable to determine the worker runtime");
         }
+
+        [Fact]
+        public async Task RunAsync_NativeRuntimeWithGoMod_ResolvesToGoAndDoesNotThrowRuntimeError()
+        {
+            // Regression: FUNCTIONS_WORKER_RUNTIME=native + go.mod should resolve to Go.
+            // GetCurrentWorkerRuntimeLanguage handles "native" by inspecting project markers,
+            // so the runtime detection path must NOT surface "Unable to determine the worker
+            // runtime" for a valid Go workspace.
+            _mockSecretsManager
+                .Setup(s => s.GetSecrets(It.IsAny<bool>()))
+                .Returns(new Dictionary<string, string>
+                {
+                    [Constants.FunctionsWorkerRuntime] = "native"
+                });
+            File.WriteAllText(Path.Combine(_tempDir, "go.mod"), "module example.com/test\n");
+            Environment.CurrentDirectory = _tempDir;
+            var action = new FuncPackAction(_mockSecretsManager.Object);
+
+            // Act & Assert: must NOT throw the "Unable to determine" CliException.
+            // Packing may still fail later (no Go binary to pack), but that's a different error.
+            Exception thrownException = null;
+            try
+            {
+                await action.RunAsync();
+            }
+            catch (Exception ex)
+            {
+                thrownException = ex;
+            }
+
+            thrownException?.Message.Should().NotContain("Unable to determine the worker runtime");
+        }
     }
 }

--- a/test/Cli/Func.UnitTests/ActionsTests/StartHostActionTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/StartHostActionTests.cs
@@ -511,5 +511,98 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
                 Environment.SetEnvironmentVariable(pythonEnvVar, originalValue);
             }
         }
+
+        [Fact]
+        public void ResolveNativeWorkerRuntime_NativeWithGoMod_ResolvesToGo()
+        {
+            string envVar = Constants.FunctionsWorkerRuntime;
+            string original = Environment.GetEnvironmentVariable(envVar);
+            Environment.SetEnvironmentVariable(envVar, "native");
+
+            var fileSystem = Substitute.For<IFileSystem>();
+            fileSystem.File.Exists(Arg.Is<string>(p => p.EndsWith("go.mod"))).Returns(true);
+
+            var secretsManager = new Mock<ISecretsManager>();
+            secretsManager.Setup(s => s.GetSecrets()).Returns(new Dictionary<string, string>());
+
+            var previous = GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone;
+
+            try
+            {
+                using (FileSystemHelpers.Override(fileSystem))
+                {
+                    GlobalCoreToolsSettings.CurrentWorkerRuntime = WorkerRuntime.None;
+                    var action = new StartHostAction(secretsManager.Object, Mock.Of<IProcessManager>());
+
+                    action.ResolveNativeWorkerRuntime();
+
+                    GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone.Should().Be(WorkerRuntime.Go);
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(envVar, original);
+                GlobalCoreToolsSettings.CurrentWorkerRuntime = previous;
+            }
+        }
+
+        [Fact]
+        public void ResolveNativeWorkerRuntime_NativeWithoutGoMod_Throws()
+        {
+            string envVar = Constants.FunctionsWorkerRuntime;
+            string original = Environment.GetEnvironmentVariable(envVar);
+            Environment.SetEnvironmentVariable(envVar, "native");
+
+            var fileSystem = Substitute.For<IFileSystem>();
+            fileSystem.File.Exists(Arg.Any<string>()).Returns(false);
+
+            var secretsManager = new Mock<ISecretsManager>();
+            secretsManager.Setup(s => s.GetSecrets()).Returns(new Dictionary<string, string>());
+
+            try
+            {
+                using (FileSystemHelpers.Override(fileSystem))
+                {
+                    var action = new StartHostAction(secretsManager.Object, Mock.Of<IProcessManager>());
+
+                    Action act = () => action.ResolveNativeWorkerRuntime();
+
+                    act.Should().Throw<CliException>()
+                        .Which.Message.Should().Contain("Run 'func init'");
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(envVar, original);
+            }
+        }
+
+        [Fact]
+        public void ResolveNativeWorkerRuntime_NonNativeRuntime_NoOp()
+        {
+            string envVar = Constants.FunctionsWorkerRuntime;
+            string original = Environment.GetEnvironmentVariable(envVar);
+            Environment.SetEnvironmentVariable(envVar, "python");
+
+            var secretsManager = new Mock<ISecretsManager>();
+            secretsManager.Setup(s => s.GetSecrets()).Returns(new Dictionary<string, string>());
+
+            var previous = GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone;
+
+            try
+            {
+                GlobalCoreToolsSettings.CurrentWorkerRuntime = WorkerRuntime.Python;
+                var action = new StartHostAction(secretsManager.Object, Mock.Of<IProcessManager>());
+
+                action.ResolveNativeWorkerRuntime();
+
+                GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone.Should().Be(WorkerRuntime.Python);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(envVar, original);
+                GlobalCoreToolsSettings.CurrentWorkerRuntime = previous;
+            }
+        }
     }
 }

--- a/test/Cli/Func.UnitTests/ActionsTests/StartHostActionTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/StartHostActionTests.cs
@@ -513,7 +513,7 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
         }
 
         [Fact]
-        public void ResolveNativeWorkerRuntime_NativeWithGoMod_ResolvesToGo()
+        public void GetCurrentWorkerRuntimeLanguage_NativeWithGoMod_ResolvesToGo()
         {
             string envVar = Constants.FunctionsWorkerRuntime;
             string original = Environment.GetEnvironmentVariable(envVar);
@@ -525,29 +525,23 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
             var secretsManager = new Mock<ISecretsManager>();
             secretsManager.Setup(s => s.GetSecrets()).Returns(new Dictionary<string, string>());
 
-            var previous = GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone;
-
             try
             {
                 using (FileSystemHelpers.Override(fileSystem))
                 {
-                    GlobalCoreToolsSettings.CurrentWorkerRuntime = WorkerRuntime.None;
-                    var action = new StartHostAction(secretsManager.Object, Mock.Of<IProcessManager>());
+                    var resolved = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(secretsManager.Object);
 
-                    action.ResolveNativeWorkerRuntime();
-
-                    GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone.Should().Be(WorkerRuntime.Go);
+                    resolved.Should().Be(WorkerRuntime.Go);
                 }
             }
             finally
             {
                 Environment.SetEnvironmentVariable(envVar, original);
-                GlobalCoreToolsSettings.CurrentWorkerRuntime = previous;
             }
         }
 
         [Fact]
-        public void ResolveNativeWorkerRuntime_NativeWithoutGoMod_Throws()
+        public void GetCurrentWorkerRuntimeLanguage_NativeWithoutGoMod_Throws()
         {
             string envVar = Constants.FunctionsWorkerRuntime;
             string original = Environment.GetEnvironmentVariable(envVar);
@@ -563,12 +557,10 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
             {
                 using (FileSystemHelpers.Override(fileSystem))
                 {
-                    var action = new StartHostAction(secretsManager.Object, Mock.Of<IProcessManager>());
-
-                    Action act = () => action.ResolveNativeWorkerRuntime();
+                    Action act = () => WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(secretsManager.Object);
 
                     act.Should().Throw<CliException>()
-                        .Which.Message.Should().Contain("Run 'func init'");
+                        .Which.Message.Should().Contain("native");
                 }
             }
             finally
@@ -578,7 +570,7 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
         }
 
         [Fact]
-        public void ResolveNativeWorkerRuntime_NonNativeRuntime_NoOp()
+        public void GetCurrentWorkerRuntimeLanguage_NonNativeRuntime_ReturnsRuntime()
         {
             string envVar = Constants.FunctionsWorkerRuntime;
             string original = Environment.GetEnvironmentVariable(envVar);
@@ -587,21 +579,15 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
             var secretsManager = new Mock<ISecretsManager>();
             secretsManager.Setup(s => s.GetSecrets()).Returns(new Dictionary<string, string>());
 
-            var previous = GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone;
-
             try
             {
-                GlobalCoreToolsSettings.CurrentWorkerRuntime = WorkerRuntime.Python;
-                var action = new StartHostAction(secretsManager.Object, Mock.Of<IProcessManager>());
+                var resolved = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(secretsManager.Object);
 
-                action.ResolveNativeWorkerRuntime();
-
-                GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone.Should().Be(WorkerRuntime.Python);
+                resolved.Should().Be(WorkerRuntime.Python);
             }
             finally
             {
                 Environment.SetEnvironmentVariable(envVar, original);
-                GlobalCoreToolsSettings.CurrentWorkerRuntime = previous;
             }
         }
     }

--- a/test/Cli/Func.UnitTests/ActionsTests/StartHostActionTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/StartHostActionTests.cs
@@ -19,6 +19,7 @@ using Xunit;
 
 namespace Azure.Functions.Cli.UnitTests.ActionsTests
 {
+    [Collection("NativeWorkerRuntimeTests")]
     public class StartHostActionTests
     {
         [SkippableFact]

--- a/test/Cli/Func.UnitTests/CommonTests/ExecutableTests.cs
+++ b/test/Cli/Func.UnitTests/CommonTests/ExecutableTests.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Runtime.InteropServices;
+using System.Text;
+using Azure.Functions.Cli.Common;
+using FluentAssertions;
+using Xunit;
+
+namespace Azure.Functions.Cli.UnitTests.CommonTests
+{
+    public class ExecutableTests
+    {
+        [Fact]
+        public async Task RunAsync_CapturesFullStdout_ForShortLivedProcess()
+        {
+            (string exe, string args) = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? ("cmd.exe", "/c echo hello-from-test")
+                : ("/bin/sh", "-c \"echo hello-from-test\"");
+
+            var sb = new StringBuilder();
+            var executable = new Executable(exe, args);
+
+            int exitCode = await executable.RunAsync(o => sb.AppendLine(o), e => sb.AppendLine(e));
+
+            exitCode.Should().Be(0);
+            sb.ToString().Should().Contain("hello-from-test");
+        }
+    }
+}

--- a/test/Cli/Func.UnitTests/CommonTests/ExecutableTests.cs
+++ b/test/Cli/Func.UnitTests/CommonTests/ExecutableTests.cs
@@ -3,8 +3,8 @@
 
 using System.Runtime.InteropServices;
 using System.Text;
+using AwesomeAssertions;
 using Azure.Functions.Cli.Common;
-using FluentAssertions;
 using Xunit;
 
 namespace Azure.Functions.Cli.UnitTests.CommonTests

--- a/test/Cli/Func.UnitTests/HelperTests/GoHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/GoHelperTests.cs
@@ -1,0 +1,130 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Runtime.InteropServices;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Helpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Azure.Functions.Cli.UnitTests.HelperTests
+{
+    public class GoHelperTests
+    {
+        [SkipIfGoNonExistFact]
+        public async Task InterpreterShouldHaveExecutablePath()
+        {
+            WorkerLanguageVersionInfo worker = await GoHelpers.GetEnvironmentGoVersion();
+
+            worker.Should().NotBeNull();
+            worker.ExecutablePath.Should().NotBeNullOrEmpty("Go executable path should not be empty");
+        }
+
+        [SkipIfGoNonExistFact]
+        public async Task InterpreterShouldHaveMajorVersion()
+        {
+            WorkerLanguageVersionInfo worker = await GoHelpers.GetEnvironmentGoVersion();
+
+            worker.Should().NotBeNull();
+            worker.Major.Should().BeGreaterOrEqualTo(1, "Go major version should be at least 1");
+        }
+
+        [SkipIfGoNonExistFact]
+        public async Task WorkerInfoRuntimeShouldBeGo()
+        {
+            WorkerLanguageVersionInfo worker = await GoHelpers.GetEnvironmentGoVersion();
+
+            worker.Should().NotBeNull();
+            worker.Runtime.Should().Be(WorkerRuntime.Go, "Worker runtime should be Go");
+        }
+
+        [Theory]
+        [InlineData("1.24.0", false)]
+        [InlineData("1.24.2", false)]
+        [InlineData("1.25.0", false)]
+        [InlineData("1.23.0", true)]
+        [InlineData("1.22.5", true)]
+        [InlineData("1.20.0", true)]
+        [InlineData("2.0.0", false)]
+        public void AssertGoVersion_ValidatesMinimumVersion(string goVersion, bool expectException)
+        {
+            var worker = new WorkerLanguageVersionInfo(WorkerRuntime.Go, goVersion, "go");
+
+            if (!expectException)
+            {
+                GoHelpers.AssertGoVersion(worker);
+            }
+            else
+            {
+                var action = () => GoHelpers.AssertGoVersion(worker);
+                action.Should().Throw<CliException>();
+            }
+        }
+
+        [Fact]
+        public void AssertGoVersion_NullVersion_ThrowsCliException()
+        {
+            var action = () => GoHelpers.AssertGoVersion(null);
+            action.Should().Throw<CliException>().Which.Message.Should().Contain("Could not find a Go installation");
+        }
+
+        [Theory]
+        [InlineData("beta1")]
+        [InlineData("notaversion")]
+        public void AssertGoVersion_UnparseableVersion_ThrowsCliException(string version)
+        {
+            var worker = new WorkerLanguageVersionInfo(WorkerRuntime.Go, version, "go");
+
+            var action = () => GoHelpers.AssertGoVersion(worker);
+            action.Should().Throw<CliException>().Which.Message.Should().Contain("Unable to parse Go version");
+        }
+
+        [Theory]
+        [InlineData("1.24.2.1")]
+        [InlineData("1.25.0-rc1")]
+        public void AssertGoVersion_ExtraVersionParts_DoesNotThrow(string version)
+        {
+            var worker = new WorkerLanguageVersionInfo(WorkerRuntime.Go, version, "go");
+
+            GoHelpers.AssertGoVersion(worker);
+        }
+    }
+
+    public sealed class SkipIfGoNonExistFact : FactAttribute
+    {
+        public SkipIfGoNonExistFact()
+        {
+            string goExe;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                goExe = "go.exe";
+            }
+            else
+            {
+                goExe = "go";
+            }
+
+            if (!CheckIfGoExists(goExe))
+            {
+                Skip = "go does not exist";
+            }
+        }
+
+        private bool CheckIfGoExists(string goExe)
+        {
+            string path = Environment.GetEnvironmentVariable("PATH");
+            if (!string.IsNullOrEmpty(path))
+            {
+                foreach (string p in path.Split(Path.PathSeparator))
+                {
+                    if (File.Exists(Path.Combine(p, goExe)))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/test/Cli/Func.UnitTests/HelperTests/GoHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/GoHelperTests.cs
@@ -88,6 +88,90 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
 
             GoHelpers.AssertGoVersion(worker);
         }
+
+        [Fact]
+        public void AssertBinaryExists_BinaryPresent_DoesNotThrow()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "func-go-test-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                var binaryName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    ? "app.exe"
+                    : "app";
+                File.WriteAllText(Path.Combine(dir, binaryName), "stub");
+
+                var action = () => GoHelpers.AssertBinaryExists(dir);
+                action.Should().NotThrow();
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void AssertBinaryExists_BinaryMissing_ThrowsActionableCliException()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "func-go-test-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                var action = () => GoHelpers.AssertBinaryExists(dir);
+
+                action.Should().Throw<CliException>()
+                    .Which.Message.Should().Contain("Could not find a built Go binary")
+                                  .And.Contain("--no-build")
+                                  .And.Contain("go build");
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [SkipIfGoNonExistFact]
+        public async Task BuildProject_ValidProject_ProducesBinary()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "func-go-build-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                File.WriteAllText(Path.Combine(dir, "go.mod"), "module example.com/test\n\ngo 1.24\n");
+                File.WriteAllText(Path.Combine(dir, "main.go"), "package main\n\nfunc main() {}\n");
+
+                await GoHelpers.BuildProject(dir);
+
+                var binaryName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    ? "app.exe"
+                    : "app";
+                File.Exists(Path.Combine(dir, binaryName)).Should().BeTrue("BuildProject should produce the worker binary");
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [SkipIfGoNonExistFact]
+        public async Task BuildProject_InvalidProject_ThrowsCliException()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "func-go-build-fail-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                File.WriteAllText(Path.Combine(dir, "go.mod"), "module example.com/test\n\ngo 1.24\n");
+                File.WriteAllText(Path.Combine(dir, "main.go"), "package main\n\nthis is not valid go\n");
+
+                Func<Task> act = () => GoHelpers.BuildProject(dir);
+                var ex = await Assert.ThrowsAsync<CliException>(act);
+                ex.Message.Should().Contain("Go build failed");
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
     }
 
     public sealed class SkipIfGoNonExistFact : FactAttribute

--- a/test/Cli/Func.UnitTests/HelperTests/GoHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/GoHelperTests.cs
@@ -3,9 +3,9 @@
 
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using AwesomeAssertions;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Helpers;
-using FluentAssertions;
 using Xunit;
 
 namespace Azure.Functions.Cli.UnitTests.HelperTests
@@ -27,7 +27,7 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
             WorkerLanguageVersionInfo worker = await GoHelpers.GetEnvironmentGoVersion();
 
             worker.Should().NotBeNull();
-            worker.Major.Should().BeGreaterOrEqualTo(1, "Go major version should be at least 1");
+            worker.Major.Should().BeGreaterThanOrEqualTo(1, "Go major version should be at least 1");
         }
 
         [SkipIfGoNonExistFact]

--- a/test/Cli/Func.UnitTests/HelperTests/GoHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/GoHelperTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Helpers;
@@ -93,13 +94,13 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
         public void AssertBinaryExists_BinaryPresent_DoesNotThrow()
         {
             var dir = Path.Combine(Path.GetTempPath(), "func-go-test-" + Guid.NewGuid().ToString("N"));
-            Directory.CreateDirectory(dir);
+            Directory.CreateDirectory(Path.Combine(dir, GoHelpers.GoBinDir));
             try
             {
                 var binaryName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                     ? "app.exe"
                     : "app";
-                File.WriteAllText(Path.Combine(dir, binaryName), "stub");
+                File.WriteAllText(Path.Combine(dir, GoHelpers.GoBinDir, binaryName), "stub");
 
                 var action = () => GoHelpers.AssertBinaryExists(dir);
                 action.Should().NotThrow();
@@ -145,7 +146,7 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
                 var binaryName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                     ? "app.exe"
                     : "app";
-                File.Exists(Path.Combine(dir, binaryName)).Should().BeTrue("BuildProject should produce the worker binary");
+                File.Exists(Path.Combine(dir, GoHelpers.GoBinDir, binaryName)).Should().BeTrue("BuildProject should produce the worker binary in bin/");
             }
             finally
             {
@@ -172,43 +173,199 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
                 Directory.Delete(dir, recursive: true);
             }
         }
+
+        [SkipIfGoNonExistFact]
+        public async Task BuildForLinux_ValidProject_ProducesLinuxAmd64Binary()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "func-go-buildlinux-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                File.WriteAllText(Path.Combine(dir, "go.mod"), "module example.com/test\n\ngo 1.24\n");
+                File.WriteAllText(Path.Combine(dir, "main.go"), "package main\n\nfunc main() {}\n");
+
+                await GoHelpers.BuildForLinux(dir);
+
+                var binary = Path.Combine(dir, GoHelpers.GoBinDir, GoHelpers.GoBinaryName);
+                File.Exists(binary).Should().BeTrue("BuildForLinux should produce the linux/amd64 worker binary");
+
+                // The produced binary is itself a linux/amd64 ELF, so AssertLinuxAmd64Binary should accept it.
+                var assert = () => GoHelpers.AssertLinuxAmd64Binary(dir);
+                assert.Should().NotThrow();
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void AssertLinuxAmd64Binary_BinaryMissing_ThrowsActionableCliException()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "func-go-elf-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                var action = () => GoHelpers.AssertLinuxAmd64Binary(dir);
+
+                action.Should().Throw<CliException>()
+                    .Which.Message.Should().Contain("Could not find a built Go binary")
+                                  .And.Contain("linux")
+                                  .And.Contain("amd64");
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void AssertLinuxAmd64Binary_NotElf_Throws()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "func-go-elf-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path.Combine(dir, GoHelpers.GoBinDir));
+            try
+            {
+                // 32 bytes of non-ELF garbage so the size check passes but the magic check fails.
+                File.WriteAllBytes(Path.Combine(dir, GoHelpers.GoBinDir, GoHelpers.GoBinaryName), new byte[32]);
+
+                var action = () => GoHelpers.AssertLinuxAmd64Binary(dir);
+                action.Should().Throw<CliException>()
+                    .Which.Message.Should().Contain("not an ELF binary");
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void AssertLinuxAmd64Binary_ElfButWrongArch_Throws()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "func-go-elf-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path.Combine(dir, GoHelpers.GoBinDir));
+            try
+            {
+                // Synthesize an ELF64 LE header but with e_machine = EM_AARCH64 (0xB7) instead of EM_X86_64.
+                var header = BuildElfHeader(machine: 0xB7);
+                File.WriteAllBytes(Path.Combine(dir, GoHelpers.GoBinDir, GoHelpers.GoBinaryName), header);
+
+                var action = () => GoHelpers.AssertLinuxAmd64Binary(dir);
+                action.Should().Throw<CliException>()
+                    .Which.Message.Should().Contain("0x00B7")
+                                  .And.Contain("not x86_64");
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void AssertLinuxAmd64Binary_ValidHeader_DoesNotThrow()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "func-go-elf-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path.Combine(dir, GoHelpers.GoBinDir));
+            try
+            {
+                File.WriteAllBytes(Path.Combine(dir, GoHelpers.GoBinDir, GoHelpers.GoBinaryName), BuildElfHeader(machine: 0x3E));
+
+                var action = () => GoHelpers.AssertLinuxAmd64Binary(dir);
+                action.Should().NotThrow();
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void AssertLinuxAmd64Binary_Elf32_Throws()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "func-go-elf-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path.Combine(dir, GoHelpers.GoBinDir));
+            try
+            {
+                // Override EI_CLASS (offset 4) to 1 (ELFCLASS32) — should be rejected even if e_machine is x86_64.
+                var header = BuildElfHeader(machine: 0x3E);
+                header[4] = 1;
+                File.WriteAllBytes(Path.Combine(dir, GoHelpers.GoBinDir, GoHelpers.GoBinaryName), header);
+
+                var action = () => GoHelpers.AssertLinuxAmd64Binary(dir);
+                action.Should().Throw<CliException>()
+                    .Which.Message.Should().Contain("not a 64-bit little-endian ELF binary");
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void GetPackFiles_ReturnsHostJsonAndAppBinary()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "func-go-files-" + Guid.NewGuid().ToString("N"));
+
+            var files = GoHelpers.GetPackFiles(root).ToArray();
+
+            files.Should().HaveCount(2);
+            files.Should().Contain(Path.Combine(root, "host.json"));
+            files.Should().Contain(Path.Combine(root, GoHelpers.GoBinDir, GoHelpers.GoBinaryName));
+        }
+
+        // Builds a minimal 20-byte ELF identification region with EI_CLASS=64-bit, EI_DATA=little-endian
+        // and an arbitrary e_machine value. AssertLinuxAmd64Binary only inspects the first 20 bytes, so
+        // this is enough to exercise its checks without producing a valid runnable binary.
+        private static byte[] BuildElfHeader(ushort machine)
+        {
+            var header = new byte[20];
+            header[0] = 0x7F;
+            header[1] = (byte)'E';
+            header[2] = (byte)'L';
+            header[3] = (byte)'F';
+            header[4] = 2; // EI_CLASS = ELFCLASS64
+            header[5] = 1; // EI_DATA  = ELFDATA2LSB
+            header[18] = (byte)(machine & 0xFF);
+            header[19] = (byte)((machine >> 8) & 0xFF);
+            return header;
+        }
     }
 
     public sealed class SkipIfGoNonExistFact : FactAttribute
     {
         public SkipIfGoNonExistFact()
         {
-            string goExe;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (!CheckIfGoWorks())
             {
-                goExe = "go.exe";
-            }
-            else
-            {
-                goExe = "go";
-            }
-
-            if (!CheckIfGoExists(goExe))
-            {
-                Skip = "go does not exist";
+                Skip = "go is not installed or not functional";
             }
         }
 
-        private bool CheckIfGoExists(string goExe)
+        private static bool CheckIfGoWorks()
         {
-            string path = Environment.GetEnvironmentVariable("PATH");
-            if (!string.IsNullOrEmpty(path))
+            try
             {
-                foreach (string p in path.Split(Path.PathSeparator))
+                using var process = new Process();
+                process.StartInfo = new ProcessStartInfo
                 {
-                    if (File.Exists(Path.Combine(p, goExe)))
-                    {
-                        return true;
-                    }
-                }
-            }
+                    FileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "go.exe" : "go",
+                    Arguments = "version",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                };
 
-            return false;
+                process.Start();
+                string output = process.StandardOutput.ReadToEnd();
+                process.WaitForExit(5000);
+
+                return process.ExitCode == 0 && output.Contains("go");
+            }
+            catch
+            {
+                return false;
+            }
         }
     }
 }

--- a/test/Cli/Func.UnitTests/HelperTests/WorkerRuntimeLanguageHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/WorkerRuntimeLanguageHelperTests.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Helpers;
+using Xunit;
+
+namespace Azure.Functions.Cli.UnitTests.HelperTests
+{
+    public class WorkerRuntimeLanguageHelperTests
+    {
+        [Fact]
+        public void NormalizeLanguage_Golang_ThrowsArgumentException()
+        {
+            // "golang" is not a valid language string; only "go" is accepted.
+            // This test ensures the resolver doesn't silently accept "golang"
+            // and map it to the wrong runtime.
+            Assert.Throws<ArgumentException>(() =>
+                WorkerRuntimeLanguageHelper.NormalizeLanguage("golang"));
+        }
+    }
+}

--- a/test/Cli/Func.UnitTests/HelperTests/ZipHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/ZipHelperTests.cs
@@ -36,8 +36,10 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
             {
                 if (_isCI)
                 {
-                    // copy the windows-built linux zip so we can include it in ci artifacts for validation on linux
-                    File.Copy(linuxZip, Path.Combine(Directory.GetCurrentDirectory(), "ZippedOnWindows.zip"), true);
+                    // Copy the windows-built linux zip so we can include it in CI artifacts for
+                    // validation on Linux. Use a deterministic repo-relative path because the
+                    // VSTest runner's working directory varies across SDK versions.
+                    File.Copy(linuxZip, Path.Combine(GetUnitTestsOutputDir(), "ZippedOnWindows.zip"), true);
                 }
 
                 VerifyWindowsZip(windowsZip);
@@ -60,6 +62,18 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
             {
                 throw new Exception("Unsupported OS");
             }
+        }
+
+        private static string GetUnitTestsOutputDir()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Azure.Functions.Cli.sln")))
+            {
+                dir = dir.Parent;
+            }
+
+            Assert.True(dir is not null, "Could not find repo root (Azure.Functions.Cli.sln).");
+            return Path.Combine(dir!.FullName, "out", "bin", "Azure.Functions.Cli.UnitTests", "debug");
         }
 
         private async Task<string> BuildAndCopyFileToZipAsync(string rid)

--- a/test/Cli/Func.UnitTests/HelperTests/ZipHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/ZipHelperTests.cs
@@ -236,7 +236,6 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
             Directory.CreateDirectory(dir);
             Directory.CreateDirectory(Path.Combine(dir, GoHelpers.GoBinDir));
 
-            var previousRuntime = GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone;
             try
             {
                 File.WriteAllText(Path.Combine(dir, "host.json"), "{}");
@@ -247,9 +246,7 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
                 File.WriteAllText(Path.Combine(dir, "go.mod"), "module example.com/test\n");
                 File.WriteAllText(Path.Combine(dir, "local.settings.json"), "{}");
 
-                GlobalCoreToolsSettings.CurrentWorkerRuntime = WorkerRuntime.Go;
-
-                var stream = await ZipHelper.GetAppZipFile(dir, buildNativeDeps: false, BuildOption.Default, noBuild: false);
+                var stream = await ZipHelper.GetAppZipFile(dir, buildNativeDeps: false, BuildOption.Default, noBuild: false, WorkerRuntime.Go);
 
                 Assert.NotNull(stream);
                 using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
@@ -264,7 +261,6 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
             }
             finally
             {
-                GlobalCoreToolsSettings.CurrentWorkerRuntime = previousRuntime;
                 Directory.Delete(dir, recursive: true);
             }
         }

--- a/test/Cli/Func.UnitTests/HelperTests/ZipHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/ZipHelperTests.cs
@@ -214,5 +214,45 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
         {
             _output.WriteLine(output);
         }
+
+        [Fact]
+        public async Task GetAppZipFile_GoRuntime_ContainsOnlyHostJsonAndApp()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(dir);
+            Directory.CreateDirectory(Path.Combine(dir, GoHelpers.GoBinDir));
+
+            var previousRuntime = GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone;
+            try
+            {
+                File.WriteAllText(Path.Combine(dir, "host.json"), "{}");
+                File.WriteAllBytes(Path.Combine(dir, GoHelpers.GoBinDir, GoHelpers.GoBinaryName), new byte[] { 0x7F, (byte)'E', (byte)'L', (byte)'F', 2, 1 });
+
+                // Files that must NOT be picked up — Go uses an explicit allowlist, not funcignore.
+                File.WriteAllText(Path.Combine(dir, "main.go"), "package main\nfunc main() {}\n");
+                File.WriteAllText(Path.Combine(dir, "go.mod"), "module example.com/test\n");
+                File.WriteAllText(Path.Combine(dir, "local.settings.json"), "{}");
+
+                GlobalCoreToolsSettings.CurrentWorkerRuntime = WorkerRuntime.Go;
+
+                var stream = await ZipHelper.GetAppZipFile(dir, buildNativeDeps: false, BuildOption.Default, noBuild: false);
+
+                Assert.NotNull(stream);
+                using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
+                var entries = archive.Entries.Select(e => e.FullName).OrderBy(n => n).ToArray();
+
+                Assert.Equal(new[] { "app", "host.json" }, entries);
+
+                // Verify Unix exec bit on the binary — without this, the Linux Functions
+                // host won't be able to launch the extracted binary.
+                var appEntry = archive.Entries.Single(e => e.FullName == "app");
+                Assert.Equal(0x49, (appEntry.ExternalAttributes >> 16) & 0x49);
+            }
+            finally
+            {
+                GlobalCoreToolsSettings.CurrentWorkerRuntime = previousRuntime;
+                Directory.Delete(dir, recursive: true);
+            }
+        }
     }
 }


### PR DESCRIPTION
Go Language Support (Preview)

This PR adds preview support for the Go programming language to Azure Functions Core Tools, enabling developers to create, build, and deploy Go-based Azure Functions.

Features Added

 - func init - Initialize Go projects with --worker-runtime go (also supports --go/--golang shortcuts)
 - func start - Run Go functions locally with hot reload support
 - func pack - Package Go functions for deployment (Linux AMD64 binary)
 - func publish - Deploy Go functions to Azure (Flex Consumption plan only)

Key Implementation Details

 - Go detected via go.mod presence (registered as FUNCTIONS_WORKER_RUNTIME=native)
 - Native worker configuration included in minified builds
 - Opt-in preview flag: FUNCTIONS_CLI_GO_PREVIEW=1
 - Requires Go 1.24 or later
 - Uses 1ES centralized Go module proxy in CI pipelines
 - Linux-only deployment (Windows host builds cross-compile to linux/amd64)

Related PRs

 - #4875 - func init support
 - #4892 - func start support  
 - #4943 - func pack and func publish support
 - #4959 - Remove legacy gozip binary
 - #4966 - Add preview opt-in flag
 - #5062 - Include native worker in minified builds