### PR TITLE
PR2: Templates.V2 engine — Node + Python v2 NewTemplate[] runner

### DIFF
--- a/Azure.Functions.Cli.slnx
+++ b/Azure.Functions.Cli.slnx
@@ -7,6 +7,7 @@
   <Folder Name="/src/">
     <Project Path="src/Abstractions/Abstractions.csproj" />
     <Project Path="src/Func/Func.csproj" />
+    <Project Path="src/Templates.V2/Templates.V2.csproj" />
   </Folder>
   <Folder Name="/src/Workloads/">
     <Project Path="src/Workloads/Host/Workloads.Host.csproj" />

--- a/src/Func/Func.csproj
+++ b/src/Func/Func.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../Abstractions/Abstractions.csproj" />
+    <ProjectReference Include="../Templates.V2/Templates.V2.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Func/Hosting/CliHostFactory.cs
+++ b/src/Func/Hosting/CliHostFactory.cs
@@ -14,6 +14,7 @@ using Azure.Functions.Cli.Http;
 using Azure.Functions.Cli.Quickstart;
 using Azure.Functions.Cli.Telemetry;
 using Azure.Functions.Cli.Templates;
+using Azure.Functions.Cli.Templates.V2;
 using Azure.Functions.Cli.Workers;
 using Azure.Monitor.OpenTelemetry.Exporter;
 using Microsoft.Extensions.Configuration;
@@ -122,6 +123,7 @@ internal static class CliHostFactory
         builder.Services.AddQuickstartManifest();
         builder.Services.AddManagedAzurite();
         builder.Services.AddTemplatesOrchestrator();
+        builder.Services.AddV2TemplateEngine();
 
         return builder;
     }

--- a/src/Templates.V2/Templates.V2.csproj
+++ b/src/Templates.V2/Templates.V2.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Description>V2 template engine — Node + Python NewTemplate[] jobs/actions DSL runner.</Description>
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="func" />
+    <InternalsVisibleTo Include="Azure.Functions.Cli.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(SrcRoot)Abstractions/Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+
+</Project>

