### PR TITLE
vnext : func quickstart command handler, providers, and list/info subcommands

### DIFF
--- a/src/Abstractions/Quickstart/IQuickstartProvider.cs
+++ b/src/Abstractions/Quickstart/IQuickstartProvider.cs
@@ -10,9 +10,10 @@ namespace Azure.Functions.Cli.Quickstart;
 /// language selection and post-scaffold guidance.
 /// </summary>
 /// <remarks>
-/// When <see cref="SupportedLanguages"/> contains more than one entry, the
-/// command prompts the user to pick a sub-language (e.g. .NET → C#/F#,
-/// Node → JavaScript/TypeScript).
+/// Available languages are derived from the manifest at runtime. The provider
+/// declares which manifest language values it handles via
+/// <see cref="ManifestLanguages"/> and owns the bidirectional mapping between
+/// user-facing names (matching <c>func init</c>) and manifest values.
 /// </remarks>
 public interface IQuickstartProvider
 {
@@ -28,14 +29,32 @@ public interface IQuickstartProvider
     public string DisplayName { get; }
 
     /// <summary>
-    /// Manifest-level language values this stack handles (e.g. ["CSharp", "FSharp"]).
-    /// When the list has more than one entry, the command prompts for a sub-language.
+    /// Manifest <see cref="QuickstartEntry.Language"/> values this provider
+    /// handles, in preferred display order (e.g. ["CSharp"] for dotnet,
+    /// ["TypeScript", "JavaScript"] for node). The command intersects these
+    /// with the manifest to determine which languages are actually available,
+    /// preserving the order declared here.
     /// </summary>
-    public IReadOnlyList<string> SupportedLanguages { get; }
+    public IReadOnlyList<string> ManifestLanguages { get; }
 
     /// <summary>
-    /// Returns post-scaffold "next steps" for the given language
+    /// Maps a manifest language value to a user-friendly display name
+    /// (e.g. "CSharp" → "C#"). Returns <paramref name="manifestLanguage"/>
+    /// unchanged when no special mapping is needed.
+    /// </summary>
+    public string GetDisplayLanguage(string manifestLanguage);
+
+    /// <summary>
+    /// Resolves user input (canonical name or alias, e.g. "c#", "csharp", "js")
+    /// to the corresponding manifest language value (e.g. "CSharp", "JavaScript").
+    /// Returns <c>null</c> when the input is not recognized by this provider.
+    /// Accepted values match <c>func init --language</c> for UX consistency.
+    /// </summary>
+    public string? ResolveManifestLanguage(string userInput);
+
+    /// <summary>
+    /// Returns post-scaffold "next steps" for the given manifest language
     /// (e.g. "npm install", "pip install -r requirements.txt", "func start").
     /// </summary>
-    public IReadOnlyList<string> GetNextSteps(string language);
+    public IReadOnlyList<string> GetNextSteps(string manifestLanguage);
 }

--- a/src/Abstractions/Quickstart/QuickstartConstants.cs
+++ b/src/Abstractions/Quickstart/QuickstartConstants.cs
@@ -17,4 +17,9 @@ public static class QuickstartConstants
     /// The GitHub hostname used for URL validation and archive downloads.
     /// </summary>
     public const string GitHubHostName = "github.com";
+
+    /// <summary>
+    /// The git ref prefix required for all template entries.
+    /// </summary>
+    public const string TagRefPrefix = "refs/tags/";
 }

--- a/src/Func/Commands/Quickstart/QuickstartCommand.cs
+++ b/src/Func/Commands/Quickstart/QuickstartCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.CommandLine;
+using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Hosting;
 using Azure.Functions.Cli.Quickstart;
@@ -18,7 +19,7 @@ internal sealed class QuickstartCommand : FuncCliCommand, IBuiltInCommand
 {
     public Option<string?> StackOption { get; } = new("--stack", "-s")
     {
-        Description = "The stack to use. Run `func workload list` to see what's installed."
+        Description = QuickstartMessages.StackOptionDescription
     };
 
     public Option<string?> LanguageOption { get; } = new("--language", "-l")
@@ -28,7 +29,7 @@ internal sealed class QuickstartCommand : FuncCliCommand, IBuiltInCommand
 
     public Option<string?> TemplateOption { get; } = new("--template", "-t")
     {
-        Description = "Template ID from the manifest (e.g. http-trigger-python-azd) — skips all prompts"
+        Description = "Template ID from the manifest (e.g. http-trigger-python-azd) — skips template selection prompts"
     };
 
     public Option<string?> ResourceOption { get; } = new("--resource", "-r")
@@ -43,7 +44,7 @@ internal sealed class QuickstartCommand : FuncCliCommand, IBuiltInCommand
 
     public Option<string?> SearchOption { get; } = new("--search")
     {
-        Description = "Case-insensitive substring filter applied to template names and descriptions"
+        Description = "Case-insensitive substring match against IDs, template names, resource type, Infrastructure as Code type, and descriptions"
     };
 
     public Option<FetchMode> FetchOption { get; } = new("--fetch")
@@ -52,25 +53,40 @@ internal sealed class QuickstartCommand : FuncCliCommand, IBuiltInCommand
         DefaultValueFactory = _ => FetchMode.Auto
     };
 
+    public Option<bool> ForceOption { get; } = new("--force")
+    {
+        Description = "Scaffolds even when the target folder isn't empty. Clears the folder (except .git) before scaffolding. In non-interactive mode, proceeds without confirmation."
+    };
+
     private readonly IInteractionService _interaction;
-    private readonly IReadOnlyList<IQuickstartProvider> _providers;
+    private readonly IQuickstartProviderResolver _resolver;
+    private readonly IQuickstartManifestService _manifestService;
+    private readonly IQuickstartScaffolder _scaffolder;
 
     public QuickstartCommand(
         QuickstartListCommand listCommand,
         QuickstartInfoCommand infoCommand,
         IInteractionService interaction,
+        IQuickstartProviderResolver resolver,
+        IQuickstartManifestService manifestService,
+        IQuickstartScaffolder scaffolder,
         IEnumerable<IQuickstartProvider> providers)
         : base("quickstart", "Browse and scaffold complete function apps from the Azure Functions template catalog.")
     {
         ArgumentNullException.ThrowIfNull(listCommand);
         ArgumentNullException.ThrowIfNull(infoCommand);
         ArgumentNullException.ThrowIfNull(interaction);
+        ArgumentNullException.ThrowIfNull(resolver);
+        ArgumentNullException.ThrowIfNull(manifestService);
+        ArgumentNullException.ThrowIfNull(scaffolder);
         ArgumentNullException.ThrowIfNull(providers);
 
         _interaction = interaction;
-        _providers = providers.ToList();
+        _resolver = resolver;
+        _manifestService = manifestService;
+        _scaffolder = scaffolder;
 
-        LanguageOption.Description = BuildLanguageOptionDescription(_providers);
+        LanguageOption.Description = BuildLanguageOptionDescription(providers.ToList());
 
         AddPathArgument();
         Options.Add(StackOption);
@@ -80,35 +96,219 @@ internal sealed class QuickstartCommand : FuncCliCommand, IBuiltInCommand
         Options.Add(IacOption);
         Options.Add(SearchOption);
         Options.Add(FetchOption);
+        Options.Add(ForceOption);
 
         Subcommands.Add(listCommand);
         Subcommands.Add(infoCommand);
     }
 
-    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
-        if (_providers.Count == 0)
+        string? requestedStack = parseResult.GetValue(StackOption);
+        string? requestedLanguage = parseResult.GetValue(LanguageOption);
+        string? templateId = parseResult.GetValue(TemplateOption);
+        string? resource = parseResult.GetValue(ResourceOption);
+        string? iac = parseResult.GetValue(IacOption);
+        string? search = parseResult.GetValue(SearchOption);
+        FetchMode fetchMode = parseResult.GetValue(FetchOption);
+        bool force = parseResult.GetValue(ForceOption);
+
+        // 1. Resolve stack → provider
+        IQuickstartProvider? provider = await _resolver.SelectProviderAsync(requestedStack, "scaffold a quickstart project", cancellationToken);
+        if (provider is null)
         {
-            _interaction.WriteWarning(
-                "The quickstart command is not yet available. Stack support is coming in a future release.");
-            return Task.FromResult(1);
+            return 1;
         }
 
