### PR TITLE
Add Azurite HTTP probe service

### DIFF
--- a/src/Func/Commands/Start/Azurite/AzuriteEndpointProbeOutcome.cs
+++ b/src/Func/Commands/Start/Azurite/AzuriteEndpointProbeOutcome.cs
@@ -1,0 +1,60 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite;
+
+/// <summary>
+/// Identifies the Azurite service an endpoint was probed for.
+/// </summary>
+internal enum AzuriteService
+{
+    Blob,
+    Queue,
+    Table,
+}
+
+/// <summary>
+/// Per-endpoint probe classification. Mirrors <see cref="AzuriteProbeStatus"/>
+/// minus <see cref="AzuriteProbeStatus.Partial"/>, which only makes sense as
+/// an aggregate.
+/// </summary>
+internal enum AzuriteEndpointStatus
+{
+    /// <summary>
+    /// The endpoint responded with markers that identify it as Azure Storage
+    /// (Azurite or otherwise): an <c>x-ms-request-id</c> or
+    /// <c>x-ms-error-code</c> header, a <c>Server</c> header that contains
+    /// "Azurite", or a storage-style error payload.
+    /// </summary>
+    Ready,
+
+    /// <summary>
+    /// The TCP connection was refused or otherwise unreachable.
+    /// </summary>
+    NotListening,
+
+    /// <summary>
+    /// The endpoint responded, but the response did not look like Azure
+    /// Storage. Something else is listening on the port.
+    /// </summary>
+    PortConflict,
+}
+
+/// <summary>
+/// Result of probing a single Azurite service endpoint.
+/// </summary>
+/// <param name="Service">Service the endpoint hosts.</param>
+/// <param name="Endpoint">Endpoint URI that was probed.</param>
+/// <param name="Status">Classification of the response.</param>
+/// <param name="HttpStatusCode">HTTP status code, when the endpoint responded.</param>
+/// <param name="RequestId"><c>x-ms-request-id</c> header value, when present.</param>
+/// <param name="ErrorCode"><c>x-ms-error-code</c> header value, when present.</param>
+/// <param name="Detail">Optional human-readable diagnostic detail.</param>
+internal sealed record AzuriteEndpointProbeOutcome(
+    AzuriteService Service,
+    Uri Endpoint,
+    AzuriteEndpointStatus Status,
+    int? HttpStatusCode = null,
+    string? RequestId = null,
+    string? ErrorCode = null,
+    string? Detail = null);

