### PR TITLE
Point "no stacks" hints at func setup, drop java/pwsh, add go

### DIFF
--- a/src/Func/Commands/InitCommand.cs
+++ b/src/Func/Commands/InitCommand.cs
@@ -187,7 +187,7 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
             .ToList();
 
         return stacks.Count == 0
-            ? "The stack to use. Install a stack workload (`func workload install <id>`) to see supported values."
+            ? "The stack to use. Set up a stack (`func setup --features <id>`) to see supported values."
             : "The stack to use. Supported values: " + string.Join(", ", stacks) + ".";
     }
 
@@ -206,7 +206,7 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
             .ToList();
 
         return languages.Count == 0
-            ? "The programming language. Install a stack workload (`func workload install <id>`) to see supported values."
+            ? "The programming language. Set up a stack (`func setup --features <id>`) to see supported values."
             : "The programming language. Supported values: " + string.Join(", ", languages) + ".";
     }
 

--- a/src/Func/Commands/Quickstart/QuickstartCommand.cs
+++ b/src/Func/Commands/Quickstart/QuickstartCommand.cs
@@ -310,7 +310,7 @@ internal sealed class QuickstartCommand : FuncCliCommand, IBuiltInCommand
             .ToList();
 
         return languages.Count == 0
-            ? "The programming language. Install a stack workload (`func workload install <id>`) to see supported values."
+            ? "The programming language. Set up a stack (`func setup --features <id>`) to see supported values."
             : "The programming language. Supported values: " + string.Join(", ", languages) + ".";
     }
 }

--- a/src/Func/Commands/Quickstart/QuickstartMessages.cs
+++ b/src/Func/Commands/Quickstart/QuickstartMessages.cs
@@ -34,7 +34,7 @@ internal static class QuickstartMessages
             .ToList();
 
         return stacks.Count == 0
-            ? "The stack to use. Install a stack workload (`func workload install <id>`) to see supported values."
+            ? "The stack to use. Set up a stack (`func setup --features <id>`) to see supported values."
             : "The stack to use. Supported values: " + string.Join(", ", stacks) + ".";
     }
 

--- a/src/Func/Workloads/KnownInstallableWorkloads.cs
+++ b/src/Func/Workloads/KnownInstallableWorkloads.cs
@@ -6,17 +6,17 @@ using System.Collections.Frozen;
 namespace Azure.Functions.Cli.Workloads;
 
 /// <summary>
-/// Static catalog of workloads the CLI knows how to suggest installing when no
+/// Static catalog of stacks the CLI knows how to suggest setting up when no
 /// suitable workload is registered at runtime. This is **not** the registry of
-/// what is currently installed — that comes from DI'd workload contributions.
-/// It exists purely to power install hints (\"Install a stack to do X: <code>func workload install dotnet</code>\")
+/// what is currently installed, that comes from DI'd workload contributions.
+/// It exists purely to power setup hints (e.g. <c>func setup --features dotnet</c>)
 /// and will be replaced by the workload loader's manifest once that lands.
 /// </summary>
 internal static class KnownInstallableWorkloads
 {
     /// <summary>
-    /// Map of workload identifier (the value passed to <c>func workload install</c>)
-    /// to the human-readable language list shown in install hints.
+    /// Map of stack identifier (the value passed to <c>func setup --features</c>)
+    /// to the human-readable language list shown in setup hints.
     /// </summary>
     public static readonly FrozenDictionary<string, string[]> LanguageMap =
         new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
@@ -24,7 +24,6 @@ internal static class KnownInstallableWorkloads
             ["dotnet"] = ["C#", "F#"],
             ["node"] = ["JavaScript", "TypeScript"],
             ["python"] = ["Python"],
-            ["java"] = ["Java"],
-            ["powershell"] = ["PowerShell"],
+            ["go"] = ["Go"],
         }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 }

--- a/src/Func/Workloads/WorkloadHintRenderer.cs
+++ b/src/Func/Workloads/WorkloadHintRenderer.cs
@@ -42,11 +42,11 @@ internal sealed class WorkloadHintRenderer(IInteractionService interaction) : IW
     {
         _interaction.WriteWarning("No stacks installed.");
         _interaction.WriteBlankLine();
-        _interaction.WriteHint($"Install a stack workload to {hint.ActionDescription}:");
+        _interaction.WriteHint($"Set up a stack to {hint.ActionDescription}:");
         _interaction.WriteBlankLine();
 
         IEnumerable<DefinitionItem> items = KnownInstallableWorkloads.LanguageMap.Select(static kvp =>
-            new DefinitionItem($"func workload install {kvp.Key}", string.Join(", ", kvp.Value)));
+            new DefinitionItem($"func setup --features {kvp.Key}", string.Join(", ", kvp.Value)));
         _interaction.WriteDefinitionList(items);
 
         _interaction.WriteBlankLine();

