### PR TITLE
workload install: require alias resolution by default

### DIFF
--- a/src/Func/Commands/Workload/WorkloadInstallCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadInstallCommand.cs
@@ -27,7 +27,7 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
 
     public Argument<string> WorkloadArgument { get; } = new("id")
     {
-        Description = "Workload package id, alias, or path to a local .nupkg.",
+        Description = "Workload alias (default) or path to a local .nupkg. Pass --exact to install by literal package id.",
     };
 
     public Option<string?> VersionOption { get; } = new("--version", "-v")
@@ -52,7 +52,7 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
 
     public Option<bool> ExactOption { get; } = new("--exact", "-e")
     {
-        Description = "Disable alias matching. <id> must be the literal package id.",
+        Description = "Treat <id> as a literal package id. Without this flag, <id> is resolved as an alias only.",
     };
 
     public WorkloadInstallCommand(

--- a/src/Func/Workloads/Install/WorkloadInstaller.cs
+++ b/src/Func/Workloads/Install/WorkloadInstaller.cs
@@ -167,7 +167,7 @@ internal sealed class WorkloadInstaller(
 
         string resolvedId = exact
             ? packageId
-            : await ResolveAliasOrIdAsync(packageId, source, includePrerelease, cancellationToken);
+            : await ResolveAliasAsync(packageId, source, includePrerelease, cancellationToken);
 
         ResolvedPackage resolved = await ResolveCatalogPackageAsync(
             resolvedId, version, source, includePrerelease, cancellationToken);
@@ -285,29 +285,30 @@ internal sealed class WorkloadInstaller(
         return true;
     }
 
-    private async Task<string> ResolveAliasOrIdAsync(
-        string aliasOrId,
+    private async Task<string> ResolveAliasAsync(
+        string alias,
         string? source,
         bool includePrerelease,
         CancellationToken cancellationToken)
     {
-        // Spec §6.1 step 2 (default flow): query the catalog for packages
-        // declaring `alias:<aliasOrId>` and pick the unique match. Zero
-        // matches falls back to treating the input as a literal package id.
-        // Multiple distinct package ids is an error; the user must re-run
-        // with --exact <packageId>.
+        // Default flow: query the catalog for packages declaring
+        // `alias:<alias>` and pick the unique match. We never fall back to
+        // treating the input as a literal package id: an attacker who
+        // publishes `node` to a configured source must not be able to
+        // satisfy `func workload install node`. Users who genuinely want to
+        // install by package id must opt in with `--exact <packageId>`.
         const int aliasSearchTake = 50;
 
         var query = new CatalogSearchQuery
         {
-            Filter = aliasOrId,
+            Filter = alias,
             IncludePrerelease = includePrerelease,
             Take = aliasSearchTake,
             Source = source,
         };
 
         IReadOnlyList<CatalogSearchResult> hits = await _catalog.SearchAsync(query, cancellationToken);
-        IReadOnlyList<string> matchedIds = FilterByAlias(hits, aliasOrId);
+        IReadOnlyList<string> matchedIds = FilterByAlias(hits, alias);
 
         // Some feeds (BaGet, older NuGet implementations) tokenize the `q=`
         // term in ways that drop hyphenated aliases like `node-worker`. When
@@ -319,15 +320,22 @@ internal sealed class WorkloadInstaller(
             IReadOnlyList<CatalogSearchResult> all = await _catalog.SearchAsync(
                 query with { Filter = null },
                 cancellationToken);
-            matchedIds = FilterByAlias(all, aliasOrId);
+            matchedIds = FilterByAlias(all, alias);
         }
 
         if (matchedIds.Count > 1)
         {
-            throw new AmbiguousPackageMatchException(aliasOrId, matchedIds);
+            throw new AmbiguousPackageMatchException(alias, matchedIds);
         }
 
-        return matchedIds.Count == 1 ? matchedIds[0] : aliasOrId;
+        if (matchedIds.Count == 0)
+        {
+            throw new Catalog.WorkloadPackageNotFoundException(
+                $"No workload with alias '{alias}' was found in the catalog. " +
+                $"To install by package id instead, pass --exact <packageId>.");
+        }
+
+        return matchedIds[0];
     }
 
     private static IReadOnlyList<string> FilterByAlias(IReadOnlyList<CatalogSearchResult> hits, string alias) =>

--- a/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
+++ b/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
@@ -492,6 +492,39 @@ public sealed class WorkloadInstallerTests : IDisposable
     }
 
     [Fact]
+    public async Task InstallFromCatalog_AliasResolution_NoMatch_Throws()
+    {
+        // Without --exact the input is an alias only. If neither the
+        // targeted nor the broad search returns a package declaring the
+        // alias, the installer must not silently treat the input as a
+        // literal package id (security: an attacker who publishes `node`
+        // to a configured source could otherwise satisfy
+        // `func workload install node`). The user has to opt in with
+        // --exact <packageId>.
+        _catalog.SearchAsync(
+                Arg.Is<CatalogSearchQuery>(q => q.Filter == "ghost"),
+                Arg.Any<CancellationToken>())
+            .Returns([]);
+        _catalog.SearchAsync(
+                Arg.Is<CatalogSearchQuery>(q => q.Filter == null),
+                Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        WorkloadInstaller installer = NewInstaller();
+        WorkloadPackageNotFoundException ex = await Assert.ThrowsAsync<WorkloadPackageNotFoundException>(
+            () => installer.InstallFromCatalogAsync(
+                "ghost", version: null, source: null,
+                includePrerelease: false, exact: false, force: false));
+
+        Assert.Contains("ghost", ex.Message);
+        Assert.Contains("--exact", ex.Message);
+        await _catalog.DidNotReceive().ResolveLatestVersionAsync(
+            Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<NuGetVersion?>(),
+            Arg.Any<bool>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+        await _catalog.DidNotReceive().DownloadAsync(Arg.Any<ResolvedPackage>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task InstallFromCatalog_AliasResolution_FallsBackToBroadSearchWhenTargetedReturnsZero()
     {
         // BaGet and older NuGet feeds tokenize the `q=` term in ways that drop


### PR DESCRIPTION
## What

Without `--exact`, `func workload install <name>` now treats the positional argument as an alias **only**. If no package in the catalog declares the alias, the command fails with a hint to pass `--exact <packageId>` instead of silently installing a package whose id happens to match the input string.

## Why

Previously `ResolveAliasOrIdAsync` returned the raw input when no alias matched, so `InstallFromCatalogAsync` would then look it up as a literal package id. That's a squatting hole: an attacker who publishes a package literally named `node` to a configured source could satisfy `func workload install node`.

After this PR the install path always operates on a package id that was either:
- explicitly opted into by the user via `--exact <packageId>`, or
- resolved from an alias declared by a package the catalog returned.

## Notes

- `func workload uninstall` already operates on `WorkloadEntry.PackageId` from the local registry (the alias is only used to find the entry), so no logic change there.
- Local `.nupkg` installs are unaffected.
- This is PR 1. PR 2 will add publisher / signing / cert-bundle validation on top.

## Tests

- New `InstallFromCatalog_AliasResolution_NoMatch_Throws` covers the strict-failure path.
- Existing alias-fallback and `--exact` tests still pass.
- Full `Func.Tests` suite: 596 / 596 pass, clean release build with `TreatWarningsAsErrors=true`.