### PR TITLE
Implement first-run experience spec

### DIFF
--- a/docs/first-run-experience.md
+++ b/docs/first-run-experience.md
@@ -66,9 +66,11 @@ Behaviour:
 
 ### Interactive
 
-- Multi-select shows all stacks (`node`, `python`, `dotnet`, `go`).
-- Stacks already installed are **disabled and grayed out**, with an
-  `(installed)` suffix. They cannot be re-toggled.
+- Multi-select shows the stacks that are not already installed.
+- Stacks already installed are filtered out of the choice list. When any
+  are filtered, a single muted line above the prompt records them:
+  `Already installed: node, python`. If every supported stack is already
+  installed, the prompt is skipped and the run exits cleanly.
 - ENTER with nothing selected is a clean opt-out: exit 0, marker written,
   hint shown ("No stacks selected").
 
@@ -96,15 +98,12 @@ These commands trigger the first-run prompt with two refinements:
 1. **Skip the prompt if any workloads are already installed.** Re-uses the
    same "workloads present ⇒ not first run" check, so existing users go
    straight to init.
-2. **After setup succeeds inside an init/new flow, refresh the workload
-   loader** before resuming. The loader currently snapshots `workloads.json`
-   at host build time; we need an explicit reload hook on `IWorkloadStore` /
-   the loader registration so the freshly installed stack is visible to the
-   same process that will run init.
-
-Without (2), `func init` would have to relaunch the CLI to pick up the new
-workload, which is a worse UX than just telling the user "setup done,
-re-run `func init`".
+2. **After setup succeeds inside an init/new flow, ask the user to re-run.**
+   The workload loader currently snapshots `workloads.json` at host build
+   time, so the freshly installed stack is not visible to the in-process
+   init/new flow. The coordinator prints "Setup complete. Re-run
+   `func init`/`func new` to use the new stacks." and exits 0. A proper
+   in-process reload hook is tracked as follow-up work.
 
 ## Subsequent-run breadcrumb
 
