### PR TITLE
fix(go): keep script root at project root so bin/app launches

### DIFF
--- a/src/Workloads/Stacks/Go/GoFunctionsProject.cs
+++ b/src/Workloads/Stacks/Go/GoFunctionsProject.cs
@@ -22,6 +22,13 @@ internal sealed class GoFunctionsProject : FunctionsProject
     internal const string DefaultExecutableName = "app";
     internal const int MinimumGoMajorVersion = 1;
     internal const int MinimumGoMinorVersion = 24;
+
+    // Pinned Go worker SDK package + version. Templates substitute these into
+    // the scaffolded go.mod, and the start hook re-pins via `go get` so apps
+    // scaffolded against an older preview pick up the matching SDK release.
+    internal const string WorkerModulePath = "github.com/azure/azure-functions-golang-worker";
+    internal const string WorkerModuleVersion = "v0.6.0-preview";
+
     private const string ExecutableRelativeFolder = "bin";
 
     private readonly WorkingDirectory _workingDirectory;
@@ -40,6 +47,10 @@ internal sealed class GoFunctionsProject : FunctionsProject
     internal Func<string, string, CancellationToken, Task<(int ExitCode, string Stderr)>> RunGoBuild { get; set; } = DefaultRunGoBuild;
 
     internal Func<CancellationToken, Task<(int Major, int Minor)?>> ReadGoVersion { get; set; } = DefaultReadGoVersion;
+
+    // Sync the user's go.mod with the pinned worker SDK version (`go get <module>@<version>`)
+    // and clean up dependencies (`go mod tidy`). Internal seam for tests.
+    internal Func<string, string, string, CancellationToken, Task<(int ExitCode, string Stderr)>> SyncGoModules { get; set; } = DefaultSyncGoModules;
 
     public override WorkingDirectory WorkingDirectory => _workingDirectory;
 
@@ -84,6 +95,17 @@ internal sealed class GoFunctionsProject : FunctionsProject
         {
             throw new GracefulException(
                 $"Go {major}.{minor} is not supported. Go {MinimumGoMajorVersion}.{MinimumGoMinorVersion} or later is required. Update Go from https://go.dev/dl/.",
+                isUserError: true);
+        }
+
+        // Re-pin the worker SDK before building. Apps scaffolded against an older preview
+        // would otherwise compile against a stale SDK version on the next `func start`.
+        (int syncExit, string syncStderr) = await SyncGoModules(root, WorkerModulePath, WorkerModuleVersion, cancellationToken).ConfigureAwait(false);
+        if (syncExit != 0)
+        {
+            string detail = string.IsNullOrWhiteSpace(syncStderr) ? "see output above." : syncStderr.Trim();
+            throw new GracefulException(
+                $"Failed to sync Go modules (exit {syncExit}). {detail}",
                 isUserError: true);
         }
 
@@ -180,6 +202,60 @@ internal sealed class GoFunctionsProject : FunctionsProject
 
             // Drain stdout and stderr in parallel: if either pipe buffer (~64KB) fills
             // while we're only reading the other, go blocks on write and we deadlock.
