### PR TITLE
workload install: verify publisher trust before installing

### DIFF
--- a/docs/building-a-workload.md
+++ b/docs/building-a-workload.md
@@ -63,7 +63,7 @@ The shape mirrors WebJobs' `IWebJobsStartup`. `Configure(FunctionsCliBuilder)` i
 4. Inside `Configure`, register an `IProjectInitializer`, an `IProjectDetector` (so the resolver can claim directories owned by your workload), and/or top-level commands via `builder.RegisterCommand(...)` plus any supporting services
 5. Add a `workload.json` next to your csproj describing the entry-point assembly and type
 6. Add a `README.md` next to the csproj — `Release.props` auto-includes it as `<PackageReadmeFile>` so it surfaces on NuGet feeds and in `func workload list`
-7. Build, package, and install with `func workload install <path-to-nupkg>`
+7. Build, package, and install with `func workload install <path-to-nupkg> --allow-untrusted` (local unsigned packs require the opt-out flag)
 
 ## Step 1: Create the Project
 

--- a/src/Func/Commands/Setup/SetupRunner.cs
+++ b/src/Func/Commands/Setup/SetupRunner.cs
@@ -564,8 +564,9 @@ internal sealed class SetupRunner(
                     includePrerelease: options.IncludePrerelease,
                     exact: true,
                     force: false,
+                    allowUntrusted: false,
                     progress: null,
-                    cancellationToken)
+                    cancellationToken: cancellationToken)
                 : await _interaction.RunWithProgressAsync(
                     $"Installing {dependency.DisplayName} {targetVersion}",
                     async (ctx, ct) => await _workloadInstaller.InstallFromCatalogAsync(
@@ -575,8 +576,9 @@ internal sealed class SetupRunner(
                         includePrerelease: options.IncludePrerelease,
                         exact: true,
                         force: false,
-                        new WorkloadInstallProgressAdapter(ctx),
-                        ct),
+                        allowUntrusted: false,
+                        progress: new WorkloadInstallProgressAdapter(ctx),
+                        cancellationToken: ct),
                     cancellationToken);
 
             string installedVersion = installResult.Entry.PackageVersion;

--- a/src/Func/Commands/Start/Initialization/Steps/InstallHostWorkloadInitializationStep.cs
+++ b/src/Func/Commands/Start/Initialization/Steps/InstallHostWorkloadInitializationStep.cs
@@ -56,8 +56,9 @@ internal sealed class InstallHostWorkloadInitializationStep(
                 includePrerelease: true,
                 exact: true,
                 force: false,
+                allowUntrusted: false,
                 progress: null,
-                cancellationToken);
+                cancellationToken: cancellationToken);
         }
         catch (WorkloadPackageNotFoundException ex)
         {

--- a/src/Func/Commands/Workload/WorkloadInstallCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadInstallCommand.cs
@@ -9,6 +9,7 @@ using Azure.Functions.Cli.Workloads;
 using Azure.Functions.Cli.Workloads.Catalog;
 using Azure.Functions.Cli.Workloads.Discovery;
 using Azure.Functions.Cli.Workloads.Install;
+using Azure.Functions.Cli.Workloads.Install.Trust;
 using Azure.Functions.Cli.Workloads.Storage;
 using NuGet.Versioning;
 
@@ -59,6 +60,11 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
         Description = "Disable alias matching. <id> must be the literal package id.",
     };
 
+    public Option<bool> AllowUntrustedOption { get; } = new("--allow-untrusted")
+    {
+        Description = "Bypass the publisher trust check. Required for installing unsigned local development packs.",
+    };
+
     public WorkloadInstallCommand(
         IInteractionService interaction,
         IWorkloadInstaller installer,
@@ -79,6 +85,7 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
         Options.Add(SourceOption);
         Options.Add(IncludePrereleaseOption);
         Options.Add(ExactOption);
+        Options.Add(AllowUntrustedOption);
         Options.Add(ForceOption);
     }
 
@@ -89,6 +96,7 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
         string? source = parseResult.GetValue(SourceOption);
         bool includePrerelease = parseResult.GetValue(IncludePrereleaseOption);
         bool exact = parseResult.GetValue(ExactOption);
+        bool allowUntrusted = parseResult.GetValue(AllowUntrustedOption);
         bool force = parseResult.GetValue(ForceOption);
 
         if (includePrerelease)
@@ -103,7 +111,7 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
             // prompt entirely. Non-interactive contexts treat the prompt as
             // a decline and exit non-zero with the same hint. Local .nupkg
             // installs bypass the check since the resolver path differs.
-            int? earlyExit = await HandleAlreadyInstalledAsync(workload, exact, source, includePrerelease, cancellationToken);
+            int? earlyExit = await HandleAlreadyInstalledAsync(workload, exact, source, includePrerelease, allowUntrusted, cancellationToken);
             if (earlyExit is { } code)
             {
                 return code;
@@ -121,7 +129,7 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
                     var progress = new WorkloadInstallProgressAdapter(ctx);
 
                     return LooksLikeLocalPackagePath(workload)
-                        ? await _installer.InstallFromPackageAsync(workload, force, progress, ct)
+                        ? await _installer.InstallFromPackageAsync(workload, force, allowUntrusted, progress, ct)
                         : await _installer.InstallFromCatalogAsync(
                             workload,
                             string.IsNullOrEmpty(versionText) ? null : NuGetVersion.Parse(versionText),
@@ -129,6 +137,7 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
                             includePrerelease,
                             exact,
                             force,
+                            allowUntrusted,
                             progress,
                             ct);
                 },
@@ -158,6 +167,12 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
         {
             throw new GracefulException(ex.Message, isUserError: true);
         }
+        catch (UntrustedWorkloadException ex)
+        {
+            throw new GracefulException(
+                $"{ex.Message} Pass --allow-untrusted to install this package anyway.",
+                isUserError: true);
+        }
         catch (FileNotFoundException ex)
         {
             throw new GracefulException(ex.Message, isUserError: true);
@@ -185,6 +200,7 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
         bool exact,
         string? source,
         bool includePrerelease,
+        bool allowUntrusted,
         CancellationToken cancellationToken)
     {
         IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
@@ -226,7 +242,7 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
             return null;
         }
 
-        return await DispatchToUpdateAsync(match.PackageId, source, includePrerelease, cancellationToken);
+        return await DispatchToUpdateAsync(match.PackageId, source, includePrerelease, allowUntrusted, cancellationToken);
     }
 
     // Delegate to the `func workload update` command (Parse + InvokeAsync) so
@@ -238,6 +254,7 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
         string packageId,
         string? source,
         bool includePrerelease,
+        bool allowUntrusted,
         CancellationToken cancellationToken)
     {
         var args = new List<string> { packageId };
@@ -249,6 +266,10 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
         if (includePrerelease)
         {
             args.Add("--prerelease");
+        }
+        if (allowUntrusted)
+        {
+            args.Add("--allow-untrusted");
         }
 
         return await _updateCommand.Parse(args.ToArray()).InvokeAsync(configuration: null, cancellationToken);

--- a/src/Func/Commands/Workload/WorkloadUpdateCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadUpdateCommand.cs
@@ -7,6 +7,7 @@ using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Workloads.Catalog;
 using Azure.Functions.Cli.Workloads.Discovery;
 using Azure.Functions.Cli.Workloads.Install;
+using Azure.Functions.Cli.Workloads.Install.Trust;
 using Azure.Functions.Cli.Workloads.Storage;
 using NuGet.Versioning;
 
@@ -60,7 +61,15 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
         Description = "Disable alias matching. <id> must be the literal package id.",
     };
 
