### PR TITLE
Persist nuspec metadata on workload install so `workload list` shows display name and description

### DIFF
--- a/src/Func/Workloads/Install/WorkloadInstaller.cs
+++ b/src/Func/Workloads/Install/WorkloadInstaller.cs
@@ -65,6 +65,8 @@ internal sealed class WorkloadInstaller(
         string packageId = nuspec.GetId().ToLowerInvariant();
         string version = nuspec.GetVersion().ToNormalizedString();
         IReadOnlyList<string> aliases = ParseAliases(nuspec.GetTags());
+        string nuspecTitle = nuspec.GetTitle();
+        string nuspecDescription = nuspec.GetDescription();
 
         if (!nuspec.GetPackageTypes().Any(t => string.Equals(t.Name, FuncCliWorkloadPackageType, StringComparison.OrdinalIgnoreCase)))
         {
@@ -125,8 +127,8 @@ internal sealed class WorkloadInstaller(
                 PackageId = packageId,
                 PackageVersion = version,
                 Aliases = aliases,
-                DisplayName = GetDisplayName(metadata, packageId),
-                Description = metadata.Description ?? string.Empty,
+                DisplayName = GetDisplayName(metadata, nuspecTitle, packageId),
+                Description = GetDescription(metadata, nuspecDescription),
                 EntryPoint = metadata.EntryPoint,
                 Kind = metadata.Kind,
                 Source = Path.GetFullPath(nupkgPath),
@@ -424,6 +426,8 @@ internal sealed class WorkloadInstaller(
             string newPackageId = nuspec.GetId().ToLowerInvariant();
             string newVersion = nuspec.GetVersion().ToNormalizedString();
             IReadOnlyList<string> aliases = ParseAliases(nuspec.GetTags());
+            string nuspecTitle = nuspec.GetTitle();
+            string nuspecDescription = nuspec.GetDescription();
 
             if (!nuspec.GetPackageTypes().Any(t => string.Equals(t.Name, FuncCliWorkloadPackageType, StringComparison.OrdinalIgnoreCase)))
             {
@@ -458,8 +462,8 @@ internal sealed class WorkloadInstaller(
                 PackageId = newPackageId,
                 PackageVersion = newVersion,
                 Aliases = aliases,
-                DisplayName = GetDisplayName(metadata, newPackageId),
-                Description = metadata.Description ?? string.Empty,
+                DisplayName = GetDisplayName(metadata, nuspecTitle, newPackageId),
+                Description = GetDescription(metadata, nuspecDescription),
                 EntryPoint = metadata.EntryPoint,
                 Kind = metadata.Kind,
                 Source = resolved.Source.Source,
@@ -618,6 +622,27 @@ internal sealed class WorkloadInstaller(
         }
     }
 
-    private static string GetDisplayName(WorkloadMetadata metadata, string packageId)
-        => string.IsNullOrWhiteSpace(metadata.DisplayName) ? packageId : metadata.DisplayName;
+    // Display name priority: workload.json (forward-compat), then nuspec
+    // <title>, then the package id so the column is never blank.
+    private static string GetDisplayName(WorkloadMetadata metadata, string? nuspecTitle, string packageId)
+    {
+        if (!string.IsNullOrWhiteSpace(metadata.DisplayName))
+        {
+            return metadata.DisplayName;
+        }
+
+        return string.IsNullOrWhiteSpace(nuspecTitle) ? packageId : nuspecTitle!;
+    }
+
+    // Description priority: workload.json (forward-compat), then the nuspec
+    // <description> NuGet already requires. Empty string when neither is set.
+    private static string GetDescription(WorkloadMetadata metadata, string? nuspecDescription)
+    {
+        if (!string.IsNullOrWhiteSpace(metadata.Description))
+        {
+            return metadata.Description;
+        }
+
+        return string.IsNullOrWhiteSpace(nuspecDescription) ? string.Empty : nuspecDescription!;
+    }
 }

--- a/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
+++ b/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
@@ -65,7 +65,7 @@ public sealed class WorkloadInstallerTests : IDisposable
                 e.PackageVersion == "1.0.0" &&
                 e.EntryPoint!.AssemblyPath == "Test.dll" &&
                 e.DisplayName == "test.workload" &&
-                e.Description == string.Empty &&
+                e.Description == "For tests." &&
                 e.Source == Path.GetFullPath(nupkg) &&
                 e.InstallRefCount == 1 &&
                 e.Aliases.SequenceEqual(new[] { "test", "stub" })),
@@ -280,14 +280,14 @@ public sealed class WorkloadInstallerTests : IDisposable
         Assert.Equal(WorkloadKind.Content, result.Entry.Kind);
         Assert.Null(result.Entry.EntryPoint);
         Assert.Equal("test.workload", result.Entry.DisplayName);
-        Assert.Equal(string.Empty, result.Entry.Description);
+        Assert.Equal("For tests.", result.Entry.Description);
 
         await _store.Received(1).SaveWorkloadAsync(
             Arg.Is<WorkloadEntry>(e =>
                 e.Kind == WorkloadKind.Content &&
                 e.EntryPoint == null &&
                 e.DisplayName == "test.workload" &&
-                e.Description == string.Empty),
+                e.Description == "For tests."),
             Arg.Any<CancellationToken>());
     }
 
@@ -581,6 +581,44 @@ public sealed class WorkloadInstallerTests : IDisposable
         Assert.Contains("test.workload", reports[1].Description);
     }
 
