### PR TITLE
Adopt existing projects in `func init`

### DIFF
--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -362,11 +362,24 @@ If a newer version is found, a notice is printed after the command completes.
    └── No matching initializer    → "No installed workload supports stack '<x>'." (exit 1)
 3. Detect existing project state:
    ├── .func/config.json present  → fully initialized; refuse without --force
-   ├── host.json only             → adopt: write .func/config.json, skip scaffolding
+   ├── host.json only             → adopt mode (see below); skip scaffolding
    └── empty                      → scaffold via IProjectInitializer.InitializeAsync
 4. Build InitContext (WorkingDirectory, ProjectName, Language, Force)
 5. Delegate to IProjectInitializer.InitializeAsync(context, parseResult) (skipped in adopt mode)
 ```
+
+**Adopt mode** (host.json present, no `.func/config.json`):
+
+1. Resolve `project_runtime` = `FUNCTIONS_WORKER_RUNTIME` env (preferred, matches the host) ?? `local.settings.json` ?? null. Warn if env and `local.settings.json` disagree.
+2. Apply:
+
+   | `project_runtime` → | `--stack` omitted | `--stack X` agrees | `--stack X` conflicts |
+   |---|---|---|---|
+   | null | current behavior (prompt / auto-select / error) | adopt with `X` | n/a |
+   | installed | adopt + snap | adopt with `X` | refuse (use `--force`) |
+   | uninstalled | adopt + hint `func setup --features <stack>` | adopt with `X` | refuse (use `--force`) |
+
+3. Write `.func/config.json` with the resolved stack. Skip scaffolding so user source is untouched. `--force` always bypasses adopt mode and takes the full scaffold path.
 
 Each registered initializer also contributes options to `func init` via `GetInitOptions(IInitOptionRegistry)`; values are read back inside `InitializeAsync` via the `ParseResult`. The registry collapses same-named contributions across workloads so shared options (e.g. `--no-bundles`) show up once in `--help` and every contributing workload reads the canonical instance.
 

--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -379,7 +379,7 @@ If a newer version is found, a notice is printed after the command completes.
    | installed | adopt + snap | adopt with `X` | refuse (use `--force`) |
    | uninstalled | refuse with `func setup --features <stack>` hint | refuse (same hint) | refuse |
 
-   Any candidate stack (from `--stack` or `local.settings.json`) that doesn't match an installed initializer is refused. The hint uses a literal `<stack>` placeholder rather than the raw runtime value, because the value itself may not be a valid feature id (e.g. typos, or `native` for Go).
+   Any candidate stack (from `--stack` or `local.settings.json`) that doesn't match an installed initializer (by canonical `Stack` id or by one of its `WorkerRuntimeAliases`) is refused. Aliases let runtime values like `dotnet-isolated` resolve to the `dotnet` stack and `native` to `go`. The hint uses a literal `<stack>` placeholder rather than the raw runtime value, because the value itself may not be a valid feature id (e.g. typos).
 
 3. Write `.func/config.json` with the resolved stack. Skip scaffolding so user source is untouched. `--force` always bypasses adopt mode and takes the full scaffold path.
 

--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -373,11 +373,13 @@ If a newer version is found, a notice is printed after the command completes.
 1. Resolve `project_runtime` from `local.settings.json`'s `FUNCTIONS_WORKER_RUNTIME`. The process env var is intentionally ignored: adoption is about the on-disk project shape.
 2. Apply:
 
-   | `project_runtime` → | `--stack` omitted | `--stack X` agrees | `--stack X` conflicts |
+   | `project_runtime` → | `--stack` omitted | `--stack X` (installed) agrees | `--stack X` conflicts |
    |---|---|---|---|
-   | null | current behavior (prompt / auto-select / error) | adopt with `X` | n/a |
+   | null | interactive: prompt "Adopting an existing project. Which stack is it?". Non-interactive: refuse with "Couldn't detect the project's stack". | adopt with `X` | n/a |
    | installed | adopt + snap | adopt with `X` | refuse (use `--force`) |
-   | uninstalled | adopt + hint `func setup --features <stack>` | adopt with `X` | refuse (use `--force`) |
+   | uninstalled | refuse with `func setup --features <stack>` hint | refuse (same hint) | refuse |
+
+   Any candidate stack (from `--stack` or `local.settings.json`) that doesn't match an installed initializer is refused. The hint uses a literal `<stack>` placeholder rather than the raw runtime value, because the value itself may not be a valid feature id (e.g. typos, or `native` for Go).
 
 3. Write `.func/config.json` with the resolved stack. Skip scaffolding so user source is untouched. `--force` always bypasses adopt mode and takes the full scaffold path.
 

--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -370,7 +370,7 @@ If a newer version is found, a notice is printed after the command completes.
 
 **Adopt mode** (host.json present, no `.func/config.json`):
 
-1. Resolve `project_runtime` = `FUNCTIONS_WORKER_RUNTIME` env (preferred, matches the host) ?? `local.settings.json` ?? null. Warn if env and `local.settings.json` disagree.
+1. Resolve `project_runtime` from `local.settings.json`'s `FUNCTIONS_WORKER_RUNTIME`. The process env var is intentionally ignored: adoption is about the on-disk project shape.
 2. Apply:
 
    | `project_runtime` → | `--stack` omitted | `--stack X` agrees | `--stack X` conflicts |

--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -360,8 +360,12 @@ If a newer version is found, a notice is printed after the command completes.
 2. Resolve the matching IProjectInitializer via CanHandle(stack)
    ├── No initializers installed  → "No language workloads installed." (exit 1)
    └── No matching initializer    → "No installed workload supports stack '<x>'." (exit 1)
-3. Build InitContext (WorkingDirectory, ProjectName, Language, Force)
-4. Delegate to IProjectInitializer.InitializeAsync(context, parseResult)
+3. Detect existing project state:
+   ├── .func/config.json present  → fully initialized; refuse without --force
+   ├── host.json only             → adopt: write .func/config.json, skip scaffolding
+   └── empty                      → scaffold via IProjectInitializer.InitializeAsync
+4. Build InitContext (WorkingDirectory, ProjectName, Language, Force)
+5. Delegate to IProjectInitializer.InitializeAsync(context, parseResult) (skipped in adopt mode)
 ```
 
 Each registered initializer also contributes options to `func init` via `GetInitOptions(IInitOptionRegistry)`; values are read back inside `InitializeAsync` via the `ParseResult`. The registry collapses same-named contributions across workloads so shared options (e.g. `--no-bundles`) show up once in `--help` and every contributing workload reads the canonical instance.

--- a/src/Abstractions/Projects/IProjectInitializer.cs
+++ b/src/Abstractions/Projects/IProjectInitializer.cs
@@ -22,6 +22,16 @@ public interface IProjectInitializer
     public string Stack { get; }
 
     /// <summary>
+    /// Additional <c>FUNCTIONS_WORKER_RUNTIME</c> values that should resolve
+    /// to this stack. Used during <c>func init</c> adoption to map the
+    /// runtime string in <c>local.settings.json</c> (e.g. "dotnet-isolated",
+    /// "native") to the canonical <see cref="Stack"/> id. Matching is
+    /// case-insensitive. Defaults to an empty list, which means
+    /// "<see cref="Stack"/> is the only accepted runtime value".
+    /// </summary>
+    public IReadOnlyList<string> WorkerRuntimeAliases => [];
+
+    /// <summary>
     /// Human-friendly name for this stack shown in interactive prompts and help text
     /// (e.g. ".NET", "Node.js"). Defaults to <see cref="Stack"/> when not overridden.
     /// </summary>

--- a/src/Func/Commands/InitCommand.cs
+++ b/src/Func/Commands/InitCommand.cs
@@ -21,8 +21,11 @@ namespace Azure.Functions.Cli.Commands;
 /// <remarks>
 /// When the target directory already contains a <c>host.json</c> but no
 /// <c>.func/config.json</c>, the command "adopts" the project: it writes the