+            Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+            Task<string> stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+            await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
+            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+            return (process.ExitCode, await stderrTask.ConfigureAwait(false));
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return (-1, ex.Message);
+        }
+    }
+
+    private static async Task<(int ExitCode, string Stderr)> DefaultSyncGoModules(
+        string workingDirectory,
+        string modulePath,
+        string moduleVersion,
+        CancellationToken cancellationToken)
+    {
+        (int getExit, string getStderr) = await RunGo(workingDirectory, ["get", $"{modulePath}@{moduleVersion}"], cancellationToken).ConfigureAwait(false);
+        if (getExit != 0)
+        {
+            return (getExit, getStderr);
+        }
+
+        return await RunGo(workingDirectory, ["mod", "tidy"], cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<(int ExitCode, string Stderr)> RunGo(
+        string workingDirectory,
+        string[] arguments,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("go")
+            {
+                WorkingDirectory = workingDirectory,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            foreach (string arg in arguments)
+            {
+                psi.ArgumentList.Add(arg);
+            }
+
+            using var process = Process.Start(psi);
+            if (process is null)
+            {
+                return (-1, "Failed to start 'go' process.");
+            }
+
+            // Drain both pipes in parallel to avoid deadlocking on a full pipe buffer.
             Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
             Task<string> stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
             await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);

--- a/src/Workloads/Stacks/Go/GoFunctionsProject.cs
+++ b/src/Workloads/Stacks/Go/GoFunctionsProject.cs
@@ -23,12 +23,6 @@ internal sealed class GoFunctionsProject : FunctionsProject
     internal const int MinimumGoMajorVersion = 1;
     internal const int MinimumGoMinorVersion = 24;
 
-    // Pinned Go worker SDK package + version. Templates substitute these into
-    // the scaffolded go.mod, and the start hook re-pins via `go get` so apps
-    // scaffolded against an older preview pick up the matching SDK release.
-    internal const string WorkerModulePath = "github.com/azure/azure-functions-golang-worker";
-    internal const string WorkerModuleVersion = "v0.6.0-preview";
-
     private const string ExecutableRelativeFolder = "bin";
 
     private readonly WorkingDirectory _workingDirectory;
@@ -48,9 +42,10 @@ internal sealed class GoFunctionsProject : FunctionsProject
 
     internal Func<CancellationToken, Task<(int Major, int Minor)?>> ReadGoVersion { get; set; } = DefaultReadGoVersion;
 
-    // Sync the user's go.mod with the pinned worker SDK version (`go get <module>@<version>`)
-    // and clean up dependencies (`go mod tidy`). Internal seam for tests.
-    internal Func<string, string, string, CancellationToken, Task<(int ExitCode, string Stderr)>> SyncGoModules { get; set; } = DefaultSyncGoModules;
+    // Run `go mod tidy` before building so missing/stale module entries are resolved
+    // (especially for apps scaffolded from the version-less go.mod template). Internal
+    // seam for tests.
+    internal Func<string, CancellationToken, Task<(int ExitCode, string Stderr)>> RunGoModTidy { get; set; } = DefaultRunGoModTidy;
 
     public override WorkingDirectory WorkingDirectory => _workingDirectory;
 
@@ -98,14 +93,15 @@ internal sealed class GoFunctionsProject : FunctionsProject
                 isUserError: true);
         }
 
-        // Re-pin the worker SDK before building. Apps scaffolded against an older preview
-        // would otherwise compile against a stale SDK version on the next `func start`.
-        (int syncExit, string syncStderr) = await SyncGoModules(root, WorkerModulePath, WorkerModuleVersion, cancellationToken).ConfigureAwait(false);
-        if (syncExit != 0)
+        // Tidy modules before building: the scaffold's go.mod omits the worker SDK
+        // require line on purpose, so `go mod tidy` resolves the latest tag from the
+        // imports in main.go. Also rescues apps whose go.sum has drifted.
+        (int tidyExit, string tidyStderr) = await RunGoModTidy(root, cancellationToken).ConfigureAwait(false);
+        if (tidyExit != 0)
         {
-            string detail = string.IsNullOrWhiteSpace(syncStderr) ? "see output above." : syncStderr.Trim();
+            string detail = string.IsNullOrWhiteSpace(tidyStderr) ? "see output above." : tidyStderr.Trim();
             throw new GracefulException(
-                $"Failed to sync Go modules (exit {syncExit}). {detail}",
+                $"'go mod tidy' failed (exit {tidyExit}). {detail}",
                 isUserError: true);
         }
 
@@ -214,20 +210,8 @@ internal sealed class GoFunctionsProject : FunctionsProject
         }
     }
 
