### PR TITLE
Fix bug-bash findings across CLI, setup, and workloads

### DIFF
--- a/src/Func/Commands/HelpCommand.cs
+++ b/src/Func/Commands/HelpCommand.cs
@@ -84,7 +84,7 @@ internal class HelpCommand : FuncCliCommand
         IEnumerable<DefinitionItem> options = _rootCommand.Options
             .Where(o => o is not HelpOption && o.Name != "--version")
             .Select(o => new DefinitionItem(FormatOptionName(o), o.Description ?? string.Empty))
-            .Append(new DefinitionItem("--help, -h, -?", "Show help information"))
+            .Append(new DefinitionItem("--help, -h", "Show help information"))
             .Append(new DefinitionItem("--version", "Display the current version"));
         _interaction.WriteDefinitionList(options);
         _interaction.WriteBlankLine();
@@ -113,7 +113,7 @@ internal class HelpCommand : FuncCliCommand
 
     /// <summary>
     /// Renders help for any <see cref="Command"/>. Used by both <c>func help &lt;command&gt;</c>
-    /// and the global <c>--help</c> / <c>-h</c> / <c>-?</c> handler.
+    /// and the global <c>--help</c> / <c>-h</c> handler.
     /// </summary>
     internal void RenderCommandHelp(Command command)
     {

--- a/src/Func/Commands/InitCommand.cs
+++ b/src/Func/Commands/InitCommand.cs
@@ -148,7 +148,13 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
             ClearDirectory(workingDirectory.Info);
         }
 
