### PR TITLE
vnext: implement quickstart manifest service

### DIFF
--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -64,6 +64,9 @@ func
 │   ├── list [path]       List available profiles
 │   ├── show <name> [path]  Show profile details
 │   └── set <name> [path]   Set the project default profile
+├── quickstart [path]     Scaffold a project from a CDN-hosted template
+│   ├── list [path]       List available quickstart templates
+│   └── info <id> [path]  Show details for a quickstart template
 ├── workload
 │   └── list              List installed workloads
 ├── version (hidden)      Print version info
@@ -316,6 +319,27 @@ At startup, the CLI runs a non-blocking background check for newer v5 releases v
 - **Rate limits**: GitHub allows 60 unauthenticated requests/hour; the 24h cache prevents hitting this
 
 If a newer version is found, a notice is printed after the command completes.
+
+## HTTP Client Defaults
+
+`HttpClientDefaults.AddCliHttpDefaults()` applies a `User-Agent` header (`AzureFunctionsCli/{version} ({os})`) to every `IHttpClientFactory` client. Individual features configure their own timeouts per-client.
+
+## Quickstart Manifest
+
+`func quickstart` scaffolds a project from a CDN-hosted template manifest.
+
+```text
+1. IQuickstartManifestService.GetManifestAsync()
+   ├── Fresh cache (< 24h) → return cached manifest, skip network
+   ├── CDN fetch with ETag/If-None-Match → 200 (cache + return) or 304 (return cached)
+   └── Network failure → stale cache fallback (any age), or error if no cache
+2. QuickstartManifest.Filter(language, resource, iac, search) → filtered entries
+3. Command scaffolds selected template
+```
+
+- **Cache**: `~/.azure-functions/quickstart/` (manifest JSON + ETag metadata), 24h TTL
+- **Validation**: only `v`-prefixed gitRef entries; HTTPS URLs on `github.com` from trusted orgs
+- **Override**: `FUNC_QUICKSTART_MANIFEST_URL` env var replaces CDN URL
 
 ## Init and New Command Flow
 

--- a/eng/build/Packages.props
+++ b/eng/build/Packages.props
@@ -5,6 +5,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />

--- a/src/Abstractions/Abstractions.csproj
+++ b/src/Abstractions/Abstractions.csproj
@@ -7,6 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="func" />
+    <InternalsVisibleTo Include="Azure.Functions.Cli.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>

--- a/src/Abstractions/Quickstart/IQuickstartManifestService.cs
+++ b/src/Abstractions/Quickstart/IQuickstartManifestService.cs
@@ -14,5 +14,5 @@ public interface IQuickstartManifestService
     /// Returns the current template manifest, fetching from the CDN if the
     /// local cache is stale or absent.
     /// </summary>
-    public Task<IReadOnlyList<QuickstartEntry>> GetManifestAsync(CancellationToken cancellationToken = default);
+    public Task<QuickstartManifest> GetManifestAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Abstractions/Quickstart/QuickstartEntry.cs
+++ b/src/Abstractions/Quickstart/QuickstartEntry.cs
@@ -10,14 +10,13 @@ namespace Azure.Functions.Cli.Quickstart;
 /// <param name="DisplayName">Human-friendly name shown in prompts and list output.</param>
 /// <param name="Language">Manifest language value (e.g. "Python", "CSharp", "TypeScript").</param>
 /// <param name="Resource">Trigger/binding resource type (e.g. "http", "blob", "timer").</param>
-/// <param name="Iac">Infrastructure-as-code type (e.g. "bicep", "terraform", "none").</param>
+/// <param name="Iac">Infrastructure-as-code type (e.g. "bicep", "terraform", "arm", "none").</param>
 /// <param name="RepositoryUrl">GitHub repository URL (HTTPS only, trusted org).</param>
 /// <param name="FolderPath">Subfolder within the repo containing the template, or "." for root.</param>
-/// <param name="GitRef">Immutable tag or SHA pinning the template version.</param>
+/// <param name="GitRef">Immutable tag pinning the template version.</param>
 /// <param name="ShortDescription">One-line summary for list output.</param>
 /// <param name="LongDescription">Detailed description for info output.</param>
 /// <param name="WhatsIncluded">Bulleted list of what the template contains.</param>
