### PR TITLE
fix(vnext): improve bundle channel resolution logic

### DIFF
--- a/src/Abstractions/Projects/CommonInitOptions.cs
+++ b/src/Abstractions/Projects/CommonInitOptions.cs
@@ -29,11 +29,11 @@ public static class CommonInitOptions
 
     /// <summary>
     /// <c>--bundles-channel</c> / <c>-c</c>. Selects the extension bundle release channel
-    /// (<see cref="BundleChannel.GA"/> by default).
+    /// (<see cref="BundleChannel.Stable"/> by default).
     /// </summary>
     public static Option<BundleChannel> BundlesChannel() => new("--bundles-channel", "-c")
     {
-        Description = "Extension bundle release channel: GA (default), Preview, or Experimental.",
-        DefaultValueFactory = _ => BundleChannel.GA,
+        Description = "Extension bundle release channel: Stable (default), Preview, or Experimental.",
+        DefaultValueFactory = _ => BundleChannel.Stable,
     };
 }

--- a/src/Abstractions/Projects/ExtensionBundle.cs
+++ b/src/Abstractions/Projects/ExtensionBundle.cs
@@ -5,11 +5,11 @@ namespace Azure.Functions.Cli.Projects;
 
 /// <summary>
 /// Release channel for the Functions extension bundle. Values map to the
-/// three published bundle ids (GA / Preview / Experimental).
+/// three published bundle ids (Stable / Preview / Experimental).
 /// </summary>
 public enum BundleChannel
 {
-    GA,
+    Stable,
     Preview,
     Experimental,
 }

--- a/src/Abstractions/Projects/ExtensionBundle.cs
+++ b/src/Abstractions/Projects/ExtensionBundle.cs
@@ -9,6 +9,7 @@ namespace Azure.Functions.Cli.Projects;
 /// </summary>
 public enum BundleChannel
 {
+    Unknown,
     Stable,
     Preview,
     Experimental,
@@ -32,6 +33,7 @@ public static class ExtensionBundle
     {
         BundleChannel.Preview => "Microsoft.Azure.Functions.ExtensionBundle.Preview",
         BundleChannel.Experimental => "Microsoft.Azure.Functions.ExtensionBundle.Experimental",
-        _ => "Microsoft.Azure.Functions.ExtensionBundle",
+        BundleChannel.Stable => "Microsoft.Azure.Functions.ExtensionBundle",
+        _ => throw new ArgumentOutOfRangeException(nameof(channel), channel, null),
     };
 }

--- a/src/Abstractions/Templates/IInstalledTemplatesWorkloads.cs
+++ b/src/Abstractions/Templates/IInstalledTemplatesWorkloads.cs
@@ -15,7 +15,7 @@ public interface IInstalledTemplatesWorkloads
     /// NuGet package-id prefix for templates content workloads. Concrete ids
     /// are <c>{Prefix}.&lt;Stack&gt;</c> (e.g. <c>Azure.Functions.Cli.Workloads.Templates.Node</c>).
     /// Matched case-insensitively at lookup time; registry stores them lowercased
-    /// per NuGet normalisation.
+    /// per NuGet normalization.
     /// </summary>
     public const string TemplatesWorkloadPackageIdPrefix = "Azure.Functions.Cli.Workloads.Templates";
 

