### PR TITLE
Refactor worker resolution with WorkerReference model

### DIFF
--- a/src/Abstractions/Projects/FunctionsProject.cs
+++ b/src/Abstractions/Projects/FunctionsProject.cs
@@ -19,7 +19,7 @@ public abstract class FunctionsProject
 
     public abstract bool SupportsExtensionBundles { get; }
 
-    public abstract IFunctionsWorker Worker { get; }
+    public abstract FunctionsWorkerReference WorkerReference { get; }
 
     public virtual Task PrepareForHostRunAsync(FunctionsProjectHostRunContext context, CancellationToken cancellationToken)
     {

--- a/src/Abstractions/Projects/ProjectCreationContext.cs
+++ b/src/Abstractions/Projects/ProjectCreationContext.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Common;
-using Azure.Functions.Cli.Workers;
 
 namespace Azure.Functions.Cli.Projects;
 
@@ -10,5 +9,4 @@ namespace Azure.Functions.Cli.Projects;
 /// Inputs passed to workload project factories.
 /// </summary>
 /// <param name="WorkingDirectory">The directory the command is operating on.</param>
-/// <param name="WorkerResolver">The resolver used to locate required Functions workers.</param>
-public sealed record ProjectCreationContext(WorkingDirectory WorkingDirectory, IFunctionsWorkerResolver WorkerResolver);
+public sealed record ProjectCreationContext(WorkingDirectory WorkingDirectory);

--- a/src/Abstractions/Workers/FunctionsWorkerReference.cs
+++ b/src/Abstractions/Workers/FunctionsWorkerReference.cs
@@ -1,0 +1,65 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workers;
+
+/// <summary>
+/// Describes how a Functions project resolves its required worker.
+/// </summary>
+public abstract class FunctionsWorkerReference
+{
+    private FunctionsWorkerReference()
+    {
+    }
+
+    public static FunctionsWorkerReference FromWorkload(string workerId)
+        => FromWorkload(new FunctionsWorkerId(workerId));
+
+    public static FunctionsWorkerReference FromWorkload(FunctionsWorkerId workerId)
+    {
+        ArgumentNullException.ThrowIfNull(workerId);
+        return new WorkloadReference(workerId);
+    }
+
+    public static FunctionsWorkerReference FromWorkerInfo(string workerId, string workerRuntime, string workerConfigPath, string version = "")
+        => FromWorkerInfo(new FunctionsWorkerId(workerId), workerRuntime, workerConfigPath, version);
+
+    public static FunctionsWorkerReference FromWorkerInfo(FunctionsWorkerId workerId, string workerRuntime, string workerConfigPath, string version = "")
+    {
+        ArgumentNullException.ThrowIfNull(workerId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(workerRuntime);
+        ArgumentException.ThrowIfNullOrWhiteSpace(workerConfigPath);
+        ArgumentNullException.ThrowIfNull(version);
+
+        IFunctionsWorker worker = new ReferencedFunctionsWorker(workerId, workerRuntime, workerConfigPath, version);
+        return new WorkerInfoReference(worker);
+    }
+
+    public abstract Task<FunctionsWorkerResolutionResult> ResolveWorkerAsync(FunctionsWorkerResolutionContext context, CancellationToken cancellationToken);
+
+    private sealed class WorkloadReference(FunctionsWorkerId workerId) : FunctionsWorkerReference
+    {
+        private readonly FunctionsWorkerId _workerId = workerId ?? throw new ArgumentNullException(nameof(workerId));
+
+        public override async Task<FunctionsWorkerResolutionResult> ResolveWorkerAsync(FunctionsWorkerResolutionContext context, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            return await context.Resolver.ResolveWorkerAsync(_workerId, cancellationToken);
+        }
+    }
+
+    private sealed class WorkerInfoReference(IFunctionsWorker worker) : FunctionsWorkerReference
+    {
+        private readonly IFunctionsWorker _worker = worker ?? throw new ArgumentNullException(nameof(worker));
+
+        public override Task<FunctionsWorkerResolutionResult> ResolveWorkerAsync(FunctionsWorkerResolutionContext context, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return Task.FromResult<FunctionsWorkerResolutionResult>(FunctionsWorkerResolutionResults.Resolved(_worker));
+        }
+    }
+
+    private sealed record ReferencedFunctionsWorker(FunctionsWorkerId Id, string WorkerRuntime, string WorkerConfigPath, string Version) : IFunctionsWorker;
+}

--- a/src/Abstractions/Workers/FunctionsWorkerResolutionContext.cs
+++ b/src/Abstractions/Workers/FunctionsWorkerResolutionContext.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workers;
+
+/// <summary>
+/// Inputs used by a worker reference to resolve a concrete worker.
+/// </summary>
+public sealed record FunctionsWorkerResolutionContext
+{
+    public FunctionsWorkerResolutionContext(IFunctionsWorkerResolver resolver)
+    {
+        Resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
+    }
+
+    public IFunctionsWorkerResolver Resolver { get; }
+}

--- a/src/Func/Bundles/ValidateExtensionBundleInitializationStep.cs
+++ b/src/Func/Bundles/ValidateExtensionBundleInitializationStep.cs
@@ -106,7 +106,7 @@ internal sealed class ValidateExtensionBundleInitializationStep : DemoInitializa
     }
 
     private static string? ResolveWorkerRuntime(StartInitializationStepContext context)
-        => context.State.Project?.StackName?.ToLowerInvariant();
+        => context.State.Worker?.WorkerRuntime;
 
     private static string? NullIfNone(string? profile) =>
         string.IsNullOrWhiteSpace(profile) || string.Equals(profile, "none", StringComparison.OrdinalIgnoreCase)

--- a/src/Func/Commands/Start/Dashboard/Demo/DemoStartInitializationRunner.cs
+++ b/src/Func/Commands/Start/Dashboard/Demo/DemoStartInitializationRunner.cs
@@ -4,8 +4,11 @@
 using Azure.Functions.Cli.Bundles;
 using Azure.Functions.Cli.Commands.Start.Initialization.Rendering;
 using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Profiles;
 using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Workers;
+using Azure.Functions.Cli.Workloads.Catalog;
 using Azure.Functions.Cli.Workloads.Install;
 using Microsoft.Extensions.Logging;
 
@@ -20,7 +23,10 @@ internal sealed class DemoStartInitializationRunner(
     IHostJsonBundleSectionReader bundleSectionReader,
     IProfileResolver profileResolver,
     IHostWorkloadResolver hostWorkloadResolver,
+    IFunctionsWorkerResolverFactory workerResolverFactory,
+    IWorkloadCatalog workloadCatalog,
     IWorkloadInstaller workloadInstaller,
+    IInteractionService interaction,
     ILoggerFactory loggerFactory,
     TimeProvider? timeProvider = null)
     : IStartInitializationRunner
@@ -40,18 +46,22 @@ internal sealed class DemoStartInitializationRunner(
     private readonly IHostWorkloadResolver _hostWorkloadResolver = hostWorkloadResolver
         ?? throw new ArgumentNullException(nameof(hostWorkloadResolver));
 
+    private readonly IFunctionsWorkerResolverFactory _workerResolverFactory = workerResolverFactory
+        ?? throw new ArgumentNullException(nameof(workerResolverFactory));
+
+    private readonly IWorkloadCatalog _workloadCatalog = workloadCatalog ?? throw new ArgumentNullException(nameof(workloadCatalog));
+
     private readonly IWorkloadInstaller _workloadInstaller = workloadInstaller
         ?? throw new ArgumentNullException(nameof(workloadInstaller));
+
+    private readonly IInteractionService _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
 
     private readonly ILoggerFactory _loggerFactory = loggerFactory
         ?? throw new ArgumentNullException(nameof(loggerFactory));
 
     private readonly TimeProvider _time = timeProvider ?? TimeProvider.System;
 
-    public async Task<StartInitializationResult> RunAsync(
-        StartInitializationContext context,
-        IStartInitializationRenderer renderer,
-        CancellationToken cancellationToken)
+    public async Task<StartInitializationResult> RunAsync(StartInitializationContext context, IStartInitializationRenderer renderer, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(renderer);
@@ -75,10 +85,8 @@ internal sealed class DemoStartInitializationRunner(
             new ResolveConstraintsInitializationStep(),
             new ValidateHostWorkloadInitializationStep(_hostWorkloadResolver, _workloadInstaller),
             new ResolveFunctionsProjectInitializationStep(_projectResolver),
-            new ValidateExtensionBundleInitializationStep(
-                _bundleResolver,
-                _bundleSectionReader,
-                _loggerFactory.CreateLogger<ValidateExtensionBundleInitializationStep>()),
+            new ResolveFunctionsWorkerInitializationStep(_workerResolverFactory,_workloadCatalog,_workloadInstaller,_interaction),
+            new ValidateExtensionBundleInitializationStep(_bundleResolver, _bundleSectionReader, _loggerFactory.CreateLogger<ValidateExtensionBundleInitializationStep>()),
             new PrepareProjectHostRunInitializationStep(),
             new StartHostInitializationStep(_time),
         ];
@@ -86,12 +94,8 @@ internal sealed class DemoStartInitializationRunner(
         return steps;
     }
 
-    private async Task RunStepsAsync(
-        StartInitializationStepCollection steps,
-        StartInitializationContext context,
-        StartInitializationState state,
-        IStartInitializationRenderer renderer,
-        CancellationToken cancellationToken)
+    private async Task RunStepsAsync(StartInitializationStepCollection steps, StartInitializationContext context, StartInitializationState state,
+        IStartInitializationRenderer renderer, CancellationToken cancellationToken)
     {
         Queue<IStartInitializationStep> pending = new(steps);
         while (pending.TryDequeue(out IStartInitializationStep? step))
@@ -111,9 +115,7 @@ internal sealed class DemoStartInitializationRunner(
         }
     }
 
-    private static Queue<IStartInitializationStep> Prepend(
-        IReadOnlyList<IStartInitializationStep> nextSteps,
-        Queue<IStartInitializationStep> pending)
+    private static Queue<IStartInitializationStep> Prepend(IReadOnlyList<IStartInitializationStep> nextSteps, Queue<IStartInitializationStep> pending)
     {
         Queue<IStartInitializationStep> updated = new();
         foreach (IStartInitializationStep nextStep in nextSteps)
@@ -129,13 +131,8 @@ internal sealed class DemoStartInitializationRunner(
         return updated;
     }
 
-    private async Task EmitAsync(
-        IStartInitializationRenderer renderer,
-        StartInitializationEvent initializationEvent,
-        CancellationToken cancellationToken)
-    {
-        await renderer.OnEventAsync(initializationEvent, cancellationToken);
-    }
+    private async Task EmitAsync(IStartInitializationRenderer renderer, StartInitializationEvent initializationEvent, CancellationToken cancellationToken)
+        => await renderer.OnEventAsync(initializationEvent, cancellationToken);
 
     private DateTimeOffset Now() => _time.GetUtcNow();
 }

--- a/src/Func/Commands/Start/Dashboard/Rendering/Initialization/JsonStartInitializationRenderer.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/Initialization/JsonStartInitializationRenderer.cs
@@ -88,10 +88,10 @@ internal sealed class JsonStartInitializationRenderer : IStartInitializationRend
                     writer.WriteString("profile", completed.Result.RunInfo.ProfileName);
                     writer.WriteString("stack", completed.Result.RunInfo.StackName);
                     writer.WriteString("host_version", completed.Result.HostVersion);
-                    writer.WriteString("worker_runtime", completed.Result.Project.Worker.WorkerRuntime);
-                    if (!string.IsNullOrWhiteSpace(completed.Result.Project.Worker.Version))
+                    writer.WriteString("worker_runtime", completed.Result.Worker.WorkerRuntime);
+                    if (!string.IsNullOrWhiteSpace(completed.Result.Worker.Version))
                     {
-                        writer.WriteString("worker_version", completed.Result.Project.Worker.Version);
+                        writer.WriteString("worker_version", completed.Result.Worker.Version);
                     }
 
                     writer.WriteBoolean("bundle_required", completed.Result.BundleRequired);
@@ -136,7 +136,6 @@ internal sealed class JsonStartInitializationRenderer : IStartInitializationRend
         {
             writer.WriteString("extension_bundle_version_range", profile.ExtensionBundleVersionRange);
         }
-        WriteStringDictionary(writer, "worker_version_ranges", profile.WorkerVersionRanges);
         WriteStringDictionary(writer, "worker_version_ranges", profile.WorkerVersionRanges);
         if (profile.SupportedRuntimes is { Count: > 0 })
         {

--- a/src/Func/Commands/Start/Initialization/StartInitializationResult.cs
+++ b/src/Func/Commands/Start/Initialization/StartInitializationResult.cs
@@ -4,6 +4,7 @@
 using Azure.Functions.Cli.Hosting.Dashboard;
 using Azure.Functions.Cli.Hosting.Events;
 using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Workers;
 
 namespace Azure.Functions.Cli.Commands.Start.Initialization;
 
@@ -17,5 +18,6 @@ internal sealed record StartInitializationResult(
     bool BundleRequired,
     string? BundleVersion,
     FunctionsProject Project,
+    IFunctionsWorker Worker,
     FunctionsProjectHostRunContext HostRunContext,
     StartInitializationProfileInfo? Profile = null);

--- a/src/Func/Commands/Start/Initialization/StartInitializationState.cs
+++ b/src/Func/Commands/Start/Initialization/StartInitializationState.cs
@@ -6,6 +6,7 @@ using Azure.Functions.Cli.Hosting.Dashboard;
 using Azure.Functions.Cli.Hosting.Events;
 using Azure.Functions.Cli.Profiles;
 using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Workers;
 using NuGet.Versioning;
 
 namespace Azure.Functions.Cli.Commands.Start.Initialization;
@@ -24,6 +25,8 @@ internal sealed class StartInitializationState
     public string? HostVersion { get; set; }
 
     public FunctionsProject? Project { get; set; }
+
+    public IFunctionsWorker? Worker { get; set; }
 
     public FunctionsProjectHostRunContext? HostRunContext { get; set; }
 
@@ -44,6 +47,7 @@ internal sealed class StartInitializationState
 
         string hostVersion = HostVersion ?? throw new InvalidOperationException("Host version was not resolved.");
         FunctionsProject project = Project ?? throw new InvalidOperationException("Functions project was not resolved.");
+        IFunctionsWorker worker = Worker ?? throw new InvalidOperationException("Functions worker was not resolved.");
         FunctionsProjectHostRunContext hostRunContext = HostRunContext
             ?? throw new InvalidOperationException("Host run context was not prepared.");
         IHostEventStream eventStream = EventStream ?? throw new InvalidOperationException("Host event stream was not initialized.");
@@ -57,6 +61,7 @@ internal sealed class StartInitializationState
             project.SupportsExtensionBundles,
             BundleVersion,
             project,
+            worker,
             hostRunContext,
             CreateProfileInfo());
     }

--- a/src/Func/Commands/Start/Initialization/Steps/PrepareProjectHostRunInitializationStep.cs
+++ b/src/Func/Commands/Start/Initialization/Steps/PrepareProjectHostRunInitializationStep.cs
@@ -33,14 +33,15 @@ internal sealed class PrepareProjectHostRunInitializationStep : DemoInitializati
             environmentVariables[name] = value;
         }
 
-        var hostRunContext = new FunctionsProjectHostRunContext(
-            project.WorkingDirectory.Info,
-            project.Worker.WorkerRuntime,
-            environmentVariables);
+        if (context.State.Worker?.WorkerRuntime is null)
+        {
+            throw new InvalidOperationException("Functions worker runtime was not resolved.");
+        }
+
+        var hostRunContext = new FunctionsProjectHostRunContext(project.WorkingDirectory.Info, context.State.Worker.WorkerRuntime, environmentVariables);
 
         await project.PrepareForHostRunAsync(hostRunContext, cancellationToken);
 
-        _ = hostRunContext.WorkerRuntime;
         context.State.HostRunContext = hostRunContext;
 
         return StartInitializationStepResult.Completed(hostRunContext.StartupDirectory.FullName);

--- a/src/Func/Commands/Start/Initialization/Steps/ResolveFunctionsProjectInitializationStep.cs
+++ b/src/Func/Commands/Start/Initialization/Steps/ResolveFunctionsProjectInitializationStep.cs
@@ -3,7 +3,6 @@
 
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Projects;
-using NuGet.Versioning;
 
 namespace Azure.Functions.Cli.Commands.Start.Initialization;
 
@@ -25,10 +24,7 @@ internal sealed class ResolveFunctionsProjectInitializationStep(IFunctionsProjec
     {
         await SimulateWorkAsync(context, cancellationToken);
 
-        IReadOnlyDictionary<string, VersionRange> workerVersionRanges =
-            context.State.ResolvedProfile?.WorkerVersionRanges
-            ?? new Dictionary<string, VersionRange>(StringComparer.OrdinalIgnoreCase);
-        var projectResolutionContext = new ProjectResolutionContext(context.Options.WorkingDirectory, workerVersionRanges);
+        var projectResolutionContext = new ProjectResolutionContext(context.Options.WorkingDirectory);
         ProjectResolutionResult resolution = await _projectResolver.ResolveProjectAsync(projectResolutionContext, cancellationToken);
 
         if (resolution is ProjectResolutionResult.NotResolved notResolved)
@@ -37,26 +33,8 @@ internal sealed class ResolveFunctionsProjectInitializationStep(IFunctionsProjec
         }
 
         var resolved = (ProjectResolutionResult.Resolved)resolution;
-        ValidateSupportedRuntime(context, resolved.Project);
         context.State.Project = resolved.Project;
 
         return StartInitializationStepResult.Completed(resolved.Project.StackDisplayName);
-    }
-
-    private static void ValidateSupportedRuntime(StartInitializationStepContext context, FunctionsProject project)
-    {
-        if (context.State.ResolvedProfile is not { SupportedRuntimes: { } supportedRuntimes } profile)
-        {
-            return;
-        }
-
-        if (supportedRuntimes.Any(runtime => string.Equals(runtime, project.Worker.WorkerRuntime, StringComparison.OrdinalIgnoreCase)))
-        {
-            return;
-        }
-
-        string message = $"Profile '{profile.Name}' does not support the detected runtime '{project.Worker.WorkerRuntime}'. "
-            + $"Supported runtimes: {string.Join(", ", supportedRuntimes)}.";
-        throw new GracefulException(message, isUserError: true);
     }
 }

--- a/src/Func/Commands/Start/Initialization/Steps/ResolveFunctionsWorkerInitializationStep.cs
+++ b/src/Func/Commands/Start/Initialization/Steps/ResolveFunctionsWorkerInitializationStep.cs
@@ -1,0 +1,281 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Workers;
+using Azure.Functions.Cli.Workloads.Catalog;
+using Azure.Functions.Cli.Workloads.Discovery;
+using Azure.Functions.Cli.Workloads.Install;
+using NuGet.Versioning;
+
+namespace Azure.Functions.Cli.Commands.Start.Initialization;
+
+/// <summary>
+/// Resolves the Functions worker required by the project.
+/// </summary>
+internal sealed class ResolveFunctionsWorkerInitializationStep(
+    IFunctionsWorkerResolverFactory workerResolverFactory,
+    IWorkloadCatalog workloadCatalog,
+    IWorkloadInstaller workloadInstaller,
+    IInteractionService interaction) : DemoInitializationStep
+{
+    public const string StepId = "resolve_worker";
+
+    private readonly IFunctionsWorkerResolverFactory _workerResolverFactory = workerResolverFactory
+        ?? throw new ArgumentNullException(nameof(workerResolverFactory));
+
+    private readonly IWorkloadCatalog _workloadCatalog = workloadCatalog ?? throw new ArgumentNullException(nameof(workloadCatalog));
+    private readonly IWorkloadInstaller _workloadInstaller = workloadInstaller ?? throw new ArgumentNullException(nameof(workloadInstaller));
+    private readonly IInteractionService _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
+
+    public override string Id => StepId;
+
+    public override string Title => "Resolve worker";
+
+    public override StartInitializationDisplayKind DisplayKind => StartInitializationDisplayKind.Progress;
+
+    public override async Task<StartInitializationStepResult> ExecuteAsync(
+        StartInitializationStepContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        await SimulateWorkAsync(context, cancellationToken);
+
+        FunctionsProject project = context.State.Project ?? throw new InvalidOperationException("Functions project was not resolved.");
+        IReadOnlyDictionary<string, VersionRange> workerVersionRanges =
+            context.State.ResolvedProfile?.WorkerVersionRanges
+            ?? new Dictionary<string, VersionRange>(StringComparer.OrdinalIgnoreCase);
+
+        FunctionsWorkerResolutionResult result = await ResolveWorkerAsync(project, workerVersionRanges, cancellationToken);
+
+        if (result is FunctionsWorkerResolutionResult.NotResolved notResolved
+            && TryGetInstallableWorker(notResolved.Failure, out FunctionsWorkerId? workerId)
+            && workerId is not null)
+        {
+            result = await TryInstallAndResolveWorkerAsync(context, project, workerId, workerVersionRanges, notResolved.Failure, cancellationToken);
+        }
+
+        if (result is not FunctionsWorkerResolutionResult.Resolved resolved)
+        {
+            var failedResult = (FunctionsWorkerResolutionResult.NotResolved)result;
+            throw CreateWorkerResolutionException(failedResult.Failure, context);
+        }
+
+        ValidateSupportedRuntime(context, resolved.Worker);
+        context.State.Worker = resolved.Worker;
+
+        string completionMessage = string.IsNullOrWhiteSpace(resolved.Worker.Version)
+            ? resolved.Worker.WorkerRuntime
+            : $"{resolved.Worker.WorkerRuntime} {resolved.Worker.Version}";
+        await context.ReportProgressAsync(100, $"Resolved worker {completionMessage}", cancellationToken);
+
+        return StartInitializationStepResult.Completed(completionMessage);
+    }
+
+    private async Task<FunctionsWorkerResolutionResult> TryInstallAndResolveWorkerAsync(
+        StartInitializationStepContext context,
+        FunctionsProject project,
+        FunctionsWorkerId workerId,
+        IReadOnlyDictionary<string, VersionRange> workerVersionRanges,
+        FunctionsWorkerResolutionFailure failure,
+        CancellationToken cancellationToken)
+    {
+        if (context.Options.Offline)
+        {
+            return FunctionsWorkerResolutionResults.NotResolved(failure);
+        }
+
+        if (!context.CanPrompt)
+        {
+            return FunctionsWorkerResolutionResults.NotResolved(failure);
+        }
+
+        string packageId = FunctionsWorkerWorkloadPackages.GetPackageId(workerId);
+
+        bool shouldInstall = await _interaction.ConfirmAsync(
+            $"The Functions worker workload '{packageId}' is required. Install it now?",
+            defaultValue: true,
+            cancellationToken);
+
+        if (!shouldInstall)
+        {
+            return FunctionsWorkerResolutionResults.NotResolved(failure);
+        }
+
+        await InstallWorkerAsync(context, workerId, workerVersionRanges, cancellationToken);
+
+        return await ResolveWorkerAsync(project, workerVersionRanges, cancellationToken);
+    }
+
+    private async Task InstallWorkerAsync(
+        StartInitializationStepContext context,
+        FunctionsWorkerId workerId,
+        IReadOnlyDictionary<string, VersionRange> workerVersionRanges,
+        CancellationToken cancellationToken)
+    {
+        string packageId = FunctionsWorkerWorkloadPackages.GetPackageId(workerId);
+        workerVersionRanges.TryGetValue(workerId.Value, out VersionRange? versionRange);
+
+        await context.ReportProgressAsync(0, $"Installing worker workload {packageId}", cancellationToken);
+
+        NuGetVersion? version = null;
+        string? source = null;
+        if (versionRange is not null)
+        {
+            ResolvedPackage? package = await _workloadCatalog.ResolveLatestVersionInRangeAsync(
+                packageId,
+                versionRange,
+                includePrerelease: false,
+                source: null,
+                cancellationToken);
+
+            if (package is null)
+            {
+                string rangeText = versionRange.OriginalString ?? versionRange.ToString();
+                string message = $"No worker workload package '{packageId}' satisfies profile range '{rangeText}'.";
+                throw new GracefulException(message, isUserError: true);
+            }
+
+            version = package.Version;
+            source = package.Source.Source;
+        }
+
+        WorkloadInstallResult result;
+        try
+        {
+            result = await _workloadInstaller.InstallFromCatalogAsync(
+                packageId,
+                version,
+                source,
+                includePrerelease: false,
+                exact: true,
+                force: false,
+                progress: null,
+                cancellationToken);
+        }
+        catch (WorkloadPackageNotFoundException ex)
+        {
+            throw CreateUserError(ex);
+        }
+        catch (AmbiguousPackageMatchException ex)
+        {
+            throw CreateUserError(ex);
+        }
+        catch (InvalidWorkloadException ex)
+        {
+            throw CreateUserError(ex);
+        }
+        catch (FileNotFoundException ex)
+        {
+            throw CreateUserError(ex);
+        }
+        catch (InvalidOperationException ex)
+        {
+            string message = $"{ex.Message} Run '{FunctionsWorkerWorkloadPackages.GetRepairCommand(workerId)}' to repair the install.";
+            throw new GracefulException(message, isUserError: true, verboseMessage: ex.ToString());
+        }
+
+        string completionMessage = result.AlreadyInstalled
+            ? $"Worker {result.Entry.PackageVersion} already installed"
+            : $"Installed worker {result.Entry.PackageVersion}";
+
+        await context.ReportProgressAsync(50, completionMessage, cancellationToken);
+    }
+
+    private async Task<FunctionsWorkerResolutionResult> ResolveWorkerAsync(
+        FunctionsProject project,
+        IReadOnlyDictionary<string, VersionRange> workerVersionRanges,
+        CancellationToken cancellationToken)
+    {
+        IFunctionsWorkerResolver resolver = _workerResolverFactory.Create(workerVersionRanges);
+        var resolutionContext = new FunctionsWorkerResolutionContext(resolver);
+        return await project.WorkerReference.ResolveWorkerAsync(resolutionContext, cancellationToken);
+    }
+
+    private static bool TryGetInstallableWorker(
+        FunctionsWorkerResolutionFailure failure,
+        out FunctionsWorkerId? workerId)
+    {
+        switch (failure)
+        {
+            case FunctionsWorkerResolutionFailure.NotInstalled notInstalled:
+                workerId = notInstalled.WorkerId;
+                return true;
+            case FunctionsWorkerResolutionFailure.MissingCompatibleVersion missingCompatibleVersion:
+                workerId = missingCompatibleVersion.WorkerId;
+                return true;
+            default:
+                workerId = null;
+                return false;
+        }
+    }
+
+    private static GracefulException CreateWorkerResolutionException(
+        FunctionsWorkerResolutionFailure failure,
+        StartInitializationStepContext context)
+    {
+        string message = failure switch
+        {
+            FunctionsWorkerResolutionFailure.NotInstalled notInstalled => CreateNotInstalledMessage(notInstalled.WorkerId, context),
+            FunctionsWorkerResolutionFailure.MissingCompatibleVersion missingCompatibleVersion => CreateMissingCompatibleVersionMessage(missingCompatibleVersion, context),
+            FunctionsWorkerResolutionFailure.InvalidInstallation invalidInstallation => CreateInvalidInstallationMessage(invalidInstallation),
+            _ => failure.Message,
+        };
+
+        return new GracefulException(message, isUserError: true);
+    }
+
+    private static string CreateNotInstalledMessage(FunctionsWorkerId workerId, StartInitializationStepContext context)
+    {
+        string installCommand = FunctionsWorkerWorkloadPackages.GetInstallCommand(workerId);
+        string message = $"The Functions worker workload for runtime '{workerId.Value}' is not installed. Run '{installCommand}' to install it.";
+        return context.Options.Offline ? $"{message} Remove '--offline' to allow automatic installation." : message;
+    }
+
+    private static string CreateMissingCompatibleVersionMessage(
+        FunctionsWorkerResolutionFailure.MissingCompatibleVersion failure,
+        StartInitializationStepContext context)
+    {
+        if (failure.VersionConstraint is null)
+        {
+            string repairCommand = FunctionsWorkerWorkloadPackages.GetRepairCommand(failure.WorkerId);
+            return $"Installed Functions worker workloads for runtime '{failure.WorkerId.Value}' do not include a valid package version. "
+                + $"Run '{repairCommand}' to repair the install.";
+        }
+
+        string installCommand = FunctionsWorkerWorkloadPackages.GetInstallCommand(failure.WorkerId);
+        string message = $"No installed Functions worker workload for runtime '{failure.WorkerId.Value}' satisfies '{failure.VersionConstraint}'. "
+            + $"Run '{installCommand}' to install a compatible version.";
+        return context.Options.Offline ? $"{message} Remove '--offline' to allow automatic installation." : message;
+    }
+
+    private static string CreateInvalidInstallationMessage(FunctionsWorkerResolutionFailure.InvalidInstallation failure)
+    {
+        string repairCommand = FunctionsWorkerWorkloadPackages.GetRepairCommand(failure.WorkerId);
+        return $"The installed Functions worker workload '{failure.PackageId}' version '{failure.PackageVersion}' is invalid: "
+            + $"{failure.Message} Run '{repairCommand}' to repair the install.";
+    }
+
+    private static void ValidateSupportedRuntime(StartInitializationStepContext context, IFunctionsWorker worker)
+    {
+        if (context.State.ResolvedProfile is not { SupportedRuntimes: { } supportedRuntimes } profile)
+        {
+            return;
+        }
+
+        if (supportedRuntimes.Any(runtime => string.Equals(runtime, worker.WorkerRuntime, StringComparison.OrdinalIgnoreCase)))
+        {
+            return;
+        }
+
+        string message = $"Profile '{profile.Name}' does not support the detected runtime '{worker.WorkerRuntime}'. "
+            + $"Supported runtimes: {string.Join(", ", supportedRuntimes)}.";
+        throw new GracefulException(message, isUserError: true);
+    }
+
+    private static GracefulException CreateUserError(Exception exception)
+        => new(exception.Message, isUserError: true, verboseMessage: exception.ToString());
+}

--- a/src/Func/DemoProject/DemoProjectFactory.cs
+++ b/src/Func/DemoProject/DemoProjectFactory.cs
@@ -20,7 +20,7 @@ internal sealed class DemoProjectFactory : IFunctionsProjectFactory
     private sealed class DemoFunctionsProject(WorkingDirectory workingDirectory) : FunctionsProject
     {
         private readonly WorkingDirectory _workingDirectory = workingDirectory ?? throw new ArgumentNullException(nameof(workingDirectory));
-        private readonly IFunctionsWorker _worker = new DotnetFunctionWorker();
+        private readonly FunctionsWorkerReference _workerReference = FunctionsWorkerReference.FromWorkerInfo(".NET", "dotnet-isolated", @"c:\test\worker.config.json", "1.0.0");
 
         public override WorkingDirectory WorkingDirectory => _workingDirectory;
 
@@ -30,17 +30,6 @@ internal sealed class DemoProjectFactory : IFunctionsProjectFactory
 
         public override bool SupportsExtensionBundles => false;
 
-        public override IFunctionsWorker Worker => _worker;
-    }
-
-    private sealed class DotnetFunctionWorker : IFunctionsWorker
-    {
-        public FunctionsWorkerId Id => new("dotnet-isolated");
-
-        public string WorkerRuntime => "dotnet-isolated";
-
-        public string WorkerConfigPath => @"c:\\demo\\worker.config.json";
-
-        public string Version => "1.0.0";
+        public override FunctionsWorkerReference WorkerReference => _workerReference;
     }
 }

