### PR TITLE
func new: surface `-name` typo as `Unrecognized option` instead of project-required error

### DIFF
--- a/src/Func/Commands/NewCommand.cs
+++ b/src/Func/Commands/NewCommand.cs
@@ -360,14 +360,7 @@ internal sealed class NewCommand : FuncCliCommand, IBuiltInCommand, ITemplateAwa
             return 0;
         }
 
-        // PathArgument's CustomParser short-circuits with a parser error
-        // (and a sentinel return value) when the user typed something like
-        // `func new -name ttpt`: the `-name` token gets bound to <path>
-        // and PathArgument flags it as an unrecognized option. SCL's
-        // ArgumentConverter then throws when we call GetValue here, even
-        // though help-time hydration only needs a directory to probe.
-        // Fall back to cwd so the user still sees the template's option
-        // surface alongside the real parse-error diagnostic.
+        // PathArgument's parse error makes GetValue throw; fall back to cwd so help still renders.
         WorkingDirectory workingDirectory;
         try
         {

--- a/src/Func/Commands/NewCommand.cs
+++ b/src/Func/Commands/NewCommand.cs
@@ -360,7 +360,24 @@ internal sealed class NewCommand : FuncCliCommand, IBuiltInCommand, ITemplateAwa
             return 0;
         }
 
-        WorkingDirectory workingDirectory = parseResult.GetValue(PathArgument!)!;
+        // PathArgument's CustomParser short-circuits with a parser error
+        // (and a sentinel return value) when the user typed something like
+        // `func new -name ttpt`: the `-name` token gets bound to <path>
+        // and PathArgument flags it as an unrecognized option. SCL's
+        // ArgumentConverter then throws when we call GetValue here, even
+        // though help-time hydration only needs a directory to probe.
+        // Fall back to cwd so the user still sees the template's option
+        // surface alongside the real parse-error diagnostic.
+        WorkingDirectory workingDirectory;
+        try
+        {
+            workingDirectory = parseResult.GetValue(PathArgument!)!;
+        }
+        catch
+        {
+            workingDirectory = WorkingDirectory.FromCwd();
+        }
+
         var invocation = new NewInvocation(
             workingDirectory,
             RequestedTemplate: templateId,

--- a/src/Func/Program.cs
+++ b/src/Func/Program.cs
@@ -81,7 +81,18 @@ using (Activity? activity = CliTelemetry.Trace.StartCommandActivity())
         // PathArgument's unrecognized-token guard.
         NewCommandArgPreparer.PrepareIfFuncNew(args, host.Services, rootCommand);
 
-        commandParseResult = rootCommand.Parse(args);
+        // POSIX bundling silently re-interprets a single-dash multi-char
+        // token like `-name` as the short alias `-n` with a bundled value
+        // `ame`. That collapses obvious long-option typos (e.g. the user
+        // typing `-name X` when they meant `--name X`) into a parse where
+        // `-n` quietly consumes a stray value and the next positional
+        // token wanders into the path argument. Turning bundling off
+        // routes the typo through PathArgument's
+        // "Unrecognized option '<token>'." path instead, matching the UX
+        // the user already sees for `func start -no-build`. Long-option
+        // `=value` and space-separated short-option values are unaffected.
+        var parserConfiguration = new ParserConfiguration { EnablePosixBundling = false };
+        commandParseResult = rootCommand.Parse(args, parserConfiguration);
         commandName = CommandNameResolver.ResolveCommandName(commandParseResult, rootCommand);
         activity?.SetCommandName(commandName);
 

--- a/src/Func/Program.cs
+++ b/src/Func/Program.cs
@@ -81,16 +81,7 @@ using (Activity? activity = CliTelemetry.Trace.StartCommandActivity())
         // PathArgument's unrecognized-token guard.
         NewCommandArgPreparer.PrepareIfFuncNew(args, host.Services, rootCommand);
 
-        // POSIX bundling silently re-interprets a single-dash multi-char
-        // token like `-name` as the short alias `-n` with a bundled value
-        // `ame`. That collapses obvious long-option typos (e.g. the user
-        // typing `-name X` when they meant `--name X`) into a parse where
-        // `-n` quietly consumes a stray value and the next positional
-        // token wanders into the path argument. Turning bundling off
-        // routes the typo through PathArgument's
-        // "Unrecognized option '<token>'." path instead, matching the UX
-        // the user already sees for `func start -no-build`. Long-option
-        // `=value` and space-separated short-option values are unaffected.
+        // Disable POSIX bundling so single-dash typos like `-name` surface as unrecognized options.
         var parserConfiguration = new ParserConfiguration { EnablePosixBundling = false };
         commandParseResult = rootCommand.Parse(args, parserConfiguration);
         commandName = CommandNameResolver.ResolveCommandName(commandParseResult, rootCommand);

--- a/test/Func.Tests/Commands/NewCommandTests.cs
+++ b/test/Func.Tests/Commands/NewCommandTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.CommandLine;
 using Azure.Functions.Cli.Commands;
 using Azure.Functions.Cli.Templates;
 using NSubstitute;
@@ -60,4 +61,33 @@ public class NewCommandTests
         Assert.Single(cmd.Arguments);
         Assert.Equal("path", cmd.Arguments[0].Name);
     }
