### PR TITLE
Set executable bit on extracted host workload binary

### DIFF
--- a/src/Func/Workloads/HostWorkloadPackage.cs
+++ b/src/Func/Workloads/HostWorkloadPackage.cs
@@ -7,7 +7,7 @@ namespace Azure.Functions.Cli.Workloads;
 
 internal static class HostWorkloadPackage
 {
-    private const string PackageIdPrefix = "Azure.Functions.Cli.Workloads.Host.";
+    internal const string PackageIdPrefix = "Azure.Functions.Cli.Workloads.Host.";
 
     public static string CurrentPackageId => FromRuntimeIdentifier(CurrentRuntimeIdentifier);
 

--- a/src/Func/Workloads/Install/WorkloadInstaller.cs
+++ b/src/Func/Workloads/Install/WorkloadInstaller.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Commands.Start.Host;
 using Azure.Functions.Cli.Workloads.Catalog;
 using Azure.Functions.Cli.Workloads.Discovery;
 using Azure.Functions.Cli.Workloads.Storage;
@@ -119,6 +120,7 @@ internal sealed class WorkloadInstaller(
                 $"Extracting workload '{packageId}' {version}"));
 
             await ExtractPackageAsync(reader, installPath, cancellationToken);
+            EnsureHostExecutableBit(installPath, packageId);
 
             WorkloadMetadata metadata = _metadataReader.Read(installPath);
 
@@ -450,6 +452,7 @@ internal sealed class WorkloadInstaller(
                 $"Extracting workload '{newPackageId}' {newVersion}"));
 
             await ExtractPackageAsync(reader, stagingPath, cancellationToken);
+            EnsureHostExecutableBit(stagingPath, newPackageId);
             WorkloadMetadata metadata = _metadataReader.Read(stagingPath);
 
             WorkloadEntry newEntry = new()
@@ -522,6 +525,44 @@ internal sealed class WorkloadInstaller(
                 $"Failed to read .nupkg at '{nupkgPath}': {ex.Message}",
                 ex);
         }