--- a/src/Func/Hosting/CliHostFactory.cs
+++ b/src/Func/Hosting/CliHostFactory.cs
@@ -6,17 +6,14 @@ using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Commands.Start.Initialization;
 using Azure.Functions.Cli.Configuration;
 using Azure.Functions.Cli.Console;
-using Azure.Functions.Cli.DemoProject;
 using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Telemetry;
 using Azure.Functions.Cli.Workers;
-using Azure.Functions.Cli.Workloads;
 using Azure.Monitor.OpenTelemetry.Exporter;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
-using static Azure.Functions.Cli.Projects.FunctionsProjectResolver;
 
 namespace Azure.Functions.Cli.Hosting;
 
@@ -95,17 +92,6 @@ internal static class CliHostFactory
         builder.Services.AddSingleton<IExtensionBundleResolver, ExtensionBundleResolver>();
         builder.Services.AddSingleton<IHostWorkloadResolver, DefaultHostWorkloadResolver>();
         builder.Services.AddSingleton<IStartInitializationRunner, DemoStartInitializationRunner>();
-        builder.Services.AddSingleton(new WorkloadProjectFactoryRegistration(
-            new RuntimeWorkloadInfo(
-                new DotnetWorkload(),
-                "test",
-                "1.0",
-                [],
-                AppContext.BaseDirectory,
-                AppContext.BaseDirectory,
-                "test",
-                "description"),
-            new DemoProjectFactory()));
 
         builder.Services.AddSingleton<StartDashboardEventStreamFactory>();
 

