### PR TITLE
Add managed-Azurite paths and func-home provider

### DIFF
--- a/src/Func/Commands/Start/Azurite/AzuriteManagedPaths.cs
+++ b/src/Func/Commands/Start/Azurite/AzuriteManagedPaths.cs
@@ -1,0 +1,64 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Configuration;
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite;
+
+/// <summary>
+/// On-disk locations the CLI uses for a managed Azurite instance. v1 keeps a
+/// single shared directory under <c>&lt;funcHome&gt;/azurite/</c>; per-scope
+/// isolation, metadata, and lease files are deferred until there is a real
+/// consumer (multi-session sharing or a cleanup command).
+/// </summary>
+internal sealed record AzuriteManagedPaths(string DataDirectory, string LogFilePath);
+
+/// <summary>
+/// Computes <see cref="AzuriteManagedPaths"/> rooted at
+/// <c>&lt;funcHome&gt;/azurite/</c>.
+/// </summary>
+internal interface IAzuriteManagedPathsProvider
+{
+    /// <summary>
+    /// Returns the path layout. No directories are created.
+    /// </summary>
+    public AzuriteManagedPaths GetPaths();
+
+    /// <summary>
+    /// Ensures the data directory and the log file's parent directory exist on disk.
+    /// </summary>
+    public Task EnsureCreatedAsync(AzuriteManagedPaths paths, CancellationToken cancellationToken);
+}
+
+/// <inheritdoc cref="IAzuriteManagedPathsProvider"/>
+internal sealed class AzuriteManagedPathsProvider(CliConfigurationPathsOptions configurationPaths) : IAzuriteManagedPathsProvider
+{
+    internal const string AzuriteFolderName = "azurite";
+    internal const string DataFolderName = "data";
+    internal const string LogFileName = "azurite.log";
+
+    private readonly CliConfigurationPathsOptions _configurationPaths = configurationPaths ?? throw new ArgumentNullException(nameof(configurationPaths));
+
+    public AzuriteManagedPaths GetPaths()
+    {
+        string root = Path.Combine(_configurationPaths.Home, AzuriteFolderName);
+        return new AzuriteManagedPaths(
+            DataDirectory: Path.Combine(root, DataFolderName),
+            LogFilePath: Path.Combine(root, LogFileName));
+    }
+
+    public Task EnsureCreatedAsync(AzuriteManagedPaths paths, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(paths);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        Directory.CreateDirectory(paths.DataDirectory);
+        string? logDir = Path.GetDirectoryName(paths.LogFilePath);
+        if (!string.IsNullOrEmpty(logDir))
+        {
+            Directory.CreateDirectory(logDir);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Func/Commands/Start/Azurite/AzuriteServiceCollectionExtensions.cs
+++ b/src/Func/Commands/Start/Azurite/AzuriteServiceCollectionExtensions.cs
@@ -29,4 +29,20 @@ internal static class AzuriteServiceCollectionExtensions
         services.AddSingleton<IAzuriteProbe, AzuriteProbe>();
         return services;
     }
+
+    /// <summary>
+    /// Registers <see cref="IClock"/> and <see cref="IAzuriteManagedPathsProvider"/>
+    /// for resolving managed-Azurite on-disk locations. The path provider
+    /// reads <c>&lt;funcHome&gt;</c> from <see cref="Configuration.CliConfigurationPathsOptions"/>,
+    /// which is registered separately by the CLI host.
+    /// </summary>
+    public static IServiceCollection AddAzuriteManagedPaths(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton<IClock, SystemClock>();
+        services.AddSingleton<IAzuriteManagedPathsProvider, AzuriteManagedPathsProvider>();
+
+        return services;
+    }
 }

--- a/src/Func/Commands/Start/Azurite/IClock.cs
+++ b/src/Func/Commands/Start/Azurite/IClock.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite;
+
+/// <summary>
+/// Abstraction over the wall clock so time-sensitive code can be substituted in tests.
+/// </summary>
+internal interface IClock
+{
+    public DateTimeOffset UtcNow { get; }
+}
+
+/// <summary>
+/// Production <see cref="IClock"/> backed by <see cref="DateTimeOffset.UtcNow"/>.
+/// </summary>
+internal sealed class SystemClock : IClock
+{
+    public DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
+}

--- a/test/Func.Tests/Commands/Start/Azurite/AzuriteManagedPathsProviderTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/AzuriteManagedPathsProviderTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Commands.Start.Azurite;
+using Azure.Functions.Cli.Configuration;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Commands.Start.Azurite;
+
+public class AzuriteManagedPathsProviderTests
+{
+    [Fact]
+    public void GetPaths_ComposesUnderFuncHomeAzurite()
+    {
+        using var temp = new TempDirectory();
+        var configurationPaths = new CliConfigurationPathsOptions(temp.Path);
+
+        var provider = new AzuriteManagedPathsProvider(configurationPaths);
+        AzuriteManagedPaths paths = provider.GetPaths();
+
+        string expectedRoot = Path.Combine(configurationPaths.Home, "azurite");
+        Assert.Equal(Path.Combine(expectedRoot, "data"), paths.DataDirectory);
+        Assert.Equal(Path.Combine(expectedRoot, "azurite.log"), paths.LogFilePath);
+    }
+
+    [Fact]
+    public void GetPaths_DoesNotCreateDirectories()
+    {
+        using var temp = new TempDirectory();
+        var configurationPaths = new CliConfigurationPathsOptions(temp.Path);
+
+        var provider = new AzuriteManagedPathsProvider(configurationPaths);
+        AzuriteManagedPaths paths = provider.GetPaths();
+
+        Assert.False(Directory.Exists(paths.DataDirectory));
+        Assert.False(Directory.Exists(Path.GetDirectoryName(paths.LogFilePath)!));
+    }
+
+    [Fact]
+    public async Task EnsureCreatedAsync_CreatesDataAndLogDirectories()
+    {
+        using var temp = new TempDirectory();
+        var configurationPaths = new CliConfigurationPathsOptions(temp.Path);
+
+        var provider = new AzuriteManagedPathsProvider(configurationPaths);
+        AzuriteManagedPaths paths = provider.GetPaths();
+
+        await provider.EnsureCreatedAsync(paths, CancellationToken.None);
+
+        Assert.True(Directory.Exists(paths.DataDirectory));
+        Assert.True(Directory.Exists(Path.GetDirectoryName(paths.LogFilePath)!));
+    }
+
+    [Fact]
+    public void Constructor_NullConfigurationPaths_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new AzuriteManagedPathsProvider(null!));
+    }
+}