-    private static async Task<(int ExitCode, string Stderr)> DefaultSyncGoModules(
-        string workingDirectory,
-        string modulePath,
-        string moduleVersion,
-        CancellationToken cancellationToken)
-    {
-        (int getExit, string getStderr) = await RunGo(workingDirectory, ["get", $"{modulePath}@{moduleVersion}"], cancellationToken).ConfigureAwait(false);
-        if (getExit != 0)
-        {
-            return (getExit, getStderr);
-        }
-
-        return await RunGo(workingDirectory, ["mod", "tidy"], cancellationToken).ConfigureAwait(false);
-    }
+    private static Task<(int ExitCode, string Stderr)> DefaultRunGoModTidy(string workingDirectory, CancellationToken cancellationToken)
+        => RunGo(workingDirectory, ["mod", "tidy"], cancellationToken);
 
     private static async Task<(int ExitCode, string Stderr)> RunGo(
         string workingDirectory,

--- a/src/Workloads/Stacks/Go/GoFunctionsProject.cs
+++ b/src/Workloads/Stacks/Go/GoFunctionsProject.cs
@@ -64,10 +64,10 @@ internal sealed class GoFunctionsProject : FunctionsProject
         if (context.SkipBuild)
         {
             // Go projects compile to bin/app; with --no-build the user is
-            // asserting that binary already exists. Trust them, skip the build,
-            // but still point the host at bin/ so it can find the executable
-            // and the function metadata generated alongside it.
-            context.StartupDirectory = new DirectoryInfo(binDirectory);
+            // asserting that binary already exists. Trust them and skip the
+            // build. Leave StartupDirectory at the project root so host.json
+            // is found there and the worker's `defaultExecutablePath = bin/app`
+            // resolves to <project>/bin/app.
             return;
         }
 
@@ -96,7 +96,10 @@ internal sealed class GoFunctionsProject : FunctionsProject
                 isUserError: true);
         }
 
-        context.StartupDirectory = new DirectoryInfo(binDirectory);
+        // StartupDirectory stays at the project root: host.json lives there, and the Go
+        // worker's `defaultExecutablePath = bin/app` is resolved relative to the script
+        // root, so AzureWebJobsScriptRoot pointing at the project root yields the
+        // correct <project>/bin/app launch path.
     }
 
     private static async Task<(int Major, int Minor)?> DefaultReadGoVersion(CancellationToken cancellationToken)

