### PR TITLE
Improve Go support: preview signposting, async drain fix, and test coverage

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -12,4 +12,3 @@
 - Fix `HttpsProxyAgent is not a constructor` error in `install.js` when installing behind a proxy (https-proxy-agent v9 requires a named import).
 - Remove `azure-functions-core-tools` from the `devDependencies` of generated function app templates (`package-js.json`, `package-js-v4.json`, `package-ts.json`, `package-ts-v4.json`). Users get the CLI from their system install; pulling it in again via `npm install` doubled disk usage and made every project's install fragile to Core Tools postinstall regressions.
 - Add Go language support to `func init`, `func start`, `func pack`, and `func publish` (#4875, #4892, #4943)
-- [Preview Feature] Add Go language support to `func init`, `func start`, `func pack`, and `func publish` (#4875, #4892, #4943)

--- a/release_notes.md
+++ b/release_notes.md
@@ -11,4 +11,4 @@
 
 - Fix `HttpsProxyAgent is not a constructor` error in `install.js` when installing behind a proxy (https-proxy-agent v9 requires a named import).
 - Remove `azure-functions-core-tools` from the `devDependencies` of generated function app templates (`package-js.json`, `package-js-v4.json`, `package-ts.json`, `package-ts-v4.json`). Users get the CLI from their system install; pulling it in again via `npm install` doubled disk usage and made every project's install fragile to Core Tools postinstall regressions.
-- Add Go language support to `func init`, `func start`, `func pack`, and `func publish` (#4875, #4892, #4943)
+- Add **preview** Go language support to `func init`, `func start`, `func pack`, and `func publish` (#4875, #4892, #4943). Behaviour, build/publish flags, and deployment layout may change before GA.

--- a/release_notes.md
+++ b/release_notes.md
@@ -12,3 +12,4 @@
 - Fix `HttpsProxyAgent is not a constructor` error in `install.js` when installing behind a proxy (https-proxy-agent v9 requires a named import).
 - Remove `azure-functions-core-tools` from the `devDependencies` of generated function app templates (`package-js.json`, `package-js-v4.json`, `package-ts.json`, `package-ts-v4.json`). Users get the CLI from their system install; pulling it in again via `npm install` doubled disk usage and made every project's install fragile to Core Tools postinstall regressions.
 - Add Go language support to `func init`, `func start`, `func pack`, and `func publish` (#4875, #4892, #4943)
+- [Preview Feature] Add Go language support to `func init`, `func start`, `func pack`, and `func publish` (#4875, #4892, #4943)

--- a/src/Cli/func/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Cli/func/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -164,16 +164,21 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 throw new CliException($"--build {PublishBuildOption} is not supported for Windows Elastic Premium Function Apps.");
             }
 
-            // Get the WorkerRuntime
-            var workerRuntime = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(_secretsManager, refreshSecrets: true);
-            if (workerRuntime != WorkerRuntime.None)
+            // Get the WorkerRuntime. Only re-resolve from local.settings.json when the Init-time
+            // value was None. This preserves the original behavior for Python/.NET/Node/PowerShell
+            // (single global read set during Init), while allowing Go's "native" → Go resolution
+            // when func publish is invoked without a prior func init.
+            var workerRuntime = GlobalCoreToolsSettings.CurrentWorkerRuntime;
+            if (workerRuntime == WorkerRuntime.None)
             {
-                GlobalCoreToolsSettings.CurrentWorkerRuntime = workerRuntime;
+                workerRuntime = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(_secretsManager, refreshSecrets: true);
+                if (workerRuntime != WorkerRuntime.None)
+                {
+                    GlobalCoreToolsSettings.CurrentWorkerRuntime = workerRuntime;
+                }
             }
-            else
-            {
-                workerRuntime = GlobalCoreToolsSettings.CurrentWorkerRuntime;
-            }
+
+            Utilities.WarnIfGoWorkerRuntime(workerRuntime);
 
             // Go is cross-compiled to linux/amd64 and currently only supported on Flex Consumption.
             // Reject Windows targets, non-Flex SKUs, and unsupported build modes up front.
@@ -692,7 +697,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             }
 
             ColoredConsole.WriteLine(GetLogMessage("Starting the function app deployment..."));
-            Func<Task<Stream>> zipStreamFactory = () => ZipHelper.GetAppZipFile(functionAppRoot, BuildNativeDeps, PublishBuildOption, NoBuild, ignoreParser, AdditionalPackages);
+            Func<Task<Stream>> zipStreamFactory = () => ZipHelper.GetAppZipFile(functionAppRoot, BuildNativeDeps, PublishBuildOption, NoBuild, GlobalCoreToolsSettings.CurrentWorkerRuntime, ignoreParser, AdditionalPackages);
 
             bool shouldSyncTriggers = true;
             bool shouldDeferPublishZipDeploy = false;

--- a/src/Cli/func/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Cli/func/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -312,7 +312,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                     }
                     else
                     {
-                        await PublishFunctionApp(functionApp, ignoreParser, additionalAppSettings);
+                        await PublishFunctionApp(functionApp, ignoreParser, additionalAppSettings, workerRuntime);
                     }
                 }
                 catch (HttpRequestException ex)
@@ -677,7 +677,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             }
         }
 
-        private async Task PublishFunctionApp(Site functionApp, GitIgnoreParser ignoreParser, IDictionary<string, string> additionalAppSettings)
+        private async Task PublishFunctionApp(Site functionApp, GitIgnoreParser ignoreParser, IDictionary<string, string> additionalAppSettings, WorkerRuntime workerRuntime)
         {
             ColoredConsole.WriteLine("Getting site publishing info...");
             var functionAppRoot = ScriptHostHelpers.GetFunctionAppRootDirectory(Environment.CurrentDirectory);
@@ -697,7 +697,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             }
 
             ColoredConsole.WriteLine(GetLogMessage("Starting the function app deployment..."));
-            Func<Task<Stream>> zipStreamFactory = () => ZipHelper.GetAppZipFile(functionAppRoot, BuildNativeDeps, PublishBuildOption, NoBuild, GlobalCoreToolsSettings.CurrentWorkerRuntime, ignoreParser, AdditionalPackages);
+            Func<Task<Stream>> zipStreamFactory = () => ZipHelper.GetAppZipFile(functionAppRoot, BuildNativeDeps, PublishBuildOption, NoBuild, workerRuntime, ignoreParser, AdditionalPackages);
 
             bool shouldSyncTriggers = true;
             bool shouldDeferPublishZipDeploy = false;

