### PR TITLE
fix(install): tolerate whitespace and optional v prefix in release parsing

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -64,12 +64,12 @@ if (-not $Version) {
     Write-Host "Resolving $label..."
     $releases = Invoke-RestMethod -Uri "$apiBase/releases?per_page=50"
     $release = $releases |
-        Where-Object { $_.tag_name -like 'v5.*' -and ($Prerelease -or -not $_.prerelease) } |
+        Where-Object { $_.tag_name -match '^v?5\.' -and ($Prerelease -or -not $_.prerelease) } |
         Select-Object -First 1
 
     if (-not $release) {
         if (-not $Prerelease) {
-            $prereleases = $releases | Where-Object { $_.tag_name -like 'v5.*' -and $_.prerelease }
+            $prereleases = $releases | Where-Object { $_.tag_name -match '^v?5\.' -and $_.prerelease }
             if ($prereleases) {
                 Write-Host 'No stable 5.x release found. Available pre-releases:' -ForegroundColor Red
                 $prereleases | Select-Object -First 5 | ForEach-Object { Write-Host "  $($_.tag_name)" -ForegroundColor Red }

--- a/install.sh
+++ b/install.sh
@@ -41,13 +41,13 @@ if [ -z "$VERSION" ]; then
     VERSION=$(echo "$RELEASES_JSON" \
         | tr ',' '\n' \
         | grep -E '"tag_name"|"prerelease"' \
-        | sed 's/.*"tag_name":"\([^"]*\)".*/tag:\1/; s/.*"prerelease":\(.*\)/pre:\1/' \
+        | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]*)".*/tag:\1/; s/.*"prerelease"[[:space:]]*:[[:space:]]*([^[:space:]]+).*/pre:\1/' \
         | paste - - \
         | awk -F'\t' -v include_pre="$PRERELEASE" '
             {
-                split($1, a, ":"); tag = a[2]
-                split($2, b, ":"); pre = b[2]
-                if (tag ~ /^v5\./ && (include_pre == "true" || pre == "false")) {
+                sub(/^tag:/, "", $1); tag = $1
+                sub(/^pre:/, "", $2); pre = $2
+                if (tag ~ /^v?5\./ && (include_pre == "true" || pre == "false")) {
                     print tag; exit
                 }
             }')
@@ -57,13 +57,13 @@ if [ -z "$VERSION" ]; then
             PRE_VERSIONS=$(echo "$RELEASES_JSON" \
                 | tr ',' '\n' \
                 | grep -E '"tag_name"|"prerelease"' \
-                | sed 's/.*"tag_name":"\([^"]*\)".*/tag:\1/; s/.*"prerelease":\(.*\)/pre:\1/' \
+                | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]*)".*/tag:\1/; s/.*"prerelease"[[:space:]]*:[[:space:]]*([^[:space:]]+).*/pre:\1/' \
                 | paste - - \
                 | awk -F'\t' '
                     {
-                        split($1, a, ":"); tag = a[2]
-                        split($2, b, ":"); pre = b[2]
-                        if (tag ~ /^v5\./ && pre == "true") { print tag; count++; if (count >= 5) exit }
+                        sub(/^tag:/, "", $1); tag = $1
+                        sub(/^pre:/, "", $2); pre = $2
+                        if (tag ~ /^v?5\./ && pre == "true") { print tag; count++; if (count >= 5) exit }
                     }')
 
             if [ -n "$PRE_VERSIONS" ]; then


### PR DESCRIPTION
## Problem

`curl -sSL https://aka.ms/func-cli/install.sh | bash` always fails with:

```
Resolving latest 5.x pre-release...
Error: Could not find a 5.x release.
```

regardless of `SOURCE` / `PRERELEASE` / `VERSION`.

## Root cause

The bash installer parses the GitHub releases API with `sed`:

```sh
sed 's/.*"tag_name":"\([^"]*\)".*/tag:\1/; s/.*"prerelease":\(.*\)/pre:\1/'
```

The patterns require `"tag_name":"..."` with no space after the colon, but the GitHub API returns `"tag_name": "..."` (with a space). The substitution never matches, so `awk` sees no usable rows and the resolver returns nothing. This breaks every invocation, not just the `jviau` fork referenced in the original report.

The tag filter also requires a leading `v` (`^v5\.` in bash, `v5.*` in PowerShell), so tags shaped like `5.0.0-…` without the `v` are silently skipped.

## Fix

- `install.sh`: switch to `sed -E` patterns that allow optional whitespace around `:`, and change the awk filter to `^v?5\.`. Applied to both the main resolver and the no-stable-release fallback that lists pre-releases.
- `install.ps1`: replace `-like 'v5.*'` with `-match '^v?5\.'` in both spots so unprefixed tags match too.

## Verification

```
PRERELEASE=true SOURCE=jviau/azure-functions-core-tools bash ./install.sh
→ Resolving latest 5.x pre-release...
→ Installing func CLI v5.0.0-preview.1.ci.26278.2 (osx-arm64)...
→ 5.0.0-preview.1.ci.26278.2+ec2c954d74849d49b7df067ec240a23b689b8730
```