### PR TITLE
Add FUNC_CLI_HOME env var to override CLI home directory

### DIFF
--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -310,6 +310,14 @@ The CLI is opt-out: when no instrumentation key is baked in (the default for loc
 
 The telemetry instrumentation key is injected at build time via `eng/build/Telemetry.props` as an assembly attribute. Local builds use an all-zeros placeholder (which disables telemetry). CI builds override via `/p:TelemetryInstrumentationKey=<key>`.
 
+## CLI Home Directory
+
+The CLI persists configuration, profiles, caches, the version-check stamp, the quickstart manifest cache, workloads, and the dotnet template hive under a single "func home" root. By default this is `~/.azure-functions/`.
+
+- **Override**: set `FUNC_CLI_HOME` to an absolute path to relocate the entire home (handy for sandboxed CI, devcontainers, or per-user installs that can't write the user profile).
+- The env var is read directly (not via `IConfiguration`) so host config, global config, or project `.func/config.json` can't redirect it.
+- Subsystems that need their own override on top of the home still honor it: `FUNC_CLI_WORKLOADS_HOME` (workloads root) and `FUNC_CLI_DOTNET_TEMPLATE_HIVE` (dotnet template hive) take precedence over `FUNC_CLI_HOME` when set.
+
 ## Version Upgrade Check
 
 At startup, the CLI runs a non-blocking background check for newer v5 releases via the GitHub Releases API.

--- a/src/Abstractions/Common/Constants.cs
+++ b/src/Abstractions/Common/Constants.cs
@@ -12,4 +12,15 @@ public static class Constants
     /// Directory name (under the user profile) the func CLI persists state in.
     /// </summary>
     public const string FuncHomeDirectoryName = ".azure-functions";
+
+    /// <summary>
+    /// Environment variable that, when explicitly set to a non-empty value,
+    /// overrides the default func CLI home directory (the on-disk root the
+    /// CLI persists configuration, profiles, caches, workloads, etc. under).
+    /// When unset, the home defaults to
+    /// <c>~/<see cref="FuncHomeDirectoryName"/></c>. Read directly (not
+    /// through <c>IConfiguration</c>) so the home cannot be redirected by
+    /// host config, global config, or project <c>.func/config.json</c>.
+    /// </summary>
+    public const string FuncHomeEnvironmentVariable = "FUNC_CLI_HOME";
 }

--- a/src/Abstractions/Common/FuncHomeResolver.cs
+++ b/src/Abstractions/Common/FuncHomeResolver.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Abstractions.Common;
+
+/// <summary>
+/// Resolves the func CLI home directory (the on-disk root the CLI persists
+/// configuration, profiles, caches, workloads, etc. under). The only
+/// configurable input is the <see cref="Constants.FuncHomeEnvironmentVariable"/>
+/// environment variable; everything else (config files, command-line options)
+/// is intentionally ignored so the home cannot be redirected by anything
+/// other than an explicit process env var.
+/// </summary>
+public static class FuncHomeResolver
+{
+    /// <summary>
+    /// Returns the env-var override if explicitly set to a non-whitespace
+    /// value, otherwise the default user-profile home
+    /// (<c>~/<see cref="Constants.FuncHomeDirectoryName"/></c>). Result is
+    /// normalised with <see cref="Path.GetFullPath(string)"/>.
+    /// </summary>
+    public static string Resolve()
+    {
+        string? configured = Environment.GetEnvironmentVariable(Constants.FuncHomeEnvironmentVariable);
+
+        string home = string.IsNullOrWhiteSpace(configured)
+            ? Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                Constants.FuncHomeDirectoryName)
+            : configured;
+
+        return Path.GetFullPath(home);
+    }
+}

--- a/src/Func/Configuration/CliConfigurationPathsOptions.cs
+++ b/src/Func/Configuration/CliConfigurationPathsOptions.cs
@@ -1,12 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using AbstractionsConstants = Azure.Functions.Cli.Abstractions.Common.Constants;
+using Azure.Functions.Cli.Abstractions.Common;
 
 namespace Azure.Functions.Cli.Configuration;
 
 /// <summary>
