### PR TITLE
Rename workload source env var to FUNC_CLI_WORKLOADS_SOURCE

### DIFF
--- a/src/Func/Common/Constants.cs
+++ b/src/Func/Common/Constants.cs
@@ -40,6 +40,15 @@ internal static class Constants
     public const string WorkloadsHomeEnvironmentVariable = "FUNC_CLI_WORKLOADS_HOME";
 
     /// <summary>
+    /// Environment variable that, when explicitly set to a non-empty value,
+    /// overrides the default workload catalog source (a v3 NuGet
+    /// <c>index.json</c> URL). Read directly (not through
+    /// <c>IConfiguration</c>) so the source cannot be redirected by host
+    /// config, global config, or project <c>.func/config.json</c>.
+    /// </summary>
+    public const string WorkloadsSourceEnvironmentVariable = "FUNC_CLI_WORKLOADS_SOURCE";
+
+    /// <summary>
     /// The telemetry instrumentation key, injected at build time via Telemetry.props.
     /// </summary>
     public static readonly string TelemetryInstrumentationKey =

--- a/src/Func/Hosting/WorkloadCatalogRegistration.cs
+++ b/src/Func/Hosting/WorkloadCatalogRegistration.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Workloads.Catalog;
 using Microsoft.Extensions.DependencyInjection;
 using NuGet.Protocol;
@@ -11,21 +12,20 @@ namespace Azure.Functions.Cli.Hosting;
 
 /// <summary>
 /// Registers the workload catalog services in DI.