-        // Implementation will be added in a follow-up PR:
-        // 1. Fetch manifest via IQuickstartManifestService
-        // 2. Resolve stack/language (prompt if interactive, error if non-TTY without --language)
-        // 3. Resolve template (--template skips prompts, otherwise filter + prompt)
-        // 4. Scaffold via IQuickstartScaffolder
+        // 2. Fetch manifest
+        QuickstartManifest manifest = await _interaction.ShowStatusAsync(
+            QuickstartMessages.FetchingCatalogStatus,
+            _manifestService.GetManifestAsync,
+            cancellationToken);
+
+        // 3. Resolve language
+        (string? manifestLanguage, int? langError) = await _resolver.ResolveOrPromptLanguageAsync(
+            requestedLanguage, provider, manifest, cancellationToken);
+        if (langError is int langCode)
+        {
+            return langCode;
+        }
+
+        // 4. Select template
+        QuickstartEntry? entry;
+        if (!string.IsNullOrWhiteSpace(templateId))
+        {
+            entry = FindTemplateById(templateId, manifestLanguage!, provider, manifest);
+            if (entry is null)
+            {
+                return 1;
+            }
+        }
+        else
+        {
+            (entry, int? errorCode) = await SelectTemplateAsync(manifest, manifestLanguage!, resource, iac, search, cancellationToken);
+            if (errorCode is int code)
+            {
+                return code;
+            }
+        }
+
+        // 5. Resolve directory + --force
+        WorkingDirectory workingDirectory = parseResult.GetValue(PathArgument!)!;
+        workingDirectory.CreateIfNotExists();
+
+        if (!force && DirectoryGuard.HasNonGitContent(workingDirectory.Info))
+        {
+            _interaction.WriteError(QuickstartMessages.DirectoryNotEmptyError);
+            return 1;
+        }
+
+        if (force)
+        {
+            if (!await ConfirmClearDirectoryAsync(workingDirectory.Info, cancellationToken))
+            {
+                _interaction.WriteHint(QuickstartMessages.CancelledHint);
+                return 1;
+            }
+
+            DirectoryGuard.ClearExceptGit(workingDirectory.Info);
+        }
+
+        // 6. Scaffold
+        await _interaction.StatusAsync(
+            $"Scaffolding '{entry!.DisplayName}'...",
+            ct => _scaffolder.ScaffoldAsync(entry, workingDirectory.Info.FullName, fetchMode, ct),
+            cancellationToken);
+
+        // 7. Next steps
+        _interaction.WriteBlankLine();
+        _interaction.WriteLine(l => l
+            .Success(QuickstartMessages.SuccessIcon)
+            .Muted("Scaffolded ")
+            .Code(entry.DisplayName)
+            .Muted(" for ")
+            .Code(provider.DisplayName)
+            .Muted("."));
+
+        IReadOnlyList<string> steps = provider.GetNextSteps(manifestLanguage!);
+        if (steps.Count > 0)
+        {
+            _interaction.WriteBlankLine();
+            _interaction.WriteHint("Next steps:");
+
+            string targetPath = workingDirectory.Info.FullName;
+            string currentDir = Directory.GetCurrentDirectory();
+            if (!string.Equals(targetPath, currentDir, StringComparison.OrdinalIgnoreCase))
+            {
+                string displayPath = workingDirectory.OriginalPath ?? targetPath;
+                _interaction.WriteLine(l => l.Muted($"{QuickstartMessages.StepBullet}Run `cd \"{displayPath}\"`"));
+            }
+
+            foreach (string step in steps)
+            {
+                _interaction.WriteLine(l => l.Muted($"{QuickstartMessages.StepBullet}{step}"));
+            }
+        }
+
+        return 0;
+    }
+
+    private QuickstartEntry? FindTemplateById(string templateId, string manifestLanguage, IQuickstartProvider provider, QuickstartManifest manifest)
+    {
+        QuickstartEntry? entry = manifest.Entries.FirstOrDefault(e =>
+            string.Equals(e.Id, templateId, StringComparison.OrdinalIgnoreCase));
+
+        if (entry is null)
+        {
+            _interaction.WriteError(
+                $"Template '{templateId}' not found in the catalog. " + QuickstartMessages.TemplateNotFoundHint);
+            return null;
+        }
+
+        if (!string.Equals(entry.Language, manifestLanguage, StringComparison.OrdinalIgnoreCase))
+        {
+            _interaction.WriteError(
+                $"Template '{templateId}' is for {entry.Language}, " +
+                $"but you selected {provider.GetDisplayLanguage(manifestLanguage)}. " +
+                $"Pass --language {entry.Language.ToLowerInvariant()} to use this template.");
+            return null;
+        }
+
+        return entry;
+    }
+
+    private async Task<(QuickstartEntry? Entry, int? ErrorCode)> SelectTemplateAsync(
+        QuickstartManifest manifest,
+        string manifestLanguage,
+        string? resource,
+        string? iac,
+        string? search,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<QuickstartEntry> filtered = manifest.Filter(manifestLanguage, resource, iac, search);
+
+        if (filtered.Count == 0)
+        {
+            _interaction.WriteError(QuickstartMessages.NoMatchingFiltersError);
+            return (null, 1);
+        }
+
+        if (filtered.Count == 1)
+        {
+            return (filtered[0], null);
+        }
+
+        if (!_interaction.IsInteractive)
+        {
+            _interaction.WriteError(QuickstartMessages.MultipleMatchesError);
+            return (null, 1);
+        }
+
+        var displayToEntry = new Dictionary<string, QuickstartEntry>(StringComparer.Ordinal);
+        foreach (QuickstartEntry entry in filtered)
+        {
+            string label = entry.ShortDescription is not null
+                ? $"{entry.DisplayName} — {entry.ShortDescription}"
+                : entry.DisplayName;
+
+            // Handle duplicate display names by appending the ID
+            if (!displayToEntry.TryAdd(label, entry))
+            {
+                label = $"{entry.DisplayName} ({entry.Id})";
+                displayToEntry[label] = entry;
+            }
+        }
+
+        string picked = await _interaction.PromptForSelectionAsync(
+            "Select a template:",
+            displayToEntry.Keys,
+            cancellationToken);
+
+        return displayToEntry.TryGetValue(picked, out QuickstartEntry? chosen) ? (chosen, null) : (null, 1);
+    }
+
+    private async Task<bool> ConfirmClearDirectoryAsync(DirectoryInfo workingDirectory, CancellationToken cancellationToken)
+    {
+        if (!DirectoryGuard.HasNonGitContent(workingDirectory))
+        {
+            return true;
+        }
+
         _interaction.WriteWarning(
-            "The quickstart command is not yet implemented. This is a placeholder for the upcoming scaffold flow.");
-        return Task.FromResult(1);
+            $"--force will delete all files in '{workingDirectory.FullName}' (except .git) before scaffolding.");
+
+        if (!_interaction.IsInteractive)
+        {
+            return true;
+        }
+
+        return await _interaction.ConfirmAsync("Continue?", defaultValue: false, cancellationToken);
     }
 
     private static string BuildLanguageOptionDescription(IReadOnlyList<IQuickstartProvider> providers)
     {
         var languages = providers
-            .SelectMany(p => p.SupportedLanguages)
-            .Where(l => !string.IsNullOrWhiteSpace(l))
+            .SelectMany(p => p.ManifestLanguages)
             .Select(l => l.Trim().ToLowerInvariant())
             .Distinct(StringComparer.Ordinal)
             .OrderBy(l => l, StringComparer.Ordinal)

--- a/src/Func/Commands/Quickstart/QuickstartInfoCommand.cs
+++ b/src/Func/Commands/Quickstart/QuickstartInfoCommand.cs
@@ -9,6 +9,8 @@ namespace Azure.Functions.Cli.Commands.Quickstart;
 
 /// <summary>
 /// Displays detailed information about a specific template by id.
+/// Resolves the owning provider from the entry's language for display-name
+/// mapping.
 /// </summary>
 internal sealed class QuickstartInfoCommand : FuncCliCommand
 {
@@ -17,31 +19,121 @@ internal sealed class QuickstartInfoCommand : FuncCliCommand
         Description = "Template ID from the manifest (e.g. http-trigger-python-azd). Use 'func quickstart list' to see available IDs."
     };
 
-    private readonly IInteractionService _interaction;
-    private readonly IReadOnlyList<IQuickstartProvider> _providers;
+    public Option<bool> JsonOption { get; } = new("--json")
+    {
+        Description = "Emit machine-readable JSON instead of formatted output."
+    };
 
-    public QuickstartInfoCommand(IInteractionService interaction, IEnumerable<IQuickstartProvider> providers)
+    private readonly IInteractionService _interaction;
+    private readonly IQuickstartProviderResolver _resolver;
+    private readonly IQuickstartManifestService _manifestService;
+
+    public QuickstartInfoCommand(
+        IInteractionService interaction,
+        IQuickstartProviderResolver resolver,
+        IQuickstartManifestService manifestService)
         : base("info", "Show detailed information about a template.")
     {
         ArgumentNullException.ThrowIfNull(interaction);
-        ArgumentNullException.ThrowIfNull(providers);
+        ArgumentNullException.ThrowIfNull(resolver);
+        ArgumentNullException.ThrowIfNull(manifestService);
 
         _interaction = interaction;
-        _providers = providers.ToList();
+        _resolver = resolver;
+        _manifestService = manifestService;
 
         Arguments.Add(TemplateIdArgument);
+        Options.Add(JsonOption);
     }
 
-    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
-        if (_providers.Count == 0)
+        string templateId = parseResult.GetValue(TemplateIdArgument)!;
+        bool json = parseResult.GetValue(JsonOption);
+
+        QuickstartManifest manifest = await _interaction.ShowStatusAsync(
+            QuickstartMessages.FetchingCatalogStatus,
+            _manifestService.GetManifestAsync,
+            cancellationToken);
+
+        QuickstartEntry? entry = manifest.Entries.FirstOrDefault(e =>
+            string.Equals(e.Id, templateId, StringComparison.OrdinalIgnoreCase));
+
+        if (entry is null)
         {
-            _interaction.WriteWarning(
-                "The quickstart command is not yet available. Stack support is coming in a future release.");
-            return Task.FromResult(1);
+            _interaction.WriteError(
+                $"Template '{templateId}' not found. " + QuickstartMessages.TemplateNotFoundHint);
+            return 1;
         }
 
-        _interaction.WriteWarning("The quickstart info command is not yet implemented.");
-        return Task.FromResult(1);
+        IQuickstartProvider? provider = _resolver.FindProviderForLanguage(entry.Language);
+        string displayLanguage = provider?.GetDisplayLanguage(entry.Language) ?? entry.Language;
+
+        if (json)
+        {
+            _interaction.WriteJson(new InfoRow(
+                entry.Id,
+                entry.DisplayName,
+                displayLanguage,
+                entry.Resource,
+                entry.Iac ?? "none",
+                entry.GitRef,
+                entry.RepositoryUrl,
+                entry.FolderPath,
+                entry.ShortDescription,
+                entry.LongDescription,
+                entry.WhatsIncluded));
+            return 0;
+        }
+
+        _interaction.WriteLine(l => l.Heading($"{entry.DisplayName}"));
+        _interaction.WriteLine(l => l.Muted($"  ID:        {entry.Id}"));
+        _interaction.WriteLine(l => l.Muted($"  Language:  {displayLanguage}"));
+        _interaction.WriteLine(l => l.Muted($"  Resource:  {entry.Resource}"));
+        _interaction.WriteLine(l => l.Muted($"  IaC:       {entry.Iac ?? "none"}"));
+        _interaction.WriteLine(l => l.Muted($"  Git Ref:   {entry.GitRef ?? "-"}"));
+        _interaction.WriteLine(l => l.Muted($"  Repo:      {entry.RepositoryUrl}"));
+        _interaction.WriteLine(l => l.Muted($"  Path:      {entry.FolderPath}"));
+
+        if (entry.ShortDescription is not null)
+        {
+            _interaction.WriteBlankLine();
+            _interaction.WriteLine(l => l.Plain(entry.ShortDescription));
+        }
+
+        if (entry.LongDescription is not null)
+        {
+            _interaction.WriteBlankLine();
+            _interaction.WriteLine(l => l.Plain(entry.LongDescription));
+        }
+
+        if (entry.WhatsIncluded is { Count: > 0 })
+        {
+            _interaction.WriteBlankLine();
+            _interaction.WriteLine(l => l.Heading(QuickstartMessages.WhatsIncludedHeading));
+            foreach (string item in entry.WhatsIncluded)
+            {
+                _interaction.WriteLine(l => l.Muted($"{QuickstartMessages.StepBullet}{item}"));
+            }
+        }
+
+        _interaction.WriteBlankLine();
+        string stack = provider?.Stack ?? entry.Language.ToLowerInvariant();
+        _interaction.WriteLine(l => l.Muted($"  Run: func quickstart <path> --stack {stack} --language {displayLanguage.ToLowerInvariant()} --template {entry.Id}"));
+
+        return 0;
     }
+
+    internal sealed record InfoRow(
+        string Id,
+        string Name,
+        string Language,
+        string Resource,
+        string Iac,
+        string? GitRef,
+        string RepositoryUrl,
+        string FolderPath,
+        string? ShortDescription,
+        string? LongDescription,
+        IReadOnlyList<string>? WhatsIncluded);
 }

--- a/src/Func/Commands/Quickstart/QuickstartListCommand.cs
+++ b/src/Func/Commands/Quickstart/QuickstartListCommand.cs
@@ -8,14 +8,20 @@ using Azure.Functions.Cli.Quickstart;
 namespace Azure.Functions.Cli.Commands.Quickstart;
 
 /// <summary>