--- a/src/Func/Projects/FunctionsProjectResolver.cs
+++ b/src/Func/Projects/FunctionsProjectResolver.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Azure.Functions.Cli.Workers;
 using Azure.Functions.Cli.Workloads;
 
 namespace Azure.Functions.Cli.Projects;
@@ -10,22 +9,17 @@ namespace Azure.Functions.Cli.Projects;
 /// Default aggregate project resolver.
 /// </summary>
 internal sealed class FunctionsProjectResolver(
-    IEnumerable<WorkloadProjectFactoryRegistration> factories,
-    IFunctionsWorkerResolverFactory workerResolverFactory)
+    IEnumerable<WorkloadProjectFactoryRegistration> factories)
     : IFunctionsProjectResolver
 {
     private readonly IReadOnlyList<WorkloadProjectFactoryRegistration> _factories =
         (factories ?? throw new ArgumentNullException(nameof(factories))).ToList();
 
-    private readonly IFunctionsWorkerResolverFactory _workerResolverFactory = workerResolverFactory
-        ?? throw new ArgumentNullException(nameof(workerResolverFactory));
-
     public async Task<ProjectResolutionResult> ResolveProjectAsync(ProjectResolutionContext context, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        IFunctionsWorkerResolver workerResolver = _workerResolverFactory.Create(context.WorkerVersionRanges);
-        var creationContext = new ProjectCreationContext(context.WorkingDirectory, workerResolver);
+        var creationContext = new ProjectCreationContext(context.WorkingDirectory);
         foreach (WorkloadProjectFactoryRegistration registration in _factories)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -46,17 +40,5 @@ internal sealed class FunctionsProjectResolver(
 
         return ProjectResolutionResults.NotResolved(
             "No installed workload recognized this directory as an Azure Functions project.");
-    }
-
-    public class DotnetWorkload : Workload
-    {
-        public override string DisplayName => ".NET Workload";
-
-        public override string Description => "Demo .NET Workload";
-
-        public override void Configure(FunctionsCliBuilder builder)
-        {
-           
-        }
     }
 }

--- a/src/Func/Projects/ProjectResolutionContext.cs
+++ b/src/Func/Projects/ProjectResolutionContext.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Common;
-using NuGet.Versioning;
 
 namespace Azure.Functions.Cli.Projects;
 
@@ -10,13 +9,4 @@ namespace Azure.Functions.Cli.Projects;
 /// Inputs to project resolution.
 /// </summary>
 /// <param name="WorkingDirectory">The directory the command is operating on.</param>
-/// <param name="WorkerVersionRanges">Profile worker version ranges keyed by Functions runtime name.</param>
-internal sealed record ProjectResolutionContext(
-    WorkingDirectory WorkingDirectory,
-    IReadOnlyDictionary<string, VersionRange> WorkerVersionRanges)
-{
-    public ProjectResolutionContext(WorkingDirectory workingDirectory)
-        : this(workingDirectory, new Dictionary<string, VersionRange>(StringComparer.OrdinalIgnoreCase))
-    {
-    }
-}
+internal sealed record ProjectResolutionContext(WorkingDirectory WorkingDirectory);

--- a/src/Func/Workers/DefaultFunctionsWorkerResolver.cs
+++ b/src/Func/Workers/DefaultFunctionsWorkerResolver.cs
@@ -14,7 +14,6 @@ internal sealed class DefaultFunctionsWorkerResolver(
     IWorkerConfigFileSystem workerConfigFileSystem,
     IReadOnlyDictionary<string, VersionRange>? activeWorkerConstraints = null) : IFunctionsWorkerResolver
 {
-    private const string WorkerPackageIdPrefix = "Azure.Functions.Cli.Workloads.Workers.";
     private const string WorkerConfigFileName = "worker.config.json";
 
     private readonly IWorkloadProvider _workloadProvider = workloadProvider ?? throw new ArgumentNullException(nameof(workloadProvider));
@@ -79,14 +78,17 @@ internal sealed class DefaultFunctionsWorkerResolver(
 
     private IReadOnlyList<ContentWorkloadInfo> GetWorkerWorkloads(FunctionsWorkerId workerId)
     {
-        string packageId = GetWorkerPackageId(workerId);
-        string alias = GetWorkerInstallAlias(workerId);
+        string packageId = FunctionsWorkerWorkloadPackages.GetPackageId(workerId);
+        string alias = GetWorkerAlias(workerId);
         List<ContentWorkloadInfo> workloads = [];
         AddDistinct(workloads, _workloadProvider.GetContentWorkloadsByPackageId(packageId));
-        AddDistinct(
-            workloads,
-            _workloadProvider.GetContentWorkloads()
-                .Where(workload => workload.Aliases.Any(candidate => string.Equals(candidate, alias, StringComparison.OrdinalIgnoreCase))));
+
+        IEnumerable<ContentWorkloadInfo> candidates = _workloadProvider.GetContentWorkloads()
+                .Where(workload => workload.Aliases.Any(candidate
+                    => string.Equals(candidate, alias, StringComparison.OrdinalIgnoreCase)));
+
+        AddDistinct(workloads, candidates);
+
         return workloads;
     }
 
@@ -108,15 +110,13 @@ internal sealed class DefaultFunctionsWorkerResolver(
     private static bool SatisfiesConstraint(NuGetVersion version, VersionRange? constraint)
         => constraint is null || constraint.Satisfies(version);
 
-    private static string GetWorkerPackageId(FunctionsWorkerId workerId) => WorkerPackageIdPrefix + workerId.Value;
-
-    private static string GetWorkerInstallAlias(FunctionsWorkerId workerId) => workerId.Value + "-worker";
+    private static string GetWorkerAlias(FunctionsWorkerId workerId) => workerId.Value + "-worker";
 
     private static FunctionsWorkerResolutionResult NotInstalled(FunctionsWorkerId workerId)
         => NotInstalledResult(
             workerId,
             $"No installed Azure Functions worker was found for '{workerId.Value}'. "
-            + $"Run 'func workload install {GetWorkerInstallAlias(workerId)}' to install it.");
+            + $"Run '{FunctionsWorkerWorkloadPackages.GetInstallCommand(workerId)}' to install it.");
 
     private static FunctionsWorkerResolutionResult NotInstalledResult(FunctionsWorkerId workerId, string message)
     {
@@ -135,7 +135,7 @@ internal sealed class DefaultFunctionsWorkerResolver(
                     workerId,
                     versionConstraint: null,
                     $"Installed Azure Functions worker workloads for '{workerId.Value}' do not include a valid package version. "
-                    + $"Run 'func workload install {GetWorkerInstallAlias(workerId)} --force' to repair the install.");
+                    + $"Run '{FunctionsWorkerWorkloadPackages.GetRepairCommand(workerId)}' to repair the install.");
 
             return FunctionsWorkerResolutionResults.NotResolved(invalidVersionFailure);
         }
@@ -145,7 +145,7 @@ internal sealed class DefaultFunctionsWorkerResolver(
             workerId,
             rangeText,
             $"Installed Azure Functions worker workloads for '{workerId.Value}' do not satisfy version range '{rangeText}'. "
-            + $"Run 'func workload install {GetWorkerInstallAlias(workerId)}' to install a compatible worker.");
+            + $"Run '{FunctionsWorkerWorkloadPackages.GetInstallCommand(workerId)}' to install a compatible worker.");
 
         return FunctionsWorkerResolutionResults.NotResolved(failure);
     }
