### PR TITLE
vnext: quickstart update env var and use fun run path hint

### DIFF
--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -341,7 +341,7 @@ If a newer version is found, a notice is printed after the command completes.
 
 - **Cache**: `~/.azure-functions/quickstart/` (manifest JSON + ETag metadata), 24h TTL
 - **Validation**: only `v`-prefixed gitRef entries; HTTPS URLs on `github.com` from trusted orgs
-- **Override**: `FUNC_QUICKSTART_MANIFEST_URL` env var replaces CDN URL
+- **Override**: `FUNC_CLI_QUICKSTART_MANIFEST_URL` env var replaces CDN URL
 
 ## Init and New Command Flow
 

--- a/src/Func/Quickstart/QuickstartRegistration.cs
+++ b/src/Func/Quickstart/QuickstartRegistration.cs
@@ -22,7 +22,7 @@ internal static class QuickstartRegistration
     /// Accepts HTTPS URLs, <c>file://</c> URIs, or absolute local file paths
     /// (e.g. <c>C:\manifest.json</c> or <c>/home/user/manifest.json</c>).
     /// </summary>
-    internal const string ManifestUrlEnvVar = "FUNC_QUICKSTART_MANIFEST_URL";
+    internal const string ManifestUrlEnvVar = "FUNC_CLI_QUICKSTART_MANIFEST_URL";
 
     public static IServiceCollection AddQuickstartManifest(this IServiceCollection services)
     {

--- a/src/Workloads/Stacks/DotNet/DotNetQuickstartProvider.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetQuickstartProvider.cs
@@ -30,6 +30,6 @@ internal sealed class DotNetQuickstartProvider : IQuickstartProvider
 
     public IReadOnlyList<string> GetNextSteps(string manifestLanguage) =>
     [
-        "Run `func run` to launch the app"
+        "Run `func run [path]` where path is root folder containing host.json to launch the app"
     ];
 }

--- a/src/Workloads/Stacks/Node/NodeQuickstartProvider.cs
+++ b/src/Workloads/Stacks/Node/NodeQuickstartProvider.cs
@@ -28,6 +28,6 @@ internal sealed class NodeQuickstartProvider : IQuickstartProvider
     public IReadOnlyList<string> GetNextSteps(string manifestLanguage) =>
     [
         "Run `npm install` to install dependencies",
-        "Run `func run` to launch the app"
+        "Run `func run [path]` where path is root folder containing host.json to launch the app"
     ];
 }

--- a/src/Workloads/Stacks/Python/PythonQuickstartProvider.cs
+++ b/src/Workloads/Stacks/Python/PythonQuickstartProvider.cs
@@ -27,6 +27,6 @@ internal sealed class PythonQuickstartProvider : IQuickstartProvider
     public IReadOnlyList<string> GetNextSteps(string manifestLanguage) =>
     [
         "Run `pip install -r requirements.txt` to install dependencies",
-        "Run `func run` to launch the app"
+        "Run `func run [path]` where path is root folder containing host.json to launch the app"
     ];
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
This pull request updates the environment variable used to override the Quickstart manifest URL and clarifies the usage instructions for launching apps in the Next Steps for .NET, Node, and Python quickstarts. The changes ensure consistency in environment variable naming and provide more explicit guidance to users on how to start their applications.

**Environment Variable Update:**

* Changed the override environment variable for the Quickstart manifest URL from `FUNC_QUICKSTART_MANIFEST_URL` to `FUNC_CLI_QUICKSTART_MANIFEST_URL` in both the documentation and code to maintain consistency. [[1]](diffhunk://#diff-2a79134c003d258441e742e0ad07b3ccfc1fce3b55b50af234305a6fdb6ca583L344-R344) [[2]](diffhunk://#diff-43b61315a4da58f7f21bc7edf1215a72864967fad66c1ac2be7a5071f6950cb7L25-R25)

**Documentation and User Guidance Improvements:**

* Updated the Next Steps instructions for .NET, Node, and Python quickstarts to specify that `func run` should be used with the `[path]` argument, clarifying that the path should be the root folder containing `host.json`. [[1]](diffhunk://#diff-986f5b6ebf5a02d481797fb4d6e4126578029320b1e5f7af7a848ab98a25314aL33-R33) [[2]](diffhunk://#diff-3eb074be25a447a7f68f884c0e5c56b74246cb514d7a94a536976f5007eeabf5L31-R31) [[3]](diffhunk://#diff-b3afb4b187537f83a255ac009fe68a8f0b2abd664bb1d218819c1a1e1c9cdb55L30-R30)
resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
