### PR TITLE
Sanitize function identifiers in Python and Node templates

### DIFF
--- a/src/Func/release_notes.md
+++ b/src/Func/release_notes.md
@@ -5,4 +5,5 @@
 - `func setup` now installs the matching stack workload (Node, Python, Go, DotNet) for the project's worker runtime, detected from `local.settings.json` or selected via prompt / `--features`.
 - `func start --no-build`: now actually skips compilation steps in stack workloads. Node skips `npm run build` (still runs `npm install` when `node_modules` is missing), Go skips `go build` (trusts the existing `bin/<module>` binary), Python is a no-op (no build step). Was previously parsed and ignored.
 - `func start`: `local.settings.json` Values no longer overwrite environment variables already set in the current shell, matching v4 behavior. Skipped keys are logged as warnings, along with empty keys. Empty string values are preserved so the host can see an intentional clear.
+- `func new`: sanitize the function-name token when rendering v2 templates so names like `HttpTrigger-Python` produce valid Python/Node identifiers instead of `SyntaxError` (#5202).
 - <entry>

--- a/src/Templates.V2/V2TemplateEngine.cs
+++ b/src/Templates.V2/V2TemplateEngine.cs
@@ -42,6 +42,8 @@ namespace Azure.Functions.Cli.Templates.V2;
 /// </remarks>
 internal sealed class V2TemplateEngine
 {
+    private const string FunctionNameVariable = "FUNCTION_NAME_INPUT";
+
     private static readonly Regex _substitutionPattern = new(@"\$\(([A-Za-z_][A-Za-z0-9_]*)\)", RegexOptions.Compiled);
 
     public TemplateApplicationResult Apply(
@@ -60,7 +62,7 @@ internal sealed class V2TemplateEngine
 
         var variables = new Dictionary<string, string>(StringComparer.Ordinal)
         {
-            ["FUNCTION_NAME_INPUT"] = functionName,
+            [FunctionNameVariable] = SanitizeFunctionIdentifier(functionName),
         };
 
         if (job?.Inputs is { Count: > 0 })
@@ -89,7 +91,15 @@ internal sealed class V2TemplateEngine
 
                 if (value is not null)
                 {
-                    variables[varName] = value;
+                    // The function name token is rendered as a Python `def`
+                    // or JS/TS function identifier in generated source, so
+                    // sanitize it here too. Without this, a name like
+                    // "HttpTrigger-Python" passed through the prompt
+                    // pipeline would emit `def HttpTrigger-Python(...)` and
+                    // fail at parse time with SyntaxError.
+                    variables[varName] = varName == FunctionNameVariable
+                        ? SanitizeFunctionIdentifier(value)
+                        : value;
                 }
             }
         }
@@ -341,4 +351,33 @@ internal sealed class V2TemplateEngine
 
     private static TemplateApplicationResult.Failed Failed(string message)
         => new(new TemplateApplicationFailure.ProviderError(message, null));
+
+    /// <summary>
+    /// Sanitizes a user-supplied function name so it is safe to emit as a Python
+    /// or JavaScript/TypeScript identifier in generated template code. Replaces
+    /// any character outside <c>[A-Za-z0-9_]</c> with <c>_</c> and prefixes a
+    /// leading <c>_</c> when the first character is a digit.
+    /// </summary>
+    internal static string SanitizeFunctionIdentifier(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            return name;
+        }
+
+        var sanitized = new System.Text.StringBuilder(name.Length + 1);
+        foreach (char c in name)
+        {
+            bool isAsciiLetter = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+            bool isAsciiDigit = c >= '0' && c <= '9';
+            sanitized.Append(isAsciiLetter || isAsciiDigit || c == '_' ? c : '_');
+        }
+
+        if (sanitized[0] >= '0' && sanitized[0] <= '9')
+        {
+            sanitized.Insert(0, '_');
+        }
+
+        return sanitized.ToString();
+    }
 }

--- a/src/Workloads/Templates/Node/release_notes.md
+++ b/src/Workloads/Templates/Node/release_notes.md
@@ -2,4 +2,5 @@
 
 ## 1.0.0
 
+- Function names containing characters that are not valid JavaScript/TypeScript identifiers (e.g. `HttpTrigger-Node`) are now sanitized before being emitted as `function` declarations and handler references, so generated sources parse cleanly (#5202).
 - Initial scaffold of the Node.js templates workload (v2 template-engine schema, Node v4 programming model). 33 templates statically authored in-repo under `content/v2/`. No CDN download of templates at pack time. **Per-channel template subsetting** is on: pack fetches `bin/extensions.json` from the active channel's latest listed bundle (CDN `index.json` + HTTP-Range zip extraction; only listed versions consumed) and filters the template set against the committed `_bindings.json` map (Templates Workload Spec §4.3 / §6.1). Cross-reference at this revision: stable 4.32.0 → 31/33, preview 4.42.0 → 33/33, experimental 4.6.0 → 31/33 (McpPromptTrigger JS+TS dropped where `mcpPromptTrigger` binding isn't yet shipped).

