### PR TITLE
enhancement: fix first-run experience

### DIFF
--- a/src/Func/Commands/Setup/SetupRenderer.cs
+++ b/src/Func/Commands/Setup/SetupRenderer.cs
@@ -134,6 +134,21 @@ internal sealed class SetupRenderer(IInteractionService interaction, SetupOutput
         _interaction.WriteSuccess("Azure Functions setup is complete.");
     }
 
+    public void SetupSkippedNoSelection()
+    {
+        if (_outputMode == SetupOutputMode.Json)
+        {
+            WriteEvent("setup.skipped", new Dictionary<string, object?>
+            {
+                ["reason"] = "no-selection",
+            });
+            return;
+        }
+
+        _interaction.WriteHint(
+            "No stacks selected. Nothing to install. Run `func setup` again, or `func setup --features <name>`, when you're ready.");
+    }
+
     public void SetupFailed(int failureCount)
     {
         if (_outputMode == SetupOutputMode.Json)

--- a/src/Func/Commands/Setup/SetupRunner.cs
+++ b/src/Func/Commands/Setup/SetupRunner.cs
@@ -268,12 +268,7 @@ internal sealed class SetupRunner(
         {
             StackChoicesResult choices = await BuildStackChoicesAsync(cancellationToken);
 
-            if (choices.AlreadyInstalled.Count > 0)
-            {
-                _interaction.WriteHint($"Already installed: {string.Join(", ", choices.AlreadyInstalled)}");
-            }
-
-            if (choices.Available.Count == 0)
+            if (!choices.HasAvailable)
             {
                 // Every supported stack is already installed; nothing to
                 // offer. Treat as a clean opt-out so the caller marks the
@@ -283,7 +278,7 @@ internal sealed class SetupRunner(
 
             IReadOnlyList<string> picked = await _interaction.PromptForMultiSelectionAsync(
                 "Select stacks to install (SPACE to toggle, ENTER to confirm; ENTER with no selection exits):",
-                choices.Available,
+                choices.PromptChoices,
                 cancellationToken);
 
             // No selection = user opted out. Signal that with null so the
@@ -319,25 +314,37 @@ internal sealed class SetupRunner(
         }
 
         List<MultiSelectionChoice> available = [];
-        List<string> alreadyInstalled = [];
+        List<MultiSelectionChoice> installedChoices = [];
+        int availableCount = 0;
         foreach (string stack in stacks.OrderBy(static stack => stack, StringComparer.OrdinalIgnoreCase))
         {
             if (installedStackPackageIds.Contains(SetupDependency.Stack(stack).PackageId))
             {
-                alreadyInstalled.Add(stack);
+                installedChoices.Add(new MultiSelectionChoice(stack, $"[grey]{stack} (installed)[/]")
+                {
+                    IsPreselected = true,
+                    IsDisabled = true,
+                });
             }
             else
             {
                 available.Add(new MultiSelectionChoice(stack, stack));
+                availableCount++;
             }
         }
 
-        return new StackChoicesResult(available, alreadyInstalled);
+        // Render available stacks first so the user's cursor lands on something
+        // actionable; installed stacks trail as muted, read-only entries.
+        List<MultiSelectionChoice> promptChoices = [.. available, .. installedChoices];
+        return new StackChoicesResult(promptChoices, availableCount);
     }
 
     private readonly record struct StackChoicesResult(
-        IReadOnlyList<MultiSelectionChoice> Available,
-        IReadOnlyList<string> AlreadyInstalled);
+        IReadOnlyList<MultiSelectionChoice> PromptChoices,
+        int AvailableCount)
+    {
+        public bool HasAvailable => AvailableCount > 0;
+    }
 
     private async Task<IReadOnlyList<SetupProfileScope>> ResolveProfileScopesAsync(SetupCommandOptions options, SetupRenderer renderer, CancellationToken cancellationToken)
     {

--- a/src/Func/Commands/Setup/SetupRunner.cs
+++ b/src/Func/Commands/Setup/SetupRunner.cs
@@ -268,7 +268,21 @@ internal sealed class SetupRunner(
         {
             StackChoicesResult choices = await BuildStackChoicesAsync(cancellationToken);
 
-            if (!choices.HasAvailable)
+            // Render installed stacks as static "fake checkbox" lines above
+            // the prompt so they're visible in context but cannot be toggled
+            // (Spectre's MultiSelectionPrompt has no read-only items, and a
+             // toggle visually implies an uninstall that `func setup` doesn't do).
+            if (choices.InstalledStacks.Count > 0)
+            {
+                _interaction.WriteBlankLine();
+                _interaction.WriteLine(l => l.Muted("Already installed (use `func workload uninstall <name>` to remove):"));
+                foreach (string stack in choices.InstalledStacks)
+                {
+                    _interaction.WriteLine(l => l.Muted($"   [✓] {stack}"));
+                }
+            }
+
+            if (choices.PromptChoices.Count == 0)
             {
                 // Every supported stack is already installed; nothing to
                 // offer. Treat as a clean opt-out so the caller marks the
@@ -307,44 +321,32 @@ internal sealed class SetupRunner(
         }
         catch (Exception)
         {
-            // Filtering installed stacks is a UX hint, not a contract.
-            // If we can't read the store, fall back to showing every stack
-            // so the user can still make a selection.
+            // Surfacing installed stacks is a UX hint, not a contract. If we
+            // can't read the store, fall back to showing every stack as
+            // available so the user can still make a selection.
             installedStackPackageIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         }
 
-        List<MultiSelectionChoice> available = [];
-        List<MultiSelectionChoice> installedChoices = [];
-        int availableCount = 0;
+        List<MultiSelectionChoice> promptChoices = [];
+        List<string> installedStacks = [];
         foreach (string stack in stacks.OrderBy(static stack => stack, StringComparer.OrdinalIgnoreCase))
         {
             if (installedStackPackageIds.Contains(SetupDependency.Stack(stack).PackageId))
             {
-                installedChoices.Add(new MultiSelectionChoice(stack, $"[grey]{stack} (installed)[/]")
-                {
-                    IsPreselected = true,
-                    IsDisabled = true,
-                });
+                installedStacks.Add(stack);
             }
             else
             {
-                available.Add(new MultiSelectionChoice(stack, stack));
-                availableCount++;
+                promptChoices.Add(new MultiSelectionChoice(stack, stack));
             }
         }
 
-        // Render available stacks first so the user's cursor lands on something
-        // actionable; installed stacks trail as muted, read-only entries.
-        List<MultiSelectionChoice> promptChoices = [.. available, .. installedChoices];
-        return new StackChoicesResult(promptChoices, availableCount);
+        return new StackChoicesResult(promptChoices, installedStacks);
     }
 
     private readonly record struct StackChoicesResult(
         IReadOnlyList<MultiSelectionChoice> PromptChoices,
-        int AvailableCount)
-    {
-        public bool HasAvailable => AvailableCount > 0;
-    }
+        IReadOnlyList<string> InstalledStacks);
 
     private async Task<IReadOnlyList<SetupProfileScope>> ResolveProfileScopesAsync(SetupCommandOptions options, SetupRenderer renderer, CancellationToken cancellationToken)
     {

--- a/src/Func/Commands/Setup/SetupRunner.cs
+++ b/src/Func/Commands/Setup/SetupRunner.cs
@@ -266,10 +266,24 @@ internal sealed class SetupRunner(
 
         if (!options.NonInteractive && _interaction.IsInteractive)
         {
-            IReadOnlyList<MultiSelectionChoice> choices = await BuildStackChoicesAsync(cancellationToken);
+            StackChoicesResult choices = await BuildStackChoicesAsync(cancellationToken);
+
+            if (choices.AlreadyInstalled.Count > 0)
+            {
+                _interaction.WriteHint($"Already installed: {string.Join(", ", choices.AlreadyInstalled)}");
+            }
+
+            if (choices.Available.Count == 0)
+            {
+                // Every supported stack is already installed; nothing to
+                // offer. Treat as a clean opt-out so the caller marks the
+                // first-run flag and exits without prompting.
+                return null;
+            }
+
             IReadOnlyList<string> picked = await _interaction.PromptForMultiSelectionAsync(
                 "Select stacks to install (SPACE to toggle, ENTER to confirm; ENTER with no selection exits):",
-                choices,
+                choices.Available,
                 cancellationToken);
 
             // No selection = user opted out. Signal that with null so the
@@ -281,7 +295,7 @@ internal sealed class SetupRunner(
         return ["runtime"];
     }
 
-    private async Task<IReadOnlyList<MultiSelectionChoice>> BuildStackChoicesAsync(CancellationToken cancellationToken)
+    private async Task<StackChoicesResult> BuildStackChoicesAsync(CancellationToken cancellationToken)
     {
         IReadOnlyList<string> stacks = SetupDependency.Stacks;
         HashSet<string> installedStackPackageIds;
@@ -298,20 +312,32 @@ internal sealed class SetupRunner(
         }
         catch (Exception)
         {
-            // Surfacing the installed indicator is a hint, not a contract.
-            // If we can't read the store we still want the user to pick.
+            // Filtering installed stacks is a UX hint, not a contract.
+            // If we can't read the store, fall back to showing every stack
+            // so the user can still make a selection.
             installedStackPackageIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         }
 
-        return [.. stacks
-            .OrderBy(static stack => stack, StringComparer.OrdinalIgnoreCase)
-            .Select(stack =>
+        List<MultiSelectionChoice> available = [];
+        List<string> alreadyInstalled = [];
+        foreach (string stack in stacks.OrderBy(static stack => stack, StringComparer.OrdinalIgnoreCase))
+        {
+            if (installedStackPackageIds.Contains(SetupDependency.Stack(stack).PackageId))
             {
-                bool installed = installedStackPackageIds.Contains(SetupDependency.Stack(stack).PackageId);
-                string label = installed ? $"{stack}  (installed)" : stack;
-                return new MultiSelectionChoice(stack, label);
-            })];
+                alreadyInstalled.Add(stack);
+            }
+            else
+            {
+                available.Add(new MultiSelectionChoice(stack, stack));
+            }
+        }
+
+        return new StackChoicesResult(available, alreadyInstalled);
     }
+
+    private readonly record struct StackChoicesResult(
+        IReadOnlyList<MultiSelectionChoice> Available,
+        IReadOnlyList<string> AlreadyInstalled);
 
     private async Task<IReadOnlyList<SetupProfileScope>> ResolveProfileScopesAsync(SetupCommandOptions options, SetupRenderer renderer, CancellationToken cancellationToken)
     {

--- a/src/Func/Commands/Setup/SetupRunner.cs
+++ b/src/Func/Commands/Setup/SetupRunner.cs
@@ -280,6 +280,8 @@ internal sealed class SetupRunner(
                 {
                     _interaction.WriteLine(l => l.Muted($"   [✓] {stack}"));
                 }
+
+                _interaction.WriteBlankLine();
             }
 
             if (choices.PromptChoices.Count == 0)

--- a/src/Func/Commands/Setup/SetupRunner.cs
+++ b/src/Func/Commands/Setup/SetupRunner.cs
@@ -5,6 +5,7 @@ using Azure.Functions.Cli.Bundles;
 using Azure.Functions.Cli.Commands.Workload;
 using Azure.Functions.Cli.Configuration;
 using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Hosting.FirstRun;
 using Azure.Functions.Cli.Profiles;
 using Azure.Functions.Cli.Workloads;
 using Azure.Functions.Cli.Workloads.Catalog;
@@ -26,7 +27,8 @@ internal sealed class SetupRunner(
     IOptionsMonitor<ProjectProfileOptions> projectProfileOptions,
     IOptionsMonitor<UserProfilePreferenceOptions> userProfilePreferenceOptions,
     ICliConfigurationProvider configurationProvider,
-    IHostJsonBundleSectionReader hostJsonBundleSectionReader) : ISetupRunner
+    IHostJsonBundleSectionReader hostJsonBundleSectionReader,
+    IFirstRunStateStore? firstRunStateStore = null) : ISetupRunner
 {
     private const string DotNetFeature = "dotnet";
     private const string DotNetProfileRuntime = "dotnet-isolated";
@@ -40,6 +42,7 @@ internal sealed class SetupRunner(
     private readonly IOptionsMonitor<UserProfilePreferenceOptions> _userProfilePreferenceOptions = userProfilePreferenceOptions ?? throw new ArgumentNullException(nameof(userProfilePreferenceOptions));
     private readonly ICliConfigurationProvider _configurationProvider = configurationProvider ?? throw new ArgumentNullException(nameof(configurationProvider));
     private readonly IHostJsonBundleSectionReader _hostJsonBundleSectionReader = hostJsonBundleSectionReader ?? throw new ArgumentNullException(nameof(hostJsonBundleSectionReader));
+    private readonly IFirstRunStateStore? _firstRunStateStore = firstRunStateStore;
 
     public async Task<SetupRunResult> RunAsync(SetupCommandOptions options, CancellationToken cancellationToken)
     {
@@ -52,7 +55,17 @@ internal sealed class SetupRunner(
         }
         try
         {
-            SetupFeaturePlan featurePlan = await ResolveFeaturesAsync(options, cancellationToken);
+            SetupFeaturePlan? featurePlan = await ResolveFeaturesAsync(options, cancellationToken);
+            if (featurePlan is null)
+            {
+                // The interactive default-features prompt was confirmed with no
+                // selection. Treat that as a clean opt-out, not a failure: the
+                // user explicitly chose to leave without installing anything.
+                renderer.SetupSkippedNoSelection();
+                await TryMarkFirstRunCompleteAsync(cancellationToken);
+                return new SetupRunResult(0);
+            }
+
             IReadOnlyList<SetupProfileScope> profileScopes = await ResolveProfileScopesAsync(options, renderer, cancellationToken);
 
             renderer.SetupStarted(options, featurePlan, profileScopes);
@@ -81,6 +94,7 @@ internal sealed class SetupRunner(
             }
 
             renderer.SetupCompleted();
+            await TryMarkFirstRunCompleteAsync(cancellationToken);
             return new SetupRunResult(0);
         }
         catch (SetupConfigurationException ex)
@@ -97,6 +111,29 @@ internal sealed class SetupRunner(
         {
             renderer.SetupFailed(ex.Message);
             return new SetupRunResult(1);
+        }
+    }
+
+    private async Task TryMarkFirstRunCompleteAsync(CancellationToken cancellationToken)
+    {
+        if (_firstRunStateStore is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await _firstRunStateStore.MarkCompleteAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            // Failing to mark the first-run marker after a successful setup
+            // is a minor nuisance (the user might see the first-run prompt
+            // one more time), not a setup failure. Stay silent.
         }
     }
 
@@ -134,11 +171,18 @@ internal sealed class SetupRunner(
         return new ProfileSetupOutcome(failures);
     }
 
-    private async Task<SetupFeaturePlan> ResolveFeaturesAsync(SetupCommandOptions options, CancellationToken cancellationToken)
+    private async Task<SetupFeaturePlan?> ResolveFeaturesAsync(SetupCommandOptions options, CancellationToken cancellationToken)
     {
-        IReadOnlyList<string> requestedFeatures = options.Features.Count == 0
+        IReadOnlyList<string>? requestedFeatures = options.Features.Count == 0
             ? await GetDefaultFeaturesAsync(options, cancellationToken)
             : options.Features;
+
+        if (requestedFeatures is null)
+        {
+            // Interactive default-features prompt confirmed with no selection;
+            // the caller treats this as a graceful exit.
+            return null;
+        }
 
         if (requestedFeatures.Count == 0)
         {
@@ -209,7 +253,7 @@ internal sealed class SetupRunner(
             includeExtensionBundle);
     }
 
-    private async Task<IReadOnlyList<string>> GetDefaultFeaturesAsync(SetupCommandOptions options, CancellationToken cancellationToken)
+    private async Task<IReadOnlyList<string>?> GetDefaultFeaturesAsync(SetupCommandOptions options, CancellationToken cancellationToken)
     {
         string? configuredStack = _configurationProvider
             .GetProjectConfiguration(options.WorkingDirectory)
@@ -222,20 +266,51 @@ internal sealed class SetupRunner(
 
         if (!options.NonInteractive && _interaction.IsInteractive)
         {
+            IReadOnlyList<MultiSelectionChoice> choices = await BuildStackChoicesAsync(cancellationToken);
             IReadOnlyList<string> picked = await _interaction.PromptForMultiSelectionAsync(
-                "Select stacks to install (SPACE to toggle, ENTER to confirm):",
-                SetupDependency.Stacks,
+                "Select stacks to install (SPACE to toggle, ENTER to confirm; ENTER with no selection exits):",
+                choices,
                 cancellationToken);
 
-            // If the user confirmed without picking anything, fall through to
-            // the runtime-only default so we still install something useful.
-            if (picked.Count > 0)
-            {
-                return picked;
-            }
+            // No selection = user opted out. Signal that with null so the
+            // caller can exit cleanly instead of falling through to a default
+            // they did not ask for.
+            return picked.Count > 0 ? picked : null;
         }
 
         return ["runtime"];
+    }
+
+    private async Task<IReadOnlyList<MultiSelectionChoice>> BuildStackChoicesAsync(CancellationToken cancellationToken)
+    {
+        IReadOnlyList<string> stacks = SetupDependency.Stacks;
+        HashSet<string> installedStackPackageIds;
+        try
+        {
+            IReadOnlyList<WorkloadEntry> installed = await _workloadStore.GetWorkloadsAsync(cancellationToken);
+            installedStackPackageIds = new HashSet<string>(
+                installed.Select(static entry => entry.PackageId),
+                StringComparer.OrdinalIgnoreCase);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            // Surfacing the installed indicator is a hint, not a contract.
+            // If we can't read the store we still want the user to pick.
+            installedStackPackageIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        return [.. stacks
+            .OrderBy(static stack => stack, StringComparer.OrdinalIgnoreCase)
+            .Select(stack =>
+            {
+                bool installed = installedStackPackageIds.Contains(SetupDependency.Stack(stack).PackageId);
+                string label = installed ? $"{stack}  (installed)" : stack;
+                return new MultiSelectionChoice(stack, label);
+            })];
     }
 
     private async Task<IReadOnlyList<SetupProfileScope>> ResolveProfileScopesAsync(SetupCommandOptions options, SetupRenderer renderer, CancellationToken cancellationToken)

--- a/src/Func/Console/IInteractionService.cs
+++ b/src/Func/Console/IInteractionService.cs
@@ -120,10 +120,21 @@ internal interface IInteractionService
 
     /// <summary>
     /// Prompts the user to select one or more values from a list of choices, using
-    /// SPACE to toggle and ENTER to confirm. Returns an empty list in non-interactive
-    /// mode. Throws <see cref="OperationCanceledException"/> on Ctrl+C.
+    /// SPACE to toggle and ENTER to confirm. Selection is optional: pressing ENTER
+    /// with nothing selected returns an empty list. Returns an empty list in
+    /// non-interactive mode. Throws <see cref="OperationCanceledException"/> on Ctrl+C.
     /// </summary>
     public Task<IReadOnlyList<string>> PromptForMultiSelectionAsync(string title, IEnumerable<string> choices, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Prompts the user to select one or more values from a list of labelled choices.
+    /// Each <see cref="MultiSelectionChoice"/> carries a <see cref="MultiSelectionChoice.Label"/>
+    /// shown to the user and a <see cref="MultiSelectionChoice.Value"/> returned in the
+    /// result. Selection is optional: pressing ENTER with nothing selected returns
+    /// an empty list. Returns an empty list in non-interactive mode. Throws
+    /// <see cref="OperationCanceledException"/> on Ctrl+C.
+    /// </summary>
+    public Task<IReadOnlyList<string>> PromptForMultiSelectionAsync(string title, IEnumerable<MultiSelectionChoice> choices, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Prompts the user for free-form text with an optional default. Returns

--- a/src/Func/Console/MultiSelectionChoice.cs
+++ b/src/Func/Console/MultiSelectionChoice.cs
@@ -5,17 +5,21 @@ namespace Azure.Functions.Cli.Console;
 
 /// <summary>
 /// One option for <see cref="IInteractionService.PromptForMultiSelectionAsync(string, IEnumerable{MultiSelectionChoice}, CancellationToken)"/>.
-/// <see cref="Value"/> is what callers receive back; <see cref="Label"/> is what the user sees.
+/// <see cref="Value"/> is what callers receive back; <see cref="Label"/> is what the
+/// user sees (Spectre markup allowed). Set <see cref="IsPreselected"/> to render the
+/// choice checked when the prompt opens. Set <see cref="IsDisabled"/> to surface a
+/// read-only entry: it still renders in the list (and is dropped from the result),
+/// so callers can show "already-done" items in context without offering them as
+/// actionable choices.
 /// </summary>
-/// <remarks>
-/// Splitting display text from the underlying value lets callers decorate
-/// choices (for example, with an "(installed)" suffix) without leaking
-/// presentation concerns into the value the caller acts on.
-/// </remarks>
 internal sealed record MultiSelectionChoice(string Value, string Label)
 {
     public MultiSelectionChoice(string value)
         : this(value, value)
     {
     }
+
+    public bool IsPreselected { get; init; }
+
+    public bool IsDisabled { get; init; }
 }

--- a/src/Func/Console/MultiSelectionChoice.cs
+++ b/src/Func/Console/MultiSelectionChoice.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Console;
+
+/// <summary>
+/// One option for <see cref="IInteractionService.PromptForMultiSelectionAsync(string, IEnumerable{MultiSelectionChoice}, CancellationToken)"/>.
+/// <see cref="Value"/> is what callers receive back; <see cref="Label"/> is what the user sees.
+/// </summary>
+/// <remarks>
+/// Splitting display text from the underlying value lets callers decorate
+/// choices (for example, with an "(installed)" suffix) without leaking
+/// presentation concerns into the value the caller acts on.
+/// </remarks>
+internal sealed record MultiSelectionChoice(string Value, string Label)
+{
+    public MultiSelectionChoice(string value)
+        : this(value, value)
+    {
+    }
+}

--- a/src/Func/Console/MultiSelectionChoice.cs
+++ b/src/Func/Console/MultiSelectionChoice.cs
@@ -6,11 +6,7 @@ namespace Azure.Functions.Cli.Console;
 /// <summary>
 /// One option for <see cref="IInteractionService.PromptForMultiSelectionAsync(string, IEnumerable{MultiSelectionChoice}, CancellationToken)"/>.
 /// <see cref="Value"/> is what callers receive back; <see cref="Label"/> is what the
-/// user sees (Spectre markup allowed). Set <see cref="IsPreselected"/> to render the
-/// choice checked when the prompt opens. Set <see cref="IsDisabled"/> to surface a
-/// read-only entry: it still renders in the list (and is dropped from the result),
-/// so callers can show "already-done" items in context without offering them as
-/// actionable choices.
+/// user sees (Spectre markup allowed).
 /// </summary>
 internal sealed record MultiSelectionChoice(string Value, string Label)
 {
@@ -18,8 +14,4 @@ internal sealed record MultiSelectionChoice(string Value, string Label)
         : this(value, value)
     {
     }
-
-    public bool IsPreselected { get; init; }
-
-    public bool IsDisabled { get; init; }
 }

--- a/src/Func/Console/SpectreInteractionService.cs
+++ b/src/Func/Console/SpectreInteractionService.cs
@@ -319,7 +319,10 @@ internal class SpectreInteractionService : IInteractionService
             .ShowAsync(_stderr, cancellationToken);
     }
 
-    public async Task<IReadOnlyList<string>> PromptForMultiSelectionAsync(string title, IEnumerable<string> choices, CancellationToken cancellationToken = default)
+    public Task<IReadOnlyList<string>> PromptForMultiSelectionAsync(string title, IEnumerable<string> choices, CancellationToken cancellationToken = default)
+        => PromptForMultiSelectionAsync(title, choices.Select(static c => new MultiSelectionChoice(c)), cancellationToken);
+
+    public async Task<IReadOnlyList<string>> PromptForMultiSelectionAsync(string title, IEnumerable<MultiSelectionChoice> choices, CancellationToken cancellationToken = default)
     {
         var choiceList = choices.ToList();
         if (!IsInteractive || choiceList.Count == 0)
@@ -327,13 +330,19 @@ internal class SpectreInteractionService : IInteractionService
             return [];
         }
 
-        List<string> selected = await new MultiSelectionPrompt<string>()
+        // NotRequired() lets the user press ENTER with nothing selected to exit
+        // the prompt cleanly. Callers treat an empty result as "no selection",
+        // which (for `func setup`) is the documented escape hatch from the
+        // stack picker.
+        List<MultiSelectionChoice> selected = await new MultiSelectionPrompt<MultiSelectionChoice>()
             .Title(title)
-            .InstructionsText("[grey](press [blue]<space>[/] to toggle, [green]<enter>[/] to confirm)[/]")
+            .NotRequired()
+            .InstructionsText("[grey](press [blue]<space>[/] to toggle, [green]<enter>[/] to confirm; ENTER with no selection exits)[/]")
+            .UseConverter(static choice => choice.Label)
             .AddChoices(choiceList)
             .ShowAsync(_stderr, cancellationToken);
 
-        return selected;
+        return [.. selected.Select(static choice => choice.Value)];
     }
 
     public async Task<string> PromptForInputAsync(string prompt, string? defaultValue = null, CancellationToken cancellationToken = default)

--- a/src/Func/Console/SpectreInteractionService.cs
+++ b/src/Func/Console/SpectreInteractionService.cs
@@ -337,7 +337,7 @@ internal class SpectreInteractionService : IInteractionService
         List<MultiSelectionChoice> selected = await new MultiSelectionPrompt<MultiSelectionChoice>()
             .Title(title)
             .NotRequired()
-            .InstructionsText("[grey](press [blue]<space>[/] to toggle, [green]<enter>[/] to confirm; ENTER with no selection exits)[/]")
+            .InstructionsText("[grey](press [blue]<space>[/] to toggle, [green]<enter>[/] to confirm; [green]<enter>[/] with no selection exits)[/]")
             .UseConverter(static choice => choice.Label)
             .AddChoices(choiceList)
             .ShowAsync(_stderr, cancellationToken);

--- a/src/Func/Console/SpectreInteractionService.cs
+++ b/src/Func/Console/SpectreInteractionService.cs
@@ -334,28 +334,15 @@ internal class SpectreInteractionService : IInteractionService
         // the prompt cleanly. Callers treat an empty result as "no selection",
         // which (for `func setup`) is the documented escape hatch from the
         // stack picker.
-        MultiSelectionPrompt<MultiSelectionChoice> prompt = new MultiSelectionPrompt<MultiSelectionChoice>()
+        List<MultiSelectionChoice> selected = await new MultiSelectionPrompt<MultiSelectionChoice>()
             .Title(title)
             .NotRequired()
             .InstructionsText("[grey](press [blue]<space>[/] to toggle, [green]<enter>[/] to confirm; ENTER with no selection exits)[/]")
             .UseConverter(static choice => choice.Label)
-            .AddChoices(choiceList);
+            .AddChoices(choiceList)
+            .ShowAsync(_stderr, cancellationToken);
 
-        foreach (MultiSelectionChoice choice in choiceList)
-        {
-            if (choice.IsPreselected)
-            {
-                prompt.Select(choice);
-            }
-        }
-
-        List<MultiSelectionChoice> selected = await prompt.ShowAsync(_stderr, cancellationToken);
-
-        // Disabled entries are decorative: they render so the user can see them
-        // in context, but toggling them has no effect. Strip them from the
-        // result so callers never act on values they didn't intend to expose
-        // as selectable.
-        return [.. selected.Where(static choice => !choice.IsDisabled).Select(static choice => choice.Value)];
+        return [.. selected.Select(static choice => choice.Value)];
     }
 
     public async Task<string> PromptForInputAsync(string prompt, string? defaultValue = null, CancellationToken cancellationToken = default)

--- a/src/Func/Console/SpectreInteractionService.cs
+++ b/src/Func/Console/SpectreInteractionService.cs
@@ -334,15 +334,28 @@ internal class SpectreInteractionService : IInteractionService
         // the prompt cleanly. Callers treat an empty result as "no selection",
         // which (for `func setup`) is the documented escape hatch from the
         // stack picker.
-        List<MultiSelectionChoice> selected = await new MultiSelectionPrompt<MultiSelectionChoice>()
+        MultiSelectionPrompt<MultiSelectionChoice> prompt = new MultiSelectionPrompt<MultiSelectionChoice>()
             .Title(title)
             .NotRequired()
             .InstructionsText("[grey](press [blue]<space>[/] to toggle, [green]<enter>[/] to confirm; ENTER with no selection exits)[/]")
             .UseConverter(static choice => choice.Label)
-            .AddChoices(choiceList)
-            .ShowAsync(_stderr, cancellationToken);
+            .AddChoices(choiceList);
 
-        return [.. selected.Select(static choice => choice.Value)];
+        foreach (MultiSelectionChoice choice in choiceList)
+        {
+            if (choice.IsPreselected)
+            {
+                prompt.Select(choice);
+            }
+        }
+
+        List<MultiSelectionChoice> selected = await prompt.ShowAsync(_stderr, cancellationToken);
+
+        // Disabled entries are decorative: they render so the user can see them
+        // in context, but toggling them has no effect. Strip them from the
+        // result so callers never act on values they didn't intend to expose
+        // as selectable.
+        return [.. selected.Where(static choice => !choice.IsDisabled).Select(static choice => choice.Value)];
     }
 
     public async Task<string> PromptForInputAsync(string prompt, string? defaultValue = null, CancellationToken cancellationToken = default)

--- a/src/Func/Hosting/FirstRun/FileFirstRunStateStore.cs
+++ b/src/Func/Hosting/FirstRun/FileFirstRunStateStore.cs
@@ -2,22 +2,54 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Configuration;
+using Azure.Functions.Cli.Workloads.Storage;
 
 namespace Azure.Functions.Cli.Hosting.FirstRun;
 
 /// <summary>
 /// File-backed first-run marker stored alongside other CLI state in the
-/// func home directory.
+/// func home directory. Also treats the presence of any installed workload
+/// as "not first run", so users who already set up the CLI in a previous
+/// session don't see the prompt again even when the marker is missing.
 /// </summary>
-internal sealed class FileFirstRunStateStore(CliConfigurationPathsOptions paths) : IFirstRunStateStore
+internal sealed class FileFirstRunStateStore(
+    CliConfigurationPathsOptions paths,
+    IWorkloadStore workloadStore) : IFirstRunStateStore
 {
     internal const string MarkerFileName = ".first-run-complete";
 
     private readonly CliConfigurationPathsOptions _paths = paths ?? throw new ArgumentNullException(nameof(paths));
+    private readonly IWorkloadStore _workloadStore = workloadStore ?? throw new ArgumentNullException(nameof(workloadStore));
 
     private string MarkerPath => Path.Combine(_paths.Home, MarkerFileName);
 
-    public bool IsFirstRun() => !File.Exists(MarkerPath);
+    public async Task<bool> IsFirstRunAsync(CancellationToken cancellationToken = default)
+    {
+        if (File.Exists(MarkerPath))
+        {
+            return false;
+        }
+
+        // Existing users may have installed workloads through `func setup`
+        // or `func workload install` before this marker was introduced, or
+        // before we wrote it on success. Treat any installed workload as
+        // "not first run" so we don't re-prompt them.
+        try
+        {
+            IReadOnlyList<WorkloadEntry> installed = await _workloadStore.GetWorkloadsAsync(cancellationToken);
+            return installed.Count == 0;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            // If we can't read the workload registry for any reason, fall
+            // back to "first run = true" so the user still sees the prompt.
+            return true;
+        }
+    }
 
     public async Task MarkCompleteAsync(CancellationToken cancellationToken)
     {

--- a/src/Func/Hosting/FirstRun/FileFirstRunStateStore.cs
+++ b/src/Func/Hosting/FirstRun/FileFirstRunStateStore.cs
@@ -12,53 +12,46 @@ namespace Azure.Functions.Cli.Hosting.FirstRun;
 /// as "not first run", so users who already set up the CLI in a previous
 /// session don't see the prompt again even when the marker is missing.
 /// </summary>
+/// <remarks>
+/// This runs on every CLI invocation, before the user's command starts, so
+/// the hot path must stay cheap. We deliberately use a file-existence probe
+/// on the workload registry rather than loading and deserializing it: the
+/// registry is only written when at least one workload has been installed,
+/// so its presence is a reliable "user has workloads" signal without any
+/// JSON parsing. The corner case (user installed workloads then uninstalled
+/// every one, leaving an empty registry file) only costs us a missing
+/// breadcrumb hint, never a wrong prompt.
+/// </remarks>
 internal sealed class FileFirstRunStateStore(
     CliConfigurationPathsOptions paths,
-    IWorkloadStore workloadStore) : IFirstRunStateStore
+    IWorkloadPaths workloadPaths) : IFirstRunStateStore
 {
     internal const string MarkerFileName = ".first-run-complete";
 
     private readonly CliConfigurationPathsOptions _paths = paths ?? throw new ArgumentNullException(nameof(paths));
-    private readonly IWorkloadStore _workloadStore = workloadStore ?? throw new ArgumentNullException(nameof(workloadStore));
+    private readonly IWorkloadPaths _workloadPaths = workloadPaths ?? throw new ArgumentNullException(nameof(workloadPaths));
 
     private string MarkerPath => Path.Combine(_paths.Home, MarkerFileName);
 
-    public async Task<bool> IsFirstRunAsync(CancellationToken cancellationToken = default)
-        => await GetStateAsync(cancellationToken) == FirstRunState.NeverPrompted;
+    public Task<bool> IsFirstRunAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(GetStateCore() == FirstRunState.NeverPrompted);
 
-    public async Task<FirstRunState> GetStateAsync(CancellationToken cancellationToken = default)
+    public Task<FirstRunState> GetStateAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(GetStateCore());
+
+    private FirstRunState GetStateCore()
     {
-        bool markerExists = File.Exists(MarkerPath);
-
-        // Existing users may have installed workloads through `func setup`
-        // or `func workload install` before this marker was introduced, or
-        // before we wrote it on success. Treat any installed workload as
-        // "not first run" so we don't re-prompt them.
-        bool hasWorkloads;
-        try
-        {
-            IReadOnlyList<WorkloadEntry> installed = await _workloadStore.GetWorkloadsAsync(cancellationToken);
-            hasWorkloads = installed.Count > 0;
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception)
-        {
-            // If we can't read the workload registry, lean toward the
-            // marker: it's the user's explicit signal. Treat as no
-            // workloads so the prompt still surfaces when there's no
-            // marker either.
-            hasWorkloads = false;
-        }
-
+        // Two cheap file-existence probes; no I/O beyond stat(2). The
+        // workload registry exists if and only if SaveWorkloadAsync has
+        // run at least once, which is the signal we actually care about
+        // (an established user, marker or not).
+        bool hasWorkloads = File.Exists(_workloadPaths.WorkloadRegistryPath);
         if (hasWorkloads)
         {
             return FirstRunState.WorkloadsInstalled;
         }
 
-        return markerExists ? FirstRunState.MarkerWithoutWorkloads : FirstRunState.NeverPrompted;
+        return File.Exists(MarkerPath) ? FirstRunState.MarkerWithoutWorkloads : FirstRunState.NeverPrompted;
     }
 
     public async Task MarkCompleteAsync(CancellationToken cancellationToken)

--- a/src/Func/Hosting/FirstRun/FileFirstRunStateStore.cs
+++ b/src/Func/Hosting/FirstRun/FileFirstRunStateStore.cs
@@ -24,20 +24,21 @@ internal sealed class FileFirstRunStateStore(
     private string MarkerPath => Path.Combine(_paths.Home, MarkerFileName);
 
     public async Task<bool> IsFirstRunAsync(CancellationToken cancellationToken = default)
+        => await GetStateAsync(cancellationToken) == FirstRunState.NeverPrompted;
+
+    public async Task<FirstRunState> GetStateAsync(CancellationToken cancellationToken = default)
     {
-        if (File.Exists(MarkerPath))
-        {
-            return false;
-        }
+        bool markerExists = File.Exists(MarkerPath);
 
         // Existing users may have installed workloads through `func setup`
         // or `func workload install` before this marker was introduced, or
         // before we wrote it on success. Treat any installed workload as
         // "not first run" so we don't re-prompt them.
+        bool hasWorkloads;
         try
         {
             IReadOnlyList<WorkloadEntry> installed = await _workloadStore.GetWorkloadsAsync(cancellationToken);
-            return installed.Count == 0;
+            hasWorkloads = installed.Count > 0;
         }
         catch (OperationCanceledException)
         {
@@ -45,10 +46,19 @@ internal sealed class FileFirstRunStateStore(
         }
         catch (Exception)
         {
-            // If we can't read the workload registry for any reason, fall
-            // back to "first run = true" so the user still sees the prompt.
-            return true;
+            // If we can't read the workload registry, lean toward the
+            // marker: it's the user's explicit signal. Treat as no
+            // workloads so the prompt still surfaces when there's no
+            // marker either.
+            hasWorkloads = false;
         }
+
+        if (hasWorkloads)
+        {
+            return FirstRunState.WorkloadsInstalled;
+        }
+
+        return markerExists ? FirstRunState.MarkerWithoutWorkloads : FirstRunState.NeverPrompted;
     }
 
     public async Task MarkCompleteAsync(CancellationToken cancellationToken)

--- a/src/Func/Hosting/FirstRun/FirstRunCoordinator.cs
+++ b/src/Func/Hosting/FirstRun/FirstRunCoordinator.cs
@@ -145,7 +145,9 @@ internal sealed class FirstRunCoordinator(
         {
             // Ctrl+C at the prompt = "stop pestering me". Write the marker
             // so we don't ask again next time, then propagate the cancel.
-            await TryMarkCompleteAsync(cancellationToken);
+            // Use None: the inbound token is already cancelled, and the
+            // intent here is precisely to persist *despite* cancellation.
+            await TryMarkCompleteAsync(CancellationToken.None);
             throw;
         }
 

--- a/src/Func/Hosting/FirstRun/FirstRunCoordinator.cs
+++ b/src/Func/Hosting/FirstRun/FirstRunCoordinator.cs
@@ -52,6 +52,14 @@ internal sealed class FirstRunCoordinator(
     private static readonly HashSet<string> _skippedTokens =
         new(StringComparer.OrdinalIgnoreCase) { "--help", "-h", "-?", "/?", "--version", "-v" };
 
+    // CommandNameResolver returns these when the user didn't actually type a
+    // command name: "help" for bare `func`, "version" for `func --verbose`,
+    // "unknown" when the parse failed. We still want to prompt + run setup in
+    // those cases, but the post-setup "Re-run `func <name>`" hint doesn't make
+    // sense (re-run what?), so we short-circuit with a generic message instead.
+    private static readonly HashSet<string> _commandNameSentinels =
+        new(StringComparer.OrdinalIgnoreCase) { "help", "version", "unknown" };
+
     private readonly IInteractionService _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
     private readonly IFirstRunStateStore _stateStore = stateStore ?? throw new ArgumentNullException(nameof(stateStore));
     private readonly ISetupRunner _setupRunner = setupRunner ?? throw new ArgumentNullException(nameof(setupRunner));
@@ -169,10 +177,23 @@ internal sealed class FirstRunCoordinator(
         // and would either fail outright ("no project here") or silently use
         // stale metadata. Asking them to re-run is the only safe answer until
         // we add an in-process reload.
-        if (setupRan && !string.IsNullOrEmpty(commandName))
+        //
+        // "help" (bare `func`), "version" (`func --verbose`), and "unknown"
+        // (parse error) aren't real commands the user typed, so the generic
+        // "setup complete" line is enough; we don't want to print
+        // "Re-run `func help`".
+        if (setupRan)
         {
             _interaction.WriteBlankLine();
-            _interaction.WriteHint($"Setup complete. Re-run `func {commandName.ToLowerInvariant()}` to use the new stacks.");
+            if (string.IsNullOrEmpty(commandName) || _commandNameSentinels.Contains(commandName))
+            {
+                _interaction.WriteHint("Setup complete. Run `func <command>` to use the new stacks.");
+            }
+            else
+            {
+                _interaction.WriteHint($"Setup complete. Re-run `func {commandName.ToLowerInvariant()}` to use the new stacks.");
+            }
+
             return 0;
         }
 

--- a/src/Func/Hosting/FirstRun/FirstRunCoordinator.cs
+++ b/src/Func/Hosting/FirstRun/FirstRunCoordinator.cs
@@ -10,82 +10,149 @@ namespace Azure.Functions.Cli.Hosting.FirstRun;
 /// <summary>
 /// Default coordinator. Skips quickly when this is clearly not the
 /// user's first interactive command, otherwise prompts and delegates
-/// to <see cref="ISetupRunner"/>.
+/// to <see cref="ISetupRunner"/>. Once setup has been handled, also
+/// surfaces a muted breadcrumb when the user previously declined but
+/// still has no workloads installed.
 /// </summary>
 internal sealed class FirstRunCoordinator(
     IInteractionService interaction,
     IFirstRunStateStore stateStore,
     ISetupRunner setupRunner) : IFirstRunCoordinator
 {
-    private const string PromptExplanation =
-        "The Azure Functions CLI uses workloads (host, runtime, language stacks) to do its work, "
-        + "and they aren't installed yet. Running `func setup` now will install everything you need to get started.";
+    private const string PromptParagraph1 =
+        "Looks like this is your first time running func.";
+
+    private const string PromptParagraph2 =
+        "The new CLI uses installable workloads to bring in language stacks "
+        + "(Node.js, Python, .NET, Go) and the host runtime. Running `func setup` "
+        + "now will install the host and the dev environment / dependencies for "
+        + "the stack(s) you pick.";
+
+    private const string PromptParagraph3 =
+        "You can always add more later with `func setup --features <node|dotnet|go|python>`.";
 
     private const string PromptMessage = "Run `func setup` now?";
 
-    // Commands that should not trigger the first-run prompt. We deliberately
-    // do NOT skip on "help" / "unknown" here: those are what the resolver
-    // returns for a bare `func` invocation, which is the canonical first-run
-    // trigger. Explicit `--help`/`-h` invocations are handled by the token
-    // check below. "version" stays because it only arises from `func --verbose`
-    // with no subcommand, which is a CLI-inspection gesture, not a real
-    // first command.
+    private const string BreadcrumbHint =
+        "Tip: run `func setup` to install your dev environment and language stack dependencies.";
+
+    // Commands that should not trigger the first-run prompt or breadcrumb.
+    // We deliberately do NOT skip on "help" / "unknown" here: those are what
+    // the resolver returns for a bare `func` invocation, which is the
+    // canonical first-run trigger. Explicit `--help`/`-h` invocations are
+    // handled by the token check below. "version" stays because it only
+    // arises from `func --verbose` with no subcommand, which is a CLI-
+    // inspection gesture, not a real first command. `init` and `new` stay
+    // off the skip list intentionally; the spec wants the prompt there too.
     private static readonly HashSet<string> _skippedCommandNames =
         new(StringComparer.OrdinalIgnoreCase) { "setup", "version" };
 
     private static readonly HashSet<string> _skippedTokens =
         new(StringComparer.OrdinalIgnoreCase) { "--help", "-h", "-?", "/?", "--version", "-v" };
 
+    // Commands that need workload-aware metadata (templates, bundles) loaded
+    // at host build time. If we install workloads inside the first-run flow
+    // for one of these, the in-process loader is still pointing at the
+    // pre-install snapshot, so we ask the user to re-run instead of letting
+    // the original command fail in confusing ways.
+    private static readonly HashSet<string> _workloadDependentCommands =
+        new(StringComparer.OrdinalIgnoreCase) { "init", "new" };
+
     private readonly IInteractionService _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
     private readonly IFirstRunStateStore _stateStore = stateStore ?? throw new ArgumentNullException(nameof(stateStore));
     private readonly ISetupRunner _setupRunner = setupRunner ?? throw new ArgumentNullException(nameof(setupRunner));
 
-    public async Task EnsureFirstRunPromptedAsync(string commandName, ParseResult parseResult, CancellationToken cancellationToken)
+    public async Task<int?> EnsureFirstRunPromptedAsync(string commandName, ParseResult parseResult, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(parseResult);
-
-        if (!await _stateStore.IsFirstRunAsync(cancellationToken))
-        {
-            return;
-        }
 
         if (!_interaction.IsInteractive)
         {
             // Don't pester the user in CI / piped scenarios, and don't mark
             // the marker either: they may run interactively next time.
-            return;
+            return null;
         }
 
+        if (IsSkipped(commandName, parseResult))
+        {
+            return null;
+        }
+
+        FirstRunState state = await _stateStore.GetStateAsync(cancellationToken);
+
+        switch (state)
+        {
+            case FirstRunState.WorkloadsInstalled:
+                return null;
+
+            case FirstRunState.MarkerWithoutWorkloads:
+                _interaction.WriteHint(BreadcrumbHint);
+                return null;
+
+            case FirstRunState.NeverPrompted:
+                return await HandleFirstRunAsync(commandName, cancellationToken);
+
+            default:
+                return null;
+        }
+    }
+
+    private static bool IsSkipped(string commandName, ParseResult parseResult)
+    {
         if (commandName is not null && _skippedCommandNames.Contains(commandName))
         {
-            return;
+            return true;
         }
 
         foreach (System.CommandLine.Parsing.Token token in parseResult.Tokens)
         {
             if (_skippedTokens.Contains(token.Value))
             {
-                return;
+                return true;
             }
         }
 
-        // Bare `func` (no args) produces a "Required command was not provided"
-        // parse error but no tokens; that's the canonical first-run trigger
-        // and we still want to prompt. For any other parse error (typo, bad
-        // option), stay quiet until the user fixes their command line.
+        // Bare `func` (no tokens) is the canonical first-run trigger and
+        // must always be considered, even if the parser produced a
+        // "Required command was not provided" error. For any other parse
+        // error (typo, bad option), stay quiet until the user fixes their
+        // command line.
         bool isBareInvocation = parseResult.Tokens.Count == 0;
         if (!isBareInvocation && parseResult.Errors.Count > 0)
         {
-            return;
+            return true;
         }
 
-        _interaction.WriteBlankLine();
-        _interaction.WriteHint(PromptExplanation);
-        bool runSetup = await _interaction.ConfirmAsync(PromptMessage, defaultValue: true, cancellationToken);
+        return false;
+    }
 
+    private async Task<int?> HandleFirstRunAsync(string commandName, CancellationToken cancellationToken)
+    {
+        _interaction.WriteBlankLine();
+        _interaction.WriteLine(PromptParagraph1);
+        _interaction.WriteBlankLine();
+        _interaction.WriteLine(PromptParagraph2);
+        _interaction.WriteBlankLine();
+        _interaction.WriteLine(PromptParagraph3);
+        _interaction.WriteBlankLine();
+
+        bool runSetup;
+        try
+        {
+            runSetup = await _interaction.ConfirmAsync(PromptMessage, defaultValue: true, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            // Ctrl+C at the prompt = "stop pestering me". Write the marker
+            // so we don't ask again next time, then propagate the cancel.
+            await TryMarkCompleteAsync(cancellationToken);
+            throw;
+        }
+
+        bool setupRan = false;
         if (runSetup)
         {
-            await RunSetupAsync(cancellationToken);
+            setupRan = await RunSetupAsync(cancellationToken);
         }
         else
         {
@@ -93,9 +160,22 @@ internal sealed class FirstRunCoordinator(
         }
 
         await _stateStore.MarkCompleteAsync(cancellationToken);
+
+        // The workload loader snapshots templates/bundles at host build
+        // time, so the in-process `init` / `new` flow won't see the
+        // freshly installed stacks. Ask the user to re-run instead of
+        // letting them hit a confusing "no templates found" error.
+        if (setupRan && commandName is not null && _workloadDependentCommands.Contains(commandName))
+        {
+            _interaction.WriteBlankLine();
+            _interaction.WriteHint($"Setup complete. Re-run `func {commandName.ToLowerInvariant()}` to use the new stacks.");
+            return 0;
+        }
+
+        return null;
     }
 
-    private async Task RunSetupAsync(CancellationToken cancellationToken)
+    private async Task<bool> RunSetupAsync(CancellationToken cancellationToken)
     {
         var options = new SetupCommandOptions(
             WorkingDirectory: new DirectoryInfo(Environment.CurrentDirectory),
@@ -111,7 +191,8 @@ internal sealed class FirstRunCoordinator(
 
         try
         {
-            await _setupRunner.RunAsync(options, cancellationToken);
+            SetupRunResult result = await _setupRunner.RunAsync(options, cancellationToken);
+            return result.ExitCode == 0;
         }
         catch (OperationCanceledException)
         {
@@ -124,6 +205,26 @@ internal sealed class FirstRunCoordinator(
             // command they typed may still succeed (or fail with its own
             // clearer error).
             _interaction.WriteWarning($"Setup did not complete: {ex.Message}");
+            return false;
+        }
+    }
+
+    private async Task TryMarkCompleteAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _stateStore.MarkCompleteAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            // The user already cancelled; let the outer catch propagate
+            // the original OCE.
+        }
+        catch (Exception)
+        {
+            // Failing to mark on a cancel path is a minor nuisance (one
+            // extra prompt next time), not worth surfacing on top of the
+            // cancellation the user just triggered.
         }
     }
 }

--- a/src/Func/Hosting/FirstRun/FirstRunCoordinator.cs
+++ b/src/Func/Hosting/FirstRun/FirstRunCoordinator.cs
@@ -36,16 +36,18 @@ internal sealed class FirstRunCoordinator(
     private const string BreadcrumbHint =
         "Tip: run `func setup` to install your dev environment and language stack dependencies.";
 
-    // Commands that should not trigger the first-run prompt or breadcrumb.
-    // We deliberately do NOT skip on "help" / "unknown" here: those are what
-    // the resolver returns for a bare `func` invocation, which is the
-    // canonical first-run trigger. Explicit `--help`/`-h` invocations are
-    // handled by the token check below. "version" stays because it only
+    // Top-level command segments that should not trigger the first-run prompt
+    // or breadcrumb. We deliberately do NOT skip on "help" / "unknown" here:
+    // those are what the resolver returns for a bare `func` invocation, which
+    // is the canonical first-run trigger. Explicit `--help`/`-h` invocations
+    // are handled by the token check below. "version" stays because it only
     // arises from `func --verbose` with no subcommand, which is a CLI-
-    // inspection gesture, not a real first command. `init` and `new` stay
-    // off the skip list intentionally; the spec wants the prompt there too.
-    private static readonly HashSet<string> _skippedCommandNames =
-        new(StringComparer.OrdinalIgnoreCase) { "setup", "version" };
+    // inspection gesture, not a real first command. "workload" covers every
+    // `func workload ...` subcommand: a user reaching for those is already
+    // managing their setup directly. `init` and `new` stay off the skip list
+    // intentionally; the spec wants the prompt there too.
+    private static readonly HashSet<string> _skippedRootCommands =
+        new(StringComparer.OrdinalIgnoreCase) { "setup", "version", "workload" };
 
     private static readonly HashSet<string> _skippedTokens =
         new(StringComparer.OrdinalIgnoreCase) { "--help", "-h", "-?", "/?", "--version", "-v" };
@@ -99,9 +101,14 @@ internal sealed class FirstRunCoordinator(
 
     private static bool IsSkipped(string commandName, ParseResult parseResult)
     {
-        if (commandName is not null && _skippedCommandNames.Contains(commandName))
+        if (!string.IsNullOrEmpty(commandName))
         {
-            return true;
+            int spaceIndex = commandName.IndexOf(' ');
+            string rootSegment = spaceIndex < 0 ? commandName : commandName[..spaceIndex];
+            if (_skippedRootCommands.Contains(rootSegment))
+            {
+                return true;
+            }
         }
 
         foreach (System.CommandLine.Parsing.Token token in parseResult.Tokens)

--- a/src/Func/Hosting/FirstRun/FirstRunCoordinator.cs
+++ b/src/Func/Hosting/FirstRun/FirstRunCoordinator.cs
@@ -44,7 +44,7 @@ internal sealed class FirstRunCoordinator(
     {
         ArgumentNullException.ThrowIfNull(parseResult);
 
-        if (!_stateStore.IsFirstRun())
+        if (!await _stateStore.IsFirstRunAsync(cancellationToken))
         {
             return;
         }

--- a/src/Func/Hosting/FirstRun/FirstRunCoordinator.cs
+++ b/src/Func/Hosting/FirstRun/FirstRunCoordinator.cs
@@ -52,14 +52,6 @@ internal sealed class FirstRunCoordinator(
     private static readonly HashSet<string> _skippedTokens =
         new(StringComparer.OrdinalIgnoreCase) { "--help", "-h", "-?", "/?", "--version", "-v" };
 
-    // Commands that need workload-aware metadata (templates, bundles) loaded
-    // at host build time. If we install workloads inside the first-run flow
-    // for one of these, the in-process loader is still pointing at the
-    // pre-install snapshot, so we ask the user to re-run instead of letting
-    // the original command fail in confusing ways.
-    private static readonly HashSet<string> _workloadDependentCommands =
-        new(StringComparer.OrdinalIgnoreCase) { "init", "new" };
-
     private readonly IInteractionService _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
     private readonly IFirstRunStateStore _stateStore = stateStore ?? throw new ArgumentNullException(nameof(stateStore));
     private readonly ISetupRunner _setupRunner = setupRunner ?? throw new ArgumentNullException(nameof(setupRunner));
@@ -170,11 +162,14 @@ internal sealed class FirstRunCoordinator(
 
         await _stateStore.MarkCompleteAsync(cancellationToken);
 
-        // The workload loader snapshots templates/bundles at host build
-        // time, so the in-process `init` / `new` flow won't see the
-        // freshly installed stacks. Ask the user to re-run instead of
-        // letting them hit a confusing "no templates found" error.
-        if (setupRan && commandName is not null && _workloadDependentCommands.Contains(commandName))
+        // After a successful setup we always short-circuit the user's original
+        // command. The workload loader snapshots templates/bundles/host metadata
+        // at host build time, so anything the user typed (init, new, run,
+        // start, quickstart, ...) is operating against the pre-install view
+        // and would either fail outright ("no project here") or silently use
+        // stale metadata. Asking them to re-run is the only safe answer until
+        // we add an in-process reload.
+        if (setupRan && !string.IsNullOrEmpty(commandName))
         {
             _interaction.WriteBlankLine();
             _interaction.WriteHint($"Setup complete. Re-run `func {commandName.ToLowerInvariant()}` to use the new stacks.");

--- a/src/Func/Hosting/FirstRun/FirstRunState.cs
+++ b/src/Func/Hosting/FirstRun/FirstRunState.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Hosting.FirstRun;
+
+/// <summary>
+/// Lifecycle states for the first-run experience. Computed from the marker
+/// file plus the installed workload registry.
+/// </summary>
+internal enum FirstRunState
+{
+    /// <summary>
+    /// No marker on disk and no installed workloads. The user should see
+    /// the first-run prompt.
+    /// </summary>
+    NeverPrompted = 0,
+
+    /// <summary>
+    /// Marker is present but no workloads are installed. Either the user
+    /// declined first-run setup, or they ran setup with an empty selection.
+    /// The user should see the muted breadcrumb hint on each command.
+    /// </summary>
+    MarkerWithoutWorkloads = 1,
+
+    /// <summary>
+    /// At least one workload is installed. The CLI is set up; no first-run
+    /// affordance is needed.
+    /// </summary>
+    WorkloadsInstalled = 2,
+}

--- a/src/Func/Hosting/FirstRun/IFirstRunCoordinator.cs
+++ b/src/Func/Hosting/FirstRun/IFirstRunCoordinator.cs
@@ -13,8 +13,11 @@ internal interface IFirstRunCoordinator
 {
     /// <summary>
     /// Offers to run setup when this looks like the user's first
-    /// invocation. Always returns once the prompt has been handled
-    /// (or skipped); the caller continues with the user's command.
+    /// invocation, or surfaces the muted breadcrumb hint when the user
+    /// has already opted out. Returns <c>null</c> when the caller should
+    /// continue with the user's command, or an exit code when the
+    /// coordinator handled the invocation itself (currently only used for
+    /// the post-setup "re-run `func init`" short-circuit).
     /// </summary>
-    public Task EnsureFirstRunPromptedAsync(string commandName, ParseResult parseResult, CancellationToken cancellationToken);
+    public Task<int?> EnsureFirstRunPromptedAsync(string commandName, ParseResult parseResult, CancellationToken cancellationToken);
 }

--- a/src/Func/Hosting/FirstRun/IFirstRunStateStore.cs
+++ b/src/Func/Hosting/FirstRun/IFirstRunStateStore.cs
@@ -14,9 +14,17 @@ internal interface IFirstRunStateStore
     /// Returns true when no first-run marker exists yet AND the user has no
     /// installed workloads, meaning the user has not yet been offered the
     /// setup prompt and has nothing on disk that would make the prompt
-    /// redundant.
+    /// redundant. Equivalent to
+    /// <c>GetStateAsync() == FirstRunState.NeverPrompted</c>.
     /// </summary>
     public Task<bool> IsFirstRunAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the current first-run lifecycle state so callers can pick
+    /// between the prompt, the breadcrumb hint, and silence in a single
+    /// read.
+    /// </summary>
+    public Task<FirstRunState> GetStateAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Records that the first-run prompt has been handled. Subsequent

--- a/src/Func/Hosting/FirstRun/IFirstRunStateStore.cs
+++ b/src/Func/Hosting/FirstRun/IFirstRunStateStore.cs
@@ -11,14 +11,16 @@ namespace Azure.Functions.Cli.Hosting.FirstRun;
 internal interface IFirstRunStateStore
 {
     /// <summary>
-    /// Returns true when no first-run marker exists yet, meaning the
-    /// user has not yet been offered the setup prompt.
+    /// Returns true when no first-run marker exists yet AND the user has no
+    /// installed workloads, meaning the user has not yet been offered the
+    /// setup prompt and has nothing on disk that would make the prompt
+    /// redundant.
     /// </summary>
-    public bool IsFirstRun();
+    public Task<bool> IsFirstRunAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Records that the first-run prompt has been handled. Subsequent
-    /// calls to <see cref="IsFirstRun"/> will return false.
+    /// calls to <see cref="IsFirstRunAsync"/> will return false.
     /// </summary>
     public Task MarkCompleteAsync(CancellationToken cancellationToken);
 }

--- a/src/Func/Program.cs
+++ b/src/Func/Program.cs
@@ -88,10 +88,16 @@ using (Activity? activity = CliTelemetry.Trace.StartCommandActivity())
         activity?.SetCommandName(commandName);
 
         IFirstRunCoordinator firstRunCoordinator = host.Services.GetRequiredService<IFirstRunCoordinator>();
-        await firstRunCoordinator.EnsureFirstRunPromptedAsync(commandName, commandParseResult, cts.Token);
-
-        var config = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
-        exitCode = await commandParseResult.InvokeAsync(config, cts.Token);
+        int? firstRunExitCode = await firstRunCoordinator.EnsureFirstRunPromptedAsync(commandName, commandParseResult, cts.Token);
+        if (firstRunExitCode is int firstRunResult)
+        {
+            exitCode = firstRunResult;
+        }
+        else
+        {
+            var config = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
+            exitCode = await commandParseResult.InvokeAsync(config, cts.Token);
+        }
     }
     catch (OperationCanceledException)
     {

--- a/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
+++ b/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
@@ -5,6 +5,8 @@ using System.Text.Json;
 using Azure.Functions.Cli.Bundles;
 using Azure.Functions.Cli.Commands.Setup;
 using Azure.Functions.Cli.Configuration;
+using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Hosting.FirstRun;
 using Azure.Functions.Cli.Profiles;
 using Azure.Functions.Cli.Workloads;
 using Azure.Functions.Cli.Workloads.Catalog;
@@ -609,6 +611,143 @@ public sealed class SetupRunnerTests : IDisposable
             Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task RunAsync_InteractiveEmptySelection_ExitsCleanlyWithSkippedHint()
+    {
+        FakeCatalog catalog = Catalog().WithLatest(_hostPackageId, "4.1.0");
+        EmptyPickInteractionService interactive = new();
+        SetupRunner runner = new(
+            interactive,
+            _store,
+            catalog,
+            _installer,
+            _profileCatalog,
+            new TestOptionsMonitor<ProjectProfileOptions>(new ProjectProfileOptions()),
+            new TestOptionsMonitor<UserProfilePreferenceOptions>(new UserProfilePreferenceOptions()),
+            new FakeCliConfigurationProvider(new Dictionary<string, string?>()),
+            _bundleReader);
+
+        SetupRunResult result = await runner.RunAsync(
+            new SetupCommandOptions(
+                new DirectoryInfo(_tempDir),
+                Features: [],
+                ProfileNames: [],
+                Source: null,
+                SetupInstallPolicy.LatestCompatible,
+                IncludePrerelease: false,
+                NonInteractive: false,
+                AssumeYes: true,
+                Check: false,
+                SetupOutputMode.Plain),
+            CancellationToken.None);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains(interactive.Lines, line => line.StartsWith("HINT:", StringComparison.Ordinal) && line.Contains("No stacks selected", StringComparison.Ordinal));
+        await _installer.DidNotReceiveWithAnyArgs().InstallFromCatalogAsync(default!, default, default, default, default, default, default, default);
+    }
+
+    [Fact]
+    public async Task RunAsync_InteractiveEmptyFolder_LabelsInstalledStacks()
+    {
+        const string nodeStack = "Azure.Functions.Cli.Workloads.Node";
+        FakeCatalog catalog = Catalog()
+            .WithLatest(_hostPackageId, "4.1.0")
+            .WithLatest(IInstalledBundleWorkloads.BundleWorkloadPackageId, "4.10.0")
+            .WithLatest(WorkerPackage("node"), "1.0.0")
+            .WithLatest(nodeStack, "1.0.0");
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>())
+            .Returns([Entry(nodeStack, "1.0.0")]);
+
+        InteractiveTestInteractionService interactive = new();
+        SetupRunner runner = new(
+            interactive,
+            _store,
+            catalog,
+            _installer,
+            _profileCatalog,
+            new TestOptionsMonitor<ProjectProfileOptions>(new ProjectProfileOptions()),
+            new TestOptionsMonitor<UserProfilePreferenceOptions>(new UserProfilePreferenceOptions()),
+            new FakeCliConfigurationProvider(new Dictionary<string, string?>()),
+            _bundleReader);
+
+        _ = await runner.RunAsync(
+            new SetupCommandOptions(
+                new DirectoryInfo(_tempDir),
+                Features: [],
+                ProfileNames: [],
+                Source: null,
+                SetupInstallPolicy.LatestCompatible,
+                IncludePrerelease: false,
+                NonInteractive: false,
+                AssumeYes: true,
+                Check: false,
+                SetupOutputMode.Plain),
+            CancellationToken.None);
+
+        Assert.Contains(interactive.Lines, line => line.StartsWith("MULTISELECT:", StringComparison.Ordinal) && line.Contains("node  (installed)", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task RunAsync_MarksFirstRunComplete_OnSuccess()
+    {
+        IFirstRunStateStore firstRunStore = Substitute.For<IFirstRunStateStore>();
+        FakeCatalog catalog = Catalog()
+            .WithLatest(_hostPackageId, "4.1.0")
+            .WithLatest(IInstalledBundleWorkloads.BundleWorkloadPackageId, "4.10.0");
+        SetupRunner runner = new(
+            _interaction,
+            _store,
+            catalog,
+            _installer,
+            _profileCatalog,
+            new TestOptionsMonitor<ProjectProfileOptions>(new ProjectProfileOptions()),
+            new TestOptionsMonitor<UserProfilePreferenceOptions>(new UserProfilePreferenceOptions()),
+            new FakeCliConfigurationProvider(new Dictionary<string, string?>()),
+            _bundleReader,
+            firstRunStore);
+
+        SetupRunResult result = await runner.RunAsync(Options(), CancellationToken.None);
+
+        Assert.Equal(0, result.ExitCode);
+        await firstRunStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunAsync_MarksFirstRunComplete_WhenInteractiveSelectionEmpty()
+    {
+        IFirstRunStateStore firstRunStore = Substitute.For<IFirstRunStateStore>();
+        EmptyPickInteractionService interactive = new();
+        FakeCatalog catalog = Catalog().WithLatest(_hostPackageId, "4.1.0");
+        SetupRunner runner = new(
+            interactive,
+            _store,
+            catalog,
+            _installer,
+            _profileCatalog,
+            new TestOptionsMonitor<ProjectProfileOptions>(new ProjectProfileOptions()),
+            new TestOptionsMonitor<UserProfilePreferenceOptions>(new UserProfilePreferenceOptions()),
+            new FakeCliConfigurationProvider(new Dictionary<string, string?>()),
+            _bundleReader,
+            firstRunStore);
+
+        SetupRunResult result = await runner.RunAsync(
+            new SetupCommandOptions(
+                new DirectoryInfo(_tempDir),
+                Features: [],
+                ProfileNames: [],
+                Source: null,
+                SetupInstallPolicy.LatestCompatible,
+                IncludePrerelease: false,
+                NonInteractive: false,
+                AssumeYes: true,
+                Check: false,
+                SetupOutputMode.Plain),
+            CancellationToken.None);
+
+        Assert.Equal(0, result.ExitCode);
+        await firstRunStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
+    }
+
     private SetupRunner CreateRunner(
         IWorkloadCatalog catalog,
         IReadOnlyDictionary<string, string?>? projectConfig = null,
@@ -790,6 +929,27 @@ public sealed class SetupRunnerTests : IDisposable
             string? first = picks.FirstOrDefault(c => string.Equals(c, "node", StringComparison.OrdinalIgnoreCase))
                 ?? picks.FirstOrDefault();
             return Task.FromResult<IReadOnlyList<string>>(first is null ? [] : [first]);
+        }
+
+        public override Task<IReadOnlyList<string>> PromptForMultiSelectionAsync(string title, IEnumerable<MultiSelectionChoice> choices, CancellationToken cancellationToken = default)
+        {
+            var picks = choices.ToList();
+            base.PromptForMultiSelectionAsync(title, picks, cancellationToken).GetAwaiter().GetResult();
+            MultiSelectionChoice? first = picks.FirstOrDefault(c => string.Equals(c.Value, "node", StringComparison.OrdinalIgnoreCase))
+                ?? picks.FirstOrDefault();
+            return Task.FromResult<IReadOnlyList<string>>(first is null ? [] : [first.Value]);
+        }
+    }
+
+    private sealed class EmptyPickInteractionService : TestInteractionService
+    {
+        public override bool IsInteractive => true;
+
+        public override Task<IReadOnlyList<string>> PromptForMultiSelectionAsync(string title, IEnumerable<MultiSelectionChoice> choices, CancellationToken cancellationToken = default)
+        {
+            var picks = choices.ToList();
+            base.PromptForMultiSelectionAsync(title, picks, cancellationToken).GetAwaiter().GetResult();
+            return Task.FromResult<IReadOnlyList<string>>([]);
         }
     }
 

--- a/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
+++ b/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
@@ -647,7 +647,7 @@ public sealed class SetupRunnerTests : IDisposable
     }
 
     [Fact]
-    public async Task RunAsync_InteractiveEmptyFolder_FiltersInstalledStacks_AndShowsAlreadyInstalledHint()
+    public async Task RunAsync_InteractiveEmptyFolder_RendersInstalledStacksAsDisabledChoices()
     {
         const string nodeStack = "Azure.Functions.Cli.Workloads.Node";
         FakeCatalog catalog = Catalog()
@@ -684,8 +684,11 @@ public sealed class SetupRunnerTests : IDisposable
                 SetupOutputMode.Plain),
             CancellationToken.None);
 
-        Assert.Contains(interactive.Lines, line => line.StartsWith("HINT:", StringComparison.Ordinal) && line.Contains("Already installed: node", StringComparison.Ordinal));
-        Assert.DoesNotContain(interactive.Lines, line => line.StartsWith("MULTISELECT:", StringComparison.Ordinal) && line.Contains("node", StringComparison.Ordinal));
+        // The stand-alone "Already installed: node" hint is gone; installed stacks
+        // now surface inline in the prompt as muted, read-only entries.
+        Assert.DoesNotContain(interactive.Lines, line => line.StartsWith("HINT:", StringComparison.Ordinal) && line.Contains("Already installed", StringComparison.Ordinal));
+        Assert.Contains(interactive.Lines, line => line.StartsWith("MULTISELECT:", StringComparison.Ordinal) && line.Contains("node (installed)", StringComparison.Ordinal));
+        Assert.Contains(interactive.MultiSelectionChoices, group => group.Any(c => c.Value == "node" && c.IsDisabled && c.IsPreselected));
     }
 
     [Fact]
@@ -936,8 +939,11 @@ public sealed class SetupRunnerTests : IDisposable
         {
             var picks = choices.ToList();
             base.PromptForMultiSelectionAsync(title, picks, cancellationToken).GetAwaiter().GetResult();
-            MultiSelectionChoice? first = picks.FirstOrDefault(c => string.Equals(c.Value, "node", StringComparison.OrdinalIgnoreCase))
-                ?? picks.FirstOrDefault();
+            // Mirror the Spectre service: disabled choices are read-only decoration
+            // and never appear in the user's selection.
+            List<MultiSelectionChoice> selectable = [.. picks.Where(c => !c.IsDisabled)];
+            MultiSelectionChoice? first = selectable.FirstOrDefault(c => string.Equals(c.Value, "node", StringComparison.OrdinalIgnoreCase))
+                ?? selectable.FirstOrDefault();
             return Task.FromResult<IReadOnlyList<string>>(first is null ? [] : [first.Value]);
         }
     }

--- a/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
+++ b/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
@@ -647,7 +647,7 @@ public sealed class SetupRunnerTests : IDisposable
     }
 
     [Fact]
-    public async Task RunAsync_InteractiveEmptyFolder_LabelsInstalledStacks()
+    public async Task RunAsync_InteractiveEmptyFolder_FiltersInstalledStacks_AndShowsAlreadyInstalledHint()
     {
         const string nodeStack = "Azure.Functions.Cli.Workloads.Node";
         FakeCatalog catalog = Catalog()
@@ -684,7 +684,8 @@ public sealed class SetupRunnerTests : IDisposable
                 SetupOutputMode.Plain),
             CancellationToken.None);
 
-        Assert.Contains(interactive.Lines, line => line.StartsWith("MULTISELECT:", StringComparison.Ordinal) && line.Contains("node  (installed)", StringComparison.Ordinal));
+        Assert.Contains(interactive.Lines, line => line.StartsWith("HINT:", StringComparison.Ordinal) && line.Contains("Already installed: node", StringComparison.Ordinal));
+        Assert.DoesNotContain(interactive.Lines, line => line.StartsWith("MULTISELECT:", StringComparison.Ordinal) && line.Contains("node", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
+++ b/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
@@ -647,7 +647,7 @@ public sealed class SetupRunnerTests : IDisposable
     }
 
     [Fact]
-    public async Task RunAsync_InteractiveEmptyFolder_RendersInstalledStacksAsDisabledChoices()
+    public async Task RunAsync_InteractiveEmptyFolder_RendersInstalledStacksAsStaticLines_AboveThePrompt()
     {
         const string nodeStack = "Azure.Functions.Cli.Workloads.Node";
         FakeCatalog catalog = Catalog()
@@ -684,11 +684,14 @@ public sealed class SetupRunnerTests : IDisposable
                 SetupOutputMode.Plain),
             CancellationToken.None);
 
-        // The stand-alone "Already installed: node" hint is gone; installed stacks
-        // now surface inline in the prompt as muted, read-only entries.
-        Assert.DoesNotContain(interactive.Lines, line => line.StartsWith("HINT:", StringComparison.Ordinal) && line.Contains("Already installed", StringComparison.Ordinal));
-        Assert.Contains(interactive.Lines, line => line.StartsWith("MULTISELECT:", StringComparison.Ordinal) && line.Contains("node (installed)", StringComparison.Ordinal));
-        Assert.Contains(interactive.MultiSelectionChoices, group => group.Any(c => c.Value == "node" && c.IsDisabled && c.IsPreselected));
+        // Installed stacks render as static "fake checkbox" lines above the
+        // prompt with the uninstall hint, and are kept out of the multi-select
+        // entirely so the user can't toggle them.
+        Assert.Contains(interactive.Lines, line => line.Contains("Already installed", StringComparison.Ordinal)
+            && line.Contains("func workload uninstall", StringComparison.Ordinal));
+        Assert.Contains(interactive.Lines, line => line.Contains("[✓] node", StringComparison.Ordinal));
+        Assert.DoesNotContain(interactive.Lines, line => line.StartsWith("MULTISELECT:", StringComparison.Ordinal) && line.Contains("node", StringComparison.Ordinal));
+        Assert.DoesNotContain(interactive.MultiSelectionChoices.SelectMany(g => g), c => c.Value == "node");
     }
 
     [Fact]
@@ -939,11 +942,8 @@ public sealed class SetupRunnerTests : IDisposable
         {
             var picks = choices.ToList();
             base.PromptForMultiSelectionAsync(title, picks, cancellationToken).GetAwaiter().GetResult();
-            // Mirror the Spectre service: disabled choices are read-only decoration
-            // and never appear in the user's selection.
-            List<MultiSelectionChoice> selectable = [.. picks.Where(c => !c.IsDisabled)];
-            MultiSelectionChoice? first = selectable.FirstOrDefault(c => string.Equals(c.Value, "node", StringComparison.OrdinalIgnoreCase))
-                ?? selectable.FirstOrDefault();
+            MultiSelectionChoice? first = picks.FirstOrDefault(c => string.Equals(c.Value, "node", StringComparison.OrdinalIgnoreCase))
+                ?? picks.FirstOrDefault();
             return Task.FromResult<IReadOnlyList<string>>(first is null ? [] : [first.Value]);
         }
     }

--- a/test/Func.Tests/Hosting/FirstRun/FileFirstRunStateStoreTests.cs
+++ b/test/Func.Tests/Hosting/FirstRun/FileFirstRunStateStoreTests.cs
@@ -3,6 +3,8 @@
 
 using Azure.Functions.Cli.Configuration;
 using Azure.Functions.Cli.Hosting.FirstRun;
+using Azure.Functions.Cli.Workloads.Storage;
+using NSubstitute;
 using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Hosting.FirstRun;
@@ -10,12 +12,16 @@ namespace Azure.Functions.Cli.Tests.Hosting.FirstRun;
 public sealed class FileFirstRunStateStoreTests : IDisposable
 {
     private readonly string _tempHome;
+    private readonly IWorkloadStore _workloadStore;
     private readonly FileFirstRunStateStore _store;
 
     public FileFirstRunStateStoreTests()
     {
         _tempHome = Path.Combine(Path.GetTempPath(), $"func-first-run-{Guid.NewGuid():N}");
-        _store = new FileFirstRunStateStore(new CliConfigurationPathsOptions(_tempHome));
+        _workloadStore = Substitute.For<IWorkloadStore>();
+        _workloadStore.GetWorkloadsAsync(Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<WorkloadEntry>());
+        _store = new FileFirstRunStateStore(new CliConfigurationPathsOptions(_tempHome), _workloadStore);
     }
 
     public void Dispose()
@@ -27,9 +33,18 @@ public sealed class FileFirstRunStateStoreTests : IDisposable
     }
 
     [Fact]
-    public void IsFirstRun_ReturnsTrue_WhenMarkerMissing()
+    public async Task IsFirstRunAsync_ReturnsTrue_WhenMarkerMissingAndNoWorkloads()
     {
-        Assert.True(_store.IsFirstRun());
+        Assert.True(await _store.IsFirstRunAsync());
+    }
+
+    [Fact]
+    public async Task IsFirstRunAsync_ReturnsFalse_WhenWorkloadsInstalled()
+    {
+        _workloadStore.GetWorkloadsAsync(Arg.Any<CancellationToken>())
+            .Returns(new[] { new WorkloadEntry { PackageId = "Azure.Functions.Cli.Workloads.Node", PackageVersion = "4.0.0" } });
+
+        Assert.False(await _store.IsFirstRunAsync());
     }
 
     [Fact]
@@ -37,7 +52,7 @@ public sealed class FileFirstRunStateStoreTests : IDisposable
     {
         await _store.MarkCompleteAsync(CancellationToken.None);
 
-        Assert.False(_store.IsFirstRun());
+        Assert.False(await _store.IsFirstRunAsync());
         Assert.True(File.Exists(Path.Combine(_tempHome, FileFirstRunStateStore.MarkerFileName)));
     }
 
@@ -54,6 +69,12 @@ public sealed class FileFirstRunStateStoreTests : IDisposable
     [Fact]
     public void Constructor_ThrowsArgumentNullException_ForNullPaths()
     {
-        Assert.Throws<ArgumentNullException>(() => new FileFirstRunStateStore(null!));
+        Assert.Throws<ArgumentNullException>(() => new FileFirstRunStateStore(null!, _workloadStore));
+    }
+
+    [Fact]
+    public void Constructor_ThrowsArgumentNullException_ForNullWorkloadStore()
+    {
+        Assert.Throws<ArgumentNullException>(() => new FileFirstRunStateStore(new CliConfigurationPathsOptions(_tempHome), null!));
     }
 }

--- a/test/Func.Tests/Hosting/FirstRun/FileFirstRunStateStoreTests.cs
+++ b/test/Func.Tests/Hosting/FirstRun/FileFirstRunStateStoreTests.cs
@@ -48,6 +48,32 @@ public sealed class FileFirstRunStateStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task GetStateAsync_ReturnsNeverPrompted_WhenMarkerMissingAndNoWorkloads()
+    {
+        Assert.Equal(FirstRunState.NeverPrompted, await _store.GetStateAsync());
+    }
+
+    [Fact]
+    public async Task GetStateAsync_ReturnsMarkerWithoutWorkloads_WhenMarkerExistsAndNoWorkloads()
+    {
+        await _store.MarkCompleteAsync(CancellationToken.None);
+
+        Assert.Equal(FirstRunState.MarkerWithoutWorkloads, await _store.GetStateAsync());
+    }
+
+    [Fact]
+    public async Task GetStateAsync_ReturnsWorkloadsInstalled_WhenWorkloadsPresent_RegardlessOfMarker()
+    {
+        _workloadStore.GetWorkloadsAsync(Arg.Any<CancellationToken>())
+            .Returns(new[] { new WorkloadEntry { PackageId = "Azure.Functions.Cli.Workloads.Node", PackageVersion = "4.0.0" } });
+
+        Assert.Equal(FirstRunState.WorkloadsInstalled, await _store.GetStateAsync());
+
+        await _store.MarkCompleteAsync(CancellationToken.None);
+        Assert.Equal(FirstRunState.WorkloadsInstalled, await _store.GetStateAsync());
+    }
+
+    [Fact]
     public async Task MarkCompleteAsync_CreatesMarker_AndIsFirstRunReturnsFalse()
     {
         await _store.MarkCompleteAsync(CancellationToken.None);

--- a/test/Func.Tests/Hosting/FirstRun/FileFirstRunStateStoreTests.cs
+++ b/test/Func.Tests/Hosting/FirstRun/FileFirstRunStateStoreTests.cs
@@ -4,7 +4,6 @@
 using Azure.Functions.Cli.Configuration;
 using Azure.Functions.Cli.Hosting.FirstRun;
 using Azure.Functions.Cli.Workloads.Storage;
-using NSubstitute;
 using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Hosting.FirstRun;
@@ -12,16 +11,16 @@ namespace Azure.Functions.Cli.Tests.Hosting.FirstRun;
 public sealed class FileFirstRunStateStoreTests : IDisposable
 {
     private readonly string _tempHome;
-    private readonly IWorkloadStore _workloadStore;
+    private readonly string _workloadHome;
+    private readonly WorkloadPathsOptions _workloadPaths;
     private readonly FileFirstRunStateStore _store;
 
     public FileFirstRunStateStoreTests()
     {
         _tempHome = Path.Combine(Path.GetTempPath(), $"func-first-run-{Guid.NewGuid():N}");
-        _workloadStore = Substitute.For<IWorkloadStore>();
-        _workloadStore.GetWorkloadsAsync(Arg.Any<CancellationToken>())
-            .Returns(Array.Empty<WorkloadEntry>());
-        _store = new FileFirstRunStateStore(new CliConfigurationPathsOptions(_tempHome), _workloadStore);
+        _workloadHome = Path.Combine(Path.GetTempPath(), $"func-first-run-workloads-{Guid.NewGuid():N}");
+        _workloadPaths = new WorkloadPathsOptions(_workloadHome);
+        _store = new FileFirstRunStateStore(new CliConfigurationPathsOptions(_tempHome), _workloadPaths);
     }
 
     public void Dispose()
@@ -29,6 +28,11 @@ public sealed class FileFirstRunStateStoreTests : IDisposable
         if (Directory.Exists(_tempHome))
         {
             Directory.Delete(_tempHome, recursive: true);
+        }
+
+        if (Directory.Exists(_workloadHome))
+        {
+            Directory.Delete(_workloadHome, recursive: true);
         }
     }
 
@@ -41,8 +45,7 @@ public sealed class FileFirstRunStateStoreTests : IDisposable
     [Fact]
     public async Task IsFirstRunAsync_ReturnsFalse_WhenWorkloadsInstalled()
     {
-        _workloadStore.GetWorkloadsAsync(Arg.Any<CancellationToken>())
-            .Returns(new[] { new WorkloadEntry { PackageId = "Azure.Functions.Cli.Workloads.Node", PackageVersion = "4.0.0" } });
+        WriteEmptyWorkloadRegistry();
 
         Assert.False(await _store.IsFirstRunAsync());
     }
@@ -64,8 +67,7 @@ public sealed class FileFirstRunStateStoreTests : IDisposable
     [Fact]
     public async Task GetStateAsync_ReturnsWorkloadsInstalled_WhenWorkloadsPresent_RegardlessOfMarker()
     {
-        _workloadStore.GetWorkloadsAsync(Arg.Any<CancellationToken>())
-            .Returns(new[] { new WorkloadEntry { PackageId = "Azure.Functions.Cli.Workloads.Node", PackageVersion = "4.0.0" } });
+        WriteEmptyWorkloadRegistry();
 
         Assert.Equal(FirstRunState.WorkloadsInstalled, await _store.GetStateAsync());
 
@@ -95,12 +97,18 @@ public sealed class FileFirstRunStateStoreTests : IDisposable
     [Fact]
     public void Constructor_ThrowsArgumentNullException_ForNullPaths()
     {
-        Assert.Throws<ArgumentNullException>(() => new FileFirstRunStateStore(null!, _workloadStore));
+        Assert.Throws<ArgumentNullException>(() => new FileFirstRunStateStore(null!, _workloadPaths));
     }
 
     [Fact]
-    public void Constructor_ThrowsArgumentNullException_ForNullWorkloadStore()
+    public void Constructor_ThrowsArgumentNullException_ForNullWorkloadPaths()
     {
         Assert.Throws<ArgumentNullException>(() => new FileFirstRunStateStore(new CliConfigurationPathsOptions(_tempHome), null!));
+    }
+
+    private void WriteEmptyWorkloadRegistry()
+    {
+        Directory.CreateDirectory(_workloadHome);
+        File.WriteAllText(_workloadPaths.WorkloadRegistryPath, "{}");
     }
 }

--- a/test/Func.Tests/Hosting/FirstRun/FirstRunCoordinatorTests.cs
+++ b/test/Func.Tests/Hosting/FirstRun/FirstRunCoordinatorTests.cs
@@ -151,8 +151,11 @@ public sealed class FirstRunCoordinatorTests
             () => coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), cts.Token));
 
         // Ctrl+C at the prompt should still write the marker so the user
-        // is not re-prompted next time.
-        await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
+        // is not re-prompted next time. The token passed to MarkCompleteAsync
+        // must NOT be the cancelled one, otherwise the real file-backed
+        // store's File.WriteAllTextAsync would throw and the marker would
+        // never land on disk.
+        await _stateStore.Received(1).MarkCompleteAsync(Arg.Is<CancellationToken>(t => !t.IsCancellationRequested));
     }
 
     [Fact]

--- a/test/Func.Tests/Hosting/FirstRun/FirstRunCoordinatorTests.cs
+++ b/test/Func.Tests/Hosting/FirstRun/FirstRunCoordinatorTests.cs
@@ -19,14 +19,20 @@ public sealed class FirstRunCoordinatorTests
     private readonly ISetupRunner _setupRunner = Substitute.For<ISetupRunner>();
     private readonly PromptingInteractionService _interaction = new();
 
-    [Fact]
-    public async Task SkipsAndDoesNotMark_WhenAlreadyComplete()
+    public FirstRunCoordinatorTests()
     {
-        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(false);
+        _stateStore.GetStateAsync(Arg.Any<CancellationToken>()).Returns(FirstRunState.NeverPrompted);
+    }
+
+    [Fact]
+    public async Task SkipsAndDoesNotMark_WhenWorkloadsInstalled()
+    {
+        _stateStore.GetStateAsync(Arg.Any<CancellationToken>()).Returns(FirstRunState.WorkloadsInstalled);
         FirstRunCoordinator coordinator = CreateCoordinator();
 
-        await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
+        int? result = await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
 
+        Assert.Null(result);
         Assert.Equal(0, _interaction.ConfirmCalls);
         await _setupRunner.DidNotReceiveWithAnyArgs().RunAsync(default!, default);
         await _stateStore.DidNotReceiveWithAnyArgs().MarkCompleteAsync(default);
@@ -35,12 +41,12 @@ public sealed class FirstRunCoordinatorTests
     [Fact]
     public async Task SkipsAndDoesNotMark_WhenNonInteractive()
     {
-        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(true);
         _interaction.InteractiveOverride = false;
         FirstRunCoordinator coordinator = CreateCoordinator();
 
-        await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
+        int? result = await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
 
+        Assert.Null(result);
         Assert.Equal(0, _interaction.ConfirmCalls);
         await _setupRunner.DidNotReceiveWithAnyArgs().RunAsync(default!, default);
         await _stateStore.DidNotReceiveWithAnyArgs().MarkCompleteAsync(default);
@@ -51,11 +57,11 @@ public sealed class FirstRunCoordinatorTests
     [InlineData("version")]
     public async Task SkipsAndDoesNotMark_ForExcludedCommands(string commandName)
     {
-        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(true);
         FirstRunCoordinator coordinator = CreateCoordinator();
 
-        await coordinator.EnsureFirstRunPromptedAsync(commandName, Parse(commandName), CancellationToken.None);
+        int? result = await coordinator.EnsureFirstRunPromptedAsync(commandName, Parse(commandName), CancellationToken.None);
 
+        Assert.Null(result);
         Assert.Equal(0, _interaction.ConfirmCalls);
         await _stateStore.DidNotReceiveWithAnyArgs().MarkCompleteAsync(default);
     }
@@ -67,11 +73,11 @@ public sealed class FirstRunCoordinatorTests
     [InlineData("-v")]
     public async Task SkipsAndDoesNotMark_WhenHelpOrVersionTokenPresent(string token)
     {
-        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(true);
         FirstRunCoordinator coordinator = CreateCoordinator();
 
-        await coordinator.EnsureFirstRunPromptedAsync("start", Parse($"start {token}"), CancellationToken.None);
+        int? result = await coordinator.EnsureFirstRunPromptedAsync("start", Parse($"start {token}"), CancellationToken.None);
 
+        Assert.Null(result);
         Assert.Equal(0, _interaction.ConfirmCalls);
         await _stateStore.DidNotReceiveWithAnyArgs().MarkCompleteAsync(default);
     }
@@ -82,12 +88,12 @@ public sealed class FirstRunCoordinatorTests
         // Bare `func` produces a "Required command was not provided" parse
         // error and the resolver labels it "unknown", but it's the canonical
         // first-run trigger and must still prompt.
-        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(true);
         _interaction.ConfirmResponse = false;
         FirstRunCoordinator coordinator = CreateCoordinator();
 
-        await coordinator.EnsureFirstRunPromptedAsync("unknown", Parse(string.Empty), CancellationToken.None);
+        int? result = await coordinator.EnsureFirstRunPromptedAsync("unknown", Parse(string.Empty), CancellationToken.None);
 
+        Assert.Null(result);
         Assert.Equal(1, _interaction.ConfirmCalls);
         await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
     }
@@ -95,13 +101,11 @@ public sealed class FirstRunCoordinatorTests
     [Fact]
     public async Task SkipsAndDoesNotMark_WhenParseHasErrorsAndTokensPresent()
     {
-        // A typo like `func startt` produces tokens and parse errors; we stay
-        // quiet until the user fixes the command line.
-        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(true);
         FirstRunCoordinator coordinator = CreateCoordinator();
 
-        await coordinator.EnsureFirstRunPromptedAsync("unknown", Parse("startt"), CancellationToken.None);
+        int? result = await coordinator.EnsureFirstRunPromptedAsync("unknown", Parse("startt"), CancellationToken.None);
 
+        Assert.Null(result);
         Assert.Equal(0, _interaction.ConfirmCalls);
         await _stateStore.DidNotReceiveWithAnyArgs().MarkCompleteAsync(default);
     }
@@ -109,14 +113,14 @@ public sealed class FirstRunCoordinatorTests
     [Fact]
     public async Task RunsSetupAndMarks_WhenUserConfirms()
     {
-        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(true);
         _interaction.ConfirmResponse = true;
         _setupRunner.RunAsync(Arg.Any<SetupCommandOptions>(), Arg.Any<CancellationToken>())
             .Returns(new SetupRunResult(0));
         FirstRunCoordinator coordinator = CreateCoordinator();
 
-        await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
+        int? result = await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
 
+        Assert.Null(result);
         Assert.Equal(1, _interaction.ConfirmCalls);
         await _setupRunner.Received(1).RunAsync(Arg.Any<SetupCommandOptions>(), Arg.Any<CancellationToken>());
         await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
@@ -125,21 +129,20 @@ public sealed class FirstRunCoordinatorTests
     [Fact]
     public async Task SkipsSetupButMarks_WhenUserDeclines()
     {
-        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(true);
         _interaction.ConfirmResponse = false;
         FirstRunCoordinator coordinator = CreateCoordinator();
 
-        await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
+        int? result = await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
 
+        Assert.Null(result);
         Assert.Equal(1, _interaction.ConfirmCalls);
         await _setupRunner.DidNotReceiveWithAnyArgs().RunAsync(default!, default);
         await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task PropagatesCancellation_FromPrompt()
+    public async Task PropagatesCancellation_FromPrompt_AndWritesMarker()
     {
-        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(true);
         var cts = new CancellationTokenSource();
         cts.Cancel();
         FirstRunCoordinator coordinator = CreateCoordinator();
@@ -147,22 +150,107 @@ public sealed class FirstRunCoordinatorTests
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
             () => coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), cts.Token));
 
-        await _stateStore.DidNotReceiveWithAnyArgs().MarkCompleteAsync(default);
+        // Ctrl+C at the prompt should still write the marker so the user
+        // is not re-prompted next time.
+        await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task SetupFailureIsSwallowed_ButMarkerStillWritten()
     {
-        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(true);
         _interaction.ConfirmResponse = true;
         _setupRunner.RunAsync(Arg.Any<SetupCommandOptions>(), Arg.Any<CancellationToken>())
             .Returns<Task<SetupRunResult>>(_ => throw new InvalidOperationException("boom"));
         FirstRunCoordinator coordinator = CreateCoordinator();
 
-        await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
+        int? result = await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
 
+        Assert.Null(result);
         Assert.Contains(_interaction.Lines, l => l.StartsWith("WARNING:", StringComparison.Ordinal) && l.Contains("boom"));
         await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("init")]
+    [InlineData("new")]
+    public async Task ShortCircuitsWithReRunHint_AfterSetupForInitOrNew(string commandName)
+    {
+        _interaction.ConfirmResponse = true;
+        _setupRunner.RunAsync(Arg.Any<SetupCommandOptions>(), Arg.Any<CancellationToken>())
+            .Returns(new SetupRunResult(0));
+        FirstRunCoordinator coordinator = CreateCoordinator();
+
+        int? result = await coordinator.EnsureFirstRunPromptedAsync(commandName, Parse(commandName), CancellationToken.None);
+
+        Assert.Equal(0, result);
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("HINT:", StringComparison.Ordinal) && l.Contains($"Re-run `func {commandName}`"));
+        await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DoesNotShortCircuit_WhenInitDeclinesSetup()
+    {
+        _interaction.ConfirmResponse = false;
+        FirstRunCoordinator coordinator = CreateCoordinator();
+
+        int? result = await coordinator.EnsureFirstRunPromptedAsync("init", Parse("init"), CancellationToken.None);
+
+        Assert.Null(result);
+        await _setupRunner.DidNotReceiveWithAnyArgs().RunAsync(default!, default);
+        await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DoesNotShortCircuit_WhenInitSetupFails()
+    {
+        _interaction.ConfirmResponse = true;
+        _setupRunner.RunAsync(Arg.Any<SetupCommandOptions>(), Arg.Any<CancellationToken>())
+            .Returns(new SetupRunResult(1));
+        FirstRunCoordinator coordinator = CreateCoordinator();
+
+        int? result = await coordinator.EnsureFirstRunPromptedAsync("init", Parse("init"), CancellationToken.None);
+
+        Assert.Null(result);
+        await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ShowsBreadcrumb_WhenMarkerPresentButNoWorkloads()
+    {
+        _stateStore.GetStateAsync(Arg.Any<CancellationToken>()).Returns(FirstRunState.MarkerWithoutWorkloads);
+        FirstRunCoordinator coordinator = CreateCoordinator();
+
+        int? result = await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
+
+        Assert.Null(result);
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("HINT:", StringComparison.Ordinal) && l.Contains("`func setup`"));
+        Assert.Equal(0, _interaction.ConfirmCalls);
+        await _stateStore.DidNotReceiveWithAnyArgs().MarkCompleteAsync(default);
+    }
+
+    [Fact]
+    public async Task DoesNotShowBreadcrumb_ForSkippedCommands()
+    {
+        _stateStore.GetStateAsync(Arg.Any<CancellationToken>()).Returns(FirstRunState.MarkerWithoutWorkloads);
+        FirstRunCoordinator coordinator = CreateCoordinator();
+
+        int? result = await coordinator.EnsureFirstRunPromptedAsync("setup", Parse("setup"), CancellationToken.None);
+
+        Assert.Null(result);
+        Assert.DoesNotContain(_interaction.Lines, l => l.Contains("`func setup`"));
+    }
+
+    [Fact]
+    public async Task DoesNotShowBreadcrumb_WhenNonInteractive()
+    {
+        _stateStore.GetStateAsync(Arg.Any<CancellationToken>()).Returns(FirstRunState.MarkerWithoutWorkloads);
+        _interaction.InteractiveOverride = false;
+        FirstRunCoordinator coordinator = CreateCoordinator();
+
+        int? result = await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
+
+        Assert.Null(result);
+        Assert.DoesNotContain(_interaction.Lines, l => l.Contains("`func setup`"));
     }
 
     private FirstRunCoordinator CreateCoordinator() => new(_interaction, _stateStore, _setupRunner);
@@ -176,6 +264,8 @@ public sealed class FirstRunCoordinatorTests
         root.Subcommands.Add(new Command("help"));
         root.Subcommands.Add(new Command("version"));
         root.Subcommands.Add(new Command("start"));
+        root.Subcommands.Add(new Command("init"));
+        root.Subcommands.Add(new Command("new"));
 
         return root.Parse(args);
     }

--- a/test/Func.Tests/Hosting/FirstRun/FirstRunCoordinatorTests.cs
+++ b/test/Func.Tests/Hosting/FirstRun/FirstRunCoordinatorTests.cs
@@ -22,7 +22,7 @@ public sealed class FirstRunCoordinatorTests
     [Fact]
     public async Task SkipsAndDoesNotMark_WhenAlreadyComplete()
     {
-        _stateStore.IsFirstRun().Returns(false);
+        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(false);
         FirstRunCoordinator coordinator = CreateCoordinator();
 
         await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
@@ -35,7 +35,7 @@ public sealed class FirstRunCoordinatorTests
     [Fact]
     public async Task SkipsAndDoesNotMark_WhenNonInteractive()
     {
-        _stateStore.IsFirstRun().Returns(true);
+        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(true);
         _interaction.InteractiveOverride = false;
         FirstRunCoordinator coordinator = CreateCoordinator();
 
@@ -51,7 +51,7 @@ public sealed class FirstRunCoordinatorTests
     [InlineData("version")]
     public async Task SkipsAndDoesNotMark_ForExcludedCommands(string commandName)
     {
-        _stateStore.IsFirstRun().Returns(true);
+        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(true);
         FirstRunCoordinator coordinator = CreateCoordinator();
 
         await coordinator.EnsureFirstRunPromptedAsync(commandName, Parse(commandName), CancellationToken.None);
@@ -67,7 +67,7 @@ public sealed class FirstRunCoordinatorTests
     [InlineData("-v")]
     public async Task SkipsAndDoesNotMark_WhenHelpOrVersionTokenPresent(string token)
     {
-        _stateStore.IsFirstRun().Returns(true);
+        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(true);
         FirstRunCoordinator coordinator = CreateCoordinator();
 
         await coordinator.EnsureFirstRunPromptedAsync("start", Parse($"start {token}"), CancellationToken.None);
@@ -82,7 +82,7 @@ public sealed class FirstRunCoordinatorTests
         // Bare `func` produces a "Required command was not provided" parse
         // error and the resolver labels it "unknown", but it's the canonical
         // first-run trigger and must still prompt.
-        _stateStore.IsFirstRun().Returns(true);
+        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(true);
         _interaction.ConfirmResponse = false;
         FirstRunCoordinator coordinator = CreateCoordinator();
 
@@ -97,7 +97,7 @@ public sealed class FirstRunCoordinatorTests
     {
         // A typo like `func startt` produces tokens and parse errors; we stay
         // quiet until the user fixes the command line.
-        _stateStore.IsFirstRun().Returns(true);
+        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(true);
         FirstRunCoordinator coordinator = CreateCoordinator();
 
         await coordinator.EnsureFirstRunPromptedAsync("unknown", Parse("startt"), CancellationToken.None);
@@ -109,7 +109,7 @@ public sealed class FirstRunCoordinatorTests
     [Fact]
     public async Task RunsSetupAndMarks_WhenUserConfirms()
     {
-        _stateStore.IsFirstRun().Returns(true);
+        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(true);
         _interaction.ConfirmResponse = true;
         _setupRunner.RunAsync(Arg.Any<SetupCommandOptions>(), Arg.Any<CancellationToken>())
             .Returns(new SetupRunResult(0));
@@ -125,7 +125,7 @@ public sealed class FirstRunCoordinatorTests
     [Fact]
     public async Task SkipsSetupButMarks_WhenUserDeclines()
     {
-        _stateStore.IsFirstRun().Returns(true);
+        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(true);
         _interaction.ConfirmResponse = false;
         FirstRunCoordinator coordinator = CreateCoordinator();
 
@@ -139,7 +139,7 @@ public sealed class FirstRunCoordinatorTests
     [Fact]
     public async Task PropagatesCancellation_FromPrompt()
     {
-        _stateStore.IsFirstRun().Returns(true);
+        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(true);
         var cts = new CancellationTokenSource();
         cts.Cancel();
         FirstRunCoordinator coordinator = CreateCoordinator();
@@ -153,7 +153,7 @@ public sealed class FirstRunCoordinatorTests
     [Fact]
     public async Task SetupFailureIsSwallowed_ButMarkerStillWritten()
     {
-        _stateStore.IsFirstRun().Returns(true);
+        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(true);
         _interaction.ConfirmResponse = true;
         _setupRunner.RunAsync(Arg.Any<SetupCommandOptions>(), Arg.Any<CancellationToken>())
             .Returns<Task<SetupRunResult>>(_ => throw new InvalidOperationException("boom"));
@@ -248,6 +248,9 @@ public sealed class FirstRunCoordinatorTests
             => Task.FromResult(string.Empty);
 
         public Task<IReadOnlyList<string>> PromptForMultiSelectionAsync(string title, IEnumerable<string> choices, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<string>>([]);
+
+        public Task<IReadOnlyList<string>> PromptForMultiSelectionAsync(string title, IEnumerable<MultiSelectionChoice> choices, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<string>>([]);
 
         public Task<string> PromptForInputAsync(string prompt, string? defaultValue = null, CancellationToken cancellationToken = default)

--- a/test/Func.Tests/Hosting/FirstRun/FirstRunCoordinatorTests.cs
+++ b/test/Func.Tests/Hosting/FirstRun/FirstRunCoordinatorTests.cs
@@ -203,6 +203,26 @@ public sealed class FirstRunCoordinatorTests
         await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
     }
 
+    [Theory]
+    [InlineData("help")]
+    [InlineData("unknown")]
+    public async Task ShortCircuitsWithGenericHint_AfterSuccessfulSetup_ForSentinelCommandNames(string commandName)
+    {
+        _interaction.ConfirmResponse = true;
+        _setupRunner.RunAsync(Arg.Any<SetupCommandOptions>(), Arg.Any<CancellationToken>())
+            .Returns(new SetupRunResult(0));
+        FirstRunCoordinator coordinator = CreateCoordinator();
+
+        // Sentinel names come from bare/unparseable invocations, so pass an
+        // empty parse result rather than parsing the sentinel as a token.
+        int? result = await coordinator.EnsureFirstRunPromptedAsync(commandName, Parse(string.Empty), CancellationToken.None);
+
+        Assert.Equal(0, result);
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("HINT:", StringComparison.Ordinal) && l.Contains("Run `func <command>`"));
+        Assert.DoesNotContain(_interaction.Lines, l => l.Contains($"Re-run `func {commandName}`"));
+        await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
+    }
+
     [Fact]
     public async Task DoesNotShortCircuit_WhenInitDeclinesSetup()
     {

--- a/test/Func.Tests/Hosting/FirstRun/FirstRunCoordinatorTests.cs
+++ b/test/Func.Tests/Hosting/FirstRun/FirstRunCoordinatorTests.cs
@@ -55,6 +55,12 @@ public sealed class FirstRunCoordinatorTests
     [Theory]
     [InlineData("setup")]
     [InlineData("version")]
+    [InlineData("workload")]
+    [InlineData("workload install")]
+    [InlineData("workload list")]
+    [InlineData("workload search")]
+    [InlineData("workload update")]
+    [InlineData("workload uninstall")]
     public async Task SkipsAndDoesNotMark_ForExcludedCommands(string commandName)
     {
         FirstRunCoordinator coordinator = CreateCoordinator();

--- a/test/Func.Tests/Hosting/FirstRun/FirstRunCoordinatorTests.cs
+++ b/test/Func.Tests/Hosting/FirstRun/FirstRunCoordinatorTests.cs
@@ -126,7 +126,11 @@ public sealed class FirstRunCoordinatorTests
 
         int? result = await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
 
-        Assert.Null(result);
+        // After a successful setup we always short-circuit the user's command,
+        // regardless of which one they typed, because the workload loader
+        // snapshot is stale until the next process.
+        Assert.Equal(0, result);
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("HINT:", StringComparison.Ordinal) && l.Contains("Re-run `func start`"));
         Assert.Equal(1, _interaction.ConfirmCalls);
         await _setupRunner.Received(1).RunAsync(Arg.Any<SetupCommandOptions>(), Arg.Any<CancellationToken>());
         await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
@@ -182,7 +186,10 @@ public sealed class FirstRunCoordinatorTests
     [Theory]
     [InlineData("init")]
     [InlineData("new")]
-    public async Task ShortCircuitsWithReRunHint_AfterSetupForInitOrNew(string commandName)
+    [InlineData("start")]
+    [InlineData("run")]
+    [InlineData("quickstart")]
+    public async Task ShortCircuitsWithReRunHint_AfterSuccessfulSetup(string commandName)
     {
         _interaction.ConfirmResponse = true;
         _setupRunner.RunAsync(Arg.Any<SetupCommandOptions>(), Arg.Any<CancellationToken>())
@@ -275,6 +282,8 @@ public sealed class FirstRunCoordinatorTests
         root.Subcommands.Add(new Command("start"));
         root.Subcommands.Add(new Command("init"));
         root.Subcommands.Add(new Command("new"));
+        root.Subcommands.Add(new Command("run"));
+        root.Subcommands.Add(new Command("quickstart"));
 
         return root.Parse(args);
     }

--- a/test/Func.Tests/TestInteractionService.cs
+++ b/test/Func.Tests/TestInteractionService.cs
@@ -152,10 +152,13 @@ internal class TestInteractionService : IInteractionService
     {
         cancellationToken.ThrowIfCancellationRequested();
         var choiceList = choices.ToList();
+        MultiSelectionChoices.Add(choiceList);
         // Capture the label so tests can assert on the decorated text (e.g. "(installed)").
         _lines.Add($"MULTISELECT: {title} [{string.Join(", ", choiceList.Select(c => c.Label))}]");
         return Task.FromResult<IReadOnlyList<string>>([]);
     }
+
+    public List<IReadOnlyList<MultiSelectionChoice>> MultiSelectionChoices { get; } = [];
 
     public Task<string> PromptForInputAsync(string prompt, string? defaultValue = null, CancellationToken cancellationToken = default)
     {

--- a/test/Func.Tests/TestInteractionService.cs
+++ b/test/Func.Tests/TestInteractionService.cs
@@ -148,6 +148,15 @@ internal class TestInteractionService : IInteractionService
         return Task.FromResult<IReadOnlyList<string>>([]);
     }
 
+    public virtual Task<IReadOnlyList<string>> PromptForMultiSelectionAsync(string title, IEnumerable<MultiSelectionChoice> choices, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var choiceList = choices.ToList();
+        // Capture the label so tests can assert on the decorated text (e.g. "(installed)").
+        _lines.Add($"MULTISELECT: {title} [{string.Join(", ", choiceList.Select(c => c.Label))}]");
+        return Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
     public Task<string> PromptForInputAsync(string prompt, string? defaultValue = null, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
Implements the first-run experience documented in
[`docs/first-run-experience.md`](docs/first-run-experience.md). The spec
itself is added as part of this PR; treat the doc as the source of truth
for behavior.

## What the user sees

- **First-time use.** On the user's first invocation (including bare
  `func`), the CLI shows a multi-paragraph explanation of the new
  workload model and asks `Run \`func setup\` now? [Y/n]`. Yes runs
  setup inline; No writes a marker and continues; Ctrl+C writes the
  marker and aborts.
- **`func setup` interactive selection.** Multi-select shows the stacks
  that are not already installed. When some stacks are already
  installed, a single muted `Already installed: node, python` line
  surfaces above the prompt. Empty selection is a clean opt-out: marker
  written, hint shown, exit 0.
- **`func init` / `func new` first-run.** The prompt fires, setup runs
  inline, and the coordinator short-circuits with
  `Setup complete. Re-run \`func init\` to use the new stacks.` so the
  user does not hit a confusing "no templates found" error from the
  cached workload loader. A proper in-process reload is tracked as
  follow-up work.
- **Subsequent runs after declining.** When the marker is present but
  no workloads are installed, every non-skipped command shows one muted
  line: `Tip: run \`func setup\` to install your dev environment and
  language stack dependencies.` Suppressed in non-interactive contexts.
- **Always-skipped surfaces.** `func setup`, `func --help` / `-h` /
  `--version` / `-v`, and parse-error invocations stay quiet.

## State

- Marker file: `~/.azure-functions/.first-run-complete` (override via
  `FUNC_HOME`). Presence is the signal; contents are informational.
- Workload registry: `~/.azure-functions/workloads.json` via
  `IWorkloadStore`.

A user is first-run only when **both** the marker is missing and the
workload registry is empty. The workload-aware check covers users who
installed workloads through `func workload install` or an earlier setup
before the marker existed.

## Type / API changes

- `IFirstRunStateStore` is async (`IsFirstRunAsync`) and gains
  `GetStateAsync` returning `FirstRunState` (`NeverPrompted`,
  `MarkerWithoutWorkloads`, `WorkloadsInstalled`). The coordinator
  picks between prompt, breadcrumb, and silent in one read.
- `IFirstRunCoordinator.EnsureFirstRunPromptedAsync` now returns
  `Task<int?>`. `null` means "continue with the user's command"; a
  value means the coordinator handled it (currently only used for the
  post-setup re-run hint on `init` / `new`, which returns `0`).
- `FileFirstRunStateStore` takes an `IWorkloadStore` and writes the
  marker on every terminal setup outcome that did not fail mid-install
  (success, opt-out, partial install with `--check`). Real install
  failures leave the marker unwritten so the user is re-prompted next
  time.

## Notes on the deferred workload loader reload

`IWorkloadStore.GetWorkloadsAsync` reads `workloads.json` fresh on every
call, but templates / bundles adapters snapshot workload metadata at
host build time. Auditing every consumer is out of scope here; the
documented fallback (re-run hint for `init` / `new`) is the path taken.
A follow-up issue should be filed for the in-process reload work.

## Tests

- Unit coverage in `FirstRunCoordinatorTests`, `FileFirstRunStateStoreTests`,
  and `SetupRunnerTests` for every behavior listed above (prompt,
  breadcrumb, Ctrl+C marker, init/new short-circuit, installed-stack
  filtering, skip list, non-interactive suppression).
- Local: 990 passed, 0 failed. Release build with
  `TreatWarningsAsErrors`: 0 warnings.

## Docs

`docs/first-run-experience.md` is the source of truth for the behavior
above. The "Implementation status" table at the bottom tracks which
items shipped here and which are deferred (loader reload).