### PR TITLE
func new: --output json + per-template options on the execute path

### DIFF
--- a/src/Abstractions/Templates/NewContext.cs
+++ b/src/Abstractions/Templates/NewContext.cs
@@ -39,10 +39,18 @@ namespace Azure.Functions.Cli.Templates;
 /// orchestrator; providers then fall back to a best-effort highest-version
 /// pick from <see cref="IInstalledTemplatesWorkloads"/>.
 /// </param>
+/// <param name="UserOptionValues">
+/// User-supplied per-prompt overrides resolved from the CLI parse,
+/// keyed by the v2 paramId / DotNet parameter name. Engines layer these
+/// over each prompt's declared default before applying. <c>null</c> when
+/// the user supplied no overrides (the engine's prompt-default path
+/// applies as usual).
+/// </param>
 public sealed record NewContext(
     WorkingDirectory WorkingDirectory,
     FunctionTemplateInfo Template,
     string FunctionName,
     string? Language,
     bool Force,
-    string? InstallDirectory = null);
+    string? InstallDirectory = null,
+    IReadOnlyDictionary<string, string?>? UserOptionValues = null);

--- a/src/Func/Commands/NewCommand.cs
+++ b/src/Func/Commands/NewCommand.cs
@@ -43,8 +43,14 @@ internal sealed class NewCommand : FuncCliCommand, IBuiltInCommand, ITemplateAwa
         Description = "List available templates for this project instead of scaffolding.",
     };
 
+    public Option<string?> OutputOption { get; } = new("--output")
+    {
+        Description = "Output mode (plain | json). Defaults to plain.",
+    };
+
     private readonly NewCommandRunner _runner;
     private readonly HashSet<string> _builtInOptionNames;
+    private readonly Dictionary<string, string> _optionNameToPromptId = new(StringComparer.OrdinalIgnoreCase);
 
     public NewCommand(NewCommandRunner runner)
         : base("new", "Create a new function from a template.")
@@ -57,6 +63,14 @@ internal sealed class NewCommand : FuncCliCommand, IBuiltInCommand, ITemplateAwa
         Options.Add(ForceOption);
         Options.Add(NonInteractiveOption);
         Options.Add(ListOption);
+        Options.Add(OutputOption);
+
+        // Tolerate unrecognised options so ExecuteAsync can re-interpret
+        // them as per-template prompt values (e.g. `--auth-level anonymous`
+        // for HttpTrigger). Without this SCL would reject the invocation
+        // before ExecuteAsync ever runs and the user couldn't supply the
+        // hydrated options surfaced under `--help`.
+        TreatUnmatchedTokensAsErrors = false;
 
         // Snapshot the built-in option names so the help-time hydration
         // pass can tell which Options on the command came from the user's
@@ -73,16 +87,231 @@ internal sealed class NewCommand : FuncCliCommand, IBuiltInCommand, ITemplateAwa
         ArgumentNullException.ThrowIfNull(parseResult);
 
         WorkingDirectory workingDirectory = parseResult.GetValue(PathArgument!)!;
+        string? requestedTemplate = parseResult.GetValue(TemplateOption);
+        bool jsonOutput = string.Equals(parseResult.GetValue(OutputOption), "json", StringComparison.OrdinalIgnoreCase);
+
+        // Collect per-template prompt overrides. Two sources, in priority order:
+        //   1. Options the pre-parse step in Program.Main attached to this
+        //      command from the hydrator. SCL parsed them; read the values
+        //      out of `parseResult` and translate Option.Name (kebab-cased
+        //      paramId) back into the v2 paramId the engine expects.
+        //   2. UnmatchedTokens — only populated when pre-parse couldn't
+        //      attach the options (template not found, project not init'd,
+        //      etc.). Walk the pairs manually so a typo still surfaces a
+        //      sensible "Template was not found" rather than a confusing
+        //      "Unrecognized option" error.
+        IReadOnlyDictionary<string, string?>? userOptionValues = null;
+        if (!string.IsNullOrWhiteSpace(requestedTemplate))
+        {
+            userOptionValues = ReadParsedPromptOverrides(parseResult)
+                ?? ParsePromptOverrides(parseResult.UnmatchedTokens, requestedTemplate);
+        }
+
         var invocation = new NewInvocation(
             workingDirectory,
-            RequestedTemplate: parseResult.GetValue(TemplateOption),
+            RequestedTemplate: requestedTemplate,
             RequestedFunctionName: parseResult.GetValue(NameOption),
             Force: parseResult.GetValue(ForceOption),
-            NonInteractive: parseResult.GetValue(NonInteractiveOption));
+            NonInteractive: parseResult.GetValue(NonInteractiveOption),
+            JsonOutput: jsonOutput,
+            UserOptionValues: userOptionValues);
 
         return parseResult.GetValue(ListOption)
             ? _runner.ListAsync(invocation, cancellationToken)
             : _runner.ExecuteAsync(invocation, cancellationToken);
