### PR TITLE
Add managed-Azurite orchestrator and wire into func start

### DIFF
--- a/src/Func/Commands/Start/Azurite/AzuriteServiceCollectionExtensions.cs
+++ b/src/Func/Commands/Start/Azurite/AzuriteServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Commands.Start.Azurite.Launching;
+using Azure.Functions.Cli.Commands.Start.Azurite.Orchestration;
 using Azure.Functions.Cli.Commands.Start.Azurite.Processes;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -8,8 +10,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 namespace Azure.Functions.Cli.Commands.Start.Azurite;
 
 /// <summary>
-/// DI registration helpers for the managed-Azurite feature. Not wired into the
-/// CLI host yet; later slices will call this from the composition root.
+/// DI registration helpers for the managed-Azurite feature.
 /// </summary>
 internal static class AzuriteServiceCollectionExtensions
 {
@@ -62,6 +63,41 @@ internal static class AzuriteServiceCollectionExtensions
         services.TryAddSingleton<IProcessRunner, ProcessRunner>();
         services.TryAddSingleton<IAzuriteExecutableLocator, AzuriteExecutableLocator>();
         services.TryAddSingleton<IDockerAvailabilityProbe, DockerAvailabilityProbe>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers <see cref="IAzuriteLauncher"/>. Kept separate from
+    /// <see cref="AddAzuriteDiscovery"/> so tests can swap the launcher
+    /// without losing the discovery helpers.
+    /// </summary>
+    public static IServiceCollection AddAzuriteLauncher(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton<IAzuriteLauncher, AzuriteLauncher>();
+        return services;
+    }
+
+    /// <summary>
+    /// Registers everything needed for the managed-Azurite feature: the
+    /// classifier, probe, discovery seams, launcher, paths, and the
+    /// orchestrator that wires them together. Idempotent: each call uses
+    /// <c>TryAdd</c> semantics so it is safe to invoke from both the
+    /// composition root and individual tests.
+    /// </summary>
+    public static IServiceCollection AddManagedAzurite(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddAzuriteProbe();
+        services.AddAzuriteDiscovery();
+        services.AddAzuriteLauncher();
+        services.AddAzuriteManagedPaths();
+
+        services.TryAddSingleton<IAzureWebJobsStorageClassifier, AzureWebJobsStorageClassifier>();
+        services.TryAddSingleton<IManagedAzuriteOrchestrator, ManagedAzuriteOrchestrator>();
 
         return services;
     }

--- a/src/Func/Commands/Start/Azurite/EnsureAzuriteInitializationStep.cs
+++ b/src/Func/Commands/Start/Azurite/EnsureAzuriteInitializationStep.cs
@@ -1,0 +1,91 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Commands.Start.Azurite.Orchestration;
+using Azure.Functions.Cli.Commands.Start.Initialization;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Projects;
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite;
+
+/// <summary>
+/// Drives the managed-Azurite orchestrator inside the start initialization
+/// pipeline. Sits between <c>prepare_host_run</c> (which materializes the
+/// effective <c>AzureWebJobsStorage</c> value) and <c>start_host</c> (which
+/// requires Azurite to be reachable for local storage configurations).
+/// </summary>
+internal sealed class EnsureAzuriteInitializationStep(
+    IManagedAzuriteOrchestrator orchestrator,
+    IProcessEnvironment processEnvironment) : DemoInitializationStep
+{
+    public const string StepId = "ensure_azurite";
+    private const string AzureWebJobsStorageName = "AzureWebJobsStorage";
+
+    private readonly IManagedAzuriteOrchestrator _orchestrator = orchestrator
+        ?? throw new ArgumentNullException(nameof(orchestrator));
+
+    private readonly IProcessEnvironment _processEnvironment = processEnvironment
+        ?? throw new ArgumentNullException(nameof(processEnvironment));
+
+    public override string Id => StepId;
+
+    public override string Title => "Ensure Azurite";
+
+    public override async Task<StartInitializationStepResult> ExecuteAsync(
+        StartInitializationStepContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        FunctionsProject project = context.State.Project
+            ?? throw new InvalidOperationException("Functions project was not resolved.");
+        FunctionsProjectHostRunContext hostRunContext = context.State.HostRunContext
+            ?? throw new InvalidOperationException("Host run context was not prepared.");
+
+        string? connectionString = ResolveStorageConnectionString(hostRunContext);
+
+        ManagedAzuriteRequest request = new(
+            StorageConnectionString: connectionString,
+            ProjectRoot: project.WorkingDirectory.Info.FullName,
+            Disabled: context.Options.NoAzurite,
+            StartupTimeout: ManagedAzuriteRequest.DefaultStartupTimeout);
+
+        ManagedAzuriteResult result = await _orchestrator.EnsureReadyAsync(request, cancellationToken);
+
+        switch (result)
+        {
+            case ManagedAzuriteResult.Disabled disabled:
+                return StartInitializationStepResult.Completed(disabled.Reason);
+
+            case ManagedAzuriteResult.UserManaged userManaged:
+                return StartInitializationStepResult.Completed(userManaged.Reason);
+
+            case ManagedAzuriteResult.Started started:
+                context.State.ManagedAzurite = ManagedAzuriteHandle.Owning(started.Process, started.Mode);
+                return StartInitializationStepResult.Completed($"Started managed Azurite ({started.Mode}).");
+
+            case ManagedAzuriteResult.Failed failed:
+                throw new GracefulException(failed.UserMessage, isUserError: true, verboseMessage: failed.VerboseDetail);
+
+            default:
+                throw new InvalidOperationException($"Unknown ManagedAzuriteResult: {result.GetType().Name}");
+        }
+    }
+
+    private string? ResolveStorageConnectionString(FunctionsProjectHostRunContext hostRunContext)
+    {
+        // Process env wins over local.settings.json by design (see
+        // PrepareProjectHostRunInitializationStep). The prepare step does not
+        // copy values that already exist in process env into the host run
+        // context, so we have to check both.
+        string? fromProcess = _processEnvironment.Get(AzureWebJobsStorageName);
+        if (!string.IsNullOrWhiteSpace(fromProcess))
+        {
+            return fromProcess;
+        }
+
+        return hostRunContext.EnvironmentVariables.TryGetValue(AzureWebJobsStorageName, out string? value)
+            ? value
+            : null;
+    }
+}

--- a/src/Func/Commands/Start/Azurite/Orchestration/IManagedAzuriteOrchestrator.cs
+++ b/src/Func/Commands/Start/Azurite/Orchestration/IManagedAzuriteOrchestrator.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite.Orchestration;
+
+/// <summary>
+/// Wires the classifier, probe, locator, Docker probe, launcher, and managed
+/// paths into the single decision the <c>func start</c> pipeline needs:
+/// "is Azurite ready, and if not, can I make it ready?". See §8.1.
+/// </summary>
+internal interface IManagedAzuriteOrchestrator
+{
+    /// <summary>
+    /// Resolves Azurite for one <c>func start</c> invocation.
+    /// </summary>
+    public Task<ManagedAzuriteResult> EnsureReadyAsync(
+        ManagedAzuriteRequest request,
+        CancellationToken cancellationToken);
+}

--- a/src/Func/Commands/Start/Azurite/Orchestration/ManagedAzuriteHandle.cs
+++ b/src/Func/Commands/Start/Azurite/Orchestration/ManagedAzuriteHandle.cs
@@ -1,0 +1,86 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Commands.Start.Azurite.Launching;
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite.Orchestration;
+
+/// <summary>
+/// Disposable wrapper around an <see cref="IAzuriteProcess"/> the CLI
+/// launched. Disposal stops the process with a short grace timeout so a
+/// <c>Ctrl+C</c> on <c>func start</c> never leaves orphaned native processes
+/// or Docker containers behind.
+/// </summary>
+/// <remarks>
+/// The handle is safe to construct for the no-process cases too
+/// (<see cref="ManagedAzuriteResult.Disabled"/> or
+/// <see cref="ManagedAzuriteResult.UserManaged"/>): disposal is a no-op so
+/// callers can <c>await using</c> unconditionally.
+/// </remarks>
+internal sealed class ManagedAzuriteHandle : IAsyncDisposable
+{
+    private static readonly TimeSpan _defaultStopGrace = TimeSpan.FromSeconds(5);
+
+    private readonly IAzuriteProcess? _process;
+    private readonly TimeSpan _stopGrace;
+    private bool _disposed;
+
+    private ManagedAzuriteHandle(IAzuriteProcess? process, AzuriteLaunchMode? mode, TimeSpan stopGrace)
+    {
+        _process = process;
+        _stopGrace = stopGrace;
+        Mode = mode;
+    }
+
+    public AzuriteLaunchMode? Mode { get; }
+
+    /// <summary>
+    /// Handle for the no-process cases (user-managed or disabled). Disposal
+    /// is a no-op.
+    /// </summary>
+    public static ManagedAzuriteHandle None() =>
+        new(process: null, mode: null, stopGrace: _defaultStopGrace);
+
+    /// <summary>
+    /// Handle that owns <paramref name="process"/> and stops it on disposal.
+    /// </summary>
+    public static ManagedAzuriteHandle Owning(IAzuriteProcess process, AzuriteLaunchMode mode) =>
+        new(process ?? throw new ArgumentNullException(nameof(process)), mode, _defaultStopGrace);
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        if (_process is null)
+        {
+            return;
+        }
+
+        // Best-effort graceful stop; the launcher already escalates to kill
+        // after its internal grace timeout. Swallow exceptions during
+        // shutdown so a launcher fault never masks the host's own outcome.
+        using CancellationTokenSource cts = new(_stopGrace);
+        try
+        {
+            await _process.StopAsync(cts.Token);
+        }
+        catch
+        {
+            // Intentional: disposal must not throw.
+        }
+
+        try
+        {
+            await _process.DisposeAsync();
+        }
+        catch
+        {
+            // Intentional: disposal must not throw.
+        }
+    }
+}