-/// Computed filesystem layout for CLI configuration.
+/// Computed filesystem layout for CLI configuration. <see cref="Home"/>
+/// resolves to <see cref="FuncHomeResolver.Resolve"/> by default, which
+/// honors the <see cref="Constants.FuncHomeEnvironmentVariable"/> env var.
 /// </summary>
 internal sealed class CliConfigurationPathsOptions
 {
@@ -14,9 +16,7 @@ internal sealed class CliConfigurationPathsOptions
     public const string ProfilesFileName = "profiles.json";
 
     public CliConfigurationPathsOptions()
-        : this(Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            AbstractionsConstants.FuncHomeDirectoryName))
+        : this(FuncHomeResolver.Resolve())
     {
     }
 

--- a/src/Func/Quickstart/QuickstartManifestOptions.cs
+++ b/src/Func/Quickstart/QuickstartManifestOptions.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using AbstractionsConstants = Azure.Functions.Cli.Abstractions.Common.Constants;
+using Azure.Functions.Cli.Abstractions.Common;
 
 namespace Azure.Functions.Cli.Quickstart;
 
@@ -32,8 +32,5 @@ internal sealed class QuickstartManifestOptions
     public TimeSpan HttpTimeout { get; set; } = TimeSpan.FromSeconds(15);
 
     private static string DefaultCacheDirectory() =>
-        Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            AbstractionsConstants.FuncHomeDirectoryName,
-            "quickstart");
+        Path.Combine(FuncHomeResolver.Resolve(), "quickstart");
 }

--- a/src/Func/Workloads/Storage/WorkloadHomeResolver.cs
+++ b/src/Func/Workloads/Storage/WorkloadHomeResolver.cs
@@ -2,33 +2,34 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Common;
-using AbstractionsConstants = Azure.Functions.Cli.Abstractions.Common.Constants;
+using AbstractionsCommon = Azure.Functions.Cli.Abstractions.Common;
+
 namespace Azure.Functions.Cli.Workloads.Storage;
 
 /// <summary>
-/// Resolves the workload root directory. The only configurable input is
-/// the <see cref="Constants.WorkloadsHomeEnvironmentVariable"/> environment
-/// variable; everything else (config files, command-line options) is
-/// intentionally ignored so workload assembly loading can't be redirected
-/// by anything other than an explicit process env var.
+/// Resolves the workload root directory. The only configurable inputs are
+/// the <see cref="Constants.WorkloadsHomeEnvironmentVariable"/> and
+/// <see cref="Abstractions.Common.Constants.FuncHomeEnvironmentVariable"/>
+/// environment variables; everything else (config files, command-line
+/// options) is intentionally ignored so workload assembly loading can't be
+/// redirected by anything other than an explicit process env var.
 /// </summary>
 internal static class WorkloadHomeResolver
 {
     /// <summary>
-    /// Returns the env-var override if explicitly set to a non-whitespace
-    /// value, otherwise the default user-profile home. Result is normalised
-    /// with <see cref="Path.GetFullPath(string)"/>.
+    /// Returns <see cref="Constants.WorkloadsHomeEnvironmentVariable"/> if
+    /// explicitly set to a non-whitespace value; otherwise falls back to the
+    /// general func CLI home (which itself honors
+    /// <see cref="Abstractions.Common.Constants.FuncHomeEnvironmentVariable"/>
+    /// and defaults to the user-profile path). Result is normalised with
+    /// <see cref="Path.GetFullPath(string)"/>.
     /// </summary>
     public static string Resolve()
     {
-        string? configured = System.Environment.GetEnvironmentVariable(Constants.WorkloadsHomeEnvironmentVariable);
+        string? configured = Environment.GetEnvironmentVariable(Constants.WorkloadsHomeEnvironmentVariable);
 
-        string home = string.IsNullOrWhiteSpace(configured)
-            ? Path.Combine(
-                System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile),
-                AbstractionsConstants.FuncHomeDirectoryName)
-            : configured;
-
-        return Path.GetFullPath(home);
+        return string.IsNullOrWhiteSpace(configured)
+            ? AbstractionsCommon.FuncHomeResolver.Resolve()
+            : Path.GetFullPath(configured);
     }
 }

