### PR TITLE
Fabiocav/project startup updates

### DIFF
--- a/src/Abstractions/Projects/FunctionsProjectHostRunContext.cs
+++ b/src/Abstractions/Projects/FunctionsProjectHostRunContext.cs
@@ -11,6 +11,7 @@ public sealed class FunctionsProjectHostRunContext
     public const string WorkerRuntimeEnvironmentVariable = "FUNCTIONS_WORKER_RUNTIME";
 
     private DirectoryInfo _startupDirectory;
+    private IFunctionsProjectHostRunReporter _reporter = NullFunctionsProjectHostRunReporter.Instance;
 
     public FunctionsProjectHostRunContext(
         DirectoryInfo startupDirectory,
@@ -34,6 +35,12 @@ public sealed class FunctionsProjectHostRunContext
     }
 
     public IDictionary<string, string> EnvironmentVariables { get; }
+
+    public IFunctionsProjectHostRunReporter Reporter
+    {
+        get => _reporter;
+        set => _reporter = value ?? throw new ArgumentNullException(nameof(value));
+    }
 
     /// <summary>
     /// When <c>true</c>, project pre-run hooks should skip optional build/restore steps

--- a/src/Abstractions/Projects/FunctionsProjectReportSeverity.cs
+++ b/src/Abstractions/Projects/FunctionsProjectReportSeverity.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Projects;
+
+/// <summary>
+/// Describes the severity of project host-run output.
+/// </summary>
+public enum FunctionsProjectReportSeverity
+{
+    Info,
+    Warning,
+    Error,
+}

--- a/src/Abstractions/Projects/IFunctionsProjectHostRunReporter.cs
+++ b/src/Abstractions/Projects/IFunctionsProjectHostRunReporter.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Projects;
+
+/// <summary>
+/// Reports project preparation status, progress, and log output before the host starts.
+/// </summary>
+public interface IFunctionsProjectHostRunReporter
+{
+    public void ReportStatus(string message);
+
+    public void ReportProgress(double percent, string? message = null);
+
+    public void WriteLog(string line, FunctionsProjectReportSeverity severity = FunctionsProjectReportSeverity.Info);
+}

--- a/src/Abstractions/Projects/IFunctionsProjectHostRunReporter.cs
+++ b/src/Abstractions/Projects/IFunctionsProjectHostRunReporter.cs
@@ -4,13 +4,11 @@
 namespace Azure.Functions.Cli.Projects;
 
 /// <summary>
-/// Reports project preparation status, progress, and log output before the host starts.
+/// Reports project preparation status and log output before the host starts.
 /// </summary>
 public interface IFunctionsProjectHostRunReporter
 {
     public void ReportStatus(string message);
-
-    public void ReportProgress(double percent, string? message = null);
 
     public void WriteLog(string line, FunctionsProjectReportSeverity severity = FunctionsProjectReportSeverity.Info);
 }

--- a/src/Abstractions/Projects/NullFunctionsProjectHostRunReporter.cs
+++ b/src/Abstractions/Projects/NullFunctionsProjectHostRunReporter.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Projects;
+
+/// <summary>
+/// Discards project host-run reports.
+/// </summary>
+public sealed class NullFunctionsProjectHostRunReporter : IFunctionsProjectHostRunReporter
+{
+    public static NullFunctionsProjectHostRunReporter Instance { get; } = new();
+
+    private NullFunctionsProjectHostRunReporter()
+    {
+    }
+
+    public void ReportStatus(string message)
+    {
+    }
+
+    public void ReportProgress(double percent, string? message = null)
+    {
+    }
+
+    public void WriteLog(string line, FunctionsProjectReportSeverity severity = FunctionsProjectReportSeverity.Info)
+    {
+    }
+}

--- a/src/Abstractions/Projects/NullFunctionsProjectHostRunReporter.cs
+++ b/src/Abstractions/Projects/NullFunctionsProjectHostRunReporter.cs
@@ -18,10 +18,6 @@ public sealed class NullFunctionsProjectHostRunReporter : IFunctionsProjectHostR
     {
     }
 
-    public void ReportProgress(double percent, string? message = null)
-    {
-    }
-
     public void WriteLog(string line, FunctionsProjectReportSeverity severity = FunctionsProjectReportSeverity.Info)
     {
     }

