### PR TITLE
Filter structured host logs by category

### DIFF
--- a/src/Workloads/Host/Logging/HostStructuredLoggingBuilderExtensions.cs
+++ b/src/Workloads/Host/Logging/HostStructuredLoggingBuilderExtensions.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -9,6 +11,18 @@ namespace Azure.Functions.Cli.Workloads.Host.Logging;
 
 internal static class HostStructuredLoggingBuilderExtensions
 {
+    private const LogLevel DefaultSystemMinimumLogLevel = LogLevel.Warning;
+    private const LogLevel DefaultUserMinimumLogLevel = LogLevel.Information;
+
+    private static readonly CategoryLogLevelFilter[] _categoryLogLevelFilters =
+    [
+        new("Azure.", LogLevel.Error),
+        new("Yarp.", LogLevel.None),
+        new("Microsoft.AspNetCore.", LogLevel.None),
+        new("Microsoft.Azure.WebJobs.Script.DependencyInjection.ScriptStartupTypeLocator", LogLevel.Error),
+        new("Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer.MemoryMappedFileAccessor", LogLevel.Error),
+    ];
+
     public static ILoggingBuilder AddHostStructuredLogging(this ILoggingBuilder builder)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -22,23 +36,59 @@ internal static class HostStructuredLoggingBuilderExtensions
 
     private static ILoggingBuilder AddHostStructuredLogFilters(this ILoggingBuilder builder)
     {
-        builder.AddFilter(static (category, logLevel) =>
-        {
-            bool isSharedMemoryWarning = logLevel == LogLevel.Warning
-                && string.Equals(
-                    category,
-                    "Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer.MemoryMappedFileAccessor",
-                    StringComparison.Ordinal);
-
-            bool isAppInsightsExtensionWarning = logLevel == LogLevel.Warning
-                && string.Equals(
-                    category,
-                    "Microsoft.Azure.WebJobs.Script.DependencyInjection.ScriptStartupTypeLocator",
-                    StringComparison.Ordinal);
-
-            return !isSharedMemoryWarning && !isAppInsightsExtensionWarning;
-        });
+        builder.AddFilter<HostStructuredLoggerProvider>(static (category, logLevel) => logLevel >= GetMinimumLogLevel(category));
 
         return builder;
+    }
+
+    private static LogLevel GetMinimumLogLevel(string? category)
+    {
+        if (string.IsNullOrEmpty(category))
+        {
+            return DefaultUserMinimumLogLevel;
+        }
+
+        foreach (CategoryLogLevelFilter categoryFilter in _categoryLogLevelFilters)
+        {
+            if (categoryFilter.Matches(category))
+            {
+                return categoryFilter.MinimumLogLevel;
+            }
+        }
+
+        if (IsSystemLogCategory(category))
+        {
+            return DefaultSystemMinimumLogLevel;
+        }
+
+        return DefaultUserMinimumLogLevel;
+    }
+
+    private static bool IsSystemLogCategory(string category)
+    {
+        if (IsUserLogCategory(category))
+        {
+            return false;
+        }
+
+        foreach (string prefix in ScriptConstants.SystemLogCategoryPrefixes)
+        {
+            if (category.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsUserLogCategory(string category)
+        => LogCategories.IsFunctionUserCategory(category)
+            || LogCategories.IsFunctionCategory(category)
+            || string.Equals(category, WorkerConstants.ConsoleLogCategoryName, StringComparison.OrdinalIgnoreCase);
+
+    private readonly record struct CategoryLogLevelFilter(string CategoryPrefix, LogLevel MinimumLogLevel)
+    {
+        public bool Matches(string category) => category.StartsWith(CategoryPrefix, StringComparison.Ordinal);
     }
 }

--- a/test/Workloads/Host.Tests/HostStructuredScriptLoggingBuilderTests.cs
+++ b/test/Workloads/Host.Tests/HostStructuredScriptLoggingBuilderTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Workloads.Host.Logging;
+using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -11,6 +12,12 @@ namespace Azure.Functions.Cli.Workloads.Host.Tests;
 
 public sealed class HostStructuredScriptLoggingBuilderTests
 {
+    private const string AzureCoreCategory = "Azure.Core";
+    private const string AppInsightsExtensionWarningCategory = "Microsoft.Azure.WebJobs.Script.DependencyInjection.ScriptStartupTypeLocator";
+    private const string SharedMemoryWarningCategory =
+        "Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer.MemoryMappedFileAccessor";
+    private const string SystemTraceMiddlewareCategory = "Microsoft.Azure.WebJobs.Script.WebHost.Middleware.SystemTraceMiddleware";
+
     [Fact]
     public void Configure_RegistersStructuredLoggerProvider()
     {
@@ -24,8 +31,15 @@ public sealed class HostStructuredScriptLoggingBuilderTests
         Assert.Contains(loggerProviders, static provider => provider is HostStructuredLoggerProvider);
     }
 
-    [Fact]
-    public void Configure_AppliesStructuredLogSuppressionFilters()
+    [Theory]
+    [InlineData(AzureCoreCategory, LogLevel.Information, false)]
+    [InlineData(AzureCoreCategory, LogLevel.Warning, false)]
+    [InlineData(AzureCoreCategory, LogLevel.Error, true)]
+    [InlineData(AppInsightsExtensionWarningCategory, LogLevel.Warning, false)]
+    [InlineData(AppInsightsExtensionWarningCategory, LogLevel.Error, true)]
+    [InlineData(SharedMemoryWarningCategory, LogLevel.Warning, false)]
+    [InlineData(SharedMemoryWarningCategory, LogLevel.Error, true)]
+    public void Configure_AppliesCategoryLogLevelFilters(string category, LogLevel logLevel, bool expected)
     {
         var services = new ServiceCollection();
         var configureBuilder = new HostStructuredScriptLoggingBuilder();
@@ -35,13 +49,48 @@ public sealed class HostStructuredScriptLoggingBuilderTests
         using ServiceProvider provider = services.BuildServiceProvider();
         LoggerFilterOptions filterOptions = provider.GetRequiredService<IOptions<LoggerFilterOptions>>().Value;
 
-        Assert.Contains(filterOptions.Rules, static rule => rule.Filter?.Invoke(
-            null,
-            "Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer.MemoryMappedFileAccessor",
-            LogLevel.Warning) == false);
-        Assert.Contains(filterOptions.Rules, static rule => rule.Filter?.Invoke(
-            null,
-            "Microsoft.Azure.WebJobs.Script.DependencyInjection.ScriptStartupTypeLocator",
-            LogLevel.Warning) == false);
+        AssertStructuredLogFilterResult(filterOptions, category, logLevel, expected);
     }
+
+    [Theory]
+    [InlineData(SystemTraceMiddlewareCategory, LogLevel.Information, false)]
+    [InlineData(SystemTraceMiddlewareCategory, LogLevel.Warning, true)]
+    [InlineData("Host.Startup", LogLevel.Information, false)]
+    [InlineData("Host.Startup", LogLevel.Warning, true)]
+    [InlineData("Function.HttpTrigger1.User", LogLevel.Debug, false)]
+    [InlineData("Function.HttpTrigger1.User", LogLevel.Information, true)]
+    [InlineData("Custom.Category", LogLevel.Debug, false)]
+    [InlineData("Custom.Category", LogLevel.Information, true)]
+    public void Configure_AppliesDefaultStructuredLogFilters(string category, LogLevel logLevel, bool expected)
+    {
+        var services = new ServiceCollection();
+        var configureBuilder = new HostStructuredScriptLoggingBuilder();
+
+        services.AddLogging(configureBuilder.Configure);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        LoggerFilterOptions filterOptions = provider.GetRequiredService<IOptions<LoggerFilterOptions>>().Value;
+
+        AssertStructuredLogFilterResult(filterOptions, category, logLevel, expected);
+    }
+
+    [Fact]
+    public void Configure_AppliesUserLogLevelToWorkerConsoleLogs()
+    {
+        var services = new ServiceCollection();
+        var configureBuilder = new HostStructuredScriptLoggingBuilder();
+
+        services.AddLogging(configureBuilder.Configure);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        LoggerFilterOptions filterOptions = provider.GetRequiredService<IOptions<LoggerFilterOptions>>().Value;
+
+        AssertStructuredLogFilterResult(filterOptions, WorkerConstants.ConsoleLogCategoryName, LogLevel.Debug, false);
+        AssertStructuredLogFilterResult(filterOptions, WorkerConstants.ConsoleLogCategoryName, LogLevel.Information, true);
+    }
+
+    private static void AssertStructuredLogFilterResult(LoggerFilterOptions filterOptions, string category, LogLevel logLevel, bool expected)
+        => Assert.Contains(filterOptions.Rules, rule =>
+            string.Equals(rule.ProviderName, typeof(HostStructuredLoggerProvider).FullName, StringComparison.Ordinal)
+            && rule.Filter?.Invoke(rule.ProviderName, category, logLevel) == expected);
 }


### PR DESCRIPTION
## Summary
- add provider-scoped structured log filtering for host workload output
- apply default system/user log thresholds to reduce dashboard noise
- add category-prefix filters for noisy dependencies, allowing Azure.* errors while suppressing Yarp/Microsoft.AspNetCore logs and known host warning categories below Error

