### PR TITLE
Normalize short C# signatures and call wrapping

### DIFF
--- a/.github/instructions/dotnet.instructions.md
+++ b/.github/instructions/dotnet.instructions.md
@@ -134,6 +134,10 @@ fire:
   a literal). When the type is hidden behind a method or property call, write
   the type explicitly. Tests opt out of this one in `.editorconfig` to reduce
   rename churn.
+- **Line wrapping**: keep method, constructor, record, and simple call
+  signatures on one line when they fit comfortably (roughly 140 columns). Use
+  the current wrapped style only for genuinely long signatures or calls with
+  nested object creation, lambdas, or several-property-deep member/method chains.
 
 ## Style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,10 @@ the full CLI.
 - Don't leave unused `using` directives.
 - Don't run `dotnet format` across unrelated files or make drive-by formatting
   changes.
+- Prefer single-line method, constructor, record, and simple call signatures when
+  they fit comfortably (roughly 140 columns). Keep the existing wrapped style for
+  genuinely long signatures or calls with nested object creation, lambdas, or
+  several-property-deep member/method chains.
 - Follow the existing `stylecop.json` / analyzer rules. Don't disable analyzers
   to silence warnings, fix the underlying issue.
 - **Address every build warning before pushing.** CI sets

--- a/src/Abstractions/Bundles/ExtensionBundleResolution.cs
+++ b/src/Abstractions/Bundles/ExtensionBundleResolution.cs
@@ -14,11 +14,7 @@ public abstract record ExtensionBundleResolution
     {
     }
 
-    public sealed record Resolved(
-        string BundleId,
-        string Version,
-        string Path,
-        ExtensionBundleSupportedRuntimeWarning? RuntimeWarning)
+    public sealed record Resolved(string BundleId, string Version, string Path, ExtensionBundleSupportedRuntimeWarning? RuntimeWarning)
         : ExtensionBundleResolution;
 
     /// <summary>
@@ -46,9 +42,6 @@ public abstract record ExtensionBundleResolution
     /// Bundle workloads are installed but none satisfy the host.json/profile constraint.
 
     /// </summary>
-    public sealed record NoCompatibleInstall(
-        string ConstraintRange,
-        IReadOnlyList<string> InstalledVersions,
-        string Hint)
+    public sealed record NoCompatibleInstall(string ConstraintRange, IReadOnlyList<string> InstalledVersions, string Hint)
         : ExtensionBundleResolution;
 }

--- a/src/Abstractions/Commands/InitContext.cs
+++ b/src/Abstractions/Commands/InitContext.cs
@@ -15,8 +15,4 @@ namespace Azure.Functions.Cli.Commands;
 /// <param name="ProjectName">Project name (from <c>--name</c> or the directory name).</param>
 /// <param name="Language">Programming language (from <c>--language</c> or a prompt). May be null.</param>
 /// <param name="Force">True if <c>--force</c> was supplied.</param>
-public sealed record InitContext(
-    WorkingDirectory WorkingDirectory,
-    string? ProjectName,
-    string? Language,
-    bool Force);
+public sealed record InitContext(WorkingDirectory WorkingDirectory, string? ProjectName, string? Language, bool Force);

--- a/src/Abstractions/Projects/IProjectInitializer.cs
+++ b/src/Abstractions/Projects/IProjectInitializer.cs
@@ -46,8 +46,5 @@ public interface IProjectInitializer
     /// <summary>
     /// Scaffolds a new project at <see cref="WorkloadContext.WorkingDirectory"/>.
     /// </summary>
-    public Task InitializeAsync(
-        InitContext context,
-        ParseResult parseResult,
-        CancellationToken cancellationToken = default);
+    public Task InitializeAsync(InitContext context, ParseResult parseResult, CancellationToken cancellationToken = default);
 }

--- a/src/Abstractions/Projects/ProjectCreationFailures.cs
+++ b/src/Abstractions/Projects/ProjectCreationFailures.cs
@@ -10,9 +10,7 @@ namespace Azure.Functions.Cli.Projects;
 /// </summary>
 public static class ProjectCreationFailures
 {
-    public static ProjectCreationFailure WorkerNotResolved(
-        FunctionsWorkerResolutionFailure workerFailure,
-        string? message = null)
+    public static ProjectCreationFailure WorkerNotResolved(FunctionsWorkerResolutionFailure workerFailure, string? message = null)
     {
         ArgumentNullException.ThrowIfNull(workerFailure);
         return new ProjectCreationFailure.WorkerNotResolved(workerFailure, message ?? workerFailure.Message);

--- a/src/Abstractions/Workers/FunctionsWorkerResolutionFailure.cs
+++ b/src/Abstractions/Workers/FunctionsWorkerResolutionFailure.cs
@@ -16,10 +16,7 @@ public abstract record FunctionsWorkerResolutionFailure
 
     public string Message { get; }
 
-    public sealed record MissingCompatibleVersion(
-        FunctionsWorkerId WorkerId,
-        string? VersionConstraint,
-        string Message)
+    public sealed record MissingCompatibleVersion(FunctionsWorkerId WorkerId, string? VersionConstraint, string Message)
         : FunctionsWorkerResolutionFailure(Message);
 
     public sealed record NotInstalled(FunctionsWorkerId WorkerId, string Message)

--- a/src/Abstractions/Workers/FunctionsWorkerResolutionFailures.cs
+++ b/src/Abstractions/Workers/FunctionsWorkerResolutionFailures.cs
@@ -23,10 +23,5 @@ public static class FunctionsWorkerResolutionFailures
         string packageVersion,
         string workerConfigPath,
         string message)
-        => new FunctionsWorkerResolutionFailure.InvalidInstallation(
-            workerId,
-            packageId,
-            packageVersion,
-            workerConfigPath,
-            message);
+        => new FunctionsWorkerResolutionFailure.InvalidInstallation(workerId, packageId, packageVersion, workerConfigPath, message);
 }

--- a/src/Func/Bundles/ExtensionBundleResolver.cs
+++ b/src/Func/Bundles/ExtensionBundleResolver.cs
@@ -88,11 +88,7 @@ internal sealed class ExtensionBundleResolver(
     {
         IReadOnlyList<string> installedVersions = [.. installed.Select(b => b.Version.ToNormalizedString())];
         string? suggested = installedVersions.FirstOrDefault();
-        string hint = BundleHintBuilder.NoCompatibleInstall(
-            context.BundleId,
-            constraintRange,
-            installedVersions,
-            suggested);
+        string hint = BundleHintBuilder.NoCompatibleInstall(context.BundleId, constraintRange, installedVersions, suggested);
 
         return new ExtensionBundleResolution.NoCompatibleInstall(constraintRange, installedVersions, hint);
     }

--- a/src/Func/Commands/InitCommand.cs
+++ b/src/Func/Commands/InitCommand.cs
@@ -44,10 +44,7 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
     private readonly IWorkloadHintRenderer _hintRenderer;
     private readonly IReadOnlyList<IProjectInitializer> _initializers;
 
-    public InitCommand(
-        IInteractionService interaction,
-        IWorkloadHintRenderer hintRenderer,
-        IEnumerable<IProjectInitializer> initializers)
+    public InitCommand(IInteractionService interaction, IWorkloadHintRenderer hintRenderer, IEnumerable<IProjectInitializer> initializers)
         : base("init", "Initialize a new Azure Functions project.")
     {
         ArgumentNullException.ThrowIfNull(interaction);
@@ -348,10 +345,7 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
             return (null, 1);
         }
 
-        string picked = await _interaction.PromptForSelectionAsync(
-            "Select a language:",
-            supported,
-            cancellationToken);
+        string picked = await _interaction.PromptForSelectionAsync("Select a language:", supported, cancellationToken);
 
         return (picked.ToLowerInvariant(), null);
     }
@@ -417,10 +411,7 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
             i => i.DisplayName,
             i => i,
             StringComparer.Ordinal);
-        string picked = await _interaction.PromptForSelectionAsync(
-            "Select a stack:",
-            displayToInitializer.Keys,
-            cancellationToken);
+        string picked = await _interaction.PromptForSelectionAsync("Select a stack:", displayToInitializer.Keys, cancellationToken);
 
         return displayToInitializer.TryGetValue(picked, out IProjectInitializer? chosen) ? chosen : null;
     }

--- a/src/Func/Commands/Quickstart/QuickstartInfoCommand.cs
+++ b/src/Func/Commands/Quickstart/QuickstartInfoCommand.cs
@@ -20,9 +20,7 @@ internal sealed class QuickstartInfoCommand : FuncCliCommand
     private readonly IInteractionService _interaction;
     private readonly IReadOnlyList<IQuickstartProvider> _providers;
 
-    public QuickstartInfoCommand(
-        IInteractionService interaction,
-        IEnumerable<IQuickstartProvider> providers)
+    public QuickstartInfoCommand(IInteractionService interaction, IEnumerable<IQuickstartProvider> providers)
         : base("info", "Show detailed information about a template.")
     {
         ArgumentNullException.ThrowIfNull(interaction);
@@ -43,8 +41,7 @@ internal sealed class QuickstartInfoCommand : FuncCliCommand
             return Task.FromResult(1);
         }
 
-        _interaction.WriteWarning(
-            "The quickstart info command is not yet implemented.");
+        _interaction.WriteWarning("The quickstart info command is not yet implemented.");
         return Task.FromResult(1);
     }
 }

--- a/src/Func/Commands/Quickstart/QuickstartListCommand.cs
+++ b/src/Func/Commands/Quickstart/QuickstartListCommand.cs
@@ -36,9 +36,7 @@ internal sealed class QuickstartListCommand : FuncCliCommand
     private readonly IInteractionService _interaction;
     private readonly IReadOnlyList<IQuickstartProvider> _providers;
 
-    public QuickstartListCommand(
-        IInteractionService interaction,
-        IEnumerable<IQuickstartProvider> providers)
+    public QuickstartListCommand(IInteractionService interaction, IEnumerable<IQuickstartProvider> providers)
         : base("list", "List available templates from the catalog.")
     {
         ArgumentNullException.ThrowIfNull(interaction);
@@ -62,8 +60,7 @@ internal sealed class QuickstartListCommand : FuncCliCommand
             return Task.FromResult(1);
         }
 
-        _interaction.WriteWarning(
-            "The quickstart list command is not yet implemented.");
+        _interaction.WriteWarning("The quickstart list command is not yet implemented.");
         return Task.FromResult(1);
     }
 }

