### PR TITLE
Show progress heartbeat during host run preparation

### DIFF
--- a/src/Func/Commands/Start/Initialization/Steps/PrepareProjectHostRunInitializationStep.cs
+++ b/src/Func/Commands/Start/Initialization/Steps/PrepareProjectHostRunInitializationStep.cs
@@ -17,9 +17,16 @@ namespace Azure.Functions.Cli.Commands.Start.Initialization;
 internal sealed class PrepareProjectHostRunInitializationStep(
     ILocalSettingsProvider localSettingsProvider,
     IProcessEnvironment processEnvironment,
-    IInteractionService interaction) : DemoInitializationStep
+    IInteractionService interaction,
+    TimeProvider? timeProvider = null,
+    TimeSpan? heartbeatInterval = null) : DemoInitializationStep
 {
     public const string StepId = "prepare_host_run";
+
+    // How often to emit a "still working" heartbeat while the underlying
+    // project preparation runs. Long enough not to spam the dashboard,
+    // short enough that the user can tell the CLI hasn't hung.
+    internal static readonly TimeSpan DefaultHeartbeatInterval = TimeSpan.FromSeconds(3);
 
     private readonly ILocalSettingsProvider _localSettingsProvider = localSettingsProvider
         ?? throw new ArgumentNullException(nameof(localSettingsProvider));
@@ -29,6 +36,10 @@ internal sealed class PrepareProjectHostRunInitializationStep(
 
     private readonly IInteractionService _interaction = interaction
         ?? throw new ArgumentNullException(nameof(interaction));
+
+    private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
+
+    private readonly TimeSpan _heartbeatInterval = heartbeatInterval ?? DefaultHeartbeatInterval;
 
     public override string Id => StepId;
 
@@ -56,11 +67,87 @@ internal sealed class PrepareProjectHostRunInitializationStep(
             environmentVariables,
             skipBuild: context.Options.NoBuild);
 
-        await project.PrepareForHostRunAsync(hostRunContext, cancellationToken);
+        await PrepareWithHeartbeatAsync(context, project, hostRunContext, cancellationToken);
 
         context.State.HostRunContext = hostRunContext;
 
         return StartInitializationStepResult.Completed(hostRunContext.StartupDirectory.FullName);
+    }
+
+    // The underlying PrepareForHostRunAsync is opaque (it shells out to `dotnet build`
+    // for .NET projects, which can take 30s+ on a cold cache). Without a periodic
+    // status update users can't tell the CLI from a hang. We tee a periodic
+    // "still working (Ns elapsed)" message into the renderer's status slot while
+    // the prepare task runs, then stop the timer in `finally` so a thrown
+    // build error still surfaces normally.
+    private async Task PrepareWithHeartbeatAsync(
+        StartInitializationStepContext context,
+        FunctionsProject project,
+        FunctionsProjectHostRunContext hostRunContext,
+        CancellationToken cancellationToken)
+    {
+        string initialMessage = BuildInitialMessage(project, hostRunContext.SkipBuild);
+        long startTimestamp = _timeProvider.GetTimestamp();
+
+        await context.ReportProgressAsync(percent: 0, message: initialMessage, cancellationToken);
+
+        using var heartbeatCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        Task heartbeatTask = RunHeartbeatAsync(context, initialMessage, startTimestamp, heartbeatCts.Token);
+
+        try
+        {
+            await project.PrepareForHostRunAsync(hostRunContext, cancellationToken);
+        }
+        finally
+        {
+            heartbeatCts.Cancel();
+            try
+            {
+                await heartbeatTask;
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected: we cancel the heartbeat once the prepare task completes.
+            }
+        }
+    }
+
+    private async Task RunHeartbeatAsync(
+        StartInitializationStepContext context,
+        string baseMessage,
+        long startTimestamp,
+        CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(_heartbeatInterval, _timeProvider, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+
+            TimeSpan elapsed = _timeProvider.GetElapsedTime(startTimestamp);
+            string message = $"{baseMessage} ({(int)elapsed.TotalSeconds}s elapsed)";
+            await context.ReportProgressAsync(percent: 0, message: message, cancellationToken);
+        }
+    }
+
+    private static string BuildInitialMessage(FunctionsProject project, bool skipBuild)
+    {
+        string projectKind = project.GetType().Name;
+        bool isDotNetSource = projectKind.Contains("DotNetSource", StringComparison.Ordinal);
+
+        if (skipBuild)
+        {
+            return "Preparing project (build skipped)...";
+        }
+
+        return isDotNetSource
+            ? "Building .NET project..."
+            : "Preparing project...";
     }
 
     private Dictionary<string, string> BuildEnvironmentVariables(StartInitializationStepContext context, FunctionsProject project, IFunctionsWorker worker)

--- a/test/Func.Tests/Commands/Start/Initialization/PrepareProjectHostRunInitializationStepTests.cs
+++ b/test/Func.Tests/Commands/Start/Initialization/PrepareProjectHostRunInitializationStepTests.cs
@@ -10,6 +10,7 @@ using Azure.Functions.Cli.Hosting.Dashboard.Rendering;
 using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Workers;
 using NSubstitute;
+using NSubstitute.Core;
 using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands.Start.Initialization;
@@ -145,6 +146,41 @@ public class PrepareProjectHostRunInitializationStepTests : IDisposable
         Assert.False(env.ContainsKey("MyKey"));
     }
 