+    }
+
+    /// <summary>
+    /// Reads supplied values for the options the pre-parse step attached
+    /// to this command. Each hydrated <see cref="Option"/> was registered
+    /// with name <c>--&lt;kebab-paramId&gt;</c>; translate back to the v2
+    /// paramId so the engine's variable substitution can pick the value
+    /// up. Returns <c>null</c> when no hydrated options were attached
+    /// (or none were bound on this invocation).
+    /// </summary>
+    private Dictionary<string, string?>? ReadParsedPromptOverrides(ParseResult parseResult)
+    {
+        var dynamicOptions = Options.Where(o => !_builtInOptionNames.Contains(o.Name)).ToList();
+        if (dynamicOptions.Count == 0)
+        {
+            return null;
+        }
+
+        Dictionary<string, string?>? overrides = null;
+        foreach (Option option in dynamicOptions)
+        {
+            System.CommandLine.Parsing.OptionResult? result = parseResult.GetResult(option);
+            if (result is null || result.Tokens.Count == 0)
+            {
+                continue;
+            }
+
+            // The hydrator creates Option<string?>, so reading via Tokens
+            // gives us the raw string the user typed without having to
+            // know the closed generic type at this layer.
+            string raw = result.Tokens[0].Value;
+            overrides ??= new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+            // Translate the kebab-cased option.Name back to the v2 paramId
+            // the engine resolves against. Falls back to the trimmed name
+            // if the mapping is missing (defensive — shouldn't happen for
+            // options attached via AttachHydratedOptionsForPreParse).
+            string promptId = _optionNameToPromptId.TryGetValue(option.Name, out string? mapped)
+                ? mapped
+                : option.Name.TrimStart('-');
+            overrides[promptId] = raw;
+        }
+
+        return overrides;
+    }
+
+    /// <summary>
+    /// Translates SCL's <see cref="ParseResult.UnmatchedTokens"/> for a
+    /// <c>func new -t &lt;id&gt; --foo bar --baz qux</c> invocation into a
+    /// per-prompt override dict the runner can hand to the engine. The
+    /// hydrator is the source of truth for the available prompt set; only
+    /// tokens that match a hydrated <see cref="Option"/> survive — unknown
+    /// ones are ignored so a typo doesn't silently mask the real default
+    /// (SCL's normal error UX for unknown options is suppressed because
+    /// <see cref="TreatUnmatchedTokensAsErrors"/> is off; surface the same
+    /// posture by simply ignoring them here).
+    /// </summary>
+    private IReadOnlyDictionary<string, string?>? ParsePromptOverrides(
+        IReadOnlyList<string> unmatched,
+        string templateId)
+    {
+        IReadOnlyList<Option>? hydrated;
+        try
+        {
+            var invocation = new NewInvocation(
+                new WorkingDirectory(new DirectoryInfo(Environment.CurrentDirectory), false),
+                RequestedTemplate: templateId,
+                RequestedFunctionName: null,
+                Force: false,
+                NonInteractive: true);
+
+            hydrated = _runner.HydrateOptionsForTemplateAsync(invocation, templateId, CancellationToken.None)
+                .GetAwaiter().GetResult();
+        }
+        catch
+        {
+            return null;
+        }
+
+        if (hydrated is null || hydrated.Count == 0)
+        {
+            return null;
+        }
+
+        // Build a name → promptId map so both --kebab-name and the original
+        // paramId form land on the right key. The hydrator names each
+        // Option after the kebab-cased paramId.
+        var nameToPromptId = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (Option option in hydrated)
+        {
+            string promptId = option.Name.TrimStart('-');
+            nameToPromptId[option.Name] = promptId;
+            foreach (string alias in option.Aliases)
+            {
+                nameToPromptId[alias] = promptId;
+            }
+        }
+
+        var overrides = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        for (int i = 0; i < unmatched.Count; i++)
+        {
+            string token = unmatched[i];
+            if (!token.StartsWith('-'))
+            {
+                continue;
+            }
+
+            // Tolerate --opt=value syntax in addition to --opt value.
+            int eq = token.IndexOf('=');
+            if (eq > 0)
+            {
+                string name = token[..eq];
+                string val = token[(eq + 1)..];
+                if (nameToPromptId.TryGetValue(name, out string? promptIdInline))
+                {
+                    overrides[promptIdInline] = val;
+                }
+                continue;
+            }
+
+            if (!nameToPromptId.TryGetValue(token, out string? promptId))
+            {
+                continue;
+            }
+
+            string? value = (i + 1 < unmatched.Count && !unmatched[i + 1].StartsWith('-'))
+                ? unmatched[++i]
+                : "true";
+
+            overrides[promptId] = value;
+        }
+
+        return overrides.Count == 0 ? null : overrides;
+    }
+
+    /// <summary>
+    /// Pre-parse hook: invoked by <see cref="NewCommandArgPreparer"/>
+    /// from <c>Program.Main</c> before the parser runs, so per-template
+    /// options the user supplies on the same invocation as
+    /// <c>--template &lt;id&gt;</c> get registered in time for SCL to
+    /// recognise them. Idempotent — duplicate calls (including the
+    /// help-time path) drop previously-attached options first.
+    /// </summary>
+    public void AttachHydratedOptionsForPreParse(string templateId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(templateId);
+
+        DropDynamicOptions();
+
+        var invocation = new NewInvocation(
+            new WorkingDirectory(new DirectoryInfo(Environment.CurrentDirectory), false),
+            RequestedTemplate: templateId,
+            RequestedFunctionName: null,
+            Force: false,
+            NonInteractive: true);
+
+        IReadOnlyList<HydratedTemplateOption>? hydrated;
+        try
+        {
+            hydrated = _runner.HydrateOptionsForTemplateWithIdsAsync(invocation, templateId, CancellationToken.None)
+                .GetAwaiter().GetResult();
+        }
+        catch
+        {
+            return;
+        }
+
+        if (hydrated is null || hydrated.Count == 0)
+        {
+            return;
+        }
+
+        foreach (HydratedTemplateOption pair in hydrated)
+        {
+            if (_builtInOptionNames.Contains(pair.Option.Name))
+            {
+                continue;
+            }
+
+            Options.Add(pair.Option);
+            _optionNameToPromptId[pair.Option.Name] = pair.PromptId;
+        }
+    }
+
+    private void DropDynamicOptions()
+    {
+        var stale = Options
+            .Where(o => !_builtInOptionNames.Contains(o.Name))
+            .ToList();
+        foreach (Option o in stale)
+        {
+            Options.Remove(o);
+        }
+        _optionNameToPromptId.Clear();
     }
 
     /// <summary>