--- a/src/Func/Commands/Setup/SetupRenderer.cs
+++ b/src/Func/Commands/Setup/SetupRenderer.cs
@@ -18,10 +18,7 @@ internal sealed class SetupRenderer(IInteractionService interaction, SetupOutput
     private readonly IInteractionService _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
     private readonly SetupOutputMode _outputMode = outputMode;
 
-    public void SetupStarted(
-        SetupCommandOptions options,
-        SetupFeaturePlan featurePlan,
-        IReadOnlyList<SetupProfileScope> profileScopes)
+    public void SetupStarted(SetupCommandOptions options, SetupFeaturePlan featurePlan, IReadOnlyList<SetupProfileScope> profileScopes)
     {
         if (_outputMode == SetupOutputMode.Json)
         {

--- a/src/Func/Commands/Setup/SetupRunner.cs
+++ b/src/Func/Commands/Setup/SetupRunner.cs
@@ -174,12 +174,7 @@ internal sealed class SetupRunner(
                 case DotNetProfileRuntime:
                     if (AddFeature(features, featureNames, DotNetFeature))
                     {
-                        AddRuntimeFeature(
-                            runtimeFeatures,
-                            runtimeFeatureNames,
-                            DotNetFeature,
-                            DotNetProfileRuntime,
-                            installWorker: false);
+                        AddRuntimeFeature(runtimeFeatures, runtimeFeatureNames, DotNetFeature, DotNetProfileRuntime, installWorker: false);
                     }
 
                     break;
@@ -337,10 +332,7 @@ internal sealed class SetupRunner(
             SetupDependency? bundleDependency = await TryCreateBundleDependencyAsync(workingDirectory, profileScope, cancellationToken);
             if (bundleDependency is null)
             {
-                var dependency = SetupDependency.Bundle(
-                    InstalledBundleScanner.StableBundleId,
-                    versionRange: null,
-                    rangeText: null);
+                var dependency = SetupDependency.Bundle(InstalledBundleScanner.StableBundleId, versionRange: null, rangeText: null);
                 failure = SetupDependencyResult.Failed(
                     dependency,
                     "The host.json extensionBundle range and profile extensionBundle range do not overlap.");
@@ -370,10 +362,7 @@ internal sealed class SetupRunner(
 
         if (hostJsonBundle is null)
         {
-            return SetupDependency.Bundle(
-                InstalledBundleScanner.StableBundleId,
-                profileRange,
-                profileRangeText);
+            return SetupDependency.Bundle(InstalledBundleScanner.StableBundleId, profileRange, profileRangeText);
         }
 
         VersionRange? effectiveRange = VersionRangeIntersection.Intersect(hostJsonBundle.Version, profileRangeText);
@@ -675,9 +664,7 @@ internal sealed record SetupProfileScope(ResolvedProfile? Profile)
     public string Name => Profile?.Name ?? "unconstrained";
 }
 
-internal sealed record SetupDependencyPlan(
-    IReadOnlyList<SetupDependency> Dependencies,
-    IReadOnlyList<SetupDependencyResult> Failures);
+internal sealed record SetupDependencyPlan(IReadOnlyList<SetupDependency> Dependencies, IReadOnlyList<SetupDependencyResult> Failures);
 
 internal sealed record SetupDependency(
     SetupDependencyKind Kind,

--- a/src/Func/Commands/Start/Azurite/AzureWebJobsStorageClassifier.cs
+++ b/src/Func/Commands/Start/Azurite/AzureWebJobsStorageClassifier.cs
@@ -62,8 +62,7 @@ internal sealed class AzureWebJobsStorageClassifier : IAzureWebJobsStorageClassi
 
         if (!hasBlob && !hasQueue && !hasTable)
         {
-            return AzureWebJobsStorageReference.NotLocal(
-                "Connection string does not reference local development storage.");
+            return AzureWebJobsStorageReference.NotLocal("Connection string does not reference local development storage.");
         }
 
         Uri? blob = TryParseEndpoint(blobValue);
@@ -74,8 +73,7 @@ internal sealed class AzureWebJobsStorageClassifier : IAzureWebJobsStorageClassi
         bool anyParsed = presentEndpoints.Any(static e => e is not null);
         if (!anyParsed)
         {
-            return AzureWebJobsStorageReference.NotLocal(
-                "Connection string endpoints could not be parsed as URIs.");
+            return AzureWebJobsStorageReference.NotLocal("Connection string endpoints could not be parsed as URIs.");
         }
 
         bool anyLocal = presentEndpoints.Any(static e => e is not null && IsLocalHost(e.Host));
@@ -83,14 +81,12 @@ internal sealed class AzureWebJobsStorageClassifier : IAzureWebJobsStorageClassi
 
         if (!anyLocal)
         {
-            return AzureWebJobsStorageReference.NotLocal(
-                "Endpoints reference a non-local storage account.");
+            return AzureWebJobsStorageReference.NotLocal("Endpoints reference a non-local storage account.");
         }
 
         if (anyNonLocal)
         {
-            return AzureWebJobsStorageReference.NotLocal(
-                "Endpoints mix local and non-local hosts; treating as non-local.");
+            return AzureWebJobsStorageReference.NotLocal("Endpoints mix local and non-local hosts; treating as non-local.");
         }
 
         if (!(hasBlob && hasQueue && hasTable) || blob is null || queue is null || table is null)
@@ -152,9 +148,7 @@ internal sealed class AzureWebJobsStorageClassifier : IAzureWebJobsStorageClassi
                 reason: $"Local emulator reference uses a custom account name '{blobAccount}'.");
         }
 
-        return AzureWebJobsStorageReference.Manageable(
-            endpoints: tuple,
-            reason: "Explicit local Azurite endpoints for devstoreaccount1.");
+        return AzureWebJobsStorageReference.Manageable(endpoints: tuple, reason: "Explicit local Azurite endpoints for devstoreaccount1.");
     }
 
     private static Dictionary<string, string> Parse(string connectionString)

--- a/src/Func/Commands/Start/Azurite/AzuriteEndpointTuple.cs
+++ b/src/Func/Commands/Start/Azurite/AzuriteEndpointTuple.cs
@@ -7,8 +7,4 @@ namespace Azure.Functions.Cli.Commands.Start.Azurite;
 /// The set of Azurite service endpoints inferred from an
 /// <c>AzureWebJobsStorage</c> connection string.
 /// </summary>
-internal sealed record AzuriteEndpointTuple(
-    Uri BlobEndpoint,
-    Uri QueueEndpoint,
-    Uri TableEndpoint,
-    string AccountName);
+internal sealed record AzuriteEndpointTuple(Uri BlobEndpoint, Uri QueueEndpoint, Uri TableEndpoint, string AccountName);

--- a/src/Func/Commands/Start/Azurite/AzuriteExecutable.cs
+++ b/src/Func/Commands/Start/Azurite/AzuriteExecutable.cs
@@ -9,7 +9,4 @@ namespace Azure.Functions.Cli.Commands.Start.Azurite;
 /// <param name="FilePath">Absolute path to the executable.</param>
 /// <param name="Source">Where the CLI found the executable.</param>
 /// <param name="Version">Version string captured from <c>azurite --version</c>, or <c>null</c> when the probe was skipped or failed.</param>
-internal sealed record AzuriteExecutable(
-    string FilePath,
-    AzuriteExecutableSource Source,
-    string? Version);
+internal sealed record AzuriteExecutable(string FilePath, AzuriteExecutableSource Source, string? Version);

--- a/src/Func/Commands/Start/Azurite/AzuriteProbe.cs
+++ b/src/Func/Commands/Start/Azurite/AzuriteProbe.cs
@@ -10,9 +10,7 @@ using Microsoft.Extensions.Logging;
 namespace Azure.Functions.Cli.Commands.Start.Azurite;
 
 /// <inheritdoc cref="IAzuriteProbe" />
-internal sealed class AzuriteProbe(
-    IHttpClientFactory httpClientFactory,
-    ILogger<AzuriteProbe> logger) : IAzuriteProbe
+internal sealed class AzuriteProbe(IHttpClientFactory httpClientFactory, ILogger<AzuriteProbe> logger) : IAzuriteProbe
 {
     /// <summary>
     /// Name of the <see cref="HttpClient"/> registered in DI for the probe.
@@ -42,9 +40,7 @@ internal sealed class AzuriteProbe(
     private readonly ILogger<AzuriteProbe> _logger =
         logger ?? throw new ArgumentNullException(nameof(logger));
 
-    public async Task<AzuriteProbeResult> ProbeAsync(
-        AzuriteEndpointTuple endpoints,
-        CancellationToken cancellationToken)
+    public async Task<AzuriteProbeResult> ProbeAsync(AzuriteEndpointTuple endpoints, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(endpoints);
 
@@ -253,9 +249,7 @@ internal sealed class AzuriteProbe(
         return false;
     }
 
-    private static async Task<bool> BodyLooksLikeStorageErrorAsync(
-        HttpResponseMessage response,
-        CancellationToken cancellationToken)
+    private static async Task<bool> BodyLooksLikeStorageErrorAsync(HttpResponseMessage response, CancellationToken cancellationToken)
     {
         if (response.Content is null)
         {

--- a/src/Func/Commands/Start/Azurite/AzuriteProbeResult.cs
+++ b/src/Func/Commands/Start/Azurite/AzuriteProbeResult.cs
@@ -22,9 +22,7 @@ internal sealed record AzuriteProbeResult
     /// </summary>
     public string? Reason { get; init; }
 
-    public static AzuriteProbeResult From(
-        IEnumerable<AzuriteEndpointProbeOutcome> outcomes,
-        string? reason = null)
+    public static AzuriteProbeResult From(IEnumerable<AzuriteEndpointProbeOutcome> outcomes, string? reason = null)
     {
         ArgumentNullException.ThrowIfNull(outcomes);
 
@@ -86,9 +84,7 @@ internal sealed record AzuriteProbeResult
         return AzuriteProbeStatus.Partial;
     }
 
-    private static string DescribeReason(
-        AzuriteProbeStatus status,
-        ImmutableArray<AzuriteEndpointProbeOutcome> outcomes)
+    private static string DescribeReason(AzuriteProbeStatus status, ImmutableArray<AzuriteEndpointProbeOutcome> outcomes)
     {
         return status switch
         {

--- a/src/Func/Commands/Start/Azurite/DockerAvailability.cs
+++ b/src/Func/Commands/Start/Azurite/DockerAvailability.cs
@@ -9,7 +9,4 @@ namespace Azure.Functions.Cli.Commands.Start.Azurite;
 /// <param name="Status">High-level outcome category.</param>
 /// <param name="Reason">Short, human-readable explanation suitable for verbose logging.</param>
 /// <param name="Version">Version string from <c>docker --version</c> when available.</param>
-internal sealed record DockerAvailability(
-    DockerAvailabilityStatus Status,
-    string Reason,
-    string? Version = null);
+internal sealed record DockerAvailability(DockerAvailabilityStatus Status, string Reason, string? Version = null);

--- a/src/Func/Commands/Start/Azurite/IAzuriteProbe.cs
+++ b/src/Func/Commands/Start/Azurite/IAzuriteProbe.cs
@@ -15,7 +15,5 @@ internal interface IAzuriteProbe
     /// </summary>
     /// <param name="endpoints">Endpoint tuple to probe. Must not be null.</param>
     /// <param name="cancellationToken">Cancellation token for the overall probe.</param>
-    public Task<AzuriteProbeResult> ProbeAsync(
-        AzuriteEndpointTuple endpoints,
-        CancellationToken cancellationToken);
+    public Task<AzuriteProbeResult> ProbeAsync(AzuriteEndpointTuple endpoints, CancellationToken cancellationToken);
 }

--- a/src/Func/Commands/Start/Azurite/Launching/AzuriteLauncher.cs
+++ b/src/Func/Commands/Start/Azurite/Launching/AzuriteLauncher.cs
@@ -93,11 +93,7 @@ internal sealed class AzuriteLauncher : IAzuriteLauncher
                 ex);
         }
 
-        IAzuriteProcess handle = new AzuriteProcess(
-            process,
-            request.Mode,
-            request.ContainerName,
-            _dockerCommand);
+        IAzuriteProcess handle = new AzuriteProcess(process, request.Mode, request.ContainerName, _dockerCommand);
 
         return Task.FromResult(handle);
     }

--- a/src/Func/Commands/Start/Azurite/Launching/AzuriteProcess.cs
+++ b/src/Func/Commands/Start/Azurite/Launching/AzuriteProcess.cs
@@ -27,11 +27,7 @@ internal sealed class AzuriteProcess : IAzuriteProcess
     private Task? _stopTask;
     private int _disposed;
 
-    public AzuriteProcess(
-        Process process,
-        AzuriteLaunchMode mode,
-        string? containerName = null,
-        string dockerCommand = "docker")
+    public AzuriteProcess(Process process, AzuriteLaunchMode mode, string? containerName = null, string dockerCommand = "docker")
     {
         _process = process ?? throw new ArgumentNullException(nameof(process));
         _mode = mode;
@@ -83,8 +79,7 @@ internal sealed class AzuriteProcess : IAzuriteProcess
         }
     }
 
-    public async IAsyncEnumerable<string> ReadStdoutLinesAsync(
-        [EnumeratorCancellation] CancellationToken cancellationToken)
+    public async IAsyncEnumerable<string> ReadStdoutLinesAsync([EnumeratorCancellation] CancellationToken cancellationToken)
     {
         await foreach (string line in _stdout.Reader.ReadAllAsync(cancellationToken))
         {
@@ -92,8 +87,7 @@ internal sealed class AzuriteProcess : IAzuriteProcess
         }
     }
 
-    public async IAsyncEnumerable<string> ReadStderrLinesAsync(
-        [EnumeratorCancellation] CancellationToken cancellationToken)
+    public async IAsyncEnumerable<string> ReadStderrLinesAsync([EnumeratorCancellation] CancellationToken cancellationToken)
     {
         await foreach (string line in _stderr.Reader.ReadAllAsync(cancellationToken))
         {

--- a/src/Func/Commands/Start/Azurite/Launching/DockerAzuriteCommandBuilder.cs
+++ b/src/Func/Commands/Start/Azurite/Launching/DockerAzuriteCommandBuilder.cs
@@ -21,9 +21,7 @@ internal static class DockerAzuriteCommandBuilder
     private const string ContainerLogDirectory = "/logs";
     private const string ContainerLogPath = "/logs/azurite.log";
 
-    public static (string FileName, IReadOnlyList<string> Arguments) Build(
-        AzuriteLaunchRequest request,
-        string dockerCommand = "docker")
+    public static (string FileName, IReadOnlyList<string> Arguments) Build(AzuriteLaunchRequest request, string dockerCommand = "docker")
     {
         ArgumentNullException.ThrowIfNull(request);
 

--- a/src/Func/Commands/Start/Azurite/Orchestration/IManagedAzuriteOrchestrator.cs
+++ b/src/Func/Commands/Start/Azurite/Orchestration/IManagedAzuriteOrchestrator.cs
@@ -13,7 +13,5 @@ internal interface IManagedAzuriteOrchestrator
     /// <summary>
     /// Resolves Azurite for one <c>func start</c> invocation.
     /// </summary>
-    public Task<ManagedAzuriteResult> EnsureReadyAsync(
-        ManagedAzuriteRequest request,
-        CancellationToken cancellationToken);
+    public Task<ManagedAzuriteResult> EnsureReadyAsync(ManagedAzuriteRequest request, CancellationToken cancellationToken);
 }

--- a/src/Func/Commands/Start/Azurite/Orchestration/ManagedAzuriteOrchestrator.cs
+++ b/src/Func/Commands/Start/Azurite/Orchestration/ManagedAzuriteOrchestrator.cs
@@ -43,9 +43,7 @@ internal sealed class ManagedAzuriteOrchestrator : IManagedAzuriteOrchestrator
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    public async Task<ManagedAzuriteResult> EnsureReadyAsync(
-        ManagedAzuriteRequest request,
-        CancellationToken cancellationToken)
+    public async Task<ManagedAzuriteResult> EnsureReadyAsync(ManagedAzuriteRequest request, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(request);
 
@@ -443,10 +441,7 @@ internal sealed class ManagedAzuriteOrchestrator : IManagedAzuriteOrchestrator
         return sb.ToString();
     }
 
-    private static string BuildProcessExitedMessage(
-        AzuriteLaunchMode mode,
-        AzuriteManagedPaths paths,
-        string? stderrTail)
+    private static string BuildProcessExitedMessage(AzuriteLaunchMode mode, AzuriteManagedPaths paths, string? stderrTail)
     {
         StringBuilder sb = new();
         if (mode == AzuriteLaunchMode.Native)
@@ -473,10 +468,7 @@ internal sealed class ManagedAzuriteOrchestrator : IManagedAzuriteOrchestrator
         return sb.ToString();
     }
 
-    private static string BuildTimeoutMessage(
-        AzuriteEndpointTuple endpoints,
-        AzuriteManagedPaths paths,
-        TimeSpan timeout)
+    private static string BuildTimeoutMessage(AzuriteEndpointTuple endpoints, AzuriteManagedPaths paths, TimeSpan timeout)
     {
         StringBuilder sb = new();
         sb.AppendLine($"Azurite did not become ready within {(int)timeout.TotalSeconds} seconds.");

--- a/src/Func/Commands/Start/Azurite/Orchestration/ManagedAzuriteRequest.cs
+++ b/src/Func/Commands/Start/Azurite/Orchestration/ManagedAzuriteRequest.cs
@@ -22,11 +22,7 @@ namespace Azure.Functions.Cli.Commands.Start.Azurite.Orchestration;
 /// <param name="StartupTimeout">
 /// Maximum time to wait for a freshly launched Azurite to become ready (§9.4).
 /// </param>
-internal sealed record ManagedAzuriteRequest(
-    string? StorageConnectionString,
-    string ProjectRoot,
-    bool Disabled,
-    TimeSpan StartupTimeout)
+internal sealed record ManagedAzuriteRequest(string? StorageConnectionString, string ProjectRoot, bool Disabled, TimeSpan StartupTimeout)
 {
     /// <summary>
     /// Default readiness timeout per design §9.4.

--- a/src/Func/Commands/Start/Azurite/Orchestration/ManagedAzuriteResult.cs
+++ b/src/Func/Commands/Start/Azurite/Orchestration/ManagedAzuriteResult.cs
@@ -35,10 +35,7 @@ internal abstract record ManagedAzuriteResult
     /// handle; the caller is responsible for disposing it when the host run
     /// ends.
     /// </summary>
-    public sealed record Started(
-        IAzuriteProcess Process,
-        AzuriteLaunchMode Mode,
-        AzuriteEndpointTuple Endpoints) : ManagedAzuriteResult;
+    public sealed record Started(IAzuriteProcess Process, AzuriteLaunchMode Mode, AzuriteEndpointTuple Endpoints) : ManagedAzuriteResult;
 
     /// <summary>
     /// Azurite cannot be made ready. <paramref name="UserMessage"/> is

--- a/src/Func/Commands/Start/Azurite/Processes/ProcessOutcome.cs
+++ b/src/Func/Commands/Start/Azurite/Processes/ProcessOutcome.cs
@@ -11,9 +11,4 @@ namespace Azure.Functions.Cli.Commands.Start.Azurite.Processes;
 /// <param name="StandardError">Captured standard error, possibly empty.</param>
 /// <param name="TimedOut"><c>true</c> when the process was killed because the per-request timeout elapsed.</param>
 /// <param name="ExecutableNotFound"><c>true</c> when the executable could not be located on the host.</param>
-internal sealed record ProcessOutcome(
-    int? ExitCode,
-    string StandardOutput,
-    string StandardError,
-    bool TimedOut,
-    bool ExecutableNotFound);
+internal sealed record ProcessOutcome(int? ExitCode, string StandardOutput, string StandardError, bool TimedOut, bool ExecutableNotFound);

--- a/src/Func/Commands/Start/Azurite/Processes/ProcessRunRequest.cs
+++ b/src/Func/Commands/Start/Azurite/Processes/ProcessRunRequest.cs
@@ -6,8 +6,4 @@ namespace Azure.Functions.Cli.Commands.Start.Azurite.Processes;
 /// <summary>
 /// Describes a child process invocation routed through <see cref="IProcessRunner"/>.
 /// </summary>
-internal sealed record ProcessRunRequest(
-    string FileName,
-    IReadOnlyList<string> Arguments,
-    string? WorkingDirectory,
-    TimeSpan Timeout);
+internal sealed record ProcessRunRequest(string FileName, IReadOnlyList<string> Arguments, string? WorkingDirectory, TimeSpan Timeout);

--- a/src/Func/Commands/Start/Dashboard/DashboardEvent.cs
+++ b/src/Func/Commands/Start/Dashboard/DashboardEvent.cs
@@ -20,14 +20,10 @@ internal sealed record HostStateChangedEvent(
     string? Trigger)
     : DashboardEvent(Timestamp);
 
-internal sealed record FunctionDiscoveredEvent(
-    DateTimeOffset Timestamp,
-    FunctionInfo Function)
+internal sealed record FunctionDiscoveredEvent(DateTimeOffset Timestamp, FunctionInfo Function)
     : DashboardEvent(Timestamp);
 
-internal sealed record FunctionRemovedEvent(
-    DateTimeOffset Timestamp,
-    string Name)
+internal sealed record FunctionRemovedEvent(DateTimeOffset Timestamp, string Name)
     : DashboardEvent(Timestamp);
 
 internal sealed record InvocationStartedEvent(
@@ -49,11 +45,7 @@ internal sealed record InvocationCompletedEvent(
     string? ErrorMessage)
     : DashboardEvent(Timestamp);
 
-internal sealed record CliDiagnosticEvent(
-    DateTimeOffset Timestamp,
-    string Code,
-    string Message,
-    string? Recommendation)
+internal sealed record CliDiagnosticEvent(DateTimeOffset Timestamp, string Code, string Message, string? Recommendation)
     : DashboardEvent(Timestamp);
 
 internal sealed record SummaryEvent(

--- a/src/Func/Commands/Start/Dashboard/DashboardRunInfo.cs
+++ b/src/Func/Commands/Start/Dashboard/DashboardRunInfo.cs
@@ -6,7 +6,4 @@ namespace Azure.Functions.Cli.Hosting.Dashboard;
 /// <summary>
 /// Metadata about the current host run that is not derived from the log stream.
 /// </summary>
-internal sealed record DashboardRunInfo(
-    string CliVersion = "n/a",
-    string ProfileName = "none",
-    string StackName = "unknown");
+internal sealed record DashboardRunInfo(string CliVersion = "n/a", string ProfileName = "none", string StackName = "unknown");

--- a/src/Func/Commands/Start/Dashboard/Demo/DemoEventSource.cs
+++ b/src/Func/Commands/Start/Dashboard/Demo/DemoEventSource.cs
@@ -573,11 +573,7 @@ internal sealed class DemoEventSource(TimeProvider? timeProvider = null) : IHost
     private static HostLogEntry MakeOrphanWarning(Random rng)
     {
         string template = _orphanWarnings[rng.Next(_orphanWarnings.Length)];
-        return MakeLog(
-            "Host.Workers",
-            LogLevel.Warning,
-            template,
-            attrs: []);
+        return MakeLog("Host.Workers", LogLevel.Warning, template, attrs: []);
     }
 
     private static (string Type, string Message, Exception Exception) PickError(Random rng)
@@ -657,11 +653,7 @@ internal sealed class DemoEventSource(TimeProvider? timeProvider = null) : IHost
         () => ("Microsoft.Azure.Cosmos.CosmosException", "Throughput limit exceeded (429)", new InvalidOperationException("Throughput limit exceeded (429)")),
     ];
 
-    private static HostLogEntry MakeHostEvent(
-        string state,
-        double? durationMs,
-        string message,
-        Dictionary<string, object?>? attrs = null)
+    private static HostLogEntry MakeHostEvent(string state, double? durationMs, string message, Dictionary<string, object?>? attrs = null)
     {
         attrs ??= [];
         attrs[HostLogAttributeKeys.HostState] = state;

--- a/src/Func/Commands/Start/Dashboard/Rendering/CompactRenderer.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/CompactRenderer.cs
@@ -812,11 +812,7 @@ internal sealed class CompactRenderer(
             ? "Waiting for events…"
             : $"No logs for {activeFunctionFilter}…";
 
-    private static bool MatchesLogFilters(
-        CompactLogLine line,
-        string? activeFunctionFilter,
-        bool errorsOnly,
-        LogLevel minimumLogLevel)
+    private static bool MatchesLogFilters(CompactLogLine line, string? activeFunctionFilter, bool errorsOnly, LogLevel minimumLogLevel)
     {
         if (activeFunctionFilter is not null
             && line.FunctionName is not null

--- a/src/Func/Commands/Start/Dashboard/Rendering/Initialization/CompactStartInitializationRenderer.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/Initialization/CompactStartInitializationRenderer.cs
@@ -308,9 +308,5 @@ internal sealed class CompactStartInitializationRenderer(
         public string? Result { get; internal set; }
     }
 
-    private sealed record StepSnapshot(
-        StartInitializationStep Step,
-        double Percent,
-        bool Completed,
-        string? Result);
+    private sealed record StepSnapshot(StartInitializationStep Step, double Percent, bool Completed, string? Result);
 }

--- a/src/Func/Commands/Start/Dashboard/Rendering/Initialization/JsonStartInitializationRenderer.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/Initialization/JsonStartInitializationRenderer.cs
@@ -165,10 +165,7 @@ internal sealed class JsonStartInitializationRenderer : IStartInitializationRend
         writer.WriteEndObject();
     }
 
-    private static void WriteStringDictionary(
-        Utf8JsonWriter writer,
-        string propertyName,
-        IReadOnlyDictionary<string, string> values)
+    private static void WriteStringDictionary(Utf8JsonWriter writer, string propertyName, IReadOnlyDictionary<string, string> values)
     {
         writer.WriteStartObject(propertyName);
         foreach ((string key, string value) in values.OrderBy(static pair => pair.Key, StringComparer.OrdinalIgnoreCase))

--- a/src/Func/Commands/Start/Host/DefaultHostProcessRunner.cs
+++ b/src/Func/Commands/Start/Host/DefaultHostProcessRunner.cs
@@ -53,12 +53,7 @@ internal sealed class DefaultHostProcessRunner(
             throw CreateStartFailure(launchInfo, ex);
         }
 
-        IHostEventStream stream = new HostProcessEventStream(
-            process,
-            _outputParser,
-            launchInfo,
-            _shutdownTimeout,
-            _timeProvider);
+        IHostEventStream stream = new HostProcessEventStream(process, _outputParser, launchInfo, _shutdownTimeout, _timeProvider);
         return Task.FromResult(stream);
     }
 

--- a/src/Func/Commands/Start/Host/HostProcessEventStream.cs
+++ b/src/Func/Commands/Start/Host/HostProcessEventStream.cs
@@ -45,8 +45,7 @@ internal sealed class HostProcessEventStream : IHostEventStream, IHostEventStrea
         _exitTask = CompleteWhenProcessExitsAsync();
     }
 
-    public async IAsyncEnumerable<HostLogEntry> ReadAsync(
-        [EnumeratorCancellation] CancellationToken cancellationToken)
+    public async IAsyncEnumerable<HostLogEntry> ReadAsync([EnumeratorCancellation] CancellationToken cancellationToken)
     {
         while (await _channel.Reader.WaitToReadAsync(cancellationToken))
         {

--- a/src/Func/Commands/Start/Host/LineHostProcessOutputParser.cs
+++ b/src/Func/Commands/Start/Host/LineHostProcessOutputParser.cs
@@ -48,11 +48,7 @@ internal sealed class LineHostProcessOutputParser : IHostProcessOutputParser
             attributes);
     }
 
-    private bool TryParseConsoleLogRecord(
-        string streamName,
-        string line,
-        DateTimeOffset timestamp,
-        out HostLogEntry? entry)
+    private bool TryParseConsoleLogRecord(string streamName, string line, DateTimeOffset timestamp, out HostLogEntry? entry)
     {
         entry = null;
         if (TryParseConsoleLogHeader(line, out LogLevel level, out string? category, out int eventId))
@@ -83,14 +79,7 @@ internal sealed class LineHostProcessOutputParser : IHostProcessOutputParser
             Dictionary<string, object?> attributes = CreateStreamAttributes(streamName);
             EnrichFromCategory(context.Category, attributes);
             EnrichFromMessage(message, attributes);
-            entry = new HostLogEntry(
-                timestamp,
-                context.Category,
-                context.Level,
-                context.EventId,
-                message,
-                Exception: null,
-                attributes);
+            entry = new HostLogEntry(timestamp, context.Category, context.Level, context.EventId, message, Exception: null, attributes);
             return true;
         }
 
@@ -98,11 +87,7 @@ internal sealed class LineHostProcessOutputParser : IHostProcessOutputParser
         return false;
     }
 
-    private static bool TryParseConsoleLogHeader(
-        string line,
-        out LogLevel level,
-        out string? category,
-        out int eventId)
+    private static bool TryParseConsoleLogHeader(string line, out LogLevel level, out string? category, out int eventId)
     {
         level = default;
         category = null;

--- a/src/Func/Commands/Start/Initialization/HostWorkloads/DefaultHostWorkloadResolver.cs
+++ b/src/Func/Commands/Start/Initialization/HostWorkloads/DefaultHostWorkloadResolver.cs
@@ -114,9 +114,7 @@ internal sealed class DefaultHostWorkloadResolver(
             ? candidates
             : [.. candidates.Where(candidate => range.Satisfies(candidate.Version))];
 
-    private async Task<ResolvedPackage> ResolveLatestInstallPackageAsync(
-        VersionRange? range,
-        CancellationToken cancellationToken)
+    private async Task<ResolvedPackage> ResolveLatestInstallPackageAsync(VersionRange? range, CancellationToken cancellationToken)
     {
         string packageId = HostWorkloadPackage.CurrentPackageId;
         ResolvedPackage? package = range is null

--- a/src/Func/Commands/Start/Initialization/HostWorkloads/HostWorkloadResolutionContext.cs
+++ b/src/Func/Commands/Start/Initialization/HostWorkloads/HostWorkloadResolutionContext.cs
@@ -8,7 +8,4 @@ namespace Azure.Functions.Cli.Commands.Start.Initialization;
 /// <summary>
 /// Inputs used to resolve the host workload for a start run.
 /// </summary>
-internal sealed record HostWorkloadResolutionContext(
-    string? RequestedHostVersion,
-    VersionRange? ProfileHostVersionRange,
-    bool Offline);
+internal sealed record HostWorkloadResolutionContext(string? RequestedHostVersion, VersionRange? ProfileHostVersionRange, bool Offline);

--- a/src/Func/Commands/Start/Initialization/IStartInitializationStep.cs
+++ b/src/Func/Commands/Start/Initialization/IStartInitializationStep.cs
@@ -16,7 +16,5 @@ internal interface IStartInitializationStep
 
     public StartInitializationDisplayKind DisplayKind { get; }
 
-    public Task<StartInitializationStepResult> ExecuteAsync(
-        StartInitializationStepContext context,
-        CancellationToken cancellationToken);
+    public Task<StartInitializationStepResult> ExecuteAsync(StartInitializationStepContext context, CancellationToken cancellationToken);
 }

--- a/src/Func/Commands/Start/Initialization/StartInitializationContext.cs
+++ b/src/Func/Commands/Start/Initialization/StartInitializationContext.cs
@@ -6,11 +6,7 @@ namespace Azure.Functions.Cli.Commands.Start.Initialization;
 /// <summary>
 /// Inputs required to initialize a host run.
 /// </summary>
-internal sealed record StartInitializationContext(
-    StartCommandOptions Options,
-    string CliVersion,
-    bool IsInteractive,
-    bool CanPrompt)
+internal sealed record StartInitializationContext(StartCommandOptions Options, string CliVersion, bool IsInteractive, bool CanPrompt)
 {
     public string ProfileName => string.IsNullOrWhiteSpace(Options.RequestedProfileName)
         ? "none"

--- a/src/Func/Commands/Start/Initialization/StartInitializationEvent.cs
+++ b/src/Func/Commands/Start/Initialization/StartInitializationEvent.cs
@@ -23,20 +23,13 @@ internal sealed record StartInitializationStepStartedEvent(DateTimeOffset Timest
 /// <summary>
 /// Emitted when a progress-based initialization step advances.
 /// </summary>
-internal sealed record StartInitializationProgressEvent(
-    DateTimeOffset Timestamp,
-    string StepId,
-    double Percent,
-    string? Message = null)
+internal sealed record StartInitializationProgressEvent(DateTimeOffset Timestamp, string StepId, double Percent, string? Message = null)
     : StartInitializationEvent(Timestamp);
 
 /// <summary>
 /// Emitted when an initialization step completes successfully.
 /// </summary>
-internal sealed record StartInitializationStepCompletedEvent(
-    DateTimeOffset Timestamp,
-    string StepId,
-    string? Message = null)
+internal sealed record StartInitializationStepCompletedEvent(DateTimeOffset Timestamp, string StepId, string? Message = null)
     : StartInitializationEvent(Timestamp);
 
 /// <summary>

--- a/src/Func/Commands/Start/Initialization/Steps/PrepareProjectHostRunInitializationStep.cs
+++ b/src/Func/Commands/Start/Initialization/Steps/PrepareProjectHostRunInitializationStep.cs
@@ -102,9 +102,7 @@ internal sealed class PrepareProjectHostRunInitializationStep(
         return environmentVariables;
     }
 
-    private void MergeLocalSettingsValues(
-        IReadOnlyDictionary<string, string> values,
-        Dictionary<string, string> environmentVariables)
+    private void MergeLocalSettingsValues(IReadOnlyDictionary<string, string> values, Dictionary<string, string> environmentVariables)
     {
         foreach ((string name, string value) in values)
         {

--- a/src/Func/Commands/Start/Initialization/Steps/ResolveConstraintsInitializationStep.cs
+++ b/src/Func/Commands/Start/Initialization/Steps/ResolveConstraintsInitializationStep.cs
@@ -42,8 +42,7 @@ internal sealed class ResolveConstraintsInitializationStep : DemoInitializationS
             ? $"; {warningCount} warning(s)"
             : string.Empty;
 
-        return StartInitializationStepResult.Completed(
-            $"Host {hostRange}; bundle {bundleRange}; workers {workerSummary}{diagnostics}");
+        return StartInitializationStepResult.Completed($"Host {hostRange}; bundle {bundleRange}; workers {workerSummary}{diagnostics}");
     }
 
     private static string FormatWorkerSummary(IReadOnlyDictionary<string, VersionRange> workerRanges)

--- a/src/Func/Commands/Start/Initialization/Steps/ResolveFunctionsWorkerInitializationStep.cs
+++ b/src/Func/Commands/Start/Initialization/Steps/ResolveFunctionsWorkerInitializationStep.cs
@@ -197,9 +197,7 @@ internal sealed class ResolveFunctionsWorkerInitializationStep(
         return await project.WorkerReference.ResolveWorkerAsync(resolutionContext, cancellationToken);
     }
 
-    private static bool TryGetInstallableWorker(
-        FunctionsWorkerResolutionFailure failure,
-        out FunctionsWorkerId? workerId)
+    private static bool TryGetInstallableWorker(FunctionsWorkerResolutionFailure failure, out FunctionsWorkerId? workerId)
     {
         switch (failure)
         {

--- a/src/Func/Commands/Start/StartCommand.cs
+++ b/src/Func/Commands/Start/StartCommand.cs
@@ -239,14 +239,10 @@ internal sealed class StartCommand : FuncCliCommand, IBuiltInCommand
         }
     }
 
-    private async Task CompleteProjectHostRunAsync(
-        StartInitializationResult initializationResult,
-        FunctionsProjectHostRunOutcome outcome)
+    private async Task CompleteProjectHostRunAsync(StartInitializationResult initializationResult, FunctionsProjectHostRunOutcome outcome)
     {
         using var cleanupCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        var completionContext = new FunctionsProjectHostRunCompletionContext(
-            initializationResult.HostRunContext,
-            outcome);
+        var completionContext = new FunctionsProjectHostRunCompletionContext(initializationResult.HostRunContext, outcome);
 
         try
         {

--- a/src/Func/Commands/Workload/WorkloadInstallCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadInstallCommand.cs
@@ -102,8 +102,7 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
             // prompt entirely. Non-interactive contexts treat the prompt as
             // a decline and exit non-zero with the same hint. Local .nupkg
             // installs bypass the check since the resolver path differs.
-            int? earlyExit = await HandleAlreadyInstalledAsync(
-                workload, exact, source, includePrerelease, cancellationToken);
+            int? earlyExit = await HandleAlreadyInstalledAsync(workload, exact, source, includePrerelease, cancellationToken);
             if (earlyExit is { } code)
             {
                 return code;

--- a/src/Func/Commands/Workload/WorkloadListCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadListCommand.cs
@@ -33,10 +33,7 @@ internal sealed class WorkloadListCommand : FuncCliCommand
         Description = "Emit machine-readable JSON instead of a table.",
     };
 
-    public WorkloadListCommand(
-        IInteractionService interaction,
-        IWorkloadProvider workloads,
-        IWorkloadStore store)
+    public WorkloadListCommand(IInteractionService interaction, IWorkloadProvider workloads, IWorkloadStore store)
         : base("list", "List installed workloads.")
     {
         _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));

--- a/src/Func/Commands/Workload/WorkloadPruneCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadPruneCommand.cs
@@ -33,10 +33,7 @@ internal sealed class WorkloadPruneCommand : FuncCliCommand
         Description = "Disable alias matching. <id> must be the literal package id.",
     };
 
-    public WorkloadPruneCommand(
-        IInteractionService interaction,
-        IWorkloadInstaller installer,
-        IWorkloadStore store)
+    public WorkloadPruneCommand(IInteractionService interaction, IWorkloadInstaller installer, IWorkloadStore store)
         : base("prune", "Remove inactive side-by-side workload installs.")
     {
         _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
@@ -64,8 +61,7 @@ internal sealed class WorkloadPruneCommand : FuncCliCommand
         IReadOnlyList<WorkloadEntry> scoped = ScopeToTarget(installed, identifier, exact);
         if (scoped.Count == 0)
         {
-            _interaction.WriteWarning(
-                $"Workload '{identifier}' is not installed; nothing to prune.");
+            _interaction.WriteWarning($"Workload '{identifier}' is not installed; nothing to prune.");
             return 0;
         }
 
@@ -107,10 +103,7 @@ internal sealed class WorkloadPruneCommand : FuncCliCommand
         return 0;
     }
 
-    private static IReadOnlyList<WorkloadEntry> ScopeToTarget(
-        IReadOnlyList<WorkloadEntry> installed,
-        string? identifier,
-        bool exact)
+    private static IReadOnlyList<WorkloadEntry> ScopeToTarget(IReadOnlyList<WorkloadEntry> installed, string? identifier, bool exact)
     {
         if (string.IsNullOrWhiteSpace(identifier))
         {

--- a/src/Func/Commands/Workload/WorkloadUninstallCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadUninstallCommand.cs
@@ -39,10 +39,7 @@ internal sealed class WorkloadUninstallCommand : FuncCliCommand
         Description = "Disable alias matching. <id> must be the literal package id.",
     };
 
-    public WorkloadUninstallCommand(
-        IInteractionService interaction,
-        IWorkloadInstaller installer,
-        IWorkloadStore store)
+    public WorkloadUninstallCommand(IInteractionService interaction, IWorkloadInstaller installer, IWorkloadStore store)
         : base("uninstall", "Uninstall a workload.")
     {
         _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
@@ -85,8 +82,7 @@ internal sealed class WorkloadUninstallCommand : FuncCliCommand
 
         if (matches.Count == 0)
         {
-            _interaction.WriteWarning(
-                $"Workload '{identifier}' is not installed; nothing to do.");
+            _interaction.WriteWarning($"Workload '{identifier}' is not installed; nothing to do.");
             return 0;
         }
 

--- a/src/Func/Commands/Workload/WorkloadUpdateCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadUpdateCommand.cs
@@ -60,10 +60,7 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
         Description = "Disable alias matching. <id> must be the literal package id.",
     };
 
-    public WorkloadUpdateCommand(
-        IInteractionService interaction,
-        IWorkloadInstaller installer,
-        IWorkloadStore store)
+    public WorkloadUpdateCommand(IInteractionService interaction, IWorkloadInstaller installer, IWorkloadStore store)
         : base("update", "Update an installed workload in place.")
     {
         _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
@@ -144,10 +141,7 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
             cancellationToken);
     }
 
-    private async Task<string> ResolveInstalledPackageIdAsync(
-        string identifier,
-        bool exact,
-        CancellationToken cancellationToken)
+    private async Task<string> ResolveInstalledPackageIdAsync(string identifier, bool exact, CancellationToken cancellationToken)
     {
         IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
 
@@ -214,11 +208,7 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
         }
     }
 
-    private async Task<int> UpdateAllAsync(
-        string? source,
-        bool includePrerelease,
-        bool allowMajor,
-        CancellationToken cancellationToken)
+    private async Task<int> UpdateAllAsync(string? source, bool includePrerelease, bool allowMajor, CancellationToken cancellationToken)
     {
         IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
         IReadOnlyList<string> packageIds = [.. installed

--- a/src/Func/Hosting/Events/InMemoryHostEventStream.cs
+++ b/src/Func/Hosting/Events/InMemoryHostEventStream.cs
@@ -38,8 +38,7 @@ internal sealed class InMemoryHostEventStream : IHostEventStream
 
     public void Complete() => _channel.Writer.TryComplete();
 
-    public async IAsyncEnumerable<HostLogEntry> ReadAsync(
-        [EnumeratorCancellation] CancellationToken cancellationToken)
+    public async IAsyncEnumerable<HostLogEntry> ReadAsync([EnumeratorCancellation] CancellationToken cancellationToken)
     {
         while (await _channel.Reader.WaitToReadAsync(cancellationToken))
         {

--- a/src/Func/Hosting/HostApplicationBuilderExtensions.cs
+++ b/src/Func/Hosting/HostApplicationBuilderExtensions.cs
@@ -30,20 +30,14 @@ internal static class HostApplicationBuilderExtensions
     /// on <see cref="HostApplicationBuilder.Services"/> after
     /// <see cref="CliHostFactory.CreateBuilder"/>.
     /// </remarks>
-    public static Task RegisterWorkloadsAsync(
-        this HostApplicationBuilder builder,
-        CancellationToken cancellationToken = default)
+    public static Task RegisterWorkloadsAsync(this HostApplicationBuilder builder, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
         IInteractionService interaction = ResolveSingletonInstance<IInteractionService>(builder);
         WorkloadPathsOptions paths = TryResolveSingletonInstance<WorkloadPathsOptions>(builder)
             ?? new WorkloadPathsOptions();
-        return WorkloadRegistration.RegisterWorkloadsAsync(
-            builder.Services,
-            paths,
-            interaction,
-            cancellationToken);
+        return WorkloadRegistration.RegisterWorkloadsAsync(builder.Services, paths, interaction, cancellationToken);
     }
 
     /// <summary>

--- a/src/Func/Hosting/WorkloadRegistration.cs
+++ b/src/Func/Hosting/WorkloadRegistration.cs
@@ -161,9 +161,7 @@ internal static class WorkloadRegistration
                 .First())];
     }
 
-    private static IReadOnlyList<ContentWorkloadInfo> CreateContentWorkloads(
-        IReadOnlyList<WorkloadEntry> entries,
-        IWorkloadPaths paths)
+    private static IReadOnlyList<ContentWorkloadInfo> CreateContentWorkloads(IReadOnlyList<WorkloadEntry> entries, IWorkloadPaths paths)
     {
         return [.. entries
             .Where(e => e.Kind == WorkloadKind.Content)

--- a/src/Func/Parser.cs
+++ b/src/Func/Parser.cs
@@ -145,10 +145,7 @@ internal static class Parser
         helpOption?.Action = action;
     }
 
-    private static void ConfigureRootAction(
-        FuncRootCommand rootCommand,
-        HelpCommand helpCommand,
-        VersionCommand versionCommand)
+    private static void ConfigureRootAction(FuncRootCommand rootCommand, HelpCommand helpCommand, VersionCommand versionCommand)
     {
         rootCommand.SetAction(parseResult =>
         {

--- a/src/Func/Projects/FunctionsProjectResolver.cs
+++ b/src/Func/Projects/FunctionsProjectResolver.cs
@@ -8,8 +8,7 @@ namespace Azure.Functions.Cli.Projects;
 /// <summary>
 /// Default aggregate project resolver.
 /// </summary>
-internal sealed class FunctionsProjectResolver(
-    IEnumerable<WorkloadProjectFactoryRegistration> factories)
+internal sealed class FunctionsProjectResolver(IEnumerable<WorkloadProjectFactoryRegistration> factories)
     : IFunctionsProjectResolver
 {
     private readonly IReadOnlyList<WorkloadProjectFactoryRegistration> _factories =
@@ -38,7 +37,6 @@ internal sealed class FunctionsProjectResolver(
             }
         }
 
-        return ProjectResolutionResults.NotResolved(
-            "No installed workload recognized this directory as an Azure Functions project.");
+        return ProjectResolutionResults.NotResolved("No installed workload recognized this directory as an Azure Functions project.");
     }
 }

--- a/src/Func/Workers/DefaultFunctionsWorkerResolver.cs
+++ b/src/Func/Workers/DefaultFunctionsWorkerResolver.cs
@@ -124,9 +124,7 @@ internal sealed class DefaultFunctionsWorkerResolver(
         return FunctionsWorkerResolutionResults.NotResolved(failure);
     }
 
-    private static FunctionsWorkerResolutionResult MissingCompatibleVersion(
-        FunctionsWorkerId workerId,
-        VersionRange? constraint)
+    private static FunctionsWorkerResolutionResult MissingCompatibleVersion(FunctionsWorkerId workerId, VersionRange? constraint)
     {
         if (constraint is null)
         {

--- a/src/Func/Workloads/Catalog/IWorkloadCatalog.cs
+++ b/src/Func/Workloads/Catalog/IWorkloadCatalog.cs
@@ -22,9 +22,7 @@ internal interface IWorkloadCatalog
     /// </summary>
     /// <param name="query">Filter, paging, and source-override bag.</param>
     /// <param name="cancellationToken">Cancellation propagated to the underlying request.</param>
-    public Task<IReadOnlyList<CatalogSearchResult>> SearchAsync(
-        CatalogSearchQuery query,
-        CancellationToken cancellationToken = default);
+    public Task<IReadOnlyList<CatalogSearchResult>> SearchAsync(CatalogSearchQuery query, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns the highest installable version of <paramref name="packageId"/>
@@ -93,7 +91,5 @@ internal interface IWorkloadCatalog
     /// <exception cref="WorkloadPackageNotFoundException">
     /// The package + version does not exist on the resolved source.
     /// </exception>
-    public Task<Stream> DownloadAsync(
-        ResolvedPackage package,
-        CancellationToken cancellationToken = default);
+    public Task<Stream> DownloadAsync(ResolvedPackage package, CancellationToken cancellationToken = default);
 }

--- a/src/Func/Workloads/Catalog/NuGetProtocolSourceClient.cs
+++ b/src/Func/Workloads/Catalog/NuGetProtocolSourceClient.cs
@@ -35,9 +35,7 @@ internal class NuGetProtocolSourceClient(SourceRepository repository)
 
     public PackageSource Source => _repository.PackageSource;
 
-    public async Task<IReadOnlyList<CatalogSearchResult>> SearchAsync(
-        CatalogSearchQuery query,
-        CancellationToken cancellationToken)
+    public async Task<IReadOnlyList<CatalogSearchResult>> SearchAsync(CatalogSearchQuery query, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(query);
 
@@ -54,9 +52,7 @@ internal class NuGetProtocolSourceClient(SourceRepository repository)
         return raw is null ? [] : ParseV3Hits(raw, Source);
     }
 
-    public async Task<IReadOnlyList<NuGetVersion>> ListVersionsAsync(
-        string packageId,
-        CancellationToken cancellationToken)
+    public async Task<IReadOnlyList<NuGetVersion>> ListVersionsAsync(string packageId, CancellationToken cancellationToken)
     {
         FindPackageByIdResource findResource = await _repository.GetResourceAsync<FindPackageByIdResource>(cancellationToken);
         using var cache = new SourceCacheContext();
@@ -70,10 +66,7 @@ internal class NuGetProtocolSourceClient(SourceRepository repository)
         return versions?.ToList() ?? [];
     }
 
-    public async Task<Stream> OpenPackageAsync(
-        string packageId,
-        NuGetVersion version,
-        CancellationToken cancellationToken)
+    public async Task<Stream> OpenPackageAsync(string packageId, NuGetVersion version, CancellationToken cancellationToken)
     {
         FindPackageByIdResource findResource = await _repository.GetResourceAsync<FindPackageByIdResource>(cancellationToken);
         using var cache = new SourceCacheContext();
@@ -118,9 +111,7 @@ internal class NuGetProtocolSourceClient(SourceRepository repository)
     /// for the source all apply. Virtual so tests can stub the JSON
     /// response without standing up an HTTP server.
     /// </summary>
-    internal virtual async Task<JObject?> FetchSearchResponseAsync(
-        Uri searchUri,
-        CancellationToken cancellationToken)
+    internal virtual async Task<JObject?> FetchSearchResponseAsync(Uri searchUri, CancellationToken cancellationToken)
     {
         HttpSourceResource httpSourceResource = await _repository.GetResourceAsync<HttpSourceResource>(cancellationToken);
         return await httpSourceResource.HttpSource.GetJObjectAsync(
@@ -135,10 +126,7 @@ internal class NuGetProtocolSourceClient(SourceRepository repository)
     /// <c>packageType=FuncCliWorkload</c> filter. Returns null when the
     /// source has no V3 service index (e.g. local file feeds).
     /// </summary>
-    private async Task<Uri?> TryBuildV3SearchUriAsync(
-        CatalogSearchQuery query,
-        int take,
-        CancellationToken cancellationToken)
+    private async Task<Uri?> TryBuildV3SearchUriAsync(CatalogSearchQuery query, int take, CancellationToken cancellationToken)
     {
         ServiceIndexResourceV3? serviceIndex = await _repository.GetResourceAsync<ServiceIndexResourceV3>(cancellationToken);
         if (serviceIndex is null)

--- a/src/Func/Workloads/Catalog/WorkloadCatalog.cs
+++ b/src/Func/Workloads/Catalog/WorkloadCatalog.cs
@@ -20,9 +20,7 @@ internal sealed class WorkloadCatalog(
     private readonly Func<PackageSource, NuGetProtocolSourceClient> _clientFactory = clientFactory ?? throw new ArgumentNullException(nameof(clientFactory));
 
     /// <inheritdoc />
-    public Task<IReadOnlyList<CatalogSearchResult>> SearchAsync(
-        CatalogSearchQuery query,
-        CancellationToken cancellationToken = default)
+    public Task<IReadOnlyList<CatalogSearchResult>> SearchAsync(CatalogSearchQuery query, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(query);
         return ResolveClient(query.Source).SearchAsync(query, cancellationToken);
@@ -101,9 +99,7 @@ internal sealed class WorkloadCatalog(
         return selected is null ? null : new ResolvedPackage(packageId.ToLowerInvariant(), selected, client.Source);
     }
 
-    private static NuGetVersion? SelectLatest(
-        IEnumerable<NuGetVersion> versions,
-        Func<NuGetVersion, bool> predicate)
+    private static NuGetVersion? SelectLatest(IEnumerable<NuGetVersion> versions, Func<NuGetVersion, bool> predicate)
     {
         NuGetVersion? best = null;
         foreach (NuGetVersion candidate in versions)

--- a/src/Func/Workloads/Catalog/WorkloadSourceResolver.cs
+++ b/src/Func/Workloads/Catalog/WorkloadSourceResolver.cs
@@ -21,8 +21,7 @@ internal static class WorkloadSourceResolver
     /// </summary>
     public static string? Resolve()
     {
-        string? configured = System.Environment.GetEnvironmentVariable(
-            Constants.WorkloadsSourceEnvironmentVariable);
+        string? configured = System.Environment.GetEnvironmentVariable(Constants.WorkloadsSourceEnvironmentVariable);
 
         return string.IsNullOrWhiteSpace(configured) ? null : configured;
     }

--- a/src/Func/Workloads/Discovery/WorkloadMetadataReader.cs
+++ b/src/Func/Workloads/Discovery/WorkloadMetadataReader.cs
@@ -142,10 +142,7 @@ internal sealed class WorkloadMetadataReader : IWorkloadMetadataReader
             "entryPoint.assemblyPath");
     }
 
-    private static void ValidateRelativePathStaysWithinPackage(
-        string value,
-        string metadataPath,
-        string fieldName)
+    private static void ValidateRelativePathStaysWithinPackage(string value, string metadataPath, string fieldName)
     {
         if (Path.IsPathRooted(value))
         {

--- a/src/Func/Workloads/Install/IWorkloadInstaller.cs
+++ b/src/Func/Workloads/Install/IWorkloadInstaller.cs
@@ -121,8 +121,5 @@ internal interface IWorkloadInstaller
     /// (<paramref name="packageId"/>, <paramref name="version"/>). Returns
     /// <c>true</c> when an entry was removed, <c>false</c> when none existed.
     /// </summary>
-    public Task<bool> UninstallAsync(
-        string packageId,
-        string version,
-        CancellationToken cancellationToken = default);
+    public Task<bool> UninstallAsync(string packageId, string version, CancellationToken cancellationToken = default);
 }

--- a/src/Func/Workloads/Install/WorkloadInstaller.cs
+++ b/src/Func/Workloads/Install/WorkloadInstaller.cs
@@ -171,8 +171,7 @@ internal sealed class WorkloadInstaller(
             ? packageId
             : await ResolveAliasOrIdAsync(packageId, source, includePrerelease, cancellationToken);
 
-        ResolvedPackage resolved = await ResolveCatalogPackageAsync(
-            resolvedId, version, source, includePrerelease, cancellationToken);
+        ResolvedPackage resolved = await ResolveCatalogPackageAsync(resolvedId, version, source, includePrerelease, cancellationToken);
 
         string tempPath = Path.Combine(
             Path.GetTempPath(),
@@ -261,17 +260,13 @@ internal sealed class WorkloadInstaller(
             return new WorkloadUpdateResult(currentEntry, currentEntry.PackageVersion, NoUpdateAvailable: true);
         }
 
-        WorkloadEntry newEntry = await StageAndSwapAsync(
-            currentEntry, resolved, progress, cancellationToken);
+        WorkloadEntry newEntry = await StageAndSwapAsync(currentEntry, resolved, progress, cancellationToken);
 
         return new WorkloadUpdateResult(newEntry, currentEntry.PackageVersion, NoUpdateAvailable: false);
     }
 
     /// <inheritdoc />
-    public async Task<bool> UninstallAsync(
-        string packageId,
-        string version,
-        CancellationToken cancellationToken = default)
+    public async Task<bool> UninstallAsync(string packageId, string version, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
         ArgumentException.ThrowIfNullOrWhiteSpace(version);
@@ -482,11 +477,7 @@ internal sealed class WorkloadInstaller(
                 WorkloadInstallPhase.Registering,
                 $"Registering workload '{newPackageId}' {newVersion}"));
 
-            await _store.ReplaceWorkloadAsync(
-                currentEntry.PackageId,
-                currentEntry.PackageVersion,
-                newEntry,
-                cancellationToken);
+            await _store.ReplaceWorkloadAsync(currentEntry.PackageId, currentEntry.PackageVersion, newEntry, cancellationToken);
 
             string oldInstallPath = _paths.GetInstallDirectory(currentEntry.PackageId, currentEntry.PackageVersion);
             if (!string.Equals(oldInstallPath, finalInstallPath, StringComparison.Ordinal))
@@ -533,10 +524,7 @@ internal sealed class WorkloadInstaller(
         }
     }
 
-    private static async Task ExtractPackageAsync(
-        PackageArchiveReader reader,
-        string destination,
-        CancellationToken cancellationToken)
+    private static async Task ExtractPackageAsync(PackageArchiveReader reader, string destination, CancellationToken cancellationToken)
     {
         // PackageArchiveReader already filters OPC metadata and rejects
         // path-escape entries. We additionally restrict the on-disk layout

--- a/src/Func/Workloads/Storage/IWorkloadStore.cs
+++ b/src/Func/Workloads/Storage/IWorkloadStore.cs
@@ -37,10 +37,7 @@ internal interface IWorkloadStore
     /// removed, <c>false</c> when no such entry existed. Other versions of
     /// the same package are left untouched.
     /// </summary>
-    public Task<bool> RemoveWorkloadAsync(
-        string packageId,
-        string version,
-        CancellationToken cancellationToken = default);
+    public Task<bool> RemoveWorkloadAsync(string packageId, string version, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Atomically removes the entry for (<paramref name="oldPackageId"/>,

--- a/src/Func/Workloads/Storage/WorkloadHomeResolver.cs
+++ b/src/Func/Workloads/Storage/WorkloadHomeResolver.cs
@@ -21,8 +21,7 @@ internal static class WorkloadHomeResolver
     /// </summary>
     public static string Resolve()
     {
-        string? configured = System.Environment.GetEnvironmentVariable(
-            Constants.WorkloadsHomeEnvironmentVariable);
+        string? configured = System.Environment.GetEnvironmentVariable(Constants.WorkloadsHomeEnvironmentVariable);
 
         string home = string.IsNullOrWhiteSpace(configured)
             ? Path.Combine(

--- a/src/Func/Workloads/Storage/WorkloadStore.cs
+++ b/src/Func/Workloads/Storage/WorkloadStore.cs
@@ -15,16 +15,13 @@ internal class WorkloadStore(IWorkloadPaths paths) : IWorkloadStore
     private readonly IWorkloadPaths _paths = paths
         ?? throw new ArgumentNullException(nameof(paths));
 
-    public async Task<IReadOnlyList<WorkloadEntry>> GetWorkloadsAsync(
-        CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<WorkloadEntry>> GetWorkloadsAsync(CancellationToken cancellationToken = default)
     {
         WorkloadRegistry registry = await ReadRegistryAsync(cancellationToken);
         return [.. registry.Workloads];
     }
 
-    public async Task SaveWorkloadAsync(
-        WorkloadEntry entry,
-        CancellationToken cancellationToken = default)
+    public async Task SaveWorkloadAsync(WorkloadEntry entry, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(entry);
         ArgumentException.ThrowIfNullOrWhiteSpace(entry.PackageId);
@@ -45,10 +42,7 @@ internal class WorkloadStore(IWorkloadPaths paths) : IWorkloadStore
         await WriteRegistryAsync(registry, cancellationToken);
     }
 
-    public async Task<bool> RemoveWorkloadAsync(
-        string packageId,
-        string version,
-        CancellationToken cancellationToken = default)
+    public async Task<bool> RemoveWorkloadAsync(string packageId, string version, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
         ArgumentException.ThrowIfNullOrWhiteSpace(version);
@@ -124,13 +118,7 @@ internal class WorkloadStore(IWorkloadPaths paths) : IWorkloadStore
 
         try
         {
-            await using var stream = new FileStream(
-                path,
-                FileMode.Open,
-                FileAccess.Read,
-                FileShare.Read,
-                bufferSize: 4096,
-                useAsync: true);
+            await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, useAsync: true);
 
             WorkloadRegistry registry = await JsonSerializer.DeserializeAsync(
                 stream,
@@ -205,10 +193,7 @@ internal class WorkloadStore(IWorkloadPaths paths) : IWorkloadStore
     /// Serialize hook. Tests substitute this to exercise the failure-path
     /// cleanup (temp file removed, original registry preserved).
     /// </summary>
-    internal virtual Task SerializeAsync(
-        Stream stream,
-        WorkloadRegistry registry,
-        CancellationToken cancellationToken)
+    internal virtual Task SerializeAsync(Stream stream, WorkloadRegistry registry, CancellationToken cancellationToken)
         => JsonSerializer.SerializeAsync(
             stream,
             registry,

--- a/src/Workloads/Host/Program.cs
+++ b/src/Workloads/Host/Program.cs
@@ -60,9 +60,7 @@ internal static class Program
         Environment.SetEnvironmentVariable("FUNCTIONS_CORETOOLS_ENVIRONMENT", "true");
     }
 
-    internal static Task StartStandardInputClosedMonitorAsync(
-        TextReader standardInput,
-        CancellationTokenSource shutdownTokenSource)
+    internal static Task StartStandardInputClosedMonitorAsync(TextReader standardInput, CancellationTokenSource shutdownTokenSource)
     {
         ArgumentNullException.ThrowIfNull(standardInput);
         ArgumentNullException.ThrowIfNull(shutdownTokenSource);
@@ -70,9 +68,7 @@ internal static class Program
         return Task.Run(() => CancelOnStandardInputClosedAsync(standardInput, shutdownTokenSource));
     }
 
-    private static async Task CancelOnStandardInputClosedAsync(
-        TextReader standardInput,
-        CancellationTokenSource shutdownTokenSource)
+    private static async Task CancelOnStandardInputClosedAsync(TextReader standardInput, CancellationTokenSource shutdownTokenSource)
     {
         try
         {

--- a/src/Workloads/Stacks/DotNet/DotNetCli/DotnetCliRunner.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetCli/DotnetCliRunner.cs
@@ -13,10 +13,7 @@ internal sealed class DotnetCliRunner(IDotnetPathResolver pathResolver) : IDotne
 {
     private readonly IDotnetPathResolver _pathResolver = pathResolver ?? throw new ArgumentNullException(nameof(pathResolver));
 
-    public async Task RunAsync(
-        IReadOnlyList<string> arguments,
-        string? workingDirectory,
-        CancellationToken cancellationToken)
+    public async Task RunAsync(IReadOnlyList<string> arguments, string? workingDirectory, CancellationToken cancellationToken)
     {
         await RunCoreAsync(arguments, workingDirectory, cancellationToken);
     }
@@ -29,10 +26,7 @@ internal sealed class DotnetCliRunner(IDotnetPathResolver pathResolver) : IDotne
         return await RunCoreAsync(arguments, workingDirectory, cancellationToken);
     }
 
-    private async Task<string> RunCoreAsync(
-        IReadOnlyList<string> arguments,
-        string? workingDirectory,
-        CancellationToken cancellationToken)
+    private async Task<string> RunCoreAsync(IReadOnlyList<string> arguments, string? workingDirectory, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(arguments);
 

--- a/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
@@ -54,10 +54,7 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli, ITemp
         return [FrameworkOption];
     }
 
-    public async Task InitializeAsync(
-        InitContext context,
-        ParseResult parseResult,
-        CancellationToken cancellationToken = default)
+    public async Task InitializeAsync(InitContext context, ParseResult parseResult, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(parseResult);
@@ -134,10 +131,7 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli, ITemp
         WriteTimestamp();
     }
 
-    private async Task RunWithTimeoutAsync(
-        IReadOnlyList<string> args,
-        string? workingDirectory,
-        CancellationToken cancellationToken)
+    private async Task RunWithTimeoutAsync(IReadOnlyList<string> args, string? workingDirectory, CancellationToken cancellationToken)
     {
         using CancellationTokenSource timeoutCts = new(OperationTimeout);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(

--- a/src/Workloads/Stacks/Go/GoProjectInitializer.cs
+++ b/src/Workloads/Stacks/Go/GoProjectInitializer.cs
@@ -59,10 +59,7 @@ internal sealed class GoProjectInitializer : IProjectInitializer
         return [SkipGoModTidyOption, NoBundleOption, BundlesChannelOption];
     }
 
-    public async Task InitializeAsync(
-        InitContext context,
-        ParseResult parseResult,
-        CancellationToken cancellationToken = default)
+    public async Task InitializeAsync(InitContext context, ParseResult parseResult, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(parseResult);

--- a/src/Workloads/Stacks/Node/NodeProjectInitializer.cs
+++ b/src/Workloads/Stacks/Node/NodeProjectInitializer.cs
@@ -59,10 +59,7 @@ internal sealed class NodeProjectInitializer : IProjectInitializer
         return [NoBundleOption, BundlesChannelOption, SkipNpmInstallOption];
     }
 
-    public async Task InitializeAsync(
-        InitContext context,
-        ParseResult parseResult,
-        CancellationToken cancellationToken = default)
+    public async Task InitializeAsync(InitContext context, ParseResult parseResult, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(parseResult);

--- a/src/Workloads/Stacks/Python/PythonProjectInitializer.cs
+++ b/src/Workloads/Stacks/Python/PythonProjectInitializer.cs
@@ -42,10 +42,7 @@ internal sealed class PythonProjectInitializer : IProjectInitializer
         return [NoBundleOption, BundlesChannelOption];
     }
 
-    public Task InitializeAsync(
-        InitContext context,
-        ParseResult parseResult,
-        CancellationToken cancellationToken = default)
+    public Task InitializeAsync(InitContext context, ParseResult parseResult, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(parseResult);

--- a/test/Func.Tests/Commands/HostProcessEventStreamTests.cs
+++ b/test/Func.Tests/Commands/HostProcessEventStreamTests.cs
@@ -14,10 +14,7 @@ public class HostProcessEventStreamTests
     [Fact]
     public async Task ReadAsync_BuffersProcessStartedAndOutputLinesUntilExit()
     {
-        var process = new CompletedHostProcess(
-            stdout: "stdout line",
-            stderr: "stderr line",
-            exitCode: 23);
+        var process = new CompletedHostProcess(stdout: "stdout line", stderr: "stderr line", exitCode: 23);
         var launchInfo = new HostProcessLaunchInfo(
             new ProcessStartInfo("host"),
             Port: 7071,

--- a/test/Func.Tests/Commands/HostProcessOutputParserTests.cs
+++ b/test/Func.Tests/Commands/HostProcessOutputParserTests.cs
@@ -16,10 +16,7 @@ public class HostProcessOutputParserTests
     {
         var parser = new LineHostProcessOutputParser();
 
-        HostLogEntry entry = parser.ParseLine(
-            HostProcessStreamNames.StandardOutput,
-            "Host started",
-            DateTimeOffset.UnixEpoch);
+        HostLogEntry entry = parser.ParseLine(HostProcessStreamNames.StandardOutput, "Host started", DateTimeOffset.UnixEpoch);
 
         Assert.Equal("Host.Process", entry.Category);
         Assert.Equal(LogLevel.Information, entry.Level);
@@ -32,10 +29,7 @@ public class HostProcessOutputParserTests
     {
         var parser = new LineHostProcessOutputParser();
 
-        HostLogEntry entry = parser.ParseLine(
-            HostProcessStreamNames.StandardError,
-            "Host failed",
-            DateTimeOffset.UnixEpoch);
+        HostLogEntry entry = parser.ParseLine(HostProcessStreamNames.StandardError, "Host failed", DateTimeOffset.UnixEpoch);
 
         Assert.Equal(LogLevel.Error, entry.Level);
         Assert.Equal("Host failed", entry.Message);

--- a/test/Func.Tests/Commands/HostProcessStartInfoFactoryTests.cs
+++ b/test/Func.Tests/Commands/HostProcessStartInfoFactoryTests.cs
@@ -105,10 +105,7 @@ public class HostProcessStartInfoFactoryTests : IDisposable
         IDictionary<string, string>? environmentVariables = null)
     {
         environmentVariables ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        var hostRunContext = new FunctionsProjectHostRunContext(
-            _startupDirectory,
-            "dotnet-isolated",
-            environmentVariables);
+        var hostRunContext = new FunctionsProjectHostRunContext(_startupDirectory, "dotnet-isolated", environmentVariables);
 
         return new HostProcessStartContext(
             CreateHostWorkload(),

--- a/test/Func.Tests/Commands/StartCommandTests.cs
+++ b/test/Func.Tests/Commands/StartCommandTests.cs
@@ -210,12 +210,7 @@ public class StartCommandTests : IDisposable
             CorsCredentials = true,
         };
         options.Get(Arg.Any<string>()).Returns(startupOptions);
-        var cmd = new StartCommand(
-            _interaction,
-            _palette,
-            _cliVersionProvider,
-            _initializationRunner,
-            options);
+        var cmd = new StartCommand(_interaction, _palette, _cliVersionProvider, _initializationRunner, options);
         var root = new RootCommand { cmd };
         var result = root.Parse($"start \"{_tempDir}\" --output=plain");
 
@@ -249,12 +244,7 @@ public class StartCommandTests : IDisposable
             Port = 9092,
         };
         options.CurrentValue.Returns(startupOptions);
-        var cmd = new StartCommand(
-            _interaction,
-            _palette,
-            _cliVersionProvider,
-            _initializationRunner,
-            options);
+        var cmd = new StartCommand(_interaction, _palette, _cliVersionProvider, _initializationRunner, options);
         var root = new RootCommand { cmd };
         string projectDirectory = Environment.CurrentDirectory;
         var result = root.Parse($"start \"{projectDirectory}\" --output=plain");
@@ -359,9 +349,7 @@ public class StartCommandTests : IDisposable
         Assert.Contains("WARNING: Project cleanup failed: cleanup failed", _interaction.Lines);
     }
 
-    private static StartInitializationResult CreateInitializationResult(
-        IHostEventStream eventStream,
-        TestFunctionsProject? project = null)
+    private static StartInitializationResult CreateInitializationResult(IHostEventStream eventStream, TestFunctionsProject? project = null)
     {
         project ??= new TestFunctionsProject();
         var hostRunContext = new FunctionsProjectHostRunContext(
@@ -411,9 +399,7 @@ public class StartCommandTests : IDisposable
 
         public override FunctionsWorkerReference WorkerReference => _workerReference;
 
-        public override Task CompleteHostRunAsync(
-            FunctionsProjectHostRunCompletionContext context,
-            CancellationToken cancellationToken)
+        public override Task CompleteHostRunAsync(FunctionsProjectHostRunCompletionContext context, CancellationToken cancellationToken)
         {
             CompletionContexts.Add(context);
             if (CleanupException is not null)

--- a/test/Func.Tests/Commands/StartInitializationTests.cs
+++ b/test/Func.Tests/Commands/StartInitializationTests.cs
@@ -368,11 +368,7 @@ public class StartInitializationTests : IDisposable
             .Returns(hostResolution);
         var renderer = new RecordingStartInitializationRenderer();
         IFunctionsWorkerResolverFactory workerResolverFactory = CreateWorkerResolverFactory();
-        var runner = CreateRunner(
-            projectResolver,
-            profileResolution,
-            hostWorkloadResolver,
-            workerResolverFactory: workerResolverFactory);
+        var runner = CreateRunner(projectResolver, profileResolution, hostWorkloadResolver, workerResolverFactory: workerResolverFactory);
         StartInitializationContext context = CreateContext(
             WorkingDirectory.FromExplicit(_tempDir),
             cliVersion: "5.0.0-test",
@@ -795,11 +791,7 @@ public class StartInitializationTests : IDisposable
         string stackName = "dotnet-isolated",
         string stackDisplayName = ".NET",
         bool supportsExtensionBundles = false)
-        => new(
-            workingDirectory,
-            stackName,
-            stackDisplayName,
-            supportsExtensionBundles);
+        => new(workingDirectory, stackName, stackDisplayName, supportsExtensionBundles);
 
     private static FunctionsProjectHostRunContext CreateHostRunContext(WorkingDirectory workingDirectory)
         => new(
@@ -898,10 +890,7 @@ public class StartInitializationTests : IDisposable
         return workerResolverFactory;
     }
 
-    private static IFunctionsWorker CreateWorker(
-        string workerId,
-        string workerRuntime,
-        string version = "1.0.0")
+    private static IFunctionsWorker CreateWorker(string workerId, string workerRuntime, string version = "1.0.0")
         => new TestFunctionsWorker(new FunctionsWorkerId(workerId), workerRuntime, "worker.config.json", version);
 
     private static IHostProcessRunner CreateSuccessfulHostProcessRunner()
@@ -1129,9 +1118,7 @@ public class StartInitializationTests : IDisposable
 
         public override FunctionsWorkerReference WorkerReference => _workerReference;
 
-        public override Task PrepareForHostRunAsync(
-            FunctionsProjectHostRunContext context,
-            CancellationToken cancellationToken)
+        public override Task PrepareForHostRunAsync(FunctionsProjectHostRunContext context, CancellationToken cancellationToken)
         {
             PrepareAction?.Invoke(context);
             PreparedContexts.Add(context);

--- a/test/Func.Tests/Commands/Workload/WorkloadListCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadListCommandTests.cs
@@ -192,9 +192,7 @@ public class WorkloadListCommandTests
         return provider;
     }
 
-    private static IReadOnlyList<TWorkload> GetWorkloadsByPackageId<TWorkload>(
-        IReadOnlyList<WorkloadInfo> workloads,
-        string packageId)
+    private static IReadOnlyList<TWorkload> GetWorkloadsByPackageId<TWorkload>(IReadOnlyList<WorkloadInfo> workloads, string packageId)
         where TWorkload : WorkloadInfo
         => [.. workloads
             .OfType<TWorkload>()

--- a/test/Func.Tests/Hosting/Dashboard/Rendering/CompactRendererFunctionBrowserTests.cs
+++ b/test/Func.Tests/Hosting/Dashboard/Rendering/CompactRendererFunctionBrowserTests.cs
@@ -526,8 +526,7 @@ public class CompactRendererFunctionBrowserTests
         Assert.Null(GetPrivate(renderer, "_activeFunctionFilter"));
     }
 
-    private static (CompactRenderer Renderer, IAnsiConsole Console, StringWriter Writer) NewRenderer(
-        DashboardRunInfo? runInfo = null)
+    private static (CompactRenderer Renderer, IAnsiConsole Console, StringWriter Writer) NewRenderer(DashboardRunInfo? runInfo = null)
     {
         var writer = new StringWriter();
         IAnsiConsole console = AnsiConsole.Create(new AnsiConsoleSettings

--- a/test/Func.Tests/Http/HttpClientDefaultsTests.cs
+++ b/test/Func.Tests/Http/HttpClientDefaultsTests.cs
@@ -91,8 +91,7 @@ public sealed class HttpClientDefaultsTests
     {
         private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler = handler;
 
-        protected override Task<HttpResponseMessage> SendAsync(
-            HttpRequestMessage request, CancellationToken cancellationToken)
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             return Task.FromResult(_handler(request));
         }

--- a/test/Func.Tests/Profiles/ProjectProfileOptionsSetupTests.cs
+++ b/test/Func.Tests/Profiles/ProjectProfileOptionsSetupTests.cs
@@ -112,9 +112,7 @@ public sealed class ProjectProfileOptionsSetupTests : IDisposable
 
     private void WriteProjectConfig(string contents)
     {
-        string folder = Path.Combine(
-            _dir.FullName,
-            CliConfigurationNames.ProjectConfigFolderName);
+        string folder = Path.Combine(_dir.FullName, CliConfigurationNames.ProjectConfigFolderName);
         Directory.CreateDirectory(folder);
 
         string path = Path.Combine(folder, CliConfigurationNames.ConfigFileName);

--- a/test/Func.Tests/Projects/FunctionsProjectHostRunContextTests.cs
+++ b/test/Func.Tests/Projects/FunctionsProjectHostRunContextTests.cs
@@ -21,9 +21,7 @@ public sealed class FunctionsProjectHostRunContextTests
             environmentVariables);
 
         Assert.Equal("dotnet-isolated", context.WorkerRuntime);
-        Assert.Equal(
-            "dotnet-isolated",
-            environmentVariables[FunctionsProjectHostRunContext.WorkerRuntimeEnvironmentVariable]);
+        Assert.Equal("dotnet-isolated", environmentVariables[FunctionsProjectHostRunContext.WorkerRuntimeEnvironmentVariable]);
     }
 
     [Fact]

--- a/test/Func.Tests/Quickstart/QuickstartManifestServiceTests.cs
+++ b/test/Func.Tests/Quickstart/QuickstartManifestServiceTests.cs
@@ -339,8 +339,7 @@ public sealed class QuickstartManifestServiceTests
 
         public FakeHttpMessageHandler(Exception exception) => _exception = exception;
 
-        protected override Task<HttpResponseMessage> SendAsync(
-            HttpRequestMessage request, CancellationToken cancellationToken)
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             if (_exception is not null)
             {

--- a/test/Func.Tests/Quickstart/QuickstartScaffolderTests.cs
+++ b/test/Func.Tests/Quickstart/QuickstartScaffolderTests.cs
@@ -19,9 +19,7 @@ public class QuickstartScaffolderTests : IDisposable
         _targetDir = Path.Combine(Path.GetTempPath(), $"func-scaffold-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_targetDir);
 
-        _gitRunner = new FakeGitRunner(
-            onRun: SimulateGitCommand,
-            onRunWithOutput: SimulateGitOutputCommand);
+        _gitRunner = new FakeGitRunner(onRun: SimulateGitCommand, onRunWithOutput: SimulateGitOutputCommand);
         ITemplateFetcher gitFetcher = new GitTemplateFetcher(_gitRunner, NullLogger<GitTemplateFetcher>.Instance);
         ITemplateFetcher httpFetcher = new HttpTemplateFetcher(
             Substitute.For<IHttpClientFactory>(),

--- a/test/Func.Tests/TestParser.cs
+++ b/test/Func.Tests/TestParser.cs
@@ -52,9 +52,7 @@ internal static class TestParser
     /// Exposed for tests that need to resolve <see cref="FuncCliCommand"/> services
     /// directly without going through <see cref="Parser.CreateCommand"/>.
     /// </summary>
-    public static IServiceProvider BuildServiceProviderWith(
-        IInteractionService interaction,
-        Action<IServiceCollection>? configure = null)
+    public static IServiceProvider BuildServiceProviderWith(IInteractionService interaction, Action<IServiceCollection>? configure = null)
     {
         ServiceCollection services = BuildBaseServices(interaction);
         configure?.Invoke(services);

--- a/test/Func.Tests/TestWorkloads.cs
+++ b/test/Func.Tests/TestWorkloads.cs
@@ -12,9 +12,7 @@ namespace Azure.Functions.Cli.Tests;
 /// </summary>
 internal static class TestWorkloads
 {
-    public static RuntimeWorkloadInfo CreateInfo(
-        string packageId = "Test.Workload.A",
-        string version = "1.0.0")
+    public static RuntimeWorkloadInfo CreateInfo(string packageId = "Test.Workload.A", string version = "1.0.0")
     {
         var instance = new TestWorkload(packageId);
         return new RuntimeWorkloadInfo(
@@ -28,9 +26,7 @@ internal static class TestWorkloads
             Description: instance.Description);
     }
 
-    public static ContentWorkloadInfo CreateContentInfo(
-        string packageId = "Test.Content.A",
-        string version = "1.0.0")
+    public static ContentWorkloadInfo CreateContentInfo(string packageId = "Test.Content.A", string version = "1.0.0")
         => new(
             PackageId: packageId,
             PackageVersion: version,
@@ -89,9 +85,7 @@ internal static class TestWorkloads
 
         public override IReadOnlyList<FuncCommand> Subcommands { get; }
 
-        public override Task<int> ExecuteAsync(
-            FuncCommandInvocationContext context,
-            CancellationToken cancellationToken)
+        public override Task<int> ExecuteAsync(FuncCommandInvocationContext context, CancellationToken cancellationToken)
             => _execute(context, cancellationToken);
     }
 }

--- a/test/Func.Tests/Workers/DefaultFunctionsWorkerResolverTests.cs
+++ b/test/Func.Tests/Workers/DefaultFunctionsWorkerResolverTests.cs
@@ -277,10 +277,7 @@ public class DefaultFunctionsWorkerResolverTests
     private DefaultFunctionsWorkerResolver CreateResolver(IReadOnlyDictionary<string, VersionRange>? workerVersionRanges = null)
         => new(_workloads, _fileSystem, workerVersionRanges);
 
-    private static ContentWorkloadInfo CreateContentWorkload(
-        string packageId,
-        string packageVersion,
-        IReadOnlyList<string>? aliases = null)
+    private static ContentWorkloadInfo CreateContentWorkload(string packageId, string packageVersion, IReadOnlyList<string>? aliases = null)
     {
         string installDirectory = Path.Combine(Path.GetTempPath(), "workloads", packageId, packageVersion);
         return new ContentWorkloadInfo(

--- a/test/Func.Tests/Workloads/Catalog/NuGetProtocolSourceClientTests.cs
+++ b/test/Func.Tests/Workloads/Catalog/NuGetProtocolSourceClientTests.cs
@@ -167,8 +167,7 @@ public sealed class NuGetProtocolSourceClientTests
             () => client.OpenPackageAsync("workload.absent", NuGetVersion.Parse("1.0.0"), CancellationToken.None));
     }
 
-    private static NuGetProtocolSourceClient NewClient(
-        FindPackageByIdResource? findResource = null)
+    private static NuGetProtocolSourceClient NewClient(FindPackageByIdResource? findResource = null)
     {
         SourceRepository repo = TestRepository.Build(_source, findResource);
         return new NuGetProtocolSourceClient(repo);

--- a/test/Func.Tests/Workloads/Catalog/TestRepository.cs
+++ b/test/Func.Tests/Workloads/Catalog/TestRepository.cs
@@ -13,9 +13,7 @@ namespace Azure.Functions.Cli.Tests.Workloads.Catalog;
 /// </summary>
 internal static class TestRepository
 {
-    public static SourceRepository Build(
-        PackageSource source,
-        params INuGetResource?[] resources)
+    public static SourceRepository Build(PackageSource source, params INuGetResource?[] resources)
     {
         var providers = new List<Lazy<INuGetResourceProvider>>();
         foreach (INuGetResource? resource in resources)

--- a/test/Func.Tests/Workloads/Catalog/WorkloadCatalogTests.cs
+++ b/test/Func.Tests/Workloads/Catalog/WorkloadCatalogTests.cs
@@ -43,8 +43,7 @@ public sealed class WorkloadCatalogTests
 
         var catalog = new WorkloadCatalog(sourceProvider, source => source.Name == _defaultSource.Name ? defaultClient : overrideClient);
 
-        IReadOnlyList<CatalogSearchResult> results = await catalog.SearchAsync(
-            new CatalogSearchQuery { Source = _altSource.Source });
+        IReadOnlyList<CatalogSearchResult> results = await catalog.SearchAsync(new CatalogSearchQuery { Source = _altSource.Source });
 
         Assert.Equal("override-pkg", Assert.Single(results).PackageId);
     }
@@ -104,8 +103,7 @@ public sealed class WorkloadCatalogTests
 
         var range = VersionRange.Parse("[1.8.1, 4.1048.200)");
 
-        ResolvedPackage? resolved = await catalog.ResolveLatestVersionInRangeAsync(
-            "alpha", range, includePrerelease: false);
+        ResolvedPackage? resolved = await catalog.ResolveLatestVersionInRangeAsync("alpha", range, includePrerelease: false);
 
         Assert.NotNull(resolved);
         Assert.Equal(V("4.1048.199"), resolved!.Version);

--- a/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
+++ b/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
@@ -380,8 +380,7 @@ public sealed class WorkloadInstallerTests : IDisposable
             .Returns((ResolvedPackage?)null);
 
         WorkloadInstaller installer = NewInstaller();
-        WorkloadUpdateResult result = await installer.UpdateAsync(
-            "test.workload", null, null, false, allowMajor: false);
+        WorkloadUpdateResult result = await installer.UpdateAsync("test.workload", null, null, false, allowMajor: false);
 
         Assert.True(result.NoUpdateAvailable);
         Assert.True(result.NoCandidateOnSource);
@@ -402,8 +401,7 @@ public sealed class WorkloadInstallerTests : IDisposable
             .Returns(NewResolved("test.workload", "1.5.0"));
 
         WorkloadInstaller installer = NewInstaller();
-        WorkloadUpdateResult result = await installer.UpdateAsync(
-            "test.workload", null, null, false, allowMajor: false);
+        WorkloadUpdateResult result = await installer.UpdateAsync("test.workload", null, null, false, allowMajor: false);
 
         Assert.True(result.NoUpdateAvailable);
         Assert.False(result.NoCandidateOnSource);
@@ -428,8 +426,7 @@ public sealed class WorkloadInstallerTests : IDisposable
             .Returns(_ => File.OpenRead(newNupkg));
 
         WorkloadInstaller installer = NewInstaller();
-        WorkloadUpdateResult result = await installer.UpdateAsync(
-            "test.workload", null, null, false, allowMajor: false);
+        WorkloadUpdateResult result = await installer.UpdateAsync("test.workload", null, null, false, allowMajor: false);
 
         Assert.False(result.NoUpdateAvailable);
         Assert.Equal("1.0.0", result.PreviousVersion);

--- a/test/Func.Tests/Workloads/Storage/WorkloadStoreTests.cs
+++ b/test/Func.Tests/Workloads/Storage/WorkloadStoreTests.cs
@@ -202,10 +202,7 @@ public class WorkloadStoreTests : IDisposable
 
     private sealed class ThrowingSerializeStore(IWorkloadPaths paths) : WorkloadStore(paths)
     {
-        internal override Task SerializeAsync(
-            Stream stream,
-            WorkloadRegistry registry,
-            CancellationToken cancellationToken)
+        internal override Task SerializeAsync(Stream stream, WorkloadRegistry registry, CancellationToken cancellationToken)
             => throw new InvalidOperationException("boom");
     }
 }


### PR DESCRIPTION
Refactors short C# method, constructor, record, and simple call signatures to stay on one line when they fit comfortably, reducing unnecessary vertical space while preserving wrapped formatting for long or complex cases.

Adds repo guidance to `AGENTS.md` and `.github/instructions/dotnet.instructions.md` so future edits keep reasonable signatures on one line and reserve wrapping for genuinely long or nested expressions.

Validation:
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build` (one unrelated existing Windows/platform failure: `AzuriteExecutableLocatorTests.FindAsync_Unix_PathLookup_OnlyTriesBareName`)