### PR TITLE
Wire stack workloads into host start path

### DIFF
--- a/src/Abstractions/Projects/FunctionsProjectHostRunContext.cs
+++ b/src/Abstractions/Projects/FunctionsProjectHostRunContext.cs
@@ -23,7 +23,6 @@ public sealed class FunctionsProjectHostRunContext
 
         _startupDirectory = startupDirectory;
         EnvironmentVariables = environmentVariables;
-        SkipBuild = skipBuild;
         WorkerRuntime = workerRuntime;
         SkipBuild = skipBuild;
     }

--- a/src/Abstractions/Projects/FunctionsProjectHostRunContext.cs
+++ b/src/Abstractions/Projects/FunctionsProjectHostRunContext.cs
@@ -15,7 +15,8 @@ public sealed class FunctionsProjectHostRunContext
     public FunctionsProjectHostRunContext(
         DirectoryInfo startupDirectory,
         string workerRuntime,
-        IDictionary<string, string> environmentVariables)
+        IDictionary<string, string> environmentVariables,
+        bool skipBuild = false)
     {
         ArgumentNullException.ThrowIfNull(startupDirectory);
         ArgumentNullException.ThrowIfNull(environmentVariables);
@@ -23,6 +24,7 @@ public sealed class FunctionsProjectHostRunContext
         _startupDirectory = startupDirectory;
         EnvironmentVariables = environmentVariables;
         WorkerRuntime = workerRuntime;
+        SkipBuild = skipBuild;
     }
 
     public DirectoryInfo StartupDirectory
@@ -32,6 +34,13 @@ public sealed class FunctionsProjectHostRunContext
     }
 
     public IDictionary<string, string> EnvironmentVariables { get; }
+
+    /// <summary>
+    /// When <c>true</c>, project pre-run hooks should skip optional build/restore steps
+    /// (e.g. <c>npm run build</c>, <c>go build</c>) but still perform dependency
+    /// installs required for the host to start.
+    /// </summary>
+    public bool SkipBuild { get; }
 
     public string WorkerRuntime
     {

--- a/src/Abstractions/Projects/FunctionsProjectHostRunContext.cs
+++ b/src/Abstractions/Projects/FunctionsProjectHostRunContext.cs
@@ -23,6 +23,7 @@ public sealed class FunctionsProjectHostRunContext
 
         _startupDirectory = startupDirectory;
         EnvironmentVariables = environmentVariables;
+        SkipBuild = skipBuild;
         WorkerRuntime = workerRuntime;
         SkipBuild = skipBuild;
     }
@@ -38,7 +39,8 @@ public sealed class FunctionsProjectHostRunContext
     /// <summary>
     /// When <c>true</c>, project pre-run hooks should skip optional build/restore steps
     /// (e.g. <c>npm run build</c>, <c>go build</c>) but still perform dependency
-    /// installs required for the host to start.
+    /// installs required for the host to start. Matches the contract of the
+    /// <c>func start --no-build</c> flag.
     /// </summary>
     public bool SkipBuild { get; }
 

--- a/src/Func/Commands/Start/Dashboard/Demo/DemoStartInitializationRunner.cs
+++ b/src/Func/Commands/Start/Dashboard/Demo/DemoStartInitializationRunner.cs
@@ -4,6 +4,7 @@
 using Azure.Functions.Cli.Bundles;
 using Azure.Functions.Cli.Commands.Start.Initialization.Rendering;
 using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Configuration;
 using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Profiles;
 using Azure.Functions.Cli.Projects;
@@ -27,6 +28,7 @@ internal sealed class DemoStartInitializationRunner(
     IWorkloadCatalog workloadCatalog,
     IWorkloadInstaller workloadInstaller,
     IInteractionService interaction,
+    ILocalSettingsProvider localSettingsProvider,
     ILoggerFactory loggerFactory,
     TimeProvider? timeProvider = null)
     : IStartInitializationRunner
@@ -55,6 +57,9 @@ internal sealed class DemoStartInitializationRunner(
         ?? throw new ArgumentNullException(nameof(workloadInstaller));
 
     private readonly IInteractionService _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
+
+    private readonly ILocalSettingsProvider _localSettingsProvider = localSettingsProvider
+        ?? throw new ArgumentNullException(nameof(localSettingsProvider));
 
     private readonly ILoggerFactory _loggerFactory = loggerFactory
         ?? throw new ArgumentNullException(nameof(loggerFactory));
@@ -85,9 +90,12 @@ internal sealed class DemoStartInitializationRunner(
             new ResolveConstraintsInitializationStep(),
             new ValidateHostWorkloadInitializationStep(_hostWorkloadResolver, _workloadInstaller),
             new ResolveFunctionsProjectInitializationStep(_projectResolver),
-            new ResolveFunctionsWorkerInitializationStep(_workerResolverFactory,_workloadCatalog,_workloadInstaller,_interaction),
-            new ValidateExtensionBundleInitializationStep(_bundleResolver, _bundleSectionReader, _loggerFactory.CreateLogger<ValidateExtensionBundleInitializationStep>()),
-            new PrepareProjectHostRunInitializationStep(),
+            new ResolveFunctionsWorkerInitializationStep(_workerResolverFactory, _workloadCatalog, _workloadInstaller, _interaction),
+            new ValidateExtensionBundleInitializationStep(
+                _bundleResolver,
+                _bundleSectionReader,
+                _loggerFactory.CreateLogger<ValidateExtensionBundleInitializationStep>()),
+            new PrepareProjectHostRunInitializationStep(_localSettingsProvider),
             new StartHostInitializationStep(_time),
         ];
 

--- a/src/Func/Commands/Start/Initialization/Steps/PrepareProjectHostRunInitializationStep.cs
+++ b/src/Func/Commands/Start/Initialization/Steps/PrepareProjectHostRunInitializationStep.cs
@@ -1,16 +1,23 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Configuration;
 using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Workers;
 
 namespace Azure.Functions.Cli.Commands.Start.Initialization;
 
 /// <summary>
 /// Lets the resolved project prepare host process state before startup.
+/// Populates the environment dictionary the host will see: <c>local.settings.json</c> values,
+/// <c>FUNCTIONS_WORKER_RUNTIME</c>, the worker directory hint, and any bundle env vars.
 /// </summary>
-internal sealed class PrepareProjectHostRunInitializationStep : DemoInitializationStep
+internal sealed class PrepareProjectHostRunInitializationStep(ILocalSettingsProvider localSettingsProvider) : DemoInitializationStep
 {
     public const string StepId = "prepare_host_run";
+
+    private readonly ILocalSettingsProvider _localSettingsProvider = localSettingsProvider
+        ?? throw new ArgumentNullException(nameof(localSettingsProvider));
 
     public override string Id => StepId;
 
@@ -27,23 +34,62 @@ internal sealed class PrepareProjectHostRunInitializationStep : DemoInitializati
         FunctionsProject project = context.State.Project
             ?? throw new InvalidOperationException("Functions project was not resolved.");
 
-        Dictionary<string, string> environmentVariables = new(context.State.HostEnvironmentVariables, StringComparer.OrdinalIgnoreCase);
-        foreach ((string name, string value) in context.State.BundleEnvVarsForHost)
-        {
-            environmentVariables[name] = value;
-        }
+        IFunctionsWorker worker = context.State.Worker
+            ?? throw new InvalidOperationException("Functions worker was not resolved.");
 
-        if (context.State.Worker?.WorkerRuntime is null)
-        {
-            throw new InvalidOperationException("Functions worker runtime was not resolved.");
-        }
+        Dictionary<string, string> environmentVariables = BuildEnvironmentVariables(context, project, worker);
 
-        var hostRunContext = new FunctionsProjectHostRunContext(project.WorkingDirectory.Info, context.State.Worker.WorkerRuntime, environmentVariables);
+        var hostRunContext = new FunctionsProjectHostRunContext(
+            project.WorkingDirectory.Info,
+            worker.WorkerRuntime,
+            environmentVariables,
+            skipBuild: context.Options.NoBuild);
 
         await project.PrepareForHostRunAsync(hostRunContext, cancellationToken);
 
         context.State.HostRunContext = hostRunContext;
 
         return StartInitializationStepResult.Completed(hostRunContext.StartupDirectory.FullName);
+    }
+
+    private Dictionary<string, string> BuildEnvironmentVariables(StartInitializationStepContext context, FunctionsProject project, IFunctionsWorker worker)
+    {
+        // Priority (low -> high): local.settings.json Values, host state, worker hints, bundle vars.
+        // Bundle vars and worker hints sit on top because the CLI just resolved them and should
+        // win over anything stale a user left in local.settings.json. In particular, the resolved
+        // FUNCTIONS_WORKER_RUNTIME overrides whatever local.settings.json declares: the project
+        // resolver picked a worker, and letting a stale value steer the host would surface as a
+        // confusing "wrong language" failure deep in startup rather than a clear resolver error.
+        var environmentVariables = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        LocalSettingsSnapshot localSettings = _localSettingsProvider.Get(project.WorkingDirectory.Info);
+        foreach ((string name, string value) in localSettings.Values)
+        {
+            environmentVariables[name] = value;
+        }
+
+        foreach ((string name, string value) in context.State.HostEnvironmentVariables)
+        {
+            environmentVariables[name] = value;
+        }
+
+        environmentVariables[FunctionsProjectHostRunContext.WorkerRuntimeEnvironmentVariable] = worker.WorkerRuntime;
+
+        string? workerDirectory = Path.GetDirectoryName(worker.WorkerConfigPath);
+        if (!string.IsNullOrEmpty(workerDirectory))
+        {
+            // The host scans `languageWorkers:<runtime>:workerDirectory` for a worker.config.json.
+            // Pointing it at the resolved workload content folder lets installed workers light up
+            // without copying assets into the project.
+            string key = $"languageWorkers:{worker.WorkerRuntime}:workerDirectory";
+            environmentVariables[key] = workerDirectory;
+        }
+
+        foreach ((string name, string value) in context.State.BundleEnvVarsForHost)
+        {
+            environmentVariables[name] = value;
+        }
+
+        return environmentVariables;
     }
 }

--- a/src/Func/release_notes.md
+++ b/src/Func/release_notes.md
@@ -3,4 +3,5 @@
 #### Changes
 
 - `func setup` now installs the matching stack workload (Node, Python, Go, DotNet) for the project's worker runtime, detected from `local.settings.json` or selected via prompt / `--features`.
+- `func start --no-build`: now actually skips compilation steps in stack workloads. Node skips `npm run build` (still runs `npm install` when `node_modules` is missing), Go skips `go build` (trusts the existing `bin/<module>` binary), Python is a no-op (no build step). Was previously parsed and ignored.
 - <entry>