-/// CLI config (stack + language) and skips scaffolding. This is how pre-v5
-/// projects opt in to the v5 CLI.
+/// CLI config and skips scaffolding. The stack is taken from
+/// <c>FUNCTIONS_WORKER_RUNTIME</c> (env or <c>local.settings.json</c>) when set,
+/// otherwise the user is prompted as usual. An explicit <c>--stack</c> that
+/// conflicts with the project's declared runtime is refused unless
+/// <c>--force</c> is passed.
 /// </remarks>
 internal class InitCommand : FuncCliCommand, IBuiltInCommand
 {
@@ -45,17 +48,28 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
 
     private readonly IInteractionService _interaction;
     private readonly IWorkloadHintRenderer _hintRenderer;
+    private readonly ILocalSettingsProvider _localSettingsProvider;
+    private readonly IProcessEnvironment _processEnvironment;
     private readonly IReadOnlyList<IProjectInitializer> _initializers;
 
-    public InitCommand(IInteractionService interaction, IWorkloadHintRenderer hintRenderer, IEnumerable<IProjectInitializer> initializers)
+    public InitCommand(
+        IInteractionService interaction,
+        IWorkloadHintRenderer hintRenderer,
+        ILocalSettingsProvider localSettingsProvider,
+        IProcessEnvironment processEnvironment,
+        IEnumerable<IProjectInitializer> initializers)
         : base("init", "Initialize a new Azure Functions project.")
     {
         ArgumentNullException.ThrowIfNull(interaction);
         ArgumentNullException.ThrowIfNull(hintRenderer);
+        ArgumentNullException.ThrowIfNull(localSettingsProvider);
+        ArgumentNullException.ThrowIfNull(processEnvironment);
         ArgumentNullException.ThrowIfNull(initializers);
 
         _interaction = interaction;
         _hintRenderer = hintRenderer;
+        _localSettingsProvider = localSettingsProvider;
+        _processEnvironment = processEnvironment;
         _initializers = initializers.ToList();
 
         StackOption.Description = BuildStackOptionDescription(_initializers);
@@ -124,27 +138,80 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
             return 1;
         }
 
-        IProjectInitializer? initializer = await SelectInitializerAsync(requestedStack, cancellationToken);
-
-        if (initializer is null)
-        {
-            return 1;
-        }
-
-        (string? resolved, int? errorCode) = await ResolveLanguageAsync(language, initializer, cancellationToken);
-        if (errorCode is int code)
-        {
-            return code;
-        }
-
-        language = resolved;
-
         // host.json without .func/config.json means a pre-existing Functions
         // project that predates the v5 CLI config. Adopt it: write the config
         // so subsequent commands know the stack/language, but skip scaffolding
         // so we don't trample the user's source. --force still means "wipe and
         // re-scaffold" and takes the normal path.
         bool adoptExisting = state == InitializationState.AdoptableExistingProject && !force;
+
+        // For adoption we try to honour what the project already declares.
+        // Resolution order matches the Functions host: env wins over
+        // local.settings.json. On conflict we warn (host doesn't refuse)
+        // but use the env value.
+        string? projectRuntime = adoptExisting ? ResolveProjectRuntime(workingDirectory.Info) : null;
+
+        if (adoptExisting && projectRuntime is not null)
+        {
+            // Explicit --stack that disagrees with the project's declared
+            // runtime is almost certainly a mistake (it would produce a
+            // .func/config.json that doesn't match what `func start` would
+            // run). --force is the existing escape hatch.
+            if (!string.IsNullOrWhiteSpace(requestedStack)
+                && !string.Equals(requestedStack, projectRuntime, StringComparison.OrdinalIgnoreCase))
+            {
+                _interaction.WriteError(
+                    $"--stack '{requestedStack}' conflicts with the project's runtime '{projectRuntime}'. " +
+                    "Re-run with the matching stack, or pass --force to override.");
+                return 1;
+            }
+
+            // Snap when the user didn't specify --stack: the project already
+            // declared its runtime, no point re-asking.
+            requestedStack ??= projectRuntime;
+        }
+
+        // For adoption with a known runtime we look up the matching
+        // initializer directly; we never prompt or auto-select because we
+        // already have a project signal. SelectInitializerAsync's prompt /
+        // workload-hint path is only for fresh inits or adoption with no
+        // runtime signal.
+        IProjectInitializer? initializer;
+        if (adoptExisting && projectRuntime is not null)
+        {
+            initializer = _initializers.FirstOrDefault(i =>
+                string.Equals(i.Stack, requestedStack, StringComparison.OrdinalIgnoreCase));
+
+            if (initializer is null)
+            {
+                // Stack named by the project isn't installed. Still adopt
+                // (write the config so other commands see the right stack),
+                // and point the user at the one command that closes the gap.
+                return AdoptWithUninstalledStack(workingDirectory.Info, requestedStack!);
+            }
+        }
+        else
+        {
+            initializer = await SelectInitializerAsync(requestedStack, cancellationToken);
+            if (initializer is null)
+            {
+                return 1;
+            }
+        }
+
+        // For adoption with no explicit --language, skip language resolution
+        // entirely: the user already has code, and prompting / erroring for
+        // a language they're not changing is just noise.
+        if (!(adoptExisting && string.IsNullOrWhiteSpace(language)))
+        {
+            (string? resolved, int? errorCode) = await ResolveLanguageAsync(language, initializer, cancellationToken);
+            if (errorCode is int code)
+            {
+                return code;
+            }
+
+            language = resolved;
+        }
 
         if (force)
         {
@@ -295,6 +362,48 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
         }
 
         return InitializationState.Empty;
+    }
+
+    // Looks up the project's worker runtime, matching the precedence the
+    // Functions host applies at run time: process env beats local.settings.json.
+    // When both are set and disagree we keep the env value (host behaviour) and
+    // warn so the user can reconcile.
+    private string? ResolveProjectRuntime(DirectoryInfo workingDirectory)
+    {
+        string? envRaw = _processEnvironment.Get(CliConfigurationNames.WorkerRuntimeSettingName);
+        string? localRaw = _localSettingsProvider.Get(workingDirectory).WorkerRuntime;
+
+        string? env = string.IsNullOrWhiteSpace(envRaw) ? null : envRaw.Trim();
+        string? local = string.IsNullOrWhiteSpace(localRaw) ? null : localRaw.Trim();
+
+        if (env is not null && local is not null
+            && !string.Equals(env, local, StringComparison.OrdinalIgnoreCase))
+        {
+            _interaction.WriteWarning(
+                $"FUNCTIONS_WORKER_RUNTIME env variable '{env}' overrides local.settings.json value '{local}'.");
+        }
+
+        return env ?? local;
+    }
+
+    // Adopt-mode path for a runtime whose stack workload isn't installed.
+    // We still write .func/config.json so subsequent commands know the stack,
+    // and we point the user at `func setup --features` to install the bits.
+    // The raw runtime value is written verbatim; if a workload normalises
+    // the stack name on first read it can rewrite the config then.
+    private int AdoptWithUninstalledStack(DirectoryInfo workingDirectory, string runtime)
+    {
+        WriteCliConfigurationFile(workingDirectory, runtime, language: null, force: false);
+        _interaction.WriteBlankLine();
+        _interaction.WriteWarning(
+            $"The '{runtime}' stack is not installed. Run `func setup --features {runtime}` to install it.");
+        _interaction.WriteLine(l => l
+            .Success("✓ ")
+            .Muted("Existing project adopted for ")
+            .Code(runtime)
+            .Muted("."));
+
+        return 0;
     }
 
     private void WriteCliConfigurationFile(DirectoryInfo workingDirectory, string? stack, string? language, bool force)

--- a/src/Func/Commands/InitCommand.cs
+++ b/src/Func/Commands/InitCommand.cs
@@ -18,6 +18,12 @@ namespace Azure.Functions.Cli.Commands;
 /// Each registered initializer may also contribute additional options to this
 /// command (e.g. dotnet's <c>--target-framework</c>).
 /// </summary>
+/// <remarks>
+/// When the target directory already contains a <c>host.json</c> but no
+/// <c>.func/config.json</c>, the command "adopts" the project: it writes the
+/// CLI config (stack + language) and skips scaffolding. This is how pre-v5
+/// projects opt in to the v5 CLI.
+/// </remarks>
 internal class InitCommand : FuncCliCommand, IBuiltInCommand
 {
     public Option<string?> StackOption { get; } = new("--stack", "-s");
@@ -105,14 +111,15 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
         }
         string? requestedStack = parseResult.GetValue(StackOption);
 
-        // Refuse to overwrite an existing Functions project. Either host.json
-        // or .func/config.json being present is enough to count: both are
-        // Functions project skeleton files we'd otherwise rewrite. --force opts in
-        // to a re-init.
-        if (!force && IsAlreadyInitialized(workingDirectory.Info, out string existingFile))
+        InitializationState state = DetectInitializationState(workingDirectory.Info);
+
+        // .func/config.json already present means the project has been fully
+        // initialized by v5; re-running without --force would silently no-op
+        // the config write and re-scaffold on top of the user's code.
+        if (state == InitializationState.FullyInitialized && !force)
         {
             _interaction.WriteError(
-                $"This directory already contains a Functions project ('{existingFile}' is present). " +
+                $"This directory already contains a Functions project ('{CliConfigurationPathsOptions.ProjectConfigDisplayPath}' is present). " +
                 "Pass --force to re-initialize.");
             return 1;
         }
@@ -131,6 +138,13 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
         }
 
         language = resolved;
+
+        // host.json without .func/config.json means a pre-existing Functions
+        // project that predates the v5 CLI config. Adopt it: write the config
+        // so subsequent commands know the stack/language, but skip scaffolding
+        // so we don't trample the user's source. --force still means "wipe and
+        // re-scaffold" and takes the normal path.
+        bool adoptExisting = state == InitializationState.AdoptableExistingProject && !force;
 
         if (force)
         {
@@ -152,6 +166,17 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
         WriteCliConfigurationFile(workingDirectory.Info, initializer.Stack, persistedLanguage, force);
         _interaction.WriteBlankLine();
 
+        if (adoptExisting)
+        {
+            _interaction.WriteLine(l => l
+                .Success("✓ ")
+                .Muted("Existing project adopted for ")
+                .Code(initializer.Stack)
+                .Muted("."));
+
+            return 0;
+        }
+
         var context = new InitContext(
             WorkingDirectory: workingDirectory,
             ProjectName: parseResult.GetValue(NameOption),
@@ -167,6 +192,20 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
             .Muted("."));
 
         return 0;
+    }
+
+    private enum InitializationState
+    {
+        // No Functions project markers present; safe to scaffold from scratch.
+        Empty,
+
+        // host.json present but the v5 config (.func/config.json) is missing.
+        // Treat as a pre-v5 project we can adopt by writing the config.
+        AdoptableExistingProject,
+
+        // .func/config.json is present. Already a v5 project; refuse without
+        // --force.
+        FullyInitialized,
     }
 
     protected override string HelpFooterHint =>
