### PR TITLE
func new --help: split template-hydrated options into their own section

### DIFF
--- a/src/Func/Commands/HelpCommand.cs
+++ b/src/Func/Commands/HelpCommand.cs
@@ -119,50 +119,104 @@ internal class HelpCommand : FuncCliCommand
     {
         string commandPath = BuildCommandPath(command);
 
-        _interaction.WriteBlankLine();
-        _interaction.WriteTitle(commandPath);
-        _interaction.WriteBlankLine();
-
-        if (!string.IsNullOrEmpty(command.Description))
-        {
-            _interaction.WriteHint(command.Description);
-            _interaction.WriteBlankLine();
-        }
-
-        _interaction.WriteSectionHeader("Usage");
-        _interaction.WriteBlankLine();
-        WriteUsageLine(command, commandPath);
-        _interaction.WriteBlankLine();
-
-        var args = command.Arguments.Where(a => !a.Hidden).ToList();
-        if (args.Count > 0)
-        {
-            _interaction.WriteSectionHeader("Arguments");
-            _interaction.WriteBlankLine();
-            _interaction.WriteDefinitionList(
-                args.Select(a => new DefinitionItem($"<{a.Name}>", a.Description ?? string.Empty)));
-            _interaction.WriteBlankLine();
-        }
-
-        var subcommands = command.Subcommands.Where(c => !c.Hidden).ToList();
-        if (subcommands.Count > 0)
-        {
-            _interaction.WriteSectionHeader("Commands");
-            _interaction.WriteBlankLine();
-            _interaction.WriteDefinitionList(
-                subcommands.Select(c => new DefinitionItem(c.Name, c.Description ?? string.Empty)));
-            _interaction.WriteBlankLine();
-        }
+        WriteHeader(commandPath, command.Description);
+        WriteUsageSection(command, commandPath);
+        WriteArgumentsSection(command);
+        WriteSubcommandsSection(command);
 
         var options = command.Options.Where(o => !o.Hidden && o is not HelpOption).ToList();
         if (options.Count > 0)
         {
-            _interaction.WriteSectionHeader("Options");
-            _interaction.WriteBlankLine();
-            _interaction.WriteDefinitionList(
-                options.Select(o => new DefinitionItem(FormatOptionName(o), o.Description ?? string.Empty)));
+            WriteOptionsSection("Options", options);
+        }
+    }
+
+    /// <summary>
+    /// Writes the command title and (when present) description block.
+    /// Exposed so custom help actions can compose their own output using
+    /// the same header style as the default renderer.
+    /// </summary>
+    internal void WriteHeader(string commandPath, string? description)
+    {
+        _interaction.WriteBlankLine();
+        _interaction.WriteTitle(commandPath);
+        _interaction.WriteBlankLine();
+
+        if (!string.IsNullOrEmpty(description))
+        {
+            _interaction.WriteHint(description);
             _interaction.WriteBlankLine();
         }
+    }
+
+    /// <summary>
+    /// Writes the "Usage" section for <paramref name="command"/>. Exposed
+    /// for reuse by custom help actions that need the same layout but a
+    /// different options section.
+    /// </summary>
+    internal void WriteUsageSection(Command command, string commandPath)
+    {
+        _interaction.WriteSectionHeader("Usage");
+        _interaction.WriteBlankLine();
+        WriteUsageLine(command, commandPath);
+        _interaction.WriteBlankLine();
+    }
+
+    /// <summary>
+    /// Writes the "Arguments" section when the command has any non-hidden
+    /// arguments. No-op otherwise. Exposed for reuse by custom help actions.
+    /// </summary>
+    internal void WriteArgumentsSection(Command command)
+    {
+        var args = command.Arguments.Where(a => !a.Hidden).ToList();
+        if (args.Count == 0)
+        {
+            return;
+        }
+
+        _interaction.WriteSectionHeader("Arguments");
+        _interaction.WriteBlankLine();
+        _interaction.WriteDefinitionList(
+            args.Select(a => new DefinitionItem($"<{a.Name}>", a.Description ?? string.Empty)));
+        _interaction.WriteBlankLine();
+    }
+
+    /// <summary>
+    /// Writes the "Commands" section when the command has any non-hidden
+    /// subcommands. No-op otherwise. Exposed for reuse by custom help actions.
+    /// </summary>
+    internal void WriteSubcommandsSection(Command command)
+    {
+        var subcommands = command.Subcommands.Where(c => !c.Hidden).ToList();
+        if (subcommands.Count == 0)
+        {
+            return;
+        }
+
+        _interaction.WriteSectionHeader("Commands");
+        _interaction.WriteBlankLine();
+        _interaction.WriteDefinitionList(
+            subcommands.Select(c => new DefinitionItem(c.Name, c.Description ?? string.Empty)));
+        _interaction.WriteBlankLine();
+    }
+
+    /// <summary>
+    /// Writes a titled options section with the standard option-name +
+    /// description layout. Exposed so custom help actions can render
+    /// multiple option groups under different titles (e.g. "Options" plus
+    /// "Template Options (&lt;id&gt;)") while keeping the formatting
+    /// identical to the default single-section renderer.
+    /// </summary>
+    internal void WriteOptionsSection(string title, IEnumerable<Option> options)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(title);
+        ArgumentNullException.ThrowIfNull(options);
+
+        _interaction.WriteSectionHeader(title);
+        _interaction.WriteBlankLine();
+        _interaction.WriteDefinitionList(
+            options.Select(o => new DefinitionItem(FormatOptionName(o), o.Description ?? string.Empty)));
+        _interaction.WriteBlankLine();
     }
 
     /// <summary>
