### PR TITLE
func new --template <id> --help: render hydrated, deduped, resource-resolved options

### DIFF
--- a/src/Func/Commands/NewCommand.cs
+++ b/src/Func/Commands/NewCommand.cs
@@ -16,7 +16,7 @@ namespace Azure.Functions.Cli.Commands;
 /// the engine-dispatch step until <see cref="ITemplateEngineProvider"/>
 /// implementations exist.
 /// </summary>
-internal sealed class NewCommand : FuncCliCommand, IBuiltInCommand
+internal sealed class NewCommand : FuncCliCommand, IBuiltInCommand, ITemplateAwareHelpProvider
 {
     public Option<string?> NameOption { get; } = new("--name", "-n")
     {
@@ -44,6 +44,7 @@ internal sealed class NewCommand : FuncCliCommand, IBuiltInCommand
     };
 
     private readonly NewCommandRunner _runner;
+    private readonly HashSet<string> _builtInOptionNames;
 
     public NewCommand(NewCommandRunner runner)
         : base("new", "Create a new function from a template.")
@@ -56,6 +57,15 @@ internal sealed class NewCommand : FuncCliCommand, IBuiltInCommand
         Options.Add(ForceOption);
         Options.Add(NonInteractiveOption);
         Options.Add(ListOption);
+
+        // Snapshot the built-in option names so the help-time hydration
+        // pass can tell which Options on the command came from the user's
+        // chosen template (added on the fly) and which were here from the
+        // start. Without this, repeated `func new -t X --help` invocations
+        // would accumulate stale hydrated options on the singleton command.
+        _builtInOptionNames = new HashSet<string>(
+            Options.Select(o => o.Name),
+            StringComparer.Ordinal);
     }
 
     protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
@@ -74,4 +84,95 @@ internal sealed class NewCommand : FuncCliCommand, IBuiltInCommand
             ? _runner.ListAsync(invocation, cancellationToken)
             : _runner.ExecuteAsync(invocation, cancellationToken);
     }
+
+    /// <summary>
+    /// Stage-B help hook: when <c>func new --template &lt;id&gt; --help</c>
+    /// fires, the renderer calls this so the command can dynamically attach
+    /// the chosen template's hydrated options before help is rendered.
+    /// Returns the number of options added (zero when nothing applies —
+    /// no template requested, project not init'd, or template not found).
+    /// </summary>
+    /// <remarks>
+    /// Always drops options added by a previous call first so the
+    /// singleton command never accumulates stale entries across
+    /// invocations. The hydrator may run async I/O (project resolution,
+    /// workload registry lookup) but the help action is sync, so this is
+    /// driven via <see cref="Task{T}.GetAwaiter"/> on the work-stealing
+    /// thread pool — fine because the renderer is itself called from a
+    /// non-UI sync context.
+    /// </remarks>
+    public int AttachHydratedOptionsForHelp(ParseResult parseResult)
+    {
+        ArgumentNullException.ThrowIfNull(parseResult);
+
+        // Drop any options we previously attached so reruns start clean.
+        // Comparing the snapshot of built-in names is safer than holding
+        // a list of "added" option instances across invocations.
+        var stale = Options
+            .Where(o => !_builtInOptionNames.Contains(o.Name))
+            .ToList();
+        foreach (Option o in stale)
+        {
+            Options.Remove(o);
+        }
+
+        string? templateId = parseResult.GetValue(TemplateOption);
+        if (string.IsNullOrWhiteSpace(templateId))
+        {
+            return 0;
+        }
+
+        WorkingDirectory workingDirectory = parseResult.GetValue(PathArgument!)!;
+        var invocation = new NewInvocation(
+            workingDirectory,
+            RequestedTemplate: templateId,
+            RequestedFunctionName: null,
+            Force: false,
+            NonInteractive: true);
+
+        IReadOnlyList<Option>? hydrated;
+        try
+        {
+            hydrated = _runner.HydrateOptionsForTemplateAsync(invocation, templateId, CancellationToken.None)
+                .GetAwaiter().GetResult();
+        }
+        catch
+        {
+            // Resolution / I/O failures are non-fatal at help time. Falling
+            // back to built-ins-only output is preferable to crashing inside
+            // the help renderer.
+            return 0;
+        }
+
+        if (hydrated is null || hydrated.Count == 0)
+        {
+            return 0;
+        }
+
+        foreach (Option o in hydrated)
+        {
+            // Skip names that collide with built-ins so we don't shadow
+            // them with template-defined duplicates.
+            if (_builtInOptionNames.Contains(o.Name))
+            {
+                continue;
+            }
+
+            Options.Add(o);
+        }
+
+        return Options.Count - _builtInOptionNames.Count;
+    }
+}
+
+/// <summary>
+/// Marker for commands whose <c>--help</c> output depends on a value bound
+/// by an earlier (stage-A) parse. The Spectre help action calls
+/// <see cref="AttachHydratedOptionsForHelp"/> on the matched command before
+/// rendering so the user sees the union of built-in options and any
+/// options the bound value (e.g. <c>--template &lt;id&gt;</c>) implies.
+/// </summary>
+internal interface ITemplateAwareHelpProvider
+{
+    public int AttachHydratedOptionsForHelp(ParseResult parseResult);
 }

