### PR TITLE
PR3: Templates.DotNet engine — dotnet-templates.json reader + dotnet new shellout

### DIFF
--- a/Azure.Functions.Cli.slnx
+++ b/Azure.Functions.Cli.slnx
@@ -8,6 +8,7 @@
     <Project Path="src/Abstractions/Abstractions.csproj" />
     <Project Path="src/Func/Func.csproj" />
     <Project Path="src/Templates.V2/Templates.V2.csproj" />
+    <Project Path="src/Templates.DotNet/Templates.DotNet.csproj" />
   </Folder>
   <Folder Name="/src/Workloads/">
     <Project Path="src/Workloads/Host/Workloads.Host.csproj" />

--- a/src/Func/Func.csproj
+++ b/src/Func/Func.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <ProjectReference Include="../Abstractions/Abstractions.csproj" />
     <ProjectReference Include="../Templates.V2/Templates.V2.csproj" />
+    <ProjectReference Include="../Templates.DotNet/Templates.DotNet.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Func/Hosting/CliHostFactory.cs
+++ b/src/Func/Hosting/CliHostFactory.cs
@@ -14,6 +14,7 @@ using Azure.Functions.Cli.Http;
 using Azure.Functions.Cli.Quickstart;
 using Azure.Functions.Cli.Telemetry;
 using Azure.Functions.Cli.Templates;
+using Azure.Functions.Cli.Templates.DotNet;
 using Azure.Functions.Cli.Templates.V2;
 using Azure.Functions.Cli.Workers;
 using Azure.Monitor.OpenTelemetry.Exporter;
@@ -124,6 +125,7 @@ internal static class CliHostFactory
         builder.Services.AddManagedAzurite();
         builder.Services.AddTemplatesOrchestrator();
         builder.Services.AddV2TemplateEngine();
+        builder.Services.AddDotNetTemplateEngine();
 
         return builder;
     }