-    public WorkloadUpdateCommand(IInteractionService interaction, IWorkloadInstaller installer, IWorkloadStore store)
+    public Option<bool> AllowUntrustedOption { get; } = new("--allow-untrusted")
+    {
+        Description = "Bypass the publisher trust check. Required for installing unsigned local development packs.",
+    };
+
+    public WorkloadUpdateCommand(
+        IInteractionService interaction,
+        IWorkloadInstaller installer,
+        IWorkloadStore store)
         : base("update", "Update an installed workload in place.")
     {
         _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
@@ -77,6 +86,7 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
         Options.Add(SourceOption);
         Options.Add(IncludePrereleaseOption);
         Options.Add(ExactOption);
+        Options.Add(AllowUntrustedOption);
 
         Validators.Add(result =>
         {
@@ -119,6 +129,7 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
         string? source = parseResult.GetValue(SourceOption);
         bool includePrerelease = parseResult.GetValue(IncludePrereleaseOption);
         bool exact = parseResult.GetValue(ExactOption);
+        bool allowUntrusted = parseResult.GetValue(AllowUntrustedOption);
 
         if (includePrerelease)
         {
@@ -127,7 +138,7 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
 
         if (all)
         {
-            return await UpdateAllAsync(source, includePrerelease, allowMajor, cancellationToken);
+            return await UpdateAllAsync(source, includePrerelease, allowMajor, allowUntrusted, cancellationToken);
         }
 
         string packageId = await ResolveInstalledPackageIdAsync(identifier!, exact, cancellationToken);
@@ -138,6 +149,7 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
             source,
             includePrerelease,
             allowMajor,
+            allowUntrusted,
             cancellationToken);
     }
 
@@ -175,6 +187,7 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
         string? source,
         bool includePrerelease,
         bool allowMajor,
+        bool allowUntrusted,
         CancellationToken cancellationToken)
     {
         try
@@ -182,7 +195,7 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
             WorkloadUpdateResult result = await _interaction.RunWithProgressAsync(
                 $"Updating workload '{packageId}'",
                 async (ctx, ct) => await _installer.UpdateAsync(
-                    packageId, targetVersion, source, includePrerelease, allowMajor,
+                    packageId, targetVersion, source, includePrerelease, allowMajor, allowUntrusted,
                     new WorkloadInstallProgressAdapter(ctx),
                     ct),
                 cancellationToken);
@@ -202,13 +215,24 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
         {
             throw new GracefulException(ex.Message, isUserError: true);
         }
+        catch (UntrustedWorkloadException ex)
+        {
+            throw new GracefulException(
+                $"{ex.Message} Pass --allow-untrusted to install this package anyway.",
+                isUserError: true);
+        }
         catch (InvalidOperationException ex)
         {
             throw new GracefulException(ex.Message, isUserError: true);
         }
     }
 
-    private async Task<int> UpdateAllAsync(string? source, bool includePrerelease, bool allowMajor, CancellationToken cancellationToken)
+    private async Task<int> UpdateAllAsync(
+        string? source,
+        bool includePrerelease,
+        bool allowMajor,
+        bool allowUntrusted,
+        CancellationToken cancellationToken)
     {
         IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
         IReadOnlyList<string> packageIds = [.. installed
@@ -234,6 +258,7 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
                         source,
                         includePrerelease,
                         allowMajor,
+                        allowUntrusted,
                         new WorkloadInstallProgressAdapter(ctx),
                         ct),
                     cancellationToken);
@@ -243,6 +268,7 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
                 ex is WorkloadPackageNotFoundException
                 or FileNotFoundException
                 or InvalidWorkloadException
+                or UntrustedWorkloadException
                 or InvalidOperationException)
             {
                 // Per-id failure must not block other workloads. Surface

--- a/src/Func/Func.csproj
+++ b/src/Func/Func.csproj
@@ -30,6 +30,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Profiles/BuiltInProfiles.json" LogicalName="Azure.Functions.Cli.Profiles.BuiltInProfiles.json" />
+    <EmbeddedResource Include="Workloads/Install/Trust/trusted-roots.pem" LogicalName="Azure.Functions.Cli.Workloads.Install.Trust.trusted-roots.pem" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Func/Hosting/WorkloadInstallRegistration.cs
+++ b/src/Func/Hosting/WorkloadInstallRegistration.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Workloads.Install;
+using Azure.Functions.Cli.Workloads.Install.Trust;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Azure.Functions.Cli.Hosting;
@@ -17,6 +18,8 @@ internal static class WorkloadInstallRegistration
     {
         ArgumentNullException.ThrowIfNull(services);
 
+        services.AddSingleton<ITrustAnchorStore, EmbeddedTrustAnchorStore>();
+        services.AddSingleton<IWorkloadTrustVerifier, WorkloadTrustVerifier>();
         services.AddSingleton<IWorkloadInstaller, WorkloadInstaller>();
 
         return services;

--- a/src/Func/Workers/DefaultFunctionsWorkerInstaller.cs
+++ b/src/Func/Workers/DefaultFunctionsWorkerInstaller.cs
@@ -65,8 +65,9 @@ internal sealed class DefaultFunctionsWorkerInstaller(
             includePrerelease: true,
             exact: true,
             force: false,
+            allowUntrusted: false,
             progress: null,
-            cancellationToken);
+            cancellationToken: cancellationToken);
 
         IFunctionsWorker worker = ResolveInstalledWorker(workerId, packageId, versionRange, result, cancellationToken);
         return new FunctionsWorkerInstallResult(worker, result);

--- a/src/Func/Workloads/Install/IWorkloadInstaller.cs
+++ b/src/Func/Workloads/Install/IWorkloadInstaller.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Workloads.Catalog;
+using Azure.Functions.Cli.Workloads.Install.Trust;
 using Azure.Functions.Cli.Workloads.Storage;
 using NuGet.Versioning;
 
@@ -23,6 +24,11 @@ internal interface IWorkloadInstaller
     /// When <c>true</c>, an existing install of the same id+version is removed
     /// before extraction.
     /// </param>
+    /// <param name="allowUntrusted">
+    /// When <c>true</c>, the publisher trust check is skipped so unsigned
+    /// or third-party packages can install. Required only for local dev
+    /// workflows; production installs leave this <c>false</c>.
+    /// </param>
     /// <param name="cancellationToken">Token to cancel the install.</param>
     /// <returns>
     /// The registry entry plus a flag indicating whether the install was a
@@ -33,6 +39,10 @@ internal interface IWorkloadInstaller
     /// The package is unreadable, missing the <c>FuncCliWorkload</c> package
     /// type, or its <c>workload.json</c> is missing or malformed.
     /// </exception>
+    /// <exception cref="UntrustedWorkloadException">
+    /// The package failed the publisher trust check and
+    /// <paramref name="allowUntrusted"/> is <c>false</c>.
+    /// </exception>
     /// <exception cref="InvalidOperationException">
     /// The install directory exists without a matching registry entry and
     /// <paramref name="force"/> is <c>false</c>.
@@ -40,6 +50,7 @@ internal interface IWorkloadInstaller
     public Task<WorkloadInstallResult> InstallFromPackageAsync(
         string nupkgPath,
         bool force = false,
+        bool allowUntrusted = false,
         IProgress<WorkloadInstallProgress>? progress = null,
         CancellationToken cancellationToken = default);
 
@@ -67,6 +78,7 @@ internal interface IWorkloadInstaller
     /// <paramref name="packageId"/> as a literal package id.
     /// </param>
     /// <param name="force">Forwarded to <see cref="InstallFromPackageAsync"/>.</param>
+    /// <param name="allowUntrusted">Forwarded to <see cref="InstallFromPackageAsync"/>.</param>
     /// <param name="cancellationToken">Token to cancel resolve, download, and install.</param>
     /// <exception cref="WorkloadPackageNotFoundException">
     /// No version matched on any configured source.
@@ -75,6 +87,10 @@ internal interface IWorkloadInstaller
     /// The alias matches multiple packages and <paramref name="exact"/> is
     /// <c>false</c>.
     /// </exception>
+    /// <exception cref="UntrustedWorkloadException">
+    /// The downloaded package failed the publisher trust check and
+    /// <paramref name="allowUntrusted"/> is <c>false</c>.
+    /// </exception>
     public Task<WorkloadInstallResult> InstallFromCatalogAsync(
         string packageId,
         NuGetVersion? version,
@@ -82,6 +98,7 @@ internal interface IWorkloadInstaller
         bool includePrerelease,
         bool exact,
         bool force,
+        bool allowUntrusted = false,
         IProgress<WorkloadInstallProgress>? progress = null,
         CancellationToken cancellationToken = default);
 
@@ -102,10 +119,19 @@ internal interface IWorkloadInstaller
     /// Default is <c>false</c> per spec; <c>--major</c> on the command sets
     /// it to <c>true</c>.
     /// </param>
+    /// <param name="allowUntrusted">
+    /// When <c>true</c>, skips the publisher trust check on the resolved
+    /// update candidate. Required for updates of locally-installed
+    /// unsigned dev packs.
+    /// </param>
     /// <param name="cancellationToken">Token propagated to catalog + I/O.</param>
     /// <exception cref="InvalidOperationException">
     /// <paramref name="packageId"/> is not installed, or
     /// <paramref name="targetInstalledVersion"/> is not present.
+    /// </exception>
+    /// <exception cref="UntrustedWorkloadException">
+    /// The resolved update candidate failed the publisher trust check and
+    /// <paramref name="allowUntrusted"/> is <c>false</c>.
     /// </exception>
     public Task<WorkloadUpdateResult> UpdateAsync(
         string packageId,
@@ -113,6 +139,7 @@ internal interface IWorkloadInstaller
         string? source,
         bool includePrerelease,
         bool allowMajor,
+        bool allowUntrusted = false,
         IProgress<WorkloadInstallProgress>? progress = null,
         CancellationToken cancellationToken = default);
 

--- a/src/Func/Workloads/Install/Trust/EmbeddedTrustAnchorStore.cs
+++ b/src/Func/Workloads/Install/Trust/EmbeddedTrustAnchorStore.cs
@@ -1,0 +1,70 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Reflection;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Azure.Functions.Cli.Workloads.Install.Trust;
+
+/// <summary>
+/// <see cref="ITrustAnchorStore"/> backed by an embedded PEM bundle
+/// (<c>trusted-roots.pem</c>) shipped inside the CLI assembly. Supports
+/// concatenated PEM-encoded X.509 certificates, the standard cert-bundle
+/// format used by tools like cURL and OpenSSL.
+/// </summary>
+internal sealed class EmbeddedTrustAnchorStore : ITrustAnchorStore
+{
+    internal const string ResourceName = "Azure.Functions.Cli.Workloads.Install.Trust.trusted-roots.pem";
+
+    private readonly Lazy<X509Certificate2Collection> _anchors;
+
+    public EmbeddedTrustAnchorStore()
+        : this(typeof(EmbeddedTrustAnchorStore).Assembly)
+    {
+    }
+
+    internal EmbeddedTrustAnchorStore(Assembly assembly)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+        _anchors = new Lazy<X509Certificate2Collection>(() => LoadFromAssembly(assembly));
+    }
+
+    /// <inheritdoc />
+    public X509Certificate2Collection GetTrustAnchors() => _anchors.Value;
+
+    private static X509Certificate2Collection LoadFromAssembly(Assembly assembly)
+    {
+        using Stream? stream = assembly.GetManifestResourceStream(ResourceName);
+        if (stream is null)
+        {
+            throw new InvalidOperationException(
+                $"Embedded trust bundle '{ResourceName}' was not found. " +
+                "This indicates a packaging bug; reinstall the CLI.");
+        }
+
+        using StreamReader reader = new(stream);
+        string pem = reader.ReadToEnd();
+
+        var collection = new X509Certificate2Collection();
+        if (string.IsNullOrWhiteSpace(pem) || !pem.Contains("-----BEGIN CERTIFICATE-----", StringComparison.Ordinal))
+        {
+            // Empty / placeholder bundle. Return an empty collection rather
+            // than throwing; the verifier surfaces a user-facing error when
+            // it sees no anchors, which is friendlier than an InvalidOp here.
+            return collection;
+        }
+
+        try
+        {
+            collection.ImportFromPem(pem);
+        }
+        catch (Exception ex) when (ex is System.Security.Cryptography.CryptographicException or FormatException)
+        {
+            throw new InvalidOperationException(
+                $"Embedded trust bundle '{ResourceName}' is malformed: {ex.Message}",
+                ex);
+        }
+
+        return collection;
+    }
+}