@@ -241,24 +280,21 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
         DirectoryGuard.ClearExceptGit(workingDirectory);
     }
 
-    private static bool IsAlreadyInitialized(DirectoryInfo workingDirectory, out string existingFile)
+    private static InitializationState DetectInitializationState(DirectoryInfo workingDirectory)
     {
-        string hostJson = Path.Combine(workingDirectory.FullName, "host.json");
-        if (File.Exists(hostJson))
-        {
-            existingFile = "host.json";
-            return true;
-        }
-
         string config = CliConfigurationPathsOptions.GetProjectConfigPath(workingDirectory);
         if (File.Exists(config))
         {
-            existingFile = Path.GetRelativePath(workingDirectory.FullName, config);
-            return true;
+            return InitializationState.FullyInitialized;
         }
 
-        existingFile = string.Empty;
-        return false;
+        string hostJson = Path.Combine(workingDirectory.FullName, "host.json");
+        if (File.Exists(hostJson))
+        {
+            return InitializationState.AdoptableExistingProject;
+        }
+
+        return InitializationState.Empty;
     }
 
     private void WriteCliConfigurationFile(DirectoryInfo workingDirectory, string? stack, string? language, bool force)

--- a/src/Func/Commands/InitCommand.cs
+++ b/src/Func/Commands/InitCommand.cs
@@ -22,7 +22,7 @@ namespace Azure.Functions.Cli.Commands;
 /// When the target directory already contains a <c>host.json</c> but no
 /// <c>.func/config.json</c>, the command "adopts" the project: it writes the
 /// CLI config and skips scaffolding. The stack is taken from
-/// <c>FUNCTIONS_WORKER_RUNTIME</c> (env or <c>local.settings.json</c>) when set,
+/// <c>local.settings.json</c>'s <c>FUNCTIONS_WORKER_RUNTIME</c> when set,
 /// otherwise the user is prompted as usual. An explicit <c>--stack</c> that
 /// conflicts with the project's declared runtime is refused unless
 /// <c>--force</c> is passed.
@@ -49,27 +49,23 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
     private readonly IInteractionService _interaction;
     private readonly IWorkloadHintRenderer _hintRenderer;
     private readonly ILocalSettingsProvider _localSettingsProvider;
-    private readonly IProcessEnvironment _processEnvironment;
     private readonly IReadOnlyList<IProjectInitializer> _initializers;
 
     public InitCommand(
         IInteractionService interaction,
         IWorkloadHintRenderer hintRenderer,
         ILocalSettingsProvider localSettingsProvider,
-        IProcessEnvironment processEnvironment,
         IEnumerable<IProjectInitializer> initializers)
         : base("init", "Initialize a new Azure Functions project.")
     {
         ArgumentNullException.ThrowIfNull(interaction);
         ArgumentNullException.ThrowIfNull(hintRenderer);
         ArgumentNullException.ThrowIfNull(localSettingsProvider);
-        ArgumentNullException.ThrowIfNull(processEnvironment);
         ArgumentNullException.ThrowIfNull(initializers);
 
         _interaction = interaction;
         _hintRenderer = hintRenderer;
         _localSettingsProvider = localSettingsProvider;
-        _processEnvironment = processEnvironment;
         _initializers = initializers.ToList();
 
         StackOption.Description = BuildStackOptionDescription(_initializers);
@@ -364,26 +360,15 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
         return InitializationState.Empty;
     }
 
-    // Looks up the project's worker runtime, matching the precedence the
-    // Functions host applies at run time: process env beats local.settings.json.
-    // When both are set and disagree we keep the env value (host behaviour) and
-    // warn so the user can reconcile.
+    // Looks up the project's worker runtime from local.settings.json. The CLI
+    // intentionally does not consult the FUNCTIONS_WORKER_RUNTIME process env
+    // var here: adoption is about the on-disk project shape, and an env var
+    // that happens to be set in the user's shell shouldn't change what we
+    // write into .func/config.json.
     private string? ResolveProjectRuntime(DirectoryInfo workingDirectory)
     {
-        string? envRaw = _processEnvironment.Get(CliConfigurationNames.WorkerRuntimeSettingName);
-        string? localRaw = _localSettingsProvider.Get(workingDirectory).WorkerRuntime;
-
-        string? env = string.IsNullOrWhiteSpace(envRaw) ? null : envRaw.Trim();
-        string? local = string.IsNullOrWhiteSpace(localRaw) ? null : localRaw.Trim();
-
-        if (env is not null && local is not null
-            && !string.Equals(env, local, StringComparison.OrdinalIgnoreCase))
-        {
-            _interaction.WriteWarning(
-                $"FUNCTIONS_WORKER_RUNTIME env variable '{env}' overrides local.settings.json value '{local}'.");
-        }
-
-        return env ?? local;
+        string? raw = _localSettingsProvider.Get(workingDirectory).WorkerRuntime;
+        return string.IsNullOrWhiteSpace(raw) ? null : raw.Trim();
     }
 
     // Adopt-mode path for a runtime whose stack workload isn't installed.

