### PR TITLE
pick AppendToFile job when create-target already exists

### DIFF
--- a/src/Templates.V2/V2TemplateEngine.cs
+++ b/src/Templates.V2/V2TemplateEngine.cs
@@ -58,7 +58,7 @@ internal sealed class V2TemplateEngine
         ArgumentNullException.ThrowIfNull(workingDirectory);
         ArgumentException.ThrowIfNullOrWhiteSpace(functionName);
 
-        V2Job? job = template.Jobs?.FirstOrDefault();
+        V2Job? job = PickJob(template, workingDirectory);
 
         var variables = new Dictionary<string, string>(StringComparer.Ordinal)
         {
@@ -222,6 +222,16 @@ internal sealed class V2TemplateEngine
 
                         try
                         {
+                            // Ensure the snippet starts on a fresh line:
+                            // append-actions in real-world templates (python
+                            // function_body.py) carry neither a leading nor
+                            // trailing newline, so back-to-back appends to a
+                            // file whose tail isn't already a newline run the
+                            // previous function's closing token into the next
+                            // decorator (e.g. ")@app.route(...)") and yield
+                            // syntactically broken output. Probe a small tail
+                            // window rather than read the entire file.
+                            EnsureTrailingNewline(fullPath);
                             File.AppendAllText(fullPath, snippet);
                             if (!writtenFiles.Contains(fullPath, StringComparer.OrdinalIgnoreCase))
                             {
@@ -351,6 +361,111 @@ internal sealed class V2TemplateEngine
 
     private static TemplateApplicationResult.Failed Failed(string message)
         => new(new TemplateApplicationFailure.ProviderError(message, null));
+
+    // Multi-job v2 templates (e.g. python) expose CreateNewApp and
+    // AppendToFile as alternatives for the same outcome — make a new
+    // function_app.py, or append a decorator to the user's existing one.
+    // Pick AppendToFile when the create-job's target already exists on
+    // disk, so `func new` after `func init` appends rather than failing
+    // with AlreadyExists (#5209). Falls back to jobs[0] for single-job
+    // templates and for any template that doesn't declare both alternatives,
+    // preserving existing behaviour.
+    private static V2Job? PickJob(NewTemplate template, DirectoryInfo workingDirectory)
+    {
+        if (template.Jobs is not { Count: > 0 })
+        {
+            return null;
+        }
+
+        if (template.Jobs.Count == 1)
+        {
+            return template.Jobs[0];
+        }
+
+        V2Job? createJob = template.Jobs.FirstOrDefault(j =>
+            string.Equals(j.Type, "CreateNewApp", StringComparison.OrdinalIgnoreCase));
+        V2Job? appendJob = template.Jobs.FirstOrDefault(j =>
+            string.Equals(j.Type, "AppendToFile", StringComparison.OrdinalIgnoreCase));
+
+        if (createJob is null)
+        {
+            return template.Jobs[0];
+        }
+
+        if (appendJob is null)
+        {
+            return createJob;
+        }
+
+        return CreateTargetExists(template, createJob, workingDirectory) ? appendJob : createJob;
+    }
+
+    // Resolves the create-job's first WriteToFile target against the job's
+    // own input defaults, then checks whether the file already exists in
+    // the working directory. Uses defaults rather than user-supplied
+    // option values because the relevant filename inputs in real-world
+    // templates are gated to non-CLI clients (VS Code), so the CLI always
+    // sees the schema default at this point.
+    private static bool CreateTargetExists(NewTemplate template, V2Job createJob, DirectoryInfo workingDirectory)
+    {
+        IReadOnlyList<V2Action> sequence = ResolveActionSequence(template, createJob);
+        V2Action? writeAction = sequence.FirstOrDefault(a =>
+            string.Equals(a.Type, "WriteToFile", StringComparison.OrdinalIgnoreCase));
+        if (writeAction?.FilePath is null)
+        {
+            return false;
+        }
+
+        Dictionary<string, string> defaults = BuildInputDefaults(createJob);
+        string? resolved = Substitute(writeAction.FilePath, defaults);
+        if (string.IsNullOrWhiteSpace(resolved))
+        {
+            return false;
+        }
+
+        string fullPath = Path.GetFullPath(Path.Combine(workingDirectory.FullName, resolved));
+        return File.Exists(fullPath);
+    }
+
+    private static Dictionary<string, string> BuildInputDefaults(V2Job job)
+    {
+        var vars = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (job.Inputs is null)
+        {
+            return vars;
+        }
+
+        foreach (V2Input input in job.Inputs)
+        {
+            string? varName = ExtractVarName(input.AssignTo);
+            if (varName is not null && input.DefaultValue is not null)
+            {
+                vars[varName] = input.DefaultValue;
+            }
+        }
+
+        return vars;
+    }
+
+    private static void EnsureTrailingNewline(string fullPath)
+    {
+        using FileStream stream = new(fullPath, FileMode.Open, FileAccess.ReadWrite, FileShare.Read);
+        if (stream.Length == 0)
+        {
+            return;
+        }
+
+        stream.Seek(-1, SeekOrigin.End);
+        int lastByte = stream.ReadByte();
+        if (lastByte == '\n')
+        {
+            return;
+        }
+
+        stream.Seek(0, SeekOrigin.End);
+        byte[] newline = System.Text.Encoding.UTF8.GetBytes(Environment.NewLine);
+        stream.Write(newline, 0, newline.Length);
+    }
 
     /// <summary>
     /// Sanitizes a user-supplied function name so it is safe to emit as a Python

--- a/src/Templates.V2/V2TemplateEngine.cs
+++ b/src/Templates.V2/V2TemplateEngine.cs
@@ -222,15 +222,9 @@ internal sealed class V2TemplateEngine
 
                         try
                         {
-                            // Ensure the snippet starts on a fresh line:
-                            // append-actions in real-world templates (python
-                            // function_body.py) carry neither a leading nor
-                            // trailing newline, so back-to-back appends to a
-                            // file whose tail isn't already a newline run the
-                            // previous function's closing token into the next
-                            // decorator (e.g. ")@app.route(...)") and yield
-                            // syntactically broken output. Probe a small tail
-                            // window rather than read the entire file.
+                            // Function-body snippets carry no leading or trailing
+                            // newline, so guard against the previous append's
+                            // closing token running into the next decorator.
                             EnsureTrailingNewline(fullPath);
                             File.AppendAllText(fullPath, snippet);
                             if (!writtenFiles.Contains(fullPath, StringComparer.OrdinalIgnoreCase))
@@ -362,14 +356,10 @@ internal sealed class V2TemplateEngine
     private static TemplateApplicationResult.Failed Failed(string message)
         => new(new TemplateApplicationFailure.ProviderError(message, null));
 
-    // Multi-job v2 templates (e.g. python) expose CreateNewApp and
-    // AppendToFile as alternatives for the same outcome — make a new
-    // function_app.py, or append a decorator to the user's existing one.
-    // Pick AppendToFile when the create-job's target already exists on
-    // disk, so `func new` after `func init` appends rather than failing
-    // with AlreadyExists (#5209). Falls back to jobs[0] for single-job
-    // templates and for any template that doesn't declare both alternatives,
-    // preserving existing behaviour.
+    // Multi-job templates expose CreateNewApp and AppendToFile as alternatives
+    // for the same target. Pick the append job when the create-target already
+    // exists, so `func new` after `func init` appends instead of failing with
+    // AlreadyExists (#5209).
     private static V2Job? PickJob(NewTemplate template, DirectoryInfo workingDirectory)
     {
         if (template.Jobs is not { Count: > 0 })
@@ -400,12 +390,9 @@ internal sealed class V2TemplateEngine
         return CreateTargetExists(template, createJob, workingDirectory) ? appendJob : createJob;
     }
 
-    // Resolves the create-job's first WriteToFile target against the job's
-    // own input defaults, then checks whether the file already exists in
-    // the working directory. Uses defaults rather than user-supplied
-    // option values because the relevant filename inputs in real-world
-    // templates are gated to non-CLI clients (VS Code), so the CLI always
-    // sees the schema default at this point.
+    // Resolves against input defaults rather than user-supplied values: the
+    // relevant filename prompts (app-fileName, app-selectedFileName) are gated
+    // to VS Code clients, so the CLI always sees the schema default here.
     private static bool CreateTargetExists(NewTemplate template, V2Job createJob, DirectoryInfo workingDirectory)
     {
         IReadOnlyList<V2Action> sequence = ResolveActionSequence(template, createJob);

--- a/test/Func.Tests/Templates/V2/V2TemplateEngineTests.cs
+++ b/test/Func.Tests/Templates/V2/V2TemplateEngineTests.cs
@@ -389,8 +389,6 @@ public class V2TemplateEngineTests : IDisposable
     [Fact]
     public void Apply_MultiJob_PicksCreateNewApp_When_Target_Missing()
     {
-        // Shape mirrors the real python v2 templates: a CreateNewApp job
-        // and an AppendToFile job that share the same target filename.
         NewTemplate template = MakeCreateOrAppendTemplate();
 
         var engine = new V2TemplateEngine();
@@ -437,9 +435,8 @@ public class V2TemplateEngineTests : IDisposable
     [Fact]
     public void Apply_MultiJob_AppendToFile_Inserts_Newline_When_Tail_Missing()
     {
-        // Pre-existing file deliberately ends without a trailing newline, as
-        // would happen after a previous AppendToFile whose snippet has no
-        // trailing newline (the real python function_body.py shape).
+        // Models the state left behind by a prior AppendToFile whose snippet
+        // had no trailing newline (the real python function_body.py shape).
         string target = Path.Combine(_workingDir, "function_app.py");
         File.WriteAllText(target, "prior_no_newline");
 
@@ -462,9 +459,6 @@ public class V2TemplateEngineTests : IDisposable
     [Fact]
     public void Apply_MultiJob_With_No_CreateNewApp_Falls_Back_To_First_Job()
     {
-        // Template with only Blueprint-style jobs (no CreateNewApp /
-        // AppendToFile pair). Picker should fall back to jobs[0], preserving
-        // legacy behaviour for templates the heuristic doesn't understand.
         NewTemplate template = new()
         {
             Id = "BlueprintOnly",

--- a/test/Func.Tests/Templates/V2/V2TemplateEngineTests.cs
+++ b/test/Func.Tests/Templates/V2/V2TemplateEngineTests.cs
@@ -385,4 +385,206 @@ public class V2TemplateEngineTests : IDisposable
         Assert.Contains("handler: HttpTrigger_Python", content);
         Assert.DoesNotContain("HttpTrigger-Python", content);
     }
+
+    [Fact]
+    public void Apply_MultiJob_PicksCreateNewApp_When_Target_Missing()
+    {
+        // Shape mirrors the real python v2 templates: a CreateNewApp job
+        // and an AppendToFile job that share the same target filename.
+        NewTemplate template = MakeCreateOrAppendTemplate();
+
+        var engine = new V2TemplateEngine();
+        TemplateApplicationResult result = engine.Apply(
+            template,
+            functionName: "MyFn",
+            optionValuesByPromptId: new Dictionary<string, string?>(),
+            workingDirectory: new DirectoryInfo(_workingDir),
+            force: false);
+
+        var created = Assert.IsType<TemplateApplicationResult.Created>(result);
+        string target = Path.GetFullPath(Path.Combine(_workingDir, "function_app.py"));
+        Assert.Equal(target, created.Files.Single());
+
+        string content = File.ReadAllText(target);
+        Assert.StartsWith("# fresh app skeleton", content);
+        Assert.DoesNotContain("@app.route", content);
+    }
+
+    [Fact]
+    public void Apply_MultiJob_PicksAppendToFile_When_Target_Exists()
+    {
+        string target = Path.Combine(_workingDir, "function_app.py");
+        File.WriteAllText(target, "# preexisting\n");
+
+        NewTemplate template = MakeCreateOrAppendTemplate();
+
+        var engine = new V2TemplateEngine();
+        TemplateApplicationResult result = engine.Apply(
+            template,
+            functionName: "MyFn",
+            optionValuesByPromptId: new Dictionary<string, string?>(),
+            workingDirectory: new DirectoryInfo(_workingDir),
+            force: false);
+
+        var created = Assert.IsType<TemplateApplicationResult.Created>(result);
+        Assert.Equal(Path.GetFullPath(target), created.Files.Single());
+
+        string content = File.ReadAllText(target);
+        Assert.StartsWith("# preexisting", content);
+        Assert.Contains("@app.route(MyFn)", content);
+    }
+
+    [Fact]
+    public void Apply_MultiJob_AppendToFile_Inserts_Newline_When_Tail_Missing()
+    {
+        // Pre-existing file deliberately ends without a trailing newline, as
+        // would happen after a previous AppendToFile whose snippet has no
+        // trailing newline (the real python function_body.py shape).
+        string target = Path.Combine(_workingDir, "function_app.py");
+        File.WriteAllText(target, "prior_no_newline");
+
+        NewTemplate template = MakeCreateOrAppendTemplate();
+
+        var engine = new V2TemplateEngine();
+        TemplateApplicationResult result = engine.Apply(
+            template,
+            functionName: "Next",
+            optionValuesByPromptId: new Dictionary<string, string?>(),
+            workingDirectory: new DirectoryInfo(_workingDir),
+            force: false);
+
+        Assert.IsType<TemplateApplicationResult.Created>(result);
+        string content = File.ReadAllText(target);
+        Assert.DoesNotContain("prior_no_newline@app.route", content);
+        Assert.Matches(@"prior_no_newline\r?\n@app\.route\(Next\)", content);
+    }
+
+    [Fact]
+    public void Apply_MultiJob_With_No_CreateNewApp_Falls_Back_To_First_Job()
+    {
+        // Template with only Blueprint-style jobs (no CreateNewApp /
+        // AppendToFile pair). Picker should fall back to jobs[0], preserving
+        // legacy behaviour for templates the heuristic doesn't understand.
+        NewTemplate template = new()
+        {
+            Id = "BlueprintOnly",
+            Jobs =
+            [
+                new V2Job
+                {
+                    Type = "CreateNewBlueprint",
+                    Actions = ["write_blueprint"],
+                },
+                new V2Job
+                {
+                    Type = "AppendToBlueprint",
+                    Actions = ["append_blueprint"],
+                },
+            ],
+            Actions =
+            [
+                new V2Action
+                {
+                    Name = "write_blueprint",
+                    Type = "WriteToFile",
+                    FilePath = "blueprint.py",
+                    FileContent = "blueprint body",
+                },
+                new V2Action
+                {
+                    Name = "append_blueprint",
+                    Type = "AppendToFile",
+                    FilePath = "blueprint.py",
+                    FileContent = "extra",
+                },
+            ],
+        };
+
+        var engine = new V2TemplateEngine();
+        TemplateApplicationResult result = engine.Apply(
+            template,
+            functionName: "MyFn",
+            optionValuesByPromptId: new Dictionary<string, string?>(),
+            workingDirectory: new DirectoryInfo(_workingDir),
+            force: false);
+
+        Assert.IsType<TemplateApplicationResult.Created>(result);
+        Assert.Equal("blueprint body", File.ReadAllText(Path.Combine(_workingDir, "blueprint.py")));
+    }
+
+    private static NewTemplate MakeCreateOrAppendTemplate() => new()
+    {
+        Id = "HttpTrigger-Python",
+        ProgrammingModel = "v2",
+        Language = "python",
+        Jobs =
+        [
+            new V2Job
+            {
+                Type = "CreateNewApp",
+                Inputs =
+                [
+                    new V2Input
+                    {
+                        ParamId = "app-fileName",
+                        AssignTo = "$(APP_FILENAME)",
+                        DefaultValue = "function_app.py",
+                        Required = true,
+                    },
+                ],
+                Actions = ["read_app", "write_app"],
+            },
+            new V2Job
+            {
+                Type = "AppendToFile",
+                Inputs =
+                [
+                    new V2Input
+                    {
+                        ParamId = "app-selectedFileName",
+                        AssignTo = "$(SELECTED_FILEPATH)",
+                        DefaultValue = "function_app.py",
+                        Required = true,
+                    },
+                ],
+                Actions = ["read_body", "append_body"],
+            },
+        ],
+        Actions =
+        [
+            new V2Action
+            {
+                Name = "read_app",
+                Type = "GetTemplateFileContent",
+                FilePath = "function_app.py",
+                AssignTo = "$(APP_CONTENT)",
+            },
+            new V2Action
+            {
+                Name = "write_app",
+                Type = "WriteToFile",
+                FilePath = "$(APP_FILENAME)",
+                Source = "$(APP_CONTENT)",
+            },
+            new V2Action
+            {
+                Name = "read_body",
+                Type = "GetTemplateFileContent",
+                FilePath = "function_body.py",
+                AssignTo = "$(BODY_CONTENT)",
+            },
+            new V2Action
+            {
+                Name = "append_body",
+                Type = "AppendToFile",
+                FilePath = "$(SELECTED_FILEPATH)",
+                Source = "$(BODY_CONTENT)",
+            },
+        ],
+        Files = new Dictionary<string, string>
+        {
+            ["function_app.py"] = "# fresh app skeleton",
+            ["function_body.py"] = "@app.route($(FUNCTION_NAME_INPUT))",
+        },
+    };
 }


### PR DESCRIPTION
## What

Fixes #5209.

`func new` immediately after `func init` for a python project failed with:

```
Error: Some files already exist:
  /Users/likasem/bugbash/MyPyApp/function_app.py
Re-run with --force to overwrite.
```

`--force` "worked" only in the sense that it clobbered the user's existing `function_app.py`, deleting any functions they'd already added — not a workable workaround.

## Why

Every python v2 template (`Workloads.Templates.Python`) ships four jobs that share a single top-level `actions[]` pool:

| idx | `type` | semantics |
|----:|--|--|
| 0 | `CreateNewApp` | write a fresh `function_app.py` from scratch |
| 1 | `AppendToFile` | append a decorator to the existing `function_app.py` |
| 2 | `CreateNewBlueprint` | (blueprint, out of scope for this PR) |
| 3 | `AppendToBlueprint` | (blueprint, out of scope for this PR) |

`V2TemplateEngine.Apply` unconditionally picked `jobs[0]` (`CreateNewApp`). Its `WriteToFile` action then saw the existing `function_app.py` (written by `func init`), added it to `existingFiles`, and the engine returned `AlreadyExists` → user sees the misleading `--force` hint.

`CreateNewApp` and `AppendToFile` are the template authors' way of expressing alternatives for the same outcome — the engine needs to look at the project state to choose between them. The doc-comment at the top of the file already acknowledged this as a known limitation:

> *"this engine selects the first job by default (matching legacy `func new` behaviour)"*

Node v2 templates were unaffected because they ship a single `CreateNewApp` job and scaffold to a per-function path (`src/functions/$(FUNCTION_NAME_INPUT).js`), so there was no collision in the first place.

## What changed

**`src/Templates.V2/V2TemplateEngine.cs`** — two related changes:

1. **Replace `Jobs?.FirstOrDefault()` with a `PickJob` heuristic.**
   - Single-job template → unchanged.
   - Multi-job, no `CreateNewApp` → fall back to `jobs[0]` (preserves legacy behaviour for templates the heuristic doesn't understand).
   - Multi-job with both `CreateNewApp` *and* `AppendToFile` → resolve the create-job's first `WriteToFile` target path against the create-job's input defaults; if that file exists on disk, run `AppendToFile`, otherwise run `CreateNewApp`.

   *Why defaults rather than user-supplied option values?* The relevant filename inputs (`app-fileName`, `app-selectedFileName`) in real-world templates are gated to non-CLI clients (`ClientId IN [VSCode]`), so the CLI always sees the schema default at this point. The template stays the source of truth.

2. **`EnsureTrailingNewline` guard on `AppendToFile`.** Discovered while smoke-testing the fix: the upstream `function_body.py` snippet has neither a leading nor trailing newline, so back-to-back appends produced syntactically broken Python — the previous function's closing `)` ran straight into the next `@app.route`:

   ```python
   # before this guard:
            status_code=200
       )@app.route(route="SecondHttp", ...)  # ← SyntaxError
   ```

   The guard probes the last byte of the target file (no full read) and writes `Environment.NewLine` only when the tail isn't already a newline. Idempotent across repeat appends.

## Verification

### Unit tests (`test/Func.Tests/Templates/V2/V2TemplateEngineTests.cs`)

Four new cases covering the picker + newline guard, plus the existing 17 still pass:

- `Apply_MultiJob_PicksCreateNewApp_When_Target_Missing`
- `Apply_MultiJob_PicksAppendToFile_When_Target_Exists`
- `Apply_MultiJob_AppendToFile_Inserts_Newline_When_Tail_Missing`
- `Apply_MultiJob_With_No_CreateNewApp_Falls_Back_To_First_Job`

```
Passed!  - Failed: 0, Passed: 21, Skipped: 0, Total: 21
```

### End-to-end (playground, win-x64)

```powershell
mkdir MyPyApp; cd $_
func init . --stack python
func new --template HttpTrigger-Python --name HttpExample --non-interactive
func new --template HttpTrigger-Python --name SecondHttp  --non-interactive
python -c "import ast; ast.parse(open('function_app.py').read()); print('SYNTAX OK')"
```

Output: both runs report `✓ Created function 'HttpTrigger-Python'.`, the resulting `function_app.py` contains the original `FunctionApp()` skeleton **plus** both `@app.route` decorators (in append order), and `ast.parse` reports `SYNTAX OK`.

### Build

- `dotnet build src/Func/Func.csproj -c Debug`: 0 warnings, 0 errors.
- `CI=true dotnet build … -c Release`: 0 warnings, 0 errors.

## Out of scope (filed-as-followups material, not changed here)

- **`--force` error wording.** `NewCommandRunner` still suggests `Re-run with --force to overwrite.` on `AlreadyExists`. With this fix the python flow no longer reaches that branch via the reported reproducer, but the message is still a footgun for any other "I already have it" case (and the wording is actively *harmful* for the python entry-point file). Worth softening separately.
- **Blueprint scaffolding (`CreateNewBlueprint` / `AppendToBlueprint`).** The two blueprint job types remain ignored. A future `func new --blueprint <module>` flag could route to them; not in scope here.
- **`import logging` missing from the python template body.** Pre-existing template-content bug visible in the playground output — needs to be fixed in `Microsoft.Azure.Functions.PythonExtensionBundle` templates upstream.

## Risk

Localized to `V2TemplateEngine.cs`. The picker is strictly opt-in for the multi-job + dual-type-pair case; every other shape (`Jobs = null`, single job, multi-job without the pair) takes the same code path as before. The newline guard only runs in the `AppendToFile` branch, which prior to this PR was unreachable via the CLI for any real-world template (because the picker always chose `CreateNewApp`), so behaviour for existing templates is preserved by construction.