--- a/src/Cli/func/Actions/HostActions/StartHostAction.cs
+++ b/src/Cli/func/Actions/HostActions/StartHostAction.cs
@@ -734,14 +734,21 @@ namespace Azure.Functions.Cli.Actions.HostActions
         private async Task PreRunConditions()
         {
             // GetCurrentWorkerRuntimeLanguage transparently resolves FUNCTIONS_WORKER_RUNTIME=native
-            // to a concrete runtime (e.g. Go via go.mod). Mirror the result into the global so
-            // downstream code that reads GlobalCoreToolsSettings.CurrentWorkerRuntime sees Go
-            // rather than None for Go projects.
-            var resolved = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(_secretsManager, refreshSecrets: true);
-            if (resolved != WorkerRuntime.None)
+            // to a concrete runtime (e.g. Go via go.mod). Only re-resolve when the Init-time value
+            // was None; otherwise use the global set during Init. Mirror resolved value into the
+            // global so downstream code that reads GlobalCoreToolsSettings.CurrentWorkerRuntime
+            // sees Go rather than None for Go projects.
+            var resolved = GlobalCoreToolsSettings.CurrentWorkerRuntime;
+            if (resolved == WorkerRuntime.None)
             {
-                GlobalCoreToolsSettings.CurrentWorkerRuntime = resolved;
+                resolved = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(_secretsManager, refreshSecrets: true);
+                if (resolved != WorkerRuntime.None)
+                {
+                    GlobalCoreToolsSettings.CurrentWorkerRuntime = resolved;
+                }
             }
+
+            Utilities.WarnIfGoWorkerRuntime(resolved);
 
             EnsureWorkerRuntimeIsSet();
 

--- a/src/Cli/func/Actions/LocalActions/InitAction/InitAction.cs
+++ b/src/Cli/func/Actions/LocalActions/InitAction/InitAction.cs
@@ -475,7 +475,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             // for go.mod on every command. See WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage.
             if (workerRuntime == Helpers.WorkerRuntime.Go)
             {
-                localSettingsJsonContent = AddLocalSetting(localSettingsJsonContent, Constants.FunctionsCliGoPreview, "true");
+                localSettingsJsonContent = AddLocalSetting(localSettingsJsonContent, Constants.FunctionsCliNativeLanguage, "go");
             }
 
             if (workerRuntime == Helpers.WorkerRuntime.Powershell)

--- a/src/Cli/func/Actions/LocalActions/PackAction/CustomPackSubcommandAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/CustomPackSubcommandAction.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Helpers;
 using Azure.Functions.Cli.Interfaces;
 using Fclp;
 using Newtonsoft.Json;
@@ -12,6 +13,11 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
     [Action(Name = "pack custom", ParentCommandName = "pack", ShowInHelp = false, HelpText = "Arguments specific to custom worker runtime apps when running func pack")]
     internal class CustomPackSubcommandAction : PackSubcommandAction
     {
+        public CustomPackSubcommandAction()
+            : base(WorkerRuntime.Custom)
+        {
+        }
+
         public override ICommandLineParserResult ParseArgs(string[] args)
         {
             return base.ParseArgs(args);

--- a/src/Cli/func/Actions/LocalActions/PackAction/DotnetPackSubcommandAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/DotnetPackSubcommandAction.cs
@@ -15,6 +15,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
         private readonly bool _isDotnetIsolated;
 
         public DotnetPackSubcommandAction(bool isDotnetIsolated)
+            : base(isDotnetIsolated ? WorkerRuntime.DotnetIsolated : WorkerRuntime.Dotnet)
         {
             _isDotnetIsolated = isDotnetIsolated;
         }

--- a/src/Cli/func/Actions/LocalActions/PackAction/GoPackSubcommandAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/GoPackSubcommandAction.cs
@@ -9,6 +9,11 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
     [Action(Name = "pack go", ParentCommandName = "pack", ShowInHelp = false, HelpText = "Arguments specific to Go apps when running func pack")]
     internal class GoPackSubcommandAction : PackSubcommandAction
     {
+        public GoPackSubcommandAction()
+            : base(WorkerRuntime.Go)
+        {
+        }
+
         public async Task RunAsync(PackOptions packOptions)
         {
             await ExecuteAsync(packOptions);

--- a/src/Cli/func/Actions/LocalActions/PackAction/NodePackSubcommandAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/NodePackSubcommandAction.cs
@@ -18,6 +18,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
         private readonly ISecretsManager _secretsManager;
 
         public NodePackSubcommandAction(ISecretsManager secretsManager)
+            : base(WorkerRuntime.Node)
         {
             _secretsManager = secretsManager;
         }
@@ -67,7 +68,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
 
         protected override Task PackFunctionAsync(string packingRoot, string outputPath, PackOptions options)
         {
-            return PackHelpers.CreatePackage(packingRoot, outputPath, options.NoBuild, WorkerRuntime.Node, TelemetryCommandEvents);
+            return PackHelpers.CreatePackage(packingRoot, outputPath, options.NoBuild, Runtime, TelemetryCommandEvents);
         }
 
         private async Task RunNodeJsBuildProcess(string functionAppRoot)

--- a/src/Cli/func/Actions/LocalActions/PackAction/NodePackSubcommandAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/NodePackSubcommandAction.cs
@@ -67,7 +67,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
 
         protected override Task PackFunctionAsync(string packingRoot, string outputPath, PackOptions options)
         {
-            return PackHelpers.CreatePackage(packingRoot, outputPath, options.NoBuild, TelemetryCommandEvents);
+            return PackHelpers.CreatePackage(packingRoot, outputPath, options.NoBuild, WorkerRuntime.Node, TelemetryCommandEvents);
         }
 
         private async Task RunNodeJsBuildProcess(string functionAppRoot)

--- a/src/Cli/func/Actions/LocalActions/PackAction/PackAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/PackAction.cs
@@ -91,6 +91,8 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
             // when "native" is set without a supported project marker.
             WorkerRuntime workerRuntime = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(_secretsManager, refreshSecrets: true);
 
+            Utilities.WarnIfGoWorkerRuntime(workerRuntime);
+
             if (workerRuntime == WorkerRuntime.None && NoBuild)
             {
                 // Narrow to top-level only to avoid false positives in node_modules/, venvs, etc.

--- a/src/Cli/func/Actions/LocalActions/PackAction/PackHelpers.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/PackHelpers.cs
@@ -63,9 +63,9 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
             }
         }
 
-        public static async Task CreatePackage(string packingRoot, string outputPath, bool noBuild, IDictionary<string, string> telemetryCommandEvents, bool buildNativeDeps = false)
+        public static async Task CreatePackage(string packingRoot, string outputPath, bool noBuild, WorkerRuntime workerRuntime, IDictionary<string, string> telemetryCommandEvents, bool buildNativeDeps = false)
         {
-            var stream = await ZipHelper.GetAppZipFile(packingRoot, buildNativeDeps, BuildOption.Default, noBuild: noBuild);
+            var stream = await ZipHelper.GetAppZipFile(packingRoot, buildNativeDeps, BuildOption.Default, noBuild: noBuild, workerRuntime);
 
             ColoredConsole.WriteLine($"Creating a new package {outputPath}");
             await FileSystemHelpers.WriteToFile(outputPath, stream);

--- a/src/Cli/func/Actions/LocalActions/PackAction/PackSubcommandAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/PackSubcommandAction.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Helpers;
+
 using Azure.Functions.Cli.Common;
 
 namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
@@ -61,7 +63,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
 
         // Hook: actual packaging operation (default zip from packingRoot)
         protected virtual Task PackFunctionAsync(string packingRoot, string outputPath, PackOptions options)
-            => PackHelpers.CreatePackage(packingRoot, outputPath, options.NoBuild, TelemetryCommandEvents);
+            => PackHelpers.CreatePackage(packingRoot, outputPath, options.NoBuild, GlobalCoreToolsSettings.CurrentWorkerRuntime, TelemetryCommandEvents);
 
         // Hook: optional cleanup after packaging
         protected virtual Task PerformCleanupAfterPackingAsync(string packingRoot, string functionAppRoot, PackOptions options) => Task.CompletedTask;

--- a/src/Cli/func/Actions/LocalActions/PackAction/PackSubcommandAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/PackSubcommandAction.cs
@@ -1,15 +1,23 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Azure.Functions.Cli.Helpers;
-
 using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Helpers;
 
 namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
 {
     // Base class for pack subcommands to reduce duplication using a template method.
     internal abstract class PackSubcommandAction : BaseAction
     {
+        protected PackSubcommandAction(WorkerRuntime workerRuntime)
+        {
+            Runtime = workerRuntime;
+        }
+
+        // The worker runtime this subcommand packs for. Set once at construction so the
+        // pack flow never has to read GlobalCoreToolsSettings.CurrentWorkerRuntime.
+        protected WorkerRuntime Runtime { get; }
+
         // Orchestrates the pack flow for subcommands that don't need extra args
         protected async Task ExecuteAsync(PackOptions options)
         {
@@ -63,7 +71,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
 
         // Hook: actual packaging operation (default zip from packingRoot)
         protected virtual Task PackFunctionAsync(string packingRoot, string outputPath, PackOptions options)
-            => PackHelpers.CreatePackage(packingRoot, outputPath, options.NoBuild, GlobalCoreToolsSettings.CurrentWorkerRuntime, TelemetryCommandEvents);
+            => PackHelpers.CreatePackage(packingRoot, outputPath, options.NoBuild, Runtime, TelemetryCommandEvents);
 
         // Hook: optional cleanup after packaging
         protected virtual Task PerformCleanupAfterPackingAsync(string packingRoot, string functionAppRoot, PackOptions options) => Task.CompletedTask;

--- a/src/Cli/func/Actions/LocalActions/PackAction/PowershellPackSubcommandAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/PowershellPackSubcommandAction.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Helpers;
 using Azure.Functions.Cli.Interfaces;
 using Fclp;
 
@@ -11,6 +12,11 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
     [Action(Name = "pack powershell", ParentCommandName = "pack", ShowInHelp = false, HelpText = "Arguments specific to PowerShell apps when running func pack")]
     internal class PowershellPackSubcommandAction : PackSubcommandAction
     {
+        public PowershellPackSubcommandAction()
+            : base(WorkerRuntime.Powershell)
+        {
+        }
+
         public override ICommandLineParserResult ParseArgs(string[] args)
         {
             return base.ParseArgs(args);

--- a/src/Cli/func/Actions/LocalActions/PackAction/PythonPackSubcommandAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/PythonPackSubcommandAction.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Helpers;
+
 using Azure.Functions.Cli.Common;
 using Colors.Net;
 using Fclp;
@@ -78,7 +80,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
         protected override Task PackFunctionAsync(string packingRoot, string outputPath, PackOptions options)
         {
             // Include BuildNativeDeps in packaging call
-            return PackHelpers.CreatePackage(packingRoot, outputPath, options.NoBuild, TelemetryCommandEvents, BuildNativeDeps);
+            return PackHelpers.CreatePackage(packingRoot, outputPath, options.NoBuild, WorkerRuntime.Python, TelemetryCommandEvents, BuildNativeDeps);
         }
 
         public override Task RunAsync()

--- a/src/Cli/func/Actions/LocalActions/PackAction/PythonPackSubcommandAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/PythonPackSubcommandAction.cs
@@ -1,9 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Azure.Functions.Cli.Helpers;
-
 using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Helpers;
 using Colors.Net;
 using Fclp;
 using Newtonsoft.Json.Linq;
@@ -14,6 +13,11 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
     [Action(Name = "pack python", ParentCommandName = "pack", ShowInHelp = true, HelpText = "Arguments specific to Python apps when running func pack")]
     internal class PythonPackSubcommandAction : PackSubcommandAction
     {
+        public PythonPackSubcommandAction()
+            : base(WorkerRuntime.Python)
+        {
+        }
+
         public bool BuildNativeDeps { get; set; }
 
         public override ICommandLineParserResult ParseArgs(string[] args)
@@ -80,7 +84,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
         protected override Task PackFunctionAsync(string packingRoot, string outputPath, PackOptions options)
         {
             // Include BuildNativeDeps in packaging call
-            return PackHelpers.CreatePackage(packingRoot, outputPath, options.NoBuild, WorkerRuntime.Python, TelemetryCommandEvents, BuildNativeDeps);
+            return PackHelpers.CreatePackage(packingRoot, outputPath, options.NoBuild, Runtime, TelemetryCommandEvents, BuildNativeDeps);
         }
 
         public override Task RunAsync()

--- a/src/Cli/func/Common/Constants.cs
+++ b/src/Cli/func/Common/Constants.cs
@@ -25,7 +25,7 @@ namespace Azure.Functions.Cli.Common
         // (Values). Never sent to the host or to Azure (the CLI strips local.settings on publish).
         // Intentionally Go-specific and short-lived: when the platform exposes a first-class
         // mapping for "native" → concrete language, this flag and its consumers should be removed.
-        public const string FunctionsCliGoPreview = "FUNCTIONS_CLI_GO_PREVIEW";
+        public const string FunctionsCliNativeLanguage = "FUNCTIONS_CLI_NATIVE_LANGUAGE";
         public const string RequirementsTxt = "requirements.txt";
         public const string PythonGettingStarted = "getting_started.md";
         public const string PySteinFunctionAppPy = "function_app.py";

--- a/src/Cli/func/Common/Constants.cs
+++ b/src/Cli/func/Common/Constants.cs
@@ -21,10 +21,10 @@ namespace Azure.Functions.Cli.Common
         public const string FunctionsWorkerRuntime = "FUNCTIONS_WORKER_RUNTIME";
         public const string FunctionsWorkerRuntimeVersion = "FUNCTIONS_WORKER_RUNTIME_VERSION";
 
-        // CLI-only preview opt-in for the Go worker. Read from env first, then local.settings.json
-        // (Values). Never sent to the host or to Azure (the CLI strips local.settings on publish).
-        // Intentionally Go-specific and short-lived: when the platform exposes a first-class
-        // mapping for "native" → concrete language, this flag and its consumers should be removed.
+        // CLI-only disambiguator for FUNCTIONS_WORKER_RUNTIME=native projects. Read from env
+        // first, then local.settings.json (Values). Never sent to the host or to Azure (the CLI
+        // strips local.settings on publish). Today only "go" is recognized; new native languages
+        // (rust, c++, etc.) extend this same value space rather than introducing parallel flags.
         public const string FunctionsCliNativeLanguage = "FUNCTIONS_CLI_NATIVE_LANGUAGE";
         public const string RequirementsTxt = "requirements.txt";
         public const string PythonGettingStarted = "getting_started.md";

--- a/src/Cli/func/Common/Executable.cs
+++ b/src/Cli/func/Common/Executable.cs
@@ -15,7 +15,7 @@ namespace Azure.Functions.Cli.Common
         // Cap the post-exit drain (see RunAsync) so a stuck async output handler can never
         // hold up the caller indefinitely. The drain only flushes already-buffered stdout/stderr
         // bytes, which normally completes in milliseconds; 5s is a defensive safety net.
-        private static readonly TimeSpan OutputDrainTimeout = TimeSpan.FromMilliseconds(5000);
+        private static readonly TimeSpan _outputDrainTimeout = TimeSpan.FromMilliseconds(5000);
 
         private readonly string _arguments;
         private readonly string _exeName;
@@ -170,7 +170,7 @@ namespace Azure.Functions.Cli.Common
         {
             try
             {
-                using var cts = new CancellationTokenSource(OutputDrainTimeout);
+                using var cts = new CancellationTokenSource(_outputDrainTimeout);
                 await Process.WaitForExitAsync(cts.Token).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
@@ -178,7 +178,7 @@ namespace Azure.Functions.Cli.Common
                 if (GlobalCoreToolsSettings.IsVerbose)
                 {
                     Colors.Net.ColoredConsole.WriteLine(VerboseColor(
-                        $"Output drain for '{_exeName}' did not complete within {OutputDrainTimeout.TotalMilliseconds}ms; returning exit code with possibly truncated output."));
+                        $"Output drain for '{_exeName}' did not complete within {_outputDrainTimeout.TotalMilliseconds}ms; returning exit code with possibly truncated output."));
                 }
             }
             catch (Exception ex) when (ex is InvalidOperationException || ex is System.ComponentModel.Win32Exception)

--- a/src/Cli/func/Common/Executable.cs
+++ b/src/Cli/func/Common/Executable.cs
@@ -15,7 +15,7 @@ namespace Azure.Functions.Cli.Common
         // Cap the post-exit drain (see RunAsync) so a stuck async output handler can never
         // hold up the caller indefinitely. The drain only flushes already-buffered stdout/stderr
         // bytes, which normally completes in milliseconds; 5s is a defensive safety net.
-        private const int OutputDrainTimeoutMs = 5000;
+        private static readonly TimeSpan OutputDrainTimeout = TimeSpan.FromMilliseconds(5000);
 
         private readonly string _arguments;
         private readonly string _exeName;
@@ -135,10 +135,10 @@ namespace Azure.Functions.Cli.Common
                         // Process exit and async output delivery are independent: the Exited event
                         // can fire before OutputDataReceived/ErrorDataReceived have drained the OS
                         // pipe buffers. For short-lived commands (e.g. `go version`) this leaves
-                        // callers reading an empty StringBuilder. WaitForExit(int) flushes the async
+                        // callers reading an empty StringBuilder. WaitForExitAsync drains the async
                         // event pump after the process has already exited, bounded so a hung handler
                         // can never block forever.
-                        DrainAsyncOutput();
+                        await DrainAsyncOutputAsync().ConfigureAwait(false);
                     }
 
                     return exitCode;
@@ -150,7 +150,7 @@ namespace Azure.Functions.Cli.Common
                     if (_streamOutput)
                     {
                         // See comment above: drain async output handlers before returning.
-                        DrainAsyncOutput();
+                        await DrainAsyncOutputAsync().ConfigureAwait(false);
                     }
 
                     return exitCode;
@@ -166,24 +166,20 @@ namespace Azure.Functions.Cli.Common
             }
         }
 
-        private void DrainAsyncOutput()
+        private async Task DrainAsyncOutputAsync()
         {
             try
             {
-                if (!Process.WaitForExit(OutputDrainTimeoutMs))
+                using var cts = new CancellationTokenSource(OutputDrainTimeout);
+                await Process.WaitForExitAsync(cts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                if (GlobalCoreToolsSettings.IsVerbose)
                 {
-                    if (GlobalCoreToolsSettings.IsVerbose)
-                    {
-                        Colors.Net.ColoredConsole.WriteLine(VerboseColor(
-                            $"Output drain for '{_exeName}' did not complete within {OutputDrainTimeoutMs}ms; returning exit code with possibly truncated output."));
-                    }
-
-                    return;
+                    Colors.Net.ColoredConsole.WriteLine(VerboseColor(
+                        $"Output drain for '{_exeName}' did not complete within {OutputDrainTimeout.TotalMilliseconds}ms; returning exit code with possibly truncated output."));
                 }
-
-                // Process exited within timeout; the no-arg overload flushes the async
-                // stdout/stderr event handlers that WaitForExit(int) does not drain.
-                Process.WaitForExit();
             }
             catch (Exception ex) when (ex is InvalidOperationException || ex is System.ComponentModel.Win32Exception)
             {

--- a/src/Cli/func/Common/Utilities.cs
+++ b/src/Cli/func/Common/Utilities.cs
@@ -72,7 +72,7 @@ namespace Azure.Functions.Cli
             }
 
             ColoredConsole
-                .WriteLine("The Go worker runtime is currently in preview. Features and behavior may change in future releases.".DarkYellow());
+                .WriteLine("Go support is in preview. The build/publish behavior and deployment layout may change before GA.".DarkYellow());
 
             ColoredConsole.WriteLine();
         }

--- a/src/Cli/func/Helpers/GlobalCoreToolsSettings.cs
+++ b/src/Cli/func/Helpers/GlobalCoreToolsSettings.cs
@@ -45,7 +45,7 @@ namespace Azure.Functions.Cli.Helpers
             {
                 if (_currentWorkerRuntime == WorkerRuntime.None)
                 {
-                    ColoredConsole.Error.WriteLine(QuietWarningColor("Can't determine project language from files. Please use one of [--dotnet-isolated, --dotnet, --javascript, --typescript, --python, --powershell, --custom, --go]"));
+                    ColoredConsole.Error.WriteLine(QuietWarningColor("Can't determine project language from files. Please use one of [--dotnet-isolated, --dotnet, --javascript, --typescript, --python, --powershell, --custom, --go (preview)]"));
                     throw new CliException($"Worker runtime cannot be '{WorkerRuntime.None}'. Please set a valid runtime.");
                 }
 

--- a/src/Cli/func/Helpers/PythonHelpers.cs
+++ b/src/Cli/func/Helpers/PythonHelpers.cs
@@ -330,15 +330,6 @@ namespace Azure.Functions.Cli.Helpers
 
             if (exitCode == 0)
             {
-                var trials = 0;
-
-                // this delay to make sure the output
-                while (string.IsNullOrWhiteSpace(sb.ToString()) && trials < 5)
-                {
-                    trials++;
-                    await Task.Delay(TimeSpan.FromMilliseconds(200));
-                }
-
                 return sb.ToString().Trim();
             }
             else

--- a/src/Cli/func/Helpers/WorkerRuntimeLanguageHelper.cs
+++ b/src/Cli/func/Helpers/WorkerRuntimeLanguageHelper.cs
@@ -26,7 +26,7 @@ namespace Azure.Functions.Cli.Helpers
         Powershell,
         [DisplayString("custom")]
         Custom,
-        [DisplayString("go")]
+        [DisplayString("go (preview)")]
         Go
     }
 
@@ -193,14 +193,14 @@ namespace Azure.Functions.Cli.Helpers
 
         public static WorkerRuntime GetCurrentWorkerRuntimeLanguage(ISecretsManager secretsManager, bool refreshSecrets = false)
         {
-            // Preview opt-in: FUNCTIONS_CLI_GO_PREVIEW lets a project declare itself as Go
+            // Preview opt-in: FUNCTIONS_CLI_NATIVE_LANGUAGE lets a project declare its native language
             // without forcing the resolver to scan the working directory for go.mod. Env var
             // wins; local.settings.json is the secondary source. See TryResolveGoPreviewFlag.
             if (TryResolveGoPreviewFlag(secretsManager, refreshSecrets))
             {
                 if (GlobalCoreToolsSettings.IsVerbose)
                 {
-                    ColoredConsole.WriteLine(VerboseColor($"Resolving worker runtime to 'go' ({Constants.FunctionsCliGoPreview} is set)."));
+                    ColoredConsole.WriteLine(VerboseColor($"Resolving worker runtime to 'go' ({Constants.FunctionsCliNativeLanguage} is set)."));
                 }
 
                 return WorkerRuntime.Go;
@@ -210,17 +210,11 @@ namespace Azure.Functions.Cli.Helpers
 
             if (string.IsNullOrWhiteSpace(setting))
             {
-                // SecretsManager.GetSecrets throws CliException when there is no project root
-                // (e.g. 'func pack' invoked from a parent directory before cwd is changed).
-                // Treat that as "no setting found" so callers can decide what to do.
-                try
-                {
-                    setting = secretsManager?.GetSecrets(refreshSecrets)?.FirstOrDefault(s => s.Key.Equals(Constants.FunctionsWorkerRuntime, StringComparison.OrdinalIgnoreCase)).Value;
-                }
-                catch (CliException)
-                {
-                    return WorkerRuntime.None;
-                }
+                // When FUNCTIONS_WORKER_RUNTIME isn't in the environment, check local.settings.json.
+                // If secrets cannot be loaded (e.g. 'func pack' invoked from a parent directory
+                // before cwd is changed), the GetSecrets exceptions will propagate to the caller.
+                // Callers that want a silent None on missing secrets should catch CliException.
+                setting = secretsManager?.GetSecrets(refreshSecrets)?.FirstOrDefault(s => s.Key.Equals(Constants.FunctionsWorkerRuntime, StringComparison.OrdinalIgnoreCase)).Value;
             }
 
             // The Functions host registers some workers under the literal "native" language
@@ -275,7 +269,7 @@ namespace Azure.Functions.Cli.Helpers
         /// </list>
         /// Add new native languages here as they are introduced. Invoked exclusively from
         /// <see cref="GetCurrentWorkerRuntimeLanguage"/> so callers never have to special-case
-        /// the "native" literal. Preferred path is the explicit <see cref="Constants.FunctionsCliGoPreview"/>
+        /// the "native" literal. Preferred path is the explicit <see cref="Constants.FunctionsCliNativeLanguage"/>
         /// opt-in checked earlier in the resolver; this fallback exists for projects that
         /// predate the flag.
         /// </remarks>
@@ -285,7 +279,7 @@ namespace Azure.Functions.Cli.Helpers
             {
                 if (GlobalCoreToolsSettings.IsVerbose)
                 {
-                    ColoredConsole.WriteLine(VerboseColor($"Resolving native worker runtime to 'go' ({GoHelpers.GoModFileName} found; consider setting {Constants.FunctionsCliGoPreview}=true in local.settings.json)."));
+                    ColoredConsole.WriteLine(VerboseColor($"Resolving native worker runtime to 'go' ({GoHelpers.GoModFileName} found; consider setting {Constants.FunctionsCliNativeLanguage}=go in local.settings.json)."));
                 }
 
                 return WorkerRuntime.Go;
@@ -293,17 +287,18 @@ namespace Azure.Functions.Cli.Helpers
 
             throw new CliException(
                 $"FUNCTIONS_WORKER_RUNTIME is set to 'native' but no supported project marker was found in '{Environment.CurrentDirectory}'. " +
-                $"Set '{Constants.FunctionsCliGoPreview}=true' in local.settings.json, or run 'func init' to initialize a supported function app in this directory.");
+                $"Set '{Constants.FunctionsCliNativeLanguage}=go' in local.settings.json, or run 'func init' to initialize a supported function app in this directory.");
         }
 
         /// <summary>
-        /// Returns <c>true</c> when the Go preview flag is set to a truthy value either in the
+        /// Returns <c>true</c> when FUNCTIONS_CLI_NATIVE_LANGUAGE is set to "go" either in the
         /// process environment or in <c>local.settings.json</c>. Env var wins; local.settings.json
         /// access failures (e.g. command run from outside a project root) are treated as "not set".
         /// </summary>
         private static bool TryResolveGoPreviewFlag(ISecretsManager secretsManager, bool refreshSecrets = false)
         {
-            if (EnvironmentHelper.GetEnvironmentVariableAsBool(Constants.FunctionsCliGoPreview))
+            var envValue = Environment.GetEnvironmentVariable(Constants.FunctionsCliNativeLanguage);
+            if (!string.IsNullOrEmpty(envValue) && envValue.Equals("go", StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
@@ -316,7 +311,7 @@ namespace Azure.Functions.Cli.Helpers
             string fromSettings;
             try
             {
-                fromSettings = secretsManager.GetSecrets(refreshSecrets)?.FirstOrDefault(s => s.Key.Equals(Constants.FunctionsCliGoPreview, StringComparison.OrdinalIgnoreCase)).Value;
+                fromSettings = secretsManager.GetSecrets(refreshSecrets)?.FirstOrDefault(s => s.Key.Equals(Constants.FunctionsCliNativeLanguage, StringComparison.OrdinalIgnoreCase)).Value;
             }
             catch (CliException)
             {
@@ -328,8 +323,7 @@ namespace Azure.Functions.Cli.Helpers
                 return false;
             }
 
-            return fromSettings.Equals("1", StringComparison.Ordinal)
-                || fromSettings.Equals("true", StringComparison.OrdinalIgnoreCase);
+            return fromSettings.Equals("go", StringComparison.OrdinalIgnoreCase);
         }
 
         public static string GetDefaultTemplateLanguageFromWorker(WorkerRuntime worker)

--- a/src/Cli/func/Helpers/WorkerRuntimeLanguageHelper.cs
+++ b/src/Cli/func/Helpers/WorkerRuntimeLanguageHelper.cs
@@ -193,10 +193,10 @@ namespace Azure.Functions.Cli.Helpers
 
         public static WorkerRuntime GetCurrentWorkerRuntimeLanguage(ISecretsManager secretsManager, bool refreshSecrets = false)
         {
-            // Preview opt-in: FUNCTIONS_CLI_NATIVE_LANGUAGE lets a project declare its native language
-            // without forcing the resolver to scan the working directory for go.mod. Env var
-            // wins; local.settings.json is the secondary source. See TryResolveGoPreviewFlag.
-            if (TryResolveGoPreviewFlag(secretsManager, refreshSecrets))
+            // FUNCTIONS_CLI_NATIVE_LANGUAGE lets a project declare its native language without
+            // forcing the resolver to scan the working directory for go.mod. Env var wins;
+            // local.settings.json is the secondary source. See TryResolveNativeLanguageAsGo.
+            if (TryResolveNativeLanguageAsGo(secretsManager, refreshSecrets))
             {
                 if (GlobalCoreToolsSettings.IsVerbose)
                 {
@@ -295,7 +295,7 @@ namespace Azure.Functions.Cli.Helpers
         /// process environment or in <c>local.settings.json</c>. Env var wins; local.settings.json
         /// access failures (e.g. command run from outside a project root) are treated as "not set".
         /// </summary>
-        private static bool TryResolveGoPreviewFlag(ISecretsManager secretsManager, bool refreshSecrets = false)
+        private static bool TryResolveNativeLanguageAsGo(ISecretsManager secretsManager, bool refreshSecrets = false)
         {
             var envValue = Environment.GetEnvironmentVariable(Constants.FunctionsCliNativeLanguage);
             if (!string.IsNullOrEmpty(envValue) && envValue.Equals("go", StringComparison.OrdinalIgnoreCase))

--- a/src/Cli/func/Helpers/ZipHelper.cs
+++ b/src/Cli/func/Helpers/ZipHelper.cs
@@ -10,7 +10,7 @@ namespace Azure.Functions.Cli.Helpers
 {
     public static class ZipHelper
     {
-        public static async Task<Stream> GetAppZipFile(string functionAppRoot, bool buildNativeDeps, BuildOption buildOption, bool noBuild, GitIgnoreParser ignoreParser = null, string additionalPackages = null)
+        public static async Task<Stream> GetAppZipFile(string functionAppRoot, bool buildNativeDeps, BuildOption buildOption, bool noBuild, WorkerRuntime workerRuntime, GitIgnoreParser ignoreParser = null, string additionalPackages = null)
         {
             var gitIgnorePath = Path.Combine(functionAppRoot, Constants.FuncIgnoreFile);
             if (ignoreParser == null && FileSystemHelpers.FileExists(gitIgnorePath))
@@ -31,16 +31,16 @@ namespace Azure.Functions.Cli.Helpers
                 ColoredConsole.WriteLine(DarkYellow("Performing local build for functions project."));
             }
 
-            if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.Python && !noBuild)
+            if (workerRuntime == WorkerRuntime.Python && !noBuild)
             {
                 return await PythonHelpers.GetPythonDeploymentPackage(FileSystemHelpers.GetLocalFiles(functionAppRoot, ignoreParser), functionAppRoot, buildNativeDeps, buildOption, additionalPackages);
             }
-            else if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.Dotnet && buildOption == BuildOption.Remote)
+            else if (workerRuntime == WorkerRuntime.Dotnet && buildOption == BuildOption.Remote)
             {
                 // Remote build for dotnet does not require bin and obj folders. They will be generated during the oryx build
                 return await CreateZip(FileSystemHelpers.GetLocalFiles(functionAppRoot, ignoreParser, false, new string[] { "bin", "obj" }), functionAppRoot, Array.Empty<string>());
             }
-            else if (GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.Go)
+            else if (workerRuntime == WorkerRuntime.Go)
             {
                 // Go deploys an explicit allowlist: host.json + the cross-compiled binary.
                 // The binary lives under bin/ locally (for .gitignore) but must appear at

--- a/test/Cli/Func.E2ETests/Commands/FuncInit/GoInitTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncInit/GoInitTests.cs
@@ -21,7 +21,7 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncInit
             var testName = nameof(Init_WithGo_GeneratesExpectedFunctionProjectFiles);
             var funcInitCommand = new FuncInitCommand(FuncPath, testName, Log ?? throw new ArgumentNullException(nameof(Log)));
             var localSettingsPath = Path.Combine(workingDir, Common.Constants.LocalSettingsJsonFileName);
-            var expectedLocalSettingsContent = new[] { Common.Constants.FunctionsWorkerRuntime, "native", Common.Constants.FunctionsCliGoPreview, "true" };
+            var expectedLocalSettingsContent = new[] { Common.Constants.FunctionsWorkerRuntime, "native", Common.Constants.FunctionsCliNativeLanguage, "go" };
             var hostJsonPath = Path.Combine(workingDir, "host.json");
             var expectedHostJsonContent = new[] { "extensionBundle" };
             var mainGoPath = Path.Combine(workingDir, "main.go");

--- a/test/Cli/Func.UnitTests/ActionsTests/InitActionGoTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/InitActionGoTests.cs
@@ -192,10 +192,9 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
         }
 
         [Theory]
-        [InlineData("true")]
-        [InlineData("True")]
-        [InlineData("TRUE")]
-        [InlineData("1")]
+        [InlineData("go")]
+        [InlineData("Go")]
+        [InlineData("GO")]
         public void GetCurrentWorkerRuntimeLanguage_GoPreviewEnvVar_ResolvesToGo(string envValue)
         {
             // Env var takes precedence over local.settings.json and the go.mod fallback.
@@ -204,11 +203,11 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
             var secretsManager = Substitute.For<ISecretsManager>();
             secretsManager.GetSecrets(Arg.Any<bool>()).Returns(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
 
-            var previousFlag = Environment.GetEnvironmentVariable(Constants.FunctionsCliGoPreview);
+            var previousFlag = Environment.GetEnvironmentVariable(Constants.FunctionsCliNativeLanguage);
             var previousRuntime = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime);
             try
             {
-                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, envValue);
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliNativeLanguage, envValue);
                 Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, null);
 
                 var resolved = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(secretsManager);
@@ -217,30 +216,30 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
             }
             finally
             {
-                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, previousFlag);
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliNativeLanguage, previousFlag);
                 Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, previousRuntime);
             }
         }
 
         [Theory]
-        [InlineData("true")]
-        [InlineData("True")]
-        [InlineData("1")]
+        [InlineData("go")]
+        [InlineData("Go")]
+        [InlineData("GO")]
         public void GetCurrentWorkerRuntimeLanguage_GoPreviewSetting_ResolvesToGo(string settingValue)
         {
             // local.settings.json wins when the env var isn't set, without any go.mod scan.
             var secretsManager = Substitute.For<ISecretsManager>();
             secretsManager.GetSecrets(Arg.Any<bool>()).Returns(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
-                { Constants.FunctionsCliGoPreview, settingValue },
+                { Constants.FunctionsCliNativeLanguage, settingValue },
                 { Constants.FunctionsWorkerRuntime, "native" },
             });
 
-            var previousFlag = Environment.GetEnvironmentVariable(Constants.FunctionsCliGoPreview);
+            var previousFlag = Environment.GetEnvironmentVariable(Constants.FunctionsCliNativeLanguage);
             var previousRuntime = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime);
             try
             {
-                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, null);
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliNativeLanguage, null);
                 Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, null);
 
                 var resolved = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(secretsManager);
@@ -249,34 +248,33 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
             }
             finally
             {
-                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, previousFlag);
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliNativeLanguage, previousFlag);
                 Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, previousRuntime);
             }
         }
 
         [Theory]
-        [InlineData("false")]
-        [InlineData("0")]
-        [InlineData("yes")]
+        [InlineData("python")]
+        [InlineData("rust")]
         [InlineData("")]
         public void GetCurrentWorkerRuntimeLanguage_GoPreviewFalsy_FallsThroughToLegacyResolution(string flagValue)
         {
-            // Falsy flag values must not short-circuit; the legacy native+go.mod path should still run.
+            // Non-"go" flag values must not short-circuit; the legacy native+go.mod path should still run.
             var secretsManager = Substitute.For<ISecretsManager>();
             secretsManager.GetSecrets(Arg.Any<bool>()).Returns(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
-                { Constants.FunctionsCliGoPreview, flagValue },
+                { Constants.FunctionsCliNativeLanguage, flagValue },
                 { Constants.FunctionsWorkerRuntime, "native" },
             });
 
             var fileSystem = Substitute.For<IFileSystem>();
             fileSystem.File.Exists(Arg.Is<string>(p => p.EndsWith("go.mod"))).Returns(true);
 
-            var previousFlag = Environment.GetEnvironmentVariable(Constants.FunctionsCliGoPreview);
+            var previousFlag = Environment.GetEnvironmentVariable(Constants.FunctionsCliNativeLanguage);
             var previousRuntime = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime);
             try
             {
-                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, null);
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliNativeLanguage, null);
                 Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, null);
 
                 using (FileSystemHelpers.Override(fileSystem))