@@ -203,8 +257,9 @@ internal class HelpCommand : FuncCliCommand
     /// <summary>
     /// Builds the full command path from the root, e.g. <c>func workload install</c>
     /// for a nested subcommand. Falls back to <c>func</c> for the root command.
+    /// Exposed for reuse by custom help actions.
     /// </summary>
-    private static string BuildCommandPath(Command command)
+    internal static string BuildCommandPath(Command command)
     {
         if (command is RootCommand)
         {

--- a/src/Func/Commands/NewCommand.cs
+++ b/src/Func/Commands/NewCommand.cs
@@ -52,6 +52,12 @@ internal sealed class NewCommand : FuncCliCommand, IBuiltInCommand, ITemplateAwa
     private readonly HashSet<string> _builtInOptionNames;
     private readonly Dictionary<string, string> _optionNameToPromptId = new(StringComparer.OrdinalIgnoreCase);
 
+    // Template id whose options are currently attached to this command.
+    // Set whenever AttachHydratedOptions* succeeds, cleared in
+    // DropDynamicOptions. The help renderer uses it (via
+    // GetTemplateHelpInfo) to title the "Template Options (<id>)" section.
+    private string? _attachedTemplateId;
+
     public NewCommand(NewCommandRunner runner)
         : base("new", "Create a new function from a template.")
     {
@@ -300,6 +306,8 @@ internal sealed class NewCommand : FuncCliCommand, IBuiltInCommand, ITemplateAwa
             Options.Add(pair.Option);
             _optionNameToPromptId[pair.Option.Name] = pair.PromptId;
         }
+
+        _attachedTemplateId = templateId;
     }
 
     private void DropDynamicOptions()
@@ -312,6 +320,7 @@ internal sealed class NewCommand : FuncCliCommand, IBuiltInCommand, ITemplateAwa
             Options.Remove(o);
         }
         _optionNameToPromptId.Clear();
+        _attachedTemplateId = null;
     }
 
     /// <summary>
@@ -390,18 +399,59 @@ internal sealed class NewCommand : FuncCliCommand, IBuiltInCommand, ITemplateAwa
             Options.Add(o);
         }
 
+        _attachedTemplateId = templateId;
         return Options.Count - _builtInOptionNames.Count;
+    }
+
+    /// <inheritdoc />
+    public TemplateHelpInfo? GetTemplateHelpInfo()
+    {
+        if (string.IsNullOrEmpty(_attachedTemplateId))
+        {
+            return null;
+        }
+
+        // Hydrated options are exactly those on the command whose names
+        // aren't in the original built-in snapshot. Using this diff is
+        // robust to either attach path (pre-parse or help-time) and stays
+        // correct even if the prompt-id map is ever populated lazily.
+        var hydrated = Options
+            .Where(o => !_builtInOptionNames.Contains(o.Name))
+            .ToList();
+
+        return hydrated.Count == 0
+            ? null
+            : new TemplateHelpInfo(_attachedTemplateId, hydrated);
     }
 }
 
 /// <summary>
 /// Marker for commands whose <c>--help</c> output depends on a value bound
