### PR TITLE
Show per-install progress bars in func setup

### DIFF
--- a/src/Func/Commands/Setup/SetupRunner.cs
+++ b/src/Func/Commands/Setup/SetupRunner.cs
@@ -444,15 +444,28 @@ internal sealed class SetupRunner(
 
         try
         {
-            WorkloadInstallResult installResult = await _workloadInstaller.InstallFromCatalogAsync(
-                package.PackageId,
-                package.Version,
-                options.Source,
-                includePrerelease: options.IncludePrerelease,
-                exact: true,
-                force: false,
-                progress: null,
-                cancellationToken);
+            WorkloadInstallResult installResult = options.OutputMode == SetupOutputMode.Json
+                ? await _workloadInstaller.InstallFromCatalogAsync(
+                    package.PackageId,
+                    package.Version,
+                    options.Source,
+                    includePrerelease: options.IncludePrerelease,
+                    exact: true,
+                    force: false,
+                    progress: null,
+                    cancellationToken)
+                : await _interaction.RunWithProgressAsync(
+                    $"Installing {dependency.DisplayName} {targetVersion}",
+                    async (ctx, ct) => await _workloadInstaller.InstallFromCatalogAsync(
+                        package.PackageId,
+                        package.Version,
+                        options.Source,
+                        includePrerelease: options.IncludePrerelease,
+                        exact: true,
+                        force: false,
+                        new WorkloadInstallProgressAdapter(ctx),
+                        ct),
+                    cancellationToken);
 
             string installedVersion = installResult.Entry.PackageVersion;
             return installResult.AlreadyInstalled

--- a/src/Func/Commands/Workload/WorkloadInstallCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadInstallCommand.cs
@@ -118,7 +118,7 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
                     : $"Installing workload '{workload}'",
                 async (ctx, ct) =>
                 {
-                    var progress = new ProgressAdapter(ctx);
+                    var progress = new WorkloadInstallProgressAdapter(ctx);
 
                     return LooksLikeLocalPackagePath(workload)
                         ? await _installer.InstallFromPackageAsync(workload, force, progress, ct)
@@ -301,18 +301,4 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
             + $"    func setup --features {feature}");
     }
 
-    /// <summary>
-    /// Bridges <see cref="IProgress{T}"/> calls from the installer onto the
-    /// <see cref="IProgressContext"/> backing the progress bar.
-    /// </summary>
-    private sealed class ProgressAdapter(IProgressContext context) : IProgress<WorkloadInstallProgress>
-    {
-        private readonly IProgressContext _context = context;
-
-        public void Report(WorkloadInstallProgress value)
-        {
-            ArgumentNullException.ThrowIfNull(value);
-            _context.SetDescription(value.Description);
-        }
-    }
 }

--- a/src/Func/Commands/Workload/WorkloadInstallProgressAdapter.cs
+++ b/src/Func/Commands/Workload/WorkloadInstallProgressAdapter.cs
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Workloads.Install;
+
+namespace Azure.Functions.Cli.Commands.Workload;
+
+/// <summary>
+/// Bridges <see cref="IProgress{T}"/> reports from <see cref="IWorkloadInstaller"/>
+/// onto the live progress bar exposed by <see cref="IInteractionService.RunWithProgressAsync{T}"/>.
+/// </summary>
+internal sealed class WorkloadInstallProgressAdapter(IProgressContext context) : IProgress<WorkloadInstallProgress>
+{
+    private readonly IProgressContext _context = context ?? throw new ArgumentNullException(nameof(context));
+
+    public void Report(WorkloadInstallProgress value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        _context.SetDescription(value.Description);
+    }
+}

--- a/src/Func/Commands/Workload/WorkloadUpdateCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadUpdateCommand.cs
@@ -183,7 +183,7 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
                 $"Updating workload '{packageId}'",
                 async (ctx, ct) => await _installer.UpdateAsync(
                     packageId, targetVersion, source, includePrerelease, allowMajor,
-                    new ProgressAdapter(ctx),
+                    new WorkloadInstallProgressAdapter(ctx),
                     ct),
                 cancellationToken);
 
