### PR TITLE
Preserve start prompt status rendering

### DIFF
--- a/src/Func/Commands/Start/Dashboard/Demo/DemoStartInitializationRunner.cs
+++ b/src/Func/Commands/Start/Dashboard/Demo/DemoStartInitializationRunner.cs
@@ -110,7 +110,7 @@ internal sealed class DemoStartInitializationRunner(
             new ResolveConstraintsInitializationStep(),
             new ValidateHostWorkloadInitializationStep(_hostWorkloadResolver, _workloadInstaller, _workloadPaths),
             new ResolveFunctionsProjectInitializationStep(_projectResolver),
-            new ResolveFunctionsWorkerInitializationStep(_workerResolverFactory, _workloadCatalog, _workloadInstaller, _interaction),
+            new ResolveFunctionsWorkerInitializationStep(_workerResolverFactory, _workloadCatalog, _workloadInstaller),
             new ValidateExtensionBundleInitializationStep(
                 _bundleResolver,
                 _bundleSectionReader,

--- a/src/Func/Commands/Start/Dashboard/Rendering/Initialization/CompactStartInitializationRenderer.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/Initialization/CompactStartInitializationRenderer.cs
@@ -72,6 +72,56 @@ internal sealed class CompactStartInitializationRenderer(
             : StopLiveDisplayAsync(liveTaskToStop, liveCtsToStop!, cancellationToken);
     }
 
+    public async Task<bool> ConfirmAsync(string prompt, bool defaultValue, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        Task? liveTaskToStop;
+        CancellationTokenSource? liveCtsToStop;
+        bool restartLiveDisplay;
+        lock (_stateLock)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            liveTaskToStop = _liveTask;
+            liveCtsToStop = _liveCts;
+            restartLiveDisplay = liveTaskToStop is not null;
+            _liveTask = null;
+            _liveCts = null;
+        }
+
+        if (liveTaskToStop is not null)
+        {
+            await StopLiveDisplayAsync(liveTaskToStop, liveCtsToStop!, cancellationToken);
+            WritePromptContext();
+        }
+
+        try
+        {
+            return await _interaction.ConfirmAsync(prompt, defaultValue, cancellationToken);
+        }
+        finally
+        {
+            if (restartLiveDisplay && !cancellationToken.IsCancellationRequested)
+            {
+                lock (_stateLock)
+                {
+                    if (!_disposed)
+                    {
+                        EnsureLiveDisplayStarted();
+                    }
+                }
+
+                SignalRedraw();
+            }
+        }
+    }
+
+    private void WritePromptContext()
+    {
+        _console.Write(BuildLayout());
+        _console.WriteLine();
+    }
+
     private void EnsureLiveDisplayStarted()
     {
         if (_liveTask is not null)

--- a/src/Func/Commands/Start/Dashboard/Rendering/Initialization/IStartInitializationRenderer.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/Initialization/IStartInitializationRenderer.cs
@@ -11,4 +11,6 @@ namespace Azure.Functions.Cli.Commands.Start.Initialization.Rendering;
 internal interface IStartInitializationRenderer : IAsyncDisposable
 {
     public Task OnEventAsync(StartInitializationEvent initializationEvent, CancellationToken cancellationToken);
+
+    public Task<bool> ConfirmAsync(string prompt, bool defaultValue, CancellationToken cancellationToken);
 }

--- a/src/Func/Commands/Start/Dashboard/Rendering/Initialization/JsonStartInitializationRenderer.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/Initialization/JsonStartInitializationRenderer.cs
@@ -111,6 +111,12 @@ internal sealed class JsonStartInitializationRenderer : IStartInitializationRend
         return Task.CompletedTask;
     }
 
+    public Task<bool> ConfirmAsync(string prompt, bool defaultValue, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        throw new InvalidOperationException("JSON initialization renderer cannot prompt for input.");
+    }
+
     public ValueTask DisposeAsync()
     {
         Flush();

--- a/src/Func/Commands/Start/Dashboard/Rendering/Initialization/PlainStartInitializationRenderer.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/Initialization/PlainStartInitializationRenderer.cs
@@ -40,6 +40,9 @@ internal sealed class PlainStartInitializationRenderer(IInteractionService inter
         return Task.CompletedTask;
     }
 
+    public async Task<bool> ConfirmAsync(string prompt, bool defaultValue, CancellationToken cancellationToken)
+        => await _interaction.ConfirmAsync(prompt, defaultValue, cancellationToken);
+
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private static string FormatMessage(string? message)

--- a/src/Func/Commands/Start/Dashboard/Rendering/Initialization/RecordingStartInitializationRenderer.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/Initialization/RecordingStartInitializationRenderer.cs
@@ -30,5 +30,8 @@ internal sealed class RecordingStartInitializationRenderer(IStartInitializationR
         await _inner.OnEventAsync(initializationEvent, cancellationToken);
     }
 
+    public async Task<bool> ConfirmAsync(string prompt, bool defaultValue, CancellationToken cancellationToken)
+        => await _inner.ConfirmAsync(prompt, defaultValue, cancellationToken);
+
     public ValueTask DisposeAsync() => _inner.DisposeAsync();
 }

--- a/src/Func/Commands/Start/Initialization/StartInitializationStepContext.cs
+++ b/src/Func/Commands/Start/Initialization/StartInitializationStepContext.cs
@@ -41,6 +41,13 @@ internal sealed class StartInitializationStepContext(
             cancellationToken);
     }
 
