### PR TITLE
Bypass proxy on Azurite probe HttpClient

### DIFF
--- a/src/Func/Commands/Start/Azurite/AzuriteServiceCollectionExtensions.cs
+++ b/src/Func/Commands/Start/Azurite/AzuriteServiceCollectionExtensions.cs
@@ -27,6 +27,17 @@ internal static class AzuriteServiceCollectionExtensions
             // probe itself also enforces a per-request timeout via a linked
             // CancellationTokenSource so callers can preempt sooner.
             client.Timeout = AzuriteProbe.PerRequestTimeout;
+        })
+        .ConfigurePrimaryHttpMessageHandler(static () => new SocketsHttpHandler
+        {
+            // Azurite always runs on the loopback interface, so a system or
+            // environment proxy (HTTP_PROXY, WinHTTP, WPAD) must never be in
+            // the path. Without this, a configured proxy intercepts the probe
+            // and returns Connection refused / timeout, the probe reports
+            // NotListening, and the orchestrator launches a second Azurite
+            // that fails to bind the already-occupied ports (issue #5200).
+            UseProxy = false,
+            AllowAutoRedirect = false,
         });
 
         services.AddSingleton<IAzuriteProbe, AzuriteProbe>();

--- a/test/Func.Tests/Commands/Start/Azurite/AzuriteProbeTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/AzuriteProbeTests.cs
@@ -46,6 +46,26 @@ public class AzuriteProbeTests : IAsyncLifetime
     }
 
     [Fact]
+    public void AddAzuriteProbe_PrimaryHandler_DisablesProxy()
+    {
+        // Regression for #5200: a configured HTTP_PROXY / system proxy must
+        // not be in the path of the probe, since Azurite always runs on the
+        // loopback interface. If the proxy is used, probes fail with
+        // Connection refused and the orchestrator launches a second Azurite
+        // on top of the already-running one.
+        var factory = _services!.GetRequiredService<IHttpMessageHandlerFactory>();
+        HttpMessageHandler handler = factory.CreateHandler(AzuriteProbe.HttpClientName);
+
+        while (handler is DelegatingHandler dh && dh.InnerHandler is { } inner)
+        {
+            handler = inner;
+        }
+
+        var sockets = Assert.IsType<SocketsHttpHandler>(handler);
+        Assert.False(sockets.UseProxy);
+    }
+
+    [Fact]
     public async Task ProbeAsync_AllEndpointsReady_ViaRequestIdHeader_ReturnsReady()
     {
         var (blob, blobUri) = StartServer(static ctx =>


### PR DESCRIPTION
Fixes #5200.

## Problem

When the user already has Azurite running on default ports and has an HTTP proxy configured (`HTTP_PROXY`, system proxy, or WPAD on Windows), `func run` fails with:

```
Starting Azurite (native) for AzureWebJobsStorage...
  Endpoints: blob 127.0.0.1:10000, queue 127.0.0.1:10001, table 127.0.0.1:10002
Error: Azurite did not become ready within 30 seconds.
```

## Root cause

`AzuriteProbe` uses a named `HttpClient` whose primary handler was the default. The default handler honours the system/env proxy even for `127.0.0.1`. With a proxy in the path, every probe request fails (connection refused or timeout), the probe returns `NotListening`, and `ManagedAzuriteOrchestrator` launches a second Azurite on top of the already-running one. The new process cannot bind the occupied ports and the readiness poll times out.

Confirmed locally: with `HTTP_PROXY=http://127.0.0.1:39999` set against a live Azurite, the probe reports `NotListening` for all three endpoints. Without the env var it reports `Ready`.

## Fix

Configure the probe's primary handler as a `SocketsHttpHandler` with `UseProxy = false`. Azurite always runs on the loopback interface, so a proxy should never be in the path.

## Tests

- New `AddAzuriteProbe_PrimaryHandler_DisablesProxy` regression test walks the configured handler chain and asserts `UseProxy = false` on the inner `SocketsHttpHandler`.
- All 104 `Azurite*` tests pass.
- Manually verified end-to-end: a probe against a live Azurite with `HTTP_PROXY` pointing at an unreachable address now correctly returns `Ready`.