@@ -162,7 +162,7 @@ internal sealed class DefaultFunctionsWorkerResolver(
             workerConfigPath,
             $"Installed Azure Functions worker '{workerId.Value}' package '{selected.Workload.PackageId}' "
             + $"{selected.Version.ToNormalizedString()} is missing '{workerConfigPath}'. "
-            + $"Run 'func workload install {GetWorkerInstallAlias(workerId)} --force' to repair the install.");
+            + $"Run '{FunctionsWorkerWorkloadPackages.GetRepairCommand(workerId)}' to repair the install.");
 
         return FunctionsWorkerResolutionResults.NotResolved(failure);
     }
@@ -171,9 +171,5 @@ internal sealed class DefaultFunctionsWorkerResolver(
 
     private sealed record InstalledWorkerCandidate(ContentWorkloadInfo Workload, NuGetVersion Version);
 
-    private sealed record ResolvedFunctionsWorker(
-        FunctionsWorkerId Id,
-        string WorkerRuntime,
-        string WorkerConfigPath,
-        string Version) : IFunctionsWorker;
+    private sealed record ResolvedFunctionsWorker(FunctionsWorkerId Id, string WorkerRuntime, string WorkerConfigPath, string Version) : IFunctionsWorker;
 }

--- a/src/Func/Workers/DefaultFunctionsWorkerResolverFactory.cs
+++ b/src/Func/Workers/DefaultFunctionsWorkerResolverFactory.cs
@@ -20,6 +20,10 @@ internal sealed class DefaultFunctionsWorkerResolverFactory(
     public IFunctionsWorkerResolver Create(IReadOnlyDictionary<string, VersionRange> workerVersionRanges)
     {
         ArgumentNullException.ThrowIfNull(workerVersionRanges);
-        return new DefaultFunctionsWorkerResolver(_workloadProvider, _workerConfigFileSystem, workerVersionRanges);
+
+        return new DefaultFunctionsWorkerResolver(
+            _workloadProvider,
+            _workerConfigFileSystem,
+            workerVersionRanges);
     }
 }

--- a/src/Func/Workers/FunctionsWorkerWorkloadPackages.cs
+++ b/src/Func/Workers/FunctionsWorkerWorkloadPackages.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workers;
+
+/// <summary>
+/// Builds worker workload package identifiers and install commands.
+/// </summary>
+internal static class FunctionsWorkerWorkloadPackages
+{
+    private const string PackageIdPrefix = "Azure.Functions.Cli.Workloads.Workers.";
+
+    public static string GetPackageId(FunctionsWorkerId workerId)
+    {
+        ArgumentNullException.ThrowIfNull(workerId);
+
+        return PackageIdPrefix + workerId.Value;
+    }
+
+    public static string GetInstallCommand(FunctionsWorkerId workerId)
+        => $"func workload install {GetPackageId(workerId)} --exact";
+
+    public static string GetRepairCommand(FunctionsWorkerId workerId)
+        => $"{GetInstallCommand(workerId)} --force";
+}

--- a/src/Func/Workers/IFunctionsWorkerResolverFactory.cs
+++ b/src/Func/Workers/IFunctionsWorkerResolverFactory.cs
@@ -6,7 +6,7 @@ using NuGet.Versioning;
 namespace Azure.Functions.Cli.Workers;
 
 /// <summary>
-/// Creates worker resolvers for one project-resolution operation.
+/// Creates worker resolvers for one operation.
 /// </summary>
 internal interface IFunctionsWorkerResolverFactory
 {

--- a/src/Workloads/Stacks/Go/GoProjectFactory.cs
+++ b/src/Workloads/Stacks/Go/GoProjectFactory.cs
@@ -15,32 +15,25 @@ internal sealed class GoProjectFactory : IFunctionsProjectFactory
 {
     private static readonly FunctionsWorkerId _workerId = new("go");
 
-    public async Task<ProjectCreationResult> TryCreateProjectAsync(ProjectCreationContext context, CancellationToken cancellationToken)
+    public Task<ProjectCreationResult> TryCreateProjectAsync(ProjectCreationContext context, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(context.WorkerResolver);
         cancellationToken.ThrowIfCancellationRequested();
 
         DirectoryInfo workingDirectory = context.WorkingDirectory.Info;
         if (!workingDirectory.Exists)
         {
-            return NotCreated("directory does not exist");
+            return Task.FromResult(NotCreated("directory does not exist"));
         }
 
         string? reason = TryGetReason(workingDirectory);
         if (reason is null)
         {
-            return NotCreated("no Go project fingerprint found");
+            return Task.FromResult(NotCreated("no Go project fingerprint found"));
         }
 
-        FunctionsWorkerResolutionResult workerResult =
-            await context.WorkerResolver.ResolveWorkerAsync(_workerId, cancellationToken);
-        return workerResult switch
-        {
-            FunctionsWorkerResolutionResult.Resolved resolved => Created(new GoFunctionsProject(context.WorkingDirectory, resolved.Worker), reason),
-            FunctionsWorkerResolutionResult.NotResolved notResolved => Failed(ProjectCreationFailures.WorkerNotResolved(notResolved.Failure)),
-            _ => throw new InvalidOperationException($"Unsupported worker resolution result: {workerResult.GetType().FullName}"),
-        };
+        FunctionsProject project = new GoFunctionsProject(context.WorkingDirectory);
+        return Task.FromResult(Created(project, reason));
     }
 
     private static string? TryGetReason(DirectoryInfo workingDirectory)
@@ -58,10 +51,10 @@ internal sealed class GoProjectFactory : IFunctionsProjectFactory
         return null;
     }
 
-    private sealed class GoFunctionsProject(WorkingDirectory workingDirectory, IFunctionsWorker worker) : FunctionsProject
+    private sealed class GoFunctionsProject(WorkingDirectory workingDirectory) : FunctionsProject
     {
         private readonly WorkingDirectory _workingDirectory = workingDirectory ?? throw new ArgumentNullException(nameof(workingDirectory));
-        private readonly IFunctionsWorker _worker = worker ?? throw new ArgumentNullException(nameof(worker));
+        private readonly FunctionsWorkerReference _workerReference = FunctionsWorkerReference.FromWorkload(_workerId);
 
         public override WorkingDirectory WorkingDirectory => _workingDirectory;
 
@@ -71,6 +64,6 @@ internal sealed class GoProjectFactory : IFunctionsProjectFactory
 
         public override bool SupportsExtensionBundles => true;
 
-        public override IFunctionsWorker Worker => _worker;
+        public override FunctionsWorkerReference WorkerReference => _workerReference;
     }
 }

--- a/src/Workloads/Stacks/Node/NodeProjectFactory.cs
+++ b/src/Workloads/Stacks/Node/NodeProjectFactory.cs
@@ -19,32 +19,25 @@ internal sealed class NodeProjectFactory : IFunctionsProjectFactory
     private static readonly FunctionsWorkerId _workerId = new("node");
     private static readonly string[] _sourceFilePatterns = ["*.js", "*.mjs", "*.cjs", "*.ts"];
 
-    public async Task<ProjectCreationResult> TryCreateProjectAsync(ProjectCreationContext context, CancellationToken cancellationToken)
+    public Task<ProjectCreationResult> TryCreateProjectAsync(ProjectCreationContext context, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(context.WorkerResolver);
         cancellationToken.ThrowIfCancellationRequested();
 
         DirectoryInfo workingDirectory = context.WorkingDirectory.Info;
         if (!workingDirectory.Exists)
         {
-            return NotCreated("directory does not exist");
+            return Task.FromResult(NotCreated("directory does not exist"));
         }
 
         string? reason = TryGetReason(workingDirectory);
         if (reason is null)
         {
-            return NotCreated("no Node project fingerprint found");
+            return Task.FromResult(NotCreated("no Node project fingerprint found"));
         }
 
-        FunctionsWorkerResolutionResult workerResult =
-            await context.WorkerResolver.ResolveWorkerAsync(_workerId, cancellationToken);
-        return workerResult switch
-        {
-            FunctionsWorkerResolutionResult.Resolved resolved => Created(new NodeFunctionsProject(context.WorkingDirectory, resolved.Worker), reason),
-            FunctionsWorkerResolutionResult.NotResolved notResolved => Failed(ProjectCreationFailures.WorkerNotResolved(notResolved.Failure)),
-            _ => throw new InvalidOperationException($"Unsupported worker resolution result: {workerResult.GetType().FullName}"),
-        };
+        FunctionsProject project = new NodeFunctionsProject(context.WorkingDirectory);
+        return Task.FromResult(Created(project, reason));
     }
 
     private static string? TryGetReason(DirectoryInfo workingDirectory)
