### PR TITLE
func setup: install templates workload for supported stacks

### DIFF
--- a/src/Func/Commands/Setup/SetupRenderer.cs
+++ b/src/Func/Commands/Setup/SetupRenderer.cs
@@ -213,6 +213,7 @@ internal sealed class SetupRenderer(IInteractionService interaction, SetupOutput
             SetupDependencyKind.Host => "host",
             SetupDependencyKind.Runtime => "runtime",
             SetupDependencyKind.Stack => "stack",
+            SetupDependencyKind.Templates => "templates",
             SetupDependencyKind.Worker => "worker",
             SetupDependencyKind.ExtensionBundle => "extension-bundle",
             _ => kind.ToString(),

--- a/src/Func/Commands/Setup/SetupRunner.cs
+++ b/src/Func/Commands/Setup/SetupRunner.cs
@@ -324,6 +324,11 @@ internal sealed class SetupRunner(
             {
                 dependencies.Add(SetupDependency.Stack(runtimeFeature.Name));
             }
+
+            if (SetupDependency.SupportsTemplates(runtimeFeature.Name))
+            {
+                dependencies.Add(SetupDependency.Templates(runtimeFeature.Name));
+            }
         }
 
         if (featurePlan.IncludeExtensionBundle)
@@ -678,12 +683,17 @@ internal sealed record SetupDependency(
 {
     private const string WorkerPackagePrefix = "Azure.Functions.Cli.Workloads.Workers.";
     private const string StackPackagePrefix = "Azure.Functions.Cli.Workloads.";
+    private const string TemplatesPackagePrefix = "Azure.Functions.Cli.Workloads.Templates.";
 
     // TODO: this should not be hardcoded in the CLI; discover the stack package
     // from the catalog (e.g. via an `alias:stack-<name>` tag) so new stacks don't
     // require a CLI release. Stacks not in this set (java, powershell, custom)
     // skip silently today.
     private static readonly HashSet<string> _stacks = new(StringComparer.OrdinalIgnoreCase) { "node", "python", "go", "dotnet" };
+
+    // Stacks that publish a templates content workload (Azure.Functions.Cli.Workloads.Templates.*).
+    // Go has no templates package today, so it is intentionally absent.
+    private static readonly HashSet<string> _templates = new(StringComparer.OrdinalIgnoreCase) { "node", "python", "dotnet" };
 
     public static SetupDependency Host(VersionRange? versionRange)
         => new(
@@ -741,6 +751,20 @@ internal sealed record SetupDependency(
 
     public static IReadOnlyList<string> Stacks => [.. _stacks];
 
+    public static SetupDependency Templates(string stack)
+        => new(
+            SetupDependencyKind.Templates,
+            stack,
+            $"{stack} templates",
+            TemplatesPackagePrefix + StackPackageSuffix(stack),
+            VersionRange: null,
+            RangeText: null,
+            ResolvedPackageId: null,
+            Optional: true);
+
+    public static bool SupportsTemplates(string stack)
+        => !string.IsNullOrWhiteSpace(stack) && _templates.Contains(stack.Trim());
+
     private static string StackPackageSuffix(string stack)
         => stack.Trim().ToLowerInvariant() switch
         {
@@ -764,6 +788,7 @@ internal enum SetupDependencyKind
     Runtime,
     Worker,
     Stack,
+    Templates,
     ExtensionBundle,
 }
 

--- a/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
+++ b/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
@@ -482,6 +482,34 @@ public sealed class SetupRunnerTests : IDisposable
     }
 
     [Fact]
+    public async Task RunAsync_FeatureForRuntime_InstallsTemplatesWorkload()
+    {
+        string workerPackageId = WorkerPackage("node");
+        const string nodeStack = "Azure.Functions.Cli.Workloads.Node";
+        const string nodeTemplates = "Azure.Functions.Cli.Workloads.Templates.Node";
+        FakeCatalog catalog = Catalog()
+            .WithLatest(_hostPackageId, "4.1.0")
+            .WithLatest(IInstalledBundleWorkloads.BundleWorkloadPackageId, "4.10.0")
+            .WithLatest(workerPackageId, "1.0.0")
+            .WithLatest(nodeStack, "1.0.0")
+            .WithLatest(nodeTemplates, "1.0.0");
+        SetupRunner runner = CreateRunner(catalog);
+
+        SetupRunResult result = await runner.RunAsync(Options(features: ["node"]), CancellationToken.None);
+
+        Assert.Equal(0, result.ExitCode);
+        await _installer.Received(1).InstallFromCatalogAsync(
+            Arg.Is<string>(id => string.Equals(id, nodeTemplates, StringComparison.OrdinalIgnoreCase)),
+            Arg.Any<NuGetVersion?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task RunAsync_FeatureWithoutStackMapping_DoesNotInstallStack()
     {
         string workerPackageId = WorkerPackage("java");


### PR DESCRIPTION
Mirrors the existing stack/worker workload install behavior in `func setup`: when a runtime feature maps to a stack that publishes a templates content workload, also install `Azure.Functions.Cli.Workloads.Templates.<stack>`.

- Supported templates stacks: `node`, `python`, `dotnet` (Go has no templates package).
- New `SetupDependencyKind.Templates` with an optional dependency, so stacks without a published templates package skip silently via the catalog-missing path.
- JSON output exposes the new kind as `"dependency_type": "templates"`.
- Adds `RunAsync_FeatureForRuntime_InstallsTemplatesWorkload` covering the node case.