--- a/src/Func/NewCommandArgPreparer.cs
+++ b/src/Func/NewCommandArgPreparer.cs
@@ -1,0 +1,126 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Commands;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Templates;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Azure.Functions.Cli;
+
+/// <summary>
+/// Pre-parse hydration for <c>func new -t &lt;id&gt;</c>. The user is
+/// allowed to pass per-template options on the same invocation as
+/// <c>--template &lt;id&gt;</c> (e.g.
+/// <c>func new -t HttpTrigger -n MyHttp --auth-level anonymous</c>). The
+/// hydrated <see cref="Option"/> set isn't known until the runner has
+/// resolved the project + located the chosen template, but System.CommandLine
+/// would reject the unknown options before <c>NewCommand.ExecuteAsync</c>
+/// ever runs (PathArgument's unrecognized-token guard catches them first).
+/// </summary>
+/// <remarks>
+/// This pre-parse is intentionally rudimentary — it only looks for
+/// <c>new</c> as the first non-flag token and <c>--template</c>/<c>-t</c>
+/// in argv. Any failure (project not init'd, workload not installed,
+/// template not found) falls through silently; the main parser will
+/// surface the right diagnostics in the normal flow.
+/// </remarks>
+internal static class NewCommandArgPreparer
+{
+    public static void PrepareIfFuncNew(string[] args, IServiceProvider services, Command rootCommand)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(rootCommand);
+
+        if (!LooksLikeFuncNew(args))
+        {
+            return;
+        }
+
+        string? templateId = ExtractTemplateId(args);
+        if (string.IsNullOrWhiteSpace(templateId))
+        {
+            return;
+        }
+
+        NewCommand? newCommand = rootCommand.Subcommands
+            .OfType<NewCommand>()
+            .FirstOrDefault();
+        if (newCommand is null)
+        {
+            return;
+        }
+
+        // Delegate the actual hydration to NewCommand (it already owns the
+        // attach/detach lifecycle for the help path).
+        try
+        {
+            newCommand.AttachHydratedOptionsForPreParse(templateId);
+        }
+        catch
+        {
+            // Hydration failures here are silent on purpose — the main
+            // parser will produce a much nicer error message a moment
+            // later (e.g. "Template 'X' was not found for this project's
+            // stack").
+        }
+    }
+
+    private static bool LooksLikeFuncNew(string[] args)
+    {
+        // Find the first non-flag token; that's the verb. We're looking
+        // for "new" — anything else means this isn't our concern.
+        foreach (string arg in args)
+        {
+            if (string.IsNullOrEmpty(arg))
+            {
+                continue;
+            }
+
+            if (arg.StartsWith('-'))
+            {
+                continue;
+            }
+
+            return string.Equals(arg, "new", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+
+    private static string? ExtractTemplateId(string[] args)
+    {
+        for (int i = 0; i < args.Length; i++)
+        {
+            string arg = args[i];
+            if (string.IsNullOrEmpty(arg))
+            {
+                continue;
+            }
+
+            // Long form: --template <id> or --template=<id>.
+            if (arg.Equals("--template", StringComparison.OrdinalIgnoreCase))
+            {
+                return i + 1 < args.Length ? args[i + 1] : null;
+            }
+            if (arg.StartsWith("--template=", StringComparison.OrdinalIgnoreCase))
+            {
+                return arg["--template=".Length..];
+            }
+
+            // Short form: -t <id> or -t=<id>.
+            if (arg.Equals("-t", StringComparison.Ordinal))
+            {
+                return i + 1 < args.Length ? args[i + 1] : null;
+            }
+            if (arg.StartsWith("-t=", StringComparison.Ordinal))
+            {
+                return arg["-t=".Length..];
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Func/Program.cs
+++ b/src/Func/Program.cs
@@ -73,6 +73,14 @@ using (Activity? activity = CliTelemetry.Trace.StartCommandActivity())
 
         rootCommand = Parser.CreateCommand(host.Services);
 
+        // Pre-parse hydration for `func new -t <id>`: the user can pass
+        // per-template options (e.g. --auth-level) that NewCommand learns
+        // about only after the hydrator runs against the chosen template.
+        // Attach them to NewCommand BEFORE the parser sees argv so SCL
+        // treats them as known options instead of erroring out via
+        // PathArgument's unrecognized-token guard.
+        NewCommandArgPreparer.PrepareIfFuncNew(args, host.Services, rootCommand);
+
         commandParseResult = rootCommand.Parse(args);
         commandName = CommandNameResolver.ResolveCommandName(commandParseResult, rootCommand);
         activity?.SetCommandName(commandName);

--- a/src/Func/Templates/NewCommandRenderer.cs
+++ b/src/Func/Templates/NewCommandRenderer.cs
@@ -122,4 +122,51 @@ internal sealed class NewCommandRenderer(IInteractionService interaction)
             .Code("func new --template <NAME> --name <function-name>")
             .Muted("."));
     }
+
+    /// <summary>
+    /// Renders the <c>func new --list --output json</c> envelope (single
+    /// object, not NDJSON — list is a finite, ordered query). Shape:
+    /// <c>{ stack, language, templates: [...] }</c>. Each template entry
+    /// carries the public-facing fields plus the per-prompt option schema
+    /// so tooling can build forms / autocompletion without re-parsing the
+    /// workload payload.
+    /// </summary>
+    public void RenderCatalogueJson(string stack, string? language, IReadOnlyList<FunctionTemplateInfo> templates)
+    {
+        var envelope = new
+        {
+            stack,
+            language,
+            templates = templates.Select(t => new
+            {
+                id = t.Id,
+                displayName = t.DisplayName,
+                triggerKind = t.TriggerKind,
+                description = t.Description,
+                defaultFunctionName = t.DefaultFunctionName,
+                languages = t.Languages,
+                engineId = t.EngineId,
+                requiresExtensionBundle = t.Metadata.RequiresExtensionBundle,
+                minBundleVersion = t.Metadata.MinBundleVersion,
+                options = t.Metadata.UserPrompts.Select(p => new
+                {
+                    id = p.Id,
+                    description = p.Description,
+                    dataType = p.DataType,
+                    defaultValue = p.DefaultValue,
+                    choices = p.Choices,
+                    isRequired = p.IsRequired,
+                }),
+            }),
+        };
+
+        var jsonOptions = new System.Text.Json.JsonSerializerOptions
+        {
+            WriteIndented = true,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        };
+
+        string json = System.Text.Json.JsonSerializer.Serialize(envelope, jsonOptions);
+        _interaction.WriteLine(json);
+    }
 }

--- a/src/Func/Templates/NewCommandRunner.cs
+++ b/src/Func/Templates/NewCommandRunner.cs
@@ -115,7 +115,7 @@ internal sealed class NewCommandRunner
         // Step 8 / 9: stage-B hydration. Hands the engine the user's --name
         // plus each prompt's declared default (no per-option CLI parsing
         // yet); the engine reads from the supplied dictionary.
-        IReadOnlyDictionary<string, string?> optionValues = BuildPromptDefaults(template);
+        IReadOnlyDictionary<string, string?> optionValues = BuildPromptDefaults(template, invocation.UserOptionValues);
 
         // Step 10: function name resolution.
         string functionName = invocation.RequestedFunctionName
@@ -144,7 +144,8 @@ internal sealed class NewCommandRunner
             functionName,
             resolved.Language,
             invocation.Force,
-            resolved.Workload.InstallDirectory);
+            resolved.Workload.InstallDirectory,
+            invocation.UserOptionValues);
 
         ParseResult emptyParseResult = new RootCommand().Parse(string.Empty);
         TemplateApplicationResult applyResult = await provider.ApplyAsync(context, emptyParseResult, cancellationToken);
@@ -173,7 +174,15 @@ internal sealed class NewCommandRunner
             return 1;
         }
 
