### PR TITLE
Filter non-workload packages from `func workload search`

### DIFF
--- a/src/Func/Workloads/Catalog/NuGetProtocolSourceClient.cs
+++ b/src/Func/Workloads/Catalog/NuGetProtocolSourceClient.cs
@@ -162,11 +162,12 @@ internal class NuGetProtocolSourceClient(SourceRepository repository)
 
     /// <summary>
     /// Parses the V3 search response and applies a defensive client-side
-    /// filter on each hit's <c>packageTypes</c> array. Feeds that honour
-    /// <c>packageType=</c> server-side return a pre-filtered set; feeds that
-    /// don't (older or non-conforming implementations) get filtered here.
-    /// Hits that omit <c>packageTypes</c> are kept, since the server filter
-    /// already had its chance.
+    /// filter on each hit's <c>packageTypes</c> array. nuget.org honours
+    /// <c>packageType=</c> only when the query string is non-empty; an
+    /// unfiltered <c>func workload search</c> otherwise leaks arbitrary
+    /// matches like <c>Azure.Functions.Cli.Abstractions</c> (see
+    /// azure-functions-core-tools#5198). Hits that omit <c>packageTypes</c>
+    /// are kept, since some V3 feeds don't surface the field.
     /// </summary>
     internal static IReadOnlyList<CatalogSearchResult> ParseV3Hits(JObject response, PackageSource source)
     {
@@ -182,6 +183,11 @@ internal class NuGetProtocolSourceClient(SourceRepository repository)
             string? versionString = (string?)hit["version"];
             if (string.IsNullOrEmpty(id) || string.IsNullOrEmpty(versionString) ||
                 !NuGetVersion.TryParse(versionString, out NuGetVersion? version))
+            {
+                continue;
+            }
+
+            if (!HitMatchesWorkloadPackageType(hit["packageTypes"]))
             {
                 continue;
             }
@@ -268,5 +274,31 @@ internal class NuGetProtocolSourceClient(SourceRepository repository)
         }
 
         return kind;
+    }
+
+    // Hits without a `packageTypes` array fall through (kept): V3 search
+    // responses don't guarantee the field, and dropping silent hits would
+    // empty out compliant feeds. When the array is present, require the
+    // FuncCliWorkload entry so arbitrary nuget.org packages don't leak
+    // through when the server-side `packageType=` filter is ignored (e.g.
+    // for empty queries).
+    private static bool HitMatchesWorkloadPackageType(JToken? packageTypes)
+    {
+        if (packageTypes is not JArray array || array.Count == 0)
+        {
+            return true;
+        }
+
+        foreach (JToken entry in array)
+        {
+            string? name = (string?)entry["name"] ?? (entry as JValue)?.Value as string;
+            if (!string.IsNullOrEmpty(name)
+                && string.Equals(name, FuncCliWorkloadPackageType, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/test/Func.Tests/Workloads/Catalog/NuGetProtocolSourceClientTests.cs
+++ b/test/Func.Tests/Workloads/Catalog/NuGetProtocolSourceClientTests.cs
@@ -102,6 +102,60 @@ public sealed class NuGetProtocolSourceClientTests
         Assert.Empty(NuGetProtocolSourceClient.ParseV3Hits(response, _source));
     }
 
+    [Fact]
+    public void ParseV3Hits_FiltersHitsLackingFuncCliWorkloadPackageType()
+    {
+        // nuget.org ignores `packageType=` when q is empty, so an unfiltered
+        // `func workload search` leaks arbitrary packages (issue #5198).
+        // Defensive filter keeps hits that omit packageTypes (some feeds
+        // don't include the field) but drops hits that declare other types.
+        var response = JObject.Parse("""
+            {
+              "data": [
+                {
+                  "id": "Workloads.Python",
+                  "version": "1.0.0",
+                  "packageTypes": [ { "name": "FuncCliWorkload" } ]
+                },
+                {
+                  "id": "Azure.Functions.Cli.Abstractions",
+                  "version": "5.0.0",
+                  "packageTypes": [ { "name": "Dependency" } ]
+                },
+                {
+                  "id": "Workloads.NoPackageTypes",
+                  "version": "1.0.0"
+                }
+              ]
+            }
+            """);
+
+        var results = NuGetProtocolSourceClient.ParseV3Hits(response, _source);
+
+        Assert.Equal(2, results.Count);
+        Assert.Contains(results, r => r.PackageId == "workloads.python");
+        Assert.Contains(results, r => r.PackageId == "workloads.nopackagetypes");
+        Assert.DoesNotContain(results, r => r.PackageId == "azure.functions.cli.abstractions");
+    }
+
+    [Fact]
+    public void ParseV3Hits_PackageTypeMatchIsCaseInsensitive()
+    {
+        var response = JObject.Parse("""
+            {
+              "data": [
+                {
+                  "id": "Workloads.Host",
+                  "version": "1.0.0",
+                  "packageTypes": [ { "name": "funccliworkload" } ]
+                }
+              ]
+            }
+            """);
+
+        Assert.Single(NuGetProtocolSourceClient.ParseV3Hits(response, _source));
+    }
+
 
     [Fact]
     public async Task ListVersionsAsync_ReturnsResolvedVersions()


### PR DESCRIPTION
Fixes #5198.

nuget.org honours the `packageType=` query-string filter only when `q=` is non-empty, so an unfiltered `func workload search` leaks arbitrary packages like `Azure.Functions.Cli.Abstractions`, `Azure.Functions.Sdk`, and `Azure.Connectors.Sdk`.

`NuGetProtocolSourceClient.ParseV3Hits` already had a doc comment claiming it applied a defensive client-side `packageTypes` filter, but the filter itself was missing. This adds it: hits that declare `packageTypes` must include `FuncCliWorkload`; hits that omit the field still fall through (some V3 feeds don't surface it).

Tests cover both the drop path (`Dependency`-typed packages) and the fall-through path (missing `packageTypes`).