@@ -108,10 +101,10 @@ internal sealed class NodeProjectFactory : IFunctionsProjectFactory
             && section.TryGetProperty(FunctionsPackage, out _);
     }
 
-    private sealed class NodeFunctionsProject(WorkingDirectory workingDirectory, IFunctionsWorker worker) : FunctionsProject
+    private sealed class NodeFunctionsProject(WorkingDirectory workingDirectory) : FunctionsProject
     {
         private readonly WorkingDirectory _workingDirectory = workingDirectory ?? throw new ArgumentNullException(nameof(workingDirectory));
-        private readonly IFunctionsWorker _worker = worker ?? throw new ArgumentNullException(nameof(worker));
+        private readonly FunctionsWorkerReference _workerReference = FunctionsWorkerReference.FromWorkload(_workerId);
 
         public override WorkingDirectory WorkingDirectory => _workingDirectory;
 
@@ -121,6 +114,6 @@ internal sealed class NodeProjectFactory : IFunctionsProjectFactory
 
         public override bool SupportsExtensionBundles => true;
 
-        public override IFunctionsWorker Worker => _worker;
+        public override FunctionsWorkerReference WorkerReference => _workerReference;
     }
 }

--- a/src/Workloads/Stacks/Python/PythonProjectFactory.cs
+++ b/src/Workloads/Stacks/Python/PythonProjectFactory.cs
@@ -15,32 +15,25 @@ internal sealed class PythonProjectFactory : IFunctionsProjectFactory
 {
     private static readonly FunctionsWorkerId _workerId = new("python");
 
-    public async Task<ProjectCreationResult> TryCreateProjectAsync(ProjectCreationContext context, CancellationToken cancellationToken)
+    public Task<ProjectCreationResult> TryCreateProjectAsync(ProjectCreationContext context, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(context.WorkerResolver);
         cancellationToken.ThrowIfCancellationRequested();
 
         DirectoryInfo workingDirectory = context.WorkingDirectory.Info;
         if (!workingDirectory.Exists)
         {
-            return NotCreated("directory does not exist");
+            return Task.FromResult(NotCreated("directory does not exist"));
         }
 
         string? reason = TryGetReason(workingDirectory);
         if (reason is null)
         {
-            return NotCreated("no Python project fingerprint found");
+            return Task.FromResult(NotCreated("no Python project fingerprint found"));
         }
 
-        FunctionsWorkerResolutionResult workerResult = await context.WorkerResolver.ResolveWorkerAsync(_workerId, cancellationToken);
-
-        return workerResult switch
-        {
-            FunctionsWorkerResolutionResult.Resolved resolved => Created(new PythonFunctionsProject(context.WorkingDirectory, resolved.Worker), reason),
-            FunctionsWorkerResolutionResult.NotResolved notResolved => Failed(ProjectCreationFailures.WorkerNotResolved(notResolved.Failure)),
-            _ => throw new InvalidOperationException($"Unsupported worker resolution result: {workerResult.GetType().FullName}"),
-        };
+        FunctionsProject project = new PythonFunctionsProject(context.WorkingDirectory);
+        return Task.FromResult(Created(project, reason));
     }
 
     private static string? TryGetReason(DirectoryInfo workingDirectory)
@@ -82,10 +75,10 @@ internal sealed class PythonProjectFactory : IFunctionsProjectFactory
         return null;
     }
 
-    private sealed class PythonFunctionsProject(WorkingDirectory workingDirectory, IFunctionsWorker worker) : FunctionsProject
+    private sealed class PythonFunctionsProject(WorkingDirectory workingDirectory) : FunctionsProject
     {
         private readonly WorkingDirectory _workingDirectory = workingDirectory ?? throw new ArgumentNullException(nameof(workingDirectory));
-        private readonly IFunctionsWorker _worker = worker ?? throw new ArgumentNullException(nameof(worker));
+        private readonly FunctionsWorkerReference _workerReference = FunctionsWorkerReference.FromWorkload(_workerId);
 
         public override WorkingDirectory WorkingDirectory => _workingDirectory;
 
@@ -95,6 +88,6 @@ internal sealed class PythonProjectFactory : IFunctionsProjectFactory
 
         public override bool SupportsExtensionBundles => true;
 
-        public override IFunctionsWorker Worker => _worker;
+        public override FunctionsWorkerReference WorkerReference => _workerReference;
     }
 }

--- a/test/Func.Tests/Bundles/ValidateExtensionBundleInitializationStepTests.cs
+++ b/test/Func.Tests/Bundles/ValidateExtensionBundleInitializationStepTests.cs
@@ -245,6 +245,7 @@ public class ValidateExtensionBundleInitializationStepTests : IDisposable
         var state = new StartInitializationState
         {
             Project = new BundleSupportingTestProject(resolvedProjectDirectory),
+            Worker = new TestFunctionsWorker(new FunctionsWorkerId("node"), "node", "worker.config.json", "1.0.0"),
             ResolvedProfile = profile,
             ProfileName = profile?.Name ?? "none",
         };
@@ -292,6 +293,12 @@ public class ValidateExtensionBundleInitializationStepTests : IDisposable
 
         public override bool SupportsExtensionBundles => true;
 
-        public override IFunctionsWorker Worker { get; } = Substitute.For<IFunctionsWorker>();
+        public override FunctionsWorkerReference WorkerReference { get; } = FunctionsWorkerReference.FromWorkload("node");
     }
+
+    private sealed record TestFunctionsWorker(
+        FunctionsWorkerId Id,
+        string WorkerRuntime,
+        string WorkerConfigPath,
+        string Version) : IFunctionsWorker;
 }

--- a/test/Func.Tests/Commands/StartCommandTests.cs
+++ b/test/Func.Tests/Commands/StartCommandTests.cs
@@ -306,7 +306,7 @@ public class StartCommandTests : IDisposable
         project ??= new TestFunctionsProject();
         var hostRunContext = new FunctionsProjectHostRunContext(
             project.WorkingDirectory.Info,
-            project.Worker.WorkerRuntime,
+            project.TestWorker.WorkerRuntime,
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
 
         var runInfo = new DashboardRunInfo(CliVersion: "5.0.0-test", ProfileName: "none", StackName: ".NET");
@@ -317,6 +317,7 @@ public class StartCommandTests : IDisposable
             BundleRequired: false,
             BundleVersion: null,
             project,
+            project.TestWorker,
             hostRunContext);
     }
 
@@ -332,11 +333,13 @@ public class StartCommandTests : IDisposable
     private sealed class TestFunctionsProject : FunctionsProject
     {
         private readonly WorkingDirectory _workingDirectory = WorkingDirectory.FromExplicit(Environment.CurrentDirectory);
-        private readonly IFunctionsWorker _worker = new TestFunctionsWorker();
+        private readonly FunctionsWorkerReference _workerReference = FunctionsWorkerReference.FromWorkload("dotnet-isolated");
 
         public List<FunctionsProjectHostRunCompletionContext> CompletionContexts { get; } = [];
 
         public Exception? CleanupException { get; init; }
+
+        public IFunctionsWorker TestWorker { get; } = new TestFunctionsWorker();
 
         public override WorkingDirectory WorkingDirectory => _workingDirectory;
 
@@ -346,7 +349,7 @@ public class StartCommandTests : IDisposable
 
         public override bool SupportsExtensionBundles => false;
 
-        public override IFunctionsWorker Worker => _worker;
+        public override FunctionsWorkerReference WorkerReference => _workerReference;
 
         public override Task CompleteHostRunAsync(
             FunctionsProjectHostRunCompletionContext context,

--- a/test/Func.Tests/Commands/StartInitializationTests.cs
+++ b/test/Func.Tests/Commands/StartInitializationTests.cs
@@ -7,6 +7,7 @@ using Azure.Functions.Cli.Bundles;
 using Azure.Functions.Cli.Commands.Start.Initialization;
 using Azure.Functions.Cli.Commands.Start.Initialization.Rendering;
 using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Hosting.Dashboard;
 using Azure.Functions.Cli.Hosting.Dashboard.Demo;
 using Azure.Functions.Cli.Hosting.Dashboard.Rendering;
@@ -15,10 +16,12 @@ using Azure.Functions.Cli.Profiles;
 using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Workers;
 using Azure.Functions.Cli.Workloads;
+using Azure.Functions.Cli.Workloads.Catalog;
 using Azure.Functions.Cli.Workloads.Install;
 using Azure.Functions.Cli.Workloads.Storage;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using NuGet.Configuration;
 using NuGet.Versioning;
 using Spectre.Console;
 using Xunit;
@@ -183,7 +186,12 @@ public class StartInitializationTests : IDisposable
         hostWorkloadResolver.ResolveAsync(Arg.Any<HostWorkloadResolutionContext>(), Arg.Any<CancellationToken>())
             .Returns(hostResolution);
         var renderer = new RecordingStartInitializationRenderer();
-        var runner = CreateRunner(projectResolver, profileResolution, hostWorkloadResolver);
+        IFunctionsWorkerResolverFactory workerResolverFactory = CreateWorkerResolverFactory();
+        var runner = CreateRunner(
+            projectResolver,
+            profileResolution,
+            hostWorkloadResolver,
+            workerResolverFactory: workerResolverFactory);
         StartInitializationContext context = CreateContext(
             WorkingDirectory.FromExplicit(_tempDir),
             cliVersion: "5.0.0-test",
@@ -200,8 +208,83 @@ public class StartInitializationTests : IDisposable
                 ReferenceEquals(hostContext.ProfileHostVersionRange, hostRange)),
             Arg.Any<CancellationToken>());
         await projectResolver.Received(1).ResolveProjectAsync(
-            Arg.Is<ProjectResolutionContext>(projectContext => HasWorkerRange(projectContext, workerRanges["node"])),
+            Arg.Is<ProjectResolutionContext>(projectContext =>
+                projectContext.WorkingDirectory.Info.FullName == _tempDir),
             Arg.Any<CancellationToken>());
+        workerResolverFactory.Received(1).Create(
+            Arg.Is<IReadOnlyDictionary<string, VersionRange>>(ranges =>
+                HasWorkerRange(ranges, workerRanges["node"])));
+    }
+
+    [Fact]
+    public async Task DemoRunner_ProfiledMissingWorkerInstallsConventionPackageAndRetries()
+    {
+        IFunctionsProjectResolver projectResolver = Substitute.For<IFunctionsProjectResolver>();
+        TestFunctionsProject project = CreateProject(
+            WorkingDirectory.FromExplicit(_tempDir),
+            stackName: "node",
+            stackDisplayName: "Node.js");
+        projectResolver.ResolveProjectAsync(Arg.Any<ProjectResolutionContext>(), Arg.Any<CancellationToken>())
+            .Returns(ProjectResolutionResults.Resolved(project, "found package.json"));
+        var workerId = new FunctionsWorkerId("node");
+        FunctionsWorkerResolutionFailure failure = CreateNotInstalledWorkerFailure("node");
+        IFunctionsWorkerResolver workerResolver = Substitute.For<IFunctionsWorkerResolver>();
+        workerResolver.ResolveWorkerAsync(workerId, Arg.Any<CancellationToken>())
+            .Returns(
+                FunctionsWorkerResolutionResults.NotResolved(failure),
+                FunctionsWorkerResolutionResults.Resolved(CreateWorker("node", "node", "3.13.0")));
+        IFunctionsWorkerResolverFactory workerResolverFactory = CreateWorkerResolverFactory(workerResolver);
+        var workerRange = VersionRange.Parse("[3.13.0]");
+        Dictionary<string, VersionRange> workerRanges = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["node"] = workerRange,
+        };
+        IWorkloadCatalog workloadCatalog = Substitute.For<IWorkloadCatalog>();
+        workloadCatalog.ResolveLatestVersionInRangeAsync(
+                FunctionsWorkerWorkloadPackages.GetPackageId(workerId),
+                workerRange,
+                includePrerelease: false,
+                source: null,
+                Arg.Any<CancellationToken>())
+            .Returns(new ResolvedPackage(
+                FunctionsWorkerWorkloadPackages.GetPackageId(workerId),
+                NuGetVersion.Parse("3.13.0"),
+                new PackageSource("https://example.test/v3/index.json")));
+        IWorkloadInstaller workloadInstaller = CreateSuccessfulInstaller();
+        IInteractionService interaction = Substitute.For<IInteractionService>();
+        interaction.ConfirmAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+        var runner = CreateRunner(
+            projectResolver,
+            CreateResolvedProfile(workerRanges),
+            CreateInstalledHostWorkloadResolver(),
+            workloadInstaller,
+            workerResolverFactory,
+            workloadCatalog,
+            interaction);
+        StartInitializationContext context = CreateContext(
+            WorkingDirectory.FromExplicit(_tempDir),
+            cliVersion: "5.0.0-test",
+            demoFunctionCount: 12,
+            demoSpeedMultiplier: 0.001,
+            demoAutoExit: true);
+
+        StartInitializationResult result = await runner.RunAsync(
+            context,
+            new RecordingStartInitializationRenderer(),
+            CancellationToken.None);
+
+        Assert.Equal("node", result.Worker.WorkerRuntime);
+        Assert.Equal("3.13.0", result.Worker.Version);
+        await workloadInstaller.Received(1).InstallFromCatalogAsync(
+            FunctionsWorkerWorkloadPackages.GetPackageId(workerId),
+            NuGetVersion.Parse("3.13.0"),
+            "https://example.test/v3/index.json",
+            includePrerelease: false,
+            exact: true,
+            force: false,
+            progress: null,
+            cancellationToken: Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -246,6 +329,43 @@ public class StartInitializationTests : IDisposable
             () => runner.RunAsync(context, new RecordingStartInitializationRenderer(), CancellationToken.None));
 
         Assert.Contains("does not support the detected runtime 'node'", ex.Message);