-/// Lists available templates from the CDN manifest, optionally filtered by
-/// language, resource, IaC type, or keyword search.
+/// Lists available templates from the CDN manifest, filtered by the resolved
+/// stack and language. Delegates stack/language resolution to
+/// <see cref="IQuickstartProviderResolver"/>.
 /// </summary>
 internal sealed class QuickstartListCommand : FuncCliCommand
 {
+    public Option<string?> StackOption { get; } = new("--stack", "-s")
+    {
+        Description = QuickstartMessages.StackOptionDescription
+    };
+
     public Option<string?> LanguageOption { get; } = new("--language", "-l")
     {
-        Description = "Filter by worker runtime or language (e.g. python, node, java, dotnet)"
+        Description = "The programming language"
     };
 
     public Option<string?> ResourceOption { get; } = new("--resource", "-r")
@@ -30,37 +36,97 @@ internal sealed class QuickstartListCommand : FuncCliCommand
 
     public Option<string?> SearchOption { get; } = new("--search")
     {
-        Description = "Case-insensitive substring match against template names, IDs, resources, tags, and descriptions"
+        Description = "Case-insensitive substring match against IDs, template names, resource type, Infrastructure as Code type, and descriptions"
+    };
+
+    public Option<bool> JsonOption { get; } = new("--json")
+    {
+        Description = "Emit machine-readable JSON instead of a table."
     };
 
     private readonly IInteractionService _interaction;
-    private readonly IReadOnlyList<IQuickstartProvider> _providers;
+    private readonly IQuickstartProviderResolver _resolver;
+    private readonly IQuickstartManifestService _manifestService;
 
-    public QuickstartListCommand(IInteractionService interaction, IEnumerable<IQuickstartProvider> providers)
+    public QuickstartListCommand(
+        IInteractionService interaction,
+        IQuickstartProviderResolver resolver,
+        IQuickstartManifestService manifestService)
         : base("list", "List available templates from the catalog.")
     {
         ArgumentNullException.ThrowIfNull(interaction);
-        ArgumentNullException.ThrowIfNull(providers);
+        ArgumentNullException.ThrowIfNull(resolver);
+        ArgumentNullException.ThrowIfNull(manifestService);
 
         _interaction = interaction;
-        _providers = providers.ToList();
+        _resolver = resolver;
+        _manifestService = manifestService;
 
+        Options.Add(StackOption);
         Options.Add(LanguageOption);
         Options.Add(ResourceOption);
         Options.Add(IacOption);
         Options.Add(SearchOption);
+        Options.Add(JsonOption);
     }
 
-    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
-        if (_providers.Count == 0)
+        string? requestedStack = parseResult.GetValue(StackOption);
+        string? requestedLanguage = parseResult.GetValue(LanguageOption);
+        string? resource = parseResult.GetValue(ResourceOption);
+        string? iac = parseResult.GetValue(IacOption);
+        string? search = parseResult.GetValue(SearchOption);
+        bool json = parseResult.GetValue(JsonOption);
+
+        // 1. Resolve stack → provider
+        IQuickstartProvider? provider = await _resolver.SelectProviderAsync(requestedStack, "list quickstart templates", cancellationToken);
+        if (provider is null)
         {
-            _interaction.WriteWarning(
-                "The quickstart command is not yet available. Stack support is coming in a future release.");
-            return Task.FromResult(1);
+            return 1;
         }
 
-        _interaction.WriteWarning("The quickstart list command is not yet implemented.");
-        return Task.FromResult(1);
+        // 2. Fetch manifest
+        QuickstartManifest manifest = await _interaction.ShowStatusAsync(
+            QuickstartMessages.FetchingCatalogStatus,
+            _manifestService.GetManifestAsync,
+            cancellationToken);
+
+        // 3. Resolve language
+        (string? manifestLanguage, int? langError) = await _resolver.ResolveOrPromptLanguageAsync(
+            requestedLanguage, provider, manifest, cancellationToken);
+        if (langError is int code)
+        {
+            return code;
+        }
+
+        // 4. Filter and display
+        IReadOnlyList<QuickstartEntry> entries = manifest.Filter(manifestLanguage, resource, iac, search);
+
+        if (entries.Count == 0)
+        {
+            _interaction.WriteWarning(QuickstartMessages.NoMatchingFiltersWarning);
+            return 0;
+        }
+
+        if (json)
+        {
+            _interaction.WriteJson(entries.Select(e => new ListRow(e.Id, e.DisplayName, e.ShortDescription ?? string.Empty)).ToList());
+            return 0;
+        }
+
+        string[] columns = ["ID", "Name", "Description"];
+        IEnumerable<string[]> rows = entries.Select(e => new[]
+        {
+            e.Id,
+            e.DisplayName,
+            e.ShortDescription ?? "-"
+        });
+
+        _interaction.WriteTable(columns, rows);
+        _interaction.WriteLine(l => l.Muted($"{entries.Count} template(s) found."));
+        return 0;
     }
+
+    internal sealed record ListRow(string Id, string Name, string Description);
 }

--- a/src/Func/Commands/Quickstart/QuickstartMessages.cs
+++ b/src/Func/Commands/Quickstart/QuickstartMessages.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Commands.Quickstart;
+
+/// <summary>
+/// Centralised user-facing strings for quickstart commands.
+/// Keeps message text discoverable and consistent across subcommands.
+/// </summary>
+internal static class QuickstartMessages
+{
+    internal const string SuccessIcon = "✓ ";
+    internal const string StepBullet = "  · ";
+
+    // Shared across commands
+    internal const string FetchingCatalogStatus = "Fetching template catalog...";
+    internal const string StackOptionDescription = "The stack to use. Run `func workload list` to see what's installed.";
+    internal const string TemplateNotFoundHint = "Run `func quickstart list` to see available templates.";
+
+    // QuickstartCommand
+    internal const string DirectoryNotEmptyError = "The target directory is not empty. Pass --force to overwrite, or choose a different path.";
+    internal const string CancelledHint = "Quickstart cancelled. The directory was not modified.";
+    internal const string NoMatchingFiltersError = "No templates match the specified filters. Run `func quickstart list` to see all available templates, or adjust --resource, --iac, or --search.";
+    internal const string MultipleMatchesError = "Multiple templates match. Re-run with --template <id> to select one, or add filters (--resource, --iac, --search) to narrow the results.";
+
+    // QuickstartListCommand
+    internal const string NoMatchingFiltersWarning = "No templates match the specified filters.";
+
+    // QuickstartInfoCommand
+    internal const string WhatsIncludedHeading = "What's included:";
+}

--- a/src/Func/Console/SpectreInteractionService.cs
+++ b/src/Func/Console/SpectreInteractionService.cs
@@ -313,6 +313,7 @@ internal class SpectreInteractionService : IInteractionService
 
         return await new SelectionPrompt<string>()
             .Title(title)
+            .EnableSearch()
             .AddChoices(choiceList)
             .ShowAsync(_stderr, cancellationToken);
     }

