### PR TITLE
enhancement: surface func setup hints

### DIFF
--- a/src/Func/Bundles/BundleHintBuilder.cs
+++ b/src/Func/Bundles/BundleHintBuilder.cs
@@ -3,22 +3,26 @@
 
 using System.Globalization;
 using System.Text;
+using Azure.Functions.Cli.Commands.Setup;
 
 namespace Azure.Functions.Cli.Bundles;
 
 /// <summary>
-
 /// Builds the user-facing <c>Hint</c> strings surfaced in resolver failures.
-
 /// </summary>
 internal static class BundleHintBuilder
 {
     private const string InstallCommandPrefix =
         $"func workload install {IInstalledBundleWorkloads.BundleWorkloadPackageId}";
 
-    public static string WorkloadMissing() =>
-        "host.json declares an extensionBundle but no bundles workload is installed. Install one with:" + Environment.NewLine +
-        $"  {InstallCommandPrefix}@<version>";
+    public static string WorkloadMissing(string? workerRuntime = null)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("host.json declares an extensionBundle but no bundles workload is installed. Install one with:");
+        sb.Append(CultureInfo.InvariantCulture, $"  {InstallCommandPrefix}@<version>");
+        AppendSetupHint(sb, workerRuntime);
+        return sb.ToString();
+    }
 
     public static string EmptyIntersection(
         string bundleId,
@@ -50,7 +54,8 @@ internal static class BundleHintBuilder
         string bundleId,
         string constraintRange,
         IReadOnlyList<string> installedVersions,
-        string? suggestedVersion)
+        string? suggestedVersion,
+        string? workerRuntime = null)
     {
         var sb = new StringBuilder();
         sb.AppendLine(CultureInfo.InvariantCulture,
@@ -70,6 +75,24 @@ internal static class BundleHintBuilder
             sb.Append(CultureInfo.InvariantCulture, $"  {InstallCommandPrefix}@{suggestedVersion} --force");
         }
 
+        AppendSetupHint(sb, workerRuntime);
         return sb.ToString();
+    }
+
+    // EmptyIntersection is intentionally left without a `func setup` hint: it
+    // signals a host.json/profile range mismatch, not a missing install, so the
+    // remediation is to edit host.json or pick a different profile rather than
+    // run `func setup`.
+    private static void AppendSetupHint(StringBuilder sb, string? workerRuntime)
+    {
+        if (!SetupFeatureCatalog.TryGetFeatureForRuntime(workerRuntime, out string feature))
+        {
+            return;
+        }
+
+        sb.AppendLine();
+        sb.AppendLine();
+        sb.Append(CultureInfo.InvariantCulture,
+            $"Or run 'func setup --features {feature}' to install the full {feature} dev environment (host, worker, stack, templates, bundle).");
     }
 }

