### PR TITLE
Updating Python workload to only include v2 templates

### DIFF
--- a/eng/build/Workloads.Templates.targets
+++ b/eng/build/Workloads.Templates.targets
@@ -4,10 +4,10 @@
     Templates workload pack-time pipeline (Node + Python).
     Downloads StaticContent files from the extension-bundle CDN for the
     channel selected by $(TemplatesChannel), filters
-    v1/templates/templates.json by $(TemplatesStackLanguageFilter),
-    generates the templates-workload.json sibling manifest from
-    $(MinBundleVersionRange), and packs the result under
-    tools/any/content/ of the workload nupkg.
+    v1/templates/templates.json and/or v2/templates/templates.json by
+    $(TemplatesStackLanguageFilter), generates the templates-workload.json
+    sibling manifest from $(MinBundleVersionRange), and packs the
+    result under tools/any/content/ of the workload nupkg.
     Skip with -p:SkipDownloadTemplates=true (dev / offline only — produces
     an empty pack with no templates payload).
 
@@ -17,13 +17,23 @@
                                        time. Build-provenance only; does
                                        not derive the workload pkg version
                                        (Templates Workload Spec §4.4.1).
-      $(TemplatesStackLanguageFilter)  Comma/semicolon allow-list of v1
-                                       metadata.language values
-                                       (e.g. JavaScript;TypeScript for
-                                       Node, Python for Python). Required.
+      $(TemplatesStackLanguageFilter)  Comma/semicolon allow-list of
+                                       language values, matched
+                                       case-insensitively. Applied to v1
+                                       `metadata.language` and v2
+                                       top-level `language`. Required when
+                                       any of $(IncludeV1Templates) or
+                                       $(IncludeV2Templates) is true.
+      $(IncludeV1Templates)            true | false. Defaults true. Set
+                                       false for stacks that ship v2-only
+                                       (e.g. Python after the v2-only
+                                       cutover — Templates Workload Spec
+                                       §5.2 / §6.2).
       $(IncludeV2Templates)            true | false. Defaults true. Set
-                                       false for stacks with no v2
-                                       programming model (e.g. Node).
+                                       false for stacks whose v2 content
+                                       is not yet available (e.g. Node,
+                                       until its v2 source pipeline lands
+                                       — Templates Workload Spec §6.1).
       $(MinBundleVersionRange)         NuGet range the workload declares
                                        compatibility with. Drives the
                                        generated templates-workload.json,
@@ -49,6 +59,7 @@
     <_TplCdnId Condition="'$(TemplatesChannel)' == 'preview'">Microsoft.Azure.Functions.ExtensionBundle.Preview</_TplCdnId>
     <_TplCdnId Condition="'$(TemplatesChannel)' == 'experimental'">Microsoft.Azure.Functions.ExtensionBundle.Experimental</_TplCdnId>
 
+    <IncludeV1Templates Condition="'$(IncludeV1Templates)' == ''">true</IncludeV1Templates>
     <IncludeV2Templates Condition="'$(IncludeV2Templates)' == ''">true</IncludeV2Templates>
 
     <_TplBaseUrl>https://cdn.functions.azure.com/public/ExtensionBundles/$(_TplCdnId)/$(SourceBundleVersion)/StaticContent</_TplBaseUrl>
@@ -73,17 +84,23 @@
            Text="TemplatesChannel '$(TemplatesChannel)' is not one of stable|preview|experimental." />
     <Error Condition="'$(SourceBundleVersion)' == ''"
            Text="SourceBundleVersion must be set (the bundle version whose StaticContent the workload snapshots)." />
+    <Error Condition="'$(IncludeV1Templates)' != 'true' and '$(IncludeV2Templates)' != 'true'"
+           Text="At least one of IncludeV1Templates or IncludeV2Templates must be true; the templates workload would otherwise ship an empty payload." />
 
