### PR TITLE
Add minimal first-run setup prompt

### DIFF
--- a/src/Func/Hosting/CliHostFactory.cs
+++ b/src/Func/Hosting/CliHostFactory.cs
@@ -9,6 +9,7 @@ using Azure.Functions.Cli.Commands.Start.Initialization;
 using Azure.Functions.Cli.Configuration;
 using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Hosting.FirstRun;
 using Azure.Functions.Cli.Http;
 using Azure.Functions.Cli.Quickstart;
 using Azure.Functions.Cli.Telemetry;
@@ -111,6 +112,7 @@ internal static class CliHostFactory
 
         builder.Services.AddCliHttpDefaults();
         builder.Services.AddBuiltInCommands();
+        builder.Services.AddFirstRunExperience();
         builder.Services.AddQuickstartScaffolder();
         builder.Services.AddWorkloadStorage();
         builder.Services.AddProfiles();

--- a/src/Func/Hosting/FirstRun/FileFirstRunStateStore.cs
+++ b/src/Func/Hosting/FirstRun/FileFirstRunStateStore.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Configuration;
+
+namespace Azure.Functions.Cli.Hosting.FirstRun;
+
+/// <summary>
+/// File-backed first-run marker stored alongside other CLI state in the
+/// func home directory.
+/// </summary>
+internal sealed class FileFirstRunStateStore(CliConfigurationPathsOptions paths) : IFirstRunStateStore
+{
+    internal const string MarkerFileName = ".first-run-complete";
+
+    private readonly CliConfigurationPathsOptions _paths = paths ?? throw new ArgumentNullException(nameof(paths));
+
+    private string MarkerPath => Path.Combine(_paths.Home, MarkerFileName);
+
+    public bool IsFirstRun() => !File.Exists(MarkerPath);
+
+    public async Task MarkCompleteAsync(CancellationToken cancellationToken)
+    {
+        Directory.CreateDirectory(_paths.Home);
+
+        // Touch the marker. Content is informational only; presence is the signal.
+        await File.WriteAllTextAsync(MarkerPath, DateTimeOffset.UtcNow.ToString("O"), cancellationToken);
+    }
+}

