### PR TITLE
Fix Linux CI: use forward slashes in Node templates pack targets

### DIFF
--- a/eng/build/Workloads.Templates.targets
+++ b/eng/build/Workloads.Templates.targets
@@ -241,23 +241,28 @@
           Condition="'$(TemplatesContentSource)' == 'static' and '$(FilterTemplatesByBundleChannel)' == 'true' and '$(IncludeV2Templates)' == 'true'"
           BeforeTargets="_GetPackageFiles"
           Inputs="$(MSBuildProjectFullPath)"
-          Outputs="$(IntermediateOutputPath)templates\bundle\extensions.json">
+          Outputs="$(IntermediateOutputPath)templates/bundle/extensions.json">
     <Error Condition="'$(TemplatesChannel)' == ''"
            Text="FilterTemplatesByBundleChannel=true requires TemplatesChannel to be set (stable | preview | experimental)." />
-    <MakeDir Directories="$(IntermediateOutputPath)templates\bundle\" />
-    <Exec Command="pwsh -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)..\scripts\fetch-bundle-extensions-json.ps1&quot; -Channel &quot;$(TemplatesChannel)&quot; -OutputPath &quot;$(IntermediateOutputPath)templates\bundle\extensions.json&quot; -VersionOut &quot;$(IntermediateOutputPath)templates\bundle\version.txt&quot;" />
+    <!--
+      Paths passed to `<Exec>` are substituted into the shell command
+      verbatim, so they must use the platform-neutral forward-slash form
+      (per AGENTS.md and the repo style guide). On Linux build agents,
+      backslashes are literal filename characters, not path separators,
+      and the staged file ends up at the wrong path.
+    -->
+    <Exec Command="pwsh -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)../scripts/fetch-bundle-extensions-json.ps1&quot; -Channel &quot;$(TemplatesChannel)&quot; -OutputPath &quot;$(IntermediateOutputPath)templates/bundle/extensions.json&quot; -VersionOut &quot;$(IntermediateOutputPath)templates/bundle/version.txt&quot;" />
   </Target>
 
   <Target Name="FilterStaticTemplatesByBundleChannel"
           DependsOnTargets="FetchBundleExtensionsForChannel"
           Condition="'$(TemplatesContentSource)' == 'static' and '$(FilterTemplatesByBundleChannel)' == 'true' and '$(IncludeV2Templates)' == 'true'"
           BeforeTargets="_GetPackageFiles"
-          Inputs="$(MSBuildProjectDirectory)/content/v2/templates/templates.json;$(MSBuildProjectDirectory)/content/v2/templates/_bindings.json;$(IntermediateOutputPath)templates\bundle\extensions.json"
-          Outputs="$(IntermediateOutputPath)templates\v2\templates\templates.json">
+          Inputs="$(MSBuildProjectDirectory)/content/v2/templates/templates.json;$(MSBuildProjectDirectory)/content/v2/templates/_bindings.json;$(IntermediateOutputPath)templates/bundle/extensions.json"
+          Outputs="$(IntermediateOutputPath)templates/v2/templates/templates.json">
     <Error Condition="!Exists('$(MSBuildProjectDirectory)/content/v2/templates/_bindings.json')"
            Text="FilterTemplatesByBundleChannel=true requires content/v2/templates/_bindings.json (per-template binding-requirements map)." />