--- a/src/Workloads/Stacks/Go/GoFunctionsProject.cs
+++ b/src/Workloads/Stacks/Go/GoFunctionsProject.cs
@@ -74,8 +74,16 @@ internal sealed class GoFunctionsProject : FunctionsProject
 
         try
         {
+            // The `module` directive is conventionally near the top of go.mod;
+            // bound the scan so a malformed file can't make us read megabytes.
+            int scanned = 0;
             foreach (string line in File.ReadLines(goModPath))
             {
+                if (++scanned > 100)
+                {
+                    break;
+                }
+
                 string trimmed = line.Trim();
                 if (!trimmed.StartsWith("module ", StringComparison.Ordinal))
                 {
@@ -108,7 +116,11 @@ internal sealed class GoFunctionsProject : FunctionsProject
     {
         try
         {
-            Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+            string? outputDir = Path.GetDirectoryName(outputPath);
+            if (!string.IsNullOrEmpty(outputDir))
+            {
+                Directory.CreateDirectory(outputDir);
+            }
 
             var psi = new ProcessStartInfo("go")
             {
@@ -129,9 +141,13 @@ internal sealed class GoFunctionsProject : FunctionsProject
                 return (-1, "Failed to start 'go' process.");
             }
 
-            string stderr = await process.StandardError.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+            // Drain stdout and stderr in parallel: if either pipe buffer (~64KB) fills
+            // while we're only reading the other, go blocks on write and we deadlock.
+            Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+            Task<string> stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+            await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
             await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
-            return (process.ExitCode, stderr);
+            return (process.ExitCode, await stderrTask.ConfigureAwait(false));
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/src/Workloads/Stacks/Go/GoFunctionsProject.cs
+++ b/src/Workloads/Stacks/Go/GoFunctionsProject.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Workers;
@@ -9,15 +10,19 @@ using Azure.Functions.Cli.Workers;
 namespace Azure.Functions.Cli.Workloads.Go;
 
 /// <summary>
-/// Go Functions project. Before the host runs, builds the user's Go module
-/// to <c>bin/&lt;module&gt;</c> so the Go worker can launch it via the
-/// <c>defaultExecutablePath</c> in <c>worker.config.json</c>.
+/// Go Functions project. Before the host runs, validates the Go toolchain and
+/// builds the user's Go module to <c>bin/app</c> (or <c>bin\app.exe</c> on
+/// Windows) so the Go worker can launch it via the <c>defaultExecutablePath</c>
+/// in <c>worker.config.json</c>.
 /// </summary>
 internal sealed class GoFunctionsProject : FunctionsProject
 {
+    // Hardcoded to match the Go worker's worker.config.json `defaultExecutablePath = bin/app`.
+    // Don't derive from go.mod: the worker spawns this exact name regardless of module.
     internal const string DefaultExecutableName = "app";
+    internal const int MinimumGoMajorVersion = 1;
+    internal const int MinimumGoMinorVersion = 24;
     private const string ExecutableRelativeFolder = "bin";
-    private const string GoModFileName = "go.mod";
 
     private readonly WorkingDirectory _workingDirectory;
     private readonly FunctionsWorkerReference _workerReference;
@@ -31,6 +36,8 @@ internal sealed class GoFunctionsProject : FunctionsProject
     // Internal seam so tests can stub out the `go build` invocation
     // without spawning real processes.
     internal Func<string, string, CancellationToken, Task<(int ExitCode, string Stderr)>> RunGoBuild { get; set; } = DefaultRunGoBuild;
+
+    internal Func<CancellationToken, Task<(int Major, int Minor)?>> ReadGoVersion { get; set; } = DefaultReadGoVersion;
 
     public override WorkingDirectory WorkingDirectory => _workingDirectory;
 
@@ -49,13 +56,29 @@ internal sealed class GoFunctionsProject : FunctionsProject
 
         if (context.SkipBuild)
         {
-            // Go projects compile to bin/<module>; with --no-build the user is
+            // Go projects compile to bin/app; with --no-build the user is
             // asserting that binary already exists. Trust them and skip.
             return;
         }
 
+        (int Major, int Minor)? version = await ReadGoVersion(cancellationToken).ConfigureAwait(false);
+        if (version is null)
+        {
+            throw new GracefulException(
+                $"Could not find a Go installation. Go {MinimumGoMajorVersion}.{MinimumGoMinorVersion} or later is required. Install Go from https://go.dev/dl/.",
+                isUserError: true);
+        }
+
+        (int major, int minor) = version.Value;
+        if (major < MinimumGoMajorVersion || (major == MinimumGoMajorVersion && minor < MinimumGoMinorVersion))
+        {
+            throw new GracefulException(
+                $"Go {major}.{minor} is not supported. Go {MinimumGoMajorVersion}.{MinimumGoMinorVersion} or later is required. Update Go from https://go.dev/dl/.",
+                isUserError: true);
+        }
+
         string root = _workingDirectory.Info.FullName;
-        string executableName = ResolveExecutableName(root);
+        string executableName = OperatingSystem.IsWindows() ? DefaultExecutableName + ".exe" : DefaultExecutableName;
         string outputPath = Path.Combine(root, ExecutableRelativeFolder, executableName);
 
         (int exitCode, string stderr) = await RunGoBuild(root, outputPath, cancellationToken).ConfigureAwait(false);
@@ -68,52 +91,48 @@ internal sealed class GoFunctionsProject : FunctionsProject
         }
     }
 
-    internal static string ResolveExecutableName(string projectRoot)
+    private static async Task<(int Major, int Minor)?> DefaultReadGoVersion(CancellationToken cancellationToken)
     {
-        // Match the Go worker's default executable name (bin/app) when we can't
-        // read a module name from go.mod. The worker.config.json hard-codes
-        // bin/app; once that becomes module-aware we can switch to module name.
-        string goModPath = Path.Combine(projectRoot, GoModFileName);
-        if (!File.Exists(goModPath))
-        {
-            return DefaultExecutableName;
-        }
-
         try
         {
-            // The `module` directive is conventionally near the top of go.mod;
-            // bound the scan so a malformed file can't make us read megabytes.
-            int scanned = 0;
-            foreach (string line in File.ReadLines(goModPath))
+            var psi = new ProcessStartInfo("go")
             {
-                if (++scanned > 100)
-                {
-                    break;
-                }
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            psi.ArgumentList.Add("version");
 
-                string trimmed = line.Trim();
-                if (!trimmed.StartsWith("module ", StringComparison.Ordinal))
-                {
-                    continue;
-                }
-
-                string modulePath = trimmed[("module ".Length)..].Trim();
-                if (modulePath.Length == 0)
-                {
-                    return DefaultExecutableName;
-                }
-
-                int lastSlash = modulePath.LastIndexOf('/');
-                string moduleName = lastSlash >= 0 ? modulePath[(lastSlash + 1)..] : modulePath;
-                return string.IsNullOrWhiteSpace(moduleName) ? DefaultExecutableName : moduleName;
+            using var process = Process.Start(psi);
+            if (process is null)
+            {
+                return null;
             }
-        }
-        catch (IOException)
-        {
-            // Falling back keeps the build attempt alive; the worker will surface a clearer error.
-        }
 
-        return DefaultExecutableName;
+            Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+            Task<string> stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+            await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
+            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+
+            if (process.ExitCode != 0)
+            {
+                return null;
+            }
+
+            // `go version` prints e.g. "go version go1.24.3 darwin/arm64"
+            Match match = Regex.Match(stdoutTask.Result, @"go(\d+)\.(\d+)");
+            if (!match.Success)
+            {
+                return null;
+            }
+
+            return (int.Parse(match.Groups[1].Value), int.Parse(match.Groups[2].Value));
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return null;
+        }
     }
 
     private static async Task<(int ExitCode, string Stderr)> DefaultRunGoBuild(

--- a/src/Workloads/Stacks/Go/GoFunctionsProject.cs
+++ b/src/Workloads/Stacks/Go/GoFunctionsProject.cs
@@ -1,0 +1,141 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Diagnostics;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Workers;
+
+namespace Azure.Functions.Cli.Workloads.Go;
+
+/// <summary>
+/// Go Functions project. Before the host runs, builds the user's Go module
+/// to <c>bin/&lt;module&gt;</c> so the Go worker can launch it via the
+/// <c>defaultExecutablePath</c> in <c>worker.config.json</c>.
+/// </summary>
+internal sealed class GoFunctionsProject : FunctionsProject
+{
+    internal const string DefaultExecutableName = "app";
+    private const string ExecutableRelativeFolder = "bin";
+    private const string GoModFileName = "go.mod";
+
+    private readonly WorkingDirectory _workingDirectory;
+    private readonly FunctionsWorkerReference _workerReference;
+
+    public GoFunctionsProject(WorkingDirectory workingDirectory)
+    {
+        _workingDirectory = workingDirectory ?? throw new ArgumentNullException(nameof(workingDirectory));
+        _workerReference = FunctionsWorkerReference.FromWorkload("go");
+    }
+
+    // Internal seam so tests can stub out the `go build` invocation
+    // without spawning real processes.
+    internal Func<string, string, CancellationToken, Task<(int ExitCode, string Stderr)>> RunGoBuild { get; set; } = DefaultRunGoBuild;
+
+    public override WorkingDirectory WorkingDirectory => _workingDirectory;
+
+    public override string StackName => "go";
+
+    public override string StackDisplayName => "Go";
+
+    public override bool SupportsExtensionBundles => true;
+
+    public override FunctionsWorkerReference WorkerReference => _workerReference;
+
+    public override async Task PrepareForHostRunAsync(FunctionsProjectHostRunContext context, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        string root = _workingDirectory.Info.FullName;
+        string executableName = ResolveExecutableName(root);
+        string outputPath = Path.Combine(root, ExecutableRelativeFolder, executableName);
+
+        (int exitCode, string stderr) = await RunGoBuild(root, outputPath, cancellationToken).ConfigureAwait(false);
+        if (exitCode != 0)
+        {
+            string detail = string.IsNullOrWhiteSpace(stderr) ? "see build output above." : stderr.Trim();
+            throw new GracefulException(
+                $"'go build' failed (exit {exitCode}). {detail}",
+                isUserError: true);
+        }
+    }
+
+    internal static string ResolveExecutableName(string projectRoot)
+    {
+        // Match the Go worker's default executable name (bin/app) when we can't
+        // read a module name from go.mod. The worker.config.json hard-codes
+        // bin/app; once that becomes module-aware we can switch to module name.
+        string goModPath = Path.Combine(projectRoot, GoModFileName);
+        if (!File.Exists(goModPath))
+        {
+            return DefaultExecutableName;
+        }
+
+        try
+        {
+            foreach (string line in File.ReadLines(goModPath))
+            {
+                string trimmed = line.Trim();
+                if (!trimmed.StartsWith("module ", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                string modulePath = trimmed[("module ".Length)..].Trim();
+                if (modulePath.Length == 0)
+                {
+                    return DefaultExecutableName;
+                }
+
+                int lastSlash = modulePath.LastIndexOf('/');
+                string moduleName = lastSlash >= 0 ? modulePath[(lastSlash + 1)..] : modulePath;
+                return string.IsNullOrWhiteSpace(moduleName) ? DefaultExecutableName : moduleName;
+            }
+        }
+        catch (IOException)
+        {
+            // Falling back keeps the build attempt alive; the worker will surface a clearer error.
+        }
+
+        return DefaultExecutableName;
+    }
+
+    private static async Task<(int ExitCode, string Stderr)> DefaultRunGoBuild(
+        string workingDirectory,
+        string outputPath,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+
+            var psi = new ProcessStartInfo("go")
+            {
+                WorkingDirectory = workingDirectory,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            psi.ArgumentList.Add("build");
+            psi.ArgumentList.Add("-o");
+            psi.ArgumentList.Add(outputPath);
+            psi.ArgumentList.Add(".");
+
+            using var process = Process.Start(psi);
+            if (process is null)
+            {
+                return (-1, "Failed to start 'go' process.");
+            }
+
+            string stderr = await process.StandardError.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+            return (process.ExitCode, stderr);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return (-1, ex.Message);
+        }
+    }
+}

--- a/src/Workloads/Stacks/Go/GoFunctionsProject.cs
+++ b/src/Workloads/Stacks/Go/GoFunctionsProject.cs
@@ -47,6 +47,13 @@ internal sealed class GoFunctionsProject : FunctionsProject
         ArgumentNullException.ThrowIfNull(context);
         cancellationToken.ThrowIfCancellationRequested();
 
+        if (context.SkipBuild)
+        {
+            // Go projects compile to bin/<module>; with --no-build the user is
+            // asserting that binary already exists. Trust them and skip.
+            return;
+        }
+
         string root = _workingDirectory.Info.FullName;
         string executableName = ResolveExecutableName(root);
         string outputPath = Path.Combine(root, ExecutableRelativeFolder, executableName);

--- a/src/Workloads/Stacks/Go/GoProjectFactory.cs
+++ b/src/Workloads/Stacks/Go/GoProjectFactory.cs
@@ -50,20 +50,4 @@ internal sealed class GoProjectFactory : IFunctionsProjectFactory
 
         return null;
     }
-
-    private sealed class GoFunctionsProject(WorkingDirectory workingDirectory) : FunctionsProject
-    {
-        private readonly WorkingDirectory _workingDirectory = workingDirectory ?? throw new ArgumentNullException(nameof(workingDirectory));
-        private readonly FunctionsWorkerReference _workerReference = FunctionsWorkerReference.FromWorkload(_workerId);
-
-        public override WorkingDirectory WorkingDirectory => _workingDirectory;
-
-        public override string StackName => "go";
-
-        public override string StackDisplayName => "Go";
-
-        public override bool SupportsExtensionBundles => true;
-
-        public override FunctionsWorkerReference WorkerReference => _workerReference;
-    }
 }

--- a/src/Workloads/Stacks/Go/release_notes.md
+++ b/src/Workloads/Stacks/Go/release_notes.md
@@ -3,3 +3,4 @@
 ## 1.0.0-preview.1
 
 - Initial scaffold of the Go workload (entry point + stub project initializer).
+- Run `go build` before host start so the Go worker can launch the project binary.

--- a/src/Workloads/Stacks/Go/release_notes.md
+++ b/src/Workloads/Stacks/Go/release_notes.md
@@ -4,3 +4,4 @@
 
 - Initial scaffold of the Go workload (entry point + stub project initializer).
 - Run `go build` before host start so the Go worker can launch the project binary.
+- Validate the Go toolchain (Go 1.24+) with a clear install hint when missing or too old, and emit the binary as `bin/app` (`bin\app.exe` on Windows) to match the Go worker's `defaultExecutablePath`.

--- a/src/Workloads/Stacks/Node/NodeFunctionsProject.cs
+++ b/src/Workloads/Stacks/Node/NodeFunctionsProject.cs
@@ -61,7 +61,8 @@ internal sealed class NodeFunctionsProject : FunctionsProject
             await RunAsync(root, ["install"], "npm install", cancellationToken).ConfigureAwait(false);
         }
 
-        if (HasBuildScript(packageJsonPath))
+        // --no-build skips compilation only; npm install above is restore, not build.
+        if (!context.SkipBuild && HasBuildScript(packageJsonPath))
         {
             await RunAsync(root, ["run", "build"], "npm run build", cancellationToken).ConfigureAwait(false);
         }

--- a/src/Workloads/Stacks/Node/NodeFunctionsProject.cs
+++ b/src/Workloads/Stacks/Node/NodeFunctionsProject.cs
@@ -1,0 +1,156 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Diagnostics;
+using System.Text.Json;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Workers;
+
+namespace Azure.Functions.Cli.Workloads.Node;
+
+/// <summary>
+/// Node.js Functions project. Before the host runs, restores
+/// <c>node_modules</c> (when missing) and runs the project's <c>build</c>
+/// script (when defined) so the host can launch compiled output.
+/// </summary>
+internal sealed class NodeFunctionsProject : FunctionsProject
+{
+    private const string PackageJsonFileName = "package.json";
+    private const string NodeModulesFolderName = "node_modules";
+
+    private readonly WorkingDirectory _workingDirectory;
+    private readonly FunctionsWorkerReference _workerReference;
+
+    public NodeFunctionsProject(WorkingDirectory workingDirectory)
+    {
+        _workingDirectory = workingDirectory ?? throw new ArgumentNullException(nameof(workingDirectory));
+        _workerReference = FunctionsWorkerReference.FromWorkload("node");
+    }
+
+    // Internal seam so tests can stub npm invocations without spawning real
+    // processes. Args is forwarded as a single argv list to keep tests
+    // simple to assert against (e.g. ["install"], ["run", "build"]).
+    internal Func<string, IReadOnlyList<string>, CancellationToken, Task<(int ExitCode, string Stderr)>> RunNpm { get; set; } = DefaultRunNpm;
+
+    public override WorkingDirectory WorkingDirectory => _workingDirectory;
+
+    public override string StackName => "node";
+
+    public override string StackDisplayName => "Node.js";
+
+    public override bool SupportsExtensionBundles => true;
+
+    public override FunctionsWorkerReference WorkerReference => _workerReference;
+
+    public override async Task PrepareForHostRunAsync(FunctionsProjectHostRunContext context, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        string root = _workingDirectory.Info.FullName;
+        string packageJsonPath = Path.Combine(root, PackageJsonFileName);
+        if (!File.Exists(packageJsonPath))
+        {
+            // Lone .js/.ts entry point with no package.json: nothing to install or build.
+            return;
+        }
+
+        if (!Directory.Exists(Path.Combine(root, NodeModulesFolderName)))
+        {
+            await RunAsync(root, ["install"], "npm install", cancellationToken).ConfigureAwait(false);
+        }
+
+        if (HasBuildScript(packageJsonPath))
+        {
+            await RunAsync(root, ["run", "build"], "npm run build", cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    internal static bool HasBuildScript(string packageJsonPath)
+    {
+        try
+        {
+            using FileStream stream = File.OpenRead(packageJsonPath);
+            using var doc = JsonDocument.Parse(stream);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object
+                || !doc.RootElement.TryGetProperty("scripts", out JsonElement scripts)
+                || scripts.ValueKind != JsonValueKind.Object)
+            {
+                return false;
+            }
+
+            return scripts.TryGetProperty("build", out JsonElement build)
+                && build.ValueKind == JsonValueKind.String
+                && !string.IsNullOrWhiteSpace(build.GetString());
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+    }
+
+    private async Task RunAsync(string root, IReadOnlyList<string> args, string display, CancellationToken cancellationToken)
+    {
+        (int exitCode, string stderr) = await RunNpm(root, args, cancellationToken).ConfigureAwait(false);
+        if (exitCode != 0)
+        {
+            string detail = string.IsNullOrWhiteSpace(stderr) ? "see output above." : stderr.Trim();
+            throw new GracefulException(
+                $"'{display}' failed (exit {exitCode}). {detail}",
+                isUserError: true);
+        }
+    }
+
+    private static async Task<(int ExitCode, string Stderr)> DefaultRunNpm(
+        string workingDirectory,
+        IReadOnlyList<string> args,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Windows resolves `npm` via the `npm.cmd` shim, which only works
+            // when launched through the shell. Direct Process.Start of "npm"
+            // fails on Windows otherwise.
+            bool isWindows = OperatingSystem.IsWindows();
+            var psi = new ProcessStartInfo
+            {
+                FileName = isWindows ? "cmd.exe" : "npm",
+                WorkingDirectory = workingDirectory,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+
+            if (isWindows)
+            {
+                psi.ArgumentList.Add("/c");
+                psi.ArgumentList.Add("npm");
+            }
+
+            foreach (string arg in args)
+            {
+                psi.ArgumentList.Add(arg);
+            }
+
+            using var process = Process.Start(psi);
+            if (process is null)
+            {
+                return (-1, "Failed to start 'npm' process.");
+            }
+
+            string stderr = await process.StandardError.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+            return (process.ExitCode, stderr);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return (-1, ex.Message);
+        }
+    }
+}

--- a/src/Workloads/Stacks/Node/NodeFunctionsProject.cs
+++ b/src/Workloads/Stacks/Node/NodeFunctionsProject.cs
@@ -144,9 +144,13 @@ internal sealed class NodeFunctionsProject : FunctionsProject
                 return (-1, "Failed to start 'npm' process.");
             }
 
-            string stderr = await process.StandardError.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+            // Drain stdout and stderr in parallel: if either pipe buffer (~64KB) fills
+            // while we're only reading the other, npm blocks on write and we deadlock.
+            Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+            Task<string> stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+            await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
             await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
-            return (process.ExitCode, stderr);
+            return (process.ExitCode, await stderrTask.ConfigureAwait(false));
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/src/Workloads/Stacks/Node/NodeProjectFactory.cs
+++ b/src/Workloads/Stacks/Node/NodeProjectFactory.cs
@@ -100,20 +100,4 @@ internal sealed class NodeProjectFactory : IFunctionsProjectFactory
             && section.ValueKind == JsonValueKind.Object
             && section.TryGetProperty(FunctionsPackage, out _);
     }
-
-    private sealed class NodeFunctionsProject(WorkingDirectory workingDirectory) : FunctionsProject
-    {
-        private readonly WorkingDirectory _workingDirectory = workingDirectory ?? throw new ArgumentNullException(nameof(workingDirectory));
-        private readonly FunctionsWorkerReference _workerReference = FunctionsWorkerReference.FromWorkload(_workerId);
-
-        public override WorkingDirectory WorkingDirectory => _workingDirectory;
-
-        public override string StackName => "node";
-
-        public override string StackDisplayName => "Node.js";
-
-        public override bool SupportsExtensionBundles => true;
-
-        public override FunctionsWorkerReference WorkerReference => _workerReference;
-    }
 }

--- a/src/Workloads/Stacks/Node/release_notes.md
+++ b/src/Workloads/Stacks/Node/release_notes.md
@@ -3,3 +3,4 @@
 ## 1.0.0-preview.1
 
 - Initial scaffold of the Node workload (entry point + stub project initializer).
+- Run `npm install` and `npm run build` (when a `build` script is declared) before host start.

--- a/src/Workloads/Stacks/Python/PythonFunctionsProject.cs
+++ b/src/Workloads/Stacks/Python/PythonFunctionsProject.cs
@@ -11,17 +11,24 @@ using Azure.Functions.Cli.Workers;
 namespace Azure.Functions.Cli.Workloads.Python;
 
 /// <summary>
-/// Python Functions project. Before the host runs, creates a project-local
-/// <c>.venv</c> (when missing) and installs <c>requirements.txt</c> into it,
-/// then points the worker at the venv so the user's deps are resolvable.
+/// Python Functions project. Before the host runs, resolves the project's
+/// virtual environment (honoring <c>$VIRTUAL_ENV</c> or a pre-existing
+/// <c>.venv</c> / <c>venv</c> / <c>env</c> folder, otherwise creating
+/// <c>.venv</c>), installs <c>requirements.txt</c> into it, and points the
+/// worker at the venv interpreter so the user's deps are resolvable.
 /// </summary>
 internal sealed class PythonFunctionsProject : FunctionsProject
 {
-    internal const string VenvFolderName = ".venv";
+    internal const string DefaultVenvFolderName = ".venv";
     internal const string IsolateWorkerDepsEnvVar = "PYTHON_ISOLATE_WORKER_DEPENDENCIES";
     internal const string WorkerExecutablePathEnvVar = "languageWorkers:python:defaultExecutablePath";
     internal const string WorkerRuntimeVersionEnvVar = "FUNCTIONS_WORKER_RUNTIME_VERSION";
+    internal const string VirtualEnvEnvVar = "VIRTUAL_ENV";
     private const string RequirementsFileName = "requirements.txt";
+
+    // Conventional venv folder names to look for in the project root before
+    // creating a new one. Order matters: most-common first.
+    private static readonly string[] _venvFolderCandidates = [".venv", "venv", "env", ".virtualenv"];
 
     private readonly WorkingDirectory _workingDirectory;
     private readonly FunctionsWorkerReference _workerReference;
@@ -38,6 +45,8 @@ internal sealed class PythonFunctionsProject : FunctionsProject
     internal Func<string, string, string, CancellationToken, Task<(int ExitCode, string Stderr)>> RunPipInstall { get; set; } = DefaultRunPipInstall;
 
     internal Func<string, CancellationToken, Task<string?>> ReadPythonVersion { get; set; } = DefaultReadPythonVersion;
+
+    internal Func<string, string?> ReadEnvironmentVariable { get; set; } = Environment.GetEnvironmentVariable;
 
     public override WorkingDirectory WorkingDirectory => _workingDirectory;
 
@@ -57,16 +66,16 @@ internal sealed class PythonFunctionsProject : FunctionsProject
         // Python has no compile step, so --no-build (context.SkipBuild) is a no-op
         // here: venv creation and pip install are restore, not build.
         string root = _workingDirectory.Info.FullName;
-        string venvPath = Path.Combine(root, VenvFolderName);
+        (string venvPath, bool venvAlreadyExisted) = ResolveVenvPath(root);
 
-        if (!Directory.Exists(venvPath))
+        if (!venvAlreadyExisted)
         {
             (int exitCode, string stderr) = await RunCreateVenv(root, venvPath, cancellationToken).ConfigureAwait(false);
             if (exitCode != 0)
             {
                 string detail = string.IsNullOrWhiteSpace(stderr) ? "see output above." : stderr.Trim();
                 throw new GracefulException(
-                    $"'python -m venv {VenvFolderName}' failed (exit {exitCode}). {detail}",
+                    $"'python -m venv {Path.GetFileName(venvPath)}' failed (exit {exitCode}). {detail}",
                     isUserError: true);
             }
         }
@@ -109,6 +118,34 @@ internal sealed class PythonFunctionsProject : FunctionsProject
         string folder = OperatingSystem.IsWindows() ? "Scripts" : "bin";
         string name = OperatingSystem.IsWindows() ? executable + ".exe" : executable;
         return Path.Combine(venvPath, folder, name);
+    }
+
+    // Pick the venv to use, in priority order:
+    //   1. $VIRTUAL_ENV (set by the `activate` script) so an explicitly-activated
+    //      venv wins, even if it lives outside the project.
+    //   2. Any conventional folder already present at the project root
+    //      (.venv, venv, env, .virtualenv).
+    //   3. Fall back to creating .venv inside the project root.
+    // Returns the resolved venv path and whether it already exists on disk; the
+    // caller skips `python -m venv` when it does.
+    private (string Path, bool AlreadyExists) ResolveVenvPath(string projectRoot)
+    {
+        string? activated = ReadEnvironmentVariable(VirtualEnvEnvVar);
+        if (!string.IsNullOrWhiteSpace(activated) && Directory.Exists(activated))
+        {
+            return (activated, true);
+        }
+
+        foreach (string candidate in _venvFolderCandidates)
+        {
+            string candidatePath = Path.Combine(projectRoot, candidate);
+            if (Directory.Exists(candidatePath))
+            {
+                return (candidatePath, true);
+            }
+        }
+
+        return (Path.Combine(projectRoot, DefaultVenvFolderName), false);
     }
 
     private static async Task<(int ExitCode, string Stderr)> DefaultRunCreateVenv(

--- a/src/Workloads/Stacks/Python/PythonFunctionsProject.cs
+++ b/src/Workloads/Stacks/Python/PythonFunctionsProject.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Workers;
@@ -18,6 +19,8 @@ internal sealed class PythonFunctionsProject : FunctionsProject
 {
     internal const string VenvFolderName = ".venv";
     internal const string IsolateWorkerDepsEnvVar = "PYTHON_ISOLATE_WORKER_DEPENDENCIES";
+    internal const string WorkerExecutablePathEnvVar = "languageWorkers:python:defaultExecutablePath";
+    internal const string WorkerRuntimeVersionEnvVar = "FUNCTIONS_WORKER_RUNTIME_VERSION";
     private const string RequirementsFileName = "requirements.txt";
 
     private readonly WorkingDirectory _workingDirectory;
@@ -33,6 +36,8 @@ internal sealed class PythonFunctionsProject : FunctionsProject
     internal Func<string, string, CancellationToken, Task<(int ExitCode, string Stderr)>> RunCreateVenv { get; set; } = DefaultRunCreateVenv;
 
     internal Func<string, string, string, CancellationToken, Task<(int ExitCode, string Stderr)>> RunPipInstall { get; set; } = DefaultRunPipInstall;
+
+    internal Func<string, CancellationToken, Task<string?>> ReadPythonVersion { get; set; } = DefaultReadPythonVersion;
 
     public override WorkingDirectory WorkingDirectory => _workingDirectory;
 
@@ -82,6 +87,21 @@ internal sealed class PythonFunctionsProject : FunctionsProject
 
         // Pin worker deps to the venv so a global site-packages can't shadow it.
         context.EnvironmentVariables[IsolateWorkerDepsEnvVar] = "1";
+
+        // Point the host at the venv interpreter so the worker process actually has
+        // the packages we just pip-installed. Without this, the host falls back to
+        // the system Python and `import <user-dep>` fails at runtime.
+        string venvPython = GetVenvExecutablePath(venvPath, "python");
+        context.EnvironmentVariables[WorkerExecutablePathEnvVar] = venvPython;
+
+        // Tell the host which Python worker to load (3.9 vs 3.13 etc.). Best-effort:
+        // if we can't parse `python --version`, we leave it unset and let the host
+        // fall back to whatever default it would pick.
+        string? majorMinor = await ReadPythonVersion(venvPython, cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrEmpty(majorMinor))
+        {
+            context.EnvironmentVariables[WorkerRuntimeVersionEnvVar] = majorMinor;
+        }
     }
 
     internal static string GetVenvExecutablePath(string venvPath, string executable)
@@ -131,6 +151,48 @@ internal sealed class PythonFunctionsProject : FunctionsProject
         CancellationToken cancellationToken)
     {
         return RunProcessAsync(pipPath, ["install", "-r", requirementsPath], workingDirectory, cancellationToken);
+    }
+
+    private static async Task<string?> DefaultReadPythonVersion(string pythonPath, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = pythonPath,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            psi.ArgumentList.Add("--version");
+
+            using var process = Process.Start(psi);
+            if (process is null)
+            {
+                return null;
+            }
+
+            Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+            Task<string> stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+            await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
+            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+
+            if (process.ExitCode != 0)
+            {
+                return null;
+            }
+
+            // `python --version` historically printed to stderr (Python 2) and now
+            // prints to stdout (Python 3). Inspect both so we don't miss it.
+            string raw = stdoutTask.Result + " " + stderrTask.Result;
+            Match match = Regex.Match(raw, @"Python\s+(\d+)\.(\d+)");
+            return match.Success ? $"{match.Groups[1].Value}.{match.Groups[2].Value}" : null;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return null;
+        }
     }
 
     private static async Task<(int ExitCode, string Stderr)> RunProcessAsync(

--- a/src/Workloads/Stacks/Python/PythonFunctionsProject.cs
+++ b/src/Workloads/Stacks/Python/PythonFunctionsProject.cs
@@ -49,6 +49,8 @@ internal sealed class PythonFunctionsProject : FunctionsProject
         ArgumentNullException.ThrowIfNull(context);
         cancellationToken.ThrowIfCancellationRequested();
 
+        // Python has no compile step, so --no-build (context.SkipBuild) is a no-op
+        // here: venv creation and pip install are restore, not build.
         string root = _workingDirectory.Info.FullName;
         string venvPath = Path.Combine(root, VenvFolderName);
 

--- a/src/Workloads/Stacks/Python/PythonFunctionsProject.cs
+++ b/src/Workloads/Stacks/Python/PythonFunctionsProject.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.ComponentModel;
 using System.Diagnostics;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Projects;
@@ -88,15 +89,37 @@ internal sealed class PythonFunctionsProject : FunctionsProject
         return Path.Combine(venvPath, folder, name);
     }
 
-    private static Task<(int ExitCode, string Stderr)> DefaultRunCreateVenv(
+    private static async Task<(int ExitCode, string Stderr)> DefaultRunCreateVenv(
         string workingDirectory,
         string venvPath,
         CancellationToken cancellationToken)
     {
-        // Prefer `python3` on POSIX so we don't pick up a Python 2 shim; fall
-        // back to `python` (Windows / pyenv users) if the first attempt fails.
-        string interpreter = OperatingSystem.IsWindows() ? "python" : "python3";
-        return RunProcessAsync(interpreter, ["-m", "venv", venvPath], workingDirectory, cancellationToken);
+        // Prefer `python3` on POSIX so we don't pick up a Python 2 shim. If the
+        // interpreter isn't on PATH (Win32Exception from Process.Start), retry
+        // with `python` so we work on Windows and pyenv setups that only expose
+        // the unversioned name.
+        string[] interpreters = OperatingSystem.IsWindows()
+            ? ["python", "python3"]
+            : ["python3", "python"];
+
+        (int ExitCode, string Stderr) last = (-1, "No Python interpreter was found.");
+        foreach (string interpreter in interpreters)
+        {
+            (int exitCode, string stderr, bool launched) = await TryRunProcessAsync(
+                interpreter,
+                ["-m", "venv", venvPath],
+                workingDirectory,
+                cancellationToken).ConfigureAwait(false);
+
+            if (launched)
+            {
+                return (exitCode, stderr);
+            }
+
+            last = (exitCode, stderr);
+        }
+
+        return last;
     }
 
     private static Task<(int ExitCode, string Stderr)> DefaultRunPipInstall(
@@ -109,6 +132,16 @@ internal sealed class PythonFunctionsProject : FunctionsProject
     }
 
     private static async Task<(int ExitCode, string Stderr)> RunProcessAsync(
+        string fileName,
+        IReadOnlyList<string> args,
+        string workingDirectory,
+        CancellationToken cancellationToken)
+    {
+        (int exitCode, string stderr, _) = await TryRunProcessAsync(fileName, args, workingDirectory, cancellationToken).ConfigureAwait(false);
+        return (exitCode, stderr);
+    }
+
+    private static async Task<(int ExitCode, string Stderr, bool Launched)> TryRunProcessAsync(
         string fileName,
         IReadOnlyList<string> args,
         string workingDirectory,
@@ -134,16 +167,25 @@ internal sealed class PythonFunctionsProject : FunctionsProject
             using var process = Process.Start(psi);
             if (process is null)
             {
-                return (-1, $"Failed to start '{fileName}' process.");
+                return (-1, $"Failed to start '{fileName}' process.", false);
             }
 
-            string stderr = await process.StandardError.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+            // Drain stdout and stderr in parallel: if either pipe buffer (~64KB) fills
+            // while we're only reading the other, the child blocks on write and we deadlock.
+            Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+            Task<string> stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+            await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
             await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
-            return (process.ExitCode, stderr);
+            return (process.ExitCode, await stderrTask.ConfigureAwait(false), true);
+        }
+        catch (Win32Exception ex)
+        {
+            // Interpreter wasn't on PATH; let the caller try a fallback.
+            return (-1, ex.Message, false);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            return (-1, ex.Message);
+            return (-1, ex.Message, true);
         }
     }
 }

--- a/src/Workloads/Stacks/Python/PythonFunctionsProject.cs
+++ b/src/Workloads/Stacks/Python/PythonFunctionsProject.cs
@@ -1,0 +1,149 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Diagnostics;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Workers;
+
+namespace Azure.Functions.Cli.Workloads.Python;
+
+/// <summary>
+/// Python Functions project. Before the host runs, creates a project-local
+/// <c>.venv</c> (when missing) and installs <c>requirements.txt</c> into it,
+/// then points the worker at the venv so the user's deps are resolvable.
+/// </summary>
+internal sealed class PythonFunctionsProject : FunctionsProject
+{
+    internal const string VenvFolderName = ".venv";
+    internal const string IsolateWorkerDepsEnvVar = "PYTHON_ISOLATE_WORKER_DEPENDENCIES";
+    private const string RequirementsFileName = "requirements.txt";
+
+    private readonly WorkingDirectory _workingDirectory;
+    private readonly FunctionsWorkerReference _workerReference;
+
+    public PythonFunctionsProject(WorkingDirectory workingDirectory)
+    {
+        _workingDirectory = workingDirectory ?? throw new ArgumentNullException(nameof(workingDirectory));
+        _workerReference = FunctionsWorkerReference.FromWorkload("python");
+    }
+
+    // Internal seams so tests can stub interpreter / pip invocations.
+    internal Func<string, string, CancellationToken, Task<(int ExitCode, string Stderr)>> RunCreateVenv { get; set; } = DefaultRunCreateVenv;
+
+    internal Func<string, string, string, CancellationToken, Task<(int ExitCode, string Stderr)>> RunPipInstall { get; set; } = DefaultRunPipInstall;
+
+    public override WorkingDirectory WorkingDirectory => _workingDirectory;
+
+    public override string StackName => "python";
+
+    public override string StackDisplayName => "Python";
+
+    public override bool SupportsExtensionBundles => true;
+
+    public override FunctionsWorkerReference WorkerReference => _workerReference;
+
+    public override async Task PrepareForHostRunAsync(FunctionsProjectHostRunContext context, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        string root = _workingDirectory.Info.FullName;
+        string venvPath = Path.Combine(root, VenvFolderName);
+
+        if (!Directory.Exists(venvPath))
+        {
+            (int exitCode, string stderr) = await RunCreateVenv(root, venvPath, cancellationToken).ConfigureAwait(false);
+            if (exitCode != 0)
+            {
+                string detail = string.IsNullOrWhiteSpace(stderr) ? "see output above." : stderr.Trim();
+                throw new GracefulException(
+                    $"'python -m venv {VenvFolderName}' failed (exit {exitCode}). {detail}",
+                    isUserError: true);
+            }
+        }
+
+        string requirementsPath = Path.Combine(root, RequirementsFileName);
+        if (File.Exists(requirementsPath))
+        {
+            string pipPath = GetVenvExecutablePath(venvPath, "pip");
+            (int exitCode, string stderr) = await RunPipInstall(root, pipPath, requirementsPath, cancellationToken).ConfigureAwait(false);
+            if (exitCode != 0)
+            {
+                string detail = string.IsNullOrWhiteSpace(stderr) ? "see output above." : stderr.Trim();
+                throw new GracefulException(
+                    $"'pip install -r {RequirementsFileName}' failed (exit {exitCode}). {detail}",
+                    isUserError: true);
+            }
+        }
+
+        // Pin worker deps to the venv so a global site-packages can't shadow it.
+        context.EnvironmentVariables[IsolateWorkerDepsEnvVar] = "1";
+    }
+
+    internal static string GetVenvExecutablePath(string venvPath, string executable)
+    {
+        string folder = OperatingSystem.IsWindows() ? "Scripts" : "bin";
+        string name = OperatingSystem.IsWindows() ? executable + ".exe" : executable;
+        return Path.Combine(venvPath, folder, name);
+    }
+
+    private static Task<(int ExitCode, string Stderr)> DefaultRunCreateVenv(
+        string workingDirectory,
+        string venvPath,
+        CancellationToken cancellationToken)
+    {
+        // Prefer `python3` on POSIX so we don't pick up a Python 2 shim; fall
+        // back to `python` (Windows / pyenv users) if the first attempt fails.
+        string interpreter = OperatingSystem.IsWindows() ? "python" : "python3";
+        return RunProcessAsync(interpreter, ["-m", "venv", venvPath], workingDirectory, cancellationToken);
+    }
+
+    private static Task<(int ExitCode, string Stderr)> DefaultRunPipInstall(
+        string workingDirectory,
+        string pipPath,
+        string requirementsPath,
+        CancellationToken cancellationToken)
+    {
+        return RunProcessAsync(pipPath, ["install", "-r", requirementsPath], workingDirectory, cancellationToken);
+    }
+
+    private static async Task<(int ExitCode, string Stderr)> RunProcessAsync(
+        string fileName,
+        IReadOnlyList<string> args,
+        string workingDirectory,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = fileName,
+                WorkingDirectory = workingDirectory,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+
+            foreach (string arg in args)
+            {
+                psi.ArgumentList.Add(arg);
+            }
+
+            using var process = Process.Start(psi);
+            if (process is null)
+            {
+                return (-1, $"Failed to start '{fileName}' process.");
+            }
+
+            string stderr = await process.StandardError.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+            return (process.ExitCode, stderr);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return (-1, ex.Message);
+        }
+    }
+}

--- a/src/Workloads/Stacks/Python/PythonProjectFactory.cs
+++ b/src/Workloads/Stacks/Python/PythonProjectFactory.cs
@@ -74,20 +74,4 @@ internal sealed class PythonProjectFactory : IFunctionsProjectFactory
 
         return null;
     }
