### PR TITLE
vnext: Add func quickstart command skeleton

### DIFF
--- a/src/Abstractions/Quickstart/FetchMode.cs
+++ b/src/Abstractions/Quickstart/FetchMode.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Quickstart;
+
+/// <summary>
+/// Controls how template content is downloaded from GitHub.
+/// </summary>
+public enum FetchMode
+{
+    /// <summary>
+    /// Probe for git availability; use git if found, otherwise fall back to HTTP.
+    /// </summary>
+    Auto,
+
+    /// <summary>
+    /// Force git clone. Fails if git is not available.
+    /// </summary>
+    Git,
+
+    /// <summary>
+    /// Force HTTP zip download. Never invokes git.
+    /// </summary>
+    Http
+}

--- a/src/Abstractions/Quickstart/FetchMode.cs
+++ b/src/Abstractions/Quickstart/FetchMode.cs
@@ -14,12 +14,12 @@ public enum FetchMode
     Auto,
 
     /// <summary>
-    /// Force git clone. Fails if git is not available.
+    /// Use git clone. Fails if git is not available.
     /// </summary>
     Git,
 
     /// <summary>
-    /// Force HTTP zip download. Never invokes git.
+    /// Use HTTP zip download. Never invokes git.
     /// </summary>
     Http
 }