+    public async Task<bool> ConfirmAsync(string prompt, bool defaultValue, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(prompt);
+
+        return await _renderer.ConfirmAsync(prompt, defaultValue, cancellationToken);
+    }
+
     internal IReadOnlyList<IStartInitializationStep> DrainNextSteps()
     {
         IStartInitializationStep[] steps = [.. _nextSteps];

--- a/src/Func/Commands/Start/Initialization/Steps/ResolveFunctionsWorkerInitializationStep.cs
+++ b/src/Func/Commands/Start/Initialization/Steps/ResolveFunctionsWorkerInitializationStep.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Common;
-using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Workers;
 using Azure.Functions.Cli.Workloads.Catalog;
@@ -15,11 +14,7 @@ namespace Azure.Functions.Cli.Commands.Start.Initialization;
 /// <summary>
 /// Resolves the Functions worker required by the project.
 /// </summary>
-internal sealed class ResolveFunctionsWorkerInitializationStep(
-    IFunctionsWorkerResolverFactory workerResolverFactory,
-    IWorkloadCatalog workloadCatalog,
-    IWorkloadInstaller workloadInstaller,
-    IInteractionService interaction) : DemoInitializationStep
+internal sealed class ResolveFunctionsWorkerInitializationStep(IFunctionsWorkerResolverFactory workerResolverFactory, IWorkloadCatalog workloadCatalog, IWorkloadInstaller workloadInstaller) : DemoInitializationStep
 {
     public const string StepId = "resolve_worker";
 
@@ -28,7 +23,6 @@ internal sealed class ResolveFunctionsWorkerInitializationStep(
 
     private readonly IWorkloadCatalog _workloadCatalog = workloadCatalog ?? throw new ArgumentNullException(nameof(workloadCatalog));
     private readonly IWorkloadInstaller _workloadInstaller = workloadInstaller ?? throw new ArgumentNullException(nameof(workloadInstaller));
-    private readonly IInteractionService _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
 
     public override string Id => StepId;
 
@@ -95,10 +89,8 @@ internal sealed class ResolveFunctionsWorkerInitializationStep(
 
         string packageId = FunctionsWorkerWorkloadPackages.GetPackageId(workerId);
 
-        // Live progress region is owned by the Spectre Progress task; leading
-        // newline keeps the prompt off the spinner's line.
-        bool shouldInstall = await _interaction.ConfirmAsync(
-            $"{Environment.NewLine}The Functions worker workload '{packageId}' is required. Install it now?",
+        bool shouldInstall = await context.ConfirmAsync(
+            $"The Functions worker workload '{packageId}' is required. Install it now?",
             defaultValue: true,
             cancellationToken);
 

--- a/test/Func.Tests/Commands/StartInitializationTests.cs
+++ b/test/Func.Tests/Commands/StartInitializationTests.cs
@@ -11,6 +11,7 @@ using Azure.Functions.Cli.Commands.Start.Initialization.Rendering;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Configuration;
 using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Console.Theme;
 using Azure.Functions.Cli.Hosting.Dashboard;
 using Azure.Functions.Cli.Hosting.Dashboard.Demo;
 using Azure.Functions.Cli.Hosting.Dashboard.Rendering;
@@ -428,17 +429,14 @@ public class StartInitializationTests : IDisposable
                 NuGetVersion.Parse("3.13.0"),
                 new PackageSource("https://example.test/v3/index.json")));
         IWorkloadInstaller workloadInstaller = CreateSuccessfulInstaller();
-        IInteractionService interaction = Substitute.For<IInteractionService>();
-        interaction.ConfirmAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
-            .Returns(true);
+        var renderer = new RecordingStartInitializationRenderer();
         var runner = CreateRunner(
             projectResolver,
             CreateResolvedProfile(workerRanges),
             CreateInstalledHostWorkloadResolver(),
             workloadInstaller,
             workerResolverFactory,
-            workloadCatalog,
-            interaction);
+            workloadCatalog);
         StartInitializationContext context = CreateContext(
             WorkingDirectory.FromExplicit(_tempDir),
             cliVersion: "5.0.0-test",
@@ -448,11 +446,14 @@ public class StartInitializationTests : IDisposable
 
         StartInitializationResult result = await runner.RunAsync(
             context,
-            new RecordingStartInitializationRenderer(),
+            renderer,
             CancellationToken.None);
 
         Assert.Equal("node", result.Worker.WorkerRuntime);
         Assert.Equal("3.13.0", result.Worker.Version);
+        Assert.Contains(
+            $"The Functions worker workload '{FunctionsWorkerWorkloadPackages.GetPackageId(workerId)}' is required. Install it now?",
+            renderer.ConfirmPrompts);
         await workloadInstaller.Received(1).InstallFromCatalogAsync(
             FunctionsWorkerWorkloadPackages.GetPackageId(workerId),
             NuGetVersion.Parse("3.13.0"),
@@ -750,6 +751,61 @@ public class StartInitializationTests : IDisposable
         }
     }
 
+    [Fact]
+    public async Task CompactRenderer_ConfirmAsync_PreservesStatusBeforePromptAndPausesLiveDisplay()
+    {
+        using var writer = new StringWriter();
+        IAnsiConsole console = CreateInteractiveConsole(writer);
+        IInteractionService interaction = Substitute.For<IInteractionService>();
+        interaction.Theme.Returns(new DefaultTheme());
+        TaskCompletionSource<bool> promptStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource<bool> promptResult = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        interaction.ConfirmAsync("Install?", true, Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                writer.WriteLine("Install?");
+                promptStarted.TrySetResult(true);
+                return promptResult.Task;
+            });
+        var renderer = new CompactStartInitializationRenderer(interaction, "5.0.0-test", console);
+
+        try
+        {
+            var initializationStartedEvent = new StartInitializationStartedEvent(DateTimeOffset.UnixEpoch, "none");
+            var step = new StartInitializationStep(
+                ResolveFunctionsWorkerInitializationStep.StepId,
+                "Resolve worker",
+                DisplayKind: StartInitializationDisplayKind.Progress);
+            var stepStartedEvent = new StartInitializationStepStartedEvent(DateTimeOffset.UnixEpoch, step);
+
+            await renderer.OnEventAsync(initializationStartedEvent, CancellationToken.None);
+            await renderer.OnEventAsync(stepStartedEvent, CancellationToken.None);
+            await WaitForOutputAsync(writer, output => output.Contains("Resolve worker", StringComparison.Ordinal));
+
+            Task<bool> confirmTask = renderer.ConfirmAsync("Install?", defaultValue: true, CancellationToken.None);
+            await promptStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+            string outputDuringPrompt = writer.ToString();
+            int statusIndex = outputDuringPrompt.LastIndexOf("Resolve worker", StringComparison.Ordinal);
+            int promptIndex = outputDuringPrompt.LastIndexOf("Install?", StringComparison.Ordinal);
+
+            await Task.Delay(300);
+
+            Assert.True(statusIndex >= 0, $"Expected status output before prompt. Output: {outputDuringPrompt}");
+            Assert.True(promptIndex > statusIndex, $"Expected prompt to render after status output. Output: {outputDuringPrompt}");
+            Assert.DoesNotContain("\r\u001b[2K", outputDuringPrompt[statusIndex..promptIndex]);
+            Assert.Equal(outputDuringPrompt, writer.ToString());
+
+            promptResult.SetResult(true);
+            Assert.True(await confirmTask);
+            await WaitForOutputAsync(writer, output => output.Length > outputDuringPrompt.Length);
+        }
+        finally
+        {
+            promptResult.TrySetResult(true);
+            await renderer.DisposeAsync();
+        }
+    }
+
     private static StartInitializationContext CreateContext(
         WorkingDirectory workingDirectory,
         string cliVersion,
@@ -810,6 +866,23 @@ public class StartInitializationTests : IDisposable
             Interactive = InteractionSupport.Yes,
             Out = new TestTerminalOutput(writer),
         });
