### PR TITLE
Resolve installed worker from install result

### DIFF
--- a/src/Func/Commands/Start/Dashboard/Demo/DemoStartInitializationRunner.cs
+++ b/src/Func/Commands/Start/Dashboard/Demo/DemoStartInitializationRunner.cs
@@ -12,7 +12,6 @@ using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Profiles;
 using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Workers;
-using Azure.Functions.Cli.Workloads.Catalog;
 using Azure.Functions.Cli.Workloads.Install;
 using Azure.Functions.Cli.Workloads.Storage;
 using Microsoft.Extensions.Logging;
@@ -29,7 +28,7 @@ internal sealed class DemoStartInitializationRunner(
     IProfileResolver profileResolver,
     IHostWorkloadResolver hostWorkloadResolver,
     IFunctionsWorkerResolverFactory workerResolverFactory,
-    IWorkloadCatalog workloadCatalog,
+    IFunctionsWorkerInstaller workerInstaller,
     IWorkloadInstaller workloadInstaller,
     IInteractionService interaction,
     ILocalSettingsProvider localSettingsProvider,
@@ -59,7 +58,7 @@ internal sealed class DemoStartInitializationRunner(
     private readonly IFunctionsWorkerResolverFactory _workerResolverFactory = workerResolverFactory
         ?? throw new ArgumentNullException(nameof(workerResolverFactory));
 
-    private readonly IWorkloadCatalog _workloadCatalog = workloadCatalog ?? throw new ArgumentNullException(nameof(workloadCatalog));
+    private readonly IFunctionsWorkerInstaller _workerInstaller = workerInstaller ?? throw new ArgumentNullException(nameof(workerInstaller));
 
     private readonly IWorkloadInstaller _workloadInstaller = workloadInstaller
         ?? throw new ArgumentNullException(nameof(workloadInstaller));
@@ -110,7 +109,7 @@ internal sealed class DemoStartInitializationRunner(
             new ResolveConstraintsInitializationStep(),
             new ValidateHostWorkloadInitializationStep(_hostWorkloadResolver, _workloadInstaller, _workloadPaths),
             new ResolveFunctionsProjectInitializationStep(_projectResolver),
-            new ResolveFunctionsWorkerInitializationStep(_workerResolverFactory, _workloadCatalog, _workloadInstaller),
+            new ResolveFunctionsWorkerInitializationStep(_workerResolverFactory, _workerInstaller),
             new ValidateExtensionBundleInitializationStep(
                 _bundleResolver,
                 _bundleSectionReader,

--- a/src/Func/Commands/Start/Initialization/StartInitializationStepContext.cs
+++ b/src/Func/Commands/Start/Initialization/StartInitializationStepContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Commands.Start.Initialization.Rendering;
+using NuGet.Protocol.Plugins;
 
 namespace Azure.Functions.Cli.Commands.Start.Initialization;
 
@@ -36,9 +37,9 @@ internal sealed class StartInitializationStepContext(
 
     public async Task ReportProgressAsync(double percent, string? message, CancellationToken cancellationToken)
     {
-        await _renderer.OnEventAsync(
-            new StartInitializationProgressEvent(_timeProvider.GetUtcNow(), _step.Id, percent, message),
-            cancellationToken);
+        var progressEvent = new StartInitializationProgressEvent(_timeProvider.GetUtcNow(), _step.Id, percent, message);
+
+        await _renderer.OnEventAsync(progressEvent, cancellationToken);
     }
 
     public async Task<bool> ConfirmAsync(string prompt, bool defaultValue, CancellationToken cancellationToken)

--- a/src/Func/Commands/Start/Initialization/Steps/ResolveFunctionsWorkerInitializationStep.cs
+++ b/src/Func/Commands/Start/Initialization/Steps/ResolveFunctionsWorkerInitializationStep.cs
@@ -14,25 +14,24 @@ namespace Azure.Functions.Cli.Commands.Start.Initialization;
 /// <summary>
 /// Resolves the Functions worker required by the project.
 /// </summary>
-internal sealed class ResolveFunctionsWorkerInitializationStep(IFunctionsWorkerResolverFactory workerResolverFactory, IWorkloadCatalog workloadCatalog, IWorkloadInstaller workloadInstaller) : DemoInitializationStep
+internal sealed class ResolveFunctionsWorkerInitializationStep(
+    IFunctionsWorkerResolverFactory workerResolverFactory,
+    IFunctionsWorkerInstaller workerInstaller) : DemoInitializationStep
 {
     public const string StepId = "resolve_worker";
 
     private readonly IFunctionsWorkerResolverFactory _workerResolverFactory = workerResolverFactory
         ?? throw new ArgumentNullException(nameof(workerResolverFactory));
 
-    private readonly IWorkloadCatalog _workloadCatalog = workloadCatalog ?? throw new ArgumentNullException(nameof(workloadCatalog));
-    private readonly IWorkloadInstaller _workloadInstaller = workloadInstaller ?? throw new ArgumentNullException(nameof(workloadInstaller));
+    private readonly IFunctionsWorkerInstaller _workerInstaller = workerInstaller ?? throw new ArgumentNullException(nameof(workerInstaller));
 
     public override string Id => StepId;
 
     public override string Title => "Resolve worker";
 
-    public override StartInitializationDisplayKind DisplayKind => StartInitializationDisplayKind.Progress;
+    public override StartInitializationDisplayKind DisplayKind => StartInitializationDisplayKind.Status;
 
-    public override async Task<StartInitializationStepResult> ExecuteAsync(
-        StartInitializationStepContext context,
-        CancellationToken cancellationToken)
+    public override async Task<StartInitializationStepResult> ExecuteAsync(StartInitializationStepContext context, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(context);
 
@@ -49,7 +48,7 @@ internal sealed class ResolveFunctionsWorkerInitializationStep(IFunctionsWorkerR
             && TryGetInstallableWorker(notResolved.Failure, out FunctionsWorkerId? workerId)
             && workerId is not null)
         {
-            result = await TryInstallAndResolveWorkerAsync(context, project, workerId, workerVersionRanges, notResolved.Failure, cancellationToken);
+            result = await TryInstallAndResolveWorkerAsync(context, workerId, workerVersionRanges, notResolved.Failure, cancellationToken);
         }
 
         if (result is not FunctionsWorkerResolutionResult.Resolved resolved)
@@ -64,6 +63,7 @@ internal sealed class ResolveFunctionsWorkerInitializationStep(IFunctionsWorkerR
         string completionMessage = string.IsNullOrWhiteSpace(resolved.Worker.Version)
             ? resolved.Worker.WorkerRuntime
             : $"{resolved.Worker.WorkerRuntime} {resolved.Worker.Version}";
+
         await context.ReportProgressAsync(100, $"Resolved worker {completionMessage}", cancellationToken);
 
         return StartInitializationStepResult.Completed(completionMessage);
@@ -71,7 +71,6 @@ internal sealed class ResolveFunctionsWorkerInitializationStep(IFunctionsWorkerR
 
     private async Task<FunctionsWorkerResolutionResult> TryInstallAndResolveWorkerAsync(
         StartInitializationStepContext context,
-        FunctionsProject project,
         FunctionsWorkerId workerId,
         IReadOnlyDictionary<string, VersionRange> workerVersionRanges,
         FunctionsWorkerResolutionFailure failure,
@@ -88,67 +87,26 @@ internal sealed class ResolveFunctionsWorkerInitializationStep(IFunctionsWorkerR
         }
 
         string packageId = FunctionsWorkerWorkloadPackages.GetPackageId(workerId);
+        await context.ReportProgressAsync(0, $"Installing worker workload {packageId}", cancellationToken);
+        FunctionsWorkerInstallResult installResult = await InstallWorkerAsync(workerId, workerVersionRanges, cancellationToken);
 
-        bool shouldInstall = await context.ConfirmAsync(
-            $"The Functions worker workload '{packageId}' is required. Install it now?",
-            defaultValue: true,
-            cancellationToken);
+        WorkloadInstallResult workloadInstallResult = installResult.WorkloadInstallResult;
+        string completionMessage = workloadInstallResult.AlreadyInstalled
+            ? $"Worker {workloadInstallResult.Entry.PackageVersion} already installed"
+            : $"Installed worker {workloadInstallResult.Entry.PackageVersion}";
+        await context.ReportProgressAsync(50, completionMessage, cancellationToken);
 
-        if (!shouldInstall)
-        {
-            return FunctionsWorkerResolutionResults.NotResolved(failure);
-        }
-
-        await InstallWorkerAsync(context, workerId, workerVersionRanges, cancellationToken);
-
-        return await ResolveWorkerAsync(project, workerVersionRanges, cancellationToken);
+        return FunctionsWorkerResolutionResults.Resolved(installResult.Worker);
     }
 
-    private async Task InstallWorkerAsync(
-        StartInitializationStepContext context,
+    private async Task<FunctionsWorkerInstallResult> InstallWorkerAsync(
         FunctionsWorkerId workerId,
         IReadOnlyDictionary<string, VersionRange> workerVersionRanges,
         CancellationToken cancellationToken)
     {
-        string packageId = FunctionsWorkerWorkloadPackages.GetPackageId(workerId);
-        workerVersionRanges.TryGetValue(workerId.Value, out VersionRange? versionRange);
-
-        await context.ReportProgressAsync(0, $"Installing worker workload {packageId}", cancellationToken);
-
-        NuGetVersion? version = null;
-        string? source = null;
-        if (versionRange is not null)
-        {
-            ResolvedPackage? package = await _workloadCatalog.ResolveLatestVersionInRangeAsync(
-                packageId,
-                versionRange,
-                includePrerelease: true,
-                source: null,
-                cancellationToken);
-
-            if (package is null)
-            {
-                string rangeText = versionRange.OriginalString ?? versionRange.ToString();
-                string message = $"No worker workload package '{packageId}' satisfies profile range '{rangeText}'.";
-                throw new GracefulException(message, isUserError: true);
-            }
-
-            version = package.Version;
-            source = package.Source.Source;
-        }
-
-        WorkloadInstallResult result;
         try
         {
-            result = await _workloadInstaller.InstallFromCatalogAsync(
-                packageId,
-                version,
-                source,
-                includePrerelease: true,
-                exact: true,
-                force: false,
-                progress: null,
-                cancellationToken);
+            return await _workerInstaller.InstallAsync(workerId, workerVersionRanges, cancellationToken);
         }
         catch (WorkloadPackageNotFoundException ex)
         {
@@ -171,12 +129,6 @@ internal sealed class ResolveFunctionsWorkerInitializationStep(IFunctionsWorkerR
             string message = $"{ex.Message} Run '{FunctionsWorkerWorkloadPackages.GetRepairCommand(workerId)}' to repair the install.";
             throw new GracefulException(message, isUserError: true, verboseMessage: ex.ToString());
         }
-
-        string completionMessage = result.AlreadyInstalled
-            ? $"Worker {result.Entry.PackageVersion} already installed"
-            : $"Installed worker {result.Entry.PackageVersion}";
-
-        await context.ReportProgressAsync(50, completionMessage, cancellationToken);
     }
 
     private async Task<FunctionsWorkerResolutionResult> ResolveWorkerAsync(

--- a/src/Func/Console/SpectreInteractionService.cs
+++ b/src/Func/Console/SpectreInteractionService.cs
@@ -299,11 +299,6 @@ internal class SpectreInteractionService : IInteractionService
             return defaultValue;
         }
 
-        // Render to _stdout (the same IAnsiConsole the dashboard renderers
-        // use) so the prompt aligns with whatever Live region preceded it.
-        // Mixing _stderr here was leaving prompts rendered next to in-place
-        // progress bars because each IAnsiConsole tracks the cursor on its
-        // own (see #5173).
         return await new ConfirmationPrompt(prompt) { DefaultValue = defaultValue }
             .ShowAsync(_stdout, cancellationToken);
     }

--- a/src/Func/Hosting/CliHostFactory.cs
+++ b/src/Func/Hosting/CliHostFactory.cs
@@ -92,7 +92,9 @@ internal static class CliHostFactory
 
         builder.Services.AddSingleton<IProcessEnvironment, ProcessEnvironment>();
         builder.Services.AddSingleton<IWorkerConfigFileSystem, WorkerConfigFileSystem>();
+        builder.Services.AddSingleton<IFunctionsWorkerContentResolver, DefaultFunctionsWorkerContentResolver>();
         builder.Services.AddSingleton<IFunctionsWorkerResolverFactory, DefaultFunctionsWorkerResolverFactory>();
+        builder.Services.AddSingleton<IFunctionsWorkerInstaller, DefaultFunctionsWorkerInstaller>();
         builder.Services.AddSingleton<IFunctionsProjectResolver, FunctionsProjectResolver>();
         builder.Services.AddSingleton<IInstalledBundleWorkloads, InstalledBundleWorkloads>();
         builder.Services.AddSingleton<InstalledBundleScanner>();

--- a/src/Func/Workers/DefaultFunctionsWorkerContentResolver.cs
+++ b/src/Func/Workers/DefaultFunctionsWorkerContentResolver.cs
@@ -1,0 +1,130 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads;
+using NuGet.Versioning;
+
+namespace Azure.Functions.Cli.Workers;
+
+/// <summary>
+/// Default worker resolver for content workload payloads.
+/// </summary>
+internal sealed class DefaultFunctionsWorkerContentResolver(IWorkerConfigFileSystem workerConfigFileSystem) : IFunctionsWorkerContentResolver
+{
+    private const string WorkerConfigFileName = "worker.config.json";
+
+    private readonly IWorkerConfigFileSystem _workerConfigFileSystem = workerConfigFileSystem
+        ?? throw new ArgumentNullException(nameof(workerConfigFileSystem));
+
+    public FunctionsWorkerResolutionResult ResolveWorker(
+        FunctionsWorkerId workerId,
+        IReadOnlyList<ContentWorkloadInfo> installedWorkers,
+        VersionRange? versionConstraint,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(workerId);
+        ArgumentNullException.ThrowIfNull(installedWorkers);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (installedWorkers.Count == 0)
+        {
+            return NotInstalled(workerId);
+        }
+
+        List<InstalledWorkerCandidate> candidates = [];
+        foreach (ContentWorkloadInfo workload in installedWorkers)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!NuGetVersion.TryParse(workload.PackageVersion, out NuGetVersion? version)
+                || !SatisfiesConstraint(version, versionConstraint))
+            {
+                continue;
+            }
+
+            candidates.Add(new InstalledWorkerCandidate(workload, version));
+        }
+
+        if (candidates.Count == 0)
+        {
+            return MissingCompatibleVersion(workerId, versionConstraint);
+        }
+
+        InstalledWorkerCandidate selected = candidates
+            .OrderByDescending(c => c.Version)
+            .First();
+
+        string workerConfigPath = Path.Combine(selected.Workload.ContentRoot, WorkerConfigFileName);
+        if (!_workerConfigFileSystem.FileExists(workerConfigPath))
+        {
+            return InvalidInstallation(workerId, selected, workerConfigPath);
+        }
+
+        IFunctionsWorker resolvedWorker = new ResolvedFunctionsWorker(
+            workerId,
+            workerId.Value,
+            workerConfigPath,
+            selected.Version.ToNormalizedString());
+
+        return FunctionsWorkerResolutionResults.Resolved(resolvedWorker);
+    }
+
+    private static bool SatisfiesConstraint(NuGetVersion version, VersionRange? constraint)
+        => constraint is null || constraint.Satisfies(version);
+
+    private static FunctionsWorkerResolutionResult NotInstalled(FunctionsWorkerId workerId)
+        => NotInstalledResult(
+            workerId,
+            $"No installed Azure Functions worker was found for '{workerId.Value}'. "
+            + $"Run '{FunctionsWorkerWorkloadPackages.GetInstallCommand(workerId)}' to install it.");
+
+    private static FunctionsWorkerResolutionResult NotInstalledResult(FunctionsWorkerId workerId, string message)
+    {
+        FunctionsWorkerResolutionFailure failure = FunctionsWorkerResolutionFailures.NotInstalled(workerId, message);
+        return FunctionsWorkerResolutionResults.NotResolved(failure);
+    }
+
+    private static FunctionsWorkerResolutionResult MissingCompatibleVersion(FunctionsWorkerId workerId, VersionRange? constraint)
+    {
+        if (constraint is null)
+        {
+            FunctionsWorkerResolutionFailure invalidVersionFailure =
+                FunctionsWorkerResolutionFailures.MissingCompatibleVersion(
+                    workerId,
+                    versionConstraint: null,
+                    $"Installed Azure Functions worker workloads for '{workerId.Value}' do not include a valid package version. "
+                    + $"Run '{FunctionsWorkerWorkloadPackages.GetRepairCommand(workerId)}' to repair the install.");
+
+            return FunctionsWorkerResolutionResults.NotResolved(invalidVersionFailure);
+        }
+
+        string rangeText = RangeText(constraint);
+        FunctionsWorkerResolutionFailure failure = FunctionsWorkerResolutionFailures.MissingCompatibleVersion(
+            workerId,
+            rangeText,
+            $"Installed Azure Functions worker workloads for '{workerId.Value}' do not satisfy version range '{rangeText}'. "
+            + $"Run '{FunctionsWorkerWorkloadPackages.GetInstallCommand(workerId)}' to install a compatible worker.");
+
+        return FunctionsWorkerResolutionResults.NotResolved(failure);
+    }
+
+    private static FunctionsWorkerResolutionResult InvalidInstallation(FunctionsWorkerId workerId, InstalledWorkerCandidate selected, string workerConfigPath)
+    {
+        FunctionsWorkerResolutionFailure failure = FunctionsWorkerResolutionFailures.InvalidInstallation(
+            workerId,
+            selected.Workload.PackageId,
+            selected.Version.ToNormalizedString(),
+            workerConfigPath,
+            $"Installed Azure Functions worker '{workerId.Value}' package '{selected.Workload.PackageId}' "
+            + $"{selected.Version.ToNormalizedString()} is missing '{workerConfigPath}'. "
+            + $"Run '{FunctionsWorkerWorkloadPackages.GetRepairCommand(workerId)}' to repair the install.");
+
+        return FunctionsWorkerResolutionResults.NotResolved(failure);
+    }
+
+    private static string RangeText(VersionRange range) => range.OriginalString ?? range.ToString();
+
+    private sealed record InstalledWorkerCandidate(ContentWorkloadInfo Workload, NuGetVersion Version);
+
+    private sealed record ResolvedFunctionsWorker(FunctionsWorkerId Id, string WorkerRuntime, string WorkerConfigPath, string Version) : IFunctionsWorker;
+}

--- a/src/Func/Workers/DefaultFunctionsWorkerInstaller.cs
+++ b/src/Func/Workers/DefaultFunctionsWorkerInstaller.cs
@@ -1,0 +1,124 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads;
+using Azure.Functions.Cli.Workloads.Catalog;
+using Azure.Functions.Cli.Workloads.Discovery;
+using Azure.Functions.Cli.Workloads.Install;
+using Azure.Functions.Cli.Workloads.Storage;
+using NuGet.Versioning;
+
+namespace Azure.Functions.Cli.Workers;
+
+/// <summary>
+/// Default installer for Functions worker content workloads.
+/// </summary>
+internal sealed class DefaultFunctionsWorkerInstaller(
+    IWorkloadCatalog workloadCatalog,
+    IWorkloadInstaller workloadInstaller,
+    IWorkloadPaths workloadPaths,
+    IFunctionsWorkerContentResolver workerContentResolver) : IFunctionsWorkerInstaller
+{
+    private readonly IWorkloadCatalog _workloadCatalog = workloadCatalog ?? throw new ArgumentNullException(nameof(workloadCatalog));
+    private readonly IWorkloadInstaller _workloadInstaller = workloadInstaller ?? throw new ArgumentNullException(nameof(workloadInstaller));
+    private readonly IWorkloadPaths _workloadPaths = workloadPaths ?? throw new ArgumentNullException(nameof(workloadPaths));
+    private readonly IFunctionsWorkerContentResolver _workerContentResolver = workerContentResolver
+        ?? throw new ArgumentNullException(nameof(workerContentResolver));
+
+    public async Task<FunctionsWorkerInstallResult> InstallAsync(
+        FunctionsWorkerId workerId,
+        IReadOnlyDictionary<string, VersionRange> workerVersionRanges,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(workerId);
+        ArgumentNullException.ThrowIfNull(workerVersionRanges);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        string packageId = FunctionsWorkerWorkloadPackages.GetPackageId(workerId);
+        workerVersionRanges.TryGetValue(workerId.Value, out VersionRange? versionRange);
+
+        NuGetVersion? version = null;
+        string? source = null;
+        if (versionRange is not null)
+        {
+            ResolvedPackage? package = await _workloadCatalog.ResolveLatestVersionInRangeAsync(
+                packageId,
+                versionRange,
+                includePrerelease: true,
+                source: null,
+                cancellationToken);
+
+            if (package is null)
+            {
+                string rangeText = versionRange.OriginalString ?? versionRange.ToString();
+                throw new WorkloadPackageNotFoundException($"No worker workload package '{packageId}' satisfies profile range '{rangeText}'.");
+            }
+
+            version = package.Version;
+            source = package.Source.Source;
+        }
+
+        WorkloadInstallResult result = await _workloadInstaller.InstallFromCatalogAsync(
+            packageId,
+            version,
+            source,
+            includePrerelease: true,
+            exact: true,
+            force: false,
+            progress: null,
+            cancellationToken);
+
+        IFunctionsWorker worker = ResolveInstalledWorker(workerId, packageId, versionRange, result, cancellationToken);
+        return new FunctionsWorkerInstallResult(worker, result);
+    }
+
+    private IFunctionsWorker ResolveInstalledWorker(
+        FunctionsWorkerId workerId,
+        string expectedPackageId,
+        VersionRange? versionRange,
+        WorkloadInstallResult result,
+        CancellationToken cancellationToken)
+    {
+        WorkloadEntry entry = result.Entry;
+        if (!string.Equals(entry.PackageId, expectedPackageId, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidWorkloadException(
+                $"Expected worker workload package '{expectedPackageId}' but installed package '{entry.PackageId}'.");
+        }
+
+        if (entry.Kind != WorkloadKind.Content)
+        {
+            throw new InvalidWorkloadException(
+                $"Expected worker workload package '{entry.PackageId}' to be kind 'content' but found '{entry.Kind.ToString().ToLowerInvariant()}'.");
+        }
+
+        ContentWorkloadInfo installedWorker = CreateContentWorkloadInfo(entry);
+        FunctionsWorkerResolutionResult resolution = _workerContentResolver.ResolveWorker(
+            workerId,
+            [installedWorker],
+            versionRange,
+            cancellationToken);
+
+        return resolution is FunctionsWorkerResolutionResult.Resolved resolved
+            ? resolved.Worker
+            : throw CreateInvalidInstalledWorkerException((FunctionsWorkerResolutionResult.NotResolved)resolution);
+    }
+
+    private ContentWorkloadInfo CreateContentWorkloadInfo(WorkloadEntry entry)
+    {
+        string installDirectory = _workloadPaths.GetInstallDirectory(entry.PackageId, entry.PackageVersion);
+        string contentRoot = Path.GetFullPath(Path.Combine(installDirectory, "tools", "any"));
+
+        return new ContentWorkloadInfo(
+            entry.PackageId,
+            entry.PackageVersion,
+            entry.Aliases,
+            installDirectory,
+            contentRoot,
+            entry.DisplayName,
+            entry.Description);
+    }
+
+    private static InvalidWorkloadException CreateInvalidInstalledWorkerException(FunctionsWorkerResolutionResult.NotResolved notResolved)
+        => new(notResolved.Failure.Message);
+}

--- a/src/Func/Workers/DefaultFunctionsWorkerResolver.cs
+++ b/src/Func/Workers/DefaultFunctionsWorkerResolver.cs
@@ -11,14 +11,12 @@ namespace Azure.Functions.Cli.Workers;
 /// </summary>
 internal sealed class DefaultFunctionsWorkerResolver(
     IWorkloadProvider workloadProvider,
-    IWorkerConfigFileSystem workerConfigFileSystem,
+    IFunctionsWorkerContentResolver workerContentResolver,
     IReadOnlyDictionary<string, VersionRange>? activeWorkerConstraints = null) : IFunctionsWorkerResolver
 {
-    private const string WorkerConfigFileName = "worker.config.json";
-
     private readonly IWorkloadProvider _workloadProvider = workloadProvider ?? throw new ArgumentNullException(nameof(workloadProvider));
-    private readonly IWorkerConfigFileSystem _workerConfigFileSystem = workerConfigFileSystem
-        ?? throw new ArgumentNullException(nameof(workerConfigFileSystem));
+    private readonly IFunctionsWorkerContentResolver _workerContentResolver = workerContentResolver
+        ?? throw new ArgumentNullException(nameof(workerContentResolver));
     private readonly IReadOnlyDictionary<string, VersionRange> _activeWorkerConstraints =
         activeWorkerConstraints is null
             ? new Dictionary<string, VersionRange>(StringComparer.OrdinalIgnoreCase)
@@ -32,48 +30,7 @@ internal sealed class DefaultFunctionsWorkerResolver(
         _activeWorkerConstraints.TryGetValue(workerId.Value, out VersionRange? constraint);
 
         IReadOnlyList<ContentWorkloadInfo> installedWorkers = GetWorkerWorkloads(workerId);
-        if (installedWorkers.Count == 0)
-        {
-            return Task.FromResult(NotInstalled(workerId));
-        }
-
-        List<InstalledWorkerCandidate> candidates = [];
-
-        foreach (ContentWorkloadInfo workload in installedWorkers)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            if (!NuGetVersion.TryParse(workload.PackageVersion, out NuGetVersion? version)
-                || !SatisfiesConstraint(version, constraint))
-            {
-                continue;
-            }
-
-            candidates.Add(new InstalledWorkerCandidate(workload, version));
-        }
-
-        if (candidates.Count == 0)
-        {
-            return Task.FromResult(MissingCompatibleVersion(workerId, constraint));
-        }
-
-        InstalledWorkerCandidate selected = candidates
-            .OrderByDescending(c => c.Version)
-            .First();
-
-        string workerConfigPath = Path.Combine(selected.Workload.ContentRoot, WorkerConfigFileName);
-        if (!_workerConfigFileSystem.FileExists(workerConfigPath))
-        {
-            return Task.FromResult(InvalidInstallation(workerId, selected, workerConfigPath));
-        }
-
-        IFunctionsWorker resolvedWorker = new ResolvedFunctionsWorker(
-            workerId,
-            workerId.Value,
-            workerConfigPath,
-            selected.Version.ToNormalizedString());
-
-        return Task.FromResult(FunctionsWorkerResolutionResults.Resolved(resolvedWorker));
+        return Task.FromResult(_workerContentResolver.ResolveWorker(workerId, installedWorkers, constraint, cancellationToken));
     }
 
     private IReadOnlyList<ContentWorkloadInfo> GetWorkerWorkloads(FunctionsWorkerId workerId)
@@ -107,67 +64,5 @@ internal sealed class DefaultFunctionsWorkerResolver(
         }
     }
 
-    private static bool SatisfiesConstraint(NuGetVersion version, VersionRange? constraint)
-        => constraint is null || constraint.Satisfies(version);
-
     private static string GetWorkerAlias(FunctionsWorkerId workerId) => workerId.Value + "-worker";
-
-    private static FunctionsWorkerResolutionResult NotInstalled(FunctionsWorkerId workerId)
-        => NotInstalledResult(
-            workerId,
-            $"No installed Azure Functions worker was found for '{workerId.Value}'. "
-            + $"Run '{FunctionsWorkerWorkloadPackages.GetInstallCommand(workerId)}' to install it.");
-
-    private static FunctionsWorkerResolutionResult NotInstalledResult(FunctionsWorkerId workerId, string message)
-    {
-        FunctionsWorkerResolutionFailure failure = FunctionsWorkerResolutionFailures.NotInstalled(workerId, message);
-        return FunctionsWorkerResolutionResults.NotResolved(failure);
-    }
-
-    private static FunctionsWorkerResolutionResult MissingCompatibleVersion(FunctionsWorkerId workerId, VersionRange? constraint)
-    {
-        if (constraint is null)
-        {
-            FunctionsWorkerResolutionFailure invalidVersionFailure =
-                FunctionsWorkerResolutionFailures.MissingCompatibleVersion(
-                    workerId,
-                    versionConstraint: null,
-                    $"Installed Azure Functions worker workloads for '{workerId.Value}' do not include a valid package version. "
-                    + $"Run '{FunctionsWorkerWorkloadPackages.GetRepairCommand(workerId)}' to repair the install.");
-
-            return FunctionsWorkerResolutionResults.NotResolved(invalidVersionFailure);
-        }
-
-        string rangeText = RangeText(constraint);
-        FunctionsWorkerResolutionFailure failure = FunctionsWorkerResolutionFailures.MissingCompatibleVersion(
-            workerId,
-            rangeText,
-            $"Installed Azure Functions worker workloads for '{workerId.Value}' do not satisfy version range '{rangeText}'. "
-            + $"Run '{FunctionsWorkerWorkloadPackages.GetInstallCommand(workerId)}' to install a compatible worker.");
-
-        return FunctionsWorkerResolutionResults.NotResolved(failure);
-    }
-
-    private static FunctionsWorkerResolutionResult InvalidInstallation(
-        FunctionsWorkerId workerId,
-        InstalledWorkerCandidate selected,
-        string workerConfigPath)
-    {
-        FunctionsWorkerResolutionFailure failure = FunctionsWorkerResolutionFailures.InvalidInstallation(
-            workerId,
-            selected.Workload.PackageId,
-            selected.Version.ToNormalizedString(),
-            workerConfigPath,
-            $"Installed Azure Functions worker '{workerId.Value}' package '{selected.Workload.PackageId}' "
-            + $"{selected.Version.ToNormalizedString()} is missing '{workerConfigPath}'. "
-            + $"Run '{FunctionsWorkerWorkloadPackages.GetRepairCommand(workerId)}' to repair the install.");
-
-        return FunctionsWorkerResolutionResults.NotResolved(failure);
-    }
-
-    private static string RangeText(VersionRange range) => range.OriginalString ?? range.ToString();
-
-    private sealed record InstalledWorkerCandidate(ContentWorkloadInfo Workload, NuGetVersion Version);
-
-    private sealed record ResolvedFunctionsWorker(FunctionsWorkerId Id, string WorkerRuntime, string WorkerConfigPath, string Version) : IFunctionsWorker;
 }

--- a/src/Func/Workers/DefaultFunctionsWorkerResolverFactory.cs
+++ b/src/Func/Workers/DefaultFunctionsWorkerResolverFactory.cs
@@ -11,11 +11,11 @@ namespace Azure.Functions.Cli.Workers;
 /// </summary>
 internal sealed class DefaultFunctionsWorkerResolverFactory(
     IWorkloadProvider workloadProvider,
-    IWorkerConfigFileSystem workerConfigFileSystem) : IFunctionsWorkerResolverFactory
+    IFunctionsWorkerContentResolver workerContentResolver) : IFunctionsWorkerResolverFactory
 {
     private readonly IWorkloadProvider _workloadProvider = workloadProvider ?? throw new ArgumentNullException(nameof(workloadProvider));
-    private readonly IWorkerConfigFileSystem _workerConfigFileSystem = workerConfigFileSystem
-        ?? throw new ArgumentNullException(nameof(workerConfigFileSystem));
+    private readonly IFunctionsWorkerContentResolver _workerContentResolver = workerContentResolver
+        ?? throw new ArgumentNullException(nameof(workerContentResolver));
 
     public IFunctionsWorkerResolver Create(IReadOnlyDictionary<string, VersionRange> workerVersionRanges)
     {
@@ -23,7 +23,7 @@ internal sealed class DefaultFunctionsWorkerResolverFactory(
 
         return new DefaultFunctionsWorkerResolver(
             _workloadProvider,
-            _workerConfigFileSystem,
+            _workerContentResolver,
             workerVersionRanges);
     }
 }

--- a/src/Func/Workers/FunctionsWorkerInstallResult.cs
+++ b/src/Func/Workers/FunctionsWorkerInstallResult.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads.Install;
+
+namespace Azure.Functions.Cli.Workers;
+
+/// <summary>
+/// Result of installing a Functions worker workload.
+/// </summary>
+/// <param name="Worker">The worker resolved from the installed content workload.</param>
+/// <param name="WorkloadInstallResult">The generic workload installation result.</param>
+internal sealed record FunctionsWorkerInstallResult(IFunctionsWorker Worker, WorkloadInstallResult WorkloadInstallResult);

--- a/src/Func/Workers/IFunctionsWorkerContentResolver.cs
+++ b/src/Func/Workers/IFunctionsWorkerContentResolver.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads;
+using NuGet.Versioning;
+
+namespace Azure.Functions.Cli.Workers;
+
+/// <summary>
+/// Resolves a worker from installed content workload metadata.
+/// </summary>
+internal interface IFunctionsWorkerContentResolver
+{
+    public FunctionsWorkerResolutionResult ResolveWorker(
+        FunctionsWorkerId workerId,
+        IReadOnlyList<ContentWorkloadInfo> installedWorkers,
+        VersionRange? versionConstraint,
+        CancellationToken cancellationToken);
+}

--- a/src/Func/Workers/IFunctionsWorkerInstaller.cs
+++ b/src/Func/Workers/IFunctionsWorkerInstaller.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads.Catalog;
+using Azure.Functions.Cli.Workloads.Discovery;
+using Azure.Functions.Cli.Workloads.Install;
+using NuGet.Versioning;
+
+namespace Azure.Functions.Cli.Workers;
+
+/// <summary>
+/// Installs content workloads that provide Functions workers.
+/// </summary>
+internal interface IFunctionsWorkerInstaller
+{
+    /// <summary>
+    /// Installs the workload package for <paramref name="workerId"/> and returns the worker resolved from the installed payload.
+    /// </summary>
+    /// <param name="workerId">Worker runtime identifier.</param>
+    /// <param name="workerVersionRanges">Profile worker version constraints keyed by runtime.</param>
+    /// <param name="cancellationToken">Cancellation propagated to catalog and install operations.</param>
+    /// <exception cref="WorkloadPackageNotFoundException">
+    /// No package or compatible package version could be found.
+    /// </exception>
+    /// <exception cref="AmbiguousPackageMatchException">
+    /// The package identifier unexpectedly matched multiple packages.
+    /// </exception>
+    /// <exception cref="InvalidWorkloadException">
+    /// The installed package is not a valid worker content workload.
+    /// </exception>
+    /// <exception cref="FileNotFoundException">
+    /// The resolved package could not be downloaded.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// The install cannot proceed because the local workload state is inconsistent.
+    /// </exception>
+    public Task<FunctionsWorkerInstallResult> InstallAsync(FunctionsWorkerId workerId, IReadOnlyDictionary<string, VersionRange> workerVersionRanges, CancellationToken cancellationToken);
+}

--- a/src/Func/Workloads/Install/WorkloadInstaller.cs
+++ b/src/Func/Workloads/Install/WorkloadInstaller.cs
@@ -171,9 +171,7 @@ internal sealed class WorkloadInstaller(
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
 
-        progress?.Report(new WorkloadInstallProgress(
-            WorkloadInstallPhase.Resolving,
-            $"Resolving workload '{packageId}'"));
+        progress?.Report(new WorkloadInstallProgress(WorkloadInstallPhase.Resolving, $"Resolving workload '{packageId}'"));
 
         string resolvedId = exact
             ? packageId

--- a/test/Func.Tests/Commands/StartInitializationTests.cs
+++ b/test/Func.Tests/Commands/StartInitializationTests.cs
@@ -20,12 +20,10 @@ using Azure.Functions.Cli.Profiles;
 using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Workers;
 using Azure.Functions.Cli.Workloads;
-using Azure.Functions.Cli.Workloads.Catalog;
 using Azure.Functions.Cli.Workloads.Install;
 using Azure.Functions.Cli.Workloads.Storage;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
-using NuGet.Configuration;
 using NuGet.Versioning;
 using Spectre.Console;
 using Xunit;
@@ -395,7 +393,7 @@ public class StartInitializationTests : IDisposable
     }
 
     [Fact]
-    public async Task DemoRunner_ProfiledMissingWorkerInstallsConventionPackageAndRetries()
+    public async Task DemoRunner_ProfiledMissingWorkerUsesInstalledWorkerWithoutRetryingResolver()
     {
         IFunctionsProjectResolver projectResolver = Substitute.For<IFunctionsProjectResolver>();
         TestFunctionsProject project = CreateProject(
@@ -408,35 +406,26 @@ public class StartInitializationTests : IDisposable
         FunctionsWorkerResolutionFailure failure = CreateNotInstalledWorkerFailure("node");
         IFunctionsWorkerResolver workerResolver = Substitute.For<IFunctionsWorkerResolver>();
         workerResolver.ResolveWorkerAsync(workerId, Arg.Any<CancellationToken>())
-            .Returns(
-                FunctionsWorkerResolutionResults.NotResolved(failure),
-                FunctionsWorkerResolutionResults.Resolved(CreateWorker("node", "node", "3.13.0")));
+            .Returns(FunctionsWorkerResolutionResults.NotResolved(failure));
         IFunctionsWorkerResolverFactory workerResolverFactory = CreateWorkerResolverFactory(workerResolver);
         var workerRange = VersionRange.Parse("[3.13.0]");
         Dictionary<string, VersionRange> workerRanges = new(StringComparer.OrdinalIgnoreCase)
         {
             ["node"] = workerRange,
         };
-        IWorkloadCatalog workloadCatalog = Substitute.For<IWorkloadCatalog>();
-        workloadCatalog.ResolveLatestVersionInRangeAsync(
-                FunctionsWorkerWorkloadPackages.GetPackageId(workerId),
-                workerRange,
-                includePrerelease: true,
-                source: null,
-                Arg.Any<CancellationToken>())
-            .Returns(new ResolvedPackage(
-                FunctionsWorkerWorkloadPackages.GetPackageId(workerId),
-                NuGetVersion.Parse("3.13.0"),
-                new PackageSource("https://example.test/v3/index.json")));
-        IWorkloadInstaller workloadInstaller = CreateSuccessfulInstaller();
+        IFunctionsWorker installedWorker = CreateWorker("node", "node", "3.13.0");
+        IFunctionsWorkerInstaller workerInstaller = Substitute.For<IFunctionsWorkerInstaller>();
+        WorkloadInstallResult workloadInstallResult = new(CreateWorkerEntry(FunctionsWorkerWorkloadPackages.GetPackageId(workerId), "3.13.0"), AlreadyInstalled: false);
+        workerInstaller.InstallAsync(workerId, Arg.Is<IReadOnlyDictionary<string, VersionRange>>(ranges => HasWorkerRange(ranges, workerRange)), Arg.Any<CancellationToken>())
+            .Returns(new FunctionsWorkerInstallResult(installedWorker, workloadInstallResult));
         var renderer = new RecordingStartInitializationRenderer();
         var runner = CreateRunner(
             projectResolver,
             CreateResolvedProfile(workerRanges),
             CreateInstalledHostWorkloadResolver(),
-            workloadInstaller,
-            workerResolverFactory,
-            workloadCatalog);
+            workerInstaller: workerInstaller,
+            workerResolverFactory: workerResolverFactory,
+            hostProcessRunner: CreateSuccessfulHostProcessRunner());
         StartInitializationContext context = CreateContext(
             WorkingDirectory.FromExplicit(_tempDir),
             cliVersion: "5.0.0-test",
@@ -451,18 +440,10 @@ public class StartInitializationTests : IDisposable
 
         Assert.Equal("node", result.Worker.WorkerRuntime);
         Assert.Equal("3.13.0", result.Worker.Version);
-        Assert.Contains(
-            $"The Functions worker workload '{FunctionsWorkerWorkloadPackages.GetPackageId(workerId)}' is required. Install it now?",
-            renderer.ConfirmPrompts);
-        await workloadInstaller.Received(1).InstallFromCatalogAsync(
-            FunctionsWorkerWorkloadPackages.GetPackageId(workerId),
-            NuGetVersion.Parse("3.13.0"),
-            "https://example.test/v3/index.json",
-            includePrerelease: true,
-            exact: true,
-            force: false,
-            progress: null,
-            cancellationToken: Arg.Any<CancellationToken>());
+        Assert.Same(installedWorker, result.Worker);
+        await workerResolver.Received(1).ResolveWorkerAsync(workerId, Arg.Any<CancellationToken>());
+        await workerInstaller.Received(1)
+            .InstallAsync(workerId, Arg.Is<IReadOnlyDictionary<string, VersionRange>>(ranges => HasWorkerRange(ranges, workerRange)), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -890,7 +871,7 @@ public class StartInitializationTests : IDisposable
         IHostWorkloadResolver? hostWorkloadResolver = null,
         IWorkloadInstaller? workloadInstaller = null,
         IFunctionsWorkerResolverFactory? workerResolverFactory = null,
-        IWorkloadCatalog? workloadCatalog = null,
+        IFunctionsWorkerInstaller? workerInstaller = null,
         IInteractionService? interaction = null,
         IHostProcessRunner? hostProcessRunner = null)
     {
@@ -909,7 +890,7 @@ public class StartInitializationTests : IDisposable
 
         workloadInstaller ??= CreateSuccessfulInstaller();
         workerResolverFactory ??= CreateWorkerResolverFactory();
-        workloadCatalog ??= Substitute.For<IWorkloadCatalog>();
+        workerInstaller ??= CreateSuccessfulWorkerInstaller();
         interaction ??= Substitute.For<IInteractionService>();
         interaction.ConfirmAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(true);
@@ -925,7 +906,7 @@ public class StartInitializationTests : IDisposable
             profileResolver,
             hostWorkloadResolver,
             workerResolverFactory,
-            workloadCatalog,
+            workerInstaller,
             workloadInstaller,
             interaction,
             new LocalSettingsProvider(),
@@ -1008,6 +989,26 @@ public class StartInitializationTests : IDisposable
             });
 
         return workloadInstaller;
+    }
+
+    private static IFunctionsWorkerInstaller CreateSuccessfulWorkerInstaller()
+    {
+        IFunctionsWorkerInstaller workerInstaller = Substitute.For<IFunctionsWorkerInstaller>();
+        workerInstaller.InstallAsync(
+                Arg.Any<FunctionsWorkerId>(),
+                Arg.Any<IReadOnlyDictionary<string, VersionRange>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                FunctionsWorkerId workerId = callInfo.ArgAt<FunctionsWorkerId>(0);
+                string packageId = FunctionsWorkerWorkloadPackages.GetPackageId(workerId);
+                string packageVersion = DefaultInstallVersion(packageId);
+                var workloadInstallResult = new WorkloadInstallResult(CreateWorkerEntry(packageId, packageVersion), AlreadyInstalled: false);
+                IFunctionsWorker worker = CreateWorker(workerId.Value, workerId.Value, packageVersion);
+                return new FunctionsWorkerInstallResult(worker, workloadInstallResult);
+            });
+
+        return workerInstaller;
     }
 
     private static string DefaultInstallVersion(string packageId)

--- a/test/Func.Tests/Workers/DefaultFunctionsWorkerInstallerTests.cs
+++ b/test/Func.Tests/Workers/DefaultFunctionsWorkerInstallerTests.cs
@@ -1,0 +1,210 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workers;
+using Azure.Functions.Cli.Workloads;
+using Azure.Functions.Cli.Workloads.Catalog;
+using Azure.Functions.Cli.Workloads.Discovery;
+using Azure.Functions.Cli.Workloads.Install;
+using Azure.Functions.Cli.Workloads.Storage;
+using NSubstitute;
+using NuGet.Configuration;
+using NuGet.Versioning;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Workers;
+
+public class DefaultFunctionsWorkerInstallerTests
+{
+    private const string WorkerRuntime = "node";
+    private const string WorkerPackageId = "Azure.Functions.Cli.Workloads.Workers.node";
+
+    private readonly IWorkloadCatalog _workloadCatalog = Substitute.For<IWorkloadCatalog>();
+    private readonly IWorkloadInstaller _workloadInstaller = Substitute.For<IWorkloadInstaller>();
+    private readonly IWorkloadPaths _workloadPaths = Substitute.For<IWorkloadPaths>();
+    private readonly IWorkerConfigFileSystem _fileSystem = Substitute.For<IWorkerConfigFileSystem>();
+
+    public DefaultFunctionsWorkerInstallerTests()
+    {
+        _workloadPaths.GetInstallDirectory(Arg.Any<string>(), Arg.Any<string>())
+            .Returns(callInfo => Path.Combine(Path.GetTempPath(), "workloads", (string)callInfo[0], (string)callInfo[1]));
+        _fileSystem.FileExists(Arg.Any<string>()).Returns(true);
+    }
+
+    [Fact]
+    public async Task InstallAsync_ProfileRangeInstallsResolvedVersionAndReturnsWorker()
+    {
+        var workerId = new FunctionsWorkerId(WorkerRuntime);
+        var range = VersionRange.Parse("[3.13.0]");
+        Dictionary<string, VersionRange> workerRanges = new(StringComparer.OrdinalIgnoreCase)
+        {
+            [WorkerRuntime] = range,
+        };
+        _workloadCatalog.ResolveLatestVersionInRangeAsync(
+                WorkerPackageId,
+                range,
+                includePrerelease: true,
+                source: null,
+                Arg.Any<CancellationToken>())
+            .Returns(new ResolvedPackage(
+                WorkerPackageId,
+                NuGetVersion.Parse("3.13.0"),
+                new PackageSource("https://example.test/v3/index.json")));
+        _workloadInstaller.InstallFromCatalogAsync(
+                Arg.Any<string>(),
+                Arg.Any<NuGetVersion?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new WorkloadInstallResult(CreateWorkerEntry("3.13.0"), AlreadyInstalled: false));
+        DefaultFunctionsWorkerInstaller installer = CreateInstaller();
+
+        FunctionsWorkerInstallResult result = await installer.InstallAsync(workerId, workerRanges, CancellationToken.None);
+
+        Assert.Equal(WorkerRuntime, result.Worker.WorkerRuntime);
+        Assert.Equal("3.13.0", result.Worker.Version);
+        Assert.False(result.WorkloadInstallResult.AlreadyInstalled);
+        Assert.Equal(
+            Path.Combine(GetInstallDirectory("3.13.0"), "tools", "any", "worker.config.json"),
+            result.Worker.WorkerConfigPath);
+        await _workloadInstaller.Received(1).InstallFromCatalogAsync(
+            WorkerPackageId,
+            Arg.Is<NuGetVersion?>(version => version != null && version.ToNormalizedString() == "3.13.0"),
+            "https://example.test/v3/index.json",
+            includePrerelease: true,
+            exact: true,
+            force: false,
+            progress: null,
+            cancellationToken: Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InstallAsync_NoProfileRangeInstallsLatestAndReturnsAlreadyInstalledWorker()
+    {
+        var workerId = new FunctionsWorkerId(WorkerRuntime);
+        _workloadInstaller.InstallFromCatalogAsync(
+                Arg.Any<string>(),
+                Arg.Any<NuGetVersion?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new WorkloadInstallResult(CreateWorkerEntry("3.14.0"), AlreadyInstalled: true));
+        DefaultFunctionsWorkerInstaller installer = CreateInstaller();
+
+        FunctionsWorkerInstallResult result = await installer.InstallAsync(workerId, new Dictionary<string, VersionRange>(), CancellationToken.None);
+
+        Assert.True(result.WorkloadInstallResult.AlreadyInstalled);
+        Assert.Equal("3.14.0", result.Worker.Version);
+        await _workloadInstaller.Received(1).InstallFromCatalogAsync(
+            WorkerPackageId,
+            version: null,
+            source: null,
+            includePrerelease: true,
+            exact: true,
+            force: false,
+            progress: null,
+            cancellationToken: Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InstallAsync_NoPackageInProfileRange_ThrowsWorkloadPackageNotFound()
+    {
+        var workerId = new FunctionsWorkerId(WorkerRuntime);
+        var range = VersionRange.Parse("[3.13.0]");
+        Dictionary<string, VersionRange> workerRanges = new(StringComparer.OrdinalIgnoreCase)
+        {
+            [WorkerRuntime] = range,
+        };
+        _workloadCatalog.ResolveLatestVersionInRangeAsync(
+                WorkerPackageId,
+                range,
+                includePrerelease: true,
+                source: null,
+                Arg.Any<CancellationToken>())
+            .Returns((ResolvedPackage?)null);
+        DefaultFunctionsWorkerInstaller installer = CreateInstaller();
+
+        WorkloadPackageNotFoundException exception = await Assert.ThrowsAsync<WorkloadPackageNotFoundException>(
+            async () => await installer.InstallAsync(workerId, workerRanges, CancellationToken.None));
+
+        Assert.Contains(WorkerPackageId, exception.Message);
+        Assert.Contains("[3.13.0]", exception.Message);
+    }
+
+    [Fact]
+    public async Task InstallAsync_InstalledPackageIsNotContent_ThrowsInvalidWorkload()
+    {
+        var workerId = new FunctionsWorkerId(WorkerRuntime);
+        WorkloadEntry entry = CreateWorkerEntry("3.13.0", WorkloadKind.Workload);
+        _workloadInstaller.InstallFromCatalogAsync(
+                Arg.Any<string>(),
+                Arg.Any<NuGetVersion?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new WorkloadInstallResult(entry, AlreadyInstalled: false));
+        DefaultFunctionsWorkerInstaller installer = CreateInstaller();
+
+        InvalidWorkloadException exception = await Assert.ThrowsAsync<InvalidWorkloadException>(
+            async () => await installer.InstallAsync(workerId, new Dictionary<string, VersionRange>(), CancellationToken.None));
+
+        Assert.Contains("kind 'content'", exception.Message);
+    }
+
+    [Fact]
+    public async Task InstallAsync_NullWorkerId_Throws()
+    {
+        DefaultFunctionsWorkerInstaller installer = CreateInstaller();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await installer.InstallAsync(null!, new Dictionary<string, VersionRange>(), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task InstallAsync_NullWorkerVersionRanges_Throws()
+    {
+        DefaultFunctionsWorkerInstaller installer = CreateInstaller();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await installer.InstallAsync(new FunctionsWorkerId(WorkerRuntime), null!, CancellationToken.None));
+    }
+
+    [Fact]
+    public void Ctor_NullDependencies_Throw()
+    {
+        var contentResolver = new DefaultFunctionsWorkerContentResolver(_fileSystem);
+
+        Assert.Throws<ArgumentNullException>(() => new DefaultFunctionsWorkerInstaller(null!, _workloadInstaller, _workloadPaths, contentResolver));
+        Assert.Throws<ArgumentNullException>(() => new DefaultFunctionsWorkerInstaller(_workloadCatalog, null!, _workloadPaths, contentResolver));
+        Assert.Throws<ArgumentNullException>(() => new DefaultFunctionsWorkerInstaller(_workloadCatalog, _workloadInstaller, null!, contentResolver));
+        Assert.Throws<ArgumentNullException>(() => new DefaultFunctionsWorkerInstaller(_workloadCatalog, _workloadInstaller, _workloadPaths, null!));
+    }
+
+    private DefaultFunctionsWorkerInstaller CreateInstaller()
+    {
+        var contentResolver = new DefaultFunctionsWorkerContentResolver(_fileSystem);
+        return new DefaultFunctionsWorkerInstaller(_workloadCatalog, _workloadInstaller, _workloadPaths, contentResolver);
+    }
+
+    private static WorkloadEntry CreateWorkerEntry(string packageVersion, WorkloadKind kind = WorkloadKind.Content)
+        => new()
+        {
+            PackageId = WorkerPackageId,
+            PackageVersion = packageVersion,
+            Kind = kind,
+            Aliases = ["node-worker"],
+            DisplayName = WorkerPackageId,
+            Description = string.Empty,
+        };
+
+    private static string GetInstallDirectory(string packageVersion) => Path.Combine(Path.GetTempPath(), "workloads", WorkerPackageId, packageVersion);
+}

--- a/test/Func.Tests/Workers/DefaultFunctionsWorkerResolverTests.cs
+++ b/test/Func.Tests/Workers/DefaultFunctionsWorkerResolverTests.cs
@@ -252,13 +252,19 @@ public class DefaultFunctionsWorkerResolverTests
     [Fact]
     public void Ctor_NullWorkloadProvider_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => new DefaultFunctionsWorkerResolver(null!, _fileSystem));
+        Assert.Throws<ArgumentNullException>(() => new DefaultFunctionsWorkerResolver(null!, CreateContentResolver()));
     }
 
     [Fact]
-    public void Ctor_NullWorkerConfigFileSystem_Throws()
+    public void Ctor_NullContentResolver_Throws()
     {
         Assert.Throws<ArgumentNullException>(() => new DefaultFunctionsWorkerResolver(_workloads, null!));
+    }
+
+    [Fact]
+    public void ContentResolverCtor_NullWorkerConfigFileSystem_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new DefaultFunctionsWorkerContentResolver(null!));
     }
 
     private void UseContentWorkloads(params ContentWorkloadInfo[] workloads)
@@ -275,7 +281,9 @@ public class DefaultFunctionsWorkerResolverTests
     }
 
     private DefaultFunctionsWorkerResolver CreateResolver(IReadOnlyDictionary<string, VersionRange>? workerVersionRanges = null)
-        => new(_workloads, _fileSystem, workerVersionRanges);
+        => new(_workloads, CreateContentResolver(), workerVersionRanges);
+
+    private DefaultFunctionsWorkerContentResolver CreateContentResolver() => new(_fileSystem);
 
     private static ContentWorkloadInfo CreateContentWorkload(string packageId, string packageVersion, IReadOnlyList<string>? aliases = null)
     {


### PR DESCRIPTION
When start initialization auto-installs a worker workload, the running CLI will still have a stale workload provider snapshot. Retrying worker resolution through the provider after install can miss the newly installed content workload until the process restarts.

The initialization step now uses the worker returned by the install flow directly instead of querying the cached provider again. This avoids a snapshot/cache invalidation for now, but is more efficient as it doesn't have to go through worker resolution again.
