### PR TITLE
func start: match v4 local.settings.json env-var precedence and diagnostics

### DIFF
--- a/src/Func/Commands/Start/Dashboard/Demo/DemoStartInitializationRunner.cs
+++ b/src/Func/Commands/Start/Dashboard/Demo/DemoStartInitializationRunner.cs
@@ -33,6 +33,7 @@ internal sealed class DemoStartInitializationRunner(
     ILocalSettingsProvider localSettingsProvider,
     IWorkloadPaths workloadPaths,
     IHostProcessRunner hostProcessRunner,
+    IProcessEnvironment processEnvironment,
     ILoggerFactory loggerFactory,
     TimeProvider? timeProvider = null)
     : IStartInitializationRunner
@@ -71,6 +72,9 @@ internal sealed class DemoStartInitializationRunner(
     private readonly IHostProcessRunner _hostProcessRunner = hostProcessRunner
         ?? throw new ArgumentNullException(nameof(hostProcessRunner));
 
+    private readonly IProcessEnvironment _processEnvironment = processEnvironment
+        ?? throw new ArgumentNullException(nameof(processEnvironment));
+
     private readonly ILoggerFactory _loggerFactory = loggerFactory
         ?? throw new ArgumentNullException(nameof(loggerFactory));
 
@@ -105,7 +109,7 @@ internal sealed class DemoStartInitializationRunner(
                 _bundleResolver,
                 _bundleSectionReader,
                 _loggerFactory.CreateLogger<ValidateExtensionBundleInitializationStep>()),
-            new PrepareProjectHostRunInitializationStep(_localSettingsProvider),
+            new PrepareProjectHostRunInitializationStep(_localSettingsProvider, _processEnvironment, _interaction),
             new StartHostInitializationStep(_hostProcessRunner, _time),
         ];
 

--- a/src/Func/Commands/Start/Initialization/Steps/PrepareProjectHostRunInitializationStep.cs
+++ b/src/Func/Commands/Start/Initialization/Steps/PrepareProjectHostRunInitializationStep.cs
@@ -114,7 +114,7 @@ internal sealed class PrepareProjectHostRunInitializationStep(
                 continue;
             }
 