--- a/src/Func/Workloads/Install/Trust/ITrustAnchorStore.cs
+++ b/src/Func/Workloads/Install/Trust/ITrustAnchorStore.cs
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Security.Cryptography.X509Certificates;
+
+namespace Azure.Functions.Cli.Workloads.Install.Trust;
+
+/// <summary>
+/// Source of trust anchors (typically root CAs) used to validate
+/// workload package signatures. A package is considered trusted when
+/// its signing certificate chains to one of these anchors under
+/// <see cref="X509ChainTrustMode.CustomRootTrust"/>.
+/// </summary>
+internal interface ITrustAnchorStore
+{
+    /// <summary>
+    /// Returns the trust anchors shipped with the CLI. The collection is
+    /// loaded once and cached for the process lifetime; callers must not
+    /// mutate it.
+    /// </summary>
+    public X509Certificate2Collection GetTrustAnchors();
+}

--- a/src/Func/Workloads/Install/Trust/IWorkloadTrustVerifier.cs
+++ b/src/Func/Workloads/Install/Trust/IWorkloadTrustVerifier.cs
@@ -1,0 +1,41 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workloads.Install.Trust;
+
+/// <summary>
+/// Gates workload installs on publisher trust. The verifier looks at
+/// both the package id (must live under the Azure Functions namespace)
+/// and the <c>.nupkg</c>'s primary signature (must chain to a trust
+/// anchor in the bundled <see cref="ITrustAnchorStore"/>). The
+/// <c>--allow-untrusted</c> flag bypasses the gate for local dev
+/// workflows.
+/// </summary>
+internal interface IWorkloadTrustVerifier
+{
+    /// <summary>
+    /// Verifies that the package at <paramref name="nupkgPath"/> with id
+    /// <paramref name="packageId"/> is allowed to install. When
+    /// <paramref name="allowUntrusted"/> is <c>true</c> the check is
+    /// skipped and a trusted result is returned.
+    /// </summary>
+    public Task<TrustVerificationResult> VerifyAsync(
+        string nupkgPath,
+        string packageId,
+        bool allowUntrusted,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Outcome of a trust check. <see cref="IsTrusted"/> is <c>true</c> when
+/// the package is allowed to install (either it passed verification or
+/// the caller opted into <c>--allow-untrusted</c>);
+/// <see cref="Reason"/> is populated on failure and is safe to surface
+/// to the user.
+/// </summary>
+internal sealed record TrustVerificationResult(bool IsTrusted, string? Reason = null)
+{
+    public static TrustVerificationResult Trusted { get; } = new(true);
+
+    public static TrustVerificationResult Untrusted(string reason) => new(false, reason);
+}

--- a/src/Func/Workloads/Install/Trust/UntrustedWorkloadException.cs
+++ b/src/Func/Workloads/Install/Trust/UntrustedWorkloadException.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workloads.Install.Trust;
+
+/// <summary>
+/// Thrown when a workload package fails the trust gate: missing/invalid
+/// signature, signing cert not in the bundle, or package id outside the
+/// Azure Functions namespace. The user can re-run with
+/// <c>--allow-untrusted</c> for local development packages.
+/// </summary>
+internal sealed class UntrustedWorkloadException : Exception
+{
+    public UntrustedWorkloadException(string message)
+        : base(message)
+    {
+    }
+
+    public UntrustedWorkloadException(string message, Exception inner)
+        : base(message, inner)
+    {
+    }
+}

--- a/src/Func/Workloads/Install/Trust/WorkloadTrustVerifier.cs
+++ b/src/Func/Workloads/Install/Trust/WorkloadTrustVerifier.cs
@@ -1,0 +1,169 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Security.Cryptography.X509Certificates;
+using NuGet.Packaging;
+using NuGet.Packaging.Signing;
+
+namespace Azure.Functions.Cli.Workloads.Install.Trust;
+
+/// <summary>
+/// Default <see cref="IWorkloadTrustVerifier"/>. Enforces two gates:
+/// (a) the package id must live under <see cref="OfficialPackageIdPrefix"/>,
+/// and (b) the <c>.nupkg</c> must carry a primary signature whose chain
+/// terminates at a trust anchor in the bundled
+/// <see cref="ITrustAnchorStore"/>. <c>--allow-untrusted</c> skips both
+/// gates so unsigned local packs can install during development.
+/// </summary>
+internal sealed class WorkloadTrustVerifier(ITrustAnchorStore anchorStore) : IWorkloadTrustVerifier
+{
+    /// <summary>
+    /// Package id prefix that identifies a workload as part of the official
+    /// Microsoft-published Azure Functions CLI surface. Case-insensitive.
+    /// </summary>
+    public const string OfficialPackageIdPrefix = "azure.functions.cli.workloads.";
+
+    private readonly ITrustAnchorStore _anchorStore = anchorStore ?? throw new ArgumentNullException(nameof(anchorStore));
+
+    /// <inheritdoc />
+    public async Task<TrustVerificationResult> VerifyAsync(
+        string nupkgPath,
+        string packageId,
+        bool allowUntrusted,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(nupkgPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+
+        if (allowUntrusted)
+        {
+            return TrustVerificationResult.Trusted;
+        }
+
+        if (!packageId.StartsWith(OfficialPackageIdPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return TrustVerificationResult.Untrusted(
+                $"Package '{packageId}' is not part of the Azure Functions CLI workload namespace " +
+                $"(expected id prefix '{OfficialPackageIdPrefix}'). " +
+                $"Pass --allow-untrusted to install anyway.");
+        }
+
+        X509Certificate2Collection anchors = _anchorStore.GetTrustAnchors();
+        if (anchors.Count == 0)
+        {
+            return TrustVerificationResult.Untrusted(
+                "No trust anchors are configured in the embedded trust bundle. " +
+                "Reinstall the CLI or pass --allow-untrusted to override.");
+        }
+
+        return await VerifySignatureAsync(nupkgPath, packageId, anchors, cancellationToken);
+    }
+
+    private static async Task<TrustVerificationResult> VerifySignatureAsync(
+        string nupkgPath,
+        string packageId,
+        X509Certificate2Collection anchors,
+        CancellationToken cancellationToken)
+    {
+        using var reader = new PackageArchiveReader(File.OpenRead(nupkgPath));
+
+        bool isSigned;
+        try
+        {
+            isSigned = await reader.IsSignedAsync(cancellationToken);
+        }
+        catch (SignatureException ex)
+        {
+            return TrustVerificationResult.Untrusted(
+                $"Package '{packageId}' has a malformed signature: {ex.Message}. " +
+                "Pass --allow-untrusted to install anyway.");
+        }
+
+        if (!isSigned)
+        {
+            return TrustVerificationResult.Untrusted(
+                $"Package '{packageId}' is not signed. " +
+                "Pass --allow-untrusted to install anyway.");
+        }
+
+        PrimarySignature signature;
+        try
+        {
+            signature = await reader.GetPrimarySignatureAsync(cancellationToken);
+        }
+        catch (SignatureException ex)
+        {
+            return TrustVerificationResult.Untrusted(
+                $"Package '{packageId}' signature could not be read: {ex.Message}. " +
+                "Pass --allow-untrusted to install anyway.");
+        }
+
+        // Build an X.509 chain using ONLY our embedded anchors. CustomRootTrust
+        // bypasses the OS trust store entirely so we don't end up trusting a
+        // package signed by every public CA the machine happens to trust.
+        X509Certificate2? signer = signature.SignerInfo.Certificate;
+        if (signer is null)
+        {
+            return TrustVerificationResult.Untrusted(
+                $"Package '{packageId}' is signed but the signer certificate could not be extracted. " +
+                "Pass --allow-untrusted to install anyway.");
+        }
+
+        // Feed any intermediates that travelled with the signature into the
+        // chain builder so it can stitch leaf-to-anchor without needing AIA
+        // network fetches (and without trusting the intermediates as roots).
+        var extraStore = new X509Certificate2Collection();
+        foreach (X509Certificate2 cert in signature.SignedCms.Certificates)
+        {
+            extraStore.Add(cert);
+        }
+
+        return IsChainTrustedTo(signer, anchors, extraStore, out string failure)
+            ? TrustVerificationResult.Trusted
+            : TrustVerificationResult.Untrusted(
+                $"Package '{packageId}' signature does not chain to a trusted publisher: {failure}. " +
+                "Pass --allow-untrusted to install anyway.");
+    }
+
+    /// <summary>
+    /// Builds an X.509 chain for <paramref name="signer"/> using
+    /// <paramref name="anchors"/> as the only acceptable roots and
+    /// <paramref name="extraStore"/> as candidate intermediates. Returns
+    /// <c>true</c> when the chain validates; <paramref name="failure"/>
+    /// is a human-readable summary of the chain status on failure.
+    /// </summary>
+    /// <remarks>
+    /// Revocation is intentionally disabled: enabling OCSP/CRL on a CLI
+    /// install path means every install needs network egress to a CA's
+    /// responder, which is a hostile dependency for offline / restricted
+    /// environments. Revocation belongs behind an opt-in flag in a
+    /// follow-up.
+    /// </remarks>
+    internal static bool IsChainTrustedTo(
+        X509Certificate2 signer,
+        X509Certificate2Collection anchors,
+        X509Certificate2Collection extraStore,
+        out string failure)
+    {
+        ArgumentNullException.ThrowIfNull(signer);
+        ArgumentNullException.ThrowIfNull(anchors);
+        ArgumentNullException.ThrowIfNull(extraStore);
+
+        using var chain = new X509Chain();
+        chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+        chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+        chain.ChainPolicy.CustomTrustStore.AddRange(anchors);
+        chain.ChainPolicy.ExtraStore.AddRange(extraStore);
+
+        if (chain.Build(signer))
+        {
+            failure = string.Empty;
+            return true;
+        }
+
+        failure = chain.ChainStatus.Length == 0
+            ? "chain could not be built"
+            : string.Join("; ", chain.ChainStatus.Select(s => s.StatusInformation.Trim()));
+        return false;
+    }
+}

--- a/src/Func/Workloads/Install/Trust/trusted-roots.pem
+++ b/src/Func/Workloads/Install/Trust/trusted-roots.pem
@@ -1,0 +1,11 @@
+# Azure Functions CLI workload trust bundle
+#
+# Concatenated PEM-encoded X.509 certificates (one or more) used as
+# custom root trust anchors when validating workload package signatures.
+# A package's signing chain must terminate at one of these certs for the
+# install to be accepted (the `--allow-untrusted` flag bypasses the
+# check for local development packs).
+#
+# TODO: Populate with the Microsoft NuGet author signing root before
+# shipping a release that gates installs on this bundle. Until then the
+# bundle is empty and every official install requires `--allow-untrusted`.

--- a/src/Func/Workloads/Install/WorkloadInstaller.cs
+++ b/src/Func/Workloads/Install/WorkloadInstaller.cs
@@ -4,6 +4,7 @@
 using Azure.Functions.Cli.Commands.Start.Host;
 using Azure.Functions.Cli.Workloads.Catalog;
 using Azure.Functions.Cli.Workloads.Discovery;
+using Azure.Functions.Cli.Workloads.Install.Trust;
 using Azure.Functions.Cli.Workloads.Storage;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
@@ -21,7 +22,8 @@ internal sealed class WorkloadInstaller(
     IWorkloadPaths paths,
     IWorkloadStore store,
     IWorkloadMetadataReader metadataReader,
-    IWorkloadCatalog catalog) : IWorkloadInstaller
+    IWorkloadCatalog catalog,
+    IWorkloadTrustVerifier trustVerifier) : IWorkloadInstaller
 {
     /// <summary>
     /// Prefix on nuspec tags that marks the tag as a CLI-facing alias, so
@@ -51,11 +53,13 @@ internal sealed class WorkloadInstaller(
     private readonly IWorkloadStore _store = store ?? throw new ArgumentNullException(nameof(store));
     private readonly IWorkloadMetadataReader _metadataReader = metadataReader ?? throw new ArgumentNullException(nameof(metadataReader));
     private readonly IWorkloadCatalog _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
+    private readonly IWorkloadTrustVerifier _trustVerifier = trustVerifier ?? throw new ArgumentNullException(nameof(trustVerifier));
 
     /// <inheritdoc />
     public async Task<WorkloadInstallResult> InstallFromPackageAsync(
         string nupkgPath,
         bool force = false,
+        bool allowUntrusted = false,
         IProgress<WorkloadInstallProgress>? progress = null,
         CancellationToken cancellationToken = default)
     {
@@ -84,6 +88,13 @@ internal sealed class WorkloadInstaller(
             throw new InvalidWorkloadException(
                 $"Package '{packageId}' is not a func CLI workload " +
                 $"(missing package type '{FuncCliWorkloadPackageType}' in its .nuspec).");
+        }
+
+        TrustVerificationResult trust = await _trustVerifier.VerifyAsync(
+            nupkgPath, packageId, allowUntrusted, cancellationToken);
+        if (!trust.IsTrusted)
+        {
+            throw new UntrustedWorkloadException(trust.Reason!);
         }
 
         string installPath = _paths.GetInstallDirectory(packageId, version);
@@ -166,6 +177,7 @@ internal sealed class WorkloadInstaller(
         bool includePrerelease,
         bool exact,
         bool force,
+        bool allowUntrusted = false,
         IProgress<WorkloadInstallProgress>? progress = null,
         CancellationToken cancellationToken = default)
     {
@@ -195,7 +207,7 @@ internal sealed class WorkloadInstaller(
                 await packageStream.CopyToAsync(tempStream, cancellationToken);
             }
 
-            return await InstallFromPackageAsync(tempPath, force, progress, cancellationToken);
+            return await InstallFromPackageAsync(tempPath, force, allowUntrusted, progress, cancellationToken);
         }
         finally
         {
@@ -222,6 +234,7 @@ internal sealed class WorkloadInstaller(
         string? source,
         bool includePrerelease,
         bool allowMajor,
+        bool allowUntrusted = false,
         IProgress<WorkloadInstallProgress>? progress = null,
         CancellationToken cancellationToken = default)
     {
@@ -266,7 +279,7 @@ internal sealed class WorkloadInstaller(
             return new WorkloadUpdateResult(currentEntry, currentEntry.PackageVersion, NoUpdateAvailable: true);
         }
 
-        WorkloadEntry newEntry = await StageAndSwapAsync(currentEntry, resolved, progress, cancellationToken);
+        WorkloadEntry newEntry = await StageAndSwapAsync(currentEntry, resolved, allowUntrusted, progress, cancellationToken);
 
         return new WorkloadUpdateResult(newEntry, currentEntry.PackageVersion, NoUpdateAvailable: false);
     }
@@ -398,6 +411,7 @@ internal sealed class WorkloadInstaller(
     private async Task<WorkloadEntry> StageAndSwapAsync(
         WorkloadEntry currentEntry,
         ResolvedPackage resolved,
+        bool allowUntrusted,
         IProgress<WorkloadInstallProgress>? progress,
         CancellationToken cancellationToken)
     {
@@ -446,6 +460,13 @@ internal sealed class WorkloadInstaller(
                 throw new InvalidWorkloadException(
                     $"Resolved package '{resolved.PackageId}' {resolved.Version.ToNormalizedString()} but the source returned " +
                     $"'{newPackageId}' {newVersion}.");
+            }
+
+            TrustVerificationResult trust = await _trustVerifier.VerifyAsync(
+                tempNupkg, newPackageId, allowUntrusted, cancellationToken);
+            if (!trust.IsTrusted)
+            {
+                throw new UntrustedWorkloadException(trust.Reason!);
             }
 
             Directory.CreateDirectory(Path.GetDirectoryName(stagingPath)!);

--- a/test/Func.Tests/Commands/HostWorkloadResolverTests.cs
+++ b/test/Func.Tests/Commands/HostWorkloadResolverTests.cs
@@ -232,6 +232,7 @@ public class HostWorkloadResolverTests
                 Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<IProgress<WorkloadInstallProgress>?>(),
                 Arg.Any<CancellationToken>())
             .Returns(installResult);
@@ -251,6 +252,7 @@ public class HostWorkloadResolverTests
             includePrerelease: true,
             exact: true,
             force: false,
+            allowUntrusted: false,
             progress: null,
             cancellationToken: Arg.Any<CancellationToken>());
     }
@@ -263,6 +265,7 @@ public class HostWorkloadResolverTests
                 Arg.Any<string>(),
                 Arg.Any<NuGetVersion?>(),
                 Arg.Any<string?>(),
+                Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<bool>(),

--- a/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
+++ b/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
@@ -47,6 +47,7 @@ public sealed class SetupRunnerTests : IDisposable
                 Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<IProgress<WorkloadInstallProgress>?>(),
                 Arg.Any<CancellationToken>())
             .Returns(callInfo =>
@@ -83,6 +84,7 @@ public sealed class SetupRunnerTests : IDisposable
             Arg.Is(false),
             Arg.Is(true),
             Arg.Is(false),
+            Arg.Any<bool>(),
             Arg.Any<IProgress<WorkloadInstallProgress>?>(),
             Arg.Any<CancellationToken>());
         await _installer.Received(1).InstallFromCatalogAsync(
@@ -92,6 +94,7 @@ public sealed class SetupRunnerTests : IDisposable
             Arg.Is(false),
             Arg.Is(true),
             Arg.Is(false),
+            Arg.Any<bool>(),
             Arg.Any<IProgress<WorkloadInstallProgress>?>(),
             Arg.Any<CancellationToken>());
     }
@@ -120,6 +123,7 @@ public sealed class SetupRunnerTests : IDisposable
             Arg.Is(false),
             Arg.Is(true),
             Arg.Is(false),
+            Arg.Any<bool>(),
             Arg.Any<IProgress<WorkloadInstallProgress>?>(),
             Arg.Any<CancellationToken>());
         await _installer.Received(1).InstallFromCatalogAsync(
@@ -129,6 +133,7 @@ public sealed class SetupRunnerTests : IDisposable
             Arg.Is(false),
             Arg.Is(true),
             Arg.Is(false),
+            Arg.Any<bool>(),
             Arg.Any<IProgress<WorkloadInstallProgress>?>(),
             Arg.Any<CancellationToken>());
 
@@ -139,12 +144,14 @@ public sealed class SetupRunnerTests : IDisposable
             Arg.Any<bool>(),
             Arg.Any<bool>(),
             Arg.Any<bool>(),
+            Arg.Any<bool>(),
             Arg.Any<IProgress<WorkloadInstallProgress>?>(),
             Arg.Any<CancellationToken>());
         await _installer.DidNotReceive().InstallFromCatalogAsync(
             Arg.Is<string>(id => id.Contains("ExtensionBundles", StringComparison.OrdinalIgnoreCase)),
             Arg.Any<NuGetVersion?>(),
             Arg.Any<string?>(),
+            Arg.Any<bool>(),
             Arg.Any<bool>(),
             Arg.Any<bool>(),
             Arg.Any<bool>(),
@@ -173,6 +180,7 @@ public sealed class SetupRunnerTests : IDisposable
             Arg.Is(true),
             Arg.Is(true),
             Arg.Is(false),
+            Arg.Is(false),
             Arg.Any<IProgress<WorkloadInstallProgress>?>(),
             Arg.Any<CancellationToken>());
         await _installer.DidNotReceive().InstallFromCatalogAsync(
@@ -182,12 +190,14 @@ public sealed class SetupRunnerTests : IDisposable
             Arg.Any<bool>(),
             Arg.Any<bool>(),
             Arg.Any<bool>(),
+            Arg.Any<bool>(),
             Arg.Any<IProgress<WorkloadInstallProgress>?>(),
             Arg.Any<CancellationToken>());
         await _installer.DidNotReceive().InstallFromCatalogAsync(
             Arg.Is<string>(id => id.Contains("ExtensionBundles", StringComparison.OrdinalIgnoreCase)),
             Arg.Any<NuGetVersion?>(),
             Arg.Any<string?>(),
+            Arg.Any<bool>(),
             Arg.Any<bool>(),
             Arg.Any<bool>(),
             Arg.Any<bool>(),
@@ -326,6 +336,7 @@ public sealed class SetupRunnerTests : IDisposable
             Arg.Is(false),
             Arg.Is(true),
             Arg.Is(false),
+            Arg.Any<bool>(),
             Arg.Any<IProgress<WorkloadInstallProgress>?>(),
             Arg.Any<CancellationToken>());
     }
@@ -349,6 +360,7 @@ public sealed class SetupRunnerTests : IDisposable
             Arg.Is(false),
             Arg.Is(true),
             Arg.Is(false),
+            Arg.Any<bool>(),
             Arg.Any<IProgress<WorkloadInstallProgress>?>(),
             Arg.Any<CancellationToken>());
     }