+    }
+
+    [Fact]
+    public async Task DemoRunner_WorkerProjectCreationFailure_ThrowsWithoutInstallingWorker()
+    {
+        IFunctionsProjectResolver projectResolver = Substitute.For<IFunctionsProjectResolver>();
+        FunctionsWorkerResolutionFailure workerFailure = CreateNotInstalledWorkerFailure("node");
+        projectResolver.ResolveProjectAsync(Arg.Any<ProjectResolutionContext>(), Arg.Any<CancellationToken>())
+            .Returns(CreateWorkerNotResolvedResult(workerFailure));
+        IWorkloadInstaller workloadInstaller = CreateSuccessfulInstaller();
+        var runner = CreateRunner(
+            projectResolver,
+            hostWorkloadResolver: CreateInstalledHostWorkloadResolver(),
+            workloadInstaller: workloadInstaller);
+        StartInitializationContext context = CreateContext(
+            WorkingDirectory.FromExplicit(_tempDir),
+            cliVersion: "5.0.0-test",
+            demoFunctionCount: 12,
+            demoSpeedMultiplier: 0.001,
+            demoAutoExit: true);
+
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => runner.RunAsync(context, new RecordingStartInitializationRenderer(), CancellationToken.None));
+
+        Assert.Contains(workerFailure.Message, ex.Message);
+        await projectResolver.Received(1).ResolveProjectAsync(
+            Arg.Any<ProjectResolutionContext>(),
+            Arg.Any<CancellationToken>());
+        await workloadInstaller.DidNotReceive().InstallFromCatalogAsync(
+            Arg.Any<string>(),
+            Arg.Any<NuGetVersion?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -299,6 +419,7 @@ public class StartInitializationTests : IDisposable
             stackName: "node",
             stackDisplayName: "Node.js");
         FunctionsProjectHostRunContext hostRunContext = CreateHostRunContext(WorkingDirectory.FromExplicit(Environment.CurrentDirectory));
+        IFunctionsWorker worker = CreateWorker("node", "node");
         var result = new StartInitializationResult(
             runInfo,
             eventStream,
@@ -306,6 +427,7 @@ public class StartInitializationTests : IDisposable
             BundleRequired: true,
             BundleVersion: "4.35.0",
             project,
+            worker,
             hostRunContext,
             profile);
         var completedEvent = new StartInitializationCompletedEvent(DateTimeOffset.UnixEpoch, result);
@@ -366,6 +488,7 @@ public class StartInitializationTests : IDisposable
         var eventStream = new InMemoryHostEventStream();
         FunctionsProject project = CreateProject(WorkingDirectory.FromExplicit(Environment.CurrentDirectory));
         FunctionsProjectHostRunContext hostRunContext = CreateHostRunContext(WorkingDirectory.FromExplicit(Environment.CurrentDirectory));
+        IFunctionsWorker worker = CreateWorker("dotnet-isolated", "dotnet-isolated");
         var result = new StartInitializationResult(
             runInfo,
             eventStream,
@@ -373,6 +496,7 @@ public class StartInitializationTests : IDisposable
             BundleRequired: false,
             BundleVersion: null,
             project,
+            worker,
             hostRunContext);
         var completedEvent = new StartInitializationCompletedEvent(DateTimeOffset.UnixEpoch, result);
 
@@ -454,7 +578,9 @@ public class StartInitializationTests : IDisposable
         string cliVersion,
         int demoFunctionCount,
         double demoSpeedMultiplier,
-        bool demoAutoExit)
+        bool demoAutoExit,
+        bool offline = false,
+        bool canPrompt = true)
     {
         var options = new StartCommandOptions(
             workingDirectory,
@@ -466,7 +592,7 @@ public class StartInitializationTests : IDisposable
             EnableAuth: false,
             RequestedProfileName: null,
             RequestedHostVersion: null,
-            Offline: false,
+            Offline: offline,
             OutputMode.Compact,
             NoTui: false,
             LogFilePath: null,
@@ -477,8 +603,8 @@ public class StartInitializationTests : IDisposable
         return new StartInitializationContext(
             options,
             cliVersion,
-            IsInteractive: true,
-            CanPrompt: true);
+            IsInteractive: canPrompt,
+            CanPrompt: canPrompt);
     }
 
     private static TestFunctionsProject CreateProject(
@@ -486,20 +612,11 @@ public class StartInitializationTests : IDisposable
         string stackName = "dotnet-isolated",
         string stackDisplayName = ".NET",
         bool supportsExtensionBundles = false)
-    {
-        IFunctionsWorker worker = Substitute.For<IFunctionsWorker>();
-        worker.Id.Returns(new FunctionsWorkerId(stackName));
-        worker.WorkerRuntime.Returns(stackName);
-        worker.WorkerConfigPath.Returns("c:\\some\\path");
-        worker.Version.Returns("1.0.0");
-
-        return new TestFunctionsProject(
+        => new(
             workingDirectory,
             stackName,
             stackDisplayName,
-            supportsExtensionBundles,
-            worker);
-    }
+            supportsExtensionBundles);
 
     private static FunctionsProjectHostRunContext CreateHostRunContext(WorkingDirectory workingDirectory)
         => new(
@@ -520,7 +637,10 @@ public class StartInitializationTests : IDisposable
         IFunctionsProjectResolver projectResolver,
         ProfileResolution? profileResolution = null,
         IHostWorkloadResolver? hostWorkloadResolver = null,
-        IWorkloadInstaller? workloadInstaller = null)
+        IWorkloadInstaller? workloadInstaller = null,
+        IFunctionsWorkerResolverFactory? workerResolverFactory = null,
+        IWorkloadCatalog? workloadCatalog = null,
+        IInteractionService? interaction = null)
     {
         IProfileResolver profileResolver = Substitute.For<IProfileResolver>();
         profileResolver.ResolveAsync(Arg.Any<ProfileResolutionContext>(), Arg.Any<CancellationToken>())
@@ -535,7 +655,12 @@ public class StartInitializationTests : IDisposable
                 .Returns(defaultHostResolution);
         }
 
-        workloadInstaller ??= CreateSuccessfulHostInstaller();
+        workloadInstaller ??= CreateSuccessfulInstaller();
+        workerResolverFactory ??= CreateWorkerResolverFactory();
+        workloadCatalog ??= Substitute.For<IWorkloadCatalog>();
+        interaction ??= Substitute.For<IInteractionService>();
+        interaction.ConfirmAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(true);
         IExtensionBundleResolver bundleResolver = Substitute.For<IExtensionBundleResolver>();
         var bundleSectionReader = new HostJsonBundleSectionReader();
 
@@ -545,11 +670,39 @@ public class StartInitializationTests : IDisposable
             bundleSectionReader,
             profileResolver,
             hostWorkloadResolver,
+            workerResolverFactory,
+            workloadCatalog,
             workloadInstaller,
+            interaction,
             NullLoggerFactory.Instance);
     }
 
-    private static IWorkloadInstaller CreateSuccessfulHostInstaller()
+    private static IFunctionsWorkerResolverFactory CreateWorkerResolverFactory(IFunctionsWorkerResolver? workerResolver = null)
+    {
+        if (workerResolver is null)
+        {
+            workerResolver = Substitute.For<IFunctionsWorkerResolver>();
+            workerResolver.ResolveWorkerAsync(Arg.Any<FunctionsWorkerId>(), Arg.Any<CancellationToken>())
+                .Returns(callInfo =>
+                {
+                    FunctionsWorkerId workerId = callInfo.ArgAt<FunctionsWorkerId>(0);
+                    return FunctionsWorkerResolutionResults.Resolved(CreateWorker(workerId.Value, workerId.Value));
+                });
+        }
+
+        IFunctionsWorkerResolverFactory workerResolverFactory = Substitute.For<IFunctionsWorkerResolverFactory>();
+        workerResolverFactory.Create(Arg.Any<IReadOnlyDictionary<string, VersionRange>>())
+            .Returns(workerResolver);
+        return workerResolverFactory;
+    }
+
+    private static IFunctionsWorker CreateWorker(
+        string workerId,
+        string workerRuntime,
+        string version = "1.0.0")
+        => new TestFunctionsWorker(new FunctionsWorkerId(workerId), workerRuntime, "worker.config.json", version);
+
+    private static IWorkloadInstaller CreateSuccessfulInstaller()
     {
         IWorkloadInstaller workloadInstaller = Substitute.For<IWorkloadInstaller>();
         workloadInstaller.InstallFromCatalogAsync(
@@ -563,12 +716,48 @@ public class StartInitializationTests : IDisposable
                 Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {
+                string packageId = callInfo.ArgAt<string>(0);
                 var version = (NuGetVersion?)callInfo[1];
-                string packageVersion = version?.ToNormalizedString() ?? "4.834.0";
-                return new WorkloadInstallResult(CreateHostEntry(packageVersion), AlreadyInstalled: false);
+                string packageVersion = version?.ToNormalizedString() ?? DefaultInstallVersion(packageId);
+                WorkloadEntry entry = string.Equals(packageId, "host", StringComparison.OrdinalIgnoreCase)
+                    ? CreateHostEntry(packageVersion)
+                    : CreateWorkerEntry(packageId, packageVersion);
+                return new WorkloadInstallResult(entry, AlreadyInstalled: false);
             });
 
         return workloadInstaller;
+    }
+
+    private static string DefaultInstallVersion(string packageId)
+        => packageId.Contains("worker", StringComparison.OrdinalIgnoreCase) ? "3.13.0" : "4.834.0";
+
+    private static IHostWorkloadResolver CreateInstalledHostWorkloadResolver()
+    {
+        IHostWorkloadResolver hostWorkloadResolver = Substitute.For<IHostWorkloadResolver>();
+        HostWorkloadResolution hostResolution = new HostWorkloadResolution.Installed(
+            CreateHostWorkload("4.1000.0"),
+            NuGetVersion.Parse("4.1000.0"),
+            ExplicitlyRequested: false);
+        hostWorkloadResolver.ResolveAsync(Arg.Any<HostWorkloadResolutionContext>(), Arg.Any<CancellationToken>())
+            .Returns(hostResolution);
+        return hostWorkloadResolver;
+    }
+
+    private static ProfileResolution CreateResolvedProfile(IReadOnlyDictionary<string, VersionRange> workerVersionRanges)
+    {
+        var profileSource = new ProfileSourceInfo(ProfileSourceKind.BuiltIn, "bundled");
+        var profile = new ResolvedProfile(
+            "flex",
+            profileSource,
+            Sku: "flex",
+            ProfileStatus.Stable,
+            DeprecationUrl: null,
+            VersionRange.Parse("[1.8.1, 4.1048.200)"),
+            workerVersionRanges,
+            ExtensionBundleVersionRange: null,
+            SupportedRuntimes: ["node"],
+            Notes: null);
+        return new ProfileResolution.Resolved(profile, []);
     }
 
     private static WorkloadEntry CreateHostEntry(string packageVersion)