-    <MakeDir Directories="$(IntermediateOutputPath)templates\v2\templates\" />
-    <Exec Command="pwsh -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)..\scripts\filter-node-templates-by-bundle.ps1&quot; -TemplatesPath &quot;$(MSBuildProjectDirectory)/content/v2/templates/templates.json&quot; -BindingsMapPath &quot;$(MSBuildProjectDirectory)/content/v2/templates/_bindings.json&quot; -ExtensionsJsonPath &quot;$(IntermediateOutputPath)templates\bundle\extensions.json&quot; -OutputPath &quot;$(IntermediateOutputPath)templates\v2\templates\templates.json&quot; -ChannelLabel &quot;$(TemplatesChannel)&quot;" />
+    <Exec Command="pwsh -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)../scripts/filter-node-templates-by-bundle.ps1&quot; -TemplatesPath &quot;$(MSBuildProjectDirectory)/content/v2/templates/templates.json&quot; -BindingsMapPath &quot;$(MSBuildProjectDirectory)/content/v2/templates/_bindings.json&quot; -ExtensionsJsonPath &quot;$(IntermediateOutputPath)templates/bundle/extensions.json&quot; -OutputPath &quot;$(IntermediateOutputPath)templates/v2/templates/templates.json&quot; -ChannelLabel &quot;$(TemplatesChannel)&quot;" />
   </Target>
 
   <Target Name="_AddStaticTemplatesToPack"
@@ -285,7 +290,7 @@
             Exclude="$(MSBuildProjectDirectory)/content/v2/templates/templates.json;$(MSBuildProjectDirectory)/content/v2/templates/_bindings.json"
             Pack="true" PackagePath="tools/any/content/v2/" Visible="false" />
       <None Condition="'$(IncludeV2Templates)' == 'true' and '$(FilterTemplatesByBundleChannel)' == 'true'"
-            Include="$(IntermediateOutputPath)templates\v2\templates\templates.json"
+            Include="$(IntermediateOutputPath)templates/v2/templates/templates.json"
             Pack="true" PackagePath="tools/any/content/v2/templates/" Visible="false" />
 
       <!--