--- a/src/Templates.V2/V2EngineProvider.cs
+++ b/src/Templates.V2/V2EngineProvider.cs
@@ -1,0 +1,135 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+
+namespace Azure.Functions.Cli.Templates.V2;
+
+/// <summary>
+/// V2 engine provider. Walks installed
+/// <c>Workloads.Templates.&lt;stack&gt;</c> rows, reads their v2 payload, and
+/// projects each <see cref="NewTemplate"/> into a
+/// <see cref="FunctionTemplateInfo"/>. Apply dispatches to
+/// <see cref="V2TemplateEngine"/>.
+/// </summary>
+/// <remarks>
+/// Channel match and min-bundle gates live in the orchestrator (PR4); this
+/// provider operates over whichever installed workload(s) the orchestrator
+/// hands it. PR2 takes the highest-version installed pkg per stack as a
+/// best-effort default and supplies the engine with each prompt's declared
+/// default value; PR4 replaces this with the orchestrator's stage-B
+/// hydrated parse result so user-supplied option values flow through.
+/// </remarks>
+public sealed class V2EngineProvider : ITemplateEngineProvider
+{
+    private readonly IInstalledTemplatesWorkloads _installed;
+    private readonly V2TemplateEngine _engine;
+
+    public V2EngineProvider(IInstalledTemplatesWorkloads installed)
+    {
+        _installed = installed ?? throw new ArgumentNullException(nameof(installed));
+        _engine = new V2TemplateEngine();
+    }
+
+    public string EngineId => EngineIds.V2;
+
+    public async Task<IReadOnlyList<FunctionTemplateInfo>> ListTemplatesAsync(
+        TemplateListContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        IReadOnlyList<InstalledTemplatesWorkload> rows = await _installed.ListInstalledAsync(context.Stack, cancellationToken);
+        if (rows.Count == 0)
+        {
+            return [];
+        }
+
+        InstalledTemplatesWorkload selected = rows
+            .OrderByDescending(r => r.PackageVersion, StringComparer.Ordinal)
+            .First();
+
+        V2Payload? payload = V2PayloadReader.Load(selected.InstallDirectory);
+        if (payload is null)
+        {
+            return [];
+        }
+
+        List<FunctionTemplateInfo> projected = [];
+        foreach (NewTemplate template in payload.Templates)
+        {
+            FunctionTemplateInfo? info = V2TemplateProjection.Project(template, payload, context.Stack);
+            if (info is not null && MatchesLanguage(info, context.Language))
+            {
+                projected.Add(info);
+            }
+        }
+
+        return projected;
+    }
+
+    public async Task<TemplateApplicationResult> ApplyAsync(
+        NewContext context,
+        ParseResult parseResult,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(parseResult);
+
+        IReadOnlyList<InstalledTemplatesWorkload> rows = await _installed.ListInstalledAsync(context.Template.Stack, cancellationToken);
+        if (rows.Count == 0)
+        {
+            return new TemplateApplicationResult.Failed(
+                new TemplateApplicationFailure.ProviderError(
+                    $"No installed templates workload found for stack '{context.Template.Stack}'.", null));
+        }
+
+        InstalledTemplatesWorkload selected = rows
+            .OrderByDescending(r => r.PackageVersion, StringComparer.Ordinal)
+            .First();
+
+        V2Payload? payload = V2PayloadReader.Load(selected.InstallDirectory);
+        NewTemplate? raw = payload?.Templates.FirstOrDefault(t =>
+            string.Equals(t.Id, context.Template.Id, StringComparison.OrdinalIgnoreCase));
+
+        if (payload is null || raw is null)
+        {
+            return new TemplateApplicationResult.Failed(
+                new TemplateApplicationFailure.ProviderError(
+                    $"Template '{context.Template.Id}' was not found in the v2 payload at '{selected.InstallDirectory}'.",
+                    null));
+        }
+
+        // PR2: seed defaults from each declared prompt. PR4 replaces this
+        // with the orchestrator's stage-B parsed values so user-supplied
+        // option values override the prompt defaults.
+        var optionValues = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        foreach (TemplateUserPrompt prompt in context.Template.Metadata.UserPrompts)
+        {
+            optionValues[prompt.Id] = prompt.DefaultValue;
+        }
+
+        return _engine.Apply(
+            raw,
+            context.FunctionName,
+            optionValues,
+            context.WorkingDirectory.Info,
+            context.Force);
+    }
+
+    private static bool MatchesLanguage(FunctionTemplateInfo info, string? requestedLanguage)
+    {
+        if (string.IsNullOrWhiteSpace(requestedLanguage))
+        {
+            return true;
+        }
+
+        if (info.Languages.Count == 0)
+        {
+            return true;
+        }
+
+        return info.Languages.Any(l =>
+            string.Equals(l, requestedLanguage, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/Templates.V2/V2PayloadReader.cs
+++ b/src/Templates.V2/V2PayloadReader.cs
@@ -1,0 +1,136 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Text.Json;
+
+namespace Azure.Functions.Cli.Templates.V2;
+
+/// <summary>
+/// Reads a templates content workload's v2 payload from disk
+/// (<c>&lt;install-dir&gt;/tools/any/content/v2/</c>). One reader call per
+/// payload root; stateless.
+/// </summary>
+internal static class V2PayloadReader
+{
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        AllowTrailingCommas = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+    };
+
+    /// <summary>
+    /// Loads <paramref name="installDirectory"/>'s v2 payload into an
+    /// in-memory <see cref="V2Payload"/>. Returns <c>null</c> when the v2
+    /// directory or <c>templates.json</c> file is missing — that's "this
+    /// installed workload has no v2 content"; the caller decides how to
+    /// surface the gap.
+    /// </summary>
+    public static V2Payload? Load(string installDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(installDirectory))
+        {
+            throw new ArgumentException("Install directory must be non-empty.", nameof(installDirectory));
+        }
+
+        string v2Root = Path.Combine(installDirectory, "tools", "any", "content", "v2");
+        if (!Directory.Exists(v2Root))
+        {
+            return null;
+        }
+
+        string templatesJson = Path.Combine(v2Root, "templates", "templates.json");
+        if (!File.Exists(templatesJson))
+        {
+            return null;
+        }
+
+        List<NewTemplate> templates = ReadJson<List<NewTemplate>>(templatesJson) ?? [];
+
+        string userPromptsJson = Path.Combine(v2Root, "bindings", "userPrompts.json");
+        List<UserPromptDoc> prompts = File.Exists(userPromptsJson)
+            ? (ReadJson<List<UserPromptDoc>>(userPromptsJson) ?? [])
+            : [];
+
+        Dictionary<string, string> resources = LoadResources(Path.Combine(v2Root, "resources"));
+
+        return new V2Payload(installDirectory, templates, IndexPrompts(prompts), resources);
+    }
+
+    private static Dictionary<string, UserPromptDoc> IndexPrompts(IEnumerable<UserPromptDoc> prompts)
+    {
+        var dict = new Dictionary<string, UserPromptDoc>(StringComparer.OrdinalIgnoreCase);
+        foreach (UserPromptDoc prompt in prompts)
+        {
+            if (string.IsNullOrWhiteSpace(prompt.Id))
+            {
+                continue;
+            }
+
+            dict[prompt.Id] = prompt;
+        }
+
+        return dict;
+    }
+
+    /// <summary>
+    /// Reads only the en-US <c>Resources.json</c> (matches templates-workload-spec.md
+    /// §5.3.1 "Localization (v1: en-US only)"). Locale variants ship in the
+    /// workload but are not consumed in v1.
+    /// </summary>
+    private static Dictionary<string, string> LoadResources(string resourcesRoot)
+    {
+        var dict = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (!Directory.Exists(resourcesRoot))
+        {
+            return dict;
+        }
+
+        string defaultFile = Path.Combine(resourcesRoot, "Resources.json");
+        if (!File.Exists(defaultFile))
+        {
+            return dict;
+        }
+
+        using FileStream stream = File.OpenRead(defaultFile);
+        using var document = JsonDocument.Parse(stream);
+        JsonElement root = document.RootElement;
+
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            return dict;
+        }
+
+        // Wrapped form: { "en": { ... } }. Unwrap to the first object child.
+        JsonProperty firstProp = root.EnumerateObject().FirstOrDefault();
+        if (firstProp.Value.ValueKind == JsonValueKind.Object)
+        {
+            root = firstProp.Value;
+        }
+
+        foreach (JsonProperty entry in root.EnumerateObject())
+        {
+            if (entry.Value.ValueKind == JsonValueKind.String)
+            {
+                dict[entry.Name] = entry.Value.GetString() ?? string.Empty;
+            }
+        }
+
+        return dict;
+    }
+
+    private static T? ReadJson<T>(string path)
+    {
+        using FileStream stream = File.OpenRead(path);
+        return JsonSerializer.Deserialize<T>(stream, _jsonOptions);
+    }
+}
+
+/// <summary>
+/// In-memory snapshot of one templates content workload's v2 payload.
+/// </summary>
+internal sealed record V2Payload(
+    string InstallDirectory,
+    IReadOnlyList<NewTemplate> Templates,
+    IReadOnlyDictionary<string, UserPromptDoc> UserPrompts,
+    IReadOnlyDictionary<string, string> Resources);

--- a/src/Templates.V2/V2Schema.cs
+++ b/src/Templates.V2/V2Schema.cs
@@ -1,0 +1,147 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Text.Json.Serialization;
+
+namespace Azure.Functions.Cli.Templates.V2;
+
+/// <summary>
+/// JSON DTOs for the v2 templates schema (templates-workload-spec.md §5.4).
+/// One <see cref="NewTemplate"/> per entry in
+/// <c>tools/any/content/v2/templates/templates.json</c>. Inline files map
+/// stores the per-template payload contents.
+/// </summary>
+internal sealed class NewTemplate
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("programmingModel")]
+    public string? ProgrammingModel { get; set; }
+
+    [JsonPropertyName("language")]
+    public string? Language { get; set; }
+
+    [JsonPropertyName("triggerType")]
+    public string? TriggerType { get; set; }
+
+    [JsonPropertyName("category")]
+    public List<string>? Category { get; set; }
+
+    [JsonPropertyName("categoryStyle")]
+    public string? CategoryStyle { get; set; }
+
+    [JsonPropertyName("jobs")]
+    public List<V2Job>? Jobs { get; set; }
+
+    [JsonPropertyName("actions")]
+    public List<V2Action>? Actions { get; set; }
+
+    [JsonPropertyName("files")]
+    public Dictionary<string, string>? Files { get; set; }
+}
+
+internal sealed class V2Job
+{
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    [JsonPropertyName("inputs")]
+    public List<V2Input>? Inputs { get; set; }
+}
+
+internal sealed class V2Input
+{
+    [JsonPropertyName("assignTo")]
+    public string? AssignTo { get; set; }
+
+    [JsonPropertyName("paramId")]
+    public string? ParamId { get; set; }
+
+    [JsonPropertyName("defaultValue")]
+    public string? DefaultValue { get; set; }
+
+    [JsonPropertyName("required")]
+    public bool Required { get; set; }
+}
+
+internal sealed class V2Action
+{
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    [JsonPropertyName("filePath")]
+    public string? FilePath { get; set; }
+
+    [JsonPropertyName("fileContent")]
+    public string? FileContent { get; set; }
+
+    [JsonPropertyName("assignTo")]
+    public string? AssignTo { get; set; }
+
+    [JsonPropertyName("source")]
+    public string? Source { get; set; }
+
+    [JsonPropertyName("continueOnError")]
+    public bool ContinueOnError { get; set; }
+}
+
+/// <summary>
+/// A single entry from <c>tools/any/content/v2/bindings/userPrompts.json</c>.
+/// </summary>
+internal sealed class UserPromptDoc
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    [JsonPropertyName("label")]
+    public string? Label { get; set; }
+
+    [JsonPropertyName("help")]
+    public string? Help { get; set; }
+
+    [JsonPropertyName("placeholder")]
+    public string? Placeholder { get; set; }
+
+    [JsonPropertyName("defaultValue")]
+    public string? DefaultValue { get; set; }
+
+    [JsonPropertyName("required")]
+    public bool? Required { get; set; }
+
+    [JsonPropertyName("validators")]
+    public List<UserPromptValidator>? Validators { get; set; }
+
+    [JsonPropertyName("enum")]
+    public List<UserPromptEnumEntry>? Enum { get; set; }
+}
+
+internal sealed class UserPromptValidator
+{
+    [JsonPropertyName("expression")]
+    public string? Expression { get; set; }
+
+    [JsonPropertyName("errorText")]
+    public string? ErrorText { get; set; }
+}
+
+internal sealed class UserPromptEnumEntry
+{
+    [JsonPropertyName("value")]
+    public string? Value { get; set; }
+
+    [JsonPropertyName("display")]
+    public string? Display { get; set; }
+}