-            if (!string.IsNullOrEmpty(_processEnvironment.Get(name)))
+            if (_processEnvironment.Get(name) is not null)
             {
                 _interaction.WriteWarning($"Skipping '{name}' from local.settings.json: already set in the current environment.");
                 continue;

--- a/src/Func/Commands/Start/Initialization/Steps/PrepareProjectHostRunInitializationStep.cs
+++ b/src/Func/Commands/Start/Initialization/Steps/PrepareProjectHostRunInitializationStep.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Configuration;
+using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Workers;
 
@@ -12,12 +14,21 @@ namespace Azure.Functions.Cli.Commands.Start.Initialization;
 /// Populates the environment dictionary the host will see: <c>local.settings.json</c> values,
 /// <c>FUNCTIONS_WORKER_RUNTIME</c>, the worker directory hint, and any bundle env vars.
 /// </summary>
-internal sealed class PrepareProjectHostRunInitializationStep(ILocalSettingsProvider localSettingsProvider) : DemoInitializationStep
+internal sealed class PrepareProjectHostRunInitializationStep(
+    ILocalSettingsProvider localSettingsProvider,
+    IProcessEnvironment processEnvironment,
+    IInteractionService interaction) : DemoInitializationStep
 {
     public const string StepId = "prepare_host_run";
 
     private readonly ILocalSettingsProvider _localSettingsProvider = localSettingsProvider
         ?? throw new ArgumentNullException(nameof(localSettingsProvider));
+
+    private readonly IProcessEnvironment _processEnvironment = processEnvironment
+        ?? throw new ArgumentNullException(nameof(processEnvironment));
+
+    private readonly IInteractionService _interaction = interaction
+        ?? throw new ArgumentNullException(nameof(interaction));
 
     public override string Id => StepId;
 
@@ -54,19 +65,17 @@ internal sealed class PrepareProjectHostRunInitializationStep(ILocalSettingsProv
 
     private Dictionary<string, string> BuildEnvironmentVariables(StartInitializationStepContext context, FunctionsProject project, IFunctionsWorker worker)
     {
-        // Priority (low -> high): local.settings.json Values, host state, worker hints, bundle vars.
-        // Bundle vars and worker hints sit on top because the CLI just resolved them and should
-        // win over anything stale a user left in local.settings.json. In particular, the resolved
-        // FUNCTIONS_WORKER_RUNTIME overrides whatever local.settings.json declares: the project
-        // resolver picked a worker, and letting a stale value steer the host would surface as a
-        // confusing "wrong language" failure deep in startup rather than a clear resolver error.
+        // Priority (low -> high): local.settings.json Values (gated by current process env),
+        // host state, worker hints, bundle vars. A shell-set env var beats local.settings.json:
+        // users override settings per-shell for CI, debugging, and secret rotation, and a stale
+        // value in local.settings.json must not silently win. Bundle vars and worker hints sit
+        // on top because the CLI just resolved them; in particular, the resolved
+        // FUNCTIONS_WORKER_RUNTIME overrides whatever local.settings.json declares so a stale
+        // value can't steer the host into a confusing "wrong language" failure deep in startup.
         var environmentVariables = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         LocalSettingsSnapshot localSettings = _localSettingsProvider.Get(project.WorkingDirectory.Info);
-        foreach ((string name, string value) in localSettings.Values)
-        {
-            environmentVariables[name] = value;
-        }
+        MergeLocalSettingsValues(localSettings.Values, environmentVariables);
 
         foreach ((string name, string value) in context.State.HostEnvironmentVariables)
         {
@@ -92,4 +101,28 @@ internal sealed class PrepareProjectHostRunInitializationStep(ILocalSettingsProv
 
         return environmentVariables;
     }
+
+    private void MergeLocalSettingsValues(
+        IReadOnlyDictionary<string, string> values,
+        Dictionary<string, string> environmentVariables)
+    {
+        foreach ((string name, string value) in values)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                _interaction.WriteWarning("Skipping local setting with empty key.");
+                continue;
+            }
+
+            if (!string.IsNullOrEmpty(_processEnvironment.Get(name)))
+            {
+                _interaction.WriteWarning($"Skipping '{name}' from local.settings.json: already set in the current environment.");
+                continue;
+            }
+
+            // Empty string is intentionally preserved: callers use it to clear an inherited value.
+            environmentVariables[name] = value;
+        }
+    }
 }
+

--- a/src/Func/Common/IProcessEnvironment.cs
+++ b/src/Func/Common/IProcessEnvironment.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Common;
+
+/// <summary>
+/// Reads environment variables from the current CLI process. A seam over
+/// <see cref="System.Environment.GetEnvironmentVariable(string)"/> so callers stay testable.
+/// </summary>
+internal interface IProcessEnvironment
+{
+    /// <summary>Returns the value of <paramref name="name"/>, or <c>null</c> when unset.</summary>
+    public string? Get(string name);
+}

--- a/src/Func/Common/ProcessEnvironment.cs
+++ b/src/Func/Common/ProcessEnvironment.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Common;
+
+internal sealed class ProcessEnvironment : IProcessEnvironment
+{
+    public string? Get(string name)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        return Environment.GetEnvironmentVariable(name);
+    }
+}

--- a/src/Func/Hosting/CliHostFactory.cs
+++ b/src/Func/Hosting/CliHostFactory.cs
@@ -85,6 +85,7 @@ internal static class CliHostFactory
                     .AddAzureMonitorMetricExporter(o => o.ConnectionString = connectionString));
         }
 
+        builder.Services.AddSingleton<IProcessEnvironment, ProcessEnvironment>();
         builder.Services.AddSingleton<IWorkerConfigFileSystem, WorkerConfigFileSystem>();
         builder.Services.AddSingleton<IFunctionsWorkerResolverFactory, DefaultFunctionsWorkerResolverFactory>();
         builder.Services.AddSingleton<IFunctionsProjectResolver, FunctionsProjectResolver>();

--- a/src/Func/release_notes.md
+++ b/src/Func/release_notes.md
@@ -4,4 +4,5 @@
 
 - `func setup` now installs the matching stack workload (Node, Python, Go, DotNet) for the project's worker runtime, detected from `local.settings.json` or selected via prompt / `--features`.
 - `func start --no-build`: now actually skips compilation steps in stack workloads. Node skips `npm run build` (still runs `npm install` when `node_modules` is missing), Go skips `go build` (trusts the existing `bin/<module>` binary), Python is a no-op (no build step). Was previously parsed and ignored.
+- `func start`: `local.settings.json` Values no longer overwrite environment variables already set in the current shell, matching v4 behavior. Skipped keys are logged as warnings, along with empty keys. Empty string values are preserved so the host can see an intentional clear.
 - <entry>