--- a/src/Workloads/Templates/Python/release_notes.md
+++ b/src/Workloads/Templates/Python/release_notes.md
@@ -3,3 +3,4 @@
 ## 1.0.0
 
 - Initial scaffold of the Python templates workload (v2 programming model only). v1 (legacy) programming-model templates are not shipped — users on v1 should migrate to v2 (see Templates Workload Spec §7.1).
+- Function names containing characters that are not valid Python identifiers (e.g. `HttpTrigger-Python`) are now sanitized before being emitted as `def` declarations, so generated `function_app.py` parses cleanly (#5202).

--- a/test/Func.Tests/Templates/V2/V2TemplateEngineTests.cs
+++ b/test/Func.Tests/Templates/V2/V2TemplateEngineTests.cs
@@ -240,4 +240,149 @@ public class V2TemplateEngineTests : IDisposable
         var failed = Assert.IsType<TemplateApplicationResult.Failed>(result);
         Assert.IsType<TemplateApplicationFailure.ProviderError>(failed.Failure);
     }
+
+    [Theory]
+    [InlineData("HttpTrigger-Python", "HttpTrigger_Python")]
+    [InlineData("HttpTrigger", "HttpTrigger")]
+    [InlineData("My-Http-Trigger", "My_Http_Trigger")]
+    [InlineData("My.Func Name", "My_Func_Name")]
+    [InlineData("1HttpTrigger", "_1HttpTrigger")]
+    [InlineData("--weird/name", "__weird_name")]
+    [InlineData("already_valid", "already_valid")]
+    public void SanitizeFunctionIdentifier_ProducesValidIdentifier(string input, string expected)
+    {
+        Assert.Equal(expected, V2TemplateEngine.SanitizeFunctionIdentifier(input));
+    }
+
+    [Theory]
+    [InlineData("HttpTrigger-Python", "HttpTrigger_Python")]
+    [InlineData("1HttpTrigger", "_1HttpTrigger")]
+    [InlineData("My.Func Name", "My_Func_Name")]
+    public void Apply_FunctionName_With_Invalid_Identifier_Chars_Is_Sanitized_In_Generated_Code(string functionName, string sanitized)
+    {
+        // Models the Python v2 + Node v4 templates: $(FUNCTION_NAME_INPUT) is
+        // rendered as both a code identifier (`def X(...)` / `function X(...)`)
+        // and as the file name. Without sanitization, a name like
+        // "HttpTrigger-Python" produces "def HttpTrigger-Python(...)" and fails
+        // at parse time with SyntaxError.
+        NewTemplate template = new()
+        {
+            Id = "HttpTrigger-Python",
+            Name = "HTTP trigger",
+            Files = new Dictionary<string, string>
+            {
+                ["function_app.py"] =
+                    "import azure.functions as func\n\n" +
+                    "app = func.FunctionApp()\n\n" +
+                    "@app.route(route=\"$(FUNCTION_NAME_INPUT)\")\n" +
+                    "def $(FUNCTION_NAME_INPUT)(req: func.HttpRequest) -> func.HttpResponse:\n" +
+                    "    return func.HttpResponse('ok')\n",
+            },
+            Actions =
+            [
+                new V2Action
+                {
+                    Type = "GetTemplateFileContent",
+                    FilePath = "function_app.py",
+                    AssignTo = "$(BODY)",
+                },
+                new V2Action
+                {
+                    Type = "WriteToFile",
+                    FilePath = "src/functions/$(FUNCTION_NAME_INPUT).py",
+                    FileContent = "$(BODY)",
+                },
+            ],
+        };
+
+        var engine = new V2TemplateEngine();
+        TemplateApplicationResult result = engine.Apply(
+            template,
+            functionName,
+            optionValuesByPromptId: new Dictionary<string, string?>(),
+            workingDirectory: new DirectoryInfo(_workingDir),
+            force: false);
+
+        var created = Assert.IsType<TemplateApplicationResult.Created>(result);
+        string expectedPath = Path.GetFullPath(Path.Combine(_workingDir, "src", "functions", $"{sanitized}.py"));
+        Assert.Equal(expectedPath, created.Files.Single());
+
+        string content = File.ReadAllText(expectedPath);
+        Assert.Contains($"def {sanitized}(", content);
+        Assert.DoesNotContain($"def {functionName}(", content);
+    }
+
+    [Fact]
+    public void Apply_FunctionName_Supplied_Via_Prompt_Value_Is_Also_Sanitized()
+    {
+        // V2EngineProvider re-supplies the function name as the prompt value
+        // (for the well-known function-name prompt ids). The engine must
+        // sanitize that path too, not just the seeded `functionName`
+        // parameter, otherwise the prompt write clobbers the seed.
+        NewTemplate template = new()
+        {
+            Id = "HttpTrigger-JavaScript",
+            Name = "HTTP trigger",
+            Jobs =
+            [
+                new V2Job
+                {
+                    Type = "CreateNewApp",
+                    Inputs =
+                    [
+                        new V2Input
+                        {
+                            AssignTo = "$(FUNCTION_NAME_INPUT)",
+                            ParamId = "trigger-functionName",
+                            Required = true,
+                        },
+                    ],
+                    Actions = ["readFn", "writeFn"],
+                },
+            ],
+            Files = new Dictionary<string, string>
+            {
+                ["function.ts"] =
+                    "export async function $(FUNCTION_NAME_INPUT)(req, ctx) { return {}; }\n" +
+                    "app.http('$(FUNCTION_NAME_INPUT)', { handler: $(FUNCTION_NAME_INPUT) });\n",
+            },
+            Actions =
+            [
+                new V2Action
+                {
+                    Name = "readFn",
+                    Type = "GetTemplateFileContent",
+                    FilePath = "function.ts",
+                    AssignTo = "$(FN_CONTENT)",
+                },
+                new V2Action
+                {
+                    Name = "writeFn",
+                    Type = "WriteToFile",
+                    FilePath = "src/functions/$(FUNCTION_NAME_INPUT).ts",
+                    Source = "$(FN_CONTENT)",
+                },
+            ],
+        };
+
+        var engine = new V2TemplateEngine();
+        TemplateApplicationResult result = engine.Apply(
+            template,
+            functionName: "HttpTrigger-Python",
+            optionValuesByPromptId: new Dictionary<string, string?>
+            {
+                ["trigger-functionName"] = "HttpTrigger-Python",
+            },
+            workingDirectory: new DirectoryInfo(_workingDir),
+            force: false);
+
+        var created = Assert.IsType<TemplateApplicationResult.Created>(result);
+        string expectedPath = Path.GetFullPath(Path.Combine(_workingDir, "src", "functions", "HttpTrigger_Python.ts"));
+        Assert.Equal(expectedPath, created.Files.Single());
+
+        string content = File.ReadAllText(expectedPath);
+        Assert.Contains("export async function HttpTrigger_Python(", content);
+        Assert.Contains("handler: HttpTrigger_Python", content);
+        Assert.DoesNotContain("HttpTrigger-Python", content);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #5202. `func new` accepted trigger names containing dashes (or other non-identifier characters) and emitted them verbatim into generated source, producing invalid Python/JS identifiers and a host-side `SyntaxError` at `func start` time.

Repro (Python):

```
func new --name HttpTrigger-Python --template "HTTP trigger" ...
# function_app.py
def HttpTrigger-Python(req: func.HttpRequest) -> func.HttpResponse:
                   ^ SyntaxError: expected '('
```

## Root cause

On vnext both Python and Node templates share the v2 schema and use the single `$(FUNCTION_NAME_INPUT)` token both as the route/display name and as the language identifier (`def $(FUNCTION_NAME_INPUT)` / `function $(FUNCTION_NAME_INPUT)`). `V2TemplateEngine` substituted the raw user input without any sanitization.

## Fix

In `src/Templates.V2/V2TemplateEngine.cs`:

1. Sanitize the seeded value of `FUNCTION_NAME_INPUT` in `Apply`.
2. Sanitize again on any prompt write to that variable. `V2EngineProvider` re-supplies `context.FunctionName` as a prompt value for ids `name`, `functionName`, `function-name`, `trigger-functionName`, etc., which would otherwise overwrite the seeded value.

Sanitization rule: replace anything outside `[A-Za-z0-9_]` with `_`; if the first character is a digit, prefix with `_`. ASCII-only, deliberately predictable.

Examples:
- `HttpTrigger-Python` -> `HttpTrigger_Python`
- `http.trigger node` -> `http_trigger_node`
- `1HttpTrigger` -> `_1HttpTrigger`

Route/display values driven by other prompt ids are untouched.

## Affected workloads

- `src/Workloads/Templates/Python/` (Python v2 templates)
- `src/Workloads/Templates/Node/` (Node v4 JS/TS templates)

Both share the engine fix; no per-workload template changes needed.

## Tests

Added to `test/Func.Tests/Templates/V2/V2TemplateEngineTests.cs`:

- `SanitizeFunctionIdentifier_ProducesValidIdentifier` (theory, 7 cases incl. leading digit, dots, spaces, multiple dashes).
- `Apply_FunctionName_With_Invalid_Identifier_Chars_Is_Sanitized_In_Generated_Code` (theory, 3 cases, Python-shaped template).
- `Apply_FunctionName_Supplied_Via_Prompt_Value_Is_Also_Sanitized` (fact, TS-shaped template, exercises the prompt-write path).

Full `test/Func.Tests` suite: 1015 passed, 0 failed. Solution builds clean with `TreatWarningsAsErrors=true`.

## Release notes

Updated `src/Func/release_notes.md`, `src/Workloads/Templates/Python/release_notes.md`, `src/Workloads/Templates/Node/release_notes.md`.