--- a/src/Templates.V2/V2ServiceCollectionExtensions.cs
+++ b/src/Templates.V2/V2ServiceCollectionExtensions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Azure.Functions.Cli.Templates.V2;
+
+/// <summary>
+/// DI registration for the V2 engine. Hosted by <c>Func.csproj</c>; surfaces
+/// a single extension method so the engine implementation stays opaque from
+/// the host's perspective.
+/// </summary>
+public static class V2ServiceCollectionExtensions
+{
+    public static IServiceCollection AddV2TemplateEngine(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton<ITemplateEngineProvider, V2EngineProvider>();
+        return services;
+    }
+}

--- a/src/Templates.V2/V2TemplateEngine.cs
+++ b/src/Templates.V2/V2TemplateEngine.cs
@@ -1,0 +1,202 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Text.RegularExpressions;
+
+namespace Azure.Functions.Cli.Templates.V2;
+
+/// <summary>
+/// Runs a <see cref="NewTemplate"/>'s job and action graph against a
+/// variables dictionary built from user-supplied option values + per-input
+/// defaults, then materialises files declared by <c>WriteToFile</c> actions.
+/// PR2 covers the two action types that drive Node and Python v2 templates
+/// (<c>GetTemplateFileContent</c>, <c>WriteToFile</c>); other action types
+/// surface as <see cref="TemplateApplicationFailure.ProviderError"/>.
+/// </summary>
+/// <remarks>
+/// Callers supply <paramref name="optionValuesByPromptId"/> — a mapping from
+/// each prompt's <see cref="TemplateUserPrompt.Id"/> (= the v2
+/// <c>paramId</c>) to the user-supplied value. PR2's provider derives this
+/// from a minimal "use defaults" map; PR4 replaces it with the stage-B
+/// parse result built by the orchestrator.
+/// </remarks>
+internal sealed class V2TemplateEngine
+{
+    private static readonly Regex _substitutionPattern = new(@"\$\(([A-Za-z_][A-Za-z0-9_]*)\)", RegexOptions.Compiled);
+
+    public TemplateApplicationResult Apply(
+        NewTemplate template,
+        string functionName,
+        IReadOnlyDictionary<string, string?> optionValuesByPromptId,
+        DirectoryInfo workingDirectory,
+        bool force)
+    {
+        ArgumentNullException.ThrowIfNull(template);
+        ArgumentNullException.ThrowIfNull(optionValuesByPromptId);
+        ArgumentNullException.ThrowIfNull(workingDirectory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(functionName);
+
+        var variables = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["FUNCTION_NAME_INPUT"] = functionName,
+        };
+
+        if (template.Jobs is { Count: > 0 })
+        {
+            foreach (V2Job job in template.Jobs)
+            {
+                if (job.Inputs is null)
+                {
+                    continue;
+                }
+
+                foreach (V2Input input in job.Inputs)
+                {
+                    if (string.IsNullOrWhiteSpace(input.AssignTo))
+                    {
+                        continue;
+                    }
+
+                    string? varName = ExtractVarName(input.AssignTo);
+                    if (varName is null)
+                    {
+                        continue;
+                    }
+
+                    string? value = ResolveInputValue(input, optionValuesByPromptId);
+                    if (value is null && input.Required)
+                    {
+                        return new TemplateApplicationResult.Failed(
+                            new TemplateApplicationFailure.InvalidPrompt(
+                                input.ParamId ?? input.AssignTo,
+                                $"Required input '{input.ParamId ?? input.AssignTo}' has no supplied value or default."));
+                    }
+
+                    if (value is not null)
+                    {
+                        variables[varName] = value;
+                    }
+                }
+            }
+        }
+
+        List<string> writtenFiles = [];
+        List<string> existingFiles = [];
+
+        if (template.Actions is { Count: > 0 })
+        {
+            foreach (V2Action action in template.Actions)
+            {
+                switch ((action.Type ?? string.Empty).ToLowerInvariant())
+                {
+                    case "gettemplatefilecontent":
+                        {
+                            string? filePath = Substitute(action.FilePath, variables);
+                            if (filePath is null)
+                            {
+                                continue;
+                            }
+
+                            if (template.Files is null || !template.Files.TryGetValue(filePath, out string? content))
+                            {
+                                return Failed(
+                                    $"GetTemplateFileContent: file '{filePath}' not found in template.files map.");
+                            }
+
+                            string? assign = ExtractVarName(action.AssignTo);
+                            if (assign is not null)
+                            {
+                                variables[assign] = Substitute(content, variables) ?? content;
+                            }
+                            break;
+                        }
+
+                    case "writetofile":
+                        {
+                            string? filePath = Substitute(action.FilePath, variables);
+                            if (filePath is null)
+                            {
+                                return Failed("WriteToFile: filePath is required.");
+                            }
+
+                            string content = Substitute(action.FileContent, variables) ?? string.Empty;
+                            string fullPath = Path.GetFullPath(Path.Combine(workingDirectory.FullName, filePath));
+
+                            if (File.Exists(fullPath) && !force)
+                            {
+                                existingFiles.Add(fullPath);
+                                continue;
+                            }
+
+                            try
+                            {
+                                Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+                                File.WriteAllText(fullPath, content);
+                                writtenFiles.Add(fullPath);
+                            }
+                            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                            {
+                                return new TemplateApplicationResult.Failed(
+                                    new TemplateApplicationFailure.WriteFailed(fullPath, ex.Message));
+                            }
+                            break;
+                        }
+
+                    default:
+                        if (!action.ContinueOnError)
+                        {
+                            return Failed($"Unsupported v2 action type '{action.Type}'.");
+                        }
+                        break;
+                }
+            }
+        }
+
+        if (existingFiles.Count > 0)
+        {
+            return new TemplateApplicationResult.AlreadyExists(existingFiles);
+        }
+
+        return new TemplateApplicationResult.Created(writtenFiles);
+    }
+
+    private static string? ResolveInputValue(V2Input input, IReadOnlyDictionary<string, string?> optionValuesByPromptId)
+    {
+        if (input.ParamId is not null
+            && optionValuesByPromptId.TryGetValue(input.ParamId, out string? supplied)
+            && !string.IsNullOrEmpty(supplied))
+        {
+            return supplied;
+        }
+
+        return input.DefaultValue;
+    }
+
+    private static string? Substitute(string? template, IReadOnlyDictionary<string, string> variables)
+    {
+        if (template is null)
+        {
+            return null;
+        }
+
+        return _substitutionPattern.Replace(template, match =>
+        {
+            string name = match.Groups[1].Value;
+            return variables.TryGetValue(name, out string? value) ? value : match.Value;
+        });
+    }
+
+    private static string? ExtractVarName(string? assignTo)
+    {
+        if (string.IsNullOrWhiteSpace(assignTo))
+        {
+            return null;
+        }
+
+        Match m = _substitutionPattern.Match(assignTo);
+        return m.Success ? m.Groups[1].Value : null;
+    }
+
+    private static TemplateApplicationResult.Failed Failed(string message)
+        => new(new TemplateApplicationFailure.ProviderError(message, null));
+}