--- a/src/Func/Hosting/FirstRun/FirstRunCoordinator.cs
+++ b/src/Func/Hosting/FirstRun/FirstRunCoordinator.cs
@@ -17,7 +17,11 @@ internal sealed class FirstRunCoordinator(
     IFirstRunStateStore stateStore,
     ISetupRunner setupRunner) : IFirstRunCoordinator
 {
-    private const string PromptMessage = "Looks like it's your first run. Run setup now?";
+    private const string PromptExplanation =
+        "The Azure Functions CLI uses workloads (host, runtime, language stacks) to do its work, "
+        + "and they aren't installed yet. Running `func setup` now will install everything you need to get started.";
+
+    private const string PromptMessage = "Run `func setup` now?";
 
     // Commands that should not trigger the first-run prompt: the user is
     // either already setting up, just inspecting the CLI, or hit a typo.
@@ -66,6 +70,7 @@ internal sealed class FirstRunCoordinator(
         }
 
         _interaction.WriteBlankLine();
+        _interaction.WriteHint(PromptExplanation);
         bool runSetup = await _interaction.ConfirmAsync(PromptMessage, defaultValue: true, cancellationToken);
 
         if (runSetup)

--- a/src/Func/Hosting/FirstRun/FirstRunCoordinator.cs
+++ b/src/Func/Hosting/FirstRun/FirstRunCoordinator.cs
@@ -1,0 +1,114 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Commands.Setup;
+using Azure.Functions.Cli.Console;
+
+namespace Azure.Functions.Cli.Hosting.FirstRun;
+
+/// <summary>
+/// Default coordinator. Skips quickly when this is clearly not the
+/// user's first interactive command, otherwise prompts and delegates
+/// to <see cref="ISetupRunner"/>.
+/// </summary>
+internal sealed class FirstRunCoordinator(
+    IInteractionService interaction,
+    IFirstRunStateStore stateStore,
+    ISetupRunner setupRunner) : IFirstRunCoordinator
+{
+    private const string PromptMessage = "Looks like it's your first run. Run setup now?";
+
+    // Commands that should not trigger the first-run prompt: the user is
+    // either already setting up, just inspecting the CLI, or hit a typo.
+    private static readonly HashSet<string> _skippedCommandNames =
+        new(StringComparer.OrdinalIgnoreCase) { "setup", "help", "version", "unknown" };
+
+    private static readonly HashSet<string> _skippedTokens =
+        new(StringComparer.OrdinalIgnoreCase) { "--help", "-h", "-?", "/?", "--version", "-v" };
+
+    private readonly IInteractionService _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
+    private readonly IFirstRunStateStore _stateStore = stateStore ?? throw new ArgumentNullException(nameof(stateStore));
+    private readonly ISetupRunner _setupRunner = setupRunner ?? throw new ArgumentNullException(nameof(setupRunner));
+
+    public async Task EnsureFirstRunPromptedAsync(string commandName, ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(parseResult);
+
+        if (!_stateStore.IsFirstRun())
+        {
+            return;
+        }
+
+        if (!_interaction.IsInteractive)
+        {
+            // Don't pester the user in CI / piped scenarios, and don't mark
+            // the marker either: they may run interactively next time.
+            return;
+        }
+
+        if (commandName is not null && _skippedCommandNames.Contains(commandName))
+        {
+            return;
+        }
+
+        if (parseResult.Errors.Count > 0)
+        {
+            return;
+        }
+
+        foreach (System.CommandLine.Parsing.Token token in parseResult.Tokens)
+        {
+            if (_skippedTokens.Contains(token.Value))
+            {
+                return;
+            }
+        }
+
+        _interaction.WriteBlankLine();
+        bool runSetup = await _interaction.ConfirmAsync(PromptMessage, defaultValue: true, cancellationToken);
+
+        if (runSetup)
+        {
+            await RunSetupAsync(cancellationToken);
+        }
+        else
+        {
+            _interaction.WriteHint("Skipping setup. Run `func setup` later when you're ready.");
+        }
+
+        await _stateStore.MarkCompleteAsync(cancellationToken);
+    }
+
+    private async Task RunSetupAsync(CancellationToken cancellationToken)
+    {
+        var options = new SetupCommandOptions(
+            WorkingDirectory: new DirectoryInfo(Environment.CurrentDirectory),
+            Features: [],
+            ProfileNames: [],
+            Source: null,
+            InstallPolicy: SetupInstallPolicy.LatestCompatible,
+            IncludePrerelease: true,
+            NonInteractive: false,
+            AssumeYes: false,
+            Check: false,
+            OutputMode: SetupOutputMode.Plain);
+
+        try
+        {
+            await _setupRunner.RunAsync(options, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Surface the failure but don't block the user's original
+            // command: they explicitly asked us to try setup, and the
+            // command they typed may still succeed (or fail with its own
+            // clearer error).
+            _interaction.WriteWarning($"Setup did not complete: {ex.Message}");
+        }
+    }
+}

--- a/src/Func/Hosting/FirstRun/FirstRunRegistration.cs
+++ b/src/Func/Hosting/FirstRun/FirstRunRegistration.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Azure.Functions.Cli.Hosting.FirstRun;
+
+internal static class FirstRunRegistration
+{
+    public static IServiceCollection AddFirstRunExperience(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton<IFirstRunStateStore, FileFirstRunStateStore>();
+        services.AddSingleton<IFirstRunCoordinator, FirstRunCoordinator>();
+        return services;
+    }
+}

--- a/src/Func/Hosting/FirstRun/IFirstRunCoordinator.cs
+++ b/src/Func/Hosting/FirstRun/IFirstRunCoordinator.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+
+namespace Azure.Functions.Cli.Hosting.FirstRun;
+
+/// <summary>
+/// Orchestrates the one-time first-run prompt that offers to run
+/// <c>func setup</c> before the user's command executes.
+/// </summary>
+internal interface IFirstRunCoordinator
+{
+    /// <summary>
+    /// Offers to run setup when this looks like the user's first
+    /// invocation. Always returns once the prompt has been handled
+    /// (or skipped); the caller continues with the user's command.
+    /// </summary>
+    public Task EnsureFirstRunPromptedAsync(string commandName, ParseResult parseResult, CancellationToken cancellationToken);
+}

--- a/src/Func/Hosting/FirstRun/IFirstRunStateStore.cs
+++ b/src/Func/Hosting/FirstRun/IFirstRunStateStore.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Hosting.FirstRun;
+
+/// <summary>
+/// Tracks whether the user has been through the first-run experience.
+/// Backed by a marker file under the func home directory so the answer
+/// survives across invocations.
+/// </summary>
+internal interface IFirstRunStateStore
+{
+    /// <summary>
+    /// Returns true when no first-run marker exists yet, meaning the
+    /// user has not yet been offered the setup prompt.
+    /// </summary>
+    public bool IsFirstRun();
+
+    /// <summary>
+    /// Records that the first-run prompt has been handled. Subsequent
+    /// calls to <see cref="IsFirstRun"/> will return false.
+    /// </summary>
+    public Task MarkCompleteAsync(CancellationToken cancellationToken);
+}

--- a/src/Func/Program.cs
+++ b/src/Func/Program.cs
@@ -9,7 +9,9 @@ using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Console.Theme;
 using Azure.Functions.Cli.Hosting;
+using Azure.Functions.Cli.Hosting.FirstRun;
 using Azure.Functions.Cli.Telemetry;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 // Force UTF-8 stdout so glyphs like →, ●, ✗, ◉ render correctly on Windows
@@ -74,6 +76,9 @@ using (Activity? activity = CliTelemetry.Trace.StartCommandActivity())
         commandParseResult = rootCommand.Parse(args);
         commandName = CommandNameResolver.ResolveCommandName(commandParseResult, rootCommand);
         activity?.SetCommandName(commandName);
+
+        IFirstRunCoordinator firstRunCoordinator = host.Services.GetRequiredService<IFirstRunCoordinator>();
+        await firstRunCoordinator.EnsureFirstRunPromptedAsync(commandName, commandParseResult, cts.Token);
 
         var config = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
         exitCode = await commandParseResult.InvokeAsync(config, cts.Token);

--- a/test/Func.Tests/Hosting/FirstRun/FileFirstRunStateStoreTests.cs
+++ b/test/Func.Tests/Hosting/FirstRun/FileFirstRunStateStoreTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Configuration;
+using Azure.Functions.Cli.Hosting.FirstRun;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Hosting.FirstRun;
+
+public sealed class FileFirstRunStateStoreTests : IDisposable
+{
+    private readonly string _tempHome;
+    private readonly FileFirstRunStateStore _store;
+
+    public FileFirstRunStateStoreTests()
+    {
+        _tempHome = Path.Combine(Path.GetTempPath(), $"func-first-run-{Guid.NewGuid():N}");
+        _store = new FileFirstRunStateStore(new CliConfigurationPathsOptions(_tempHome));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempHome))
+        {
+            Directory.Delete(_tempHome, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void IsFirstRun_ReturnsTrue_WhenMarkerMissing()
+    {
+        Assert.True(_store.IsFirstRun());
+    }
+
+    [Fact]
+    public async Task MarkCompleteAsync_CreatesMarker_AndIsFirstRunReturnsFalse()
+    {
+        await _store.MarkCompleteAsync(CancellationToken.None);
+
+        Assert.False(_store.IsFirstRun());
+        Assert.True(File.Exists(Path.Combine(_tempHome, FileFirstRunStateStore.MarkerFileName)));
+    }
+
+    [Fact]
+    public async Task MarkCompleteAsync_CreatesHomeDirectory_WhenMissing()
+    {
+        Assert.False(Directory.Exists(_tempHome));
+
+        await _store.MarkCompleteAsync(CancellationToken.None);
+
+        Assert.True(Directory.Exists(_tempHome));
+    }
+
+    [Fact]
+    public void Constructor_ThrowsArgumentNullException_ForNullPaths()
+    {
+        Assert.Throws<ArgumentNullException>(() => new FileFirstRunStateStore(null!));
+    }
+}

--- a/test/Func.Tests/Hosting/FirstRun/FirstRunCoordinatorTests.cs
+++ b/test/Func.Tests/Hosting/FirstRun/FirstRunCoordinatorTests.cs
@@ -1,0 +1,228 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Commands;
+using Azure.Functions.Cli.Commands.Setup;
+using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Console.Theme;
+using Azure.Functions.Cli.Hosting.FirstRun;
+using NSubstitute;
+using Spectre.Console.Rendering;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Hosting.FirstRun;
+
+public sealed class FirstRunCoordinatorTests
+{
+    private readonly IFirstRunStateStore _stateStore = Substitute.For<IFirstRunStateStore>();
+    private readonly ISetupRunner _setupRunner = Substitute.For<ISetupRunner>();
+    private readonly PromptingInteractionService _interaction = new();
+
+    [Fact]
+    public async Task SkipsAndDoesNotMark_WhenAlreadyComplete()
+    {
+        _stateStore.IsFirstRun().Returns(false);
+        FirstRunCoordinator coordinator = CreateCoordinator();
+
+        await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
+
+        Assert.Equal(0, _interaction.ConfirmCalls);
+        await _setupRunner.DidNotReceiveWithAnyArgs().RunAsync(default!, default);
+        await _stateStore.DidNotReceiveWithAnyArgs().MarkCompleteAsync(default);
+    }
+
+    [Fact]
+    public async Task SkipsAndDoesNotMark_WhenNonInteractive()
+    {
+        _stateStore.IsFirstRun().Returns(true);
+        _interaction.InteractiveOverride = false;
+        FirstRunCoordinator coordinator = CreateCoordinator();
+
+        await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
+
+        Assert.Equal(0, _interaction.ConfirmCalls);
+        await _setupRunner.DidNotReceiveWithAnyArgs().RunAsync(default!, default);
+        await _stateStore.DidNotReceiveWithAnyArgs().MarkCompleteAsync(default);
+    }
+
+    [Theory]
+    [InlineData("setup")]
+    [InlineData("help")]
+    [InlineData("version")]
+    [InlineData("unknown")]
+    public async Task SkipsAndDoesNotMark_ForExcludedCommands(string commandName)
+    {
+        _stateStore.IsFirstRun().Returns(true);
+        FirstRunCoordinator coordinator = CreateCoordinator();
+
+        await coordinator.EnsureFirstRunPromptedAsync(commandName, Parse(commandName), CancellationToken.None);
+
+        Assert.Equal(0, _interaction.ConfirmCalls);
+        await _stateStore.DidNotReceiveWithAnyArgs().MarkCompleteAsync(default);
+    }
+
+    [Theory]
+    [InlineData("--help")]
+    [InlineData("-h")]
+    [InlineData("--version")]
+    [InlineData("-v")]
+    public async Task SkipsAndDoesNotMark_WhenHelpOrVersionTokenPresent(string token)
+    {
+        _stateStore.IsFirstRun().Returns(true);
+        FirstRunCoordinator coordinator = CreateCoordinator();
+
+        await coordinator.EnsureFirstRunPromptedAsync("start", Parse($"start {token}"), CancellationToken.None);
+
+        Assert.Equal(0, _interaction.ConfirmCalls);
+        await _stateStore.DidNotReceiveWithAnyArgs().MarkCompleteAsync(default);
+    }
+
+    [Fact]
+    public async Task RunsSetupAndMarks_WhenUserConfirms()
+    {
+        _stateStore.IsFirstRun().Returns(true);
+        _interaction.ConfirmResponse = true;
+        _setupRunner.RunAsync(Arg.Any<SetupCommandOptions>(), Arg.Any<CancellationToken>())
+            .Returns(new SetupRunResult(0));
+        FirstRunCoordinator coordinator = CreateCoordinator();
+
+        await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
+
+        Assert.Equal(1, _interaction.ConfirmCalls);
+        await _setupRunner.Received(1).RunAsync(Arg.Any<SetupCommandOptions>(), Arg.Any<CancellationToken>());
+        await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SkipsSetupButMarks_WhenUserDeclines()
+    {
+        _stateStore.IsFirstRun().Returns(true);
+        _interaction.ConfirmResponse = false;
+        FirstRunCoordinator coordinator = CreateCoordinator();
+
+        await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
+
+        Assert.Equal(1, _interaction.ConfirmCalls);
+        await _setupRunner.DidNotReceiveWithAnyArgs().RunAsync(default!, default);
+        await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PropagatesCancellation_FromPrompt()
+    {
+        _stateStore.IsFirstRun().Returns(true);
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+        FirstRunCoordinator coordinator = CreateCoordinator();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), cts.Token));
+
+        await _stateStore.DidNotReceiveWithAnyArgs().MarkCompleteAsync(default);
+    }
+
+    [Fact]
+    public async Task SetupFailureIsSwallowed_ButMarkerStillWritten()
+    {
+        _stateStore.IsFirstRun().Returns(true);
+        _interaction.ConfirmResponse = true;
+        _setupRunner.RunAsync(Arg.Any<SetupCommandOptions>(), Arg.Any<CancellationToken>())
+            .Returns<Task<SetupRunResult>>(_ => throw new InvalidOperationException("boom"));
+        FirstRunCoordinator coordinator = CreateCoordinator();
+
+        await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
+
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("WARNING:", StringComparison.Ordinal) && l.Contains("boom"));
+        await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
+    }
+
+    private FirstRunCoordinator CreateCoordinator() => new(_interaction, _stateStore, _setupRunner);
+
+    private static ParseResult Parse(string args)
+    {
+        var root = new FuncRootCommand();
+
+        // Minimal subcommands so Parse can resolve common test cases without errors.
+        root.Subcommands.Add(new Command("setup"));
+        root.Subcommands.Add(new Command("help"));
+        root.Subcommands.Add(new Command("version"));
+        root.Subcommands.Add(new Command("start"));
+
+        return root.Parse(args);
+    }
+
+    private sealed class PromptingInteractionService : IInteractionService
+    {
+        private readonly List<string> _lines = [];
+
+        public IReadOnlyList<string> Lines => _lines;
+
+        public bool InteractiveOverride { get; set; } = true;
+
+        public bool ConfirmResponse { get; set; } = true;
+
+        public int ConfirmCalls { get; private set; }
+
+        public ITheme Theme { get; } = new DefaultTheme();
+
+        public bool IsInteractive => InteractiveOverride;
+
+        public void WriteLine(string text) => _lines.Add(text);
+
+        public void WriteBlankLine() => _lines.Add(string.Empty);
+
+        public void WriteLine(Action<InlineLine> build) => _lines.Add("LINE");
+
+        public void Write(IRenderable renderable) => _lines.Add($"RENDERABLE: {renderable.GetType().Name}");
+
+        public void WriteTitle(string text) => _lines.Add($"TITLE: {text}");
+
+        public void WriteSectionHeader(string title) => _lines.Add($"RULE: {title}");
+
+        public void WriteHint(string message) => _lines.Add($"HINT: {message}");
+
+        public void WriteSuccess(string message) => _lines.Add($"SUCCESS: {message}");
+
+        public void WriteError(string message) => _lines.Add($"ERROR: {message}");
+
+        public void WriteWarning(string message) => _lines.Add($"WARNING: {message}");
+
+        public void WriteDefinitionList(IEnumerable<DefinitionItem> items)
+        {
+        }
+
+        public void WriteTable(string[] columns, IEnumerable<string[]> rows)
+        {
+        }
+
+        public void WriteJson(object value)
+        {
+        }
+
+        public Task<T> ShowStatusAsync<T>(string statusMessage, Func<CancellationToken, Task<T>> action, CancellationToken cancellationToken = default)
+            => action(cancellationToken);
+
+        public Task StatusAsync(string statusMessage, Func<CancellationToken, Task> action, CancellationToken cancellationToken = default)
+            => action(cancellationToken);
+
+        public Task<T> RunWithProgressAsync<T>(string initialDescription, Func<IProgressContext, CancellationToken, Task<T>> action, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<bool> ConfirmAsync(string prompt, bool defaultValue = false, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ConfirmCalls++;
+            return Task.FromResult(ConfirmResponse);
+        }
+
+        public Task<string> PromptForSelectionAsync(string title, IEnumerable<string> choices, CancellationToken cancellationToken = default)
+            => Task.FromResult(string.Empty);
+
+        public Task<IReadOnlyList<string>> PromptForMultiSelectionAsync(string title, IEnumerable<string> choices, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<string>>([]);
+
+        public Task<string> PromptForInputAsync(string prompt, string? defaultValue = null, CancellationToken cancellationToken = default)
+            => Task.FromResult(defaultValue ?? string.Empty);
+    }
+}


### PR DESCRIPTION
## What

On the user's first interactive invocation of `func` (anything other than `setup`, `help`, `version`, or a `--help`/`--version` flag), prompt once:

> Looks like it's your first run. Run setup now? [Y/n]

- Enter / `y` → runs `func setup` (delegates to existing `SetupRunner` with empty features so it uses the existing stack picker), then continues with the user's original command.
- `n` → writes a hint and continues.

Either way a marker file at `~/.azure-functions/.first-run-complete` is written so the prompt is shown at most once. Non-interactive / CI shells skip silently without writing the marker (so an interactive run later still gets the prompt). Setup failures surface as warnings but never block the original command.

## How

New `Hosting/FirstRun/` module:

- `IFirstRunStateStore` + `FileFirstRunStateStore` (marker file)
- `IFirstRunCoordinator` + `FirstRunCoordinator` (skip rules + prompt + delegate to `ISetupRunner`)
- `FirstRunRegistration` (DI extension)

`CliHostFactory` registers the services; `Program.cs` calls `EnsureFirstRunPromptedAsync` between parse and `InvokeAsync`.

## Tests

- `FileFirstRunStateStoreTests` (4 tests)
- `FirstRunCoordinatorTests` (14 tests across skip rules, confirm/decline, cancellation, setup failure)
- Full `Func.Tests` suite: 883/883 passing.
- Clean release build with `CI=true` (no warnings).