-
-    private sealed class PythonFunctionsProject(WorkingDirectory workingDirectory) : FunctionsProject
-    {
-        private readonly WorkingDirectory _workingDirectory = workingDirectory ?? throw new ArgumentNullException(nameof(workingDirectory));
-        private readonly FunctionsWorkerReference _workerReference = FunctionsWorkerReference.FromWorkload(_workerId);
-
-        public override WorkingDirectory WorkingDirectory => _workingDirectory;
-
-        public override string StackName => "python";
-
-        public override string StackDisplayName => "Python";
-
-        public override bool SupportsExtensionBundles => true;
-
-        public override FunctionsWorkerReference WorkerReference => _workerReference;
-    }
 }

--- a/src/Workloads/Stacks/Python/release_notes.md
+++ b/src/Workloads/Stacks/Python/release_notes.md
@@ -3,3 +3,4 @@
 ## 1.0.0-preview.1
 
 - Initial scaffold of the Python workload (entry point + stub project initializer).
+- Create a `.venv` (if missing), run `pip install -r requirements.txt`, and set `PYTHON_ISOLATE_WORKER_DEPENDENCIES=1` before host start.

--- a/src/Workloads/Stacks/Python/release_notes.md
+++ b/src/Workloads/Stacks/Python/release_notes.md
@@ -4,4 +4,5 @@
 
 - Initial scaffold of the Python workload (entry point + stub project initializer).
 - Create a `.venv` (if missing), run `pip install -r requirements.txt`, and set `PYTHON_ISOLATE_WORKER_DEPENDENCIES=1` before host start.
