### PR TITLE
Add telemetry notice to install scripts

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -146,6 +146,16 @@ if ($os -eq 'win') {
 
 Write-Host "func CLI $Version installed to $InstallDir"
 
+# --- Telemetry notice ---
+
+Write-Host ''
+Write-Host 'Telemetry'
+Write-Host '---------'
+Write-Host 'The Azure Functions CLI collects usage data in order to help us improve your experience.'
+Write-Host "The data is anonymous and doesn't include any user specific or personal information. The data is collected by Microsoft."
+Write-Host ''
+Write-Host "You can opt-out of telemetry by setting the FUNC_CLI_TELEMETRY_OPTOUT environment variable to any value other than 'no', 'n', '0', 'false', or 'off' using your favorite shell."
+
 # --- Bug bash env vars ---
 
 if ($BugBash) {

--- a/install.sh
+++ b/install.sh
@@ -141,6 +141,16 @@ fi
 echo "func CLI ${VERSION} installed to ${INSTALL_DIR}"
 func --version
 
+# --- Telemetry notice ---
+
+echo ""
+echo "Telemetry"
+echo "---------"
+echo "The Azure Functions CLI collects usage data in order to help us improve your experience."
+echo "The data is anonymous and doesn't include any user specific or personal information. The data is collected by Microsoft."
+echo ""
+echo "You can opt-out of telemetry by setting the FUNC_CLI_TELEMETRY_OPTOUT environment variable to any value other than 'no', 'n', '0', 'false', or 'off' using your favorite shell."
+
 # --- Bug bash env vars ---
 
 if [ "$BUGBASH" = "true" ]; then


### PR DESCRIPTION
Appends a telemetry notice to the end of `install.sh` and `install.ps1` (before the bug bash block), mirroring the legacy Core Tools notice but pointing at the new `FUNC_CLI_TELEMETRY_OPTOUT` env var and the accepted opt-out values documented in the README.