@@ -372,6 +384,7 @@ public sealed class SetupRunnerTests : IDisposable
             Arg.Any<bool>(),
             Arg.Any<bool>(),
             Arg.Any<bool>(),
+            Arg.Any<bool>(),
             Arg.Any<IProgress<WorkloadInstallProgress>?>(),
             Arg.Any<CancellationToken>());
     }
@@ -392,6 +405,7 @@ public sealed class SetupRunnerTests : IDisposable
             Arg.Any<string>(),
             Arg.Any<NuGetVersion?>(),
             Arg.Any<string?>(),
+            Arg.Any<bool>(),
             Arg.Any<bool>(),
             Arg.Any<bool>(),
             Arg.Any<bool>(),
@@ -479,6 +493,7 @@ public sealed class SetupRunnerTests : IDisposable
             Arg.Any<bool>(),
             Arg.Any<bool>(),
             Arg.Any<bool>(),
+            Arg.Any<bool>(),
             Arg.Any<IProgress<WorkloadInstallProgress>?>(),
             Arg.Any<CancellationToken>());
     }
@@ -507,6 +522,7 @@ public sealed class SetupRunnerTests : IDisposable
             Arg.Any<bool>(),
             Arg.Any<bool>(),
             Arg.Any<bool>(),
+            Arg.Any<bool>(),
             Arg.Any<IProgress<WorkloadInstallProgress>?>(),
             Arg.Any<CancellationToken>());
     }