--- a/src/Func/Commands/Start/Azurite/Orchestration/ManagedAzuriteOrchestrator.cs
+++ b/src/Func/Commands/Start/Azurite/Orchestration/ManagedAzuriteOrchestrator.cs
@@ -114,6 +114,7 @@ internal sealed class ManagedAzuriteOrchestrator : IManagedAzuriteOrchestrator
                     .Muted("Using existing Azurite endpoint at ")
                     .Path(endpoints.BlobEndpoint.ToString())
                     .Muted("."));
+                _interaction.WriteBlankLine();
                 return new ManagedAzuriteResult.UserManaged(endpoints, "Endpoints already responded with storage-shaped replies.");
 
             case AzuriteProbeStatus.PortConflict:

--- a/src/Func/Commands/Start/Azurite/Orchestration/ManagedAzuriteOrchestrator.cs
+++ b/src/Func/Commands/Start/Azurite/Orchestration/ManagedAzuriteOrchestrator.cs
@@ -1,0 +1,500 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Text;
+using Azure.Functions.Cli.Commands.Start.Azurite.Launching;
+using Azure.Functions.Cli.Console;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite.Orchestration;
+
+/// <inheritdoc cref="IManagedAzuriteOrchestrator"/>
+internal sealed class ManagedAzuriteOrchestrator : IManagedAzuriteOrchestrator
+{
+    private const string AzuriteInstallUrl = "https://aka.ms/azfunc-azurite";
+    private static readonly TimeSpan _pollInterval = TimeSpan.FromMilliseconds(250);
+
+    private readonly IAzureWebJobsStorageClassifier _classifier;
+    private readonly IAzuriteProbe _probe;
+    private readonly IAzuriteExecutableLocator _executableLocator;
+    private readonly IDockerAvailabilityProbe _dockerProbe;
+    private readonly IAzuriteLauncher _launcher;
+    private readonly IAzuriteManagedPathsProvider _pathsProvider;
+    private readonly IInteractionService _interaction;
+    private readonly ILogger<ManagedAzuriteOrchestrator> _logger;
+
+    public ManagedAzuriteOrchestrator(
+        IAzureWebJobsStorageClassifier classifier,
+        IAzuriteProbe probe,
+        IAzuriteExecutableLocator executableLocator,
+        IDockerAvailabilityProbe dockerProbe,
+        IAzuriteLauncher launcher,
+        IAzuriteManagedPathsProvider pathsProvider,
+        IInteractionService interaction,
+        ILogger<ManagedAzuriteOrchestrator> logger)
+    {
+        _classifier = classifier ?? throw new ArgumentNullException(nameof(classifier));
+        _probe = probe ?? throw new ArgumentNullException(nameof(probe));
+        _executableLocator = executableLocator ?? throw new ArgumentNullException(nameof(executableLocator));
+        _dockerProbe = dockerProbe ?? throw new ArgumentNullException(nameof(dockerProbe));
+        _launcher = launcher ?? throw new ArgumentNullException(nameof(launcher));
+        _pathsProvider = pathsProvider ?? throw new ArgumentNullException(nameof(pathsProvider));
+        _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<ManagedAzuriteResult> EnsureReadyAsync(
+        ManagedAzuriteRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (request.Disabled)
+        {
+            _logger.LogInformation("Managed Azurite disabled via --no-azurite.");
+            return new ManagedAzuriteResult.Disabled("--no-azurite was specified.");
+        }
+
+        AzureWebJobsStorageReference classification = _classifier.Classify(request.StorageConnectionString);
+        _logger.LogInformation(
+            "AzureWebJobsStorage classified as {Classification}: {Reason}",
+            classification.Classification,
+            classification.Reason);
+
+        switch (classification.Classification)
+        {
+            case AzureWebJobsStorageClassification.NotLocal:
+                return new ManagedAzuriteResult.Disabled(classification.Reason);
+
+            case AzureWebJobsStorageClassification.UserConfiguredAzurite:
+                return await EnsureUserConfiguredAsync(classification, cancellationToken);
+
+            case AzureWebJobsStorageClassification.ManageableAzurite:
+                return await EnsureManageableAsync(request, classification, cancellationToken);
+
+            default:
+                return new ManagedAzuriteResult.Failed(
+                    $"Unsupported AzureWebJobsStorage classification: {classification.Classification}.");
+        }
+    }
+
+    private async Task<ManagedAzuriteResult> EnsureUserConfiguredAsync(
+        AzureWebJobsStorageReference classification,
+        CancellationToken cancellationToken)
+    {
+        AzuriteEndpointTuple endpoints = classification.Endpoints ?? DefaultEndpoints();
+        AzuriteProbeResult probe = await _probe.ProbeAsync(endpoints, cancellationToken);
+
+        if (probe.Status == AzuriteProbeStatus.Ready)
+        {
+            _logger.LogInformation("User-configured Azurite is already running.");
+            return new ManagedAzuriteResult.UserManaged(endpoints, classification.Reason);
+        }
+
+        string message = BuildUserConfiguredFailureMessage(endpoints);
+        return new ManagedAzuriteResult.Failed(message, probe.Reason);
+    }
+
+    private async Task<ManagedAzuriteResult> EnsureManageableAsync(
+        ManagedAzuriteRequest request,
+        AzureWebJobsStorageReference classification,
+        CancellationToken cancellationToken)
+    {
+        AzuriteEndpointTuple endpoints = classification.Endpoints ?? DefaultEndpoints();
+
+        AzuriteProbeResult probe = await _probe.ProbeAsync(endpoints, cancellationToken);
+        switch (probe.Status)
+        {
+            case AzuriteProbeStatus.Ready:
+                // §11 user-managed-reuse fallback: when MVP discovers something
+                // already on the ports, treat it as user-managed and skip
+                // launching our own.
+                _logger.LogInformation("Existing Azurite endpoint detected; reusing it without launching a managed instance.");
+                _interaction.WriteLine(l => l
+                    .Muted("Using existing Azurite endpoint at ")
+                    .Path(endpoints.BlobEndpoint.ToString())
+                    .Muted("."));
+                return new ManagedAzuriteResult.UserManaged(endpoints, "Endpoints already responded with storage-shaped replies.");
+
+            case AzuriteProbeStatus.PortConflict:
+            case AzuriteProbeStatus.Partial:
+                return new ManagedAzuriteResult.Failed(
+                    BuildPortConflictMessage(endpoints, probe),
+                    probe.Reason);
+
+            case AzuriteProbeStatus.NotListening:
+                break;
+        }
+
+        AzuriteExecutable? executable = await _executableLocator.FindAsync(request.ProjectRoot, cancellationToken);
+        if (executable is not null)
+        {
+            return await LaunchAsync(
+                request,
+                endpoints,
+                AzuriteLaunchMode.Native,
+                executable.FilePath,
+                executable.Version,
+                cancellationToken);
+        }
+
+        DockerAvailability docker = await _dockerProbe.ProbeAsync(cancellationToken);
+        if (docker.Status != DockerAvailabilityStatus.Available)
+        {
+            return new ManagedAzuriteResult.Failed(
+                BuildDockerUnavailableMessage(docker),
+                docker.Reason);
+        }
+
+        return await LaunchAsync(
+            request,
+            endpoints,
+            AzuriteLaunchMode.Docker,
+            executablePath: null,
+            executableVersion: docker.Version,
+            cancellationToken);
+    }
+
+    private async Task<ManagedAzuriteResult> LaunchAsync(
+        ManagedAzuriteRequest request,
+        AzuriteEndpointTuple endpoints,
+        AzuriteLaunchMode mode,
+        string? executablePath,
+        string? executableVersion,
+        CancellationToken cancellationToken)
+    {
+        AzuriteManagedPaths paths = _pathsProvider.GetPaths();
+        await _pathsProvider.EnsureCreatedAsync(paths, cancellationToken);
+
+        WriteStartBanner(mode, executablePath, executableVersion, endpoints, paths);
+
+        AzuriteLaunchRequest launchRequest = new(
+            mode: mode,
+            blobPort: endpoints.BlobEndpoint.Port,
+            queuePort: endpoints.QueueEndpoint.Port,
+            tablePort: endpoints.TableEndpoint.Port,
+            dataPath: paths.DataDirectory,
+            logPath: paths.LogFilePath,
+            executablePath: executablePath,
+            dockerImage: mode == AzuriteLaunchMode.Docker ? AzuriteDockerImage.Default : null,
+            containerName: mode == AzuriteLaunchMode.Docker ? "func-azurite" : null);
+
+        IAzuriteProcess process;
+        try
+        {
+            process = await _launcher.StartAsync(launchRequest, cancellationToken);
+        }
+        catch (AzuriteLaunchException ex)
+        {
+            return new ManagedAzuriteResult.Failed(
+                $"Azurite could not be launched: {ex.Message}",
+                ex.ToString());
+        }
+
+        PollOutcome poll = await PollReadyAsync(process, endpoints, request.StartupTimeout, cancellationToken);
+        switch (poll.Kind)
+        {
+            case PollOutcomeKind.Ready:
+                _interaction.WriteSuccess($"Azurite ready ({poll.Elapsed.TotalSeconds:0.0}s).");
+                return new ManagedAzuriteResult.Started(process, mode, endpoints);
+
+            case PollOutcomeKind.ProcessExited:
+                await SafeDisposeAsync(process);
+                return new ManagedAzuriteResult.Failed(
+                    BuildProcessExitedMessage(mode, paths, poll.StderrTail),
+                    poll.StderrTail);
+
+            case PollOutcomeKind.TimedOut:
+            default:
+                await StopAndDisposeAsync(process);
+                return new ManagedAzuriteResult.Failed(
+                    BuildTimeoutMessage(endpoints, paths, request.StartupTimeout),
+                    poll.StderrTail);
+        }
+    }
+
+    private async Task<PollOutcome> PollReadyAsync(
+        IAzuriteProcess process,
+        AzuriteEndpointTuple endpoints,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        using CancellationTokenSource timeoutCts = new(timeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken, timeoutCts.Token);
+
+        long startTimestamp = System.Diagnostics.Stopwatch.GetTimestamp();
+        Task<int> exitTask = process.WaitForExitAsync(linkedCts.Token);
+
+        while (true)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                throw new OperationCanceledException(cancellationToken);
+            }
+
+            if (exitTask.IsCompleted)
+            {
+                string stderr = await TryReadStderrTailAsync(process);
+                return new PollOutcome(
+                    PollOutcomeKind.ProcessExited,
+                    System.Diagnostics.Stopwatch.GetElapsedTime(startTimestamp),
+                    stderr);
+            }
+
+            AzuriteProbeResult probe;
+            try
+            {
+                probe = await _probe.ProbeAsync(endpoints, linkedCts.Token);
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                string stderr = await TryReadStderrTailAsync(process);
+                return new PollOutcome(
+                    PollOutcomeKind.TimedOut,
+                    System.Diagnostics.Stopwatch.GetElapsedTime(startTimestamp),
+                    stderr);
+            }
+
+            if (probe.Status == AzuriteProbeStatus.Ready)
+            {
+                return new PollOutcome(
+                    PollOutcomeKind.Ready,
+                    System.Diagnostics.Stopwatch.GetElapsedTime(startTimestamp),
+                    StderrTail: null);
+            }
+
+            var delay = Task.Delay(_pollInterval, linkedCts.Token);
+            Task completed = await Task.WhenAny(delay, exitTask);
+            if (completed == exitTask)
+            {
+                string stderr = await TryReadStderrTailAsync(process);
+                return new PollOutcome(
+                    PollOutcomeKind.ProcessExited,
+                    System.Diagnostics.Stopwatch.GetElapsedTime(startTimestamp),
+                    stderr);
+            }
+
+            if (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                string stderr = await TryReadStderrTailAsync(process);
+                return new PollOutcome(
+                    PollOutcomeKind.TimedOut,
+                    System.Diagnostics.Stopwatch.GetElapsedTime(startTimestamp),
+                    stderr);
+            }
+        }
+    }
+
+    private static async Task<string> TryReadStderrTailAsync(IAzuriteProcess process)
+    {
+        // Drain stderr with a tight per-line budget so we never block readiness
+        // diagnostics on a process that has stopped writing.
+        using CancellationTokenSource readCts = new(TimeSpan.FromMilliseconds(500));
+        Queue<string> lines = new(capacity: 10);
+        try
+        {
+            await foreach (string line in process.ReadStderrLinesAsync(readCts.Token))
+            {
+                if (lines.Count == 10)
+                {
+                    lines.Dequeue();
+                }
+
+                lines.Enqueue(line);
+            }
+        }
+        catch
+        {
+            // Best effort: stderr capture must not mask the launch failure.
+        }
+
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    private static async Task SafeDisposeAsync(IAzuriteProcess process)
+    {
+        try
+        {
+            await process.DisposeAsync();
+        }
+        catch
+        {
+            // Best effort.
+        }
+    }
+
+    private static async Task StopAndDisposeAsync(IAzuriteProcess process)
+    {
+        using CancellationTokenSource stopCts = new(TimeSpan.FromSeconds(5));
+        try
+        {
+            await process.StopAsync(stopCts.Token);
+        }
+        catch
+        {
+            // Best effort.
+        }
+
+        await SafeDisposeAsync(process);
+    }
+
+    private void WriteStartBanner(
+        AzuriteLaunchMode mode,
+        string? executablePath,
+        string? executableVersion,
+        AzuriteEndpointTuple endpoints,
+        AzuriteManagedPaths paths)
+    {
+        string modeLabel = mode == AzuriteLaunchMode.Native ? "native" : "Docker";
+        _interaction.WriteLine(l =>
+        {
+            l.Plain("Starting Azurite (").Emphasis(modeLabel).Plain(") for AzureWebJobsStorage...");
+        });
+
+        if (mode == AzuriteLaunchMode.Native && !string.IsNullOrEmpty(executablePath))
+        {
+            _interaction.WriteLine(l => l.Muted("  Executable: ").Path(executablePath));
+        }
+        else if (mode == AzuriteLaunchMode.Docker)
+        {
+            _interaction.WriteLine(l => l.Muted("  Image: ").Path(AzuriteDockerImage.Default));
+        }
+
+        if (!string.IsNullOrEmpty(executableVersion))
+        {
+            _interaction.WriteLine(l => l.Muted("  Version: ").Plain(executableVersion));
+        }
+
+        _interaction.WriteLine(l => l.Muted("  Data: ").Path(paths.DataDirectory));
+        _interaction.WriteLine(l => l.Muted("  Logs: ").Path(paths.LogFilePath));
+        _interaction.WriteLine(l => l
+            .Muted("  Endpoints: blob ")
+            .Plain(FormatEndpoint(endpoints.BlobEndpoint))
+            .Muted(", queue ")
+            .Plain(FormatEndpoint(endpoints.QueueEndpoint))
+            .Muted(", table ")
+            .Plain(FormatEndpoint(endpoints.TableEndpoint)));
+    }
+
+    private static string FormatEndpoint(Uri uri) => $"{uri.Host}:{uri.Port}";
+
+    private static AzuriteEndpointTuple DefaultEndpoints()
+    {
+        Uri Build(int port) => new UriBuilder("http", "127.0.0.1", port, $"/{AzureWebJobsStorageClassifier.DevelopmentStorageAccountName}").Uri;
+        return new AzuriteEndpointTuple(
+            BlobEndpoint: Build(AzureWebJobsStorageClassifier.DefaultBlobPort),
+            QueueEndpoint: Build(AzureWebJobsStorageClassifier.DefaultQueuePort),
+            TableEndpoint: Build(AzureWebJobsStorageClassifier.DefaultTablePort),
+            AccountName: AzureWebJobsStorageClassifier.DevelopmentStorageAccountName);
+    }
+
+    private static string BuildUserConfiguredFailureMessage(AzuriteEndpointTuple endpoints)
+    {
+        StringBuilder sb = new();
+        sb.AppendLine("AzureWebJobsStorage points to a local storage emulator, but the Azure Functions CLI cannot start this configuration automatically.");
+        sb.AppendLine();
+        sb.AppendLine("Start Azurite with these endpoints, then run 'func start' again:");
+        sb.AppendLine($"  Blob:  {endpoints.BlobEndpoint}");
+        sb.AppendLine($"  Queue: {endpoints.QueueEndpoint}");
+        sb.Append($"  Table: {endpoints.TableEndpoint}");
+        return sb.ToString();
+    }
+
+    private static string BuildPortConflictMessage(AzuriteEndpointTuple endpoints, AzuriteProbeResult probe)
+    {
+        StringBuilder sb = new();
+        sb.AppendLine("AzureWebJobsStorage points to local storage, but another process is using the Azurite ports.");
+        sb.AppendLine();
+        sb.AppendLine("Stop whatever is on these ports, then run 'func start' again:");
+        sb.AppendLine($"  Blob:  {endpoints.BlobEndpoint}");
+        sb.AppendLine($"  Queue: {endpoints.QueueEndpoint}");
+        sb.Append($"  Table: {endpoints.TableEndpoint}");
+        if (!string.IsNullOrWhiteSpace(probe.Reason))
+        {
+            sb.AppendLine();
+            sb.AppendLine();
+            sb.Append($"Detail: {probe.Reason}");
+        }
+
+        return sb.ToString();
+    }
+
+    private static string BuildDockerUnavailableMessage(DockerAvailability docker)
+    {
+        StringBuilder sb = new();
+        sb.AppendLine("AzureWebJobsStorage points to local storage, but Azurite is not running.");
+        sb.AppendLine();
+        sb.AppendLine("The Azure Functions CLI could not find an Azurite executable and Docker is not available.");
+        sb.AppendLine();
+        sb.AppendLine("Install one of the following and run 'func start' again:");
+        sb.AppendLine("  - Azurite:       npm install -g azurite");
+        sb.AppendLine("  - Docker Desktop: https://docs.docker.com/desktop/");
+        sb.AppendLine();
+        sb.Append($"Learn more: {AzuriteInstallUrl}");
+        if (docker.Status == DockerAvailabilityStatus.DaemonUnavailable)
+        {
+            sb.AppendLine();
+            sb.AppendLine();
+            sb.Append("Docker was detected but the daemon is not reachable. Start Docker Desktop and try again.");
+        }
+
+        return sb.ToString();
+    }
+
+    private static string BuildProcessExitedMessage(
+        AzuriteLaunchMode mode,
+        AzuriteManagedPaths paths,
+        string? stderrTail)
+    {
+        StringBuilder sb = new();
+        if (mode == AzuriteLaunchMode.Native)
+        {
+            sb.AppendLine("Azurite exited before it was ready.");
+        }
+        else
+        {
+            sb.AppendLine("The Azurite Docker container exited before it was ready.");
+            sb.AppendLine($"Image: {AzuriteDockerImage.Default}");
+            sb.AppendLine("Container: func-azurite (run 'docker logs func-azurite' for details)");
+        }
+
+        sb.AppendLine();
+        sb.Append($"Log file: {paths.LogFilePath}");
+        if (!string.IsNullOrWhiteSpace(stderrTail))
+        {
+            sb.AppendLine();
+            sb.AppendLine();
+            sb.AppendLine("Last output:");
+            sb.Append(stderrTail);
+        }
+
+        return sb.ToString();
+    }
+
+    private static string BuildTimeoutMessage(
+        AzuriteEndpointTuple endpoints,
+        AzuriteManagedPaths paths,
+        TimeSpan timeout)
+    {
+        StringBuilder sb = new();
+        sb.AppendLine($"Azurite did not become ready within {(int)timeout.TotalSeconds} seconds.");
+        sb.AppendLine();
+        sb.AppendLine("Expected endpoints:");
+        sb.AppendLine($"  Blob:  {endpoints.BlobEndpoint}");
+        sb.AppendLine($"  Queue: {endpoints.QueueEndpoint}");
+        sb.AppendLine($"  Table: {endpoints.TableEndpoint}");
+        sb.AppendLine();
+        sb.Append($"Log file: {paths.LogFilePath}");
+        return sb.ToString();
+    }
+
+    private enum PollOutcomeKind
+    {
+        Ready,
+        ProcessExited,
+        TimedOut,
+    }
+
+    private readonly record struct PollOutcome(PollOutcomeKind Kind, TimeSpan Elapsed, string? StderrTail);
+}

