### PR TITLE
Default --prerelease to true while workloads are in preview

### DIFF
--- a/src/Func/Commands/Setup/SetupCommand.cs
+++ b/src/Func/Commands/Setup/SetupCommand.cs
@@ -45,7 +45,8 @@ internal sealed class SetupCommand : FuncCliCommand, IBuiltInCommand
 
     public Option<bool> PrereleaseOption { get; } = new("--prerelease")
     {
-        Description = "Allow prerelease workload versions when resolving from the catalog.",
+        Description = "Allow prerelease workload versions when resolving from the catalog. Default: enabled while workloads are in preview.",
+        DefaultValueFactory = _ => true,
     };
 
     public Option<bool> NonInteractiveOption { get; } = new("--non-interactive")

--- a/src/Func/Commands/Setup/SetupRunner.cs
+++ b/src/Func/Commands/Setup/SetupRunner.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Bundles;
+using Azure.Functions.Cli.Commands.Workload;
 using Azure.Functions.Cli.Configuration;
 using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Profiles;
@@ -42,6 +43,10 @@ internal sealed class SetupRunner(
         ArgumentNullException.ThrowIfNull(options);
 
         var renderer = new SetupRenderer(_interaction, options.OutputMode);
+        if (options.IncludePrerelease && options.OutputMode != SetupOutputMode.Json)
+        {
+            _interaction.WriteHint(WorkloadInstallCommand.PrereleasePreviewHint);
+        }
         try
         {
             SetupFeaturePlan featurePlan = await ResolveFeaturesAsync(options, cancellationToken);

--- a/src/Func/Commands/Start/Initialization/HostWorkloads/DefaultHostWorkloadResolver.cs
+++ b/src/Func/Commands/Start/Initialization/HostWorkloads/DefaultHostWorkloadResolver.cs
@@ -115,9 +115,9 @@ internal sealed class DefaultHostWorkloadResolver(
         string packageId = HostWorkloadPackage.CurrentPackageId;
         ResolvedPackage? package = range is null
             ? await _workloadCatalog.ResolveLatestVersionAsync(
-                packageId, includePrerelease: false, currentVersion: null, allowMajor: true, source: null, cancellationToken)
+                packageId, includePrerelease: true, currentVersion: null, allowMajor: true, source: null, cancellationToken)
             : await _workloadCatalog.ResolveLatestVersionInRangeAsync(
-                packageId, range, includePrerelease: false, source: null, cancellationToken);
+                packageId, range, includePrerelease: true, source: null, cancellationToken);
 
         if (package is not null)
         {

--- a/src/Func/Commands/Start/Initialization/Steps/InstallHostWorkloadInitializationStep.cs
+++ b/src/Func/Commands/Start/Initialization/Steps/InstallHostWorkloadInitializationStep.cs
@@ -48,7 +48,7 @@ internal sealed class InstallHostWorkloadInitializationStep(
                 HostWorkloadPackage.CurrentPackageId,
                 _hostVersion,
                 source: null,
-                includePrerelease: false,
+                includePrerelease: true,
                 exact: true,
                 force: false,
                 progress: null,

--- a/src/Func/Commands/Start/Initialization/Steps/ResolveFunctionsWorkerInitializationStep.cs
+++ b/src/Func/Commands/Start/Initialization/Steps/ResolveFunctionsWorkerInitializationStep.cs
@@ -128,7 +128,7 @@ internal sealed class ResolveFunctionsWorkerInitializationStep(
             ResolvedPackage? package = await _workloadCatalog.ResolveLatestVersionInRangeAsync(
                 packageId,
                 versionRange,
-                includePrerelease: false,
+                includePrerelease: true,
                 source: null,
                 cancellationToken);
 
@@ -150,7 +150,7 @@ internal sealed class ResolveFunctionsWorkerInitializationStep(
                 packageId,
                 version,
                 source,
-                includePrerelease: false,
+                includePrerelease: true,
                 exact: true,
                 force: false,
                 progress: null,

--- a/src/Func/Commands/Workload/WorkloadInstallCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadInstallCommand.cs
@@ -20,6 +20,8 @@ namespace Azure.Functions.Cli.Commands.Workload;
 /// </summary>
 internal sealed class WorkloadInstallCommand : FuncCliCommand
 {
+    internal const string PrereleasePreviewHint = "Including prerelease workload versions (workloads are in preview). Pass --prerelease false to disable.";
+
     private readonly IInteractionService _interaction;
     private readonly IWorkloadInstaller _installer;
     private readonly IWorkloadStore _store;
@@ -42,7 +44,8 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
 
     public Option<bool> IncludePrereleaseOption { get; } = new("--prerelease")
     {
-        Description = "Allow prerelease versions when resolving from the catalog. Default: stable only.",
+        Description = "Allow prerelease versions when resolving from the catalog. Default: enabled while workloads are in preview.",
+        DefaultValueFactory = _ => true,
     };
 
     public Option<bool> ForceOption { get; } = new("--force", "-f")
@@ -86,6 +89,11 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
         bool includePrerelease = parseResult.GetValue(IncludePrereleaseOption);
         bool exact = parseResult.GetValue(ExactOption);
         bool force = parseResult.GetValue(ForceOption);
+
+        if (includePrerelease)
+        {
+            _interaction.WriteHint(PrereleasePreviewHint);
+        }
 
         if (!force && !LooksLikeLocalPackagePath(workload))
         {

--- a/src/Func/Commands/Workload/WorkloadSearchCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadSearchCommand.cs
@@ -34,7 +34,8 @@ internal sealed class WorkloadSearchCommand : FuncCliCommand
 
     public Option<bool> IncludePrereleaseOption { get; } = new("--prerelease")
     {
-        Description = "Include prerelease versions in the results.",
+        Description = "Include prerelease versions in the results. Default: enabled while workloads are in preview.",
+        DefaultValueFactory = _ => true,
     };
 
     public Option<bool> JsonOption { get; } = new("--json")
@@ -60,6 +61,11 @@ internal sealed class WorkloadSearchCommand : FuncCliCommand
         string? source = parseResult.GetValue(SourceOption);
         bool includePrerelease = parseResult.GetValue(IncludePrereleaseOption);
         bool json = parseResult.GetValue(JsonOption);
+
+        if (includePrerelease && !json)
+        {
+            _interaction.WriteHint(WorkloadInstallCommand.PrereleasePreviewHint);
+        }
 
         // TODO: surface --skip and --take for paging once we have a UX
         // story for repeated queries (see workload spec §4.1).

--- a/src/Func/Commands/Workload/WorkloadUpdateCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadUpdateCommand.cs
@@ -51,7 +51,8 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
 
     public Option<bool> IncludePrereleaseOption { get; } = new("--prerelease")
     {
-        Description = "Allow prerelease versions when resolving from the catalog. Default: stable only.",
+        Description = "Allow prerelease versions when resolving from the catalog. Default: enabled while workloads are in preview.",
+        DefaultValueFactory = _ => true,
     };
 
     public Option<bool> ExactOption { get; } = new("--exact", "-e")
@@ -121,6 +122,11 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
         string? source = parseResult.GetValue(SourceOption);
         bool includePrerelease = parseResult.GetValue(IncludePrereleaseOption);
         bool exact = parseResult.GetValue(ExactOption);
+
+        if (includePrerelease)
+        {
+            _interaction.WriteHint(WorkloadInstallCommand.PrereleasePreviewHint);
+        }
 
         if (all)
         {

--- a/test/Func.Tests/Commands/HostWorkloadResolverTests.cs
+++ b/test/Func.Tests/Commands/HostWorkloadResolverTests.cs
@@ -105,7 +105,7 @@ public class HostWorkloadResolverTests
         _workloadCatalog.ResolveLatestVersionInRangeAsync(
                 _hostPackageId,
                 Arg.Any<VersionRange>(),
-                false,
+                true,
                 null,
                 Arg.Any<CancellationToken>())
             .Returns(resolved);
@@ -202,7 +202,7 @@ public class HostWorkloadResolverTests
             packageId: _hostPackageId,
             version: Arg.Is<NuGetVersion?>(version => version != null && version.ToNormalizedString() == "4.1000.0"),
             source: null,
-            includePrerelease: false,
+            includePrerelease: true,
             exact: true,
             force: false,
             progress: null,

--- a/test/Func.Tests/Commands/StartInitializationTests.cs
+++ b/test/Func.Tests/Commands/StartInitializationTests.cs
@@ -290,7 +290,7 @@ public class StartInitializationTests : IDisposable
         workloadCatalog.ResolveLatestVersionInRangeAsync(
                 FunctionsWorkerWorkloadPackages.GetPackageId(workerId),
                 workerRange,
-                includePrerelease: false,
+                includePrerelease: true,
                 source: null,
                 Arg.Any<CancellationToken>())
             .Returns(new ResolvedPackage(
@@ -327,7 +327,7 @@ public class StartInitializationTests : IDisposable
             FunctionsWorkerWorkloadPackages.GetPackageId(workerId),
             NuGetVersion.Parse("3.13.0"),
             "https://example.test/v3/index.json",
-            includePrerelease: false,
+            includePrerelease: true,
             exact: true,
             force: false,
             progress: null,

--- a/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
@@ -49,7 +49,7 @@ public class WorkloadInstallCommandTests
 
         Assert.Equal(0, exit);
         await _installer.Received(1).InstallFromCatalogAsync(
-            "Test.Workload", null, null, false, false, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
+            "Test.Workload", null, null, true, false, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -92,7 +92,7 @@ public class WorkloadInstallCommandTests
             "Test.Workload",
             Arg.Is<NuGetVersion>(v => v != null && v.ToNormalizedString() == "1.2.3"),
             null,
-            false,
+            true,
             false,
             true,
             Arg.Any<IProgress<WorkloadInstallProgress>?>(),
@@ -109,7 +109,7 @@ public class WorkloadInstallCommandTests
 
         Assert.Equal(0, exit);
         await _installer.Received(1).InstallFromCatalogAsync(
-            "test.workload", null, null, false, true, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
+            "test.workload", null, null, true, true, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -124,7 +124,7 @@ public class WorkloadInstallCommandTests
 
         Assert.Equal(0, exit);
         await _installer.Received(1).InstallFromCatalogAsync(
-            "Test.Workload", null, "/tmp/local-feed", false, false, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
+            "Test.Workload", null, "/tmp/local-feed", true, false, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -402,7 +402,7 @@ public class WorkloadInstallCommandTests
 
         Assert.Equal(0, exit);
         await _installer.Received(1).InstallFromCatalogAsync(
-            "alias1", null, null, false, true, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
+            "alias1", null, null, true, true, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -424,7 +424,7 @@ public class WorkloadInstallCommandTests
 
         Assert.Equal(0, exit);
         await _installer.Received(1).InstallFromCatalogAsync(
-            "Test.Workload", null, null, false, false, true, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
+            "Test.Workload", null, null, true, false, true, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
         await _store.DidNotReceive().GetWorkloadsAsync(Arg.Any<CancellationToken>());
     }
 

--- a/test/Func.Tests/Commands/Workload/WorkloadSearchCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadSearchCommandTests.cs
@@ -126,7 +126,8 @@ public class WorkloadSearchCommandTests
         Assert.Equal(0, exit);
         Assert.NotNull(captured);
         Assert.Null(captured!.Filter);
-        Assert.False(captured.IncludePrerelease);
+        // Default while workloads are in preview: --prerelease is implicitly on.
+        Assert.True(captured.IncludePrerelease);
         Assert.Null(captured.Source);
         Assert.Equal(20, captured.Take);
     }


### PR DESCRIPTION
All v5 workloads currently ship preview-only, so resolving against the catalog with `--prerelease=false` by default just hides the only versions that exist. Flip the default to `true` and log a one-line hint when it kicks in.

## Changes

- `func workload install|update|search` and `func setup` now default `--prerelease` to `true` (via `DefaultValueFactory`).
- Internal callsites (`DefaultHostWorkloadResolver`, `InstallHostWorkloadInitializationStep`, `ResolveFunctionsWorkerInitializationStep`) pass `includePrerelease: true`.
- Each user-facing command emits a hint when prerelease is on: *"Including prerelease workload versions (workloads are in preview). Pass --prerelease false to disable."* (suppressed in JSON/NDJSON modes).
- Tests updated to match the new default.

## Validation

- `dotnet build -c Release` (CI=true): 0 warnings, 0 errors.
- `dotnet test` (Func.Tests): 657 passed, 0 failed.