--- a/src/Workloads/Stacks/Go/GoProjectInitializer.cs
+++ b/src/Workloads/Stacks/Go/GoProjectInitializer.cs
@@ -17,8 +17,6 @@ namespace Azure.Functions.Cli.Workloads.Go;
 internal sealed class GoProjectInitializer : IProjectInitializer
 {
     private const string ModuleNamePlaceholder = "{ModuleName}";
-    private const string WorkerModulePathPlaceholder = "{WorkerModulePath}";
-    private const string WorkerModuleVersionPlaceholder = "{WorkerModuleVersion}";
     private const string DefaultModuleName = "app";
     private static readonly Assembly _assembly = typeof(GoProjectInitializer).Assembly;
 
@@ -87,13 +85,11 @@ internal sealed class GoProjectInitializer : IProjectInitializer
 
         ProjectFiles.WriteIfMissing(
             Path.Combine(root, "go.mod"),
-            // The exact worker SDK version is owned by GoFunctionsProject. `func start` re-pins
-            // via `go get` + `go mod tidy`, so apps scaffolded against an older preview pick up
-            // the matching SDK on the next run.
-            ProjectFiles.ReadTemplate(_assembly, "go.mod")
-                .Replace(ModuleNamePlaceholder, moduleName)
-                .Replace(WorkerModulePathPlaceholder, GoFunctionsProject.WorkerModulePath)
-                .Replace(WorkerModuleVersionPlaceholder, GoFunctionsProject.WorkerModuleVersion),
+            // go.mod intentionally omits a require line for azure-functions-golang-worker;
+            // `go mod tidy` (here on init, and again on every `func start`) resolves the
+            // latest available tag from the imports in main.go, so users pick up new SDK
+            // releases without contributors having to bump a pinned version.
+            ProjectFiles.ReadTemplate(_assembly, "go.mod").Replace(ModuleNamePlaceholder, moduleName),
             force);
 
         ProjectFiles.WriteIfMissing(

--- a/src/Workloads/Stacks/Go/GoProjectInitializer.cs
+++ b/src/Workloads/Stacks/Go/GoProjectInitializer.cs
@@ -17,6 +17,8 @@ namespace Azure.Functions.Cli.Workloads.Go;
 internal sealed class GoProjectInitializer : IProjectInitializer
 {
     private const string ModuleNamePlaceholder = "{ModuleName}";
+    private const string WorkerModulePathPlaceholder = "{WorkerModulePath}";
+    private const string WorkerModuleVersionPlaceholder = "{WorkerModuleVersion}";
     private const string DefaultModuleName = "app";
     private static readonly Assembly _assembly = typeof(GoProjectInitializer).Assembly;
 
@@ -85,13 +87,13 @@ internal sealed class GoProjectInitializer : IProjectInitializer
 
         ProjectFiles.WriteIfMissing(
             Path.Combine(root, "go.mod"),
-            // TODO: revisit how the Go worker version is pinned. Go modules
-            // don't support relaxed ranges (e.g. `1.x`), so today we hard-pin
-            // a preview version in the template. Once the worker hits GA, we
-            // should explore a "stay current" strategy, e.g. running
-            // `go get github.com/azure/azure-functions-golang-worker@v0`
-            // after scaffold so users always get the newest line.
-            ProjectFiles.ReadTemplate(_assembly, "go.mod").Replace(ModuleNamePlaceholder, moduleName),
+            // The exact worker SDK version is owned by GoFunctionsProject. `func start` re-pins
+            // via `go get` + `go mod tidy`, so apps scaffolded against an older preview pick up
+            // the matching SDK on the next run.
+            ProjectFiles.ReadTemplate(_assembly, "go.mod")
+                .Replace(ModuleNamePlaceholder, moduleName)
+                .Replace(WorkerModulePathPlaceholder, GoFunctionsProject.WorkerModulePath)
+                .Replace(WorkerModuleVersionPlaceholder, GoFunctionsProject.WorkerModuleVersion),
             force);
 
         ProjectFiles.WriteIfMissing(

--- a/src/Workloads/Stacks/Go/Templates/go.mod
+++ b/src/Workloads/Stacks/Go/Templates/go.mod
@@ -2,4 +2,4 @@ module {ModuleName}
 
 go 1.24
 
-require github.com/azure/azure-functions-golang-worker v0.2.0-preview
+require {WorkerModulePath} {WorkerModuleVersion}

--- a/src/Workloads/Stacks/Go/Templates/go.mod
+++ b/src/Workloads/Stacks/Go/Templates/go.mod
@@ -1,5 +1,3 @@
 module {ModuleName}
 
 go 1.24
-
-require {WorkerModulePath} {WorkerModuleVersion}

--- a/src/Workloads/Stacks/Go/Templates/main.go
+++ b/src/Workloads/Stacks/Go/Templates/main.go
@@ -1,13 +1,25 @@
 package main
 
 import (
+"log"
+"net/http"
+
 "github.com/azure/azure-functions-golang-worker/sdk"
 "github.com/azure/azure-functions-golang-worker/worker"
 )
 
+// HTTPTriggerHandler handles standard HTTP requests
+func HTTPTriggerHandler(w http.ResponseWriter, r *http.Request) {
+log.Printf("Processing HTTP Trigger for %s", r.URL.Path)
+w.WriteHeader(http.StatusOK)
+w.Write([]byte("Hello from Go Worker!"))
+}
+
 func main() {
-    app := sdk.FunctionApp()
-    // Register your functions on `app` here, then start the worker.
-    // See https://aka.ms/azure-functions/go for examples.
-    worker.Start(app)
+app := sdk.FunctionApp()
+app.HTTP("hello", HTTPTriggerHandler,
+sdk.WithMethods("GET", "POST"),
+sdk.WithAuth("anonymous"),
+)
+worker.Start(app)
 }

--- a/src/Workloads/Stacks/Go/release_notes.md
+++ b/src/Workloads/Stacks/Go/release_notes.md
@@ -5,3 +5,5 @@
 - Initial scaffold of the Go workload (entry point + stub project initializer).
 - Run `go build` before host start so the Go worker can launch the project binary.
 - Validate the Go toolchain (Go 1.24+) with a clear install hint when missing or too old, and emit the binary as `bin/app` (`bin\app.exe` on Windows) to match the Go worker's `defaultExecutablePath`.
+- Sync the worker SDK with `go get github.com/azure/azure-functions-golang-worker@v0.6.0-preview` + `go mod tidy` on `func start`, so apps scaffolded against an older preview pull the matching SDK before building.
+- Scaffold `main.go` with an HTTP-triggered "hello" function instead of an empty `main`, so a fresh `func init` is runnable end to end.

--- a/src/Workloads/Stacks/Go/release_notes.md
+++ b/src/Workloads/Stacks/Go/release_notes.md
@@ -5,5 +5,5 @@
 - Initial scaffold of the Go workload (entry point + stub project initializer).
 - Run `go build` before host start so the Go worker can launch the project binary.
 - Validate the Go toolchain (Go 1.24+) with a clear install hint when missing or too old, and emit the binary as `bin/app` (`bin\app.exe` on Windows) to match the Go worker's `defaultExecutablePath`.
-- Sync the worker SDK with `go get github.com/azure/azure-functions-golang-worker@v0.6.0-preview` + `go mod tidy` on `func start`, so apps scaffolded against an older preview pull the matching SDK before building.
+- Run `go mod tidy` before `go build` on `func start` so the version-less scaffold (and any drifted `go.sum`) resolves to the latest Go worker SDK release.
 - Scaffold `main.go` with an HTTP-triggered "hello" function instead of an empty `main`, so a fresh `func init` is runnable end to end.

--- a/test/Workloads/Stacks/Go.Tests/GoFunctionsProjectTests.cs
+++ b/test/Workloads/Stacks/Go.Tests/GoFunctionsProjectTests.cs
@@ -111,11 +111,66 @@ public class GoFunctionsProjectTests : IDisposable
         Assert.Contains("Go 1.21 is not supported", ex.Message);
     }
 
+    [Fact]
+    public async Task PrepareForHostRun_syncs_modules_before_building()
+    {
+        File.WriteAllText(Path.Combine(_projectDir.FullName, "go.mod"), "module example.com/myapp\n\ngo 1.24\n");
+
+        var calls = new List<string>();
+        GoFunctionsProject project = CreateProject((_, _, _) =>
+        {
+            calls.Add("build");
+            return Task.FromResult((0, string.Empty));
+        });
+        project.SyncGoModules = (root, modulePath, moduleVersion, _) =>
+        {
+            calls.Add($"sync:{root}:{modulePath}@{moduleVersion}");
+            return Task.FromResult((0, string.Empty));
+        };
+
+        await project.PrepareForHostRunAsync(CreateContext(), default);
+
+        Assert.Equal(2, calls.Count);
+        Assert.Equal($"sync:{_projectDir.FullName}:{GoFunctionsProject.WorkerModulePath}@{GoFunctionsProject.WorkerModuleVersion}", calls[0]);
+        Assert.Equal("build", calls[1]);
+    }
+
+    [Fact]
+    public async Task PrepareForHostRun_throws_graceful_when_sync_fails()
+    {
+        GoFunctionsProject project = CreateProject((_, _, _) => Task.FromResult((0, string.Empty)));
+        project.SyncGoModules = (_, _, _, _) => Task.FromResult((1, "module not found"));
+
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => project.PrepareForHostRunAsync(CreateContext(), default));
+
+        Assert.True(ex.IsUserError);
+        Assert.Contains("sync Go modules", ex.Message);
+        Assert.Contains("module not found", ex.Message);
+    }
+
+    [Fact]
+    public async Task PrepareForHostRun_skips_sync_when_SkipBuild()
+    {
+        bool syncInvoked = false;
+        GoFunctionsProject project = CreateProject((_, _, _) => Task.FromResult((0, string.Empty)));
+        project.SyncGoModules = (_, _, _, _) =>
+        {
+            syncInvoked = true;
+            return Task.FromResult((0, string.Empty));
+        };
+
+        await project.PrepareForHostRunAsync(CreateContext(skipBuild: true), default);
+
+        Assert.False(syncInvoked);
+    }
+
     private GoFunctionsProject CreateProject(Func<string, string, CancellationToken, Task<(int, string)>> runner)
         => new(WorkingDirectory.FromExplicit(_projectDir.FullName))
         {
             RunGoBuild = runner,
             ReadGoVersion = _ => Task.FromResult<(int, int)?>((1, 24)),
+            SyncGoModules = (_, _, _, _) => Task.FromResult((0, string.Empty)),
         };
 
     private FunctionsProjectHostRunContext CreateContext(bool skipBuild = false)

--- a/test/Workloads/Stacks/Go.Tests/GoFunctionsProjectTests.cs
+++ b/test/Workloads/Stacks/Go.Tests/GoFunctionsProjectTests.cs
@@ -112,7 +112,7 @@ public class GoFunctionsProjectTests : IDisposable
     }
 
     [Fact]
-    public async Task PrepareForHostRun_syncs_modules_before_building()
+    public async Task PrepareForHostRun_runs_go_mod_tidy_before_building()
     {
         File.WriteAllText(Path.Combine(_projectDir.FullName, "go.mod"), "module example.com/myapp\n\ngo 1.24\n");
 
@@ -122,47 +122,47 @@ public class GoFunctionsProjectTests : IDisposable
             calls.Add("build");
             return Task.FromResult((0, string.Empty));
         });