@@ -140,13 +139,23 @@ Rules:
 | Marker at `~/.azure-functions/.first-run-complete` | Done |
 | Workload-aware first-run check | Done (PR #5220) |
 | Marker written on `func setup` success and opt-out | Done (PR #5220) |
-| Multi-select labels installed stacks with `(installed)` | Done (PR #5220) |
+| Multi-select labels installed stacks with `(installed)` | Superseded |
 | Empty selection exits cleanly | Done (PR #5220) |
-| Bare `func` triggers the prompt | **Pending** |
-| New, longer prompt copy with `--features` hint | **Pending** |
-| Ctrl+C writes the marker | **Pending** |
-| Already-installed stacks are disabled (not just labelled) | **Pending** |
-| `func init` / `func new` trigger prompt + workload loader reload | **Pending** |
-| Subsequent-run breadcrumb | **Pending** |
+| Bare `func` triggers the prompt | Done |
+| New, longer prompt copy with `--features` hint | Done |
+| Ctrl+C writes the marker | Done |
+| Already-installed stacks are disabled (not just labelled) | Done (filtered out; shown above the prompt) |
+| `func init` / `func new` trigger prompt | Done |
+| `func init` / `func new` workload loader reload | Deferred (re-run hint shown; tracking follow-up) |
+| Subsequent-run breadcrumb | Done |
 
-Pending items are tracked in the follow-up implementation PR.
+### Notes on the deferred reload
+
+`IWorkloadStore.GetWorkloadsAsync` reads `workloads.json` from disk on every
+call, so the store itself stays fresh after an in-process install. The
+problem is the templates/bundles loader stack that snapshots workload
+metadata at host build time. Rather than audit and rewire every consumer,
+the coordinator currently short-circuits with a "Setup complete. Re-run
+`func init`/`func new` to use the new stacks." hint and exits 0 when first-
+run setup runs inside an `init` / `new` invocation. Replacing this with a
+proper in-process reload is tracked as follow-up work.

--- a/src/Func/Commands/Setup/SetupRunner.cs
+++ b/src/Func/Commands/Setup/SetupRunner.cs
@@ -266,10 +266,24 @@ internal sealed class SetupRunner(
 
         if (!options.NonInteractive && _interaction.IsInteractive)
         {
-            IReadOnlyList<MultiSelectionChoice> choices = await BuildStackChoicesAsync(cancellationToken);
+            StackChoicesResult choices = await BuildStackChoicesAsync(cancellationToken);
+
+            if (choices.AlreadyInstalled.Count > 0)
+            {
+                _interaction.WriteHint($"Already installed: {string.Join(", ", choices.AlreadyInstalled)}");
+            }
+
+            if (choices.Available.Count == 0)
+            {
+                // Every supported stack is already installed; nothing to
+                // offer. Treat as a clean opt-out so the caller marks the
+                // first-run flag and exits without prompting.
+                return null;
+            }
+
             IReadOnlyList<string> picked = await _interaction.PromptForMultiSelectionAsync(
                 "Select stacks to install (SPACE to toggle, ENTER to confirm; ENTER with no selection exits):",
-                choices,
+                choices.Available,
                 cancellationToken);
 
             // No selection = user opted out. Signal that with null so the
@@ -281,7 +295,7 @@ internal sealed class SetupRunner(
         return ["runtime"];
     }
 
-    private async Task<IReadOnlyList<MultiSelectionChoice>> BuildStackChoicesAsync(CancellationToken cancellationToken)
+    private async Task<StackChoicesResult> BuildStackChoicesAsync(CancellationToken cancellationToken)
     {
         IReadOnlyList<string> stacks = SetupDependency.Stacks;
         HashSet<string> installedStackPackageIds;
@@ -298,20 +312,32 @@ internal sealed class SetupRunner(
         }
         catch (Exception)
         {
-            // Surfacing the installed indicator is a hint, not a contract.
-            // If we can't read the store we still want the user to pick.
+            // Filtering installed stacks is a UX hint, not a contract.
+            // If we can't read the store, fall back to showing every stack
+            // so the user can still make a selection.
             installedStackPackageIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         }
 
-        return [.. stacks
-            .OrderBy(static stack => stack, StringComparer.OrdinalIgnoreCase)
-            .Select(stack =>
+        List<MultiSelectionChoice> available = [];
+        List<string> alreadyInstalled = [];
+        foreach (string stack in stacks.OrderBy(static stack => stack, StringComparer.OrdinalIgnoreCase))
+        {
+            if (installedStackPackageIds.Contains(SetupDependency.Stack(stack).PackageId))
             {
-                bool installed = installedStackPackageIds.Contains(SetupDependency.Stack(stack).PackageId);
-                string label = installed ? $"{stack}  (installed)" : stack;
-                return new MultiSelectionChoice(stack, label);
-            })];
+                alreadyInstalled.Add(stack);
+            }
+            else
+            {
+                available.Add(new MultiSelectionChoice(stack, stack));
+            }
+        }
+
+        return new StackChoicesResult(available, alreadyInstalled);
     }
+
+    private readonly record struct StackChoicesResult(
+        IReadOnlyList<MultiSelectionChoice> Available,
+        IReadOnlyList<string> AlreadyInstalled);
 
     private async Task<IReadOnlyList<SetupProfileScope>> ResolveProfileScopesAsync(SetupCommandOptions options, SetupRenderer renderer, CancellationToken cancellationToken)
     {

--- a/src/Func/Hosting/FirstRun/FileFirstRunStateStore.cs
+++ b/src/Func/Hosting/FirstRun/FileFirstRunStateStore.cs
@@ -24,20 +24,21 @@ internal sealed class FileFirstRunStateStore(
     private string MarkerPath => Path.Combine(_paths.Home, MarkerFileName);
 
     public async Task<bool> IsFirstRunAsync(CancellationToken cancellationToken = default)
+        => await GetStateAsync(cancellationToken) == FirstRunState.NeverPrompted;
+
+    public async Task<FirstRunState> GetStateAsync(CancellationToken cancellationToken = default)
     {
-        if (File.Exists(MarkerPath))
-        {
-            return false;
-        }
+        bool markerExists = File.Exists(MarkerPath);
 
         // Existing users may have installed workloads through `func setup`
         // or `func workload install` before this marker was introduced, or
         // before we wrote it on success. Treat any installed workload as
         // "not first run" so we don't re-prompt them.
+        bool hasWorkloads;
         try
         {
             IReadOnlyList<WorkloadEntry> installed = await _workloadStore.GetWorkloadsAsync(cancellationToken);
-            return installed.Count == 0;
+            hasWorkloads = installed.Count > 0;
         }
         catch (OperationCanceledException)
         {
@@ -45,10 +46,19 @@ internal sealed class FileFirstRunStateStore(
         }
         catch (Exception)
         {
-            // If we can't read the workload registry for any reason, fall
-            // back to "first run = true" so the user still sees the prompt.
-            return true;
+            // If we can't read the workload registry, lean toward the
+            // marker: it's the user's explicit signal. Treat as no
+            // workloads so the prompt still surfaces when there's no
+            // marker either.
+            hasWorkloads = false;
         }
+
+        if (hasWorkloads)
+        {
+            return FirstRunState.WorkloadsInstalled;
+        }
+
+        return markerExists ? FirstRunState.MarkerWithoutWorkloads : FirstRunState.NeverPrompted;
     }
 
     public async Task MarkCompleteAsync(CancellationToken cancellationToken)

--- a/src/Func/Hosting/FirstRun/FirstRunCoordinator.cs
+++ b/src/Func/Hosting/FirstRun/FirstRunCoordinator.cs
@@ -10,82 +10,149 @@ namespace Azure.Functions.Cli.Hosting.FirstRun;
 /// <summary>
 /// Default coordinator. Skips quickly when this is clearly not the
 /// user's first interactive command, otherwise prompts and delegates
-/// to <see cref="ISetupRunner"/>.
+/// to <see cref="ISetupRunner"/>. Once setup has been handled, also
+/// surfaces a muted breadcrumb when the user previously declined but
+/// still has no workloads installed.
 /// </summary>
 internal sealed class FirstRunCoordinator(
     IInteractionService interaction,
     IFirstRunStateStore stateStore,
     ISetupRunner setupRunner) : IFirstRunCoordinator
 {
-    private const string PromptExplanation =
-        "The Azure Functions CLI uses workloads (host, runtime, language stacks) to do its work, "
-        + "and they aren't installed yet. Running `func setup` now will install everything you need to get started.";
+    private const string PromptParagraph1 =
+        "Looks like this is your first time running func.";
+
+    private const string PromptParagraph2 =
+        "The new CLI uses installable workloads to bring in language stacks "
+        + "(Node.js, Python, .NET, Go) and the host runtime. Running `func setup` "
+        + "now will install the host and the dev environment / dependencies for "
+        + "the stack(s) you pick.";
+
+    private const string PromptParagraph3 =
+        "You can always add more later with `func setup --features <node|dotnet|go|python>`.";
 
     private const string PromptMessage = "Run `func setup` now?";
 
-    // Commands that should not trigger the first-run prompt. We deliberately
-    // do NOT skip on "help" / "unknown" here: those are what the resolver
-    // returns for a bare `func` invocation, which is the canonical first-run
-    // trigger. Explicit `--help`/`-h` invocations are handled by the token
-    // check below. "version" stays because it only arises from `func --verbose`
-    // with no subcommand, which is a CLI-inspection gesture, not a real
-    // first command.
+    private const string BreadcrumbHint =
+        "Tip: run `func setup` to install your dev environment and language stack dependencies.";
+
+    // Commands that should not trigger the first-run prompt or breadcrumb.
+    // We deliberately do NOT skip on "help" / "unknown" here: those are what
+    // the resolver returns for a bare `func` invocation, which is the
+    // canonical first-run trigger. Explicit `--help`/`-h` invocations are
+    // handled by the token check below. "version" stays because it only
+    // arises from `func --verbose` with no subcommand, which is a CLI-
+    // inspection gesture, not a real first command. `init` and `new` stay
+    // off the skip list intentionally; the spec wants the prompt there too.
     private static readonly HashSet<string> _skippedCommandNames =
         new(StringComparer.OrdinalIgnoreCase) { "setup", "version" };
 
     private static readonly HashSet<string> _skippedTokens =
         new(StringComparer.OrdinalIgnoreCase) { "--help", "-h", "-?", "/?", "--version", "-v" };
 
+    // Commands that need workload-aware metadata (templates, bundles) loaded
+    // at host build time. If we install workloads inside the first-run flow
+    // for one of these, the in-process loader is still pointing at the
+    // pre-install snapshot, so we ask the user to re-run instead of letting
+    // the original command fail in confusing ways.
+    private static readonly HashSet<string> _workloadDependentCommands =
+        new(StringComparer.OrdinalIgnoreCase) { "init", "new" };
+
     private readonly IInteractionService _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
     private readonly IFirstRunStateStore _stateStore = stateStore ?? throw new ArgumentNullException(nameof(stateStore));
     private readonly ISetupRunner _setupRunner = setupRunner ?? throw new ArgumentNullException(nameof(setupRunner));
 
-    public async Task EnsureFirstRunPromptedAsync(string commandName, ParseResult parseResult, CancellationToken cancellationToken)
+    public async Task<int?> EnsureFirstRunPromptedAsync(string commandName, ParseResult parseResult, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(parseResult);
-
-        if (!await _stateStore.IsFirstRunAsync(cancellationToken))
-        {
-            return;
-        }
 
         if (!_interaction.IsInteractive)
         {
             // Don't pester the user in CI / piped scenarios, and don't mark
             // the marker either: they may run interactively next time.
-            return;
+            return null;
         }
 
+        if (IsSkipped(commandName, parseResult))
+        {
+            return null;
+        }
+
+        FirstRunState state = await _stateStore.GetStateAsync(cancellationToken);
+
+        switch (state)
+        {
+            case FirstRunState.WorkloadsInstalled:
+                return null;
+
+            case FirstRunState.MarkerWithoutWorkloads:
+                _interaction.WriteHint(BreadcrumbHint);
+                return null;
+
+            case FirstRunState.NeverPrompted:
+                return await HandleFirstRunAsync(commandName, cancellationToken);
+
+            default:
+                return null;
+        }
+    }
+
+    private static bool IsSkipped(string commandName, ParseResult parseResult)
+    {
         if (commandName is not null && _skippedCommandNames.Contains(commandName))
         {
-            return;
+            return true;
         }
 
         foreach (System.CommandLine.Parsing.Token token in parseResult.Tokens)
         {
             if (_skippedTokens.Contains(token.Value))
             {
-                return;
+                return true;
             }
         }
 
-        // Bare `func` (no args) produces a "Required command was not provided"
-        // parse error but no tokens; that's the canonical first-run trigger
-        // and we still want to prompt. For any other parse error (typo, bad
-        // option), stay quiet until the user fixes their command line.
+        // Bare `func` (no tokens) is the canonical first-run trigger and
+        // must always be considered, even if the parser produced a
+        // "Required command was not provided" error. For any other parse
+        // error (typo, bad option), stay quiet until the user fixes their
+        // command line.
         bool isBareInvocation = parseResult.Tokens.Count == 0;
         if (!isBareInvocation && parseResult.Errors.Count > 0)
         {
-            return;
+            return true;
         }
 
-        _interaction.WriteBlankLine();
-        _interaction.WriteHint(PromptExplanation);
-        bool runSetup = await _interaction.ConfirmAsync(PromptMessage, defaultValue: true, cancellationToken);
+        return false;
+    }
 
+    private async Task<int?> HandleFirstRunAsync(string commandName, CancellationToken cancellationToken)
+    {
+        _interaction.WriteBlankLine();
+        _interaction.WriteLine(PromptParagraph1);
+        _interaction.WriteBlankLine();
+        _interaction.WriteLine(PromptParagraph2);
+        _interaction.WriteBlankLine();
+        _interaction.WriteLine(PromptParagraph3);
+        _interaction.WriteBlankLine();
+
+        bool runSetup;
+        try
+        {
+            runSetup = await _interaction.ConfirmAsync(PromptMessage, defaultValue: true, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            // Ctrl+C at the prompt = "stop pestering me". Write the marker
+            // so we don't ask again next time, then propagate the cancel.
+            await TryMarkCompleteAsync(cancellationToken);
+            throw;
+        }
+
+        bool setupRan = false;
         if (runSetup)
         {
-            await RunSetupAsync(cancellationToken);
+            setupRan = await RunSetupAsync(cancellationToken);
         }
         else
         {
@@ -93,9 +160,22 @@ internal sealed class FirstRunCoordinator(
         }
 
         await _stateStore.MarkCompleteAsync(cancellationToken);
+
+        // The workload loader snapshots templates/bundles at host build
+        // time, so the in-process `init` / `new` flow won't see the
+        // freshly installed stacks. Ask the user to re-run instead of
+        // letting them hit a confusing "no templates found" error.
+        if (setupRan && commandName is not null && _workloadDependentCommands.Contains(commandName))
+        {
+            _interaction.WriteBlankLine();
+            _interaction.WriteHint($"Setup complete. Re-run `func {commandName.ToLowerInvariant()}` to use the new stacks.");
+            return 0;
+        }
+
+        return null;
     }
 
-    private async Task RunSetupAsync(CancellationToken cancellationToken)
+    private async Task<bool> RunSetupAsync(CancellationToken cancellationToken)
     {
         var options = new SetupCommandOptions(
             WorkingDirectory: new DirectoryInfo(Environment.CurrentDirectory),
@@ -111,7 +191,8 @@ internal sealed class FirstRunCoordinator(
 
         try
         {
-            await _setupRunner.RunAsync(options, cancellationToken);
+            SetupRunResult result = await _setupRunner.RunAsync(options, cancellationToken);
+            return result.ExitCode == 0;
         }
         catch (OperationCanceledException)
         {
@@ -124,6 +205,26 @@ internal sealed class FirstRunCoordinator(
             // command they typed may still succeed (or fail with its own
             // clearer error).
             _interaction.WriteWarning($"Setup did not complete: {ex.Message}");
+            return false;
+        }
+    }
+
+    private async Task TryMarkCompleteAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _stateStore.MarkCompleteAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            // The user already cancelled; let the outer catch propagate
+            // the original OCE.
+        }
+        catch (Exception)
+        {
+            // Failing to mark on a cancel path is a minor nuisance (one
+            // extra prompt next time), not worth surfacing on top of the
+            // cancellation the user just triggered.
         }
     }
 }

--- a/src/Func/Hosting/FirstRun/FirstRunState.cs
+++ b/src/Func/Hosting/FirstRun/FirstRunState.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Hosting.FirstRun;
+
+/// <summary>
+/// Lifecycle states for the first-run experience. Computed from the marker
+/// file plus the installed workload registry.
+/// </summary>
+internal enum FirstRunState
+{
+    /// <summary>
+    /// No marker on disk and no installed workloads. The user should see
+    /// the first-run prompt.
+    /// </summary>
+    NeverPrompted = 0,
+
+    /// <summary>
+    /// Marker is present but no workloads are installed. Either the user
+    /// declined first-run setup, or they ran setup with an empty selection.
+    /// The user should see the muted breadcrumb hint on each command.
+    /// </summary>
+    MarkerWithoutWorkloads = 1,
+
+    /// <summary>
+    /// At least one workload is installed. The CLI is set up; no first-run
+    /// affordance is needed.
+    /// </summary>
+    WorkloadsInstalled = 2,
+}

--- a/src/Func/Hosting/FirstRun/IFirstRunCoordinator.cs
+++ b/src/Func/Hosting/FirstRun/IFirstRunCoordinator.cs
@@ -13,8 +13,11 @@ internal interface IFirstRunCoordinator
 {
     /// <summary>
     /// Offers to run setup when this looks like the user's first
-    /// invocation. Always returns once the prompt has been handled
-    /// (or skipped); the caller continues with the user's command.
+    /// invocation, or surfaces the muted breadcrumb hint when the user
+    /// has already opted out. Returns <c>null</c> when the caller should
+    /// continue with the user's command, or an exit code when the
+    /// coordinator handled the invocation itself (currently only used for
+    /// the post-setup "re-run `func init`" short-circuit).
     /// </summary>
-    public Task EnsureFirstRunPromptedAsync(string commandName, ParseResult parseResult, CancellationToken cancellationToken);
+    public Task<int?> EnsureFirstRunPromptedAsync(string commandName, ParseResult parseResult, CancellationToken cancellationToken);
 }

--- a/src/Func/Hosting/FirstRun/IFirstRunStateStore.cs
+++ b/src/Func/Hosting/FirstRun/IFirstRunStateStore.cs
@@ -14,9 +14,17 @@ internal interface IFirstRunStateStore
     /// Returns true when no first-run marker exists yet AND the user has no
     /// installed workloads, meaning the user has not yet been offered the
     /// setup prompt and has nothing on disk that would make the prompt
-    /// redundant.
+    /// redundant. Equivalent to
+    /// <c>GetStateAsync() == FirstRunState.NeverPrompted</c>.
     /// </summary>
     public Task<bool> IsFirstRunAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the current first-run lifecycle state so callers can pick
+    /// between the prompt, the breadcrumb hint, and silence in a single
+    /// read.
+    /// </summary>
+    public Task<FirstRunState> GetStateAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Records that the first-run prompt has been handled. Subsequent

--- a/src/Func/Program.cs
+++ b/src/Func/Program.cs
@@ -86,10 +86,16 @@ using (Activity? activity = CliTelemetry.Trace.StartCommandActivity())
         activity?.SetCommandName(commandName);
 
         IFirstRunCoordinator firstRunCoordinator = host.Services.GetRequiredService<IFirstRunCoordinator>();
-        await firstRunCoordinator.EnsureFirstRunPromptedAsync(commandName, commandParseResult, cts.Token);
-
-        var config = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
-        exitCode = await commandParseResult.InvokeAsync(config, cts.Token);
+        int? firstRunExitCode = await firstRunCoordinator.EnsureFirstRunPromptedAsync(commandName, commandParseResult, cts.Token);
+        if (firstRunExitCode is int firstRunResult)
+        {
+            exitCode = firstRunResult;
+        }
+        else
+        {
+            var config = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
+            exitCode = await commandParseResult.InvokeAsync(config, cts.Token);
+        }
     }
     catch (OperationCanceledException)
     {

--- a/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
+++ b/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
@@ -647,7 +647,7 @@ public sealed class SetupRunnerTests : IDisposable
     }
 
     [Fact]
-    public async Task RunAsync_InteractiveEmptyFolder_LabelsInstalledStacks()
+    public async Task RunAsync_InteractiveEmptyFolder_FiltersInstalledStacks_AndShowsAlreadyInstalledHint()
     {
         const string nodeStack = "Azure.Functions.Cli.Workloads.Node";
         FakeCatalog catalog = Catalog()
@@ -684,7 +684,8 @@ public sealed class SetupRunnerTests : IDisposable
                 SetupOutputMode.Plain),
             CancellationToken.None);
 
-        Assert.Contains(interactive.Lines, line => line.StartsWith("MULTISELECT:", StringComparison.Ordinal) && line.Contains("node  (installed)", StringComparison.Ordinal));
+        Assert.Contains(interactive.Lines, line => line.StartsWith("HINT:", StringComparison.Ordinal) && line.Contains("Already installed: node", StringComparison.Ordinal));
+        Assert.DoesNotContain(interactive.Lines, line => line.StartsWith("MULTISELECT:", StringComparison.Ordinal) && line.Contains("node", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/test/Func.Tests/Hosting/FirstRun/FileFirstRunStateStoreTests.cs
+++ b/test/Func.Tests/Hosting/FirstRun/FileFirstRunStateStoreTests.cs
@@ -48,6 +48,32 @@ public sealed class FileFirstRunStateStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task GetStateAsync_ReturnsNeverPrompted_WhenMarkerMissingAndNoWorkloads()
+    {
+        Assert.Equal(FirstRunState.NeverPrompted, await _store.GetStateAsync());
+    }
+
+    [Fact]
+    public async Task GetStateAsync_ReturnsMarkerWithoutWorkloads_WhenMarkerExistsAndNoWorkloads()
+    {
+        await _store.MarkCompleteAsync(CancellationToken.None);
+
+        Assert.Equal(FirstRunState.MarkerWithoutWorkloads, await _store.GetStateAsync());
+    }
+
+    [Fact]
+    public async Task GetStateAsync_ReturnsWorkloadsInstalled_WhenWorkloadsPresent_RegardlessOfMarker()
+    {
+        _workloadStore.GetWorkloadsAsync(Arg.Any<CancellationToken>())
+            .Returns(new[] { new WorkloadEntry { PackageId = "Azure.Functions.Cli.Workloads.Node", PackageVersion = "4.0.0" } });
+
+        Assert.Equal(FirstRunState.WorkloadsInstalled, await _store.GetStateAsync());
+
+        await _store.MarkCompleteAsync(CancellationToken.None);
+        Assert.Equal(FirstRunState.WorkloadsInstalled, await _store.GetStateAsync());
+    }
+
+    [Fact]
     public async Task MarkCompleteAsync_CreatesMarker_AndIsFirstRunReturnsFalse()
     {
         await _store.MarkCompleteAsync(CancellationToken.None);

--- a/test/Func.Tests/Hosting/FirstRun/FirstRunCoordinatorTests.cs
+++ b/test/Func.Tests/Hosting/FirstRun/FirstRunCoordinatorTests.cs
@@ -19,14 +19,20 @@ public sealed class FirstRunCoordinatorTests
     private readonly ISetupRunner _setupRunner = Substitute.For<ISetupRunner>();
     private readonly PromptingInteractionService _interaction = new();
 
-    [Fact]
-    public async Task SkipsAndDoesNotMark_WhenAlreadyComplete()
+    public FirstRunCoordinatorTests()
     {
-        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(false);
+        _stateStore.GetStateAsync(Arg.Any<CancellationToken>()).Returns(FirstRunState.NeverPrompted);
+    }
+
+    [Fact]
+    public async Task SkipsAndDoesNotMark_WhenWorkloadsInstalled()
+    {
+        _stateStore.GetStateAsync(Arg.Any<CancellationToken>()).Returns(FirstRunState.WorkloadsInstalled);
         FirstRunCoordinator coordinator = CreateCoordinator();
 
-        await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
+        int? result = await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
 
+        Assert.Null(result);
         Assert.Equal(0, _interaction.ConfirmCalls);
         await _setupRunner.DidNotReceiveWithAnyArgs().RunAsync(default!, default);
         await _stateStore.DidNotReceiveWithAnyArgs().MarkCompleteAsync(default);
@@ -35,12 +41,12 @@ public sealed class FirstRunCoordinatorTests
     [Fact]
     public async Task SkipsAndDoesNotMark_WhenNonInteractive()
     {
-        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(true);
         _interaction.InteractiveOverride = false;
         FirstRunCoordinator coordinator = CreateCoordinator();
 
-        await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
+        int? result = await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
 
+        Assert.Null(result);
         Assert.Equal(0, _interaction.ConfirmCalls);
         await _setupRunner.DidNotReceiveWithAnyArgs().RunAsync(default!, default);
         await _stateStore.DidNotReceiveWithAnyArgs().MarkCompleteAsync(default);
@@ -51,11 +57,11 @@ public sealed class FirstRunCoordinatorTests
     [InlineData("version")]
     public async Task SkipsAndDoesNotMark_ForExcludedCommands(string commandName)
     {
-        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(true);
         FirstRunCoordinator coordinator = CreateCoordinator();
 
-        await coordinator.EnsureFirstRunPromptedAsync(commandName, Parse(commandName), CancellationToken.None);
+        int? result = await coordinator.EnsureFirstRunPromptedAsync(commandName, Parse(commandName), CancellationToken.None);
 
+        Assert.Null(result);
         Assert.Equal(0, _interaction.ConfirmCalls);
         await _stateStore.DidNotReceiveWithAnyArgs().MarkCompleteAsync(default);
     }
@@ -67,11 +73,11 @@ public sealed class FirstRunCoordinatorTests
     [InlineData("-v")]
     public async Task SkipsAndDoesNotMark_WhenHelpOrVersionTokenPresent(string token)
     {
-        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(true);
         FirstRunCoordinator coordinator = CreateCoordinator();
 
-        await coordinator.EnsureFirstRunPromptedAsync("start", Parse($"start {token}"), CancellationToken.None);
+        int? result = await coordinator.EnsureFirstRunPromptedAsync("start", Parse($"start {token}"), CancellationToken.None);
 
+        Assert.Null(result);
         Assert.Equal(0, _interaction.ConfirmCalls);
         await _stateStore.DidNotReceiveWithAnyArgs().MarkCompleteAsync(default);
     }
@@ -82,12 +88,12 @@ public sealed class FirstRunCoordinatorTests
         // Bare `func` produces a "Required command was not provided" parse
         // error and the resolver labels it "unknown", but it's the canonical
         // first-run trigger and must still prompt.
-        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(true);
         _interaction.ConfirmResponse = false;
         FirstRunCoordinator coordinator = CreateCoordinator();
 
-        await coordinator.EnsureFirstRunPromptedAsync("unknown", Parse(string.Empty), CancellationToken.None);
+        int? result = await coordinator.EnsureFirstRunPromptedAsync("unknown", Parse(string.Empty), CancellationToken.None);
 
+        Assert.Null(result);
         Assert.Equal(1, _interaction.ConfirmCalls);
         await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
     }
@@ -95,13 +101,11 @@ public sealed class FirstRunCoordinatorTests
     [Fact]
     public async Task SkipsAndDoesNotMark_WhenParseHasErrorsAndTokensPresent()
     {
-        // A typo like `func startt` produces tokens and parse errors; we stay
-        // quiet until the user fixes the command line.
-        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(true);
         FirstRunCoordinator coordinator = CreateCoordinator();
 
-        await coordinator.EnsureFirstRunPromptedAsync("unknown", Parse("startt"), CancellationToken.None);
+        int? result = await coordinator.EnsureFirstRunPromptedAsync("unknown", Parse("startt"), CancellationToken.None);
 
+        Assert.Null(result);
         Assert.Equal(0, _interaction.ConfirmCalls);
         await _stateStore.DidNotReceiveWithAnyArgs().MarkCompleteAsync(default);
     }
@@ -109,14 +113,14 @@ public sealed class FirstRunCoordinatorTests
     [Fact]
     public async Task RunsSetupAndMarks_WhenUserConfirms()
     {
-        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(true);
         _interaction.ConfirmResponse = true;
         _setupRunner.RunAsync(Arg.Any<SetupCommandOptions>(), Arg.Any<CancellationToken>())
             .Returns(new SetupRunResult(0));
         FirstRunCoordinator coordinator = CreateCoordinator();
 
-        await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
+        int? result = await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
 
+        Assert.Null(result);
         Assert.Equal(1, _interaction.ConfirmCalls);
         await _setupRunner.Received(1).RunAsync(Arg.Any<SetupCommandOptions>(), Arg.Any<CancellationToken>());
         await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
@@ -125,21 +129,20 @@ public sealed class FirstRunCoordinatorTests
     [Fact]
     public async Task SkipsSetupButMarks_WhenUserDeclines()
     {
-        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(true);
         _interaction.ConfirmResponse = false;
         FirstRunCoordinator coordinator = CreateCoordinator();
 
-        await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
+        int? result = await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
 
+        Assert.Null(result);
         Assert.Equal(1, _interaction.ConfirmCalls);
         await _setupRunner.DidNotReceiveWithAnyArgs().RunAsync(default!, default);
         await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task PropagatesCancellation_FromPrompt()
+    public async Task PropagatesCancellation_FromPrompt_AndWritesMarker()
     {
-        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(true);
         var cts = new CancellationTokenSource();
         cts.Cancel();
         FirstRunCoordinator coordinator = CreateCoordinator();
@@ -147,22 +150,107 @@ public sealed class FirstRunCoordinatorTests
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
             () => coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), cts.Token));
 
-        await _stateStore.DidNotReceiveWithAnyArgs().MarkCompleteAsync(default);
+        // Ctrl+C at the prompt should still write the marker so the user
+        // is not re-prompted next time.
+        await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task SetupFailureIsSwallowed_ButMarkerStillWritten()
     {
-        _stateStore.IsFirstRunAsync(Arg.Any<CancellationToken>()).Returns(true);
         _interaction.ConfirmResponse = true;
         _setupRunner.RunAsync(Arg.Any<SetupCommandOptions>(), Arg.Any<CancellationToken>())
             .Returns<Task<SetupRunResult>>(_ => throw new InvalidOperationException("boom"));
         FirstRunCoordinator coordinator = CreateCoordinator();
 
-        await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
+        int? result = await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
 
+        Assert.Null(result);
         Assert.Contains(_interaction.Lines, l => l.StartsWith("WARNING:", StringComparison.Ordinal) && l.Contains("boom"));
         await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("init")]
+    [InlineData("new")]
+    public async Task ShortCircuitsWithReRunHint_AfterSetupForInitOrNew(string commandName)
+    {
+        _interaction.ConfirmResponse = true;
+        _setupRunner.RunAsync(Arg.Any<SetupCommandOptions>(), Arg.Any<CancellationToken>())
+            .Returns(new SetupRunResult(0));
+        FirstRunCoordinator coordinator = CreateCoordinator();
+
+        int? result = await coordinator.EnsureFirstRunPromptedAsync(commandName, Parse(commandName), CancellationToken.None);
+
+        Assert.Equal(0, result);
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("HINT:", StringComparison.Ordinal) && l.Contains($"Re-run `func {commandName}`"));
+        await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DoesNotShortCircuit_WhenInitDeclinesSetup()
+    {
+        _interaction.ConfirmResponse = false;
+        FirstRunCoordinator coordinator = CreateCoordinator();
+
+        int? result = await coordinator.EnsureFirstRunPromptedAsync("init", Parse("init"), CancellationToken.None);
+
+        Assert.Null(result);
+        await _setupRunner.DidNotReceiveWithAnyArgs().RunAsync(default!, default);
+        await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DoesNotShortCircuit_WhenInitSetupFails()
+    {
+        _interaction.ConfirmResponse = true;
+        _setupRunner.RunAsync(Arg.Any<SetupCommandOptions>(), Arg.Any<CancellationToken>())
+            .Returns(new SetupRunResult(1));
+        FirstRunCoordinator coordinator = CreateCoordinator();
+
+        int? result = await coordinator.EnsureFirstRunPromptedAsync("init", Parse("init"), CancellationToken.None);
+
+        Assert.Null(result);
+        await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ShowsBreadcrumb_WhenMarkerPresentButNoWorkloads()
+    {
+        _stateStore.GetStateAsync(Arg.Any<CancellationToken>()).Returns(FirstRunState.MarkerWithoutWorkloads);
+        FirstRunCoordinator coordinator = CreateCoordinator();
+
+        int? result = await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
+
+        Assert.Null(result);
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("HINT:", StringComparison.Ordinal) && l.Contains("`func setup`"));
+        Assert.Equal(0, _interaction.ConfirmCalls);
+        await _stateStore.DidNotReceiveWithAnyArgs().MarkCompleteAsync(default);
+    }
+
+    [Fact]
+    public async Task DoesNotShowBreadcrumb_ForSkippedCommands()
+    {
+        _stateStore.GetStateAsync(Arg.Any<CancellationToken>()).Returns(FirstRunState.MarkerWithoutWorkloads);
+        FirstRunCoordinator coordinator = CreateCoordinator();
+
+        int? result = await coordinator.EnsureFirstRunPromptedAsync("setup", Parse("setup"), CancellationToken.None);
+
+        Assert.Null(result);
+        Assert.DoesNotContain(_interaction.Lines, l => l.Contains("`func setup`"));
+    }
+
+    [Fact]
+    public async Task DoesNotShowBreadcrumb_WhenNonInteractive()
+    {
+        _stateStore.GetStateAsync(Arg.Any<CancellationToken>()).Returns(FirstRunState.MarkerWithoutWorkloads);
+        _interaction.InteractiveOverride = false;
+        FirstRunCoordinator coordinator = CreateCoordinator();
+
+        int? result = await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
+
+        Assert.Null(result);
+        Assert.DoesNotContain(_interaction.Lines, l => l.Contains("`func setup`"));
     }
 
     private FirstRunCoordinator CreateCoordinator() => new(_interaction, _stateStore, _setupRunner);
@@ -176,6 +264,8 @@ public sealed class FirstRunCoordinatorTests
         root.Subcommands.Add(new Command("help"));
         root.Subcommands.Add(new Command("version"));
         root.Subcommands.Add(new Command("start"));
+        root.Subcommands.Add(new Command("init"));
+        root.Subcommands.Add(new Command("new"));
 
         return root.Parse(args);
     }


### PR DESCRIPTION
Stacked on top of #5220. Targeted at `liliankasem/feat/setup-ux` so the diff
shows only this PR's changes; merge into `vnext` after #5220 lands.

Implements the pending items from
[`docs/first-run-experience.md`](docs/first-run-experience.md).

## Items

1. **Bare `func` triggers the prompt.** Tightened the bare-invocation
   check in `FirstRunCoordinator.IsSkipped` so any invocation with
   `Tokens.Count == 0` reaches the prompt, regardless of whether the
   parser reports a "Required command was not provided" error.

2. **New prompt copy.** Replaced the short explanation with the
   multi-paragraph copy from the spec (workloads, language stacks, host
   runtime, `--features <node|dotnet|go|python>` hint). Routed through
   `IInteractionService.WriteLine` / `WriteHint` (no raw `Console`).

3. **Ctrl+C writes the marker.** The confirm prompt is wrapped so
   `OperationCanceledException` writes the first-run marker before
   rethrowing. Best-effort: a failure to write the marker is swallowed
   so the original cancellation surfaces unchanged.

4. **Installed stacks are filtered out, not labelled.** Spectre's
   `MultiSelectionPrompt<T>` does not support per-row disabling, so I
   went with the preferred option from the brief: filter installed
   stacks out of the choice list and surface them as a single muted
   `Already installed: node, python` hint above the prompt. If every
   supported stack is already installed, the prompt is skipped and the
   run treats it as a clean opt-out.

5. **`func init` / `func new` prompt + post-setup hint.** Neither was
   in the skip list, so the prompt already fires (verified with new
   tests). After the in-process setup succeeds, the coordinator
   short-circuits with `Setup complete. Re-run \`func init\` to use the
   new stacks.` and returns exit code 0. **Spike result on the workload
   loader reload:** `IWorkloadStore.GetWorkloadsAsync` reads
   `workloads.json` fresh on every call, but the templates / bundles
   adapter stack snapshots metadata at host build time. Auditing every
   consumer is out of scope for this PR; the spec's documented fallback
   (re-run hint) is the path taken here. Follow-up issue will be filed
   for the in-process reload work.

6. **Subsequent-run breadcrumb.** Added a `FirstRunState` enum
   (`NeverPrompted`, `MarkerWithoutWorkloads`, `WorkloadsInstalled`)
   exposed via `IFirstRunStateStore.GetStateAsync`. The coordinator
   uses the new state in one read to pick between prompt / breadcrumb
   / silent. The muted `Tip: run \`func setup\` to install your dev
   environment and language stack dependencies.` line is suppressed
   for the same skip list as the prompt and in non-interactive
   contexts.

## Type / API changes

- `IFirstRunCoordinator.EnsureFirstRunPromptedAsync` now returns
  `Task<int?>`. `null` means "continue with the user's command";
  a value means the coordinator handled it (currently only the
  post-setup re-run hint for `init` / `new`, which returns `0`).
- `IFirstRunStateStore` gains `GetStateAsync`. `IsFirstRunAsync` stays
  for backward compatibility and is implemented in terms of the new
  state.

## Tests

All new behavior covered in `FirstRunCoordinatorTests` (+10 cases) and
`FileFirstRunStateStoreTests` (+3 cases). `SetupRunnerTests` updated to
assert the new "Already installed" hint. Local run: 990 passed,
release build (CI warnings-as-errors): 0 warnings.

## Docs

`docs/first-run-experience.md` "Implementation status" table updated and
the "interactive" and "init/new" sections rewritten to match the
shipped behavior. Note added about the deferred loader reload.