+    [Fact]
+    public async Task HeartbeatEmitsPeriodicProgressMessages()
+    {
+        SetLocalSettings([]);
+        StartInitializationStepContext context = NewContext(out IStartInitializationRenderer renderer, project: new SlowFakeProject(_projectDir, TimeSpan.FromMilliseconds(200)));
+
+        var step = new PrepareProjectHostRunInitializationStep(
+            _localSettings,
+            _processEnv,
+            _interaction,
+            timeProvider: null,
+            heartbeatInterval: TimeSpan.FromMilliseconds(30));
+
+        await step.ExecuteAsync(context, CancellationToken.None);
+
+        List<StartInitializationProgressEvent> progressEvents = [];
+        foreach (ICall call in renderer.ReceivedCalls())
+        {
+            if (call.GetMethodInfo().Name != nameof(IStartInitializationRenderer.OnEventAsync))
+            {
+                continue;
+            }
+
+            if (call.GetArguments().FirstOrDefault() is StartInitializationProgressEvent progress
+                && progress.StepId == PrepareProjectHostRunInitializationStep.StepId)
+            {
+                progressEvents.Add(progress);
+            }
+        }
+
+        Assert.NotEmpty(progressEvents);
+        Assert.Contains(progressEvents, e => e.Message is not null && e.Message.Contains("Preparing project", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(progressEvents, e => e.Message is not null && e.Message.Contains("elapsed", StringComparison.OrdinalIgnoreCase));
+    }
+
     private void SetLocalSettings(Dictionary<string, string> values)
     {
         var snapshot = new LocalSettingsSnapshot { Values = values };
@@ -155,6 +191,9 @@ public class PrepareProjectHostRunInitializationStepTests : IDisposable
         => new(_localSettings, _processEnv, _interaction);
 
     private StartInitializationStepContext NewContext()
+        => NewContext(out _);
+
+    private StartInitializationStepContext NewContext(out IStartInitializationRenderer renderer, FunctionsProject? project = null)
     {
         var options = new StartCommandOptions(
             WorkingDirectory.FromExplicit(_projectDir),
@@ -166,13 +205,13 @@ public class PrepareProjectHostRunInitializationStepTests : IDisposable
         var init = new StartInitializationContext(options, "5.0.0-test", IsInteractive: false, CanPrompt: false);
         var state = new StartInitializationState
         {
-            Project = new FakeProject(_projectDir),
+            Project = project ?? new FakeProject(_projectDir),
             Worker = CreateWorker(),
             ProfileName = "none",
         };
-        IStartInitializationRenderer renderer = Substitute.For<IStartInitializationRenderer>();
+        renderer = Substitute.For<IStartInitializationRenderer>();
         IStartInitializationStep stepStub = Substitute.For<IStartInitializationStep>();
-        stepStub.Id.Returns("test");
+        stepStub.Id.Returns(PrepareProjectHostRunInitializationStep.StepId);
         return new StartInitializationStepContext(init, state, stepStub, renderer, TimeProvider.System);
     }
 
@@ -195,5 +234,21 @@ public class PrepareProjectHostRunInitializationStepTests : IDisposable
         public override bool SupportsExtensionBundles => true;
 
         public override FunctionsWorkerReference WorkerReference { get; } = FunctionsWorkerReference.FromWorkload("node");
+    }
+
+    private sealed class SlowFakeProject(string directory, TimeSpan delay) : FunctionsProject
+    {
+        public override WorkingDirectory WorkingDirectory { get; } = WorkingDirectory.FromExplicit(directory);
+
+        public override string StackName => "node";
+
+        public override string StackDisplayName => "Node.js";
+
+        public override bool SupportsExtensionBundles => true;
+
+        public override FunctionsWorkerReference WorkerReference { get; } = FunctionsWorkerReference.FromWorkload("node");
+
+        public override Task PrepareForHostRunAsync(FunctionsProjectHostRunContext context, CancellationToken cancellationToken)
+            => Task.Delay(delay, cancellationToken);
     }
 }


### PR DESCRIPTION
Fixes #5217.

`PrepareProjectHostRunInitializationStep` wraps `project.PrepareForHostRunAsync` with a heartbeat that emits a `Building project... (Ns elapsed)` progress event every few seconds while the underlying work runs. Without this the init dashboard appears frozen during long `dotnet build` runs on a cold cache (often 30s+).

## What changes

- New private `PrepareWithHeartbeatAsync` helper teed onto the existing prepare call.
- Initial message is tailored: `Building .NET project...` for .NET source projects, `Preparing project (build skipped)...` when `--no-build` is set, `Preparing project...` otherwise.
- Heartbeat fires every 3s by default; both the interval and the `TimeProvider` are constructor-injectable so the behaviour is deterministic in tests.
- Heartbeat task is cancelled and awaited in a `finally` so a thrown build error still surfaces normally.

## Tests
- New `HeartbeatEmitsPeriodicProgressMessages` test uses a slow fake project + 30ms heartbeat interval and asserts that at least one `(Ns elapsed)` progress event is emitted to the renderer.
- All existing `PrepareProjectHostRunInitializationStepTests` still pass (9 of 9).

## Why this is a separate PR
Originally bundled with #5220 (`func setup` UX fixes), extracted because it touches the start init pipeline rather than the first-run / setup flow.