+- Honor an activated venv via `$VIRTUAL_ENV` and reuse pre-existing `venv`, `env`, or `.virtualenv` folders before falling back to creating `.venv`.
 - Point the host at the venv interpreter via `languageWorkers:python:defaultExecutablePath` and surface the detected Python major.minor as `FUNCTIONS_WORKER_RUNTIME_VERSION` so the worker sees the user's installed packages.

--- a/src/Workloads/Stacks/Python/release_notes.md
+++ b/src/Workloads/Stacks/Python/release_notes.md
@@ -4,3 +4,4 @@
 
 - Initial scaffold of the Python workload (entry point + stub project initializer).
 - Create a `.venv` (if missing), run `pip install -r requirements.txt`, and set `PYTHON_ISOLATE_WORKER_DEPENDENCIES=1` before host start.
+- Point the host at the venv interpreter via `languageWorkers:python:defaultExecutablePath` and surface the detected Python major.minor as `FUNCTIONS_WORKER_RUNTIME_VERSION` so the worker sees the user's installed packages.

--- a/test/Func.Tests/Commands/StartInitializationTests.cs
+++ b/test/Func.Tests/Commands/StartInitializationTests.cs
@@ -7,6 +7,7 @@ using Azure.Functions.Cli.Bundles;
 using Azure.Functions.Cli.Commands.Start.Initialization;
 using Azure.Functions.Cli.Commands.Start.Initialization.Rendering;
 using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Configuration;
 using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Hosting.Dashboard;
 using Azure.Functions.Cli.Hosting.Dashboard.Demo;