-/// by an earlier (stage-A) parse. The Spectre help action calls
+/// before the main parse. The Spectre help action calls
 /// <see cref="AttachHydratedOptionsForHelp"/> on the matched command before
 /// rendering so the user sees the union of built-in options and any
 /// options the bound value (e.g. <c>--template &lt;id&gt;</c>) implies.
+/// <see cref="GetTemplateHelpInfo"/> then lets the renderer separate the
+/// hydrated options into their own section.
 /// </summary>
 internal interface ITemplateAwareHelpProvider
 {
     public int AttachHydratedOptionsForHelp(ParseResult parseResult);
+
+    /// <summary>
+    /// Returns the template id + the options hydrated for that template,
+    /// or <c>null</c> when no template-derived options are currently
+    /// attached. Called after <see cref="AttachHydratedOptionsForHelp"/>
+    /// so the help renderer can split a "Template Options (&lt;id&gt;)"
+    /// section out of the main "Options" section.
+    /// </summary>
+    public TemplateHelpInfo? GetTemplateHelpInfo();
 }
+
+/// <summary>
+/// A template id paired with the CLI options the template hydrates.
+/// Returned by <see cref="ITemplateAwareHelpProvider.GetTemplateHelpInfo"/>
+/// so the help renderer can render those options under their own section
+/// heading instead of mixing them with the command's built-in options.
+/// </summary>
+internal sealed record TemplateHelpInfo(string TemplateId, IReadOnlyList<Option> HydratedOptions);

--- a/src/Func/Commands/SpectreHelpAction.cs
+++ b/src/Func/Commands/SpectreHelpAction.cs
@@ -10,10 +10,23 @@ namespace Azure.Functions.Cli.Commands;
 /// Replaces System.CommandLine's built-in help action on every command
 /// so that --help and -h render uniform Spectre-based output.
 /// Uses the HelpCommand's renderer to generate help from real Command metadata.
+///
+/// Acts as a small dispatcher: when the matched command needs specialised
+/// rendering (e.g. <see cref="ITemplateAwareHelpProvider"/> commands need
+/// dynamically-attached options grouped under their own section header),
+/// the dispatch is delegated to a sibling action so this class stays free
+/// of per-command rendering rules.
 /// </summary>
