### PR TITLE
Prompt first-run setup on bare `func` invocation

### DIFF
--- a/src/Func/Hosting/FirstRun/FirstRunCoordinator.cs
+++ b/src/Func/Hosting/FirstRun/FirstRunCoordinator.cs
@@ -23,10 +23,15 @@ internal sealed class FirstRunCoordinator(
 
     private const string PromptMessage = "Run `func setup` now?";
 
-    // Commands that should not trigger the first-run prompt: the user is
-    // either already setting up, just inspecting the CLI, or hit a typo.
+    // Commands that should not trigger the first-run prompt. We deliberately
+    // do NOT skip on "help" / "unknown" here: those are what the resolver
+    // returns for a bare `func` invocation, which is the canonical first-run
+    // trigger. Explicit `--help`/`-h` invocations are handled by the token
+    // check below. "version" stays because it only arises from `func --verbose`
+    // with no subcommand, which is a CLI-inspection gesture, not a real
+    // first command.
     private static readonly HashSet<string> _skippedCommandNames =
-        new(StringComparer.OrdinalIgnoreCase) { "setup", "help", "version", "unknown" };
+        new(StringComparer.OrdinalIgnoreCase) { "setup", "version" };
 
     private static readonly HashSet<string> _skippedTokens =
         new(StringComparer.OrdinalIgnoreCase) { "--help", "-h", "-?", "/?", "--version", "-v" };
@@ -56,17 +61,22 @@ internal sealed class FirstRunCoordinator(
             return;
         }
 
-        if (parseResult.Errors.Count > 0)
-        {
-            return;
-        }
-
         foreach (System.CommandLine.Parsing.Token token in parseResult.Tokens)
         {
             if (_skippedTokens.Contains(token.Value))
             {
                 return;
             }
+        }
+
+        // Bare `func` (no args) produces a "Required command was not provided"
+        // parse error but no tokens; that's the canonical first-run trigger
+        // and we still want to prompt. For any other parse error (typo, bad
+        // option), stay quiet until the user fixes their command line.
+        bool isBareInvocation = parseResult.Tokens.Count == 0;
+        if (!isBareInvocation && parseResult.Errors.Count > 0)
+        {
+            return;
         }
 
         _interaction.WriteBlankLine();

--- a/test/Func.Tests/Hosting/FirstRun/FirstRunCoordinatorTests.cs
+++ b/test/Func.Tests/Hosting/FirstRun/FirstRunCoordinatorTests.cs
@@ -48,9 +48,7 @@ public sealed class FirstRunCoordinatorTests
 
     [Theory]
     [InlineData("setup")]
-    [InlineData("help")]
     [InlineData("version")]
-    [InlineData("unknown")]
     public async Task SkipsAndDoesNotMark_ForExcludedCommands(string commandName)
     {
         _stateStore.IsFirstRun().Returns(true);
@@ -73,6 +71,36 @@ public sealed class FirstRunCoordinatorTests
         FirstRunCoordinator coordinator = CreateCoordinator();
 
         await coordinator.EnsureFirstRunPromptedAsync("start", Parse($"start {token}"), CancellationToken.None);
+
+        Assert.Equal(0, _interaction.ConfirmCalls);
+        await _stateStore.DidNotReceiveWithAnyArgs().MarkCompleteAsync(default);
+    }
+
+    [Fact]
+    public async Task PromptsOnBareFunc_WhenNoSubcommandGiven()
+    {
+        // Bare `func` produces a "Required command was not provided" parse
+        // error and the resolver labels it "unknown", but it's the canonical
+        // first-run trigger and must still prompt.
+        _stateStore.IsFirstRun().Returns(true);
+        _interaction.ConfirmResponse = false;
+        FirstRunCoordinator coordinator = CreateCoordinator();
+
+        await coordinator.EnsureFirstRunPromptedAsync("unknown", Parse(string.Empty), CancellationToken.None);
+
+        Assert.Equal(1, _interaction.ConfirmCalls);
+        await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SkipsAndDoesNotMark_WhenParseHasErrorsAndTokensPresent()
+    {
+        // A typo like `func startt` produces tokens and parse errors; we stay
+        // quiet until the user fixes the command line.
+        _stateStore.IsFirstRun().Returns(true);
+        FirstRunCoordinator coordinator = CreateCoordinator();
+
+        await coordinator.EnsureFirstRunPromptedAsync("unknown", Parse("startt"), CancellationToken.None);
 
         Assert.Equal(0, _interaction.ConfirmCalls);
         await _stateStore.DidNotReceiveWithAnyArgs().MarkCompleteAsync(default);


### PR DESCRIPTION
## Problem

Running bare `func` on a fresh install never showed the first-run setup prompt, even after deleting the `.first-run-complete` marker.

## Root cause

`System.CommandLine` emits a `Required command was not provided` parse error for bare `func`, so `CommandNameResolver.ResolveCommandName` returns `"unknown"`. `FirstRunCoordinator` was silencing the prompt twice over:

1. `"unknown"` (and `"help"`) lived in `_skippedCommandNames`.
2. `parseResult.Errors.Count > 0` short-circuited before any prompt could fire.

Either alone was enough to swallow the canonical first-run path.

## Fix

- Drop `"help"` and `"unknown"` from `_skippedCommandNames` (kept `"setup"` and `"version"`; `"version"` only arises from `func --verbose` with no subcommand, which is CLI inspection rather than a real first command).
- Move the errors check below the token check and gate it on the invocation actually having tokens. Bare `func` (zero tokens) prompts; typos like `func startt` still stay quiet.
- Explicit `--help`/`-h`/`-?`/`/?`/`--version`/`-v` continue to skip via the existing token check.

## Tests

- Updated `SkipsAndDoesNotMark_ForExcludedCommands` theory: `"help"` and `"unknown"` removed, `"setup"` and `"version"` retained.
- Added `PromptsOnBareFunc_WhenNoSubcommandGiven` (parses `string.Empty`, expects the confirm prompt and a marker write).
- Added `SkipsAndDoesNotMark_WhenParseHasErrorsAndTokensPresent` to lock in the typo path.

All 973 `Func.Tests` pass locally. Verified manually with a TTY:

```
FUNC_CLI_HOME=$(mktemp -d) script -q /dev/null dotnet out/bin/Func/debug/func.dll
> The Azure Functions CLI uses workloads (host, runtime, language stacks) ...
> Run `func setup` now? [Y/n]:
```