@@ -531,6 +547,7 @@ public sealed class SetupRunnerTests : IDisposable
                 && !id.StartsWith("Azure.Functions.Cli.Workloads.ExtensionBundles", StringComparison.OrdinalIgnoreCase)),
             Arg.Any<NuGetVersion?>(),
             Arg.Any<string?>(),
+            Arg.Any<bool>(),
             Arg.Any<bool>(),
             Arg.Any<bool>(),
             Arg.Any<bool>(),
@@ -584,6 +601,7 @@ public sealed class SetupRunnerTests : IDisposable
             Arg.Any<bool>(),
             Arg.Any<bool>(),
             Arg.Any<bool>(),
+            Arg.Any<bool>(),
             Arg.Any<IProgress<WorkloadInstallProgress>?>(),
             Arg.Any<CancellationToken>());
     }
@@ -604,6 +622,7 @@ public sealed class SetupRunnerTests : IDisposable
                 || id.StartsWith("Azure.Functions.Cli.Workloads.DotNet", StringComparison.OrdinalIgnoreCase)),
             Arg.Any<NuGetVersion?>(),
             Arg.Any<string?>(),
+            Arg.Any<bool>(),
             Arg.Any<bool>(),
             Arg.Any<bool>(),
             Arg.Any<bool>(),
@@ -643,7 +662,7 @@ public sealed class SetupRunnerTests : IDisposable
 
         Assert.Equal(0, result.ExitCode);
         Assert.Contains(interactive.Lines, line => line.StartsWith("HINT:", StringComparison.Ordinal) && line.Contains("No stacks selected", StringComparison.Ordinal));
-        await _installer.DidNotReceiveWithAnyArgs().InstallFromCatalogAsync(default!, default, default, default, default, default, default, default);
+        await _installer.DidNotReceiveWithAnyArgs().InstallFromCatalogAsync(default!, default, default, default, default, default, default, default, default);
     }
 
     [Fact]

--- a/test/Func.Tests/Commands/StartInitializationTests.cs
+++ b/test/Func.Tests/Commands/StartInitializationTests.cs
@@ -267,6 +267,7 @@ public class StartInitializationTests : IDisposable
                 Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<IProgress<WorkloadInstallProgress>?>(),
                 Arg.Any<CancellationToken>())
             .Returns(Task.FromException<WorkloadInstallResult>(
@@ -525,6 +526,7 @@ public class StartInitializationTests : IDisposable
             Arg.Any<string>(),
             Arg.Any<NuGetVersion?>(),
             Arg.Any<string?>(),
+            Arg.Any<bool>(),
             Arg.Any<bool>(),
             Arg.Any<bool>(),
             Arg.Any<bool>(),
@@ -1143,6 +1145,7 @@ public class StartInitializationTests : IDisposable
                 Arg.Any<string>(),
                 Arg.Any<NuGetVersion?>(),
                 Arg.Any<string?>(),
+                Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<bool>(),

--- a/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
@@ -50,7 +50,7 @@ public class WorkloadInstallCommandTests
 
         Assert.Equal(0, exit);
         await _installer.Received(1).InstallFromCatalogAsync(
-            "Test.Workload", null, null, true, false, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
+            "Test.Workload", null, null, true, false, false, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -76,6 +76,7 @@ public class WorkloadInstallCommandTests
             true,
             true,
             true,
+            Arg.Any<bool>(),
             Arg.Any<IProgress<WorkloadInstallProgress>?>(),
             Arg.Any<CancellationToken>());
     }
@@ -96,6 +97,7 @@ public class WorkloadInstallCommandTests
             true,
             false,
             true,
+            false,
             Arg.Any<IProgress<WorkloadInstallProgress>?>(),
             Arg.Any<CancellationToken>());
     }