--- a/test/Func.Tests/Commands/Start/Initialization/PrepareProjectHostRunInitializationStepTests.cs
+++ b/test/Func.Tests/Commands/Start/Initialization/PrepareProjectHostRunInitializationStepTests.cs
@@ -1,0 +1,187 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Commands.Start.Initialization;
+using Azure.Functions.Cli.Commands.Start.Initialization.Rendering;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Configuration;
+using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Hosting.Dashboard.Rendering;
+using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Workers;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Commands.Start.Initialization;
+
+public class PrepareProjectHostRunInitializationStepTests : IDisposable
+{
+    private readonly string _projectDir;
+    private readonly IInteractionService _interaction = Substitute.For<IInteractionService>();
+    private readonly IProcessEnvironment _processEnv = Substitute.For<IProcessEnvironment>();
+    private readonly ILocalSettingsProvider _localSettings = Substitute.For<ILocalSettingsProvider>();
+
+    public PrepareProjectHostRunInitializationStepTests()
+    {
+        _projectDir = Path.Combine(Path.GetTempPath(), "prep-host-step-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_projectDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_projectDir))
+        {
+            Directory.Delete(_projectDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task PopulatesEnvFromLocalSettings()
+    {
+        SetLocalSettings(new() { ["MyKey"] = "MyValue" });
+        StartInitializationStepContext context = NewContext();
+
+        await NewStep().ExecuteAsync(context, CancellationToken.None);
+
+        Assert.Equal("MyValue", context.State.HostRunContext!.EnvironmentVariables["MyKey"]);
+        _interaction.DidNotReceiveWithAnyArgs().WriteWarning(default!);
+    }
+
+    [Fact]
+    public async Task EmptyKey_IsSkippedAndWarns()
+    {
+        SetLocalSettings(new() { [string.Empty] = "anything" });
+        StartInitializationStepContext context = NewContext();
+
+        await NewStep().ExecuteAsync(context, CancellationToken.None);
+
+        Assert.False(context.State.HostRunContext!.EnvironmentVariables.ContainsKey(string.Empty));
+        _interaction.Received(1).WriteWarning(Arg.Is<string>(m => m.Contains("empty key", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    [Fact]
+    public async Task EmptyStringValue_IsPreserved()
+    {
+        SetLocalSettings(new() { ["ClearMe"] = string.Empty });
+        StartInitializationStepContext context = NewContext();
+
+        await NewStep().ExecuteAsync(context, CancellationToken.None);
+
+        Assert.True(context.State.HostRunContext!.EnvironmentVariables.TryGetValue("ClearMe", out string? value));
+        Assert.Equal(string.Empty, value);
+        _interaction.DidNotReceiveWithAnyArgs().WriteWarning(default!);
+    }
+
+    [Fact]
+    public async Task ProcessEnvSet_OverridesLocalSettings_AndWarns()
+    {
+        SetLocalSettings(new() { ["MyKey"] = "fromFile" });
+        _processEnv.Get("MyKey").Returns("fromShell");
+        StartInitializationStepContext context = NewContext();
+
+        await NewStep().ExecuteAsync(context, CancellationToken.None);
+
+        Assert.False(context.State.HostRunContext!.EnvironmentVariables.ContainsKey("MyKey"));
+        _interaction.Received(1).WriteWarning(Arg.Is<string>(m => m.Contains("MyKey") && m.Contains("already set", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    [Fact]
+    public async Task ProcessEnvSet_IsCaseInsensitive()
+    {
+        SetLocalSettings(new() { ["MYKEY"] = "fromFile" });
+        _processEnv.Get("MYKEY").Returns("fromShell");
+        StartInitializationStepContext context = NewContext();
+
+        await NewStep().ExecuteAsync(context, CancellationToken.None);
+
+        Assert.False(context.State.HostRunContext!.EnvironmentVariables.ContainsKey("MYKEY"));
+        Assert.False(context.State.HostRunContext!.EnvironmentVariables.ContainsKey("MyKey"));
+    }
+
+    [Fact]
+    public async Task ProcessEnvEmptyOrNull_DoesNotBlockLocalSettings()
+    {
+        SetLocalSettings(new() { ["KeyA"] = "valueA", ["KeyB"] = "valueB" });
+        _processEnv.Get("KeyA").Returns((string?)null);
+        _processEnv.Get("KeyB").Returns(string.Empty);
+        StartInitializationStepContext context = NewContext();
+
+        await NewStep().ExecuteAsync(context, CancellationToken.None);
+
+        Assert.Equal("valueA", context.State.HostRunContext!.EnvironmentVariables["KeyA"]);
+        Assert.Equal("valueB", context.State.HostRunContext!.EnvironmentVariables["KeyB"]);
+        _interaction.DidNotReceiveWithAnyArgs().WriteWarning(default!);
+    }
+
+    [Fact]
+    public async Task ProcessEnvPrecedence_DoesNotAffectOtherSources()
+    {
+        SetLocalSettings(new() { ["MyKey"] = "fromFile" });
+        _processEnv.Get("MyKey").Returns("fromShell");
+        _processEnv.Get("HostKey").Returns("fromShell");
+        _processEnv.Get("BundleKey").Returns("fromShell");
+
+        StartInitializationStepContext context = NewContext();
+        context.State.HostEnvironmentVariables["HostKey"] = "fromHost";
+        context.State.BundleEnvVarsForHost["BundleKey"] = "fromBundle";
+
+        await NewStep().ExecuteAsync(context, CancellationToken.None);
+
+        IDictionary<string, string> env = context.State.HostRunContext!.EnvironmentVariables;
+        Assert.Equal("fromHost", env["HostKey"]);
+        Assert.Equal("fromBundle", env["BundleKey"]);
+        Assert.False(env.ContainsKey("MyKey"));
+    }
+
+    private void SetLocalSettings(Dictionary<string, string> values)
+    {
+        var snapshot = new LocalSettingsSnapshot { Values = values };
+        _localSettings.Get(Arg.Any<DirectoryInfo>()).Returns(snapshot);
+    }
+
+    private PrepareProjectHostRunInitializationStep NewStep()
+        => new(_localSettings, _processEnv, _interaction);
+
+    private StartInitializationStepContext NewContext()
+    {
+        var options = new StartCommandOptions(
+            WorkingDirectory.FromExplicit(_projectDir),
+            Port: null, Cors: [], CorsCredentials: false, Functions: [],
+            NoBuild: false, EnableAuth: false, RequestedProfileName: null, RequestedHostVersion: null,
+            Offline: false, OutputMode: OutputMode.Plain, NoTui: true, LogFilePath: null,
+            DemoMode: true, DemoFunctionCount: 0, DemoSpeedMultiplier: 0.001, DemoAutoExit: true);
+
+        var init = new StartInitializationContext(options, "5.0.0-test", IsInteractive: false, CanPrompt: false);
+        var state = new StartInitializationState
+        {
+            Project = new FakeProject(_projectDir),
+            Worker = CreateWorker(),
+            ProfileName = "none",
+        };
+        IStartInitializationRenderer renderer = Substitute.For<IStartInitializationRenderer>();
+        IStartInitializationStep stepStub = Substitute.For<IStartInitializationStep>();
+        stepStub.Id.Returns("test");
+        return new StartInitializationStepContext(init, state, stepStub, renderer, TimeProvider.System);
+    }
+
+    private static IFunctionsWorker CreateWorker()
+    {
+        IFunctionsWorker worker = Substitute.For<IFunctionsWorker>();
+        worker.WorkerRuntime.Returns("node");
+        worker.WorkerConfigPath.Returns(Path.Combine(Path.GetTempPath(), "node", "worker.config.json"));
+        return worker;
+    }
+
+    private sealed class FakeProject(string directory) : FunctionsProject
+    {
+        public override WorkingDirectory WorkingDirectory { get; } = WorkingDirectory.FromExplicit(directory);
+
+        public override string StackName => "node";
+
+        public override string StackDisplayName => "Node.js";
+
+        public override bool SupportsExtensionBundles => true;
+
+        public override FunctionsWorkerReference WorkerReference { get; } = FunctionsWorkerReference.FromWorkload("node");
+    }
+}

--- a/test/Func.Tests/Commands/Start/Initialization/PrepareProjectHostRunInitializationStepTests.cs
+++ b/test/Func.Tests/Commands/Start/Initialization/PrepareProjectHostRunInitializationStepTests.cs
@@ -25,6 +25,7 @@ public class PrepareProjectHostRunInitializationStepTests : IDisposable
     {
         _projectDir = Path.Combine(Path.GetTempPath(), "prep-host-step-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(_projectDir);
+        _processEnv.Get(Arg.Any<string>()).Returns((string?)null);
     }
 
     public void Dispose()
@@ -99,18 +100,29 @@ public class PrepareProjectHostRunInitializationStepTests : IDisposable
     }
 
     [Fact]
-    public async Task ProcessEnvEmptyOrNull_DoesNotBlockLocalSettings()
+    public async Task ProcessEnvNull_DoesNotBlockLocalSettings()
     {
-        SetLocalSettings(new() { ["KeyA"] = "valueA", ["KeyB"] = "valueB" });
+        SetLocalSettings(new() { ["KeyA"] = "valueA" });
         _processEnv.Get("KeyA").Returns((string?)null);
-        _processEnv.Get("KeyB").Returns(string.Empty);
         StartInitializationStepContext context = NewContext();
 
         await NewStep().ExecuteAsync(context, CancellationToken.None);
 
         Assert.Equal("valueA", context.State.HostRunContext!.EnvironmentVariables["KeyA"]);
-        Assert.Equal("valueB", context.State.HostRunContext!.EnvironmentVariables["KeyB"]);
         _interaction.DidNotReceiveWithAnyArgs().WriteWarning(default!);
+    }
+
+    [Fact]
+    public async Task ProcessEnvEmptyString_BlocksLocalSettings()
+    {
+        SetLocalSettings(new() { ["KeyB"] = "valueB" });
+        _processEnv.Get("KeyB").Returns(string.Empty);
+        StartInitializationStepContext context = NewContext();
+
+        await NewStep().ExecuteAsync(context, CancellationToken.None);
+
+        Assert.False(context.State.HostRunContext!.EnvironmentVariables.ContainsKey("KeyB"));
+        _interaction.Received(1).WriteWarning(Arg.Is<string>(s => s.Contains("KeyB")));
     }
 
     [Fact]

--- a/test/Func.Tests/Commands/StartInitializationTests.cs
+++ b/test/Func.Tests/Commands/StartInitializationTests.cs
@@ -865,6 +865,7 @@ public class StartInitializationTests : IDisposable
             new LocalSettingsProvider(),
             workloadPaths,
             hostProcessRunner,
+            new ProcessEnvironment(),
             NullLoggerFactory.Instance);
     }
 


### PR DESCRIPTION
Brings v5's `local.settings.json` -> host env var behavior into parity with v4. Three changes to `PrepareProjectHostRunInitializationStep.BuildEnvironmentVariables`:

1. **Real env wins over `local.settings.json`.** v4 (`StartHostAction.UpdateEnvironmentVariables` on `main`) skips a key when `Environment.GetEnvironmentVariable(key)` is already set in the CLI's process. v5 was letting `local.settings.json` overwrite anything. This was a real bug: shell-set env vars are explicit per-shell overrides (CI, debug, secret rotation) and must win over the file. Now they do.
2. **Empty-value handling.** `""` is preserved verbatim in the env-var dict (callers use it to clear an inherited value). The v5 snapshot layer already drops JSON-null values, so v4's null-skip branch has no work to do here.
3. **Warnings.** Skipped keys (empty key, already in env) are surfaced through `IInteractionService.WriteWarning` (no `Console.*` calls per AGENTS.md).

### Implementation

- New `IProcessEnvironment` seam in `src/Func/Common/` with a `string? Get(string)` wrapper over `Environment.GetEnvironmentVariable`, so the precedence check is testable without mutating real process state. No existing seam fit.
- `PrepareProjectHostRunInitializationStep` now takes `IProcessEnvironment` + `IInteractionService`. Priority comment in `BuildEnvironmentVariables` updated to call out the new precedence.
- `DemoStartInitializationRunner` threads the new deps through.
- `CliHostFactory` registers `IProcessEnvironment` as a singleton.

### Tests

`test/Func.Tests/Commands/Start/Initialization/PrepareProjectHostRunInitializationStepTests.cs` covers: normal pass-through, empty key (skip + warn), empty-string value (preserved), process env present (skip + warn), case-insensitive precedence, empty/null process env doesn't block, and that the precedence rule only applies to local.settings (host + bundle vars still flow through).

Validated with `CI=true dotnet build -c Release` (0 warnings, 0 errors) and `dotnet test test/Func.Tests/Func.Tests.csproj` (603 passing) plus the Node stack tests for safety.

### Notes

- Stacked on #5097 (`liliankasem/feat/stack-host-start-hooks`), which introduces the `BuildEnvironmentVariables` method this PR modifies. Once #5097 merges into `vnext`, this PR will retarget to `vnext` directly.
- No worker-version updates needed.
- Release notes entry added in `src/Func/release_notes.md`.
