### PR TITLE
Drop redundant alias:templates-<stack> tag from Node and Python templates workloads

### DIFF
--- a/src/Workloads/Templates/Node/README.md
+++ b/src/Workloads/Templates/Node/README.md
@@ -46,15 +46,15 @@ recorded in three locations that all derive from the single
 ```bash
 func workload install Azure.Functions.Cli.Workloads.Templates.Node@1.0.0
 # or by alias
-func workload install templates-node@1.0.0
+func workload install node-templates@1.0.0
 ```
 
 Preview / experimental channels resolve via the matching prerelease
 label:
 
 ```bash
-func workload install templates-node@1.0.0-preview
-func workload install templates-node@1.0.0-experimental
+func workload install node-templates@1.0.0-preview
+func workload install node-templates@1.0.0-experimental
 ```
 
 Multiple templates versions coexist via `--force` (Workload Spec §4.6).

--- a/src/Workloads/Templates/Node/Workloads.Templates.Node.csproj
+++ b/src/Workloads/Templates/Node/Workloads.Templates.Node.csproj
@@ -5,7 +5,7 @@
     <Title>Azure Functions Node.js Templates</Title>
     <Description>Node.js function templates for the func CLI. Compatible with Microsoft.Azure.Functions.ExtensionBundle (minBundle:$(MinBundleVersionRange)).</Description>
     <PackageType>FuncCliWorkload</PackageType>
-    <PackageTags>kind:content alias:templates-node alias:node-templates func-workload minBundle:$(MinBundleVersionRange)</PackageTags>
+    <PackageTags>kind:content alias:node-templates func-workload minBundle:$(MinBundleVersionRange)</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/src/Workloads/Templates/Python/README.md
+++ b/src/Workloads/Templates/Python/README.md
@@ -52,15 +52,15 @@ recorded in three locations that all derive from the single
 ```bash
 func workload install Azure.Functions.Cli.Workloads.Templates.Python@1.0.0
 # or by alias
-func workload install templates-python@1.0.0
+func workload install python-templates@1.0.0
 ```
 
 Preview / experimental channels resolve via the matching prerelease
 label:
 
 ```bash
-func workload install templates-python@1.0.0-preview
-func workload install templates-python@1.0.0-experimental
+func workload install python-templates@1.0.0-preview
+func workload install python-templates@1.0.0-experimental
 ```
 
 Multiple templates versions coexist via `--force` (Workload Spec §4.6).

--- a/src/Workloads/Templates/Python/Workloads.Templates.Python.csproj
+++ b/src/Workloads/Templates/Python/Workloads.Templates.Python.csproj
@@ -5,7 +5,7 @@
     <Title>Azure Functions Python Templates</Title>
     <Description>Python function templates for the func CLI. Compatible with Microsoft.Azure.Functions.ExtensionBundle (minBundle:$(MinBundleVersionRange)).</Description>
     <PackageType>FuncCliWorkload</PackageType>
-    <PackageTags>kind:content alias:templates-python alias:python-templates func-workload minBundle:$(MinBundleVersionRange)</PackageTags>
+    <PackageTags>kind:content alias:python-templates func-workload minBundle:$(MinBundleVersionRange)</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>


### PR DESCRIPTION
## Summary

Addresses PR #5141 reviewer feedback: drop the redundant `alias:templates-<stack>` tag from the Node and Python templates workloads. Keeps only `alias:<stack>-templates`, matching the convention the DotNet templates workload already uses (`alias:dotnet-templates`).

> "same feedback here about alias keep only alias:node-templates (same for python)"

## Changes (4 files, +8 / −8)

- **`src/Workloads/Templates/Node/Workloads.Templates.Node.csproj`** — `PackageTags`: `kind:content alias:templates-node alias:node-templates …` → `kind:content alias:node-templates …`.
- **`src/Workloads/Templates/Python/Workloads.Templates.Python.csproj`** — same shape; keeps only `alias:python-templates`.
- **`src/Workloads/Templates/Node/README.md`** — install hint examples now use `node-templates@…`.
- **`src/Workloads/Templates/Python/README.md`** — install hint examples now use `python-templates@…`.

## Verification

Repacked both workloads against the rebased branch tip and inspected the produced nuspec `<tags>` directly:

```
Python  <tags>kind:content alias:python-templates func-workload minBundle:[4.0.0,)</tags>
Node    <tags>kind:content alias:node-templates   func-workload minBundle:[4.0.0,)</tags>
```

DotNet templates workload was already on this convention (`alias:dotnet-templates`); no change needed.

## Out of scope

The companion spec update (`docs/proposed/templates-workload-spec.md` §5.1 `Tags` line, dropping `alias:templates-<stack>`) lives in the separate `docs` worktree and will ship as a follow-up against the `docs` branch.