--- a/src/Func/Commands/Start/Azurite/Orchestration/ManagedAzuriteRequest.cs
+++ b/src/Func/Commands/Start/Azurite/Orchestration/ManagedAzuriteRequest.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite.Orchestration;
+
+/// <summary>
+/// Inputs the managed-Azurite orchestrator needs to decide whether to start
+/// Azurite for a single <c>func start</c> invocation.
+/// </summary>
+/// <param name="StorageConnectionString">
+/// Effective <c>AzureWebJobsStorage</c> value after settings + process-env
+/// merging. Null or whitespace is treated the same as "no local storage".
+/// </param>
+/// <param name="ProjectRoot">
+/// Absolute path to the resolved project root. Passed to the executable
+/// locator so it can find a project-local npm Azurite binary first.
+/// </param>
+/// <param name="Disabled">
+/// <c>true</c> when the user passed <c>--no-azurite</c>; the orchestrator
+/// short-circuits before any I/O.
+/// </param>
+/// <param name="StartupTimeout">
+/// Maximum time to wait for a freshly launched Azurite to become ready (§9.4).
+/// </param>
+internal sealed record ManagedAzuriteRequest(
+    string? StorageConnectionString,
+    string ProjectRoot,
+    bool Disabled,
+    TimeSpan StartupTimeout)
+{
+    /// <summary>
+    /// Default readiness timeout per design §9.4.
+    /// </summary>
+    public static TimeSpan DefaultStartupTimeout { get; } = TimeSpan.FromSeconds(30);
+}

