### PR TITLE
Fix Python worker defaultExecutablePath env var key on POSIX

### DIFF
--- a/src/Workloads/Stacks/Python/PythonFunctionsProject.cs
+++ b/src/Workloads/Stacks/Python/PythonFunctionsProject.cs
@@ -21,7 +21,7 @@ internal sealed class PythonFunctionsProject : FunctionsProject
 {
     internal const string DefaultVenvFolderName = ".venv";
     internal const string IsolateWorkerDepsEnvVar = "PYTHON_ISOLATE_WORKER_DEPENDENCIES";
-    internal const string WorkerExecutablePathEnvVar = "languageWorkers:python:defaultExecutablePath";
+    internal const string WorkerExecutablePathEnvVar = "languageWorkers__python__defaultExecutablePath";
     internal const string WorkerRuntimeVersionEnvVar = "FUNCTIONS_WORKER_RUNTIME_VERSION";
     internal const string VirtualEnvEnvVar = "VIRTUAL_ENV";
     private const string RequirementsFileName = "requirements.txt";

--- a/src/Workloads/Stacks/Python/release_notes.md
+++ b/src/Workloads/Stacks/Python/release_notes.md
@@ -5,4 +5,5 @@
 - Initial scaffold of the Python workload (entry point + stub project initializer).
 - Create a `.venv` (if missing), run `pip install -r requirements.txt`, and set `PYTHON_ISOLATE_WORKER_DEPENDENCIES=1` before host start.
 - Honor an activated venv via `$VIRTUAL_ENV` and reuse pre-existing `venv`, `env`, or `.virtualenv` folders before falling back to creating `.venv`.
-- Point the host at the venv interpreter via `languageWorkers:python:defaultExecutablePath` and surface the detected Python major.minor as `FUNCTIONS_WORKER_RUNTIME_VERSION` so the worker sees the user's installed packages.
+- Point the host at the venv interpreter via `languageWorkers__python__defaultExecutablePath` and surface the detected Python major.minor as `FUNCTIONS_WORKER_RUNTIME_VERSION` so the worker sees the user's installed packages.
+- Fix Python worker startup on macOS/Linux by using `__` delimiter in `languageWorkers__python__defaultExecutablePath` (mirrors #5212 for `workerDirectory`).


### PR DESCRIPTION
Fixes #5211 and likely #5213.

## Root cause

On macOS/Linux the Python worker fails to start because the venv interpreter override env var name used `:` instead of `__`:

```
languageWorkers:python:defaultExecutablePath=.../.venv/bin/python
```

POSIX shells and the host's `ConfigurationBuilder` both reject the `:` form. The host expects `__` (which it translates back to `:` for `IConfiguration`).

PR #5212 ("Fixing environment variable delimiter to ensure cross-plat compatibility") landed the same fix for `languageWorkers__<runtime>__workerDirectory` in `PrepareProjectHostRunInitializationStep.cs`, but missed Python's `defaultExecutablePath` in `PythonFunctionsProject.cs`.

## Fix

One-line change to the constant in `src/Workloads/Stacks/Python/PythonFunctionsProject.cs`:

```diff
- internal const string WorkerExecutablePathEnvVar = "languageWorkers:python:defaultExecutablePath";
+ internal const string WorkerExecutablePathEnvVar = "languageWorkers__python__defaultExecutablePath";
```

Existing tests reference the constant by name, so they pick up the new value automatically. All 53 tests in `Workloads.Python.Tests` pass.

## Out of scope (intentionally)

- #5202 dash-in-project-name bug
- Surfacing worker stderr in the host start output
- Adding integration tests that actually launch the worker