@@ -146,6 +147,52 @@ public class StartInitializationTests : IDisposable
         Assert.Same(result.HostRunContext, project.PreparedContexts.Single());
         Assert.Equal(startupDirectory.FullName, result.HostRunContext.StartupDirectory.FullName);
         Assert.Equal("dotnet-isolated", result.HostRunContext.WorkerRuntime);
+    }
+
+    [Fact]
+    public async Task DemoRunner_PopulatesEnvironmentVariablesForHostRun()
+    {
+        File.WriteAllText(
+            Path.Combine(_tempDir, "local.settings.json"),
+            """{ "Values": { "FROM_LOCAL": "yes", "FUNCTIONS_WORKER_RUNTIME": "stale" } }""");
+
+        string workerDir = Path.Combine(_tempDir, "workers", "node");
+        Directory.CreateDirectory(workerDir);
+        string workerConfigPath = Path.Combine(workerDir, "worker.config.json");
+
+        IFunctionsProjectResolver projectResolver = Substitute.For<IFunctionsProjectResolver>();
+        TestFunctionsProject project = CreateProject(
+            WorkingDirectory.FromExplicit(_tempDir),
+            stackName: "node",
+            stackDisplayName: "Node.js");
+        projectResolver.ResolveProjectAsync(Arg.Any<ProjectResolutionContext>(), Arg.Any<CancellationToken>())
+            .Returns(ProjectResolutionResults.Resolved(project, "found package.json"));
+
+        IFunctionsWorkerResolver workerResolver = Substitute.For<IFunctionsWorkerResolver>();
+        workerResolver.ResolveWorkerAsync(Arg.Any<FunctionsWorkerId>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                FunctionsWorkerId id = callInfo.ArgAt<FunctionsWorkerId>(0);
+                IFunctionsWorker worker = new TestFunctionsWorker(id, id.Value, workerConfigPath, "1.0.0");
+                return FunctionsWorkerResolutionResults.Resolved(worker);
+            });
+        IFunctionsWorkerResolverFactory workerResolverFactory = CreateWorkerResolverFactory(workerResolver);
+
+        var renderer = new RecordingStartInitializationRenderer();
+        var runner = CreateRunner(projectResolver, workerResolverFactory: workerResolverFactory);
+        StartInitializationContext context = CreateContext(
+            WorkingDirectory.FromExplicit(_tempDir),
+            cliVersion: "5.0.0-test",
+            demoFunctionCount: 1,
+            demoSpeedMultiplier: 0.001,
+            demoAutoExit: true);
+
+        StartInitializationResult result = await runner.RunAsync(context, renderer, CancellationToken.None);
+
+        IDictionary<string, string> env = result.HostRunContext.EnvironmentVariables;
+        Assert.Equal("yes", env["FROM_LOCAL"]);
+        Assert.Equal("node", env["FUNCTIONS_WORKER_RUNTIME"]);
+        Assert.Equal(workerDir, env["languageWorkers:node:workerDirectory"]);
     }
 
     [Fact]
@@ -622,7 +669,10 @@ public class StartInitializationTests : IDisposable
         => new(
             workingDirectory.Info,
             "dotnet-isolated",
-            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["FUNCTIONS_WORKER_RUNTIME"] = "dotnet-isolated",
+            });
 
     private static IAnsiConsole CreateInteractiveConsole(TextWriter writer)
         => AnsiConsole.Create(new AnsiConsoleSettings
@@ -674,6 +724,7 @@ public class StartInitializationTests : IDisposable
             workloadCatalog,
             workloadInstaller,
             interaction,
+            new LocalSettingsProvider(),
             NullLoggerFactory.Instance);
     }
 