--- a/src/Func/Commands/Start/Azurite/Orchestration/ManagedAzuriteResult.cs
+++ b/src/Func/Commands/Start/Azurite/Orchestration/ManagedAzuriteResult.cs
@@ -1,0 +1,49 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Commands.Start.Azurite.Launching;
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite.Orchestration;
+
+/// <summary>
+/// Discriminated outcome of <see cref="IManagedAzuriteOrchestrator.EnsureReadyAsync"/>.
+/// The four shapes mirror the branches in §8.1: do nothing, reuse an
+/// existing instance, hand back a process we started, or fail fast with a
+/// user-facing message.
+/// </summary>
+internal abstract record ManagedAzuriteResult
+{
+    private ManagedAzuriteResult()
+    {
+    }
+
+    /// <summary>
+    /// The CLI must not manage Azurite for this invocation. Either
+    /// <c>--no-azurite</c> was set or <c>AzureWebJobsStorage</c> does not
+    /// reference a local emulator.
+    /// </summary>
+    public sealed record Disabled(string Reason) : ManagedAzuriteResult;
+
+    /// <summary>
+    /// Azurite was already responding on the configured endpoints. The CLI
+    /// reused it and does not own its lifetime.
+    /// </summary>
+    public sealed record UserManaged(AzuriteEndpointTuple Endpoints, string Reason) : ManagedAzuriteResult;
+
+    /// <summary>
+    /// The CLI launched Azurite. <paramref name="Process"/> is the running
+    /// handle; the caller is responsible for disposing it when the host run
+    /// ends.
+    /// </summary>
+    public sealed record Started(
+        IAzuriteProcess Process,
+        AzuriteLaunchMode Mode,
+        AzuriteEndpointTuple Endpoints) : ManagedAzuriteResult;
+
+    /// <summary>
+    /// Azurite cannot be made ready. <paramref name="UserMessage"/> is
+    /// surfaced verbatim to the user; <paramref name="VerboseDetail"/> is
+    /// captured for logs and the verbose error pane.
+    /// </summary>
+    public sealed record Failed(string UserMessage, string? VerboseDetail = null) : ManagedAzuriteResult;
+}