--- a/src/Func/Commands/InitCommand.cs
+++ b/src/Func/Commands/InitCommand.cs
@@ -149,13 +149,27 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
         IProjectInitializer? initializer;
         if (adoptExisting)
         {
+            // Resolve both signals to a concrete initializer (or null) using
+            // alias-aware matching, so e.g. "dotnet-isolated" in
+            // local.settings.json maps to the dotnet initializer and
+            // `--stack dotnet` is recognized as agreeing with it.
+            IProjectInitializer? requested = !string.IsNullOrWhiteSpace(requestedStack)
+                ? FindInitializerForCandidate(requestedStack)
+                : null;
+            IProjectInitializer? declared = projectRuntime is not null
+                ? FindInitializerForCandidate(projectRuntime)
+                : null;
+
             // Explicit --stack that disagrees with the project's declared
             // runtime is almost certainly a mistake (it would produce a
             // .func/config.json that doesn't match what `func start` would
-            // run). --force is the existing escape hatch.
-            if (!string.IsNullOrWhiteSpace(requestedStack)
-                && projectRuntime is not null
-                && !string.Equals(requestedStack, projectRuntime, StringComparison.OrdinalIgnoreCase))
+            // run). --force is the existing escape hatch. We only block on a
+            // genuine conflict: when both signals resolve to known stacks
+            // and those stacks differ. An uninstalled-vs-installed mismatch
+            // is handled below by the "not installed" path.
+            if (requested is not null
+                && declared is not null
+                && !string.Equals(requested.Stack, declared.Stack, StringComparison.OrdinalIgnoreCase))
             {
                 _interaction.WriteError(
                     $"--stack '{requestedStack}' conflicts with the project's runtime '{projectRuntime}'. " +
@@ -166,29 +180,24 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
             // Pick a candidate: explicit --stack wins, else snap to the
             // project's declared runtime.
             string? candidate = !string.IsNullOrWhiteSpace(requestedStack) ? requestedStack : projectRuntime;
+            initializer = requested ?? declared;
 
-            if (candidate is not null)
+            if (candidate is not null && initializer is null)
             {
-                initializer = _initializers.FirstOrDefault(i =>
-                    string.Equals(i.Stack, candidate, StringComparison.OrdinalIgnoreCase));
-
-                if (initializer is null)
-                {
-                    // Candidate isn't an installed stack. Refuse rather than
-                    // write a config we can't validate. The hint uses a
-                    // `<stack>` placeholder on purpose: the candidate string
-                    // may itself be unknown (e.g. a typo, or "native" for
-                    // Go) and echoing it would promise a `func setup`
-                    // command that won't necessarily work.
-                    _interaction.WriteError(
-                        $"The '{candidate}' stack is not installed. " +
-                        "Run `func setup --features <stack>` to setup your dev environment, then re-run `func init`.");
-                    return 1;
-                }
-
-                requestedStack = initializer.Stack;
+                // Candidate isn't an installed stack (and isn't an alias of
+                // one). Refuse rather than write a config we can't validate.
+                // The hint uses a `<stack>` placeholder on purpose: the
+                // candidate string may itself be unknown (e.g. a typo or a
+                // runtime value with no installed alias owner) and echoing
+                // it would promise a `func setup` command that won't
+                // necessarily work.
+                _interaction.WriteError(
+                    $"The '{candidate}' stack is not installed. " +
+                    "Run `func setup --features <stack>` to setup your dev environment, then re-run `func init`.");
+                return 1;
             }
-            else
+
+            if (initializer is null)
             {
                 // No project signal and no --stack. Don't auto-select: even
                 // when only one initializer is installed, writing the wrong
@@ -199,9 +208,9 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
                 {
                     return 1;
                 }
-
-                requestedStack = initializer.Stack;
             }
+
+            requestedStack = initializer.Stack;
         }
         else
         {
@@ -386,6 +395,17 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
     {
         string? raw = _localSettingsProvider.Get(workingDirectory).WorkerRuntime;
         return string.IsNullOrWhiteSpace(raw) ? null : raw.Trim();
+    }
+
+    // Resolves a candidate string (from --stack or local.settings.json) to
+    // an installed initializer. Matches against each initializer's canonical
+    // Stack id first, then its WorkerRuntimeAliases (e.g. "dotnet-isolated"
+    // → dotnet, "native" → go). Case-insensitive.
+    private IProjectInitializer? FindInitializerForCandidate(string candidate)
+    {
+        return _initializers.FirstOrDefault(i =>
+            string.Equals(i.Stack, candidate, StringComparison.OrdinalIgnoreCase)
+            || i.WorkerRuntimeAliases.Any(a => string.Equals(a, candidate, StringComparison.OrdinalIgnoreCase)));
     }
 
     // Adoption-mode stack picker for the "no project signal" case. We never

--- a/src/Func/Commands/InitCommand.cs
+++ b/src/Func/Commands/InitCommand.cs
@@ -20,12 +20,13 @@ namespace Azure.Functions.Cli.Commands;
 /// </summary>
 /// <remarks>
 /// When the target directory already contains a <c>host.json</c> but no
-/// <c>.func/config.json</c>, the command "adopts" the project: it writes the
-/// CLI config and skips scaffolding. The stack is taken from
-/// <c>local.settings.json</c>'s <c>FUNCTIONS_WORKER_RUNTIME</c> when set,
-/// otherwise the user is prompted as usual. An explicit <c>--stack</c> that
-/// conflicts with the project's declared runtime is refused unless
-/// <c>--force</c> is passed.
+/// <c>.func/config.json</c>, the command "adopts" the project: it writes
+/// the CLI config and skips scaffolding. The stack is taken from
+/// <c>--stack</c> if provided, otherwise from <c>local.settings.json</c>'s
+/// <c>FUNCTIONS_WORKER_RUNTIME</c>. If the resolved stack isn't installed,
+/// adoption is refused with a pointer to <c>func setup</c>. When neither
+/// signal is available the user is prompted interactively, or the command
+/// refuses non-interactively. <c>--force</c> bypasses adopt mode entirely.
 /// </remarks>
 internal class InitCommand : FuncCliCommand, IBuiltInCommand
 {
@@ -141,19 +142,19 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
         // re-scaffold" and takes the normal path.
         bool adoptExisting = state == InitializationState.AdoptableExistingProject && !force;
 
-        // For adoption we try to honour what the project already declares.
-        // Resolution order matches the Functions host: env wins over
-        // local.settings.json. On conflict we warn (host doesn't refuse)
-        // but use the env value.
+        // For adoption we honour what the project already declares.
+        // Source: local.settings.json's FUNCTIONS_WORKER_RUNTIME.
         string? projectRuntime = adoptExisting ? ResolveProjectRuntime(workingDirectory.Info) : null;
 
-        if (adoptExisting && projectRuntime is not null)
+        IProjectInitializer? initializer;
+        if (adoptExisting)
         {
             // Explicit --stack that disagrees with the project's declared
             // runtime is almost certainly a mistake (it would produce a
             // .func/config.json that doesn't match what `func start` would
             // run). --force is the existing escape hatch.
             if (!string.IsNullOrWhiteSpace(requestedStack)
+                && projectRuntime is not null
                 && !string.Equals(requestedStack, projectRuntime, StringComparison.OrdinalIgnoreCase))
             {
                 _interaction.WriteError(
@@ -162,28 +163,44 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
                 return 1;
             }
 
-            // Snap when the user didn't specify --stack: the project already
-            // declared its runtime, no point re-asking.
-            requestedStack ??= projectRuntime;
-        }
+            // Pick a candidate: explicit --stack wins, else snap to the
+            // project's declared runtime.
+            string? candidate = !string.IsNullOrWhiteSpace(requestedStack) ? requestedStack : projectRuntime;
 
-        // For adoption with a known runtime we look up the matching
-        // initializer directly; we never prompt or auto-select because we
-        // already have a project signal. SelectInitializerAsync's prompt /
-        // workload-hint path is only for fresh inits or adoption with no
-        // runtime signal.
-        IProjectInitializer? initializer;
-        if (adoptExisting && projectRuntime is not null)
-        {
-            initializer = _initializers.FirstOrDefault(i =>
-                string.Equals(i.Stack, requestedStack, StringComparison.OrdinalIgnoreCase));
-
-            if (initializer is null)
+            if (candidate is not null)
             {
-                // Stack named by the project isn't installed. Still adopt
-                // (write the config so other commands see the right stack),
-                // and point the user at the one command that closes the gap.
-                return AdoptWithUninstalledStack(workingDirectory.Info, requestedStack!);
+                initializer = _initializers.FirstOrDefault(i =>
+                    string.Equals(i.Stack, candidate, StringComparison.OrdinalIgnoreCase));
+
+                if (initializer is null)
+                {
+                    // Candidate isn't an installed stack. Refuse rather than
+                    // write a config we can't validate. The hint uses a
+                    // `<stack>` placeholder on purpose: the candidate string
+                    // may itself be unknown (e.g. a typo, or "native" for
+                    // Go) and echoing it would promise a `func setup`
+                    // command that won't necessarily work.
+                    _interaction.WriteError(
+                        $"The '{candidate}' stack is not installed. " +
+                        "Run `func setup --features <stack>` to setup your dev environment, then re-run `func init`.");
+                    return 1;
+                }
+
+                requestedStack = initializer.Stack;
+            }
+            else
+            {
+                // No project signal and no --stack. Don't auto-select: even
+                // when only one initializer is installed, writing the wrong
+                // stack to an existing project's .func/config.json is worse
+                // than asking. Prompt when we can, refuse when we can't.
+                initializer = await PromptForAdoptionStackAsync(cancellationToken);
+                if (initializer is null)
+                {
+                    return 1;
+                }
+
+                requestedStack = initializer.Stack;
             }
         }
         else
@@ -371,24 +388,39 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
         return string.IsNullOrWhiteSpace(raw) ? null : raw.Trim();
     }
 
-    // Adopt-mode path for a runtime whose stack workload isn't installed.
-    // We still write .func/config.json so subsequent commands know the stack,
-    // and we point the user at `func setup --features` to install the bits.
-    // The raw runtime value is written verbatim; if a workload normalises
-    // the stack name on first read it can rewrite the config then.
-    private int AdoptWithUninstalledStack(DirectoryInfo workingDirectory, string runtime)
+    // Adoption-mode stack picker for the "no project signal" case. We never
+    // auto-select here: in adoption, picking the wrong stack would write a
+    // bad .func/config.json into a real project. Prompt when we're talking
+    // to a human, refuse with an actionable error otherwise.
+    private async Task<IProjectInitializer?> PromptForAdoptionStackAsync(CancellationToken cancellationToken)
     {
-        WriteCliConfigurationFile(workingDirectory, runtime, language: null, force: false);
-        _interaction.WriteBlankLine();
-        _interaction.WriteWarning(
-            $"The '{runtime}' stack is not installed. Run `func setup --features {runtime}` to install it.");
-        _interaction.WriteLine(l => l
-            .Success("✓ ")
-            .Muted("Existing project adopted for ")
-            .Code(runtime)
-            .Muted("."));
+        string[] installed = [.. _initializers.Select(i => i.Stack)];
 
-        return 0;
+        if (_initializers.Count == 0)
+        {
+            _hintRenderer.Render(new WorkloadHint(
+                WorkloadHintKind.NoWorkloadsInstalled, "initialize a project", null, installed));
+            return null;
+        }
+
+        if (!_interaction.IsInteractive)
+        {
+            _interaction.WriteError(
+                "Couldn't detect the project's stack from local.settings.json. " +
+                "Re-run with --stack <stack> to tell `func init` which stack to adopt.");
+            return null;
+        }
+
+        var displayToInitializer = _initializers.ToDictionary(
+            i => i.DisplayName,
+            i => i,
+            StringComparer.Ordinal);
+        string picked = await _interaction.PromptForSelectionAsync(
+            "Adopting an existing project. Which stack is it?",
+            displayToInitializer.Keys,
+            cancellationToken);
+
+        return displayToInitializer.TryGetValue(picked, out IProjectInitializer? chosen) ? chosen : null;
     }
 
     private void WriteCliConfigurationFile(DirectoryInfo workingDirectory, string? stack, string? language, bool force)

--- a/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs
@@ -31,6 +31,8 @@ internal sealed class DotNetProjectInitializer(IDotnetCliRunner dotnetCli, ITemp
 
     public string DisplayName => ".NET";
 
+    public IReadOnlyList<string> WorkerRuntimeAliases { get; } = ["dotnet-isolated"];
+
     public IReadOnlyDictionary<string, IReadOnlyList<string>> SupportedLanguageAliases { get; } = new Dictionary<string, IReadOnlyList<string>>()
     {
         { "C#", ["csharp"] },

--- a/src/Workloads/Stacks/Go/GoProjectInitializer.cs
+++ b/src/Workloads/Stacks/Go/GoProjectInitializer.cs
@@ -28,6 +28,8 @@ internal sealed class GoProjectInitializer : IProjectInitializer
 
     public string DisplayName => "Go";
 
+    public IReadOnlyList<string> WorkerRuntimeAliases { get; } = ["native"];
+
     public IReadOnlyDictionary<string, IReadOnlyList<string>> SupportedLanguageAliases { get; } =
         new Dictionary<string, IReadOnlyList<string>>()
         {

--- a/test/Func.Tests/Commands/InitCommandTests.cs
+++ b/test/Func.Tests/Commands/InitCommandTests.cs
@@ -4,8 +4,11 @@
 using System.CommandLine;
 using System.Text.Json;
 using Azure.Functions.Cli.Commands;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Configuration;
 using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Workloads;
+using NSubstitute;
 using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands;
@@ -14,17 +17,25 @@ public class InitCommandTests
 {
     private readonly TestInteractionService _interaction;
     private readonly RecordingWorkloadHintRenderer _hintRenderer;
+    private readonly ILocalSettingsProvider _localSettings;
+    private readonly IProcessEnvironment _processEnvironment;
 
     public InitCommandTests()
     {
         _interaction = new TestInteractionService();
         _hintRenderer = new RecordingWorkloadHintRenderer();
+        _localSettings = Substitute.For<ILocalSettingsProvider>();
+        _localSettings.Get(Arg.Any<DirectoryInfo>()).Returns(LocalSettingsSnapshot.Empty);
+        _processEnvironment = Substitute.For<IProcessEnvironment>();
     }
+
+    private InitCommand CreateCommand(IEnumerable<IProjectInitializer> initializers) =>
+        new(_interaction, _hintRenderer, _localSettings, _processEnvironment, initializers);
 
     [Fact]
     public void InitCommand_HasExpectedOptions()
     {
-        var cmd = new InitCommand(_interaction, _hintRenderer, []);
+        var cmd = CreateCommand([]);
         var optionNames = cmd.Options.Select(o => o.Name).ToList();
 
         Assert.Contains("--stack", optionNames);
@@ -36,7 +47,7 @@ public class InitCommandTests
     [Fact]
     public void InitCommand_StackOptionDescription_NoInitializers_PointsAtWorkloadInstall()
     {
-        var cmd = new InitCommand(_interaction, _hintRenderer, []);
+        var cmd = CreateCommand([]);
         string description = cmd.StackOption.Description ?? string.Empty;
 
         Assert.Contains("Install a stack workload", description);
@@ -46,9 +57,7 @@ public class InitCommandTests
     [Fact]
     public void InitCommand_StackOptionDescription_ListsInstalledStacks_SortedAndLowercased()
     {
-        var cmd = new InitCommand(
-            _interaction,
-            _hintRenderer,
+        var cmd = CreateCommand(
             [new FakeProjectInitializer("Python"), new FakeProjectInitializer("dotnet"), new FakeProjectInitializer("node")]);
         string description = cmd.StackOption.Description ?? string.Empty;
 
@@ -58,7 +67,7 @@ public class InitCommandTests
     [Fact]
     public void InitCommand_HelpFooterHint_PointsAtWorkloadSearch()
     {
-        var cmd = new InitCommand(_interaction, _hintRenderer, []);
+        var cmd = CreateCommand([]);
 
         Assert.Contains("func workload search --stack", cmd.GetHelpFooterHint() ?? string.Empty);
     }
@@ -75,7 +84,7 @@ public class InitCommandTests
     [Fact]
     public void InitCommand_HasPathArgument()
     {
-        var cmd = new InitCommand(_interaction, _hintRenderer, []);
+        var cmd = CreateCommand([]);
         Assert.Single(cmd.Arguments);
         Assert.Equal("path", cmd.Arguments[0].Name);
     }
@@ -213,7 +222,7 @@ public class InitCommandTests
         bool force = false,
         IReadOnlyList<string>? extraArgs = null)
     {
-        var cmd = new InitCommand(_interaction, _hintRenderer, initializers);
+        var cmd = CreateCommand(initializers);
         var root = new RootCommand { cmd };
         var args = new List<string> { "init", path };
         if (stack is not null)
@@ -479,6 +488,218 @@ public class InitCommandTests
         }
     }
 
+    [Fact]
+    public async Task InitCommand_Adopt_SnapsStackFromEnvVar()
+    {
+        // host.json only + FUNCTIONS_WORKER_RUNTIME=python in process env → snap to python,
+        // initializer is not invoked (existing project), config records python.
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(newDir);
+            File.WriteAllText(Path.Combine(newDir, "host.json"), "{}");
+            _processEnvironment.Get("FUNCTIONS_WORKER_RUNTIME").Returns("python");
+
+            var python = new FakeProjectInitializer("python");
+            int exitCode = await RunInitAsync(newDir, [python], language: null, stack: null);
+
+            Assert.Equal(0, exitCode);
+            Assert.False(python.WasInvoked);
+            AssertConfigJsonHasShape(newDir, expectedStack: "python", expectedLanguage: null);
+        }
+        finally
+        {
+            CleanupDirectory(newDir);
+        }
+    }
+
+    [Fact]
+    public async Task InitCommand_Adopt_SnapsStackFromLocalSettings()
+    {
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(newDir);
+            File.WriteAllText(Path.Combine(newDir, "host.json"), "{}");
+            StubLocalSettingsRuntime("node");
+
+            var node = new FakeProjectInitializer("node");
+            int exitCode = await RunInitAsync(newDir, [node], language: null, stack: null);
+
+            Assert.Equal(0, exitCode);
+            Assert.False(node.WasInvoked);
+            AssertConfigJsonHasShape(newDir, expectedStack: "node", expectedLanguage: null);
+        }
+        finally
+        {
+            CleanupDirectory(newDir);
+        }
+    }
+
+    [Fact]
+    public async Task InitCommand_Adopt_EnvVarOverridesLocalSettings_WithWarning()
+    {
+        // When env and local.settings.json disagree, env wins (matches the host)
+        // and the user gets a warning so they can reconcile.
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(newDir);
+            File.WriteAllText(Path.Combine(newDir, "host.json"), "{}");
+            _processEnvironment.Get("FUNCTIONS_WORKER_RUNTIME").Returns("python");
+            StubLocalSettingsRuntime("node");
+
+            var python = new FakeProjectInitializer("python");
+            var node = new FakeProjectInitializer("node");
+            int exitCode = await RunInitAsync(newDir, [python, node], language: null, stack: null);
+
+            Assert.Equal(0, exitCode);
+            AssertConfigJsonHasShape(newDir, expectedStack: "python", expectedLanguage: null);
+            Assert.Contains(_interaction.Lines, l =>
+                l.StartsWith("WARNING:") && l.Contains("python") && l.Contains("node"));
+        }
+        finally
+        {
+            CleanupDirectory(newDir);
+        }
+    }
+
+    [Fact]
+    public async Task InitCommand_Adopt_UninstalledStack_WritesConfigAndSuggestsSetup()
+    {
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(newDir);
+            File.WriteAllText(Path.Combine(newDir, "host.json"), "{}");
+            _processEnvironment.Get("FUNCTIONS_WORKER_RUNTIME").Returns("ruby");
+
+            var python = new FakeProjectInitializer("python");
+            int exitCode = await RunInitAsync(newDir, [python], language: null, stack: null);
+
+            Assert.Equal(0, exitCode);
+            Assert.False(python.WasInvoked);
+            // Config is still written so subsequent commands see the right stack.
+            AssertConfigJsonHasShape(newDir, expectedStack: "ruby", expectedLanguage: null);
+            Assert.Contains(_interaction.Lines, l =>
+                l.StartsWith("WARNING:") && l.Contains("func setup --features ruby"));
+        }
+        finally
+        {
+            CleanupDirectory(newDir);
+        }
+    }
+
+    [Fact]
+    public async Task InitCommand_Adopt_RefusesWhenStackOptionConflictsWithProjectRuntime()
+    {
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(newDir);
+            File.WriteAllText(Path.Combine(newDir, "host.json"), "{}");
+            _processEnvironment.Get("FUNCTIONS_WORKER_RUNTIME").Returns("python");
+
+            var python = new FakeProjectInitializer("python");
+            var node = new FakeProjectInitializer("node");
+            int exitCode = await RunInitAsync(newDir, [python, node], language: null, stack: "node");
+
+            Assert.Equal(1, exitCode);
+            Assert.False(python.WasInvoked);
+            Assert.False(node.WasInvoked);
+            Assert.False(File.Exists(Path.Combine(newDir, ".func", "config.json")));
+            Assert.Contains(_interaction.Lines, l => l.Contains("conflicts") && l.Contains("python") && l.Contains("node"));
+        }
+        finally
+        {
+            CleanupDirectory(newDir);
+        }
+    }
+
+    [Fact]
+    public async Task InitCommand_Adopt_AllowsStackOptionWhenItMatchesProjectRuntime()
+    {
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(newDir);
+            File.WriteAllText(Path.Combine(newDir, "host.json"), "{}");
+            _processEnvironment.Get("FUNCTIONS_WORKER_RUNTIME").Returns("python");
+
+            var python = new FakeProjectInitializer("python");
+            int exitCode = await RunInitAsync(newDir, python, language: null, stack: "python");
+
+            Assert.Equal(0, exitCode);
+            Assert.False(python.WasInvoked);
+            AssertConfigJsonHasShape(newDir, expectedStack: "python", expectedLanguage: null);
+        }
+        finally
+        {
+            CleanupDirectory(newDir);
+        }
+    }
+
+    [Fact]
+    public async Task InitCommand_Adopt_NoProjectSignal_FallsBackToCurrentBehavior()
+    {
+        // host.json only with no env / local.settings.json signal: single installed
+        // workload is still auto-selected, but scaffolding is skipped (adoption).
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(newDir);
+            File.WriteAllText(Path.Combine(newDir, "host.json"), "{}");
+
+            var python = new FakeProjectInitializer("python");
+            int exitCode = await RunInitAsync(newDir, python, language: null);
+
+            Assert.Equal(0, exitCode);
+            Assert.False(python.WasInvoked);
+            AssertConfigJsonHasShape(newDir, expectedStack: "python", expectedLanguage: null);
+        }
+        finally
+        {
+            CleanupDirectory(newDir);
+        }
+    }
+
+    [Fact]
+    public async Task InitCommand_Adopt_ForceOverridesConflict()
+    {
+        // --force is the documented escape hatch: it wipes the directory and
+        // re-scaffolds with the requested stack, regardless of project signal.
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(newDir);
+            File.WriteAllText(Path.Combine(newDir, "host.json"), "{}");
+            _processEnvironment.Get("FUNCTIONS_WORKER_RUNTIME").Returns("python");
+
+            var node = new FakeProjectInitializer("node");
+            int exitCode = await RunInitAsync(newDir, node, language: null, stack: "node", force: true);
+
+            Assert.Equal(0, exitCode);
+            Assert.True(node.WasInvoked);
+            AssertConfigJsonHasShape(newDir, expectedStack: "node", expectedLanguage: null);
+        }
+        finally
+        {
+            CleanupDirectory(newDir);
+        }
+    }
+
+    private void StubLocalSettingsRuntime(string runtime)
+    {
+        var snapshot = new LocalSettingsSnapshot
+        {
+            Values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["FUNCTIONS_WORKER_RUNTIME"] = runtime,
+            },
+        };
+        _localSettings.Get(Arg.Any<DirectoryInfo>()).Returns(snapshot);
+    }
+
     private static void AssertConfigJsonHasShape(string directory, string? expectedStack, string? expectedLanguage)
     {
         string configPath = Path.Combine(directory, ".func", "config.json");
@@ -585,7 +806,7 @@ public class InitCommandTests
             "python",
             optionFactory: r => [r.GetOrAdd(new Option<bool>("--no-bundles"))]);
 
-        var cmd = new InitCommand(_interaction, _hintRenderer, [first, second]);
+        var cmd = CreateCommand([first, second]);
 
         int matches = cmd.Options.Count(o => o.Name == "--no-bundles");
         Assert.Equal(1, matches);
@@ -640,7 +861,7 @@ public class InitCommandTests
             optionFactory: r => [r.GetOrAdd(new Option<string>("--no-bundles"))]);
 
         var ex = Assert.Throws<InvalidOperationException>(() =>
-            new InitCommand(_interaction, _hintRenderer, [first, second]));
+            CreateCommand([first, second]));
 
         Assert.Contains("python", ex.Message);
         Assert.Contains("node", ex.Message);