--- a/test/Func.Tests/Commands/InitCommandTests.cs
+++ b/test/Func.Tests/Commands/InitCommandTests.cs
@@ -39,8 +39,8 @@ public class InitCommandTests
         var cmd = new InitCommand(_interaction, _hintRenderer, []);
         string description = cmd.StackOption.Description ?? string.Empty;
 
-        Assert.Contains("Install a stack workload", description);
-        Assert.Contains("func workload install", description);
+        Assert.Contains("Set up a stack", description);
+        Assert.Contains("func setup --features", description);
     }
 
     [Fact]

--- a/test/Func.Tests/Commands/InitCommandTests.cs
+++ b/test/Func.Tests/Commands/InitCommandTests.cs
@@ -34,7 +34,7 @@ public class InitCommandTests
     }
 
     [Fact]
-    public void InitCommand_StackOptionDescription_NoInitializers_PointsAtWorkloadInstall()
+    public void InitCommand_StackOptionDescription_NoInitializers_PointsAtSetup()
     {
         var cmd = new InitCommand(_interaction, _hintRenderer, []);
         string description = cmd.StackOption.Description ?? string.Empty;

--- a/test/Func.Tests/Commands/Quickstart/QuickstartCommandTests.cs
+++ b/test/Func.Tests/Commands/Quickstart/QuickstartCommandTests.cs
@@ -41,13 +41,13 @@ public class QuickstartCommandTests
     }
 
     [Fact]
-    public void QuickstartCommand_StackOptionDescription_NoProviders_PointsAtWorkloadInstall()
+    public void QuickstartCommand_StackOptionDescription_NoProviders_PointsAtSetup()
     {
         QuickstartCommand cmd = CreateCommand();
         string description = cmd.StackOption.Description ?? string.Empty;
 
-        Assert.Contains("Install a stack workload", description);
-        Assert.Contains("func workload install", description);
+        Assert.Contains("Set up a stack", description);
+        Assert.Contains("func setup --features", description);
     }
 
     [Fact]

--- a/test/Func.Tests/Commands/Quickstart/QuickstartListCommandTests.cs
+++ b/test/Func.Tests/Commands/Quickstart/QuickstartListCommandTests.cs
@@ -33,14 +33,14 @@ public class QuickstartListCommandTests
     }
 
     [Fact]
-    public void QuickstartListCommand_StackOptionDescription_NoProviders_PointsAtWorkloadInstall()
+    public void QuickstartListCommand_StackOptionDescription_NoProviders_PointsAtSetup()
     {
         QuickstartListCommand cmd = CreateCommand();
         Option<string?> stackOption = cmd.StackOption;
         string description = stackOption.Description ?? string.Empty;
 
-        Assert.Contains("Install a stack workload", description);
-        Assert.Contains("func workload install", description);
+        Assert.Contains("Set up a stack", description);
+        Assert.Contains("func setup --features", description);
     }
 
     [Fact]


### PR DESCRIPTION
When no stack workloads are installed, `func init` / `func quickstart` (and friends) suggested `func workload install <id>` for `dotnet`, `node`, `python`, `java`, `powershell`. Two problems:

- `java` and `powershell` stack workloads don't exist.
- We've standardised on `func setup --features <id>` as the user-facing entry point; `func workload install` is the lower-level tool.

Changes:
- `KnownInstallableWorkloads.LanguageMap`: drop `java` / `powershell`, add `go`.
- `WorkloadHintRenderer` no-stacks-installed hint now reads "Set up a stack to <action>:" with `func setup --features <id>` rows.
- `InitCommand` `--stack` / `--language` empty-state descriptions point at `func setup --features <id>`.
- `QuickstartMessages` / `QuickstartCommand` empty-state descriptions point at `func setup --features <id>`.
- Tests renamed `_PointsAtWorkloadInstall` → `_PointsAtSetup` and updated to assert the new wording.

The `func workload search` discovery hint is unchanged: search is still the right command for discovering installable stacks.

Example output now:

```
Warning: No stacks installed.

Set up a stack to scaffold a quickstart project:

 func setup --features dotnet  C#, F#
 func setup --features node    JavaScript, TypeScript
 func setup --features python  Python
 func setup --features go      Go

Run func workload search to discover available stacks.
```