### PR TITLE
build(vnext): per-RID pack for host workload

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,6 +6,7 @@
     <IsPackable>true</IsPackable>
     <IsPublishable>false</IsPublishable>
     <UpdateBuildNumber Condition="'$(IsReleaseCI)' == 'true'">true</UpdateBuildNumber>
+    <_CliRuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</_CliRuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Func/Func.csproj
+++ b/src/Func/Func.csproj
@@ -5,18 +5,16 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
+    <RuntimeIdentifiers>$(_CliRuntimeIdentifiers)</RuntimeIdentifiers>
     <AssemblyName>func</AssemblyName>
     <RootNamespace>$(TopLevelNamespace)</RootNamespace>
     <InvariantGlobalization>false</InvariantGlobalization>
-    <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>true</PublishSingleFile>
     <IsPackable>false</IsPackable>
     <IsPublishable>true</IsPublishable>
     <EnableDemoProject>true</EnableDemoProject>
   </PropertyGroup>
-
-  
 
   <ItemGroup>
     <InternalsVisibleTo Include="Azure.Functions.Cli.Tests" />

--- a/src/Workloads/Host/Build.Inner.targets
+++ b/src/Workloads/Host/Build.Inner.targets
@@ -1,20 +1,14 @@
 <Project>
 
-  <PropertyGroup>
-    <_HostWorkloadExplicitRuntimeIdentifier>$(RuntimeIdentifier)</_HostWorkloadExplicitRuntimeIdentifier>
-    <PackRidSpecificHostWorkload>false</PackRidSpecificHostWorkload>
-    <PackageId Condition="'$(PackRidSpecificHostWorkload)' == 'true' And '$(_HostWorkloadExplicitRuntimeIdentifier)' != ''">$(AssemblyName).$(_HostWorkloadExplicitRuntimeIdentifier)</PackageId>
-    <PackageTags Condition="'$(PackRidSpecificHostWorkload)' == 'true' And '$(_HostWorkloadExplicitRuntimeIdentifier)' != ''">$(PackageTags) rid:$(_HostWorkloadExplicitRuntimeIdentifier)</PackageTags>
+  <PropertyGroup Condition="'$(RuntimeIdentifier)' != ''">
+    <PackageId>$(AssemblyName).$(RuntimeIdentifier)</PackageId>
+    <PackageTags>$(PackageTags) rid:$(RuntimeIdentifier)</PackageTags>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);StageHostWorkloadPayload</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
-  <Target Name="ValidateHostRidSpecificPackage" BeforeTargets="ResolvePackageAssets;GenerateNuspec" Condition="'$(PackRidSpecificHostWorkload)' == 'true'">
+  <Target Name="ValidatePackWithRuntimeIdentifier" BeforeTargets="ResolvePackageAssets;GenerateNuspec" Condition="'$(RuntimeIdentifier)' == ''">
     <Error
-      Condition="'$(_HostWorkloadExplicitRuntimeIdentifier)' == ''"
-      Text="PackRidSpecificHostWorkload requires RuntimeIdentifier. Pass -r &lt;rid&gt; when packing the host workload." />
-    <Error
-      Condition="'$(SelfContained)' != 'true'"
-      Text="PackRidSpecificHostWorkload requires SelfContained=true." />
+      Text="RuntimeIdentifier is required when packing the host workload. Pass -r &lt;rid&gt; when packing the host workload." />
   </Target>
 
   <Target Name="StageHostWorkloadPayload">

--- a/src/Workloads/Host/Build.Outer.targets
+++ b/src/Workloads/Host/Build.Outer.targets
@@ -32,14 +32,9 @@
     <MSBuild Projects="@(_ProjectsForDispatch)" Targets="Pack" BuildInParallel="true"/>
   </Target>
 
-  <Target Name="Build" DependsOnTargets="_ResolveInnerProjects">
-    <ItemGroup>
-      <!-- Also build the AnyCPU version for tests. -->
-      <_ProjectsForDispatch Include="$(MSBuildProjectFullPath)" />
-    </ItemGroup>
-
-    <!-- Set 'IsInnerBuild=true' here to avoid infinite recursion with the RID-less build. -->
-    <MSBuild Projects="@(_ProjectsForDispatch)" Targets="Build" BuildInParallel="true" Properties="IsInnerBuild=true"/>
+  <Target Name="_DispatchInnerBuilds" BeforeTargets="Build" DependsOnTargets="_ResolveInnerProjects">
+    <!-- Don't override the default build behavior, but hook onto it to ensure all the RID-specific builds are performed. -->
+    <MSBuild Projects="@(_ProjectsForDispatch)" Targets="Build" BuildInParallel="true" />
   </Target>
 
 </Project>