--- a/src/Func/Commands/Start/Dashboard/Demo/DemoStartInitializationRunner.cs
+++ b/src/Func/Commands/Start/Dashboard/Demo/DemoStartInitializationRunner.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Bundles;
+using Azure.Functions.Cli.Commands.Start.Azurite;
+using Azure.Functions.Cli.Commands.Start.Azurite.Orchestration;
 using Azure.Functions.Cli.Commands.Start.Initialization.Rendering;
 using Azure.Functions.Cli.Commands.Start.Host;
 using Azure.Functions.Cli.Common;
@@ -34,6 +36,7 @@ internal sealed class DemoStartInitializationRunner(
     IWorkloadPaths workloadPaths,
     IHostProcessRunner hostProcessRunner,
     IProcessEnvironment processEnvironment,
+    IManagedAzuriteOrchestrator managedAzuriteOrchestrator,
     ILoggerFactory loggerFactory,
     TimeProvider? timeProvider = null)
     : IStartInitializationRunner
@@ -75,6 +78,9 @@ internal sealed class DemoStartInitializationRunner(
     private readonly IProcessEnvironment _processEnvironment = processEnvironment
         ?? throw new ArgumentNullException(nameof(processEnvironment));
 
+    private readonly IManagedAzuriteOrchestrator _managedAzuriteOrchestrator = managedAzuriteOrchestrator
+        ?? throw new ArgumentNullException(nameof(managedAzuriteOrchestrator));
+
     private readonly ILoggerFactory _loggerFactory = loggerFactory
         ?? throw new ArgumentNullException(nameof(loggerFactory));
 
@@ -110,6 +116,7 @@ internal sealed class DemoStartInitializationRunner(
                 _bundleSectionReader,
                 _loggerFactory.CreateLogger<ValidateExtensionBundleInitializationStep>()),
             new PrepareProjectHostRunInitializationStep(_localSettingsProvider, _processEnvironment, _interaction),
+            new EnsureAzuriteInitializationStep(_managedAzuriteOrchestrator, _processEnvironment),
             new StartHostInitializationStep(_hostProcessRunner, _time),
         ];
 

--- a/src/Func/Commands/Start/Initialization/StartCommandOptions.cs
+++ b/src/Func/Commands/Start/Initialization/StartCommandOptions.cs
@@ -26,4 +26,5 @@ internal sealed record StartCommandOptions(
     bool DemoMode,
     int DemoFunctionCount,
     double DemoSpeedMultiplier,
-    bool DemoAutoExit);
+    bool DemoAutoExit,
+    bool NoAzurite = false);

--- a/src/Func/Commands/Start/Initialization/StartInitializationResult.cs
+++ b/src/Func/Commands/Start/Initialization/StartInitializationResult.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Commands.Start.Azurite.Orchestration;
 using Azure.Functions.Cli.Hosting.Dashboard;
 using Azure.Functions.Cli.Hosting.Events;
 using Azure.Functions.Cli.Projects;
@@ -20,4 +21,5 @@ internal sealed record StartInitializationResult(
     FunctionsProject Project,
     IFunctionsWorker Worker,
     FunctionsProjectHostRunContext HostRunContext,
-    StartInitializationProfileInfo? Profile = null);
+    StartInitializationProfileInfo? Profile = null,
+    ManagedAzuriteHandle? ManagedAzurite = null);

--- a/src/Func/Commands/Start/Initialization/StartInitializationState.cs
+++ b/src/Func/Commands/Start/Initialization/StartInitializationState.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Commands.Start.Azurite.Orchestration;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Hosting.Dashboard;
 using Azure.Functions.Cli.Hosting.Events;
@@ -44,6 +45,14 @@ internal sealed class StartInitializationState
 
     public IHostEventStream? EventStream { get; set; }
 
+    /// <summary>
+    /// Disposable handle for the managed Azurite process the CLI launched
+    /// for this run, or null when there is no managed process (user-managed,
+    /// non-local storage, or <c>--no-azurite</c>). The <see cref="StartCommand"/>
+    /// owns disposal once <see cref="ToResult"/> has been called.
+    /// </summary>
+    public ManagedAzuriteHandle? ManagedAzurite { get; set; }
+
     public StartInitializationResult ToResult(StartInitializationContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -66,7 +75,8 @@ internal sealed class StartInitializationState
             project,
             worker,
             hostRunContext,
-            CreateProfileInfo());
+            CreateProfileInfo(),
+            ManagedAzurite);
     }
 
     private StartInitializationProfileInfo? CreateProfileInfo()

--- a/src/Func/Commands/Start/StartCommand.cs
+++ b/src/Func/Commands/Start/StartCommand.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine;
 using System.Globalization;
+using Azure.Functions.Cli.Commands.Start.Azurite.Orchestration;
 using Azure.Functions.Cli.Commands.Start.Initialization;
 using Azure.Functions.Cli.Commands.Start.Initialization.Rendering;
 using Azure.Functions.Cli.Common;
@@ -91,6 +92,11 @@ internal sealed class StartCommand : FuncCliCommand, IBuiltInCommand
         Hidden = true,
     };
 
+    public Option<bool> NoAzuriteOption { get; } = new("--no-azurite")
+    {
+        Description = "Disable managed Azurite. The host will start without probing or starting a local emulator."
+    };
+
     // Demo-only knob: scales the number of functions DemoEventSource
     // generates so layout variants (full-table ≤8 vs. status-strip >8) can
     // be demoed without code changes. Hidden from --help; intended for
@@ -151,6 +157,7 @@ internal sealed class StartCommand : FuncCliCommand, IBuiltInCommand
         Options.Add(LogFileOption);
         Options.Add(DemoOption);
         Options.Add(DemoFunctionsOption);
+        Options.Add(NoAzuriteOption);
     }
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
@@ -202,6 +209,11 @@ internal sealed class StartCommand : FuncCliCommand, IBuiltInCommand
         IHostEventStream dashboardEventStream = _eventStreamFactory.Create(mode, initializationEvents, initializationResult.EventStream);
         var pipeline = new DashboardPipeline(state, dashboardEventStream, renderer, eventSink);
         FunctionsProjectHostRunOutcome? outcome = null;
+        // Stop any managed Azurite instance the orchestrator launched when
+        // the host run completes (success, failure, or Ctrl+C). Wrapping the
+        // host run in `await using` guarantees the process never outlives
+        // `func start`.
+        await using ManagedAzuriteHandle? azurite = initializationResult.ManagedAzurite;
         try
         {
             int exitCode = await pipeline.RunAsync(cancellationToken);
@@ -299,7 +311,8 @@ internal sealed class StartCommand : FuncCliCommand, IBuiltInCommand
                 parseResult.GetValue(DemoFunctionsOption),
                 Environment.GetEnvironmentVariable("FUNC_DEMO_FUNCTIONS")),
             ParseSpeedMultiplier(Environment.GetEnvironmentVariable("FUNC_DEMO_SPEED")),
-            ParseAutoExit(Environment.GetEnvironmentVariable("FUNC_DEMO_AUTOEXIT")));
+            ParseAutoExit(Environment.GetEnvironmentVariable("FUNC_DEMO_AUTOEXIT")),
+            parseResult.GetValue(NoAzuriteOption));
 
     private static string[] ParseCors(string? cors)
         => string.IsNullOrWhiteSpace(cors)

--- a/src/Func/Hosting/CliHostFactory.cs
+++ b/src/Func/Hosting/CliHostFactory.cs
@@ -3,6 +3,7 @@
 
 using Azure.Functions.Cli.Bundles;
 using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Commands.Start.Azurite;
 using Azure.Functions.Cli.Commands.Start.Host;
 using Azure.Functions.Cli.Commands.Start.Initialization;
 using Azure.Functions.Cli.Configuration;
@@ -116,6 +117,7 @@ internal static class CliHostFactory
         builder.Services.AddWorkloadCatalog();
         builder.Services.AddWorkloadInstaller();
         builder.Services.AddQuickstartManifest();