@@ -288,7 +286,7 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
             }
             finally
             {
-                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, previousFlag);
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliNativeLanguage, previousFlag);
                 Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, previousRuntime);
             }
         }
@@ -301,11 +299,11 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
             var secretsManager = Substitute.For<ISecretsManager>();
             secretsManager.GetSecrets(Arg.Any<bool>()).Returns(_ => throw new CliException("no project"));
 
-            var previousFlag = Environment.GetEnvironmentVariable(Constants.FunctionsCliGoPreview);
+            var previousFlag = Environment.GetEnvironmentVariable(Constants.FunctionsCliNativeLanguage);
             var previousRuntime = Environment.GetEnvironmentVariable(Constants.FunctionsWorkerRuntime);
             try
             {
-                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, "true");
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliNativeLanguage, "go");
                 Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, null);
 
                 var resolved = WorkerRuntimeLanguageHelper.GetCurrentWorkerRuntimeLanguage(secretsManager);
@@ -314,7 +312,7 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
             }
             finally
             {
-                Environment.SetEnvironmentVariable(Constants.FunctionsCliGoPreview, previousFlag);
+                Environment.SetEnvironmentVariable(Constants.FunctionsCliNativeLanguage, previousFlag);
                 Environment.SetEnvironmentVariable(Constants.FunctionsWorkerRuntime, previousRuntime);
             }
         }