@@ -659,7 +880,7 @@ public class InitCommandTests
             optionFactory: r => [r.GetOrAdd(new Option<string>("--clean", "-c"))]);
 
         var ex = Assert.Throws<InvalidOperationException>(() =>
-            new InitCommand(_interaction, _hintRenderer, [first, second]));
+            CreateCommand([first, second]));
 
         Assert.Contains("-c", ex.Message);
         Assert.Contains("--clean", ex.Message);

--- a/test/Func.Tests/Commands/InitCommandTests.cs
+++ b/test/Func.Tests/Commands/InitCommandTests.cs
@@ -512,8 +512,12 @@ public class InitCommandTests
     }
 
     [Fact]
-    public async Task InitCommand_Adopt_UninstalledStack_WritesConfigAndSuggestsSetup()
+    public async Task InitCommand_Adopt_UninstalledStack_RefusesAndSuggestsSetup()
     {
+        // project_runtime points at a stack with no installed initializer:
+        // refuse rather than write a config we can't validate. The setup
+        // hint uses a `<stack>` placeholder (not the raw runtime value),
+        // because the runtime string may itself not be a valid feature id.
         var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
         try
         {
@@ -524,12 +528,13 @@ public class InitCommandTests
             var python = new FakeProjectInitializer("python");
             int exitCode = await RunInitAsync(newDir, [python], language: null, stack: null);
 
-            Assert.Equal(0, exitCode);
+            Assert.Equal(1, exitCode);
             Assert.False(python.WasInvoked);
-            // Config is still written so subsequent commands see the right stack.
-            AssertConfigJsonHasShape(newDir, expectedStack: "ruby", expectedLanguage: null);
+            Assert.False(File.Exists(Path.Combine(newDir, ".func", "config.json")));
             Assert.Contains(_interaction.Lines, l =>
-                l.StartsWith("WARNING:") && l.Contains("func setup --features ruby"));
+                l.StartsWith("ERROR:")
+                && l.Contains("'ruby' stack is not installed")
+                && l.Contains("func setup --features <stack>"));
         }
         finally
         {
@@ -587,10 +592,13 @@ public class InitCommandTests
     }
 
     [Fact]
