### PR TITLE
Lowercase and centralize .func/config.json schema keys

### DIFF
--- a/src/Func/Commands/InitCommand.cs
+++ b/src/Func/Commands/InitCommand.cs
@@ -272,11 +272,11 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
             var stackConfig = new Dictionary<string, string>(StringComparer.Ordinal);
             if (!string.IsNullOrWhiteSpace(stack))
             {
-                stackConfig[nameof(StackOptions.Runtime)] = stack;
+                stackConfig[StackOptions.RuntimeKey] = stack;
             }
             if (!string.IsNullOrWhiteSpace(language))
             {
-                stackConfig[nameof(StackOptions.Language)] = language;
+                stackConfig[StackOptions.LanguageKey] = language;
             }
 
             var payload = new Dictionary<string, object>(StringComparer.Ordinal);

--- a/src/Func/Commands/InitCommand.cs
+++ b/src/Func/Commands/InitCommand.cs
@@ -272,11 +272,11 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
             var stackConfig = new Dictionary<string, string>(StringComparer.Ordinal);
             if (!string.IsNullOrWhiteSpace(stack))
             {
-                stackConfig[StackOptions.RuntimeKey] = stack;
+                stackConfig["runtime"] = stack;
             }
             if (!string.IsNullOrWhiteSpace(language))
             {
-                stackConfig[StackOptions.LanguageKey] = language;
+                stackConfig["language"] = language;
             }
 
             var payload = new Dictionary<string, object>(StringComparer.Ordinal);