--- a/src/Func/Commands/SpectreHelpAction.cs
+++ b/src/Func/Commands/SpectreHelpAction.cs
@@ -24,6 +24,17 @@ internal sealed class SpectreHelpAction(HelpCommand helpCommand) : SynchronousCo
             return _helpCommand.ShowGeneralHelp();
         }
 
+        // Stage-B help hydration: when the matched command is a
+        // template-aware verb (e.g. `func new`) and the user supplied a
+        // stage-A value the help renderer needs to know about
+        // (`--template <id>`), let the command attach the relevant
+        // dynamic options before we hand it to the renderer. Falls
+        // through to a built-ins-only render when the hook returns 0.
+        if (command is ITemplateAwareHelpProvider templateAware)
+        {
+            templateAware.AttachHydratedOptionsForHelp(parseResult);
+        }
+
         _helpCommand.RenderCommandHelp(command);
         return 0;
     }

--- a/src/Func/Templates/NewCommandRunner.cs
+++ b/src/Func/Templates/NewCommandRunner.cs
@@ -177,6 +177,41 @@ internal sealed class NewCommandRunner
         return 0;
     }
 
+    /// <summary>
+    /// Resolves the single template identified by <paramref name="templateId"/>
+    /// for the project at <paramref name="invocation"/>, then hands back the
+    /// hydrated <see cref="Option"/> list the stage-B help renderer needs.
+    /// Returns <c>null</c> when the project can't be resolved, the templates
+    /// workload isn't installed, or <paramref name="templateId"/> doesn't
+    /// match any catalogued template — the caller decides whether to fall
+    /// back to a built-ins-only help render or surface the failure.
+    /// </summary>
+    public async Task<IReadOnlyList<Option>?> HydrateOptionsForTemplateAsync(
+        NewInvocation invocation,
+        string templateId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(invocation);
+        ArgumentException.ThrowIfNullOrWhiteSpace(templateId);
+
+        ResolvedContext? resolved = await ResolveContextAsync(invocation, cancellationToken);
+        if (resolved is null)
+        {
+            return null;
+        }
+
+        IReadOnlyList<FunctionTemplateInfo> templates = await ListTemplatesAsync(resolved, cancellationToken);
+        FunctionTemplateInfo? template = templates.FirstOrDefault(t =>
+            string.Equals(t.Id, templateId, StringComparison.OrdinalIgnoreCase));
+
+        if (template is null)
+        {
+            return null;
+        }
+
+        return _optionHydrator.Hydrate(template);
+    }
+
     private async Task<ResolvedContext?> ResolveContextAsync(
         NewInvocation invocation,
         CancellationToken cancellationToken)

--- a/src/Templates.V2/V2TemplateProjection.cs
+++ b/src/Templates.V2/V2TemplateProjection.cs
@@ -19,7 +19,14 @@ internal static class V2TemplateProjection
             return null;
         }
 
+        // The same prompt id can appear on inputs across multiple jobs
+        // (a v2 template typically has CreateNewApp / AppendToFile /
+        // CreateNewBlueprint / AppendToBlueprint jobs all asking for the
+        // same trigger-functionName). Dedupe on the prompt id so the
+        // hydrator surfaces each option once.
         List<TemplateUserPrompt> prompts = [];
+        HashSet<string> seenPromptIds = new(StringComparer.OrdinalIgnoreCase);
+
         if (template.Jobs is { Count: > 0 })
         {
             foreach (V2Job job in template.Jobs)
@@ -32,10 +39,17 @@ internal static class V2TemplateProjection
                 foreach (V2Input input in job.Inputs)
                 {
                     TemplateUserPrompt? prompt = ProjectInput(input, payload);
-                    if (prompt is not null)
+                    if (prompt is null)
                     {
-                        prompts.Add(prompt);
+                        continue;
                     }
+
+                    if (!seenPromptIds.Add(prompt.Id))
+                    {
+                        continue;
+                    }
+
+                    prompts.Add(prompt);
                 }
             }
         }
@@ -71,7 +85,7 @@ internal static class V2TemplateProjection
 
         payload.UserPrompts.TryGetValue(input.ParamId, out UserPromptDoc? doc);
         string id = input.ParamId;
-        string? description = doc?.Label;
+        string? description = ResolveResource(doc?.Label, payload.Resources);
         string dataType = doc?.Enum is { Count: > 0 } ? "choice" : "string";
         string? defaultValue = input.DefaultValue ?? doc?.DefaultValue;
         IReadOnlyList<string>? choices = doc?.Enum?