+        builder.Services.AddManagedAzurite();
 
         return builder;
     }

--- a/test/Func.Tests/Commands/Start/Azurite/AzuriteServiceCollectionExtensionsTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/AzuriteServiceCollectionExtensionsTests.cs
@@ -1,0 +1,70 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Commands.Start.Azurite;
+using Azure.Functions.Cli.Commands.Start.Azurite.Launching;
+using Azure.Functions.Cli.Commands.Start.Azurite.Orchestration;
+using Azure.Functions.Cli.Configuration;
+using Azure.Functions.Cli.Console;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Commands.Start.Azurite;
+
+public class AzuriteServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddAzuriteProbe_ResolvesIAzuriteProbe()
+    {
+        IServiceProvider provider = BaseServices().AddAzuriteProbe().BuildServiceProvider();
+        Assert.NotNull(provider.GetRequiredService<IAzuriteProbe>());
+    }
+
+    [Fact]
+    public void AddAzuriteManagedPaths_ResolvesPathsProviderAndClock()
+    {
+        IServiceProvider provider = BaseServices().AddAzuriteManagedPaths().BuildServiceProvider();
+        Assert.NotNull(provider.GetRequiredService<IAzuriteManagedPathsProvider>());
+        Assert.NotNull(provider.GetRequiredService<IClock>());
+    }
+
+    [Fact]
+    public void AddAzuriteDiscovery_ResolvesLocatorAndDockerProbe()
+    {
+        IServiceProvider provider = BaseServices().AddAzuriteDiscovery().BuildServiceProvider();
+        Assert.NotNull(provider.GetRequiredService<IAzuriteExecutableLocator>());
+        Assert.NotNull(provider.GetRequiredService<IDockerAvailabilityProbe>());
+    }
+
+    [Fact]
+    public void AddAzuriteLauncher_ResolvesLauncher()
+    {
+        IServiceCollection services = BaseServices().AddAzuriteDiscovery().AddAzuriteLauncher();
+        IServiceProvider provider = services.BuildServiceProvider();
+        Assert.NotNull(provider.GetRequiredService<IAzuriteLauncher>());
+    }
+
+    [Fact]
+    public void AddManagedAzurite_ResolvesOrchestratorAndAllDependencies()
+    {
+        IServiceProvider provider = BaseServices().AddManagedAzurite().BuildServiceProvider();
+
+        Assert.NotNull(provider.GetRequiredService<IManagedAzuriteOrchestrator>());
+        Assert.NotNull(provider.GetRequiredService<IAzureWebJobsStorageClassifier>());
+        Assert.NotNull(provider.GetRequiredService<IAzuriteProbe>());
+        Assert.NotNull(provider.GetRequiredService<IAzuriteExecutableLocator>());
+        Assert.NotNull(provider.GetRequiredService<IDockerAvailabilityProbe>());
+        Assert.NotNull(provider.GetRequiredService<IAzuriteLauncher>());
+        Assert.NotNull(provider.GetRequiredService<IAzuriteManagedPathsProvider>());
+    }
+
+    private static IServiceCollection BaseServices()
+    {
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddSingleton(new CliConfigurationPathsOptions(Path.GetTempPath()));
+        services.AddSingleton(Substitute.For<IInteractionService>());
+        return services;
+    }
+}

