### PR TITLE
split func new --list NAME column into NAME + TEMPLATE ID

### DIFF
--- a/src/Func/Templates/NewCommandRenderer.cs
+++ b/src/Func/Templates/NewCommandRenderer.cs
@@ -107,9 +107,10 @@ internal sealed class NewCommandRenderer(IInteractionService interaction)
             return;
         }
 
-        string[] columns = ["NAME", "DESCRIPTION"];
+        string[] columns = ["NAME", "TEMPLATE ID", "DESCRIPTION"];
         IEnumerable<string[]> rows = templates.Select(t => new[]
         {
+            string.IsNullOrWhiteSpace(t.DisplayName) ? t.Id : t.DisplayName,
             t.Id,
             t.Description ?? string.Empty,
         });
@@ -118,7 +119,7 @@ internal sealed class NewCommandRenderer(IInteractionService interaction)
         _interaction.WriteBlankLine();
         _interaction.WriteLine(l => l
             .Muted("Create one with: ")
-            .Code("func new --template <NAME> --name <function-name>")
+            .Code("func new --template <TEMPLATE_ID> --name <function-name>")
             .Muted("."));
     }
 

--- a/test/Func.Tests/Templates/NewCommandRendererTests.cs
+++ b/test/Func.Tests/Templates/NewCommandRendererTests.cs
@@ -1,0 +1,72 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Templates;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Templates;
+
+public class NewCommandRendererTests
+{
+    [Fact]
+    public void RenderCatalogue_Emits_Three_Columns_Name_TemplateId_Description()
+    {
+        var interaction = new TestInteractionService();
+        var renderer = new NewCommandRenderer(interaction);
+
+        IReadOnlyList<FunctionTemplateInfo> templates =
+        [
+            MakeTemplate(id: "blob", displayName: "BlobTrigger", description: "blob desc"),
+            MakeTemplate(id: "durableentityclass", displayName: "DurableFunctionsEntityClass", description: "entity desc"),
+        ];
+
+        renderer.RenderCatalogue("dotnet", "c#", templates);
+
+        Assert.Contains("TABLE: [NAME, TEMPLATE ID, DESCRIPTION]", interaction.Lines);
+        Assert.Contains("  ROW: [BlobTrigger, blob, blob desc]", interaction.Lines);
+        Assert.Contains("  ROW: [DurableFunctionsEntityClass, durableentityclass, entity desc]", interaction.Lines);
+    }
+
+    [Fact]
+    public void RenderCatalogue_Falls_Back_To_Id_When_DisplayName_Missing()
+    {
+        var interaction = new TestInteractionService();
+        var renderer = new NewCommandRenderer(interaction);
+
+        IReadOnlyList<FunctionTemplateInfo> templates =
+        [
+            MakeTemplate(id: "anonymous", displayName: string.Empty, description: "no display"),
+        ];
+
+        renderer.RenderCatalogue("dotnet", null, templates);
+
+        Assert.Contains("  ROW: [anonymous, anonymous, no display]", interaction.Lines);
+    }
+
+    [Fact]
+    public void RenderCatalogue_Footer_Uses_TemplateId_Placeholder()
+    {
+        var interaction = new TestInteractionService();
+        var renderer = new NewCommandRenderer(interaction);
+
+        renderer.RenderCatalogue(
+            "dotnet",
+            "c#",
+            [MakeTemplate(id: "http", displayName: "HttpTrigger", description: "")]);
+
+        Assert.Contains(
+            interaction.Lines,
+            l => l.Contains("func new --template <TEMPLATE_ID> --name <function-name>", System.StringComparison.Ordinal));
+    }
+
+    private static FunctionTemplateInfo MakeTemplate(string id, string displayName, string? description) =>
+        new(
+            Id: id,
+            Stack: "dotnet",
+            EngineId: EngineIds.V2,
+            DisplayName: displayName,
+            Description: description,
+            DefaultFunctionName: null,
+            Languages: [],
+            Metadata: new TemplateMetadata([], RequiresExtensionBundle: false, MinBundleVersion: null));
+}