@@ -582,6 +771,32 @@ public class StartInitializationTests : IDisposable
             Description = string.Empty,
         };
 
+    private static WorkloadEntry CreateWorkerEntry(string packageId, string packageVersion)
+        => new()
+        {
+            PackageId = packageId,
+            PackageVersion = packageVersion,
+            Kind = WorkloadKind.Content,
+            Aliases = packageId.EndsWith("-worker", StringComparison.OrdinalIgnoreCase) ? [packageId] : [],
+            DisplayName = packageId,
+            Description = string.Empty,
+        };
+
+    private static FunctionsWorkerResolutionFailure CreateNotInstalledWorkerFailure(string runtime)
+    {
+        var workerId = new FunctionsWorkerId(runtime);
+        string packageId = $"Azure.Functions.Cli.Workloads.Workers.{runtime}";
+        return FunctionsWorkerResolutionFailures.NotInstalled(
+            workerId,
+            $"No installed Azure Functions worker was found for '{runtime}'. Run 'func workload install {packageId} --exact' to install it.");
+    }
+
+    private static ProjectResolutionResult CreateWorkerNotResolvedResult(FunctionsWorkerResolutionFailure workerFailure)
+    {
+        ProjectCreationFailure failure = new ProjectCreationFailure.WorkerNotResolved(workerFailure, workerFailure.Message);
+        return ProjectResolutionResults.NotResolved(workerFailure.Message, failure);
+    }
+
     private static ContentWorkloadInfo CreateHostWorkload(string packageVersion)
         => new(
             PackageId: HostWorkloadPackage.CurrentPackageId,
@@ -592,8 +807,8 @@ public class StartInitializationTests : IDisposable
             DisplayName: "Azure Functions host",
             Description: string.Empty);
 
-    private static bool HasWorkerRange(ProjectResolutionContext context, VersionRange expectedRange)
-        => context.WorkerVersionRanges.TryGetValue("node", out VersionRange? actualRange)
+    private static bool HasWorkerRange(IReadOnlyDictionary<string, VersionRange> ranges, VersionRange expectedRange)
+        => ranges.TryGetValue("node", out VersionRange? actualRange)
            && ReferenceEquals(actualRange, expectedRange);
 
     private static int FindStartedStepIndex(IReadOnlyList<StartInitializationEvent> events, string stepId)
@@ -643,11 +858,10 @@ public class StartInitializationTests : IDisposable
         WorkingDirectory workingDirectory,
         string stackName,
         string stackDisplayName,
-        bool supportsExtensionBundles,
-        IFunctionsWorker worker) : FunctionsProject
+        bool supportsExtensionBundles) : FunctionsProject
     {
         private readonly WorkingDirectory _workingDirectory = workingDirectory;
-        private readonly IFunctionsWorker _worker = worker;
+        private readonly FunctionsWorkerReference _workerReference = FunctionsWorkerReference.FromWorkload(stackName);
 
         public List<FunctionsProjectHostRunContext> PreparedContexts { get; } = [];
 
@@ -661,7 +875,7 @@ public class StartInitializationTests : IDisposable
 
         public override bool SupportsExtensionBundles => supportsExtensionBundles;
 
-        public override IFunctionsWorker Worker => _worker;
+        public override FunctionsWorkerReference WorkerReference => _workerReference;
 
         public override Task PrepareForHostRunAsync(
             FunctionsProjectHostRunContext context,
@@ -672,6 +886,12 @@ public class StartInitializationTests : IDisposable
             return Task.CompletedTask;
         }
     }
+
+    private sealed record TestFunctionsWorker(
+        FunctionsWorkerId Id,
+        string WorkerRuntime,
+        string WorkerConfigPath,
+        string Version) : IFunctionsWorker;
 
     private sealed class TestTerminalOutput(TextWriter writer) : IAnsiConsoleOutput
     {

--- a/test/Func.Tests/Projects/FunctionsProjectHostRunContextTests.cs
+++ b/test/Func.Tests/Projects/FunctionsProjectHostRunContextTests.cs
@@ -72,7 +72,7 @@ public sealed class FunctionsProjectHostRunContextTests
         var project = new TestFunctionsProject();
         var hostRunContext = new FunctionsProjectHostRunContext(
             project.WorkingDirectory.Info,
-            project.Worker.WorkerRuntime,
+            project.TestWorker.WorkerRuntime,
             new Dictionary<string, string>());
         var completionContext = new FunctionsProjectHostRunCompletionContext(
             hostRunContext,
@@ -85,7 +85,9 @@ public sealed class FunctionsProjectHostRunContextTests
     private sealed class TestFunctionsProject : FunctionsProject
     {
         private readonly WorkingDirectory _workingDirectory = WorkingDirectory.FromExplicit(Environment.CurrentDirectory);
-        private readonly IFunctionsWorker _worker = new TestFunctionsWorker();
+        private readonly FunctionsWorkerReference _workerReference = FunctionsWorkerReference.FromWorkload("dotnet-isolated");
+
+        public IFunctionsWorker TestWorker { get; } = new TestFunctionsWorker();
 
         public override WorkingDirectory WorkingDirectory => _workingDirectory;
 
@@ -95,7 +97,7 @@ public sealed class FunctionsProjectHostRunContextTests
 
         public override bool SupportsExtensionBundles => false;
 
-        public override IFunctionsWorker Worker => _worker;
+        public override FunctionsWorkerReference WorkerReference => _workerReference;
     }
 
     private sealed class TestFunctionsWorker : IFunctionsWorker

--- a/test/Func.Tests/Projects/FunctionsProjectResolverTests.cs
+++ b/test/Func.Tests/Projects/FunctionsProjectResolverTests.cs
@@ -6,7 +6,6 @@ using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Workers;
 using Azure.Functions.Cli.Workloads;
 using NSubstitute;
-using NuGet.Versioning;
 using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Projects;
@@ -14,14 +13,6 @@ namespace Azure.Functions.Cli.Tests.Projects;
 public sealed class FunctionsProjectResolverTests
 {
     private readonly WorkingDirectory _workingDirectory = WorkingDirectory.FromExplicit(Environment.CurrentDirectory);
-    private readonly IFunctionsWorkerResolver _workerResolver = Substitute.For<IFunctionsWorkerResolver>();
-    private readonly IFunctionsWorkerResolverFactory _workerResolverFactory = Substitute.For<IFunctionsWorkerResolverFactory>();
-
-    public FunctionsProjectResolverTests()
-    {
-        _workerResolverFactory.Create(Arg.Any<IReadOnlyDictionary<string, VersionRange>>())
-            .Returns(_workerResolver);
-    }
 
     [Fact]
     public async Task ResolveProjectAsync_FirstFactoryCreatesProject_ReturnsProject()
@@ -113,25 +104,8 @@ public sealed class FunctionsProjectResolverTests
 
         await factory.Received(1).TryCreateProjectAsync(
             Arg.Is<ProjectCreationContext>(context =>
-                context.WorkingDirectory == _workingDirectory
-                && ReferenceEquals(context.WorkerResolver, _workerResolver)),
+                context.WorkingDirectory == _workingDirectory),
             Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task ResolveProjectAsync_PassesWorkerConstraintsToResolverFactory()
-    {
-        IFunctionsProjectFactory factory = NewFactory(ProjectCreationResults.NotCreated("not mine"));
-        FunctionsProjectResolver resolver = NewResolver([factory]);
-        Dictionary<string, VersionRange> ranges = new(StringComparer.OrdinalIgnoreCase)
-        {
-            ["node"] = VersionRange.Parse("[3.13.0]"),
-        };
-        var context = new ProjectResolutionContext(_workingDirectory, ranges);
-
-        await resolver.ResolveProjectAsync(context, CancellationToken.None);
-
-        _workerResolverFactory.Received(1).Create(ranges);
     }
 
     private ProjectResolutionContext CreateContext() => new(_workingDirectory);
@@ -140,8 +114,7 @@ public sealed class FunctionsProjectResolverTests
         => new(
             factories.Select((factory, index) => new WorkloadProjectFactoryRegistration(
                 TestWorkloads.CreateInfo($"Test.Workload.{index}"),
-                factory)),
-            _workerResolverFactory);
+                factory)));
 
     private static IFunctionsProjectFactory NewFactory(ProjectCreationResult result)
     {

--- a/test/Func.Tests/Workers/DefaultFunctionsWorkerResolverTests.cs
+++ b/test/Func.Tests/Workers/DefaultFunctionsWorkerResolverTests.cs
@@ -125,7 +125,7 @@ public class DefaultFunctionsWorkerResolverTests
         FunctionsWorkerResolutionFailure.NotInstalled failure =
             Assert.IsType<FunctionsWorkerResolutionFailure.NotInstalled>(notResolved.Failure);
         Assert.Equal("ruby", failure.WorkerId.Value);
-        Assert.Contains("func workload install ruby-worker", failure.Message);
+        Assert.Contains("func workload install Azure.Functions.Cli.Workloads.Workers.ruby --exact", failure.Message);
     }
 
     [Fact]
@@ -143,7 +143,7 @@ public class DefaultFunctionsWorkerResolverTests
             Assert.IsType<FunctionsWorkerResolutionFailure.MissingCompatibleVersion>(notResolved.Failure);
         Assert.Equal("node", failure.WorkerId.Value);
         Assert.Null(failure.VersionConstraint);
-        Assert.Contains("func workload install node-worker --force", failure.Message);
+        Assert.Contains("func workload install Azure.Functions.Cli.Workloads.Workers.node --exact --force", failure.Message);
         _fileSystem.DidNotReceive().FileExists(Arg.Any<string>());
     }
 
@@ -202,7 +202,7 @@ public class DefaultFunctionsWorkerResolverTests
         FunctionsWorkerResolutionFailure.MissingCompatibleVersion failure =
             Assert.IsType<FunctionsWorkerResolutionFailure.MissingCompatibleVersion>(notResolved.Failure);
         Assert.Equal("[3.13.0]", failure.VersionConstraint);
-        Assert.Contains("func workload install node-worker", failure.Message);
+        Assert.Contains("func workload install Azure.Functions.Cli.Workloads.Workers.node --exact", failure.Message);
     }
 
     [Fact]
@@ -225,7 +225,7 @@ public class DefaultFunctionsWorkerResolverTests
         Assert.Equal(PythonWorkerPackageId, failure.PackageId);
         Assert.Equal("4.43.0", failure.PackageVersion);
         Assert.Equal(workerConfigPath, failure.WorkerConfigPath);
-        Assert.Contains("func workload install python-worker --force", failure.Message);
+        Assert.Contains("func workload install Azure.Functions.Cli.Workloads.Workers.python --exact --force", failure.Message);
     }
 
     [Fact]
@@ -292,4 +292,5 @@ public class DefaultFunctionsWorkerResolverTests
             packageId,
             string.Empty);
     }
+
 }