--- a/src/Workloads/Stacks/DotNet/TemplateHivePathProvider.cs
+++ b/src/Workloads/Stacks/DotNet/TemplateHivePathProvider.cs
@@ -8,7 +8,9 @@ namespace Azure.Functions.Cli.Workloads.DotNet;
 /// <summary>
 /// Default implementation that resolves the template hive path, honoring the
 /// <c>FUNC_CLI_DOTNET_TEMPLATE_HIVE</c> environment variable when set, and
-/// falling back to <c>~/.azure-functions/dotnet-template-hive</c>.
+/// otherwise falling back to <c>&lt;func cli home&gt;/dotnet-template-hive</c>
+/// (where the home itself honors <see cref="Constants.FuncHomeEnvironmentVariable"/>
+/// and defaults to <c>~/.azure-functions</c>).
 /// </summary>
 internal sealed class TemplateHivePathProvider : ITemplateHivePathProvider
 {
@@ -26,10 +28,7 @@ internal sealed class TemplateHivePathProvider : ITemplateHivePathProvider
         string? configured = Environment.GetEnvironmentVariable(HivePathEnvironmentVariable);
 
         string hivePath = string.IsNullOrWhiteSpace(configured)
-            ? Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-                Constants.FuncHomeDirectoryName,
-                HiveDirectoryName)
+            ? Path.Combine(FuncHomeResolver.Resolve(), HiveDirectoryName)
             : configured;
 
         HivePath = Path.GetFullPath(hivePath);

--- a/test/Func.Tests/Common/FuncHomeResolverTests.cs
+++ b/test/Func.Tests/Common/FuncHomeResolverTests.cs
@@ -1,0 +1,71 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Abstractions.Common;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Common;
+
+[Collection("FuncHomeEnvVarTests")]
+public class FuncHomeResolverTests
+{
+    [Fact]
+    public void Resolve_WithoutEnvVar_ReturnsUserProfileDefault()
+    {
+        string expected = Path.GetFullPath(Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            Constants.FuncHomeDirectoryName));
+
+        string resolved = WithEnv(null, FuncHomeResolver.Resolve);
+
+        Assert.Equal(expected, resolved);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Resolve_WithBlankEnvVar_FallsBackToUserProfileDefault(string blank)
+    {
+        string expected = Path.GetFullPath(Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            Constants.FuncHomeDirectoryName));
+
+        string resolved = WithEnv(blank, FuncHomeResolver.Resolve);
+
+        Assert.Equal(expected, resolved);
+    }
+
+    [Fact]
+    public void Resolve_WithEnvVar_ReturnsNormalisedOverride()
+    {
+        string custom = Path.Combine(Path.GetTempPath(), "func-home-" + Guid.NewGuid().ToString("N"));
+
+        string resolved = WithEnv(custom, FuncHomeResolver.Resolve);
+
+        Assert.Equal(Path.GetFullPath(custom), resolved);
+    }
+
+    [Fact]
+    public void Resolve_WithRelativeEnvVar_NormalisesToFullPath()
+    {
+        string relative = Path.Combine("relative", "func-home");
+
+        string resolved = WithEnv(relative, FuncHomeResolver.Resolve);
+
+        Assert.Equal(Path.GetFullPath(relative), resolved);
+    }
+
+    private static string WithEnv(string? value, Func<string> action)
+    {
+        string? previous = Environment.GetEnvironmentVariable(Constants.FuncHomeEnvironmentVariable);
+        try
+        {
+            Environment.SetEnvironmentVariable(Constants.FuncHomeEnvironmentVariable, value);
+            return action();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(Constants.FuncHomeEnvironmentVariable, previous);
+        }
+    }
+}