--- a/src/Func/Commands/Start/Dashboard/Demo/DemoStartInitializationRunner.cs
+++ b/src/Func/Commands/Start/Dashboard/Demo/DemoStartInitializationRunner.cs
@@ -131,7 +131,16 @@ internal sealed class DemoStartInitializationRunner(
             await EmitAsync(renderer, new StartInitializationStepStartedEvent(Now(), new StartInitializationStep(step)), cancellationToken);
 
             var stepContext = new StartInitializationStepContext(context, state, step, renderer, _time);
-            StartInitializationStepResult result = await step.ExecuteAsync(stepContext, cancellationToken);
+            StartInitializationStepResult result;
+            try
+            {
+                result = await step.ExecuteAsync(stepContext, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                await EmitAsync(renderer, new StartInitializationStepFailedEvent(Now(), step.Id, ex.Message), cancellationToken);
+                throw;
+            }
 
             await EmitAsync(renderer, new StartInitializationStepCompletedEvent(Now(), step.Id, result.Message), cancellationToken);
 

--- a/src/Func/Commands/Start/Dashboard/Rendering/Initialization/CompactStartInitializationRenderer.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/Initialization/CompactStartInitializationRenderer.cs
@@ -53,8 +53,14 @@ internal sealed class CompactStartInitializationRenderer(
                 case StartInitializationProgressEvent progress:
                     UpdateProgress(progress);
                     break;
+                case StartInitializationLogEvent log:
+                    WriteLog(log);
+                    break;
                 case StartInitializationStepCompletedEvent completed:
                     CompleteStep(completed);
+                    break;
+                case StartInitializationStepFailedEvent failed:
+                    FailStep(failed);
                     break;
                 case StartInitializationCompletedEvent:
                     liveTaskToStop = _liveTask;
@@ -149,10 +155,30 @@ internal sealed class CompactStartInitializationRenderer(
             return;
         }
 
-        step.Percent = Math.Clamp(progress.Percent, 0, 100);
+        if (!double.IsNaN(progress.Percent))
+        {
+            step.Percent = Math.Clamp(progress.Percent, 0, 100);
+            step.HasProgress = true;
+        }
+
         if (!string.IsNullOrWhiteSpace(progress.Message))
         {
             step.Message = progress.Message;
+        }
+    }
+
+    private void WriteLog(StartInitializationLogEvent log)
+    {
+        if (FindStep(log.StepId) is not { } step)
+        {
+            return;
+        }
+
+        step.TotalLogLineCount++;
+        step.LogLines.Enqueue(log.Line);
+        while (step.LogLines.Count > StepState.LogTailCapacity)
+        {
+            step.LogLines.Dequeue();
         }
     }
 
@@ -165,7 +191,23 @@ internal sealed class CompactStartInitializationRenderer(
 
         step.Completed = true;
         step.Percent = 100;
+        step.HasProgress = true;
         step.Result = completed.Message;
+        if (ReferenceEquals(_activeStep, step))
+        {
+            _activeStep = null;
+        }
+    }
+
+    private void FailStep(StartInitializationStepFailedEvent failed)
+    {
+        if (FindStep(failed.StepId) is not { } step)
+        {
+            return;
+        }
+
+        step.Failed = true;
+        step.Result = failed.Message;
         if (ReferenceEquals(_activeStep, step))
         {
             _activeStep = null;
@@ -232,7 +274,16 @@ internal sealed class CompactStartInitializationRenderer(
             spinnerFrameIndex = _spinnerFrameIndex;
             steps =
             [
-                .. _steps.Select(static step => new StepSnapshot(step.Step, step.Percent, step.Completed, step.Message, step.Result))
+                .. _steps.Select(static step => new StepSnapshot(
+                    step.Step,
+                    step.Percent,
+                    step.HasProgress,
+                    step.Completed,
+                    step.Failed,
+                    step.Message,
+                    step.Result,
+                    step.TotalLogLineCount,
+                    [.. step.LogLines]))
             ];
         }
 
@@ -246,6 +297,10 @@ internal sealed class CompactStartInitializationRenderer(
         foreach (StepSnapshot step in steps)
         {
             rows.Add(new Markup(BuildStepMarkup(step, spinnerFrameIndex)));
+            foreach (string logRow in BuildLogRows(step))
+            {
+                rows.Add(new Markup(logRow));
+            }
         }
 
         return new Rows(rows);
@@ -255,15 +310,17 @@ internal sealed class CompactStartInitializationRenderer(
     {
         string icon = step.Completed
             ? Styled(CompletedIcon, Theme.Success)
+            : step.Failed
+            ? Styled(FailedIcon, Theme.Error)
             : Styled(GetSpinnerFrame(spinnerFrameIndex), Theme.Active);
 
         string title = Markup.Escape(FormatStepTitle(step));
 
-        string progress = step.Step.DisplayKind == StartInitializationDisplayKind.Progress && !step.Completed
+        string progress = step.Step.DisplayKind == StartInitializationDisplayKind.Progress && !step.Completed && !step.Failed && step.HasProgress
             ? $" {FormatProgress(step.Percent)}"
             : string.Empty;
 
-        if (step.Completed)
+        if (step.Completed || step.Failed)
         {
             string result = step.Result is null
                 ? string.Empty
@@ -278,6 +335,25 @@ internal sealed class CompactStartInitializationRenderer(
                 : $" [dim]({Markup.Escape(step.Message)})[/]";
 
             return $"{icon} [dim]{title}[/]{progress}{message}";
+        }
+    }
+
+    private IEnumerable<string> BuildLogRows(StepSnapshot step)
+    {
+        if (step.TotalLogLineCount == 0)
+        {
+            yield break;
+        }
+
+        if (step.Completed && !step.Failed)
+        {
+            yield return $"  [dim]{LogSummaryPrefix} {step.TotalLogLineCount:0} lines\u2026[/]";
+            yield break;
+        }
+
+        foreach (string line in step.LogLines)
+        {
+            yield return $"  [dim]{LogGutter} {Markup.Escape(line)}[/]";
         }
     }
 
@@ -299,6 +375,12 @@ internal sealed class CompactStartInitializationRenderer(
     }
 
     private string CompletedIcon => _console.Profile.Capabilities.Unicode ? "\u2713" : "[x]";
+
+    private string FailedIcon => _console.Profile.Capabilities.Unicode ? "\u00d7" : "[!]";
+
+    private string LogGutter => _console.Profile.Capabilities.Unicode ? "\u2502" : "|";
+
+    private string LogSummaryPrefix => _console.Profile.Capabilities.Unicode ? "\u2514" : "`";
 
     private char ProgressCompleteCharacter => _console.Profile.Capabilities.Unicode ? '\u2501' : '=';
 
@@ -358,16 +440,35 @@ internal sealed class CompactStartInitializationRenderer(
 
     private sealed class StepState(StartInitializationStep step)
     {
+        public const int LogTailCapacity = 10;
+
         public StartInitializationStep Step { get; } = step;
 
         public double Percent { get; set; }
 
+        public bool HasProgress { get; set; }
+
         public bool Completed { get; set; }
+
+        public bool Failed { get; set; }
 
         public string? Message { get; set; }
 
         public string? Result { get; internal set; }
+
+        public Queue<string> LogLines { get; } = [];
+
+        public int TotalLogLineCount { get; set; }
     }
 
-    private sealed record StepSnapshot(StartInitializationStep Step, double Percent, bool Completed, string? Message, string? Result);
+    private sealed record StepSnapshot(
+        StartInitializationStep Step,
+        double Percent,
+        bool HasProgress,
+        bool Completed,
+        bool Failed,
+        string? Message,
+        string? Result,
+        int TotalLogLineCount,
+        IReadOnlyList<string> LogLines);
 }

--- a/src/Func/Commands/Start/Dashboard/Rendering/Initialization/CompactStartInitializationRenderer.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/Initialization/CompactStartInitializationRenderer.cs
@@ -347,7 +347,7 @@ internal sealed class CompactStartInitializationRenderer(
 
         if (step.Completed && !step.Failed)
         {
-            yield return $"  [dim]{LogSummaryPrefix} {step.TotalLogLineCount:0} lines\u2026[/]";
+            yield return $"  [dim]{LogSummaryPrefix} {step.TotalLogLineCount:0} lines{Ellipsis}[/]";
             yield break;
         }
 
@@ -381,6 +381,8 @@ internal sealed class CompactStartInitializationRenderer(
     private string LogGutter => _console.Profile.Capabilities.Unicode ? "\u2502" : "|";
 
     private string LogSummaryPrefix => _console.Profile.Capabilities.Unicode ? "\u2514" : "`";
+
+    private string Ellipsis => _console.Profile.Capabilities.Unicode ? "\u2026" : "...";
 
     private char ProgressCompleteCharacter => _console.Profile.Capabilities.Unicode ? '\u2501' : '=';
 

--- a/src/Func/Commands/Start/Dashboard/Rendering/Initialization/CompactStartInitializationRenderer.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/Initialization/CompactStartInitializationRenderer.cs
@@ -28,6 +28,7 @@ internal sealed class CompactStartInitializationRenderer(
     private CancellationTokenSource? _liveCts;
     private Task? _liveTask;
     private int _spinnerFrameIndex;
+    private bool _hasFailure;
     private bool _disposed;
 
     private ITheme Theme => _interaction.Theme;
@@ -208,6 +209,7 @@ internal sealed class CompactStartInitializationRenderer(
 
         step.Failed = true;
         step.Result = failed.Message;
+        _hasFailure = true;
         if (ReferenceEquals(_activeStep, step))
         {
             _activeStep = null;
@@ -334,7 +336,7 @@ internal sealed class CompactStartInitializationRenderer(
                 ? string.Empty
                 : $" [dim]({Markup.Escape(step.Message)})[/]";
 
-            return $"{icon} [dim]{title}[/]{progress}{message}";
+            return $"{icon} {title}{progress}{message}";
         }
     }
 
@@ -345,16 +347,45 @@ internal sealed class CompactStartInitializationRenderer(
             yield break;
         }
 
+        // On success the step's title line already carries the curated result, so collapse the log area
+        // entirely (including the line-count footer) to keep the completed checklist to one line per step.
         if (step.Completed && !step.Failed)
         {
-            yield return $"  [dim]{LogSummaryPrefix} {step.TotalLogLineCount:0} lines{Ellipsis}[/]";
             yield break;
         }
 
+        // While the step is still running (or has failed), show the tail of the log with a connecting
+        // gutter and anchor it with a corner-glyph footer carrying the running line count.
         foreach (string line in step.LogLines)
         {
-            yield return $"  [dim]{LogGutter} {Markup.Escape(line)}[/]";
+            yield return $"  [dim]{LogGutter} {Markup.Escape(TruncateToWidth(line))}[/]";
         }
+
+        yield return $"  [dim]{LogSummaryPrefix} {FormatLineCount(step.TotalLogLineCount)}[/]";
+    }
+
+    private static string FormatLineCount(int count)
+        => count == 1 ? "1 line" : $"{count} lines";
+
+    private string TruncateToWidth(string line)
+    {
+        // Account for the two-space indent, the gutter glyph, and the trailing space before the text so a
+        // long line is clipped instead of wrapping onto the next row, which would break the gutter column.
+        const int gutterWidth = 4;
+        int available = _console.Profile.Width - gutterWidth;
+        if (available <= 0)
+        {
+            return string.Empty;
+        }
+
+        if (line.Length <= available)
+        {
+            return line;
+        }
+
+        string ellipsis = Ellipsis;
+        int keep = Math.Max(0, available - ellipsis.Length);
+        return string.Concat(line.AsSpan(0, keep), ellipsis);
     }
 
     private string FormatProgress(double percent)
@@ -407,11 +438,13 @@ internal sealed class CompactStartInitializationRenderer(
 
         Task? liveTaskToStop;
         CancellationTokenSource? liveCtsToStop;
+        bool hasFailure;
         lock (_stateLock)
         {
             _disposed = true;
             liveTaskToStop = _liveTask;
             liveCtsToStop = _liveCts;
+            hasFailure = _hasFailure;
             _liveTask = null;
             _liveCts = null;
         }
@@ -419,6 +452,14 @@ internal sealed class CompactStartInitializationRenderer(
         if (liveTaskToStop is not null)
         {
             await StopLiveDisplayAsync(liveTaskToStop, liveCtsToStop!, CancellationToken.None);
+
+            // The live display is configured with AutoClear, so stopping it erases the rendered frame.
+            // When a step failed there is no completion hand-off to the dashboard, so re-render the final
+            // frame statically to keep the failed checklist and its log tail on screen for the user.
+            if (hasFailure)
+            {
+                WritePromptContext();
+            }
         }
 
         _redrawSignal.Dispose();

--- a/src/Func/Commands/Start/Dashboard/Rendering/Initialization/JsonStartInitializationRenderer.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/Initialization/JsonStartInitializationRenderer.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Text.Json;
 using Azure.Functions.Cli.Commands.Start.Initialization;
 using Azure.Functions.Cli.Hosting.Events;
+using Azure.Functions.Cli.Projects;
 
 namespace Azure.Functions.Cli.Commands.Start.Initialization.Rendering;
 
@@ -65,11 +66,23 @@ internal sealed class JsonStartInitializationRenderer : IStartInitializationRend
                 WriteRecord(CliEventKinds.StartInitializationProgress, progress.Timestamp, writer =>
                 {
                     writer.WriteString("step", progress.StepId);
-                    writer.WriteNumber("percent", Math.Round(progress.Percent, 3));
+                    if (!double.IsNaN(progress.Percent))
+                    {
+                        writer.WriteNumber("percent", Math.Round(progress.Percent, 3));
+                    }
+
                     if (!string.IsNullOrWhiteSpace(progress.Message))
                     {
                         writer.WriteString("message", progress.Message);
                     }
+                });
+                break;
+            case StartInitializationLogEvent log:
+                WriteRecord(CliEventKinds.StartInitializationLog, log.Timestamp, writer =>
+                {
+                    writer.WriteString("step", log.StepId);
+                    writer.WriteString("line", log.Line);
+                    writer.WriteString("severity", FormatSeverity(log.Severity));
                 });
                 break;
             case StartInitializationStepCompletedEvent completed:
@@ -79,6 +92,16 @@ internal sealed class JsonStartInitializationRenderer : IStartInitializationRend
                     if (!string.IsNullOrWhiteSpace(completed.Message))
                     {
                         writer.WriteString("message", completed.Message);
+                    }
+                });
+                break;
+            case StartInitializationStepFailedEvent failed:
+                WriteRecord(CliEventKinds.StartInitializationStepFailed, failed.Timestamp, writer =>
+                {
+                    writer.WriteString("step", failed.StepId);
+                    if (!string.IsNullOrWhiteSpace(failed.Message))
+                    {
+                        writer.WriteString("message", failed.Message);
                     }
                 });
                 break;
@@ -130,6 +153,9 @@ internal sealed class JsonStartInitializationRenderer : IStartInitializationRend
 
     private static string FormatDisplayKind(StartInitializationDisplayKind kind)
         => kind.ToString().ToLowerInvariant();
+
+    private static string FormatSeverity(FunctionsProjectReportSeverity severity)
+        => severity.ToString().ToLowerInvariant();
 
     private static void WriteProfile(Utf8JsonWriter writer, StartInitializationProfileInfo profile)
     {

--- a/src/Func/Commands/Start/Dashboard/Rendering/Initialization/PlainStartInitializationRenderer.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/Initialization/PlainStartInitializationRenderer.cs
@@ -26,10 +26,16 @@ internal sealed class PlainStartInitializationRenderer(IInteractionService inter
                 _interaction.WriteLine($"[init] {step.Step.Title}");
                 break;
             case StartInitializationProgressEvent progress:
-                _interaction.WriteLine($"[init] {progress.StepId} {progress.Percent:0}% {progress.Message}".TrimEnd());
+                _interaction.WriteLine(FormatProgress(progress));
+                break;
+            case StartInitializationLogEvent log:
+                _interaction.WriteLine($"[init] {log.StepId}  {log.Line}");
                 break;
             case StartInitializationStepCompletedEvent completed:
                 _interaction.WriteLine($"[init] {completed.StepId} complete{FormatMessage(completed.Message)}");
+                break;
+            case StartInitializationStepFailedEvent failed:
+                _interaction.WriteLine($"[init] {failed.StepId} failed{FormatMessage(failed.Message)}");
                 break;
             case StartInitializationCompletedEvent completed:
                 _interaction.WriteLine(
@@ -47,6 +53,11 @@ internal sealed class PlainStartInitializationRenderer(IInteractionService inter
 
     private static string FormatMessage(string? message)
         => string.IsNullOrWhiteSpace(message) ? string.Empty : $": {message}";
+
+    private static string FormatProgress(StartInitializationProgressEvent progress)
+        => double.IsNaN(progress.Percent)
+            ? $"[init] {progress.StepId} {progress.Message}".TrimEnd()
+            : $"[init] {progress.StepId} {progress.Percent:0}% {progress.Message}".TrimEnd();
 
     private static string FormatProfile(StartInitializationProfileInfo? profile)
         => profile is null

--- a/src/Func/Commands/Start/Initialization/FunctionsProjectHostRunReporter.cs
+++ b/src/Func/Commands/Start/Initialization/FunctionsProjectHostRunReporter.cs
@@ -1,0 +1,88 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Threading.Channels;
+using Azure.Functions.Cli.Projects;
+
+namespace Azure.Functions.Cli.Commands.Start.Initialization;
+
+/// <summary>
+/// Bridges synchronous project reports into the asynchronous initialization renderer.
+/// </summary>
+internal sealed class FunctionsProjectHostRunReporter : IFunctionsProjectHostRunReporter, IAsyncDisposable
+{
+    private readonly StartInitializationStepContext _context;
+    private readonly CancellationToken _cancellationToken;
+    private readonly Channel<Func<CancellationToken, Task>> _reports = Channel.CreateUnbounded<Func<CancellationToken, Task>>(new UnboundedChannelOptions
+    {
+        SingleReader = true,
+        SingleWriter = false,
+        AllowSynchronousContinuations = false,
+    });
+    private readonly Task _reader;
+
+    public FunctionsProjectHostRunReporter(StartInitializationStepContext context, CancellationToken cancellationToken)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _cancellationToken = cancellationToken;
+        _reader = Task.Run(ProcessReportsAsync, CancellationToken.None);
+    }
+
+    public void ReportStatus(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return;
+        }
+
+        Enqueue(ct => _context.ReportStatusAsync(message, ct));
+    }
+
+    public void ReportProgress(double percent, string? message = null)
+        => Enqueue(ct => _context.ReportProgressAsync(percent, message, ct));
+
+    public void WriteLog(string line, FunctionsProjectReportSeverity severity = FunctionsProjectReportSeverity.Info)
+    {
+        if (line is null)
+        {
+            return;
+        }
+
+        Enqueue(ct => _context.ReportLogAsync(line, severity, ct));
+    }
+
+    public async Task CompleteAsync()
+    {
+        _reports.Writer.TryComplete();
+        await _reader;
+    }
+
+    public async ValueTask DisposeAsync()
+        => await CompleteAsync();
+
+    private void Enqueue(Func<CancellationToken, Task> report)
+    {
+        if (!_reports.Writer.TryWrite(report))
+        {
+            return;
+        }
+    }
+
+    private async Task ProcessReportsAsync()
+    {
+        await foreach (Func<CancellationToken, Task> report in _reports.Reader.ReadAllAsync(CancellationToken.None))
+        {
+            try
+            {
+                await report(_cancellationToken);
+            }
+            catch (OperationCanceledException) when (_cancellationToken.IsCancellationRequested)
+            {
+            }
+            catch (Exception)
+            {
+                // Project reporting is best-effort UI feedback; renderer failures must not escape into workload preparation.
+            }
+        }
+    }
+}

--- a/src/Func/Commands/Start/Initialization/FunctionsProjectHostRunReporter.cs
+++ b/src/Func/Commands/Start/Initialization/FunctionsProjectHostRunReporter.cs
@@ -38,9 +38,6 @@ internal sealed class FunctionsProjectHostRunReporter : IFunctionsProjectHostRun
         Enqueue(ct => _context.ReportStatusAsync(message, ct));
     }
 
-    public void ReportProgress(double percent, string? message = null)
-        => Enqueue(ct => _context.ReportProgressAsync(percent, message, ct));
-
     public void WriteLog(string line, FunctionsProjectReportSeverity severity = FunctionsProjectReportSeverity.Info)
     {
         if (line is null)

--- a/src/Func/Commands/Start/Initialization/StartInitializationEvent.cs
+++ b/src/Func/Commands/Start/Initialization/StartInitializationEvent.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Projects;
+
 namespace Azure.Functions.Cli.Commands.Start.Initialization;
 
 /// <summary>
@@ -27,9 +29,21 @@ internal sealed record StartInitializationProgressEvent(DateTimeOffset Timestamp
     : StartInitializationEvent(Timestamp);
 
 /// <summary>
+/// Emitted when an initialization step streams log output.
+/// </summary>
+internal sealed record StartInitializationLogEvent(DateTimeOffset Timestamp, string StepId, string Line, FunctionsProjectReportSeverity Severity)
+    : StartInitializationEvent(Timestamp);
+
+/// <summary>
 /// Emitted when an initialization step completes successfully.
 /// </summary>
 internal sealed record StartInitializationStepCompletedEvent(DateTimeOffset Timestamp, string StepId, string? Message = null)
+    : StartInitializationEvent(Timestamp);
+
+/// <summary>
+/// Emitted when an initialization step fails before the exception propagates.
+/// </summary>
+internal sealed record StartInitializationStepFailedEvent(DateTimeOffset Timestamp, string StepId, string? Message = null)
     : StartInitializationEvent(Timestamp);
 
 /// <summary>

--- a/src/Func/Commands/Start/Initialization/StartInitializationLogEventStream.cs
+++ b/src/Func/Commands/Start/Initialization/StartInitializationLogEventStream.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using Azure.Functions.Cli.Hosting.Events;
+using Azure.Functions.Cli.Projects;
 using Microsoft.Extensions.Logging;
 
 namespace Azure.Functions.Cli.Commands.Start.Initialization;
@@ -44,6 +45,12 @@ internal sealed class StartInitializationLogEventStream(IEnumerable<StartInitial
                 case StartInitializationStepCompletedEvent completed:
                     entries.Add(CreateEntry(completed, stepsById));
                     break;
+                case StartInitializationStepFailedEvent failed:
+                    entries.Add(CreateEntry(failed, stepsById));
+                    break;
+                case StartInitializationLogEvent log:
+                    entries.Add(CreateEntry(log));
+                    break;
             }
         }
 
@@ -73,6 +80,57 @@ internal sealed class StartInitializationLogEventStream(IEnumerable<StartInitial
             Exception: null,
             attributes);
     }
+
+    private static HostLogEntry CreateEntry(
+        StartInitializationStepFailedEvent failed,
+        IReadOnlyDictionary<string, StartInitializationStep> stepsById)
+    {
+        string title = stepsById.TryGetValue(failed.StepId, out StartInitializationStep? step)
+            ? step.Title
+            : failed.StepId;
+
+        Dictionary<string, object?> attributes = new()
+        {
+            [HostLogAttributeKeys.CliEventKind] = CliEventKinds.StartInitializationStepFailed,
+            ["start.initialization.step"] = failed.StepId,
+        };
+
+        return new HostLogEntry(
+            failed.Timestamp,
+            StartupCategory,
+            LogLevel.Error,
+            default,
+            FormatMessage(title, failed.Message),
+            Exception: null,
+            attributes);
+    }
+
+    private static HostLogEntry CreateEntry(StartInitializationLogEvent log)
+    {
+        Dictionary<string, object?> attributes = new()
+        {
+            [HostLogAttributeKeys.CliEventKind] = CliEventKinds.StartInitializationLog,
+            ["start.initialization.step"] = log.StepId,
+            ["start.initialization.severity"] = log.Severity.ToString().ToLowerInvariant(),
+        };
+
+        return new HostLogEntry(
+            log.Timestamp,
+            StartupCategory,
+            ToLogLevel(log.Severity),
+            default,
+            log.Line,
+            Exception: null,
+            attributes);
+    }
+
+    private static LogLevel ToLogLevel(FunctionsProjectReportSeverity severity)
+        => severity switch
+        {
+            FunctionsProjectReportSeverity.Warning => LogLevel.Warning,
+            FunctionsProjectReportSeverity.Error => LogLevel.Error,
+            _ => LogLevel.Information,
+        };
 
     private static string FormatMessage(string title, string? message)
         => string.IsNullOrWhiteSpace(message)

--- a/src/Func/Commands/Start/Initialization/StartInitializationStepContext.cs
+++ b/src/Func/Commands/Start/Initialization/StartInitializationStepContext.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Commands.Start.Initialization.Rendering;
-using NuGet.Protocol.Plugins;
+using Azure.Functions.Cli.Projects;
 
 namespace Azure.Functions.Cli.Commands.Start.Initialization;
 
@@ -40,6 +40,24 @@ internal sealed class StartInitializationStepContext(
         var progressEvent = new StartInitializationProgressEvent(_timeProvider.GetUtcNow(), _step.Id, percent, message);
 
         await _renderer.OnEventAsync(progressEvent, cancellationToken);
+    }
+
+    public async Task ReportStatusAsync(string message, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+
+        var progressEvent = new StartInitializationProgressEvent(_timeProvider.GetUtcNow(), _step.Id, double.NaN, message);
+
+        await _renderer.OnEventAsync(progressEvent, cancellationToken);
+    }
+
+    public async Task ReportLogAsync(string line, FunctionsProjectReportSeverity severity, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(line);
+
+        var logEvent = new StartInitializationLogEvent(_timeProvider.GetUtcNow(), _step.Id, line, severity);
+
+        await _renderer.OnEventAsync(logEvent, cancellationToken);
     }
 
     public async Task<bool> ConfirmAsync(string prompt, bool defaultValue, CancellationToken cancellationToken)

--- a/src/Func/Commands/Start/Initialization/Steps/PrepareProjectHostRunInitializationStep.cs
+++ b/src/Func/Commands/Start/Initialization/Steps/PrepareProjectHostRunInitializationStep.cs
@@ -34,6 +34,8 @@ internal sealed class PrepareProjectHostRunInitializationStep(
 
     public override string Title => "Prepare project";
 
+    public override StartInitializationDisplayKind DisplayKind => StartInitializationDisplayKind.Progress;
+
     public override async Task<StartInitializationStepResult> ExecuteAsync(StartInitializationStepContext context, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -52,7 +54,11 @@ internal sealed class PrepareProjectHostRunInitializationStep(
             environmentVariables,
             skipBuild: context.Options.NoBuild);
 
+        await using var reporter = new FunctionsProjectHostRunReporter(context, cancellationToken);
+        hostRunContext.Reporter = reporter;
+
         await project.PrepareForHostRunAsync(hostRunContext, cancellationToken);
+        await reporter.CompleteAsync();
 
         context.State.HostRunContext = hostRunContext;
 
@@ -119,4 +125,3 @@ internal sealed class PrepareProjectHostRunInitializationStep(
         }
     }
 }
-

--- a/src/Func/Hosting/Events/HostLogAttributeKeys.cs
+++ b/src/Func/Hosting/Events/HostLogAttributeKeys.cs
@@ -116,7 +116,11 @@ internal static class CliEventKinds
 
     public const string StartInitializationProgress = "start_initialization_progress";
 
+    public const string StartInitializationLog = "start_initialization_log";
+
     public const string StartInitializationStepCompleted = "start_initialization_step_completed";
+
+    public const string StartInitializationStepFailed = "start_initialization_step_failed";
 
     public const string StartInitializationCompleted = "start_initialization_completed";
 }

--- a/src/Workloads/Stacks/DotNet/DotNetCli/DotnetCliRunner.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetCli/DotnetCliRunner.cs
@@ -1,8 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.ComponentModel;
 using System.Diagnostics;
+using System.Text;
 
 namespace Azure.Functions.Cli.Workloads.DotNet;
 
@@ -15,21 +15,110 @@ internal sealed class DotnetCliRunner(IDotnetPathResolver pathResolver) : IDotne
 
     public async Task RunAsync(IReadOnlyList<string> arguments, string? workingDirectory, CancellationToken cancellationToken)
     {
-        await RunCoreAsync(arguments, workingDirectory, cancellationToken);
+        // Output is captured so it can be attached to the exception on failure, but is otherwise discarded.
+        StringBuilder stdout = new();
+        StringBuilder stderr = new();
+
+        // Each callback is invoked only from its own stream's thread (serialized per stream), so the two
+        // builders are never touched concurrently and need no synchronization.
+        int exitCode = await ExecuteAsync(
+            arguments,
+            workingDirectory,
+            line => stdout.AppendLine(line),
+            line => stderr.AppendLine(line),
+            cancellationToken);
+
+        if (exitCode != 0)
+        {
+            throw new DotnetCliException(exitCode, stderr.ToString(), stdout.ToString(), string.Join(' ', arguments));
+        }
     }
 
-    public async Task<string> RunWithOutputAsync(
+    public async Task RunStreamingAsync(IReadOnlyList<string> arguments, string? workingDirectory, Action<string>? onOutputLine,
+        Action<string>? onErrorLine, CancellationToken cancellationToken)
+    {
+        int exitCode = await ExecuteAsync(arguments, workingDirectory, onOutputLine, onErrorLine, cancellationToken);
+
+        if (exitCode != 0)
+        {
+            // Output has already been surfaced live through the callbacks, so the exception only needs
+            // to carry the exit code and command.
+            throw new DotnetCliException(exitCode, string.Empty, string.Empty, string.Join(' ', arguments));
+        }
+    }
+
+    /// <summary>
+    /// Starts <c>dotnet</c>, streams each line of standard output and standard error to the supplied
+    /// callbacks as it is produced, waits for exit, and returns the process exit code.
+    /// </summary>
+    private async Task<int> ExecuteAsync(
         IReadOnlyList<string> arguments,
         string? workingDirectory,
+        Action<string>? onOutputLine,
+        Action<string>? onErrorLine,
         CancellationToken cancellationToken)
-    {
-        return await RunCoreAsync(arguments, workingDirectory, cancellationToken);
-    }
-
-    private async Task<string> RunCoreAsync(IReadOnlyList<string> arguments, string? workingDirectory, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(arguments);
 
+        using Process process = new() { StartInfo = CreateStartInfo(arguments, workingDirectory) };
+
+        // stdout and stderr are delivered on separate thread-pool threads, so each stream gets its own
+        // completion signal. The handlers share no mutable state, so the two threads never race each other;
+        // each line callback is invoked only from its own stream's thread (serialized per stream).
+        TaskCompletionSource stdoutComplete = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource stderrComplete = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data is null)
+            {
+                stdoutComplete.TrySetResult();
+            }
+            else
+            {
+                onOutputLine?.Invoke(e.Data);
+            }
+        };
+
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data is null)
+            {
+                stderrComplete.TrySetResult();
+            }
+            else
+            {
+                onErrorLine?.Invoke(e.Data);
+            }
+        };
+
+        if (!process.Start())
+        {
+            throw new InvalidOperationException("Failed to start dotnet process.");
+        }
+
+        try
+        {
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            await process.WaitForExitAsync(cancellationToken);
+
+            // WaitForExitAsync does not guarantee the async stream readers have drained, so wait for the
+            // trailing (null Data) sentinel on both streams to ensure every line has been delivered.
+            await stdoutComplete.Task;
+            await stderrComplete.Task;
+
+            return process.ExitCode;
+        }
+        finally
+        {
+            KillProcess(process);
+        }
+    }
+
+    private ProcessStartInfo CreateStartInfo(IReadOnlyList<string> arguments, string? workingDirectory)
+    {
         ProcessStartInfo psi = new()
         {
             FileName = _pathResolver.Resolve(),
@@ -49,37 +138,7 @@ internal sealed class DotnetCliRunner(IDotnetPathResolver pathResolver) : IDotne
             psi.ArgumentList.Add(arg);
         }
 
-        using Process process = Process.Start(psi)
-            ?? throw new InvalidOperationException("Failed to start dotnet process.");
-
-        try
-        {
-            // Read both streams concurrently to avoid deadlock when either
-            // buffer fills while the other is being awaited.
-            Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
-            Task<string> stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
-
-            await Task.WhenAll(stdoutTask, stderrTask);
-            await process.WaitForExitAsync(cancellationToken);
-
-            string stdout = await stdoutTask;
-            string stderr = await stderrTask;
-
-            if (process.ExitCode != 0)
-            {
-                throw new DotnetCliException(
-                    process.ExitCode,
-                    stderr,
-                    stdout,
-                    string.Join(' ', arguments));
-            }
-
-            return stdout;
-        }
-        finally
-        {
-            KillProcess(process);
-        }
+        return psi;
     }
 
     private static void KillProcess(Process process)

--- a/src/Workloads/Stacks/DotNet/DotNetCli/IDotnetCliRunner.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetCli/IDotnetCliRunner.cs
@@ -19,12 +19,24 @@ internal interface IDotnetCliRunner
     public Task RunAsync(IReadOnlyList<string> arguments, string? workingDirectory, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Executes <c>dotnet</c> with the supplied arguments and returns captured standard output.
+    /// Executes <c>dotnet</c> with the supplied arguments, invoking the supplied callbacks for each
+    /// line of standard output and standard error as it is produced by the child process.
     /// </summary>
     /// <param name="arguments">The arguments to pass to <c>dotnet</c>.</param>
     /// <param name="workingDirectory">Optional working directory for the process.</param>
+    /// <param name="onOutputLine">Invoked for each line written to standard output. Invocations for
+    /// standard output are serialized with respect to one another but may run concurrently with
+    /// <paramref name="onErrorLine"/>; the callback must be safe to call from a thread-pool thread.</param>
+    /// <param name="onErrorLine">Invoked for each line written to standard error. Invocations for
+    /// standard error are serialized with respect to one another but may run concurrently with
+    /// <paramref name="onOutputLine"/>; the callback must be safe to call from a thread-pool thread.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <exception cref="InvalidOperationException">The process could not be started.</exception>
     /// <exception cref="DotnetCliException">The process exited with a non-zero exit code.</exception>
-    public Task<string> RunWithOutputAsync(IReadOnlyList<string> arguments, string? workingDirectory, CancellationToken cancellationToken);
+    public Task RunStreamingAsync(
+        IReadOnlyList<string> arguments,
+        string? workingDirectory,
+        Action<string>? onOutputLine,
+        Action<string>? onErrorLine,
+        CancellationToken cancellationToken);
 }

--- a/src/Workloads/Stacks/DotNet/DotNetSourceProject.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetSourceProject.cs
@@ -36,10 +36,12 @@ internal sealed class DotNetSourceProject(WorkingDirectory workingDirectory, str
 
         string targetName = context.SkipBuild ? "GetTargetPath" : "Build";
 
-        context.StartupDirectory = await BuildAndGetOutputDirectoryAsync(projectDir, targetName, context.SkipBuild, cancellationToken);
+        context.Reporter.ReportStatus(context.SkipBuild ? "Resolving .NET build output" : "Running dotnet build");
+
+        context.StartupDirectory = await BuildAndGetOutputDirectoryAsync(projectDir, targetName, context.SkipBuild, context.Reporter, cancellationToken);
     }
 
-    private async Task<DirectoryInfo> BuildAndGetOutputDirectoryAsync(string projectDir, string targetName, bool requireAssemblyExists, CancellationToken cancellationToken)
+    private async Task<DirectoryInfo> BuildAndGetOutputDirectoryAsync(string projectDir, string targetName, bool requireAssemblyExists, IFunctionsProjectHostRunReporter reporter, CancellationToken cancellationToken)
     {
         string json;
         try
@@ -51,6 +53,8 @@ internal sealed class DotNetSourceProject(WorkingDirectory workingDirectory, str
         }
         catch (DotnetCliException ex)
         {
+            WriteLogLines(reporter, ex.StandardOutput, FunctionsProjectReportSeverity.Info);
+            WriteLogLines(reporter, ex.StandardError, FunctionsProjectReportSeverity.Error);
             string detail = string.IsNullOrWhiteSpace(ex.StandardError) ? "see build output above." : ex.StandardError.Trim();
 
             throw new GracefulException($"'dotnet build' failed (exit {ex.ExitCode}). {detail}", isUserError: true);
@@ -108,5 +112,13 @@ internal sealed class DotNetSourceProject(WorkingDirectory workingDirectory, str
         throw new GracefulException(
             $"Could not determine output directory for project '{Path.GetFileName(ProjectFilePath)}'. The '{targetName}' target result did not contain expected output paths.",
             isUserError: true);
+    }
+
+    private static void WriteLogLines(IFunctionsProjectHostRunReporter reporter, string output, FunctionsProjectReportSeverity severity)
+    {
+        foreach (string line in output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
+        {
+            reporter.WriteLog(line, severity);
+        }
     }
 }

--- a/src/Workloads/Stacks/DotNet/DotNetSourceProject.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetSourceProject.cs
@@ -24,9 +24,7 @@ internal sealed class DotNetSourceProject(WorkingDirectory workingDirectory, str
         cancellationToken.ThrowIfCancellationRequested();
 
         string projectDir = Path.GetDirectoryName(ProjectFilePath)
-            ?? throw new GracefulException(
-                $"Could not determine directory for project file '{ProjectFilePath}'.",
-                isUserError: true);
+            ?? throw new GracefulException($"Could not determine directory for project file '{ProjectFilePath}'.", isUserError: true);
 
         // Both paths run `dotnet build` and read an MSBuild target result as JSON; only the requested
         // target differs. The default build runs the "Build" target (compiles, then reports the actual
@@ -43,24 +41,40 @@ internal sealed class DotNetSourceProject(WorkingDirectory workingDirectory, str
 
     private async Task<DirectoryInfo> BuildAndGetOutputDirectoryAsync(string projectDir, string targetName, bool requireAssemblyExists, IFunctionsProjectHostRunReporter reporter, CancellationToken cancellationToken)
     {
-        string json;
+        // Stream the build output live (stdout as informational, stderr as error) while MSBuild writes the
+        // structured target result to a temp file via --getResultOutputFile. In this mode the human-readable
+        // build console output (including compiler errors) goes to stdout, leaving stdout free of the JSON we
+        // need for path resolution.
+        string resultFile = Path.Combine(Path.GetTempPath(), $"func-dotnet-build-{Guid.NewGuid():N}.json");
+
         try
         {
-            json = await _dotnetCli.RunWithOutputAsync(
-                ["build", ProjectFilePath, $"--getTargetResult:{targetName}"],
-                projectDir,
-                cancellationToken);
+            try
+            {
+                await _dotnetCli.RunStreamingAsync(
+                    ["build", ProjectFilePath, $"--getTargetResult:{targetName}", $"--getResultOutputFile:{resultFile}"],
+                    projectDir,
+                    line => reporter.WriteLog(line, FunctionsProjectReportSeverity.Info),
+                    line => reporter.WriteLog(line, FunctionsProjectReportSeverity.Error),
+                    cancellationToken);
+            }
+            catch (DotnetCliException ex)
+            {
+                // The build output has already been streamed live through the callbacks above, so point the
+                // user there instead of repeating it in the message.
+                throw new GracefulException($"'dotnet build' failed (exit {ex.ExitCode}).", isUserError: true);
+            }
+
+            string json = File.Exists(resultFile)
+                ? await File.ReadAllTextAsync(resultFile, cancellationToken)
+                : string.Empty;
+
+            return ParseTargetResult(json.Trim(), targetName, requireAssemblyExists);
         }
-        catch (DotnetCliException ex)
+        finally
         {
-            WriteLogLines(reporter, ex.StandardOutput, FunctionsProjectReportSeverity.Info);
-            WriteLogLines(reporter, ex.StandardError, FunctionsProjectReportSeverity.Error);
-            string detail = string.IsNullOrWhiteSpace(ex.StandardError) ? "see build output above." : ex.StandardError.Trim();
-
-            throw new GracefulException($"'dotnet build' failed (exit {ex.ExitCode}). {detail}", isUserError: true);
+            TryDeleteFile(resultFile);
         }
-
-        return ParseTargetResult(json.Trim(), targetName, requireAssemblyExists);
     }
 
     internal DirectoryInfo ParseTargetResult(string json, string targetName, bool requireAssemblyExists = false)
@@ -114,11 +128,17 @@ internal sealed class DotNetSourceProject(WorkingDirectory workingDirectory, str
             isUserError: true);
     }
 
-    private static void WriteLogLines(IFunctionsProjectHostRunReporter reporter, string output, FunctionsProjectReportSeverity severity)
+    private static void TryDeleteFile(string path)
     {
-        foreach (string line in output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
+        try
         {
-            reporter.WriteLog(line, severity);
+            File.Delete(path);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
         }
     }
 }

--- a/src/Workloads/Stacks/Go/GoFunctionsProject.cs
+++ b/src/Workloads/Stacks/Go/GoFunctionsProject.cs
@@ -90,12 +90,13 @@ internal sealed class GoFunctionsProject : FunctionsProject
 
         context.Reporter.ReportStatus("Running go build");
         (int exitCode, string stderr) = await RunGoBuild(root, outputPath, cancellationToken).ConfigureAwait(false);
+
         WriteLogLines(context.Reporter, stderr, exitCode == 0 ? FunctionsProjectReportSeverity.Info : FunctionsProjectReportSeverity.Error);
+
         if (exitCode != 0)
         {
-            string detail = string.IsNullOrWhiteSpace(stderr) ? "see build output above." : stderr.Trim();
             throw new GracefulException(
-                $"'go build' failed (exit {exitCode}). {detail}",
+                $"'go build' failed (exit {exitCode}). {stderr?.Trim()}",
                 isUserError: true);
         }
 

--- a/src/Workloads/Stacks/Go/GoFunctionsProject.cs
+++ b/src/Workloads/Stacks/Go/GoFunctionsProject.cs
@@ -71,6 +71,7 @@ internal sealed class GoFunctionsProject : FunctionsProject
             return;
         }
 
+        context.Reporter.ReportStatus("Checking Go toolchain");
         (int Major, int Minor)? version = await ReadGoVersion(cancellationToken).ConfigureAwait(false);
         if (version is null)
         {
@@ -87,7 +88,9 @@ internal sealed class GoFunctionsProject : FunctionsProject
                 isUserError: true);
         }
 
+        context.Reporter.ReportStatus("Running go build");
         (int exitCode, string stderr) = await RunGoBuild(root, outputPath, cancellationToken).ConfigureAwait(false);
+        WriteLogLines(context.Reporter, stderr, exitCode == 0 ? FunctionsProjectReportSeverity.Info : FunctionsProjectReportSeverity.Error);
         if (exitCode != 0)
         {
             string detail = string.IsNullOrWhiteSpace(stderr) ? "see build output above." : stderr.Trim();
@@ -97,6 +100,14 @@ internal sealed class GoFunctionsProject : FunctionsProject
         }
 
         context.StartupDirectory = new DirectoryInfo(binDirectory);
+    }
+
+    private static void WriteLogLines(IFunctionsProjectHostRunReporter reporter, string output, FunctionsProjectReportSeverity severity)
+    {
+        foreach (string line in output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
+        {
+            reporter.WriteLog(line, severity);
+        }
     }
 
     private static async Task<(int Major, int Minor)?> DefaultReadGoVersion(CancellationToken cancellationToken)

--- a/src/Workloads/Stacks/Node/NodeFunctionsProject.cs
+++ b/src/Workloads/Stacks/Node/NodeFunctionsProject.cs
@@ -58,13 +58,13 @@ internal sealed class NodeFunctionsProject : FunctionsProject
 
         if (!Directory.Exists(Path.Combine(root, NodeModulesFolderName)))
         {
-            await RunAsync(root, ["install"], "npm install", cancellationToken).ConfigureAwait(false);
+            await RunAsync(root, ["install"], "npm install", context.Reporter, cancellationToken).ConfigureAwait(false);
         }
 
         // --no-build skips compilation only; npm install above is restore, not build.
         if (!context.SkipBuild && HasBuildScript(packageJsonPath))
         {
-            await RunAsync(root, ["run", "build"], "npm run build", cancellationToken).ConfigureAwait(false);
+            await RunAsync(root, ["run", "build"], "npm run build", context.Reporter, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -95,15 +95,30 @@ internal sealed class NodeFunctionsProject : FunctionsProject
         }
     }
 
-    private async Task RunAsync(string root, IReadOnlyList<string> args, string display, CancellationToken cancellationToken)
+    private async Task RunAsync(
+        string root,
+        IReadOnlyList<string> args,
+        string display,
+        IFunctionsProjectHostRunReporter reporter,
+        CancellationToken cancellationToken)
     {
+        reporter.ReportStatus($"Running {display}");
         (int exitCode, string stderr) = await RunNpm(root, args, cancellationToken).ConfigureAwait(false);
+        WriteLogLines(reporter, stderr, exitCode == 0 ? FunctionsProjectReportSeverity.Info : FunctionsProjectReportSeverity.Error);
         if (exitCode != 0)
         {
             string detail = string.IsNullOrWhiteSpace(stderr) ? "see output above." : stderr.Trim();
             throw new GracefulException(
                 $"'{display}' failed (exit {exitCode}). {detail}",
                 isUserError: true);
+        }
+    }
+
+    private static void WriteLogLines(IFunctionsProjectHostRunReporter reporter, string output, FunctionsProjectReportSeverity severity)
+    {
+        foreach (string line in output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
+        {
+            reporter.WriteLog(line, severity);
         }
     }
 

--- a/src/Workloads/Stacks/Node/NodeFunctionsProject.cs
+++ b/src/Workloads/Stacks/Node/NodeFunctionsProject.cs
@@ -95,21 +95,18 @@ internal sealed class NodeFunctionsProject : FunctionsProject
         }
     }
 
-    private async Task RunAsync(
-        string root,
-        IReadOnlyList<string> args,
-        string display,
-        IFunctionsProjectHostRunReporter reporter,
-        CancellationToken cancellationToken)
+    private async Task RunAsync(string root, IReadOnlyList<string> args, string display, IFunctionsProjectHostRunReporter reporter, CancellationToken cancellationToken)
     {
         reporter.ReportStatus($"Running {display}");
+
         (int exitCode, string stderr) = await RunNpm(root, args, cancellationToken).ConfigureAwait(false);
+
         WriteLogLines(reporter, stderr, exitCode == 0 ? FunctionsProjectReportSeverity.Info : FunctionsProjectReportSeverity.Error);
+
         if (exitCode != 0)
         {
-            string detail = string.IsNullOrWhiteSpace(stderr) ? "see output above." : stderr.Trim();
             throw new GracefulException(
-                $"'{display}' failed (exit {exitCode}). {detail}",
+                $"'{display}' failed (exit {exitCode}). {stderr?.Trim()}",
                 isUserError: true);
         }
     }

--- a/src/Workloads/Stacks/Python/PythonFunctionsProject.cs
+++ b/src/Workloads/Stacks/Python/PythonFunctionsProject.cs
@@ -70,7 +70,9 @@ internal sealed class PythonFunctionsProject : FunctionsProject
 
         if (!venvAlreadyExisted)
         {
+            context.Reporter.ReportStatus($"Creating Python virtual environment in {Path.GetFileName(venvPath)}");
             (int exitCode, string stderr) = await RunCreateVenv(root, venvPath, cancellationToken).ConfigureAwait(false);
+            WriteLogLines(context.Reporter, stderr, exitCode == 0 ? FunctionsProjectReportSeverity.Info : FunctionsProjectReportSeverity.Error);
             if (exitCode != 0)
             {
                 string detail = string.IsNullOrWhiteSpace(stderr) ? "see output above." : stderr.Trim();
@@ -84,7 +86,9 @@ internal sealed class PythonFunctionsProject : FunctionsProject
         if (File.Exists(requirementsPath))
         {
             string pipPath = GetVenvExecutablePath(venvPath, "pip");
+            context.Reporter.ReportStatus($"Installing Python dependencies from {RequirementsFileName}");
             (int exitCode, string stderr) = await RunPipInstall(root, pipPath, requirementsPath, cancellationToken).ConfigureAwait(false);
+            WriteLogLines(context.Reporter, stderr, exitCode == 0 ? FunctionsProjectReportSeverity.Info : FunctionsProjectReportSeverity.Error);
             if (exitCode != 0)
             {
                 string detail = string.IsNullOrWhiteSpace(stderr) ? "see output above." : stderr.Trim();
@@ -110,6 +114,14 @@ internal sealed class PythonFunctionsProject : FunctionsProject
         if (!string.IsNullOrEmpty(majorMinor))
         {
             context.EnvironmentVariables[WorkerRuntimeVersionEnvVar] = majorMinor;
+        }
+    }
+
+    private static void WriteLogLines(IFunctionsProjectHostRunReporter reporter, string output, FunctionsProjectReportSeverity severity)
+    {
+        foreach (string line in output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
+        {
+            reporter.WriteLog(line, severity);
         }
     }
 

--- a/src/Workloads/Stacks/Python/PythonFunctionsProject.cs
+++ b/src/Workloads/Stacks/Python/PythonFunctionsProject.cs
@@ -71,13 +71,15 @@ internal sealed class PythonFunctionsProject : FunctionsProject
         if (!venvAlreadyExisted)
         {
             context.Reporter.ReportStatus($"Creating Python virtual environment in {Path.GetFileName(venvPath)}");
+
             (int exitCode, string stderr) = await RunCreateVenv(root, venvPath, cancellationToken).ConfigureAwait(false);
+
             WriteLogLines(context.Reporter, stderr, exitCode == 0 ? FunctionsProjectReportSeverity.Info : FunctionsProjectReportSeverity.Error);
+
             if (exitCode != 0)
             {
-                string detail = string.IsNullOrWhiteSpace(stderr) ? "see output above." : stderr.Trim();
                 throw new GracefulException(
-                    $"'python -m venv {Path.GetFileName(venvPath)}' failed (exit {exitCode}). {detail}",
+                    $"'python -m venv {Path.GetFileName(venvPath)}' failed (exit {exitCode}). {stderr?.Trim()}",
                     isUserError: true);
             }
         }
@@ -85,15 +87,17 @@ internal sealed class PythonFunctionsProject : FunctionsProject
         string requirementsPath = Path.Combine(root, RequirementsFileName);
         if (File.Exists(requirementsPath))
         {
-            string pipPath = GetVenvExecutablePath(venvPath, "pip");
             context.Reporter.ReportStatus($"Installing Python dependencies from {RequirementsFileName}");
+
+            string pipPath = GetVenvExecutablePath(venvPath, "pip");
             (int exitCode, string stderr) = await RunPipInstall(root, pipPath, requirementsPath, cancellationToken).ConfigureAwait(false);
+
             WriteLogLines(context.Reporter, stderr, exitCode == 0 ? FunctionsProjectReportSeverity.Info : FunctionsProjectReportSeverity.Error);
+
             if (exitCode != 0)
             {
-                string detail = string.IsNullOrWhiteSpace(stderr) ? "see output above." : stderr.Trim();
                 throw new GracefulException(
-                    $"'pip install -r {RequirementsFileName}' failed (exit {exitCode}). {detail}",
+                    $"'pip install -r {RequirementsFileName}' failed (exit {exitCode}). {stderr?.Trim()}",
                     isUserError: true);
             }
         }
@@ -160,10 +164,7 @@ internal sealed class PythonFunctionsProject : FunctionsProject
         return (Path.Combine(projectRoot, DefaultVenvFolderName), false);
     }
 
-    private static async Task<(int ExitCode, string Stderr)> DefaultRunCreateVenv(
-        string workingDirectory,
-        string venvPath,
-        CancellationToken cancellationToken)
+    private static async Task<(int ExitCode, string Stderr)> DefaultRunCreateVenv(string workingDirectory, string venvPath, CancellationToken cancellationToken)
     {
         // Prefer `python3` on POSIX so we don't pick up a Python 2 shim. If the
         // interpreter isn't on PATH (Win32Exception from Process.Start), retry
@@ -193,11 +194,7 @@ internal sealed class PythonFunctionsProject : FunctionsProject
         return last;
     }
 
-    private static Task<(int ExitCode, string Stderr)> DefaultRunPipInstall(
-        string workingDirectory,
-        string pipPath,
-        string requirementsPath,
-        CancellationToken cancellationToken)
+    private static Task<(int ExitCode, string Stderr)> DefaultRunPipInstall(string workingDirectory, string pipPath, string requirementsPath, CancellationToken cancellationToken)
     {
         return RunProcessAsync(pipPath, ["install", "-r", requirementsPath], workingDirectory, cancellationToken);
     }

--- a/test/Func.Tests/Commands/Start/Initialization/PrepareProjectHostRunInitializationStepTests.cs
+++ b/test/Func.Tests/Commands/Start/Initialization/PrepareProjectHostRunInitializationStepTests.cs
@@ -145,6 +145,57 @@ public class PrepareProjectHostRunInitializationStepTests : IDisposable
         Assert.False(env.ContainsKey("MyKey"));
     }
 
+    [Fact]
+    public async Task ExecuteAsync_WiresReporterToProjectContext()
+    {
+        SetLocalSettings([]);
+        var renderer = new RecordingRenderer();
+        var project = new ReportingProject(_projectDir);
+        StartInitializationStepContext context = NewContext(project, renderer);
+
+        await NewStep().ExecuteAsync(context, CancellationToken.None);
+
+        Assert.NotNull(context.State.HostRunContext!.Reporter);
+        Assert.Contains(renderer.Events, ev => ev is StartInitializationProgressEvent progress
+            && progress.StepId == PrepareProjectHostRunInitializationStep.StepId
+            && double.IsNaN(progress.Percent)
+            && progress.Message == "running npm install");
+        Assert.Contains(renderer.Events, ev => ev is StartInitializationProgressEvent progress
+            && progress.StepId == PrepareProjectHostRunInitializationStep.StepId
+            && progress.Percent == 25
+            && progress.Message == "installing");
+        Assert.Contains(renderer.Events, ev => ev is StartInitializationLogEvent log
+            && log.StepId == PrepareProjectHostRunInitializationStep.StepId
+            && log.Line == "npm install output"
+            && log.Severity == FunctionsProjectReportSeverity.Warning);
+    }
+
+    [Fact]
+    public async Task Reporter_ForwardsStatusProgressAndLog()
+    {
+        var renderer = new RecordingRenderer();
+        StartInitializationStepContext context = NewContext(renderer: renderer, stepId: "adapter_step");
+        await using var reporter = new FunctionsProjectHostRunReporter(context, CancellationToken.None);
+
+        reporter.ReportStatus("building");
+        reporter.ReportProgress(75, "almost done");
+        reporter.WriteLog("build output", FunctionsProjectReportSeverity.Error);
+        await reporter.CompleteAsync();
+
+        Assert.Contains(renderer.Events, ev => ev is StartInitializationProgressEvent progress
+            && progress.StepId == "adapter_step"
+            && double.IsNaN(progress.Percent)
+            && progress.Message == "building");
+        Assert.Contains(renderer.Events, ev => ev is StartInitializationProgressEvent progress
+            && progress.StepId == "adapter_step"
+            && progress.Percent == 75
+            && progress.Message == "almost done");
+        Assert.Contains(renderer.Events, ev => ev is StartInitializationLogEvent log
+            && log.StepId == "adapter_step"
+            && log.Line == "build output"
+            && log.Severity == FunctionsProjectReportSeverity.Error);
+    }
+
     private void SetLocalSettings(Dictionary<string, string> values)
     {
         var snapshot = new LocalSettingsSnapshot { Values = values };
@@ -154,7 +205,10 @@ public class PrepareProjectHostRunInitializationStepTests : IDisposable
     private PrepareProjectHostRunInitializationStep NewStep()
         => new(_localSettings, _processEnv, _interaction);
 
-    private StartInitializationStepContext NewContext()
+    private StartInitializationStepContext NewContext(
+        FunctionsProject? project = null,
+        IStartInitializationRenderer? renderer = null,
+        string? stepId = null)
     {
         var options = new StartCommandOptions(
             WorkingDirectory.FromExplicit(_projectDir),
@@ -166,13 +220,13 @@ public class PrepareProjectHostRunInitializationStepTests : IDisposable
         var init = new StartInitializationContext(options, "5.0.0-test", IsInteractive: false, CanPrompt: false);
         var state = new StartInitializationState
         {
-            Project = new FakeProject(_projectDir),
+            Project = project ?? new FakeProject(_projectDir),
             Worker = CreateWorker(),
             ProfileName = "none",
         };
-        IStartInitializationRenderer renderer = Substitute.For<IStartInitializationRenderer>();
+        renderer ??= Substitute.For<IStartInitializationRenderer>();
         IStartInitializationStep stepStub = Substitute.For<IStartInitializationStep>();
-        stepStub.Id.Returns("test");
+        stepStub.Id.Returns(stepId ?? PrepareProjectHostRunInitializationStep.StepId);
         return new StartInitializationStepContext(init, state, stepStub, renderer, TimeProvider.System);
     }
 
@@ -184,7 +238,7 @@ public class PrepareProjectHostRunInitializationStepTests : IDisposable
         return worker;
     }
 
-    private sealed class FakeProject(string directory) : FunctionsProject
+    private class FakeProject(string directory) : FunctionsProject
     {
         public override WorkingDirectory WorkingDirectory { get; } = WorkingDirectory.FromExplicit(directory);
 
@@ -195,5 +249,32 @@ public class PrepareProjectHostRunInitializationStepTests : IDisposable
         public override bool SupportsExtensionBundles => true;
 
         public override FunctionsWorkerReference WorkerReference { get; } = FunctionsWorkerReference.FromWorkload("node");
+    }
+
+    private sealed class ReportingProject(string directory) : FakeProject(directory)
+    {
+        public override Task PrepareForHostRunAsync(FunctionsProjectHostRunContext context, CancellationToken cancellationToken)
+        {
+            context.Reporter.ReportStatus("running npm install");
+            context.Reporter.ReportProgress(25, "installing");
+            context.Reporter.WriteLog("npm install output", FunctionsProjectReportSeverity.Warning);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingRenderer : IStartInitializationRenderer
+    {
+        public List<StartInitializationEvent> Events { get; } = [];
+
+        public Task OnEventAsync(StartInitializationEvent initializationEvent, CancellationToken cancellationToken)
+        {
+            Events.Add(initializationEvent);
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> ConfirmAsync(string prompt, bool defaultValue, CancellationToken cancellationToken)
+            => Task.FromResult(defaultValue);
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 }

--- a/test/Func.Tests/Commands/Start/Initialization/PrepareProjectHostRunInitializationStepTests.cs
+++ b/test/Func.Tests/Commands/Start/Initialization/PrepareProjectHostRunInitializationStepTests.cs
@@ -160,10 +160,6 @@ public class PrepareProjectHostRunInitializationStepTests : IDisposable
             && progress.StepId == PrepareProjectHostRunInitializationStep.StepId
             && double.IsNaN(progress.Percent)
             && progress.Message == "running npm install");
-        Assert.Contains(renderer.Events, ev => ev is StartInitializationProgressEvent progress
-            && progress.StepId == PrepareProjectHostRunInitializationStep.StepId
-            && progress.Percent == 25
-            && progress.Message == "installing");
         Assert.Contains(renderer.Events, ev => ev is StartInitializationLogEvent log
             && log.StepId == PrepareProjectHostRunInitializationStep.StepId
             && log.Line == "npm install output"
@@ -171,14 +167,13 @@ public class PrepareProjectHostRunInitializationStepTests : IDisposable
     }
 
     [Fact]
-    public async Task Reporter_ForwardsStatusProgressAndLog()
+    public async Task Reporter_ForwardsStatusAndLog()
     {
         var renderer = new RecordingRenderer();
         StartInitializationStepContext context = NewContext(renderer: renderer, stepId: "adapter_step");
         await using var reporter = new FunctionsProjectHostRunReporter(context, CancellationToken.None);
 
         reporter.ReportStatus("building");
-        reporter.ReportProgress(75, "almost done");
         reporter.WriteLog("build output", FunctionsProjectReportSeverity.Error);
         await reporter.CompleteAsync();
 
@@ -186,10 +181,6 @@ public class PrepareProjectHostRunInitializationStepTests : IDisposable
             && progress.StepId == "adapter_step"
             && double.IsNaN(progress.Percent)
             && progress.Message == "building");
-        Assert.Contains(renderer.Events, ev => ev is StartInitializationProgressEvent progress
-            && progress.StepId == "adapter_step"
-            && progress.Percent == 75
-            && progress.Message == "almost done");
         Assert.Contains(renderer.Events, ev => ev is StartInitializationLogEvent log
             && log.StepId == "adapter_step"
             && log.Line == "build output"
@@ -256,7 +247,6 @@ public class PrepareProjectHostRunInitializationStepTests : IDisposable
         public override Task PrepareForHostRunAsync(FunctionsProjectHostRunContext context, CancellationToken cancellationToken)
         {
             context.Reporter.ReportStatus("running npm install");
-            context.Reporter.ReportProgress(25, "installing");
             context.Reporter.WriteLog("npm install output", FunctionsProjectReportSeverity.Warning);
             return Task.CompletedTask;
         }

--- a/test/Func.Tests/Commands/StartInitializationTests.cs
+++ b/test/Func.Tests/Commands/StartInitializationTests.cs
@@ -763,6 +763,8 @@ public class StartInitializationTests : IDisposable
         await renderer.OnEventAsync(new StartInitializationStepStartedEvent(DateTimeOffset.UnixEpoch, step), CancellationToken.None);
         await renderer.OnEventAsync(new StartInitializationLogEvent(DateTimeOffset.UnixEpoch, "prepare", "error tail", FunctionsProjectReportSeverity.Error), CancellationToken.None);
         await renderer.OnEventAsync(new StartInitializationStepFailedEvent(DateTimeOffset.UnixEpoch, "prepare", "build failed"), CancellationToken.None);
+        await WaitForOutputAsync(writer, output => output.Contains("build failed", StringComparison.Ordinal)
+            && output.Contains("error tail", StringComparison.Ordinal));
         await renderer.DisposeAsync();
 
         string output = writer.ToString();

--- a/test/Func.Tests/Commands/StartInitializationTests.cs
+++ b/test/Func.Tests/Commands/StartInitializationTests.cs
@@ -320,12 +320,17 @@ public class StartInitializationTests : IDisposable
             demoSpeedMultiplier: 0.001,
             demoAutoExit: true,
             demoMode: false);
+        var renderer = new RecordingStartInitializationRenderer();
 
         GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => runner.RunAsync(context, new RecordingStartInitializationRenderer(), CancellationToken.None));
+            () => runner.RunAsync(context, renderer, CancellationToken.None));
 
         Assert.Contains(ValidateHostWorkloadInitializationStep.HostContentRootEnvironmentVariable, ex.Message);
         Assert.Contains("host executable was not found", ex.Message);
+        Assert.Contains(renderer.Events, ev => ev is StartInitializationStepFailedEvent failed
+            && failed.StepId == ValidateHostWorkloadInitializationStep.StepId
+            && failed.Message is not null
+            && failed.Message.Contains("host executable was not found", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -553,6 +558,43 @@ public class StartInitializationTests : IDisposable
     }
 
     [Fact]
+    public async Task JsonRenderer_EmitsInitializationLogAndFailureRecords()
+    {
+        using var stream = new MemoryStream();
+        var renderer = new JsonStartInitializationRenderer(stream, ownsStream: false);
+        var logEvent = new StartInitializationLogEvent(DateTimeOffset.UnixEpoch, "prepare", "npm output", FunctionsProjectReportSeverity.Warning);
+        var failedEvent = new StartInitializationStepFailedEvent(DateTimeOffset.UnixEpoch, "prepare", "build failed");
+
+        await renderer.OnEventAsync(logEvent, CancellationToken.None);
+        await renderer.OnEventAsync(failedEvent, CancellationToken.None);
+        await renderer.DisposeAsync();
+
+        string[] lines = Encoding.UTF8.GetString(stream.ToArray()).Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.Equal(2, lines.Length);
+        using var log = JsonDocument.Parse(lines[0]);
+        Assert.Equal("start_initialization_log", log.RootElement.GetProperty("kind").GetString());
+        Assert.Equal("prepare", log.RootElement.GetProperty("step").GetString());
+        Assert.Equal("npm output", log.RootElement.GetProperty("line").GetString());
+        Assert.Equal("warning", log.RootElement.GetProperty("severity").GetString());
+        using var failed = JsonDocument.Parse(lines[1]);
+        Assert.Equal("start_initialization_step_failed", failed.RootElement.GetProperty("kind").GetString());
+        Assert.Equal("build failed", failed.RootElement.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public async Task PlainRenderer_EmitsInitializationLogRecords()
+    {
+        var interaction = new TestInteractionService();
+        var renderer = new PlainStartInitializationRenderer(interaction);
+        var logEvent = new StartInitializationLogEvent(DateTimeOffset.UnixEpoch, "prepare", "npm output", FunctionsProjectReportSeverity.Info);
+
+        await renderer.OnEventAsync(logEvent, CancellationToken.None);
+
+        Assert.Contains("[init] prepare  npm output", interaction.Lines);
+    }
+
+    [Fact]
     public async Task JsonRenderer_EmitsProfileDetailsOnCompletion()
     {
         using var stream = new MemoryStream();
@@ -673,6 +715,61 @@ public class StartInitializationTests : IDisposable
         Assert.Contains(" 50%", output);
         Assert.DoesNotContain("\u001b[2J", output);
         Assert.Contains("Preparing download", output);
+    }
+
+    [Fact]
+    public async Task CompactRenderer_RendersBoundedLogTailAndCollapsesOnSuccess()
+    {
+        using var writer = new StringWriter();
+        IAnsiConsole console = CreateInteractiveConsole(writer);
+        var renderer = new CompactStartInitializationRenderer(new TestInteractionService(), "5.0.0-test", console);
+        var step = new StartInitializationStep("prepare", "Prepare project", DisplayKind: StartInitializationDisplayKind.Progress);
+
+        await renderer.OnEventAsync(new StartInitializationStartedEvent(DateTimeOffset.UnixEpoch, "none"), CancellationToken.None);
+        await renderer.OnEventAsync(new StartInitializationStepStartedEvent(DateTimeOffset.UnixEpoch, step), CancellationToken.None);
+        await renderer.OnEventAsync(new StartInitializationProgressEvent(DateTimeOffset.UnixEpoch, "prepare", double.NaN, "running npm install"), CancellationToken.None);
+        for (int i = 1; i <= 12; i++)
+        {
+            await renderer.OnEventAsync(new StartInitializationLogEvent(DateTimeOffset.UnixEpoch, "prepare", $"entry {i:00}", FunctionsProjectReportSeverity.Info), CancellationToken.None);
+        }
+
+        await WaitForOutputAsync(writer, output => output.Contains("entry 12", StringComparison.Ordinal));
+        string runningOutput = writer.ToString();
+
+        Assert.Contains("running npm install", runningOutput);
+        Assert.DoesNotContain("entry 01", runningOutput);
+        Assert.DoesNotContain("entry 02", runningOutput);
+        Assert.Contains("entry 03", runningOutput);
+        Assert.Contains("entry 12", runningOutput);
+
+        await renderer.OnEventAsync(new StartInitializationStepCompletedEvent(DateTimeOffset.UnixEpoch, "prepare", "ready"), CancellationToken.None);
+        await renderer.OnEventAsync(new StartInitializationCompletedEvent(DateTimeOffset.UnixEpoch, CreateResult()), CancellationToken.None);
+        await renderer.DisposeAsync();
+
+        string completedOutput = writer.ToString();
+        Assert.Contains("12 lines", completedOutput);
+        Assert.Contains("ready", completedOutput);
+    }
+
+    [Fact]
+    public async Task CompactRenderer_RetainsLogTailOnFailure()
+    {
+        using var writer = new StringWriter();
+        IAnsiConsole console = CreateInteractiveConsole(writer);
+        var renderer = new CompactStartInitializationRenderer(new TestInteractionService(), "5.0.0-test", console);
+        var step = new StartInitializationStep("prepare", "Prepare project", DisplayKind: StartInitializationDisplayKind.Progress);
+
+        await renderer.OnEventAsync(new StartInitializationStartedEvent(DateTimeOffset.UnixEpoch, "none"), CancellationToken.None);
+        await renderer.OnEventAsync(new StartInitializationStepStartedEvent(DateTimeOffset.UnixEpoch, step), CancellationToken.None);
+        await renderer.OnEventAsync(new StartInitializationLogEvent(DateTimeOffset.UnixEpoch, "prepare", "error tail", FunctionsProjectReportSeverity.Error), CancellationToken.None);
+        await renderer.OnEventAsync(new StartInitializationStepFailedEvent(DateTimeOffset.UnixEpoch, "prepare", "build failed"), CancellationToken.None);
+        await renderer.DisposeAsync();
+
+        string output = writer.ToString();
+
+        Assert.Contains("build failed", output);
+        Assert.Contains("error tail", output);
+        Assert.DoesNotContain("1 lines", output);
     }
 
     [Fact]
@@ -838,6 +935,24 @@ public class StartInitializationTests : IDisposable
             {
                 ["FUNCTIONS_WORKER_RUNTIME"] = "dotnet-isolated",
             });
+
+    private static StartInitializationResult CreateResult()
+    {
+        var runInfo = new DashboardRunInfo(CliVersion: "5.0.0-test", ProfileName: "none", StackName: ".NET");
+        var eventStream = new InMemoryHostEventStream();
+        FunctionsProject project = CreateProject(WorkingDirectory.FromExplicit(Environment.CurrentDirectory));
+        FunctionsProjectHostRunContext hostRunContext = CreateHostRunContext(WorkingDirectory.FromExplicit(Environment.CurrentDirectory));
+        IFunctionsWorker worker = CreateWorker("dotnet-isolated", "dotnet-isolated");
+        return new StartInitializationResult(
+            runInfo,
+            eventStream,
+            HostVersion: "4.834.0",
+            BundleRequired: false,
+            BundleVersion: null,
+            project,
+            worker,
+            hostRunContext);
+    }
 
     private static IAnsiConsole CreateInteractiveConsole(TextWriter writer)
         => AnsiConsole.Create(new AnsiConsoleSettings

--- a/test/Func.Tests/Commands/StartInitializationTests.cs
+++ b/test/Func.Tests/Commands/StartInitializationTests.cs
@@ -718,7 +718,7 @@ public class StartInitializationTests : IDisposable
     }
 
     [Fact]
-    public async Task CompactRenderer_RendersBoundedLogTailAndCollapsesOnSuccess()
+    public async Task CompactRenderer_RendersBoundedLogTailAndFullyCollapsesOnSuccess()
     {
         using var writer = new StringWriter();
         IAnsiConsole console = CreateInteractiveConsole(writer);
@@ -747,8 +747,61 @@ public class StartInitializationTests : IDisposable
         await renderer.DisposeAsync();
 
         string completedOutput = writer.ToString();
-        Assert.Contains("12 lines", completedOutput);
         Assert.Contains("ready", completedOutput);
+
+        // On success the log area collapses entirely. The old collapsed summary row was the only place a
+        // line count was followed by an ellipsis ("N lines…"), so its absence guards the full collapse.
+        string ellipsis = console.Profile.Capabilities.Unicode ? "\u2026" : "...";
+        Assert.DoesNotContain($"lines{ellipsis}", completedOutput);
+    }
+
+    [Fact]
+    public async Task CompactRenderer_ShowsRunningLineCountWhileStreaming()
+    {
+        using var writer = new StringWriter();
+        IAnsiConsole console = CreateInteractiveConsole(writer);
+        var renderer = new CompactStartInitializationRenderer(new TestInteractionService(), "5.0.0-test", console);
+        var step = new StartInitializationStep("prepare", "Prepare project", DisplayKind: StartInitializationDisplayKind.Progress);
+
+        await renderer.OnEventAsync(new StartInitializationStartedEvent(DateTimeOffset.UnixEpoch, "none"), CancellationToken.None);
+        await renderer.OnEventAsync(new StartInitializationStepStartedEvent(DateTimeOffset.UnixEpoch, step), CancellationToken.None);
+        for (int i = 1; i <= 3; i++)
+        {
+            await renderer.OnEventAsync(new StartInitializationLogEvent(DateTimeOffset.UnixEpoch, "prepare", $"line {i}", FunctionsProjectReportSeverity.Info), CancellationToken.None);
+        }
+
+        await WaitForOutputAsync(writer, output => output.Contains("3 lines", StringComparison.Ordinal));
+
+        await renderer.DisposeAsync();
+
+        string output = writer.ToString();
+        Assert.Contains("3 lines", output);
+        Assert.Contains("line 3", output);
+    }
+
+    [Fact]
+    public async Task CompactRenderer_TruncatesLongLogLinesToWidth()
+    {
+        using var writer = new StringWriter();
+        IAnsiConsole console = CreateInteractiveConsole(writer);
+        string longLine = new('x', console.Profile.Width * 2);
+        var renderer = new CompactStartInitializationRenderer(new TestInteractionService(), "5.0.0-test", console);
+        var step = new StartInitializationStep("prepare", "Prepare project", DisplayKind: StartInitializationDisplayKind.Progress);
+
+        await renderer.OnEventAsync(new StartInitializationStartedEvent(DateTimeOffset.UnixEpoch, "none"), CancellationToken.None);
+        await renderer.OnEventAsync(new StartInitializationStepStartedEvent(DateTimeOffset.UnixEpoch, step), CancellationToken.None);
+        await renderer.OnEventAsync(new StartInitializationLogEvent(DateTimeOffset.UnixEpoch, "prepare", longLine, FunctionsProjectReportSeverity.Info), CancellationToken.None);
+
+        string ellipsis = console.Profile.Capabilities.Unicode ? "\u2026" : "...";
+        await WaitForOutputAsync(writer, output => output.Contains(ellipsis, StringComparison.Ordinal));
+
+        await renderer.DisposeAsync();
+
+        string output = writer.ToString();
+
+        // No single rendered line should reach the untruncated length, so the full run never appears.
+        Assert.DoesNotContain(longLine, output);
+        Assert.Contains(ellipsis, output);
     }
 
     [Fact]

--- a/test/Func.Tests/Projects/FunctionsProjectHostRunContextTests.cs
+++ b/test/Func.Tests/Projects/FunctionsProjectHostRunContextTests.cs
@@ -93,7 +93,6 @@ public sealed class FunctionsProjectHostRunContextTests
         IFunctionsProjectHostRunReporter reporter = NullFunctionsProjectHostRunReporter.Instance;
 
         reporter.ReportStatus("working");
-        reporter.ReportProgress(50, "halfway");
         reporter.WriteLog("line", FunctionsProjectReportSeverity.Warning);
     }
 

--- a/test/Func.Tests/Projects/FunctionsProjectHostRunContextTests.cs
+++ b/test/Func.Tests/Projects/FunctionsProjectHostRunContextTests.cs
@@ -65,6 +65,39 @@ public sealed class FunctionsProjectHostRunContextTests
     }
 
     [Fact]
+    public void Constructor_ProvidesNonNullReporter()
+    {
+        var context = new FunctionsProjectHostRunContext(
+            new DirectoryInfo(Environment.CurrentDirectory),
+            "dotnet-isolated",
+            new Dictionary<string, string>());
+
+        Assert.NotNull(context.Reporter);
+        Assert.IsType<NullFunctionsProjectHostRunReporter>(context.Reporter);
+    }
+
+    [Fact]
+    public void Reporter_SetToNull_Throws()
+    {
+        var context = new FunctionsProjectHostRunContext(
+            new DirectoryInfo(Environment.CurrentDirectory),
+            "dotnet-isolated",
+            new Dictionary<string, string>());
+
+        Assert.Throws<ArgumentNullException>(() => context.Reporter = null!);
+    }
+
+    [Fact]
+    public void NullFunctionsProjectHostRunReporter_Methods_DoNotThrow()
+    {
+        IFunctionsProjectHostRunReporter reporter = NullFunctionsProjectHostRunReporter.Instance;
+
+        reporter.ReportStatus("working");
+        reporter.ReportProgress(50, "halfway");
+        reporter.WriteLog("line", FunctionsProjectReportSeverity.Warning);
+    }
+
+    [Fact]
     public async Task FunctionsProject_DefaultLifecycleHooks_CompleteSuccessfully()
     {
         var project = new TestFunctionsProject();

--- a/test/Workloads/Stacks/DotNet.Tests/DotNetSourceProjectTests.cs
+++ b/test/Workloads/Stacks/DotNet.Tests/DotNetSourceProjectTests.cs
@@ -4,7 +4,6 @@
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Projects;
 using NSubstitute;
-using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.DotNet.Tests;
@@ -43,11 +42,7 @@ public class DotNetSourceProjectTests : IDisposable
         string assemblyPath = Path.Combine(_projectDir.FullName, "bin", "Debug", "net10.0", "MyApp.dll");
         string json = BuildTargetResultJson(assemblyPath, "Build");
 
-        _dotnetCli.RunWithOutputAsync(
-                Arg.Is<IReadOnlyList<string>>(args => args[0] == "build" && args.Contains("--getTargetResult:Build")),
-                Arg.Any<string?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(json);
+        SetupStreamingBuild("--getTargetResult:Build", json);
 
         DotNetSourceProject project = CreateProject(projectFile);
         FunctionsProjectHostRunContext context = CreateHostRunContext();
@@ -56,6 +51,36 @@ public class DotNetSourceProjectTests : IDisposable
 
         string expectedDir = Path.GetDirectoryName(assemblyPath)!;
         Assert.Equal(expectedDir, context.StartupDirectory.FullName.TrimEnd(Path.DirectorySeparatorChar));
+    }
+
+    [Fact]
+    public async Task PrepareForHostRunAsync_streams_build_output_to_reporter()
+    {
+        string projectFile = Path.Combine(_projectDir.FullName, "MyApp.csproj");
+        File.WriteAllText(projectFile, "<Project></Project>");
+
+        string assemblyPath = Path.Combine(_projectDir.FullName, "bin", "Debug", "net10.0", "MyApp.dll");
+        string json = BuildTargetResultJson(assemblyPath, "Build");
+
+        SetupStreamingBuild(
+            "--getTargetResult:Build",
+            json,
+            outputLines: ["  MyApp -> MyApp.dll", "Build succeeded."],
+            errorLines: ["warning XYZ: heads up"]);
+
+        var reporter = new CapturingReporter();
+        DotNetSourceProject project = CreateProject(projectFile);
+        FunctionsProjectHostRunContext context = CreateHostRunContext();
+        context.Reporter = reporter;
+
+        await project.PrepareForHostRunAsync(context, default);
+
+        Assert.Contains(
+            reporter.Logs,
+            entry => entry.Severity == FunctionsProjectReportSeverity.Info && entry.Line == "Build succeeded.");
+        Assert.Contains(
+            reporter.Logs,
+            entry => entry.Severity == FunctionsProjectReportSeverity.Error && entry.Line == "warning XYZ: heads up");
     }
 
     [Fact]
@@ -71,11 +96,7 @@ public class DotNetSourceProjectTests : IDisposable
         Directory.CreateDirectory(Path.GetDirectoryName(assemblyPath)!);
         File.WriteAllText(assemblyPath, string.Empty);
 
-        _dotnetCli.RunWithOutputAsync(
-                Arg.Is<IReadOnlyList<string>>(args => args.Contains("--getTargetResult:GetTargetPath")),
-                Arg.Any<string?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(json);
+        SetupStreamingBuild("--getTargetResult:GetTargetPath", json);
 
         DotNetSourceProject project = CreateProject(projectFile);
         FunctionsProjectHostRunContext context = CreateHostRunContext(skipBuild: true);
@@ -83,9 +104,11 @@ public class DotNetSourceProjectTests : IDisposable
         await project.PrepareForHostRunAsync(context, default);
 
         // Should NOT have called the build target
-        await _dotnetCli.DidNotReceive().RunWithOutputAsync(
+        await _dotnetCli.DidNotReceive().RunStreamingAsync(
             Arg.Is<IReadOnlyList<string>>(args => args.Contains("--getTargetResult:Build")),
             Arg.Any<string?>(),
+            Arg.Any<Action<string>?>(),
+            Arg.Any<Action<string>?>(),
             Arg.Any<CancellationToken>());
 
         string expectedDir = Path.GetDirectoryName(assemblyPath)!;
@@ -102,11 +125,7 @@ public class DotNetSourceProjectTests : IDisposable
         string assemblyPath = Path.Combine(_projectDir.FullName, "bin", "Debug", "net10.0", "MyApp.dll");
         string json = BuildTargetResultJson(assemblyPath, "GetTargetPath");
 
-        _dotnetCli.RunWithOutputAsync(
-                Arg.Is<IReadOnlyList<string>>(args => args.Contains("--getTargetResult:GetTargetPath")),
-                Arg.Any<string?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(json);
+        SetupStreamingBuild("--getTargetResult:GetTargetPath", json);
 
         DotNetSourceProject project = CreateProject(projectFile);
         FunctionsProjectHostRunContext context = CreateHostRunContext(skipBuild: true);
@@ -125,11 +144,9 @@ public class DotNetSourceProjectTests : IDisposable
         string projectFile = Path.Combine(_projectDir.FullName, "MyApp.csproj");
         File.WriteAllText(projectFile, "<Project></Project>");
 
-        _dotnetCli.RunWithOutputAsync(
-                Arg.Is<IReadOnlyList<string>>(args => args.Contains("--getTargetResult:GetTargetPath")),
-                Arg.Any<string?>(),
-                Arg.Any<CancellationToken>())
-            .Throws(new DotnetCliException(1, "Target path resolution failed", "", "build MyApp.csproj"));
+        SetupStreamingFailure(
+            "--getTargetResult:GetTargetPath",
+            new DotnetCliException(1, "Target path resolution failed", "", "build MyApp.csproj"));
 
         DotNetSourceProject project = CreateProject(projectFile);
         FunctionsProjectHostRunContext context = CreateHostRunContext(skipBuild: true);
@@ -148,11 +165,7 @@ public class DotNetSourceProjectTests : IDisposable
         string projectFile = Path.Combine(_projectDir.FullName, "MyApp.csproj");
         File.WriteAllText(projectFile, "<Project></Project>");
 
-        _dotnetCli.RunWithOutputAsync(
-                Arg.Is<IReadOnlyList<string>>(args => args[0] == "build" && args.Contains("--getTargetResult:Build")),
-                Arg.Any<string?>(),
-                Arg.Any<CancellationToken>())
-            .Returns("   \n");
+        SetupStreamingBuild("--getTargetResult:Build", "   \n");
 
         DotNetSourceProject project = CreateProject(projectFile);
         FunctionsProjectHostRunContext context = CreateHostRunContext();
@@ -170,11 +183,9 @@ public class DotNetSourceProjectTests : IDisposable
         string projectFile = Path.Combine(_projectDir.FullName, "MyApp.csproj");
         File.WriteAllText(projectFile, "<Project></Project>");
 
-        _dotnetCli.RunWithOutputAsync(
-                Arg.Is<IReadOnlyList<string>>(args => args[0] == "build" && args.Contains("--getTargetResult:Build")),
-                Arg.Any<string?>(),
-                Arg.Any<CancellationToken>())
-            .Throws(new DotnetCliException(1, "Build failed", "", "build MyApp.csproj"));
+        SetupStreamingFailure(
+            "--getTargetResult:Build",
+            new DotnetCliException(1, "Build failed", "", "build MyApp.csproj"));
 
         DotNetSourceProject project = CreateProject(projectFile);
         FunctionsProjectHostRunContext context = CreateHostRunContext();
@@ -260,6 +271,85 @@ public class DotNetSourceProjectTests : IDisposable
 
     private FunctionsProjectHostRunContext CreateHostRunContext(bool skipBuild = false)
         => new(_projectDir, "dotnet", new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase), skipBuild);
+
+    private void SetupStreamingBuild(string targetResultArg, string json, string[]? outputLines = null, string[]? errorLines = null)
+    {
+        _dotnetCli
+            .When(x => x.RunStreamingAsync(
+                Arg.Is<IReadOnlyList<string>>(args => args.Contains(targetResultArg)),
+                Arg.Any<string?>(),
+                Arg.Any<Action<string>?>(),
+                Arg.Any<Action<string>?>(),
+                Arg.Any<CancellationToken>()))
+            .Do(callInfo =>
+            {
+                IReadOnlyList<string> args = callInfo.ArgAt<IReadOnlyList<string>>(0);
+                Action<string>? onOutput = callInfo.ArgAt<Action<string>?>(2);
+                Action<string>? onError = callInfo.ArgAt<Action<string>?>(3);
+
+                foreach (string line in outputLines ?? [])
+                {
+                    onOutput?.Invoke(line);
+                }
+
+                foreach (string line in errorLines ?? [])
+                {
+                    onError?.Invoke(line);
+                }
+
+                // Mirror MSBuild's --getResultOutputFile behavior: the structured result is written to the
+                // file path supplied in the arguments rather than to stdout.
+                File.WriteAllText(GetResultFilePath(args), json);
+            });
+    }
+
+    private void SetupStreamingFailure(string targetResultArg, Exception exception)
+    {
+        _dotnetCli
+            .When(x => x.RunStreamingAsync(
+                Arg.Is<IReadOnlyList<string>>(args => args.Contains(targetResultArg)),
+                Arg.Any<string?>(),
+                Arg.Any<Action<string>?>(),
+                Arg.Any<Action<string>?>(),
+                Arg.Any<CancellationToken>()))
+            .Do(_ => throw exception);
+    }
+
+    private static string GetResultFilePath(IReadOnlyList<string> args)
+    {
+        const string prefix = "--getResultOutputFile:";
+        string arg = args.First(a => a.StartsWith(prefix, StringComparison.Ordinal));
+        return arg[prefix.Length..];
+    }
+
+    private sealed class CapturingReporter : IFunctionsProjectHostRunReporter
+    {
+        private readonly List<(string Line, FunctionsProjectReportSeverity Severity)> _logs = [];
+        private readonly object _gate = new();
+
+        public IReadOnlyList<(string Line, FunctionsProjectReportSeverity Severity)> Logs
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _logs.ToArray();
+                }
+            }
+        }
+
+        public void ReportStatus(string message)
+        {
+        }
+
+        public void WriteLog(string line, FunctionsProjectReportSeverity severity = FunctionsProjectReportSeverity.Info)
+        {
+            lock (_gate)
+            {
+                _logs.Add((line, severity));
+            }
+        }
+    }
 
     private static string BuildTargetResultJson(string assemblyFullPath, string targetName)
     {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

Fixes https://github.com/Azure/azure-functions-core-tools/issues/5217

### Issue describing the changes in this PR

Summary

When func start prepares a project for the host run (restoring/building/installing for the active stack), the CLI previously went quiet and only surfaced (limited) output if something failed. This PR adds a host-run reporting contract, bridges stack project reports into the start-initialization event stream, and streams build/prepare output live under the spinner, with a compact renderer that collapses each step to a single checklist line on success and retains the failing step's log tail on failure.

What changed

Reporting contract (Abstractions)

 - New public contract for projects to report during host-run preparation/
 - Deliberately does not expose a determinate ReportProgress lever: progress for external build processes (dotnet/npm/tsc/go/pip) is opaque, so the public surface stays to coarse status + log output. Internal determinate steps still use ReportProgressAsync.
 - The severity enum is an extensibility-surface vocabulary that intentionally avoids using Microsoft.Extensions.Logging.LogLevel into the project contract; it is mapped to LogLevel/JSON at the rendering boundary.

Live dotnet build streaming

 - IDotnetCliRunner.RunStreamingAsync streams stdout/stderr and throws DotnetCliException on non-zero exit.
 - RunAsync (buffered) and the streaming path now share one process-execution core (ExecuteAsync + CreateStartInfo), removing duplicated start/exit/kill logic.
 - Build is invoked with --getResultOutputFile so normal build console output streams on stdout while the target-result JSON is written to a temp file (parsed for the output dir, then deleted).
 - DotNetSourceProject wires build output into the reporter (stdout→Info, stderr→Error).

Compact renderer polish

 - While a step streams: bounded log tail with a connecting gutter carrying a running line count.
 - Long lines are truncated to console width so they no longer wrap past the gutter.
 - On success: the log area collapses entirely (footer included) so each finished step is a single checklist line.
 - On failure: the final frame is re-rendered after the AutoClear live display stops, so the failed checklist and its log tail stay on screen.

Stacks

 - Go/Node/Python projects report status + stream log lines through the new reporter, with severity chosen by exit code. (no live streaming at this point. Will add in follow up PRs)
 
 The new experience:
 
 When running:
<img width="1872" height="274" alt="Progress" src="https://github.com/user-attachments/assets/aef1c780-5152-4916-84d8-f0cecdac570e" />

Collapsed on success:
<img width="1088" height="126" alt="Success" src="https://github.com/user-attachments/assets/8ce40ab5-4f8d-4859-9a72-28f79df4f0eb" />

Persist tail on failure:
<img width="1914" height="290" alt="Error" src="https://github.com/user-attachments/assets/3339d0f2-0ee0-4695-a73c-7f5a95cd2c9e" />
