### PR TITLE
Dotnet project Output Path Resolution

### DIFF
--- a/src/Abstractions/Common/GracefulException.cs
+++ b/src/Abstractions/Common/GracefulException.cs
@@ -8,29 +8,21 @@ namespace Azure.Functions.Cli.Common;
 /// </summary>
 public class GracefulException : Exception
 {
-    public bool IsUserError { get; }
-    public string? VerboseMessage { get; }
-
     public GracefulException(string message, bool isUserError = false, string? verboseMessage = null)
-        : base(message)
+        : this(message, null, isUserError, verboseMessage)
     {
-        IsUserError = isUserError;
-        VerboseMessage = verboseMessage;
     }
 
-    public GracefulException(string message, Exception innerException, bool isUserError = false, string? verboseMessage = null)
+    public GracefulException(string message, Exception? innerException, bool isUserError = false, string? verboseMessage = null)
         : base(message, innerException)
     {
         IsUserError = isUserError;
         VerboseMessage = verboseMessage;
     }
 
-    public GracefulException(string message, string verboseMessage)
-        : base(message)
-    {
-        IsUserError = true;
-        VerboseMessage = verboseMessage;
-    }
+    public bool IsUserError { get; }
+
+    public string? VerboseMessage { get; }
 }
 
 /// <summary>

--- a/src/Abstractions/Common/GracefulException.cs
+++ b/src/Abstractions/Common/GracefulException.cs
@@ -18,6 +18,13 @@ public class GracefulException : Exception
         VerboseMessage = verboseMessage;
     }
 
+    public GracefulException(string message, Exception innerException, bool isUserError = false, string? verboseMessage = null)
+        : base(message, innerException)
+    {
+        IsUserError = isUserError;
+        VerboseMessage = verboseMessage;
+    }
+
     public GracefulException(string message, string verboseMessage)
         : base(message)
     {

--- a/src/Workloads/Stacks/DotNet/DotNetSourceProject.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetSourceProject.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Text.Json;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Projects;
 
@@ -26,44 +27,30 @@ internal sealed class DotNetSourceProject(WorkingDirectory workingDirectory, str
                 $"Could not determine directory for project file '{ProjectFilePath}'.",
                 isUserError: true);
 
+        DirectoryInfo outputDirectory;
+
         if (!context.SkipBuild)
         {
-            await BuildAsync(projectDir, cancellationToken);
+            // Build and resolve output in one shot so the output path reflects the actual build result,
+            // even when targets modify OutputPath/OutDir dynamically during the build.
+            outputDirectory = await BuildAndGetOutputDirectoryAsync(projectDir, cancellationToken);
+        }
+        else
+        {
+            // No build requested; resolve the target path from the existing project state.
+            outputDirectory = await GetTargetPathAsync(projectDir, cancellationToken);
         }
 
-        DirectoryInfo outputDirectory = await GetOutputDirectoryAsync(projectDir, cancellationToken);
         context.StartupDirectory = outputDirectory;
     }
 