--- a/src/Func/Bundles/BundleHelpers.cs
+++ b/src/Func/Bundles/BundleHelpers.cs
@@ -1,0 +1,74 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Projects;
+using NuGet.Versioning;
+
+namespace Azure.Functions.Cli.Bundles;
+
+/// <summary>
+/// Helper methods for bundle-related operations.
+/// </summary>
+internal static class BundleHelpers
+{
+    public const string StableBundleId = "Microsoft.Azure.Functions.ExtensionBundle";
+    public const string PreviewBundleId = "Microsoft.Azure.Functions.ExtensionBundle.Preview";
+    public const string ExperimentalBundleId = "Microsoft.Azure.Functions.ExtensionBundle.Experimental";
+
+    public const string PreviewLabel = "preview";
+    public const string ExperimentalLabel = "experimental";
+
+    private static readonly Dictionary<string, BundleChannel> _bundleIdToChannelMap =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            [StableBundleId] = BundleChannel.Stable,
+            [PreviewBundleId] = BundleChannel.Preview,
+            [ExperimentalBundleId] = BundleChannel.Experimental
+        };
+
+    private static readonly Dictionary<string, BundleChannel> _releaseToChannelMap =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            [PreviewLabel] = BundleChannel.Preview,
+            [ExperimentalLabel] = BundleChannel.Experimental
+        };
+
+    /// <summary>
+    /// Determines the channel of a bundle based on its ID.
+    /// </summary>
+    /// <param name="bundleId">The bundle ID.</param>
+    /// <returns>The channel of the bundle.</returns>
+    public static BundleChannel GetBundleChannel(string bundleId)
+    {
+        if (_bundleIdToChannelMap.TryGetValue(bundleId, out BundleChannel channel))
+        {
+            return channel;
+        }
+
+        throw new ArgumentException("Invalid bundle ID.", nameof(bundleId));
+    }
+
+    /// <summary>
+    /// Determines the channel of a bundle based on its version.
+    /// </summary>
+    /// <param name="version">The nuget package version.</param>
+    /// <returns>The channel of the bundle.</returns>
+    public static BundleChannel GetBundleChannel(NuGetVersion version)
+    {
+        ArgumentNullException.ThrowIfNull(version);
+        if (!version.IsPrerelease)
+        {
+            // shortcut for optimization.
+            return BundleChannel.Stable;
+        }
+
+        // Prerelease check above ensures that the version has a label.
+        string label = version.ReleaseLabels.FirstOrDefault()!;
+        if (_releaseToChannelMap.TryGetValue(label, out BundleChannel channel))
+        {
+            return channel;
+        }
+
+        return BundleChannel.Stable; // no matching label, assume stable.
+    }
+}

--- a/src/Func/Bundles/BundleHelpers.cs
+++ b/src/Func/Bundles/BundleHelpers.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Diagnostics.CodeAnalysis;
 using Azure.Functions.Cli.Projects;
 using NuGet.Versioning;
 
@@ -15,6 +16,7 @@ internal static class BundleHelpers
     public const string PreviewBundleId = "Microsoft.Azure.Functions.ExtensionBundle.Preview";
     public const string ExperimentalBundleId = "Microsoft.Azure.Functions.ExtensionBundle.Experimental";
 
+    public const string StableLabel = "stable";
     public const string PreviewLabel = "preview";
     public const string ExperimentalLabel = "experimental";
 
@@ -34,13 +36,45 @@ internal static class BundleHelpers
         };
 
     /// <summary>