--- a/test/Workloads/Stacks/Go.Tests/GoFunctionsProjectTests.cs
+++ b/test/Workloads/Stacks/Go.Tests/GoFunctionsProjectTests.cs
@@ -31,53 +31,30 @@ public class GoFunctionsProjectTests : IDisposable
     }
 
     [Fact]
-    public async Task PrepareForHostRun_invokes_go_build_to_module_bin()
+    public async Task PrepareForHostRun_invokes_go_build_to_bin_app()
     {
         File.WriteAllText(Path.Combine(_projectDir.FullName, "go.mod"), "module example.com/myapp\n\ngo 1.24\n");
 
         string? observedRoot = null;
         string? observedOutput = null;
-        var project = new GoFunctionsProject(WorkingDirectory.FromExplicit(_projectDir.FullName))
+        GoFunctionsProject project = CreateProject((root, output, _) =>
         {
-            RunGoBuild = (root, output, _) =>
-            {
-                observedRoot = root;
-                observedOutput = output;
-                return Task.FromResult((0, string.Empty));
-            },
-        };
+            observedRoot = root;
+            observedOutput = output;
+            return Task.FromResult((0, string.Empty));
+        });
 
         await project.PrepareForHostRunAsync(CreateContext(), default);
 
+        string expectedName = OperatingSystem.IsWindows() ? "app.exe" : "app";
         Assert.Equal(_projectDir.FullName, observedRoot);
-        Assert.Equal(Path.Combine(_projectDir.FullName, "bin", "myapp"), observedOutput);
-    }
-
-    [Fact]
-    public async Task PrepareForHostRun_falls_back_to_default_executable_when_no_go_mod()
-    {
-        string? observedOutput = null;
-        var project = new GoFunctionsProject(WorkingDirectory.FromExplicit(_projectDir.FullName))
-        {
-            RunGoBuild = (_, output, _) =>
-            {
-                observedOutput = output;
-                return Task.FromResult((0, string.Empty));
-            },
-        };
-
-        await project.PrepareForHostRunAsync(CreateContext(), default);
-
-        Assert.Equal(Path.Combine(_projectDir.FullName, "bin", GoFunctionsProject.DefaultExecutableName), observedOutput);
+        Assert.Equal(Path.Combine(_projectDir.FullName, "bin", expectedName), observedOutput);
     }
 
     [Fact]
     public async Task PrepareForHostRun_throws_graceful_on_nonzero_exit()
     {
-        var project = new GoFunctionsProject(WorkingDirectory.FromExplicit(_projectDir.FullName))
-        {
-            RunGoBuild = (_, _, _) => Task.FromResult((1, "compile error")),
-        };
+        GoFunctionsProject project = CreateProject((_, _, _) => Task.FromResult((1, "compile error")));
 
         GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
             () => project.PrepareForHostRunAsync(CreateContext(), default));
@@ -90,24 +67,51 @@ public class GoFunctionsProjectTests : IDisposable
     [Fact]
     public async Task PrepareForHostRun_skips_build_when_SkipBuild()
     {
-        File.WriteAllText(Path.Combine(_projectDir.FullName, "go.mod"), "module example.com/myapp\n");
         bool invoked = false;
-        var project = new GoFunctionsProject(WorkingDirectory.FromExplicit(_projectDir.FullName))
+        GoFunctionsProject project = CreateProject((_, _, _) =>
         {
-            RunGoBuild = (_, _, _) =>
-            {
-                invoked = true;
-                return Task.FromResult((0, string.Empty));
-            },
-        };
+            invoked = true;
+            return Task.FromResult((0, string.Empty));
+        });
 
         await project.PrepareForHostRunAsync(CreateContext(skipBuild: true), default);
 
         Assert.False(invoked);
     }
 
-    private FunctionsProjectHostRunContext CreateContext(bool skipBuild = false)
-        => new(_projectDir, "go", new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    [Fact]
+    public async Task PrepareForHostRun_throws_graceful_when_go_not_installed()
+    {
+        GoFunctionsProject project = CreateProject((_, _, _) => Task.FromResult((0, string.Empty)));
+        project.ReadGoVersion = _ => Task.FromResult<(int, int)?>(null);
+
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => project.PrepareForHostRunAsync(CreateContext(), default));
+
+        Assert.True(ex.IsUserError);
+        Assert.Contains("Could not find a Go installation", ex.Message);
+    }
+
+    [Fact]
+    public async Task PrepareForHostRun_throws_graceful_when_go_too_old()
+    {
+        GoFunctionsProject project = CreateProject((_, _, _) => Task.FromResult((0, string.Empty)));
+        project.ReadGoVersion = _ => Task.FromResult<(int, int)?>((1, 21));
+
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => project.PrepareForHostRunAsync(CreateContext(), default));
+
+        Assert.True(ex.IsUserError);
+        Assert.Contains("Go 1.21 is not supported", ex.Message);
+    }
+
+    private GoFunctionsProject CreateProject(Func<string, string, CancellationToken, Task<(int, string)>> runner)
+        => new(WorkingDirectory.FromExplicit(_projectDir.FullName))
         {
-        }, skipBuild);
+            RunGoBuild = runner,
+            ReadGoVersion = _ => Task.FromResult<(int, int)?>((1, 24)),
+        };
+
+    private FunctionsProjectHostRunContext CreateContext(bool skipBuild = false)
+        => new(_projectDir, "go", new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase), skipBuild);
 }

--- a/test/Workloads/Stacks/Go.Tests/GoFunctionsProjectTests.cs
+++ b/test/Workloads/Stacks/Go.Tests/GoFunctionsProjectTests.cs
@@ -87,9 +87,27 @@ public class GoFunctionsProjectTests : IDisposable
         Assert.Contains("compile error", ex.Message);
     }
 
-    private FunctionsProjectHostRunContext CreateContext()
+    [Fact]
+    public async Task PrepareForHostRun_skips_build_when_SkipBuild()
+    {
+        File.WriteAllText(Path.Combine(_projectDir.FullName, "go.mod"), "module example.com/myapp\n");
+        bool invoked = false;
+        var project = new GoFunctionsProject(WorkingDirectory.FromExplicit(_projectDir.FullName))
+        {
+            RunGoBuild = (_, _, _) =>
+            {
+                invoked = true;
+                return Task.FromResult((0, string.Empty));
+            },
+        };
+
+        await project.PrepareForHostRunAsync(CreateContext(skipBuild: true), default);
+
+        Assert.False(invoked);
+    }
+
+    private FunctionsProjectHostRunContext CreateContext(bool skipBuild = false)
         => new(_projectDir, "go", new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            ["FUNCTIONS_WORKER_RUNTIME"] = "go",
-        });
+        }, skipBuild);
 }

--- a/test/Workloads/Stacks/Go.Tests/GoFunctionsProjectTests.cs
+++ b/test/Workloads/Stacks/Go.Tests/GoFunctionsProjectTests.cs
@@ -1,0 +1,95 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Projects;
+using Xunit;
+
+namespace Azure.Functions.Cli.Workloads.Go.Tests;
+
+public class GoFunctionsProjectTests : IDisposable
+{
+    private readonly DirectoryInfo _projectDir;
+
+    public GoFunctionsProjectTests()
+    {
+        _projectDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "func-go-project-" + Guid.NewGuid().ToString("N")));
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (_projectDir.Exists)
+            {
+                _projectDir.Delete(recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    [Fact]
+    public async Task PrepareForHostRun_invokes_go_build_to_module_bin()
+    {
+        File.WriteAllText(Path.Combine(_projectDir.FullName, "go.mod"), "module example.com/myapp\n\ngo 1.24\n");
+
+        string? observedRoot = null;
+        string? observedOutput = null;
+        var project = new GoFunctionsProject(WorkingDirectory.FromExplicit(_projectDir.FullName))
+        {
+            RunGoBuild = (root, output, _) =>
+            {
+                observedRoot = root;
+                observedOutput = output;
+                return Task.FromResult((0, string.Empty));
+            },
+        };
+
+        await project.PrepareForHostRunAsync(CreateContext(), default);
+
+        Assert.Equal(_projectDir.FullName, observedRoot);
+        Assert.Equal(Path.Combine(_projectDir.FullName, "bin", "myapp"), observedOutput);
+    }
+
+    [Fact]
+    public async Task PrepareForHostRun_falls_back_to_default_executable_when_no_go_mod()
+    {
+        string? observedOutput = null;
+        var project = new GoFunctionsProject(WorkingDirectory.FromExplicit(_projectDir.FullName))
+        {
+            RunGoBuild = (_, output, _) =>
+            {
+                observedOutput = output;
+                return Task.FromResult((0, string.Empty));
+            },
+        };
+
+        await project.PrepareForHostRunAsync(CreateContext(), default);
+
+        Assert.Equal(Path.Combine(_projectDir.FullName, "bin", GoFunctionsProject.DefaultExecutableName), observedOutput);
+    }
+
+    [Fact]
+    public async Task PrepareForHostRun_throws_graceful_on_nonzero_exit()
+    {
+        var project = new GoFunctionsProject(WorkingDirectory.FromExplicit(_projectDir.FullName))
+        {
+            RunGoBuild = (_, _, _) => Task.FromResult((1, "compile error")),
+        };
+
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => project.PrepareForHostRunAsync(CreateContext(), default));
+
+        Assert.True(ex.IsUserError);
+        Assert.Contains("go build", ex.Message);
+        Assert.Contains("compile error", ex.Message);
+    }
+
+    private FunctionsProjectHostRunContext CreateContext()
+        => new(_projectDir, "go", new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["FUNCTIONS_WORKER_RUNTIME"] = "go",
+        });
+}

--- a/test/Workloads/Stacks/Node.Tests/NodeFunctionsProjectTests.cs
+++ b/test/Workloads/Stacks/Node.Tests/NodeFunctionsProjectTests.cs
@@ -1,0 +1,128 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Projects;
+using Xunit;
+
+namespace Azure.Functions.Cli.Workloads.Node.Tests;
+
+public class NodeFunctionsProjectTests : IDisposable
+{
+    private readonly DirectoryInfo _projectDir;
+
+    public NodeFunctionsProjectTests()
+    {
+        _projectDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "func-node-project-" + Guid.NewGuid().ToString("N")));
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (_projectDir.Exists)
+            {
+                _projectDir.Delete(recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    [Fact]
+    public async Task PrepareForHostRun_without_package_json_is_noop()
+    {
+        bool invoked = false;
+        NodeFunctionsProject project = CreateProject((_, _, _) =>
+        {
+            invoked = true;
+            return Task.FromResult((0, string.Empty));
+        });
+
+        await project.PrepareForHostRunAsync(CreateContext(), default);
+
+        Assert.False(invoked);
+    }
+
+    [Fact]
+    public async Task PrepareForHostRun_runs_npm_install_when_node_modules_missing()
+    {
+        WritePackageJson("""{ "name": "x", "version": "1.0.0" }""");
+        var commands = new List<IReadOnlyList<string>>();
+        NodeFunctionsProject project = CreateProject((_, args, _) =>
+        {
+            commands.Add(args);
+            return Task.FromResult((0, string.Empty));
+        });
+
+        await project.PrepareForHostRunAsync(CreateContext(), default);
+
+        Assert.Single(commands);
+        Assert.Equal(new[] { "install" }, commands[0]);
+    }
+
+    [Fact]
+    public async Task PrepareForHostRun_skips_install_when_node_modules_present()
+    {
+        WritePackageJson("""{ "name": "x", "version": "1.0.0" }""");
+        Directory.CreateDirectory(Path.Combine(_projectDir.FullName, "node_modules"));
+        var commands = new List<IReadOnlyList<string>>();
+        NodeFunctionsProject project = CreateProject((_, args, _) =>
+        {
+            commands.Add(args);
+            return Task.FromResult((0, string.Empty));
+        });
+
+        await project.PrepareForHostRunAsync(CreateContext(), default);
+
+        Assert.Empty(commands);
+    }
+
+    [Fact]
+    public async Task PrepareForHostRun_runs_build_script_when_declared()
+    {
+        WritePackageJson("""{ "name": "x", "scripts": { "build": "tsc" } }""");
+        Directory.CreateDirectory(Path.Combine(_projectDir.FullName, "node_modules"));
+        var commands = new List<IReadOnlyList<string>>();
+        NodeFunctionsProject project = CreateProject((_, args, _) =>
+        {
+            commands.Add(args);
+            return Task.FromResult((0, string.Empty));
+        });
+
+        await project.PrepareForHostRunAsync(CreateContext(), default);
+
+        Assert.Single(commands);
+        Assert.Equal(new[] { "run", "build" }, commands[0]);
+    }
+
+    [Fact]
+    public async Task PrepareForHostRun_throws_graceful_on_install_failure()
+    {
+        WritePackageJson("""{ "name": "x" }""");
+        NodeFunctionsProject project = CreateProject((_, _, _) => Task.FromResult((1, "ENOENT")));
+
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => project.PrepareForHostRunAsync(CreateContext(), default));
+
+        Assert.True(ex.IsUserError);
+        Assert.Contains("npm install", ex.Message);
+        Assert.Contains("ENOENT", ex.Message);
+    }
+
+    private NodeFunctionsProject CreateProject(Func<string, IReadOnlyList<string>, CancellationToken, Task<(int, string)>> runner)
+        => new(WorkingDirectory.FromExplicit(_projectDir.FullName))
+        {
+            RunNpm = runner,
+        };
+
+    private void WritePackageJson(string contents)
+        => File.WriteAllText(Path.Combine(_projectDir.FullName, "package.json"), contents);
+
+    private FunctionsProjectHostRunContext CreateContext()
+        => new(_projectDir, "node", new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["FUNCTIONS_WORKER_RUNTIME"] = "node",
+        });
+}