-    <DownloadFile SourceUrl="$(_TplBaseUrl)/v1/templates/templates.json"
+    <DownloadFile Condition="'$(IncludeV1Templates)' == 'true'"
+                  SourceUrl="$(_TplBaseUrl)/v1/templates/templates.json"
                   DestinationFolder="$(IntermediateOutputPath)templates\v1\templates\"
                   SkipUnchangedFiles="true" Retries="3" />
-    <DownloadFile SourceUrl="$(_TplBaseUrl)/v1/bindings/bindings.json"
+    <DownloadFile Condition="'$(IncludeV1Templates)' == 'true'"
+                  SourceUrl="$(_TplBaseUrl)/v1/bindings/bindings.json"
                   DestinationFolder="$(IntermediateOutputPath)templates\v1\bindings\"
                   SkipUnchangedFiles="true" Retries="3" />
-    <DownloadFile SourceUrl="$(_TplBaseUrl)/v1/resources/Resources.json"
+    <DownloadFile Condition="'$(IncludeV1Templates)' == 'true'"
+                  SourceUrl="$(_TplBaseUrl)/v1/resources/Resources.json"
                   DestinationFolder="$(IntermediateOutputPath)templates\v1\resources\"
                   SkipUnchangedFiles="true" Retries="3" />
-    <DownloadFile SourceUrl="$(_TplBaseUrl)/v1/resources/Resources.%(_TplLocale.Identity).json"
+    <DownloadFile Condition="'$(IncludeV1Templates)' == 'true'"
+                  SourceUrl="$(_TplBaseUrl)/v1/resources/Resources.%(_TplLocale.Identity).json"
                   DestinationFolder="$(IntermediateOutputPath)templates\v1\resources\"
                   SkipUnchangedFiles="true" Retries="3"
                   ContinueOnError="true" />
@@ -111,16 +128,30 @@
 
   <Target Name="FilterTemplatesByLanguage"
           DependsOnTargets="DownloadTemplatesContent"
-          Condition="'$(SkipDownloadTemplates)' != 'true'"
+          Condition="'$(SkipDownloadTemplates)' != 'true' and '$(IncludeV1Templates)' == 'true'"
           BeforeTargets="_GetPackageFiles"
           Inputs="$(IntermediateOutputPath)templates\.downloaded"
-          Outputs="$(IntermediateOutputPath)templates\.filtered">
+          Outputs="$(IntermediateOutputPath)templates\.filtered.v1">
     <Error Condition="'$(TemplatesStackLanguageFilter)' == ''"
            Text="TemplatesStackLanguageFilter must be set (e.g. 'JavaScript;TypeScript' for Node, 'Python' for Python)." />
 
-    <Exec Command="pwsh -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)..\scripts\filter-templates.ps1&quot; -Path &quot;$(IntermediateOutputPath)templates\v1\templates\templates.json&quot; -Languages &quot;$(TemplatesStackLanguageFilter)&quot;" />
+    <Exec Command="pwsh -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)..\scripts\filter-templates.ps1&quot; -Path &quot;$(IntermediateOutputPath)templates\v1\templates\templates.json&quot; -Languages &quot;$(TemplatesStackLanguageFilter)&quot; -Mode v1" />
 
-    <Touch Files="$(IntermediateOutputPath)templates\.filtered" AlwaysCreate="true" />
+    <Touch Files="$(IntermediateOutputPath)templates\.filtered.v1" AlwaysCreate="true" />
+  </Target>
+
+  <Target Name="FilterTemplatesByLanguageV2"
+          DependsOnTargets="DownloadTemplatesContent"
+          Condition="'$(SkipDownloadTemplates)' != 'true' and '$(IncludeV2Templates)' == 'true'"
+          BeforeTargets="_GetPackageFiles"
+          Inputs="$(IntermediateOutputPath)templates\.downloaded"
+          Outputs="$(IntermediateOutputPath)templates\.filtered.v2">
+    <Error Condition="'$(TemplatesStackLanguageFilter)' == ''"
+           Text="TemplatesStackLanguageFilter must be set (e.g. 'JavaScript;TypeScript' for Node, 'Python' for Python)." />
+
+    <Exec Command="pwsh -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)..\scripts\filter-templates.ps1&quot; -Path &quot;$(IntermediateOutputPath)templates\v2\templates\templates.json&quot; -Languages &quot;$(TemplatesStackLanguageFilter)&quot; -Mode v2" />
+
+    <Touch Files="$(IntermediateOutputPath)templates\.filtered.v2" AlwaysCreate="true" />
   </Target>
 
   <Target Name="GenerateTemplatesWorkloadJson"
