### PR TITLE
Add --bugbash flag to install scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Both scripts auto-detect your OS and architecture, download the latest 5.x relea
 | Include pre-releases | `& ([scriptblock]::Create((irm https://aka.ms/func-cli/install.ps1))) -Prerelease` | `curl -sSL https://aka.ms/func-cli/install.sh \| PRERELEASE=true bash` |
 | Specific version | `& ([scriptblock]::Create((irm https://aka.ms/func-cli/install.ps1))) -Version 5.0.0` | `curl -sSL https://aka.ms/func-cli/install.sh \| VERSION=5.0.0 bash` |
 | Custom install dir | `& ([scriptblock]::Create((irm https://aka.ms/func-cli/install.ps1))) -InstallDir ~/my-tools` | `curl -sSL https://aka.ms/func-cli/install.sh \| INSTALL_DIR=~/my-tools bash` |
+| Bug bash env vars | `& ([scriptblock]::Create((irm https://aka.ms/func-cli/install.ps1))) -BugBash` | `curl -sSL https://aka.ms/func-cli/install.sh \| BUGBASH=true bash` |
+
+The `-BugBash` / `BUGBASH=true` option installs the CLI and then sets the pre-release workloads feed and quickstart manifest env vars (`FUNC_CLI_WORKLOADS_SOURCE`, `FUNC_CLI_QUICKSTART_MANIFEST_URL`, `FUNC_CLI_WORKLOADS_PRERELEASE`) required for bug bash testing. The values are exported in the current session and persisted (to your shell profile on Linux/macOS, or user environment variables on Windows). The installer prints the exact assignments so you can re-set them if you switch terminals.
 
 ### Unattended install
 

--- a/install.ps1
+++ b/install.ps1
@@ -20,12 +20,17 @@
 
 .PARAMETER Force
     Overwrite an existing installation.
+
+.PARAMETER BugBash
+    After installing, set the FUNC_CLI_WORKLOADS_SOURCE, FUNC_CLI_QUICKSTART_MANIFEST_URL,
+    and FUNC_CLI_WORKLOADS_PRERELEASE environment variables required for the bug bash.
 #>
 
 param(
     [string] $Version,
     [switch] $Prerelease,
     [switch] $Force,
+    [switch] $BugBash,
     [string] $Source = 'Azure/azure-functions-core-tools',
     [string] $InstallDir = (Join-Path $HOME '.azure-functions')
 )
@@ -140,3 +145,46 @@ if ($os -eq 'win') {
 }
 
 Write-Host "func CLI $Version installed to $InstallDir"