-    public async Task InitCommand_Adopt_NoProjectSignal_FallsBackToCurrentBehavior()
+    public async Task InitCommand_Adopt_NoProjectSignal_NonInteractive_Refuses()
     {
-        // host.json only with no local.settings.json signal: single installed
-        // workload is still auto-selected, but scaffolding is skipped (adoption).
+        // In adopt mode with no --stack and no FUNCTIONS_WORKER_RUNTIME, we
+        // don't auto-select even when only one initializer is installed:
+        // writing the wrong stack into an existing project's config is worse
+        // than failing fast. Non-interactive callers (CI, piped) get an
+        // actionable error.
         var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
         try
         {
@@ -600,9 +608,71 @@ public class InitCommandTests
             var python = new FakeProjectInitializer("python");
             int exitCode = await RunInitAsync(newDir, python, language: null);
 
+            Assert.Equal(1, exitCode);
+            Assert.False(python.WasInvoked);
+            Assert.False(File.Exists(Path.Combine(newDir, ".func", "config.json")));
+            Assert.Contains(_interaction.Lines, l =>
+                l.StartsWith("ERROR:") && l.Contains("Couldn't detect the project's stack"));
+        }
+        finally
+        {
+            CleanupDirectory(newDir);
+        }
+    }
+
+    [Fact]
+    public async Task InitCommand_Adopt_NoProjectSignal_Interactive_PromptsForStack()
+    {
+        // Interactive callers get a prompt that names adoption explicitly so
+        // they know what they're answering for. The prompt's first choice is
+        // selected by the test interaction service.
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(newDir);
+            File.WriteAllText(Path.Combine(newDir, "host.json"), "{}");
+
+            var interactive = new InteractiveTestInteractionService();
+            var python = new FakeProjectInitializer("python");
+            var command = new InitCommand(interactive, _hintRenderer, _localSettings, [python]);
+            var root = new RootCommand { command };
+
+            int exitCode = await root.Parse(["init", newDir]).InvokeAsync();
+
             Assert.Equal(0, exitCode);
             Assert.False(python.WasInvoked);
             AssertConfigJsonHasShape(newDir, expectedStack: "python", expectedLanguage: null);
+            Assert.Contains(interactive.Lines, l =>
+                l.StartsWith("SELECT:") && l.Contains("Adopting an existing project"));
+        }
+        finally
+        {
+            CleanupDirectory(newDir);
+        }
+    }
+
+    [Fact]
+    public async Task InitCommand_Adopt_StackOption_UninstalledStack_Refuses()
+    {
+        // --stack X where X isn't installed should be refused just like the
+        // uninstalled local.settings.json case. Same hint, same exit code,
+        // no config written.
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(newDir);
+            File.WriteAllText(Path.Combine(newDir, "host.json"), "{}");
+
+            var python = new FakeProjectInitializer("python");
+            int exitCode = await RunInitAsync(newDir, [python], language: null, stack: "ruby");
+
+            Assert.Equal(1, exitCode);
+            Assert.False(python.WasInvoked);
+            Assert.False(File.Exists(Path.Combine(newDir, ".func", "config.json")));
+            Assert.Contains(_interaction.Lines, l =>
+                l.StartsWith("ERROR:")
+                && l.Contains("'ruby' stack is not installed")
+                && l.Contains("func setup --features <stack>"));
         }
         finally
         {
@@ -864,5 +934,10 @@ public class InitCommandTests
             onInitialize?.Invoke(this, parseResult);
             return Task.CompletedTask;
         }
+    }
+
+    private sealed class InteractiveTestInteractionService : TestInteractionService
+    {
+        public override bool IsInteractive => true;
     }
 }

--- a/test/Func.Tests/Commands/InitCommandTests.cs
+++ b/test/Func.Tests/Commands/InitCommandTests.cs
@@ -486,6 +486,87 @@ public class InitCommandTests
     }
 
     [Fact]
