### PR TITLE
build(vnext): mark workers as 'preview.1'

### DIFF
--- a/src/Workloads/Workers/Node/Directory.Version.props
+++ b/src/Workloads/Workers/Node/Directory.Version.props
@@ -16,6 +16,7 @@
   <PropertyGroup>
     <WorkerVersion>3.13.0</WorkerVersion>
     <VersionPrefix>$(WorkerVersion)</VersionPrefix>
+    <VersionSuffix>preview.1</VersionSuffix>
   </PropertyGroup>
 
 </Project>

--- a/src/Workloads/Workers/Python/Directory.Version.props
+++ b/src/Workloads/Workers/Python/Directory.Version.props
@@ -16,6 +16,7 @@
   <PropertyGroup>
     <WorkerVersion>4.43.0</WorkerVersion>
     <VersionPrefix>$(WorkerVersion)</VersionPrefix>
+    <VersionSuffix>preview.1</VersionSuffix>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Marking node and python worker workloads as preview.