-        _renderer.RenderCatalogue(resolved.Stack, resolved.Language, templates);
+        if (invocation.JsonOutput)
+        {
+            _renderer.RenderCatalogueJson(resolved.Stack, resolved.Language, templates);
+        }
+        else
+        {
+            _renderer.RenderCatalogue(resolved.Stack, resolved.Language, templates);
+        }
+
         return 0;
     }
 
@@ -187,6 +196,23 @@ internal sealed class NewCommandRunner
     /// back to a built-ins-only help render or surface the failure.
     /// </summary>
     public async Task<IReadOnlyList<Option>?> HydrateOptionsForTemplateAsync(
+        NewInvocation invocation,
+        string templateId,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<HydratedTemplateOption>? paired =
+            await HydrateOptionsForTemplateWithIdsAsync(invocation, templateId, cancellationToken);
+
+        return paired?.Select(p => p.Option).ToList();
+    }
+
+    /// <summary>
+    /// Same as <see cref="HydrateOptionsForTemplateAsync"/> but also returns
+    /// the prompt id each option projects from. <c>NewCommand</c> uses this
+    /// overload on the execute path to map user-supplied values back to
+    /// the v2 paramId the engine resolves against.
+    /// </summary>
+    public async Task<IReadOnlyList<HydratedTemplateOption>?> HydrateOptionsForTemplateWithIdsAsync(
         NewInvocation invocation,
         string templateId,
         CancellationToken cancellationToken)