--- a/src/Abstractions/Quickstart/IQuickstartManifestService.cs
+++ b/src/Abstractions/Quickstart/IQuickstartManifestService.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Quickstart;
+
+/// <summary>
+/// Fetches and caches the CDN-hosted template manifest used by
+/// <c>func quickstart</c>. Implementations handle ETag caching,
+/// TTL refresh, and fallback strategies.
+/// </summary>
+public interface IQuickstartManifestService
+{
+    /// <summary>
+    /// Returns the current template manifest, fetching from the CDN if the
+    /// local cache is stale or absent.
+    /// </summary>
+    public Task<IReadOnlyList<QuickstartEntry>> GetManifestAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Abstractions/Quickstart/IQuickstartProvider.cs
+++ b/src/Abstractions/Quickstart/IQuickstartProvider.cs
@@ -1,0 +1,41 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Quickstart;
+
+/// <summary>
+/// Declares a workload's participation in the <c>func quickstart</c> flow.
+/// Each stack that supports quickstart scaffolding registers an implementation
+/// with DI; the command discovers all providers and uses them to drive
+/// language selection and post-scaffold guidance.
+/// </summary>
+/// <remarks>
+/// When <see cref="SupportedLanguages"/> contains more than one entry, the
+/// command prompts the user to pick a sub-language (e.g. .NET → C#/F#,
+/// Node → JavaScript/TypeScript).
+/// </remarks>
+public interface IQuickstartProvider
+{
+    /// <summary>
+    /// The canonical stack id (e.g. "dotnet", "node", "python").
+    /// </summary>
+    public string Stack { get; }
+
+    /// <summary>
+    /// Human-friendly label shown in the interactive runtime prompt
+    /// (e.g. ".NET", "Node", "Python").
+    /// </summary>
+    public string DisplayName { get; }
+
+    /// <summary>
+    /// Manifest-level language values this stack handles (e.g. ["CSharp", "FSharp"]).
+    /// When the list has more than one entry, the command prompts for a sub-language.
+    /// </summary>
+    public IReadOnlyList<string> SupportedLanguages { get; }
+
+    /// <summary>
+    /// Returns post-scaffold "next steps" for the given language
+    /// (e.g. "npm install", "pip install -r requirements.txt", "func start").
+    /// </summary>
+    public IReadOnlyList<string> GetNextSteps(string language);
+}

--- a/src/Abstractions/Quickstart/IQuickstartScaffolder.cs
+++ b/src/Abstractions/Quickstart/IQuickstartScaffolder.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Quickstart;
+
+/// <summary>
+/// Downloads a template from its source repository and writes the files
+/// into the target directory. Handles git clone, HTTP zip download,
+/// path traversal prevention, and metadata cleanup.
+/// </summary>
+public interface IQuickstartScaffolder
+{
+    /// <summary>
+    /// Scaffolds the given template entry into <paramref name="targetDirectory"/>.
+    /// </summary>
+    public Task ScaffoldAsync(
+        QuickstartEntry entry,
+        string targetDirectory,
+        FetchMode fetchMode,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Abstractions/Quickstart/QuickstartEntry.cs
+++ b/src/Abstractions/Quickstart/QuickstartEntry.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Quickstart;
+
+/// <summary>
+/// A single template entry from the CDN manifest.
+/// </summary>
+/// <param name="Id">Unique template identifier (e.g. "http-trigger-python-azd").</param>
+/// <param name="DisplayName">Human-friendly name shown in prompts and list output.</param>
+/// <param name="Language">Manifest language value (e.g. "Python", "CSharp", "TypeScript").</param>
+/// <param name="Resource">Trigger/binding resource type (e.g. "http", "blob", "timer").</param>
+/// <param name="Iac">Infrastructure-as-code type (e.g. "bicep", "terraform", "none").</param>
+/// <param name="RepositoryUrl">GitHub repository URL (HTTPS only, trusted org).</param>
+/// <param name="FolderPath">Subfolder within the repo containing the template, or "." for root.</param>
+/// <param name="GitRef">Immutable tag or SHA pinning the template version.</param>
+/// <param name="ShortDescription">One-line summary for list output.</param>
+/// <param name="LongDescription">Detailed description for info output.</param>
+/// <param name="WhatsIncluded">Bulleted list of what the template contains.</param>
+/// <param name="Tags">Searchable tags for filtering.</param>
+/// <param name="Priority">Sort priority (lower = higher in list).</param>
+public sealed record QuickstartEntry(
+    string Id,
+    string DisplayName,
+    string Language,
+    string Resource,
+    string? Iac,
+    string RepositoryUrl,
+    string FolderPath,
+    string? GitRef,
+    string? ShortDescription,
+    string? LongDescription,
+    IReadOnlyList<string>? WhatsIncluded,
+    IReadOnlyList<string>? Tags,
+    int Priority);

--- a/src/Func/Commands/Quickstart/QuickstartCommand.cs
+++ b/src/Func/Commands/Quickstart/QuickstartCommand.cs
@@ -1,0 +1,98 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Hosting;
+using Azure.Functions.Cli.Quickstart;
+
+namespace Azure.Functions.Cli.Commands.Quickstart;
+
+/// <summary>
+/// Top-level <c>func quickstart</c> command. Fetches a CDN-hosted manifest of
+/// complete function-app templates and scaffolds the selected one into a target
+/// directory. Delegates language resolution to registered <see cref="IQuickstartProvider"/>
+/// implementations contributed by each stack workload.
+/// </summary>
+internal sealed class QuickstartCommand : FuncCliCommand, IBuiltInCommand
+{
+    public Option<string?> LanguageOption { get; } = new("--language", "-l")
+    {
+        Description = "Worker runtime or language (e.g. python, node, java, dotnet, csharp, fsharp, javascript, typescript, powershell)"
+    };
+
+    public Option<string?> TemplateOption { get; } = new("--template", "-t")
+    {
+        Description = "Template id from the manifest (e.g. http-trigger-python-azd) — skips all prompts"
+    };
+
+    public Option<string?> ResourceOption { get; } = new("--resource", "-r")
+    {
+        Description = "Filter by trigger/binding resource (e.g. http, timer, blob, eventhub, servicebus, cosmos, sql, mcp, durable)"
+    };
+
+    public Option<string?> IacOption { get; } = new("--iac")
+    {
+        Description = "Filter by infrastructure-as-code type (e.g. bicep, terraform, none)"
+    };
+
+    public Option<string?> SearchOption { get; } = new("--search", "-s")
+    {
+        Description = "Case-insensitive substring filter applied to template names and descriptions"
+    };
+
+    public Option<FetchMode> FetchOption { get; } = new("--fetch")
+    {
+        Description = "Download strategy: auto (default), git, or http",
+        DefaultValueFactory = _ => FetchMode.Auto
+    };
+
+    private readonly IInteractionService _interaction;
+    private readonly IReadOnlyList<IQuickstartProvider> _providers;
+
+    public QuickstartCommand(
+        QuickstartListCommand listCommand,
+        QuickstartInfoCommand infoCommand,
+        IInteractionService interaction,
+        IEnumerable<IQuickstartProvider> providers)
+        : base("quickstart", "Browse and scaffold complete function apps from the Azure Functions template catalog.")
+    {
+        ArgumentNullException.ThrowIfNull(listCommand);
+        ArgumentNullException.ThrowIfNull(infoCommand);
+        ArgumentNullException.ThrowIfNull(interaction);
+        ArgumentNullException.ThrowIfNull(providers);
+
+        _interaction = interaction;
+        _providers = providers.ToList();
+
+        AddPathArgument();
+        Options.Add(LanguageOption);
+        Options.Add(TemplateOption);
+        Options.Add(ResourceOption);
+        Options.Add(IacOption);
+        Options.Add(SearchOption);
+        Options.Add(FetchOption);
+
+        Subcommands.Add(listCommand);
+        Subcommands.Add(infoCommand);
+    }
+
+    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        if (_providers.Count == 0)
+        {
+            _interaction.WriteWarning(
+                "The quickstart command is not yet available. Stack support is coming in a future release.");
+            return Task.FromResult(1);
+        }
+
+        // Implementation will be added in a follow-up PR:
+        // 1. Fetch manifest via IQuickstartManifestService
+        // 2. Resolve language (prompt if interactive, error if non-TTY without --language)
+        // 3. Resolve template (--template skips prompts, otherwise filter + prompt)
+        // 4. Scaffold via IQuickstartScaffolder
+        _interaction.WriteWarning(
+            "The quickstart command is not yet implemented. This is a placeholder for the upcoming scaffold flow.");
+        return Task.FromResult(1);
+    }
+}

--- a/src/Func/Commands/Quickstart/QuickstartCommand.cs
+++ b/src/Func/Commands/Quickstart/QuickstartCommand.cs
@@ -16,14 +16,19 @@ namespace Azure.Functions.Cli.Commands.Quickstart;
 /// </summary>
 internal sealed class QuickstartCommand : FuncCliCommand, IBuiltInCommand
 {
+    public Option<string?> StackOption { get; } = new("--stack", "-s")
+    {
+        Description = "The stack to use. Run `func workload list` to see what's installed."
+    };
+
     public Option<string?> LanguageOption { get; } = new("--language", "-l")
     {
-        Description = "Worker runtime or language (e.g. python, node, java, dotnet, csharp, fsharp, javascript, typescript, powershell)"
+        Description = "The programming language"
     };
 
     public Option<string?> TemplateOption { get; } = new("--template", "-t")
     {
-        Description = "Template id from the manifest (e.g. http-trigger-python-azd) — skips all prompts"
+        Description = "Template ID from the manifest (e.g. http-trigger-python-azd) — skips all prompts"
     };
 
     public Option<string?> ResourceOption { get; } = new("--resource", "-r")
@@ -36,7 +41,7 @@ internal sealed class QuickstartCommand : FuncCliCommand, IBuiltInCommand
         Description = "Filter by infrastructure-as-code type (e.g. bicep, terraform, none)"
     };
 
-    public Option<string?> SearchOption { get; } = new("--search", "-s")
+    public Option<string?> SearchOption { get; } = new("--search")
     {
         Description = "Case-insensitive substring filter applied to template names and descriptions"
     };
@@ -65,7 +70,10 @@ internal sealed class QuickstartCommand : FuncCliCommand, IBuiltInCommand
         _interaction = interaction;
         _providers = providers.ToList();
 
+        LanguageOption.Description = BuildLanguageOptionDescription(_providers);
+
         AddPathArgument();
+        Options.Add(StackOption);
         Options.Add(LanguageOption);
         Options.Add(TemplateOption);
         Options.Add(ResourceOption);
@@ -88,11 +96,26 @@ internal sealed class QuickstartCommand : FuncCliCommand, IBuiltInCommand
 
         // Implementation will be added in a follow-up PR:
         // 1. Fetch manifest via IQuickstartManifestService
-        // 2. Resolve language (prompt if interactive, error if non-TTY without --language)
+        // 2. Resolve stack/language (prompt if interactive, error if non-TTY without --language)
         // 3. Resolve template (--template skips prompts, otherwise filter + prompt)
         // 4. Scaffold via IQuickstartScaffolder
         _interaction.WriteWarning(
             "The quickstart command is not yet implemented. This is a placeholder for the upcoming scaffold flow.");
         return Task.FromResult(1);
+    }
+
+    private static string BuildLanguageOptionDescription(IReadOnlyList<IQuickstartProvider> providers)
+    {
+        var languages = providers
+            .SelectMany(p => p.SupportedLanguages)
+            .Where(l => !string.IsNullOrWhiteSpace(l))
+            .Select(l => l.Trim().ToLowerInvariant())
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(l => l, StringComparer.Ordinal)
+            .ToList();
+
+        return languages.Count == 0
+            ? "The programming language. Install a stack workload (`func workload install <id>`) to see supported values."
+            : "The programming language. Supported values: " + string.Join(", ", languages) + ".";
     }
 }