+    [Fact]
+    public async Task InstallFromPackage_PersistsNuspecTitleAndDescriptionWhenMetadataIsBlank()
+    {
+        string nupkg = BuildNupkg(title: "Functions Host", description: "Azure Functions host workload.");
+
+        WorkloadInstaller installer = NewInstaller();
+        WorkloadInstallResult result = await installer.InstallFromPackageAsync(nupkg);
+
+        Assert.Equal("Functions Host", result.Entry.DisplayName);
+        Assert.Equal("Azure Functions host workload.", result.Entry.Description);
+
+        await _store.Received(1).SaveWorkloadAsync(
+            Arg.Is<WorkloadEntry>(e =>
+                e.DisplayName == "Functions Host" &&
+                e.Description == "Azure Functions host workload."),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InstallFromPackage_WorkloadJsonMetadataWinsOverNuspec()
+    {
+        string nupkg = BuildNupkg(title: "Nuspec Title", description: "Nuspec description.");
+        _metadataReader.Read(Arg.Any<string>())
+            .Returns(new WorkloadMetadata
+            {
+                Schema = "https://example/workload.schema.json",
+                EntryPoint = new EntryPointSpec { AssemblyPath = "Test.dll", Type = "Test.Type" },
+                DisplayName = "Manifest Name",
+                Description = "Manifest description.",
+            });
+
+        WorkloadInstaller installer = NewInstaller();
+        WorkloadInstallResult result = await installer.InstallFromPackageAsync(nupkg);
+
+        Assert.Equal("Manifest Name", result.Entry.DisplayName);
+        Assert.Equal("Manifest description.", result.Entry.Description);
+    }
+
     private sealed class RecordingProgress(List<WorkloadInstallProgress> sink) : IProgress<WorkloadInstallProgress>
     {
         public void Report(WorkloadInstallProgress value) => sink.Add(value);
@@ -607,6 +645,8 @@ public sealed class WorkloadInstallerTests : IDisposable
         string? tags = null,
         bool includeFuncCliWorkloadType = true,
         string version = "1.0.0",
+        string? title = null,
+        string description = "For tests.",
         IEnumerable<(string SourcePath, string TargetPath)>? extraFiles = null)
     {
         string stubAssembly = Path.Combine(_root, $"stub-{Guid.NewGuid():N}.dll");
@@ -616,9 +656,13 @@ public sealed class WorkloadInstallerTests : IDisposable
         {
             Id = "Test.Workload",
             Version = NuGetVersion.Parse(version),
-            Description = "For tests.",
+            Description = description,
         };
         builder.Authors.Add("test");
+        if (title is not null)
+        {
+            builder.Title = title;
+        }
         if (tags is not null)
         {
             foreach (string tag in tags.Split(' ', StringSplitOptions.RemoveEmptyEntries))


### PR DESCRIPTION
## Bug

After `func workload install <id>`, `func workload list` showed the package id under Display Name and `-` under Description, while `func workload search` rendered the nuspec `<title>` and `<description>` correctly.

The installer only read `DisplayName` / `Description` from the package's `workload.json`, which workloads (e.g. Host, Node, DotNet) don't populate. The persisted `WorkloadEntry` ended up with an empty display name (falling back to the package id) and an empty description.

## Fix

`WorkloadInstaller` now reads `NuspecReader.GetTitle()` and `NuspecReader.GetDescription()` from the `.nuspec` and uses them as fallbacks when `workload.json` doesn't supply `DisplayName` / `Description`. Applied on both code paths that build a `WorkloadEntry`:

- `InstallFromPackageAsync` (initial install)
- catalog update path that swaps the entry

Priority: `workload.json` value (forward-compat), then nuspec value, then package id (display name only). The registry now stores the same strings the search command surfaces, so list mirrors search.

## Tests

- New `InstallFromPackage_PersistsNuspecTitleAndDescriptionWhenMetadataIsBlank` confirms nuspec values are persisted.
- New `InstallFromPackage_WorkloadJsonMetadataWinsOverNuspec` confirms manifest values take precedence.
- Updated existing assertions in `InstallFromPackage_HappyPath_ExtractsAndPersists` and `InstallFromPackage_ContentOnly_PersistsContentKind` to match the new behavior (test nupkgs already had a description set).
- All 597 `Func.Tests` pass.
- `CI=true dotnet build -c Release` is clean (0 warnings).

## Repro

```bash
func workload install host --source http://localhost:5555/v3/index.json --prerelease
func workload list   # before: package id, "-"   /   after: nuspec Title and Description
func workload search --prerelease
```