--- a/test/Func.Tests/Commands/Start/Azurite/Orchestration/ManagedAzuriteOrchestratorTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/Orchestration/ManagedAzuriteOrchestratorTests.cs
@@ -1,0 +1,328 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+using Azure.Functions.Cli.Commands.Start.Azurite;
+using Azure.Functions.Cli.Commands.Start.Azurite.Launching;
+using Azure.Functions.Cli.Commands.Start.Azurite.Orchestration;
+using Azure.Functions.Cli.Console;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Commands.Start.Azurite.Orchestration;
+
+public class ManagedAzuriteOrchestratorTests
+{
+    private const string ProjectRoot = "/proj";
+    private const string Conn = "UseDevelopmentStorage=true";
+
+    private readonly IAzureWebJobsStorageClassifier _classifier = Substitute.For<IAzureWebJobsStorageClassifier>();
+    private readonly IAzuriteProbe _probe = Substitute.For<IAzuriteProbe>();
+    private readonly IAzuriteExecutableLocator _locator = Substitute.For<IAzuriteExecutableLocator>();
+    private readonly IDockerAvailabilityProbe _dockerProbe = Substitute.For<IDockerAvailabilityProbe>();
+    private readonly IAzuriteLauncher _launcher = Substitute.For<IAzuriteLauncher>();
+    private readonly IAzuriteManagedPathsProvider _paths = Substitute.For<IAzuriteManagedPathsProvider>();
+    private readonly IInteractionService _interaction = Substitute.For<IInteractionService>();
+
+    public ManagedAzuriteOrchestratorTests()
+    {
+        AzuriteManagedPaths managed = new(
+            DataDirectory: Path.Combine(Path.GetTempPath(), "azurite-data"),
+            LogFilePath: Path.Combine(Path.GetTempPath(), "azurite", "azurite.log"));
+        _paths.GetPaths().Returns(managed);
+        _paths.EnsureCreatedAsync(Arg.Any<AzuriteManagedPaths>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+    }
+
+    private ManagedAzuriteOrchestrator CreateSut() => new(
+        _classifier, _probe, _locator, _dockerProbe, _launcher, _paths,
+        _interaction, NullLogger<ManagedAzuriteOrchestrator>.Instance);
+
+    private static ManagedAzuriteRequest Request(bool disabled = false, TimeSpan? timeout = null) =>
+        new(Conn, ProjectRoot, disabled, timeout ?? TimeSpan.FromSeconds(5));
+
+    private static AzureWebJobsStorageReference Manageable() =>
+        AzureWebJobsStorageReference.Manageable(endpoints: null, reason: "UseDevelopmentStorage=true.");
+
+    private static AzureWebJobsStorageReference UserConfigured() =>
+        AzureWebJobsStorageReference.UserConfigured(endpoints: null, reason: "User-configured proxy.");
+
+    private static AzuriteProbeResult ProbeReady() => AzuriteProbeResult.From(new[]
+    {
+        new AzuriteEndpointProbeOutcome(AzuriteService.Blob, new Uri("http://127.0.0.1:10000/devstoreaccount1"), AzuriteEndpointStatus.Ready),
+        new AzuriteEndpointProbeOutcome(AzuriteService.Queue, new Uri("http://127.0.0.1:10001/devstoreaccount1"), AzuriteEndpointStatus.Ready),
+        new AzuriteEndpointProbeOutcome(AzuriteService.Table, new Uri("http://127.0.0.1:10002/devstoreaccount1"), AzuriteEndpointStatus.Ready),
+    });
+
+    private static AzuriteProbeResult ProbeNotListening() => AzuriteProbeResult.From(new[]
+    {
+        new AzuriteEndpointProbeOutcome(AzuriteService.Blob, new Uri("http://127.0.0.1:10000/devstoreaccount1"), AzuriteEndpointStatus.NotListening),
+        new AzuriteEndpointProbeOutcome(AzuriteService.Queue, new Uri("http://127.0.0.1:10001/devstoreaccount1"), AzuriteEndpointStatus.NotListening),
+        new AzuriteEndpointProbeOutcome(AzuriteService.Table, new Uri("http://127.0.0.1:10002/devstoreaccount1"), AzuriteEndpointStatus.NotListening),
+    });
+
+    private static AzuriteProbeResult ProbePortConflict() => AzuriteProbeResult.From(new[]
+    {
+        new AzuriteEndpointProbeOutcome(AzuriteService.Blob, new Uri("http://127.0.0.1:10000/devstoreaccount1"), AzuriteEndpointStatus.PortConflict),
+        new AzuriteEndpointProbeOutcome(AzuriteService.Queue, new Uri("http://127.0.0.1:10001/devstoreaccount1"), AzuriteEndpointStatus.PortConflict),
+        new AzuriteEndpointProbeOutcome(AzuriteService.Table, new Uri("http://127.0.0.1:10002/devstoreaccount1"), AzuriteEndpointStatus.PortConflict),
+    });
+
+    [Fact]
+    public async Task Disabled_ReturnsDisabled_WithoutTouchingOtherDependencies()
+    {
+        ManagedAzuriteOrchestrator sut = CreateSut();
+
+        ManagedAzuriteResult result = await sut.EnsureReadyAsync(Request(disabled: true), CancellationToken.None);
+
+        Assert.IsType<ManagedAzuriteResult.Disabled>(result);
+        await _probe.DidNotReceive().ProbeAsync(Arg.Any<AzuriteEndpointTuple>(), Arg.Any<CancellationToken>());
+        await _locator.DidNotReceive().FindAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _launcher.DidNotReceive().StartAsync(Arg.Any<AzuriteLaunchRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task NotLocalStorage_ReturnsDisabled()
+    {
+        _classifier.Classify(Arg.Any<string>()).Returns(AzureWebJobsStorageReference.NotLocal("Real Azure Storage."));
+
+        ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), CancellationToken.None);
+
+        Assert.IsType<ManagedAzuriteResult.Disabled>(result);
+        await _probe.DidNotReceive().ProbeAsync(Arg.Any<AzuriteEndpointTuple>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UserConfigured_AndProbeReady_ReturnsUserManaged()
+    {
+        _classifier.Classify(Conn).Returns(UserConfigured());
+        _probe.ProbeAsync(Arg.Any<AzuriteEndpointTuple>(), Arg.Any<CancellationToken>()).Returns(ProbeReady());
+
+        ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), CancellationToken.None);
+
+        Assert.IsType<ManagedAzuriteResult.UserManaged>(result);
+        await _launcher.DidNotReceive().StartAsync(Arg.Any<AzuriteLaunchRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UserConfigured_AndProbeNotReady_ReturnsFailed_WithGuidance()
+    {
+        _classifier.Classify(Conn).Returns(UserConfigured());
+        _probe.ProbeAsync(Arg.Any<AzuriteEndpointTuple>(), Arg.Any<CancellationToken>()).Returns(ProbeNotListening());
+
+        ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), CancellationToken.None);
+
+        var failed = Assert.IsType<ManagedAzuriteResult.Failed>(result);
+        Assert.Contains("cannot start this configuration automatically", failed.UserMessage);
+        Assert.Contains("Start Azurite", failed.UserMessage);
+    }
+
+    [Fact]
+    public async Task Manageable_AndProbeReady_ReturnsUserManaged_WithoutLaunching()
+    {
+        _classifier.Classify(Conn).Returns(Manageable());
+        _probe.ProbeAsync(Arg.Any<AzuriteEndpointTuple>(), Arg.Any<CancellationToken>()).Returns(ProbeReady());
+
+        ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), CancellationToken.None);
+
+        Assert.IsType<ManagedAzuriteResult.UserManaged>(result);
+        await _launcher.DidNotReceive().StartAsync(Arg.Any<AzuriteLaunchRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Manageable_PortConflict_ReturnsFailed_WithPortConflictMessage()
+    {
+        _classifier.Classify(Conn).Returns(Manageable());
+        _probe.ProbeAsync(Arg.Any<AzuriteEndpointTuple>(), Arg.Any<CancellationToken>()).Returns(ProbePortConflict());
+
+        ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), CancellationToken.None);
+
+        var failed = Assert.IsType<ManagedAzuriteResult.Failed>(result);
+        Assert.Contains("another process is using the Azurite ports", failed.UserMessage);
+    }
+
+    [Fact]
+    public async Task Manageable_NotListening_NativeFound_LaunchesNative_AndReturnsStarted()
+    {
+        _classifier.Classify(Conn).Returns(Manageable());
+        SetupProbeSequence(ProbeNotListening(), ProbeReady());
+        _locator.FindAsync(ProjectRoot, Arg.Any<CancellationToken>())
+            .Returns(new AzuriteExecutable("/usr/bin/azurite", AzuriteExecutableSource.Path, "3.30.0"));
+
+        FakeAzuriteProcess fake = new();
+        _launcher.StartAsync(Arg.Any<AzuriteLaunchRequest>(), Arg.Any<CancellationToken>()).Returns(fake);
+
+        ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), CancellationToken.None);
+
+        var started = Assert.IsType<ManagedAzuriteResult.Started>(result);
+        Assert.Equal(AzuriteLaunchMode.Native, started.Mode);
+        Assert.Same(fake, started.Process);
+        await _launcher.Received(1).StartAsync(
+            Arg.Is<AzuriteLaunchRequest>(r => r.Mode == AzuriteLaunchMode.Native && r.ExecutablePath == "/usr/bin/azurite"),
+            Arg.Any<CancellationToken>());
+        await _dockerProbe.DidNotReceive().ProbeAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Manageable_NotListening_NoNativeButDockerAvailable_LaunchesDocker()
+    {
+        _classifier.Classify(Conn).Returns(Manageable());
+        SetupProbeSequence(ProbeNotListening(), ProbeReady());
+        _locator.FindAsync(ProjectRoot, Arg.Any<CancellationToken>()).Returns((AzuriteExecutable?)null);
+        _dockerProbe.ProbeAsync(Arg.Any<CancellationToken>())
+            .Returns(new DockerAvailability(DockerAvailabilityStatus.Available, "ok", "Docker 25.0"));
+
+        FakeAzuriteProcess fake = new();
+        _launcher.StartAsync(Arg.Any<AzuriteLaunchRequest>(), Arg.Any<CancellationToken>()).Returns(fake);
+
+        ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), CancellationToken.None);
+
+        var started = Assert.IsType<ManagedAzuriteResult.Started>(result);
+        Assert.Equal(AzuriteLaunchMode.Docker, started.Mode);
+        await _launcher.Received(1).StartAsync(
+            Arg.Is<AzuriteLaunchRequest>(r => r.Mode == AzuriteLaunchMode.Docker),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Manageable_NotListening_NoNativeAndDockerUnavailable_ReturnsFailedWithInstallGuidance()
+    {
+        _classifier.Classify(Conn).Returns(Manageable());
+        _probe.ProbeAsync(Arg.Any<AzuriteEndpointTuple>(), Arg.Any<CancellationToken>()).Returns(ProbeNotListening());
+        _locator.FindAsync(ProjectRoot, Arg.Any<CancellationToken>()).Returns((AzuriteExecutable?)null);
+        _dockerProbe.ProbeAsync(Arg.Any<CancellationToken>())
+            .Returns(new DockerAvailability(DockerAvailabilityStatus.ExecutableNotFound, "not found"));
+
+        ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), CancellationToken.None);
+
+        var failed = Assert.IsType<ManagedAzuriteResult.Failed>(result);
+        Assert.Contains("Azurite is not running", failed.UserMessage);
+        Assert.Contains("npm install -g azurite", failed.UserMessage);
+        Assert.Contains("Docker Desktop", failed.UserMessage);
+        await _launcher.DidNotReceive().StartAsync(Arg.Any<AzuriteLaunchRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PollingTimesOut_StopsProcess_ReturnsFailed()
+    {
+        _classifier.Classify(Conn).Returns(Manageable());
+        _probe.ProbeAsync(Arg.Any<AzuriteEndpointTuple>(), Arg.Any<CancellationToken>()).Returns(ProbeNotListening());
+        _locator.FindAsync(ProjectRoot, Arg.Any<CancellationToken>())
+            .Returns(new AzuriteExecutable("/usr/bin/azurite", AzuriteExecutableSource.Path, "3.30.0"));
+
+        FakeAzuriteProcess fake = new();
+        _launcher.StartAsync(Arg.Any<AzuriteLaunchRequest>(), Arg.Any<CancellationToken>()).Returns(fake);
+
+        ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(
+            Request(timeout: TimeSpan.FromMilliseconds(300)),
+            CancellationToken.None);
+
+        var failed = Assert.IsType<ManagedAzuriteResult.Failed>(result);
+        Assert.Contains("did not become ready", failed.UserMessage);
+        Assert.True(fake.StopCalled, "Orchestrator must stop the process on timeout.");
+    }
+
+    [Fact]
+    public async Task ProcessExitsBeforeReady_ReturnsFailedWithStderrTail()
+    {
+        _classifier.Classify(Conn).Returns(Manageable());
+        _probe.ProbeAsync(Arg.Any<AzuriteEndpointTuple>(), Arg.Any<CancellationToken>()).Returns(ProbeNotListening());
+        _locator.FindAsync(ProjectRoot, Arg.Any<CancellationToken>())
+            .Returns(new AzuriteExecutable("/usr/bin/azurite", AzuriteExecutableSource.Path, "3.30.0"));
+
+        FakeAzuriteProcess fake = new(exitedImmediately: true, stderr: ["ENOENT: missing data dir"]);
+        _launcher.StartAsync(Arg.Any<AzuriteLaunchRequest>(), Arg.Any<CancellationToken>()).Returns(fake);
+
+        ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), CancellationToken.None);
+
+        var failed = Assert.IsType<ManagedAzuriteResult.Failed>(result);
+        Assert.Contains("Azurite exited before it was ready", failed.UserMessage);
+        Assert.Contains("ENOENT", failed.UserMessage);
+    }
+
+    [Fact]
+    public async Task CancellationDuringPolling_StopsProcess_AndPropagates()
+    {
+        _classifier.Classify(Conn).Returns(Manageable());
+        _probe.ProbeAsync(Arg.Any<AzuriteEndpointTuple>(), Arg.Any<CancellationToken>()).Returns(ProbeNotListening());
+        _locator.FindAsync(ProjectRoot, Arg.Any<CancellationToken>())
+            .Returns(new AzuriteExecutable("/usr/bin/azurite", AzuriteExecutableSource.Path, "3.30.0"));
+
+        FakeAzuriteProcess fake = new();
+        _launcher.StartAsync(Arg.Any<AzuriteLaunchRequest>(), Arg.Any<CancellationToken>()).Returns(fake);
+
+        using var cts = new CancellationTokenSource();
+        Task<ManagedAzuriteResult> resultTask = CreateSut().EnsureReadyAsync(
+            Request(timeout: TimeSpan.FromSeconds(30)),
+            cts.Token);
+
+        await Task.Delay(100);
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => resultTask);
+    }
+
+    private void SetupProbeSequence(params AzuriteProbeResult[] results)
+    {
+        if (results.Length == 0)
+        {
+            return;
+        }
+
+        if (results.Length == 1)
+        {
+            _probe.ProbeAsync(Arg.Any<AzuriteEndpointTuple>(), Arg.Any<CancellationToken>()).Returns(results[0]);
+            return;
+        }
+
+        _probe.ProbeAsync(Arg.Any<AzuriteEndpointTuple>(), Arg.Any<CancellationToken>())
+            .Returns(results[0], [.. results.Skip(1)]);
+    }
+
+    private sealed class FakeAzuriteProcess : IAzuriteProcess
+    {
+        private readonly TaskCompletionSource<int> _exit = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly ImmutableArray<string> _stderr;
+
+        public FakeAzuriteProcess(bool exitedImmediately = false, string[]? stderr = null)
+        {
+            _stderr = stderr is null ? [] : [.. stderr];
+            if (exitedImmediately)
+            {
+                _exit.TrySetResult(1);
+            }
+        }
+
+        public int ProcessId => 12345;
+
+        public bool StopCalled { get; private set; }
+
+        public Task<int> WaitForExitAsync(CancellationToken cancellationToken) => _exit.Task;
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            StopCalled = true;
+            _exit.TrySetResult(143);
+            return Task.CompletedTask;
+        }
+
+        public async IAsyncEnumerable<string> ReadStdoutLinesAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        public async IAsyncEnumerable<string> ReadStderrLinesAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            foreach (string line in _stderr)
+            {
+                yield return line;
+            }
+
+            await Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/test/Func.Tests/Commands/StartInitializationTests.cs
+++ b/test/Func.Tests/Commands/StartInitializationTests.cs
@@ -4,6 +4,7 @@
 using System.Text;
 using System.Text.Json;
 using Azure.Functions.Cli.Bundles;