+
+    /// <summary>
+    /// Regression guard for a misleading-error UX bug: typing
+    /// <c>func new --template HttpTrigger-Python -name ttpt</c> used to
+    /// collapse <c>-name</c> into the short alias <c>-n</c> with bundled
+    /// value <c>ame</c> (POSIX bundling), then bind <c>ttpt</c> to the
+    /// path argument. Project resolution would fail against the non-
+    /// existent <c>ttpt</c> directory and the user saw a confusing
+    /// <c>"needs a Functions project"</c> message instead of the typo
+    /// diagnostic <c>func start -no-build</c> already produced.
+    ///
+    /// Fix: disable POSIX bundling at the root parse level so single-dash
+    /// multi-character typos fall through to PathArgument's
+    /// <c>"Unrecognized option '&lt;token&gt;'."</c> path.
+    /// </summary>
+    [Fact]
+    public void NewCommand_SingleDashLongOption_ReportsUnrecognizedOption()
+    {
+        var root = TestParser.CreateRoot(_interaction);
+
+        ParseResult result = root.Parse(
+            new[] { "new", "--template", "HttpTrigger-Python", "-name", "ttpt" },
+            new ParserConfiguration { EnablePosixBundling = false });
+
+        Assert.Contains(
+            result.Errors,
+            e => e.Message.Contains("Unrecognized option '-name'", System.StringComparison.Ordinal));
+    }
 }
+

--- a/test/Func.Tests/Commands/NewCommandTests.cs
+++ b/test/Func.Tests/Commands/NewCommandTests.cs
@@ -62,20 +62,7 @@ public class NewCommandTests
         Assert.Equal("path", cmd.Arguments[0].Name);
     }
 