-        project.SyncGoModules = (root, modulePath, moduleVersion, _) =>
+        project.RunGoModTidy = (root, _) =>
         {
-            calls.Add($"sync:{root}:{modulePath}@{moduleVersion}");
+            calls.Add($"tidy:{root}");
             return Task.FromResult((0, string.Empty));
         };
 
         await project.PrepareForHostRunAsync(CreateContext(), default);
 
         Assert.Equal(2, calls.Count);
-        Assert.Equal($"sync:{_projectDir.FullName}:{GoFunctionsProject.WorkerModulePath}@{GoFunctionsProject.WorkerModuleVersion}", calls[0]);
+        Assert.Equal($"tidy:{_projectDir.FullName}", calls[0]);
         Assert.Equal("build", calls[1]);
     }
 
     [Fact]
-    public async Task PrepareForHostRun_throws_graceful_when_sync_fails()
+    public async Task PrepareForHostRun_throws_graceful_when_tidy_fails()
     {
         GoFunctionsProject project = CreateProject((_, _, _) => Task.FromResult((0, string.Empty)));
-        project.SyncGoModules = (_, _, _, _) => Task.FromResult((1, "module not found"));
+        project.RunGoModTidy = (_, _) => Task.FromResult((1, "module not found"));
 
         GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
             () => project.PrepareForHostRunAsync(CreateContext(), default));
 
         Assert.True(ex.IsUserError);
