### PR TITLE
Remove `-s` alias from `quickstart list --search`

### DIFF
--- a/src/Func/Commands/Quickstart/QuickstartListCommand.cs
+++ b/src/Func/Commands/Quickstart/QuickstartListCommand.cs
@@ -28,7 +28,7 @@ internal sealed class QuickstartListCommand : FuncCliCommand
         Description = "Filter by infrastructure-as-code type (e.g. bicep, terraform, none)"
     };
 
-    public Option<string?> SearchOption { get; } = new("--search", "-s")
+    public Option<string?> SearchOption { get; } = new("--search")
     {
         Description = "Case-insensitive substring match against template names, IDs, resources, tags, and descriptions"
     };


### PR DESCRIPTION
`-s` is reserved as the short alias for `--stack` across the CLI (`init`, `quickstart`, external workload commands). `quickstart list --search` was also claiming `-s`, which would collide with the parent `--stack` option. Drop the alias and keep `--search` long-form only.