--- a/src/Workloads/Host/Build.Outer.targets
+++ b/src/Workloads/Host/Build.Outer.targets
@@ -1,0 +1,45 @@
+<Project>
+
+  <!--
+    These targets enable multi-TFM style building and packing for the host workload.
+    We want to pack the host workload SEPARATELY for multiple runtime identifiers as self contained.
+    The default behavior is to pack all into a single nupkg, we want one per RID.
+    To do this we customize build and pack targets:
+    1. For build, dispatch a unique inner build per RID plus a RID-less build for tests.
+    2. For pack, dispatch a unique inner pack per RID (no RID-less here).
+  -->
+
+  <PropertyGroup>
+    <!-- Enable roll-forward to latest patch.  This allows one restore operation
+         to apply to all of the self-contained publish operations. -->
+    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
+  </PropertyGroup>
+
+  <Target Name="_ResolveInnerProjects">
+    <ItemGroup>
+      <!-- Transform RuntimeIdentifiers property to item -->
+      <_RuntimeIdentifiersToDispatch Include="$(RuntimeIdentifiers)" />
+
+      <!-- Transform _RuntimeIdentifiersToDispatch items to project items to pass to MSBuild task -->
+      <_ProjectsForDispatch Include="@(_RuntimeIdentifiersToDispatch->'$(MSBuildProjectFullPath)')">
+        <!-- Delay setting SelfContained until now to avoid RuntimeIdentifier being set prematurely. -->
+        <AdditionalProperties>RuntimeIdentifier=%(_RuntimeIdentifiersToDispatch.Identity);SelfContained=true</AdditionalProperties>
+      </_ProjectsForDispatch>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="Pack" DependsOnTargets="_ResolveInnerProjects">
+    <MSBuild Projects="@(_ProjectsForDispatch)" Targets="Pack" BuildInParallel="true"/>
+  </Target>
+
+  <Target Name="Build" DependsOnTargets="_ResolveInnerProjects">
+    <ItemGroup>
+      <!-- Also build the AnyCPU version for tests. -->
+      <_ProjectsForDispatch Include="$(MSBuildProjectFullPath)" />
+    </ItemGroup>
+
+    <!-- Set 'IsInnerBuild=true' here to avoid infinite recursion with the RID-less build. -->
+    <MSBuild Projects="@(_ProjectsForDispatch)" Targets="Build" BuildInParallel="true" Properties="IsInnerBuild=true"/>
+  </Target>
+
+</Project>

--- a/src/Workloads/Host/Workloads.Host.csproj
+++ b/src/Workloads/Host/Workloads.Host.csproj
@@ -1,8 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project>
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
+    <RuntimeIdentifiers>$(_CliRuntimeIdentifiers)</RuntimeIdentifiers>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
     <Title>Azure Functions Host</Title>
     <Description>Azure Functions CLI content workload that ships the Azure Functions host.</Description>
@@ -19,24 +21,20 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Diagnostics.EventLog">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="System.Diagnostics.EventLog" />
+    <PackageReference Update="@(PackageReference)" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
     <None Include="workload.json" Pack="true" PackagePath="/" />
   </ItemGroup>
 
-  <Import Project="PackHostWorkload.targets" />
+  <!-- When calling 'dotnet pack' without a runtime identifier, we will fan out to a per-RID pack. -->
+  <Import Project="Build.Inner.targets" Condition="'$(RuntimeIdentifier)' != ''" />
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+  <Import Project="Build.Outer.targets" Condition="'$(RuntimeIdentifier)' == '' AND '$(IsInnerBuild)' != 'true'" />
 
 </Project>


### PR DESCRIPTION
This PR refactors the nuget packaging msbuild logic for the host workload. Now calling `dotnet pack` will fan out to packing each RID separately. Calling `dotnet pack -r {RID}` will pack that individual RID.

This PR also forces `self-contained` during pack.