--- a/src/Func/Commands/Quickstart/QuickstartInfoCommand.cs
+++ b/src/Func/Commands/Quickstart/QuickstartInfoCommand.cs
@@ -1,0 +1,50 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Quickstart;
+
+namespace Azure.Functions.Cli.Commands.Quickstart;
+
+/// <summary>
+/// Displays detailed information about a specific template by id.
+/// </summary>
+internal sealed class QuickstartInfoCommand : FuncCliCommand
+{
+    public Argument<string> TemplateIdArgument { get; } = new("id")
+    {
+        Description = "Template id from the manifest (e.g. http-trigger-python-azd). Use 'func quickstart list' to see available ids."
+    };
+
+    private readonly IInteractionService _interaction;
+    private readonly IReadOnlyList<IQuickstartProvider> _providers;
+
+    public QuickstartInfoCommand(
+        IInteractionService interaction,
+        IEnumerable<IQuickstartProvider> providers)
+        : base("info", "Show detailed information about a template.")
+    {
+        ArgumentNullException.ThrowIfNull(interaction);
+        ArgumentNullException.ThrowIfNull(providers);
+
+        _interaction = interaction;
+        _providers = providers.ToList();
+
+        Arguments.Add(TemplateIdArgument);
+    }
+
+    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        if (_providers.Count == 0)
+        {
+            _interaction.WriteWarning(
+                "The quickstart command is not yet available. Stack support is coming in a future release.");
+            return Task.FromResult(1);
+        }
+
+        _interaction.WriteWarning(
+            "The quickstart info command is not yet implemented.");
+        return Task.FromResult(1);
+    }
+}