### PR DESCRIPTION
## What

Fixes #5208.

`func new --list` showed a single **NAME** column populated with each template's literal short name (`Id`). Those short names come straight from the upstream template authors (Microsoft.Azure.Functions.Worker.ItemTemplates and the v3 templates feed) and have never been normalised — so the column was a casing salad:

| Style                       | Examples                                                                 |
|-----------------------------|--------------------------------------------------------------------------|
| lower-case                  | `blob`, `cosmos`, `http`, `queue`, `timer`, `signalr`                    |
| camelCase                   | `daprPublishOutputBinding`, `daprServiceInvocationTrigger`               |
| compressed lower-case       | `durableentityclass`, `durableentityfunction`, `mcptooltrigger`, `eventgridblob` |
| terse aliases               | `rqueue` (RabbitMQ), `squeue` (Service Bus), `stopic` (Service Bus)      |

These are stable command-line tokens the CLI has to keep accepting, so renaming them isn't an option. The CLI does already carry a friendlier per-template name (`FunctionTemplateInfo.DisplayName`) that's set by the template author and is, in practice, consistently cased — it's surfaced in the interactive picker and in `--output json`, but `--list`'s plain-text view never used it.

## How

Split the table into three columns so both axes are visible:

```
NAME                                  TEMPLATE ID                      DESCRIPTION
BlobTrigger                           blob                             A C# function …
CosmosDBTrigger                       cosmos                           A C# function …
DaprPublishOutputBindingIsolated      daprPublishOutputBinding         A C# function …
DurableFunctionsEntityClass           durableentityclass               A C# Entity class …
EventGridBlobTrigger                  eventgridblob                    A C# function …
HttpTrigger                           http                             A C# function …
McpToolTrigger                        mcptooltrigger                   A C# function …
RabbitMQTrigger                       rqueue                           A C# function …
ServiceBusQueueTrigger                squeue                           A C# function …
TimerTrigger                          timer                            A C# function …
```

- **NAME** — `t.DisplayName` (template-author casing, consistent across the upstream feeds), with `t.Id` as a fallback if a template author left the name blank.
- **TEMPLATE ID** — `t.Id`, unchanged; the literal value `--template <id>` accepts.
- **DESCRIPTION** — unchanged.

The trailing hint shifts from `func new --template <NAME> --name <function-name>` to `func new --template <TEMPLATE_ID> --name <function-name>` so users know which column to copy from.

## What's not changing

- **Picker UI.** The interactive `func new` picker already renders `"<DisplayName> (<id>)"` and was not affected by the casing issue.
- **`--output json` shape.** Still `{ id, displayName, description, … }`. Tooling consumers see exactly what they did before.
- **Accepted `--template` values.** Still the same ids. No alias work.
- **Template authors / upstream feeds.** Not touched.

## Tests

`test/Func.Tests/Templates/NewCommandRendererTests.cs` (new) — three cases:

- `RenderCatalogue_Emits_Three_Columns_Name_TemplateId_Description` — locks in column names + cell content.
- `RenderCatalogue_Falls_Back_To_Id_When_DisplayName_Missing` — graceful degradation.
- `RenderCatalogue_Footer_Uses_TemplateId_Placeholder` — guards the hint wording.

Existing 1062 tests in `Func.Tests` continue to pass; total now **1065/1065** (Release, `CI=true`). Debug + Release builds: 0 warnings, 0 errors.

## Risk

Localised to one `RenderCatalogue` method. JSON output, picker, parsing, and acceptance of `--template <id>` are all unchanged. Worst-case fallout is a wider table; mitigated for narrow terminals by Spectre's existing word-wrap (visible in the dotnet workload's longer entries — same wrapping behaviour the two-column view already exhibits for long descriptions).