--- a/test/Workloads/Stacks/Node.Tests/NodeFunctionsProjectTests.cs
+++ b/test/Workloads/Stacks/Node.Tests/NodeFunctionsProjectTests.cs
@@ -111,6 +111,40 @@ public class NodeFunctionsProjectTests : IDisposable
         Assert.Contains("ENOENT", ex.Message);
     }
 
+    [Fact]
+    public async Task PrepareForHostRun_skips_build_script_when_SkipBuild()
+    {
+        WritePackageJson("""{ "name": "x", "scripts": { "build": "tsc" } }""");
+        Directory.CreateDirectory(Path.Combine(_projectDir.FullName, "node_modules"));
+        var commands = new List<IReadOnlyList<string>>();
+        NodeFunctionsProject project = CreateProject((_, args, _) =>
+        {
+            commands.Add(args);
+            return Task.FromResult((0, string.Empty));
+        });
+
+        await project.PrepareForHostRunAsync(CreateContext(skipBuild: true), default);
+
+        Assert.Empty(commands);
+    }
+
+    [Fact]
+    public async Task PrepareForHostRun_still_runs_install_when_SkipBuild()
+    {
+        WritePackageJson("""{ "name": "x", "scripts": { "build": "tsc" } }""");
+        var commands = new List<IReadOnlyList<string>>();
+        NodeFunctionsProject project = CreateProject((_, args, _) =>
+        {
+            commands.Add(args);
+            return Task.FromResult((0, string.Empty));
+        });
+
+        await project.PrepareForHostRunAsync(CreateContext(skipBuild: true), default);
+
+        Assert.Single(commands);
+        Assert.Equal(new[] { "install" }, commands[0]);
+    }
+
     private NodeFunctionsProject CreateProject(Func<string, IReadOnlyList<string>, CancellationToken, Task<(int, string)>> runner)
         => new(WorkingDirectory.FromExplicit(_projectDir.FullName))
         {
@@ -120,9 +154,8 @@ public class NodeFunctionsProjectTests : IDisposable
     private void WritePackageJson(string contents)
         => File.WriteAllText(Path.Combine(_projectDir.FullName, "package.json"), contents);
 
-    private FunctionsProjectHostRunContext CreateContext()
+    private FunctionsProjectHostRunContext CreateContext(bool skipBuild = false)
         => new(_projectDir, "node", new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            ["FUNCTIONS_WORKER_RUNTIME"] = "node",
-        });
+        }, skipBuild);
 }

--- a/test/Workloads/Stacks/Python.Tests/PythonFunctionsProjectTests.cs
+++ b/test/Workloads/Stacks/Python.Tests/PythonFunctionsProjectTests.cs
@@ -1,0 +1,154 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Projects;
+using Xunit;
+
+namespace Azure.Functions.Cli.Workloads.Python.Tests;
+
+public class PythonFunctionsProjectTests : IDisposable
+{
+    private readonly DirectoryInfo _projectDir;
+
+    public PythonFunctionsProjectTests()
+    {
+        _projectDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "func-py-project-" + Guid.NewGuid().ToString("N")));
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (_projectDir.Exists)
+            {
+                _projectDir.Delete(recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    [Fact]
+    public async Task PrepareForHostRun_creates_venv_and_installs_requirements()
+    {
+        File.WriteAllText(Path.Combine(_projectDir.FullName, "requirements.txt"), "azure-functions");
+        string? venvCreatedAt = null;
+        string? pipUsed = null;
+        string? requirementsUsed = null;
+
+        var project = new PythonFunctionsProject(WorkingDirectory.FromExplicit(_projectDir.FullName))
+        {
+            RunCreateVenv = (_, path, _) =>
+            {
+                venvCreatedAt = path;
+                Directory.CreateDirectory(path);
+                return Task.FromResult((0, string.Empty));
+            },
+            RunPipInstall = (_, pip, req, _) =>
+            {
+                pipUsed = pip;
+                requirementsUsed = req;
+                return Task.FromResult((0, string.Empty));
+            },
+        };
+        FunctionsProjectHostRunContext context = CreateContext();
+
+        await project.PrepareForHostRunAsync(context, default);
+
+        Assert.Equal(Path.Combine(_projectDir.FullName, PythonFunctionsProject.VenvFolderName), venvCreatedAt);
+        Assert.NotNull(pipUsed);
+        Assert.Contains(PythonFunctionsProject.VenvFolderName, pipUsed!);
+        Assert.Equal(Path.Combine(_projectDir.FullName, "requirements.txt"), requirementsUsed);
+        Assert.Equal("1", context.EnvironmentVariables[PythonFunctionsProject.IsolateWorkerDepsEnvVar]);
+    }
+
+    [Fact]
+    public async Task PrepareForHostRun_skips_venv_creation_when_already_present()
+    {
+        Directory.CreateDirectory(Path.Combine(_projectDir.FullName, PythonFunctionsProject.VenvFolderName));
+        bool venvCreated = false;
+        var project = new PythonFunctionsProject(WorkingDirectory.FromExplicit(_projectDir.FullName))
+        {
+            RunCreateVenv = (_, _, _) =>
+            {
+                venvCreated = true;
+                return Task.FromResult((0, string.Empty));
+            },
+            RunPipInstall = (_, _, _, _) => Task.FromResult((0, string.Empty)),
+        };
+
+        await project.PrepareForHostRunAsync(CreateContext(), default);
+
+        Assert.False(venvCreated);
+    }
+
+    [Fact]
+    public async Task PrepareForHostRun_skips_pip_when_no_requirements()
+    {
+        bool pipRan = false;
+        var project = new PythonFunctionsProject(WorkingDirectory.FromExplicit(_projectDir.FullName))
+        {
+            RunCreateVenv = (_, path, _) =>
+            {
+                Directory.CreateDirectory(path);
+                return Task.FromResult((0, string.Empty));
+            },
+            RunPipInstall = (_, _, _, _) =>
+            {
+                pipRan = true;
+                return Task.FromResult((0, string.Empty));
+            },
+        };
+
+        await project.PrepareForHostRunAsync(CreateContext(), default);
+
+        Assert.False(pipRan);
+    }
+
+    [Fact]
+    public async Task PrepareForHostRun_throws_graceful_on_venv_failure()
+    {
+        var project = new PythonFunctionsProject(WorkingDirectory.FromExplicit(_projectDir.FullName))
+        {
+            RunCreateVenv = (_, _, _) => Task.FromResult((1, "python not found")),
+            RunPipInstall = (_, _, _, _) => Task.FromResult((0, string.Empty)),
+        };
+
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => project.PrepareForHostRunAsync(CreateContext(), default));
+
+        Assert.True(ex.IsUserError);
+        Assert.Contains("venv", ex.Message);
+        Assert.Contains("python not found", ex.Message);
+    }
+
+    [Fact]
+    public async Task PrepareForHostRun_throws_graceful_on_pip_failure()
+    {
+        File.WriteAllText(Path.Combine(_projectDir.FullName, "requirements.txt"), "broken==");
+        var project = new PythonFunctionsProject(WorkingDirectory.FromExplicit(_projectDir.FullName))
+        {
+            RunCreateVenv = (_, path, _) =>
+            {
+                Directory.CreateDirectory(path);
+                return Task.FromResult((0, string.Empty));
+            },
+            RunPipInstall = (_, _, _, _) => Task.FromResult((2, "invalid spec")),
+        };
+
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => project.PrepareForHostRunAsync(CreateContext(), default));
+
+        Assert.True(ex.IsUserError);
+        Assert.Contains("pip install", ex.Message);
+        Assert.Contains("invalid spec", ex.Message);
+    }
+
+    private FunctionsProjectHostRunContext CreateContext()
+        => new(_projectDir, "python", new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["FUNCTIONS_WORKER_RUNTIME"] = "python",
+        });
+}

--- a/test/Workloads/Stacks/Python.Tests/PythonFunctionsProjectTests.cs
+++ b/test/Workloads/Stacks/Python.Tests/PythonFunctionsProjectTests.cs
@@ -53,14 +53,15 @@ public class PythonFunctionsProjectTests : IDisposable
                 return Task.FromResult((0, string.Empty));
             },
             ReadPythonVersion = (_, _) => Task.FromResult<string?>("3.11"),
+            ReadEnvironmentVariable = _ => null,
         };
         FunctionsProjectHostRunContext context = CreateContext();
 
         await project.PrepareForHostRunAsync(context, default);
 
-        Assert.Equal(Path.Combine(_projectDir.FullName, PythonFunctionsProject.VenvFolderName), venvCreatedAt);
+        Assert.Equal(Path.Combine(_projectDir.FullName, PythonFunctionsProject.DefaultVenvFolderName), venvCreatedAt);
         Assert.NotNull(pipUsed);
-        Assert.Contains(PythonFunctionsProject.VenvFolderName, pipUsed!);
+        Assert.Contains(PythonFunctionsProject.DefaultVenvFolderName, pipUsed!);
         Assert.Equal(Path.Combine(_projectDir.FullName, "requirements.txt"), requirementsUsed);
         Assert.Equal("1", context.EnvironmentVariables[PythonFunctionsProject.IsolateWorkerDepsEnvVar]);
     }
@@ -68,7 +69,7 @@ public class PythonFunctionsProjectTests : IDisposable
     [Fact]
     public async Task PrepareForHostRun_skips_venv_creation_when_already_present()
     {
-        Directory.CreateDirectory(Path.Combine(_projectDir.FullName, PythonFunctionsProject.VenvFolderName));
+        Directory.CreateDirectory(Path.Combine(_projectDir.FullName, PythonFunctionsProject.DefaultVenvFolderName));
         bool venvCreated = false;
         var project = new PythonFunctionsProject(WorkingDirectory.FromExplicit(_projectDir.FullName))
         {
@@ -79,6 +80,7 @@ public class PythonFunctionsProjectTests : IDisposable
             },
             RunPipInstall = (_, _, _, _) => Task.FromResult((0, string.Empty)),
             ReadPythonVersion = (_, _) => Task.FromResult<string?>("3.11"),
+            ReadEnvironmentVariable = _ => null,
         };
 
         await project.PrepareForHostRunAsync(CreateContext(), default);
