### PR TITLE
Fix install.js (HttpsProxyAgent, chalk, engines) and remove core-tools devDep from templates

### DIFF
--- a/eng/tools/publish-tools/npm/lib/install.js
+++ b/eng/tools/publish-tools/npm/lib/install.js
@@ -2,7 +2,7 @@
 
 const extract = require('extract-zip');
 const url = require('url');
-const HttpsProxyAgent = require('https-proxy-agent');
+const { HttpsProxyAgent } = require('https-proxy-agent');
 const https = require('https');
 const version = require('../package.json').version;
 const consolidatedBuildId = "4.0." + require('../package.json').consolidatedBuildId;

--- a/eng/tools/publish-tools/npm/npm-shrinkwrap.json
+++ b/eng/tools/publish-tools/npm/npm-shrinkwrap.json
@@ -15,7 +15,7 @@
         "linux"
       ],
       "dependencies": {
-        "chalk": "5.6.2",
+        "chalk": "^4.1.2",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "9.0.0",
         "progress": "2.0.3",
@@ -27,13 +27,13 @@
         "func": "lib/main.js"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=20"
       }
     },
     "node_modules/@types/node": {
-      "version": "25.8.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
-      "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -57,6 +57,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/balanced-match": {
@@ -90,16 +105,38 @@
       }
     },
     "node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
       "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -188,6 +225,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.0.0.tgz",
@@ -202,9 +248,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
-      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -313,6 +359,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/undici-types": {

--- a/eng/tools/publish-tools/npm/package.json
+++ b/eng/tools/publish-tools/npm/package.json
@@ -25,10 +25,10 @@
     "linux"
   ],
   "engines": {
-    "node": ">=14.18.0"
+    "node": ">=20"
   },
   "dependencies": {
-    "chalk": "5.6.2",
+    "chalk": "^4.1.2",
     "https-proxy-agent": "9.0.0",
     "extract-zip": "^2.0.1",
     "progress": "2.0.3",

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,4 +1,4 @@
-# Azure Functions CLI 4.11.0
+# Azure Functions CLI 4.11.1
 
 #### Host Version
 
@@ -8,3 +8,5 @@
   - Host Runtime Version: 4.48.100 (includes 4.848.100, 4.648.100)
 
 #### Changes
+
+- Fix `HttpsProxyAgent is not a constructor` error in `install.js` when installing behind a proxy (https-proxy-agent v9 requires a named import).

--- a/release_notes.md
+++ b/release_notes.md
@@ -10,3 +10,4 @@
 #### Changes
 
 - Fix `HttpsProxyAgent is not a constructor` error in `install.js` when installing behind a proxy (https-proxy-agent v9 requires a named import).
+- Remove `azure-functions-core-tools` from the `devDependencies` of generated function app templates (`package-js.json`, `package-js-v4.json`, `package-ts.json`, `package-ts-v4.json`). Users get the CLI from their system install; pulling it in again via `npm install` doubled disk usage and made every project's install fragile to Core Tools postinstall regressions.

--- a/src/Cli/func/Directory.Version.props
+++ b/src/Cli/func/Directory.Version.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>4.11.0</VersionPrefix>
+    <VersionPrefix>4.11.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>

--- a/src/Cli/func/StaticResources/package-js-v4.json
+++ b/src/Cli/func/StaticResources/package-js-v4.json
@@ -10,7 +10,5 @@
   "dependencies": {
     "@azure/functions": "^4.0.0"
   },
-  "devDependencies": {
-    "azure-functions-core-tools": "^4.x"
-  }
+  "devDependencies": {}
 }

--- a/src/Cli/func/StaticResources/package-js.json
+++ b/src/Cli/func/StaticResources/package-js.json
@@ -7,7 +7,5 @@
     "test": "echo \"No tests yet...\""
   },
   "dependencies": {},
-  "devDependencies": {
-    "azure-functions-core-tools": "^4.x"
-  }
+  "devDependencies": {}
 }

--- a/src/Cli/func/StaticResources/package-ts-v4.json
+++ b/src/Cli/func/StaticResources/package-ts-v4.json
@@ -15,7 +15,6 @@
     "@azure/functions": "^4.0.0"
   },
   "devDependencies": {
-    "azure-functions-core-tools": "^4.x",
     "@types/node": "18.x",
     "typescript": "^5.0.0",
     "rimraf": "^5.0.0"

--- a/src/Cli/func/StaticResources/package-ts.json
+++ b/src/Cli/func/StaticResources/package-ts.json
@@ -12,7 +12,6 @@
   "dependencies": {},
   "devDependencies": {
     "@azure/functions": "^3.0.0",
-    "azure-functions-core-tools": "^4.x",
     "@types/node": "18.x",
     "typescript": "^5.0.0"
   }


### PR DESCRIPTION
## Problem

Commit dd0181766f1767d89150bad8a0e2c9802ff45eac bumped npm publish-tools dependencies but introduced several issues:

### 1. `HttpsProxyAgent is not a constructor` (reported)
`https-proxy-agent@9` switched to a named export. Installs behind a corporate proxy fail with:
```
TypeError: HttpsProxyAgent is not a constructor
    at .../node_modules/azure-functions-core-tools/lib/install.js:75
```

### 2. `chalk.red is not a function` (latent)
`chalk@5` is ESM-only. `require('chalk')` either throws `ERR_REQUIRE_ESM` or returns the ESM namespace where `chalk.red` is `undefined`. Both error paths in `install.js` (download failure, request error) would throw `TypeError` instead of printing the actual error. Masked today because the proxy bug fires first.

### 3. `engines.node` understated
`rimraf@6` and `https-proxy-agent@9` both declare `engines.node: >=20`, but `package.json` advertised `>=14.18.0`.

### 4. Generated templates pull Core Tools as a devDependency
The function-app templates (`package-js.json`, `package-js-v4.json`, `package-ts.json`, `package-ts-v4.json`) all list `azure-functions-core-tools: ^4.x` as a devDependency. That means every `func init` runs `npm install azure-functions-core-tools` and triggers its postinstall script. So a broken postinstall in the published Core Tools causes `func init` to silently fail to install `@azure/functions`, and then `func start` reports `Cannot find module '@azure/functions'`. This was breaking the Node e2e tests on every CI run, with no visible npm error (`NpmHelper.Install` uses `ignoreError: true` and discards stdout/stderr).

## Fix
- `install.js`: use the named import `const { HttpsProxyAgent } = require('https-proxy-agent');`
- `package.json` (npm wrapper): downgrade `chalk` to `^4.1.2` (last CJS release, same API), bump `engines.node` to `>=20`, regenerate `npm-shrinkwrap.json`
- Templates: remove `azure-functions-core-tools` from the four template `devDependencies`. The CLI is installed system-wide; pulling a second copy into every project's `node_modules` doubled disk usage and made each install fragile to Core Tools postinstall regressions. `@azure/functions` stays as a runtime dependency for the V4 model.
- Bump Core Tools to `4.11.1` and update `release_notes.md`

## Validation
- `npm install` of the npm wrapper followed by a script that requires every module `install.js` uses (`HttpsProxyAgent`, `chalk.red`, `ProgressBar`, `rimrafSync`, `extract`, etc.) succeeds on Node 24.
- Syntax-checked the other install scripts (`chocolatey/installps_template` via the PowerShell parser, `ubuntu/postinst_template` via `sh -n`, Python build scripts via `py_compile`).
- No test asserts on `azure-functions-core-tools` being present in the generated `package.json`.