+    public async Task InitCommand_Adopt_SnapsViaRuntimeAlias()
+    {
+        // local.settings.json declares "dotnet-isolated" but the dotnet
+        // initializer owns that runtime as an alias. We should snap to the
+        // initializer's canonical stack id ("dotnet"), not error.
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(newDir);
+            File.WriteAllText(Path.Combine(newDir, "host.json"), "{}");
+            StubLocalSettingsRuntime("dotnet-isolated");
+
+            var dotnet = new FakeProjectInitializer("dotnet", workerRuntimeAliases: ["dotnet-isolated"]);
+            int exitCode = await RunInitAsync(newDir, [dotnet], language: null, stack: null);
+
+            Assert.Equal(0, exitCode);
+            Assert.False(dotnet.WasInvoked);
+            AssertConfigJsonHasShape(newDir, expectedStack: "dotnet", expectedLanguage: null);
+        }
+        finally
+        {
+            CleanupDirectory(newDir);
+        }
+    }
+
+    [Fact]
+    public async Task InitCommand_Adopt_StackOptionAgreesViaRuntimeAlias()
+    {
+        // --stack dotnet against a project whose local.settings.json says
+        // "dotnet-isolated" should resolve via the alias and adopt
+        // (not flag a phantom conflict).
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(newDir);
+            File.WriteAllText(Path.Combine(newDir, "host.json"), "{}");
+            StubLocalSettingsRuntime("dotnet-isolated");
+
+            var dotnet = new FakeProjectInitializer("dotnet", workerRuntimeAliases: ["dotnet-isolated"]);
+            int exitCode = await RunInitAsync(newDir, dotnet, language: null, stack: "dotnet");
+
+            Assert.Equal(0, exitCode);
+            Assert.False(dotnet.WasInvoked);
+            AssertConfigJsonHasShape(newDir, expectedStack: "dotnet", expectedLanguage: null);
+        }
+        finally
+        {
+            CleanupDirectory(newDir);
+        }
+    }
+
+    [Fact]
+    public async Task InitCommand_Adopt_StackOptionAlias_Recognized()
+    {
+        // The reverse direction: --stack dotnet-isolated (an alias) should
+        // resolve to the dotnet initializer when adopting an empty
+        // local.settings.json project.
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(newDir);
+            File.WriteAllText(Path.Combine(newDir, "host.json"), "{}");
+
+            var interactive = new InteractiveTestInteractionService();
+            var dotnet = new FakeProjectInitializer("dotnet", workerRuntimeAliases: ["dotnet-isolated"]);
+            var command = new InitCommand(interactive, _hintRenderer, _localSettings, [dotnet]);
+            var root = new RootCommand { command };
+
+            int exitCode = await root.Parse(["init", newDir, "--stack", "dotnet-isolated"]).InvokeAsync();
+
+            Assert.Equal(0, exitCode);
+            Assert.False(dotnet.WasInvoked);
+            AssertConfigJsonHasShape(newDir, expectedStack: "dotnet", expectedLanguage: null);
+        }
+        finally
+        {
+            CleanupDirectory(newDir);
+        }
+    }
+
+    [Fact]
     public async Task InitCommand_Adopt_SnapsStackFromLocalSettings()
     {
         // host.json + local.settings.json FUNCTIONS_WORKER_RUNTIME=python → snap
@@ -909,7 +990,8 @@ public class InitCommandTests
         IReadOnlyList<string>? supportedLanguages = null,
         IReadOnlyDictionary<string, IReadOnlyList<string>>? aliases = null,
         Func<IInitOptionRegistry, IReadOnlyList<Option>>? optionFactory = null,
-        Action<FakeProjectInitializer, ParseResult>? onInitialize = null) : IProjectInitializer
+        Action<FakeProjectInitializer, ParseResult>? onInitialize = null,
+        IReadOnlyList<string>? workerRuntimeAliases = null) : IProjectInitializer
     {
         public string Stack { get; } = stack;
 
@@ -917,6 +999,8 @@ public class InitCommandTests
 
         public IReadOnlyDictionary<string, IReadOnlyList<string>> SupportedLanguageAliases { get; } =
             aliases ?? new Dictionary<string, IReadOnlyList<string>>();
+
+        public IReadOnlyList<string> WorkerRuntimeAliases { get; } = workerRuntimeAliases ?? [];
 
         public bool WasInvoked { get; private set; }
 

--- a/test/Func.Tests/Commands/InitCommandTests.cs
+++ b/test/Func.Tests/Commands/InitCommandTests.cs
@@ -348,8 +348,11 @@ public class InitCommandTests
     }
 
     [Fact]