--- a/eng/scripts/fetch-bundle-extensions-json.ps1
+++ b/eng/scripts/fetch-bundle-extensions-json.ps1
@@ -59,6 +59,13 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+# Normalize path separators upfront. On Linux, backslashes are literal
+# filename characters, not directory separators, so any call site that
+# passes a Windows-style path produces a single mangled file under the
+# parent directory. .NET accepts forward slashes on both platforms.
+$OutputPath = $OutputPath -replace '\\', '/'
+if ($VersionOut) { $VersionOut = $VersionOut -replace '\\', '/' }
+
 $cdnRoot = 'https://cdn.functions.azure.com/public/ExtensionBundles'
 $bundleId = switch ($Channel) {
     'stable'       { 'Microsoft.Azure.Functions.ExtensionBundle' }

--- a/eng/scripts/filter-node-templates-by-bundle.ps1
+++ b/eng/scripts/filter-node-templates-by-bundle.ps1
@@ -63,6 +63,14 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+# Normalize path separators upfront. On Linux, backslashes are literal
+# filename characters, not directory separators. .NET accepts forward
+# slashes on both platforms.
+$TemplatesPath      = $TemplatesPath      -replace '\\', '/'
+$BindingsMapPath    = $BindingsMapPath    -replace '\\', '/'
+$ExtensionsJsonPath = $ExtensionsJsonPath -replace '\\', '/'
+$OutputPath         = $OutputPath         -replace '\\', '/'
+
 foreach ($p in $TemplatesPath, $BindingsMapPath, $ExtensionsJsonPath) {
     if (-not (Test-Path -LiteralPath $p)) {
         throw "filter-node-templates-by-bundle: file not found: $p"


### PR DESCRIPTION
## Summary

Hotfix for the Linux CI build failure on the merge of PR #5143. The Node static-mode targets I added used Windows-style backslashes in paths passed to `<Exec>` and recorded in `<Outputs>` attributes. On Linux build agents (1ES Ubuntu hosted pool), backslashes are literal filename characters — not path separators — so the build failed at the filter step.

## Symptom (from the failing build log)

```
fetch-bundle-extensions-json: wrote 6310 bytes to /mnt/vss/_work/1/s/out/obj/Workloads.Templates.Node/release/templates\bundle\extensions.json
…
[31;1mException: …filter-node-templates-by-bundle: file not found:
/mnt/vss/_work/1/s/out/obj/Workloads.Templates.Node/release/templates\bundle\extensions.json
…
error MSB3073: The command "pwsh … filter-node-templates-by-bundle.ps1 …" exited with code 1.
```

`fetch-bundle-extensions-json.ps1` wrote `bin/extensions.json` to a single mangled file named `templates\bundle\extensions.json` (backslashes treated as part of the filename) inside the `release/` directory. The follow-on `filter-node-templates-by-bundle.ps1`'s `Test-Path -LiteralPath` then couldn't resolve the same literal string against the file the OS actually created — failing the build.

## Fix

`eng/build/Workloads.Templates.targets` — every path my two new Node targets pass to `<Exec>` or record in `<Inputs>`/`<Outputs>` is now in the **forward-slash** form mandated by AGENTS.md ("Path separators: use forward slashes (/) in MSBuild paths (csproj/props/targets/slnx), not backslashes."). Specifically:

- `Outputs="$(IntermediateOutputPath)templates/bundle/extensions.json"` (was `templates\bundle\extensions.json`)
- `Outputs="$(IntermediateOutputPath)templates/v2/templates/templates.json"` (was `templates\v2\templates\templates.json`)
- `Inputs="…/templates\bundle\extensions.json"` → `…/templates/bundle/extensions.json`
- `<Exec Command="… -OutputPath &quot;$(IntermediateOutputPath)templates/bundle/extensions.json&quot; …">`
- `<Exec Command="… -ExtensionsJsonPath &quot;$(IntermediateOutputPath)templates/bundle/extensions.json&quot; -OutputPath &quot;$(IntermediateOutputPath)templates/v2/templates/templates.json&quot; …">`

Also dropped the now-redundant `<MakeDir>` steps — `fetch-bundle-extensions-json.ps1` already calls `New-Item -ItemType Directory -Force` on its own output's parent.

### Defense in depth (PowerShell scripts)

Added a one-liner at the top of each script that normalizes input paths from backslashes to forward slashes, so a stale call site can't reproduce this exact failure mode again:

```powershell
$OutputPath = $OutputPath -replace '\\', '/'
```

`.NET` accepts forward slashes on both Windows and Linux, so this is safe on both platforms.

### Why CDN-mode targets were left alone

Pre-existing CDN-mode targets (`DownloadTemplatesContent`, `FilterTemplatesByLanguage`, etc.) still use backslashes in their paths. Those work on Linux because they only flow through built-in MSBuild tasks (`<DownloadFile>`, `<None Include>`) which normalize path separators internally. They weren't part of the failing change, so this PR doesn't touch them — surgical fix only.

## Verification

Local repack of the Node workload (stable channel default):

```
fetch-bundle-extensions-json: channel=stable id=…ExtensionBundle version=4.32.0
fetch-bundle-extensions-json: extracting bin/extensions.json from https://…/4.32.0/…4.32.0.zip
fetch-bundle-extensions-json: wrote 6310 bytes to
  C:/root/worktreeRepos/nodeworkload/out/obj/Workloads.Templates.Node/release/templates/bundle/extensions.json
filter-node-templates-by-bundle (stable) : kept 31 of 33 entries; dropped 2.
Successfully created package Azure.Functions.Cli.Workloads.Templates.Node.1.0.0-dev.nupkg.
```

All paths are now clean forward-slash form. Filter step succeeds. The build-failure path string `…release/templates\bundle\extensions.json` is gone.

## Side note: "why is Node downloading a bundle?"

It isn't. The fetch script issues **two HTTP Range requests** against `<bundle>.zip` (last ~64 KB for the central directory + the entry's bytes) to extract just `bin/extensions.json` — total transfer per pack is ~10 KB, not the full 150–250 MB bundle. The 230 MB download in the same build log is from the unrelated `Workloads.ExtensionBundles` workload, which has always shipped the full bundle as its own content payload.
