### PR TITLE
Add AzureWebJobsStorage classifier for managed Azurite

### DIFF
--- a/src/Func/Commands/Start/Azurite/AzureWebJobsStorageClassification.cs
+++ b/src/Func/Commands/Start/Azurite/AzureWebJobsStorageClassification.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite;
+
+/// <summary>
+/// Classifies an <c>AzureWebJobsStorage</c> connection string with respect to
+/// the managed-Azurite feature.
+/// </summary>
+internal enum AzureWebJobsStorageClassification
+{
+    /// <summary>
+    /// The value does not reference a local storage emulator. Core Tools must
+    /// not probe or manage Azurite for this connection.
+    /// </summary>
+    NotLocal,
+
+    /// <summary>
+    /// The value references local development storage in a shape Core Tools
+    /// can reproduce, so it may start a managed Azurite instance if needed.
+    /// </summary>
+    ManageableAzurite,
+
+    /// <summary>
+    /// The value references local development storage but requires
+    /// user-specific configuration Core Tools cannot reproduce. Core Tools may
+    /// probe the endpoints but must not start Azurite for this connection.
+    /// </summary>
+    UserConfiguredAzurite,
+}

--- a/src/Func/Commands/Start/Azurite/AzureWebJobsStorageClassification.cs
+++ b/src/Func/Commands/Start/Azurite/AzureWebJobsStorageClassification.cs
@@ -10,20 +10,20 @@ namespace Azure.Functions.Cli.Commands.Start.Azurite;
 internal enum AzureWebJobsStorageClassification
 {
     /// <summary>
-    /// The value does not reference a local storage emulator. Core Tools must
+    /// The value does not reference a local storage emulator. The CLI must
     /// not probe or manage Azurite for this connection.
     /// </summary>
     NotLocal,
 
     /// <summary>
-    /// The value references local development storage in a shape Core Tools
+    /// The value references local development storage in a shape the CLI
     /// can reproduce, so it may start a managed Azurite instance if needed.
     /// </summary>
     ManageableAzurite,
 
     /// <summary>
     /// The value references local development storage but requires
-    /// user-specific configuration Core Tools cannot reproduce. Core Tools may
+    /// user-specific configuration the CLI cannot reproduce. The CLI may
     /// probe the endpoints but must not start Azurite for this connection.
     /// </summary>
     UserConfiguredAzurite,

--- a/src/Func/Commands/Start/Azurite/AzureWebJobsStorageClassifier.cs
+++ b/src/Func/Commands/Start/Azurite/AzureWebJobsStorageClassifier.cs
@@ -1,0 +1,249 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Collections.Frozen;
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite;
+
+/// <inheritdoc cref="IAzureWebJobsStorageClassifier" />
+internal sealed class AzureWebJobsStorageClassifier : IAzureWebJobsStorageClassifier
+{
+    internal const string DevelopmentStorageAccountName = "devstoreaccount1";
+    internal const int DefaultBlobPort = 10000;
+    internal const int DefaultQueuePort = 10001;
+    internal const int DefaultTablePort = 10002;
+
+    private static readonly FrozenSet<string> _literalLocalHosts = new[]
+    {
+        "localhost",
+        "127.0.0.1",
+        "::1",
+        "[::1]",
+        "host.docker.internal",
+    }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    private static readonly string[] _productStyleSubdomains = ["blob", "queue", "table"];
+
+    public AzureWebJobsStorageReference Classify(string? connectionString)
+    {
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            return AzureWebJobsStorageReference.NotLocal("Connection string is empty.");
+        }
+
+        Dictionary<string, string> parts;
+        try
+        {
+            parts = Parse(connectionString);
+        }
+        catch (FormatException ex)
+        {
+            return AzureWebJobsStorageReference.NotLocal($"Connection string could not be parsed: {ex.Message}");
+        }
+
+        if (parts.TryGetValue("UseDevelopmentStorage", out string? devValue) &&
+            string.Equals(devValue, "true", StringComparison.OrdinalIgnoreCase))
+        {
+            if (parts.ContainsKey("DevelopmentStorageProxyUri"))
+            {
+                return AzureWebJobsStorageReference.UserConfigured(
+                    endpoints: null,
+                    reason: "UseDevelopmentStorage=true with a custom DevelopmentStorageProxyUri.");
+            }
+
+            return AzureWebJobsStorageReference.Manageable(
+                endpoints: null,
+                reason: "UseDevelopmentStorage=true with default Azurite endpoints.");
+        }
+
+        bool hasBlob = parts.TryGetValue("BlobEndpoint", out string? blobValue);
+        bool hasQueue = parts.TryGetValue("QueueEndpoint", out string? queueValue);
+        bool hasTable = parts.TryGetValue("TableEndpoint", out string? tableValue);
+
+        if (!hasBlob && !hasQueue && !hasTable)
+        {
+            return AzureWebJobsStorageReference.NotLocal(
+                "Connection string does not reference local development storage.");
+        }
+
+        Uri? blob = TryParseEndpoint(blobValue);
+        Uri? queue = TryParseEndpoint(queueValue);
+        Uri? table = TryParseEndpoint(tableValue);
+
+        Uri?[] presentEndpoints = [blob, queue, table];
+        bool anyParsed = presentEndpoints.Any(static e => e is not null);
+        if (!anyParsed)
+        {
+            return AzureWebJobsStorageReference.NotLocal(
+                "Connection string endpoints could not be parsed as URIs.");
+        }
+
+        bool anyLocal = presentEndpoints.Any(static e => e is not null && IsLocalHost(e.Host));
+        bool anyNonLocal = presentEndpoints.Any(static e => e is not null && !IsLocalHost(e.Host));
+
+        if (!anyLocal)
+        {
+            return AzureWebJobsStorageReference.NotLocal(
+                "Endpoints reference a non-local storage account.");
+        }
+
+        if (anyNonLocal)
+        {
+            return AzureWebJobsStorageReference.NotLocal(
+                "Endpoints mix local and non-local hosts; treating as non-local.");
+        }
+
+        if (!(hasBlob && hasQueue && hasTable) || blob is null || queue is null || table is null)
+        {
+            return AzureWebJobsStorageReference.UserConfigured(
+                endpoints: null,
+                reason: "Local emulator reference is missing one or more of Blob, Queue, or Table endpoints.");
+        }
+
+        if (!string.Equals(blob.Scheme, "http", StringComparison.OrdinalIgnoreCase) ||
+            !string.Equals(queue.Scheme, "http", StringComparison.OrdinalIgnoreCase) ||
+            !string.Equals(table.Scheme, "http", StringComparison.OrdinalIgnoreCase))
+        {
+            return AzureWebJobsStorageReference.UserConfigured(
+                endpoints: BuildTuple(blob, queue, table, accountName: null),
+                reason: "Local emulator reference uses HTTPS, which requires user-supplied certificates.");
+        }
+
+        if (LooksProductStyle(blob) || LooksProductStyle(queue) || LooksProductStyle(table))
+        {
+            return AzureWebJobsStorageReference.UserConfigured(
+                endpoints: BuildTuple(blob, queue, table, accountName: null),
+                reason: "Local emulator reference uses production-style account subdomains.");
+        }
+
+        string? accountFromKey = parts.TryGetValue("AccountName", out string? explicitAccount) ? explicitAccount : null;
+        string? blobAccount = ExtractPathAccount(blob);
+        string? queueAccount = ExtractPathAccount(queue);
+        string? tableAccount = ExtractPathAccount(table);
+
+        if (blobAccount is null || queueAccount is null || tableAccount is null)
+        {
+            return AzureWebJobsStorageReference.UserConfigured(
+                endpoints: BuildTuple(blob, queue, table, accountFromKey),
+                reason: "Local emulator endpoints do not follow the path-style account format.");
+        }
+
+        if (!string.Equals(blobAccount, queueAccount, StringComparison.Ordinal) ||
+            !string.Equals(blobAccount, tableAccount, StringComparison.Ordinal))
+        {
+            return AzureWebJobsStorageReference.UserConfigured(
+                endpoints: BuildTuple(blob, queue, table, accountFromKey ?? blobAccount),
+                reason: "Local emulator endpoints reference inconsistent account names.");
+        }
+
+        if (accountFromKey is not null && !string.Equals(accountFromKey, blobAccount, StringComparison.Ordinal))
+        {
+            return AzureWebJobsStorageReference.UserConfigured(
+                endpoints: BuildTuple(blob, queue, table, accountFromKey),
+                reason: "AccountName does not match the account encoded in the local emulator endpoints.");
+        }
+
+        AzuriteEndpointTuple tuple = BuildTuple(blob, queue, table, blobAccount);
+
+        if (!string.Equals(blobAccount, DevelopmentStorageAccountName, StringComparison.Ordinal))
+        {
+            return AzureWebJobsStorageReference.UserConfigured(
+                endpoints: tuple,
+                reason: $"Local emulator reference uses a custom account name '{blobAccount}'.");
+        }
+
+        return AzureWebJobsStorageReference.Manageable(
+            endpoints: tuple,
+            reason: "Explicit local Azurite endpoints for devstoreaccount1.");
+    }
+
+    private static Dictionary<string, string> Parse(string connectionString)
+    {
+        Dictionary<string, string> result = new(StringComparer.OrdinalIgnoreCase);
+        foreach (string raw in connectionString.Split(';'))
+        {
+            string segment = raw.Trim();
+            if (segment.Length == 0)
+            {
+                continue;
+            }
+
+            int eq = segment.IndexOf('=');
+            if (eq <= 0)
+            {
+                throw new FormatException($"Segment '{segment}' is not in key=value form.");
+            }
+
+            string key = segment[..eq].Trim();
+            string value = segment[(eq + 1)..].Trim();
+            if (key.Length == 0)
+            {
+                throw new FormatException("Empty key in connection string segment.");
+            }
+
+            result[key] = value;
+        }
+
+        return result;
+    }
+
+    private static Uri? TryParseEndpoint(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return Uri.TryCreate(value, UriKind.Absolute, out Uri? uri) ? uri : null;
+    }
+
+    internal static bool IsLocalHost(string host)
+    {
+        if (string.IsNullOrEmpty(host))
+        {
+            return false;
+        }
+
+        if (_literalLocalHosts.Contains(host))
+        {
+            return true;
+        }
+
+        return host.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool LooksProductStyle(Uri endpoint)
+    {
+        string host = endpoint.Host;
+        int firstDot = host.IndexOf('.');
+        if (firstDot <= 0)
+        {
+            return false;
+        }
+
+        string remainder = host[(firstDot + 1)..];
+        int nextDot = remainder.IndexOf('.');
+        if (nextDot <= 0)
+        {
+            return false;
+        }
+
+        string serviceSegment = remainder[..nextDot];
+        return _productStyleSubdomains.Contains(serviceSegment, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static string? ExtractPathAccount(Uri endpoint)
+    {
+        string path = endpoint.AbsolutePath.Trim('/');
+        if (path.Length == 0)
+        {
+            return null;
+        }
+
+        int slash = path.IndexOf('/');
+        return slash < 0 ? path : path[..slash];
+    }
+
+    private static AzuriteEndpointTuple BuildTuple(Uri blob, Uri queue, Uri table, string? accountName)
+        => new(blob, queue, table, accountName ?? string.Empty);
+}

--- a/src/Func/Commands/Start/Azurite/AzureWebJobsStorageReference.cs
+++ b/src/Func/Commands/Start/Azurite/AzureWebJobsStorageReference.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite;
+
+/// <summary>
+/// Result of classifying an <c>AzureWebJobsStorage</c> connection string.
+/// </summary>
+internal sealed record AzureWebJobsStorageReference
+{
+    public required AzureWebJobsStorageClassification Classification { get; init; }
+
+    /// <summary>
+    /// Endpoints inferred from the connection string when the value enumerates
+    /// explicit Blob, Queue, and Table endpoints. Null for the
+    /// <c>UseDevelopmentStorage=true</c> shorthand (the caller fills in the
+    /// defaults) and for non-local values.
+    /// </summary>
+    public AzuriteEndpointTuple? Endpoints { get; init; }
+
+    /// <summary>
+    /// Short human-readable explanation of the classification, suitable for
+    /// verbose logging and diagnostics.
+    /// </summary>
+    public required string Reason { get; init; }
+
+    public static AzureWebJobsStorageReference NotLocal(string reason) => new()
+    {
+        Classification = AzureWebJobsStorageClassification.NotLocal,
+        Reason = reason,
+    };
+
+    public static AzureWebJobsStorageReference Manageable(AzuriteEndpointTuple? endpoints, string reason) => new()
+    {
+        Classification = AzureWebJobsStorageClassification.ManageableAzurite,
+        Endpoints = endpoints,
+        Reason = reason,
+    };
+
+    public static AzureWebJobsStorageReference UserConfigured(AzuriteEndpointTuple? endpoints, string reason) => new()
+    {
+        Classification = AzureWebJobsStorageClassification.UserConfiguredAzurite,
+        Endpoints = endpoints,
+        Reason = reason,
+    };
+}

--- a/src/Func/Commands/Start/Azurite/AzuriteEndpointTuple.cs
+++ b/src/Func/Commands/Start/Azurite/AzuriteEndpointTuple.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite;
+
+/// <summary>
+/// The set of Azurite service endpoints inferred from an
+/// <c>AzureWebJobsStorage</c> connection string.
+/// </summary>
+internal sealed record AzuriteEndpointTuple(
+    Uri BlobEndpoint,
+    Uri QueueEndpoint,
+    Uri TableEndpoint,
+    string AccountName);

--- a/src/Func/Commands/Start/Azurite/IAzureWebJobsStorageClassifier.cs
+++ b/src/Func/Commands/Start/Azurite/IAzureWebJobsStorageClassifier.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite;
+
+/// <summary>
+/// Classifies an <c>AzureWebJobsStorage</c> connection string into the
+/// categories the managed-Azurite feature reasons over.
+/// </summary>
+internal interface IAzureWebJobsStorageClassifier
+{
+    /// <summary>
+    /// Classifies <paramref name="connectionString"/>. Null, empty, or
+    /// whitespace input is treated as <see cref="AzureWebJobsStorageClassification.NotLocal"/>.
+    /// The classifier is pure: it never performs I/O.
+    /// </summary>
+    public AzureWebJobsStorageReference Classify(string? connectionString);
+}

--- a/test/Func.Tests/Commands/Start/Azurite/AzureWebJobsStorageClassifierTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/AzureWebJobsStorageClassifierTests.cs
@@ -1,0 +1,286 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Commands.Start.Azurite;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Commands.Start.Azurite;
+
+public class AzureWebJobsStorageClassifierTests
+{
+    private const string DevAccountKey =
+        "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+
+    private readonly AzureWebJobsStorageClassifier _classifier = new();
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Classify_NullOrWhitespace_ReturnsNotLocal(string? value)
+    {
+        var result = _classifier.Classify(value);
+
+        Assert.Equal(AzureWebJobsStorageClassification.NotLocal, result.Classification);
+        Assert.Null(result.Endpoints);
+    }
+
+    [Fact]
+    public void Classify_UseDevelopmentStorageTrue_IsManageable()
+    {
+        var result = _classifier.Classify("UseDevelopmentStorage=true");
+
+        Assert.Equal(AzureWebJobsStorageClassification.ManageableAzurite, result.Classification);
+        Assert.Null(result.Endpoints);
+    }
+
+    [Fact]
+    public void Classify_UseDevelopmentStorageTrue_KeyIsCaseInsensitive()
+    {
+        var result = _classifier.Classify("usedevelopmentstorage=TRUE");
+
+        Assert.Equal(AzureWebJobsStorageClassification.ManageableAzurite, result.Classification);
+    }
+
+    [Fact]
+    public void Classify_UseDevelopmentStorageWithProxy_IsUserConfigured()
+    {
+        var result = _classifier.Classify(
+            "UseDevelopmentStorage=true;DevelopmentStorageProxyUri=http://127.0.0.1");
+
+        Assert.Equal(AzureWebJobsStorageClassification.UserConfiguredAzurite, result.Classification);
+    }
+
+    [Fact]
+    public void Classify_ExplicitDefaultAzuriteEndpoints_IsManageable()
+    {
+        var cs = $"DefaultEndpointsProtocol=http;" +
+            $"AccountName=devstoreaccount1;" +
+            $"AccountKey={DevAccountKey};" +
+            "BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;" +
+            "QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;" +
+            "TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;";
+
+        var result = _classifier.Classify(cs);
+
+        Assert.Equal(AzureWebJobsStorageClassification.ManageableAzurite, result.Classification);
+        Assert.NotNull(result.Endpoints);
+        Assert.Equal("devstoreaccount1", result.Endpoints!.AccountName);
+        Assert.Equal(10000, result.Endpoints.BlobEndpoint.Port);
+        Assert.Equal(10001, result.Endpoints.QueueEndpoint.Port);
+        Assert.Equal(10002, result.Endpoints.TableEndpoint.Port);
+    }
+
+    [Fact]
+    public void Classify_CustomLocalPortsForDevStoreAccount_IsManageable()
+    {
+        var cs = "DefaultEndpointsProtocol=http;" +
+            "AccountName=devstoreaccount1;" +
+            $"AccountKey={DevAccountKey};" +
+            "BlobEndpoint=http://127.0.0.1:20000/devstoreaccount1;" +
+            "QueueEndpoint=http://127.0.0.1:20001/devstoreaccount1;" +
+            "TableEndpoint=http://127.0.0.1:20002/devstoreaccount1;";
+
+        var result = _classifier.Classify(cs);
+
+        Assert.Equal(AzureWebJobsStorageClassification.ManageableAzurite, result.Classification);
+        Assert.Equal(20000, result.Endpoints!.BlobEndpoint.Port);
+    }
+
+    [Fact]
+    public void Classify_HttpsLocalEndpoints_IsUserConfigured()
+    {
+        var cs = "DefaultEndpointsProtocol=https;" +
+            "AccountName=devstoreaccount1;" +
+            $"AccountKey={DevAccountKey};" +
+            "BlobEndpoint=https://localhost:10000/devstoreaccount1;" +
+            "QueueEndpoint=https://localhost:10001/devstoreaccount1;" +
+            "TableEndpoint=https://localhost:10002/devstoreaccount1;";
+
+        var result = _classifier.Classify(cs);
+
+        Assert.Equal(AzureWebJobsStorageClassification.UserConfiguredAzurite, result.Classification);
+    }
+
+    [Fact]
+    public void Classify_CustomAccountNameLocalEndpoints_IsUserConfigured()
+    {
+        var cs = "DefaultEndpointsProtocol=http;" +
+            "AccountName=account1;" +
+            $"AccountKey={DevAccountKey};" +
+            "BlobEndpoint=http://127.0.0.1:10000/account1;" +
+            "QueueEndpoint=http://127.0.0.1:10001/account1;" +
+            "TableEndpoint=http://127.0.0.1:10002/account1;";
+
+        var result = _classifier.Classify(cs);
+
+        Assert.Equal(AzureWebJobsStorageClassification.UserConfiguredAzurite, result.Classification);
+        Assert.NotNull(result.Endpoints);
+        Assert.Equal("account1", result.Endpoints!.AccountName);
+    }
+
+    [Fact]
+    public void Classify_ProductStyleLocalhost_IsUserConfigured()
+    {
+        var cs = "DefaultEndpointsProtocol=http;" +
+            "AccountName=account1;" +
+            $"AccountKey={DevAccountKey};" +
+            "BlobEndpoint=http://account1.blob.localhost:10000;" +
+            "QueueEndpoint=http://account1.queue.localhost:10001;" +
+            "TableEndpoint=http://account1.table.localhost:10002;";
+
+        var result = _classifier.Classify(cs);
+
+        Assert.Equal(AzureWebJobsStorageClassification.UserConfiguredAzurite, result.Classification);
+    }
+
+    [Fact]
+    public void Classify_PartialLocalEndpoints_IsUserConfigured()
+    {
+        var cs = "DefaultEndpointsProtocol=http;" +
+            "BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;" +
+            "QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;";
+
+        var result = _classifier.Classify(cs);
+
+        Assert.Equal(AzureWebJobsStorageClassification.UserConfiguredAzurite, result.Classification);
+        Assert.Null(result.Endpoints);
+    }
+
+    [Fact]
+    public void Classify_AzureCloudConnectionString_IsNotLocal()
+    {
+        var cs = $"DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey={DevAccountKey};" +
+            "EndpointSuffix=core.windows.net";
+
+        var result = _classifier.Classify(cs);
+
+        Assert.Equal(AzureWebJobsStorageClassification.NotLocal, result.Classification);
+    }
+
+    [Fact]
+    public void Classify_SasConnectionString_IsNotLocal()
+    {
+        var cs = "BlobEndpoint=https://myaccount.blob.core.windows.net;SharedAccessSignature=sv=2024";
+
+        var result = _classifier.Classify(cs);
+
+        Assert.Equal(AzureWebJobsStorageClassification.NotLocal, result.Classification);
+    }
+
+    [Fact]
+    public void Classify_ExplicitCloudEndpoints_IsNotLocal()
+    {
+        var cs = "DefaultEndpointsProtocol=https;" +
+            $"AccountName=myaccount;AccountKey={DevAccountKey};" +
+            "BlobEndpoint=https://myaccount.blob.core.windows.net;" +
+            "QueueEndpoint=https://myaccount.queue.core.windows.net;" +
+            "TableEndpoint=https://myaccount.table.core.windows.net;";
+
+        var result = _classifier.Classify(cs);
+
+        Assert.Equal(AzureWebJobsStorageClassification.NotLocal, result.Classification);
+    }
+
+    [Fact]
+    public void Classify_MixedLocalAndCloudEndpoints_IsNotLocal()
+    {
+        var cs = "BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;" +
+            "QueueEndpoint=https://myaccount.queue.core.windows.net;" +
+            "TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;";
+
+        var result = _classifier.Classify(cs);
+
+        Assert.Equal(AzureWebJobsStorageClassification.NotLocal, result.Classification);
+    }
+
+    [Fact]
+    public void Classify_KeysAreCaseInsensitive()
+    {
+        var cs = "BLOBENDPOINT=http://127.0.0.1:10000/devstoreaccount1;" +
+            "queueendpoint=http://127.0.0.1:10001/devstoreaccount1;" +
+            "TableEndPoint=http://127.0.0.1:10002/devstoreaccount1;";
+
+        var result = _classifier.Classify(cs);
+
+        Assert.Equal(AzureWebJobsStorageClassification.ManageableAzurite, result.Classification);
+    }
+
+    [Fact]
+    public void Classify_ExtraSemicolonsAndWhitespace_AreTolerated()
+    {
+        var cs = ";; BlobEndpoint = http://127.0.0.1:10000/devstoreaccount1 ;; " +
+            " QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1; " +
+            "TableEndpoint=http://127.0.0.1:10002/devstoreaccount1 ; ;";
+
+        var result = _classifier.Classify(cs);
+
+        Assert.Equal(AzureWebJobsStorageClassification.ManageableAzurite, result.Classification);
+        Assert.Equal("devstoreaccount1", result.Endpoints!.AccountName);
+    }
+
+    [Fact]
+    public void Classify_AccountKeyContainingEqualsSigns_ParsesCorrectly()
+    {
+        var cs = $"AccountName=devstoreaccount1;AccountKey={DevAccountKey};" +
+            "BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;" +
+            "QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;" +
+            "TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;";
+
+        var result = _classifier.Classify(cs);
+
+        Assert.Equal(AzureWebJobsStorageClassification.ManageableAzurite, result.Classification);
+    }
+
+    [Theory]
+    [InlineData("localhost")]
+    [InlineData("LOCALHOST")]
+    [InlineData("127.0.0.1")]
+    [InlineData("[::1]")]
+    [InlineData("host.docker.internal")]
+    [InlineData("foo.localhost")]
+    [InlineData("account1.blob.localhost")]
+    public void IsLocalHost_RecognizesLocalHosts(string host)
+        => Assert.True(AzureWebJobsStorageClassifier.IsLocalHost(host));
+
+    [Theory]
+    [InlineData("myaccount.blob.core.windows.net")]
+    [InlineData("example.com")]
+    [InlineData("")]
+    [InlineData("10.0.0.1")]
+    public void IsLocalHost_RejectsNonLocalHosts(string host)
+        => Assert.False(AzureWebJobsStorageClassifier.IsLocalHost(host));
+
+    [Fact]
+    public void Classify_LocalhostByName_IsManageable()
+    {
+        var cs = "BlobEndpoint=http://localhost:10000/devstoreaccount1;" +
+            "QueueEndpoint=http://localhost:10001/devstoreaccount1;" +
+            "TableEndpoint=http://localhost:10002/devstoreaccount1;";
+
+        var result = _classifier.Classify(cs);
+
+        Assert.Equal(AzureWebJobsStorageClassification.ManageableAzurite, result.Classification);
+    }
+
+    [Fact]
+    public void Classify_AccountNameMismatchWithEndpointPath_IsUserConfigured()
+    {
+        var cs = "AccountName=devstoreaccount1;" +
+            "BlobEndpoint=http://127.0.0.1:10000/otheraccount;" +
+            "QueueEndpoint=http://127.0.0.1:10001/otheraccount;" +
+            "TableEndpoint=http://127.0.0.1:10002/otheraccount;";
+
+        var result = _classifier.Classify(cs);
+
+        Assert.Equal(AzureWebJobsStorageClassification.UserConfiguredAzurite, result.Classification);
+    }
+
+    [Fact]
+    public void Classify_MalformedSegment_IsNotLocal()
+    {
+        var result = _classifier.Classify("garbage-without-equals");
+
+        Assert.Equal(AzureWebJobsStorageClassification.NotLocal, result.Classification);
+    }
+}


### PR DESCRIPTION
First slice of the managed-Azurite feature. Design doc: #5015.

This PR is intentionally narrow: it adds the pure parser + classifier and nothing else. No wiring into `func start`, no probe, no process / Docker management. Those land in follow-up slices once this contract is reviewed.

## What's here

Under `src/Func/Commands/Start/Azurite/`:

- `AzureWebJobsStorageClassification` — enum: `NotLocal`, `ManageableAzurite`, `UserConfiguredAzurite`.
- `AzuriteEndpointTuple` — blob / queue / table URIs + account name.
- `AzureWebJobsStorageReference` — result record (classification + optional endpoints + reason).
- `IAzureWebJobsStorageClassifier` + `AzureWebJobsStorageClassifier` — pure, no I/O.

## Classification rules

Matches §6 and §16.1 of the design doc:

| Input | Result |
| --- | --- |
| `UseDevelopmentStorage=true` (no proxy) | `ManageableAzurite` |
| `UseDevelopmentStorage=true;DevelopmentStorageProxyUri=...` | `UserConfiguredAzurite` |
| Explicit HTTP `devstoreaccount1` endpoints on local hosts (default or custom ports) | `ManageableAzurite` |
| HTTPS local endpoints | `UserConfiguredAzurite` |
| Custom account name on local hosts | `UserConfiguredAzurite` |
| Production-style `*.localhost` subdomains | `UserConfiguredAzurite` |
| Partial endpoints (missing blob/queue/table) | `UserConfiguredAzurite` |
| Azure cloud, SAS, mixed local/cloud, malformed, empty | `NotLocal` |

Local hosts: `localhost`, `127.0.0.1`, `::1`, `[::1]`, `*.localhost`, `host.docker.internal`.

## Tests

33 new tests in `AzureWebJobsStorageClassifierTests`, covering every bullet in §16.1: positive shapes, negative shapes, case-insensitive keys, whitespace / extra semicolons, account-key segments containing `=`, account-name mismatches, and the local-host matcher.

Full `Func.Tests` suite (690) green on Release.

## Out of scope (follow-up slices)

- HTTP probe service (Ready / NotListening / PortConflict / Partial).
- Azurite executable + Docker discovery.
- Native and Docker startup.
- Scope ID derivation, lease files, metadata.
- `--no-azurite` option and `StartCommand` wiring.
- User-facing output via `IInteractionService`.

### Pull request checklist

- [x] My changes **do not** require documentation changes (no user-facing surface yet)
- [x] My changes **do not** need to be backported to a previous version
- [x] My changes **should not** be added to the release notes for the next release (no user-visible behavior)
- [x] I have added all required tests for this slice (unit tests)