+    }
+
+    /// <summary>
+    /// Targeted workaround: NuGet's zip extraction does not preserve Unix
+    /// mode bits, so the host apphost lands without the execute bit and
+    /// the launcher fails with "Permission denied". We narrowly chmod the
+    /// single well-known host binary path, and only for the host workload
+    /// package family (<c>Azure.Functions.Cli.Workloads.Host.*</c>), so no
+    /// other package can use this code path to mark files executable.
+    /// A general per-package executables mechanism can replace this later.
+    /// </summary>
+    private static void EnsureHostExecutableBit(string installPath, string packageId)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        if (!packageId.StartsWith(HostWorkloadPackage.PackageIdPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        string hostBinary = Path.Combine(
+            installPath,
+            "tools",
+            "any",
+            HostProcessStartInfoFactory.ExecutableBaseName);
+
+        if (!File.Exists(hostBinary))
+        {
+            return;
+        }
+
+        UnixFileMode mode = File.GetUnixFileMode(hostBinary);
+        File.SetUnixFileMode(
+            hostBinary,
+            mode | UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute);
     }
 
     private static async Task ExtractPackageAsync(PackageArchiveReader reader, string destination, CancellationToken cancellationToken)

--- a/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
+++ b/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
@@ -638,12 +638,66 @@ public sealed class WorkloadInstallerTests : IDisposable
 
     private WorkloadInstaller NewInstaller() => new(_paths, _store, _metadataReader, _catalog);
 
+    [Fact]
+    public async Task InstallFromPackage_HostPackage_SetsExecutableBitOnHostBinary_OnUnix()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        string nupkg = BuildNupkg(
+            id: "Azure.Functions.Cli.Workloads.Host.osx-arm64",
+            payloadFileName: "Azure.Functions.Cli.Workloads.Host");
+
+        WorkloadInstaller installer = NewInstaller();
+        WorkloadInstallResult result = await installer.InstallFromPackageAsync(nupkg);
+
+        string hostBinary = Path.Combine(
+            _paths.GetInstallDirectory(result.Entry.PackageId, result.Entry.PackageVersion),
+            "tools", "any", "Azure.Functions.Cli.Workloads.Host");
+
+        Assert.True(File.Exists(hostBinary));
+        UnixFileMode mode = File.GetUnixFileMode(hostBinary);
+        Assert.True(mode.HasFlag(UnixFileMode.UserExecute));
+        Assert.True(mode.HasFlag(UnixFileMode.GroupExecute));
+        Assert.True(mode.HasFlag(UnixFileMode.OtherExecute));
+    }
+
+    [Fact]
+    public async Task InstallFromPackage_NonHostPackage_DoesNotChmodPayload_OnUnix()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        // A non-host package that happens to ship a file at the same
+        // relative path must not be touched: only Host.* packages opt in.
+        string nupkg = BuildNupkg(
+            id: "Some.Other.Workload",
+            payloadFileName: "Azure.Functions.Cli.Workloads.Host");
+
+        WorkloadInstaller installer = NewInstaller();
+        WorkloadInstallResult result = await installer.InstallFromPackageAsync(nupkg);
+
+        string payload = Path.Combine(
+            _paths.GetInstallDirectory(result.Entry.PackageId, result.Entry.PackageVersion),
+            "tools", "any", "Azure.Functions.Cli.Workloads.Host");
+
+        Assert.True(File.Exists(payload));
+        UnixFileMode mode = File.GetUnixFileMode(payload);
+        Assert.False(mode.HasFlag(UnixFileMode.UserExecute));
+    }
+
     private string BuildNupkg(
         string? tags = null,
         bool includeFuncCliWorkloadType = true,
         string version = "1.0.0",
         string? title = null,
         string description = "For tests.",
+        string id = "Test.Workload",
+        string payloadFileName = "Test.dll",
         IEnumerable<(string SourcePath, string TargetPath)>? extraFiles = null)
     {
         string stubAssembly = Path.Combine(_root, $"stub-{Guid.NewGuid():N}.dll");
@@ -651,7 +705,7 @@ public sealed class WorkloadInstallerTests : IDisposable
 
         var builder = new PackageBuilder
         {
-            Id = "Test.Workload",
+            Id = id,
             Version = NuGetVersion.Parse(version),
             Description = description,
         };
@@ -676,7 +730,7 @@ public sealed class WorkloadInstallerTests : IDisposable
         builder.Files.Add(new PhysicalPackageFile
         {
             SourcePath = stubAssembly,
-            TargetPath = $"tools/{NuGetFramework.Parse("any").GetShortFolderName()}/Test.dll",
+            TargetPath = $"tools/{NuGetFramework.Parse("any").GetShortFolderName()}/{payloadFileName}",
         });
 
         if (extraFiles is not null)
@@ -687,7 +741,7 @@ public sealed class WorkloadInstallerTests : IDisposable
             }
         }
 
-        string path = Path.Combine(_root, $"Test.Workload.{Guid.NewGuid():N}.nupkg");
+        string path = Path.Combine(_root, $"{id}.{Guid.NewGuid():N}.nupkg");
         using (FileStream stream = File.Create(path))
         {
             builder.Save(stream);


### PR DESCRIPTION
## Problem

On macOS / Linux, starting func against an installed workload fails with:

```
Error: Failed to start host process '.../Azure.Functions.Cli.Workloads.Host':
... Permission denied
```

NuGet zip extraction does not preserve Unix mode bits, so the extracted host binary lands without the executable bit set.

## Fix

Narrow workaround: in `WorkloadInstaller`, after extracting a package whose id starts with `Azure.Functions.Cli.Workloads.Host.` (the host workload family), chmod the single well-known host binary at `tools/any/Azure.Functions.Cli.Workloads.Host` on Unix. No-op on Windows. No other package is affected.

### Why this shape

- Reviewer feedback on the prior revision (which sniffed ELF / Mach-O / shebang magic bytes everywhere) flagged that it was too broad and "scary."
- This revision touches exactly one path in exactly one package family. The package id check is the safety gate.
- A general per-package executables mechanism (e.g. `executables` in `workload.json`) can replace this later when more packages need it.

### Changes

- `HostWorkloadPackage.PackageIdPrefix` promoted to `public const` so the installer can match against it.
- `WorkloadInstaller.EnsureHostExecutableBit` called after extraction in both the install and update/staging paths.
- Tests cover the host package (gets +x) and a non-host package shipping the same relative file name (does not get +x).

## Validation

- `dotnet test test/Func.Tests/Func.Tests.csproj`: 820 passed, 0 failed.
- Reproduced the original `Permission denied` locally and confirmed it goes away with a freshly installed host workload built from this branch.