@@ -146,11 +177,12 @@
   </Target>
 
   <Target Name="_AddTemplatesToPack"
-          DependsOnTargets="FilterTemplatesByLanguage;GenerateTemplatesWorkloadJson"
+          DependsOnTargets="FilterTemplatesByLanguage;FilterTemplatesByLanguageV2;GenerateTemplatesWorkloadJson"
           Condition="'$(SkipDownloadTemplates)' != 'true'"
           BeforeTargets="_GetPackageFiles">
     <ItemGroup>
-      <None Include="$(IntermediateOutputPath)templates\v1\**\*.json"
+      <None Condition="'$(IncludeV1Templates)' == 'true'"
+            Include="$(IntermediateOutputPath)templates\v1\**\*.json"
             Pack="true" PackagePath="tools/any/content/v1/" Visible="false" />
       <None Condition="'$(IncludeV2Templates)' == 'true'"
             Include="$(IntermediateOutputPath)templates\v2\**\*.json"

--- a/eng/scripts/filter-templates.ps1
+++ b/eng/scripts/filter-templates.ps1
@@ -1,25 +1,40 @@
 #!/usr/bin/env pwsh
 <#
 .SYNOPSIS
-    Filters a v1 StaticContent templates.json file in place by metadata.language.
+    Filters a StaticContent templates.json file in place by language.
 
 .DESCRIPTION
     Reads the templates.json file at -Path (expected to be a JSON array of
-    Template objects from a Functions extension bundle's StaticContent/v1
-    subtree), keeps only entries whose metadata.language matches one of the
-    values in -Languages, and writes the filtered array back to -Path.
+    template objects from a Functions extension bundle's StaticContent
+    subtree), keeps only entries whose language matches one of the values
+    in -Languages, and writes the filtered array back to -Path.
 
-    Used at templates-workload pack time to drop Template entries that don't
-    belong to the current per-stack workload. See
+    -Mode v1 (default) reads `metadata.language` on each entry (v1 schema:
+    `Template[]`).
+    -Mode v2 reads top-level `language` on each entry (v2 schema:
+    `NewTemplate[]`).
+
+    Matching is case-insensitive (PowerShell `-contains` semantics) so the
+    same allow-list — e.g. `Python` or `JavaScript;TypeScript` — applies
+    cleanly to both v1 (`metadata.language: "Python"`) and v2
+    (`language: "python"`).
+
+    Used at templates-workload pack time to drop entries that don't belong
+    to the current per-stack workload. See
     proposed/templates-workload-spec.md §6.1 / §6.2.
 
 .PARAMETER Path
     Path to the templates.json file to filter in place.
 
 .PARAMETER Languages
-    Comma- or semicolon-separated allow-list of metadata.language values
+    Comma- or semicolon-separated allow-list of language values
     (e.g. "JavaScript,TypeScript" for Node; "Python" for Python).