--- a/test/Func.Tests/Workers/FunctionsWorkerReferenceTests.cs
+++ b/test/Func.Tests/Workers/FunctionsWorkerReferenceTests.cs
@@ -1,0 +1,94 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workers;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Workers;
+
+public class FunctionsWorkerReferenceTests
+{
+    [Fact]
+    public async Task ResolveWorkerAsync_WorkloadReference_UsesWorkerResolver()
+    {
+        IFunctionsWorkerResolver resolver = Substitute.For<IFunctionsWorkerResolver>();
+        IFunctionsWorker worker = Substitute.For<IFunctionsWorker>();
+        var expected = FunctionsWorkerResolutionResults.Resolved(worker);
+        resolver.ResolveWorkerAsync(
+                Arg.Is<FunctionsWorkerId>(workerId => workerId.Value == "node"),
+                Arg.Any<CancellationToken>())
+            .Returns(expected);
+        var reference = FunctionsWorkerReference.FromWorkload("node");
+        var context = new FunctionsWorkerResolutionContext(resolver);
+
+        FunctionsWorkerResolutionResult result = await reference.ResolveWorkerAsync(context, CancellationToken.None);
+
+        Assert.Same(expected, result);
+    }
+
+    [Fact]
+    public async Task ResolveWorkerAsync_WorkerInfoReference_ReturnsWorkerInfo()
+    {
+        const string WorkerConfigPath = "worker.config.json";
+        IFunctionsWorkerResolver resolver = Substitute.For<IFunctionsWorkerResolver>();
+        var reference = FunctionsWorkerReference.FromWorkerInfo(
+            "custom",
+            "custom",
+            WorkerConfigPath,
+            "1.0.0");
+        var context = new FunctionsWorkerResolutionContext(resolver);
+
+        FunctionsWorkerResolutionResult result = await reference.ResolveWorkerAsync(context, CancellationToken.None);
+
+        FunctionsWorkerResolutionResult.Resolved resolved = Assert.IsType<FunctionsWorkerResolutionResult.Resolved>(result);
+        Assert.Equal("custom", resolved.Worker.Id.Value);
+        Assert.Equal("custom", resolved.Worker.WorkerRuntime);
+        Assert.Equal(WorkerConfigPath, resolved.Worker.WorkerConfigPath);
+        Assert.Equal("1.0.0", resolved.Worker.Version);
+        _ = resolver.DidNotReceive().ResolveWorkerAsync(Arg.Any<FunctionsWorkerId>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void FromWorkerInfo_NullWorkerId_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => FunctionsWorkerReference.FromWorkerInfo(
+            (FunctionsWorkerId)null!,
+            "custom",
+            "worker.config.json"));
+    }
+
+    [Fact]
+    public void FromWorkerInfo_EmptyWorkerRuntime_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => FunctionsWorkerReference.FromWorkerInfo(
+            new FunctionsWorkerId("custom"),
+            string.Empty,
+            "worker.config.json"));
+    }
+
+    [Fact]
+    public void FromWorkerInfo_EmptyWorkerConfigPath_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => FunctionsWorkerReference.FromWorkerInfo(
+            new FunctionsWorkerId("custom"),
+            "custom",
+            string.Empty));
+    }
+
+    [Fact]
+    public void FromWorkerInfo_NullVersion_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => FunctionsWorkerReference.FromWorkerInfo(
+            new FunctionsWorkerId("custom"),
+            "custom",
+            "worker.config.json",
+            null!));
+    }
+
+    [Fact]
+    public void Ctor_NullResolver_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new FunctionsWorkerResolutionContext(null!));
+    }
+}

--- a/test/Workloads/Stacks/Go.Tests/GoProjectFactoryTests.cs
+++ b/test/Workloads/Stacks/Go.Tests/GoProjectFactoryTests.cs
@@ -91,7 +91,8 @@ public class GoProjectFactoryTests : IDisposable
         ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
         Assert.Equal("go", created.Project.StackName);
         Assert.Equal("Go", created.Project.StackDisplayName);
-        Assert.Equal("native", created.Project.Worker.WorkerRuntime);
+        IFunctionsWorker worker = await ResolveWorkerAsync(created.Project);
+        Assert.Equal("native", worker.WorkerRuntime);
         Assert.NotNull(created.Reason);
     }
 
@@ -119,7 +120,7 @@ public class GoProjectFactoryTests : IDisposable
     }
 
     [Fact]
-    public async Task MatchingDirectory_WhenWorkerNotResolved_Fails()
+    public async Task MatchingDirectory_WhenWorkerNotResolved_WorkerReferenceReportsFailure()
     {
         WriteFile("go.mod", "module example");
         FunctionsWorkerResolutionFailure failure = FunctionsWorkerResolutionFailures.NotInstalled(
@@ -130,10 +131,12 @@ public class GoProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new GoProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Failed failed = Assert.IsType<ProjectCreationResult.Failed>(result);
-        ProjectCreationFailure.WorkerNotResolved workerFailure =
-            Assert.IsType<ProjectCreationFailure.WorkerNotResolved>(failed.Failure);
-        Assert.Same(failure, workerFailure.WorkerFailure);
+        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
+        FunctionsWorkerResolutionResult workerResult = await created.Project.WorkerReference.ResolveWorkerAsync(
+            new FunctionsWorkerResolutionContext(_workerResolver),
+            default);
+        FunctionsWorkerResolutionResult.NotResolved notResolved = Assert.IsType<FunctionsWorkerResolutionResult.NotResolved>(workerResult);
+        Assert.Same(failure, notResolved.Failure);
     }
 
     [Fact]
@@ -147,7 +150,16 @@ public class GoProjectFactoryTests : IDisposable
         => File.WriteAllText(Path.Combine(_projectDir.FullName, name), contents);
 
     private ProjectCreationContext CreateContext()
-        => new(WorkingDirectory.FromExplicit(_projectDir.FullName), _workerResolver);
+        => new(WorkingDirectory.FromExplicit(_projectDir.FullName));
+
+    private async Task<IFunctionsWorker> ResolveWorkerAsync(FunctionsProject project)
+    {
+        FunctionsWorkerResolutionResult result = await project.WorkerReference.ResolveWorkerAsync(
+            new FunctionsWorkerResolutionContext(_workerResolver),
+            default);
+        FunctionsWorkerResolutionResult.Resolved resolved = Assert.IsType<FunctionsWorkerResolutionResult.Resolved>(result);
+        return resolved.Worker;
+    }
 
     private static IFunctionsWorker CreateWorker(string workerId, string workerRuntime)
         => new TestFunctionsWorker(new FunctionsWorkerId(workerId), workerRuntime, "worker.config.json", "1.0.0");

--- a/test/Workloads/Stacks/Node.Tests/NodeProjectFactoryTests.cs
+++ b/test/Workloads/Stacks/Node.Tests/NodeProjectFactoryTests.cs
@@ -97,7 +97,8 @@ public class NodeProjectFactoryTests : IDisposable
         ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
         Assert.Equal("node", created.Project.StackName);
         Assert.Equal("Node.js", created.Project.StackDisplayName);
-        Assert.Equal("node", created.Project.Worker.WorkerRuntime);
+        IFunctionsWorker worker = await ResolveWorkerAsync(created.Project);
+        Assert.Equal("node", worker.WorkerRuntime);
         Assert.NotNull(created.Reason);
     }
 
@@ -160,7 +161,7 @@ public class NodeProjectFactoryTests : IDisposable
     }
 
     [Fact]
-    public async Task MatchingDirectory_WhenWorkerNotResolved_Fails()
+    public async Task MatchingDirectory_WhenWorkerNotResolved_WorkerReferenceReportsFailure()
     {
         WriteFile("package.json", "{}");
         FunctionsWorkerResolutionFailure failure = FunctionsWorkerResolutionFailures.NotInstalled(
@@ -171,10 +172,12 @@ public class NodeProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new NodeProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Failed failed = Assert.IsType<ProjectCreationResult.Failed>(result);
-        ProjectCreationFailure.WorkerNotResolved workerFailure =
-            Assert.IsType<ProjectCreationFailure.WorkerNotResolved>(failed.Failure);
-        Assert.Same(failure, workerFailure.WorkerFailure);
+        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
+        FunctionsWorkerResolutionResult workerResult = await created.Project.WorkerReference.ResolveWorkerAsync(
+            new FunctionsWorkerResolutionContext(_workerResolver),
+            default);
+        FunctionsWorkerResolutionResult.NotResolved notResolved = Assert.IsType<FunctionsWorkerResolutionResult.NotResolved>(workerResult);
+        Assert.Same(failure, notResolved.Failure);
     }
 
     [Fact]
@@ -188,7 +191,16 @@ public class NodeProjectFactoryTests : IDisposable
         => File.WriteAllText(Path.Combine(_projectDir.FullName, name), contents);
 
     private ProjectCreationContext CreateContext(DirectoryInfo? directory = null)
-        => new(WorkingDirectory.FromExplicit((directory ?? _projectDir).FullName), _workerResolver);
+        => new(WorkingDirectory.FromExplicit((directory ?? _projectDir).FullName));
+
+    private async Task<IFunctionsWorker> ResolveWorkerAsync(FunctionsProject project)
+    {
+        FunctionsWorkerResolutionResult result = await project.WorkerReference.ResolveWorkerAsync(
+            new FunctionsWorkerResolutionContext(_workerResolver),
+            default);
+        FunctionsWorkerResolutionResult.Resolved resolved = Assert.IsType<FunctionsWorkerResolutionResult.Resolved>(result);
+        return resolved.Worker;
+    }
 
     private static IFunctionsWorker CreateWorker(string workerId, string workerRuntime)
         => new TestFunctionsWorker(new FunctionsWorkerId(workerId), workerRuntime, "worker.config.json", "1.0.0");

--- a/test/Workloads/Stacks/Python.Tests/PythonProjectFactoryTests.cs
+++ b/test/Workloads/Stacks/Python.Tests/PythonProjectFactoryTests.cs
@@ -109,7 +109,8 @@ public class PythonProjectFactoryTests : IDisposable
         ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
         Assert.Equal("python", created.Project.StackName);
         Assert.Equal("Python", created.Project.StackDisplayName);
-        Assert.Equal("python", created.Project.Worker.WorkerRuntime);
+        IFunctionsWorker worker = await ResolveWorkerAsync(created.Project);
+        Assert.Equal("python", worker.WorkerRuntime);
         Assert.NotNull(created.Reason);
     }
 
@@ -164,7 +165,7 @@ public class PythonProjectFactoryTests : IDisposable
     }
 
     [Fact]
-    public async Task MatchingDirectory_WhenWorkerNotResolved_Fails()
+    public async Task MatchingDirectory_WhenWorkerNotResolved_WorkerReferenceReportsFailure()
     {
         WriteFile("requirements.txt", string.Empty);
         FunctionsWorkerResolutionFailure failure = FunctionsWorkerResolutionFailures.NotInstalled(
@@ -175,10 +176,12 @@ public class PythonProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new PythonProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Failed failed = Assert.IsType<ProjectCreationResult.Failed>(result);
-        ProjectCreationFailure.WorkerNotResolved workerFailure =
-            Assert.IsType<ProjectCreationFailure.WorkerNotResolved>(failed.Failure);
-        Assert.Same(failure, workerFailure.WorkerFailure);
+        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
+        FunctionsWorkerResolutionResult workerResult = await created.Project.WorkerReference.ResolveWorkerAsync(
+            new FunctionsWorkerResolutionContext(_workerResolver),
+            default);
+        FunctionsWorkerResolutionResult.NotResolved notResolved = Assert.IsType<FunctionsWorkerResolutionResult.NotResolved>(workerResult);
+        Assert.Same(failure, notResolved.Failure);
     }
 
     [Fact]
@@ -192,7 +195,16 @@ public class PythonProjectFactoryTests : IDisposable
         => File.WriteAllText(Path.Combine(_projectDir.FullName, name), contents);
 
     private ProjectCreationContext CreateContext(DirectoryInfo? directory = null)
-        => new(WorkingDirectory.FromExplicit((directory ?? _projectDir).FullName), _workerResolver);
+        => new(WorkingDirectory.FromExplicit((directory ?? _projectDir).FullName));
+
+    private async Task<IFunctionsWorker> ResolveWorkerAsync(FunctionsProject project)
+    {
+        FunctionsWorkerResolutionResult result = await project.WorkerReference.ResolveWorkerAsync(
+            new FunctionsWorkerResolutionContext(_workerResolver),
+            default);
+        FunctionsWorkerResolutionResult.Resolved resolved = Assert.IsType<FunctionsWorkerResolutionResult.Resolved>(result);
+        return resolved.Worker;
+    }
 
     private static IFunctionsWorker CreateWorker(string workerId, string workerRuntime)
         => new TestFunctionsWorker(new FunctionsWorkerId(workerId), workerRuntime, "worker.config.json", "1.0.0");


### PR DESCRIPTION
Decouples Functions project resolution from Functions worker resolution/install for `func start`.
 
 Projects now declare a `FunctionsWorkerReference` instead of returning a resolved `IFunctionsWorker`. The start initialization pipeline resolves that reference in a dedicated worker step, which allows worker workload resolution, prompting, install, retry, and runtime validation to happen explicitly after project detection.