+/// <see cref="WorkloadCatalogOptions"/> is constructed directly (no
+/// <see cref="Microsoft.Extensions.Configuration.IConfiguration"/> binding):
+/// the only supported override for <c>Source</c> is the
+/// <see cref="Constants.WorkloadsSourceEnvironmentVariable"/> env var, read
+/// inside the options constructor via
+/// <see cref="WorkloadSourceResolver.Resolve"/>.
 /// </summary>
 internal static class WorkloadCatalogRegistration
 {
-    /// <summary>
-    /// Configuration section the catalog options bind from.
-    /// </summary>
-    public const string ConfigurationSection = "Workloads:Catalog";
-
     public static IServiceCollection AddWorkloadCatalog(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        services.AddOptions<WorkloadCatalogOptions>()
-            .BindConfiguration(ConfigurationSection)
-            .ValidateOnStart();
+        services.AddSingleton<WorkloadCatalogOptions>(_ => new WorkloadCatalogOptions());
 
         services.AddSingleton<IPackageSourceProvider, PackageSourceProvider>();
         services.AddSingleton<Func<PackageSource, NuGetProtocolSourceClient>>(_ => CreateSourceClient);

--- a/src/Func/Workloads/Catalog/IPackageSourceProvider.cs
+++ b/src/Func/Workloads/Catalog/IPackageSourceProvider.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Common;
 using PackageSource = NuGet.Configuration.PackageSource;
 
 namespace Azure.Functions.Cli.Workloads.Catalog;
@@ -13,7 +14,8 @@ internal interface IPackageSourceProvider
     /// <summary>
     /// Returns the source to consult. <paramref name="source"/> takes precedence
     /// (typically from <c>--source</c>); <c>null</c> falls through to the
-    /// configured <c>Workloads:Catalog:Source</c>, then the nuget.org default.
+    /// <see cref="Constants.WorkloadsSourceEnvironmentVariable"/> env var,
+    /// then the nuget.org default.
     /// </summary>
     /// <param name="source">
     /// Optional explicit source: a v3 <c>index.json</c> URL or a local

--- a/src/Func/Workloads/Catalog/PackageSourceProvider.cs
+++ b/src/Func/Workloads/Catalog/PackageSourceProvider.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Microsoft.Extensions.Options;
 using PackageSource = NuGet.Configuration.PackageSource;
 
 namespace Azure.Functions.Cli.Workloads.Catalog;
@@ -10,7 +9,7 @@ namespace Azure.Functions.Cli.Workloads.Catalog;
 /// Default <see cref="IPackageSourceProvider"/>. Precedence: <c>--source</c> override,
 /// then <see cref="WorkloadCatalogOptions.Source"/>, then nuget.org as a fallback.
 /// </summary>
-internal sealed class PackageSourceProvider(IOptions<WorkloadCatalogOptions> options) : IPackageSourceProvider
+internal sealed class PackageSourceProvider(WorkloadCatalogOptions options) : IPackageSourceProvider
 {
     /// <summary>
     /// Public nuget.org v3 service index, used when no source is configured.
@@ -19,7 +18,7 @@ internal sealed class PackageSourceProvider(IOptions<WorkloadCatalogOptions> opt
 
     private const string DefaultSourceName = "nuget.org";
 
-    private readonly WorkloadCatalogOptions _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+    private readonly WorkloadCatalogOptions _options = options ?? throw new ArgumentNullException(nameof(options));
 
     /// <inheritdoc />
     public PackageSource GetSource(string? source = null)

--- a/src/Func/Workloads/Catalog/WorkloadCatalogOptions.cs
+++ b/src/Func/Workloads/Catalog/WorkloadCatalogOptions.cs
@@ -1,18 +1,41 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Common;
+
 namespace Azure.Functions.Cli.Workloads.Catalog;
 
 /// <summary>
-/// Configuration for the workload catalog. Bound from the
-/// <c>Workloads:Catalog</c> section; the matching environment variable is
-/// <c>FUNC_CLI_Workloads__Catalog__Source</c>.
+/// Configuration for the workload catalog. The only supported override for
+/// <see cref="Source"/> is the
+/// <see cref="Constants.WorkloadsSourceEnvironmentVariable"/> environment
+/// variable, read inside the default constructor via
+/// <see cref="WorkloadSourceResolver.Resolve"/>. Other configuration sources
+/// (json files, local.settings, in-memory) are not honored.
 /// </summary>
 internal sealed class WorkloadCatalogOptions
 {
     /// <summary>
-    /// Feed location to consult: either a v3 <c>index.json</c> URL or a
-    /// local directory path. <c>null</c> / empty falls back to nuget.org.
+    /// Resolves <see cref="Source"/> from
+    /// <see cref="Constants.WorkloadsSourceEnvironmentVariable"/>.
     /// </summary>
-    public string? Source { get; set; }
+    public WorkloadCatalogOptions()
+        : this(WorkloadSourceResolver.Resolve())
+    {
+    }
+
+    /// <summary>
+    /// Test-only seam for supplying <see cref="Source"/> directly so unit
+    /// tests don't have to mutate process-global env vars.
+    /// </summary>
+    internal WorkloadCatalogOptions(string? source)
+    {
+        Source = source;
+    }
+
+    /// <summary>
+    /// Feed location to consult: a v3 <c>index.json</c> URL. <c>null</c>
+    /// falls back to nuget.org.
+    /// </summary>
+    public string? Source { get; }
 }

--- a/src/Func/Workloads/Catalog/WorkloadSourceResolver.cs
+++ b/src/Func/Workloads/Catalog/WorkloadSourceResolver.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Common;
+
+namespace Azure.Functions.Cli.Workloads.Catalog;
+
+/// <summary>
+/// Resolves the configured workload catalog source. The only configurable
+/// input is the <see cref="Constants.WorkloadsSourceEnvironmentVariable"/>
+/// environment variable; config files and command-line settings are
+/// intentionally ignored so the workload feed can't be redirected by
+/// anything other than an explicit process env var or a per-invocation
+/// <c>--source</c> override.
+/// </summary>
+internal static class WorkloadSourceResolver
+{
+    /// <summary>
+    /// Returns the env-var override if explicitly set to a non-whitespace
+    /// value, otherwise <c>null</c> to fall back to the catalog default.
+    /// </summary>
+    public static string? Resolve()
+    {
+        string? configured = System.Environment.GetEnvironmentVariable(
+            Constants.WorkloadsSourceEnvironmentVariable);
+
+        return string.IsNullOrWhiteSpace(configured) ? null : configured;
+    }
+}

--- a/test/Func.Tests/Workloads/Catalog/PackageSourceProviderTests.cs
+++ b/test/Func.Tests/Workloads/Catalog/PackageSourceProviderTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Workloads.Catalog;
-using Microsoft.Extensions.Options;
 using Xunit;
 using PackageSource = NuGet.Configuration.PackageSource;
 
@@ -75,7 +74,6 @@ public sealed class PackageSourceProviderTests
 
     private static PackageSourceProvider NewProvider(string? source = null)
     {
-        var options = Options.Create(new WorkloadCatalogOptions { Source = source });
-        return new PackageSourceProvider(options);
+        return new PackageSourceProvider(new WorkloadCatalogOptions(source));
     }
 }


### PR DESCRIPTION
Renames the workload catalog source env var from `FUNC_CLI_Workloads__Catalog__Source` to `FUNC_CLI_WORKLOADS_SOURCE` and stops binding it through `IConfiguration`.

The env var is now read directly via a small `WorkloadSourceResolver`, mirroring the `FUNC_CLI_WORKLOADS_HOME` / `WorkloadHomeResolver` pattern. This keeps the workload feed from being redirected by host config, global config, or project `.func/config.json` — only an explicit process env var or per-invocation `--source` override can change it.

### Changes
- New `Constants.WorkloadsSourceEnvironmentVariable` + `WorkloadSourceResolver`.
- `WorkloadCatalogOptions` reads the env var in its default constructor; test-only ctor accepts an explicit source.
- `WorkloadCatalogRegistration` registers `WorkloadCatalogOptions` as a plain singleton (no `BindConfiguration` / `IOptions<>`).
- `PackageSourceProvider` takes `WorkloadCatalogOptions` directly.
- Doc comments and tests updated.