@@ -234,7 +234,7 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
                         source,
                         includePrerelease,
                         allowMajor,
-                        new ProgressAdapter(ctx),
+                        new WorkloadInstallProgressAdapter(ctx),
                         ct),
                     cancellationToken);
                 RenderSingle(result);
@@ -283,18 +283,4 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
             $"Updated workload '{display}' from {result.PreviousVersion} to {result.Entry.PackageVersion}.");
     }
 
-    /// <summary>
-    /// Bridges <see cref="IProgress{T}"/> reports from the installer onto
-    /// the live progress bar.
-    /// </summary>
-    private sealed class ProgressAdapter(IProgressContext context) : IProgress<WorkloadInstallProgress>
-    {
-        private readonly IProgressContext _context = context;
-
-        public void Report(WorkloadInstallProgress value)
-        {
-            ArgumentNullException.ThrowIfNull(value);
-            _context.SetDescription(value.Description);
-        }
-    }
 }

--- a/src/Func/Console/SpectreInteractionService.cs
+++ b/src/Func/Console/SpectreInteractionService.cs
@@ -180,6 +180,7 @@ internal class SpectreInteractionService : IInteractionService
         T result = default!;
         await _stderr.Progress()
             .AutoRefresh(true)
+            .AutoClear(true)
             .HideCompleted(true)
             .Columns(
                 new TaskDescriptionColumn { Alignment = Justify.Left },

--- a/src/Func/Console/SpectreInteractionService.cs
+++ b/src/Func/Console/SpectreInteractionService.cs
@@ -180,7 +180,7 @@ internal class SpectreInteractionService : IInteractionService
         T result = default!;
         await _stderr.Progress()
             .AutoRefresh(true)
-            .HideCompleted(false)
+            .HideCompleted(true)
             .Columns(
                 new TaskDescriptionColumn { Alignment = Justify.Left },
                 new ProgressBarColumn(),


### PR DESCRIPTION
## Summary

`func setup` now renders a progress bar for each workload it installs, so users see what's currently being installed and that it's making progress. Particularly useful for the Python worker, which is ~273 MB compressed / 849 MB / 13.6k files unpacked and feels indistinguishable from a hang.

### Before

```
Setting up Azure Functions
✓ Installed host 4.1048.200-local.20260530021444.
✓ Installed python worker 4.43.0-local.20260530021444.
...
```

(...with a multi-minute silent pause on the python worker line.)

### After

```
Setting up Azure Functions
⠋ Installing python worker 4.43.0-local.20260530021444  ━━━━━━━━━━ 23%
```

…with the label cycling through the installer's existing phases (`Resolving…` → `Downloading…` → `Extracting…` → `Registering…`) and then collapsing to:

```
✓ Installed python worker 4.43.0-local.20260530021444.
```

## What changed

- `SetupRunner.EnsureDependencyAsync` wraps the `InstallFromCatalogAsync` call in `IInteractionService.RunWithProgressAsync`, with the initial label `Installing {DisplayName} {targetVersion}`. The installer already reports phases via `IProgress<WorkloadInstallProgress>`; setup was passing `null` and discarding them.
- JSON output mode (`--output json`) skips the progress wrapper so the structured event stream stays clean.
- Extracted the duplicated `ProgressAdapter` from `WorkloadInstallCommand` and `WorkloadUpdateCommand` into a shared `WorkloadInstallProgressAdapter`.

## Behavior in non-TTY (CI logs)

Spectre's `RunWithProgressAsync` falls back to its `LoggingProgressContext`, which prints one line per phase transition. CI logs gain visibility too, no garbled escape codes.

## Validation

- Clean release build, 0 warnings.
- Full test suite: 1004/1004 pass. Existing setup/workload tests already mocked `Arg.Any<IProgress<WorkloadInstallProgress>?>()`, so no test changes were required.

## Follow-up (not in this PR)

The python worker is slow because the upstream package ships every (Python version × OS × arch) combo (~849 MB / 13.6k files). A proper fix is splitting `Workloads.Workers.Python` per RID so installs only fetch the slice they need. This PR is the UX mitigation in the meantime.