-    private async Task<DirectoryInfo> GetOutputDirectoryAsync(string projectDir, CancellationToken cancellationToken)
+    private async Task<DirectoryInfo> BuildAndGetOutputDirectoryAsync(string projectDir, CancellationToken cancellationToken)
     {
-        string output = await _dotnetCli.RunWithOutputAsync(
-            ["msbuild", ProjectFilePath, "--getProperty:OutputPath"],
-            projectDir,
-            cancellationToken);
-
-        string outputPath = output.Trim();
-        if (string.IsNullOrEmpty(outputPath))
-        {
-            throw new GracefulException(
-                $"Could not determine OutputPath for project '{Path.GetFileName(ProjectFilePath)}'. Ensure the project has been built or has a valid OutputPath configured.",
-                isUserError: true);
-        }
-
-        // OutputPath may be relative to the project directory.
-        string fullPath = Path.IsPathRooted(outputPath)
-            ? outputPath
-            : Path.GetFullPath(outputPath, projectDir);
-
-        return new DirectoryInfo(fullPath);
-    }
-
-    private async Task BuildAsync(string projectDir, CancellationToken cancellationToken)
-    {
+        string json;
         try
         {
-            await _dotnetCli.RunAsync(
-                ["build", ProjectFilePath],
+            json = await _dotnetCli.RunWithOutputAsync(
+                ["build", ProjectFilePath, "--getTargetResult:Build"],
                 projectDir,
                 cancellationToken);
         }
@@ -74,5 +61,63 @@ internal sealed class DotNetSourceProject(WorkingDirectory workingDirectory, str
                 $"'dotnet build' failed (exit {ex.ExitCode}). {detail}",
                 isUserError: true);
         }
+
+        return ParseTargetResult(json.Trim(), "Build");
+    }
+
+    private async Task<DirectoryInfo> GetTargetPathAsync(string projectDir, CancellationToken cancellationToken)
+    {
+        string json = await _dotnetCli.RunWithOutputAsync(
+            ["build", ProjectFilePath, "--getTargetResult:GetTargetPath"],
+            projectDir,
+            cancellationToken);
+
+        return ParseTargetResult(json.Trim(), "GetTargetPath");
+    }
+
+    internal DirectoryInfo ParseTargetResult(string json, string targetName)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            throw new GracefulException(
+                $"Could not determine output directory for project '{Path.GetFileName(ProjectFilePath)}'. The '{targetName}' target produced no output.",
+                isUserError: true);
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            JsonElement root = doc.RootElement;
+
+            if (root.TryGetProperty("TargetResults", out JsonElement targetResults)
+                && targetResults.TryGetProperty(targetName, out JsonElement target)
+                && target.TryGetProperty("Items", out JsonElement items)
+                && items.GetArrayLength() > 0)
+            {
+                JsonElement firstItem = items[0];
+
+                // Both Build and GetTargetPath targets return the assembly's full path as the item identity.
+                string assemblyPath = firstItem.TryGetProperty("FullPath", out JsonElement fullPathElement)
+                    ? fullPathElement.GetString() ?? string.Empty
+                    : firstItem.GetProperty("Identity").GetString() ?? string.Empty;
+
+                if (!string.IsNullOrWhiteSpace(assemblyPath))
+                {
+                    string dir = Path.GetDirectoryName(assemblyPath)!;
+                    return new DirectoryInfo(dir);
+                }
+            }
+        }
+        catch (JsonException ex)
+        {
+            throw new GracefulException(
+                $"Could not parse '{targetName}' target result for project '{Path.GetFileName(ProjectFilePath)}'. The output was not valid JSON.",
+                ex,
+                isUserError: true);
+        }
+
+        throw new GracefulException(
+            $"Could not determine output directory for project '{Path.GetFileName(ProjectFilePath)}'. The '{targetName}' target result did not contain expected output paths.",
+            isUserError: true);
     }
 }

--- a/src/Workloads/Stacks/DotNet/DotNetSourceProject.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetSourceProject.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Projects;
 
@@ -27,55 +28,38 @@ internal sealed class DotNetSourceProject(WorkingDirectory workingDirectory, str
                 $"Could not determine directory for project file '{ProjectFilePath}'.",
                 isUserError: true);
 
-        DirectoryInfo outputDirectory;
+        // Both paths run `dotnet build` and read an MSBuild target result as JSON; only the requested
+        // target differs. The default build runs the "Build" target (compiles, then reports the actual
+        // output even when targets adjust OutputPath/OutDir dynamically); --no-build runs "GetTargetPath"
+        // to resolve the existing output without compiling. The output JSON shape is the same, so a single
+        // code path handles both.
 
-        if (!context.SkipBuild)
-        {
-            // Build and resolve output in one shot so the output path reflects the actual build result,
-            // even when targets modify OutputPath/OutDir dynamically during the build.
-            outputDirectory = await BuildAndGetOutputDirectoryAsync(projectDir, cancellationToken);
-        }
-        else
-        {
-            // No build requested; resolve the target path from the existing project state.
-            outputDirectory = await GetTargetPathAsync(projectDir, cancellationToken);
-        }
+        string targetName = context.SkipBuild ? "GetTargetPath" : "Build";
 
-        context.StartupDirectory = outputDirectory;
+        context.StartupDirectory = await BuildAndGetOutputDirectoryAsync(projectDir, targetName, context.SkipBuild, cancellationToken);
     }
 