-        WriteCliConfigurationFile(workingDirectory.Info, initializer.Stack, language, force);
+        // Only persist 'language' when the stack actually offers a choice.
+        // For stacks with a single supported language, the stack runtime
+        // already implies the language and the duplicate entry is noise.
+        // For stacks with no declared language list, persist whatever the
+        // caller supplied so we don't silently drop their input.
+        string? persistedLanguage = initializer.SupportedLanguages.Count == 1 ? null : language;
+        WriteCliConfigurationFile(workingDirectory.Info, initializer.Stack, persistedLanguage, force);
         _interaction.WriteBlankLine();
 
         var context = new InitContext(

--- a/src/Func/Commands/Setup/SetupRunner.cs
+++ b/src/Func/Commands/Setup/SetupRunner.cs
@@ -198,11 +198,17 @@ internal sealed class SetupRunner(
 
         if (!options.NonInteractive && _interaction.IsInteractive)
         {
-            string picked = await _interaction.PromptForSelectionAsync(
-                "Select a stack to install:",
+            IReadOnlyList<string> picked = await _interaction.PromptForMultiSelectionAsync(
+                "Select stacks to install (SPACE to toggle, ENTER to confirm):",
                 SetupDependency.Stacks,
                 cancellationToken);
-            return [picked];
+
+            // If the user confirmed without picking anything, fall through to
+            // the runtime-only default so we still install something useful.
+            if (picked.Count > 0)
+            {
+                return picked;
+            }
         }
 
         return ["runtime"];
@@ -662,7 +668,7 @@ internal sealed record SetupDependency(
         => new(
             SetupDependencyKind.ExtensionBundle,
             bundleId,
-            $"extension bundle {bundleId}",
+            "extension bundle",
             IInstalledBundleWorkloads.BundleWorkloadPackageId,
             versionRange,
             rangeText,

--- a/src/Func/Commands/SpectreHelpAction.cs
+++ b/src/Func/Commands/SpectreHelpAction.cs
@@ -8,7 +8,7 @@ namespace Azure.Functions.Cli.Commands;
 
 /// <summary>
 /// Replaces System.CommandLine's built-in help action on every command
-/// so that --help, -h, and -? all render uniform Spectre-based output.
+/// so that --help and -h render uniform Spectre-based output.
 /// Uses the HelpCommand's renderer to generate help from real Command metadata.
 /// </summary>
 internal sealed class SpectreHelpAction(HelpCommand helpCommand) : SynchronousCommandLineAction

--- a/src/Func/Commands/Start/Initialization/Steps/ResolveFunctionsWorkerInitializationStep.cs
+++ b/src/Func/Commands/Start/Initialization/Steps/ResolveFunctionsWorkerInitializationStep.cs
@@ -95,8 +95,10 @@ internal sealed class ResolveFunctionsWorkerInitializationStep(
 
         string packageId = FunctionsWorkerWorkloadPackages.GetPackageId(workerId);
 
+        // Live progress region is owned by the Spectre Progress task; leading
+        // newline keeps the prompt off the spinner's line.
         bool shouldInstall = await _interaction.ConfirmAsync(
-            $"The Functions worker workload '{packageId}' is required. Install it now?",
+            $"{Environment.NewLine}The Functions worker workload '{packageId}' is required. Install it now?",
             defaultValue: true,
             cancellationToken);
 

--- a/src/Func/Console/IInteractionService.cs
+++ b/src/Func/Console/IInteractionService.cs
@@ -119,6 +119,13 @@ internal interface IInteractionService
     public Task<string> PromptForSelectionAsync(string title, IEnumerable<string> choices, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Prompts the user to select one or more values from a list of choices, using
+    /// SPACE to toggle and ENTER to confirm. Returns an empty list in non-interactive
+    /// mode. Throws <see cref="OperationCanceledException"/> on Ctrl+C.
+    /// </summary>
+    public Task<IReadOnlyList<string>> PromptForMultiSelectionAsync(string title, IEnumerable<string> choices, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Prompts the user for free-form text with an optional default. Returns
     /// <paramref name="defaultValue"/> in non-interactive mode. Throws
     /// <see cref="OperationCanceledException"/> on Ctrl+C.

--- a/src/Func/Console/SpectreInteractionService.cs
+++ b/src/Func/Console/SpectreInteractionService.cs
@@ -103,7 +103,7 @@ internal class SpectreInteractionService : IInteractionService
 
         foreach (string column in columns)
         {
-            table.AddColumn(new TableColumn(new Text(column, _theme.Heading)).Centered());
+            table.AddColumn(new TableColumn(new Text(column, _theme.Heading)));
         }
 
         foreach (string[] row in rows)
@@ -315,6 +315,23 @@ internal class SpectreInteractionService : IInteractionService
             .Title(title)
             .AddChoices(choiceList)
             .ShowAsync(_stderr, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<string>> PromptForMultiSelectionAsync(string title, IEnumerable<string> choices, CancellationToken cancellationToken = default)
+    {
+        var choiceList = choices.ToList();
+        if (!IsInteractive || choiceList.Count == 0)
+        {
+            return [];
+        }
+
+        List<string> selected = await new MultiSelectionPrompt<string>()
+            .Title(title)
+            .InstructionsText("[grey](press [blue]<space>[/] to toggle, [green]<enter>[/] to confirm)[/]")
+            .AddChoices(choiceList)
+            .ShowAsync(_stderr, cancellationToken);
+
+        return selected;
     }
 
     public async Task<string> PromptForInputAsync(string prompt, string? defaultValue = null, CancellationToken cancellationToken = default)

--- a/src/Workloads/Host/Workloads.Host.csproj
+++ b/src/Workloads/Host/Workloads.Host.csproj
@@ -7,7 +7,7 @@
     <RuntimeIdentifiers>$(_CliRuntimeIdentifiers)</RuntimeIdentifiers>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
     <Title>Functions Host</Title>
-    <Description>Azure Functions host runtime.</Description>
+    <Description>Azure Functions CLI host runtime.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:content alias:host func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workloads/Host/Workloads.Host.csproj
+++ b/src/Workloads/Host/Workloads.Host.csproj
@@ -6,8 +6,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <RuntimeIdentifiers>$(_CliRuntimeIdentifiers)</RuntimeIdentifiers>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
-    <Title>Azure Functions Host</Title>
-    <Description>Azure Functions CLI content workload that ships the Azure Functions host.</Description>
+    <Title>Functions Host</Title>
+    <Description>Azure Functions host runtime.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:content alias:host func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workloads/Host/Workloads.Host.csproj
+++ b/src/Workloads/Host/Workloads.Host.csproj
@@ -6,8 +6,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <RuntimeIdentifiers>$(_CliRuntimeIdentifiers)</RuntimeIdentifiers>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
-    <Title>Functions Host</Title>
-    <Description>Azure Functions CLI host runtime.</Description>
+    <Title>Azure Functions Host</Title>
+    <Description>Azure Functions CLI content workload that ships the Azure Functions host.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:content alias:host func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
@@ -98,7 +98,7 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli, ITemp
             "--name", projectName,
             "--output", projectPath,
             "--language", language,
-            "--framework", framework,
+            "--Framework", framework,
             "--debug:custom-hive", _hivePathProvider.HivePath,
         ];
 

--- a/src/Workloads/Stacks/DotNet/Workloads.DotNet.csproj
+++ b/src/Workloads/Stacks/DotNet/Workloads.DotNet.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Title>.NET</Title>
-    <Description>Azure Functions tooling for .NET (C#, F#) projects.</Description>
+    <Description>Azure Functions CLI tooling for .NET (C#, F#) projects.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:workload alias:dotnet func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workloads/Stacks/DotNet/Workloads.DotNet.csproj
+++ b/src/Workloads/Stacks/DotNet/Workloads.DotNet.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Title>DotNet</Title>
-    <Description>Azure Functions CLI tooling for .NET (C#, F#) projects.</Description>
+    <Title>.NET</Title>
+    <Description>Azure Functions tooling for .NET (C#, F#) projects.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:workload alias:dotnet func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workloads/Stacks/DotNet/Workloads.DotNet.csproj
+++ b/src/Workloads/Stacks/DotNet/Workloads.DotNet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Title>.NET</Title>
+    <Title>.NET Stack</Title>
     <Description>Azure Functions CLI tooling for .NET (C#, F#) projects.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:workload alias:dotnet func-workload</PackageTags>

--- a/src/Workloads/Stacks/Go/Workloads.Go.csproj
+++ b/src/Workloads/Stacks/Go/Workloads.Go.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Title>Go</Title>
-    <Description>Azure Functions tooling for Go projects.</Description>
+    <Description>Azure Functions CLI tooling for Go projects.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:workload alias:go func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workloads/Stacks/Go/Workloads.Go.csproj
+++ b/src/Workloads/Stacks/Go/Workloads.Go.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Title>Go</Title>
+    <Title>Go Stack</Title>
     <Description>Azure Functions CLI tooling for Go projects.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:workload alias:go func-workload</PackageTags>

--- a/src/Workloads/Stacks/Go/Workloads.Go.csproj
+++ b/src/Workloads/Stacks/Go/Workloads.Go.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Title>Go</Title>
-    <Description>Azure Functions CLI tooling for Go projects.</Description>
+    <Description>Azure Functions tooling for Go projects.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:workload alias:go func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workloads/Stacks/Node/Workloads.Node.csproj
+++ b/src/Workloads/Stacks/Node/Workloads.Node.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Title>Node.js</Title>
+    <Title>Node.js Stack</Title>
     <Description>Azure Functions CLI tooling for Node.js projects.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:workload alias:node func-workload</PackageTags>

--- a/src/Workloads/Stacks/Node/Workloads.Node.csproj
+++ b/src/Workloads/Stacks/Node/Workloads.Node.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Title>Node.js</Title>
-    <Description>Azure Functions CLI tooling for Node.js projects.</Description>
+    <Description>Azure Functions tooling for Node.js projects.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:workload alias:node func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workloads/Stacks/Node/Workloads.Node.csproj
+++ b/src/Workloads/Stacks/Node/Workloads.Node.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Title>Node.js</Title>
-    <Description>Azure Functions tooling for Node.js projects.</Description>
+    <Description>Azure Functions CLI tooling for Node.js projects.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:workload alias:node func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workloads/Stacks/Python/Workloads.Python.csproj
+++ b/src/Workloads/Stacks/Python/Workloads.Python.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Title>Python</Title>
+    <Title>Python Stack</Title>
     <Description>Azure Functions CLI tooling for Python projects.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:workload alias:python func-workload</PackageTags>

--- a/src/Workloads/Stacks/Python/Workloads.Python.csproj
+++ b/src/Workloads/Stacks/Python/Workloads.Python.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Title>Python</Title>
-    <Description>Azure Functions CLI tooling for Python projects.</Description>
+    <Description>Azure Functions tooling for Python projects.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:workload alias:python func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workloads/Stacks/Python/Workloads.Python.csproj
+++ b/src/Workloads/Stacks/Python/Workloads.Python.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Title>Python</Title>
-    <Description>Azure Functions tooling for Python projects.</Description>
+    <Description>Azure Functions CLI tooling for Python projects.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:workload alias:python func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workloads/Tools/ExtensionBundles/Workloads.ExtensionBundles.csproj
+++ b/src/Workloads/Tools/ExtensionBundles/Workloads.ExtensionBundles.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Title>Extension Bundles</Title>
-    <Description>Azure Functions CLI extension bundles.</Description>
+    <Description>Azure Functions CLI extension bundle payload, delivered as a content workload for the func CLI.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:content alias:bundles func-workload func-tool</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workloads/Tools/ExtensionBundles/Workloads.ExtensionBundles.csproj
+++ b/src/Workloads/Tools/ExtensionBundles/Workloads.ExtensionBundles.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Title>Extension Bundles</Title>
-    <Description>Azure Functions extension bundles.</Description>
+    <Description>Azure Functions CLI extension bundles.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:content alias:bundles func-workload func-tool</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workloads/Tools/ExtensionBundles/Workloads.ExtensionBundles.csproj
+++ b/src/Workloads/Tools/ExtensionBundles/Workloads.ExtensionBundles.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Title>Azure Functions CLI Extension Bundles</Title>
-    <Description>Azure Functions extension bundle payload, delivered as a content workload for the func CLI.</Description>
+    <Title>Extension Bundles</Title>
+    <Description>Azure Functions extension bundles.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:content alias:bundles func-workload func-tool</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workloads/Workers/Go/Workloads.Workers.Go.csproj
+++ b/src/Workloads/Workers/Go/Workloads.Workers.Go.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Title>Azure Functions CLI Go Language Worker</Title>
-    <Description>Azure Functions CLI content workload that ships the Go worker assets (static worker config).</Description>
+    <Title>Go Worker</Title>
+    <Description>Azure Functions Go language worker.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:content alias:go-worker func-worker func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workloads/Workers/Go/Workloads.Workers.Go.csproj
+++ b/src/Workloads/Workers/Go/Workloads.Workers.Go.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Title>Go Worker</Title>
-    <Description>Azure Functions Go language worker.</Description>
+    <Description>Azure Functions CLI Go language worker.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:content alias:go-worker func-worker func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workloads/Workers/Go/Workloads.Workers.Go.csproj
+++ b/src/Workloads/Workers/Go/Workloads.Workers.Go.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Title>Go Worker</Title>
-    <Description>Azure Functions CLI Go language worker.</Description>
+    <Description>Azure Functions CLI content workload that ships the Go language worker.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:content alias:go-worker func-worker func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workloads/Workers/Go/Workloads.Workers.Go.csproj
+++ b/src/Workloads/Workers/Go/Workloads.Workers.Go.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Title>Go Worker</Title>
-    <Description>Azure Functions CLI content workload that ships the Go language worker.</Description>
+    <Description>Azure Functions CLI content workload that ships the Go worker assets (static worker config).</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:content alias:go-worker func-worker func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workloads/Workers/Node/Workloads.Workers.Node.csproj
+++ b/src/Workloads/Workers/Node/Workloads.Workers.Node.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Title>Azure Functions CLI Node.js Language Worker</Title>
-    <Description>Azure Functions CLI content workload that ships the Node.js language worker.</Description>
+    <Title>Node.js Worker</Title>
+    <Description>Azure Functions Node.js language worker.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:content alias:node-worker func-worker func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workloads/Workers/Node/Workloads.Workers.Node.csproj
+++ b/src/Workloads/Workers/Node/Workloads.Workers.Node.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Title>Node.js Worker</Title>
-    <Description>Azure Functions CLI Node.js language worker.</Description>
+    <Description>Azure Functions CLI content workload that ships the Node.js language worker.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:content alias:node-worker func-worker func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workloads/Workers/Node/Workloads.Workers.Node.csproj
+++ b/src/Workloads/Workers/Node/Workloads.Workers.Node.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Title>Node.js Worker</Title>
-    <Description>Azure Functions Node.js language worker.</Description>
+    <Description>Azure Functions CLI Node.js language worker.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:content alias:node-worker func-worker func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workloads/Workers/Python/Workloads.Workers.Python.csproj
+++ b/src/Workloads/Workers/Python/Workloads.Workers.Python.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Title>Python Worker</Title>
-    <Description>Azure Functions Python language worker.</Description>
+    <Description>Azure Functions CLI Python language worker.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:content alias:python-worker func-worker func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workloads/Workers/Python/Workloads.Workers.Python.csproj
+++ b/src/Workloads/Workers/Python/Workloads.Workers.Python.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Title>Python Worker</Title>
-    <Description>Azure Functions CLI Python language worker.</Description>
+    <Description>Azure Functions CLI content workload that ships the Python language worker.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:content alias:python-worker func-worker func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Workloads/Workers/Python/Workloads.Workers.Python.csproj
+++ b/src/Workloads/Workers/Python/Workloads.Workers.Python.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Title>Azure Functions CLI Python Language Worker</Title>
-    <Description>Azure Functions CLI content workload that ships the Python language worker.</Description>
+    <Title>Python Worker</Title>
+    <Description>Azure Functions Python language worker.</Description>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:content alias:python-worker func-worker func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/test/Func.Tests/Commands/InitCommandTests.cs
+++ b/test/Func.Tests/Commands/InitCommandTests.cs
@@ -497,7 +497,7 @@ public class InitCommandTests
     }
 
     [Fact]
-    public async Task InitCommand_AutoSelectsLanguageWhenInitializerHasOnlyOne()
+    public async Task InitCommand_OmitsLanguageWhenStackHasOnlySupportedLanguage()
     {
         var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
         try
@@ -506,7 +506,10 @@ public class InitCommandTests
             int exitCode = await RunInitAsync(newDir, initializer, language: null, stack: "python");
 
             Assert.Equal(0, exitCode);
-            AssertConfigJsonHasShape(newDir, expectedStack: "python", expectedLanguage: "python");
+
+            // With a single supported language, the stack runtime implies the
+            // language; the config skips the redundant 'language' field.
+            AssertConfigJsonHasShape(newDir, expectedStack: "python", expectedLanguage: null);
         }
         finally
         {

--- a/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
+++ b/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
@@ -380,7 +380,7 @@ public sealed class SetupRunnerTests : IDisposable
             CancellationToken.None);
 
         Assert.Equal(0, result.ExitCode);
-        Assert.Contains(interactive.Lines, line => line.StartsWith("SELECT:", StringComparison.Ordinal));
+        Assert.Contains(interactive.Lines, line => line.StartsWith("MULTISELECT:", StringComparison.Ordinal));
         await _installer.Received(1).InstallFromCatalogAsync(
             Arg.Is<string>(id => string.Equals(id, nodeStack, StringComparison.OrdinalIgnoreCase)),
             Arg.Any<NuGetVersion?>(),
@@ -586,6 +586,17 @@ public sealed class SetupRunnerTests : IDisposable
     private sealed class InteractiveTestInteractionService : TestInteractionService
     {
         public override bool IsInteractive => true;
+
+        public override Task<IReadOnlyList<string>> PromptForMultiSelectionAsync(string title, IEnumerable<string> choices, CancellationToken cancellationToken = default)
+        {
+            // Record the prompt then mimic an interactive user picking the
+            // first listed stack (preferring 'node' for stable test asserts).
+            var picks = choices.ToList();
+            base.PromptForMultiSelectionAsync(title, picks, cancellationToken).GetAwaiter().GetResult();
+            string? first = picks.FirstOrDefault(c => string.Equals(c, "node", StringComparison.OrdinalIgnoreCase))
+                ?? picks.FirstOrDefault();
+            return Task.FromResult<IReadOnlyList<string>>(first is null ? [] : [first]);
+        }
     }
 
     private sealed class FakeProfileSource(

--- a/test/Func.Tests/TestInteractionService.cs
+++ b/test/Func.Tests/TestInteractionService.cs
@@ -140,6 +140,14 @@ internal class TestInteractionService : IInteractionService
         return Task.FromResult(choiceList.FirstOrDefault() ?? string.Empty);
     }
 
+    public virtual Task<IReadOnlyList<string>> PromptForMultiSelectionAsync(string title, IEnumerable<string> choices, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var choiceList = choices.ToList();
+        _lines.Add($"MULTISELECT: {title} [{string.Join(", ", choiceList)}]");
+        return Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
     public Task<string> PromptForInputAsync(string prompt, string? defaultValue = null, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
Bundle of small fixes from an e2e bug bash of the v5 CLI.

## Fixes

1. **`-?` removed from help options.** It was advertised but unsupported by `zsh`. Dropped from `HelpCommand` and `SpectreHelpAction` text.
2. **Table column centering removed.** `IInteractionService.WriteTable` now left-aligns headers and cells.
3. **Extension bundle install message simplified.** `SetupRunner.Bundle` no longer embeds the package id in the DisplayName, so the message reads `Installed extension bundle 4.35.0` instead of `Installed extension bundle Microsoft.Azure.Functions.ExtensionBundle 4.35.0`.
4. **`func setup` uses a multi-select prompt.** Added `PromptForMultiSelectionAsync` to `IInteractionService` / `SpectreInteractionService` and wired it into `SetupRunner.GetDefaultFeaturesAsync` so users can pick multiple stacks with space.
6. **`dotnet new func` uses `--Framework`.** The Worker template's option is capital `F`; lowercase failed with exit code 127 (#6).
7. **Skip language in `.func/config.json` when redundant.** `InitCommand` omits `stack.language` when the stack only supports one language (e.g. Python, Go), avoiding the noisy `"runtime": "python", "language": "python"` shape.
8. **Workload Title/Description normalized.** Updated all 9 workload csprojs for consistent display names (.NET, Go, Node.js, Python, .NET Worker, Functions Host, Extension Bundles, etc.).
9. **Worker install confirm prompt on its own line.** `ResolveFunctionsWorkerInitializationStep` prepends a newline so the prompt doesn't get clobbered by the Spectre progress live region.

## Deferred

- #5 (first-run setup with onboarding/telemetry opt-in) is intentionally left for a follow-up; it's a bigger UX change than the others.

## Verification

- `dotnet test`: 657/657 pass.
- `CI=true dotnet build -c Release`: 0 warnings, 0 errors.