### PR TITLE
hydrate-dotnet-templates: read per-template description from VS host files (#5206 follow-up)

### DIFF
--- a/eng/scripts/hydrate-dotnet-templates.ps1
+++ b/eng/scripts/hydrate-dotnet-templates.ps1
@@ -148,6 +148,88 @@ if (-not $cache.ContainsKey('TemplateInfo')) {
     throw "templatecache.json has no TemplateInfo array at $cachePath."
 }
 
+# ── 3a. Build identity → host description map from the installed nupkg ──
+#
+# templatecache.json does not surface the per-template `description` field
+# from Visual Studio host files (e.g. `vs-2017.3.host.json`), which is the
+# only place upstream Microsoft.Azure.Functions.Worker.ItemTemplates
+# populates a human-readable one-line description per template. We crack
+# the installed nupkg open and read those host files directly so the
+# DESCRIPTION column of `func new --list` is informative.
+function Get-HostDescriptionByIdentity([string]$nupkgPath) {
+    $map = @{}
+    if (-not (Test-Path -LiteralPath $nupkgPath)) {
+        Write-Host "Host descriptions: nupkg not found at $nupkgPath, skipping enrichment."
+        return $map
+    }
+
+    $expandDir = Join-Path ([System.IO.Path]::GetDirectoryName($nupkgPath)) '_host_metadata_expanded'
+    if (Test-Path -LiteralPath $expandDir) { Remove-Item -LiteralPath $expandDir -Recurse -Force }
+    New-Item -ItemType Directory -Path $expandDir -Force | Out-Null
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($nupkgPath, $expandDir)
+
+    $cfgDirs = Get-ChildItem -LiteralPath (Join-Path $expandDir 'content') -Recurse -Directory -Filter '.template.config' -ErrorAction SilentlyContinue
+    foreach ($cfg in $cfgDirs) {
+        $tplJsonPath = Join-Path $cfg.FullName 'template.json'
+        if (-not (Test-Path -LiteralPath $tplJsonPath)) { continue }
+
+        try {
+            $tpl = Get-Content -LiteralPath $tplJsonPath -Raw -Encoding UTF8 | ConvertFrom-Json
+        } catch { continue }
+        if (-not $tpl.identity) { continue }
+
+        $description = $null
+        # Prefer dotnetcli.host.json (CLI-targeted) over IDE host files, then
+        # fall back to any *.host.json sibling. Each can carry description.text.
+        $hostCandidates = @(
+            (Join-Path $cfg.FullName 'dotnetcli.host.json'),
+            (Join-Path $cfg.FullName 'ide.host.json')
+        ) + (Get-ChildItem -LiteralPath $cfg.FullName -Filter '*.host.json' -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName })
+
+        $hostCandidates = $hostCandidates | Where-Object { $_ -and (Test-Path -LiteralPath $_) } | Select-Object -Unique
+        foreach ($hp in $hostCandidates) {
+            try {
+                $h = Get-Content -LiteralPath $hp -Raw -Encoding UTF8 | ConvertFrom-Json
+            } catch { continue }
+            if ($h.description -and $h.description.text -and -not [string]::IsNullOrWhiteSpace([string]$h.description.text)) {
+                $description = [string]$h.description.text
+                break
+            }
+        }
+
+        if ($description) {
+            $map[[string]$tpl.identity] = $description
+        }
+    }
+
+    # Clean up the expanded copy; we have everything in-memory now.
+    Remove-Item -LiteralPath $expandDir -Recurse -Force -ErrorAction SilentlyContinue
+
+    Write-Host "Host descriptions: hydrated $($map.Count) entries from $nupkgPath."
+    return $map
+}
+
+$packagesDir = Join-Path $HiveRoot '.templateengine/packages'
+$installedNupkg = Get-ChildItem -LiteralPath $packagesDir -Filter "$PackageId.$PackageVersion.nupkg" -File -ErrorAction SilentlyContinue |
+    Select-Object -First 1
+if (-not $installedNupkg) {
+    # Some flows resolve a different concrete version (e.g. when caller
+    # passes "*" or omits version). Fall back to any nupkg matching the
+    # package id prefix.
+    $installedNupkg = Get-ChildItem -LiteralPath $packagesDir -Filter "$PackageId.*.nupkg" -File -ErrorAction SilentlyContinue |
+        Sort-Object Name -Descending |
+        Select-Object -First 1
+}
+
+$hostDescriptionsByIdentity = @{}
+if ($installedNupkg) {
+    $hostDescriptionsByIdentity = Get-HostDescriptionByIdentity $installedNupkg.FullName
+} else {
+    Write-Host "Host descriptions: no nupkg found under $packagesDir, projection will fall back to engine cache description (typically empty)."
+}
+
 # ── 4. Filter to Functions item templates ────────────────────────────────
 $entries = @($cache['TemplateInfo'] | Where-Object {
     $classifications = @()
@@ -305,7 +387,16 @@ function Convert-Entry([hashtable]$t) {
         identity        = [string]$t['Identity']
         groupIdentity   = if ($t['GroupIdentity']) { [string]$t['GroupIdentity'] } else { $null }
         name            = [string]$t['Name']
-        description     = if ($t.ContainsKey('Description') -and [string]$t['Description']) { [string]$t['Description'] } else { $null }
+        description     = & {
+            $identity = [string]$t['Identity']
+            if ($hostDescriptionsByIdentity.ContainsKey($identity)) {
+                return $hostDescriptionsByIdentity[$identity]
+            }
+            if ($t.ContainsKey('Description') -and [string]$t['Description']) {
+                return [string]$t['Description']
+            }
+            return $null
+        }
         author          = if ($t.ContainsKey('Author') -and [string]$t['Author']) { [string]$t['Author'] } else { $null }
         language        = $language
         type            = $type

--- a/eng/scripts/hydrate-dotnet-templates.ps1
+++ b/eng/scripts/hydrate-dotnet-templates.ps1
@@ -388,6 +388,14 @@ function Convert-Entry([hashtable]$t) {
         groupIdentity   = if ($t['GroupIdentity']) { [string]$t['GroupIdentity'] } else { $null }
         name            = [string]$t['Name']
         description     = & {
+            # Preference order:
+            #   1. Host file description.text (only inserted into the map
+            #      when non-empty by Get-HostDescriptionByIdentity, so a
+            #      ContainsKey hit always yields a real string).
+            #   2. Cache Description (template.json <description>; empty
+            #      for 0/36 Functions item templates today, kept as a
+            #      forward-compat backstop).
+            #   3. null -> column renders blank.
             $identity = [string]$t['Identity']
             if ($hostDescriptionsByIdentity.ContainsKey($identity)) {
                 return $hostDescriptionsByIdentity[$identity]


### PR DESCRIPTION
Follows up on #5233. Closes the upstream-data side of #5206.

## Why

The dotnet item-templates `template.json` files in `Microsoft.Azure.Functions.Worker.ItemTemplates` ship **0/36** populated `<description>` fields — that's why `func new --list` had a blank DESCRIPTION column before #5233. #5233 worked around this with a synthesized `"<Name> (<classification>)"` string from the data we already had. This PR replaces that synthesized text with **real per-template one-liners** that live in the same nupkg, in a place the hydrate script wasn't looking.

The Visual Studio New Item dialog reads a sibling host file (`vs-2017.3.host.json`, `dotnetcli.host.json`, or `ide.host.json`) next to each `template.json`. Those files **do** populate a real one-line description for every template — 36/36 in the current package:

| Template | Hydrated `description` |
|---|---|
| `http` | A C# function that will be run whenever it receives an HTTP request |
| `blob` | A C# function that will be run whenever a blob is added to a specified container. |
| `timer` | A C# function that will be run on a specified schedule |
| `cosmos` | A C# function that will be run whenever documents change in a document container. |
| `eventgrid` | A C# function that will be run whenever an event grid receives a new event |
| `queue` | A C# function that will be run whenever a message is added to a specified Azure Queue Storage |
| `durable` | A C# Orchestration function that invokes activity functions in a sequence. |
| `durableentityclass` | A C# Entity class that acts as a stateful counter in Durable Functions. |
| `mcptooltrigger` | A C# function that will be run whenever it receives an MCP Tool invocation |
| `kustoinput` | A C# function that takes a KQL query or KQL function and returns the output of the query |
| `sqltrigger` | A C# function that takes a SQL table to monitor for changes and invokes the function with updated rows. |
| `servicebusqueuetrigger` | A C# function that will be run whenever a message is added to a specified Service Bus queue |

(All 36 entries are populated similarly — the table above is a representative slice.)

## What changes

`eng/scripts/hydrate-dotnet-templates.ps1` now, in addition to reading `templatecache.json` (which the templating engine's hive caches), also opens the installed nupkg from `<HiveRoot>/.templateengine/packages/<PackageId>.<Version>.nupkg`, walks every `content/<Template>/.template.config/` directory, parses each sibling host file (`dotnetcli.host.json` → `ide.host.json` → any `*.host.json`), and builds a `{ identity → description.text }` map. When projecting each cache entry into `dotnet-templates.json`, the host-file description takes precedence over the cache's `Description` field (which is empty for every Functions item template today).

Pure tooling-side change; no C# touched, no schema change, no behavioural change in the runtime for cases where the cache already carries a description.

### Renderer-side fallback in #5233 stays as a defensive backstop

#5233 added a fallback in `DotNetTemplateProjection.ResolveDescription` to synthesize `"<Name> (<classification>)"` when `head.Description` is empty. With this PR landed, that path will essentially never fire because the hydrate script populates `description` for 36/36 entries — but the fallback stays in place so that any future template shipped without a host file still renders a non-empty column. Belt-and-braces.

## Validation

- **Re-hydrated** against the same upstream package version pinned in the playground catalog (`Microsoft.Azure.Functions.Worker.ItemTemplates@4.0.5569`):
  - `Host descriptions: hydrated 36 entries from …\packages\Microsoft.Azure.Functions.Worker.ItemTemplates.4.0.5569.nupkg.`
  - `Projected 36 entries (after parameter filter).`
  - 36/36 templates carry a non-empty `description` field in the resulting `dotnet-templates.json` (compared to 0/36 before).
- **Smoke-tested** end-to-end: swapped the rehydrated catalog into the playground `FUNC_CLI_WORKLOADS_HOME` and ran `func new --list` in an initialized dotnet project — every row now shows the real description (`http` → "A C# function that will be run whenever it receives an HTTP request", etc.).

## Future work (not in this PR)

The host files also expose a friendlier display name per template (e.g. `"Blob trigger"` vs `BlobTrigger`, `"Cosmos DB Trigger"` vs `CosmosDBTrigger`, `"Durable Functions Entity (class)"` vs `DurableFunctionsEntityClass`). Surfacing that as the NAME column or as a new `friendlyName`/`displayName` would require a small schema addition + a projection change. Out of scope here to keep this PR purely a content fix.