--- a/src/Func/Commands/Quickstart/QuickstartInfoCommand.cs
+++ b/src/Func/Commands/Quickstart/QuickstartInfoCommand.cs
@@ -14,7 +14,7 @@ internal sealed class QuickstartInfoCommand : FuncCliCommand
 {
     public Argument<string> TemplateIdArgument { get; } = new("id")
     {
-        Description = "Template id from the manifest (e.g. http-trigger-python-azd). Use 'func quickstart list' to see available ids."
+        Description = "Template ID from the manifest (e.g. http-trigger-python-azd). Use 'func quickstart list' to see available IDs."
     };
 
     private readonly IInteractionService _interaction;

--- a/src/Func/Commands/Quickstart/QuickstartListCommand.cs
+++ b/src/Func/Commands/Quickstart/QuickstartListCommand.cs
@@ -1,0 +1,69 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Quickstart;
+
+namespace Azure.Functions.Cli.Commands.Quickstart;
+
+/// <summary>
+/// Lists available templates from the CDN manifest, optionally filtered by
+/// language, resource, IaC type, or keyword search.
+/// </summary>
+internal sealed class QuickstartListCommand : FuncCliCommand
+{
+    public Option<string?> LanguageOption { get; } = new("--language", "-l")
+    {
+        Description = "Filter by worker runtime or language (e.g. python, node, java, dotnet)"
+    };
+
+    public Option<string?> ResourceOption { get; } = new("--resource", "-r")
+    {
+        Description = "Filter by trigger/binding resource (e.g. http, timer, blob, eventhub, servicebus, cosmos, sql, mcp, durable)"
+    };
+
+    public Option<string?> IacOption { get; } = new("--iac")
+    {
+        Description = "Filter by infrastructure-as-code type (e.g. bicep, terraform, none)"
+    };
+
+    public Option<string?> SearchOption { get; } = new("--search", "-s")
+    {
+        Description = "Case-insensitive substring match against template names, ids, resources, tags, and descriptions"
+    };
+
+    private readonly IInteractionService _interaction;
+    private readonly IReadOnlyList<IQuickstartProvider> _providers;
+
+    public QuickstartListCommand(
+        IInteractionService interaction,
+        IEnumerable<IQuickstartProvider> providers)
+        : base("list", "List available templates from the catalog.")
+    {
+        ArgumentNullException.ThrowIfNull(interaction);
+        ArgumentNullException.ThrowIfNull(providers);
+
+        _interaction = interaction;
+        _providers = providers.ToList();
+
+        Options.Add(LanguageOption);
+        Options.Add(ResourceOption);
+        Options.Add(IacOption);
+        Options.Add(SearchOption);
+    }
+
+    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        if (_providers.Count == 0)
+        {
+            _interaction.WriteWarning(
+                "The quickstart command is not yet available. Stack support is coming in a future release.");
+            return Task.FromResult(1);
+        }
+
+        _interaction.WriteWarning(
+            "The quickstart list command is not yet implemented.");
+        return Task.FromResult(1);
+    }
+}