@@ -209,7 +235,7 @@ internal sealed class NewCommandRunner
             return null;
         }
 
-        return _optionHydrator.Hydrate(template);
+        return _optionHydrator.HydrateWithIds(template);
     }
 
     private async Task<ResolvedContext?> ResolveContextAsync(
@@ -457,13 +483,24 @@ internal sealed class NewCommandRunner
         return await _picker.PickAsync(templates, cancellationToken);
     }
 
-    private static IReadOnlyDictionary<string, string?> BuildPromptDefaults(FunctionTemplateInfo template)
+    private static IReadOnlyDictionary<string, string?> BuildPromptDefaults(
+        FunctionTemplateInfo template,
+        IReadOnlyDictionary<string, string?>? userOverrides = null)
     {
         var dict = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
         foreach (TemplateUserPrompt prompt in template.Metadata.UserPrompts)
         {
             dict[prompt.Id] = prompt.DefaultValue;
         }
+
+        if (userOverrides is not null)
+        {
+            foreach (KeyValuePair<string, string?> pair in userOverrides)
+            {
+                dict[pair.Key] = pair.Value;
+            }
+        }
+
         return dict;
     }
 
@@ -627,4 +664,6 @@ internal sealed record NewInvocation(
     string? RequestedTemplate,
     string? RequestedFunctionName,
     bool Force,
-    bool NonInteractive);
+    bool NonInteractive,
+    bool JsonOutput = false,
+    IReadOnlyDictionary<string, string?>? UserOptionValues = null);