-    /// <summary>
-    /// Regression guard for a misleading-error UX bug: typing
-    /// <c>func new --template HttpTrigger-Python -name ttpt</c> used to
-    /// collapse <c>-name</c> into the short alias <c>-n</c> with bundled
-    /// value <c>ame</c> (POSIX bundling), then bind <c>ttpt</c> to the
-    /// path argument. Project resolution would fail against the non-
-    /// existent <c>ttpt</c> directory and the user saw a confusing
-    /// <c>"needs a Functions project"</c> message instead of the typo
-    /// diagnostic <c>func start -no-build</c> already produced.
-    ///
-    /// Fix: disable POSIX bundling at the root parse level so single-dash
-    /// multi-character typos fall through to PathArgument's
-    /// <c>"Unrecognized option '&lt;token&gt;'."</c> path.
-    /// </summary>
+    // Single-dash typos like `-name` must surface as unrecognized options, not "needs a project".
     [Fact]
     public void NewCommand_SingleDashLongOption_ReportsUnrecognizedOption()
     {


### PR DESCRIPTION
### Summary

Fix a misleading-error UX bug where `func new --template HttpTrigger-Python -name ttpt` reported a project-required error instead of flagging the obvious option typo.

### Repro

In an init'd Python project, run:

```
func new --template HttpTrigger-Python -name ttpt
```

### Before

```
Error: `func new --list` needs a Functions project.
Run func init first to choose a stack and language.
```

The user typed `-name` (a single-dash typo of `--name`). `System.CommandLine`'s POSIX bundling silently re-interpreted the token as the short alias `-n` carrying a bundled value `ame`. The trailing `ttpt` then bound to the `[path]` argument, project resolution failed against the non-existent `ttpt` subdirectory, and `RenderProjectRequired()` fired.

For comparison, `func start -no-build` (no `-n` alias on `run` so bundling can't engage) already produced the helpful diagnostic:

```
Unrecognized option '-no-build'.

func run
...
```

### After

```
'ttpt' was not matched. Did you mean one of the following?
-t

Unrecognized option '-name'.


func new

Create a new function from a template.

Usage

  func new [path] [options]

Arguments

  <path>    The project directory to use (defaults to current directory)

Options

  --name, -n           Function name. Defaults to the template's default
                       function name.
  --template, -t       Template ID. Omit in an interactive shell to pick from a
                       list.
  --force              Overwrite existing files.
  --non-interactive    Refuse to prompt; exit 1 if any required input is
                       missing.
  --list, -l           List available templates for this project instead of
                       scaffolding.
  --output             Output mode (plain | json). Defaults to plain.

Template Options (HttpTrigger-Python)

  --app-file-name                   Provide a filename for your function
  --trigger-function-name           Provide a function name
  --http-trigger-auth-level         Authorization level
  --app-selected-file-name          File Name
  --blueprint-file-name             Blueprint function file Name
  --blueprint-existing-file-name    Select a file to save for your blueprint
                                    function
```

Exit code `1`. UX now matches `func start -no-build`, and the template-options section is still surfaced so the user can confirm what they meant to type.

### Changes

* **`src/Func/Program.cs`** — Pass `new ParserConfiguration { EnablePosixBundling = false }` to `rootCommand.Parse(args, …)`. Routes single-dash multi-char typos through `PathArgument`'s existing "Unrecognized option '`<token>`'." path. Long-option `=value` and space-separated short-option values are unaffected.
* **`src/Func/Commands/NewCommand.cs`** — Wrap `parseResult.GetValue(PathArgument!)` in `AttachHydratedOptionsForHelp` in try/catch. When `PathArgument`'s `CustomParser` short-circuits with a parser error and a sentinel return value (which happens for the same typo), SCL's `ArgumentConverter` throws `InvalidOperationException` on the second read. Falling back to cwd keeps help-time hydration alive so the template-options section still renders alongside the real parse-error diagnostic.
* **`test/Func.Tests/Commands/NewCommandTests.cs`** — New `NewCommand_SingleDashLongOption_ReportsUnrecognizedOption` regression guard.

### Side effects of disabling POSIX bundling

Users can no longer write bundled short-options like `-pPORT` (value crammed onto the alias) or `-abc` (three boolean flags fused). The supported forms are unchanged:

* `-p PORT` (space-separated value) ✅
* `-p=PORT` (explicit `=` value) ✅
* `-a -b -c` (separate flags) ✅
* `--long=value` ✅

No tests or production code in this repo rely on POSIX bundling (verified via repo-wide grep).

### Validation

* `dotnet build src/Func/Func.csproj` — clean.
* `dotnet test test/Func.Tests/Func.Tests.csproj --filter "NewCommand|StartCommand|Parser"` — 56/56 passing (including the new regression test).
* Manual playground sweep:
  * `func new -t HttpTrigger-Python --name Foo --non-interactive` — scaffolds.
  * `func new -t HttpTrigger-Python -n Foo --non-interactive` — scaffolds (short alias, space-separated).
  * `func new -t HttpTrigger-Python --name Foo --http-trigger-auth-level FUNCTION --non-interactive` — hydrated template option respected.
  * `func init . -l python -s python` — init short aliases unaffected.
  * `func start -no-build` — unchanged.