@@ -110,7 +112,7 @@ public class WorkloadInstallCommandTests
 
         Assert.Equal(0, exit);
         await _installer.Received(1).InstallFromCatalogAsync(
-            "test.workload", null, null, true, true, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
+            "test.workload", null, null, true, true, false, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -125,7 +127,7 @@ public class WorkloadInstallCommandTests
 
         Assert.Equal(0, exit);
         await _installer.Received(1).InstallFromCatalogAsync(
-            "Test.Workload", null, "/tmp/local-feed", true, false, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
+            "Test.Workload", null, "/tmp/local-feed", true, false, false, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -187,7 +189,7 @@ public class WorkloadInstallCommandTests
     {
         _installer.InstallFromCatalogAsync(
                 Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Returns(new WorkloadInstallResult(
                 new WorkloadEntry
                 {
@@ -214,7 +216,7 @@ public class WorkloadInstallCommandTests
     {
         _installer.InstallFromCatalogAsync(
                 Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Throws(new AmbiguousPackageMatchException(
                 "myalias", new[] { "Pkg.A", "Pkg.B" }));
 
@@ -231,7 +233,7 @@ public class WorkloadInstallCommandTests
     {
         _installer.InstallFromCatalogAsync(
                 Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Throws(new WorkloadPackageNotFoundException("not on any source"));
 
         var cmd = NewInstall();
@@ -246,7 +248,7 @@ public class WorkloadInstallCommandTests
     {
         _installer.InstallFromCatalogAsync(
                 Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Throws(new InvalidWorkloadException("bad package"));
 
         var cmd = NewInstall();
@@ -261,7 +263,7 @@ public class WorkloadInstallCommandTests
     {
         _installer.InstallFromCatalogAsync(
                 Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Throws(new InvalidOperationException(
                 "Workload 'x' version '1' is already installed at '/p' but is missing from the registry."));
 
@@ -278,7 +280,7 @@ public class WorkloadInstallCommandTests
     {
         _installer.InstallFromCatalogAsync(
                 Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Throws(new NullReferenceException("oops"));
 
         var cmd = NewInstall();
@@ -293,7 +295,7 @@ public class WorkloadInstallCommandTests
         await File.WriteAllBytesAsync(tempPkg, [0x50, 0x4B]);
         try
         {
-            _installer.InstallFromPackageAsync(tempPkg, Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
+            _installer.InstallFromPackageAsync(tempPkg, Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
                 .Returns(new WorkloadInstallResult(
                     new WorkloadEntry
                     {
@@ -308,9 +310,9 @@ public class WorkloadInstallCommandTests
 
             Assert.Equal(0, exit);
             await _installer.Received(1).InstallFromPackageAsync(
-                tempPkg, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
+                tempPkg, false, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
             await _installer.DidNotReceiveWithAnyArgs().InstallFromCatalogAsync(
-                default!, default, default, default, default, default, default);
+                default!, default, default, default, default, default, default, default, default);
         }
         finally
         {
@@ -337,7 +339,7 @@ public class WorkloadInstallCommandTests
         Assert.Equal(1, exit);
         await _installer.DidNotReceive().InstallFromCatalogAsync(
             Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
+            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
         Assert.Contains(_interaction.Lines, l =>
             l.StartsWith("HINT:") && l.Contains("func workload update test"));
     }
@@ -403,7 +405,7 @@ public class WorkloadInstallCommandTests
 
         Assert.Equal(0, exit);
         await _installer.Received(1).InstallFromCatalogAsync(
-            "alias1", null, null, true, true, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
+            "alias1", null, null, true, true, false, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -425,7 +427,7 @@ public class WorkloadInstallCommandTests
 
         Assert.Equal(0, exit);
         await _installer.Received(1).InstallFromCatalogAsync(
-            "Test.Workload", null, null, true, false, true, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
+            "Test.Workload", null, null, true, false, true, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
         await _store.DidNotReceive().GetWorkloadsAsync(Arg.Any<CancellationToken>());
     }
 
@@ -438,7 +440,7 @@ public class WorkloadInstallCommandTests
         IProgress<WorkloadInstallProgress>? captured = null;
         _installer.InstallFromCatalogAsync(
                 Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(),
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(),
                 Arg.Do<IProgress<WorkloadInstallProgress>?>(p => captured = p),
                 Arg.Any<CancellationToken>())
             .Returns(_ =>
@@ -472,7 +474,7 @@ public class WorkloadInstallCommandTests
     private void StubCatalogResult(bool alreadyInstalled = false, string packageId = "test.workload") =>
         _installer.InstallFromCatalogAsync(
                 Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Returns(new WorkloadInstallResult(
                 new WorkloadEntry
                 {
@@ -582,7 +584,7 @@ public class WorkloadInstallNextStepsHintTests
     private void StubInstall(string packageId, bool alreadyInstalled = false) =>
         _installer.InstallFromCatalogAsync(
                 Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Returns(new WorkloadInstallResult(
                 new WorkloadEntry
                 {

--- a/test/Func.Tests/Commands/Workload/WorkloadUpdateCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadUpdateCommandTests.cs
@@ -116,7 +116,7 @@ public class WorkloadUpdateCommandTests
         _installer.UpdateAsync(
                 "Test.Workload",
                 Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Returns(new WorkloadUpdateResult(
                 Entry: new WorkloadEntry { PackageId = "test.workload", PackageVersion = "1.1.0" },
                 PreviousVersion: "1.0.0",
@@ -140,7 +140,7 @@ public class WorkloadUpdateCommandTests
         _installer.UpdateAsync(
                 "Test.Workload",
                 Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Returns(new WorkloadUpdateResult(
                 Entry: new WorkloadEntry { PackageId = "test.workload", PackageVersion = "1.0.0" },
                 PreviousVersion: "1.0.0",
@@ -162,7 +162,7 @@ public class WorkloadUpdateCommandTests
     {
         _installer.UpdateAsync(
                 Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Returns(new WorkloadUpdateResult(
                 Entry: new WorkloadEntry { PackageId = "test.workload", PackageVersion = "2.0.0" },
                 PreviousVersion: "1.0.0",
@@ -184,6 +184,7 @@ public class WorkloadUpdateCommandTests
             "https://example/v3/index.json",
             true,
             true,
+            Arg.Any<bool>(),
             Arg.Any<IProgress<WorkloadInstallProgress>?>(),
             Arg.Any<CancellationToken>());
     }
@@ -193,7 +194,7 @@ public class WorkloadUpdateCommandTests
     {
         _installer.UpdateAsync(
                 Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Throws(new InvalidOperationException("Workload 'test.workload' is not installed."));
 
         var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store);
@@ -209,7 +210,7 @@ public class WorkloadUpdateCommandTests
     {
         _installer.UpdateAsync(
                 Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Throws(new WorkloadPackageNotFoundException("nope"));
 
         var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store);
@@ -232,7 +233,7 @@ public class WorkloadUpdateCommandTests
         Assert.Contains(_interaction.Lines, l => l.StartsWith("HINT:") && l.Contains("No workloads installed"));
         await _installer.DidNotReceive().UpdateAsync(
             Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
+            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -247,7 +248,7 @@ public class WorkloadUpdateCommandTests
         _installer.UpdateAsync(
                 "a.workload",
                 Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Returns(new WorkloadUpdateResult(
                 new WorkloadEntry { PackageId = "a.workload", PackageVersion = "1.2.0" },
                 "1.1.0",
@@ -255,7 +256,7 @@ public class WorkloadUpdateCommandTests
         _installer.UpdateAsync(
                 "b.workload",
                 Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Returns(new WorkloadUpdateResult(
                 new WorkloadEntry { PackageId = "b.workload", PackageVersion = "2.0.0" },
                 "2.0.0",
@@ -267,10 +268,10 @@ public class WorkloadUpdateCommandTests
         Assert.Equal(0, exit);
         await _installer.Received(1).UpdateAsync(
             "a.workload", Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
+            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
         await _installer.Received(1).UpdateAsync(
             "b.workload", Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
+            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
         Assert.Contains(_interaction.Lines, l => l.StartsWith("SUCCESS:") && l.Contains("a.workload"));
         Assert.Contains(_interaction.Lines, l => l.StartsWith("WARNING:") && l.Contains("b.workload"));
     }
@@ -286,12 +287,12 @@ public class WorkloadUpdateCommandTests
         _installer.UpdateAsync(
                 "a.workload",
                 Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Throws(new WorkloadPackageNotFoundException("not on feed"));
         _installer.UpdateAsync(
                 "b.workload",
                 Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Returns(new WorkloadUpdateResult(
                 new WorkloadEntry { PackageId = "b.workload", PackageVersion = "2.1.0" },
                 "2.0.0",
@@ -311,7 +312,7 @@ public class WorkloadUpdateCommandTests
         _installer.UpdateAsync(
                 "Test.Workload",
                 Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Returns(new WorkloadUpdateResult(
                 Entry: new WorkloadEntry { PackageId = "test.workload", PackageVersion = "1.0.0" },
                 PreviousVersion: "1.0.0",
@@ -344,7 +345,7 @@ public class WorkloadUpdateCommandTests
         _installer.UpdateAsync(
                 "test.workload",
                 Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Returns(new WorkloadUpdateResult(
                 new WorkloadEntry { PackageId = "test.workload", PackageVersion = "1.1.0" },
                 "1.0.0",
@@ -357,7 +358,7 @@ public class WorkloadUpdateCommandTests
         await _installer.Received(1).UpdateAsync(
             "test.workload",
             Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
+            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -375,7 +376,7 @@ public class WorkloadUpdateCommandTests
         _installer.UpdateAsync(
                 "demo",
                 Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Throws(new InvalidOperationException("Workload 'demo' is not installed."));
 
         var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store);
@@ -386,7 +387,7 @@ public class WorkloadUpdateCommandTests
         await _installer.DidNotReceive().UpdateAsync(
             "test.workload",
             Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
+            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -408,7 +409,7 @@ public class WorkloadUpdateCommandTests
         Assert.True(ex.IsUserError);
         await _installer.DidNotReceive().UpdateAsync(
             Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
-            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
+            Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
     }
 
     private static Task<int> InvokeAsync(WorkloadUpdateCommand cmd, params string[] args)

--- a/test/Func.Tests/Workers/DefaultFunctionsWorkerInstallerTests.cs
+++ b/test/Func.Tests/Workers/DefaultFunctionsWorkerInstallerTests.cs
@@ -57,6 +57,7 @@ public class DefaultFunctionsWorkerInstallerTests
                 Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<IProgress<WorkloadInstallProgress>?>(),
                 Arg.Any<CancellationToken>())
             .Returns(new WorkloadInstallResult(CreateWorkerEntry("3.13.0"), AlreadyInstalled: false));
@@ -92,6 +93,7 @@ public class DefaultFunctionsWorkerInstallerTests
                 Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<bool>(),
+                Arg.Any<bool>(),
                 Arg.Any<IProgress<WorkloadInstallProgress>?>(),
                 Arg.Any<CancellationToken>())
             .Returns(new WorkloadInstallResult(CreateWorkerEntry("3.14.0"), AlreadyInstalled: true));
@@ -108,7 +110,7 @@ public class DefaultFunctionsWorkerInstallerTests
             includePrerelease: true,
             exact: true,
             force: false,
-            progress: null,
+            Arg.Any<bool>(),progress: null,
             cancellationToken: Arg.Any<CancellationToken>());
     }
 
@@ -146,6 +148,7 @@ public class DefaultFunctionsWorkerInstallerTests
                 Arg.Any<string>(),
                 Arg.Any<NuGetVersion?>(),
                 Arg.Any<string?>(),
+                Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<bool>(),

--- a/test/Func.Tests/Workloads/Install/Trust/EmbeddedTrustAnchorStoreTests.cs
+++ b/test/Func.Tests/Workloads/Install/Trust/EmbeddedTrustAnchorStoreTests.cs
@@ -1,0 +1,101 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using Azure.Functions.Cli.Workloads.Install.Trust;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Workloads.Install.Trust;
+
+public sealed class EmbeddedTrustAnchorStoreTests
+{
+    [Fact]
+    public void DefaultConstructor_LoadsBundledResource_DoesNotThrow()
+    {
+        var store = new EmbeddedTrustAnchorStore();
+
+        X509Certificate2Collection anchors = store.GetTrustAnchors();
+
+        // The shipped bundle may be empty (placeholder) or populated. Either is
+        // a valid load; we only assert the call returns without throwing.
+        Assert.NotNull(anchors);
+    }
+
+    [Fact]
+    public void GetTrustAnchors_CachesAcrossCalls()
+    {
+        var store = new EmbeddedTrustAnchorStore();
+
+        X509Certificate2Collection first = store.GetTrustAnchors();
+        X509Certificate2Collection second = store.GetTrustAnchors();
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void Constructor_NullAssembly_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new EmbeddedTrustAnchorStore(null!));
+    }
+
+    [Fact]
+    public void GetTrustAnchors_MissingResource_Throws()
+    {
+        var store = new EmbeddedTrustAnchorStore(typeof(string).Assembly);
+
+        Assert.Throws<InvalidOperationException>(store.GetTrustAnchors);
+    }
+
+    [Fact]
+    public void GetTrustAnchors_PopulatedBundle_LoadsCertificate()
+    {
+        Assembly assembly = AssemblyWithPemResource(MakeSelfSignedPem());
+
+        var store = new EmbeddedTrustAnchorStore(assembly);
+        var anchors = store.GetTrustAnchors();
+
+        Assert.Single(anchors);
+        Assert.Contains("Test Bundled Root", anchors[0].Subject);
+    }
+
+    [Fact]
+    public void GetTrustAnchors_EmptyBundle_ReturnsEmpty()
+    {
+        // Placeholder bundles ship with a comment-only PEM file before the
+        // real cert is added. The store treats that as "no anchors" rather
+        // than blowing up.
+        Assembly assembly = AssemblyWithPemResource("# placeholder, no certs yet\n");
+
+        var store = new EmbeddedTrustAnchorStore(assembly);
+        var anchors = store.GetTrustAnchors();
+
+        Assert.Empty(anchors);
+    }
+
+    private static string MakeSelfSignedPem()
+    {
+        using var key = RSA.Create(2048);
+        var req = new CertificateRequest("CN=Test Bundled Root", key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        req.CertificateExtensions.Add(new X509BasicConstraintsExtension(true, false, 0, true));
+        using X509Certificate2 cert = req.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(30));
+        return cert.ExportCertificatePem();
+    }
+
+    private static Assembly AssemblyWithPemResource(string pem)
+    {
+        // Stand up an in-memory assembly that ships the embedded PEM under
+        // the exact logical name the store expects. Lets us exercise the
+        // happy/malformed paths without touching the real bundle file.
+        var bytes = Encoding.UTF8.GetBytes(pem);
+        return new InMemoryAssemblyWithResource(EmbeddedTrustAnchorStore.ResourceName, bytes);
+    }
+
+    private sealed class InMemoryAssemblyWithResource(string resourceName, byte[] payload) : Assembly
+    {
+        public override Stream? GetManifestResourceStream(string name) =>
+            name == resourceName ? new MemoryStream(payload, writable: false) : null;
+    }
+}

--- a/test/Func.Tests/Workloads/Install/Trust/WorkloadTrustVerifierTests.cs
+++ b/test/Func.Tests/Workloads/Install/Trust/WorkloadTrustVerifierTests.cs
@@ -1,0 +1,200 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Azure.Functions.Cli.Workloads.Install.Trust;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Workloads.Install.Trust;
+
+public sealed class WorkloadTrustVerifierTests : IDisposable
+{
+    private readonly string _root;
+    private readonly ITrustAnchorStore _store = Substitute.For<ITrustAnchorStore>();
+
+    public WorkloadTrustVerifierTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), $"func-trust-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_root);
+        _store.GetTrustAnchors().Returns([]);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch
+        {
+            // best-effort temp cleanup; surfacing this would mask the real failure
+        }
+    }
+
+    [Fact]
+    public async Task AllowUntrusted_ShortCircuits_Trusted()
+    {
+        var verifier = new WorkloadTrustVerifier(_store);
+
+        TrustVerificationResult result = await verifier.VerifyAsync(
+            "/nonexistent.nupkg", "anything", allowUntrusted: true);
+
+        Assert.True(result.IsTrusted);
+        _store.DidNotReceiveWithAnyArgs().GetTrustAnchors();
+    }
+
+    [Fact]
+    public async Task NonOfficialPrefix_Untrusted()
+    {
+        var verifier = new WorkloadTrustVerifier(_store);
+
+        TrustVerificationResult result = await verifier.VerifyAsync(
+            "/nonexistent.nupkg", "contoso.totally.legit", allowUntrusted: false);
+
+        Assert.False(result.IsTrusted);
+        Assert.Contains("not part of the Azure Functions CLI workload namespace", result.Reason);
+    }
+
+    [Fact]
+    public async Task NoTrustAnchorsConfigured_Untrusted()
+    {
+        var verifier = new WorkloadTrustVerifier(_store);
+
+        TrustVerificationResult result = await verifier.VerifyAsync(
+            "/nonexistent.nupkg", "azure.functions.cli.workloads.node", allowUntrusted: false);
+
+        Assert.False(result.IsTrusted);
+        Assert.Contains("No trust anchors", result.Reason);
+    }
+
+    [Fact]
+    public async Task UnsignedPackage_Untrusted()
+    {
+        using X509Certificate2 anchor = CreateSelfSignedRoot("CN=Test Anchor");
+        _store.GetTrustAnchors().Returns([anchor]);
+
+        string nupkg = BuildUnsignedNupkg();
+        var verifier = new WorkloadTrustVerifier(_store);
+
+        TrustVerificationResult result = await verifier.VerifyAsync(
+            nupkg, "azure.functions.cli.workloads.node", allowUntrusted: false);
+
+        Assert.False(result.IsTrusted);
+        Assert.Contains("not signed", result.Reason);
+    }
+
+    [Fact]
+    public async Task NullOrEmptyArguments_Throw()
+    {
+        var verifier = new WorkloadTrustVerifier(_store);
+
+        await Assert.ThrowsAnyAsync<ArgumentException>(
+            () => verifier.VerifyAsync(null!, "id", false));
+        await Assert.ThrowsAnyAsync<ArgumentException>(
+            () => verifier.VerifyAsync("/x.nupkg", "", false));
+    }
+
+    [Fact]
+    public void Constructor_NullStore_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new WorkloadTrustVerifier(null!));
+    }
+
+    [Fact]
+    public void IsChainTrustedTo_LeafChainsToBundledRoot_Trusted()
+    {
+        using X509Certificate2 root = CreateSelfSignedRoot("CN=Test Root");
+        using X509Certificate2 leaf = CreateLeafSignedBy(root, "CN=Test Leaf");
+
+        bool trusted = WorkloadTrustVerifier.IsChainTrustedTo(
+            leaf,
+            anchors: [root],
+            extraStore: [],
+            out string failure);
+
+        Assert.True(trusted, $"Expected chain to validate, got: {failure}");
+        Assert.Empty(failure);
+    }
+
+    [Fact]
+    public void IsChainTrustedTo_LeafDoesNotChainToBundledRoot_Untrusted()
+    {
+        using X509Certificate2 trustedRoot = CreateSelfSignedRoot("CN=Trusted Root");
+        using X509Certificate2 untrustedRoot = CreateSelfSignedRoot("CN=Untrusted Root");
+        using X509Certificate2 leaf = CreateLeafSignedBy(untrustedRoot, "CN=Foreign Leaf");
+
+        bool trusted = WorkloadTrustVerifier.IsChainTrustedTo(
+            leaf,
+            anchors: [trustedRoot],
+            extraStore: [],
+            out string failure);
+
+        Assert.False(trusted);
+        Assert.NotEmpty(failure);
+    }
+
+    [Fact]
+    public void IsChainTrustedTo_NullArgs_Throw()
+    {
+        using X509Certificate2 root = CreateSelfSignedRoot("CN=Root");
+        Assert.Throws<ArgumentNullException>(() =>
+            WorkloadTrustVerifier.IsChainTrustedTo(null!, [], [], out _));
+        Assert.Throws<ArgumentNullException>(() =>
+            WorkloadTrustVerifier.IsChainTrustedTo(root, null!, [], out _));
+        Assert.Throws<ArgumentNullException>(() =>
+            WorkloadTrustVerifier.IsChainTrustedTo(root, [], null!, out _));
+    }
+
+    private static X509Certificate2 CreateSelfSignedRoot(string subject)
+    {
+        using var key = RSA.Create(2048);
+        var req = new CertificateRequest(subject, key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        req.CertificateExtensions.Add(new X509BasicConstraintsExtension(certificateAuthority: true, hasPathLengthConstraint: false, pathLengthConstraint: 0, critical: true));
+        req.CertificateExtensions.Add(new X509KeyUsageExtension(X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.DigitalSignature, critical: true));
+        return req.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(30));
+    }
+
+    private static X509Certificate2 CreateLeafSignedBy(X509Certificate2 issuer, string subject)
+    {
+        using var key = RSA.Create(2048);
+        var req = new CertificateRequest(subject, key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        req.CertificateExtensions.Add(new X509BasicConstraintsExtension(certificateAuthority: false, hasPathLengthConstraint: false, pathLengthConstraint: 0, critical: true));
+        req.CertificateExtensions.Add(new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature, critical: true));
+
+        byte[] serial = new byte[8];
+        RandomNumberGenerator.Fill(serial);
+
+        return req.Create(issuer, DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(15), serial);
+    }
+
+    // Minimal .nupkg synthesis: just a zip with a .nuspec. NuGet's
+    // PackageArchiveReader is happy to open it; IsSignedAsync returns false
+    // because there's no .signature.p7s entry. That's all we need to exercise
+    // the "unsigned package" branch without dragging in a real signing cert.
+    private string BuildUnsignedNupkg()
+    {
+        string path = Path.Combine(_root, $"unsigned-{Guid.NewGuid():N}.nupkg");
+        using (FileStream stream = File.Create(path))
+        using (var archive = new ZipArchive(stream, ZipArchiveMode.Create))
+        {
+            ZipArchiveEntry entry = archive.CreateEntry("test.nuspec");
+            using StreamWriter writer = new(entry.Open());
+            writer.Write("""
+                <?xml version="1.0" encoding="utf-8"?>
+                <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+                  <metadata>
+                    <id>azure.functions.cli.workloads.node</id>
+                    <version>1.0.0</version>
+                    <authors>test</authors>
+                    <description>For tests.</description>
+                  </metadata>
+                </package>
+                """);
+        }
+
+        return path;
+    }
+}

--- a/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
+++ b/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
@@ -5,6 +5,7 @@ using Azure.Functions.Cli.Workloads;
 using Azure.Functions.Cli.Workloads.Catalog;
 using Azure.Functions.Cli.Workloads.Discovery;
 using Azure.Functions.Cli.Workloads.Install;
+using Azure.Functions.Cli.Workloads.Install.Trust;
 using Azure.Functions.Cli.Workloads.Storage;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -147,6 +148,41 @@ public sealed class WorkloadInstallerTests : IDisposable
         FileNotFoundException ex = await Assert.ThrowsAsync<FileNotFoundException>(
             () => installer.InstallFromPackageAsync(Path.Combine(_root, "missing.nupkg")));
         Assert.Contains("does not exist", ex.Message);
+    }
+
+    [Fact]
+    public async Task InstallFromPackage_VerifierUntrusted_Throws_AndNoFilesWritten()
+    {
+        string nupkg = BuildNupkg();
+        var verifier = Substitute.For<IWorkloadTrustVerifier>();
+        verifier.VerifyAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(TrustVerificationResult.Untrusted("publisher not trusted"));
+
+        WorkloadInstaller installer = NewInstaller(verifier);
+        UntrustedWorkloadException ex = await Assert.ThrowsAsync<UntrustedWorkloadException>(
+            () => installer.InstallFromPackageAsync(nupkg));
+
+        Assert.Equal("publisher not trusted", ex.Message);
+        Assert.False(Directory.Exists(_paths.GetInstallDirectory("test.workload", "1.0.0")));
+        await _store.DidNotReceive().SaveWorkloadAsync(Arg.Any<WorkloadEntry>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InstallFromPackage_AllowUntrusted_ForwardsToVerifier()
+    {
+        string nupkg = BuildNupkg();
+        var verifier = Substitute.For<IWorkloadTrustVerifier>();
+        verifier.VerifyAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(TrustVerificationResult.Trusted);
+
+        WorkloadInstaller installer = NewInstaller(verifier);
+        await installer.InstallFromPackageAsync(nupkg, force: false, allowUntrusted: true);
+
+        await verifier.Received(1).VerifyAsync(
+            Arg.Any<string>(),
+            "test.workload",
+            allowUntrusted: true,
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -573,7 +609,7 @@ public sealed class WorkloadInstallerTests : IDisposable
         var progress = new RecordingProgress(reports);
 
         WorkloadInstaller installer = NewInstaller();
-        await installer.InstallFromPackageAsync(nupkg, force: false, progress);
+        await installer.InstallFromPackageAsync(nupkg, force: false, allowUntrusted: false, progress: progress);
 
         Assert.Collection(
             reports,
@@ -641,7 +677,16 @@ public sealed class WorkloadInstallerTests : IDisposable
         NuGetVersion.Parse(version),
         new PackageSource("https://example/v3/index.json", "test"));
 
-    private WorkloadInstaller NewInstaller() => new(_paths, _store, _metadataReader, _catalog);
+    private WorkloadInstaller NewInstaller(IWorkloadTrustVerifier? trustVerifier = null)
+    {
+        if (trustVerifier is null)
+        {
+            trustVerifier = Substitute.For<IWorkloadTrustVerifier>();
+            trustVerifier.VerifyAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                .Returns(TrustVerificationResult.Trusted);
+        }
+        return new(_paths, _store, _metadataReader, _catalog, trustVerifier);
+    }
 
     [Fact]
     public async Task InstallFromPackage_HostPackage_SetsExecutableBitOnHostBinary_OnUnix()


### PR DESCRIPTION
## What

Gates `func workload install` / `update` on publisher trust. Before any payload is extracted, the verifier checks two things:

1. **Package id prefix:** must start with `azure.functions.cli.workloads.` (the official Microsoft-published namespace).
2. **Signature chain:** the `.nupkg` must carry a primary signature whose signing certificate chains to a root in the bundled trust anchor store (`trusted-roots.pem`, embedded resource). The chain is built with `X509ChainTrustMode.CustomRootTrust`, so only the bundled roots are trusted, not whatever happens to be in the OS trust store.

Either failure rejects the install with a clear `GracefulException`. A single opt-out flag, `--allow-untrusted`, bypasses both gates and applies to catalog installs, local `.nupkg` installs, and `update`. Required for dev workflows where someone packs a workload locally and installs the unsigned `.nupkg`.

## Why a real cert bundle (not fingerprint pinning)

An earlier iteration of this PR pinned SHA-256 fingerprints of specific signing certs. That had two problems:

- No notion of expiry or chain. Anything that matched the hash was trusted forever, even if Microsoft rotated the cert or it was revoked.
- Brittle to legitimate cert rotation: rotating the leaf required shipping a CLI update.

A PEM bundle of *roots* (the same model cURL and OpenSSL use for the public web PKI) lets the publisher rotate intermediates and leafs freely; we only re-bundle when the root itself rotates. Revocation is intentionally `NoCheck` for v1 (OCSP/CRL on a CLI install path means every install needs network egress to a CA responder, hostile in offline/restricted environments). Opt-in revocation is a sensible follow-up.

## Out of scope

- OCSP / CRL checks (follow-up, behind a flag).
- Repository signatures (Microsoft publishes author-signed packages).
- Auto-rotating the bundle from a remote endpoint (future PR).

## Release blocker

`src/Func/Workloads/Install/Trust/trusted-roots.pem` ships as a placeholder (comment-only file). The mechanism is in place; the actual Microsoft NuGet author signing root must be added before a release that gates installs on this bundle. Until then the empty bundle causes every install of an `azure.functions.cli.workloads.*` package to fail trust verification unless `--allow-untrusted` is passed.

## Tests

- `WorkloadTrustVerifierTests`: allow-untrusted bypass, prefix mismatch, empty anchor store, unsigned package, null-arg validation, plus chain-validates-to-bundled-root and chain-does-not-validate paths using synthesized self-signed certs via `CertificateRequest`.
- `EmbeddedTrustAnchorStoreTests`: default load, caching, missing resource, populated bundle, empty/placeholder bundle.
- `WorkloadInstallerTests`: verifier wired into the installer; untrusted result short-circuits install; `allowUntrusted` flag forwards through the pipeline.
- `WorkloadInstallCommandTests` / `WorkloadUpdateCommandTests`: `--allow-untrusted` flag is plumbed.

All 612 tests pass; `CI=true dotnet build -c Release` is clean (0 warnings).