--- a/src/Func/Commands/Start/Azurite/AzuriteProbe.cs
+++ b/src/Func/Commands/Start/Azurite/AzuriteProbe.cs
@@ -1,0 +1,379 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Net.Http.Headers;
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Xml.Linq;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite;
+
+/// <inheritdoc cref="IAzuriteProbe" />
+internal sealed class AzuriteProbe(
+    IHttpClientFactory httpClientFactory,
+    ILogger<AzuriteProbe> logger) : IAzuriteProbe
+{
+    /// <summary>
+    /// Name of the <see cref="HttpClient"/> registered in DI for the probe.
+    /// </summary>
+    internal const string HttpClientName = "AzuriteProbe";
+
+    /// <summary>
+    /// Storage REST API version sent with every probe request.
+    /// </summary>
+    internal const string StorageApiVersion = "2021-12-02";
+
+    /// <summary>
+    /// Per-request timeout. Short by design so an unresponsive port does not
+    /// stall the overall probe.
+    /// </summary>
+    internal static readonly TimeSpan PerRequestTimeout = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// Maximum number of bytes inspected from a response body when looking for
+    /// an Azure Storage error payload.
+    /// </summary>
+    private const int MaxBodyInspectBytes = 8 * 1024;
+
+    private readonly IHttpClientFactory _httpClientFactory =
+        httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+
+    private readonly ILogger<AzuriteProbe> _logger =
+        logger ?? throw new ArgumentNullException(nameof(logger));
+
+    public async Task<AzuriteProbeResult> ProbeAsync(
+        AzuriteEndpointTuple endpoints,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        Task<AzuriteEndpointProbeOutcome> blobTask = ProbeServiceAsync(
+            AzuriteService.Blob,
+            BuildBlobProbeUri(endpoints.BlobEndpoint),
+            endpoints.BlobEndpoint,
+            cancellationToken);
+
+        Task<AzuriteEndpointProbeOutcome> queueTask = ProbeServiceAsync(
+            AzuriteService.Queue,
+            BuildQueueProbeUri(endpoints.QueueEndpoint),
+            endpoints.QueueEndpoint,
+            cancellationToken);
+
+        Task<AzuriteEndpointProbeOutcome> tableTask = ProbeServiceAsync(
+            AzuriteService.Table,
+            BuildTableProbeUri(endpoints.TableEndpoint),
+            endpoints.TableEndpoint,
+            cancellationToken);
+
+        AzuriteEndpointProbeOutcome[] outcomes = await Task.WhenAll(blobTask, queueTask, tableTask)
+            .ConfigureAwait(false);
+
+        var result = AzuriteProbeResult.From(outcomes);
+        _logger.LogDebug(
+            "Azurite probe completed with status {ProbeStatus}: {ProbeReason}",
+            result.Status,
+            result.Reason);
+        return result;
+    }
+
+    internal static Uri BuildBlobProbeUri(Uri blob) => AppendQuery(blob, "comp=list");
+
+    internal static Uri BuildQueueProbeUri(Uri queue) => AppendQuery(queue, "comp=list");
+
+    internal static Uri BuildTableProbeUri(Uri table)
+    {
+        UriBuilder builder = new(table);
+        string path = builder.Path;
+        if (!path.EndsWith('/'))
+        {
+            path += "/";
+        }
+
+        builder.Path = path + "Tables";
+        builder.Query = string.Empty;
+        return builder.Uri;
+    }
+
+    private static Uri AppendQuery(Uri endpoint, string query)
+    {
+        UriBuilder builder = new(endpoint);
+        if (string.IsNullOrEmpty(builder.Query))
+        {
+            builder.Query = query;
+        }
+        else
+        {
+            builder.Query = builder.Query.TrimStart('?') + "&" + query;
+        }
+
+        return builder.Uri;
+    }
+
+    private async Task<AzuriteEndpointProbeOutcome> ProbeServiceAsync(
+        AzuriteService service,
+        Uri probeUri,
+        Uri originalEndpoint,
+        CancellationToken cancellationToken)
+    {
+        HttpClient client = _httpClientFactory.CreateClient(HttpClientName);
+
+        using HttpRequestMessage request = new(HttpMethod.Get, probeUri);
+        request.Headers.TryAddWithoutValidation("x-ms-version", StorageApiVersion);
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(PerRequestTimeout);
+
+        try
+        {
+            using HttpResponseMessage response = await client
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, timeoutCts.Token)
+                .ConfigureAwait(false);
+
+            string? requestId = TryGetSingleHeader(response.Headers, "x-ms-request-id");
+            string? errorCode = TryGetSingleHeader(response.Headers, "x-ms-error-code");
+            bool serverIsAzurite = ServerHeaderContainsAzurite(response.Headers.Server);
+
+            bool storageShaped = requestId is not null || errorCode is not null || serverIsAzurite;
+
+            if (!storageShaped)
+            {
+                storageShaped = await BodyLooksLikeStorageErrorAsync(response, timeoutCts.Token)
+                    .ConfigureAwait(false);
+            }
+
+            AzuriteEndpointStatus status = storageShaped
+                ? AzuriteEndpointStatus.Ready
+                : AzuriteEndpointStatus.PortConflict;
+
+            _logger.LogDebug(
+                "Probed {Service} endpoint {Endpoint}: HTTP {StatusCode}, ready={Ready}",
+                service,
+                originalEndpoint,
+                (int)response.StatusCode,
+                storageShaped);
+
+            return new AzuriteEndpointProbeOutcome(
+                service,
+                originalEndpoint,
+                status,
+                HttpStatusCode: (int)response.StatusCode,
+                RequestId: requestId,
+                ErrorCode: errorCode);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogDebug(
+                "Probe for {Service} endpoint {Endpoint} timed out after {TimeoutSeconds}s",
+                service,
+                originalEndpoint,
+                PerRequestTimeout.TotalSeconds);
+            return new AzuriteEndpointProbeOutcome(
+                service,
+                originalEndpoint,
+                AzuriteEndpointStatus.NotListening,
+                Detail: $"Probe timed out after {PerRequestTimeout.TotalSeconds:F0}s.");
+        }
+        catch (HttpRequestException ex) when (IsConnectionRefused(ex))
+        {
+            _logger.LogDebug(
+                ex,
+                "Probe for {Service} endpoint {Endpoint} was refused",
+                service,
+                originalEndpoint);
+            return new AzuriteEndpointProbeOutcome(
+                service,
+                originalEndpoint,
+                AzuriteEndpointStatus.NotListening,
+                Detail: ex.Message);
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogDebug(
+                ex,
+                "Probe for {Service} endpoint {Endpoint} failed",
+                service,
+                originalEndpoint);
+            return new AzuriteEndpointProbeOutcome(
+                service,
+                originalEndpoint,
+                AzuriteEndpointStatus.NotListening,
+                Detail: ex.Message);
+        }
+    }
+
+    private static bool IsConnectionRefused(HttpRequestException ex)
+    {
+        for (Exception? current = ex; current is not null; current = current.InnerException)
+        {
+            if (current is SocketException sock)
+            {
+                return sock.SocketErrorCode is SocketError.ConnectionRefused
+                    or SocketError.HostUnreachable
+                    or SocketError.NetworkUnreachable
+                    or SocketError.HostNotFound
+                    or SocketError.TryAgain;
+            }
+        }
+
+        return false;
+    }
+
+    private static string? TryGetSingleHeader(HttpResponseHeaders headers, string name)
+    {
+        if (headers.TryGetValues(name, out IEnumerable<string>? values))
+        {
+            foreach (string value in values)
+            {
+                if (!string.IsNullOrEmpty(value))
+                {
+                    return value;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static bool ServerHeaderContainsAzurite(HttpHeaderValueCollection<ProductInfoHeaderValue> server)
+    {
+        foreach (ProductInfoHeaderValue value in server)
+        {
+            if (value.Product is { } product &&
+                product.Name.Contains("Azurite", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static async Task<bool> BodyLooksLikeStorageErrorAsync(
+        HttpResponseMessage response,
+        CancellationToken cancellationToken)
+    {
+        if (response.Content is null)
+        {
+            return false;
+        }
+
+        string body;
+        try
+        {
+            await using Stream stream = await response.Content
+                .ReadAsStreamAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            byte[] buffer = new byte[MaxBodyInspectBytes];
+            int read = await ReadUpToAsync(stream, buffer, cancellationToken).ConfigureAwait(false);
+            if (read <= 0)
+            {
+                return false;
+            }
+
+            body = System.Text.Encoding.UTF8.GetString(buffer, 0, read);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            // Body inspection is best-effort: if we cannot read it, fall back to
+            // header-only signals (already checked by the caller).
+            return false;
+        }
+
+        string trimmed = body.TrimStart();
+        if (trimmed.StartsWith('<'))
+        {
+            return XmlLooksLikeStorageError(trimmed);
+        }
+
+        if (trimmed.StartsWith('{'))
+        {
+            return JsonLooksLikeStorageError(trimmed);
+        }
+
+        return false;
+    }
+
+    private static async Task<int> ReadUpToAsync(
+        Stream stream,
+        byte[] buffer,
+        CancellationToken cancellationToken)
+    {
+        int total = 0;
+        while (total < buffer.Length)
+        {
+            int read = await stream
+                .ReadAsync(buffer.AsMemory(total, buffer.Length - total), cancellationToken)
+                .ConfigureAwait(false);
+            if (read == 0)
+            {
+                break;
+            }
+
+            total += read;
+        }
+
+        return total;
+    }
+
+    private static bool XmlLooksLikeStorageError(string body)
+    {
+        try
+        {
+            var doc = XDocument.Parse(body);
+            XElement? root = doc.Root;
+            if (root is null || !string.Equals(root.Name.LocalName, "Error", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            foreach (XElement child in root.Elements())
+            {
+                if (string.Equals(child.Name.LocalName, "Code", StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+        catch (System.Xml.XmlException)
+        {
+            return false;
+        }
+    }
+
+    private static bool JsonLooksLikeStorageError(string body)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                return false;
+            }
+
+            if (!doc.RootElement.TryGetProperty("error", out JsonElement error) ||
+                error.ValueKind != JsonValueKind.Object)
+            {
+                return false;
+            }
+
+            return error.TryGetProperty("code", out JsonElement code) &&
+                code.ValueKind == JsonValueKind.String;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+}

--- a/src/Func/Commands/Start/Azurite/AzuriteProbeResult.cs
+++ b/src/Func/Commands/Start/Azurite/AzuriteProbeResult.cs
@@ -1,0 +1,118 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Collections.Immutable;
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite;
+
+/// <summary>
+/// Aggregate result of probing an Azurite endpoint tuple.
+/// </summary>
+internal sealed record AzuriteProbeResult
+{
+    public required AzuriteProbeStatus Status { get; init; }
+
+    /// <summary>
+    /// Per-endpoint outcomes in Blob / Queue / Table order.
+    /// </summary>
+    public required ImmutableArray<AzuriteEndpointProbeOutcome> Endpoints { get; init; }
+
+    /// <summary>
+    /// Short human-readable explanation, suitable for verbose logging.
+    /// </summary>
+    public string? Reason { get; init; }
+
+    public static AzuriteProbeResult From(
+        IEnumerable<AzuriteEndpointProbeOutcome> outcomes,
+        string? reason = null)
+    {
+        ArgumentNullException.ThrowIfNull(outcomes);
+
+        ImmutableArray<AzuriteEndpointProbeOutcome> array = [.. outcomes];
+        AzuriteProbeStatus status = Classify(array);
+        return new AzuriteProbeResult
+        {
+            Status = status,
+            Endpoints = array,
+            Reason = reason ?? DescribeReason(status, array),
+        };
+    }
+
+    private static AzuriteProbeStatus Classify(ImmutableArray<AzuriteEndpointProbeOutcome> outcomes)
+    {
+        if (outcomes.IsDefaultOrEmpty)
+        {
+            return AzuriteProbeStatus.NotListening;
+        }
+
+        bool allReady = true;
+        bool allNotListening = true;
+        bool allPortConflict = true;
+
+        foreach (AzuriteEndpointProbeOutcome outcome in outcomes)
+        {
+            switch (outcome.Status)
+            {
+                case AzuriteEndpointStatus.Ready:
+                    allNotListening = false;
+                    allPortConflict = false;
+                    break;
+                case AzuriteEndpointStatus.NotListening:
+                    allReady = false;
+                    allPortConflict = false;
+                    break;
+                case AzuriteEndpointStatus.PortConflict:
+                    allReady = false;
+                    allNotListening = false;
+                    break;
+            }
+        }
+
+        if (allReady)
+        {
+            return AzuriteProbeStatus.Ready;
+        }
+
+        if (allNotListening)
+        {
+            return AzuriteProbeStatus.NotListening;
+        }
+
+        if (allPortConflict)
+        {
+            return AzuriteProbeStatus.PortConflict;
+        }
+
+        return AzuriteProbeStatus.Partial;
+    }
+
+    private static string DescribeReason(
+        AzuriteProbeStatus status,
+        ImmutableArray<AzuriteEndpointProbeOutcome> outcomes)
+    {
+        return status switch
+        {
+            AzuriteProbeStatus.Ready =>
+                "All Azurite endpoints returned storage-shaped responses.",
+            AzuriteProbeStatus.NotListening =>
+                "No process is listening on the Azurite endpoints.",
+            AzuriteProbeStatus.PortConflict =>
+                "Azurite endpoints responded but no responses were storage-shaped; another process is on the ports.",
+            AzuriteProbeStatus.Partial =>
+                $"Mixed Azurite endpoint readiness ({Summarize(outcomes)}).",
+            _ => string.Empty,
+        };
+    }
+
+    private static string Summarize(ImmutableArray<AzuriteEndpointProbeOutcome> outcomes)
+    {
+        string[] parts = new string[outcomes.Length];
+        for (int i = 0; i < outcomes.Length; i++)
+        {
+            AzuriteEndpointProbeOutcome o = outcomes[i];
+            parts[i] = $"{o.Service}={o.Status}";
+        }
+
+        return string.Join(", ", parts);
+    }
+}

--- a/src/Func/Commands/Start/Azurite/AzuriteProbeStatus.cs
+++ b/src/Func/Commands/Start/Azurite/AzuriteProbeStatus.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite;
+
+/// <summary>
+/// Overall result of probing an Azurite endpoint tuple. Mirrors the table in
+/// §7.6 of the managed-Azurite design.
+/// </summary>
+internal enum AzuriteProbeStatus
+{
+    /// <summary>
+    /// All required endpoints returned storage-shaped responses.
+    /// </summary>
+    Ready,
+
+    /// <summary>
+    /// No process accepts connections on any of the required endpoints.
+    /// </summary>
+    NotListening,
+
+    /// <summary>
+    /// Every required endpoint responded, but none returned a storage-shaped
+    /// response. A non-storage service is occupying the ports.
+    /// </summary>
+    PortConflict,
+
+    /// <summary>
+    /// A mix of ready, not-listening, and/or non-storage responses across the
+    /// required endpoints.
+    /// </summary>
+    Partial,
+}

--- a/src/Func/Commands/Start/Azurite/AzuriteServiceCollectionExtensions.cs
+++ b/src/Func/Commands/Start/Azurite/AzuriteServiceCollectionExtensions.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite;
+
+/// <summary>
+/// DI registration helpers for the managed-Azurite feature. Not wired into the
+/// CLI host yet; later slices will call this from the composition root.
+/// </summary>
+internal static class AzuriteServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <see cref="IAzuriteProbe"/> and its named <see cref="HttpClient"/>.
+    /// </summary>
+    public static IServiceCollection AddAzuriteProbe(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddHttpClient(AzuriteProbe.HttpClientName, static client =>
+        {
+            // Cover connect + send + receive headers for a single probe. The
+            // probe itself also enforces a per-request timeout via a linked
+            // CancellationTokenSource so callers can preempt sooner.
+            client.Timeout = AzuriteProbe.PerRequestTimeout;
+        });
+
+        services.AddSingleton<IAzuriteProbe, AzuriteProbe>();
+        return services;
+    }
+}

--- a/src/Func/Commands/Start/Azurite/IAzuriteProbe.cs
+++ b/src/Func/Commands/Start/Azurite/IAzuriteProbe.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite;
+
+/// <summary>
+/// Probes Azurite blob, queue, and table endpoints using HTTP only and reports
+/// whether the emulator is ready, not listening, or being shadowed by another
+/// process on the ports.
+/// </summary>
+internal interface IAzuriteProbe
+{
+    /// <summary>
+    /// Probes <paramref name="endpoints"/> in parallel.
+    /// </summary>
+    /// <param name="endpoints">Endpoint tuple to probe. Must not be null.</param>
+    /// <param name="cancellationToken">Cancellation token for the overall probe.</param>
+    public Task<AzuriteProbeResult> ProbeAsync(
+        AzuriteEndpointTuple endpoints,
+        CancellationToken cancellationToken);
+}

--- a/test/Func.Tests/Commands/Start/Azurite/AzuriteProbeTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/AzuriteProbeTests.cs
@@ -1,0 +1,351 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using Azure.Functions.Cli.Commands.Start.Azurite;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Commands.Start.Azurite;
+
+public class AzuriteProbeTests : IAsyncLifetime
+{
+    private readonly List<IDisposable> _disposables = [];
+    private ServiceProvider? _services;
+
+    public Task InitializeAsync()
+    {
+        var collection = new ServiceCollection();
+        collection.AddAzuriteProbe();
+        _services = collection.BuildServiceProvider();
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        foreach (var disposable in _disposables)
+        {
+            try
+            {
+                disposable.Dispose();
+            }
+            catch
+            {
+                // Best effort cleanup: a server may have already faulted.
+            }
+        }
+
+        if (_services is not null)
+        {
+            await _services.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task ProbeAsync_AllEndpointsReady_ViaRequestIdHeader_ReturnsReady()
+    {
+        var (blob, blobUri) = StartServer(static ctx =>
+        {
+            ctx.Response.Headers.Add("x-ms-request-id", "abc-123");
+            ctx.Response.StatusCode = 400;
+        });
+        var (queue, queueUri) = StartServer(static ctx =>
+        {
+            ctx.Response.Headers.Add("x-ms-request-id", "def-456");
+            ctx.Response.StatusCode = 403;
+        });
+        var (table, tableUri) = StartServer(static ctx =>
+        {
+            ctx.Response.Headers.Add("x-ms-request-id", "ghi-789");
+            ctx.Response.StatusCode = 200;
+        });
+        _disposables.Add(blob);
+        _disposables.Add(queue);
+        _disposables.Add(table);
+
+        var probe = _services!.GetRequiredService<IAzuriteProbe>();
+        var endpoints = new AzuriteEndpointTuple(blobUri, queueUri, tableUri, "devstoreaccount1");
+
+        var result = await probe.ProbeAsync(endpoints, CancellationToken.None);
+
+        Assert.Equal(AzuriteProbeStatus.Ready, result.Status);
+        Assert.All(result.Endpoints, o =>
+            Assert.Equal(AzuriteEndpointStatus.Ready, o.Status));
+        Assert.Contains(result.Endpoints, o => o.RequestId == "abc-123");
+    }
+
+    [Fact]
+    public async Task ProbeAsync_EndpointReady_ViaErrorCodeHeader_IsRecognized()
+    {
+        var (server, uri) = StartServer(static ctx =>
+        {
+            ctx.Response.Headers.Add("x-ms-error-code", "AuthenticationFailed");
+            ctx.Response.StatusCode = 403;
+        });
+        _disposables.Add(server);
+
+        var outcome = await ProbeSingleAsync(uri);
+
+        Assert.Equal(AzuriteEndpointStatus.Ready, outcome.Status);
+        Assert.Equal("AuthenticationFailed", outcome.ErrorCode);
+    }
+
+    [Fact]
+    public async Task ProbeAsync_EndpointReady_ViaAzuriteServerHeader_IsRecognized()
+    {
+        var (server, uri) = StartServer(static ctx =>
+        {
+            // HttpListener owns the Server header; allow user overrides.
+            ctx.Response.Headers.Remove("Server");
+            ctx.Response.Headers.Add("Server", "Azurite-Blob/3.35.0");
+            ctx.Response.StatusCode = 200;
+        });
+        _disposables.Add(server);
+
+        var outcome = await ProbeSingleAsync(uri);
+
+        Assert.Equal(AzuriteEndpointStatus.Ready, outcome.Status);
+    }
+
+    [Fact]
+    public async Task ProbeAsync_PlainHttpResponse_WithNoStorageHeaders_IsPortConflict()
+    {
+        var (blob, blobUri) = StartServer(WritePlainOk);
+        var (queue, queueUri) = StartServer(WritePlainOk);
+        var (table, tableUri) = StartServer(WritePlainOk);
+        _disposables.Add(blob);
+        _disposables.Add(queue);
+        _disposables.Add(table);
+
+        var probe = _services!.GetRequiredService<IAzuriteProbe>();
+        var endpoints = new AzuriteEndpointTuple(blobUri, queueUri, tableUri, "devstoreaccount1");
+
+        var result = await probe.ProbeAsync(endpoints, CancellationToken.None);
+
+        Assert.Equal(AzuriteProbeStatus.PortConflict, result.Status);
+        Assert.All(result.Endpoints, o =>
+            Assert.Equal(AzuriteEndpointStatus.PortConflict, o.Status));
+    }
+
+    [Fact]
+    public async Task ProbeAsync_AllEndpointsRefused_IsNotListening()
+    {
+        // Reserve and release three ports so connections are refused immediately.
+        var blobUri = NewUriOnUnusedPort();
+        var queueUri = NewUriOnUnusedPort();
+        var tableUri = NewUriOnUnusedPort();
+
+        var probe = _services!.GetRequiredService<IAzuriteProbe>();
+        var endpoints = new AzuriteEndpointTuple(blobUri, queueUri, tableUri, "devstoreaccount1");
+
+        var result = await probe.ProbeAsync(endpoints, CancellationToken.None);
+
+        Assert.Equal(AzuriteProbeStatus.NotListening, result.Status);
+        Assert.All(result.Endpoints, o =>
+            Assert.Equal(AzuriteEndpointStatus.NotListening, o.Status));
+    }
+
+    [Fact]
+    public async Task ProbeAsync_TwoReadyOneRefused_IsPartial()
+    {
+        var (blob, blobUri) = StartServer(static ctx =>
+        {
+            ctx.Response.Headers.Add("x-ms-request-id", "abc");
+            ctx.Response.StatusCode = 400;
+        });
+        var (queue, queueUri) = StartServer(static ctx =>
+        {
+            ctx.Response.Headers.Add("x-ms-request-id", "def");
+            ctx.Response.StatusCode = 400;
+        });
+        _disposables.Add(blob);
+        _disposables.Add(queue);
+
+        var tableUri = NewUriOnUnusedPort();
+
+        var probe = _services!.GetRequiredService<IAzuriteProbe>();
+        var endpoints = new AzuriteEndpointTuple(blobUri, queueUri, tableUri, "devstoreaccount1");
+
+        var result = await probe.ProbeAsync(endpoints, CancellationToken.None);
+
+        Assert.Equal(AzuriteProbeStatus.Partial, result.Status);
+
+        var byService = result.Endpoints.ToDictionary(o => o.Service);
+        Assert.Equal(AzuriteEndpointStatus.Ready, byService[AzuriteService.Blob].Status);
+        Assert.Equal(AzuriteEndpointStatus.Ready, byService[AzuriteService.Queue].Status);
+        Assert.Equal(AzuriteEndpointStatus.NotListening, byService[AzuriteService.Table].Status);
+    }
+
+    [Fact]
+    public async Task ProbeAsync_NotListeningAndPortConflict_IsPartial()
+    {
+        // One endpoint refused + two non-storage responders: not "all PortConflict",
+        // not "all NotListening", so must aggregate to Partial.
+        var blobUri = NewUriOnUnusedPort();
+        var (queue, queueUri) = StartServer(WritePlainOk);
+        var (table, tableUri) = StartServer(WritePlainOk);
+        _disposables.Add(queue);
+        _disposables.Add(table);
+
+        var probe = _services!.GetRequiredService<IAzuriteProbe>();
+        var endpoints = new AzuriteEndpointTuple(blobUri, queueUri, tableUri, "devstoreaccount1");
+
+        var result = await probe.ProbeAsync(endpoints, CancellationToken.None);
+
+        Assert.Equal(AzuriteProbeStatus.Partial, result.Status);
+
+        var byService = result.Endpoints.ToDictionary(o => o.Service);
+        Assert.Equal(AzuriteEndpointStatus.NotListening, byService[AzuriteService.Blob].Status);
+        Assert.Equal(AzuriteEndpointStatus.PortConflict, byService[AzuriteService.Queue].Status);
+        Assert.Equal(AzuriteEndpointStatus.PortConflict, byService[AzuriteService.Table].Status);
+    }
+
+    [Fact]
+    public async Task ProbeAsync_AlreadyCancelledToken_Throws()
+    {
+        var blobUri = NewUriOnUnusedPort();
+        var queueUri = NewUriOnUnusedPort();
+        var tableUri = NewUriOnUnusedPort();
+
+        var probe = _services!.GetRequiredService<IAzuriteProbe>();
+        var endpoints = new AzuriteEndpointTuple(blobUri, queueUri, tableUri, "devstoreaccount1");
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => probe.ProbeAsync(endpoints, cts.Token));
+    }
+
+    private async Task<AzuriteEndpointProbeOutcome> ProbeSingleAsync(Uri uri)
+    {
+        // Use the live endpoint for one service and free ports for the other two
+        // so the per-endpoint outcome is exercised directly.
+        var others1 = NewUriOnUnusedPort();
+        var others2 = NewUriOnUnusedPort();
+
+        var probe = _services!.GetRequiredService<IAzuriteProbe>();
+        var endpoints = new AzuriteEndpointTuple(uri, others1, others2, "devstoreaccount1");
+
+        var result = await probe.ProbeAsync(endpoints, CancellationToken.None);
+        return result.Endpoints.First(o => o.Service == AzuriteService.Blob);
+    }
+
+    private static void WritePlainOk(HttpListenerContext ctx)
+    {
+        ctx.Response.StatusCode = 200;
+        var bytes = Encoding.UTF8.GetBytes("hello from a non-storage server");
+        ctx.Response.ContentLength64 = bytes.Length;
+        ctx.Response.OutputStream.Write(bytes, 0, bytes.Length);
+    }
+
+    private static (TestHttpServer Server, Uri Endpoint) StartServer(Action<HttpListenerContext> handler)
+    {
+        var port = GetFreePort();
+        var prefix = $"http://127.0.0.1:{port}/";
+        var server = new TestHttpServer(prefix, handler);
+        server.Start();
+        // Use the path-style endpoint shape the classifier produces.
+        var endpoint = new Uri($"http://127.0.0.1:{port}/devstoreaccount1");
+        return (server, endpoint);
+    }
+
+    private static Uri NewUriOnUnusedPort()
+    {
+        var port = GetFreePort();
+        return new Uri($"http://127.0.0.1:{port}/devstoreaccount1");
+    }
+
+    private static int GetFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    private sealed class TestHttpServer(string prefix, Action<HttpListenerContext> handler) : IDisposable
+    {
+        private readonly HttpListener _listener = new();
+        private readonly CancellationTokenSource _cts = new();
+        private Task? _loop;
+
+        public void Start()
+        {
+            _listener.Prefixes.Add(prefix);
+            _listener.Start();
+            _loop = Task.Run(LoopAsync);
+        }
+
+        private async Task LoopAsync()
+        {
+            while (!_cts.IsCancellationRequested)
+            {
+                HttpListenerContext ctx;
+                try
+                {
+                    ctx = await _listener.GetContextAsync();
+                }
+                catch
+                {
+                    return;
+                }
+
+                try
+                {
+                    handler(ctx);
+                }
+                catch
+                {
+                    // Tests assert via probe output; suppress handler faults.
+                }
+                finally
+                {
+                    try
+                    {
+                        ctx.Response.Close();
+                    }
+                    catch
+                    {
+                        // Connection already closed.
+                    }
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            _cts.Cancel();
+            try
+            {
+                _listener.Stop();
+            }
+            catch
+            {
+                // Already stopped.
+            }
+
+            try
+            {
+                _loop?.Wait(TimeSpan.FromSeconds(2));
+            }
+            catch
+            {
+                // Loop already exited.
+            }
+
+            ((IDisposable)_listener).Dispose();
+            _cts.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Slice 2 of the managed-Azurite feature. Implements the HTTP probe service from §7 / §16.2 of the design doc. No wiring into `func start`, no process / Docker management; those are later slices.

## What's in the slice

Under `src/Func/Commands/Start/Azurite/`:

- `AzuriteProbeStatus` enum: `Ready`, `NotListening`, `PortConflict`, `Partial` (matches the §7.6 table).
- `AzuriteService` + `AzuriteEndpointStatus` + `AzuriteEndpointProbeOutcome` record: per-endpoint result with HTTP status, request id, error code, and optional detail.
- `AzuriteProbeResult` record with `From(...)` factory that classifies the aggregate per §7.6.
- `IAzuriteProbe` / `AzuriteProbe`: `HttpClient`-only probe (no Azure Storage SDK). Uses `IHttpClientFactory` with a named `"AzuriteProbe"` client. Builds the three probes per §7.2–§7.4 (`?comp=list` for blob/queue, `/Tables` for table) with `x-ms-version: 2021-12-02`. Storage-shaped detection per §7.5 covers `x-ms-request-id` / `x-ms-error-code` headers, `Server: Azurite*`, and storage-style XML or JSON error bodies. Connection-refused / unreachable sockets map to `NotListening`; cancellation propagates. The three probes run in parallel via `Task.WhenAll`.
- `AzuriteServiceCollectionExtensions.AddAzuriteProbe`: DI helper. Defined but **not wired** into the CLI composition root yet.

## Tests

`test/Func.Tests/Commands/Start/Azurite/AzuriteProbeTests.cs` uses an in-process `HttpListener` (dependency-free, cross-platform) to cover the §16.2 cases:

- `x-ms-request-id` response → storage-shaped → `Ready`.
- `x-ms-error-code` response → storage-shaped.
- `Server: Azurite-Blob/3.35.0` header → storage-shaped.
- Plain HTTP 200 with no storage markers on all three → `PortConflict`.
- All three endpoints on unused ports → `NotListening`.
- Two ready + one refused → `Partial`.
- Already-cancelled token → `OperationCanceledException`.

## Verification

- `CI=true dotnet build -c Release`: clean (0 warnings, 0 errors).
- `dotnet test test/Func.Tests/Func.Tests.csproj -c Release`: 697 passed, 0 failed.

## Out of scope

- Wiring into `StartCommand` or any startup step.
- Process / Docker discovery and startup.
- Scope id, lease, metadata files.
- `--no-azurite` flag.
- Release notes.