### PR TITLE
Reduce noise, improve and readability of func start dashboard logs

### DIFF
--- a/docs/func-start-json-schema.md
+++ b/docs/func-start-json-schema.md
@@ -132,7 +132,15 @@ for every entry the host produces.
   "event_id": 1,
   "event_name": "InvocationStarted",
   "message": "Executing 'HttpTrigger1' (Reason='HTTP', Id=…)",
-  "exception": null,
+  "exception": {
+    "type": "System.InvalidOperationException",
+    "message": "Access denied",
+    "stack": "at Functions.HttpTrigger1.Run(...)",
+    "inner_exception": {
+      "type": "Worker.UserException",
+      "message": "Underlying worker failure"
+    }
+  },
   "attributes": {
     "function.name": "HttpTrigger1",
     "function.invocation_id": "8f2a1c92-3d04-4e1f-9a55-2e4f7a9e8b01",
@@ -148,7 +156,7 @@ for every entry the host produces.
 | `event_id` | number | Numeric EventId (often `0` if unspecified). |
 | `event_name` | string \| absent | Friendly EventId name when present. |
 | `message` | string | The rendered log message. |
-| `exception` | object \| `null` | `{ type, message, stack? }` when the entry carried an exception. |
+| `exception` | object \| absent | `{ type, message, stack?, inner_exception? }` when the entry carried an exception. `inner_exception` repeats the same shape recursively. |
 | `attributes` | object | Free-form key-value bag. Well-known keys listed in *Attribute conventions* below. |
 
 ### `host_state_changed`
@@ -258,7 +266,12 @@ duration; carries `error` details if the invocation failed.
   "duration_ms": 38,
   "error": {
     "type": "System.IO.IOException",
-    "message": "Access denied"
+    "message": "Access denied",
+    "stack": "at Functions.HttpTrigger1.Run(...)",
+    "inner_exception": {
+      "type": "Worker.UserException",
+      "message": "Underlying worker failure"
+    }
   }
 }
 ```
@@ -267,7 +280,7 @@ duration; carries `error` details if the invocation failed.
 |-------|------|-------|
 | `result` | string | `succeeded` or `failed`. |
 | `duration_ms` | number \| absent | Wall-clock execution time. |
-| `error` | object \| absent | `{ type, message }` when `result == "failed"`. |
+| `error` | object \| absent | `{ type, message, stack?, inner_exception? }` when `result == "failed"`. `inner_exception` repeats the same shape recursively. |
 
 ### `cli_diagnostic`
 

--- a/src/Func/Commands/Start/Dashboard/DashboardEvent.cs
+++ b/src/Func/Commands/Start/Dashboard/DashboardEvent.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Hosting.Events;
+
 namespace Azure.Functions.Cli.Hosting.Dashboard;
 
 /// <summary>
@@ -41,9 +43,15 @@ internal sealed record InvocationCompletedEvent(
     string? TraceId,
     string Result,
     double? DurationMs,
-    string? ErrorType,
-    string? ErrorMessage)
-    : DashboardEvent(Timestamp);
+    HostLogExceptionDetails? Error)
+    : DashboardEvent(Timestamp)
+{
+    public string? ErrorType => Error?.Type;
+
+    public string? ErrorMessage => Error?.Message;
+
+    public string? ErrorSummary => Error?.FormatSummary();
+}
 
 internal sealed record CliDiagnosticEvent(DateTimeOffset Timestamp, string Code, string Message, string? Recommendation)
     : DashboardEvent(Timestamp);

--- a/src/Func/Commands/Start/Dashboard/DashboardState.cs
+++ b/src/Func/Commands/Start/Dashboard/DashboardState.cs
@@ -303,8 +303,7 @@ internal sealed class DashboardState
             _succeededInvocations++;
         }
 
-        string? errorType = null;
-        string? errorMessage = null;
+        HostLogExceptionDetails? error = failed ? entry.ExceptionDetails : null;
 
         if (_functions.TryGetValue(name, out FunctionEntry? f))
         {
@@ -320,12 +319,7 @@ internal sealed class DashboardState
             {
                 f.TotalErrors++;
                 f.Status = FunctionStatus.Error;
-                if (entry.Exception is not null)
-                {
-                    errorType = entry.Exception.GetType().FullName;
-                    errorMessage = entry.Exception.Message;
-                    f.LastErrorMessage = errorMessage;
-                }
+                f.LastErrorMessage = error?.FormatSummary();
             }
             else if (f.ActiveInvocations == 0 && f.Status != FunctionStatus.Error)
             {
@@ -334,7 +328,7 @@ internal sealed class DashboardState
         }
 
         string? trace = entry.GetAttribute<string>(HostLogAttributeKeys.TraceId);
-        return new InvocationCompletedEvent(entry.Timestamp, name, id, trace, result, duration, errorType, errorMessage);
+        return new InvocationCompletedEvent(entry.Timestamp, name, id, trace, result, duration, error);
     }
 
     private static bool IsImplicitFunctionDiscovery(HostLogEntry entry, string? kind)

--- a/src/Func/Commands/Start/Dashboard/Rendering/CompactLogLineFormatter.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/CompactLogLineFormatter.cs
@@ -112,12 +112,6 @@ internal sealed class CompactLogLineFormatter(ITheme theme, FunctionPalette pale
             }
         }
 
-        string source = functionName ?? entry.Category;
-        int sourceWidth = Math.Max(SourceColumnWidth, source.Length);
-        string nameMarkup = functionName is not null
-            ? $"[{_palette.GetColorFor(functionName)}]{Markup.Escape(functionName),-SourceColumnWidth}[/]"
-            : $"[{MutedTag}]{Markup.Escape(entry.Category),-SourceColumnWidth}[/]";
-
         string levelMarkup = entry.Level switch
         {
             LogLevel.Error or LogLevel.Critical => $"[{ErrorTag}]✗[/]",
@@ -125,8 +119,22 @@ internal sealed class CompactLogLineFormatter(ITheme theme, FunctionPalette pale
             _ => $"[{MutedTag}]·[/]",
         };
 
-        string prefix = string.Create(CultureInfo.InvariantCulture, $" [{MutedTag}]{ts}[/]  {nameMarkup}  {levelMarkup}  ");
-        int prefixWidth = 1 + ts.Length + 2 + sourceWidth + 2 + 1 + 2;
+        string prefix;
+        int prefixWidth;
+        if (functionName is not null)
+        {
+            int sourceWidth = Math.Max(SourceColumnWidth, functionName.Length);
+            string nameMarkup = $"[{_palette.GetColorFor(functionName)}]{Markup.Escape(functionName),-SourceColumnWidth}[/]";
+            prefix = string.Create(CultureInfo.InvariantCulture, $" [{MutedTag}]{ts}[/]  {nameMarkup}  {levelMarkup}  ");
+            prefixWidth = 1 + ts.Length + 2 + sourceWidth + 2 + 1 + 2;
+        }
+        else
+        {
+            // Host/system logs no longer surface their category; keep just the timestamp and level marker.
+            prefix = string.Create(CultureInfo.InvariantCulture, $" [{MutedTag}]{ts}[/]  {levelMarkup}  ");
+            prefixWidth = 1 + ts.Length + 2 + 1 + 2;
+        }
+
         return CreateWrappedLine(prefix, prefixWidth, FormatMessage(entry), functionName, isError, effectiveLogLevel);
     }
 

--- a/src/Func/Commands/Start/Dashboard/Rendering/CompactLogLineFormatter.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/CompactLogLineFormatter.cs
@@ -130,9 +130,14 @@ internal sealed class CompactLogLineFormatter(ITheme theme, FunctionPalette pale
         }
         else
         {
-            // Host/system logs no longer surface their category; keep just the timestamp and level marker.
-            prefix = string.Create(CultureInfo.InvariantCulture, $" [{MutedTag}]{ts}[/]  {levelMarkup}  ");
-            prefixWidth = 1 + ts.Length + 2 + 1 + 2;
+            // Host/system logs no longer surface their category. Reserve the source column so the level
+            // marker and message stay aligned with function lines; logs replayed from the CLI's startup
+            // initialization steps get an "Initialization" label so that phase reads as a coherent group.
+            string sourceMarkup = IsInitializationStep(entry)
+                ? $"[{MutedTag}]{"Initialization",-SourceColumnWidth}[/]"
+                : new string(' ', SourceColumnWidth);
+            prefix = string.Create(CultureInfo.InvariantCulture, $" [{MutedTag}]{ts}[/]  {sourceMarkup}  {levelMarkup}  ");
+            prefixWidth = 1 + ts.Length + 2 + SourceColumnWidth + 2 + 1 + 2;
         }
 
         return CreateWrappedLine(prefix, prefixWidth, FormatMessage(entry), functionName, isError, effectiveLogLevel);
@@ -247,6 +252,12 @@ internal sealed class CompactLogLineFormatter(ITheme theme, FunctionPalette pale
         return message.StartsWith("Executing '", StringComparison.Ordinal)
             || message.StartsWith("Executed '", StringComparison.Ordinal);
     }
+
+    private static bool IsInitializationStep(HostLogEntry entry)
+        => string.Equals(
+            entry.GetAttribute<string>(HostLogAttributeKeys.CliEventKind),
+            CliEventKinds.StartInitializationStepCompleted,
+            StringComparison.Ordinal);
 
     private static string? GetFunctionName(HostLogEntry entry, IReadOnlyList<DashboardEvent> events)
     {

--- a/src/Func/Commands/Start/Dashboard/Rendering/CompactLogLineFormatter.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/CompactLogLineFormatter.cs
@@ -232,11 +232,6 @@ internal sealed class CompactLogLineFormatter(ITheme theme, FunctionPalette pale
             return false;
         }
 
-        if (string.Equals(entry.Category, "Microsoft.Azure.WebJobs.Hosting.OptionsLoggingService", StringComparison.Ordinal))
-        {
-            return true;
-        }
-
         return entry.ExceptionDetails is null
             && (string.IsNullOrWhiteSpace(entry.Message)
                 || IsFunctionsInvocationEnvelope(entry.Message));

--- a/src/Func/Commands/Start/Dashboard/Rendering/CompactLogLineFormatter.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/CompactLogLineFormatter.cs
@@ -114,9 +114,9 @@ internal sealed class CompactLogLineFormatter(ITheme theme, FunctionPalette pale
 
         string levelMarkup = entry.Level switch
         {
-            LogLevel.Error or LogLevel.Critical => $"[{ErrorTag}]✗[/]",
-            LogLevel.Warning => $"[{WarningTag}]![/]",
-            _ => $"[{MutedTag}]·[/]",
+            LogLevel.Error or LogLevel.Critical => $"[{ErrorTag}]●[/]",
+            LogLevel.Warning => $"[{WarningTag}]●[/]",
+            _ => $"[{MutedTag}]●[/]",
         };
 
         string prefix;

--- a/src/Func/Commands/Start/Dashboard/Rendering/CompactLogLineFormatter.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/CompactLogLineFormatter.cs
@@ -99,7 +99,7 @@ internal sealed class CompactLogLineFormatter(ITheme theme, FunctionPalette pale
                     bool failed = string.Equals(inv.Result, "failed", StringComparison.OrdinalIgnoreCase);
                     string arrow = failed ? $"[{ErrorTag}]✗[/]" : $"[{SuccessTag}]←[/]";
                     string suffix = failed
-                        ? $"[{ErrorTag}]{Markup.Escape(inv.ErrorType ?? string.Empty)}: {Markup.Escape(inv.ErrorMessage ?? string.Empty)}[/]"
+                        ? $"[{ErrorTag}]{Markup.Escape(inv.ErrorSummary ?? string.Empty)}[/]"
                         : $"[{MutedTag}]{(inv.DurationMs.HasValue ? ((long)inv.DurationMs.Value).ToString(CultureInfo.InvariantCulture) + "ms" : string.Empty)}[/]";
 
                     return CreateSingleLine(
@@ -127,11 +127,24 @@ internal sealed class CompactLogLineFormatter(ITheme theme, FunctionPalette pale
 
         string prefix = string.Create(CultureInfo.InvariantCulture, $" [{MutedTag}]{ts}[/]  {nameMarkup}  {levelMarkup}  ");
         int prefixWidth = 1 + ts.Length + 2 + sourceWidth + 2 + 1 + 2;
-        return CreateWrappedLine(prefix, prefixWidth, entry.Message, functionName, isError, effectiveLogLevel);
+        return CreateWrappedLine(prefix, prefixWidth, FormatMessage(entry), functionName, isError, effectiveLogLevel);
     }
 
     private static CompactLogLine CreateSingleLine(string markup, string? functionName, bool isError, LogLevel level)
         => new(new Markup(markup), functionName, isError, level);
+
+    private static string FormatMessage(HostLogEntry entry)
+    {
+        string? exceptionSummary = entry.ExceptionDetails?.FormatSummary();
+        if (string.IsNullOrEmpty(exceptionSummary))
+        {
+            return entry.Message;
+        }
+
+        return string.IsNullOrWhiteSpace(entry.Message)
+            ? exceptionSummary
+            : entry.Message + Environment.NewLine + exceptionSummary;
+    }
 
     private static CompactLogLine CreateWrappedLine(
         string prefixMarkup,
@@ -211,8 +224,9 @@ internal sealed class CompactLogLineFormatter(ITheme theme, FunctionPalette pale
             return true;
         }
 
-        return string.IsNullOrWhiteSpace(entry.Message)
-            || IsFunctionsInvocationEnvelope(entry.Message);
+        return entry.ExceptionDetails is null
+            && (string.IsNullOrWhiteSpace(entry.Message)
+                || IsFunctionsInvocationEnvelope(entry.Message));
     }
 
     private static bool IsFunctionsInvocationEnvelope(string message)

--- a/src/Func/Commands/Start/Dashboard/Rendering/CompactRenderer.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/CompactRenderer.cs
@@ -113,7 +113,17 @@ internal sealed class CompactRenderer(
         {
             if (_logScrollOffset > 0 && MatchesLogFilters(line, _activeFunctionFilter, _errorsOnly, _minimumLogLevel))
             {
-                _logScrollOffset = Math.Min(MaxLogTailLines, _logScrollOffset + line.RenderRows(GetViewportWidth()).Count);
+                int width = GetViewportWidth();
+                int addedRows = line.RenderRows(width).Count;
+
+                // Account for the blank separator row that BuildLogVisualRows inserts
+                // before a multi-line entry so a held scrollback position stays anchored.
+                if (SeparatorPrecedesNewEntry(line, width))
+                {
+                    addedRows++;
+                }
+
+                _logScrollOffset = Math.Min(MaxLogTailLines, _logScrollOffset + addedRows);
             }
         }
 
@@ -442,12 +452,44 @@ internal sealed class CompactRenderer(
         }
 
         var rows = new List<IRenderable>();
-        foreach (CompactLogLine line in tail)
+        bool previousWasMultiline = false;
+        for (int i = 0; i < tail.Length; i++)
         {
-            rows.AddRange(line.RenderRows(viewportWidth));
+            IReadOnlyList<IRenderable> lineRows = tail[i].RenderRows(viewportWidth);
+            bool multiline = lineRows.Count > 1;
+
+            // Only separate multi-line entries (wrapped messages or exception
+            // summaries) so they read as a distinct block. Consecutive single-line
+            // entries stay dense to keep the live tail compact. A single space (not
+            // string.Empty) is required: Spectre's Rows collapses an empty Markup.
+            if (i > 0 && (previousWasMultiline || multiline))
+            {
+                rows.Add(new Markup(" "));
+            }
+
+            rows.AddRange(lineRows);
+            previousWasMultiline = multiline;
         }
 
         return rows;
+    }
+
+    private static bool IsMultiline(CompactLogLine line, int viewportWidth) => line.RenderRows(viewportWidth).Count > 1;
+
+    private bool SeparatorPrecedesNewEntry(CompactLogLine current, int viewportWidth)
+    {
+        CompactLogLine[] snapshot = _logBuffer.Snapshot();
+        CompactLogLine? previous = null;
+        for (int i = snapshot.Length - 2; i >= 0; i--)
+        {
+            if (MatchesLogFilters(snapshot[i], _activeFunctionFilter, _errorsOnly, _minimumLogLevel))
+            {
+                previous = snapshot[i];
+                break;
+            }
+        }
+
+        return previous is not null && (IsMultiline(previous, viewportWidth) || IsMultiline(current, viewportWidth));
     }
 
     private static IRenderable BuildLogRows(List<IRenderable> visualRows, int logBudget)

--- a/src/Func/Commands/Start/Dashboard/Rendering/JsonRenderer.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/JsonRenderer.cs
@@ -49,6 +49,7 @@ internal sealed class JsonRenderer : IDashboardRenderer
     public Task OnEventAsync(HostLogEntry entry, IReadOnlyList<DashboardEvent> events, CancellationToken cancellationToken)
     {
         if (events.Count == 0
+            && entry.ExceptionDetails is null
             && (string.IsNullOrWhiteSpace(entry.Message) || IsSuppressedLogCategory(entry.Category)))
         {
             return Task.CompletedTask;
@@ -108,9 +109,9 @@ internal sealed class JsonRenderer : IDashboardRenderer
             }
 
             writer.WriteString("message", entry.Message);
-            if (entry.Exception is not null)
+            if (entry.ExceptionDetails is not null)
             {
-                WriteException(writer, "exception", entry.Exception);
+                WriteException(writer, "exception", entry.ExceptionDetails);
             }
 
             WriteAttributes(writer, entry.Attributes);
@@ -206,20 +207,9 @@ internal sealed class JsonRenderer : IDashboardRenderer
                         writer.WriteNumber("duration_ms", Math.Round(d, 3));
                     }
 
-                    if (!string.IsNullOrEmpty(inv.ErrorType) || !string.IsNullOrEmpty(inv.ErrorMessage))
+                    if (inv.Error is not null)
                     {
-                        writer.WriteStartObject("error");
-                        if (!string.IsNullOrEmpty(inv.ErrorType))
-                        {
-                            writer.WriteString("type", inv.ErrorType);
-                        }
-
-                        if (!string.IsNullOrEmpty(inv.ErrorMessage))
-                        {
-                            writer.WriteString("message", inv.ErrorMessage);
-                        }
-
-                        writer.WriteEndObject();
+                        WriteException(writer, "error", inv.Error);
                     }
                 });
                 break;
@@ -326,14 +316,26 @@ internal sealed class JsonRenderer : IDashboardRenderer
         }
     }
 
-    private static void WriteException(Utf8JsonWriter writer, string propertyName, Exception ex)
+    private static void WriteException(Utf8JsonWriter writer, string propertyName, HostLogExceptionDetails exception)
     {
-        writer.WriteStartObject(propertyName);
-        writer.WriteString("type", ex.GetType().FullName ?? ex.GetType().Name);
-        writer.WriteString("message", ex.Message);
-        if (!string.IsNullOrEmpty(ex.StackTrace))
+        writer.WritePropertyName(propertyName);
+        WriteExceptionObject(writer, exception);
+    }
+
+    private static void WriteExceptionObject(Utf8JsonWriter writer, HostLogExceptionDetails exception)
+    {
+        writer.WriteStartObject();
+        writer.WriteString("type", exception.Type);
+        writer.WriteString("message", exception.Message);
+        if (!string.IsNullOrEmpty(exception.Stack))
         {
-            writer.WriteString("stack", ex.StackTrace);
+            writer.WriteString("stack", exception.Stack);
+        }
+
+        if (exception.InnerException is not null)
+        {
+            writer.WritePropertyName("inner_exception");
+            WriteExceptionObject(writer, exception.InnerException);
         }
 
         writer.WriteEndObject();

--- a/src/Func/Commands/Start/Dashboard/Rendering/JsonRenderer.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/JsonRenderer.cs
@@ -50,7 +50,7 @@ internal sealed class JsonRenderer : IDashboardRenderer
     {
         if (events.Count == 0
             && entry.ExceptionDetails is null
-            && (string.IsNullOrWhiteSpace(entry.Message) || IsSuppressedLogCategory(entry.Category)))
+            && string.IsNullOrWhiteSpace(entry.Message))
         {
             return Task.CompletedTask;
         }
@@ -117,9 +117,6 @@ internal sealed class JsonRenderer : IDashboardRenderer
             WriteAttributes(writer, entry.Attributes);
         });
     }
-
-    private static bool IsSuppressedLogCategory(string category)
-        => string.Equals(category, "Microsoft.Azure.WebJobs.Hosting.OptionsLoggingService", StringComparison.Ordinal);
 
     private void WriteEvent(DashboardEvent ev)
     {

--- a/src/Func/Commands/Start/Dashboard/Rendering/PlainRenderer.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/PlainRenderer.cs
@@ -96,11 +96,6 @@ internal sealed class PlainRenderer(IInteractionService interaction, IAnsiConsol
 
     private static bool ShouldRenderPlainLog(HostLogEntry entry, IReadOnlyList<DashboardEvent> events)
     {
-        if (IsSuppressedLogCategory(entry.Category))
-        {
-            return false;
-        }
-
         string? kind = entry.GetAttribute<string>(HostLogAttributeKeys.CliEventKind);
         if (kind is not (null or CliEventKinds.Log))
         {
@@ -132,9 +127,6 @@ internal sealed class PlainRenderer(IInteractionService interaction, IAnsiConsol
 
         return entry.ExceptionDetails?.FormatSummary() ?? string.Empty;
     }
-
-    private static bool IsSuppressedLogCategory(string category)
-        => string.Equals(category, "Microsoft.Azure.WebJobs.Hosting.OptionsLoggingService", StringComparison.Ordinal);
 
     private void PrintBanner()
     {

--- a/src/Func/Commands/Start/Dashboard/Rendering/PlainRenderer.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/PlainRenderer.cs
@@ -58,15 +58,13 @@ internal sealed class PlainRenderer(IInteractionService interaction, IAnsiConsol
 
         // Plain log lines (no synthetic kind matched, no `cli.event_kind`
         // marker) are still useful — surface them as a generic [log] line.
-        // Suppress the WebJobs invocation envelope ("Executing '...'" /
-        // "Executed '...'") because the synthetic events already convey it.
-        string? kind = entry.GetAttribute<string>(HostLogAttributeKeys.CliEventKind);
-        if (events.Count == 0
-            && kind is null or CliEventKinds.Log
-            && !IsSuppressedLogCategory(entry.Category)
-            && !IsWebJobsInvocationEnvelope(entry.Message))
+        // Suppress the WebJobs invocation envelope only when it has no
+        // attached exception details; otherwise the legacy experience showed
+        // those details and we need to preserve them.
+        if (ShouldRenderPlainLog(entry, events))
         {
-            if (string.IsNullOrWhiteSpace(entry.Message))
+            string message = FormatLogMessage(entry);
+            if (string.IsNullOrWhiteSpace(message))
             {
                 return Task.CompletedTask;
             }
@@ -78,10 +76,10 @@ internal sealed class PlainRenderer(IInteractionService interaction, IAnsiConsol
                 LogLevel.Warning => "[warn]",
                 _ => "[log]",
             };
-            _interaction.WriteLine($"{FormatTimestamp(entry.Timestamp)}  {tag,-18} {function}  {entry.Message}");
-            if (entry.Exception is not null)
+            _interaction.WriteLine($"{FormatTimestamp(entry.Timestamp)}  {tag,-18} {function}  {message}");
+            if (!string.IsNullOrWhiteSpace(entry.Message) && entry.ExceptionDetails is not null)
             {
-                _interaction.WriteLine($"                                 {entry.Exception.GetType().FullName}: {entry.Exception.Message}");
+                _interaction.WriteLine($"                                 {entry.ExceptionDetails.FormatSummary()}");
             }
         }
 
@@ -92,6 +90,45 @@ internal sealed class PlainRenderer(IInteractionService interaction, IAnsiConsol
         => !string.IsNullOrEmpty(message) && (
             message.StartsWith("Executing '", StringComparison.Ordinal) ||
             message.StartsWith("Executed '", StringComparison.Ordinal));
+
+    private static bool ShouldRenderPlainLog(HostLogEntry entry, IReadOnlyList<DashboardEvent> events)
+    {
+        if (IsSuppressedLogCategory(entry.Category))
+        {
+            return false;
+        }
+
+        string? kind = entry.GetAttribute<string>(HostLogAttributeKeys.CliEventKind);
+        if (kind is not (null or CliEventKinds.Log))
+        {
+            return false;
+        }
+
+        if (events.Count > 0)
+        {
+            return entry.ExceptionDetails is not null && !HasRenderedExceptionDetails(events);
+        }
+
+        if (entry.ExceptionDetails is null && IsWebJobsInvocationEnvelope(entry.Message))
+        {
+            return false;
+        }
+
+        return entry.ExceptionDetails is not null || !string.IsNullOrWhiteSpace(entry.Message);
+    }
+
+    private static bool HasRenderedExceptionDetails(IReadOnlyList<DashboardEvent> events)
+        => events.Any(static ev => ev is InvocationCompletedEvent { Error: not null });
+
+    private static string FormatLogMessage(HostLogEntry entry)
+    {
+        if (!string.IsNullOrWhiteSpace(entry.Message))
+        {
+            return entry.Message;
+        }
+
+        return entry.ExceptionDetails?.FormatSummary() ?? string.Empty;
+    }
 
     private static bool IsSuppressedLogCategory(string category)
         => string.Equals(category, "Microsoft.Azure.WebJobs.Hosting.OptionsLoggingService", StringComparison.Ordinal);
@@ -194,9 +231,9 @@ internal sealed class PlainRenderer(IInteractionService interaction, IAnsiConsol
                     : "?";
                 string verb = string.Equals(inv.Result, "failed", StringComparison.OrdinalIgnoreCase) ? "failed" : "succeeded";
                 _interaction.WriteLine($"{FormatTimestamp(inv.Timestamp)}  [invocation end]   {inv.Function}  {verb} in {dur} (id={ShortId(inv.InvocationId)})");
-                if (verb == "failed" && !string.IsNullOrEmpty(inv.ErrorMessage))
+                if (verb == "failed" && !string.IsNullOrEmpty(inv.ErrorSummary))
                 {
-                    _interaction.WriteLine($"                                 {inv.ErrorType}: {inv.ErrorMessage}");
+                    _interaction.WriteLine($"                                 {inv.ErrorSummary}");
                 }
                 break;
             }

--- a/src/Func/Commands/Start/Dashboard/Rendering/PlainRenderer.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/PlainRenderer.cs
@@ -69,14 +69,17 @@ internal sealed class PlainRenderer(IInteractionService interaction, IAnsiConsol
                 return Task.CompletedTask;
             }
 
-            string function = entry.GetAttribute<string>(HostLogAttributeKeys.FunctionName) ?? entry.Category;
+            string? function = entry.GetAttribute<string>(HostLogAttributeKeys.FunctionName);
             string tag = entry.Level switch
             {
                 LogLevel.Error or LogLevel.Critical => "[error]",
                 LogLevel.Warning => "[warn]",
                 _ => "[log]",
             };
-            _interaction.WriteLine($"{FormatTimestamp(entry.Timestamp)}  {tag,-18} {function}  {message}");
+            string line = function is not null
+                ? $"{FormatTimestamp(entry.Timestamp)}  {tag,-18} {function}  {message}"
+                : $"{FormatTimestamp(entry.Timestamp)}  {tag,-18} {message}";
+            _interaction.WriteLine(line);
             if (!string.IsNullOrWhiteSpace(entry.Message) && entry.ExceptionDetails is not null)
             {
                 _interaction.WriteLine($"                                 {entry.ExceptionDetails.FormatSummary()}");

--- a/src/Func/Commands/Start/Host/LineHostProcessOutputParser.cs
+++ b/src/Func/Commands/Start/Host/LineHostProcessOutputParser.cs
@@ -192,7 +192,8 @@ internal sealed class LineHostProcessOutputParser : IHostProcessOutputParser
                 LogLevel level = ParseLevel(ReadString(root, "level"), streamName);
                 EventId eventId = ReadEventId(root);
                 string message = ReadString(root, "message") ?? line;
-                Exception? exception = ReadException(root);
+                HostLogExceptionDetails? exceptionDetails = ReadException(root);
+                Exception? exception = exceptionDetails is not null ? new HostProcessException(exceptionDetails) : null;
                 Dictionary<string, object?> attributes = root.TryGetProperty("attributes", out JsonElement attributesElement)
                     && attributesElement.ValueKind == JsonValueKind.Object
                         ? ReadAttributes(attributesElement)
@@ -202,7 +203,10 @@ internal sealed class LineHostProcessOutputParser : IHostProcessOutputParser
                 EnrichFromCategory(category, attributes);
                 EnrichFromMessage(message, attributes);
 
-                entry = new HostLogEntry(timestamp, category, level, eventId, message, exception, attributes);
+                entry = new HostLogEntry(timestamp, category, level, eventId, message, exception, attributes)
+                {
+                    ExceptionDetails = exceptionDetails,
+                };
                 return true;
             }
         }
@@ -242,15 +246,27 @@ internal sealed class LineHostProcessOutputParser : IHostProcessOutputParser
         return new EventId(id, name);
     }
 
-    private static Exception? ReadException(JsonElement root)
+    private static HostLogExceptionDetails? ReadException(JsonElement root)
     {
         if (!root.TryGetProperty("exception", out JsonElement exception) || exception.ValueKind != JsonValueKind.Object)
         {
             return null;
         }
 
+        return ReadExceptionObject(exception);
+    }
+
+    private static HostLogExceptionDetails ReadExceptionObject(JsonElement exception)
+    {
+        string type = ReadString(exception, "type") ?? typeof(Exception).FullName!;
         string message = ReadString(exception, "message") ?? "Host process exception.";
-        return new HostProcessException(message, ReadString(exception, "type"), ReadString(exception, "stack"));
+        string? stack = ReadString(exception, "stack");
+        HostLogExceptionDetails? innerException = exception.TryGetProperty("inner_exception", out JsonElement inner)
+            && inner.ValueKind == JsonValueKind.Object
+                ? ReadExceptionObject(inner)
+                : null;
+
+        return new HostLogExceptionDetails(type, message, stack, innerException);
     }
 
     private static Dictionary<string, object?> ReadAttributes(JsonElement attributesElement)
@@ -492,11 +508,11 @@ internal sealed class LineHostProcessOutputParser : IHostProcessOutputParser
         return end > start ? value[start..end].Trim('\'', '"') : null;
     }
 
-    private sealed class HostProcessException(string message, string? type, string? remoteStack) : Exception(message)
+    private sealed class HostProcessException(HostLogExceptionDetails details) : Exception(details.Message)
     {
-        public string? RemoteType { get; } = type;
+        public string RemoteType => details.Type;
 
-        public string? RemoteStack { get; } = remoteStack;
+        public string? RemoteStack => details.Stack;
     }
 
     private readonly record struct ConsoleLogContext(string Category, LogLevel Level, EventId EventId);

--- a/src/Func/Hosting/Events/HostLogEntry.cs
+++ b/src/Func/Hosting/Events/HostLogEntry.cs
@@ -33,6 +33,8 @@ internal sealed record HostLogEntry(
     public static IReadOnlyDictionary<string, object?> EmptyAttributes { get; } =
         new Dictionary<string, object?>(0);
 
+    public HostLogExceptionDetails? ExceptionDetails { get; init; } = Exception is not null ? HostLogExceptionDetails.FromException(Exception) : null;
+
     /// <summary>
     /// Convenience accessor: returns the attribute value as <typeparamref name="T"/>
     /// when present and assignable, otherwise <paramref name="fallback"/>.

--- a/src/Func/Hosting/Events/HostLogExceptionDetails.cs
+++ b/src/Func/Hosting/Events/HostLogExceptionDetails.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Text;
+
+namespace Azure.Functions.Cli.Hosting.Events;
+
+/// <summary>
+/// Structured exception details reported by the host process.
+/// </summary>
+internal sealed record HostLogExceptionDetails(string Type, string Message, string? Stack = null, HostLogExceptionDetails? InnerException = null)
+{
+    public static HostLogExceptionDetails FromException(Exception exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+
+        return new HostLogExceptionDetails(
+            exception.GetType().FullName ?? exception.GetType().Name,
+            exception.Message,
+            exception.StackTrace,
+            exception.InnerException is not null ? FromException(exception.InnerException) : null);
+    }
+
+    public string FormatSummary()
+    {
+        var builder = new StringBuilder();
+        AppendSummary(builder, this);
+        return builder.ToString();
+    }
+
+    private static void AppendSummary(StringBuilder builder, HostLogExceptionDetails exception)
+    {
+        builder.Append(exception.Type);
+        if (!string.IsNullOrEmpty(exception.Message))
+        {
+            builder.Append(": ");
+            builder.Append(exception.Message);
+        }
+
+        if (exception.InnerException is not null)
+        {
+            builder.Append(" ---> ");
+            AppendSummary(builder, exception.InnerException);
+        }
+    }
+}

--- a/src/Workloads/Host/Logging/HostStructuredEventWriter.cs
+++ b/src/Workloads/Host/Logging/HostStructuredEventWriter.cs
@@ -235,9 +235,15 @@ internal static class HostStructuredEventWriter
         writer.WriteEndObject();
     }
 
-    private static void WriteException(Utf8JsonWriter writer, Exception exception)
+    internal static void WriteException(Utf8JsonWriter writer, Exception exception)
     {
         writer.WriteStartObject("exception");
+        WriteExceptionProperties(writer, exception);
+        writer.WriteEndObject();
+    }
+
+    private static void WriteExceptionProperties(Utf8JsonWriter writer, Exception exception)
+    {
         writer.WriteString("type", exception.GetType().FullName ?? exception.GetType().Name);
         writer.WriteString("message", exception.Message);
         if (!string.IsNullOrEmpty(exception.StackTrace))
@@ -245,7 +251,12 @@ internal static class HostStructuredEventWriter
             writer.WriteString("stack", exception.StackTrace);
         }
 
-        writer.WriteEndObject();
+        if (exception.InnerException is not null)
+        {
+            writer.WriteStartObject("inner_exception");
+            WriteExceptionProperties(writer, exception.InnerException);
+            writer.WriteEndObject();
+        }
     }
 
     private static void WriteProperty(Utf8JsonWriter writer, string name, object? value)

--- a/src/Workloads/Host/Logging/HostStructuredLoggingBuilderExtensions.cs
+++ b/src/Workloads/Host/Logging/HostStructuredLoggingBuilderExtensions.cs
@@ -19,6 +19,7 @@ internal static class HostStructuredLoggingBuilderExtensions
         new("Azure.", LogLevel.Error),
         new("Yarp.", LogLevel.None),
         new("Microsoft.AspNetCore.", LogLevel.None),
+        new("Microsoft.Azure.WebJobs.Hosting.OptionsLoggingService", LogLevel.None),
         new("Microsoft.Azure.WebJobs.Script.DependencyInjection.ScriptStartupTypeLocator", LogLevel.Error),
         new("Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer.MemoryMappedFileAccessor", LogLevel.Error),
     ];

--- a/src/Workloads/Host/Logging/RawHostLogCaptureProvider.cs
+++ b/src/Workloads/Host/Logging/RawHostLogCaptureProvider.cs
@@ -107,7 +107,7 @@ internal sealed class RawHostLogCaptureProvider : ILoggerProvider, ISupportExter
             WriteScopes(writer);
             if (exception is not null)
             {
-                WriteException(writer, exception);
+                HostStructuredEventWriter.WriteException(writer, exception);
             }
 
             writer.WriteEndObject();
@@ -189,19 +189,6 @@ internal sealed class RawHostLogCaptureProvider : ILoggerProvider, ISupportExter
         {
             writer.WriteString("type", scope.GetType().FullName);
             writer.WriteString("text", Convert.ToString(scope, CultureInfo.InvariantCulture));
-        }
-
-        writer.WriteEndObject();
-    }
-
-    private static void WriteException(Utf8JsonWriter writer, Exception exception)
-    {
-        writer.WriteStartObject("exception");
-        writer.WriteString("type", exception.GetType().FullName ?? exception.GetType().Name);
-        writer.WriteString("message", exception.Message);
-        if (!string.IsNullOrEmpty(exception.StackTrace))
-        {
-            writer.WriteString("stack", exception.StackTrace);
         }
 
         writer.WriteEndObject();

--- a/test/Func.Tests/Commands/HostProcessOutputParserTests.cs
+++ b/test/Func.Tests/Commands/HostProcessOutputParserTests.cs
@@ -58,7 +58,12 @@ public class HostProcessOutputParserTests
               "exception": {
                 "type": "System.InvalidOperationException",
                 "message": "boom",
-                "stack": "remote stack"
+                "stack": "remote stack",
+                "inner_exception": {
+                  "type": "Worker.UserException",
+                  "message": "inner boom",
+                  "stack": "inner stack"
+                }
               }
             }
             """;
@@ -82,6 +87,13 @@ public class HostProcessOutputParserTests
         Assert.NotNull(methods);
         Assert.Equal(["get", "post"], methods);
         Assert.Equal("boom", entry.Exception?.Message);
+        Assert.NotNull(entry.ExceptionDetails);
+        Assert.Equal("System.InvalidOperationException", entry.ExceptionDetails.Type);
+        Assert.Equal("remote stack", entry.ExceptionDetails.Stack);
+        Assert.NotNull(entry.ExceptionDetails.InnerException);
+        Assert.Equal("Worker.UserException", entry.ExceptionDetails.InnerException.Type);
+        Assert.Equal("inner boom", entry.ExceptionDetails.InnerException.Message);
+        Assert.Equal("inner stack", entry.ExceptionDetails.InnerException.Stack);
     }
 
     [Fact]

--- a/test/Func.Tests/Hosting/Dashboard/DashboardStateTests.cs
+++ b/test/Func.Tests/Hosting/Dashboard/DashboardStateTests.cs
@@ -107,8 +107,13 @@ public class DashboardStateTests
     {
         var state = new DashboardState();
         state.Observe(DiscoverHttp("HttpTrigger1"));
+        var exceptionDetails = new HostLogExceptionDetails(
+            "Microsoft.Azure.WebJobs.Host.FunctionInvocationException",
+            "Exception while executing function",
+            "outer stack",
+            new HostLogExceptionDetails("Worker.UserException", "inner boom", "inner stack", null));
 
-        state.Observe(MakeEntry(
+        IReadOnlyList<DashboardEvent> events = state.Observe(MakeEntry(
             "Function.HttpTrigger1",
             LogLevel.Error,
             "Executed 'HttpTrigger1' (Failed)",
@@ -120,12 +125,23 @@ public class DashboardStateTests
                 [HostLogAttributeKeys.FunctionResult] = "failed",
                 [HostLogAttributeKeys.DurationMs] = 38.0,
             },
-            exception: new InvalidOperationException("boom")));
+            exception: new InvalidOperationException("placeholder"),
+            exceptionDetails: exceptionDetails));
+
+        var completed = Assert.Single(events.OfType<InvocationCompletedEvent>());
+        Assert.Equal("Microsoft.Azure.WebJobs.Host.FunctionInvocationException", completed.ErrorType);
+        Assert.Equal("Exception while executing function", completed.ErrorMessage);
+        Assert.Equal("Worker.UserException", completed.Error?.InnerException?.Type);
+        Assert.Equal("inner boom", completed.Error?.InnerException?.Message);
 
         DashboardSnapshot snap = state.Snapshot();
         Assert.Equal(FunctionStatus.Error, snap.Functions[0].Status);
         Assert.Equal(1, snap.Functions[0].TotalErrors);
         Assert.Equal(1, snap.FailedInvocations);
+        const string ExpectedLastErrorMessage =
+            "Microsoft.Azure.WebJobs.Host.FunctionInvocationException: Exception while executing function" +
+            " ---> Worker.UserException: inner boom";
+        Assert.Equal(ExpectedLastErrorMessage, snap.Functions[0].LastErrorMessage);
         Assert.True(snap.ErrorCount > 0);
     }
 
@@ -201,6 +217,10 @@ public class DashboardStateTests
         LogLevel level,
         string message,
         Dictionary<string, object?> attributes,
-        Exception? exception = null)
-        => new(DateTimeOffset.UtcNow, category, level, default, message, exception, attributes);
+        Exception? exception = null,
+        HostLogExceptionDetails? exceptionDetails = null)
+    {
+        var entry = new HostLogEntry(DateTimeOffset.UtcNow, category, level, default, message, exception, attributes);
+        return exceptionDetails is not null ? entry with { ExceptionDetails = exceptionDetails } : entry;
+    }
 }

--- a/test/Func.Tests/Hosting/Dashboard/Rendering/CompactLogComponentsTests.cs
+++ b/test/Func.Tests/Hosting/Dashboard/Rendering/CompactLogComponentsTests.cs
@@ -97,8 +97,7 @@ public class CompactLogComponentsTests
                 TraceId: null,
                 Result: "failed",
                 DurationMs: 42,
-                ErrorType: "InvalidOperationException",
-                ErrorMessage: "Boom"),
+                Error: new HostLogExceptionDetails("InvalidOperationException", "Boom", null, null)),
         ];
 
         CompactLogLine line = formatter.Format(entry, events, listenUri: null)!;
@@ -109,6 +108,62 @@ public class CompactLogComponentsTests
         string output = Render(line.Renderable);
         Assert.Contains("InvalidOperationException", output);
         Assert.Contains("Boom", output);
+    }
+
+    [Fact]
+    public void Format_WithExceptionDetails_RendersSummaryAndKeepsShortCategory()
+    {
+        var formatter = new CompactLogLineFormatter(new DefaultTheme(), new FunctionPalette());
+        var exceptionDetails = new HostLogExceptionDetails(
+            "Microsoft.Azure.WebJobs.Script.Workers.WorkerProcessExitException",
+            "Language worker process exited.",
+            Stack: null,
+            InnerException: new HostLogExceptionDetails("System.InvalidOperationException", "A connection string was not found.", null, null));
+        var entry = new HostLogEntry(
+            DateTimeOffset.UnixEpoch,
+            "Grpc",
+            LogLevel.Error,
+            default,
+            "Language Worker Process exited.",
+            Exception: null,
+            HostLogEntry.EmptyAttributes)
+        {
+            ExceptionDetails = exceptionDetails,
+        };
+
+        CompactLogLine line = formatter.Format(entry, [], listenUri: null)!;
+
+        string output = RenderRows(line);
+        Assert.Null(line.FunctionName);
+        Assert.True(line.IsError);
+        Assert.Equal(LogLevel.Error, line.Level);
+        Assert.Contains("Grpc", output);
+        Assert.DoesNotContain("Microsoft.Azure.WebJobs.Script.Grpc", output);
+        Assert.Contains("Language Worker Process exited.", output);
+        Assert.Contains("Microsoft.Azure.WebJobs.Script.Workers.WorkerProcessExitException", output);
+        Assert.Contains("A connection string was not found.", output);
+    }
+
+    [Fact]
+    public void Format_WithExceptionDetailsOnly_RendersSummary()
+    {
+        var formatter = new CompactLogLineFormatter(new DefaultTheme(), new FunctionPalette());
+        var entry = new HostLogEntry(
+            DateTimeOffset.UnixEpoch,
+            "Grpc",
+            LogLevel.Error,
+            default,
+            string.Empty,
+            Exception: null,
+            HostLogEntry.EmptyAttributes)
+        {
+            ExceptionDetails = new HostLogExceptionDetails("System.InvalidOperationException", "A connection string was not found.", null, null),
+        };
+
+        CompactLogLine? line = formatter.Format(entry, [], listenUri: null);
+
+        Assert.NotNull(line);
+        Assert.Contains("A connection string was not found.", RenderRows(line));
     }
 
     [Fact]
@@ -157,8 +212,12 @@ public class CompactLogComponentsTests
             Interactive = InteractionSupport.No,
             Out = new AnsiConsoleOutput(writer),
         });
+        console.Profile.Width = 240;
 
         console.Write(renderable);
         return writer.ToString();
     }
+
+    private static string RenderRows(CompactLogLine line)
+        => string.Join(Environment.NewLine, line.RenderRows(width: 240).Select(Render));
 }

--- a/test/Func.Tests/Hosting/Dashboard/Rendering/CompactLogComponentsTests.cs
+++ b/test/Func.Tests/Hosting/Dashboard/Rendering/CompactLogComponentsTests.cs
@@ -111,7 +111,7 @@ public class CompactLogComponentsTests
     }
 
     [Fact]
-    public void Format_WithExceptionDetails_RendersSummaryAndKeepsShortCategory()
+    public void Format_WithExceptionDetails_RendersSummaryWithoutCategory()
     {
         var formatter = new CompactLogLineFormatter(new DefaultTheme(), new FunctionPalette());
         var exceptionDetails = new HostLogExceptionDetails(
@@ -137,8 +137,7 @@ public class CompactLogComponentsTests
         Assert.Null(line.FunctionName);
         Assert.True(line.IsError);
         Assert.Equal(LogLevel.Error, line.Level);
-        Assert.Contains("Grpc", output);
-        Assert.DoesNotContain("Microsoft.Azure.WebJobs.Script.Grpc", output);
+        Assert.DoesNotContain("Grpc", output);
         Assert.Contains("Language Worker Process exited.", output);
         Assert.Contains("Microsoft.Azure.WebJobs.Script.Workers.WorkerProcessExitException", output);
         Assert.Contains("A connection string was not found.", output);

--- a/test/Func.Tests/Hosting/Dashboard/Rendering/CompactLogComponentsTests.cs
+++ b/test/Func.Tests/Hosting/Dashboard/Rendering/CompactLogComponentsTests.cs
@@ -184,24 +184,6 @@ public class CompactLogComponentsTests
     }
 
     [Fact]
-    public void Format_WithOptionsLoggingService_SuppressesLine()
-    {
-        var formatter = new CompactLogLineFormatter(new DefaultTheme(), new FunctionPalette());
-        var entry = new HostLogEntry(
-            DateTimeOffset.UnixEpoch,
-            "Microsoft.Azure.WebJobs.Hosting.OptionsLoggingService",
-            LogLevel.Information,
-            new EventId(0),
-            "ConcurrencyOptions",
-            Exception: null,
-            HostLogEntry.EmptyAttributes);
-
-        CompactLogLine? line = formatter.Format(entry, [], listenUri: null);
-
-        Assert.Null(line);
-    }
-
-    [Fact]
     public void Format_WithInitializationStepLog_LabelsSourceAsInitialization()
     {
         var formatter = new CompactLogLineFormatter(new DefaultTheme(), new FunctionPalette());

--- a/test/Func.Tests/Hosting/Dashboard/Rendering/CompactLogComponentsTests.cs
+++ b/test/Func.Tests/Hosting/Dashboard/Rendering/CompactLogComponentsTests.cs
@@ -201,6 +201,51 @@ public class CompactLogComponentsTests
         Assert.Null(line);
     }
 
+    [Fact]
+    public void Format_WithInitializationStepLog_LabelsSourceAsInitialization()
+    {
+        var formatter = new CompactLogLineFormatter(new DefaultTheme(), new FunctionPalette());
+        var entry = new HostLogEntry(
+            DateTimeOffset.UnixEpoch,
+            "[startup]",
+            LogLevel.Information,
+            default,
+            "Resolving host workload",
+            Exception: null,
+            new Dictionary<string, object?>
+            {
+                [HostLogAttributeKeys.CliEventKind] = CliEventKinds.StartInitializationStepCompleted,
+            });
+
+        CompactLogLine line = formatter.Format(entry, [], listenUri: null)!;
+
+        string output = RenderRows(line);
+        Assert.Null(line.FunctionName);
+        Assert.Contains("Initialization", output);
+        Assert.Contains("Resolving host workload", output);
+    }
+
+    [Fact]
+    public void Format_WithPlainHostLog_DoesNotLabelInitialization()
+    {
+        var formatter = new CompactLogLineFormatter(new DefaultTheme(), new FunctionPalette());
+        var entry = new HostLogEntry(
+            DateTimeOffset.UnixEpoch,
+            "Host.Startup",
+            LogLevel.Information,
+            default,
+            "Reading host configuration",
+            Exception: null,
+            HostLogEntry.EmptyAttributes);
+
+        CompactLogLine line = formatter.Format(entry, [], listenUri: null)!;
+
+        string output = RenderRows(line);
+        Assert.Null(line.FunctionName);
+        Assert.DoesNotContain("Initialization", output);
+        Assert.Contains("Reading host configuration", output);
+    }
+
     private static string Render(IRenderable renderable)
     {
         using var writer = new StringWriter();

--- a/test/Func.Tests/Hosting/Dashboard/Rendering/JsonRendererTests.cs
+++ b/test/Func.Tests/Hosting/Dashboard/Rendering/JsonRendererTests.cs
@@ -89,6 +89,92 @@ public class JsonRendererTests
         Assert.Equal("host_state_changed", records[1].RootElement.GetProperty("kind").GetString());
     }
 
+    [Fact]
+    public async Task EmitsRemoteExceptionDetailsForLogsAndInvocationEvents()
+    {
+        var (renderer, stream) = NewRenderer();
+        var state = new DashboardState();
+        await renderer.OnStartAsync(state, default);
+        var exceptionDetails = new HostLogExceptionDetails(
+            "Microsoft.Azure.WebJobs.Host.FunctionInvocationException",
+            "Exception while executing function",
+            "outer stack",
+            new HostLogExceptionDetails("Worker.UserException", "inner boom", "inner stack", null));
+        var entry = new HostLogEntry(
+            DateTimeOffset.UtcNow,
+            "Function.HttpTrigger1.User",
+            LogLevel.Error,
+            default,
+            "Executed 'Functions.HttpTrigger1' (Failed, Id=id-1, Duration=10ms)",
+            new InvalidOperationException("placeholder"),
+            new Dictionary<string, object?>
+            {
+                [HostLogAttributeKeys.CliEventKind] = CliEventKinds.InvocationCompleted,
+                [HostLogAttributeKeys.FunctionName] = "HttpTrigger1",
+                [HostLogAttributeKeys.FunctionInvocationId] = "id-1",
+                [HostLogAttributeKeys.FunctionResult] = "failed",
+                [HostLogAttributeKeys.DurationMs] = 10.0,
+            })
+        {
+            ExceptionDetails = exceptionDetails,
+        };
+
+        await renderer.OnEventAsync(entry, state.Observe(entry), default);
+        await renderer.DisposeAsync();
+
+        IReadOnlyList<JsonDocument> records = ReadAll(stream);
+        JsonElement logException = records
+            .Single(doc => doc.RootElement.GetProperty("kind").GetString() == "log")
+            .RootElement
+            .GetProperty("exception");
+        Assert.Equal("Microsoft.Azure.WebJobs.Host.FunctionInvocationException", logException.GetProperty("type").GetString());
+        Assert.Equal("outer stack", logException.GetProperty("stack").GetString());
+        Assert.Equal("Worker.UserException", logException.GetProperty("inner_exception").GetProperty("type").GetString());
+        Assert.Equal("inner stack", logException.GetProperty("inner_exception").GetProperty("stack").GetString());
+
+        JsonElement eventError = records
+            .Single(doc => doc.RootElement.GetProperty("kind").GetString() == "invocation_completed")
+            .RootElement
+            .GetProperty("error");
+        Assert.Equal("Microsoft.Azure.WebJobs.Host.FunctionInvocationException", eventError.GetProperty("type").GetString());
+        Assert.Equal("Exception while executing function", eventError.GetProperty("message").GetString());
+        Assert.Equal("outer stack", eventError.GetProperty("stack").GetString());
+        Assert.Equal("Worker.UserException", eventError.GetProperty("inner_exception").GetProperty("type").GetString());
+        Assert.Equal("inner boom", eventError.GetProperty("inner_exception").GetProperty("message").GetString());
+        Assert.Equal("inner stack", eventError.GetProperty("inner_exception").GetProperty("stack").GetString());
+    }
+
+    [Fact]
+    public async Task EmitsExceptionOnlyLogRecords()
+    {
+        var (renderer, stream) = NewRenderer();
+        var exceptionDetails = new HostLogExceptionDetails(
+            "Microsoft.Azure.WebJobs.Script.Workers.WorkerProcessExitException",
+            "A connection string was not found. Please set your connection string.",
+            null,
+            null);
+        var entry = new HostLogEntry(
+            DateTimeOffset.UtcNow,
+            "Microsoft.Azure.WebJobs.Hosting.OptionsLoggingService",
+            LogLevel.Error,
+            default,
+            string.Empty,
+            null,
+            new Dictionary<string, object?>())
+        {
+            ExceptionDetails = exceptionDetails,
+        };
+
+        await renderer.OnEventAsync(entry, [], default);
+        await renderer.DisposeAsync();
+
+        JsonElement exception = Assert.Single(ReadAll(stream))
+            .RootElement
+            .GetProperty("exception");
+        Assert.Equal("Microsoft.Azure.WebJobs.Script.Workers.WorkerProcessExitException", exception.GetProperty("type").GetString());
+        Assert.Equal("A connection string was not found. Please set your connection string.", exception.GetProperty("message").GetString());
+    }
+
     private static (JsonRenderer renderer, MemoryStream stream) NewRenderer()
     {
         var stream = new MemoryStream();

--- a/test/Func.Tests/Hosting/Dashboard/Rendering/PlainRendererTests.cs
+++ b/test/Func.Tests/Hosting/Dashboard/Rendering/PlainRendererTests.cs
@@ -105,7 +105,7 @@ public class PlainRendererTests
     }
 
     [Fact]
-    public async Task LogEnvelope_WithExceptionDetails_RendersSummaryAndKeepsShortCategory()
+    public async Task LogEnvelope_WithExceptionDetails_RendersSummaryWithoutCategory()
     {
         (PlainRenderer renderer, StringWriter writer, _) = NewRenderer();
         var state = new DashboardState();
@@ -127,8 +127,7 @@ public class PlainRendererTests
         await renderer.OnEventAsync(entry, state.Observe(entry), default);
 
         string output = writer.ToString();
-        Assert.Contains("Grpc", output);
-        Assert.DoesNotContain("Microsoft.Azure.WebJobs.Script.Grpc", output);
+        Assert.DoesNotContain("Grpc", output);
         Assert.Contains("WorkerProcessExitException", output);
         Assert.Contains("A connection string was not found.", output);
     }
@@ -148,7 +147,7 @@ public class PlainRendererTests
         await renderer.OnEventAsync(entry, state.Observe(entry), default);
 
         string output = writer.ToString();
-        Assert.Contains("Grpc", output);
+        Assert.DoesNotContain("Grpc", output);
         Assert.Contains("A connection string was not found.", output);
     }
 

--- a/test/Func.Tests/Hosting/Dashboard/Rendering/PlainRendererTests.cs
+++ b/test/Func.Tests/Hosting/Dashboard/Rendering/PlainRendererTests.cs
@@ -72,6 +72,86 @@ public class PlainRendererTests
         Assert.DoesNotContain("\u001b]8;", output);
     }
 
+    [Fact]
+    public async Task FailedInvocation_RendersExceptionSummaryOnce()
+    {
+        (PlainRenderer renderer, StringWriter writer, _) = NewRenderer();
+        var state = new DashboardState();
+        var exceptionDetails = new HostLogExceptionDetails(
+            "Microsoft.Azure.WebJobs.Script.Workers.WorkerProcessExitException",
+            "Language worker process exited.",
+            Stack: null,
+            InnerException: new HostLogExceptionDetails("System.InvalidOperationException", "A connection string was not found.", null, null));
+        HostLogEntry entry = MakeEntry(
+            new Dictionary<string, object?>
+            {
+                [HostLogAttributeKeys.CliEventKind] = CliEventKinds.InvocationCompleted,
+                [HostLogAttributeKeys.FunctionName] = "HttpTrigger1",
+                [HostLogAttributeKeys.FunctionInvocationId] = "11111111-1111-1111-1111-111111111111",
+                [HostLogAttributeKeys.FunctionResult] = "failed",
+                [HostLogAttributeKeys.DurationMs] = 10d,
+            },
+            category: "Function.HttpTrigger1",
+            level: LogLevel.Error,
+            message: "Executed 'Functions.HttpTrigger1' (Failed, Id=11111111-1111-1111-1111-111111111111, Duration=10ms)",
+            exceptionDetails: exceptionDetails);
+
+        await renderer.OnEventAsync(entry, state.Observe(entry), default);
+
+        string output = writer.ToString();
+        Assert.Contains("[invocation end]", output);
+        Assert.Contains("WorkerProcessExitException", output);
+        Assert.Equal(1, CountOccurrences(output, "A connection string was not found."));
+    }
+
+    [Fact]
+    public async Task LogEnvelope_WithExceptionDetails_RendersSummaryAndKeepsShortCategory()
+    {
+        (PlainRenderer renderer, StringWriter writer, _) = NewRenderer();
+        var state = new DashboardState();
+        var exceptionDetails = new HostLogExceptionDetails(
+            "Microsoft.Azure.WebJobs.Script.Workers.WorkerProcessExitException",
+            "Language worker process exited.",
+            Stack: null,
+            InnerException: new HostLogExceptionDetails("System.InvalidOperationException", "A connection string was not found.", null, null));
+        HostLogEntry entry = MakeEntry(
+            new Dictionary<string, object?>
+            {
+                [HostLogAttributeKeys.CliEventKind] = CliEventKinds.Log,
+            },
+            category: "Grpc",
+            level: LogLevel.Error,
+            message: "Executed 'Functions.HttpTrigger1' (Failed, Id=11111111-1111-1111-1111-111111111111, Duration=10ms)",
+            exceptionDetails: exceptionDetails);
+
+        await renderer.OnEventAsync(entry, state.Observe(entry), default);
+
+        string output = writer.ToString();
+        Assert.Contains("Grpc", output);
+        Assert.DoesNotContain("Microsoft.Azure.WebJobs.Script.Grpc", output);
+        Assert.Contains("WorkerProcessExitException", output);
+        Assert.Contains("A connection string was not found.", output);
+    }
+
+    [Fact]
+    public async Task Log_WithExceptionDetailsOnly_RendersSummary()
+    {
+        (PlainRenderer renderer, StringWriter writer, _) = NewRenderer();
+        var state = new DashboardState();
+        HostLogEntry entry = MakeEntry(
+            [],
+            category: "Grpc",
+            level: LogLevel.Error,
+            message: string.Empty,
+            exceptionDetails: new HostLogExceptionDetails("System.InvalidOperationException", "A connection string was not found.", null, null));
+
+        await renderer.OnEventAsync(entry, state.Observe(entry), default);
+
+        string output = writer.ToString();
+        Assert.Contains("Grpc", output);
+        Assert.Contains("A connection string was not found.", output);
+    }
+
     private static async Task PumpScenarioAsync(PlainRenderer renderer)
     {
         var state = new DashboardState();
@@ -110,10 +190,23 @@ public class PlainRendererTests
             Interactive = InteractionSupport.No,
             Out = new AnsiConsoleOutput(writer),
         });
+        console.Profile.Width = 240;
+
         var interaction = new SpectreInteractionService(new DefaultTheme(), console, console);
         return (new PlainRenderer(interaction, console), writer, console);
     }
 
-    private static HostLogEntry MakeEntry(Dictionary<string, object?> attrs)
-        => new(DateTimeOffset.UtcNow, "Host.Lifecycle", LogLevel.Information, default, "msg", null, attrs);
+    private static HostLogEntry MakeEntry(
+        Dictionary<string, object?> attrs,
+        string category = "Host.Lifecycle",
+        LogLevel level = LogLevel.Information,
+        string message = "msg",
+        HostLogExceptionDetails? exceptionDetails = null)
+    {
+        var entry = new HostLogEntry(DateTimeOffset.UtcNow, category, level, default, message, null, attrs);
+        return exceptionDetails is not null ? entry with { ExceptionDetails = exceptionDetails } : entry;
+    }
+
+    private static int CountOccurrences(string value, string search)
+        => (value.Length - value.Replace(search, string.Empty, StringComparison.Ordinal).Length) / search.Length;
 }

--- a/test/Workloads/Host.Tests/HostStructuredEventWriterTests.cs
+++ b/test/Workloads/Host.Tests/HostStructuredEventWriterTests.cs
@@ -95,6 +95,31 @@ public sealed class HostStructuredEventWriterTests
     }
 
     [Fact]
+    public void WriteLog_WithNestedException_WritesInnerExceptionDetails()
+    {
+        using var writer = new StringWriter(CultureInfo.InvariantCulture);
+        var exception = new InvalidOperationException("outer failure", new Exception("inner failure"));
+
+        HostStructuredEventWriter.WriteLog(
+            "Function.HttpTrigger1.User",
+            LogLevel.Error,
+            new EventId(0),
+            "Invocation failed",
+            new Dictionary<string, object?>(StringComparer.Ordinal),
+            exception,
+            writer: writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        JsonElement exceptionJson = document.RootElement.GetProperty("exception");
+        Assert.Equal(typeof(InvalidOperationException).FullName, exceptionJson.GetProperty("type").GetString());
+        Assert.Equal("outer failure", exceptionJson.GetProperty("message").GetString());
+
+        JsonElement innerExceptionJson = exceptionJson.GetProperty("inner_exception");
+        Assert.Equal(typeof(Exception).FullName, innerExceptionJson.GetProperty("type").GetString());
+        Assert.Equal("inner failure", innerExceptionJson.GetProperty("message").GetString());
+    }
+
+    [Fact]
     public void WriteFunctionDiscovered_EmitsDashboardMetadata()
     {
         using var writer = new StringWriter(CultureInfo.InvariantCulture);

--- a/test/Workloads/Host.Tests/HostStructuredScriptLoggingBuilderTests.cs
+++ b/test/Workloads/Host.Tests/HostStructuredScriptLoggingBuilderTests.cs
@@ -17,6 +17,7 @@ public sealed class HostStructuredScriptLoggingBuilderTests
     private const string SharedMemoryWarningCategory =
         "Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer.MemoryMappedFileAccessor";
     private const string SystemTraceMiddlewareCategory = "Microsoft.Azure.WebJobs.Script.WebHost.Middleware.SystemTraceMiddleware";
+    private const string OptionsLoggingCategory = "Microsoft.Azure.WebJobs.Hosting.OptionsLoggingService";
 
     [Fact]
     public void Configure_RegistersStructuredLoggerProvider()
@@ -39,6 +40,9 @@ public sealed class HostStructuredScriptLoggingBuilderTests
     [InlineData(AppInsightsExtensionWarningCategory, LogLevel.Error, true)]
     [InlineData(SharedMemoryWarningCategory, LogLevel.Warning, false)]
     [InlineData(SharedMemoryWarningCategory, LogLevel.Error, true)]
+    [InlineData(OptionsLoggingCategory, LogLevel.Warning, false)]
+    [InlineData(OptionsLoggingCategory, LogLevel.Error, false)]
+    [InlineData(OptionsLoggingCategory, LogLevel.Critical, false)]
     public void Configure_AppliesCategoryLogLevelFilters(string category, LogLevel logLevel, bool expected)
     {
         var services = new ServiceCollection();


### PR DESCRIPTION
### Issue describing the changes in this PR

<!-- No tracking issue; please link one if applicable. -->

Refines the `func start` dashboard log experience to reduce noise and improve details and readability. Builds on the host structured-log filtering already merged via #5191.

Fixes #5178

**Changes (one per commit):**
- **Preserve and surface nested host exception details** - capture the full inner-exception chain from host structured records and render it across the Compact/Plain/Json renderers. Introduces `HostLogExceptionDetails` (a descriptor record, intentionally **not** named `*Exception` since it is not throwable).
- **Drop log category from dashboard renderers for host/system logs** - host/system categories are no longer printed; user/function context is surfaced instead.
- **Use a single bullet glyph for dashboard log level markers** - replaces the per-level glyphs (`·`/`!`/`✗`) with a single `●` colored by level.
- **Separate multi-line dashboard log entries with a blank row** - improves readability of multi-line entries in the Compact view (conditional; Plain stays dense).
- **Align category-less dashboard logs and label initialization steps** - category-less host logs are aligned to the source column, and startup initialization-step logs are labeled `Initialization`.
- **Consolidate OptionsLoggingService suppression in the host log filter** - moves the `Microsoft.Azure.WebJobs.Hosting.OptionsLoggingService` startup options-dump suppression out of all three renderers and into the host workload's category filter at `LogLevel.None`, matching how `Azure.`/`Yarp.`/`Microsoft.AspNetCore.` are handled.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [x] Otherwise: `docs/func-start-json-schema.md` is updated in this PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)