--- a/src/Func/Commands/Quickstart/QuickstartListCommand.cs
+++ b/src/Func/Commands/Quickstart/QuickstartListCommand.cs
@@ -30,7 +30,7 @@ internal sealed class QuickstartListCommand : FuncCliCommand
 
     public Option<string?> SearchOption { get; } = new("--search", "-s")
     {
-        Description = "Case-insensitive substring match against template names, ids, resources, tags, and descriptions"
+        Description = "Case-insensitive substring match against template names, IDs, resources, tags, and descriptions"
     };
 
     private readonly IInteractionService _interaction;

--- a/src/Func/Hosting/BuiltInCommands.cs
+++ b/src/Func/Hosting/BuiltInCommands.cs
@@ -3,6 +3,7 @@
 
 using Azure.Functions.Cli.Commands;
 using Azure.Functions.Cli.Commands.Profile;
+using Azure.Functions.Cli.Commands.Quickstart;
 using Azure.Functions.Cli.Commands.Setup;
 using Azure.Functions.Cli.Commands.Start.Initialization;
 using Azure.Functions.Cli.Commands.Workload;
@@ -62,6 +63,11 @@ internal static class BuiltInCommands
         services.AddSingleton<WorkloadSearchCommand>();
         services.AddSingleton<WorkloadPruneCommand>();
         services.AddSingleton<FuncCliCommand, WorkloadCommand>();
+
+        // Quickstart command and subcommands
+        services.AddSingleton<FuncCliCommand, QuickstartCommand>();
+        services.AddSingleton<QuickstartListCommand>();
+        services.AddSingleton<QuickstartInfoCommand>();
 
         return services;
     }

--- a/test/Func.Tests/Commands/Quickstart/QuickstartCommandTests.cs
+++ b/test/Func.Tests/Commands/Quickstart/QuickstartCommandTests.cs
@@ -21,6 +21,7 @@ public class QuickstartCommandTests
 
         var optionNames = cmd.Options.Select(o => o.Name).ToList();
 
+        Assert.Contains("--stack", optionNames);
         Assert.Contains("--language", optionNames);
         Assert.Contains("--template", optionNames);
         Assert.Contains("--resource", optionNames);