-internal sealed class SpectreHelpAction(HelpCommand helpCommand) : SynchronousCommandLineAction
+internal sealed class SpectreHelpAction : SynchronousCommandLineAction
 {
-    private readonly HelpCommand _helpCommand = helpCommand ?? throw new ArgumentNullException(nameof(helpCommand));
+    private readonly HelpCommand _helpCommand;
+    private readonly TemplateAwareHelpAction _templateAwareHelp;
+
+    public SpectreHelpAction(HelpCommand helpCommand, TemplateAwareHelpAction templateAwareHelp)
+    {
+        _helpCommand = helpCommand ?? throw new ArgumentNullException(nameof(helpCommand));
+        _templateAwareHelp = templateAwareHelp ?? throw new ArgumentNullException(nameof(templateAwareHelp));
+    }
 
     public override int Invoke(ParseResult parseResult)
     {
@@ -24,15 +37,9 @@ internal sealed class SpectreHelpAction(HelpCommand helpCommand) : SynchronousCo
             return _helpCommand.ShowGeneralHelp();
         }
 
-        // Stage-B help hydration: when the matched command is a
-        // template-aware verb (e.g. `func new`) and the user supplied a
-        // stage-A value the help renderer needs to know about
-        // (`--template <id>`), let the command attach the relevant
-        // dynamic options before we hand it to the renderer. Falls
-        // through to a built-ins-only render when the hook returns 0.
-        if (command is ITemplateAwareHelpProvider templateAware)
+        if (command is ITemplateAwareHelpProvider)
         {
-            templateAware.AttachHydratedOptionsForHelp(parseResult);
+            return _templateAwareHelp.Invoke(parseResult);
         }
 
         _helpCommand.RenderCommandHelp(command);

--- a/src/Func/Commands/TemplateAwareHelpAction.cs
+++ b/src/Func/Commands/TemplateAwareHelpAction.cs
@@ -1,0 +1,104 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using System.CommandLine.Help;
+using System.CommandLine.Invocation;
+
+namespace Azure.Functions.Cli.Commands;
+
+/// <summary>
+/// Help action for commands that implement <see cref="ITemplateAwareHelpProvider"/>
+/// (currently <c>func new</c>). Differs from <see cref="SpectreHelpAction"/> in two
+/// ways:
+///
+/// <list type="number">
+///   <item>It first asks the command to attach any options hydrated from a
+///         pre-bound value (e.g. <c>--template &lt;id&gt;</c>), so the user
+///         sees the union of built-in options and template-derived options.</item>
+///   <item>It renders the hydrated options under their own
+///         "Template Options (&lt;id&gt;)" section so the visual split between
+///         universal options and template-specific options is obvious.</item>
+/// </list>
+///
+/// The generic header / usage / arguments / subcommands rendering is delegated
+/// to <see cref="HelpCommand"/> via its <c>Write*</c> helpers so the default
+/// renderer stays the single source of truth for layout.
+/// </summary>
+internal sealed class TemplateAwareHelpAction : SynchronousCommandLineAction
+{
+    private readonly HelpCommand _helpCommand;
+
+    public TemplateAwareHelpAction(HelpCommand helpCommand)
+    {
+        _helpCommand = helpCommand ?? throw new ArgumentNullException(nameof(helpCommand));
+    }
+
+    public override int Invoke(ParseResult parseResult)
+    {
+        Command command = parseResult.CommandResult.Command;
+
+        if (command is not ITemplateAwareHelpProvider templateAware)
+        {
+            // Defensive fallback: a non-template-aware command should never
+            // be wired up to this action, but if it is, render the standard
+            // help instead of crashing.
+            _helpCommand.RenderCommandHelp(command);
+            return 0;
+        }
+
+        // Attach any options the bound value implies (e.g. the prompts for
+        // the chosen template) so they appear in the rendered list. A
+        // resolution failure here is non-fatal — the renderer just shows
+        // built-ins.
+        templateAware.AttachHydratedOptionsForHelp(parseResult);
+
+        string commandPath = HelpCommand.BuildCommandPath(command);
+
+        _helpCommand.WriteHeader(commandPath, command.Description);
+        _helpCommand.WriteUsageSection(command, commandPath);
+        _helpCommand.WriteArgumentsSection(command);
+        _helpCommand.WriteSubcommandsSection(command);
+
+        WriteOptionSections(command, templateAware);
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Renders the options block as either a single "Options" section (when
+    /// no template-hydrated options are attached) or as two sections — the
+    /// built-in "Options" plus a "Template Options (&lt;id&gt;)" block — so
+    /// the user can tell at a glance which options exist for every template
+    /// vs which exist only because of their <c>--template</c> choice.
+    /// </summary>
+    private void WriteOptionSections(Command command, ITemplateAwareHelpProvider templateAware)
+    {
+        var allOptions = command.Options.Where(o => !o.Hidden && o is not HelpOption).ToList();
+        TemplateHelpInfo? templateHelp = templateAware.GetTemplateHelpInfo();
+
+        if (templateHelp is null || templateHelp.HydratedOptions.Count == 0)
+        {
+            if (allOptions.Count > 0)
+            {
+                _helpCommand.WriteOptionsSection("Options", allOptions);
+            }
+
+            return;
+        }
+
+        var hydratedNames = new HashSet<string>(
+            templateHelp.HydratedOptions.Select(o => o.Name),
+            StringComparer.Ordinal);
+
+        var builtIn = allOptions.Where(o => !hydratedNames.Contains(o.Name)).ToList();
+        if (builtIn.Count > 0)
+        {
+            _helpCommand.WriteOptionsSection("Options", builtIn);
+        }
+
+        _helpCommand.WriteOptionsSection(
+            $"Template Options ({templateHelp.TemplateId})",
+            templateHelp.HydratedOptions);
+    }
+}

--- a/src/Func/Parser.cs
+++ b/src/Func/Parser.cs
@@ -124,7 +124,8 @@ internal static class Parser
 
     private static void ReplaceHelpAction(FuncRootCommand rootCommand, HelpCommand helpCommand)
     {
-        var spectreHelp = new SpectreHelpAction(helpCommand);
+        var templateAwareHelp = new TemplateAwareHelpAction(helpCommand);
+        var spectreHelp = new SpectreHelpAction(helpCommand, templateAwareHelp);
 
         SetHelpAction(rootCommand, spectreHelp);
 


### PR DESCRIPTION
## func new --help: separate built-in options from template-hydrated options

When the user runs `func new --template <id> --help`, the renderer hydrates the chosen template's prompt-derived options and appends them to the command's option list. Before this change, those hydrated options were rendered in the same "Options" section as `--name`, `--template`, `--force`, etc., making it visually impossible to tell which options are universal vs which exist only because of the selected template.

### What this PR does

`func new -t <id> --help` now renders the hydrated options under a dedicated section header:

```
Options

  --name, -n           Function name. Defaults to the template's default function name.
  --template, -t       Template ID. Omit in an interactive shell to pick from a list.
  --force              Overwrite existing files.
  --non-interactive    Refuse to prompt; exit 1 if any required input is missing.
  --list, -l           List available templates for this project instead of scaffolding.
  --output             Output mode (plain | json). Defaults to plain.

Template Options (QueueTrigger-Python)

  --app-file-name                   Provide a filename for your function
  --trigger-function-name           Provide a function name
  --queue-trigger-queue-name        Queue name
  --queue-trigger-connection        Storage account connection
  --app-selected-file-name          File Name
  --blueprint-file-name             Blueprint function file Name
  --blueprint-existing-file-name    Select a file to save for your blueprint function
```

`func new --help` (no template requested) renders an unchanged single "Options" section. Other commands (`func workload install --help`, etc.) are untouched.

### Implementation

The template-specific rendering lives in its own action so the generic help path stays free of `func new`-specific knowledge:

- **New `TemplateAwareHelpAction`** (sibling of `SpectreHelpAction`) owns every aspect of template-aware help — attaching hydrated options, partitioning them out of the option list, and emitting the second `Template Options (<id>)` section header. It reuses the existing `HelpCommand` layout helpers for the header / usage / arguments / subcommands blocks so the formatting stays consistent with the default renderer.
- **`HelpCommand`** is now broken into small, reusable `internal` writers — `WriteHeader`, `WriteUsageSection`, `WriteArgumentsSection`, `WriteSubcommandsSection`, `WriteOptionsSection`. `RenderCommandHelp` calls them in sequence and is otherwise unchanged behaviorally. No conditional logic for template-aware commands lives in `HelpCommand`.
- **`SpectreHelpAction`** is a tiny dispatcher: `RootCommand` → general help; `ITemplateAwareHelpProvider` → delegate to `TemplateAwareHelpAction`; everything else → default `RenderCommandHelp`. It contains no template-specific rendering logic.
- **`NewCommand`** exposes a new `GetTemplateHelpInfo()` on `ITemplateAwareHelpProvider` returning a `TemplateHelpInfo(string TemplateId, IReadOnlyList<Option> HydratedOptions)`. The template id is tracked via a new `_attachedTemplateId` field so the renderer can title the section with the same id the user passed to `--template`. Returns `null` whenever no hydrated options are currently attached.
- **`Parser.ReplaceHelpAction`** wires `TemplateAwareHelpAction` into `SpectreHelpAction` once at startup. Since SCL 2.0.6 only installs a single `HelpOption` on the root, the dispatcher is the only practical place to route per-command help — but the routing itself is one `is` check, with all behavior delegated to the dedicated action.

### Testing

- Build clean (0 warnings, 0 errors).
- `dotnet test test/Func.Tests --filter HelpCommandTests|NewCommand|SpectreHelp|Parser` → 42/42 pass.
- Manual smoke in the playground against `HttpTrigger-Python`, `QueueTrigger-Python`, and the no-template path; `func workload install --help` confirms unrelated commands render exactly as before.
