### PR TITLE
Fixing environment variable delimiter to ensure cross-plat compatibility

### DIFF
--- a/src/Func/Commands/Start/Initialization/Steps/PrepareProjectHostRunInitializationStep.cs
+++ b/src/Func/Commands/Start/Initialization/Steps/PrepareProjectHostRunInitializationStep.cs
@@ -90,7 +90,7 @@ internal sealed class PrepareProjectHostRunInitializationStep(
             // The host scans `languageWorkers:<runtime>:workerDirectory` for a worker.config.json.
             // Pointing it at the resolved workload content folder lets installed workers light up
             // without copying assets into the project.
-            string key = $"languageWorkers:{worker.WorkerRuntime}:workerDirectory";
+            string key = $"languageWorkers__{worker.WorkerRuntime}__workerDirectory";
             environmentVariables[key] = workerDirectory;
         }
 

--- a/test/Func.Tests/Commands/StartInitializationTests.cs
+++ b/test/Func.Tests/Commands/StartInitializationTests.cs
@@ -193,7 +193,7 @@ public class StartInitializationTests : IDisposable
         IDictionary<string, string> env = result.HostRunContext.EnvironmentVariables;
         Assert.Equal("yes", env["FROM_LOCAL"]);
         Assert.Equal("node", env["FUNCTIONS_WORKER_RUNTIME"]);
-        Assert.Equal(workerDir, env["languageWorkers:node:workerDirectory"]);
+        Assert.Equal(workerDir, env["languageWorkers__node__workerDirectory"]);
     }
 
     [Fact]


### PR DESCRIPTION
This pull request updates the way environment variable keys are formatted for language worker directories to use double underscores (`__`) as separators instead of colons (`:`). This change ensures consistency and compatibility with configuration conventions.

resolves #5205