--- a/test/Func.Tests/Commands/Quickstart/QuickstartCommandTests.cs
+++ b/test/Func.Tests/Commands/Quickstart/QuickstartCommandTests.cs
@@ -1,0 +1,64 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Commands;
+using Azure.Functions.Cli.Commands.Quickstart;
+using Azure.Functions.Cli.Quickstart;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Commands.Quickstart;
+
+public class QuickstartCommandTests
+{
+    private readonly TestInteractionService _interaction = new();
+
+    [Fact]
+    public void QuickstartCommand_HasExpectedOptions()
+    {
+        var listCmd = new QuickstartListCommand(_interaction, []);
+        var infoCmd = new QuickstartInfoCommand(_interaction, []);
+        var cmd = new QuickstartCommand(listCmd, infoCmd, _interaction, []);
+
+        var optionNames = cmd.Options.Select(o => o.Name).ToList();
+
+        Assert.Contains("--language", optionNames);
+        Assert.Contains("--template", optionNames);
+        Assert.Contains("--resource", optionNames);
+        Assert.Contains("--iac", optionNames);
+        Assert.Contains("--search", optionNames);
+        Assert.Contains("--fetch", optionNames);
+    }
+
+    [Fact]
+    public void QuickstartCommand_HasSubcommands()
+    {
+        var listCmd = new QuickstartListCommand(_interaction, []);
+        var infoCmd = new QuickstartInfoCommand(_interaction, []);
+        var cmd = new QuickstartCommand(listCmd, infoCmd, _interaction, []);
+
+        var subcommandNames = cmd.Subcommands.Select(c => c.Name).ToList();
+
+        Assert.Contains("list", subcommandNames);
+        Assert.Contains("info", subcommandNames);
+    }
+
+    [Fact]
+    public void QuickstartCommand_HasPathArgument()
+    {
+        var listCmd = new QuickstartListCommand(_interaction, []);
+        var infoCmd = new QuickstartInfoCommand(_interaction, []);
+        var cmd = new QuickstartCommand(listCmd, infoCmd, _interaction, []);
+
+        Assert.Single(cmd.Arguments);
+        Assert.Equal("path", cmd.Arguments[0].Name);
+    }
+
+    [Fact]
+    public void QuickstartCommand_RegisteredInParser()
+    {
+        var root = TestParser.CreateRoot(_interaction);
+        var names = root.Subcommands.Select(c => c.Name).ToList();
+
+        Assert.Contains("quickstart", names);
+    }
+}


### PR DESCRIPTION
## Summary

Adds the bare-bones command skeleton for `func quickstart` — a new top-level command that will scaffold complete function apps from a CDN-hosted template manifest (designed in #5026). This PR is intentionally minimal: interfaces, models, and stub commands only. Functional implementation comes in follow-up PRs.

### What's in this PR

**Abstractions** (`src/Abstractions/Quickstart/`):
- `IQuickstartProvider` — per-stack interface workloads implement to opt into quickstart (analogous to `IProjectInitializer` for `func init`)
- `IQuickstartManifestService` — shared service interface for CDN manifest fetching
- `IQuickstartScaffolder` — shared service interface for template download + write
- `QuickstartEntry` — manifest entry model record
- `FetchMode` — enum: `Auto`, `Git`, `Http`

**Commands** (`src/Func/Commands/Quickstart/`):
- `QuickstartCommand` — parent `func quickstart` with `--language`, `--template`, `--resource`, `--iac`, `--search`, `--fetch` options
- `QuickstartListCommand` — `func quickstart list` with filter options
- `QuickstartInfoCommand` — `func quickstart info <id>`

**DI registration** — commands registered in `BuiltInCommands.cs`

All commands currently show "not yet available" until stack workloads register `IQuickstartProvider` implementations.

### Design decisions

- **Workload-extensible**: follows the `IProjectInitializer` pattern — each stack opts in by implementing `IQuickstartProvider`, shared helpers (manifest, scaffolder) are reusable
- **Sub-language prompting**: derived from `SupportedLanguages.Count > 1` (e.g. dotnet → C#/F#, node → JS/TS)
- **No implementations yet**: services and per-stack providers will be added in focused follow-up PRs

### Issue describing the changes in this PR

Design: #5026

### Pull request checklist

* [x] My changes **do not** require documentation changes
* [x] My changes **do not** need to be backported to a previous version
* [x] My changes **should not** be added to the release notes for the next release
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

This is the first in a series of incremental PRs implementing `func quickstart`. Follow-ups:
1. Manifest service implementation (CDN fetch, ETag caching, TTL)
2. Scaffolder implementation (git clone, HTTP zip, path traversal prevention)
3. Per-stack `IQuickstartProvider` implementations (dotnet, go, node, python — java and powershell when vnext adds those stacks)
4. Full command logic (interactive prompts, filtering, non-TTY fallback)