--- a/src/Templates.V2/V2TemplateProjection.cs
+++ b/src/Templates.V2/V2TemplateProjection.cs
@@ -1,0 +1,110 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Templates.V2;
+
+/// <summary>
+/// Projects a v2 <see cref="NewTemplate"/> + its referenced
+/// <see cref="UserPromptDoc"/>s into the engine-agnostic
+/// <see cref="FunctionTemplateInfo"/> the orchestrator consumes.
+/// </summary>
+internal static class V2TemplateProjection
+{
+    public static FunctionTemplateInfo? Project(NewTemplate template, V2Payload payload, string stack)
+    {
+        ArgumentNullException.ThrowIfNull(template);
+        ArgumentNullException.ThrowIfNull(payload);
+        if (string.IsNullOrWhiteSpace(template.Id))
+        {
+            return null;
+        }
+
+        List<TemplateUserPrompt> prompts = [];
+        if (template.Jobs is { Count: > 0 })
+        {
+            foreach (V2Job job in template.Jobs)
+            {
+                if (job.Inputs is null)
+                {
+                    continue;
+                }
+
+                foreach (V2Input input in job.Inputs)
+                {
+                    TemplateUserPrompt? prompt = ProjectInput(input, payload);
+                    if (prompt is not null)
+                    {
+                        prompts.Add(prompt);
+                    }
+                }
+            }
+        }
+
+        string? description = ResolveResource(template.Description, payload.Resources);
+        string displayName = ResolveResource(template.Name, payload.Resources) ?? template.Id;
+        string triggerKind = template.TriggerType ?? template.CategoryStyle ?? "function";
+
+        IReadOnlyList<string> languages = string.IsNullOrWhiteSpace(template.Language)
+            ? []
+            : [template.Language];
+
+        TemplateMetadata metadata = new(prompts, RequiresExtensionBundle: true, MinBundleVersion: null);
+
+        return new FunctionTemplateInfo(
+            Id: template.Id,
+            Stack: stack,
+            EngineId: EngineIds.V2,
+            DisplayName: displayName,
+            TriggerKind: triggerKind,
+            Description: description,
+            DefaultFunctionName: null,
+            Languages: languages,
+            Metadata: metadata);
+    }
+
+    private static TemplateUserPrompt? ProjectInput(V2Input input, V2Payload payload)
+    {
+        if (string.IsNullOrWhiteSpace(input.ParamId))
+        {
+            return null;
+        }
+
+        payload.UserPrompts.TryGetValue(input.ParamId, out UserPromptDoc? doc);
+        string id = input.ParamId;
+        string? description = doc?.Label;
+        string dataType = doc?.Enum is { Count: > 0 } ? "choice" : "string";
+        string? defaultValue = input.DefaultValue ?? doc?.DefaultValue;
+        IReadOnlyList<string>? choices = doc?.Enum?
+            .Where(e => !string.IsNullOrWhiteSpace(e.Value))
+            .Select(e => e.Value!)
+            .ToList();
+        bool required = input.Required || (doc?.Required ?? false);
+        string? validator = doc?.Validators?.FirstOrDefault()?.Expression;
+
+        return new TemplateUserPrompt(
+            Id: id,
+            Description: description,
+            DataType: dataType,
+            DefaultValue: defaultValue,
+            Choices: choices,
+            IsRequired: required,
+            ValidatorRegex: validator,
+            ShortAlias: null,
+            LongAlias: null);
+    }
+
+    private static string? ResolveResource(string? maybeResourceKey, IReadOnlyDictionary<string, string> resources)
+    {
+        if (string.IsNullOrWhiteSpace(maybeResourceKey))
+        {
+            return maybeResourceKey;
+        }
+
+        if (maybeResourceKey.StartsWith('$') && resources.TryGetValue(maybeResourceKey[1..], out string? resolved))
+        {
+            return resolved;
+        }
+
+        return maybeResourceKey;
+    }
+}