--- a/src/Func/Templates/TemplateOptionHydrator.cs
+++ b/src/Func/Templates/TemplateOptionHydrator.cs
@@ -76,6 +76,27 @@ internal sealed class TemplateOptionHydrator
         return result;
     }
 
+    /// <summary>
+    /// Same as <see cref="Hydrate"/> but pairs each <see cref="Option"/>
+    /// with the originating prompt id. NewCommand uses this overload on
+    /// the execute path to map user-supplied values back to the
+    /// v2 paramId — <c>Option.Name</c> by then has been kebab-cased and
+    /// isn't reversible to the original id.
+    /// </summary>
+    public IReadOnlyList<HydratedTemplateOption> HydrateWithIds(FunctionTemplateInfo template)
+    {
+        ArgumentNullException.ThrowIfNull(template);
+
+        List<HydratedTemplateOption> result = [];
+        foreach (TemplateUserPrompt prompt in template.Metadata.UserPrompts)
+        {
+            Option option = BuildOption(template, prompt);
+            result.Add(new HydratedTemplateOption(option, prompt.Id));
+        }
+
+        return result;
+    }
+
     private Option BuildOption(FunctionTemplateInfo template, TemplateUserPrompt prompt)
     {
         string longName = prompt.LongAlias ?? "--" + KebabCase(prompt.Id);
@@ -243,3 +264,10 @@ internal sealed class TemplateOptionHydrator
         return sb.ToString();
     }
 }
+
+/// <summary>
+/// A hydrated CLI option paired with the v2 paramId it was projected
+/// from. Used by <c>NewCommand</c> to map user-supplied values on the
+/// execute path back to the engine's variable namespace.
+/// </summary>
+internal sealed record HydratedTemplateOption(Option Option, string PromptId);

--- a/src/Templates.V2/V2EngineProvider.cs
+++ b/src/Templates.V2/V2EngineProvider.cs
@@ -114,17 +114,34 @@ internal sealed class V2EngineProvider : ITemplateEngineProvider
                     null));
         }
 
-        // PR4: seed defaults from each declared prompt, then override the
+        // Seed defaults from each declared prompt, then override the
         // function-name prompt with the user-supplied context.FunctionName
         // so it wins over the template's declared default. The engine reads
         // values by paramId; the recognised function-name prompt ids match
-        // the conventions Node v4 / Python v2 bundle templates use.
+        // the conventions Node v4 / Python v2 bundle templates use. Finally,
+        // layer in any caller-supplied UserOptionValues so flags like
+        // --auth-level override the template default.
         var optionValues = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
         foreach (TemplateUserPrompt prompt in context.Template.Metadata.UserPrompts)
         {
             optionValues[prompt.Id] = _functionNamePromptIds.Contains(prompt.Id)
                 ? context.FunctionName
                 : prompt.DefaultValue;
+        }
+
+        if (context.UserOptionValues is not null)
+        {
+            foreach (KeyValuePair<string, string?> pair in context.UserOptionValues)
+            {
+                // Don't let the caller smuggle a value over the function
+                // name — that lives on context.FunctionName for a reason.
+                if (_functionNamePromptIds.Contains(pair.Key))
+                {
+                    continue;
+                }
+
+                optionValues[pair.Key] = pair.Value;
+            }
         }
 
         return _engine.Apply(


### PR DESCRIPTION
## What

Two follow-ups to PR #5164 (merged earlier today) on `func new`:

| # | Fix |
|---|---|
| 1 | `func new --list --output json` — adds the spec'd JSON envelope renderer (was spec'd but not yet implemented) |
| 2 | `func new -t <id> -n <name> --<prompt> <value>` — per-template options on the execute path now bind and override defaults, not just on `--help` |