--- a/src/Func/Commands/InitCommand.cs
+++ b/src/Func/Commands/InitCommand.cs
@@ -272,17 +272,17 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
             var stackConfig = new Dictionary<string, string>(StringComparer.Ordinal);
             if (!string.IsNullOrWhiteSpace(stack))
             {
-                stackConfig["runtime"] = stack;
+                stackConfig[CliConfigurationNames.StackRuntimeKey] = stack;
             }
             if (!string.IsNullOrWhiteSpace(language))
             {
-                stackConfig["language"] = language;
+                stackConfig[CliConfigurationNames.StackLanguageKey] = language;
             }
 
             var payload = new Dictionary<string, object>(StringComparer.Ordinal);
             if (stackConfig.Count > 0)
             {
-                payload[StackOptions.SectionName] = stackConfig;
+                payload[CliConfigurationNames.StackSectionName] = stackConfig;
             }
 
             string json = JsonSerializer.Serialize(payload, new JsonSerializerOptions

--- a/src/Func/Commands/Setup/SetupRenderer.cs
+++ b/src/Func/Commands/Setup/SetupRenderer.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Azure.Functions.Cli.Configuration;
 using Azure.Functions.Cli.Console;
 
 namespace Azure.Functions.Cli.Commands.Setup;
@@ -28,7 +29,7 @@ internal sealed class SetupRenderer(IInteractionService interaction, SetupOutput
             {
                 ["features"] = featurePlan.Features,
                 ["worker_runtimes"] = featurePlan.WorkerRuntimes,
-                ["profiles"] = profileScopes.Select(scope => scope.Profile?.Name).Where(name => name is not null).ToArray(),
+                [CliConfigurationNames.ProfilesKey] = profileScopes.Select(scope => scope.Profile?.Name).Where(name => name is not null).ToArray(),
                 ["source"] = options.Source,
                 ["install_policy"] = ToPolicyText(options.InstallPolicy),
                 ["check"] = options.Check,

--- a/src/Func/Commands/Setup/SetupRunner.cs
+++ b/src/Func/Commands/Setup/SetupRunner.cs
@@ -189,7 +189,7 @@ internal sealed class SetupRunner(
     {
         string? configuredStack = _configurationProvider
             .GetProjectConfiguration(workingDirectory)
-            [$"{StackOptions.SectionName}:runtime"];
+            [$"{CliConfigurationNames.StackSectionName}:{CliConfigurationNames.StackRuntimeKey}"];
 
         return string.IsNullOrWhiteSpace(configuredStack)
             ? ["runtime"]

--- a/src/Func/Commands/Setup/SetupRunner.cs
+++ b/src/Func/Commands/Setup/SetupRunner.cs
@@ -189,7 +189,7 @@ internal sealed class SetupRunner(
     {
         string? configuredStack = _configurationProvider
             .GetProjectConfiguration(workingDirectory)
-            [$"{StackOptions.SectionName}:{nameof(StackOptions.Runtime)}"];
+            [$"{StackOptions.SectionName}:{StackOptions.RuntimeKey}"];
 
         return string.IsNullOrWhiteSpace(configuredStack)
             ? ["runtime"]

--- a/src/Func/Commands/Setup/SetupRunner.cs
+++ b/src/Func/Commands/Setup/SetupRunner.cs
@@ -189,7 +189,7 @@ internal sealed class SetupRunner(
     {
         string? configuredStack = _configurationProvider
             .GetProjectConfiguration(workingDirectory)
-            [$"{StackOptions.SectionName}:{StackOptions.RuntimeKey}"];
+            [$"{StackOptions.SectionName}:runtime"];
 
         return string.IsNullOrWhiteSpace(configuredStack)
             ? ["runtime"]

--- a/src/Func/Configuration/CliConfigurationNames.cs
+++ b/src/Func/Configuration/CliConfigurationNames.cs
@@ -11,4 +11,12 @@ internal static class CliConfigurationNames
     public const string LocalSettingsValuesSectionName = "Values";
     public const string LocalSettingsHostSectionName = "Host";
     public const string WorkerRuntimeSettingName = "FUNCTIONS_WORKER_RUNTIME";
+
+    // Schema keys for .func/config.json. Lowercase to match the file's
+    // existing "profiles" / "defaultProfile" convention.
+    public const string StackSectionName = "stack";
+    public const string StackRuntimeKey = "runtime";
+    public const string StackLanguageKey = "language";
+    public const string ProfilesKey = "profiles";
+    public const string DefaultProfileKey = "defaultProfile";
 }

--- a/src/Func/Configuration/LocalSettingsConfigurationProvider.cs
+++ b/src/Func/Configuration/LocalSettingsConfigurationProvider.cs
@@ -20,7 +20,7 @@ internal sealed class LocalSettingsConfigurationProvider(
 
         if (localSettings.WorkerRuntime is { Length: > 0 } runtime)
         {
-            data[$"{StackOptions.SectionName}:{StackOptions.RuntimeKey}"] = runtime;
+            data[$"{StackOptions.SectionName}:runtime"] = runtime;
         }
 
         if (localSettings.Host?.LocalHttpPort is { } port)

--- a/src/Func/Configuration/LocalSettingsConfigurationProvider.cs
+++ b/src/Func/Configuration/LocalSettingsConfigurationProvider.cs
@@ -20,7 +20,7 @@ internal sealed class LocalSettingsConfigurationProvider(
 
         if (localSettings.WorkerRuntime is { Length: > 0 } runtime)
         {
-            data[$"{StackOptions.SectionName}:{nameof(StackOptions.Runtime)}"] = runtime;
+            data[$"{StackOptions.SectionName}:{StackOptions.RuntimeKey}"] = runtime;
         }
 
         if (localSettings.Host?.LocalHttpPort is { } port)

--- a/src/Func/Configuration/LocalSettingsConfigurationProvider.cs
+++ b/src/Func/Configuration/LocalSettingsConfigurationProvider.cs
@@ -20,7 +20,7 @@ internal sealed class LocalSettingsConfigurationProvider(
 
         if (localSettings.WorkerRuntime is { Length: > 0 } runtime)
         {
-            data[$"{StackOptions.SectionName}:runtime"] = runtime;
+            data[$"{CliConfigurationNames.StackSectionName}:{CliConfigurationNames.StackRuntimeKey}"] = runtime;
         }
 
         if (localSettings.Host?.LocalHttpPort is { } port)

--- a/src/Func/Configuration/StackOptions.cs
+++ b/src/Func/Configuration/StackOptions.cs
@@ -5,7 +5,7 @@ namespace Azure.Functions.Cli.Configuration;
 
 internal sealed class StackOptions
 {
-    public const string SectionName = "stack";
+    public const string SectionName = CliConfigurationNames.StackSectionName;
 
     public string? Runtime { get; set; }
 

--- a/src/Func/Configuration/StackOptions.cs
+++ b/src/Func/Configuration/StackOptions.cs
@@ -7,10 +7,6 @@ internal sealed class StackOptions
 {
     public const string SectionName = "stack";
 
-    public const string RuntimeKey = "runtime";
-
-    public const string LanguageKey = "language";
-
     public string? Runtime { get; set; }
 
     public string? Language { get; set; }

--- a/src/Func/Configuration/StackOptions.cs
+++ b/src/Func/Configuration/StackOptions.cs
@@ -5,7 +5,11 @@ namespace Azure.Functions.Cli.Configuration;
 
 internal sealed class StackOptions
 {
-    public const string SectionName = "Stack";
+    public const string SectionName = "stack";
+
+    public const string RuntimeKey = "runtime";
+
+    public const string LanguageKey = "language";
 
     public string? Runtime { get; set; }
 

--- a/src/Func/Profiles/ProjectProfileConfigStore.cs
+++ b/src/Func/Profiles/ProjectProfileConfigStore.cs
@@ -32,8 +32,8 @@ internal sealed class ProjectProfileConfigStore(IProfileFileSystem fileSystem) :
         List<string> profiles = ReadProfiles(root);
         string selectedProfile = EnsureProfile(profiles, normalizedProfileName, out bool addedProfile);
 
-        root["profiles"] = CreateProfilesArray(profiles);
-        root["defaultProfile"] = selectedProfile;
+        root[CliConfigurationNames.ProfilesKey] = CreateProfilesArray(profiles);
+        root[CliConfigurationNames.DefaultProfileKey] = selectedProfile;
 
         string updatedJson = root.ToJsonString(_jsonOptions) + Environment.NewLine;
         await WriteProjectConfigAsync(configPath, updatedJson, cancellationToken);
@@ -104,12 +104,12 @@ internal sealed class ProjectProfileConfigStore(IProfileFileSystem fileSystem) :
 
     private static List<string> ReadProfiles(JsonObject root)
     {
-        if (root["profiles"] is null)
+        if (root[CliConfigurationNames.ProfilesKey] is null)
         {
             return [];
         }
 
-        if (root["profiles"] is not JsonArray profilesArray)
+        if (root[CliConfigurationNames.ProfilesKey] is not JsonArray profilesArray)
         {
             throw new ProfileConfigurationException($"Project config '{_projectConfigDisplayName}' property 'profiles' must be an array.");
         }

--- a/test/Func.Tests/Commands/InitCommandTests.cs
+++ b/test/Func.Tests/Commands/InitCommandTests.cs
@@ -95,9 +95,9 @@ public class InitCommandTests
             Assert.True(File.Exists(configPath), $"Expected .func/config.json at {configPath}.");
 
             using var doc = JsonDocument.Parse(File.ReadAllText(configPath));
-            JsonElement stack = doc.RootElement.GetProperty("Stack");
-            Assert.Equal("python", stack.GetProperty("Runtime").GetString());
-            Assert.Equal("python", stack.GetProperty("Language").GetString());
+            JsonElement stack = doc.RootElement.GetProperty("stack");
+            Assert.Equal("python", stack.GetProperty("runtime").GetString());
+            Assert.Equal("python", stack.GetProperty("language").GetString());
         }
         finally
         {
@@ -152,9 +152,9 @@ public class InitCommandTests
 
             string configPath = Path.Combine(newDir, ".func", "config.json");
             using var doc = JsonDocument.Parse(File.ReadAllText(configPath));
-            JsonElement stack = doc.RootElement.GetProperty("Stack");
-            Assert.Equal("dotnet", stack.GetProperty("Runtime").GetString());
-            Assert.False(stack.TryGetProperty("Language", out _));
+            JsonElement stack = doc.RootElement.GetProperty("stack");
+            Assert.Equal("dotnet", stack.GetProperty("runtime").GetString());
+            Assert.False(stack.TryGetProperty("language", out _));
         }
         finally
         {
@@ -450,22 +450,22 @@ public class InitCommandTests
         using var doc = JsonDocument.Parse(File.ReadAllText(configPath));
         if (expectedStack is null)
         {
-            Assert.False(doc.RootElement.TryGetProperty("Stack", out _));
+            Assert.False(doc.RootElement.TryGetProperty("stack", out _));
         }
         else
         {
-            Assert.Equal(expectedStack, doc.RootElement.GetProperty("Stack").GetProperty("Runtime").GetString());
+            Assert.Equal(expectedStack, doc.RootElement.GetProperty("stack").GetProperty("runtime").GetString());
         }
         if (expectedLanguage is null)
         {
-            if (doc.RootElement.TryGetProperty("Stack", out JsonElement stack))
+            if (doc.RootElement.TryGetProperty("stack", out JsonElement stack))
             {
-                Assert.False(stack.TryGetProperty("Language", out _));
+                Assert.False(stack.TryGetProperty("language", out _));
             }
         }
         else
         {
-            Assert.Equal(expectedLanguage, doc.RootElement.GetProperty("Stack").GetProperty("Language").GetString());
+            Assert.Equal(expectedLanguage, doc.RootElement.GetProperty("stack").GetProperty("language").GetString());
         }
     }
 

--- a/test/Func.Tests/Commands/Profile/ProfileCommandTests.cs
+++ b/test/Func.Tests/Commands/Profile/ProfileCommandTests.cs
@@ -174,8 +174,8 @@ public sealed class ProfileCommandTests : IDisposable
         WriteProjectConfig(
             """
             {
-              "Stack": {
-                "Runtime": "node"
+              "stack": {
+                "runtime": "node"
               },
               "profiles": [ "flex" ],
               "defaultProfile": "flex"
@@ -189,7 +189,7 @@ public sealed class ProfileCommandTests : IDisposable
         Assert.Equal(0, exit);
         using JsonDocument document = ReadProjectConfig();
         JsonElement root = document.RootElement;
-        Assert.Equal("node", root.GetProperty("Stack").GetProperty("Runtime").GetString());
+        Assert.Equal("node", root.GetProperty("stack").GetProperty("runtime").GetString());
         Assert.Equal("staging", root.GetProperty("defaultProfile").GetString());
         string?[] profiles = [.. root.GetProperty("profiles").EnumerateArray().Select(p => p.GetString())];
         string?[] expectedProfiles = ["flex", "staging"];

--- a/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
+++ b/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
@@ -102,7 +102,7 @@ public sealed class SetupRunnerTests : IDisposable
             .WithLatest(workerPackageId, "1.2.3");
         SetupRunner runner = CreateRunner(catalog, projectConfig: new Dictionary<string, string?>
         {
-            [$"{StackOptions.SectionName}:{StackOptions.RuntimeKey}"] = "dotnet-isolated",
+            [$"{StackOptions.SectionName}:runtime"] = "dotnet-isolated",
         });
 
         SetupRunResult result = await runner.RunAsync(Options(), CancellationToken.None);

--- a/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
+++ b/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
@@ -102,7 +102,7 @@ public sealed class SetupRunnerTests : IDisposable
             .WithLatest(workerPackageId, "1.2.3");
         SetupRunner runner = CreateRunner(catalog, projectConfig: new Dictionary<string, string?>
         {
-            [$"{StackOptions.SectionName}:runtime"] = "dotnet-isolated",
+            [$"{CliConfigurationNames.StackSectionName}:{CliConfigurationNames.StackRuntimeKey}"] = "dotnet-isolated",
         });
 
         SetupRunResult result = await runner.RunAsync(Options(), CancellationToken.None);

--- a/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
+++ b/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
@@ -102,7 +102,7 @@ public sealed class SetupRunnerTests : IDisposable
             .WithLatest(workerPackageId, "1.2.3");
         SetupRunner runner = CreateRunner(catalog, projectConfig: new Dictionary<string, string?>
         {
-            [$"{StackOptions.SectionName}:{nameof(StackOptions.Runtime)}"] = "dotnet-isolated",
+            [$"{StackOptions.SectionName}:{StackOptions.RuntimeKey}"] = "dotnet-isolated",
         });
 
         SetupRunResult result = await runner.RunAsync(Options(), CancellationToken.None);

--- a/test/Func.Tests/Configuration/LocalSettingsConfigurationProviderTests.cs
+++ b/test/Func.Tests/Configuration/LocalSettingsConfigurationProviderTests.cs
@@ -40,7 +40,7 @@ public sealed class LocalSettingsConfigurationProviderTests : IDisposable
             .Add(new LocalSettingsConfigurationSource(_dir, new LocalSettingsProvider()))
             .Build();
 
-        Assert.Equal("node", configuration["Stack:Runtime"]);
+        Assert.Equal("node", configuration["stack:runtime"]);
         Assert.Equal("7073", configuration["HostStartup:Port"]);
         Assert.Equal("*", configuration["HostStartup:Cors"]);
         Assert.Equal("True", configuration["HostStartup:CorsCredentials"]);
@@ -56,7 +56,7 @@ public sealed class LocalSettingsConfigurationProviderTests : IDisposable
             .Add(new LocalSettingsConfigurationSource(_dir, new LocalSettingsProvider()))
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["Stack:Runtime"] = "python",
+                ["stack:runtime"] = "python",
             })
             .Build();
 
@@ -74,16 +74,16 @@ public sealed class LocalSettingsConfigurationProviderTests : IDisposable
         IConfigurationRoot configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["Stack:Runtime"] = "environment",
+                ["stack:runtime"] = "environment",
             })
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["Stack:Runtime"] = "global",
+                ["stack:runtime"] = "global",
             })
             .Add(new LocalSettingsConfigurationSource(_dir, new LocalSettingsProvider()))
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["Stack:Runtime"] = "project",
+                ["stack:runtime"] = "project",
             })
             .Build();
 
@@ -101,11 +101,11 @@ public sealed class LocalSettingsConfigurationProviderTests : IDisposable
         IConfigurationRoot configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["Stack:Runtime"] = "environment",
+                ["stack:runtime"] = "environment",
             })
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["Stack:Runtime"] = "global",
+                ["stack:runtime"] = "global",
             })
             .Add(new LocalSettingsConfigurationSource(_dir, new LocalSettingsProvider()))
             .Build();
@@ -156,20 +156,20 @@ public sealed class LocalSettingsConfigurationProviderTests : IDisposable
 
         Assert.Equal("project-profile", configuration["profiles:0"]);
         Assert.Null(configuration["defaultProfile"]);
-        Assert.Equal("node", configuration["Stack:Runtime"]);
+        Assert.Equal("node", configuration["stack:runtime"]);
     }
 
     [Fact]
     public void CliConfigurationProvider_EffectiveConfigurationPreservesSourcePrecedence()
     {
-        WriteUserConfig("""{"Stack":{"Runtime":"user"}}""");
+        WriteUserConfig("""{"stack":{"runtime":"user"}}""");
         WriteSettings("""{"Values":{"FUNCTIONS_WORKER_RUNTIME":"local"}}""");
-        WriteProjectConfig("""{"Stack":{"Runtime":"project"}}""");
+        WriteProjectConfig("""{"stack":{"runtime":"project"}}""");
         var configurationProvider = new CliConfigurationProvider(new LocalSettingsProvider(), _userDir);
 
         IConfiguration configuration = configurationProvider.GetEffectiveConfiguration(_dir);
 
-        Assert.Equal("project", configuration["Stack:Runtime"]);
+        Assert.Equal("project", configuration["stack:runtime"]);
     }
 
     [Fact]


### PR DESCRIPTION
Lowercase the `.func/config.json` schema keys (`stack` / `runtime` / `language`) so the entire file uses a single convention alongside the already-lowercase `profiles` / `defaultProfile`. Also centralizes all schema key names in `CliConfigurationNames` so readers and writers reference the same constants instead of duplicating string literals.

### Before

```json
{
  "Stack": {
    "Runtime": "node",
    "Language": "typescript"
  },
  "profiles": ["flex"],
  "defaultProfile": "flex"
}
```

### After

```json
{
  "stack": {
    "runtime": "node",
    "language": "typescript"
  },
  "profiles": ["flex"],
  "defaultProfile": "flex"
}
```

### Changes
- `CliConfigurationNames`: new constants `StackSectionName`, `StackRuntimeKey`, `StackLanguageKey`, `ProfilesKey`, `DefaultProfileKey`.
- `StackOptions.SectionName` is now a thin alias to `CliConfigurationNames.StackSectionName`.
- `InitCommand`, `LocalSettingsConfigurationProvider`, `SetupRunner`, `SetupRenderer`, `ProjectProfileConfigStore`: replaced inline string literals / `nameof(StackOptions.Runtime/Language)` with the central constants.
- Tests updated to match.

C# property names (`StackOptions.Runtime`, `StackOptions.Language`) stay PascalCase per .NET convention; only the on-disk keys are lowercase. `IConfiguration` binding is case-insensitive so any existing PascalCase config files continue to load.