--- a/src/Func/Bundles/ExtensionBundleResolver.cs
+++ b/src/Func/Bundles/ExtensionBundleResolver.cs
@@ -32,7 +32,7 @@ internal sealed class ExtensionBundleResolver(
         if (scan.TotalInstalledRows == 0)
         {
             return Record(context, context.HostJsonVersionRange,
-                new ExtensionBundleResolution.WorkloadMissing(BundleHintBuilder.WorkloadMissing()),
+                new ExtensionBundleResolution.WorkloadMissing(BundleHintBuilder.WorkloadMissing(context.WorkerRuntime)),
                 sw);
         }
 
@@ -88,7 +88,7 @@ internal sealed class ExtensionBundleResolver(
     {
         IReadOnlyList<string> installedVersions = [.. installed.Select(b => b.Version.ToNormalizedString())];
         string? suggested = installedVersions.FirstOrDefault();
-        string hint = BundleHintBuilder.NoCompatibleInstall(context.BundleId, constraintRange, installedVersions, suggested);
+        string hint = BundleHintBuilder.NoCompatibleInstall(context.BundleId, constraintRange, installedVersions, suggested, context.WorkerRuntime);
 
         return new ExtensionBundleResolution.NoCompatibleInstall(constraintRange, installedVersions, hint);
     }

--- a/src/Func/Commands/Setup/SetupCommand.cs
+++ b/src/Func/Commands/Setup/SetupCommand.cs
@@ -72,7 +72,11 @@ internal sealed class SetupCommand : FuncCliCommand, IBuiltInCommand
     private readonly ISetupRunner _runner;
 
     public SetupCommand(ISetupRunner runner)
-        : base("setup", "Prepare local Azure Functions dependencies.")
+        : base(
+            "setup",
+            "Prepare local Azure Functions CLI dependencies. "
+            + "Installs everything needed to develop and run a Functions app for the chosen stack(s) (host, worker, stack, templates, extension bundle). "
+            + "For installing individual workload packages, see 'func workload'.")
     {
         _runner = runner ?? throw new ArgumentNullException(nameof(runner));
 

--- a/src/Func/Commands/Setup/SetupFeatureCatalog.cs
+++ b/src/Func/Commands/Setup/SetupFeatureCatalog.cs
@@ -1,0 +1,97 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Bundles;
+using Azure.Functions.Cli.Workloads;
+
+namespace Azure.Functions.Cli.Commands.Setup;
+
+// Maps workload package ids and worker runtimes to the matching
+// `func setup --features <name>` value, so the bundle resolver and the
+// workload install command can point users at the higher-level setup
+// command using a single source of truth.
+internal static class SetupFeatureCatalog
+{
+    public const string RuntimeFeature = "runtime";
+    public const string HostFeature = "host";
+
+    private const string WorkerPackagePrefix = "Azure.Functions.Cli.Workloads.Workers.";
+    private const string TemplatesPackagePrefix = "Azure.Functions.Cli.Workloads.Templates.";
+    private const string StackPackagePrefix = "Azure.Functions.Cli.Workloads.";
+
+    private static readonly HashSet<string> _supportedStacks =
+        new(StringComparer.OrdinalIgnoreCase) { "dotnet", "node", "python", "go" };
+
+    public static bool TryGetFeatureForRuntime(string? workerRuntime, out string feature)
+    {
+        if (!string.IsNullOrWhiteSpace(workerRuntime))
+        {
+            string normalized = workerRuntime.Trim().ToLowerInvariant();
+            if (_supportedStacks.Contains(normalized))
+            {
+                feature = normalized;
+                return true;
+            }
+        }
+
+        feature = string.Empty;
+        return false;
+    }
+
+    public static bool TryGetFeatureForPackageId(string? packageId, out string feature)
+    {
+        feature = string.Empty;
+        if (string.IsNullOrWhiteSpace(packageId))
+        {
+            return false;
+        }
+
+        string id = packageId.Trim();
+
+        if (id.StartsWith(HostWorkloadPackage.PackageIdPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            feature = HostFeature;
+            return true;
+        }
+
+        if (string.Equals(id, IInstalledBundleWorkloads.BundleWorkloadPackageId, StringComparison.OrdinalIgnoreCase))
+        {
+            feature = RuntimeFeature;
+            return true;
+        }
+
+        if (TryGetStackFeatureFromPrefix(id, WorkerPackagePrefix, out feature)
+            || TryGetStackFeatureFromPrefix(id, TemplatesPackagePrefix, out feature)
+            // Stack prefix is also a prefix of worker/templates ids, so it must run last.
+            || TryGetStackFeatureFromPrefix(id, StackPackagePrefix, out feature))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryGetStackFeatureFromPrefix(string id, string prefix, out string feature)
+    {
+        feature = string.Empty;
+        if (!id.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) || id.Length <= prefix.Length)
+        {
+            return false;
+        }
+
+        string suffix = id[prefix.Length..];
+        if (suffix.Contains('.'))
+        {
+            return false;
+        }
+
+        string normalized = suffix.ToLowerInvariant();
+        if (_supportedStacks.Contains(normalized))
+        {
+            feature = normalized;
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Func/Commands/Workload/WorkloadCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadCommand.cs
@@ -21,7 +21,11 @@ internal sealed class WorkloadCommand : FuncCliCommand, IBuiltInCommand
         WorkloadUpdateCommand updateCommand,
         WorkloadSearchCommand searchCommand,
         WorkloadPruneCommand pruneCommand)
-        : base("workload", "Manage Func CLI workloads.")
+        : base(
+            "workload",
+            "Manage Func CLI workloads. "
+            + "Each subcommand acts on a single workload package (install, uninstall, list, update, search, prune). "
+            + "For setting up a full dev environment for a stack, see 'func setup'.")
     {
         ArgumentNullException.ThrowIfNull(listCommand);
         ArgumentNullException.ThrowIfNull(installCommand);

--- a/src/Func/Commands/Workload/WorkloadInstallCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadInstallCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.CommandLine;
+using Azure.Functions.Cli.Commands.Setup;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Workloads;
@@ -141,6 +142,7 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
             else
             {
                 _interaction.WriteSuccess(message);
+                WriteNextStepsHintIfApplicable(result.Entry);
             }
             return 0;
         }
@@ -267,6 +269,36 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
                 => $"{verb} (content at '{entry.Source}').",
             _ => $"{verb}.",
         };
+    }
+
+    // Surfaces the higher-level `func setup --features <name>` command after a
+    // single-component install so users who reached for `func workload install`
+    // by mistake (e.g. issue #5214) discover the planner. Suppressed in
+    // non-interactive contexts to keep CI / JSON output clean and only fires
+    // when the installed package id maps to a known feature group.
+    private void WriteNextStepsHintIfApplicable(WorkloadEntry entry)
+    {
+        if (!_interaction.IsInteractive)
+        {
+            return;
+        }
+
+        if (!SetupFeatureCatalog.TryGetFeatureForPackageId(entry.PackageId, out string feature))
+        {
+            return;
+        }
+
+        string scope = feature switch
+        {
+            SetupFeatureCatalog.RuntimeFeature => "the Functions host and the extension bundle",
+            SetupFeatureCatalog.HostFeature => "the Functions host",
+            _ => $"the full {feature} dev environment (host, worker, stack, templates, bundle)",
+        };
+
+        _interaction.WriteHint(
+            "Next steps:" + Environment.NewLine
+            + $"  This installs a single workload. To install {scope}, run:" + Environment.NewLine
+            + $"    func setup --features {feature}");
     }
 
     /// <summary>

--- a/test/Func.Tests/Bundles/BundleHintBuilderTests.cs
+++ b/test/Func.Tests/Bundles/BundleHintBuilderTests.cs
@@ -58,5 +58,52 @@ public class BundleHintBuilderTests
         string hint = BundleHintBuilder.WorkloadMissing();
 
         Assert.Contains($"func workload install {IInstalledBundleWorkloads.BundleWorkloadPackageId}", hint);
+        Assert.DoesNotContain("func setup", hint);
+    }
+
+    [Fact]
+    public void WorkloadMissing_KnownRuntime_AppendsSetupFeatureHint()
+    {
+        string hint = BundleHintBuilder.WorkloadMissing(workerRuntime: "go");
+
+        Assert.Contains("func workload install", hint);
+        Assert.Contains("func setup --features go", hint);
+    }
+
+    [Fact]
+    public void WorkloadMissing_UnknownRuntime_DoesNotAppendSetupHint()
+    {
+        string hint = BundleHintBuilder.WorkloadMissing(workerRuntime: "ruby");
+
+        Assert.Contains("func workload install", hint);
+        Assert.DoesNotContain("func setup", hint);
+    }
+
+    [Fact]
+    public void NoCompatibleInstall_KnownRuntime_AppendsSetupFeatureHint()
+    {
+        string hint = BundleHintBuilder.NoCompatibleInstall(
+            "Microsoft.Azure.Functions.ExtensionBundle",
+            "[4.22.0, 5.0.0)",
+            ["4.10.0"],
+            suggestedVersion: "4.10.0",
+            workerRuntime: "node");
+
+        Assert.Contains("func setup --features node", hint);
+    }
+
+    [Fact]
+    public void EmptyIntersection_DoesNotIncludeSetupHint()
+    {
+        // Empty-intersection is a host.json/profile mismatch, not a missing install,
+        // so `func setup` is not the right remediation and should not appear.
+        string hint = BundleHintBuilder.EmptyIntersection(
+            "Microsoft.Azure.Functions.ExtensionBundle",
+            "[3.*, 4.0.0)",
+            "[4.*, 5.0.0)",
+            highestVersionSatisfyingHostJsonOnly: "3.36.0",
+            profileName: "stable");
+
+        Assert.DoesNotContain("func setup", hint);
     }
 }

--- a/test/Func.Tests/Bundles/ExtensionBundleResolverTests.cs
+++ b/test/Func.Tests/Bundles/ExtensionBundleResolverTests.cs
@@ -64,6 +64,25 @@ public class ExtensionBundleResolverTests
     }
 
     [Fact]
+    public async Task NoInstalledRows_KnownRuntime_HintIncludesFuncSetup()
+    {
+        ExtensionBundleResolution result = await Build([]).ResolveAsync(Context(host: "[4.0.0, 5.0.0)", workerRuntime: "go"));
+
+        ExtensionBundleResolution.WorkloadMissing missing = Assert.IsType<ExtensionBundleResolution.WorkloadMissing>(result);
+        Assert.Contains("func setup --features go", missing.Hint);
+    }
+
+    [Fact]
+    public async Task NoInstalledMatch_KnownRuntime_HintIncludesFuncSetup()
+    {
+        ExtensionBundleResolution result = await Build([Row("4.10.0")])
+            .ResolveAsync(Context(host: "[5.0.0, 6.0.0)", workerRuntime: "node"));
+
+        ExtensionBundleResolution.NoCompatibleInstall none = Assert.IsType<ExtensionBundleResolution.NoCompatibleInstall>(result);
+        Assert.Contains("func setup --features node", none.Hint);
+    }
+
+    [Fact]
     public async Task TelemetryReason_IsOkOnResolved()
     {
         var telemetry = new RecordingTelemetry();
@@ -116,8 +135,8 @@ public class ExtensionBundleResolverTests
     private static InstalledBundleWorkload Row(string version)
         => new(version, "/install/" + version);
 
-    private static ExtensionBundleProjectContext Context(string host, string? profile = null) =>
-        new(BundleId, host, "dotnet", ProfileName: profile is null ? null : "stable", ProfileBundleVersionRange: profile);
+    private static ExtensionBundleProjectContext Context(string host, string? profile = null, string workerRuntime = "dotnet") =>
+        new(BundleId, host, workerRuntime, ProfileName: profile is null ? null : "stable", ProfileBundleVersionRange: profile);
 
     private sealed class RecordingTelemetry : IBundleResolveTelemetry
     {

--- a/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.CommandLine;
+using Azure.Functions.Cli.Bundles;
 using Azure.Functions.Cli.Commands.Workload;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Workloads;
@@ -468,14 +469,14 @@ public class WorkloadInstallCommandTests
         Assert.Contains(_interaction.Lines, l => l == "PROGRESS: Registering workload 'test.workload' 1.0.0");
     }
 
-    private void StubCatalogResult(bool alreadyInstalled = false) =>
+    private void StubCatalogResult(bool alreadyInstalled = false, string packageId = "test.workload") =>
         _installer.InstallFromCatalogAsync(
                 Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
                 Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
             .Returns(new WorkloadInstallResult(
                 new WorkloadEntry
                 {
-                    PackageId = "test.workload",
+                    PackageId = packageId,
                     PackageVersion = "1.0.0",
                     EntryPoint = new EntryPointSpec { AssemblyPath = "x.dll", Type = "T" },
                 },
@@ -487,5 +488,120 @@ public class WorkloadInstallCommandTests
         root.Subcommands.Add(cmd);
         var config = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
         return root.Parse(new[] { cmd.Name }.Concat(args).ToArray()).InvokeAsync(config);
+    }
+}
+
+// Separate fixture so the IsInteractive override doesn't bleed into the
+// other tests that rely on the default (non-interactive) behavior.
+public class WorkloadInstallNextStepsHintTests
+{
+    private readonly InteractiveTestInteractionService _interaction = new();
+    private readonly IWorkloadInstaller _installer = Substitute.For<IWorkloadInstaller>();
+    private readonly IWorkloadStore _store = Substitute.For<IWorkloadStore>();
+
+    private WorkloadInstallCommand NewInstall() => new(_interaction, _installer, _store, new WorkloadUpdateCommand(_interaction, _installer, _store));
+
+    [Theory]
+    [InlineData("Azure.Functions.Cli.Workloads.Workers.go", "go")]
+    [InlineData("Azure.Functions.Cli.Workloads.Workers.node", "node")]
+    [InlineData("Azure.Functions.Cli.Workloads.Go", "go")]
+    [InlineData("Azure.Functions.Cli.Workloads.Python", "python")]
+    [InlineData("Azure.Functions.Cli.Workloads.Templates.Node", "node")]
+    public async Task Install_KnownFeaturePackage_PrintsSetupHint(string packageId, string expectedFeature)
+    {
+        StubInstall(packageId);
+
+        await InvokeAsync(NewInstall(), packageId);
+
+        Assert.Contains(_interaction.Lines, l =>
+            l.StartsWith("HINT:", StringComparison.Ordinal)
+            && l.Contains("Next steps:", StringComparison.Ordinal)
+            && l.Contains($"func setup --features {expectedFeature}", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Install_BundlePackage_SuggestsRuntimeFeature()
+    {
+        StubInstall(IInstalledBundleWorkloads.BundleWorkloadPackageId);
+
+        await InvokeAsync(NewInstall(), IInstalledBundleWorkloads.BundleWorkloadPackageId);
+
+        Assert.Contains(_interaction.Lines, l =>
+            l.StartsWith("HINT:", StringComparison.Ordinal)
+            && l.Contains("func setup --features runtime", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Install_HostPackage_SuggestsHostFeature()
+    {
+        const string hostPackageId = "Azure.Functions.Cli.Workloads.Host.osx-arm64";
+        StubInstall(hostPackageId);
+
+        await InvokeAsync(NewInstall(), hostPackageId);
+
+        Assert.Contains(_interaction.Lines, l =>
+            l.StartsWith("HINT:", StringComparison.Ordinal)
+            && l.Contains("func setup --features host", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Install_UnknownPackage_DoesNotPrintHint()
+    {
+        StubInstall("Third.Party.Workload");
+
+        await InvokeAsync(NewInstall(), "Third.Party.Workload");
+
+        Assert.DoesNotContain(_interaction.Lines, l =>
+            l.StartsWith("HINT:", StringComparison.Ordinal) && l.Contains("Next steps:", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Install_AlreadyInstalled_DoesNotPrintHint()
+    {
+        StubInstall("Azure.Functions.Cli.Workloads.Workers.go", alreadyInstalled: true);
+
+        await InvokeAsync(NewInstall(), "Azure.Functions.Cli.Workloads.Workers.go");
+
+        Assert.DoesNotContain(_interaction.Lines, l =>
+            l.StartsWith("HINT:", StringComparison.Ordinal) && l.Contains("Next steps:", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Install_NonInteractive_DoesNotPrintHint()
+    {
+        var nonInteractive = new TestInteractionService();
+        StubInstall("Azure.Functions.Cli.Workloads.Workers.go");
+        var cmd = new WorkloadInstallCommand(nonInteractive, _installer, _store, new WorkloadUpdateCommand(nonInteractive, _installer, _store));
+
+        await InvokeAsync(cmd, "Azure.Functions.Cli.Workloads.Workers.go");
+
+        Assert.DoesNotContain(nonInteractive.Lines, l =>
+            l.StartsWith("HINT:", StringComparison.Ordinal) && l.Contains("Next steps:", StringComparison.Ordinal));
+    }
+
+    private void StubInstall(string packageId, bool alreadyInstalled = false) =>
+        _installer.InstallFromCatalogAsync(
+                Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
+                Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
+            .Returns(new WorkloadInstallResult(
+                new WorkloadEntry
+                {
+                    PackageId = packageId,
+                    PackageVersion = "1.0.0",
+                    EntryPoint = new EntryPointSpec { AssemblyPath = "x.dll", Type = "T" },
+                },
+                alreadyInstalled));
+
+    private static Task<int> InvokeAsync(WorkloadInstallCommand cmd, params string[] args)
+    {
+        var root = new RootCommand();
+        root.Subcommands.Add(cmd);
+        var config = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
+        return root.Parse(new[] { cmd.Name }.Concat(args).ToArray()).InvokeAsync(config);
+    }
+
+    private sealed class InteractiveTestInteractionService : TestInteractionService
+    {
+        public override bool IsInteractive => true;
     }
 }


### PR DESCRIPTION
Draft. Addresses #5214 (Go workload install didn't set up everything).

Docs (proposal write-up, user-facing one-pager) live on the orphan `docs/` branch, not here.

## Changes

- **Bundle resolver hints.** When `func start` fails because a bundle workload is missing or incompatible, the hint now also suggests `func setup --features <stack>` (derived from `WorkerRuntime`), in addition to the raw `func workload install <package>` line.
- **Cross-referenced help text.** `func setup` and `func workload` descriptions point at each other.
- **Post-install Next steps panel.** After `func workload install <name>` succeeds (and the install wasn't a no-op), if the package belongs to a known feature group (worker, stack, templates, bundle, or host), print a Next steps hint pointing at `func setup --features <feature>`. Suppressed when interactive UI is off or the workload was already installed.

A new `SetupFeatureCatalog` internal helper owns the package-id / runtime → feature mapping so the bundle hint and the post-install hint share one source of truth.

## Out of scope

- Host workload missing hint, workload install confirmation prompt, manifest `feature` field.
- No changes to `SetupRunner`, profile resolution, or workload manifest schema.

## Tests

`dotnet test test/Func.Tests/Func.Tests.csproj --filter "FullyQualifiedName~Bundles|FullyQualifiedName~Workload|FullyQualifiedName~Setup"` → 387 passed, 0 failed.

New tests cover the bundle hint (known/unknown runtime), runtime plumbing through `ExtensionBundleResolver`, and all post-install hint cases (worker, stack, templates, bundle, host, unknown, already-installed, non-interactive).