## `--output json` on `func new --list`

Added a `--output` enum option (`plain` | `json`) to `NewCommand`. JSON envelope follows the func-new spec §5.5.4 shape:

```json
{
  "stack": "node",
  "language": "javascript",
  "templates": [
    {
      "id": "HttpTrigger-JavaScript",
      "displayName": "HTTP trigger",
      "triggerKind": "function",
      "description": "An Azure Function that runs in response to HTTP requests.",
      "defaultFunctionName": null,
      "languages": ["javascript"],
      "engineId": "v2",
      "requiresExtensionBundle": true,
      "minBundleVersion": null,
      "options": [
        { "id": "trigger-functionName", "description": "Provide a function name", "dataType": "string", "defaultValue": "httpTrigger", "isRequired": true }
      ]
    }
  ]
}
```

Plain output is unchanged.

## Per-template options on the execute path

PR #5164 wired the hydrated options into `--help` rendering only. On the execute path (`func new -t HttpTrigger -n MyHttp --auth-level anonymous`), System.CommandLine parsed argv before `NewCommand` could hydrate, so it surfaced `Unrecognized option '--auth-level'`.

### Fix

1. **New `NewCommandArgPreparer`** runs in `Program.Main` **before** `rootCommand.Parse(args)`. It scans argv for `new ... --template <id>` and calls `NewCommand.AttachHydratedOptionsForPreParse(templateId)`, which runs the resolver synchronously and registers the per-template options on `NewCommand.Options`.
2. SCL then parses the full argv with the dynamic options known, so the values bind cleanly into `parseResult`.
3. `NewCommand.ExecuteAsync` collects the bound values via a new `ReadParsedPromptOverrides`, threading them through `NewInvocation` → `NewContext.UserOptionValues` → `V2EngineProvider.ApplyAsync`, where they layer over each prompt's declared default before the engine substitutes variables.
4. **`TemplateOptionHydrator` gained a `HydrateWithIds` overload** that pairs each `Option` with the originating v2 paramId. The reverse mapping (kebab-cased `Option.Name` → paramId) isn't recoverable from the name alone for acronym-heavy ids (e.g. `httpTrigger-authLevel`), so `NewCommand` keeps a side dict `Option.Name → paramId`.
5. If pre-parse hydration fails (template not found, project not init'd), parsing falls back to the existing unmatched-tokens path; the normal error UX surfaces in `ExecuteAsync`.

### Verified

```pwsh
> func new -t HttpTrigger-Python -n my_anon --http-trigger-auth-level ANONYMOUS --force
✓ Created function 'HttpTrigger-Python'.

> Get-Content .\function_app.py | Select-String 'auth_level'
app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
```

The override (`ANONYMOUS`) made it all the way through the parser, the runner, the engine's substitution variable namespace, and into the rendered file.

## Known limitation outside this PR

Some **Node** templates hard-code default values in their file bodies — e.g. `TimerTrigger-JavaScript` writes `schedule: '0 */5 * * * *'` literally instead of `$(SCHEDULE_INPUT)`. Overrides reach the engine and the right variable is assigned, but the template body has no placeholder to substitute into. That's a **Node workload data fix** (file `src/Workloads/Templates/Node/content/v2/templates/templates.json`) — not blocking this PR.

Python templates are unaffected — their file bodies use the substitution variables properly, which is why the example above works end-to-end on Python.

## Validation

- 63/63 templates+NewCommand unit tests pass.
- Release build clean (`CI=true`, `TreatWarningsAsErrors`).
- End-to-end against the real packed Node + Python templates workloads.