--- a/test/Func.Tests/Templates/V2/V2EngineProviderTests.cs
+++ b/test/Func.Tests/Templates/V2/V2EngineProviderTests.cs
@@ -1,0 +1,122 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Templates;
+using Azure.Functions.Cli.Templates.V2;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Templates.V2;
+
+public class V2EngineProviderTests : IDisposable
+{
+    private readonly string _workloadHome;
+    private readonly string _installDir;
+
+    public V2EngineProviderTests()
+    {
+        _workloadHome = Path.Combine(Path.GetTempPath(), "func-new-pr2-provider-" + Guid.NewGuid().ToString("N"));
+        _installDir = Path.Combine(_workloadHome, "node-templates-1.0.0");
+        Directory.CreateDirectory(_installDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_workloadHome, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    [Fact]
+    public async Task ListTemplatesAsync_Empty_Registry_Returns_Empty()
+    {
+        IInstalledTemplatesWorkloads installed = Substitute.For<IInstalledTemplatesWorkloads>();
+        installed.ListInstalledAsync("node", Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<InstalledTemplatesWorkload>());
+
+        var provider = new V2EngineProvider(installed);
+        IReadOnlyList<FunctionTemplateInfo> templates = await provider.ListTemplatesAsync(
+            new TemplateListContext(new Cli.Common.WorkingDirectory(new DirectoryInfo(_workloadHome), false), "node", "javascript"),
+            CancellationToken.None);
+
+        Assert.Empty(templates);
+    }
+
+    [Fact]
+    public async Task ListTemplatesAsync_Reads_Fixture_Payload_And_Projects_Templates()
+    {
+        WriteFixturePayload(_installDir);
+
+        IInstalledTemplatesWorkloads installed = Substitute.For<IInstalledTemplatesWorkloads>();
+        installed.ListInstalledAsync("node", Arg.Any<CancellationToken>())
+            .Returns([new InstalledTemplatesWorkload("node", "1.0.0", _installDir)]);
+
+        var provider = new V2EngineProvider(installed);
+        IReadOnlyList<FunctionTemplateInfo> templates = await provider.ListTemplatesAsync(
+            new TemplateListContext(new Cli.Common.WorkingDirectory(new DirectoryInfo(_workloadHome), false), "node", null),
+            CancellationToken.None);
+
+        var http = Assert.Single(templates);
+        Assert.Equal("HttpTrigger-JavaScript", http.Id);
+        Assert.Equal(EngineIds.V2, http.EngineId);
+        Assert.Equal("node", http.Stack);
+        Assert.Equal("HTTP trigger", http.DisplayName);
+    }
+
+    [Fact]
+    public async Task ListTemplatesAsync_Filters_By_Language()
+    {
+        WriteFixturePayload(_installDir);
+
+        IInstalledTemplatesWorkloads installed = Substitute.For<IInstalledTemplatesWorkloads>();
+        installed.ListInstalledAsync("node", Arg.Any<CancellationToken>())
+            .Returns([new InstalledTemplatesWorkload("node", "1.0.0", _installDir)]);
+
+        var provider = new V2EngineProvider(installed);
+        IReadOnlyList<FunctionTemplateInfo> typescriptOnly = await provider.ListTemplatesAsync(
+            new TemplateListContext(new Cli.Common.WorkingDirectory(new DirectoryInfo(_workloadHome), false), "node", "typescript"),
+            CancellationToken.None);
+
+        // The fixture template has language="javascript"; "typescript" filter drops it.
+        Assert.Empty(typescriptOnly);
+    }
+
+    private static void WriteFixturePayload(string installDir)
+    {
+        string v2 = Path.Combine(installDir, "tools", "any", "content", "v2");
+        Directory.CreateDirectory(Path.Combine(v2, "templates"));
+        Directory.CreateDirectory(Path.Combine(v2, "bindings"));
+        Directory.CreateDirectory(Path.Combine(v2, "resources"));
+
+        File.WriteAllText(Path.Combine(v2, "templates", "templates.json"), """
+        [
+          {
+            "id": "HttpTrigger-JavaScript",
+            "name": "HTTP trigger",
+            "description": "An HTTP-triggered function.",
+            "language": "javascript",
+            "triggerType": "http",
+            "jobs": [
+              {
+                "type": "CreateNewApp",
+                "inputs": [
+                  { "paramId": "trigger-functionName", "assignTo": "$(FUNCTION_NAME_INPUT)", "defaultValue": "HttpTrigger" }
+                ]
+              }
+            ],
+            "actions": [
+              { "type": "WriteToFile", "filePath": "src/functions/$(FUNCTION_NAME_INPUT).js", "fileContent": "// generated" }
+            ]
+          }
+        ]
+        """);
+
+        File.WriteAllText(Path.Combine(v2, "bindings", "userPrompts.json"), """
+        [
+          { "id": "trigger-functionName", "label": "Function name", "defaultValue": "HttpTrigger" }
+        ]
+        """);
+
+        File.WriteAllText(Path.Combine(v2, "resources", "Resources.json"), """
+        { "HttpTrigger_description": "An HTTP-triggered function." }
+        """);
+    }
+}

--- a/test/Func.Tests/Templates/V2/V2TemplateEngineTests.cs
+++ b/test/Func.Tests/Templates/V2/V2TemplateEngineTests.cs
@@ -1,0 +1,243 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Templates;
+using Azure.Functions.Cli.Templates.V2;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Templates.V2;
+
+public class V2TemplateEngineTests : IDisposable
+{
+    private readonly string _workingDir;
+
+    public V2TemplateEngineTests()
+    {
+        _workingDir = Path.Combine(Path.GetTempPath(), "func-new-pr2-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_workingDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_workingDir, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    [Fact]
+    public void Apply_WriteToFile_Substitutes_FunctionName_And_Writes()
+    {
+        NewTemplate template = new()
+        {
+            Id = "HttpTrigger-JavaScript",
+            Name = "HTTP trigger",
+            Files = new Dictionary<string, string>
+            {
+                ["index.js"] = "module.exports = async function (context, req) { return { body: 'hello $(FUNCTION_NAME_INPUT)' }; };",
+            },
+            Actions =
+            [
+                new V2Action
+                {
+                    Type = "GetTemplateFileContent",
+                    FilePath = "index.js",
+                    AssignTo = "$(INDEX_CONTENT)",
+                },
+                new V2Action
+                {
+                    Type = "WriteToFile",
+                    FilePath = "src/functions/$(FUNCTION_NAME_INPUT).js",
+                    FileContent = "$(INDEX_CONTENT)",
+                },
+            ],
+        };
+
+        var engine = new V2TemplateEngine();
+        TemplateApplicationResult result = engine.Apply(
+            template,
+            functionName: "MyHttp",
+            optionValuesByPromptId: new Dictionary<string, string?>(),
+            workingDirectory: new DirectoryInfo(_workingDir),
+            force: false);
+
+        var created = Assert.IsType<TemplateApplicationResult.Created>(result);
+        string expectedPath = Path.GetFullPath(Path.Combine(_workingDir, "src", "functions", "MyHttp.js"));
+        Assert.Single(created.Files);
+        Assert.Equal(expectedPath, created.Files[0]);
+        Assert.True(File.Exists(expectedPath));
+        string content = File.ReadAllText(expectedPath);
+        Assert.Contains("hello MyHttp", content);
+    }
+
+    [Fact]
+    public void Apply_Existing_File_Without_Force_Returns_AlreadyExists()
+    {
+        string target = Path.Combine(_workingDir, "out.txt");
+        File.WriteAllText(target, "preexisting");
+
+        NewTemplate template = new()
+        {
+            Id = "DummyTemplate",
+            Actions =
+            [
+                new V2Action
+                {
+                    Type = "WriteToFile",
+                    FilePath = "out.txt",
+                    FileContent = "new content",
+                },
+            ],
+        };
+
+        var engine = new V2TemplateEngine();
+        TemplateApplicationResult result = engine.Apply(
+            template,
+            functionName: "Fn",
+            optionValuesByPromptId: new Dictionary<string, string?>(),
+            workingDirectory: new DirectoryInfo(_workingDir),
+            force: false);
+
+        var existed = Assert.IsType<TemplateApplicationResult.AlreadyExists>(result);
+        Assert.Single(existed.ExistingFiles);
+        Assert.Equal("preexisting", File.ReadAllText(target));
+    }
+
+    [Fact]
+    public void Apply_Force_Overwrites_Existing_File()
+    {
+        string target = Path.Combine(_workingDir, "out.txt");
+        File.WriteAllText(target, "preexisting");
+
+        NewTemplate template = new()
+        {
+            Id = "DummyTemplate",
+            Actions =
+            [
+                new V2Action
+                {
+                    Type = "WriteToFile",
+                    FilePath = "out.txt",
+                    FileContent = "new content",
+                },
+            ],
+        };
+
+        var engine = new V2TemplateEngine();
+        TemplateApplicationResult result = engine.Apply(
+            template,
+            functionName: "Fn",
+            optionValuesByPromptId: new Dictionary<string, string?>(),
+            workingDirectory: new DirectoryInfo(_workingDir),
+            force: true);
+
+        Assert.IsType<TemplateApplicationResult.Created>(result);
+        Assert.Equal("new content", File.ReadAllText(target));
+    }
+
+    [Fact]
+    public void Apply_Substitutes_Option_Values_From_PromptId_Map()
+    {
+        NewTemplate template = new()
+        {
+            Id = "HttpTrigger",
+            Jobs =
+            [
+                new V2Job
+                {
+                    Type = "CreateNewApp",
+                    Inputs =
+                    [
+                        new V2Input
+                        {
+                            ParamId = "authLevel",
+                            AssignTo = "$(AUTH_LEVEL)",
+                            DefaultValue = "function",
+                        },
+                    ],
+                },
+            ],
+            Actions =
+            [
+                new V2Action
+                {
+                    Type = "WriteToFile",
+                    FilePath = "config.txt",
+                    FileContent = "auth=$(AUTH_LEVEL)",
+                },
+            ],
+        };
+
+        var engine = new V2TemplateEngine();
+        TemplateApplicationResult result = engine.Apply(
+            template,
+            functionName: "Fn",
+            optionValuesByPromptId: new Dictionary<string, string?>
+            {
+                ["authLevel"] = "anonymous",
+            },
+            workingDirectory: new DirectoryInfo(_workingDir),
+            force: false);
+
+        Assert.IsType<TemplateApplicationResult.Created>(result);
+        Assert.Equal("auth=anonymous", File.ReadAllText(Path.Combine(_workingDir, "config.txt")));
+    }
+
+    [Fact]
+    public void Apply_Required_Input_Without_Value_Fails_InvalidPrompt()
+    {
+        NewTemplate template = new()
+        {
+            Id = "HttpTrigger",
+            Jobs =
+            [
+                new V2Job
+                {
+                    Type = "CreateNewApp",
+                    Inputs =
+                    [
+                        new V2Input
+                        {
+                            ParamId = "queueName",
+                            AssignTo = "$(QUEUE_NAME)",
+                            Required = true,
+                        },
+                    ],
+                },
+            ],
+        };
+
+        var engine = new V2TemplateEngine();
+        TemplateApplicationResult result = engine.Apply(
+            template,
+            functionName: "Fn",
+            optionValuesByPromptId: new Dictionary<string, string?>(),
+            workingDirectory: new DirectoryInfo(_workingDir),
+            force: false);
+
+        var failed = Assert.IsType<TemplateApplicationResult.Failed>(result);
+        var invalid = Assert.IsType<TemplateApplicationFailure.InvalidPrompt>(failed.Failure);
+        Assert.Equal("queueName", invalid.PromptId);
+    }
+
+    [Fact]
+    public void Apply_Unsupported_Action_Type_Surfaces_ProviderError()
+    {
+        NewTemplate template = new()
+        {
+            Id = "T",
+            Actions =
+            [
+                new V2Action { Type = "RunSomeShellCommand" },
+            ],
+        };
+
+        var engine = new V2TemplateEngine();
+        TemplateApplicationResult result = engine.Apply(
+            template,
+            functionName: "Fn",
+            optionValuesByPromptId: new Dictionary<string, string?>(),
+            workingDirectory: new DirectoryInfo(_workingDir),
+            force: false);
+
+        var failed = Assert.IsType<TemplateApplicationResult.Failed>(result);
+        Assert.IsType<TemplateApplicationFailure.ProviderError>(failed.Failure);
+    }
+}


### PR DESCRIPTION
## PR2 of 4 — `Templates.V2` engine (Node + Python `NewTemplate[]` runner)

> **Base branch:** `nasoni/func-new-pr1-abstractions` — this PR is layered on top of #PR1. Merge that one first.

Adds the V2 template engine per [`docs/proposed/func-new.spec.md`](https://github.com/Azure/azure-functions-core-tools/blob/vnext/docs/proposed/func-new.spec.md) §4.3 — the engine the v5 Node + Python templates content workloads ship against ([`templates-workload-spec.md`](https://github.com/Azure/azure-functions-core-tools/blob/vnext/docs/proposed/templates-workload-spec.md) §5.2 / §5.4).

### What's in this PR

**New CLI-internal csproj** — `src/Templates.V2/Templates.V2.csproj` (per spec Q3: two separate engine csprojs). `IsPackable=false`; project-referenced from `Func.csproj`.

**Files:**
- `V2Schema.cs` — JSON DTOs: `NewTemplate`, `V2Job`, `V2Action`, `V2Input`, `UserPromptDoc`, `UserPromptValidator`, `UserPromptEnumEntry`
- `V2PayloadReader` — loads `<install-dir>/tools/any/content/v2/` (templates.json, bindings/userPrompts.json, resources/Resources.json — en-US only per templates-workload-spec.md §5.3.1's localization disposition)
- `V2TemplateProjection` — projects `NewTemplate` → `FunctionTemplateInfo` (resolves `$key` resource references, projects `UserPrompts` into `TemplateUserPrompt`)
- `V2TemplateEngine` — jobs/actions runner. Supports `GetTemplateFileContent` and `WriteToFile` (the two action types the v4-derived Node templates and Python v2 bundle templates rely on). `$(VAR)` substitution; honours `force`; surfaces `InvalidPrompt` for required inputs without values; `ProviderError` for unsupported action types
- `V2EngineProvider` — internal `ITemplateEngineProvider` impl; walks installed `Workloads.Templates.<stack>` rows, reads highest-version payload, projects and filters by language. Channel match + min-bundle gates land in PR4
- `V2ServiceCollectionExtensions.AddV2TemplateEngine()` — public DI registration

**Wiring:**
- `Func.csproj` — ProjectReference to `Templates.V2`
- `Azure.Functions.Cli.slnx` — adds Templates.V2 to `/src/`
- `CliHostFactory` — calls `builder.Services.AddV2TemplateEngine()`

**Tests** — `test/Func.Tests/Templates/V2/`:
- `V2TemplateEngineTests` — substitution, `force` semantics, `AlreadyExists`, required-input failure, unsupported-action failure
- `V2EngineProviderTests` — empty registry, fixture payload round-trip (writes a `templates.json` + `userPrompts.json` + `Resources.json` on disk and asserts the provider projects them correctly), language filter

### Verification

- **Release build clean** under `CI=true / TreatWarningsAsErrors`.
- 867 / 868 tests pass (9 new V2 tests). The one pre-existing failure (`AzuriteExecutableLocator`) is unrelated to this PR.

### Chain context

This is PR2 of 4:

1. PR1 — abstractions + orchestrator scaffold ← **merge first**
2. **PR2 (this PR)** — `Templates.V2` engine
3. PR3 — `Templates.DotNet` engine
4. PR4 — channel match + bundle gates + end-to-end integration

The V2 engine works today against installed `Workloads.Templates.{Node,Python}` content workloads, but the orchestrator only invokes it once PR4 wires the channel-match and dispatch steps.