--- a/test/Func.Tests/Workloads/Storage/WorkloadHomeResolverTests.cs
+++ b/test/Func.Tests/Workloads/Storage/WorkloadHomeResolverTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads.Storage;
+using Xunit;
+using AbstractionsConstants = Azure.Functions.Cli.Abstractions.Common.Constants;
+using FuncConstants = Azure.Functions.Cli.Common.Constants;
+
+namespace Azure.Functions.Cli.Tests.Workloads.Storage;
+
+[Collection("FuncHomeEnvVarTests")]
+public class WorkloadHomeResolverTests
+{
+    [Fact]
+    public void Resolve_WithWorkloadsHomeSet_PrefersWorkloadsHomeOverFuncHome()
+    {
+        string workloadsHome = Path.Combine(Path.GetTempPath(), "wl-" + Guid.NewGuid().ToString("N"));
+        string funcHome = Path.Combine(Path.GetTempPath(), "fh-" + Guid.NewGuid().ToString("N"));
+
+        string resolved = WithEnv(workloadsHome, funcHome, WorkloadHomeResolver.Resolve);
+
+        Assert.Equal(Path.GetFullPath(workloadsHome), resolved);
+    }
+
+    [Fact]
+    public void Resolve_WithoutWorkloadsHome_FallsBackToFuncHomeEnvVar()
+    {
+        string funcHome = Path.Combine(Path.GetTempPath(), "fh-" + Guid.NewGuid().ToString("N"));
+
+        string resolved = WithEnv(null, funcHome, WorkloadHomeResolver.Resolve);
+
+        Assert.Equal(Path.GetFullPath(funcHome), resolved);
+    }
+
+    [Fact]
+    public void Resolve_WithNeitherEnvVar_FallsBackToUserProfileDefault()
+    {
+        string expected = Path.GetFullPath(Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            AbstractionsConstants.FuncHomeDirectoryName));
+
+        string resolved = WithEnv(null, null, WorkloadHomeResolver.Resolve);
+
+        Assert.Equal(expected, resolved);
+    }
+
+    private static string WithEnv(string? workloadsHome, string? funcHome, Func<string> action)
+    {
+        string? previousWorkloads = Environment.GetEnvironmentVariable(FuncConstants.WorkloadsHomeEnvironmentVariable);
+        string? previousFunc = Environment.GetEnvironmentVariable(AbstractionsConstants.FuncHomeEnvironmentVariable);
+        try
+        {
+            Environment.SetEnvironmentVariable(FuncConstants.WorkloadsHomeEnvironmentVariable, workloadsHome);
+            Environment.SetEnvironmentVariable(AbstractionsConstants.FuncHomeEnvironmentVariable, funcHome);
+            return action();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(FuncConstants.WorkloadsHomeEnvironmentVariable, previousWorkloads);
+            Environment.SetEnvironmentVariable(AbstractionsConstants.FuncHomeEnvironmentVariable, previousFunc);
+        }
+    }
+}


### PR DESCRIPTION
Introduces `FUNC_CLI_HOME` so users can relocate the func CLI's on-disk root (default unchanged: `~/.azure-functions/`). Useful for sandboxed CI, devcontainers, and per-user installs that can't write the user profile.

## Changes

- New `FuncHomeResolver` in `Abstractions` (env var > user-profile default, normalized via `Path.GetFullPath`).
- Read directly from the process env (not `IConfiguration`), matching the existing `FUNC_CLI_WORKLOADS_HOME` / `FUNC_CLI_DOTNET_TEMPLATE_HIVE` pattern, so it can't be redirected by host/global/project config.
- Wired into all four consumers:
  - `CliConfigurationPathsOptions` (config, profiles, version-check cache)
  - `QuickstartManifestOptions` (quickstart manifest cache)
  - `WorkloadHomeResolver` (`FUNC_CLI_WORKLOADS_HOME` still wins when set)
  - `TemplateHivePathProvider` (`FUNC_CLI_DOTNET_TEMPLATE_HIVE` still wins when set)
- New "CLI Home Directory" section in `docs/cli-architecture.md`.

## Tests

- `FuncHomeResolverTests`: default, blank, set, and relative env-var cases.
- `WorkloadHomeResolverTests`: precedence between `FUNC_CLI_WORKLOADS_HOME` and `FUNC_CLI_HOME`.
- Full Func.Tests suite green (849 passed).