+
+# --- Bug bash env vars ---
+
+if ($BugBash) {
+    $bugBashWorkloadsSource = 'https://pkgs.dev.azure.com/azfunc/public/_packaging/pre-release/nuget/v3/index.json'
+    $bugBashQuickstartManifestUrl = 'https://raw.githubusercontent.com/Azure/azure-functions-templates/dev/Functions.Templates/Template-Manifest/manifest.json'
+
+    $env:FUNC_CLI_WORKLOADS_SOURCE = $bugBashWorkloadsSource
+    $env:FUNC_CLI_QUICKSTART_MANIFEST_URL = $bugBashQuickstartManifestUrl
+    $env:FUNC_CLI_WORKLOADS_PRERELEASE = 'true'
+
+    if ($os -eq 'win') {
+        [Environment]::SetEnvironmentVariable('FUNC_CLI_WORKLOADS_SOURCE', $bugBashWorkloadsSource, 'User')
+        [Environment]::SetEnvironmentVariable('FUNC_CLI_QUICKSTART_MANIFEST_URL', $bugBashQuickstartManifestUrl, 'User')
+        [Environment]::SetEnvironmentVariable('FUNC_CLI_WORKLOADS_PRERELEASE', 'true', 'User')
+        $persistedLocation = 'user environment variables'
+    } else {
+        $bugBashProfile = if ($env:SHELL -like '*zsh*') { "$HOME/.zshrc" } else { "$HOME/.bashrc" }
+        @(
+            '',
+            '# Azure Functions CLI bug bash env vars',
+            "export FUNC_CLI_WORKLOADS_SOURCE=`"$bugBashWorkloadsSource`"",
+            "export FUNC_CLI_QUICKSTART_MANIFEST_URL=`"$bugBashQuickstartManifestUrl`"",
+            'export FUNC_CLI_WORKLOADS_PRERELEASE=true'
+        ) | Add-Content -Path $bugBashProfile
+        $persistedLocation = $bugBashProfile
+    }
+
+    Write-Host ''
+    Write-Host '========================================================================' -ForegroundColor Yellow
+    Write-Host '  BUG BASH MODE: required environment variables have been set' -ForegroundColor Yellow
+    Write-Host '========================================================================' -ForegroundColor Yellow
+    Write-Host "Added to current session and persisted to: $persistedLocation" -ForegroundColor Yellow
+    Write-Host ''
+    Write-Host "  `$env:FUNC_CLI_WORKLOADS_SOURCE = `"$bugBashWorkloadsSource`""
+    Write-Host "  `$env:FUNC_CLI_QUICKSTART_MANIFEST_URL = `"$bugBashQuickstartManifestUrl`""
+    Write-Host "  `$env:FUNC_CLI_WORKLOADS_PRERELEASE = `"true`""
+    Write-Host ''
+    Write-Host 'WARNING: these env vars MUST be set in your shell for the bug bash.' -ForegroundColor Yellow
+    Write-Host 'If you open a new terminal session that does not inherit these values,' -ForegroundColor Yellow
+    Write-Host 're-run the three assignments above before using func.' -ForegroundColor Yellow
+    Write-Host '========================================================================' -ForegroundColor Yellow
+}

--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,20 @@ INSTALL_DIR="${INSTALL_DIR:-$HOME/.azure-functions}"
 VERSION="${VERSION:-}"
 PRERELEASE="${PRERELEASE:-false}"
 FORCE="${FORCE:-false}"
+BUGBASH="${BUGBASH:-false}"
+
+# --- Parse flags ---
+
+for arg in "$@"; do
+    case "$arg" in
+        --bugbash) BUGBASH="true" ;;
+        --prerelease) PRERELEASE="true" ;;
+        --force) FORCE="true" ;;
+    esac
+done
+
+BUGBASH_WORKLOADS_SOURCE="https://pkgs.dev.azure.com/azfunc/public/_packaging/pre-release/nuget/v3/index.json"
+BUGBASH_QUICKSTART_MANIFEST_URL="https://raw.githubusercontent.com/Azure/azure-functions-templates/dev/Functions.Templates/Template-Manifest/manifest.json"
 
 # --- Detect platform ---
 
@@ -126,3 +140,41 @@ fi
 
 echo "func CLI ${VERSION} installed to ${INSTALL_DIR}"
 func --version
+
+# --- Bug bash env vars ---
+
+if [ "$BUGBASH" = "true" ]; then
+    SHELL_NAME=$(basename "${SHELL:-bash}")
+    case "$SHELL_NAME" in
+        zsh)  BUGBASH_PROFILE="$HOME/.zshrc" ;;
+        bash) BUGBASH_PROFILE="$HOME/.bashrc" ;;
+        *)    BUGBASH_PROFILE="$HOME/.profile" ;;
+    esac
+
+    {
+        echo ""
+        echo "# Azure Functions CLI bug bash env vars"
+        echo "export FUNC_CLI_WORKLOADS_SOURCE=\"${BUGBASH_WORKLOADS_SOURCE}\""
+        echo "export FUNC_CLI_QUICKSTART_MANIFEST_URL=\"${BUGBASH_QUICKSTART_MANIFEST_URL}\""
+        echo "export FUNC_CLI_WORKLOADS_PRERELEASE=true"
+    } >> "$BUGBASH_PROFILE"
+
+    export FUNC_CLI_WORKLOADS_SOURCE="${BUGBASH_WORKLOADS_SOURCE}"
+    export FUNC_CLI_QUICKSTART_MANIFEST_URL="${BUGBASH_QUICKSTART_MANIFEST_URL}"
+    export FUNC_CLI_WORKLOADS_PRERELEASE=true
+
+    echo ""
+    echo -e "\033[33m========================================================================\033[0m"
+    echo -e "\033[33m  BUG BASH MODE: required environment variables have been set\033[0m"
+    echo -e "\033[33m========================================================================\033[0m"
+    echo -e "\033[33mAdded to current session and appended to ${BUGBASH_PROFILE}:\033[0m"
+    echo ""
+    echo "  export FUNC_CLI_WORKLOADS_SOURCE=\"${BUGBASH_WORKLOADS_SOURCE}\""
+    echo "  export FUNC_CLI_QUICKSTART_MANIFEST_URL=\"${BUGBASH_QUICKSTART_MANIFEST_URL}\""
+    echo "  export FUNC_CLI_WORKLOADS_PRERELEASE=true"
+    echo ""
+    echo -e "\033[33mWARNING: these env vars MUST be set in your shell for the bug bash.\033[0m"
+    echo -e "\033[33mIf you open a new terminal session (or a shell that doesn't load\033[0m"
+    echo -e "\033[33m${BUGBASH_PROFILE}), re-run the three exports above before using func.\033[0m"
+    echo -e "\033[33m========================================================================\033[0m"
+fi


### PR DESCRIPTION
## What

Adds a `--bugbash` / `-BugBash` / `BUGBASH=true` option to both `install.sh` and `install.ps1`. After installing the CLI, the option:

1. Sets the bug bash env vars in the current session:
   - `FUNC_CLI_WORKLOADS_SOURCE=https://pkgs.dev.azure.com/azfunc/public/_packaging/pre-release/nuget/v3/index.json`
   - `FUNC_CLI_QUICKSTART_MANIFEST_URL=https://raw.githubusercontent.com/Azure/azure-functions-templates/dev/Functions.Templates/Template-Manifest/manifest.json`
   - `FUNC_CLI_WORKLOADS_PRERELEASE=true`
2. Persists them so they survive a shell restart:
   - Linux/macOS: appended to `~/.zshrc` / `~/.bashrc` / `~/.profile`
   - Windows (PowerShell): user environment variables via `[Environment]::SetEnvironmentVariable(..., 'User')`
3. Prints a prominent yellow warning block listing the exact assignments so testers can re-set them manually if they switch to a different terminal session.

## Usage

```bash
curl -sSL https://aka.ms/func-cli/install.sh | BUGBASH=true bash
```

```powershell
& ([scriptblock]::Create((irm https://aka.ms/func-cli/install.ps1))) -BugBash
```

## Docs

Updated the install options table in `README.md` with the new flag and a short explanation.