### PR TITLE
[vnext] Bump dotnet templates version to 4.0.5584

### DIFF
--- a/src/Workloads/Templates/DotNet/Directory.Version.props
+++ b/src/Workloads/Templates/DotNet/Directory.Version.props
@@ -27,7 +27,7 @@
     <VersionPrefix>$(TemplatesVersion)</VersionPrefix>
 
     <SourceItemTemplatesPackageId>Microsoft.Azure.Functions.Worker.ItemTemplates</SourceItemTemplatesPackageId>
-    <SourceItemTemplatesVersion>4.0.5569</SourceItemTemplatesVersion>
+    <SourceItemTemplatesVersion>4.0.5584</SourceItemTemplatesVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Bumps `SourceItemTemplatesVersion` in `src/Workloads/Templates/DotNet/Directory.Version.props` from `4.0.5569` to `4.0.5584` to pick up the latest released [azure-functions-templates](https://github.com/Azure/azure-functions-templates) NuGet packages.