### PR TITLE
Support dotnet setup stack workload

### DIFF
--- a/src/Func/Commands/Setup/SetupCommand.cs
+++ b/src/Func/Commands/Setup/SetupCommand.cs
@@ -16,9 +16,9 @@ internal sealed class SetupCommand : FuncCliCommand, IBuiltInCommand
     {
         Description =
             "Components to install. Repeatable or comma-separated. One of:\n"
-            + "  node | python | go | dotnet-isolated   full dev setup for the stack\n"
-            + "  runtime                                host + extension bundle\n"
-            + "  host                                   host only",
+            + "  node | python | go | dotnet   full dev setup for the stack\n"
+            + "  runtime                       host + extension bundle\n"
+            + "  host                          host only",
         Arity = ArgumentArity.OneOrMore,
     };
 

--- a/src/Func/Commands/Setup/SetupRenderer.cs
+++ b/src/Func/Commands/Setup/SetupRenderer.cs
@@ -74,7 +74,12 @@ internal sealed class SetupRenderer(IInteractionService interaction, SetupOutput
         {
             Dictionary<string, object?> payload = DependencyPayload(profileScope, dependency);
             payload["status"] = ToStatusText(result.Status);
-            payload["package_id"] = result.PackageId ?? dependency.ResolvedPackageId ?? dependency.PackageId;
+            string? packageId = result.PackageId ?? GetPackageId(dependency);
+            if (packageId is not null)
+            {
+                payload["package_id"] = packageId;
+            }
+
             payload["version"] = result.Version;
             payload["message"] = result.Message;
             WriteEvent("dependency.result", payload);
@@ -184,21 +189,34 @@ internal sealed class SetupRenderer(IInteractionService interaction, SetupOutput
     }
 
     private static Dictionary<string, object?> DependencyPayload(SetupProfileScope profileScope, SetupDependency dependency)
-        => new()
+    {
+        Dictionary<string, object?> payload = new()
         {
             ["profile"] = profileScope.Profile?.Name,
             ["dependency_type"] = ToDependencyKindText(dependency.Kind),
             ["name"] = dependency.Name,
-            ["package_id"] = dependency.ResolvedPackageId ?? dependency.PackageId,
             ["version_range"] = dependency.RangeText,
         };
+
+        string? packageId = GetPackageId(dependency);
+        if (packageId is not null)
+        {
+            payload["package_id"] = packageId;
+        }
+
+        return payload;
+    }
+
+    private static string? GetPackageId(SetupDependency dependency)
+        => dependency.Kind == SetupDependencyKind.Runtime ? null : dependency.ResolvedPackageId ?? dependency.PackageId;
 
     private static string ToDependencyKindText(SetupDependencyKind kind)
         => kind switch
         {
             SetupDependencyKind.Host => "host",
-            SetupDependencyKind.Worker => "worker",
+            SetupDependencyKind.Runtime => "runtime",
             SetupDependencyKind.Stack => "stack",
+            SetupDependencyKind.Worker => "worker",
             SetupDependencyKind.ExtensionBundle => "extension-bundle",
             _ => kind.ToString(),
         };

--- a/src/Func/Commands/Setup/SetupRunner.cs
+++ b/src/Func/Commands/Setup/SetupRunner.cs
@@ -28,6 +28,9 @@ internal sealed class SetupRunner(
     ICliConfigurationProvider configurationProvider,
     IHostJsonBundleSectionReader hostJsonBundleSectionReader) : ISetupRunner
 {
+    private const string DotNetFeature = "dotnet";
+    private const string DotNetProfileRuntime = "dotnet-isolated";
+
     private readonly IInteractionService _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
     private readonly IWorkloadStore _workloadStore = workloadStore ?? throw new ArgumentNullException(nameof(workloadStore));
     private readonly IWorkloadCatalog _workloadCatalog = workloadCatalog ?? throw new ArgumentNullException(nameof(workloadCatalog));
@@ -97,12 +100,7 @@ internal sealed class SetupRunner(
         }
     }
 
-    private async Task<ProfileSetupOutcome> RunProfileAsync(
-        SetupCommandOptions options,
-        SetupFeaturePlan featurePlan,
-        SetupProfileScope profileScope,
-        SetupRenderer renderer,
-        CancellationToken cancellationToken)
+    private async Task<ProfileSetupOutcome> RunProfileAsync(SetupCommandOptions options, SetupFeaturePlan featurePlan, SetupProfileScope profileScope, SetupRenderer renderer, CancellationToken cancellationToken)
     {
         SetupDependencyPlan plan = await BuildDependencyPlanAsync(options.WorkingDirectory, featurePlan, profileScope, cancellationToken);
         int failures = 0;
@@ -147,33 +145,58 @@ internal sealed class SetupRunner(
             throw new SetupConfigurationException("At least one setup feature is required.");
         }
 
-        HashSet<string> normalizedFeatures = new(StringComparer.OrdinalIgnoreCase);
+        List<string> features = [];
+        HashSet<string> featureNames = new(StringComparer.OrdinalIgnoreCase);
+        List<SetupRuntimeFeature> runtimeFeatures = [];
+        HashSet<string> runtimeFeatureNames = new(StringComparer.OrdinalIgnoreCase);
         HashSet<string> workerRuntimes = new(StringComparer.OrdinalIgnoreCase);
         bool includeExtensionBundle = false;
 
         foreach (string rawFeature in requestedFeatures)
         {
             string feature = NormalizeFeature(rawFeature);
-            if (!normalizedFeatures.Add(feature))
-            {
-                continue;
-            }
 
             switch (feature)
             {
                 case "host":
+                    AddFeature(features, featureNames, "host");
                     break;
 
                 case "runtime":
-                    includeExtensionBundle = true;
+                    if (AddFeature(features, featureNames, "runtime"))
+                    {
+                        includeExtensionBundle = true;
+                    }
+
                     break;
 
-                case "dotnet":
+                case DotNetFeature:
+                case DotNetProfileRuntime:
+                    if (AddFeature(features, featureNames, DotNetFeature))
+                    {
+                        AddRuntimeFeature(
+                            runtimeFeatures,
+                            runtimeFeatureNames,
+                            DotNetFeature,
+                            DotNetProfileRuntime,
+                            installWorker: false);
+                    }
+
+                    break;
+
                 case ".net":
+                    throw new SetupConfigurationException($"The '{rawFeature}' feature is not supported. Use 'dotnet'.");
+
                 case "dotnet-inprocess":
-                    throw new SetupConfigurationException("The 'dotnet' feature is not supported. Use 'dotnet-isolated'.");
+                    throw new SetupConfigurationException($"The '{rawFeature}' feature is not supported. Use 'dotnet'.");
 
                 default:
+                    if (!AddFeature(features, featureNames, feature))
+                    {
+                        break;
+                    }
+
+                    AddRuntimeFeature(runtimeFeatures, runtimeFeatureNames, feature, profileRuntime: feature, installWorker: true);
                     workerRuntimes.Add(feature);
                     if (GetBundlePolicy(feature) == SetupBundlePolicy.DefaultStable)
                     {
@@ -185,7 +208,8 @@ internal sealed class SetupRunner(
         }
 
         return new SetupFeaturePlan(
-            [.. normalizedFeatures],
+            [.. features],
+            [.. runtimeFeatures],
             [.. workerRuntimes.OrderBy(static runtime => runtime, StringComparer.OrdinalIgnoreCase)],
             includeExtensionBundle);
     }
@@ -213,10 +237,7 @@ internal sealed class SetupRunner(
         return ["runtime"];
     }
 
-    private async Task<IReadOnlyList<SetupProfileScope>> ResolveProfileScopesAsync(
-        SetupCommandOptions options,
-        SetupRenderer renderer,
-        CancellationToken cancellationToken)
+    private async Task<IReadOnlyList<SetupProfileScope>> ResolveProfileScopesAsync(SetupCommandOptions options, SetupRenderer renderer, CancellationToken cancellationToken)
     {
         string projectDirectory = Path.GetFullPath(options.WorkingDirectory.FullName);
         ProjectProfileOptions projectOptions = _projectProfileOptions.Get(projectDirectory);
@@ -255,10 +276,7 @@ internal sealed class SetupRunner(
         return [SetupProfileScope.Unconstrained];
     }
 
-    private SetupProfileScope CreateProfileScope(
-        string profileName,
-        IReadOnlyList<ProfileSourceSnapshot> snapshots,
-        SetupRenderer renderer)
+    private SetupProfileScope CreateProfileScope(string profileName, IReadOnlyList<ProfileSourceSnapshot> snapshots, SetupRenderer renderer)
     {
         ResolvedProfile profile = _profileCatalog.ResolveProfile(profileName, snapshots);
         if (profile.Status == ProfileStatus.Deprecated)
@@ -266,42 +284,44 @@ internal sealed class SetupRunner(
             string suffix = string.IsNullOrWhiteSpace(profile.DeprecationUrl)
                 ? string.Empty
                 : $" See {profile.DeprecationUrl}.";
+
             renderer.Warning($"Profile '{profile.Name}' is deprecated.{suffix}");
         }
 
         return new SetupProfileScope(profile);
     }
 
-    private async Task<SetupDependencyPlan> BuildDependencyPlanAsync(
-        DirectoryInfo workingDirectory,
-        SetupFeaturePlan featurePlan,
-        SetupProfileScope profileScope,
-        CancellationToken cancellationToken)
+    private async Task<SetupDependencyPlan> BuildDependencyPlanAsync(DirectoryInfo workingDirectory, SetupFeaturePlan featurePlan, SetupProfileScope profileScope, CancellationToken cancellationToken)
     {
         List<SetupDependency> dependencies = [];
         List<SetupDependencyResult> failures = [];
 
         dependencies.Add(SetupDependency.Host(profileScope.Profile?.HostVersionRange));
 
-        foreach (string workerRuntime in featurePlan.WorkerRuntimes)
+        foreach (SetupRuntimeFeature runtimeFeature in featurePlan.RuntimeFeatures)
         {
             if (profileScope.Profile?.SupportedRuntimes is { } supportedRuntimes
-                && !supportedRuntimes.Any(runtime => string.Equals(runtime, workerRuntime, StringComparison.OrdinalIgnoreCase)))
+                && !supportedRuntimes.Any(runtime => string.Equals(runtime, runtimeFeature.ProfileRuntime, StringComparison.OrdinalIgnoreCase)))
             {
-                var dependency = SetupDependency.Worker(workerRuntime, versionRange: null);
-                string message = $"Profile '{profileScope.Profile.Name}' does not support runtime '{workerRuntime}'. "
+                SetupDependency dependency = runtimeFeature.InstallWorker
+                    ? SetupDependency.Worker(runtimeFeature.Name, versionRange: null)
+                    : SetupDependency.Runtime(runtimeFeature.Name);
+                string message = $"Profile '{profileScope.Profile.Name}' does not support runtime '{runtimeFeature.Name}'. "
                     + $"Supported runtimes: {string.Join(", ", supportedRuntimes)}.";
                 failures.Add(SetupDependencyResult.Failed(dependency, message));
                 continue;
             }
 
-            VersionRange? workerRange = null;
-            profileScope.Profile?.WorkerVersionRanges.TryGetValue(workerRuntime, out workerRange);
-            dependencies.Add(SetupDependency.Worker(workerRuntime, workerRange));
-
-            if (SetupDependency.SupportsStack(workerRuntime))
+            if (runtimeFeature.InstallWorker)
             {
-                dependencies.Add(SetupDependency.Stack(workerRuntime));
+                VersionRange? workerRange = null;
+                profileScope.Profile?.WorkerVersionRanges.TryGetValue(runtimeFeature.ProfileRuntime, out workerRange);
+                dependencies.Add(SetupDependency.Worker(runtimeFeature.Name, workerRange));
+            }
+
+            if (SetupDependency.SupportsStack(runtimeFeature.Name))
+            {
+                dependencies.Add(SetupDependency.Stack(runtimeFeature.Name));
             }
         }
 
@@ -572,6 +592,30 @@ internal sealed class SetupRunner(
         return result;
     }
 
+    private static bool AddFeature(List<string> features, HashSet<string> featureNames, string feature)
+    {
+        if (!featureNames.Add(feature))
+        {
+            return false;
+        }
+
+        features.Add(feature);
+        return true;
+    }
+
+    private static void AddRuntimeFeature(
+        List<SetupRuntimeFeature> runtimeFeatures,
+        HashSet<string> runtimeFeatureNames,
+        string name,
+        string profileRuntime,
+        bool installWorker)
+    {
+        if (runtimeFeatureNames.Add(name))
+        {
+            runtimeFeatures.Add(new SetupRuntimeFeature(name, profileRuntime, installWorker));
+        }
+    }
+
     private static string NormalizeFeature(string value)
     {
         string? normalized = NullIfWhiteSpace(value);
@@ -590,9 +634,13 @@ internal sealed class SetupRunner(
         => range is null ? null : range.OriginalString ?? range.ToString();
 
     private static SetupBundlePolicy GetBundlePolicy(string workerRuntime)
-        => string.Equals(workerRuntime, "dotnet-isolated", StringComparison.OrdinalIgnoreCase)
+        => IsDotNetRuntime(workerRuntime)
             ? SetupBundlePolicy.NotSupported
             : SetupBundlePolicy.DefaultStable;
+
+    private static bool IsDotNetRuntime(string runtime)
+        => string.Equals(runtime, DotNetFeature, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(runtime, DotNetProfileRuntime, StringComparison.OrdinalIgnoreCase);
 
     private sealed record CatalogResolution(ResolvedPackage? Package, string? FailureMessage, bool PackageMissing)
     {
@@ -608,8 +656,11 @@ internal sealed class SetupRunner(
 
 internal sealed record SetupFeaturePlan(
     IReadOnlyList<string> Features,
+    IReadOnlyList<SetupRuntimeFeature> RuntimeFeatures,
     IReadOnlyList<string> WorkerRuntimes,
     bool IncludeExtensionBundle);
+
+internal sealed record SetupRuntimeFeature(string Name, string ProfileRuntime, bool InstallWorker);
 
 internal sealed record SetupProfileScope(ResolvedProfile? Profile)
 {
@@ -639,8 +690,7 @@ internal sealed record SetupDependency(
     // from the catalog (e.g. via an `alias:stack-<name>` tag) so new stacks don't
     // require a CLI release. Stacks not in this set (java, powershell, custom)
     // skip silently today.
-    private static readonly HashSet<string> _stacks =
-        new(StringComparer.OrdinalIgnoreCase) { "node", "python", "go", "dotnet-isolated" };
+    private static readonly HashSet<string> _stacks = new(StringComparer.OrdinalIgnoreCase) { "node", "python", "go", "dotnet" };
 
     public static SetupDependency Host(VersionRange? versionRange)
         => new(
@@ -650,6 +700,16 @@ internal sealed record SetupDependency(
             HostWorkloadPackage.CurrentPackageId,
             versionRange,
             SetupRunnerRangeText(versionRange),
+            ResolvedPackageId: null);
+
+    public static SetupDependency Runtime(string runtime)
+        => new(
+            SetupDependencyKind.Runtime,
+            runtime,
+            $"{runtime} runtime",
+            runtime,
+            VersionRange: null,
+            RangeText: null,
             ResolvedPackageId: null);
 
     public static SetupDependency Worker(string runtime, VersionRange? versionRange)
@@ -688,10 +748,15 @@ internal sealed record SetupDependency(
 
     public static IReadOnlyList<string> Stacks => [.. _stacks];
 
-    // dotnet-isolated maps to the .dotnet package suffix; the rest concat
-    // directly (NuGet package ids are case-insensitive).
     private static string StackPackageSuffix(string stack)
-        => string.Equals(stack, "dotnet-isolated", StringComparison.OrdinalIgnoreCase) ? "dotnet" : stack;
+        => stack.Trim().ToLowerInvariant() switch
+        {
+            "dotnet" => "DotNet",
+            "node" => "Node",
+            "python" => "Python",
+            "go" => "Go",
+            _ => stack,
+        };
 
     private static string SetupRunnerWorkerPackageId(string runtime) => WorkerPackagePrefix + runtime;
 
@@ -703,6 +768,7 @@ internal sealed record SetupDependency(
 internal enum SetupDependencyKind
 {
     Host,
+    Runtime,
     Worker,
     Stack,
     ExtensionBundle,
@@ -737,7 +803,12 @@ internal sealed record SetupDependencyResult(
         => new(dependency, SetupDependencyStatus.Skipped, dependency.PackageId, Version: null, message);
 
     public static SetupDependencyResult Failed(SetupDependency dependency, string message)
-        => new(dependency, SetupDependencyStatus.Failed, dependency.PackageId, Version: null, message);
+        => new(
+            dependency,
+            SetupDependencyStatus.Failed,
+            dependency.Kind == SetupDependencyKind.Runtime ? null : dependency.PackageId,
+            Version: null,
+            message);
 }
 
 internal sealed record ProfileSetupOutcome(int FailureCount);

--- a/test/Func.Tests/Commands/Setup/SetupCommandTests.cs
+++ b/test/Func.Tests/Commands/Setup/SetupCommandTests.cs
@@ -52,6 +52,16 @@ public sealed class SetupCommandTests : IDisposable
     }
 
     [Fact]
+    public void SetupCommand_FeaturesHelp_UsesDotnetFeatureName()
+    {
+        var cmd = new SetupCommand(Substitute.For<ISetupRunner>());
+        string description = cmd.FeaturesOption.Description ?? string.Empty;
+
+        Assert.Contains("dotnet", description);
+        Assert.DoesNotContain("dotnet-isolated", description);
+    }
+
+    [Fact]
     public void SetupCommand_RegisteredInParser()
     {
         var root = TestParser.CreateRoot(_interaction);

--- a/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
+++ b/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
@@ -22,6 +22,7 @@ namespace Azure.Functions.Cli.Tests.Commands.Setup;
 public sealed class SetupRunnerTests : IDisposable
 {
     private static readonly string _hostPackageId = HostWorkloadPackage.CurrentPackageId;
+    private static readonly string _dotNetStackPackageId = "Azure.Functions.Cli.Workloads.DotNet";
 
     private readonly string _tempDir;
     private readonly TestInteractionService _interaction = new();
@@ -93,33 +94,44 @@ public sealed class SetupRunnerTests : IDisposable
             Arg.Any<CancellationToken>());
     }
 
-    [Fact]
-    public async Task RunAsync_ConfiguredDotnetIsolated_InstallsStackAndSkipsWorkerAndBundle()
+    [Theory]
+    [InlineData("dotnet")]
+    [InlineData("dotnet-isolated")]
+    public async Task RunAsync_ConfiguredDotnetRuntime_InstallsHostAndStackAndSkipsWorkerAndBundle(string configuredRuntime)
     {
-        string workerPackageId = WorkerPackage("dotnet-isolated");
-        const string dotnetStack = "Azure.Functions.Cli.Workloads.dotnet";
         FakeCatalog catalog = Catalog()
             .WithLatest(_hostPackageId, "4.1.0")
-            .WithLatest(dotnetStack, "1.0.0");
+            .WithLatest(_dotNetStackPackageId, "1.0.0");
         SetupRunner runner = CreateRunner(catalog, projectConfig: new Dictionary<string, string?>
         {
-            [$"{CliConfigurationNames.StackSectionName}:{CliConfigurationNames.StackRuntimeKey}"] = "dotnet-isolated",
+            [$"{CliConfigurationNames.StackSectionName}:{CliConfigurationNames.StackRuntimeKey}"] = configuredRuntime,
         });
 
         SetupRunResult result = await runner.RunAsync(Options(), CancellationToken.None);
 
         Assert.Equal(0, result.ExitCode);
+
         await _installer.Received(1).InstallFromCatalogAsync(
-            Arg.Is<string>(id => string.Equals(id, dotnetStack, StringComparison.OrdinalIgnoreCase)),
-            Arg.Any<NuGetVersion?>(),
+            Arg.Is<string>(id => string.Equals(id, _hostPackageId, StringComparison.OrdinalIgnoreCase)),
+            Arg.Is<NuGetVersion>(version => version.ToNormalizedString() == "4.1.0"),
             Arg.Any<string?>(),
-            Arg.Any<bool>(),
-            Arg.Any<bool>(),
-            Arg.Any<bool>(),
+            Arg.Is(false),
+            Arg.Is(true),
+            Arg.Is(false),
             Arg.Any<IProgress<WorkloadInstallProgress>?>(),
             Arg.Any<CancellationToken>());
+        await _installer.Received(1).InstallFromCatalogAsync(
+            Arg.Is<string>(id => string.Equals(id, _dotNetStackPackageId, StringComparison.OrdinalIgnoreCase)),
+            Arg.Is<NuGetVersion>(version => version.ToNormalizedString() == "1.0.0"),
+            Arg.Any<string?>(),
+            Arg.Is(false),
+            Arg.Is(true),
+            Arg.Is(false),
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+
         await _installer.DidNotReceive().InstallFromCatalogAsync(
-            Arg.Is<string>(id => string.Equals(id, workerPackageId, StringComparison.OrdinalIgnoreCase)),
+            Arg.Is<string>(id => id.Contains(".Workers.", StringComparison.OrdinalIgnoreCase)),
             Arg.Any<NuGetVersion?>(),
             Arg.Any<string?>(),
             Arg.Any<bool>(),
@@ -136,6 +148,160 @@ public sealed class SetupRunnerTests : IDisposable
             Arg.Any<bool>(),
             Arg.Any<IProgress<WorkloadInstallProgress>?>(),
             Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunAsync_DotnetFeature_InstallsDotnetStackAndSkipsWorkerAndBundle()
+    {
+        const string source = "http://localhost:5555/v3/index.json";
+        FakeCatalog catalog = Catalog()
+            .WithLatest(_hostPackageId, "4.1.0")
+            .WithLatest(_dotNetStackPackageId, "1.0.0");
+        SetupRunner runner = CreateRunner(catalog);
+
+        SetupRunResult result = await runner.RunAsync(
+            Options(features: ["dotnet"], source: source, includePrerelease: true),
+            CancellationToken.None);
+
+        Assert.Equal(0, result.ExitCode);
+        await _installer.Received(1).InstallFromCatalogAsync(
+            Arg.Is<string>(id => string.Equals(id, _dotNetStackPackageId, StringComparison.OrdinalIgnoreCase)),
+            Arg.Is<NuGetVersion>(version => version.ToNormalizedString() == "1.0.0"),
+            Arg.Is<string?>(actual => actual == source),
+            Arg.Is(true),
+            Arg.Is(true),
+            Arg.Is(false),
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+        await _installer.DidNotReceive().InstallFromCatalogAsync(
+            Arg.Is<string>(id => id.Contains(".Workers.", StringComparison.OrdinalIgnoreCase)),
+            Arg.Any<NuGetVersion?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+        await _installer.DidNotReceive().InstallFromCatalogAsync(
+            Arg.Is<string>(id => id.Contains("ExtensionBundles", StringComparison.OrdinalIgnoreCase)),
+            Arg.Any<NuGetVersion?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunAsync_DotnetFeature_AllowsProfileWithDotnetIsolatedRuntime()
+    {
+        SetupRunner runner = CreateRunner(
+            Catalog()
+                .WithLatest(_hostPackageId, "4.1.0")
+                .WithLatest(_dotNetStackPackageId, "1.0.0"),
+            profileCatalog: new ProfileCatalog([
+                new FakeProfileSource(new ProfileSourceInfo(ProfileSourceKind.BuiltIn, "built-in"), [
+                    new("flex", new ProfileDefinition
+                    {
+                        Host = new ProfileVersionConstraint { Version = "[4.0.0, 5.0.0)" },
+                        SupportedRuntimes = ["dotnet-isolated"],
+                    }),
+                ]),
+            ]));
+
+        SetupRunResult result = await runner.RunAsync(Options(features: ["dotnet"], profiles: ["flex"]), CancellationToken.None);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.DoesNotContain(_interaction.Lines, line => line.Contains("does not support runtime", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Theory]
+    [InlineData("dotnet")]
+    [InlineData("dotnet-isolated")]
+    public async Task RunAsync_JsonOutput_DotnetRuntimeUsesDotnetFeatureName(string requestedFeature)
+    {
+        SetupRunner runner = CreateRunner(
+            Catalog()
+                .WithLatest(_hostPackageId, "4.1.0")
+                .WithLatest(_dotNetStackPackageId, "1.0.0"));
+
+        SetupRunResult result = await runner.RunAsync(
+            Options(features: [requestedFeature], outputMode: SetupOutputMode.Json),
+            CancellationToken.None);
+
+        Assert.Equal(0, result.ExitCode);
+        using var started = JsonDocument.Parse(_interaction.Lines[0]);
+        JsonElement root = started.RootElement;
+        string[] features = [.. root.GetProperty("features").EnumerateArray().Select(feature => feature.GetString()!)];
+        string[] workerRuntimes = [.. root.GetProperty("worker_runtimes").EnumerateArray().Select(runtime => runtime.GetString()!)];
+
+        Assert.Equal(["dotnet"], features);
+        Assert.Empty(workerRuntimes);
+        Assert.DoesNotContain(_interaction.Lines, line => line.Contains("dotnet-isolated", StringComparison.OrdinalIgnoreCase));
+        string stackLine = Assert.Single(
+            _interaction.Lines,
+            line => line.Contains("\"type\":\"dependency.detected\"", StringComparison.OrdinalIgnoreCase)
+                && line.Contains("\"dependency_type\":\"stack\"", StringComparison.OrdinalIgnoreCase));
+        using var stackEvent = JsonDocument.Parse(stackLine);
+        JsonElement stackRoot = stackEvent.RootElement;
+
+        Assert.Equal("dotnet", stackRoot.GetProperty("name").GetString());
+        Assert.Equal(_dotNetStackPackageId, stackRoot.GetProperty("package_id").GetString(), ignoreCase: true);
+    }
+
+    [Theory]
+    [InlineData("dotnet")]
+    [InlineData("dotnet-isolated")]
+    public async Task RunAsync_DotnetRuntimeUnsupportedProfile_ReportsDotnetFeatureName(string requestedFeature)
+    {
+        SetupRunner runner = CreateRunner(
+            Catalog().WithLatest(_hostPackageId, "4.1.0"),
+            profileCatalog: new ProfileCatalog([
+                new FakeProfileSource(new ProfileSourceInfo(ProfileSourceKind.BuiltIn, "built-in"), [
+                    new("flex", new ProfileDefinition
+                    {
+                        Host = new ProfileVersionConstraint { Version = "[4.0.0, 5.0.0)" },
+                        SupportedRuntimes = ["python"],
+                    }),
+                ]),
+            ]));
+
+        SetupRunResult result = await runner.RunAsync(Options(features: [requestedFeature], profiles: ["flex"]), CancellationToken.None);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains(_interaction.Lines, line => line.Contains("does not support runtime 'dotnet'", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(_interaction.Lines, line => line.Contains("dotnet-isolated", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task RunAsync_JsonOutput_DotnetUnsupportedProfileReportsRuntimeDiagnostic()
+    {
+        SetupRunner runner = CreateRunner(
+            Catalog().WithLatest(_hostPackageId, "4.1.0"),
+            profileCatalog: new ProfileCatalog([
+                new FakeProfileSource(new ProfileSourceInfo(ProfileSourceKind.BuiltIn, "built-in"), [
+                    new("flex", new ProfileDefinition
+                    {
+                        Host = new ProfileVersionConstraint { Version = "[4.0.0, 5.0.0)" },
+                        SupportedRuntimes = ["python"],
+                    }),
+                ]),
+            ]));
+
+        SetupRunResult result = await runner.RunAsync(
+            Options(features: ["dotnet"], profiles: ["flex"], outputMode: SetupOutputMode.Json),
+            CancellationToken.None);
+
+        Assert.Equal(1, result.ExitCode);
+        string failureLine = Assert.Single(_interaction.Lines, line => line.Contains("\"status\":\"failed\"", StringComparison.OrdinalIgnoreCase));
+        using var failure = JsonDocument.Parse(failureLine);
+        JsonElement root = failure.RootElement;
+
+        Assert.Equal("runtime", root.GetProperty("dependency_type").GetString());
+        Assert.Equal("dotnet", root.GetProperty("name").GetString());
+        Assert.False(root.TryGetProperty("package_id", out _));
+        Assert.DoesNotContain("dotnet-isolated", failureLine, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -435,6 +601,7 @@ public sealed class SetupRunnerTests : IDisposable
         IReadOnlyList<string>? profiles = null,
         string? source = null,
         SetupInstallPolicy installPolicy = SetupInstallPolicy.LatestCompatible,
+        bool includePrerelease = false,
         bool check = false,
         SetupOutputMode outputMode = SetupOutputMode.Plain)
         => new(
@@ -443,7 +610,7 @@ public sealed class SetupRunnerTests : IDisposable
             profiles ?? [],
             source,
             installPolicy,
-            IncludePrerelease: false,
+            IncludePrerelease: includePrerelease,
             NonInteractive: true,
             AssumeYes: true,
             check,
@@ -451,8 +618,7 @@ public sealed class SetupRunnerTests : IDisposable
 
     private static FakeCatalog Catalog() => new();
 
-    private static string WorkerPackage(string runtime)
-        => "Azure.Functions.Cli.Workloads.Workers." + runtime;
+    private static string WorkerPackage(string runtime) => $"Azure.Functions.Cli.Workloads.Workers.{runtime}";
 
     private static WorkloadEntry Entry(
         string packageId,


### PR DESCRIPTION
## Summary
- Map setup's public `dotnet` feature to the `Azure.Functions.Cli.Workloads.DotNet` stack workload.
- Keep `dotnet-isolated` as an accepted alias while rendering `dotnet` in setup output and diagnostics.
- Continue skipping the nonexistent .NET worker and extension bundle.

## Validation
- `dotnet test test\Func.Tests\Func.Tests.csproj --filter "FullyQualifiedName~Setup" --no-restore`
- `$env:CI='true'; dotnet build test\Func.Tests\Func.Tests.csproj -c Release --no-restore`