### PR DESCRIPTION
## What

Three follow-up fixes to `func new --template <id> --help` against `vnext`, all surfaced by running against the real packed Node/Python templates workloads:

| # | Commit | Fix |
|---|---|---|
| 1 | `75220c46` | `func new --template <id> --help` actually renders the hydrated per-template options (was silently dropped) |
| 2 | `f4100d3c` | Per-prompt `$xxx_label` resource keys (e.g. `$trigger_functionName_label`) get resolved to the user-facing English text |
| 2 | `f4100d3c` | Same prompt id referenced by N jobs of the same template (e.g. CreateNewApp + AppendToFile + CreateNewBlueprint + AppendToBlueprint all want `trigger-functionName`) is now surfaced once, not N times |

## Bug 1 — stage-B `--help` wasn't wired

`NewCommandRunner.cs:130` called `_optionHydrator.Hydrate(template)` and immediately discarded the result (`_ = hydrated;`). The hydrated `Option<T>` list never reached the parser, so `func new --template <id> --help` looked identical to top-level help no matter which template was specified.

**Fix:** introduce `ITemplateAwareHelpProvider`, implemented by `NewCommand`. `SpectreHelpAction.Invoke` calls it after matching the command but before rendering, so the command can dynamically attach options that depend on a stage-A value. `NewCommand.AttachHydratedOptionsForHelp` drops any previously-attached dynamic options (so reruns start clean), reads `--template <id>` from the parse result, runs the resolution + hydration pipeline synchronously via `GetAwaiter().GetResult()`, and attaches the resulting `Option<T>` instances to the command's `Options` collection before help renders.

A new `NewCommandRunner.HydrateOptionsForTemplateAsync` re-uses the same `ResolveContextAsync` + `ListTemplatesAsync` pipeline `ListAsync` runs, finds the matching template, and returns `_optionHydrator.Hydrate(template)`. Resolution failures (no project, no workload, no matching template) return `null` so the help renderer falls back to built-ins-only output instead of crashing.

## Bug 2a — `$xxx_label` resource keys not resolved

`V2TemplateProjection.ProjectInput` set the prompt description to `doc?.Label` directly. The label in real `userPrompts.json` files is a resource key like `"label": "$trigger_functionName_label"` and needs to be looked up in `Resources.json`. Project-level Name and Description were already going through `ResolveResource` — the same helper just wasn't being applied to prompts.

**Fix:** route `doc.Label` through `ResolveResource(doc?.Label, payload.Resources)`.

## Bug 2b — same prompt repeated across jobs

A v2 template typically has 4 jobs (`CreateNewApp`, `AppendToFile`, `CreateNewBlueprint`, `AppendToBlueprint`) that share the same inputs. The projection iterated every job's `Inputs` and pushed each prompt without deduping. Result: `func new -t HttpTrigger-Python --help` listed `--trigger-function-name` 4×.

**Fix:** a `HashSet<string>` (case-insensitive) guards the prompt list against duplicate `paramId`s.

## Before / after

```
$ func new --template HttpTrigger-Python --help
```

**Before:**
```
--app-file-name                   $app_filename_label
--trigger-function-name           $trigger_functionName_label
--http-trigger-auth-level         $httpTrigger_authLevel_label
--app-selected-file-name          $app_selected_filename_label
--trigger-function-name           $trigger_functionName_label
--http-trigger-auth-level         $httpTrigger_authLevel_label
--blueprint-file-name             $blueprint_filename_label
--trigger-function-name           $trigger_functionName_label
--http-trigger-auth-level         $httpTrigger_authLevel_label
--blueprint-existing-file-name    $blueprint_selected_filename_label
--trigger-function-name           $trigger_functionName_label
--http-trigger-auth-level         $httpTrigger_authLevel_label
```

**After:**
```
--app-file-name                   Provide a filename for your function
--trigger-function-name           Provide a function name
--http-trigger-auth-level         Authorization level
--app-selected-file-name          File Name
--blueprint-file-name             Blueprint function file Name
--blueprint-existing-file-name    Select a file to save for your blueprint function
```

12 rows → 6 unique rows, all with English labels.

## Scope

- Help-rendering only. **The hydrated options are still ignored on non-help invocations** — supporting user-supplied per-prompt argv values (e.g. `func new -t HttpTrigger -n MyHttp --auth-level anonymous`) needs a stage-B re-parse in `ExecuteAsync`; that's tracked as a follow-up. This PR closes the discoverability gap so users at least see what each template accepts.
- Existing **9 / 9** V2 unit tests still pass. Release build clean (`CI=true`, `TreatWarningsAsErrors`).

## Validation

End-to-end against the real packed Node + Python templates workloads. Both stacks now render hydrated, deduped, English-labelled options under `--help`.