-/// <param name="Tags">Searchable tags for filtering.</param>
 /// <param name="Priority">Sort priority (lower = higher in list).</param>
 public sealed record QuickstartEntry(
     string Id,
@@ -31,5 +30,4 @@ public sealed record QuickstartEntry(
     string? ShortDescription,
     string? LongDescription,
     IReadOnlyList<string>? WhatsIncluded,
-    IReadOnlyList<string>? Tags,
     int Priority);

--- a/src/Abstractions/Quickstart/QuickstartManifest.cs
+++ b/src/Abstractions/Quickstart/QuickstartManifest.cs
@@ -1,0 +1,90 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Quickstart;
+
+/// <summary>
+/// The deserialized CDN manifest with convenience filter methods.
+/// </summary>
+public sealed class QuickstartManifest
+{
+    /// <summary>
+    /// All entries after validation and trusted-org filtering has been applied.
+    /// </summary>
+    public IReadOnlyList<QuickstartEntry> Entries { get; }
+
+    public QuickstartManifest(IReadOnlyList<QuickstartEntry> entries)
+    {
+        Entries = entries ?? throw new ArgumentNullException(nameof(entries));
+    }
+
+    /// <summary>
+    /// Returns entries matching all supplied non-null/non-empty criteria,
+    /// ordered by <see cref="QuickstartEntry.Priority"/>.
+    /// </summary>
+    public IReadOnlyList<QuickstartEntry> Filter(
+        string? language = null,
+        string? resource = null,
+        string? iac = null,
+        string? search = null)
+    {
+        IEnumerable<QuickstartEntry> results = Entries;
+
+        if (!string.IsNullOrWhiteSpace(language))
+        {
+            results = results.Where(e =>
+                string.Equals(e.Language, language, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrWhiteSpace(resource))
+        {
+            results = results.Where(e =>
+                string.Equals(e.Resource, resource, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrWhiteSpace(iac))
+        {
+            results = results.Where(e =>
+                string.Equals(e.Iac, iac, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            results = results.Where(e => MatchesSearch(e, search));
+        }
+
+        return [.. results.OrderBy(e => e.Priority)];
+    }
+
+    private static bool MatchesSearch(QuickstartEntry entry, string search)
+    {
+        if (entry.Id.Contains(search, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (entry.DisplayName.Contains(search, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (entry.Resource.Contains(search, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (entry.Iac is not null &&
+            entry.Iac.Contains(search, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (entry.LongDescription is not null &&
+            entry.LongDescription.Contains(search, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Abstractions/Quickstart/QuickstartManifest.cs
+++ b/src/Abstractions/Quickstart/QuickstartManifest.cs
@@ -13,7 +13,7 @@ public sealed class QuickstartManifest
     /// </summary>
     public IReadOnlyList<QuickstartEntry> Entries { get; }
 
-    public QuickstartManifest(IReadOnlyList<QuickstartEntry> entries)
+    internal QuickstartManifest(IReadOnlyList<QuickstartEntry> entries)
     {
         Entries = entries ?? throw new ArgumentNullException(nameof(entries));
     }

--- a/src/Abstractions/Quickstart/QuickstartManifest.cs
+++ b/src/Abstractions/Quickstart/QuickstartManifest.cs
@@ -15,7 +15,8 @@ public sealed class QuickstartManifest
 
     internal QuickstartManifest(IReadOnlyList<QuickstartEntry> entries)
     {
-        Entries = entries ?? throw new ArgumentNullException(nameof(entries));
+        Entries = [.. (entries ?? throw new ArgumentNullException(nameof(entries)))
+            .OrderBy(e => e.Priority)];
     }
 
     /// <summary>
@@ -53,7 +54,7 @@ public sealed class QuickstartManifest
             results = results.Where(e => MatchesSearch(e, search));
         }
 
-        return [.. results.OrderBy(e => e.Priority)];
+        return [.. results];
     }
 
     private static bool MatchesSearch(QuickstartEntry entry, string search)

--- a/src/Func/Func.csproj
+++ b/src/Func/Func.csproj
@@ -39,6 +39,7 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" />
     <PackageReference Include="NuGet.Versioning" />

--- a/src/Func/Hosting/CliHostFactory.cs
+++ b/src/Func/Hosting/CliHostFactory.cs
@@ -8,6 +8,8 @@ using Azure.Functions.Cli.Configuration;
 using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.DemoProject;
 using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Http;
+using Azure.Functions.Cli.Quickstart;
 using Azure.Functions.Cli.Telemetry;
 using Azure.Functions.Cli.Workers;
 using Azure.Functions.Cli.Workloads;
@@ -113,11 +115,13 @@ internal static class CliHostFactory
         builder.Services.AddSingleton<IConfigureOptions<StackOptions>, StackOptionsSetup>();
         builder.Services.AddSingleton<IConfigureOptions<HostStartupOptions>, HostStartupOptionsSetup>();
 
+        builder.Services.AddCliHttpDefaults();
         builder.Services.AddBuiltInCommands();
         builder.Services.AddWorkloadStorage();
         builder.Services.AddProfiles();
         builder.Services.AddWorkloadCatalog();
         builder.Services.AddWorkloadInstaller();
+        builder.Services.AddQuickstartManifest();
 
         return builder;
     }

--- a/src/Func/Http/HttpClientDefaults.cs
+++ b/src/Func/Http/HttpClientDefaults.cs
@@ -18,11 +18,13 @@ internal static class HttpClientDefaults
 
     public static IServiceCollection AddCliHttpDefaults(this IServiceCollection services)
     {
+        ArgumentNullException.ThrowIfNull(services);
+
         services.ConfigureHttpClientDefaults(builder =>
         {
             builder.ConfigureHttpClient(client =>
             {
-                client.DefaultRequestHeaders.UserAgent.ParseAdd(_userAgent);
+                client.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", _userAgent);
             });
         });
 

--- a/src/Func/Http/HttpClientDefaults.cs
+++ b/src/Func/Http/HttpClientDefaults.cs
@@ -1,0 +1,41 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Azure.Functions.Cli.Http;
+
+/// <summary>
+/// Configures CLI-wide HTTP client defaults (User-Agent, etc.) applied to all
+/// named and unnamed <see cref="HttpClient"/> instances created via
+/// <see cref="IHttpClientFactory"/>.
+/// </summary>
+internal static class HttpClientDefaults
+{
+    private static readonly string _userAgent = BuildUserAgent();
+
+    public static IServiceCollection AddCliHttpDefaults(this IServiceCollection services)
+    {
+        services.ConfigureHttpClientDefaults(builder =>
+        {
+            builder.ConfigureHttpClient(client =>
+            {
+                client.DefaultRequestHeaders.UserAgent.ParseAdd(_userAgent);
+            });
+        });
+
+        return services;
+    }
+
+    private static string BuildUserAgent()
+    {
+        string version = typeof(HttpClientDefaults).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion?.Split('+')[0] ?? "unknown";
+
+        string os = RuntimeInformation.OSDescription;
+        return $"AzureFunctionsCli/{version} ({os})";
+    }
+}

--- a/src/Func/Quickstart/IManifestCache.cs
+++ b/src/Func/Quickstart/IManifestCache.cs
@@ -37,9 +37,4 @@ internal interface IManifestCache
     /// Returns <see langword="true"/> if a cached manifest file exists on disk.
     /// </summary>
     public bool ManifestExists();
-
-    /// <summary>
-    /// Reads a local file override, or <see langword="null"/> if the file doesn't exist.
-    /// </summary>
-    public Task<string?> TryReadLocalFileAsync(string path, CancellationToken cancellationToken);
 }

--- a/src/Func/Quickstart/IManifestCache.cs
+++ b/src/Func/Quickstart/IManifestCache.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Quickstart;
+
+/// <summary>
+/// Abstracts filesystem operations for the quickstart manifest cache.
+/// </summary>
+internal interface IManifestCache
+{
+    /// <summary>
+    /// Ensures the cache directory exists.
+    /// </summary>
+    public void EnsureDirectory();
+
+    /// <summary>
+    /// Reads the cached manifest JSON, or <see langword="null"/> if it doesn't exist or is unreadable.
+    /// </summary>
+    public string? TryReadManifest();
+
+    /// <summary>
+    /// Writes the manifest JSON to the cache.
+    /// </summary>
+    public void WriteManifest(string json);
+
+    /// <summary>
+    /// Reads the cache metadata, or <see langword="null"/> if it doesn't exist or is unreadable.
+    /// </summary>
+    public ManifestCacheMeta? TryReadMeta();
+
+    /// <summary>
+    /// Writes cache metadata.
+    /// </summary>
+    public void WriteMeta(ManifestCacheMeta meta);
+
+    /// <summary>
+    /// Returns <see langword="true"/> if a cached manifest file exists on disk.
+    /// </summary>
+    public bool ManifestExists();
+
+    /// <summary>
+    /// Reads a local file override, or <see langword="null"/> if the file doesn't exist.
+    /// </summary>
+    public Task<string?> TryReadLocalFileAsync(string path, CancellationToken cancellationToken);
+}

--- a/src/Func/Quickstart/ManifestCache.cs
+++ b/src/Func/Quickstart/ManifestCache.cs
@@ -70,8 +70,17 @@ internal sealed class ManifestCache(IOptions<QuickstartManifestOptions> options)
 
     private static void AtomicWrite(string destinationPath, string content)
     {
-        string tempPath = destinationPath + ".tmp";
-        File.WriteAllText(tempPath, content);
-        File.Move(tempPath, destinationPath, overwrite: true);
+        string tempPath = $"{destinationPath}.{Path.GetRandomFileName()}.tmp";
+        try
+        {
+            File.WriteAllText(tempPath, content);
+            File.Move(tempPath, destinationPath, overwrite: true);
+        }
+        catch
+        {
+            // Best-effort cleanup of the unique temp file.
+            try { File.Delete(tempPath); } catch { }
+            throw;
+        }
     }
 }

--- a/src/Func/Quickstart/ManifestCache.cs
+++ b/src/Func/Quickstart/ManifestCache.cs
@@ -37,7 +37,7 @@ internal sealed class ManifestCache(IOptions<QuickstartManifestOptions> options)
     }
 
     /// <inheritdoc/>
-    public void WriteManifest(string json) => File.WriteAllText(ManifestFilePath, json);
+    public void WriteManifest(string json) => AtomicWrite(ManifestFilePath, json);
 
     /// <inheritdoc/>
     public ManifestCacheMeta? TryReadMeta()
@@ -62,20 +62,16 @@ internal sealed class ManifestCache(IOptions<QuickstartManifestOptions> options)
     public void WriteMeta(ManifestCacheMeta meta)
     {
         string json = JsonSerializer.Serialize(meta, QuickstartJsonContext.Default.ManifestCacheMeta);
-        File.WriteAllText(MetaFilePath, json);
+        AtomicWrite(MetaFilePath, json);
     }
 
     /// <inheritdoc/>
     public bool ManifestExists() => File.Exists(ManifestFilePath);
 
-    /// <inheritdoc/>
-    public async Task<string?> TryReadLocalFileAsync(string path, CancellationToken cancellationToken)
+    private static void AtomicWrite(string destinationPath, string content)
     {
-        if (!File.Exists(path))
-        {
-            return null;
-        }
-
-        return await File.ReadAllTextAsync(path, cancellationToken);
+        string tempPath = destinationPath + ".tmp";
+        File.WriteAllText(tempPath, content);
+        File.Move(tempPath, destinationPath, overwrite: true);
     }
 }

--- a/src/Func/Quickstart/ManifestCache.cs
+++ b/src/Func/Quickstart/ManifestCache.cs
@@ -1,0 +1,81 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+
+namespace Azure.Functions.Cli.Quickstart;
+
+/// <summary>
+/// Filesystem-backed cache for the quickstart manifest.
+/// </summary>
+internal sealed class ManifestCache(IOptions<QuickstartManifestOptions> options) : IManifestCache
+{
+    private const string ManifestFileName = "manifest.json";
+    private const string MetaFileName = "manifest-meta.json";
+
+    private readonly QuickstartManifestOptions _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+
+    private string ManifestFilePath => Path.Combine(_options.CacheDirectory, ManifestFileName);
+
+    private string MetaFilePath => Path.Combine(_options.CacheDirectory, MetaFileName);
+
+    /// <inheritdoc/>
+    public void EnsureDirectory() => Directory.CreateDirectory(_options.CacheDirectory);
+
+    /// <inheritdoc/>
+    public string? TryReadManifest()
+    {
+        try
+        {
+            return File.Exists(ManifestFilePath) ? File.ReadAllText(ManifestFilePath) : null;
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+    }
+
+    /// <inheritdoc/>
+    public void WriteManifest(string json) => File.WriteAllText(ManifestFilePath, json);
+
+    /// <inheritdoc/>
+    public ManifestCacheMeta? TryReadMeta()
+    {
+        try
+        {
+            if (!File.Exists(MetaFilePath))
+            {
+                return null;
+            }
+
+            string json = File.ReadAllText(MetaFilePath);
+            return JsonSerializer.Deserialize(json, QuickstartJsonContext.Default.ManifestCacheMeta);
+        }
+        catch (Exception ex) when (ex is IOException or JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <inheritdoc/>
+    public void WriteMeta(ManifestCacheMeta meta)
+    {
+        string json = JsonSerializer.Serialize(meta, QuickstartJsonContext.Default.ManifestCacheMeta);
+        File.WriteAllText(MetaFilePath, json);
+    }
+
+    /// <inheritdoc/>
+    public bool ManifestExists() => File.Exists(ManifestFilePath);
+
+    /// <inheritdoc/>
+    public async Task<string?> TryReadLocalFileAsync(string path, CancellationToken cancellationToken)
+    {
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        return await File.ReadAllTextAsync(path, cancellationToken);
+    }
+}

--- a/src/Func/Quickstart/ManifestCacheMeta.cs
+++ b/src/Func/Quickstart/ManifestCacheMeta.cs
@@ -1,0 +1,9 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Quickstart;
+
+/// <summary>
+/// Cached manifest metadata: ETag and timestamp of last successful fetch.
+/// </summary>
+internal sealed record ManifestCacheMeta(string ETag, DateTimeOffset CachedAt);

--- a/src/Func/Quickstart/QuickstartJsonContext.cs
+++ b/src/Func/Quickstart/QuickstartJsonContext.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Text.Json.Serialization;
+
+namespace Azure.Functions.Cli.Quickstart;
+
+/// <summary>
+/// Source-generated <see cref="JsonSerializerContext"/> for quickstart manifest
+/// deserialization. Keeps JSON reflection-free (AOT/trim-friendly).
+/// </summary>
+[JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
+[JsonSerializable(typeof(QuickstartManifestEnvelope))]
+[JsonSerializable(typeof(ManifestCacheMeta))]
+internal sealed partial class QuickstartJsonContext : JsonSerializerContext;

--- a/src/Func/Quickstart/QuickstartManifestEnvelope.cs
+++ b/src/Func/Quickstart/QuickstartManifestEnvelope.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Text.Json.Serialization;
+
+namespace Azure.Functions.Cli.Quickstart;
+
+/// <summary>
+/// Represents the CDN manifest envelope: <c>{ "templates": [...] }</c>.
+/// </summary>
+internal sealed record QuickstartManifestEnvelope
+{
+    [JsonPropertyName("templates")]
+    public List<QuickstartEntry> Templates { get; init; } = [];
+}

--- a/src/Func/Quickstart/QuickstartManifestOptions.cs
+++ b/src/Func/Quickstart/QuickstartManifestOptions.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using AbstractionsConstants = Azure.Functions.Cli.Abstractions.Common.Constants;
+
+namespace Azure.Functions.Cli.Quickstart;
+
+/// <summary>
+/// Configuration for the quickstart manifest service.
+/// </summary>
+internal sealed class QuickstartManifestOptions
+{
+    /// <summary>
+    /// Primary CDN URL for the manifest JSON.
+    /// </summary>
+    public string ManifestUrl { get; set; } =
+        "https://cdn.functions.azure.com/public/templates-manifest/manifest.json";
+
+    /// <summary>
+    /// Directory where the manifest JSON and ETag metadata are cached.
+    /// </summary>
+    public string CacheDirectory { get; set; } = DefaultCacheDirectory();
+
+    /// <summary>
+    /// How long a cached manifest is considered fresh before re-validation.
+    /// </summary>
+    public TimeSpan CacheTtl { get; set; } = TimeSpan.FromHours(24);
+
+    /// <summary>
+    /// HTTP timeout for fetching the manifest from the CDN.
+    /// </summary>
+    public TimeSpan HttpTimeout { get; set; } = TimeSpan.FromSeconds(15);
+
+    private static string DefaultCacheDirectory() =>
+        Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            AbstractionsConstants.FuncHomeDirectoryName,
+            "quickstart");
+}

--- a/src/Func/Quickstart/QuickstartManifestService.cs
+++ b/src/Func/Quickstart/QuickstartManifestService.cs
@@ -75,7 +75,6 @@ internal sealed class QuickstartManifestService(
     private async Task<QuickstartManifest?> TryFetchFromCdnAsync(string? etag, CancellationToken cancellationToken)
     {
         HttpClient httpClient = _httpClientFactory.CreateClient(QuickstartRegistration.HttpClientName);
-        httpClient.Timeout = _options.HttpTimeout;
         using HttpRequestMessage request = new(HttpMethod.Get, _options.ManifestUrl);
         if (!string.IsNullOrEmpty(etag))
         {
@@ -87,7 +86,7 @@ internal sealed class QuickstartManifestService(
         if (response.StatusCode == HttpStatusCode.NotModified)
         {
             _logger.LogDebug("Manifest not modified (304); refreshing cache timestamp.");
-            _cache.WriteMeta(new ManifestCacheMeta(etag!, _timeProvider.GetUtcNow()));
+            _cache.WriteMeta(new ManifestCacheMeta(etag ?? string.Empty, _timeProvider.GetUtcNow()));
             return LoadCachedManifest();
         }
 
@@ -132,7 +131,7 @@ internal sealed class QuickstartManifestService(
     {
         _logger.LogDebug("Loading quickstart manifest from local file '{Path}'.", path);
 
-        string? json = await _cache.TryReadLocalFileAsync(path, cancellationToken);
+        string? json = File.Exists(path) ? await File.ReadAllTextAsync(path, cancellationToken) : null;
         if (json is null)
         {
             throw new FileNotFoundException(

--- a/src/Func/Quickstart/QuickstartManifestService.cs
+++ b/src/Func/Quickstart/QuickstartManifestService.cs
@@ -140,11 +140,21 @@ internal sealed class QuickstartManifestService(
                 path);
         }
 
-        List<QuickstartEntry>? entries = DeserializeEntries(json)
-            ?? throw new InvalidOperationException(
-                $"Manifest override file '{path}' is empty or malformed.");
+        string errorMessage = $"Manifest override file '{path}' is empty or malformed.";
 
-        return BuildManifest(entries);
+        List<QuickstartEntry>? entries;
+        try
+        {
+            entries = DeserializeEntries(json);
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException(errorMessage, ex);
+        }
+
+        return entries is not null
+            ? BuildManifest(entries)
+            : throw new InvalidOperationException(errorMessage);
     }
 
     private QuickstartManifest BuildManifest(List<QuickstartEntry> entries)
@@ -183,7 +193,11 @@ internal sealed class QuickstartManifestService(
             string.IsNullOrWhiteSpace(entry.RepositoryUrl) ||
             string.IsNullOrWhiteSpace(entry.FolderPath))
         {
-            _logger.LogDebug("Dropping quickstart entry with missing required field: '{Id}'.", entry.Id);
+            string identifier = !string.IsNullOrWhiteSpace(entry.Id) ? entry.Id
+                : !string.IsNullOrWhiteSpace(entry.DisplayName) ? entry.DisplayName
+                : !string.IsNullOrWhiteSpace(entry.RepositoryUrl) ? entry.RepositoryUrl
+                : "(unknown)";
+            _logger.LogDebug("Dropping quickstart entry '{Identifier}': missing required fields.", identifier);
             return false;
         }
 

--- a/src/Func/Quickstart/QuickstartManifestService.cs
+++ b/src/Func/Quickstart/QuickstartManifestService.cs
@@ -1,0 +1,235 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Net;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Azure.Functions.Cli.Quickstart;
+
+/// <summary>
+/// Fetches the quickstart manifest from the CDN with ETag-based caching
+/// and stale-cache fallback on network failures.
+/// </summary>
+internal sealed class QuickstartManifestService(
+    IHttpClientFactory httpClientFactory,
+    IManifestCache cache,
+    IOptions<QuickstartManifestOptions> options,
+    TimeProvider timeProvider,
+    ILogger<QuickstartManifestService> logger) : IQuickstartManifestService
+{
+    private const string GitRefPrefix = "v";
+    private const string HttpSchemePrefix = "http";
+
+    private readonly IHttpClientFactory _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+    private readonly IManifestCache _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+    private readonly QuickstartManifestOptions _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+    private readonly TimeProvider _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+    private readonly ILogger<QuickstartManifestService> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+    /// <inheritdoc/>
+    public async Task<QuickstartManifest> GetManifestAsync(CancellationToken cancellationToken = default)
+    {
+        _cache.EnsureDirectory();
+
+        if (TryGetLocalFilePath(_options.ManifestUrl, out string? localPath) && localPath is not null)
+        {
+            return await LoadFromLocalFileAsync(localPath, cancellationToken);
+        }
+
+        ManifestCacheMeta? cachedMeta = _cache.TryReadMeta();
+        if (cachedMeta is not null && IsCacheFresh(cachedMeta))
+        {
+            _logger.LogDebug("Quickstart manifest cache is fresh; using cached copy.");
+            return LoadCachedManifest();
+        }
+
+        // Try CDN with ETag conditional request.
+        try
+        {
+            QuickstartManifest? result = await TryFetchFromCdnAsync(cachedMeta?.ETag, cancellationToken);
+            if (result is not null)
+            {
+                return result;
+            }
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException)
+        {
+            _logger.LogWarning(ex, "CDN fetch failed for quickstart manifest.");
+        }
+
+        // Fallback: return stale cache if available.
+        QuickstartManifest? cached = TryLoadCachedManifest();
+        if (cached is not null)
+        {
+            _logger.LogWarning("Using stale cached quickstart manifest.");
+            return cached;
+        }
+
+        throw new InvalidOperationException(
+            "Unable to fetch the quickstart manifest and no cached copy is available. " +
+            "Check your network connection and try again.");
+    }
+
+    private async Task<QuickstartManifest?> TryFetchFromCdnAsync(string? etag, CancellationToken cancellationToken)
+    {
+        HttpClient httpClient = _httpClientFactory.CreateClient(QuickstartRegistration.HttpClientName);
+        httpClient.Timeout = _options.HttpTimeout;
+        using HttpRequestMessage request = new(HttpMethod.Get, _options.ManifestUrl);
+        if (!string.IsNullOrEmpty(etag))
+        {
+            request.Headers.TryAddWithoutValidation("If-None-Match", etag);
+        }
+
+        using HttpResponseMessage response = await httpClient.SendAsync(request, cancellationToken);
+
+        if (response.StatusCode == HttpStatusCode.NotModified)
+        {
+            _logger.LogDebug("Manifest not modified (304); refreshing cache timestamp.");
+            _cache.WriteMeta(new ManifestCacheMeta(etag!, _timeProvider.GetUtcNow()));
+            return LoadCachedManifest();
+        }
+
+        response.EnsureSuccessStatusCode();
+
+        string content = await response.Content.ReadAsStringAsync(cancellationToken);
+        string? newEtag = response.Headers.ETag?.Tag;
+
+        List<QuickstartEntry>? entries = DeserializeEntries(content);
+        if (entries is null)
+        {
+            return null;
+        }
+
+        _cache.WriteManifest(content);
+        _cache.WriteMeta(new ManifestCacheMeta(newEtag ?? string.Empty, _timeProvider.GetUtcNow()));
+        return BuildManifest(entries);
+    }
+
+    private static bool TryGetLocalFilePath(string url, out string? localPath)
+    {
+        localPath = null;
+
+        // Support file:// URIs
+        if (Uri.TryCreate(url, UriKind.Absolute, out Uri? uri) && uri.IsFile)
+        {
+            localPath = uri.LocalPath;
+            return true;
+        }
+
+        // Support raw absolute file paths (Windows or Unix)
+        if (Path.IsPathFullyQualified(url) && !url.StartsWith(HttpSchemePrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            localPath = url;
+            return true;
+        }
+
+        return false;
+    }
+
+    private async Task<QuickstartManifest> LoadFromLocalFileAsync(string path, CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Loading quickstart manifest from local file '{Path}'.", path);
+
+        string? json = await _cache.TryReadLocalFileAsync(path, cancellationToken);
+        if (json is null)
+        {
+            throw new FileNotFoundException(
+                $"Manifest override file '{path}' does not exist. " +
+                $"Check the {QuickstartRegistration.ManifestUrlEnvVar} environment variable.",
+                path);
+        }
+
+        List<QuickstartEntry>? entries = DeserializeEntries(json)
+            ?? throw new InvalidOperationException(
+                $"Manifest override file '{path}' is empty or malformed.");
+
+        return BuildManifest(entries);
+    }
+
+    private QuickstartManifest BuildManifest(List<QuickstartEntry> entries)
+    {
+        List<QuickstartEntry> filtered = [];
+        foreach (QuickstartEntry entry in entries)
+        {
+            if (!HasRequiredFields(entry))
+            {
+                continue;
+            }
+
+            if (!HasValidGitRef(entry))
+            {
+                continue;
+            }
+
+            if (!QuickstartUrlValidator.IsAllowed(entry.RepositoryUrl))
+            {
+                _logger.LogDebug(
+                    "Dropping quickstart entry '{Id}': repository URL not allowed.", entry.Id);
+                continue;
+            }
+
+            filtered.Add(entry);
+        }
+
+        return new QuickstartManifest(filtered);
+    }
+
+    private bool HasRequiredFields(QuickstartEntry entry)
+    {
+        if (string.IsNullOrWhiteSpace(entry.Id) ||
+            string.IsNullOrWhiteSpace(entry.Language) ||
+            string.IsNullOrWhiteSpace(entry.Resource) ||
+            string.IsNullOrWhiteSpace(entry.RepositoryUrl) ||
+            string.IsNullOrWhiteSpace(entry.FolderPath))
+        {
+            _logger.LogDebug("Dropping quickstart entry with missing required field: '{Id}'.", entry.Id);
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool HasValidGitRef(QuickstartEntry entry)
+    {
+        return !string.IsNullOrWhiteSpace(entry.GitRef)
+            && entry.GitRef.StartsWith(GitRefPrefix, StringComparison.Ordinal);
+    }
+
+    private static List<QuickstartEntry>? DeserializeEntries(string json)
+    {
+        QuickstartManifestEnvelope? envelope = JsonSerializer.Deserialize(
+            json, QuickstartJsonContext.Default.QuickstartManifestEnvelope);
+
+        return envelope?.Templates;
+    }
+
+    private bool IsCacheFresh(ManifestCacheMeta meta) =>
+        _timeProvider.GetUtcNow() - meta.CachedAt < _options.CacheTtl
+        && _cache.ManifestExists();
+
+    private QuickstartManifest LoadCachedManifest() =>
+        TryLoadCachedManifest()
+        ?? throw new InvalidOperationException("Cached manifest file is missing or corrupt.");
+
+    private QuickstartManifest? TryLoadCachedManifest()
+    {
+        try
+        {
+            string? json = _cache.TryReadManifest();
+            if (json is null)
+            {
+                return null;
+            }
+
+            List<QuickstartEntry>? entries = DeserializeEntries(json);
+            return entries is null ? null : BuildManifest(entries);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "Failed to read cached quickstart manifest.");
+            return null;
+        }
+    }
+}

--- a/src/Func/Quickstart/QuickstartManifestService.cs
+++ b/src/Func/Quickstart/QuickstartManifestService.cs
@@ -110,15 +110,19 @@ internal sealed class QuickstartManifestService(
     {
         localPath = null;
 
-        // Support file:// URIs
-        if (Uri.TryCreate(url, UriKind.Absolute, out Uri? uri) && uri.IsFile)
+        // Support file:// URIs (but not UNC file URIs like file://server/share)
+        if (Uri.TryCreate(url, UriKind.Absolute, out Uri? uri) && uri.IsFile && !uri.IsUnc)
         {
             localPath = uri.LocalPath;
             return true;
         }
 
-        // Support raw absolute file paths (Windows or Unix)
-        if (Path.IsPathFullyQualified(url) && !url.StartsWith(HttpSchemePrefix, StringComparison.OrdinalIgnoreCase))
+        // Support raw absolute file paths: drive-letter (C:\...) or Unix root (/).
+        // UNC paths (\\server\share) are not accepted; use file:// URI instead.
+        if (Path.IsPathFullyQualified(url)
+            && !url.StartsWith(HttpSchemePrefix, StringComparison.OrdinalIgnoreCase)
+            && !url.StartsWith("//", StringComparison.Ordinal)
+            && !url.StartsWith(@"\\", StringComparison.Ordinal))
         {
             localPath = url;
             return true;
@@ -162,8 +166,11 @@ internal sealed class QuickstartManifestService(
         List<QuickstartEntry> filtered = [];
         foreach (QuickstartEntry entry in entries)
         {
-            if (!HasRequiredFields(entry))
+            (string Identifier, List<string> MissingFields)? missingInfo = GetMissingFields(entry);
+            if (missingInfo is not null)
             {
+                _logger.LogDebug("Dropping quickstart entry '{Identifier}': missing {Fields}.",
+                    missingInfo.Value.Identifier, string.Join(", ", missingInfo.Value.MissingFields));
                 continue;
             }
 
@@ -185,23 +192,26 @@ internal sealed class QuickstartManifestService(
         return new QuickstartManifest(filtered);
     }
 
-    private bool HasRequiredFields(QuickstartEntry entry)
+    private static (string Identifier, List<string> MissingFields)? GetMissingFields(QuickstartEntry entry)
     {
-        if (string.IsNullOrWhiteSpace(entry.Id) ||
-            string.IsNullOrWhiteSpace(entry.Language) ||
-            string.IsNullOrWhiteSpace(entry.Resource) ||
-            string.IsNullOrWhiteSpace(entry.RepositoryUrl) ||
-            string.IsNullOrWhiteSpace(entry.FolderPath))
+        List<string> missing = [];
+        if (string.IsNullOrWhiteSpace(entry.Id)) missing.Add(nameof(entry.Id));
+        if (string.IsNullOrWhiteSpace(entry.Language)) missing.Add(nameof(entry.Language));
+        if (string.IsNullOrWhiteSpace(entry.Resource)) missing.Add(nameof(entry.Resource));
+        if (string.IsNullOrWhiteSpace(entry.RepositoryUrl)) missing.Add(nameof(entry.RepositoryUrl));
+        if (string.IsNullOrWhiteSpace(entry.FolderPath)) missing.Add(nameof(entry.FolderPath));
+
+        if (missing.Count == 0)
         {
-            string identifier = !string.IsNullOrWhiteSpace(entry.Id) ? entry.Id
-                : !string.IsNullOrWhiteSpace(entry.DisplayName) ? entry.DisplayName
-                : !string.IsNullOrWhiteSpace(entry.RepositoryUrl) ? entry.RepositoryUrl
-                : "(unknown)";
-            _logger.LogDebug("Dropping quickstart entry '{Identifier}': missing required fields.", identifier);
-            return false;
+            return null;
         }
 
-        return true;
+        string identifier = !string.IsNullOrWhiteSpace(entry.Id) ? entry.Id
+            : !string.IsNullOrWhiteSpace(entry.DisplayName) ? entry.DisplayName
+            : !string.IsNullOrWhiteSpace(entry.RepositoryUrl) ? entry.RepositoryUrl
+            : "(unknown)";
+
+        return (identifier, missing);
     }
 
     private static bool HasValidGitRef(QuickstartEntry entry)

--- a/src/Func/Quickstart/QuickstartRegistration.cs
+++ b/src/Func/Quickstart/QuickstartRegistration.cs
@@ -19,7 +19,8 @@ internal static class QuickstartRegistration
 
     /// <summary>
     /// Environment variable that overrides the CDN manifest URL.
-    /// Accepts HTTPS URLs or local file paths.
+    /// Accepts HTTPS URLs, <c>file://</c> URIs, or absolute local file paths
+    /// (e.g. <c>C:\manifest.json</c> or <c>/home/user/manifest.json</c>).
     /// </summary>
     internal const string ManifestUrlEnvVar = "FUNC_QUICKSTART_MANIFEST_URL";
 

--- a/src/Func/Quickstart/QuickstartRegistration.cs
+++ b/src/Func/Quickstart/QuickstartRegistration.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Azure.Functions.Cli.Quickstart;
 
@@ -35,10 +37,15 @@ internal static class QuickstartRegistration
                 }
             });
 
-        services.AddHttpClient(HttpClientName);
+        services.AddHttpClient(HttpClientName)
+            .ConfigureHttpClient((sp, client) =>
+            {
+                QuickstartManifestOptions opts = sp.GetRequiredService<IOptions<QuickstartManifestOptions>>().Value;
+                client.Timeout = opts.HttpTimeout;
+            });
 
         services.AddSingleton<IManifestCache, ManifestCache>();
-        services.AddSingleton(TimeProvider.System);
+        services.TryAddSingleton(TimeProvider.System);
         services.AddSingleton<IQuickstartManifestService, QuickstartManifestService>();
 
         return services;

--- a/src/Func/Quickstart/QuickstartRegistration.cs
+++ b/src/Func/Quickstart/QuickstartRegistration.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Azure.Functions.Cli.Quickstart;
+
+/// <summary>
+/// DI extension that registers quickstart manifest services.
+/// </summary>
+internal static class QuickstartRegistration
+{
+    /// <summary>
+    /// Named HttpClient for manifest fetches.
+    /// </summary>
+    internal const string HttpClientName = "QuickstartManifest";
+
+    /// <summary>
+    /// Environment variable that overrides the CDN manifest URL.
+    /// Accepts HTTPS URLs or local file paths.
+    /// </summary>
+    internal const string ManifestUrlEnvVar = "FUNC_QUICKSTART_MANIFEST_URL";
+
+    public static IServiceCollection AddQuickstartManifest(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddOptions<QuickstartManifestOptions>()
+            .Configure(opts =>
+            {
+                string? overrideUrl = Environment.GetEnvironmentVariable(ManifestUrlEnvVar);
+                if (!string.IsNullOrWhiteSpace(overrideUrl))
+                {
+                    opts.ManifestUrl = overrideUrl;
+                }
+            });
+
+        services.AddHttpClient(HttpClientName);
+
+        services.AddSingleton<IManifestCache, ManifestCache>();
+        services.AddSingleton(TimeProvider.System);
+        services.AddSingleton<IQuickstartManifestService, QuickstartManifestService>();
+
+        return services;
+    }
+}

--- a/src/Func/Quickstart/QuickstartUrlValidator.cs
+++ b/src/Func/Quickstart/QuickstartUrlValidator.cs
@@ -1,0 +1,58 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Quickstart;
+
+/// <summary>
+/// Allow-lists repository URLs for quickstart entries.
+/// Only HTTPS GitHub URLs from trusted organizations are accepted.
+/// </summary>
+internal static class QuickstartUrlValidator
+{
+    private const string RequiredScheme = "https";
+    private const string RequiredHost = "github.com";
+
+    internal static readonly IReadOnlySet<string> TrustedOrganizations =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "azure",
+            "azure-samples",
+            "microsoft",
+        };
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="url"/> is an HTTPS URL
+    /// on <c>github.com</c> whose first path segment is one of the
+    /// <see cref="TrustedOrganizations"/>, with no embedded credentials.
+    /// </summary>
+    internal static bool IsAllowed(string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return false;
+        }
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out Uri? uri))
+        {
+            return false;
+        }
+
+        if (!string.Equals(uri.Scheme, RequiredScheme, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(uri.UserInfo))
+        {
+            return false;
+        }
+
+        if (!string.Equals(uri.Host, RequiredHost, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        string[] segments = uri.AbsolutePath.Trim('/').Split('/', 2);
+        return segments.Length >= 1 && TrustedOrganizations.Contains(segments[0]);
+    }
+}

--- a/src/Func/Quickstart/QuickstartUrlValidator.cs
+++ b/src/Func/Quickstart/QuickstartUrlValidator.cs
@@ -52,7 +52,14 @@ internal static class QuickstartUrlValidator
             return false;
         }
 
-        string[] segments = uri.AbsolutePath.Trim('/').Split('/', 2);
-        return segments.Length >= 1 && TrustedOrganizations.Contains(segments[0]);
+        if (!uri.IsDefaultPort)
+        {
+            return false;
+        }
+
+        string[] segments = uri.AbsolutePath.Trim('/').Split('/', 3);
+        return segments.Length >= 2
+            && TrustedOrganizations.Contains(segments[0])
+            && segments[1].Length > 0;
     }
 }

--- a/test/Func.Tests/Http/HttpClientDefaultsTests.cs
+++ b/test/Func.Tests/Http/HttpClientDefaultsTests.cs
@@ -1,0 +1,100 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Http;
+
+public sealed class HttpClientDefaultsTests
+{
+    [Fact]
+    public async Task AddCliHttpDefaults_SetsUserAgentOnAllClients()
+    {
+        string? capturedUserAgent = null;
+        var handler = new CapturingHttpMessageHandler(request =>
+        {
+            capturedUserAgent = request.Headers.UserAgent.ToString();
+            return new HttpResponseMessage(System.Net.HttpStatusCode.OK);
+        });
+
+        ServiceCollection services = new();
+        services.AddCliHttpDefaults();
+        services.AddHttpClient("TestClient")
+            .ConfigurePrimaryHttpMessageHandler(() => handler);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        IHttpClientFactory factory = provider.GetRequiredService<IHttpClientFactory>();
+        HttpClient client = factory.CreateClient("TestClient");
+
+        await client.GetAsync("https://example.com");
+
+        Assert.NotNull(capturedUserAgent);
+        Assert.StartsWith("AzureFunctionsCli/", capturedUserAgent);
+        Assert.Contains("(", capturedUserAgent);
+    }
+
+    [Fact]
+    public async Task AddCliHttpDefaults_AppliesUserAgentToUnnamedClients()
+    {
+        string? capturedUserAgent = null;
+        var handler = new CapturingHttpMessageHandler(request =>
+        {
+            capturedUserAgent = request.Headers.UserAgent.ToString();
+            return new HttpResponseMessage(System.Net.HttpStatusCode.OK);
+        });
+
+        ServiceCollection services = new();
+        services.AddCliHttpDefaults();
+        services.AddHttpClient(string.Empty)
+            .ConfigurePrimaryHttpMessageHandler(() => handler);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        IHttpClientFactory factory = provider.GetRequiredService<IHttpClientFactory>();
+        HttpClient client = factory.CreateClient(string.Empty);
+
+        await client.GetAsync("https://example.com");
+
+        Assert.NotNull(capturedUserAgent);
+        Assert.StartsWith("AzureFunctionsCli/", capturedUserAgent);
+    }
+
+    [Fact]
+    public async Task AddCliHttpDefaults_UserAgentIncludesVersionAndPlatform()
+    {
+        string? capturedUserAgent = null;
+        var handler = new CapturingHttpMessageHandler(request =>
+        {
+            capturedUserAgent = request.Headers.UserAgent.ToString();
+            return new HttpResponseMessage(System.Net.HttpStatusCode.OK);
+        });
+
+        ServiceCollection services = new();
+        services.AddCliHttpDefaults();
+        services.AddHttpClient("VersionCheck")
+            .ConfigurePrimaryHttpMessageHandler(() => handler);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        IHttpClientFactory factory = provider.GetRequiredService<IHttpClientFactory>();
+        HttpClient client = factory.CreateClient("VersionCheck");
+
+        await client.GetAsync("https://example.com");
+
+        Assert.NotNull(capturedUserAgent);
+        // Format: AzureFunctionsCli/{version} ({os})
+        Assert.Matches(@"^AzureFunctionsCli/\S+ \(.+\)$", capturedUserAgent);
+    }
+
+    private sealed class CapturingHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
+        : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler = handler;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_handler(request));
+        }
+    }
+}

--- a/test/Func.Tests/Quickstart/QuickstartManifestServiceTests.cs
+++ b/test/Func.Tests/Quickstart/QuickstartManifestServiceTests.cs
@@ -202,28 +202,33 @@ public sealed class QuickstartManifestServiceTests
     public async Task GetManifestAsync_LoadsFromLocalFile_WhenOverrideIsFilePath()
     {
         string manifest = CreateManifestJson("local-entry", "Python", "http", "v1.0.0");
-        IManifestCache cache = Substitute.For<IManifestCache>();
-        cache.TryReadLocalFileAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(manifest);
+        string tempFile = Path.Combine(Path.GetTempPath(), $"test-manifest-{Guid.NewGuid()}.json");
+        try
+        {
+            File.WriteAllText(tempFile, manifest);
+            IManifestCache cache = Substitute.For<IManifestCache>();
 
-        _options.ManifestUrl = Path.Combine(Path.GetTempPath(), "local-manifest.json");
-        QuickstartManifestService service = CreateService(
-            new HttpResponseMessage(HttpStatusCode.InternalServerError), cache);
+            _options.ManifestUrl = tempFile;
+            QuickstartManifestService service = CreateService(
+                new HttpResponseMessage(HttpStatusCode.InternalServerError), cache);
 
-        QuickstartManifest result = await service.GetManifestAsync();
+            QuickstartManifest result = await service.GetManifestAsync();
 
-        Assert.Single(result.Entries);
-        Assert.Equal("local-entry", result.Entries[0].Id);
+            Assert.Single(result.Entries);
+            Assert.Equal("local-entry", result.Entries[0].Id);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
     }
 
     [Fact]
     public async Task GetManifestAsync_Throws_WhenLocalFileDoesNotExist()
     {
         IManifestCache cache = Substitute.For<IManifestCache>();
-        cache.TryReadLocalFileAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns((string?)null);
 
-        _options.ManifestUrl = Path.Combine(Path.GetTempPath(), "nonexistent.json");
+        _options.ManifestUrl = Path.Combine(Path.GetTempPath(), $"nonexistent-{Guid.NewGuid()}.json");
         QuickstartManifestService service = CreateService(
             new HttpResponseMessage(HttpStatusCode.InternalServerError), cache);
 

--- a/test/Func.Tests/Quickstart/QuickstartManifestServiceTests.cs
+++ b/test/Func.Tests/Quickstart/QuickstartManifestServiceTests.cs
@@ -235,6 +235,31 @@ public sealed class QuickstartManifestServiceTests
         await Assert.ThrowsAsync<FileNotFoundException>(() => service.GetManifestAsync());
     }
 
+    [Fact]
+    public async Task GetManifestAsync_Throws_WhenLocalFileContainsMalformedJson()
+    {
+        string tempFile = Path.Combine(Path.GetTempPath(), $"test-manifest-{Guid.NewGuid()}.json");
+        try
+        {
+            File.WriteAllText(tempFile, "{ not valid json }}}");
+            IManifestCache cache = Substitute.For<IManifestCache>();
+
+            _options.ManifestUrl = tempFile;
+            QuickstartManifestService service = CreateService(
+                new HttpResponseMessage(HttpStatusCode.InternalServerError), cache);
+
+            InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => service.GetManifestAsync());
+
+            Assert.Contains("empty or malformed", ex.Message);
+            Assert.IsType<System.Text.Json.JsonException>(ex.InnerException);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
     private QuickstartManifestService CreateService(HttpResponseMessage response, IManifestCache cache)
     {
         var handler = new FakeHttpMessageHandler(response);

--- a/test/Func.Tests/Quickstart/QuickstartManifestServiceTests.cs
+++ b/test/Func.Tests/Quickstart/QuickstartManifestServiceTests.cs
@@ -260,6 +260,24 @@ public sealed class QuickstartManifestServiceTests
         }
     }
 
+    [Theory]
+    [InlineData(@"\\server\share\manifest.json")]
+    [InlineData("//server/share/manifest.json")]
+    public async Task GetManifestAsync_DoesNotTreatUncPathAsLocalFile(string uncPath)
+    {
+        string manifest = CreateManifestJson("cdn-entry", "Python", "http", "v1.0.0");
+        IManifestCache cache = CreateCache(manifestJson: null, meta: null);
+
+        _options.ManifestUrl = uncPath;
+        QuickstartManifestService service = CreateService(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(manifest) }, cache);
+
+        QuickstartManifest result = await service.GetManifestAsync();
+
+        Assert.Single(result.Entries);
+        Assert.Equal("cdn-entry", result.Entries[0].Id);
+    }
+
     private QuickstartManifestService CreateService(HttpResponseMessage response, IManifestCache cache)
     {
         var handler = new FakeHttpMessageHandler(response);

--- a/test/Func.Tests/Quickstart/QuickstartManifestServiceTests.cs
+++ b/test/Func.Tests/Quickstart/QuickstartManifestServiceTests.cs
@@ -1,0 +1,305 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Net;
+using Azure.Functions.Cli.Quickstart;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Quickstart;
+
+public sealed class QuickstartManifestServiceTests
+{
+    private readonly QuickstartManifestOptions _options = new()
+    {
+        ManifestUrl = "https://cdn.functions.azure.com/test/manifest.json",
+        CacheDirectory = "/tmp/quickstart-test",
+        CacheTtl = TimeSpan.FromHours(24),
+    };
+
+    [Fact]
+    public async Task GetManifestAsync_FetchesFromCdn_WhenNoCacheExists()
+    {
+        string manifest = CreateManifestJson("http-python", "Python", "http", "v1.0.0");
+        IManifestCache cache = CreateCache(manifestJson: null, meta: null);
+        QuickstartManifestService service = CreateService(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(manifest),
+                Headers = { ETag = new System.Net.Http.Headers.EntityTagHeaderValue("\"etag1\"") },
+            },
+            cache);
+
+        QuickstartManifest result = await service.GetManifestAsync();
+
+        Assert.Single(result.Entries);
+        Assert.Equal("http-python", result.Entries[0].Id);
+        cache.Received(1).WriteManifest(manifest);
+        cache.Received(1).WriteMeta(Arg.Any<ManifestCacheMeta>());
+    }
+
+    [Fact]
+    public async Task GetManifestAsync_UsesCachedManifest_WhenCacheIsFresh()
+    {
+        string manifest = CreateManifestJson("cached-entry", "Python", "http", "v1.0.0");
+        ManifestCacheMeta meta = new("\"etag1\"", DateTimeOffset.UtcNow);
+        IManifestCache cache = CreateCache(manifestJson: manifest, meta: meta);
+
+        QuickstartManifestService service = CreateService(
+            new HttpResponseMessage(HttpStatusCode.InternalServerError), cache);
+
+        QuickstartManifest result = await service.GetManifestAsync();
+
+        Assert.Single(result.Entries);
+        Assert.Equal("cached-entry", result.Entries[0].Id);
+    }
+
+    [Fact]
+    public async Task GetManifestAsync_RefreshesCacheTimestamp_On304()
+    {
+        string manifest = CreateManifestJson("existing-entry", "Python", "http", "v1.0.0");
+        ManifestCacheMeta staleMeta = new("\"etag1\"", DateTimeOffset.UtcNow.AddHours(-25));
+        IManifestCache cache = CreateCache(manifestJson: manifest, meta: staleMeta);
+
+        QuickstartManifestService service = CreateService(
+            new HttpResponseMessage(HttpStatusCode.NotModified), cache);
+
+        QuickstartManifest result = await service.GetManifestAsync();
+
+        Assert.Single(result.Entries);
+        Assert.Equal("existing-entry", result.Entries[0].Id);
+        cache.Received(1).WriteMeta(Arg.Is<ManifestCacheMeta>(m => m.ETag == "\"etag1\""));
+    }
+
+    [Fact]
+    public async Task GetManifestAsync_FallsBackToStaleCache_OnNetworkFailure()
+    {
+        string manifest = CreateManifestJson("stale-entry", "Python", "http", "v1.0.0");
+        ManifestCacheMeta staleMeta = new("\"etag1\"", DateTimeOffset.UtcNow.AddHours(-25));
+        IManifestCache cache = CreateCache(manifestJson: manifest, meta: staleMeta);
+
+        QuickstartManifestService service = CreateService(
+            new HttpRequestException("Network unreachable"), cache);
+
+        QuickstartManifest result = await service.GetManifestAsync();
+
+        Assert.Single(result.Entries);
+        Assert.Equal("stale-entry", result.Entries[0].Id);
+    }
+
+    [Fact]
+    public async Task GetManifestAsync_Throws_WhenNoNetworkAndNoCache()
+    {
+        IManifestCache cache = CreateCache(manifestJson: null, meta: null);
+
+        QuickstartManifestService service = CreateService(
+            new HttpRequestException("Network unreachable"), cache);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetManifestAsync());
+    }
+
+    [Fact]
+    public async Task GetManifestAsync_FiltersOutEntriesWithoutGitRef()
+    {
+        string manifest = CreateManifestJsonRaw(
+        [
+            CreateEntryJson("has-ref", "Python", "http", "v1.0.0"),
+            CreateEntryJson("no-ref", "Python", "http", null),
+        ]);
+        IManifestCache cache = CreateCache(manifestJson: null, meta: null);
+
+        QuickstartManifestService service = CreateService(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(manifest) }, cache);
+
+        QuickstartManifest result = await service.GetManifestAsync();
+
+        Assert.Single(result.Entries);
+        Assert.Equal("has-ref", result.Entries[0].Id);
+    }
+
+    [Fact]
+    public async Task GetManifestAsync_FiltersOutEntriesWithNonVPrefixedGitRef()
+    {
+        string manifest = CreateManifestJsonRaw(
+        [
+            CreateEntryJson("tagged", "Python", "http", "v1.0.0"),
+            CreateEntryJson("branch", "Python", "http", "main"),
+        ]);
+        IManifestCache cache = CreateCache(manifestJson: null, meta: null);
+
+        QuickstartManifestService service = CreateService(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(manifest) }, cache);
+
+        QuickstartManifest result = await service.GetManifestAsync();
+
+        Assert.Single(result.Entries);
+        Assert.Equal("tagged", result.Entries[0].Id);
+    }
+
+    [Fact]
+    public async Task GetManifestAsync_FiltersOutUntrustedRepoUrls()
+    {
+        string json = """
+            { "templates": [
+                { "id": "trusted", "displayName": "Trusted", "language": "Python", "resource": "http",
+                  "repositoryUrl": "https://github.com/Azure-Samples/test-repo", "folderPath": ".", "gitRef": "v1.0.0",
+                  "priority": 100 },
+                { "id": "untrusted", "displayName": "Untrusted", "language": "Python", "resource": "http",
+                  "repositoryUrl": "https://github.com/random-user/test-repo", "folderPath": ".", "gitRef": "v1.0.0",
+                  "priority": 100 }
+            ]}
+            """;
+        IManifestCache cache = CreateCache(manifestJson: null, meta: null);
+
+        QuickstartManifestService service = CreateService(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(json) }, cache);
+
+        QuickstartManifest result = await service.GetManifestAsync();
+
+        Assert.Single(result.Entries);
+        Assert.Equal("trusted", result.Entries[0].Id);
+    }
+
+    [Fact]
+    public async Task GetManifestAsync_DoesNotFilterByLanguage()
+    {
+        string manifest = CreateManifestJsonRaw(
+        [
+            CreateEntryJson("python-entry", "Python", "http", "v1.0.0"),
+            CreateEntryJson("bicep-entry", "Bicep", "http", "v1.0.0"),
+            CreateEntryJson("terraform-entry", "Terraform", "http", "v1.0.0"),
+        ]);
+        IManifestCache cache = CreateCache(manifestJson: null, meta: null);
+
+        QuickstartManifestService service = CreateService(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(manifest) }, cache);
+
+        QuickstartManifest result = await service.GetManifestAsync();
+
+        Assert.Equal(3, result.Entries.Count);
+    }
+
+    [Fact]
+    public async Task GetManifestAsync_FallsBackToCache_WhenResponseIsMalformed()
+    {
+        string json = """[ { "id": "bare-entry" } ]""";
+        string cachedManifest = CreateManifestJson("cached", "Python", "http", "v1.0.0");
+        ManifestCacheMeta meta = new("\"etag1\"", DateTimeOffset.UtcNow.AddHours(-25));
+        IManifestCache cache = CreateCache(manifestJson: cachedManifest, meta: meta);
+
+        QuickstartManifestService service = CreateService(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(json) }, cache);
+
+        QuickstartManifest result = await service.GetManifestAsync();
+
+        Assert.Single(result.Entries);
+        Assert.Equal("cached", result.Entries[0].Id);
+    }
+
+    [Fact]
+    public async Task GetManifestAsync_LoadsFromLocalFile_WhenOverrideIsFilePath()
+    {
+        string manifest = CreateManifestJson("local-entry", "Python", "http", "v1.0.0");
+        IManifestCache cache = Substitute.For<IManifestCache>();
+        cache.TryReadLocalFileAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(manifest);
+
+        _options.ManifestUrl = Path.Combine(Path.GetTempPath(), "local-manifest.json");
+        QuickstartManifestService service = CreateService(
+            new HttpResponseMessage(HttpStatusCode.InternalServerError), cache);
+
+        QuickstartManifest result = await service.GetManifestAsync();
+
+        Assert.Single(result.Entries);
+        Assert.Equal("local-entry", result.Entries[0].Id);
+    }
+
+    [Fact]
+    public async Task GetManifestAsync_Throws_WhenLocalFileDoesNotExist()
+    {
+        IManifestCache cache = Substitute.For<IManifestCache>();
+        cache.TryReadLocalFileAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+
+        _options.ManifestUrl = Path.Combine(Path.GetTempPath(), "nonexistent.json");
+        QuickstartManifestService service = CreateService(
+            new HttpResponseMessage(HttpStatusCode.InternalServerError), cache);
+
+        await Assert.ThrowsAsync<FileNotFoundException>(() => service.GetManifestAsync());
+    }
+
+    private QuickstartManifestService CreateService(HttpResponseMessage response, IManifestCache cache)
+    {
+        var handler = new FakeHttpMessageHandler(response);
+        return CreateServiceFromHandler(handler, cache);
+    }
+
+    private QuickstartManifestService CreateService(Exception exception, IManifestCache cache)
+    {
+        var handler = new FakeHttpMessageHandler(exception);
+        return CreateServiceFromHandler(handler, cache);
+    }
+
+    private QuickstartManifestService CreateServiceFromHandler(FakeHttpMessageHandler handler, IManifestCache cache)
+    {
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("https://cdn.functions.azure.com") };
+        IHttpClientFactory factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient(QuickstartRegistration.HttpClientName).Returns(httpClient);
+        IOptions<QuickstartManifestOptions> opts = Options.Create(_options);
+
+        return new QuickstartManifestService(factory, cache, opts, TimeProvider.System,
+            NullLogger<QuickstartManifestService>.Instance);
+    }
+
+    private static IManifestCache CreateCache(string? manifestJson, ManifestCacheMeta? meta)
+    {
+        IManifestCache cache = Substitute.For<IManifestCache>();
+        cache.TryReadMeta().Returns(meta);
+        cache.TryReadManifest().Returns(manifestJson);
+        cache.ManifestExists().Returns(manifestJson is not null);
+        return cache;
+    }
+
+    private static string CreateManifestJson(string id, string language, string resource, string gitRef)
+    {
+        return CreateManifestJsonRaw([CreateEntryJson(id, language, resource, gitRef)]);
+    }
+
+    private static string CreateManifestJsonRaw(string[] entries)
+    {
+        return $$"""{ "templates": [{{string.Join(",", entries)}}] }""";
+    }
+
+    private static string CreateEntryJson(string id, string language, string resource, string? gitRef)
+    {
+        string gitRefPart = gitRef is not null ? $""", "gitRef": "{gitRef}" """ : "";
+        return $$"""
+            { "id": "{{id}}", "displayName": "{{id}}", "language": "{{language}}",
+              "resource": "{{resource}}", "repositoryUrl": "https://github.com/Azure-Samples/test-repo",
+              "folderPath": ".", "priority": 100{{gitRefPart}} }
+            """;
+    }
+
+    private sealed class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage? _response;
+        private readonly Exception? _exception;
+
+        public FakeHttpMessageHandler(HttpResponseMessage response) => _response = response;
+
+        public FakeHttpMessageHandler(Exception exception) => _exception = exception;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (_exception is not null)
+            {
+                return Task.FromException<HttpResponseMessage>(_exception);
+            }
+
+            return Task.FromResult(_response!);
+        }
+    }
+}

--- a/test/Func.Tests/Quickstart/QuickstartManifestTests.cs
+++ b/test/Func.Tests/Quickstart/QuickstartManifestTests.cs
@@ -1,0 +1,177 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Quickstart;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Quickstart;
+
+public sealed class QuickstartManifestTests
+{
+    private static QuickstartEntry CreateEntry(
+        string id = "test-entry",
+        string language = "Python",
+        string resource = "http",
+        string? iac = "bicep",
+        string displayName = "Test Entry",
+        string? shortDescription = "A test template",
+        string? longDescription = null,
+        IReadOnlyList<string>? tags = null,
+        int priority = 100) =>
+        new(id, displayName, language, resource, iac,
+            "https://github.com/Azure-Samples/test-repo", ".", "v1.0.0",
+            shortDescription, longDescription, null, tags ?? [], priority);
+
+    [Fact]
+    public void Filter_ByLanguage_ReturnsMatchingEntries()
+    {
+        QuickstartManifest manifest = new(
+        [
+            CreateEntry(id: "python-entry", language: "Python"),
+            CreateEntry(id: "node-entry", language: "TypeScript"),
+        ]);
+
+        IReadOnlyList<QuickstartEntry> results = manifest.Filter(language: "Python");
+
+        Assert.Single(results);
+        Assert.Equal("python-entry", results[0].Id);
+    }
+
+    [Fact]
+    public void Filter_ByLanguage_IsCaseInsensitive()
+    {
+        QuickstartManifest manifest = new([CreateEntry(language: "Python")]);
+
+        IReadOnlyList<QuickstartEntry> results = manifest.Filter(language: "python");
+
+        Assert.Single(results);
+    }
+
+    [Fact]
+    public void Filter_ByResource_ReturnsMatchingEntries()
+    {
+        QuickstartManifest manifest = new(
+        [
+            CreateEntry(id: "http-entry", resource: "http"),
+            CreateEntry(id: "timer-entry", resource: "timer"),
+        ]);
+
+        IReadOnlyList<QuickstartEntry> results = manifest.Filter(resource: "timer");
+
+        Assert.Single(results);
+        Assert.Equal("timer-entry", results[0].Id);
+    }
+
+    [Fact]
+    public void Filter_ByIac_ReturnsMatchingEntries()
+    {
+        QuickstartManifest manifest = new(
+        [
+            CreateEntry(id: "bicep-entry", iac: "bicep"),
+            CreateEntry(id: "terraform-entry", iac: "terraform"),
+        ]);
+
+        IReadOnlyList<QuickstartEntry> results = manifest.Filter(iac: "bicep");
+
+        Assert.Single(results);
+        Assert.Equal("bicep-entry", results[0].Id);
+    }
+
+    [Fact]
+    public void Filter_BySearch_MatchesId()
+    {
+        QuickstartManifest manifest = new([CreateEntry(id: "http-trigger-python-azd")]);
+
+        IReadOnlyList<QuickstartEntry> results = manifest.Filter(search: "python");
+
+        Assert.Single(results);
+    }
+
+    [Fact]
+    public void Filter_BySearch_MatchesDisplayName()
+    {
+        QuickstartManifest manifest = new([CreateEntry(displayName: "HTTP Trigger with OpenAI")]);
+
+        IReadOnlyList<QuickstartEntry> results = manifest.Filter(search: "openai");
+
+        Assert.Single(results);
+    }
+
+    [Fact]
+    public void Filter_BySearch_MatchesLongDescription()
+    {
+        QuickstartManifest manifest = new([CreateEntry(iac: "none", longDescription: "Deploy with Bicep to Azure")]);
+
+        IReadOnlyList<QuickstartEntry> results = manifest.Filter(search: "Deploy with");
+
+        Assert.Single(results);
+    }
+
+    [Fact]
+    public void Filter_BySearch_MatchesIac()
+    {
+        QuickstartManifest manifest = new([CreateEntry(iac: "terraform")]);
+
+        IReadOnlyList<QuickstartEntry> results = manifest.Filter(search: "terraform");
+
+        Assert.Single(results);
+    }
+
+    [Fact]
+    public void Filter_MultipleCriteria_AppliesAll()
+    {
+        QuickstartManifest manifest = new(
+        [
+            CreateEntry(id: "match", language: "Python", resource: "http"),
+            CreateEntry(id: "wrong-lang", language: "TypeScript", resource: "http"),
+            CreateEntry(id: "wrong-resource", language: "Python", resource: "timer"),
+        ]);
+
+        IReadOnlyList<QuickstartEntry> results = manifest.Filter(language: "Python", resource: "http");
+
+        Assert.Single(results);
+        Assert.Equal("match", results[0].Id);
+    }
+
+    [Fact]
+    public void Filter_ReturnsResultsOrderedByPriority()
+    {
+        QuickstartManifest manifest = new(
+        [
+            CreateEntry(id: "low-priority", priority: 300),
+            CreateEntry(id: "high-priority", priority: 10),
+            CreateEntry(id: "mid-priority", priority: 100),
+        ]);
+
+        IReadOnlyList<QuickstartEntry> results = manifest.Filter();
+
+        Assert.Equal("high-priority", results[0].Id);
+        Assert.Equal("mid-priority", results[1].Id);
+        Assert.Equal("low-priority", results[2].Id);
+    }
+
+    [Fact]
+    public void Filter_NoCriteria_ReturnsAllEntriesOrdered()
+    {
+        QuickstartManifest manifest = new(
+        [
+            CreateEntry(id: "a", priority: 2),
+            CreateEntry(id: "b", priority: 1),
+        ]);
+
+        IReadOnlyList<QuickstartEntry> results = manifest.Filter();
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal("b", results[0].Id);
+    }
+
+    [Fact]
+    public void Filter_NoMatches_ReturnsEmptyList()
+    {
+        QuickstartManifest manifest = new([CreateEntry(language: "Python")]);
+
+        IReadOnlyList<QuickstartEntry> results = manifest.Filter(language: "Go");
+
+        Assert.Empty(results);
+    }
+}

--- a/test/Func.Tests/Quickstart/QuickstartManifestTests.cs
+++ b/test/Func.Tests/Quickstart/QuickstartManifestTests.cs
@@ -16,11 +16,10 @@ public sealed class QuickstartManifestTests
         string displayName = "Test Entry",
         string? shortDescription = "A test template",
         string? longDescription = null,
-        IReadOnlyList<string>? tags = null,
         int priority = 100) =>
         new(id, displayName, language, resource, iac,
             "https://github.com/Azure-Samples/test-repo", ".", "v1.0.0",
-            shortDescription, longDescription, null, tags ?? [], priority);
+            shortDescription, longDescription, null, priority);
 
     [Fact]
     public void Filter_ByLanguage_ReturnsMatchingEntries()

--- a/test/Func.Tests/Quickstart/QuickstartUrlValidatorTests.cs
+++ b/test/Func.Tests/Quickstart/QuickstartUrlValidatorTests.cs
@@ -64,4 +64,16 @@ public sealed class QuickstartUrlValidatorTests
     {
         Assert.False(QuickstartUrlValidator.IsAllowed("file:///c:/manifests/test.json"));
     }
+
+    [Fact]
+    public void IsAllowed_RejectsNonDefaultPort()
+    {
+        Assert.False(QuickstartUrlValidator.IsAllowed("https://github.com:8080/Azure/some-repo"));
+    }
+
+    [Fact]
+    public void IsAllowed_RejectsOrgWithoutRepo()
+    {
+        Assert.False(QuickstartUrlValidator.IsAllowed("https://github.com/Azure"));
+    }
 }

--- a/test/Func.Tests/Quickstart/QuickstartUrlValidatorTests.cs
+++ b/test/Func.Tests/Quickstart/QuickstartUrlValidatorTests.cs
@@ -1,0 +1,67 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Quickstart;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Quickstart;
+
+public sealed class QuickstartUrlValidatorTests
+{
+    [Theory]
+    [InlineData("https://github.com/Azure/some-repo")]
+    [InlineData("https://github.com/azure/some-repo")]
+    [InlineData("https://github.com/Azure-Samples/functions-quickstart-python")]
+    [InlineData("https://github.com/azure-samples/functions-quickstart-python")]
+    [InlineData("https://github.com/Microsoft/some-repo")]
+    [InlineData("https://github.com/microsoft/some-repo")]
+    public void IsAllowed_AcceptsTrustedOrganizations(string url)
+    {
+        Assert.True(QuickstartUrlValidator.IsAllowed(url));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void IsAllowed_RejectsNullOrEmpty(string? url)
+    {
+        Assert.False(QuickstartUrlValidator.IsAllowed(url));
+    }
+
+    [Fact]
+    public void IsAllowed_RejectsHttpScheme()
+    {
+        Assert.False(QuickstartUrlValidator.IsAllowed("http://github.com/Azure/some-repo"));
+    }
+
+    [Fact]
+    public void IsAllowed_RejectsNonGitHubHost()
+    {
+        Assert.False(QuickstartUrlValidator.IsAllowed("https://gitlab.com/Azure/some-repo"));
+    }
+
+    [Fact]
+    public void IsAllowed_RejectsUntrustedOrganization()
+    {
+        Assert.False(QuickstartUrlValidator.IsAllowed("https://github.com/random-user/some-repo"));
+    }
+
+    [Fact]
+    public void IsAllowed_RejectsEmbeddedCredentials()
+    {
+        Assert.False(QuickstartUrlValidator.IsAllowed("https://user:pass@github.com/Azure/some-repo"));
+    }
+
+    [Fact]
+    public void IsAllowed_RejectsInvalidUri()
+    {
+        Assert.False(QuickstartUrlValidator.IsAllowed("not-a-url"));
+    }
+
+    [Fact]
+    public void IsAllowed_RejectsFileScheme()
+    {
+        Assert.False(QuickstartUrlValidator.IsAllowed("file:///c:/manifests/test.json"));
+    }
+}


### PR DESCRIPTION
### Issue describing the changes in this PR

resolves #5026 (partial - manifest service layer only)

This is PR 2 in the incremental `func quickstart` series (after skeleton #5099). It implements the manifest service that fetches, caches, validates, and filters CDN-hosted template entries.

**What is included:**
- `QuickstartManifestService` - fetch from CDN with ETag/304 support, stale cache fallback on network failure
- `IManifestCache` - filesystem abstraction for testability (follows `IProfileFileSystem` pattern)
- `QuickstartManifest` - rich wrapper with `Filter(language, resource, iac, search)` and priority ordering
- `QuickstartUrlValidator` - HTTPS + trusted host/org allow-listing for template URLs
- `HttpClientDefaults` - CLI-wide User-Agent header (`AzureFunctionsCli/{version} ({os})`) applied to all HTTP clients
- `QuickstartManifestOptions` - configurable CDN URL, cache dir, TTL, HTTP timeout
- Source-gen JSON context for AOT/trim-friendly deserialization
- 46 new tests (service, manifest filtering, URL validation, HTTP defaults)
- Architecture doc updated

### Pull request checklist

* [x] My changes **do not** require documentation changes
* [x] My changes **do not** need to be backported to a previous version
* [x] My changes **should not** be added to the release notes for the next release
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

- Only `v`-prefixed `gitRef` entries are accepted (semver release tags), signed tag verification in scaffolding service
- URL allow-list: HTTPS only, `github.com` host, trusted orgs (`Azure`, `Azure-Samples`, `microsoft`)
- Free-text search covers: Id, DisplayName, Resource, Iac, LongDescription