+using Azure.Functions.Cli.Commands.Start.Azurite.Orchestration;
 using Azure.Functions.Cli.Commands.Start.Host;
 using Azure.Functions.Cli.Commands.Start.Initialization;
 using Azure.Functions.Cli.Commands.Start.Initialization.Rendering;
@@ -866,7 +867,16 @@ public class StartInitializationTests : IDisposable
             workloadPaths,
             hostProcessRunner,
             new ProcessEnvironment(),
+            CreateDisabledAzuriteOrchestrator(),
             NullLoggerFactory.Instance);
+    }
+
+    private static IManagedAzuriteOrchestrator CreateDisabledAzuriteOrchestrator()
+    {
+        IManagedAzuriteOrchestrator orchestrator = Substitute.For<IManagedAzuriteOrchestrator>();
+        orchestrator.EnsureReadyAsync(Arg.Any<ManagedAzuriteRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ManagedAzuriteResult.Disabled("Azurite skipped in tests."));
+        return orchestrator;
     }
 
     private static IFunctionsWorkerResolverFactory CreateWorkerResolverFactory(IFunctionsWorkerResolver? workerResolver = null)


### PR DESCRIPTION
## Summary

**This is the user-visible MVP slice** of the managed-Azurite feature. It ties together every prior slice (classifier, probe, executable locator, Docker probe, launcher, paths) so `func start` can detect a local-storage configuration, transparently start Azurite (native or Docker), wait until it is ready, and tear it down again when the host exits.

Design: [`proposed/managed-azurite.md`](https://github.com/Azure/azure-functions-core-tools/blob/fabiocav/doc-azurite/proposed/managed-azurite.md) (PR #5015). Sections implemented here:

- §5.1 trigger conditions, §5.2 `--no-azurite` opt-out, §5.3 verbose logging, §5.4 default output.
- §8.1 resolution flow (simplified per MVP scope).
- §9.4 startup polling (250 ms interval, 30 s default timeout).
- §13.1–§13.5 failure messages.

## New types

Under `src/Func/Commands/Start/Azurite/Orchestration/`:

- `IManagedAzuriteOrchestrator` / `ManagedAzuriteOrchestrator`
- `ManagedAzuriteRequest`, `ManagedAzuriteResult` (`Disabled` / `UserManaged` / `Started` / `Failed`)
- `ManagedAzuriteHandle` (`IAsyncDisposable` wrapper that stops the process on dispose)

Under `src/Func/Commands/Start/Azurite/`:

- `EnsureAzuriteInitializationStep` (bridges the init pipeline to the orchestrator)
- `AddAzuriteLauncher()` and `AddManagedAzurite()` DI extensions

## Wiring

- DI composition root: `src/Func/Hosting/CliHostFactory.cs` (`builder.Services.AddManagedAzurite();`).
- StartCommand: `--no-azurite` option, `await using ManagedAzuriteHandle` scoped to the host run so Ctrl+C cleanly stops native processes and Docker containers (no leaks).
- Init pipeline: new step registered between `PrepareProjectHostRun` and `StartHost` in `DemoStartInitializationRunner`.

## Out of scope (intentionally deferred)

- Lease file / multi-`func start` coordination (§11). MVP relies on §11 user-managed-reuse fallback: if probe finds Azurite already up, treat as user-managed.
- Storage scope IDs / `HostIdResolver` / `scope.json` metadata (§10.4). Single shared `<funcHome>/azurite/` instance.
- Different-scope port-conflict reporting (§11.4). Port-in-use bubbles up via the standard launch failure path.
- `func azurite clean` command (§10.6).

## Tests

- `ManagedAzuriteOrchestratorTests` — 11 NSubstitute-based scenarios covering: disabled flag, non-local storage, user-configured ready/not-ready, manageable ready/port-conflict, native launch, Docker fallback, install-guidance failure, polling timeout, process early exit, cancellation propagation.
- `AzuriteServiceCollectionExtensionsTests` — smoke-tests each `AddAzurite*` extension and the `AddManagedAzurite` umbrella.
- `StartInitializationTests` updated to supply an orchestrator stub.
- Full suite: **835 passed, 0 failed** with `CI=true dotnet test -c Release`.

## Docs

Scanned `README.md` and `docs/` for existing Azurite / `AzureWebJobsStorage` references; none found, so no documentation updates were necessary in this PR. User-facing reference material for the managed-Azurite feature can land alongside (or after) the design doc PR #5015 merges.

## Checklist

- [x] `CI=true dotnet build -c Release` is clean (0 warnings, 0 errors)
- [x] `CI=true dotnet test -c Release` is green (835/835)
- [x] All new types `internal`, primary-constructor DI, no `Console.*` / `AnsiConsole.*` in product code
- [x] User-facing messages reviewed for tone (no "Core Tools", "v5" branding, actionable next-step language)
- [x] No `release_notes.md` change (feature still flagged behind MVP scope; parent session can request later)
- [x] No `Co-authored-by: Copilot` trailer