-        Assert.Contains("sync Go modules", ex.Message);
+        Assert.Contains("go mod tidy", ex.Message);
         Assert.Contains("module not found", ex.Message);
     }
 
     [Fact]
-    public async Task PrepareForHostRun_skips_sync_when_SkipBuild()
+    public async Task PrepareForHostRun_skips_tidy_when_SkipBuild()
     {
-        bool syncInvoked = false;
+        bool tidyInvoked = false;
         GoFunctionsProject project = CreateProject((_, _, _) => Task.FromResult((0, string.Empty)));
-        project.SyncGoModules = (_, _, _, _) =>
+        project.RunGoModTidy = (_, _) =>
         {
-            syncInvoked = true;
+            tidyInvoked = true;
             return Task.FromResult((0, string.Empty));
         };
 
         await project.PrepareForHostRunAsync(CreateContext(skipBuild: true), default);
 
-        Assert.False(syncInvoked);
+        Assert.False(tidyInvoked);
     }
 
     private GoFunctionsProject CreateProject(Func<string, string, CancellationToken, Task<(int, string)>> runner)
@@ -170,7 +170,7 @@ public class GoFunctionsProjectTests : IDisposable
         {
             RunGoBuild = runner,
             ReadGoVersion = _ => Task.FromResult<(int, int)?>((1, 24)),
-            SyncGoModules = (_, _, _, _) => Task.FromResult((0, string.Empty)),
+            RunGoModTidy = (_, _) => Task.FromResult((0, string.Empty)),
         };
 
     private FunctionsProjectHostRunContext CreateContext(bool skipBuild = false)

--- a/test/Workloads/Stacks/Go.Tests/GoFunctionsProjectTests.cs
+++ b/test/Workloads/Stacks/Go.Tests/GoFunctionsProjectTests.cs
@@ -50,7 +50,9 @@ public class GoFunctionsProjectTests : IDisposable
         string expectedName = OperatingSystem.IsWindows() ? "app.exe" : "app";
         Assert.Equal(_projectDir.FullName, observedRoot);
         Assert.Equal(Path.Combine(_projectDir.FullName, "bin", expectedName), observedOutput);
-        Assert.Equal(Path.Combine(_projectDir.FullName, "bin"), context.StartupDirectory.FullName);
+        // StartupDirectory must remain the project root so the host finds host.json
+        // and the worker's `defaultExecutablePath = bin/app` resolves correctly.
+        Assert.Equal(_projectDir.FullName, context.StartupDirectory.FullName);
     }
 
     [Fact]
@@ -80,7 +82,7 @@ public class GoFunctionsProjectTests : IDisposable
         await project.PrepareForHostRunAsync(context, default);
 
         Assert.False(invoked);