--- a/test/Cli/Func.UnitTests/HelperTests/WorkerRuntimeLanguageHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/WorkerRuntimeLanguageHelperTests.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Helpers;
+using Xunit;
+
+namespace Azure.Functions.Cli.UnitTests.HelperTests
+{
+    public class WorkerRuntimeLanguageHelperTests
+    {
+        [Fact]
+        public void NormalizeLanguage_Golang_ThrowsArgumentException()
+        {
+            // "golang" is not a valid language string; only "go" is accepted.
+            // This test ensures the resolver doesn't silently accept "golang"
+            // and map it to the wrong runtime.
+            Assert.Throws<ArgumentException>(() =>
+                WorkerRuntimeLanguageHelper.NormalizeLanguage("golang"));
+        }
+    }
+}

--- a/test/Cli/Func.UnitTests/HelperTests/ZipHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/ZipHelperTests.cs
@@ -236,7 +236,6 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
             Directory.CreateDirectory(dir);
             Directory.CreateDirectory(Path.Combine(dir, GoHelpers.GoBinDir));
 
-            var previousRuntime = GlobalCoreToolsSettings.CurrentWorkerRuntimeOrNone;
             try
             {
                 File.WriteAllText(Path.Combine(dir, "host.json"), "{}");
@@ -246,8 +245,6 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
                 File.WriteAllText(Path.Combine(dir, "main.go"), "package main\nfunc main() {}\n");
                 File.WriteAllText(Path.Combine(dir, "go.mod"), "module example.com/test\n");
                 File.WriteAllText(Path.Combine(dir, "local.settings.json"), "{}");
-
-                GlobalCoreToolsSettings.CurrentWorkerRuntime = WorkerRuntime.Go;
 
                 var stream = await ZipHelper.GetAppZipFile(dir, buildNativeDeps: false, BuildOption.Default, noBuild: false, WorkerRuntime.Go);
 
@@ -264,7 +261,6 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
             }
             finally
             {
-                GlobalCoreToolsSettings.CurrentWorkerRuntime = previousRuntime;
                 Directory.Delete(dir, recursive: true);
             }
         }