-    public async Task InitCommand_PreservesExistingHostJson_WhenForceIsNotSet()
+    public async Task InitCommand_AdoptsExistingProject_WhenOnlyHostJsonPresent()
     {
+        // host.json without .func/config.json means a pre-v5 project. `func init`
+        // should adopt it: write .func/config.json, preserve host.json and any
+        // user source, and skip scaffolding.
         var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
         try
         {
@@ -357,15 +360,19 @@ public class InitCommandTests
             string hostPath = Path.Combine(newDir, "host.json");
             const string existingContent = "{\"version\":\"2.0\",\"customMarker\":true}";
             File.WriteAllText(hostPath, existingContent);
+            string userFile = Path.Combine(newDir, "MyFunction.cs");
+            File.WriteAllText(userFile, "// user code");
 
             var initializer = new FakeProjectInitializer("python");
             int exitCode = await RunInitAsync(newDir, initializer, language: null, stack: "python");
 
-            // host.json present means the folder is already a Functions project;
-            // command refuses without --force, initializer never runs.
-            Assert.Equal(1, exitCode);
+            Assert.Equal(0, exitCode);
+            // Scaffolding is skipped: existing files survive untouched and the
+            // initializer is not invoked.
             Assert.False(initializer.WasInvoked);
             Assert.Equal(existingContent, File.ReadAllText(hostPath));
+            Assert.True(File.Exists(userFile));
+            AssertConfigJsonHasShape(newDir, expectedStack: "python", expectedLanguage: null);
         }
         finally
         {
@@ -374,22 +381,22 @@ public class InitCommandTests
     }
 
     [Fact]
-    public async Task InitCommand_RefusesEarly_WhenAlreadyInitialized()
+    public async Task InitCommand_RefusesEarly_WhenFullyInitialized()
     {
-        // A directory that already has a host.json is treated as initialized:
-        // no config write, exit 1.
+        // A directory that already has .func/config.json (a v5 project) is
+        // refused without --force: no overwrite, no scaffolding, exit 1.
         var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
         try
         {
-            Directory.CreateDirectory(newDir);
-            File.WriteAllText(Path.Combine(newDir, "host.json"), "{\"version\":\"2.0\"}");
+            Directory.CreateDirectory(Path.Combine(newDir, ".func"));
+            File.WriteAllText(Path.Combine(newDir, ".func", "config.json"), "{}");
 
             var initializer = new FakeProjectInitializer("python");
             int exitCode = await RunInitAsync(newDir, initializer, language: null, stack: "python");
 
             Assert.Equal(1, exitCode);
             Assert.False(initializer.WasInvoked);
-            Assert.False(File.Exists(Path.Combine(newDir, ".func", "config.json")));
+            Assert.Equal("{}", File.ReadAllText(Path.Combine(newDir, ".func", "config.json")));
         }
         finally
         {

--- a/test/Func.Tests/Commands/InitCommandTests.cs
+++ b/test/Func.Tests/Commands/InitCommandTests.cs
@@ -4,7 +4,6 @@
 using System.CommandLine;
 using System.Text.Json;
 using Azure.Functions.Cli.Commands;
-using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Configuration;
 using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Workloads;
@@ -18,7 +17,6 @@ public class InitCommandTests
     private readonly TestInteractionService _interaction;
     private readonly RecordingWorkloadHintRenderer _hintRenderer;
     private readonly ILocalSettingsProvider _localSettings;
-    private readonly IProcessEnvironment _processEnvironment;
 
     public InitCommandTests()
     {
@@ -26,11 +24,10 @@ public class InitCommandTests
         _hintRenderer = new RecordingWorkloadHintRenderer();
         _localSettings = Substitute.For<ILocalSettingsProvider>();
         _localSettings.Get(Arg.Any<DirectoryInfo>()).Returns(LocalSettingsSnapshot.Empty);
-        _processEnvironment = Substitute.For<IProcessEnvironment>();
     }
 
     private InitCommand CreateCommand(IEnumerable<IProjectInitializer> initializers) =>
-        new(_interaction, _hintRenderer, _localSettings, _processEnvironment, initializers);
+        new(_interaction, _hintRenderer, _localSettings, initializers);
 
     [Fact]
     public void InitCommand_HasExpectedOptions()
@@ -489,16 +486,17 @@ public class InitCommandTests
     }
 
     [Fact]
-    public async Task InitCommand_Adopt_SnapsStackFromEnvVar()
+    public async Task InitCommand_Adopt_SnapsStackFromLocalSettings()
     {
-        // host.json only + FUNCTIONS_WORKER_RUNTIME=python in process env → snap to python,
-        // initializer is not invoked (existing project), config records python.
+        // host.json + local.settings.json FUNCTIONS_WORKER_RUNTIME=python → snap
+        // to python, initializer is not invoked (existing project), config
+        // records python.
         var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
         try
         {
             Directory.CreateDirectory(newDir);
             File.WriteAllText(Path.Combine(newDir, "host.json"), "{}");
-            _processEnvironment.Get("FUNCTIONS_WORKER_RUNTIME").Returns("python");
+            StubLocalSettingsRuntime("python");
 
             var python = new FakeProjectInitializer("python");
             int exitCode = await RunInitAsync(newDir, [python], language: null, stack: null);
@@ -514,57 +512,6 @@ public class InitCommandTests
     }
 
     [Fact]
-    public async Task InitCommand_Adopt_SnapsStackFromLocalSettings()
-    {
-        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
-        try
-        {
-            Directory.CreateDirectory(newDir);
-            File.WriteAllText(Path.Combine(newDir, "host.json"), "{}");
-            StubLocalSettingsRuntime("node");
-
-            var node = new FakeProjectInitializer("node");
-            int exitCode = await RunInitAsync(newDir, [node], language: null, stack: null);
-
-            Assert.Equal(0, exitCode);
-            Assert.False(node.WasInvoked);
-            AssertConfigJsonHasShape(newDir, expectedStack: "node", expectedLanguage: null);
-        }
-        finally
-        {
-            CleanupDirectory(newDir);
-        }
-    }
-
-    [Fact]
-    public async Task InitCommand_Adopt_EnvVarOverridesLocalSettings_WithWarning()
-    {
-        // When env and local.settings.json disagree, env wins (matches the host)
-        // and the user gets a warning so they can reconcile.
-        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
-        try
-        {
-            Directory.CreateDirectory(newDir);
-            File.WriteAllText(Path.Combine(newDir, "host.json"), "{}");
-            _processEnvironment.Get("FUNCTIONS_WORKER_RUNTIME").Returns("python");
-            StubLocalSettingsRuntime("node");
-
-            var python = new FakeProjectInitializer("python");
-            var node = new FakeProjectInitializer("node");
-            int exitCode = await RunInitAsync(newDir, [python, node], language: null, stack: null);
-
-            Assert.Equal(0, exitCode);
-            AssertConfigJsonHasShape(newDir, expectedStack: "python", expectedLanguage: null);
-            Assert.Contains(_interaction.Lines, l =>
-                l.StartsWith("WARNING:") && l.Contains("python") && l.Contains("node"));
-        }
-        finally
-        {
-            CleanupDirectory(newDir);
-        }
-    }
-
-    [Fact]
     public async Task InitCommand_Adopt_UninstalledStack_WritesConfigAndSuggestsSetup()
     {
         var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
@@ -572,7 +519,7 @@ public class InitCommandTests
         {
             Directory.CreateDirectory(newDir);
             File.WriteAllText(Path.Combine(newDir, "host.json"), "{}");
-            _processEnvironment.Get("FUNCTIONS_WORKER_RUNTIME").Returns("ruby");
+            StubLocalSettingsRuntime("ruby");
 
             var python = new FakeProjectInitializer("python");
             int exitCode = await RunInitAsync(newDir, [python], language: null, stack: null);
@@ -598,7 +545,7 @@ public class InitCommandTests
         {
             Directory.CreateDirectory(newDir);
             File.WriteAllText(Path.Combine(newDir, "host.json"), "{}");
-            _processEnvironment.Get("FUNCTIONS_WORKER_RUNTIME").Returns("python");
+            StubLocalSettingsRuntime("python");
 
             var python = new FakeProjectInitializer("python");
             var node = new FakeProjectInitializer("node");
@@ -624,7 +571,7 @@ public class InitCommandTests
         {
             Directory.CreateDirectory(newDir);
             File.WriteAllText(Path.Combine(newDir, "host.json"), "{}");
-            _processEnvironment.Get("FUNCTIONS_WORKER_RUNTIME").Returns("python");
+            StubLocalSettingsRuntime("python");
 
             var python = new FakeProjectInitializer("python");
             int exitCode = await RunInitAsync(newDir, python, language: null, stack: "python");
@@ -642,7 +589,7 @@ public class InitCommandTests
     [Fact]
     public async Task InitCommand_Adopt_NoProjectSignal_FallsBackToCurrentBehavior()
     {
-        // host.json only with no env / local.settings.json signal: single installed
+        // host.json only with no local.settings.json signal: single installed
         // workload is still auto-selected, but scaffolding is skipped (adoption).
         var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
         try
@@ -673,7 +620,7 @@ public class InitCommandTests
         {
             Directory.CreateDirectory(newDir);
             File.WriteAllText(Path.Combine(newDir, "host.json"), "{}");
-            _processEnvironment.Get("FUNCTIONS_WORKER_RUNTIME").Returns("python");
+            StubLocalSettingsRuntime("python");
 
             var node = new FakeProjectInitializer("node");
             int exitCode = await RunInitAsync(newDir, node, language: null, stack: "node", force: true);

--- a/test/Func.Tests/TestParser.cs
+++ b/test/Func.Tests/TestParser.cs
@@ -83,6 +83,14 @@ internal static class TestParser
         services.AddSingleton(Substitute.For<Cli.Bundles.IHostJsonBundleSectionReader>());
         services.AddSingleton(Substitute.For<Cli.Bundles.IExtensionBundleResolver>());
         services.AddSingleton(Substitute.For<IStartInitializationRunner>());
+
+        // InitCommand reads FUNCTIONS_WORKER_RUNTIME and local.settings.json
+        // to drive adoption decisions. Default both to "nothing set" so tests
+        // that don't care behave as if there's no project signal.
+        ILocalSettingsProvider emptyLocalSettings = Substitute.For<ILocalSettingsProvider>();
+        emptyLocalSettings.Get(Arg.Any<DirectoryInfo>()).Returns(LocalSettingsSnapshot.Empty);
+        services.AddSingleton(emptyLocalSettings);
+        services.AddSingleton(Substitute.For<Cli.Common.IProcessEnvironment>());
         ISetupRunner setupRunner = Substitute.For<ISetupRunner>();
         setupRunner.RunAsync(Arg.Any<SetupCommandOptions>(), Arg.Any<CancellationToken>())
             .Returns(new SetupRunResult(0));

--- a/test/Func.Tests/TestParser.cs
+++ b/test/Func.Tests/TestParser.cs
@@ -84,13 +84,12 @@ internal static class TestParser
         services.AddSingleton(Substitute.For<Cli.Bundles.IExtensionBundleResolver>());
         services.AddSingleton(Substitute.For<IStartInitializationRunner>());
 
-        // InitCommand reads FUNCTIONS_WORKER_RUNTIME and local.settings.json
-        // to drive adoption decisions. Default both to "nothing set" so tests
-        // that don't care behave as if there's no project signal.
+        // InitCommand reads local.settings.json to drive adoption decisions.
+        // Default to "nothing set" so tests that don't care behave as if there's
+        // no project signal.
         ILocalSettingsProvider emptyLocalSettings = Substitute.For<ILocalSettingsProvider>();
         emptyLocalSettings.Get(Arg.Any<DirectoryInfo>()).Returns(LocalSettingsSnapshot.Empty);
         services.AddSingleton(emptyLocalSettings);
-        services.AddSingleton(Substitute.For<Cli.Common.IProcessEnvironment>());
         ISetupRunner setupRunner = Substitute.For<ISetupRunner>();
         setupRunner.RunAsync(Arg.Any<SetupCommandOptions>(), Arg.Any<CancellationToken>())
             .Returns(new SetupRunResult(0));


### PR DESCRIPTION
Fixes #5228.

Today `func init` refuses to run inside a folder that already has a Functions project. v5 considers a project initialized when `.func/config.json` exists, but plenty of real projects predate that marker (they only have `host.json`). Asking those users to either delete files or pass `--force` (which scaffolds on top of their code) is a bad first experience.

## Behavior

- **Empty folder**: scaffold (unchanged).
- **`host.json` present, no `.func/config.json`**: **adopt** — write `.func/config.json` based on the project's stack and skip scaffolding so user source is untouched.
- **`.func/config.json` present**: refuse unless `--force` (unchanged).
- **`--force`**: always scaffolds, bypassing adopt mode.

## Adopt-mode stack resolution

**Step 1 — pick the project signal:**

`project_runtime` = `local.settings.json`'s `FUNCTIONS_WORKER_RUNTIME` ?? null

The process env var is intentionally ignored. Adoption is about the on-disk project shape; an env var set in the user's shell shouldn't change what we write into `.func/config.json`.

**Step 2 — apply this 3×3:**

| `project_runtime` → | `--stack` omitted | `--stack X` (installed) agrees | `--stack X` conflicts |
|---|---|---|---|
| **null** | interactive: prompt "Adopting an existing project. Which stack is it?". Non-interactive: refuse with "Couldn't detect the project's stack". | adopt with `X` | n/a |
| **installed** | adopt + snap | adopt with `X` | refuse (use `--force` to override) |
| **uninstalled** | refuse with `func setup --features <stack>` hint | refuse (same hint) | refuse |

Any candidate stack (from `--stack` or `local.settings.json`) that doesn't match an installed initializer is refused. The hint uses a literal `<stack>` placeholder rather than the raw runtime value, because the value itself may not be a valid feature id (e.g. typos, or `native` for Go).

## Tests

35 `InitCommand` tests cover every cell in the matrix, including: adoption when only `host.json` is present, snap from `local.settings.json`, refuse-on-conflict, refuse-on-uninstalled (both signal sources), refuse-when-no-signal in non-interactive mode, prompt-when-no-signal in interactive mode, `--force` override, and the pre-existing fresh-init flows.

Full suite: 981 passing.