-        Assert.Equal(Path.Combine(_projectDir.FullName, "bin"), context.StartupDirectory.FullName);
+        Assert.Equal(_projectDir.FullName, context.StartupDirectory.FullName);
     }
 
     [Fact]

--- a/test/Workloads/Stacks/Go.Tests/GoProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/Go.Tests/GoProjectInitializerTests.cs
@@ -61,7 +61,7 @@ public class GoProjectInitializerTests : IDisposable
         string goMod = File.ReadAllText(Path.Combine(_projectDir.FullName, "go.mod"));
         Assert.Contains("module my-go-app", goMod);
         Assert.Contains("go 1.24", goMod);
-        Assert.Contains("github.com/azure/azure-functions-golang-worker", goMod);
+        Assert.Contains($"{GoFunctionsProject.WorkerModulePath} {GoFunctionsProject.WorkerModuleVersion}", goMod);
 
         string mainGo = File.ReadAllText(Path.Combine(_projectDir.FullName, "main.go"));
         Assert.Contains("github.com/azure/azure-functions-golang-worker/sdk", mainGo);

--- a/test/Workloads/Stacks/Go.Tests/GoProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/Go.Tests/GoProjectInitializerTests.cs
@@ -61,7 +61,8 @@ public class GoProjectInitializerTests : IDisposable
         string goMod = File.ReadAllText(Path.Combine(_projectDir.FullName, "go.mod"));
         Assert.Contains("module my-go-app", goMod);
         Assert.Contains("go 1.24", goMod);
-        Assert.Contains($"{GoFunctionsProject.WorkerModulePath} {GoFunctionsProject.WorkerModuleVersion}", goMod);
+        // go.mod intentionally omits a `require` line; `go mod tidy` resolves it from main.go imports.
+        Assert.DoesNotContain("require", goMod);
 
         string mainGo = File.ReadAllText(Path.Combine(_projectDir.FullName, "main.go"));
         Assert.Contains("github.com/azure/azure-functions-golang-worker/sdk", mainGo);


### PR DESCRIPTION
Fixes Go stack startup issues uncovered during bug bash.

## 1. Script root regression (PR #5204)

The Go worker's `worker.config.json` declares `defaultExecutablePath = bin/app`, which the Functions host resolves relative to the script root. PR #5204 set `StartupDirectory` to `<project>/bin`, so script root became `bin/` and the host tried to launch `<project>/bin/bin/app` (which doesn't exist). It also moved the script root away from `host.json` at the project root.

Symptom from `func start`:

```
Worker.rpcWorkerProcess.native ✗ Failed to start Worker Channel. Process fileName: bin/app
WebHostRpcWorkerChannelManager ✗ Failed to start language worker process for runtime: native
```

**Fix:** `GoFunctionsProject.PrepareForHostRunAsync` leaves `StartupDirectory` at the project root for both the build and `--no-build` paths. Matches v4 behavior where `ScriptPath = Environment.CurrentDirectory`.

## 2. Resolve worker SDK via `go mod tidy`

The v5 scaffold template hard-pinned `v0.2.0-preview`; the current worker is `v0.6.0-preview`. Apps scaffolded earlier (or against the old template) compiled against a stale SDK.

**Fix (matches `main`'s PR #5093 approach):** scaffold a version-less `go.mod` and let `go mod tidy` resolve the worker SDK from `main.go` imports. Run `go mod tidy` on `func start` (before `go build`) so existing apps with stale `go.sum` or missing module entries are rescued automatically. Skipped under `--no-build`. No pinned version means no contributor burden on each worker release.

## 3. Runnable scaffold

The previous `main.go` template was an empty `main` with a comment to "register your functions here", so a fresh `func init -stack go && func start` produced a worker with zero functions.

**Fix:** scaffold a `main.go` with an HTTP-triggered `hello` function (matching the v4 template in `main`), so a fresh init is runnable end to end.

## Tests

`Workloads.Go.Tests`: 36/36 pass. New coverage for:

- `StartupDirectory` staying at the project root (build + skip-build).
- `RunGoModTidy` running before `go build`.
- Tidy failure surfacing as a graceful user error.
- Tidy skipped under `--no-build`.
- Scaffold `go.mod` omitting the `require` line.

Verified end to end locally by rebuilding the Go workload, reinstalling, and running `func init -stack go` + `func start` against a fresh Go project.