--- a/src/Func/Quickstart/GitTemplateFetcher.cs
+++ b/src/Func/Quickstart/GitTemplateFetcher.cs
@@ -12,7 +12,6 @@ namespace Azure.Functions.Cli.Quickstart;
 /// </summary>
 internal sealed class GitTemplateFetcher(IGitRunner gitRunner, ILogger<GitTemplateFetcher> logger) : ITemplateFetcher
 {
-    private const string TagRefPrefix = "refs/tags/";
 
     private readonly IGitRunner _gitRunner = gitRunner ?? throw new ArgumentNullException(nameof(gitRunner));
     private readonly ILogger<GitTemplateFetcher> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -25,26 +24,20 @@ internal sealed class GitTemplateFetcher(IGitRunner gitRunner, ILogger<GitTempla
     {
         ArgumentNullException.ThrowIfNull(entry);
 
-        if (string.IsNullOrWhiteSpace(entry.GitRef))
-        {
-            throw new ArgumentException(
-                $"Template '{entry.Id}' has no GitRef. Only tag-pinned templates are supported.",
-                nameof(entry));
-        }
-
-        await InitAndFetchTagAsync(entry, tempDirectory, cancellationToken);
-        await VerifyTagIntegrityAsync(entry, tempDirectory, cancellationToken);
+        string gitRef = entry.GitRef!;
+        await InitAndFetchTagAsync(entry, gitRef, tempDirectory, cancellationToken);
+        await VerifyTagIntegrityAsync(entry, gitRef, tempDirectory, cancellationToken);
     }
 
     /// <summary>
     /// Fetches a specific tag using init + remote add + fetch refspec + checkout.
     /// This avoids <c>git clone --branch</c> which could resolve a branch with the same name.
     /// </summary>
-    private async Task InitAndFetchTagAsync(QuickstartEntry entry, string tempDirectory, CancellationToken cancellationToken)
+    private async Task InitAndFetchTagAsync(QuickstartEntry entry, string gitRef, string tempDirectory, CancellationToken cancellationToken)
     {
-        _logger.LogDebug("Fetching tag {GitRef} from {Url}", entry.GitRef, entry.RepositoryUrl);
+        _logger.LogDebug("Fetching tag {GitRef} from {Url}", gitRef, entry.RepositoryUrl);
 
-        string tagRefspec = $"{TagRefPrefix}{entry.GitRef}:{TagRefPrefix}{entry.GitRef}";
+        string tagRefspec = $"{gitRef}:{gitRef}";
 
         await _gitRunner.RunAsync(["init", tempDirectory], workingDirectory: null, cancellationToken);
 
@@ -63,13 +56,13 @@ internal sealed class GitTemplateFetcher(IGitRunner gitRunner, ILogger<GitTempla
         catch (GitRunnerException ex)
         {
             throw new InvalidOperationException(
-                $"'{entry.GitRef}' is not a tag on '{entry.RepositoryUrl}'. " +
+                $"'{gitRef}' is not a tag on '{entry.RepositoryUrl}'. " +
                 "Only tag-based git refs are supported. Branch refs (e.g. 'main') are not accepted.",
                 ex);
         }
 
         await _gitRunner.RunAsync(
-            ["-C", tempDirectory, "checkout", "--detach", $"{TagRefPrefix}{entry.GitRef}"],
+            ["-C", tempDirectory, "checkout", "--detach", gitRef],
             workingDirectory: null,
             cancellationToken);
     }
@@ -77,28 +70,28 @@ internal sealed class GitTemplateFetcher(IGitRunner gitRunner, ILogger<GitTempla
     /// <summary>
     /// Verifies the checked-out commit matches the tag's target and that the tag is annotated.
     /// </summary>
-    private async Task VerifyTagIntegrityAsync(QuickstartEntry entry, string tempDirectory, CancellationToken cancellationToken)
+    private async Task VerifyTagIntegrityAsync(QuickstartEntry entry, string gitRef, string tempDirectory, CancellationToken cancellationToken)
     {
-        _logger.LogDebug("Verifying tag integrity for {GitRef}", entry.GitRef);
+        _logger.LogDebug("Verifying tag integrity for {GitRef}", gitRef);
 
         try
         {
             string objectType = await _gitRunner.RunWithOutputAsync(
-                ["-C", tempDirectory, "cat-file", "-t", $"{TagRefPrefix}{entry.GitRef}"],
+                ["-C", tempDirectory, "cat-file", "-t", gitRef],
                 workingDirectory: null,
                 cancellationToken);
 
             if (!string.Equals(objectType, "tag", StringComparison.Ordinal))
             {
                 throw new InvalidOperationException(
-                    $"Tag '{entry.GitRef}' in '{entry.RepositoryUrl}' is a lightweight tag (object type: '{objectType}'). " +
+                    $"Tag '{gitRef}' in '{entry.RepositoryUrl}' is a lightweight tag (object type: '{objectType}'). " +
                     "Only annotated tags are accepted for template integrity.");
             }
         }
         catch (GitRunnerException ex)
         {
             throw new InvalidOperationException(
-                $"Tag '{entry.GitRef}' could not be verified in '{entry.RepositoryUrl}'.",
+                $"Tag '{gitRef}' could not be verified in '{entry.RepositoryUrl}'.",
                 ex);
         }
 
@@ -108,14 +101,14 @@ internal sealed class GitTemplateFetcher(IGitRunner gitRunner, ILogger<GitTempla
             cancellationToken);
 
         string tagTarget = await _gitRunner.RunWithOutputAsync(
-            ["-C", tempDirectory, "rev-list", "-n", "1", $"{TagRefPrefix}{entry.GitRef}"],
+            ["-C", tempDirectory, "rev-list", "-n", "1", gitRef],
             workingDirectory: null,
             cancellationToken);
 
         if (!string.Equals(headCommit, tagTarget, StringComparison.Ordinal))
         {
             throw new InvalidOperationException(
-                $"Tag '{entry.GitRef}' target ({tagTarget}) does not match HEAD ({headCommit}). " +
+                $"Tag '{gitRef}' target ({tagTarget}) does not match HEAD ({headCommit}). " +
                 "The tag may have been tampered with.");
         }
     }

--- a/src/Func/Quickstart/HttpTemplateFetcher.cs
+++ b/src/Func/Quickstart/HttpTemplateFetcher.cs
@@ -21,7 +21,7 @@ internal sealed class HttpTemplateFetcher(IHttpClientFactory httpClientFactory, 
 
     private const string ArchiveFileName = "archive.zip";
     private const string ExtractionDirectory = "extracted";
-    private const string ArchiveUrlPathSegment = "/archive/refs/tags/";
+    private const string ArchiveUrlPathSegment = "/archive/";
     private const string ArchiveUrlExtension = ".zip";
 
     private readonly IHttpClientFactory _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
@@ -33,6 +33,8 @@ internal sealed class HttpTemplateFetcher(IHttpClientFactory httpClientFactory, 
     /// <inheritdoc />
     public async Task FetchAsync(QuickstartEntry entry, string tempDirectory, CancellationToken cancellationToken)
     {
+        ArgumentNullException.ThrowIfNull(entry);
+
         string archiveUrl = BuildArchiveUrl(entry);
         _logger.LogDebug("Downloading archive from {Url}", archiveUrl);
 
@@ -43,7 +45,7 @@ internal sealed class HttpTemplateFetcher(IHttpClientFactory httpClientFactory, 
         {
             throw new InvalidOperationException(
                 $"Tag '{entry.GitRef}' not found in repository '{entry.RepositoryUrl}'. " +
-                "The template manifest may be out of date. Try running 'func quickstart list --refresh'.");
+                "The template manifest may be out of date.");
         }
 
         response.EnsureSuccessStatusCode();
@@ -91,7 +93,7 @@ internal sealed class HttpTemplateFetcher(IHttpClientFactory httpClientFactory, 
         }
     }
 
-    private static string BuildArchiveUrl(QuickstartEntry entry)
+    internal static string BuildArchiveUrl(QuickstartEntry entry)
     {
         var uri = new Uri(entry.RepositoryUrl);
 

--- a/src/Func/Quickstart/IQuickstartProviderResolver.cs
+++ b/src/Func/Quickstart/IQuickstartProviderResolver.cs
@@ -1,0 +1,55 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Quickstart;
+
+/// <summary>
+/// Encapsulates the stack → provider and language resolution flow shared by
+/// all <c>func quickstart</c> subcommands. Commands pass an action description
+/// so hint messages stay contextual.
+/// </summary>
+internal interface IQuickstartProviderResolver
+{
+    /// <summary>
+    /// Resolves a stack option to a single <see cref="IQuickstartProvider"/>.
+    /// When the stack is unambiguous (single workload, explicit match), returns
+    /// it directly. Otherwise prompts interactively or renders a workload hint
+    /// and returns <c>null</c>.
+    /// </summary>
+    public Task<IQuickstartProvider?> SelectProviderAsync(string? requestedStack, string actionDescription, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Resolves user language input (e.g. "c#", "js") to a manifest language
+    /// value via the provider's mapping. Returns <c>null</c> when the input is
+    /// not recognized or has no templates.
+    /// </summary>
+    public string? ResolveLanguage(string? requestedLanguage, IQuickstartProvider provider, QuickstartManifest manifest);
+
+    /// <summary>
+    /// Prompts interactively for a language when none was supplied on the
+    /// command line and the provider supports multiple languages. Auto-selects
+    /// when only one language has templates.
+    /// </summary>
+    public Task<(string? Language, int? ErrorCode)> PromptForLanguageAsync(IQuickstartProvider provider, QuickstartManifest manifest, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Resolves the language from user input or, when absent, prompts
+    /// interactively. Combines <see cref="ResolveLanguage"/> and
+    /// <see cref="PromptForLanguageAsync"/> into a single call so commands
+    /// don't duplicate the resolve-then-prompt flow.
+    /// </summary>
+    public Task<(string? Language, int? ErrorCode)> ResolveOrPromptLanguageAsync(
+        string? requestedLanguage, IQuickstartProvider provider, QuickstartManifest manifest, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Returns the manifest language values that the provider handles and that
+    /// have at least one entry in the manifest.
+    /// </summary>
+    public IReadOnlyList<string> GetAvailableManifestLanguages(IQuickstartProvider provider, QuickstartManifest manifest);
+
+    /// <summary>
+    /// Finds the provider that owns the given manifest language value, or
+    /// <c>null</c> if no installed provider claims it.
+    /// </summary>
+    public IQuickstartProvider? FindProviderForLanguage(string manifestLanguage);
+}

--- a/src/Func/Quickstart/QuickstartManifestService.cs
+++ b/src/Func/Quickstart/QuickstartManifestService.cs
@@ -19,7 +19,6 @@ internal sealed class QuickstartManifestService(
     TimeProvider timeProvider,
     ILogger<QuickstartManifestService> logger) : IQuickstartManifestService
 {
-    private const string GitRefPrefix = "v";
     private const string HttpSchemePrefix = "http";
 
     private readonly IHttpClientFactory _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
@@ -220,7 +219,7 @@ internal sealed class QuickstartManifestService(
     private static bool HasValidGitRef(QuickstartEntry entry)
     {
         return entry.GitRef is not null
-            && entry.GitRef.StartsWith(GitRefPrefix, StringComparison.Ordinal);
+            && entry.GitRef.StartsWith(QuickstartConstants.TagRefPrefix, StringComparison.Ordinal);
     }
 
     private static List<QuickstartEntry>? DeserializeEntries(string json)

--- a/src/Func/Quickstart/QuickstartProviderResolver.cs
+++ b/src/Func/Quickstart/QuickstartProviderResolver.cs
@@ -1,0 +1,184 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Workloads;
+
+namespace Azure.Functions.Cli.Quickstart;
+
+/// <summary>
+/// Default implementation of <see cref="IQuickstartProviderResolver"/>.
+/// Centralises stack and language resolution so individual quickstart
+/// subcommands stay thin.
+/// </summary>
+internal sealed class QuickstartProviderResolver(
+    IInteractionService interaction,
+    IWorkloadHintRenderer hintRenderer,
+    IEnumerable<IQuickstartProvider> providers) : IQuickstartProviderResolver
+{
+    private readonly IInteractionService _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
+    private readonly IWorkloadHintRenderer _hintRenderer = hintRenderer ?? throw new ArgumentNullException(nameof(hintRenderer));
+    private readonly IReadOnlyList<IQuickstartProvider> _providers = (providers ?? throw new ArgumentNullException(nameof(providers))).ToList();
+
+    public async Task<IQuickstartProvider?> SelectProviderAsync(string? requestedStack, string actionDescription, CancellationToken cancellationToken)
+    {
+        string[] installed = [.. _providers.Select(p => p.Stack)];
+
+        if (_providers.Count == 0)
+        {
+            _hintRenderer.Render(new WorkloadHint(
+                WorkloadHintKind.NoWorkloadsInstalled, actionDescription, null, installed));
+            return null;
+        }
+
+        if (!string.IsNullOrEmpty(requestedStack))
+        {
+            IQuickstartProvider? match = _providers.FirstOrDefault(p =>
+                string.Equals(p.Stack, requestedStack, StringComparison.OrdinalIgnoreCase));
+            if (match is not null)
+            {
+                return match;
+            }
+
+            _hintRenderer.Render(new WorkloadHint(
+                WorkloadHintKind.NoMatchingStack, actionDescription, requestedStack, installed));
+            return null;
+        }
+
+        if (_providers.Count == 1)
+        {
+            IQuickstartProvider sole = _providers[0];
+            _hintRenderer.Render(new WorkloadHint(
+                WorkloadHintKind.AutoSelectedSoleWorkload, actionDescription, sole.Stack, installed));
+            return sole;
+        }
+
+        if (!_interaction.IsInteractive)
+        {
+            _hintRenderer.Render(new WorkloadHint(
+                WorkloadHintKind.AmbiguousStackChoice, actionDescription, null, installed));
+            return null;
+        }
+
+        var displayToProvider = new Dictionary<string, IQuickstartProvider>(StringComparer.Ordinal);
+        foreach (IQuickstartProvider p in _providers)
+        {
+            displayToProvider.TryAdd(p.DisplayName, p);
+        }
+        string picked = await _interaction.PromptForSelectionAsync(
+            "Select a stack:",
+            displayToProvider.Keys,
+            cancellationToken);
+
+        return displayToProvider.TryGetValue(picked, out IQuickstartProvider? chosen) ? chosen : null;
+    }
+
+    public string? ResolveLanguage(string? requestedLanguage, IQuickstartProvider provider, QuickstartManifest manifest)
+    {
+        if (string.IsNullOrWhiteSpace(requestedLanguage))
+        {
+            return null;
+        }
+
+        string? manifestLanguage = provider.ResolveManifestLanguage(requestedLanguage.Trim());
+        if (manifestLanguage is null)
+        {
+            IEnumerable<string> displayNames = GetAvailableManifestLanguages(provider, manifest)
+                .Select(provider.GetDisplayLanguage);
+            _interaction.WriteError(
+                $"Language '{requestedLanguage}' is not supported by the '{provider.Stack}' stack. " +
+                $"Supported values: {string.Join(", ", displayNames)}.");
+            return null;
+        }
+
+        IReadOnlyList<string> available = GetAvailableManifestLanguages(provider, manifest);
+        if (!available.Contains(manifestLanguage, StringComparer.OrdinalIgnoreCase))
+        {
+            _interaction.WriteError(
+                $"No quickstart templates found for language '{provider.GetDisplayLanguage(manifestLanguage)}' " +
+                $"in the '{provider.Stack}' stack.");
+            return null;
+        }
+
+        return manifestLanguage;
+    }
+
+    public async Task<(string? Language, int? ErrorCode)> ResolveOrPromptLanguageAsync(
+        string? requestedLanguage,
+        IQuickstartProvider provider,
+        QuickstartManifest manifest,
+        CancellationToken cancellationToken)
+    {
+        string? resolved = ResolveLanguage(requestedLanguage, provider, manifest);
+        if (resolved is null && requestedLanguage is not null)
+        {
+            return (null, 1);
+        }
+
+        if (resolved is not null)
+        {
+            return (resolved, null);
+        }
+
+        return await PromptForLanguageAsync(provider, manifest, cancellationToken);
+    }
+
+    public async Task<(string? Language, int? ErrorCode)> PromptForLanguageAsync(
+        IQuickstartProvider provider,
+        QuickstartManifest manifest,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<string> available = GetAvailableManifestLanguages(provider, manifest);
+
+        if (available.Count == 0)
+        {
+            _interaction.WriteError(
+                $"No quickstart templates found for the '{provider.Stack}' stack.");
+            return (null, 1);
+        }
+
+        if (available.Count == 1)
+        {
+            return (available[0], null);
+        }
+
+        if (!_interaction.IsInteractive)
+        {
+            IEnumerable<string> displayNames = available.Select(provider.GetDisplayLanguage);
+            _interaction.WriteError(
+                $"The '{provider.Stack}' stack supports multiple languages. " +
+                $"Re-run with --language <{string.Join("|", displayNames)}>.");
+            return (null, 1);
+        }
+
+        var displayToManifest = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (string lang in available)
+        {
+            string display = provider.GetDisplayLanguage(lang);
+            displayToManifest.TryAdd(display, lang);
+        }
+
+        string picked = await _interaction.PromptForSelectionAsync(
+            "Select a language:",
+            displayToManifest.Keys,
+            cancellationToken);
+
+        return (displayToManifest[picked], null);
+    }
+
+    public IReadOnlyList<string> GetAvailableManifestLanguages(IQuickstartProvider provider, QuickstartManifest manifest)
+    {
+        HashSet<string> manifestLanguages = new(
+            manifest.Entries.Select(e => e.Language),
+            StringComparer.OrdinalIgnoreCase);
+
+        return [.. provider.ManifestLanguages
+            .Where(manifestLanguages.Contains)];
+    }
+
+    public IQuickstartProvider? FindProviderForLanguage(string manifestLanguage)
+    {
+        return _providers.FirstOrDefault(p =>
+            p.ManifestLanguages.Contains(manifestLanguage, StringComparer.OrdinalIgnoreCase));
+    }
+}

--- a/src/Func/Quickstart/QuickstartRegistration.cs
+++ b/src/Func/Quickstart/QuickstartRegistration.cs
@@ -48,6 +48,7 @@ internal static class QuickstartRegistration
         services.AddSingleton<IManifestCache, ManifestCache>();
         services.TryAddSingleton(TimeProvider.System);
         services.AddSingleton<IQuickstartManifestService, QuickstartManifestService>();
+        services.AddSingleton<IQuickstartProviderResolver, QuickstartProviderResolver>();
 
         return services;
     }

--- a/src/Func/Quickstart/QuickstartScaffolder.cs
+++ b/src/Func/Quickstart/QuickstartScaffolder.cs
@@ -140,7 +140,7 @@ internal sealed class QuickstartScaffolder(
         if (string.IsNullOrWhiteSpace(entry.GitRef))
         {
             throw new ArgumentException(
-                $"Template '{entry.Id}' has no GitRef. A git tag or branch reference is required.",
+                $"Template '{entry.Id}' has no GitRef. Only tag-pinned templates are supported.",
                 nameof(entry));
         }
 
@@ -148,6 +148,14 @@ internal sealed class QuickstartScaffolder(
         {
             throw new ArgumentException(
                 $"Invalid GitRef '{entry.GitRef}': must not start with '-' (potential flag injection).",
+                nameof(entry));
+        }
+
+        if (!entry.GitRef.StartsWith(QuickstartConstants.TagRefPrefix, StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                $"Template '{entry.Id}' has GitRef '{entry.GitRef}' which is not a tag ref. "
+                + "Only refs/tags/* are accepted.",
                 nameof(entry));
         }
 

--- a/src/Workloads/Stacks/DotNet/DotNetQuickstartProvider.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetQuickstartProvider.cs
@@ -30,7 +30,6 @@ internal sealed class DotNetQuickstartProvider : IQuickstartProvider
 
     public IReadOnlyList<string> GetNextSteps(string manifestLanguage) =>
     [
-        "Verify `local.settings.json` exists and has the required settings values",
         "Run `func run` to launch the app"
     ];
 }

--- a/src/Workloads/Stacks/DotNet/DotNetQuickstartProvider.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetQuickstartProvider.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Quickstart;
+
+namespace Azure.Functions.Cli.Workloads.DotNet;
+
+/// <summary>
+/// Quickstart provider for the .NET stack (C# only).
+/// </summary>
+internal sealed class DotNetQuickstartProvider : IQuickstartProvider
+{
+    public string Stack => "dotnet";
+
+    public string DisplayName => ".NET";
+
+    public IReadOnlyList<string> ManifestLanguages { get; } = ["CSharp"];
+
+    public string GetDisplayLanguage(string manifestLanguage) => manifestLanguage switch
+    {
+        "CSharp" => "C#",
+        _ => manifestLanguage
+    };
+
+    public string? ResolveManifestLanguage(string userInput) => userInput.ToLowerInvariant() switch
+    {
+        "c#" or "csharp" => "CSharp",
+        _ => null
+    };
+
+    public IReadOnlyList<string> GetNextSteps(string manifestLanguage) =>
+    [
+        "Verify `local.settings.json` exists and has the required settings values",
+        "Run `func run` to launch the app"
+    ];
+}

--- a/src/Workloads/Stacks/DotNet/DotNetWorkload.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetWorkload.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Quickstart;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Azure.Functions.Cli.Workloads.DotNet;
@@ -22,6 +23,7 @@ public sealed class DotNetWorkload : Workload
         builder.Services.AddSingleton<IDotnetCliRunner, DotnetCliRunner>();
         builder.Services.AddSingleton<ITemplateHivePathProvider, TemplateHivePathProvider>();
         builder.Services.AddSingleton<IProjectInitializer, DotNetProjectInitializer>();
+        builder.Services.AddSingleton<IQuickstartProvider, DotNetQuickstartProvider>();
         builder.AddProjectFactory<DotNetProjectFactory>();
     }
 }

--- a/src/Workloads/Stacks/Node/NodeQuickstartProvider.cs
+++ b/src/Workloads/Stacks/Node/NodeQuickstartProvider.cs
@@ -28,7 +28,6 @@ internal sealed class NodeQuickstartProvider : IQuickstartProvider
     public IReadOnlyList<string> GetNextSteps(string manifestLanguage) =>
     [
         "Run `npm install` to install dependencies",
-        "Verify `local.settings.json` exists and has the required settings values",
         "Run `func run` to launch the app"
     ];
 }

--- a/src/Workloads/Stacks/Node/NodeQuickstartProvider.cs
+++ b/src/Workloads/Stacks/Node/NodeQuickstartProvider.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Quickstart;
+
+namespace Azure.Functions.Cli.Workloads.Node;
+
+/// <summary>
+/// Quickstart provider for the Node stack (JavaScript and TypeScript).
+/// </summary>
+internal sealed class NodeQuickstartProvider : IQuickstartProvider
+{
+    public string Stack => "node";
+
+    public string DisplayName => "Node";
+
+    public IReadOnlyList<string> ManifestLanguages { get; } = ["TypeScript", "JavaScript"];
+
+    public string GetDisplayLanguage(string manifestLanguage) => manifestLanguage;
+
+    public string? ResolveManifestLanguage(string userInput) => userInput.ToLowerInvariant() switch
+    {
+        "javascript" or "js" => "JavaScript",
+        "typescript" or "ts" => "TypeScript",
+        _ => null
+    };
+
+    public IReadOnlyList<string> GetNextSteps(string manifestLanguage) =>
+    [
+        "Run `npm install` to install dependencies",
+        "Verify `local.settings.json` exists and has the required settings values",
+        "Run `func run` to launch the app"
+    ];
+}

--- a/src/Workloads/Stacks/Node/NodeWorkload.cs
+++ b/src/Workloads/Stacks/Node/NodeWorkload.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Quickstart;
 using Azure.Functions.Cli.Workloads;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -21,6 +22,7 @@ public sealed class NodeWorkload : Workload
     {
         ArgumentNullException.ThrowIfNull(builder);
         builder.Services.AddSingleton<IProjectInitializer, NodeProjectInitializer>();
+        builder.Services.AddSingleton<IQuickstartProvider, NodeQuickstartProvider>();
         builder.AddProjectFactory(new NodeProjectFactory());
     }
 }

--- a/src/Workloads/Stacks/Python/PythonQuickstartProvider.cs
+++ b/src/Workloads/Stacks/Python/PythonQuickstartProvider.cs
@@ -27,7 +27,6 @@ internal sealed class PythonQuickstartProvider : IQuickstartProvider
     public IReadOnlyList<string> GetNextSteps(string manifestLanguage) =>
     [
         "Run `pip install -r requirements.txt` to install dependencies",
-        "Verify `local.settings.json` exists and has the required settings values",
         "Run `func run` to launch the app"
     ];
 }

--- a/src/Workloads/Stacks/Python/PythonQuickstartProvider.cs
+++ b/src/Workloads/Stacks/Python/PythonQuickstartProvider.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Quickstart;
+
+namespace Azure.Functions.Cli.Workloads.Python;
+
+/// <summary>
+/// Quickstart provider for the Python stack.
+/// </summary>
+internal sealed class PythonQuickstartProvider : IQuickstartProvider
+{
+    public string Stack => "python";
+
+    public string DisplayName => "Python";
+
+    public IReadOnlyList<string> ManifestLanguages { get; } = ["Python"];
+
+    public string GetDisplayLanguage(string manifestLanguage) => manifestLanguage;
+
+    public string? ResolveManifestLanguage(string userInput) => userInput.ToLowerInvariant() switch
+    {
+        "python" or "py" => "Python",
+        _ => null
+    };
+
+    public IReadOnlyList<string> GetNextSteps(string manifestLanguage) =>
+    [
+        "Run `pip install -r requirements.txt` to install dependencies",
+        "Verify `local.settings.json` exists and has the required settings values",
+        "Run `func run` to launch the app"
+    ];
+}

--- a/src/Workloads/Stacks/Python/PythonWorkload.cs
+++ b/src/Workloads/Stacks/Python/PythonWorkload.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Quickstart;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Azure.Functions.Cli.Workloads.Python;
@@ -20,6 +21,7 @@ public sealed class PythonWorkload : Workload
     {
         ArgumentNullException.ThrowIfNull(builder);
         builder.Services.AddSingleton<IProjectInitializer, PythonProjectInitializer>();
+        builder.Services.AddSingleton<IQuickstartProvider, PythonQuickstartProvider>();
         builder.AddProjectFactory(new PythonProjectFactory());
     }
 }

--- a/test/Func.Tests/Commands/Quickstart/QuickstartCommandTests.cs
+++ b/test/Func.Tests/Commands/Quickstart/QuickstartCommandTests.cs
@@ -4,6 +4,7 @@
 using Azure.Functions.Cli.Commands;
 using Azure.Functions.Cli.Commands.Quickstart;
 using Azure.Functions.Cli.Quickstart;
+using NSubstitute;
 using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands.Quickstart;
@@ -11,13 +12,21 @@ namespace Azure.Functions.Cli.Tests.Commands.Quickstart;
 public class QuickstartCommandTests
 {
     private readonly TestInteractionService _interaction = new();
+    private readonly IQuickstartProviderResolver _resolver = Substitute.For<IQuickstartProviderResolver>();
+    private readonly IQuickstartManifestService _manifestService = Substitute.For<IQuickstartManifestService>();
+    private readonly IQuickstartScaffolder _scaffolder = Substitute.For<IQuickstartScaffolder>();
+
+    private QuickstartCommand CreateCommand(params IQuickstartProvider[] providers)
+    {
+        var listCmd = new QuickstartListCommand(_interaction, _resolver, _manifestService);
+        var infoCmd = new QuickstartInfoCommand(_interaction, _resolver, _manifestService);
+        return new QuickstartCommand(listCmd, infoCmd, _interaction, _resolver, _manifestService, _scaffolder, providers);
+    }
 
     [Fact]
     public void QuickstartCommand_HasExpectedOptions()
     {
-        var listCmd = new QuickstartListCommand(_interaction, []);
-        var infoCmd = new QuickstartInfoCommand(_interaction, []);
-        var cmd = new QuickstartCommand(listCmd, infoCmd, _interaction, []);
+        QuickstartCommand cmd = CreateCommand();
 
         var optionNames = cmd.Options.Select(o => o.Name).ToList();
 
@@ -28,14 +37,13 @@ public class QuickstartCommandTests
         Assert.Contains("--iac", optionNames);
         Assert.Contains("--search", optionNames);
         Assert.Contains("--fetch", optionNames);
+        Assert.Contains("--force", optionNames);
     }
 
     [Fact]
     public void QuickstartCommand_HasSubcommands()
     {
-        var listCmd = new QuickstartListCommand(_interaction, []);
-        var infoCmd = new QuickstartInfoCommand(_interaction, []);
-        var cmd = new QuickstartCommand(listCmd, infoCmd, _interaction, []);
+        QuickstartCommand cmd = CreateCommand();
 
         var subcommandNames = cmd.Subcommands.Select(c => c.Name).ToList();
 
@@ -46,9 +54,7 @@ public class QuickstartCommandTests
     [Fact]
     public void QuickstartCommand_HasPathArgument()
     {
-        var listCmd = new QuickstartListCommand(_interaction, []);
-        var infoCmd = new QuickstartInfoCommand(_interaction, []);
-        var cmd = new QuickstartCommand(listCmd, infoCmd, _interaction, []);
+        QuickstartCommand cmd = CreateCommand();
 
         Assert.Single(cmd.Arguments);
         Assert.Equal("path", cmd.Arguments[0].Name);

--- a/test/Func.Tests/Commands/Quickstart/QuickstartInfoCommandTests.cs
+++ b/test/Func.Tests/Commands/Quickstart/QuickstartInfoCommandTests.cs
@@ -1,0 +1,148 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Commands.Quickstart;
+using Azure.Functions.Cli.Quickstart;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Commands.Quickstart;
+
+public class QuickstartInfoCommandTests
+{
+    private readonly TestInteractionService _interaction = new();
+    private readonly IQuickstartProviderResolver _resolver = Substitute.For<IQuickstartProviderResolver>();
+    private readonly IQuickstartManifestService _manifestService = Substitute.For<IQuickstartManifestService>();
+
+    private QuickstartInfoCommand CreateCommand() => new(_interaction, _resolver, _manifestService);
+
+    [Fact]
+    public void QuickstartInfoCommand_HasJsonOption()
+    {
+        QuickstartInfoCommand cmd = CreateCommand();
+        Assert.Contains(cmd.Options, o => o.Name == "--json");
+    }
+
+    [Fact]
+    public void QuickstartInfoCommand_HasTemplateIdArgument()
+    {
+        QuickstartInfoCommand cmd = CreateCommand();
+        Assert.Single(cmd.Arguments);
+        Assert.Equal("id", cmd.Arguments[0].Name);
+    }
+
+    [Fact]
+    public async Task Info_NotFound_ReturnsOne()
+    {
+        _manifestService.GetManifestAsync(Arg.Any<CancellationToken>())
+            .Returns(new QuickstartManifest([]));
+
+        int exit = await InvokeAsync(CreateCommand(), "nonexistent");
+
+        Assert.Equal(1, exit);
+        Assert.Contains(_interaction.Lines, l => l.Contains("not found"));
+    }
+
+    [Fact]
+    public async Task Info_FormattedOutput_ShowsEntryDetails()
+    {
+        QuickstartEntry entry = QuickstartTestHelpers.CreateEntry();
+        _manifestService.GetManifestAsync(Arg.Any<CancellationToken>())
+            .Returns(new QuickstartManifest([entry]));
+
+        IQuickstartProvider provider = QuickstartTestHelpers.CreateProvider();
+        _resolver.FindProviderForLanguage("Python").Returns(provider);
+        provider.GetDisplayLanguage("Python").Returns("Python");
+
+        int exit = await InvokeAsync(CreateCommand(), "http-py");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain(_interaction.Lines, l => l.StartsWith("JSON:"));
+        Assert.Contains(_interaction.Lines, l => l.Contains("http-py"));
+        Assert.Contains(_interaction.Lines, l => l.Contains("Python"));
+        Assert.Contains(_interaction.Lines, l => l.Contains("http"));
+    }
+
+    [Fact]
+    public async Task Info_Json_EmitsJsonInsteadOfFormatted()
+    {
+        QuickstartEntry entry = QuickstartTestHelpers.CreateEntry();
+        _manifestService.GetManifestAsync(Arg.Any<CancellationToken>())
+            .Returns(new QuickstartManifest([entry]));
+
+        IQuickstartProvider provider = QuickstartTestHelpers.CreateProvider();
+        _resolver.FindProviderForLanguage("Python").Returns(provider);
+        provider.GetDisplayLanguage("Python").Returns("Python");
+
+        int exit = await InvokeAsync(CreateCommand(), "http-py", "--json");
+
+        Assert.Equal(0, exit);
+        string jsonLine = _interaction.Lines.Single(l => l.StartsWith("JSON:"));
+        Assert.Contains("\"id\":\"http-py\"", jsonLine);
+        Assert.Contains("\"name\":\"HTTP Trigger\"", jsonLine);
+        Assert.Contains("\"language\":\"Python\"", jsonLine);
+        Assert.Contains("\"resource\":\"http\"", jsonLine);
+        Assert.Contains("\"iac\":\"bicep\"", jsonLine);
+    }
+
+    [Fact]
+    public async Task Info_Json_NoProvider_FallsBackToRawLanguage()
+    {
+        QuickstartEntry entry = QuickstartTestHelpers.CreateEntry(language: "FSharp");
+        _manifestService.GetManifestAsync(Arg.Any<CancellationToken>())
+            .Returns(new QuickstartManifest([entry]));
+
+        _resolver.FindProviderForLanguage("FSharp").Returns((IQuickstartProvider?)null);
+
+        int exit = await InvokeAsync(CreateCommand(), "http-py", "--json");
+
+        Assert.Equal(0, exit);
+        string jsonLine = _interaction.Lines.Single(l => l.StartsWith("JSON:"));
+        Assert.Contains("\"language\":\"FSharp\"", jsonLine);
+    }
+
+    [Fact]
+    public async Task Info_Json_NullIac_DefaultsToNone()
+    {
+        QuickstartEntry entry = QuickstartTestHelpers.CreateEntry(iac: null);
+        _manifestService.GetManifestAsync(Arg.Any<CancellationToken>())
+            .Returns(new QuickstartManifest([entry]));
+
+        IQuickstartProvider provider = QuickstartTestHelpers.CreateProvider();
+        _resolver.FindProviderForLanguage("Python").Returns(provider);
+        provider.GetDisplayLanguage("Python").Returns("Python");
+
+        int exit = await InvokeAsync(CreateCommand(), "http-py", "--json");
+
+        Assert.Equal(0, exit);
+        string jsonLine = _interaction.Lines.Single(l => l.StartsWith("JSON:"));
+        Assert.Contains("\"iac\":\"none\"", jsonLine);
+    }
+
+    [Fact]
+    public async Task Info_CaseInsensitiveIdLookup()
+    {
+        QuickstartEntry entry = QuickstartTestHelpers.CreateEntry();
+        _manifestService.GetManifestAsync(Arg.Any<CancellationToken>())
+            .Returns(new QuickstartManifest([entry]));
+
+        IQuickstartProvider provider = QuickstartTestHelpers.CreateProvider();
+        _resolver.FindProviderForLanguage("Python").Returns(provider);
+        provider.GetDisplayLanguage("Python").Returns("Python");
+
+        int exit = await InvokeAsync(CreateCommand(), "HTTP-PY");
+
+        Assert.Equal(0, exit);
+        Assert.Contains(_interaction.Lines, l => l.Contains("http-py"));
+    }
+
+    // --- helpers ---
+
+    private static Task<int> InvokeAsync(QuickstartInfoCommand cmd, params string[] args)
+    {
+        var root = new RootCommand();
+        root.Subcommands.Add(cmd);
+        return root.Parse(new[] { cmd.Name }.Concat(args).ToArray()).InvokeAsync();
+    }
+}

--- a/test/Func.Tests/Commands/Quickstart/QuickstartListCommandTests.cs
+++ b/test/Func.Tests/Commands/Quickstart/QuickstartListCommandTests.cs
@@ -1,0 +1,152 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Commands.Quickstart;
+using Azure.Functions.Cli.Quickstart;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Commands.Quickstart;
+
+public class QuickstartListCommandTests
+{
+    private readonly TestInteractionService _interaction = new();
+    private readonly IQuickstartProviderResolver _resolver = Substitute.For<IQuickstartProviderResolver>();
+    private readonly IQuickstartManifestService _manifestService = Substitute.For<IQuickstartManifestService>();
+
+    private QuickstartListCommand CreateCommand() => new(_interaction, _resolver, _manifestService);
+
+    [Fact]
+    public void QuickstartListCommand_HasExpectedOptions()
+    {
+        QuickstartListCommand cmd = CreateCommand();
+        var optionNames = cmd.Options.Select(o => o.Name).ToList();
+
+        Assert.Contains("--stack", optionNames);
+        Assert.Contains("--language", optionNames);
+        Assert.Contains("--resource", optionNames);
+        Assert.Contains("--iac", optionNames);
+        Assert.Contains("--search", optionNames);
+        Assert.Contains("--json", optionNames);
+    }
+
+    [Fact]
+    public async Task List_NoProvider_ReturnsOne()
+    {
+        _resolver.SelectProviderAsync(Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((IQuickstartProvider?)null);
+
+        int exit = await InvokeAsync(CreateCommand(), "--stack", "missing");
+
+        Assert.Equal(1, exit);
+    }
+
+    [Fact]
+    public async Task List_Table_RendersEntriesAsTable()
+    {
+        IQuickstartProvider provider = QuickstartTestHelpers.CreateProvider();
+        QuickstartManifest manifest = SetupManifest(
+            QuickstartTestHelpers.CreateEntry("http-py", "HTTP Trigger", "Python", "A Python HTTP trigger"),
+            QuickstartTestHelpers.CreateEntry("timer-py", "Timer Trigger", "Python", "A Python timer trigger"));
+
+        SetupResolverSuccess(provider, manifest, "Python");
+
+        int exit = await InvokeAsync(CreateCommand());
+
+        Assert.Equal(0, exit);
+        Assert.Contains("TABLE: [ID, Name, Description]", _interaction.Lines);
+        Assert.DoesNotContain(_interaction.Lines, l => l.StartsWith("JSON:"));
+    }
+
+    [Fact]
+    public async Task List_Json_EmitsJsonInsteadOfTable()
+    {
+        IQuickstartProvider provider = QuickstartTestHelpers.CreateProvider();
+        QuickstartManifest manifest = SetupManifest(
+            QuickstartTestHelpers.CreateEntry("http-py", "HTTP Trigger", "Python", "A Python HTTP trigger"));
+
+        SetupResolverSuccess(provider, manifest, "Python");
+
+        int exit = await InvokeAsync(CreateCommand(), "--json");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain(_interaction.Lines, l => l.StartsWith("TABLE:"));
+        string jsonLine = _interaction.Lines.Single(l => l.StartsWith("JSON:"));
+        Assert.Contains("\"id\":\"http-py\"", jsonLine);
+        Assert.Contains("\"name\":\"HTTP Trigger\"", jsonLine);
+        Assert.Contains("\"description\":\"A Python HTTP trigger\"", jsonLine);
+    }
+
+    [Fact]
+    public async Task List_Json_EmptyDescription_DefaultsToEmptyString()
+    {
+        IQuickstartProvider provider = QuickstartTestHelpers.CreateProvider();
+        QuickstartManifest manifest = SetupManifest(
+            QuickstartTestHelpers.CreateEntry("no-desc", "No Desc Template", "Python", shortDescription: null));
+
+        SetupResolverSuccess(provider, manifest, "Python");
+
+        int exit = await InvokeAsync(CreateCommand(), "--json");
+
+        Assert.Equal(0, exit);
+        string jsonLine = _interaction.Lines.Single(l => l.StartsWith("JSON:"));
+        Assert.Contains("\"description\":\"\"", jsonLine);
+    }
+
+    [Fact]
+    public async Task List_NoMatchingTemplates_WritesWarning()
+    {
+        IQuickstartProvider provider = QuickstartTestHelpers.CreateProvider();
+        QuickstartManifest manifest = SetupManifest();
+
+        SetupResolverSuccess(provider, manifest, "Python");
+
+        int exit = await InvokeAsync(CreateCommand());
+
+        Assert.Equal(0, exit);
+        Assert.Contains(_interaction.Lines, l => l.Contains("No templates match"));
+    }
+
+    [Fact]
+    public async Task List_LanguageResolutionFails_ReturnsOne()
+    {
+        IQuickstartProvider provider = QuickstartTestHelpers.CreateProvider();
+        QuickstartManifest manifest = SetupManifest();
+
+        _resolver.SelectProviderAsync(Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(provider);
+        _manifestService.GetManifestAsync(Arg.Any<CancellationToken>())
+            .Returns(manifest);
+        _resolver.ResolveOrPromptLanguageAsync(Arg.Any<string?>(), provider, manifest, Arg.Any<CancellationToken>())
+            .Returns((null, (int?)1));
+
+        int exit = await InvokeAsync(CreateCommand(), "--language", "unknown");
+
+        Assert.Equal(1, exit);
+    }
+
+    // --- helpers ---
+
+    private QuickstartManifest SetupManifest(params QuickstartEntry[] entries)
+    {
+        var manifest = new QuickstartManifest([.. entries]);
+        _manifestService.GetManifestAsync(Arg.Any<CancellationToken>()).Returns(manifest);
+        return manifest;
+    }
+
+    private void SetupResolverSuccess(IQuickstartProvider provider, QuickstartManifest manifest, string manifestLanguage)
+    {
+        _resolver.SelectProviderAsync(Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(provider);
+        _resolver.ResolveOrPromptLanguageAsync(Arg.Any<string?>(), provider, manifest, Arg.Any<CancellationToken>())
+            .Returns((manifestLanguage, (int?)null));
+    }
+
+    private static Task<int> InvokeAsync(QuickstartListCommand cmd, params string[] args)
+    {
+        var root = new RootCommand();
+        root.Subcommands.Add(cmd);
+        return root.Parse(new[] { cmd.Name }.Concat(args).ToArray()).InvokeAsync();
+    }
+}

--- a/test/Func.Tests/Commands/Quickstart/QuickstartTestHelpers.cs
+++ b/test/Func.Tests/Commands/Quickstart/QuickstartTestHelpers.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Quickstart;
+using NSubstitute;
+
+namespace Azure.Functions.Cli.Tests.Commands.Quickstart;
+
+internal static class QuickstartTestHelpers
+{
+    public static IQuickstartProvider CreateProvider(
+        string stack = "python",
+        string displayName = "Python",
+        params string[] manifestLanguages)
+    {
+        if (manifestLanguages.Length == 0)
+        {
+            manifestLanguages = ["Python"];
+        }
+
+        IQuickstartProvider provider = Substitute.For<IQuickstartProvider>();
+        provider.Stack.Returns(stack);
+        provider.DisplayName.Returns(displayName);
+        provider.ManifestLanguages.Returns(manifestLanguages.ToList().AsReadOnly());
+        return provider;
+    }
+
+    public static QuickstartEntry CreateEntry(
+        string id = "http-py",
+        string displayName = "HTTP Trigger",
+        string language = "Python",
+        string? shortDescription = "A Python HTTP trigger",
+        string resource = "http",
+        string? iac = "bicep") =>
+        new(id, displayName, language, resource, iac,
+            "https://github.com/Azure-Samples/test-repo", ".", "refs/tags/v1.0.0",
+            shortDescription, null, null, 100);
+}

--- a/test/Func.Tests/Quickstart/HttpTemplateFetcherTests.cs
+++ b/test/Func.Tests/Quickstart/HttpTemplateFetcherTests.cs
@@ -1,0 +1,80 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Quickstart;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Quickstart;
+
+public class HttpTemplateFetcherTests
+{
+    [Theory]
+    [InlineData("https://github.com/Azure-Samples/functions-quickstart", "refs/tags/v1.0.0",
+        "https://github.com/Azure-Samples/functions-quickstart/archive/refs/tags/v1.0.0.zip")]
+    [InlineData("https://github.com/Azure-Samples/functions-quickstart/", "refs/tags/v2.0.0",
+        "https://github.com/Azure-Samples/functions-quickstart/archive/refs/tags/v2.0.0.zip")]
+    [InlineData("https://github.com/microsoft/my-repo", "refs/tags/release-1.0",
+        "https://github.com/microsoft/my-repo/archive/refs/tags/release-1.0.zip")]
+    public void BuildArchiveUrl_ValidEntry_ReturnsCorrectUrl(string repoUrl, string gitRef, string expected)
+    {
+        QuickstartEntry entry = CreateEntry(repositoryUrl: repoUrl, gitRef: gitRef);
+
+        string result = HttpTemplateFetcher.BuildArchiveUrl(entry);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void BuildArchiveUrl_TrailingSlashOnRepo_StripsSlashBeforeArchive()
+    {
+        QuickstartEntry entry = CreateEntry(repositoryUrl: "https://github.com/Azure-Samples/repo/");
+
+        string result = HttpTemplateFetcher.BuildArchiveUrl(entry);
+
+        Assert.DoesNotContain("//archive", result);
+        Assert.Contains("/archive/refs/tags/v1.0.0.zip", result);
+    }
+
+    [Fact]
+    public void BuildArchiveUrl_NonGitHubHost_ThrowsInvalidOperationException()
+    {
+        QuickstartEntry entry = CreateEntry(repositoryUrl: "https://gitlab.com/org/repo");
+
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+            () => HttpTemplateFetcher.BuildArchiveUrl(entry));
+        Assert.Contains("github.com", ex.Message);
+    }
+
+    [Fact]
+    public void BuildArchiveUrl_GitRefDoesNotGetDoubled()
+    {
+        QuickstartEntry entry = CreateEntry(gitRef: "refs/tags/v1.0.0");
+
+        string result = HttpTemplateFetcher.BuildArchiveUrl(entry);
+
+        // Must contain exactly one occurrence of "refs/tags/"
+        int firstIndex = result.IndexOf("refs/tags/", StringComparison.Ordinal);
+        int secondIndex = result.IndexOf("refs/tags/", firstIndex + 1, StringComparison.Ordinal);
+        Assert.True(firstIndex >= 0, "URL should contain refs/tags/");
+        Assert.True(secondIndex < 0, "URL should not contain refs/tags/ twice");
+    }
+
+    private static QuickstartEntry CreateEntry(
+        string repositoryUrl = "https://github.com/Azure-Samples/functions-quickstart",
+        string gitRef = "refs/tags/v1.0.0")
+    {
+        return new QuickstartEntry(
+            Id: "test-template",
+            DisplayName: "Test Template",
+            Language: "Python",
+            Resource: "http",
+            Iac: "bicep",
+            RepositoryUrl: repositoryUrl,
+            FolderPath: ".",
+            GitRef: gitRef,
+            ShortDescription: "A test template",
+            LongDescription: null,
+            WhatsIncluded: null,
+            Priority: 1);
+    }
+}

--- a/test/Func.Tests/Quickstart/QuickstartManifestServiceTests.cs
+++ b/test/Func.Tests/Quickstart/QuickstartManifestServiceTests.cs
@@ -22,7 +22,7 @@ public sealed class QuickstartManifestServiceTests
     [Fact]
     public async Task GetManifestAsync_FetchesFromCdn_WhenNoCacheExists()
     {
-        string manifest = CreateManifestJson("http-python", "Python", "http", "v1.0.0");
+        string manifest = CreateManifestJson("http-python", "Python", "http", "refs/tags/v1.0.0");
         IManifestCache cache = CreateCache(manifestJson: null, meta: null);
         QuickstartManifestService service = CreateService(
             new HttpResponseMessage(HttpStatusCode.OK)
@@ -43,7 +43,7 @@ public sealed class QuickstartManifestServiceTests
     [Fact]
     public async Task GetManifestAsync_UsesCachedManifest_WhenCacheIsFresh()
     {
-        string manifest = CreateManifestJson("cached-entry", "Python", "http", "v1.0.0");
+        string manifest = CreateManifestJson("cached-entry", "Python", "http", "refs/tags/v1.0.0");
         ManifestCacheMeta meta = new("\"etag1\"", DateTimeOffset.UtcNow);
         IManifestCache cache = CreateCache(manifestJson: manifest, meta: meta);
 
@@ -59,7 +59,7 @@ public sealed class QuickstartManifestServiceTests
     [Fact]
     public async Task GetManifestAsync_RefreshesCacheTimestamp_On304()
     {
-        string manifest = CreateManifestJson("existing-entry", "Python", "http", "v1.0.0");
+        string manifest = CreateManifestJson("existing-entry", "Python", "http", "refs/tags/v1.0.0");
         ManifestCacheMeta staleMeta = new("\"etag1\"", DateTimeOffset.UtcNow.AddHours(-25));
         IManifestCache cache = CreateCache(manifestJson: manifest, meta: staleMeta);
 
@@ -76,7 +76,7 @@ public sealed class QuickstartManifestServiceTests
     [Fact]
     public async Task GetManifestAsync_FallsBackToStaleCache_OnNetworkFailure()
     {
-        string manifest = CreateManifestJson("stale-entry", "Python", "http", "v1.0.0");
+        string manifest = CreateManifestJson("stale-entry", "Python", "http", "refs/tags/v1.0.0");
         ManifestCacheMeta staleMeta = new("\"etag1\"", DateTimeOffset.UtcNow.AddHours(-25));
         IManifestCache cache = CreateCache(manifestJson: manifest, meta: staleMeta);
 
@@ -105,7 +105,7 @@ public sealed class QuickstartManifestServiceTests
     {
         string manifest = CreateManifestJsonRaw(
         [
-            CreateEntryJson("has-ref", "Python", "http", "v1.0.0"),
+            CreateEntryJson("has-ref", "Python", "http", "refs/tags/v1.0.0"),
             CreateEntryJson("no-ref", "Python", "http", null),
         ]);
         IManifestCache cache = CreateCache(manifestJson: null, meta: null);
@@ -120,12 +120,31 @@ public sealed class QuickstartManifestServiceTests
     }
 
     [Fact]
-    public async Task GetManifestAsync_FiltersOutEntriesWithNonVPrefixedGitRef()
+    public async Task GetManifestAsync_FiltersOutEntriesWithShortTagGitRef()
     {
         string manifest = CreateManifestJsonRaw(
         [
-            CreateEntryJson("tagged", "Python", "http", "v1.0.0"),
-            CreateEntryJson("branch", "Python", "http", "main"),
+            CreateEntryJson("full-ref", "Python", "http", "refs/tags/v1.0.0"),
+            CreateEntryJson("short-tag", "Python", "http", "v1.0.0"),
+        ]);
+        IManifestCache cache = CreateCache(manifestJson: null, meta: null);
+
+        QuickstartManifestService service = CreateService(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(manifest) }, cache);
+
+        QuickstartManifest result = await service.GetManifestAsync();
+
+        Assert.Single(result.Entries);
+        Assert.Equal("full-ref", result.Entries[0].Id);
+    }
+
+    [Fact]
+    public async Task GetManifestAsync_FiltersOutEntriesWithBranchGitRef()
+    {
+        string manifest = CreateManifestJsonRaw(
+        [
+            CreateEntryJson("tagged", "Python", "http", "refs/tags/v1.0.0"),
+            CreateEntryJson("branch", "Python", "http", "refs/heads/main"),
         ]);
         IManifestCache cache = CreateCache(manifestJson: null, meta: null);
 
@@ -144,10 +163,10 @@ public sealed class QuickstartManifestServiceTests
         string json = """
             { "templates": [
                 { "id": "trusted", "displayName": "Trusted", "language": "Python", "resource": "http",
-                  "repositoryUrl": "https://github.com/Azure-Samples/test-repo", "folderPath": ".", "gitRef": "v1.0.0",
+                  "repositoryUrl": "https://github.com/Azure-Samples/test-repo", "folderPath": ".", "gitRef": "refs/tags/v1.0.0",
                   "priority": 100 },
                 { "id": "untrusted", "displayName": "Untrusted", "language": "Python", "resource": "http",
-                  "repositoryUrl": "https://github.com/random-user/test-repo", "folderPath": ".", "gitRef": "v1.0.0",
+                  "repositoryUrl": "https://github.com/random-user/test-repo", "folderPath": ".", "gitRef": "refs/tags/v1.0.0",
                   "priority": 100 }
             ]}
             """;
@@ -167,9 +186,9 @@ public sealed class QuickstartManifestServiceTests
     {
         string manifest = CreateManifestJsonRaw(
         [
-            CreateEntryJson("python-entry", "Python", "http", "v1.0.0"),
-            CreateEntryJson("bicep-entry", "Bicep", "http", "v1.0.0"),
-            CreateEntryJson("terraform-entry", "Terraform", "http", "v1.0.0"),
+            CreateEntryJson("python-entry", "Python", "http", "refs/tags/v1.0.0"),
+            CreateEntryJson("bicep-entry", "Bicep", "http", "refs/tags/v1.0.0"),
+            CreateEntryJson("terraform-entry", "Terraform", "http", "refs/tags/v1.0.0"),
         ]);
         IManifestCache cache = CreateCache(manifestJson: null, meta: null);
 
@@ -185,7 +204,7 @@ public sealed class QuickstartManifestServiceTests
     public async Task GetManifestAsync_FallsBackToCache_WhenResponseIsMalformed()
     {
         string json = """[ { "id": "bare-entry" } ]""";
-        string cachedManifest = CreateManifestJson("cached", "Python", "http", "v1.0.0");
+        string cachedManifest = CreateManifestJson("cached", "Python", "http", "refs/tags/v1.0.0");
         ManifestCacheMeta meta = new("\"etag1\"", DateTimeOffset.UtcNow.AddHours(-25));
         IManifestCache cache = CreateCache(manifestJson: cachedManifest, meta: meta);
 
@@ -201,7 +220,7 @@ public sealed class QuickstartManifestServiceTests
     [Fact]
     public async Task GetManifestAsync_LoadsFromLocalFile_WhenOverrideIsFilePath()
     {
-        string manifest = CreateManifestJson("local-entry", "Python", "http", "v1.0.0");
+        string manifest = CreateManifestJson("local-entry", "Python", "http", "refs/tags/v1.0.0");
         string tempFile = Path.Combine(Path.GetTempPath(), $"test-manifest-{Guid.NewGuid()}.json");
         try
         {
@@ -265,7 +284,7 @@ public sealed class QuickstartManifestServiceTests
     [InlineData("//server/share/manifest.json")]
     public async Task GetManifestAsync_DoesNotTreatUncPathAsLocalFile(string uncPath)
     {
-        string manifest = CreateManifestJson("cdn-entry", "Python", "http", "v1.0.0");
+        string manifest = CreateManifestJson("cdn-entry", "Python", "http", "refs/tags/v1.0.0");
         IManifestCache cache = CreateCache(manifestJson: null, meta: null);
 
         _options.ManifestUrl = uncPath;
@@ -350,3 +369,4 @@ public sealed class QuickstartManifestServiceTests
         }
     }
 }
+

--- a/test/Func.Tests/Quickstart/QuickstartManifestTests.cs
+++ b/test/Func.Tests/Quickstart/QuickstartManifestTests.cs
@@ -18,7 +18,7 @@ public sealed class QuickstartManifestTests
         string? longDescription = null,
         int priority = 100) =>
         new(id, displayName, language, resource, iac,
-            "https://github.com/Azure-Samples/test-repo", ".", "v1.0.0",
+            "https://github.com/Azure-Samples/test-repo", ".", "refs/tags/v1.0.0",
             shortDescription, longDescription, null, priority);
 
     [Fact]
@@ -174,3 +174,4 @@ public sealed class QuickstartManifestTests
         Assert.Empty(results);
     }
 }
+

--- a/test/Func.Tests/Quickstart/QuickstartScaffolderTests.cs
+++ b/test/Func.Tests/Quickstart/QuickstartScaffolderTests.cs
@@ -90,28 +90,23 @@ public class QuickstartScaffolderTests : IDisposable
     }
 
     [Fact]
-    public async Task ScaffoldAsync_BranchRef_ThrowsInvalidOperationException()
+    public async Task ScaffoldAsync_BranchRef_ThrowsArgumentException()
     {
-        // fetch with refs/tags/ refspec fails when the ref is a branch (no matching tag)
-        var branchRunner = new FakeGitRunner(onRun: (args, _) =>
-        {
-            if (args.Contains("fetch"))
-            {
-                throw new GitRunnerException(128, "", "fatal: couldn't find remote ref", "fetch");
-            }
-        });
-        ITemplateFetcher gitFetcher = new GitTemplateFetcher(branchRunner, NullLogger<GitTemplateFetcher>.Instance);
-        IFetchModeResolver resolver = new FetchModeResolver(branchRunner);
-        var scaffolder = new QuickstartScaffolder(
-            [gitFetcher],
-            resolver,
-            NullLogger<QuickstartScaffolder>.Instance);
-        QuickstartEntry entry = CreateEntry(gitRef: "main");
+        QuickstartEntry entry = CreateEntry(gitRef: "refs/heads/main");
 
-        InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None));
-        Assert.Contains("not a tag", ex.Message);
-        Assert.Contains("Branch refs", ex.Message);
+        ArgumentException ex = await Assert.ThrowsAsync<ArgumentException>(
+            () => _scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None));
+        Assert.Contains("not a tag ref", ex.Message);
+    }
+
+    [Fact]
+    public async Task ScaffoldAsync_BareTagName_ThrowsArgumentException()
+    {
+        QuickstartEntry entry = CreateEntry(gitRef: "v1.0.0");
+
+        ArgumentException ex = await Assert.ThrowsAsync<ArgumentException>(
+            () => _scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None));
+        Assert.Contains("not a tag ref", ex.Message);
     }
 
     [Fact]
@@ -131,17 +126,6 @@ public class QuickstartScaffolderTests : IDisposable
 
         ArgumentException ex = await Assert.ThrowsAsync<ArgumentException>(
             () => _scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None));
-        Assert.Contains("no GitRef", ex.Message);
-    }
-
-    [Fact]
-    public async Task GitTemplateFetcher_NullGitRef_ThrowsArgumentException()
-    {
-        var fetcher = new GitTemplateFetcher(_gitRunner, NullLogger<GitTemplateFetcher>.Instance);
-        QuickstartEntry entry = CreateEntry(gitRef: null);
-
-        ArgumentException ex = await Assert.ThrowsAsync<ArgumentException>(
-            () => fetcher.FetchAsync(entry, _targetDir, CancellationToken.None));
         Assert.Contains("no GitRef", ex.Message);
     }
 
@@ -439,7 +423,7 @@ public class QuickstartScaffolderTests : IDisposable
     }
 
     private static QuickstartEntry CreateEntry(
-        string? gitRef = "v1.0.0",
+        string? gitRef = "refs/tags/v1.0.0",
         string folderPath = ".",
         string repositoryUrl = "https://github.com/Azure-Samples/functions-quickstart")
     {
@@ -458,3 +442,4 @@ public class QuickstartScaffolderTests : IDisposable
             Priority: 1);
     }
 }
+

--- a/test/Func.Tests/TestParser.cs
+++ b/test/Func.Tests/TestParser.cs
@@ -7,6 +7,7 @@ using Azure.Functions.Cli.Commands.Start.Initialization;
 using Azure.Functions.Cli.Configuration;
 using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Hosting;
+using Azure.Functions.Cli.Quickstart;
 using Azure.Functions.Cli.Workloads;
 using Azure.Functions.Cli.Workloads.Loading;
 using Azure.Functions.Cli.Workloads.Storage;
@@ -99,6 +100,11 @@ internal static class TestParser
         // resolve without standing up the real install/uninstall side effects.
         services.AddSingleton(Substitute.For<Cli.Workloads.Install.IWorkloadInstaller>());
         services.AddSingleton(Substitute.For<Cli.Workloads.Catalog.IWorkloadCatalog>());
+
+        // Quickstart: stub manifest service, scaffolder, and resolver so the command resolves.
+        services.AddSingleton(Substitute.For<IQuickstartManifestService>());
+        services.AddSingleton(Substitute.For<IQuickstartScaffolder>());
+        services.AddSingleton(Substitute.For<IQuickstartProviderResolver>());
 
         return services;
     }


### PR DESCRIPTION
### Issue describing the changes in this PR

Wrap up of `func quickstart` implementation (#5026, #5111).

This PR adds the command handler, provider resolver, quickstart providers (DotNet, Node, Python), `list`/`info` subcommands, and centralised constants/messages.

### Pull request checklist

* [x] My changes **do not** require documentation changes
* [x] My changes **do not** need to be backported to a previous version
* [x] My changes **should not** be added to the release notes for the next release
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

**What's in this PR:**
- `QuickstartCommand.ExecuteAsync` — full handler flow (stack/provider resolution → manifest fetch → template selection → scaffold → next-steps output)
- `IQuickstartProviderResolver` / `QuickstartProviderResolver` — resolves stack name to provider via DI
- `DotNetQuickstartProvider`, `NodeQuickstartProvider`, `PythonQuickstartProvider` — language mapping, display names, manifest language sets
- `QuickstartListCommand` / `QuickstartInfoCommand` — list available templates (with `--json`) and show template details
- `QuickstartMessages` — centralised user-facing strings for all quickstart commands
- `QuickstartConstants.TagRefPrefix` — shared `refs/tags/` constant (used by ManifestService and Scaffolder)
- `EnableSearch()` on all interactive selection prompts — type-to-jump in template/stack pickers
- `HttpTemplateFetcherTests`, `QuickstartListCommandTests`, `QuickstartInfoCommandTests`, updated `QuickstartCommandTests`
- 93 quickstart tests passing