-    Matching is case-sensitive to align with the bundle's canonical values.
+    Matching is case-insensitive.
+
+.PARAMETER Mode
+    Programming-model schema selector. `v1` reads `metadata.language`
+    (legacy `Template[]`). `v2` reads top-level `language`
+    (`NewTemplate[]`). Defaults to `v1` for backwards compatibility.
 #>
 [CmdletBinding()]
 param(
@@ -27,7 +42,11 @@ param(
     [string]$Path,
 
     [Parameter(Mandatory=$true)]
-    [string]$Languages
+    [string]$Languages,
+
+    [Parameter(Mandatory=$false)]
+    [ValidateSet('v1','v2')]
+    [string]$Mode = 'v1'
 )
 
 $ErrorActionPreference = 'Stop'
@@ -52,7 +71,10 @@ if ($all -isnot [System.Collections.IEnumerable] -or $all -is [string]) {
 }
 
 $beforeCount = @($all).Count
-$kept = @($all | Where-Object { $allow -contains $_.metadata.language })
+$kept = switch ($Mode) {
+    'v1' { @($all | Where-Object { $allow -contains $_.metadata.language }) }
+    'v2' { @($all | Where-Object { $allow -contains $_.language }) }
+}
 $afterCount = $kept.Count
 
 # ConvertTo-Json drops the array wrapper for 0- and 1-element collections.
@@ -70,4 +92,4 @@ else {
 $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
 [System.IO.File]::WriteAllText($Path, $json + "`n", $utf8NoBom)
 
-Write-Host "filter-templates: $Path  kept $afterCount of $beforeCount entries (languages: $($allow -join ', '))."
+Write-Host "filter-templates ($Mode): $Path  kept $afterCount of $beforeCount entries (languages: $($allow -join ', '))."

--- a/src/Workloads/Templates/Node/workload.json
+++ b/src/Workloads/Templates/Node/workload.json
@@ -2,5 +2,5 @@
   "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
   "kind": "content",
   "displayName": "Node.js function templates",
-  "description": "Function-scaffold templates for Node.js Azure Functions projects. Compatible with Microsoft.Azure.Functions.ExtensionBundle (see templates-workload.json for the exact min-bundle range)."
+  "description": "Function-scaffold templates for Node.js Azure Functions projects."
 }

--- a/src/Workloads/Templates/Python/README.md
+++ b/src/Workloads/Templates/Python/README.md
@@ -1,12 +1,17 @@
 # Azure Functions CLI: Python templates workload
 
 This package ships function-scaffold templates for Python Azure
-Functions projects (v1 and v2 programming models), consumed by the
+Functions projects (**v2 programming model only**), consumed by the
 `func` CLI's `func new` command. It is a **content workload**
 (Workload Spec §3; Templates Workload Spec §4.1): the package carries
 template files only, with no entry-point assembly and no runtime
 services. `func new` resolves the install directory by package id and
 reads the template payload directly.
+
+> **v1 (legacy) programming model templates are not shipped** in the
+> v5 Python templates workload (Templates Workload Spec §5.2 / §6.2
+> / §7.1). Users still authoring against the v1 programming model
+> should migrate to v2 or stay on v4 tooling.
 
 The workload pkg version is independent of the source bundle version
 (Templates Workload Spec §4.4.1). The channel a workload was built
@@ -71,27 +76,21 @@ dotnet pack ... /p:TemplatesChannel=experimental
 ```
 
 `$(SourceBundleVersion)` selects the bundle version whose
-`StaticContent/v1` and `StaticContent/v2` subtrees are snapshotted at
-build time. It is recorded as build provenance only; it does not
-derive the templates pkg version (Templates Workload Spec §4.4.1).
+`StaticContent/v2` subtree is snapshotted at build time. It is
+recorded as build provenance only; it does not derive the templates
+pkg version (Templates Workload Spec §4.4.1).
 
 ## Layout
 
 The package places the template payload under `tools/any/content/`,
-matching the upstream extension bundle's `StaticContent/v1/` and
-`StaticContent/v2/` subtrees with the `StaticContent/` wrapper
-stripped (Templates Workload Spec §5.2). Python ships both
-programming-model subtrees:
+matching the upstream extension bundle's `StaticContent/v2/` subtree
+with the `StaticContent/` wrapper stripped (Templates Workload Spec
+§5.2). Python ships only the v2 programming-model subtree:
 
 ```
 <workload-home>/workloads/azure.functions.cli.workloads.templates.python/<version>/
   tools/any/content/
     templates-workload.json      ← min-bundle sibling manifest
-    v1/                          ← legacy programming model
-      bindings/bindings.json
-      resources/Resources.json
-      resources/Resources.<locale>.json
-      templates/templates.json   ← Template[] with files inline
     v2/                          ← v2 programming model
       bindings/userPrompts.json
       resources/Resources.json
@@ -100,13 +99,12 @@ programming-model subtrees:
   workload.json
 ```
 
-Template files are carried **inline** inside each `Template` /
-`NewTemplate` entry's `files: { <filename>: <contents> }` map; there
-are no separate per-template file directories on disk (Templates
-Workload Spec §5.2). v1 templates may reference prompt ids defined in
-`v2/bindings/userPrompts.json` — the prompt catalog is unified across
-model versions. `tools/any/` is the canonical content-workload payload
-path.
+Template files are carried **inline** inside each `NewTemplate`
+entry's `files: { <filename>: <contents> }` map; there are no separate
+per-template file directories on disk (Templates Workload Spec §5.2).
+v2 templates reference prompt ids defined in `v2/bindings/userPrompts.json`
+via `paramId` references inside `jobs[].inputs[]`. `tools/any/` is the
+canonical content-workload payload path.
 
 ## Links
 

--- a/src/Workloads/Templates/Python/Workloads.Templates.Python.csproj
+++ b/src/Workloads/Templates/Python/Workloads.Templates.Python.csproj
@@ -13,6 +13,7 @@
     <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>
 
     <TemplatesStackLanguageFilter>Python</TemplatesStackLanguageFilter>
+    <IncludeV1Templates>false</IncludeV1Templates>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Workloads/Templates/Python/release_notes.md
+++ b/src/Workloads/Templates/Python/release_notes.md
@@ -2,4 +2,4 @@
 
 ## 1.0.0
 
-- Initial scaffold of the Python templates workload (v1 + v2 programming models).
+- Initial scaffold of the Python templates workload (v2 programming model only). v1 (legacy) programming-model templates are not shipped — users on v1 should migrate to v2 (see Templates Workload Spec §7.1).

--- a/src/Workloads/Templates/Python/workload.json
+++ b/src/Workloads/Templates/Python/workload.json
@@ -2,5 +2,5 @@
   "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
   "kind": "content",
   "displayName": "Python function templates",
-  "description": "Function-scaffold templates for Python Azure Functions projects (v1 and v2 programming models). Compatible with Microsoft.Azure.Functions.ExtensionBundle (see templates-workload.json for the exact min-bundle range)."
+  "description": "Function-scaffold templates for Python Azure Functions projects (v2 programming model)."
 }


### PR DESCRIPTION
## Summary

Switches the Python templates workload to **v2-only** and adds the build-infra plumbing required to support per-stack v2 selection.

In the upstream extension bundle, v2 currently ships **Python-only** template content (`StaticContent/v2/templates/templates.json` has no JavaScript / TypeScript entries today). The Python templates workload therefore drops v1 (legacy programming model) entirely; v1 users either migrate to v2 or stay on v4 tooling. The Node templates workload is left untouched in this PR — its v2 source is a follow-up task tracked separately because the bundle does not yet publish v2 Node templates.

Companion docs PR (separate worktree, against `docs` branch) updates [`docs/proposed/templates-workload-spec.md`](https://github.com/Azure/azure-functions-core-tools/blob/docs/proposed/templates-workload-spec.md) §3, §4.3 table, §4.4.2, §5.1, §5.2, §5.4, §6.1, §6.2, §7.1, §8 to reflect the v2-only direction. Spec PR is opened separately.

## Changes

### Shared build infra
- **`eng/build/Workloads.Templates.targets`** — adds `$(IncludeV1Templates)` (default `true`, symmetric with the existing `$(IncludeV2Templates)`). Both v1 and v2 CDN downloads, filter targets, and pack `<None>` items are now independently gated. Adds a new `FilterTemplatesByLanguageV2` target that filters `v2/templates/templates.json` per the active language allow-list. An `<Error>` fires if both include flags are false (would otherwise produce an empty payload).
- **`eng/scripts/filter-templates.ps1`** — adds `-Mode v1|v2` parameter. v1 reads `metadata.language`; v2 reads top-level `language`. Matching is now case-insensitive (PowerShell `-contains`), so the existing `Python` allow-list cleanly matches v2's lowercase `python` value.

### Python templates workload (now v2-only)
- **`src/Workloads/Templates/Python/Workloads.Templates.Python.csproj`** — `<IncludeV1Templates>false</IncludeV1Templates>`.
- **`src/Workloads/Templates/Python/workload.json`** — description trimmed to `"Function-scaffold templates for Python Azure Functions projects (v2 programming model)."` (bundle-compatibility sentence dropped; min-bundle stays authoritative in `content/templates-workload.json`).
- **`src/Workloads/Templates/Python/README.md`** — rewrote layout section to show only `v2/`; added migration callout for v1 users.
- **`src/Workloads/Templates/Python/release_notes.md`** — 1.0.0 entry now reads "Initial scaffold of the Python templates workload (v2 programming model only)."

### Node templates workload
- **`src/Workloads/Templates/Node/workload.json`** — description trimmed to drop the same bundle-compatibility sentence for consistency. Pipeline behavior unchanged: still ships v1 (`IncludeV2Templates=false` was already in place). The v2 cutover for Node is a separate follow-up.

## Verification

Local emulation of `eng/ci/public-build.yml` (with `CI=true`, which sets `TreatWarningsAsErrors=true` per `eng/build/Engineering.props`):

| Step | Command | Result |
|------|---------|--------|
| Restore | `dotnet restore Azure.Functions.Cli.slnx` | clean |
| Build | `dotnet build Azure.Functions.Cli.slnx -c release --no-restore` | **0 warnings, 0 errors** |
| Test | `dotnet test Azure.Functions.Cli.slnx -c release --no-build` | **834 of 835 passed** |
| Pack | `dotnet pack Azure.Functions.Cli.slnx -c release --no-build -o <out>` | 13 nupkgs |

Single test failure is `AzuriteExecutableLocatorTests.FindAsync_Unix_PathLookup_OnlyTriesBareName` — confirmed **pre-existing and unrelated** (lives in `func start`'s Azurite subsystem, untouched by this PR; same failure reproduces on clean HEAD by `git stash`-ing this PR's diff).

Python nupkg payload contents inspected post-pack:

```
workload.json
tools/any/content/templates-workload.json
tools/any/content/v2/bindings/userPrompts.json
tools/any/content/v2/resources/Resources.json
tools/any/content/v2/resources/Resources.<locale>.json     (18 locales)
tools/any/content/v2/templates/templates.json              (18 of 18 Python entries kept)
```

**No `v1/` directory in the Python nupkg.** Filter target log: `filter-templates (v2): … kept 18 of 18 entries (languages: Python).`

Node templates workload pack continues to produce the same v1-only payload as before this PR (no regression: `kept 56 of 150 entries (languages: JavaScript, TypeScript)`).

## Out of scope (follow-ups)

- **Node v2 source pipeline.** The upstream extension bundle does not yet publish v2 templates for Node. How v2 Node templates are authored and delivered (added to the bundle upstream, sourced from a sibling repo, or generated in-tree) is tracked as a separate task; once the source is decided, flipping the Node workload is a one-line csproj change (`<IncludeV1Templates>false</IncludeV1Templates>` + `<IncludeV2Templates>true</IncludeV2Templates>`).
- Spec update (`docs/proposed/templates-workload-spec.md`) ships as a separate PR against the `docs` branch.
