### PR TITLE
func init python: fix aka.ms link for v2 programming model (#5199)

### DIFF
--- a/src/Workloads/Stacks/Python/Templates/getting_started.md
+++ b/src/Workloads/Stacks/Python/Templates/getting_started.md
@@ -1,7 +1,7 @@
 # Getting started with Azure Functions for Python
 
 This project was scaffolded by `func init --stack python`. It uses the
-[v2 Python programming model](https://aka.ms/azure-functions/python/v2),
+[v2 Python programming model](https://aka.ms/pythonprogrammingmodel),
 where functions are decorated on a `FunctionApp` instance in
 `function_app.py`.
 

--- a/test/Workloads/Stacks/Python.Tests/PythonProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/Python.Tests/PythonProjectInitializerTests.cs
@@ -94,6 +94,10 @@ public class PythonProjectInitializerTests : IDisposable
         Assert.Contains("azure-functions", File.ReadAllText(Path.Combine(_projectDir.FullName, "requirements.txt")));
 
         Assert.True(File.Exists(Path.Combine(_projectDir.FullName, "getting_started.md")));
+        string gettingStarted = File.ReadAllText(Path.Combine(_projectDir.FullName, "getting_started.md"));
+        Assert.Contains("https://aka.ms/pythonprogrammingmodel", gettingStarted);
+        Assert.DoesNotContain("aka.ms/azure-functions/python/v2", gettingStarted);
+
         Assert.True(File.Exists(Path.Combine(_projectDir.FullName, ".gitignore")));
 
         Assert.True(File.Exists(Path.Combine(_projectDir.FullName, "local.settings.json")));


### PR DESCRIPTION
## Summary

Closes #5199.

The `getting_started.md` file emitted by `func init --stack python` linked to **`https://aka.ms/azure-functions/python/v2`** for the v2 Python programming model. That aka.ms slug does not resolve. The canonical slug for the same docs is **`https://aka.ms/pythonprogrammingmodel`**, which is what we use elsewhere (e.g. the v4 CLI README).

## Change

`src/Workloads/Stacks/Python/Templates/getting_started.md`:

```diff
-[v2 Python programming model](https://aka.ms/azure-functions/python/v2),
+[v2 Python programming model](https://aka.ms/pythonprogrammingmodel),
```

## Before

```
This project was scaffolded by `func init --stack python`. It uses the
[v2 Python programming model](https://aka.ms/azure-functions/python/v2),
where functions are decorated on a `FunctionApp` instance in
`function_app.py`.
```

## After

```
This project was scaffolded by `func init --stack python`. It uses the
[v2 Python programming model](https://aka.ms/pythonprogrammingmodel),
where functions are decorated on a `FunctionApp` instance in
`function_app.py`.
```

## Regression guard

Extended `PythonProjectInitializerTests.InitializeAsync_WritesExpectedFiles` to read the generated `getting_started.md` and assert both:

* it contains `https://aka.ms/pythonprogrammingmodel`
* it does **not** contain `aka.ms/azure-functions/python/v2`

## Validation

```
dotnet test test/Workloads/Stacks/Python.Tests/Workloads.Python.Tests.csproj --filter "FullyQualifiedName~PythonProjectInitializer"
Passed!  - Failed: 0, Passed: 19, Skipped: 0, Total: 19
```