@@ -103,6 +105,7 @@ public class PythonFunctionsProjectTests : IDisposable
                 return Task.FromResult((0, string.Empty));
             },
             ReadPythonVersion = (_, _) => Task.FromResult<string?>("3.11"),
+            ReadEnvironmentVariable = _ => null,
         };
 
         await project.PrepareForHostRunAsync(CreateContext(), default);
@@ -117,6 +120,7 @@ public class PythonFunctionsProjectTests : IDisposable
         {
             RunCreateVenv = (_, _, _) => Task.FromResult((1, "python not found")),
             RunPipInstall = (_, _, _, _) => Task.FromResult((0, string.Empty)),
+            ReadEnvironmentVariable = _ => null,
         };
 
         GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
@@ -139,6 +143,7 @@ public class PythonFunctionsProjectTests : IDisposable
                 return Task.FromResult((0, string.Empty));
             },
             RunPipInstall = (_, _, _, _) => Task.FromResult((2, "invalid spec")),
+            ReadEnvironmentVariable = _ => null,
         };
 
         GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
@@ -162,13 +167,14 @@ public class PythonFunctionsProjectTests : IDisposable
             },
             RunPipInstall = (_, _, _, _) => Task.FromResult((0, string.Empty)),
             ReadPythonVersion = (_, _) => Task.FromResult<string?>("3.12"),
+            ReadEnvironmentVariable = _ => null,
         };
         FunctionsProjectHostRunContext context = CreateContext();
 
         await project.PrepareForHostRunAsync(context, default);
 
         string expectedExe = PythonFunctionsProject.GetVenvExecutablePath(
-            Path.Combine(_projectDir.FullName, PythonFunctionsProject.VenvFolderName),
+            Path.Combine(_projectDir.FullName, PythonFunctionsProject.DefaultVenvFolderName),
             "python");
 
         Assert.Equal(expectedExe, context.EnvironmentVariables[PythonFunctionsProject.WorkerExecutablePathEnvVar]);
@@ -187,6 +193,7 @@ public class PythonFunctionsProjectTests : IDisposable
             },
             RunPipInstall = (_, _, _, _) => Task.FromResult((0, string.Empty)),
             ReadPythonVersion = (_, _) => Task.FromResult<string?>(null),
+            ReadEnvironmentVariable = _ => null,
         };
         FunctionsProjectHostRunContext context = CreateContext();
 
@@ -194,6 +201,74 @@ public class PythonFunctionsProjectTests : IDisposable
 
         Assert.False(context.EnvironmentVariables.ContainsKey(PythonFunctionsProject.WorkerRuntimeVersionEnvVar));
         Assert.True(context.EnvironmentVariables.ContainsKey(PythonFunctionsProject.WorkerExecutablePathEnvVar));
+    }
+
+    [Fact]
+    public async Task PrepareForHostRun_uses_VIRTUAL_ENV_when_set_and_skips_create()
+    {
+        string activatedVenv = Path.Combine(_projectDir.FullName, "my-shared-env");
+        Directory.CreateDirectory(activatedVenv);
+        bool venvCreated = false;
+        string? pipUsed = null;
+
+        var project = new PythonFunctionsProject(WorkingDirectory.FromExplicit(_projectDir.FullName))
+        {
+            RunCreateVenv = (_, _, _) =>
+            {
+                venvCreated = true;
+                return Task.FromResult((0, string.Empty));
+            },
+            RunPipInstall = (_, pip, _, _) =>
+            {
+                pipUsed = pip;
+                return Task.FromResult((0, string.Empty));
+            },
+            ReadPythonVersion = (_, _) => Task.FromResult<string?>("3.11"),
+            ReadEnvironmentVariable = name => name == PythonFunctionsProject.VirtualEnvEnvVar ? activatedVenv : null,
+        };
+        File.WriteAllText(Path.Combine(_projectDir.FullName, "requirements.txt"), "azure-functions");
+        FunctionsProjectHostRunContext context = CreateContext();
+
+        await project.PrepareForHostRunAsync(context, default);
+
+        Assert.False(venvCreated);
+        Assert.NotNull(pipUsed);
+        Assert.Contains("my-shared-env", pipUsed!);
+        Assert.Contains("my-shared-env", context.EnvironmentVariables[PythonFunctionsProject.WorkerExecutablePathEnvVar]);
+    }
+
+    [Theory]
+    [InlineData("venv")]
+    [InlineData("env")]
+    [InlineData(".virtualenv")]
+    public async Task PrepareForHostRun_reuses_existing_conventional_venv_folder(string folderName)
+    {
+        Directory.CreateDirectory(Path.Combine(_projectDir.FullName, folderName));
+        bool venvCreated = false;
+        string? pipUsed = null;
+
+        var project = new PythonFunctionsProject(WorkingDirectory.FromExplicit(_projectDir.FullName))
+        {
+            RunCreateVenv = (_, _, _) =>
+            {
+                venvCreated = true;
+                return Task.FromResult((0, string.Empty));
+            },
+            RunPipInstall = (_, pip, _, _) =>
+            {
+                pipUsed = pip;
+                return Task.FromResult((0, string.Empty));
+            },
+            ReadPythonVersion = (_, _) => Task.FromResult<string?>("3.11"),
+            ReadEnvironmentVariable = _ => null,
+        };
+        File.WriteAllText(Path.Combine(_projectDir.FullName, "requirements.txt"), "azure-functions");
+
+        await project.PrepareForHostRunAsync(CreateContext(), default);
+
+        Assert.False(venvCreated);
+        Assert.NotNull(pipUsed);
+        Assert.Contains(folderName, pipUsed!);
     }
 
     private FunctionsProjectHostRunContext CreateContext()

--- a/test/Workloads/Stacks/Python.Tests/PythonFunctionsProjectTests.cs
+++ b/test/Workloads/Stacks/Python.Tests/PythonFunctionsProjectTests.cs
@@ -52,6 +52,7 @@ public class PythonFunctionsProjectTests : IDisposable
                 requirementsUsed = req;
                 return Task.FromResult((0, string.Empty));
             },
+            ReadPythonVersion = (_, _) => Task.FromResult<string?>("3.11"),
         };
         FunctionsProjectHostRunContext context = CreateContext();
 
@@ -77,6 +78,7 @@ public class PythonFunctionsProjectTests : IDisposable
                 return Task.FromResult((0, string.Empty));
             },
             RunPipInstall = (_, _, _, _) => Task.FromResult((0, string.Empty)),
+            ReadPythonVersion = (_, _) => Task.FromResult<string?>("3.11"),
         };
 
         await project.PrepareForHostRunAsync(CreateContext(), default);
@@ -100,6 +102,7 @@ public class PythonFunctionsProjectTests : IDisposable
                 pipRan = true;
                 return Task.FromResult((0, string.Empty));
             },
+            ReadPythonVersion = (_, _) => Task.FromResult<string?>("3.11"),
         };
 
         await project.PrepareForHostRunAsync(CreateContext(), default);
@@ -144,6 +147,53 @@ public class PythonFunctionsProjectTests : IDisposable
         Assert.True(ex.IsUserError);
         Assert.Contains("pip install", ex.Message);
         Assert.Contains("invalid spec", ex.Message);
+    }
+
+    [Fact]
+    public async Task PrepareForHostRun_sets_worker_executable_path_and_runtime_version()
+    {
+        File.WriteAllText(Path.Combine(_projectDir.FullName, "requirements.txt"), "azure-functions");
+        var project = new PythonFunctionsProject(WorkingDirectory.FromExplicit(_projectDir.FullName))
+        {
+            RunCreateVenv = (_, path, _) =>
+            {
+                Directory.CreateDirectory(path);
+                return Task.FromResult((0, string.Empty));
+            },
+            RunPipInstall = (_, _, _, _) => Task.FromResult((0, string.Empty)),
+            ReadPythonVersion = (_, _) => Task.FromResult<string?>("3.12"),
+        };
+        FunctionsProjectHostRunContext context = CreateContext();
+
+        await project.PrepareForHostRunAsync(context, default);
+
+        string expectedExe = PythonFunctionsProject.GetVenvExecutablePath(
+            Path.Combine(_projectDir.FullName, PythonFunctionsProject.VenvFolderName),
+            "python");
+
+        Assert.Equal(expectedExe, context.EnvironmentVariables[PythonFunctionsProject.WorkerExecutablePathEnvVar]);
+        Assert.Equal("3.12", context.EnvironmentVariables[PythonFunctionsProject.WorkerRuntimeVersionEnvVar]);
+    }
+
+    [Fact]
+    public async Task PrepareForHostRun_omits_runtime_version_when_python_version_unreadable()
+    {
+        var project = new PythonFunctionsProject(WorkingDirectory.FromExplicit(_projectDir.FullName))
+        {
+            RunCreateVenv = (_, path, _) =>
+            {
+                Directory.CreateDirectory(path);
+                return Task.FromResult((0, string.Empty));
+            },
+            RunPipInstall = (_, _, _, _) => Task.FromResult((0, string.Empty)),
+            ReadPythonVersion = (_, _) => Task.FromResult<string?>(null),
+        };
+        FunctionsProjectHostRunContext context = CreateContext();
+
+        await project.PrepareForHostRunAsync(context, default);
+
+        Assert.False(context.EnvironmentVariables.ContainsKey(PythonFunctionsProject.WorkerRuntimeVersionEnvVar));
+        Assert.True(context.EnvironmentVariables.ContainsKey(PythonFunctionsProject.WorkerExecutablePathEnvVar));
     }
 
     private FunctionsProjectHostRunContext CreateContext()


### PR DESCRIPTION
Hook the Go, Node, and Python workloads into `func start` and have `PrepareProjectHostRunInitializationStep` populate real environment variables for the host process.

## Changes

**`PrepareProjectHostRunInitializationStep`**
Injects `ILocalSettingsProvider` and merges env vars in priority order:
1. `local.settings.json` `Values`
2. `state.HostEnvironmentVariables` (reserved for future steps)
3. `FUNCTIONS_WORKER_RUNTIME` from the resolved worker (always wins over stale `local.settings`)
4. `languageWorkers:<runtime>:workerDirectory` from the worker's config path (lights up installed workers without copying assets)
5. `state.BundleEnvVarsForHost`

**Per-stack `PrepareForHostRunAsync` hooks**
Each stack's `FunctionsProject` now extracts into its own file with an internal `Func<>` runner seam for testability.

- **Go**: runs `go build -o bin/<module> .` (module name read from `go.mod`, falls back to `bin/app`).
- **Node**: runs `npm install` when `node_modules` is missing, then `npm run build` when `package.json` declares a `build` script.
- **Python**: creates `.venv` if missing, runs `pip install -r requirements.txt`, sets `PYTHON_ISOLATE_WORKER_DEPENDENCIES=1`.

All failures bubble as `GracefulException(isUserError: true)` so the start command surfaces clean errors.

## Tests

- New `{Go,Node,Python}FunctionsProjectTests` exercise happy paths, idempotency (skip when deps already satisfied), and graceful failure on non-zero exit.
- `StartInitializationTests` extended with `DemoRunner_PopulatesEnvironmentVariablesForHostRun`: real `local.settings.json` on disk, asserts merge priority and that `languageWorkers:node:workerDirectory` resolves to the worker config's directory.
- Full suite green; clean `Release` build (no warnings).