--- a/test/Cli/Func.UnitTests/HelperTests/ZipHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/ZipHelperTests.cs
@@ -249,7 +249,7 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
 
                 GlobalCoreToolsSettings.CurrentWorkerRuntime = WorkerRuntime.Go;
 
-                var stream = await ZipHelper.GetAppZipFile(dir, buildNativeDeps: false, BuildOption.Default, noBuild: false);
+                var stream = await ZipHelper.GetAppZipFile(dir, buildNativeDeps: false, BuildOption.Default, noBuild: false, WorkerRuntime.Go);
 
                 Assert.NotNull(stream);
                 using var archive = new ZipArchive(stream, ZipArchiveMode.Read);


### PR DESCRIPTION
### Summary of Changes
 
 #### 1. Environment Variable Rename
 - **Before:** `FUNCTIONS_CLI_GO_PREVIEW` with boolean values (`"true"`, `"1"`, etc.)
 - **After:** `FUNCTIONS_CLI_NATIVE_LANGUAGE` with language identifier (`"go"`)
 - **Rationale:** Better extensibility for future native languages beyond Go
 
 #### 2. Preview Signposting
 - Added `"(preview)"` to `WorkerRuntime.Go` DisplayString attribute
 - Added `"(preview)"` to error messages in GlobalCoreToolsSettings
 - Added `[Preview Feature]` prefix to release notes
 - Added preview warnings to `func start`, `func pack`, and `func publish` commands
 
 #### 3. Async Output Drain Fix
 - Changed `DrainAsyncOutput()` → `DrainAsyncOutputAsync()`
 - Replaced `WaitForExit(5000)` + `WaitForExit()` with `WaitForExitAsync(CancellationToken)`
 - **Fix:** Properly bounds the drain timeout (5s) instead of having unbounded wait
 - **Impact:** Applies to all streamOutput callers (npm, dotnet, python, az, git, etc.)
 
 #### 4. Python Retry Workaround Removal
 - Removed retry loop in `PythonHelpers.VerifyVersion`
 - **Rationale:** Now obsolete with proper async drain in place
 
 #### 5. Runtime Resolution Optimization
 - Only re-resolve runtime when `GlobalCoreToolsSettings.CurrentWorkerRuntime == WorkerRuntime.None`
 - **Before:** Re-resolved on every publish/start for all languages
 - **After:** Single read during Init for Python/.NET/Node/PowerShell; re-resolve only for Go without prior init
 - Applied to both `PublishFunctionAppAction` and `StartHostAction`
 
 #### 6. Parameter Threading
 - Added `WorkerRuntime` parameter to `ZipHelper.GetAppZipFile()`
 - Added `WorkerRuntime` parameter to `PackHelpers.CreatePackage()`
 - Updated all call sites to explicitly pass runtime
 - **Rationale:** Eliminates implicit dependency on global settings
 
 #### 7. Test Coverage
 - Added `WorkerRuntimeLanguageHelperTests.cs` with test for `NormalizeLanguage("golang")` throwing `ArgumentException`
 
 #### 8. Exception Handling
 - Removed `catch (CliException)` in `GetCurrentWorkerRuntimeLanguage`
 - **Rationale:** Allows actionable errors ("no project root", "failed to decrypt") to surface to users
 
 #### 9. Test Updates
 - Updated all Go-related tests to use new environment variable name and value scheme
 - Changed test values from boolean (`"true"`, `"1"`) to language identifier (`"go"`, `"Go"`, `"GO"`)
 
 ### Files Changed
 - 17 modified files
 - 1 new test file
 - 0 breaking changes (environment variable is internal CLI-only, never sent to host or Azure)
 
 ### Testing
 - ✅ Full release build passes
 - ✅ All existing tests updated
 - ✅ New test coverage added
 - ✅ Warnings appear correctly in start/pack/publish commands
 
 ### Review Comments Addressed
 All 13 inline comments from @lilyjma have been implemented as suggested