### PR TITLE
Drop misleading percentage column from func setup progress bar

### DIFF
--- a/src/Func/Console/SpectreInteractionService.cs
+++ b/src/Func/Console/SpectreInteractionService.cs
@@ -184,8 +184,7 @@ internal class SpectreInteractionService : IInteractionService
             .HideCompleted(true)
             .Columns(
                 new TaskDescriptionColumn { Alignment = Justify.Left },
-                new ProgressBarColumn(),
-                new PercentageColumn(),
+                new ProgressBarColumn { Width = 30 },
                 new SpinnerColumn(Spinner.Known.Dots))
             .StartAsync(async ctx =>
             {


### PR DESCRIPTION
Follow-up to #5242.

## Why

The workload installer only reports **phase transitions** (`Resolving` → `Downloading` → `Extracting` → `Registering`) via `IProgress<WorkloadInstallProgress>`. It never reports bytes or percentages, and the adapter only calls `SetDescription`. The Spectre `ProgressTask` is already created with `IsIndeterminate = true`.

Despite that, the column list included `PercentageColumn()`, which for an indeterminate task renders as `--%`. That's noise at best and implies progress tracking we aren't actually doing.

## What changed

- `SpectreInteractionService.RunWithProgressAsync`: drop `PercentageColumn`, cap `ProgressBarColumn` width to 30 so the pulse stays tight.

## Result

```
⠋ Installing python worker 4.43.0-local.20260530021444  ━━━━━━━━━━
```

(Indeterminate animated pulse, no fake `--%`.)

## Validation

- Release build: 0 warnings.
- `dotnet test test/Func.Tests`: 1113/1113 pass.