+    /// Converts a bundle channel to its display string.
+    /// </summary>
+    /// <param name="channel">The channel to convert.</param>
+    /// <returns>The display string for the channel.</returns>
+    public static string ToDisplayString(this BundleChannel channel) =>
+        channel switch
+        {
+            BundleChannel.Unknown => "unknown",
+            BundleChannel.Stable => StableLabel,
+            BundleChannel.Preview => PreviewLabel,
+            BundleChannel.Experimental => ExperimentalLabel,
+            _ => throw new ArgumentOutOfRangeException(nameof(channel), channel, null)
+        };
+
+    /// <summary>
+    /// Gets the channel label for a given bundle ID.
+    /// </summary>
+    /// <param name="bundleId">The bundle ID.</param>
+    /// <param name="channelLabel">The channel label.</param>
+    /// <returns>True if the channel label is found, false otherwise.</returns>
+    public static bool TryGetBundleChannel(string bundleId, out BundleChannel channel)
+    {
+        if (_bundleIdToChannelMap.TryGetValue(bundleId, out channel))
+        {
+            return true;
+        }
+
+        channel = BundleChannel.Unknown;
+        return false;
+    }
+
+    /// <summary>
     /// Determines the channel of a bundle based on its ID.
     /// </summary>
     /// <param name="bundleId">The bundle ID.</param>
     /// <returns>The channel of the bundle.</returns>
     public static BundleChannel GetBundleChannel(string bundleId)
     {
-        if (_bundleIdToChannelMap.TryGetValue(bundleId, out BundleChannel channel))
+        if (TryGetBundleChannel(bundleId, out BundleChannel channel))
         {
             return channel;
         }

--- a/src/Func/Bundles/InstalledBundleScanner.cs
+++ b/src/Func/Bundles/InstalledBundleScanner.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Projects;
 using NuGet.Versioning;
 
 namespace Azure.Functions.Cli.Bundles;
@@ -15,19 +16,16 @@ internal sealed class InstalledBundleScanner(IInstalledBundleWorkloads installed
     // Matches the pack location in src/Workloads/Tools/ExtensionBundles/DownloadDefaultBundle.targets.
     private static readonly string _bundlePayloadSubpath = Path.Combine("tools", "any");
 
-    public const string StableBundleId = "Microsoft.Azure.Functions.ExtensionBundle";
-    public const string PreviewBundleId = "Microsoft.Azure.Functions.ExtensionBundle.Preview";
-    public const string ExperimentalBundleId = "Microsoft.Azure.Functions.ExtensionBundle.Experimental";
-
-    private const string PreviewLabel = "preview";
-    private const string ExperimentalLabel = "experimental";
-
     private readonly IInstalledBundleWorkloads _installed = installed ?? throw new ArgumentNullException(nameof(installed));
 
-    public async Task<ScanResult> ScanAsync(string bundleId, CancellationToken cancellationToken = default)
+    public Task<ScanResult> ScanAsync(string bundleId, CancellationToken cancellationToken = default)
     {
-        ArgumentException.ThrowIfNullOrEmpty(bundleId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(bundleId);
+        return ScanAsync(BundleHelpers.GetBundleChannel(bundleId), cancellationToken);
+    }
 
+    public async Task<ScanResult> ScanAsync(BundleChannel channel, CancellationToken cancellationToken = default)
+    {
         IReadOnlyList<InstalledBundleWorkload> rows = await _installed.ListInstalledAsync(cancellationToken);
 
         if (rows.Count == 0)
@@ -47,7 +45,7 @@ internal sealed class InstalledBundleScanner(IInstalledBundleWorkloads installed
             // Stable host.json id → workload versions with no prerelease label.
             // Preview host.json id → workload versions whose prerelease label is `preview`.
             // Experimental host.json id → workload versions whose prerelease label is `experimental`.
-            if (!MatchesBundleIdFilter(bundleId, version))
+            if (BundleHelpers.GetBundleChannel(version) != channel)
             {
                 continue;
             }
@@ -58,44 +56,6 @@ internal sealed class InstalledBundleScanner(IInstalledBundleWorkloads installed
 
         filtered.Sort((a, b) => b.Version.CompareTo(a.Version));
         return new ScanResult(rows.Count, filtered);
-    }
-
-    private static bool MatchesBundleIdFilter(string bundleId, NuGetVersion version)
-    {
-        if (string.Equals(bundleId, StableBundleId, StringComparison.OrdinalIgnoreCase))
-        {
-            return !version.IsPrerelease;
-        }
-
-        if (string.Equals(bundleId, PreviewBundleId, StringComparison.OrdinalIgnoreCase))
-        {
-            return HasReleaseLabel(version, PreviewLabel);
-        }
-
-        if (string.Equals(bundleId, ExperimentalBundleId, StringComparison.OrdinalIgnoreCase))
-        {
-            return HasReleaseLabel(version, ExperimentalLabel);
-        }
-
-        return true;
-    }
-
-    private static bool HasReleaseLabel(NuGetVersion version, string label)
-    {
-        if (!version.IsPrerelease)
-        {
-            return false;
-        }
-
-        foreach (string candidate in version.ReleaseLabels)
-        {
-            if (string.Equals(candidate, label, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 }
 

--- a/src/Func/Commands/Setup/SetupRunner.cs
+++ b/src/Func/Commands/Setup/SetupRunner.cs
@@ -337,7 +337,7 @@ internal sealed class SetupRunner(
             SetupDependency? bundleDependency = await TryCreateBundleDependencyAsync(workingDirectory, profileScope, cancellationToken);
             if (bundleDependency is null)
             {
-                var dependency = SetupDependency.Bundle(InstalledBundleScanner.StableBundleId, versionRange: null, rangeText: null);
+                var dependency = SetupDependency.Bundle(BundleHelpers.StableBundleId, versionRange: null, rangeText: null);
                 failure = SetupDependencyResult.Failed(
                     dependency,
                     "The host.json extensionBundle range and profile extensionBundle range do not overlap.");
@@ -367,7 +367,7 @@ internal sealed class SetupRunner(
 
         if (hostJsonBundle is null)
         {
-            return SetupDependency.Bundle(InstalledBundleScanner.StableBundleId, profileRange, profileRangeText);
+            return SetupDependency.Bundle(BundleHelpers.StableBundleId, profileRange, profileRangeText);
         }
 
         VersionRange? effectiveRange = VersionRangeIntersection.Intersect(hostJsonBundle.Version, profileRangeText);

--- a/src/Func/Templates/NewCommandRunner.cs
+++ b/src/Func/Templates/NewCommandRunner.cs
@@ -268,8 +268,7 @@ internal sealed class NewCommandRunner
         // Step 4 (Node/Python): channel match against host.json.
         InstalledTemplatesWorkload? workload;
         string? bundleId = null;
-        string? channelLabel = null;
-
+        BundleChannel channel = BundleChannel.Unknown;
         if (string.Equals(stack, "dotnet", StringComparison.OrdinalIgnoreCase))
         {
             IReadOnlyList<InstalledTemplatesWorkload> allRows =
@@ -296,39 +295,38 @@ internal sealed class NewCommandRunner
             }
 
             bundleId = section.Id;
-            channelLabel = TemplatesChannelMapper.GetChannelLabel(bundleId);
-            if (channelLabel is null)
+            if (!BundleHelpers.TryGetBundleChannel(bundleId, out channel))
             {
-                _interaction.WriteError($"Unrecognised extension bundle id '{bundleId}'.");
+                _interaction.WriteError($"Unrecognized extension bundle id '{bundleId}'.");
                 _interaction.WriteLine(l => l
                     .Muted("Use one of: ")
-                    .Code(TemplatesChannelMapper.StableBundleId)
+                    .Code(BundleHelpers.StableBundleId)
                     .Muted(", ")
-                    .Code(TemplatesChannelMapper.PreviewBundleId)
+                    .Code(BundleHelpers.PreviewBundleId)
                     .Muted(", or ")
-                    .Code(TemplatesChannelMapper.ExperimentalBundleId)
+                    .Code(BundleHelpers.ExperimentalBundleId)
                     .Muted("."));
                 return null;
             }
 
             IReadOnlyList<InstalledTemplatesWorkload> allRows =
                 await _installedTemplatesWorkloads.ListInstalledAsync(stack, cancellationToken);
-            workload = TemplatesChannelMapper.PickChannelMatched(allRows, channelLabel);
+            workload = TemplatesChannelMapper.PickChannelMatched(allRows, channel);
         }
 
         if (workload is null)
         {
-            if (channelLabel is null)
+            if (channel is BundleChannel.Unknown)
             {
                 _renderer.RenderNoTemplatesWorkloadInstalled(stack);
             }
             else
             {
-                string channelName = TemplatesChannelMapper.GetChannelDisplayName(channelLabel);
+                string channelName = channel.ToDisplayString();
                 string suggestedPkg = TemplatesWorkloadConstants.GetPackageId(stack);
-                string suggestedVer = string.IsNullOrEmpty(channelLabel)
+                string suggestedVer = channel == BundleChannel.Stable
                     ? "<version>"
-                    : $"<version>-{channelLabel}";
+                    : $"<version>-{channelName}.1";
                 _interaction.WriteError(
                     $"No installed templates workload matches this project's bundle channel " +
                     $"({bundleId} -> channel '{channelName}').");
@@ -356,7 +354,7 @@ internal sealed class NewCommandRunner
             language,
             workload,
             bundleId,
-            channelLabel);
+            channel);
     }
 
     private async Task<int> EnforceBundleGatesAsync(
@@ -651,7 +649,7 @@ internal sealed class NewCommandRunner
         string Language,
         InstalledTemplatesWorkload Workload,
         string? BundleId,
-        string? ChannelLabel);
+        BundleChannel Channel);
 }
 
 /// <summary>

--- a/src/Func/Templates/TemplatesChannelMapper.cs
+++ b/src/Func/Templates/TemplatesChannelMapper.cs
@@ -1,6 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Bundles;
+using Azure.Functions.Cli.Projects;
+using NuGet.Versioning;
+
 namespace Azure.Functions.Cli.Templates;
 
 /// <summary>
@@ -16,73 +20,6 @@ namespace Azure.Functions.Cli.Templates;
 /// </remarks>
 internal static class TemplatesChannelMapper
 {
-    public const string StableLabel = "";
-    public const string PreviewLabel = "preview";
-    public const string ExperimentalLabel = "experimental";
-
-    public const string StableBundleId = "Microsoft.Azure.Functions.ExtensionBundle";
-    public const string PreviewBundleId = "Microsoft.Azure.Functions.ExtensionBundle.Preview";
-    public const string ExperimentalBundleId = "Microsoft.Azure.Functions.ExtensionBundle.Experimental";
-
-    /// <summary>
-    /// Returns the templates channel prerelease label for the supplied
-    /// <c>host.json</c> bundle id, or <c>null</c> when the id is not one of
-    /// the three recognised channels.
-    /// </summary>
-    public static string? GetChannelLabel(string? bundleId)
-    {
-        if (string.IsNullOrWhiteSpace(bundleId))
-        {
-            return null;
-        }
-
-        return bundleId.Trim() switch
-        {
-            string s when s.Equals(StableBundleId, StringComparison.OrdinalIgnoreCase) => StableLabel,
-            string s when s.Equals(PreviewBundleId, StringComparison.OrdinalIgnoreCase) => PreviewLabel,
-            string s when s.Equals(ExperimentalBundleId, StringComparison.OrdinalIgnoreCase) => ExperimentalLabel,
-            _ => null,
-        };
-    }
-
-    /// <summary>
-    /// Returns a human-readable channel name (<c>"stable"</c>, <c>"preview"</c>,
-    /// <c>"experimental"</c>) for diagnostics / hint copy. The empty label
-    /// for stable is rendered as <c>"stable"</c>.
-    /// </summary>
-    public static string GetChannelDisplayName(string channelLabel) =>
-        string.IsNullOrEmpty(channelLabel) ? "stable" : channelLabel;
-
-    /// <summary>
-    /// Extracts the prerelease label from a workload pkg version (e.g.
-    /// <c>"1.0.0-preview"</c> → <c>"preview"</c>, <c>"1.0.0"</c> → empty).
-    /// Case-insensitive on the prerelease part. The label is compared
-    /// against <see cref="GetChannelLabel"/> output.
-    /// </summary>
-    public static string GetPrereleaseLabel(string packageVersion)
-    {
-        if (string.IsNullOrWhiteSpace(packageVersion))
-        {
-            return string.Empty;
-        }
-
-        int dash = packageVersion.IndexOf('-');
-        if (dash < 0 || dash == packageVersion.Length - 1)
-        {
-            return string.Empty;
-        }
-
-        string suffix = packageVersion[(dash + 1)..];
-        // Trim build metadata after '+' per SemVer.
-        int plus = suffix.IndexOf('+');
-        if (plus >= 0)
-        {
-            suffix = suffix[..plus];
-        }
-
-        return suffix.ToLowerInvariant();
-    }
-
     /// <summary>
     /// Picks the channel-matched installed workload row whose prerelease
     /// label equals <paramref name="channelLabel"/>. Returns the highest
@@ -90,26 +27,33 @@ internal static class TemplatesChannelMapper
     /// for PR4; PR5 can switch to NuGetVersion comparison if needed).
     /// Returns <c>null</c> when no row matches.
     /// </summary>
+    /// <param name="rows">The list of installed templates workloads to search.</param>
+    /// <param name="channel">The channel to match.</param>
+    /// <returns>The matching installed templates workload, or <c>null</c> if none found.</returns>
     public static InstalledTemplatesWorkload? PickChannelMatched(
-        IReadOnlyList<InstalledTemplatesWorkload> rows,
-        string channelLabel)
+        IReadOnlyList<InstalledTemplatesWorkload> rows, BundleChannel channel)
     {
         ArgumentNullException.ThrowIfNull(rows);
-        ArgumentNullException.ThrowIfNull(channelLabel);
+        if (channel == BundleChannel.Unknown)
+        {
+            return null;
+        }
 
         InstalledTemplatesWorkload? best = null;
+        NuGetVersion? bestVersion = null;
         foreach (InstalledTemplatesWorkload row in rows)
         {
-            string rowLabel = GetPrereleaseLabel(row.PackageVersion);
-            if (!string.Equals(rowLabel, channelLabel, StringComparison.OrdinalIgnoreCase))
+            NuGetVersion rowVersion = new(row.PackageVersion);
+            BundleChannel matched = BundleHelpers.GetBundleChannel(rowVersion);
+            if (matched != channel)
             {
                 continue;
             }
 
-            if (best is null
-                || string.Compare(row.PackageVersion, best.PackageVersion, StringComparison.Ordinal) > 0)
+            if (best is null || rowVersion.CompareTo(bestVersion) > 0)
             {
                 best = row;
+                bestVersion = rowVersion;
             }
         }
 

--- a/src/Workloads/Tools/ExtensionBundles/Directory.Version.props
+++ b/src/Workloads/Tools/ExtensionBundles/Directory.Version.props
@@ -34,7 +34,8 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(BundleChannel)' != 'stable'">
-    <VersionPrefix>$(BundleVersion)-$(BundleChannel)</VersionPrefix>
+    <VersionPrefix>$(BundleVersion)</VersionPrefix>
+    <VersionSuffix>$(BundleChannel).1</VersionSuffix>
   </PropertyGroup>
 
 </Project>

--- a/test/Func.Tests/Bundles/BundleHelpersTests.cs
+++ b/test/Func.Tests/Bundles/BundleHelpersTests.cs
@@ -108,4 +108,61 @@ public class BundleHelpersTests
     {
         Assert.Throws<ArgumentException>(() => BundleHelpers.GetBundleChannel(bundleId));
     }
+
+    // --- TryGetBundleChannel ---
+
+    [Theory]
+    [InlineData("Microsoft.Azure.Functions.ExtensionBundle", BundleChannel.Stable)]
+    [InlineData("Microsoft.Azure.Functions.ExtensionBundle.Preview", BundleChannel.Preview)]
+    [InlineData("Microsoft.Azure.Functions.ExtensionBundle.Experimental", BundleChannel.Experimental)]
+    public void TryGetBundleChannel_KnownId_ReturnsTrueWithChannel(string bundleId, BundleChannel expected)
+    {
+        var result = BundleHelpers.TryGetBundleChannel(bundleId, out var channel);
+        Assert.True(result);
+        Assert.Equal(expected, channel);
+    }
+
+    [Theory]
+    [InlineData("microsoft.azure.functions.extensionbundle")]
+    [InlineData("MICROSOFT.AZURE.FUNCTIONS.EXTENSIONBUNDLE.PREVIEW")]
+    public void TryGetBundleChannel_CaseInsensitive_ReturnsTrue(string bundleId)
+    {
+        Assert.True(BundleHelpers.TryGetBundleChannel(bundleId, out _));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("Unknown.Bundle")]
+    public void TryGetBundleChannel_UnknownId_ReturnsFalseWithUnknown(string bundleId)
+    {
+        var result = BundleHelpers.TryGetBundleChannel(bundleId, out var channel);
+        Assert.False(result);
+        Assert.Equal(BundleChannel.Unknown, channel);
+    }
+
+    // --- ToDisplayString ---
+
+    [Theory]
+    [InlineData(BundleChannel.Unknown, "unknown")]
+    [InlineData(BundleChannel.Stable, "stable")]
+    [InlineData(BundleChannel.Preview, "preview")]
+    [InlineData(BundleChannel.Experimental, "experimental")]
+    public void ToDisplayString_ReturnsExpected(BundleChannel channel, string expected)
+    {
+        Assert.Equal(expected, channel.ToDisplayString());
+    }
+
+    [Fact]
+    public void ToDisplayString_InvalidChannel_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => ((BundleChannel)99).ToDisplayString());
+    }
+
+    // --- GetBundleChannel(NuGetVersion) null guard ---
+
+    [Fact]
+    public void GetBundleChannelByVersion_Null_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => BundleHelpers.GetBundleChannel((NuGetVersion)null!));
+    }
 }

--- a/test/Func.Tests/Bundles/BundleHelpersTests.cs
+++ b/test/Func.Tests/Bundles/BundleHelpersTests.cs
@@ -1,0 +1,111 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Projects;
+using NuGet.Versioning;
+using Xunit;
+
+namespace Azure.Functions.Cli.Bundles.Tests;
+
+public class BundleHelpersTests
+{
+    [Theory]
+    [InlineData("1.0.0")]
+    [InlineData("4.17.0")]
+    [InlineData("5.0.0")]
+    public void GetBundleChannel_StableVersion_ReturnsStable(string version)
+    {
+        var v = NuGetVersion.Parse(version);
+        Assert.Equal(BundleChannel.Stable, BundleHelpers.GetBundleChannel(v));
+    }
+
+    [Theory]
+    [InlineData("4.17.0-preview.1")]
+    [InlineData("4.17.0-preview.1.ci.11111.0")]
+    [InlineData("5.0.0-preview")]
+    [InlineData("5.0.0-Preview.2")]
+    public void GetBundleChannel_PreviewLabel_ReturnsPreview(string version)
+    {
+        var v = NuGetVersion.Parse(version);
+        Assert.Equal(BundleChannel.Preview, BundleHelpers.GetBundleChannel(v));
+    }
+
+    [Theory]
+    [InlineData("4.17.0-experimental.1")]
+    [InlineData("4.17.0-experimental.1.ci.11111.0")]
+    [InlineData("5.0.0-experimental")]
+    [InlineData("5.0.0-Experimental.3")]
+    public void GetBundleChannel_ExperimentalLabel_ReturnsExperimental(string version)
+    {
+        var v = NuGetVersion.Parse(version);
+        Assert.Equal(BundleChannel.Experimental, BundleHelpers.GetBundleChannel(v));
+    }
+
+    [Theory]
+    [InlineData("5.0.0-rc.1")]
+    [InlineData("4.17.0-beta.2")]
+    [InlineData("5.0.0-alpha")]
+    [InlineData("5.0.0-ci.11111.0")]
+    [InlineData("5.0.0-dev.11111.0")]
+    public void GetBundleChannel_UnknownPrereleaseLabel_ReturnsStable(string version)
+    {
+        var v = NuGetVersion.Parse(version);
+        Assert.Equal(BundleChannel.Stable, BundleHelpers.GetBundleChannel(v));
+    }
+
+    [Fact]
+    public void GetBundleChannel_PreviewBeforeExperimental_ReturnsPreview()
+    {
+        // Only the first release label is checked; "preview" is first here.
+        var v = NuGetVersion.Parse("5.0.0-preview.experimental.1");
+        Assert.Equal(BundleChannel.Preview, BundleHelpers.GetBundleChannel(v));
+    }
+
+    [Fact]
+    public void GetBundleChannel_ExperimentalBeforePreview_ReturnsExperimental()
+    {
+        // Only the first release label is checked; "experimental" is first here.
+        var v = NuGetVersion.Parse("5.0.0-experimental.preview.1");
+        Assert.Equal(BundleChannel.Experimental, BundleHelpers.GetBundleChannel(v));
+    }
+
+    // --- GetBundleChannel(string bundleId) ---
+
+    [Fact]
+    public void GetBundleChannelByBundleId_StableId_ReturnsStable()
+    {
+        Assert.Equal(BundleChannel.Stable, BundleHelpers.GetBundleChannel(BundleHelpers.StableBundleId));
+    }
+
+    [Fact]
+    public void GetBundleChannelByBundleId_PreviewId_ReturnsPreview()
+    {
+        Assert.Equal(BundleChannel.Preview, BundleHelpers.GetBundleChannel(BundleHelpers.PreviewBundleId));
+    }
+
+    [Fact]
+    public void GetBundleChannelByBundleId_ExperimentalId_ReturnsExperimental()
+    {
+        Assert.Equal(BundleChannel.Experimental, BundleHelpers.GetBundleChannel(BundleHelpers.ExperimentalBundleId));
+    }
+
+    [Theory]
+    [InlineData("microsoft.azure.functions.extensionbundle", BundleChannel.Stable)]
+    [InlineData("MICROSOFT.AZURE.FUNCTIONS.EXTENSIONBUNDLE.PREVIEW", BundleChannel.Preview)]
+    [InlineData("Microsoft.Azure.Functions.ExtensionBundle.EXPERIMENTAL", BundleChannel.Experimental)]
+    public void GetBundleChannelByBundleId_CaseInsensitive(string bundleId, BundleChannel expectedChannel)
+    {
+        // Should not throw — case-insensitive matching.
+        var channel = BundleHelpers.GetBundleChannel(bundleId);
+        Assert.Equal(expectedChannel, channel);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("SomeOther.Bundle")]
+    [InlineData("Microsoft.Azure.Functions.ExtensionBundle.Unknown")]
+    public void GetBundleChannelByBundleId_InvalidId_Throws(string bundleId)
+    {
+        Assert.Throws<ArgumentException>(() => BundleHelpers.GetBundleChannel(bundleId));
+    }
+}

--- a/test/Func.Tests/Bundles/ExtensionBundleResolverTests.cs
+++ b/test/Func.Tests/Bundles/ExtensionBundleResolverTests.cs
@@ -8,7 +8,7 @@ namespace Azure.Functions.Cli.Bundles.Tests;
 
 public class ExtensionBundleResolverTests
 {
-    private const string BundleId = InstalledBundleScanner.StableBundleId;
+    private const string BundleId = BundleHelpers.StableBundleId;
 
     [Fact]
     public async Task HostJsonRangeOnly_PicksHighestInstalled()

--- a/test/Func.Tests/Bundles/InstalledBundleScannerTests.cs
+++ b/test/Func.Tests/Bundles/InstalledBundleScannerTests.cs
@@ -8,9 +8,9 @@ namespace Azure.Functions.Cli.Bundles.Tests;
 
 public class InstalledBundleScannerTests
 {
-    private const string StableId = InstalledBundleScanner.StableBundleId;
-    private const string PreviewId = InstalledBundleScanner.PreviewBundleId;
-    private const string ExperimentalId = InstalledBundleScanner.ExperimentalBundleId;
+    private const string StableId = BundleHelpers.StableBundleId;
+    private const string PreviewId = BundleHelpers.PreviewBundleId;
+    private const string ExperimentalId = BundleHelpers.ExperimentalBundleId;
 
     [Fact]
     public async Task NoRows_ReportsZeroTotal()

--- a/test/Func.Tests/Templates/TemplatesChannelMapperTests.cs
+++ b/test/Func.Tests/Templates/TemplatesChannelMapperTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Templates;
 using Xunit;
 
@@ -8,36 +9,6 @@ namespace Azure.Functions.Cli.Tests.Templates;
 
 public class TemplatesChannelMapperTests
 {
-    [Theory]
-    [InlineData("Microsoft.Azure.Functions.ExtensionBundle", "")]
-    [InlineData("Microsoft.Azure.Functions.ExtensionBundle.Preview", "preview")]
-    [InlineData("Microsoft.Azure.Functions.ExtensionBundle.Experimental", "experimental")]
-    [InlineData("microsoft.azure.functions.extensionbundle", "")]
-    public void GetChannelLabel_Maps_Recognised_Ids(string bundleId, string expected)
-    {
-        Assert.Equal(expected, TemplatesChannelMapper.GetChannelLabel(bundleId));
-    }
-
-    [Theory]
-    [InlineData("")]
-    [InlineData(null)]
-    [InlineData("Some.Other.Bundle")]
-    public void GetChannelLabel_Unrecognised_Returns_Null(string? bundleId)
-    {
-        Assert.Null(TemplatesChannelMapper.GetChannelLabel(bundleId));
-    }
-
-    [Theory]
-    [InlineData("1.0.0", "")]
-    [InlineData("1.0.0-preview", "preview")]
-    [InlineData("1.0.0-experimental", "experimental")]
-    [InlineData("1.0.0-PREVIEW", "preview")]
-    [InlineData("1.0.0-preview+meta", "preview")]
-    public void GetPrereleaseLabel_Extracts_Label(string version, string expected)
-    {
-        Assert.Equal(expected, TemplatesChannelMapper.GetPrereleaseLabel(version));
-    }
-
     [Fact]
     public void PickChannelMatched_Returns_Highest_Of_Matching_Channel()
     {
@@ -49,11 +20,11 @@ public class TemplatesChannelMapperTests
             new("node", "1.1.0-preview", "/n/1.1.0-preview"),
         ];
 
-        InstalledTemplatesWorkload? stable = TemplatesChannelMapper.PickChannelMatched(rows, "");
+        InstalledTemplatesWorkload? stable = TemplatesChannelMapper.PickChannelMatched(rows, BundleChannel.Stable);
         Assert.NotNull(stable);
         Assert.Equal("1.1.0", stable.PackageVersion);
 
-        InstalledTemplatesWorkload? preview = TemplatesChannelMapper.PickChannelMatched(rows, "preview");
+        InstalledTemplatesWorkload? preview = TemplatesChannelMapper.PickChannelMatched(rows, BundleChannel.Preview);
         Assert.NotNull(preview);
         Assert.Equal("1.1.0-preview", preview.PackageVersion);
     }
@@ -66,6 +37,6 @@ public class TemplatesChannelMapperTests
             new("node", "1.0.0", "/n/1.0.0"),
         ];
 
-        Assert.Null(TemplatesChannelMapper.PickChannelMatched(rows, "experimental"));
+        Assert.Null(TemplatesChannelMapper.PickChannelMatched(rows, BundleChannel.Experimental));
     }
 }


### PR DESCRIPTION
- Update bundle channel resolution logic to allow for release segments mapping to a stable channel. This allows for preview semantics as we iterate on stable releases, such as `4.35.0-rc.1`. This will unblock using the local nupkg with the `-dev` suffix as is, as well as non-release CI packages.
- Refactor template <--> bundle matching
- Fix template package version comparison
    - previous code was using a simple string ordinal comparison, which is not correct when comparing SemVer2 (`1.10.0` would be considered less than `1.9.0` with string comparison).