### PR TITLE
Pack workloads with PackAllRids=true in build-workloads skill

### DIFF
--- a/.github/skills/build-workloads/SKILL.md
+++ b/.github/skills/build-workloads/SKILL.md
@@ -27,7 +27,10 @@ feed.
    `NUGET-SERVER-API-KEY`. Packages persist in a named Docker volume so reruns
    keep history.
 2. Packs every workload csproj listed in `Azure.Functions.Cli.slnx` under
-   `src/Workloads/**`, into a single output folder.
+   `src/Workloads/**`, into a single output folder. Packs with
+   `PackAllRids=true` so RID-specific packages (notably the per-RID Host
+   workload, e.g. `Azure.Functions.Cli.Workloads.Host.osx-arm64`) are
+   produced alongside the RID-less ones, matching what CI publishes.
 3. Pushes each produced `.nupkg` to the feed, skipping duplicates so a rerun
    without bumping `VersionPrefix` is idempotent.
 4. Echoes the install command the user runs from another shell:

--- a/.github/skills/build-workloads/scripts/build-workloads.ps1
+++ b/.github/skills/build-workloads/scripts/build-workloads.ps1
@@ -121,7 +121,8 @@ if (-not $NoBuild) {
             'pack', $proj,
             '-c', $Configuration,
             '-o', $outputDir,
-            '--nologo'
+            '--nologo',
+            '-p:PackAllRids=true'
         )
         if ($VersionSuffix) { $packArgs += @('--version-suffix', $VersionSuffix) }
         Invoke-Native -File 'dotnet' -Arguments $packArgs


### PR DESCRIPTION
Without `PackAllRids`, the Host workload csproj only emits the RID-less `Azure.Functions.Cli.Workloads.Host` package. The host resolver looks for per-RID packages (e.g. `Azure.Functions.Cli.Workloads.Host.osx-arm64`), so `func setup` against the local feed fails with:

```
Error: No host workload version is available from the configured workload catalog.
```

This passes `-p:PackAllRids=true` when packing so RID-specific packages are produced too, matching what CI publishes.