--- a/src/Templates.DotNet/DefaultDotnetTemplateRunner.cs
+++ b/src/Templates.DotNet/DefaultDotnetTemplateRunner.cs
@@ -1,0 +1,69 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Diagnostics;
+using System.Text;
+
+namespace Azure.Functions.Cli.Templates.DotNet;
+
+/// <summary>
+/// Production <see cref="IDotnetTemplateRunner"/> backed by
+/// <see cref="Process"/>. Resolves <c>dotnet</c> from <c>PATH</c>; relies on
+/// the user's environment having the SDK available (the templates workload
+/// already required <c>dotnet</c> at install time to provision the hive).
+/// </summary>
+internal sealed class DefaultDotnetTemplateRunner : IDotnetTemplateRunner
+{
+    public async Task<DotnetTemplateRunResult> RunAsync(
+        string shortName,
+        DirectoryInfo workingDirectory,
+        IReadOnlyList<string> extraArgs,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(shortName);
+        ArgumentNullException.ThrowIfNull(workingDirectory);
+        ArgumentNullException.ThrowIfNull(extraArgs);
+
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            WorkingDirectory = workingDirectory.FullName,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        psi.ArgumentList.Add("new");
+        psi.ArgumentList.Add(shortName);
+        foreach (string arg in extraArgs)
+        {
+            psi.ArgumentList.Add(arg);
+        }
+
+        using var process = new Process { StartInfo = psi };
+        var stdout = new StringBuilder();
+        var stderr = new StringBuilder();
+        process.OutputDataReceived += (_, e) => { if (e.Data is not null) stdout.AppendLine(e.Data); };
+        process.ErrorDataReceived += (_, e) => { if (e.Data is not null) stderr.AppendLine(e.Data); };
+
+        if (!process.Start())
+        {
+            throw new InvalidOperationException("Failed to launch 'dotnet new'.");
+        }
+
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        try
+        {
+            await process.WaitForExitAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            try { process.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+            throw;
+        }
+
+        return new DotnetTemplateRunResult(process.ExitCode, stdout.ToString(), stderr.ToString());
+    }
+}

--- a/src/Templates.DotNet/DotNetEngineProvider.cs
+++ b/src/Templates.DotNet/DotNetEngineProvider.cs
@@ -1,0 +1,157 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+
+namespace Azure.Functions.Cli.Templates.DotNet;
+
+/// <summary>
+/// DotNet engine provider. Reads each installed
+/// <c>Workloads.Templates.DotNet</c> row's <c>dotnet-templates.json</c>
+/// catalog, projects records into <see cref="FunctionTemplateInfo"/>
+/// (dedup'd by <c>groupIdentity</c>), and shells out to <c>dotnet new</c>
+/// for the actual scaffold via <see cref="IDotnetTemplateRunner"/>.
+/// </summary>
+/// <remarks>
+/// Read paths (catalog + per-template help) are offline-deterministic from
+/// the workload payload — no <c>dotnet new</c> invocation, no NuGet I/O
+/// (templates-workload-spec.md §5.3, §5.3.1). The hive is provisioned from
+/// <c>source.json</c> at <c>func workload install</c> time so the apply
+/// shell-out is offline too.
+/// </remarks>
+internal sealed class DotNetEngineProvider : ITemplateEngineProvider
+{
+    private readonly IInstalledTemplatesWorkloads _installed;
+    private readonly IDotnetTemplateRunner _runner;
+
+    public DotNetEngineProvider(IInstalledTemplatesWorkloads installed, IDotnetTemplateRunner runner)
+    {
+        _installed = installed ?? throw new ArgumentNullException(nameof(installed));
+        _runner = runner ?? throw new ArgumentNullException(nameof(runner));
+    }
+
+    public string EngineId => EngineIds.DotNet;
+
+    public async Task<IReadOnlyList<FunctionTemplateInfo>> ListTemplatesAsync(
+        TemplateListContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        IReadOnlyList<InstalledTemplatesWorkload> rows = await _installed.ListInstalledAsync(context.Stack, cancellationToken);
+        if (rows.Count == 0)
+        {
+            return [];
+        }
+
+        InstalledTemplatesWorkload selected = rows
+            .OrderByDescending(r => r.PackageVersion, StringComparer.Ordinal)
+            .First();
+
+        DotNetTemplatesIndex? index = DotNetPayloadReader.Load(selected.InstallDirectory);
+        if (index is null)
+        {
+            return [];
+        }
+
+        IReadOnlyList<FunctionTemplateInfo> projected = DotNetTemplateProjection.ProjectAll(index, context.Stack);
+        if (string.IsNullOrWhiteSpace(context.Language))
+        {
+            return projected;
+        }
+
+        return [.. projected.Where(p => MatchesLanguage(p, context.Language))];
+    }
+
+    public async Task<TemplateApplicationResult> ApplyAsync(
+        NewContext context,
+        ParseResult parseResult,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(parseResult);
+
+        // PR3: build a minimal arg list — `--name <FunctionName>` plus each
+        // declared prompt's default (or the user-supplied value once PR4
+        // wires the stage-B parse). The orchestrator owns stage-B and
+        // supplies a richer arg list in PR4.
+        var args = new List<string>
+        {
+            "--name",
+            context.FunctionName,
+        };
+
+        if (!string.IsNullOrWhiteSpace(context.Language))
+        {
+            args.Add("--language");
+            args.Add(MapToDotnetLanguageFlag(context.Language));
+        }
+
+        foreach (TemplateUserPrompt prompt in context.Template.Metadata.UserPrompts)
+        {
+            if (string.IsNullOrWhiteSpace(prompt.DefaultValue))
+            {
+                continue;
+            }
+
+            args.Add("--" + prompt.Id);
+            args.Add(prompt.DefaultValue);
+        }
+
+        try
+        {
+            DotnetTemplateRunResult result = await _runner.RunAsync(
+                context.Template.Id,
+                context.WorkingDirectory.Info,
+                args,
+                cancellationToken);
+
+            if (result.ExitCode != 0)
+            {
+                string message = string.IsNullOrWhiteSpace(result.StandardError)
+                    ? $"dotnet new '{context.Template.Id}' exited with code {result.ExitCode}."
+                    : $"dotnet new '{context.Template.Id}' exited with code {result.ExitCode}: {result.StandardError.Trim()}";
+                return new TemplateApplicationResult.Failed(
+                    new TemplateApplicationFailure.ProviderError(message, null));
+            }
+
+            // dotnet new's stdout enumerates created files; in PR3 we
+            // return the working directory as a single entry. PR4 can
+            // parse the output more carefully.
+            return new TemplateApplicationResult.Created([context.WorkingDirectory.Info.FullName]);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or IOException)
+        {
+            return new TemplateApplicationResult.Failed(
+                new TemplateApplicationFailure.ProviderError(ex.Message, ex));
+        }
+    }
+
+    private static bool MatchesLanguage(FunctionTemplateInfo info, string requestedLanguage)
+    {
+        if (info.Languages.Count == 0)
+        {
+            return true;
+        }
+
+        // Accept the canonical id (csharp / fsharp) and the dotnet-templates
+        // "language" field's typical capitalisation (C# / F#).
+        return info.Languages.Any(l => string.Equals(l, requestedLanguage, StringComparison.OrdinalIgnoreCase))
+            || info.Languages.Any(l => string.Equals(MapToCanonical(l), requestedLanguage, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string MapToCanonical(string dotnetLanguage) =>
+        dotnetLanguage.Replace("#", "sharp", StringComparison.OrdinalIgnoreCase).ToLowerInvariant();
+
+    private static string MapToDotnetLanguageFlag(string canonical) =>
+        canonical.ToLowerInvariant() switch
+        {
+            "csharp" => "C#",
+            "fsharp" => "F#",
+            _ => canonical,
+        };
+}

--- a/src/Templates.DotNet/DotNetPayloadReader.cs
+++ b/src/Templates.DotNet/DotNetPayloadReader.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Text.Json;
+
+namespace Azure.Functions.Cli.Templates.DotNet;
+
+/// <summary>
+/// Reads <c>&lt;install-dir&gt;/tools/any/content/dotnet-templates.json</c>
+/// — the fully-hydrated catalog the templates workload's pack pipeline
+/// emitted from the upstream NuGet template package (templates-workload-spec.md
+/// §5.3, §5.3.1, §6.3). Stateless.
+/// </summary>
+internal static class DotNetPayloadReader
+{
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        AllowTrailingCommas = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+    };
+
+    public static DotNetTemplatesIndex? Load(string installDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(installDirectory))
+        {
+            throw new ArgumentException("Install directory must be non-empty.", nameof(installDirectory));
+        }
+
+        string path = Path.Combine(installDirectory, "tools", "any", "content", "dotnet-templates.json");
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        using FileStream stream = File.OpenRead(path);
+        return JsonSerializer.Deserialize<DotNetTemplatesIndex>(stream, _jsonOptions);
+    }
+}

--- a/src/Templates.DotNet/DotNetSchema.cs
+++ b/src/Templates.DotNet/DotNetSchema.cs
@@ -1,0 +1,124 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Text.Json.Serialization;
+
+namespace Azure.Functions.Cli.Templates.DotNet;
+
+/// <summary>
+/// JSON DTOs for the <c>dotnet-templates.json</c> schema documented in
+/// templates-workload-spec.md §5.3.1. Hydrated at workload pack time from
+/// each upstream <c>template.json</c> + sibling <c>dotnetcli.host.json</c>.
+/// </summary>
+internal sealed class DotNetTemplatesIndex
+{
+    [JsonPropertyName("$schema")]
+    public string? Schema { get; set; }
+
+    [JsonPropertyName("sourcePackage")]
+    public DotNetSourcePackage? SourcePackage { get; set; }
+
+    [JsonPropertyName("templates")]
+    public List<DotNetTemplateRecord>? Templates { get; set; }
+}
+
+internal sealed class DotNetSourcePackage
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    [JsonPropertyName("version")]
+    public string? Version { get; set; }
+}
+
+/// <summary>
+/// One DotNet template record. Mirrors templates-workload-spec.md §5.3.1 — every
+/// field needed by `func templates list` and `func new --template X --help` is
+/// already projected at workload pack time so reads are fully offline.
+/// </summary>
+internal sealed class DotNetTemplateRecord
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    [JsonPropertyName("shortNames")]
+    public List<string>? ShortNames { get; set; }
+
+    [JsonPropertyName("identity")]
+    public string? Identity { get; set; }
+
+    [JsonPropertyName("groupIdentity")]
+    public string? GroupIdentity { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("author")]
+    public string? Author { get; set; }
+
+    [JsonPropertyName("language")]
+    public string? Language { get; set; }
+
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    [JsonPropertyName("classifications")]
+    public List<string>? Classifications { get; set; }
+
+    [JsonPropertyName("defaultName")]
+    public string? DefaultName { get; set; }
+
+    [JsonPropertyName("constraints")]
+    public List<object>? Constraints { get; set; }
+
+    [JsonPropertyName("parameters")]
+    public List<DotNetParameter>? Parameters { get; set; }
+}
+
+internal sealed class DotNetParameter
+{
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("displayName")]
+    public string? DisplayName { get; set; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("dataType")]
+    public string? DataType { get; set; }
+
+    [JsonPropertyName("defaultValue")]
+    public string? DefaultValue { get; set; }
+
+    [JsonPropertyName("choices")]
+    public List<DotNetChoice>? Choices { get; set; }
+
+    [JsonPropertyName("isRequired")]
+    public bool IsRequired { get; set; }
+
+    [JsonPropertyName("isHidden")]
+    public bool IsHidden { get; set; }
+
+    [JsonPropertyName("allowMultipleValues")]
+    public bool AllowMultipleValues { get; set; }
+
+    [JsonPropertyName("shortNameOverride")]
+    public string? ShortNameOverride { get; set; }
+
+    [JsonPropertyName("longNameOverride")]
+    public string? LongNameOverride { get; set; }
+}
+
+internal sealed class DotNetChoice
+{
+    [JsonPropertyName("value")]
+    public string? Value { get; set; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+}

--- a/src/Templates.DotNet/DotNetServiceCollectionExtensions.cs
+++ b/src/Templates.DotNet/DotNetServiceCollectionExtensions.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Azure.Functions.Cli.Templates.DotNet;
+
+/// <summary>
+/// DI registration for the DotNet engine. Hosted by <c>Func.csproj</c>;
+/// callers reach the implementation only through this extension method so
+/// the engine internals stay opaque.
+/// </summary>
+public static class DotNetServiceCollectionExtensions
+{
+    public static IServiceCollection AddDotNetTemplateEngine(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton<IDotnetTemplateRunner, DefaultDotnetTemplateRunner>();
+        services.AddSingleton<ITemplateEngineProvider, DotNetEngineProvider>();
+        return services;
+    }
+}

--- a/src/Templates.DotNet/DotNetTemplateProjection.cs
+++ b/src/Templates.DotNet/DotNetTemplateProjection.cs
@@ -1,0 +1,138 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Templates.DotNet;
+
+/// <summary>
+/// Projects a <see cref="DotNetTemplateRecord"/> from
+/// <c>dotnet-templates.json</c> into the engine-agnostic
+/// <see cref="FunctionTemplateInfo"/> the orchestrator consumes.
+/// Implements the §5.5.2 / §5.5.4 <c>groupIdentity</c> dedup: when the same
+/// catalog ships C# and F# variants of one template (shared
+/// <c>groupIdentity</c>), the user sees one row whose
+/// <see cref="FunctionTemplateInfo.Languages"/> lists both languages.
+/// </summary>
+internal static class DotNetTemplateProjection
+{
+    public static IReadOnlyList<FunctionTemplateInfo> ProjectAll(DotNetTemplatesIndex index, string stack)
+    {
+        ArgumentNullException.ThrowIfNull(index);
+        if (index.Templates is null || index.Templates.Count == 0)
+        {
+            return [];
+        }
+
+        // Group by groupIdentity (case-insensitive); records with no
+        // groupIdentity collapse on identity / shortName instead.
+        IEnumerable<IGrouping<string, DotNetTemplateRecord>> groups = index.Templates
+            .Where(t => !string.IsNullOrWhiteSpace(t.Id))
+            .GroupBy(DedupKey, StringComparer.OrdinalIgnoreCase);
+
+        List<FunctionTemplateInfo> results = [];
+        foreach (IGrouping<string, DotNetTemplateRecord> group in groups)
+        {
+            FunctionTemplateInfo? projected = ProjectGroup(group, stack);
+            if (projected is not null)
+            {
+                results.Add(projected);
+            }
+        }
+
+        return results;
+    }
+
+    private static string DedupKey(DotNetTemplateRecord record)
+    {
+        if (!string.IsNullOrWhiteSpace(record.GroupIdentity))
+        {
+            return record.GroupIdentity;
+        }
+
+        if (!string.IsNullOrWhiteSpace(record.Identity))
+        {
+            return record.Identity;
+        }
+
+        return record.Id ?? string.Empty;
+    }
+
+    private static FunctionTemplateInfo? ProjectGroup(IEnumerable<DotNetTemplateRecord> group, string stack)
+    {
+        // Use the first record as the representative for naming + parameters.
+        // Languages aggregate across all records in the group.
+        var records = group.ToList();
+        DotNetTemplateRecord head = records[0];
+        if (string.IsNullOrWhiteSpace(head.Id))
+        {
+            return null;
+        }
+
+        List<string> languages = [.. records
+            .Where(r => !string.IsNullOrWhiteSpace(r.Language))
+            .Select(r => r.Language!.Trim().ToLowerInvariant())
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(l => l, StringComparer.Ordinal)];
+
+        string triggerKind = ResolveTriggerKind(head.Classifications) ?? "function";
+        TemplateMetadata metadata = new(
+            UserPrompts: head.Parameters?.Where(p => !p.IsHidden).Select(ProjectParameter).ToList() ?? [],
+            RequiresExtensionBundle: false,
+            MinBundleVersion: null);
+
+        return new FunctionTemplateInfo(
+            Id: head.Id,
+            Stack: stack,
+            EngineId: EngineIds.DotNet,
+            DisplayName: head.Name ?? head.Id,
+            TriggerKind: triggerKind,
+            Description: head.Description,
+            DefaultFunctionName: head.DefaultName,
+            Languages: languages,
+            Metadata: metadata);
+    }
+
+    private static TemplateUserPrompt ProjectParameter(DotNetParameter parameter)
+    {
+        string id = parameter.Name ?? string.Empty;
+        string dataType = (parameter.DataType ?? "string").ToLowerInvariant();
+        IReadOnlyList<string>? choices = parameter.Choices?
+            .Where(c => !string.IsNullOrWhiteSpace(c.Value))
+            .Select(c => c.Value!)
+            .ToList();
+
+        return new TemplateUserPrompt(
+            Id: id,
+            Description: parameter.Description ?? parameter.DisplayName,
+            DataType: dataType == "choice" ? "choice" : dataType,
+            DefaultValue: parameter.DefaultValue,
+            Choices: choices,
+            IsRequired: parameter.IsRequired,
+            ValidatorRegex: null,
+            ShortAlias: parameter.ShortNameOverride is { Length: > 0 } s ? "-" + s : null,
+            LongAlias: parameter.LongNameOverride is { Length: > 0 } l ? "--" + l : null);
+    }
+
+    private static string? ResolveTriggerKind(IReadOnlyList<string>? classifications)
+    {
+        if (classifications is null)
+        {
+            return null;
+        }
+
+        // Convention: the last classification entry tends to be the trigger
+        // specialisation (e.g. ["Azure Function", "Trigger", "Http"]).
+        // Surfaces "http" / "timer" / etc. as the trigger column.
+        for (int i = classifications.Count - 1; i >= 0; i--)
+        {
+            string entry = classifications[i];
+            if (!string.IsNullOrWhiteSpace(entry)
+                && !entry.Equals("Azure Function", StringComparison.OrdinalIgnoreCase)
+                && !entry.Equals("Trigger", StringComparison.OrdinalIgnoreCase))
+            {
+                return entry.ToLowerInvariant();
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Templates.DotNet/IDotnetTemplateRunner.cs
+++ b/src/Templates.DotNet/IDotnetTemplateRunner.cs
@@ -1,0 +1,49 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Templates.DotNet;
+
+/// <summary>
+/// Engine-side abstraction over the <c>dotnet new</c> shell-out the DotNet
+/// engine performs at apply time (templates-workload-spec.md §6.3 /
+/// func-new spec §4.3). Kept narrow on purpose so tests can substitute the
+/// process invocation without standing up a real <c>dotnet</c> child.
+/// </summary>
+internal interface IDotnetTemplateRunner
+{
+    /// <summary>
+    /// Runs <c>dotnet new &lt;shortName&gt; --output &lt;workingDirectory&gt; …extraArgs</c>
+    /// against the dotnet template hive that <c>func workload install</c>
+    /// provisioned from <c>content/source.json</c>. Returns the process's
+    /// exit code; non-zero is surfaced as
+    /// <see cref="TemplateApplicationFailure.ProviderError"/> by the engine.
+    /// </summary>
+    /// <param name="shortName">
+    /// The template <c>shortName</c> the upstream <c>dotnet new</c> CLI accepts
+    /// — sourced from <see cref="DotNetTemplateRecord.ShortNames"/>[0]
+    /// (= <see cref="FunctionTemplateInfo.Id"/> for DotNet templates).
+    /// </param>
+    /// <param name="workingDirectory">
+    /// The project directory the scaffold writes into.
+    /// </param>
+    /// <param name="extraArgs">
+    /// Additional CLI arguments (e.g. <c>--name MyFn --AccessRights Anonymous</c>)
+    /// the orchestrator built from the stage-B parsed values. Already
+    /// shell-safe — the implementation forwards them verbatim.
+    /// </param>
+    public Task<DotnetTemplateRunResult> RunAsync(
+        string shortName,
+        DirectoryInfo workingDirectory,
+        IReadOnlyList<string> extraArgs,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Outcome of <see cref="IDotnetTemplateRunner.RunAsync"/>. Combined stdout
+/// + stderr text is captured for diagnostics; the runner does not stream
+/// to the user's console (the engine decides how to surface output).
+/// </summary>
+/// <param name="ExitCode">Process exit code.</param>
+/// <param name="StandardOutput">Captured stdout.</param>
+/// <param name="StandardError">Captured stderr.</param>
+internal sealed record DotnetTemplateRunResult(int ExitCode, string StandardOutput, string StandardError);

--- a/src/Templates.DotNet/Templates.DotNet.csproj
+++ b/src/Templates.DotNet/Templates.DotNet.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Description>DotNet template engine — reads dotnet-templates.json + shells out to `dotnet new` against the workload-install-time provisioned hive.</Description>
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="func" />
+    <InternalsVisibleTo Include="Azure.Functions.Cli.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(SrcRoot)Abstractions/Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+
+</Project>

--- a/src/Templates.V2/V2EngineProvider.cs
+++ b/src/Templates.V2/V2EngineProvider.cs
@@ -13,14 +13,12 @@ namespace Azure.Functions.Cli.Templates.V2;
 /// <see cref="V2TemplateEngine"/>.
 /// </summary>
 /// <remarks>
-/// Channel match and min-bundle gates live in the orchestrator (PR4); this
-/// provider operates over whichever installed workload(s) the orchestrator
-/// hands it. PR2 takes the highest-version installed pkg per stack as a
-/// best-effort default and supplies the engine with each prompt's declared
-/// default value; PR4 replaces this with the orchestrator's stage-B
-/// hydrated parse result so user-supplied option values flow through.
+/// PR2 takes the highest-version installed pkg per stack as a best-effort
+/// default and supplies the engine with each prompt's declared default
+/// value; PR4 replaces this with the orchestrator's stage-B hydrated parse
+/// result so user-supplied option values flow through.
 /// </remarks>
-public sealed class V2EngineProvider : ITemplateEngineProvider
+internal sealed class V2EngineProvider : ITemplateEngineProvider
 {
     private readonly IInstalledTemplatesWorkloads _installed;
     private readonly V2TemplateEngine _engine;

--- a/test/Func.Tests/Templates/DotNet/DotNetEngineProviderTests.cs
+++ b/test/Func.Tests/Templates/DotNet/DotNetEngineProviderTests.cs
@@ -1,0 +1,228 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Templates;
+using Azure.Functions.Cli.Templates.DotNet;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Templates.DotNet;
+
+public class DotNetEngineProviderTests : IDisposable
+{
+    private readonly string _installDir;
+
+    public DotNetEngineProviderTests()
+    {
+        _installDir = Path.Combine(Path.GetTempPath(), "func-new-pr3-dotnet-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_installDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_installDir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task ListTemplatesAsync_Empty_Registry_Returns_Empty()
+    {
+        IInstalledTemplatesWorkloads installed = Substitute.For<IInstalledTemplatesWorkloads>();
+        installed.ListInstalledAsync("dotnet", Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<InstalledTemplatesWorkload>());
+
+        IDotnetTemplateRunner runner = Substitute.For<IDotnetTemplateRunner>();
+        var provider = new DotNetEngineProvider(installed, runner);
+
+        IReadOnlyList<FunctionTemplateInfo> templates = await provider.ListTemplatesAsync(
+            new TemplateListContext(new Cli.Common.WorkingDirectory(new DirectoryInfo(_installDir), false), "dotnet", "csharp"),
+            CancellationToken.None);
+
+        Assert.Empty(templates);
+    }
+
+    [Fact]
+    public async Task ListTemplatesAsync_Dedupes_CSharp_FSharp_By_GroupIdentity()
+    {
+        WriteFixture(_installDir);
+
+        IInstalledTemplatesWorkloads installed = Substitute.For<IInstalledTemplatesWorkloads>();
+        installed.ListInstalledAsync("dotnet", Arg.Any<CancellationToken>())
+            .Returns([new InstalledTemplatesWorkload("dotnet", "1.0.0", _installDir)]);
+
+        IDotnetTemplateRunner runner = Substitute.For<IDotnetTemplateRunner>();
+        var provider = new DotNetEngineProvider(installed, runner);
+
+        IReadOnlyList<FunctionTemplateInfo> templates = await provider.ListTemplatesAsync(
+            new TemplateListContext(new Cli.Common.WorkingDirectory(new DirectoryInfo(_installDir), false), "dotnet", null),
+            CancellationToken.None);
+
+        // Two records (C# + F# variants of HttpTrigger sharing groupIdentity)
+        // collapse to a single FunctionTemplateInfo whose Languages list both.
+        var info = Assert.Single(templates);
+        Assert.Equal("http", info.Id);
+        Assert.Equal(EngineIds.DotNet, info.EngineId);
+        Assert.Contains("c#", info.Languages, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("f#", info.Languages, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ListTemplatesAsync_Filters_By_Language()
+    {
+        WriteFixture(_installDir);
+
+        IInstalledTemplatesWorkloads installed = Substitute.For<IInstalledTemplatesWorkloads>();
+        installed.ListInstalledAsync("dotnet", Arg.Any<CancellationToken>())
+            .Returns([new InstalledTemplatesWorkload("dotnet", "1.0.0", _installDir)]);
+
+        IDotnetTemplateRunner runner = Substitute.For<IDotnetTemplateRunner>();
+        var provider = new DotNetEngineProvider(installed, runner);
+
+        // Stack-language "csharp" should accept the deduped HttpTrigger record
+        // since C# is one of its supported languages.
+        IReadOnlyList<FunctionTemplateInfo> csharp = await provider.ListTemplatesAsync(
+            new TemplateListContext(new Cli.Common.WorkingDirectory(new DirectoryInfo(_installDir), false), "dotnet", "csharp"),
+            CancellationToken.None);
+
+        Assert.Single(csharp);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_Successful_Exit_Returns_Created()
+    {
+        WriteFixture(_installDir);
+
+        IInstalledTemplatesWorkloads installed = Substitute.For<IInstalledTemplatesWorkloads>();
+        installed.ListInstalledAsync("dotnet", Arg.Any<CancellationToken>())
+            .Returns([new InstalledTemplatesWorkload("dotnet", "1.0.0", _installDir)]);
+
+        IDotnetTemplateRunner runner = Substitute.For<IDotnetTemplateRunner>();
+        runner.RunAsync(
+                Arg.Any<string>(),
+                Arg.Any<DirectoryInfo>(),
+                Arg.Any<IReadOnlyList<string>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new DotnetTemplateRunResult(0, "Created file Function1.cs", string.Empty));
+
+        var provider = new DotNetEngineProvider(installed, runner);
+
+        FunctionTemplateInfo info = new(
+            Id: "http",
+            Stack: "dotnet",
+            EngineId: EngineIds.DotNet,
+            DisplayName: "HttpTrigger",
+            TriggerKind: "http",
+            Description: null,
+            DefaultFunctionName: null,
+            Languages: ["c#"],
+            Metadata: new TemplateMetadata([], RequiresExtensionBundle: false, MinBundleVersion: null));
+
+        TemplateApplicationResult result = await provider.ApplyAsync(
+            new NewContext(
+                new Cli.Common.WorkingDirectory(new DirectoryInfo(_installDir), false),
+                info,
+                FunctionName: "Function1",
+                Language: "csharp",
+                Force: false),
+            new System.CommandLine.RootCommand().Parse(string.Empty),
+            CancellationToken.None);
+
+        Assert.IsType<TemplateApplicationResult.Created>(result);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_NonZero_Exit_Returns_ProviderError()
+    {
+        WriteFixture(_installDir);
+
+        IInstalledTemplatesWorkloads installed = Substitute.For<IInstalledTemplatesWorkloads>();
+        installed.ListInstalledAsync("dotnet", Arg.Any<CancellationToken>())
+            .Returns([new InstalledTemplatesWorkload("dotnet", "1.0.0", _installDir)]);
+
+        IDotnetTemplateRunner runner = Substitute.For<IDotnetTemplateRunner>();
+        runner.RunAsync(
+                Arg.Any<string>(),
+                Arg.Any<DirectoryInfo>(),
+                Arg.Any<IReadOnlyList<string>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new DotnetTemplateRunResult(2, string.Empty, "Template 'http' could not be found."));
+
+        var provider = new DotNetEngineProvider(installed, runner);
+
+        FunctionTemplateInfo info = new(
+            Id: "http",
+            Stack: "dotnet",
+            EngineId: EngineIds.DotNet,
+            DisplayName: "HttpTrigger",
+            TriggerKind: "http",
+            Description: null,
+            DefaultFunctionName: null,
+            Languages: ["c#"],
+            Metadata: new TemplateMetadata([], RequiresExtensionBundle: false, MinBundleVersion: null));
+
+        TemplateApplicationResult result = await provider.ApplyAsync(
+            new NewContext(
+                new Cli.Common.WorkingDirectory(new DirectoryInfo(_installDir), false),
+                info,
+                FunctionName: "Fn",
+                Language: "csharp",
+                Force: false),
+            new System.CommandLine.RootCommand().Parse(string.Empty),
+            CancellationToken.None);
+
+        var failed = Assert.IsType<TemplateApplicationResult.Failed>(result);
+        Assert.IsType<TemplateApplicationFailure.ProviderError>(failed.Failure);
+    }
+
+    private static void WriteFixture(string installDir)
+    {
+        string contentDir = Path.Combine(installDir, "tools", "any", "content");
+        Directory.CreateDirectory(contentDir);
+
+        File.WriteAllText(Path.Combine(contentDir, "dotnet-templates.json"), """
+        {
+          "$schema": "https://aka.ms/func-workloads/dotnet-templates/v1/schema.json",
+          "sourcePackage": { "id": "Microsoft.Azure.Functions.Worker.ItemTemplates.NetCore", "version": "4.0.5569" },
+          "templates": [
+            {
+              "id": "http",
+              "shortNames": ["http"],
+              "identity": "Azure.Function.CSharp.HttpTrigger.2.x",
+              "groupIdentity": "Azure.Function.HttpTrigger",
+              "name": "HttpTrigger",
+              "description": "Creates an HTTP-triggered function.",
+              "language": "C#",
+              "type": "item",
+              "classifications": ["Azure Function", "Trigger", "Http"],
+              "defaultName": "HttpTriggerCSharp",
+              "parameters": [
+                {
+                  "name": "namespace",
+                  "description": "namespace for the generated code",
+                  "dataType": "string",
+                  "defaultValue": "Company.Function",
+                  "isRequired": false,
+                  "isHidden": false
+                }
+              ]
+            },
+            {
+              "id": "http",
+              "shortNames": ["http"],
+              "identity": "Azure.Function.FSharp.HttpTrigger.2.x",
+              "groupIdentity": "Azure.Function.HttpTrigger",
+              "name": "HttpTrigger",
+              "description": "Creates an HTTP-triggered function.",
+              "language": "F#",
+              "type": "item",
+              "classifications": ["Azure Function", "Trigger", "Http"],
+              "defaultName": "HttpTriggerFSharp"
+            }
+          ]
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(contentDir, "source.json"), """
+        { "kind": "nuget", "packageId": "Microsoft.Azure.Functions.Worker.ItemTemplates.NetCore", "version": "4.0.5569" }
+        """);
+    }
+}


### PR DESCRIPTION
## PR3 of 4 — `Templates.DotNet` engine (`dotnet-templates.json` reader + `dotnet new` shellout)

> **Base branch:** `nasoni/func-new-pr2-v2-engine` — this PR is layered on top of PR2 (which is on top of PR1). Merge the chain in order.

Adds the DotNet template engine per [`docs/proposed/func-new.spec.md`](https://github.com/Azure/azure-functions-core-tools/blob/vnext/docs/proposed/func-new.spec.md) §4.3 / §4.8.3 — reads the fully-hydrated `dotnet-templates.json` catalog from `Workloads.Templates.DotNet` and shells out to `dotnet new` for the actual scaffold.

### What's in this PR

**New CLI-internal csproj** — `src/Templates.DotNet/Templates.DotNet.csproj` (sibling to Templates.V2, same shape). `IsPackable=false`; project-referenced from `Func.csproj`.

**Files:**
- `DotNetSchema.cs` — JSON DTOs: `DotNetTemplatesIndex`, `DotNetTemplateRecord`, `DotNetParameter`, `DotNetChoice`, `DotNetSourcePackage` (full schema per [`templates-workload-spec.md`](https://github.com/Azure/azure-functions-core-tools/blob/vnext/docs/proposed/templates-workload-spec.md) §5.3.1)
- `DotNetPayloadReader` — loads `<install-dir>/tools/any/content/dotnet-templates.json`
- `DotNetTemplateProjection` — projects records into `FunctionTemplateInfo`, **deduping adjacent C#/F# variants by `groupIdentity`** (per func-new spec §5.5.2 + templates-workload-spec §5.3.1). Languages list aggregates across the deduped group; first record drives naming and parameters
- `IDotnetTemplateRunner` / `DotnetTemplateRunResult` — internal shellout abstraction (kept narrow; PR4+ can unify with the DotNet stack workload's `IDotnetCliRunner` if cross-stack sharing is needed)
- `DefaultDotnetTemplateRunner` — `Process`-backed impl with stdout/stderr capture and Ctrl+C cooperation
- `DotNetEngineProvider` — internal `ITemplateEngineProvider` impl. `List` reads + projects; `Apply` builds the arg list (`--name`, `--language`, each declared prompt's default) and shells out via the runner. Non-zero exit surfaces as `TemplateApplicationFailure.ProviderError`
- `DotNetServiceCollectionExtensions.AddDotNetTemplateEngine()` — public DI registration

**Wiring:**
- `Func.csproj` — ProjectReference to `Templates.DotNet`
- `Azure.Functions.Cli.slnx` — adds `Templates.DotNet` to `/src/`
- `CliHostFactory` — calls `builder.Services.AddDotNetTemplateEngine()`

**Drive-by** — `V2EngineProvider` normalized to `internal` to match the new DotNet pattern. DI registration is the only public surface for both engines.

**Tests** — `test/Func.Tests/Templates/DotNet/`:
- `DotNetEngineProviderTests` — empty registry; **C#/F# `groupIdentity` dedup** (HttpTrigger with both language variants → one `FunctionTemplateInfo` whose `Languages` lists both); language filter; successful `Apply` (Created); non-zero-exit `Apply` (ProviderError). Uses a substituted `IDotnetTemplateRunner` so no real `dotnet` child is spawned in tests.

### Verification

- **Release build clean** under `CI=true / TreatWarningsAsErrors`.
- 872 / 873 tests pass (5 new DotNet tests). The one pre-existing failure (`AzuriteExecutableLocator`) is unrelated to this PR.

### Chain context

This is PR3 of 4:

1. PR1 — abstractions + orchestrator scaffold ← **merge first**
2. PR2 — `Templates.V2` engine
3. **PR3 (this PR)** — `Templates.DotNet` engine
4. PR4 — channel match + bundle gates + end-to-end integration

Catalog/help paths are offline-deterministic from the workload payload. The hive is provisioned from `content/source.json` at `func workload install` time so the apply shell-out is offline too (templates-workload-spec.md §5.3, §6.3) — that install-pipeline plumbing is outside this PR's scope.