+
+    private static async Task WaitForOutputAsync(StringWriter writer, Func<string, bool> predicate)
+    {
+        string output = string.Empty;
+        for (int attempt = 0; attempt < 20; attempt++)
+        {
+            output = writer.ToString();
+            if (predicate(output))
+            {
+                return;
+            }
+
+            await Task.Delay(100);
+        }
+
+        Assert.True(predicate(output), $"Expected output condition was not met. Output: {output}");
+    }
 
     private static DemoStartInitializationRunner CreateRunner(
         IFunctionsProjectResolver projectResolver,
@@ -1068,10 +1141,21 @@ public class StartInitializationTests : IDisposable
     {
         public List<StartInitializationEvent> Events { get; } = [];
 
+        public List<string> ConfirmPrompts { get; } = [];
+
+        public bool ConfirmResult { get; set; } = true;
+
         public Task OnEventAsync(StartInitializationEvent initializationEvent, CancellationToken cancellationToken)
         {
             Events.Add(initializationEvent);
             return Task.CompletedTask;
+        }
+
+        public Task<bool> ConfirmAsync(string prompt, bool defaultValue, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ConfirmPrompts.Add(prompt);
+            return Task.FromResult(ConfirmResult);
         }
 
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;


### PR DESCRIPTION
Updates func start initialization prompting so interactive prompts go through the active initialization renderer. In compact mode, the renderer pauses the Spectre live display, preserves the current status snapshot, prints the prompt on the next line, and then resumes live rendering after the prompt completes.