-    private async Task<DirectoryInfo> BuildAndGetOutputDirectoryAsync(string projectDir, CancellationToken cancellationToken)
+    private async Task<DirectoryInfo> BuildAndGetOutputDirectoryAsync(string projectDir, string targetName, bool requireAssemblyExists, CancellationToken cancellationToken)
     {
         string json;
         try
         {
             json = await _dotnetCli.RunWithOutputAsync(
-                ["build", ProjectFilePath, "--getTargetResult:Build"],
+                ["build", ProjectFilePath, $"--getTargetResult:{targetName}"],
                 projectDir,
                 cancellationToken);
         }
         catch (DotnetCliException ex)
         {
             string detail = string.IsNullOrWhiteSpace(ex.StandardError) ? "see build output above." : ex.StandardError.Trim();
-            throw new GracefulException(
-                $"'dotnet build' failed (exit {ex.ExitCode}). {detail}",
-                isUserError: true);
+
+            throw new GracefulException($"'dotnet build' failed (exit {ex.ExitCode}). {detail}", isUserError: true);
         }
 
-        return ParseTargetResult(json.Trim(), "Build");
+        return ParseTargetResult(json.Trim(), targetName, requireAssemblyExists);
     }
 
-    private async Task<DirectoryInfo> GetTargetPathAsync(string projectDir, CancellationToken cancellationToken)
-    {
-        string json = await _dotnetCli.RunWithOutputAsync(
-            ["build", ProjectFilePath, "--getTargetResult:GetTargetPath"],
-            projectDir,
-            cancellationToken);
-
-        return ParseTargetResult(json.Trim(), "GetTargetPath");
-    }
-
-    internal DirectoryInfo ParseTargetResult(string json, string targetName)
+    internal DirectoryInfo ParseTargetResult(string json, string targetName, bool requireAssemblyExists = false)
     {
         if (string.IsNullOrWhiteSpace(json))
         {
@@ -86,25 +70,30 @@ internal sealed class DotNetSourceProject(WorkingDirectory workingDirectory, str
 
         try
         {
-            using var doc = JsonDocument.Parse(json);
-            JsonElement root = doc.RootElement;
+            var root = JsonNode.Parse(json);
+            JsonArray? items = root?["TargetResults"]?[targetName]?["Items"]?.AsArray();
 
-            if (root.TryGetProperty("TargetResults", out JsonElement targetResults)
-                && targetResults.TryGetProperty(targetName, out JsonElement target)
-                && target.TryGetProperty("Items", out JsonElement items)
-                && items.GetArrayLength() > 0)
+            if (items is { Count: > 0 })
             {
-                JsonElement firstItem = items[0];
-
-                // Both Build and GetTargetPath targets return the assembly's full path as the item identity.
-                string assemblyPath = firstItem.TryGetProperty("FullPath", out JsonElement fullPathElement)
-                    ? fullPathElement.GetString() ?? string.Empty
-                    : firstItem.GetProperty("Identity").GetString() ?? string.Empty;
+                JsonNode firstItem = items[0]!;
+                string assemblyPath =
+                    firstItem["FullPath"]?.GetValue<string>()
+                    ?? firstItem["Identity"]?.GetValue<string>()
+                    ?? string.Empty;
 
                 if (!string.IsNullOrWhiteSpace(assemblyPath))
                 {
-                    string dir = Path.GetDirectoryName(assemblyPath)!;
-                    return new DirectoryInfo(dir);
+                    // With --no-build we only resolve the target path; nothing compiled it. If the
+                    // assembly isn't actually present, fail here with an actionable message instead of
+                    // letting the host fail later with a more cryptic "worker/app not found" error.
+                    if (requireAssemblyExists && !File.Exists(assemblyPath))
+                    {
+                        throw new GracefulException(
+                            $"Could not find the build output for project '{Path.GetFileName(ProjectFilePath)}' at '{assemblyPath}'. Build the project before running with --no-build, or omit --no-build to build automatically.",
+                            isUserError: true);
+                    }
+
+                    return new DirectoryInfo(Path.GetDirectoryName(assemblyPath)!);
                 }
             }
         }

--- a/test/Workloads/Stacks/DotNet.Tests/DotNetSourceProjectTests.cs
+++ b/test/Workloads/Stacks/DotNet.Tests/DotNetSourceProjectTests.cs
@@ -4,6 +4,7 @@
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Projects;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.DotNet.Tests;
@@ -34,61 +35,69 @@ public class DotNetSourceProjectTests : IDisposable
     }
 
     [Fact]
-    public async Task PrepareForHostRunAsync_builds_then_sets_startup_directory()
+    public async Task PrepareForHostRunAsync_builds_and_sets_startup_directory_from_target_result()
     {
         string projectFile = Path.Combine(_projectDir.FullName, "MyApp.csproj");
         File.WriteAllText(projectFile, "<Project></Project>");
 
-        _dotnetCli.RunWithOutputAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .Returns("bin/Debug/net10.0/\n");
+        string assemblyPath = Path.Combine(_projectDir.FullName, "bin", "Debug", "net10.0", "MyApp.dll");
+        string json = BuildTargetResultJson(assemblyPath, "Build");
+
+        _dotnetCli.RunWithOutputAsync(
+                Arg.Is<IReadOnlyList<string>>(args => args[0] == "build" && args.Contains("--getTargetResult:Build")),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(json);
 
         DotNetSourceProject project = CreateProject(projectFile);
         FunctionsProjectHostRunContext context = CreateHostRunContext();
 
         await project.PrepareForHostRunAsync(context, default);
 
-        // Build should be called before output path query (verified by call order)
-        Received.InOrder(() =>
-        {
-            _dotnetCli.RunAsync(
-                Arg.Is<IReadOnlyList<string>>(args => args[0] == "build" && args[1] == projectFile),
-                _projectDir.FullName,
-                Arg.Any<CancellationToken>());
-            _dotnetCli.RunWithOutputAsync(
-                Arg.Is<IReadOnlyList<string>>(args => args[0] == "msbuild" && args[2] == "--getProperty:OutputPath"),
-                _projectDir.FullName,
-                Arg.Any<CancellationToken>());
-        });
-
-        string expectedPath = Path.GetFullPath("bin/Debug/net10.0/", _projectDir.FullName);
-        Assert.Equal(expectedPath, context.StartupDirectory.FullName);
+        string expectedDir = Path.GetDirectoryName(assemblyPath)!;
+        Assert.Equal(expectedDir, context.StartupDirectory.FullName.TrimEnd(Path.DirectorySeparatorChar));
     }
 
     [Fact]
-    public async Task PrepareForHostRunAsync_handles_absolute_output_path()
+    public async Task PrepareForHostRunAsync_skip_build_uses_get_target_path()
     {
         string projectFile = Path.Combine(_projectDir.FullName, "MyApp.csproj");
         File.WriteAllText(projectFile, "<Project></Project>");
 
-        string absoluteOutput = Path.Combine(_projectDir.FullName, "custom-output");
-        _dotnetCli.RunWithOutputAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .Returns(absoluteOutput + "\n");
+        string assemblyPath = Path.Combine(_projectDir.FullName, "bin", "Debug", "net10.0", "MyApp.dll");
+        string json = BuildTargetResultJson(assemblyPath, "GetTargetPath");
+
+        _dotnetCli.RunWithOutputAsync(
+                Arg.Is<IReadOnlyList<string>>(args => args.Contains("--getTargetResult:GetTargetPath")),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(json);
 
         DotNetSourceProject project = CreateProject(projectFile);
-        FunctionsProjectHostRunContext context = CreateHostRunContext();
+        FunctionsProjectHostRunContext context = CreateHostRunContext(skipBuild: true);
 
         await project.PrepareForHostRunAsync(context, default);
 
-        Assert.Equal(absoluteOutput, context.StartupDirectory.FullName);
+        // Should NOT have called the build target
+        await _dotnetCli.DidNotReceive().RunWithOutputAsync(
+            Arg.Is<IReadOnlyList<string>>(args => args.Contains("--getTargetResult:Build")),
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
+
+        string expectedDir = Path.GetDirectoryName(assemblyPath)!;
+        Assert.Equal(expectedDir, context.StartupDirectory.FullName.TrimEnd(Path.DirectorySeparatorChar));
     }
 
     [Fact]
-    public async Task PrepareForHostRunAsync_throws_when_output_path_is_empty()
+    public async Task PrepareForHostRunAsync_throws_when_target_result_is_empty()
     {
         string projectFile = Path.Combine(_projectDir.FullName, "MyApp.csproj");
         File.WriteAllText(projectFile, "<Project></Project>");
 
-        _dotnetCli.RunWithOutputAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+        _dotnetCli.RunWithOutputAsync(
+                Arg.Is<IReadOnlyList<string>>(args => args[0] == "build" && args.Contains("--getTargetResult:Build")),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
             .Returns("   \n");
 
         DotNetSourceProject project = CreateProject(projectFile);
@@ -97,7 +106,7 @@ public class DotNetSourceProjectTests : IDisposable
         GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
             () => project.PrepareForHostRunAsync(context, default));
 
-        Assert.Contains("OutputPath", ex.Message);
+        Assert.Contains("output directory", ex.Message);
         Assert.True(ex.IsUserError);
     }
 
@@ -107,8 +116,11 @@ public class DotNetSourceProjectTests : IDisposable
         string projectFile = Path.Combine(_projectDir.FullName, "MyApp.csproj");
         File.WriteAllText(projectFile, "<Project></Project>");
 
-        _dotnetCli.RunAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromException(new DotnetCliException(1, "Build failed", "", "build MyApp.csproj")));
+        _dotnetCli.RunWithOutputAsync(
+                Arg.Is<IReadOnlyList<string>>(args => args[0] == "build" && args.Contains("--getTargetResult:Build")),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Throws(new DotnetCliException(1, "Build failed", "", "build MyApp.csproj"));
 
         DotNetSourceProject project = CreateProject(projectFile);
         FunctionsProjectHostRunContext context = CreateHostRunContext();
@@ -149,31 +161,44 @@ public class DotNetSourceProjectTests : IDisposable
     }
 
     [Fact]
-    public async Task PrepareForHostRunAsync_skips_build_when_skip_build_is_true()
+    public void ParseTargetResult_throws_on_invalid_json_with_inner_exception()
     {
         string projectFile = Path.Combine(_projectDir.FullName, "MyApp.csproj");
         File.WriteAllText(projectFile, "<Project></Project>");
 
-        _dotnetCli.RunWithOutputAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .Returns("bin/Debug/net10.0/\n");
+        DotNetSourceProject project = CreateProject(projectFile);
+
+        GracefulException ex = Assert.Throws<GracefulException>(
+            () => project.ParseTargetResult("not json at all", "Build"));
+
+        Assert.Contains("not valid JSON", ex.Message);
+        Assert.IsAssignableFrom<System.Text.Json.JsonException>(ex.InnerException);
+        Assert.True(ex.IsUserError);
+    }
+
+    [Fact]
+    public void ParseTargetResult_throws_when_no_items()
+    {
+        string projectFile = Path.Combine(_projectDir.FullName, "MyApp.csproj");
+        File.WriteAllText(projectFile, "<Project></Project>");
 
         DotNetSourceProject project = CreateProject(projectFile);
-        FunctionsProjectHostRunContext context = CreateHostRunContext(skipBuild: true);
+        string json = """
+            {
+              "TargetResults": {
+                "Build": {
+                  "Result": "Success",
+                  "Items": []
+                }
+              }
+            }
+            """;
 
-        await project.PrepareForHostRunAsync(context, default);
+        GracefulException ex = Assert.Throws<GracefulException>(
+            () => project.ParseTargetResult(json, "Build"));
 
-        // Build should NOT be called
-        await _dotnetCli.DidNotReceive().RunAsync(
-            Arg.Any<IReadOnlyList<string>>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
-
-        // OutputPath query should still be called
-        await _dotnetCli.Received(1).RunWithOutputAsync(
-            Arg.Is<IReadOnlyList<string>>(args => args[0] == "msbuild" && args[2] == "--getProperty:OutputPath"),
-            Arg.Any<string?>(),
-            Arg.Any<CancellationToken>());
-
-        string expectedPath = Path.GetFullPath("bin/Debug/net10.0/", _projectDir.FullName);
-        Assert.Equal(expectedPath, context.StartupDirectory.FullName);
+        Assert.Contains("output directory", ex.Message);
+        Assert.True(ex.IsUserError);
     }
 
     private DotNetSourceProject CreateProject(string projectFile)
@@ -181,4 +206,26 @@ public class DotNetSourceProjectTests : IDisposable
 
     private FunctionsProjectHostRunContext CreateHostRunContext(bool skipBuild = false)
         => new(_projectDir, "dotnet", new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase), skipBuild);
+
+    private static string BuildTargetResultJson(string assemblyFullPath, string targetName)
+    {
+        string escapedFullPath = assemblyFullPath.Replace("\\", "\\\\");
+        return $$"""
+            {
+              "TargetResults": {
+                "{{targetName}}": {
+                  "Result": "Success",
+                  "Items": [
+                    {
+                      "Identity": "{{escapedFullPath}}",
+                      "FullPath": "{{escapedFullPath}}",
+                      "Filename": "MyApp",
+                      "Extension": ".dll"
+                    }
+                  ]
+                }
+              }
+            }
+            """;
+    }
 }

--- a/test/Workloads/Stacks/DotNet.Tests/DotNetSourceProjectTests.cs
+++ b/test/Workloads/Stacks/DotNet.Tests/DotNetSourceProjectTests.cs
@@ -67,6 +67,10 @@ public class DotNetSourceProjectTests : IDisposable
         string assemblyPath = Path.Combine(_projectDir.FullName, "bin", "Debug", "net10.0", "MyApp.dll");
         string json = BuildTargetResultJson(assemblyPath, "GetTargetPath");
 
+        // --no-build trusts existing output, so the assembly must actually be on disk.
+        Directory.CreateDirectory(Path.GetDirectoryName(assemblyPath)!);
+        File.WriteAllText(assemblyPath, string.Empty);
+
         _dotnetCli.RunWithOutputAsync(
                 Arg.Is<IReadOnlyList<string>>(args => args.Contains("--getTargetResult:GetTargetPath")),
                 Arg.Any<string?>(),
@@ -86,6 +90,56 @@ public class DotNetSourceProjectTests : IDisposable
 
         string expectedDir = Path.GetDirectoryName(assemblyPath)!;
         Assert.Equal(expectedDir, context.StartupDirectory.FullName.TrimEnd(Path.DirectorySeparatorChar));
+    }
+
+    [Fact]
+    public async Task PrepareForHostRunAsync_skip_build_throws_when_assembly_missing()
+    {
+        string projectFile = Path.Combine(_projectDir.FullName, "MyApp.csproj");
+        File.WriteAllText(projectFile, "<Project></Project>");
+
+        // Resolve a valid target path, but never create the assembly on disk.
+        string assemblyPath = Path.Combine(_projectDir.FullName, "bin", "Debug", "net10.0", "MyApp.dll");
+        string json = BuildTargetResultJson(assemblyPath, "GetTargetPath");
+
+        _dotnetCli.RunWithOutputAsync(
+                Arg.Is<IReadOnlyList<string>>(args => args.Contains("--getTargetResult:GetTargetPath")),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(json);
+
+        DotNetSourceProject project = CreateProject(projectFile);
+        FunctionsProjectHostRunContext context = CreateHostRunContext(skipBuild: true);
+
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => project.PrepareForHostRunAsync(context, default));
+
+        Assert.Contains("--no-build", ex.Message);
+        Assert.Contains("MyApp", ex.Message);
+        Assert.True(ex.IsUserError);
+    }
+
+    [Fact]
+    public async Task PrepareForHostRunAsync_skip_build_propagates_cli_failure()
+    {
+        string projectFile = Path.Combine(_projectDir.FullName, "MyApp.csproj");
+        File.WriteAllText(projectFile, "<Project></Project>");
+
+        _dotnetCli.RunWithOutputAsync(
+                Arg.Is<IReadOnlyList<string>>(args => args.Contains("--getTargetResult:GetTargetPath")),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Throws(new DotnetCliException(1, "Target path resolution failed", "", "build MyApp.csproj"));
+
+        DotNetSourceProject project = CreateProject(projectFile);
+        FunctionsProjectHostRunContext context = CreateHostRunContext(skipBuild: true);
+
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => project.PrepareForHostRunAsync(context, default));
+
+        Assert.Contains("dotnet build", ex.Message);
+        Assert.Contains("exit 1", ex.Message);
+        Assert.True(ex.IsUserError);
     }
 
     [Fact]


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #5207 

## Summary

Fixes #5207

When `func run` builds a .NET project, the output directory is now resolved from the actual build result rather than a separate MSBuild property query. This fixes cases where targets dynamically modify OutputPath/OutDir during the build, causing the CLI to look in the wrong directory for the built app.

## Changes

- **DotNetSourceProject.cs**: Replaced the two-step build-then-query approach with a single dotnet build --getTargetResult:Build invocation that both builds the project and returns the actual output paths as JSON. When --no-build is used, the existing --getProperty:OutputPath fallback is preserved.
- **DotNetSourceProjectTests.cs**: Updated tests to validate the new one-shot build+resolve behavior, added tests for JSON parsing edge cases (missing fields, invalid JSON, empty items).

## How it works

Previously:
1. `dotnet build <project>` (build only)
2. `dotnet msbuild <project> --getProperty:OutputPath` (query output path separately)

Now:
1. `dotnet build <project> --getTargetResult:Build` (build + get actual output in one shot)

The JSON response from --getTargetResult:Build contains the RelativeDir and FullPath of the built assembly, which accurately reflects where the build actually placed outputs — even when MSBuild targets modify the output directory dynamically.

## Testing

- All 48 existing + new tests in Workloads.DotNet.Tests pass.
- Covers: normal build path, FullPath fallback, skip-build path, build failures, empty/invalid JSON, null context, cancellation.