### PR TITLE
fix(tests): wait for 'ready' before completion in CompactRenderer collapse test

### DIFF
--- a/test/Func.Tests/Commands/StartInitializationTests.cs
+++ b/test/Func.Tests/Commands/StartInitializationTests.cs
@@ -743,6 +743,7 @@ public class StartInitializationTests : IDisposable
         Assert.Contains("entry 12", runningOutput);
 
         await renderer.OnEventAsync(new StartInitializationStepCompletedEvent(DateTimeOffset.UnixEpoch, "prepare", "ready"), CancellationToken.None);
+        await WaitForOutputAsync(writer, output => output.Contains("ready", StringComparison.Ordinal));
         await renderer.OnEventAsync(new StartInitializationCompletedEvent(DateTimeOffset.UnixEpoch, CreateResult()), CancellationToken.None);
         await renderer.DisposeAsync();
 


### PR DESCRIPTION
## Summary

`CompactRenderer_RendersBoundedLogTailAndFullyCollapsesOnSuccess` is flaky on CI (observed on PR #5239). The renderer dispatches rendering asynchronously, so sending the step-completed event (with details `"ready"`) and the completion event back-to-back can let the collapsed view land in the writer before `"ready"` is flushed, failing `Assert.Contains("ready", completedOutput)`.

## Fix

Add a single `WaitForOutputAsync` gate between the step-completed and the completed events, matching the pattern used by the other streaming assertions in the same test. Test-only change; no production code touched.

## Verification

- Target test passed 10/10 consecutive runs locally.
- Full `Func.Tests` suite: 1071 passed, 0 failed.