### PR TITLE
Add hidden func pack and func publish v4-redirect stubs

### DIFF
--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -27,7 +27,7 @@ Program.cs
   ├── Parser.CreateCommand(host.Services)
   │   ├── Build root command
   │   ├── Resolve every FuncCliCommand from DI:
-  │   │     ├── Built-in commands (IBuiltInCommand): init, new, start, version, help, profile, workload
+  │   │     ├── Built-in commands (IBuiltInCommand): init, new, start, pack, publish, version, help, profile, workload
   │   │     └── ExternalCommand wrappers (each carries the WorkloadInfo for the
   │   │         workload that called RegisterCommand)
   │   ├── Skip workload commands that collide with built-ins or with each
@@ -70,6 +70,8 @@ func
 ├── workload
 │   └── list              List installed workloads
 ├── version (hidden)      Print version info
+├── pack (hidden)         Stub — directs users to v4 Core Tools
+├── publish (hidden)      Stub — directs users to Azure CLI / v4 Core Tools
 └── help (hidden)         Print help
 ```
 

--- a/src/Func/Commands/PackCommand.cs
+++ b/src/Func/Commands/PackCommand.cs
@@ -8,8 +8,8 @@ using Azure.Functions.Cli.Hosting;
 namespace Azure.Functions.Cli.Commands;
 
 /// <summary>
-/// Stub for the legacy v4 <c>func pack</c> command. Packaging is not part of
-/// the v5 CLI; this command exists only to redirect users to v4 with a clear
+/// Stub for the legacy v4 <c>func pack</c> command. Packaging is not supported
+/// in v5 yet; this command exists only to redirect users to v4 with a clear
 /// message instead of falling through to "command not found".
 /// </summary>
 internal sealed class PackCommand : FuncCliCommand, IBuiltInCommand
@@ -17,7 +17,7 @@ internal sealed class PackCommand : FuncCliCommand, IBuiltInCommand
     private readonly IInteractionService _interaction;
 
     public PackCommand(IInteractionService interaction)
-        : base("pack", "Package a function app for deployment (not supported in v5).")
+        : base("pack", "Package a function app for deployment (not supported yet).")
     {
         _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
         Hidden = true;
@@ -26,9 +26,9 @@ internal sealed class PackCommand : FuncCliCommand, IBuiltInCommand
 
     protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
-        _interaction.WriteWarning("'func pack' is not supported in v5 of the Azure Functions CLI.");
+        _interaction.WriteWarning("'func pack' is not supported yet in v5 of the Azure Functions CLI.");
         _interaction.WriteBlankLine();
-        _interaction.WriteLine("To package a function app, use v4 of Core Tools:");
+        _interaction.WriteLine("In the meantime, to package a function app, use v4 of Core Tools:");
         _interaction.WriteLine(l => l.Muted("  ").Plain("https://learn.microsoft.com/azure/azure-functions/functions-run-local"));
         return Task.FromResult(1);
     }

--- a/src/Func/Commands/PackCommand.cs
+++ b/src/Func/Commands/PackCommand.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Hosting;
+
+namespace Azure.Functions.Cli.Commands;
+
+/// <summary>
+/// Stub for the legacy v4 <c>func pack</c> command. Packaging is not part of
+/// the v5 CLI; this command exists only to redirect users to v4 with a clear
+/// message instead of falling through to "command not found".
+/// </summary>
+internal sealed class PackCommand : FuncCliCommand, IBuiltInCommand
+{
+    private readonly IInteractionService _interaction;
+
+    public PackCommand(IInteractionService interaction)
+        : base("pack", "Package a function app for deployment (not supported in v5).")
+    {
+        _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
+        Hidden = true;
+        TreatUnmatchedTokensAsErrors = false;
+    }
+
+    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        _interaction.WriteWarning("'func pack' is not supported in v5 of the Azure Functions CLI.");
+        _interaction.WriteBlankLine();
+        _interaction.WriteLine("To package a function app, use v4 of Core Tools:");
+        _interaction.WriteLine(l => l.Muted("  ").Plain("https://learn.microsoft.com/azure/azure-functions/functions-run-local"));
+        return Task.FromResult(1);
+    }
+}

--- a/src/Func/Commands/PublishCommand.cs
+++ b/src/Func/Commands/PublishCommand.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Hosting;
+
+namespace Azure.Functions.Cli.Commands;
+
+/// <summary>
+/// Stub for the legacy v4 <c>func publish</c> command. Deployment is not part
+/// of the v5 CLI; we redirect users to the Azure CLI's
+/// <c>az functionapp deployment</c> family, falling back to v4 Core Tools for
+/// the legacy publish flow.
+/// </summary>
+internal sealed class PublishCommand : FuncCliCommand, IBuiltInCommand
+{
+    private readonly IInteractionService _interaction;
+
+    public PublishCommand(IInteractionService interaction)
+        : base("publish", "Publish a function app to Azure (not supported in v5).")
+    {
+        _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
+        Hidden = true;
+        TreatUnmatchedTokensAsErrors = false;
+    }
+
+    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        _interaction.WriteWarning("'func publish' is not supported in v5 of the Azure Functions CLI.");
+        _interaction.WriteBlankLine();
+        _interaction.WriteLine("Use the Azure CLI to deploy your function app, for example:");
+        _interaction.WriteLine(l => l.Muted("  ").Code("az functionapp deployment source config-zip -g <resource-group> -n <app-name> --src <zip-path>"));
+        _interaction.WriteBlankLine();
+        _interaction.WriteLine("Or use v4 of Core Tools for the legacy 'func azure functionapp publish' flow:");
+        _interaction.WriteLine(l => l.Muted("  ").Plain("https://learn.microsoft.com/azure/azure-functions/functions-run-local"));
+        return Task.FromResult(1);
+    }
+}

--- a/src/Func/Hosting/BuiltInCommands.cs
+++ b/src/Func/Hosting/BuiltInCommands.cs
@@ -39,6 +39,8 @@ internal static class BuiltInCommands
         services.AddSingleton<FuncCliCommand, InitCommand>();
         services.AddSingleton<FuncCliCommand, NewCommand>();
         services.AddSingleton<FuncCliCommand, StartCommand>();
+        services.AddSingleton<FuncCliCommand, PackCommand>();
+        services.AddSingleton<FuncCliCommand, PublishCommand>();
         services.AddSingleton<ProfileListCommand>();
         services.AddSingleton<ProfileShowCommand>();
         services.AddSingleton<ProfileSetCommand>();

--- a/test/Func.Tests/Commands/PackCommandTests.cs
+++ b/test/Func.Tests/Commands/PackCommandTests.cs
@@ -27,7 +27,7 @@ public class PackCommandTests
         var exitCode = await parseResult.InvokeAsync();
 
         Assert.NotEqual(0, exitCode);
-        Assert.Contains("not supported in v5", _interaction.AllOutput);
+        Assert.Contains("not supported yet", _interaction.AllOutput);
         Assert.Contains("v4", _interaction.AllOutput);
         Assert.Contains("functions-run-local", _interaction.AllOutput);
     }
@@ -41,6 +41,6 @@ public class PackCommandTests
         var exitCode = await parseResult.InvokeAsync();
 
         Assert.NotEqual(0, exitCode);
-        Assert.Contains("not supported in v5", _interaction.AllOutput);
+        Assert.Contains("not supported yet", _interaction.AllOutput);
     }
 }

--- a/test/Func.Tests/Commands/PackCommandTests.cs
+++ b/test/Func.Tests/Commands/PackCommandTests.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Commands;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Commands;
+
+public class PackCommandTests
+{
+    private readonly TestInteractionService _interaction = new();
+
+    [Fact]
+    public void Pack_IsHidden()
+    {
+        var command = new PackCommand(_interaction);
+
+        Assert.True(command.Hidden);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PrintsV4Redirect_AndReturnsNonZero()
+    {
+        var command = new PackCommand(_interaction);
+        var parseResult = command.Parse([]);
+
+        var exitCode = await parseResult.InvokeAsync();
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("not supported in v5", _interaction.AllOutput);
+        Assert.Contains("v4", _interaction.AllOutput);
+        Assert.Contains("functions-run-local", _interaction.AllOutput);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_IgnoresExtraArguments()
+    {
+        var command = new PackCommand(_interaction);
+        var parseResult = command.Parse(["--output", "bin/release", "myapp.zip"]);
+
+        var exitCode = await parseResult.InvokeAsync();
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("not supported in v5", _interaction.AllOutput);
+    }
+}

--- a/test/Func.Tests/Commands/PublishCommandTests.cs
+++ b/test/Func.Tests/Commands/PublishCommandTests.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Commands;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Commands;
+
+public class PublishCommandTests
+{
+    private readonly TestInteractionService _interaction = new();
+
+    [Fact]
+    public void Publish_IsHidden()
+    {
+        var command = new PublishCommand(_interaction);
+
+        Assert.True(command.Hidden);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PrintsAzCliSampleAndV4Redirect_AndReturnsNonZero()
+    {
+        var command = new PublishCommand(_interaction);
+        var parseResult = command.Parse([]);
+
+        var exitCode = await parseResult.InvokeAsync();
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("not supported in v5", _interaction.AllOutput);
+        Assert.Contains("az functionapp deployment", _interaction.AllOutput);
+        Assert.Contains("functions-run-local", _interaction.AllOutput);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_IgnoresExtraArguments()
+    {
+        var command = new PublishCommand(_interaction);
+        var parseResult = command.Parse(["myapp", "--slot", "staging"]);
+
+        var exitCode = await parseResult.InvokeAsync();
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("not supported in v5", _interaction.AllOutput);
+    }
+}


### PR DESCRIPTION
Adds two new hidden built-in commands so users coming from v4 muscle memory get a clear message instead of "command not found".

## What

- **`func pack`** (hidden): warns that packaging isn't supported in v5 and links to the v4 install guide.
- **`func publish`** (hidden): warns that publishing isn't supported in v5, suggests an `az functionapp deployment source config-zip` sample, and links to the v4 install guide as a fallback.

Both commands:
- Are marked `Hidden = true` so they don't show in `--help`.
- Set `TreatUnmatchedTokensAsErrors = false` so users can pass v4-style args (e.g. `func publish myapp --slot staging`) without hitting a parser error before seeing the message.
- Return exit code 1.

## Example output

```
$ func pack
Warning: 'func pack' is not supported in v5 of the Azure Functions CLI.

To package a function app, use v4 of Core Tools:
  https://learn.microsoft.com/azure/azure-functions/functions-run-local
```

```
$ func publish
Warning: 'func publish' is not supported in v5 of the Azure Functions CLI.

Use the Azure CLI to deploy your function app, for example:
  az functionapp deployment source config-zip -g <resource-group> -n <app-name> --src <zip-path>

Or use v4 of Core Tools for the legacy 'func azure functionapp publish' flow:
  https://learn.microsoft.com/azure/azure-functions/functions-run-local
```

## Files

- `src/Func/Commands/PackCommand.cs`, `PublishCommand.cs` (new)
- `src/Func/Hosting/BuiltInCommands.cs` (register both)
- `test/Func.Tests/Commands/Pack|PublishCommandTests.cs` (new, 6 tests)
- `docs/cli-architecture.md` (command tree)

Builds clean (`CI=true`, `TreatWarningsAsErrors`) and new tests + `ParserTests` pass.