--- a/test/Func.Tests/Commands/Start/Azurite/TempDirectory.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/TempDirectory.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Tests.Commands.Start.Azurite;
+
+/// <summary>
+/// Per-test temp directory created under the OS temp folder and recursively
+/// deleted on dispose. Use as a stand-in for <c>&lt;funcHome&gt;</c>.
+/// </summary>
+internal sealed class TempDirectory : IDisposable
+{
+    public TempDirectory()
+    {
+        Path = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(),
+            "func-azurite-tests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path);
+    }
+
+    public string Path { get; }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best effort: leaving a stray temp folder is preferable to failing
+            // tests on teardown.
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds the minimum filesystem primitives the managed-Azurite feature needs: a clock seam and a small `AzuriteManagedPaths` record describing where Azurite data and logs live on disk. Reuses the existing `CliConfigurationPathsOptions.Home` for `<funcHome>` rather than introducing a parallel resolver. Nothing is wired into the composition root yet; a later slice will consume these from `StartCommand`.

Tracks the design doc in PR #5015. Covers only:

- §10.1 — `<funcHome>/azurite/` layout (rooted at the existing `CliConfigurationPathsOptions.Home`, i.e. `<userprofile>/.azure-functions`).
- §10.3 — log path (`<funcHome>/azurite/azurite.log`).

A single shared `<funcHome>/azurite/data/` directory is used in v1. Per-scope isolation, `scope.json` metadata, and lease files are deferred until there is a real consumer (multi-session sharing, or a `func azurite clean` command).

## New types

Under `src/Func/Commands/Start/Azurite/`:

- `IClock` / `SystemClock` — clock seam for future log/output formatting and the orchestrator.
- `AzuriteManagedPaths` (record) — `DataDirectory` + `LogFilePath`.
- `IAzuriteManagedPathsProvider` / `AzuriteManagedPathsProvider` — reads `<funcHome>` from `CliConfigurationPathsOptions` and composes the path record; `EnsureCreatedAsync` creates directories on demand.
- Extended `AzuriteServiceCollectionExtensions` with `AddAzuriteManagedPaths()`.

## Out of scope (deferred)

- Per-scope directory layout, `StorageScopeId`, `IHostIdResolver` (no consumer yet).
- `scope.json` metadata read/write/touch.
- Lease files, holder tracking, conflict/join logic, `IProcessAliveChecker`.
- Process launching, endpoint probing, executable/Docker discovery, orchestration.
- `StartCommand` wiring, `--no-azurite`, future `func azurite clean` (§10.6).

## Validation

- `CI=true dotnet build -c Release` — 0 warnings, 0 errors.
- `dotnet test test/Func.Tests/Func.Tests.csproj -c Release` — 770 passed.

## Checklist

- [x] Tests added (`AzuriteManagedPathsProviderTests`).
- [x] No docs changes needed (no user-facing surface yet).
- [x] No release notes needed (no user-facing surface yet).