### PR TITLE
Add v5 issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/03-v5-bug-bash.yml
+++ b/.github/ISSUE_TEMPLATE/03-v5-bug-bash.yml
@@ -1,0 +1,57 @@
+name: V5 Bug Bash Report
+description: Report a bug, issue, or suggestion from the Azure Functions CLI v5 bug bash.
+title: "[v5 bug bash] "
+labels: ["v5", "bug-bash"]
+body:
+- id: version
+  type: textarea
+  attributes:
+    label: Version
+    description: Output of `func --verbose` (include the Core Tools version and RID).
+    placeholder: |
+      $ func --verbose
+      ...
+- id: os
+  type: textarea
+  attributes:
+    label: OS / shell
+    placeholder: e.g., macOS 14.4, zsh; Windows 11, PowerShell 7.4
+- id: stack
+  type: textarea
+  attributes:
+    label: Stack
+    description: If applicable, the worker stack and runtime version.
+    placeholder: e.g., node 20.11, python 3.11, dotnet 8.0, go 1.22
+- id: description
+  type: textarea
+  attributes:
+    label: Description
+    placeholder: Description of the bug, issue, or suggestion.
+  validations:
+    required: true
+- id: repro
+  type: textarea
+  attributes:
+    label: Steps to reproduce
+    placeholder: Steps to reproduce, including the exact commands run.
+  validations:
+    required: true
+- id: expected
+  type: textarea
+  attributes:
+    label: Expected behavior
+    placeholder: What you expected to happen.
+- id: actual
+  type: textarea
+  attributes:
+    label: Actual behavior
+    description: Actual behavior and the full command output. For colored output, re-run with `NO_COLOR=1` set before copying.
+    placeholder: |
+      $ NO_COLOR=1 func ...
+      ...
+- id: logs
+  type: textarea
+  attributes:
+    label: Stack trace / logs
+    description: If this is a crash, re-run with `--verbose` and paste the output here.
+    render: shell

--- a/.github/ISSUE_TEMPLATE/03-v5-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/03-v5-bug-report.yml
@@ -1,7 +1,7 @@
-name: V5 Bug Bash Report
-description: Report a bug, issue, or suggestion from the Azure Functions CLI v5 bug bash.
-title: "[v5 bug bash] "
-labels: ["v5", "bug-bash"]
+name: V5 Bug Report
+description: Report a bug or issue with the Azure Functions CLI v5.
+title: "[v5] "
+labels: ["v5"]
 body:
 - id: version
   type: textarea
@@ -26,7 +26,7 @@ body:
   type: textarea
   attributes:
     label: Description
-    placeholder: Description of the bug, issue, or suggestion.
+    placeholder: Description of the bug or issue.
   validations:
     required: true
 - id: repro


### PR DESCRIPTION
Adds a dedicated bug report template for Azure Functions CLI v5 so reports auto-tag with `v5` for triage. Used during the v5 bug bash and beyond.