### PR TITLE
Append newline to WriteSectionHeader

### DIFF
--- a/src/Func/Console/SpectreInteractionService.cs
+++ b/src/Func/Console/SpectreInteractionService.cs
@@ -50,7 +50,7 @@ internal class SpectreInteractionService : IInteractionService
         _stdout.Write(new Paragraph(text, _theme.Title).Append(Environment.NewLine));
 
     public void WriteSectionHeader(string title) =>
-        _stdout.Write(title, _theme.Heading);
+        _stdout.Write(new Paragraph(title, _theme.Heading).Append(Environment.NewLine));
 
     public void WriteHint(string message) =>
         _stdout.Write(new Paragraph(message, _theme.Muted).Append(Environment.NewLine));


### PR DESCRIPTION
`SpectreInteractionService.WriteSectionHeader` wrote the heading text without a trailing newline, so the next line of output glued onto the same line (e.g. `Profile flexError: ...` instead of `Profile flex\nError: ...`).

Fix: append `Environment.NewLine` to the `Paragraph`, matching `WriteTitle`/`WriteHint`/etc.

No callers depended on the missing newline. No existing tests for `SpectreInteractionService` to extend.

Verified locally with `dotnet build -c Debug` and `dotnet test --no-build -c Debug` (all green).