### PR TITLE
build(templates/dotnet): restore upstream nupkg via PackageDownload

### DIFF
--- a/eng/build/Workloads.Templates.DotNet.targets
+++ b/eng/build/Workloads.Templates.DotNet.targets
@@ -5,8 +5,10 @@
 
     Hydrates the workload payload (tools/any/content/dotnet-templates.json
     + tools/any/content/source.json) from the upstream
-    Microsoft.Azure.Functions.Worker.ItemTemplates NuGet package via
-    `dotnet new install` against a build-scoped template hive. See
+    Microsoft.Azure.Functions.Worker.ItemTemplates NuGet package. The
+    package is restored into the global packages folder by the
+    <PackageDownload> item in the csproj; this target consumes the
+    already-downloaded nupkg locally and does not reach the network. See
     proposed/templates-workload-spec.md §5.3 / §5.3.1 / §6.3 for the
     contract and the projection rules.
 
@@ -24,11 +26,6 @@
           carry no dotnet-templates.json and no source.json. Warning is
           emitted; do not use for release packs.
 
-      $(DotnetTemplatesNuGetSource) = <feed url or local path>
-          Forwarded as the `add-source` flag to `dotnet new install`. Useful
-          when the upstream pkg is staged in a private feed or local
-          fallback.
-
     All intermediate output stages under $(IntermediateOutputPath)
     dotnet-templates\:
         hive\        DOTNET_CLI_HOME for the dotnet new install.
@@ -38,19 +35,27 @@
 
     $(IntermediateOutputPath) is only populated when targets execute, so
     every dependent path is composed inline in target attributes rather
-    than in a top-level <PropertyGroup>.
+    than in a top-level <PropertyGroup>. $(NuGetPackageRoot) is set by
+    NuGet at evaluation time after restore, so the resolved nupkg path
+    is safe to define at the project level.
   -->
+
+  <PropertyGroup>
+    <_DotnetTemplatesNupkg Condition="'$(SourceItemTemplatesPackageId)' != '' and '$(SourceItemTemplatesVersion)' != '' and '$(NuGetPackageRoot)' != ''">$([MSBuild]::NormalizePath('$(NuGetPackageRoot)', '$(SourceItemTemplatesPackageId.ToLowerInvariant())', '$(SourceItemTemplatesVersion)', '$(SourceItemTemplatesPackageId.ToLowerInvariant()).$(SourceItemTemplatesVersion).nupkg'))</_DotnetTemplatesNupkg>
+  </PropertyGroup>
 
   <Target Name="HydrateDotnetTemplates"
           Condition="'$(SkipHydrateDotnetTemplates)' != 'true'"
           BeforeTargets="GenerateNuspec;_GetPackageFiles"
-          Inputs="$(MSBuildProjectFullPath);$(MSBuildThisFileFullPath);$(MSBuildThisFileDirectory)..\scripts\hydrate-dotnet-templates.ps1"
+          Inputs="$(MSBuildProjectFullPath);$(MSBuildThisFileFullPath);$(MSBuildThisFileDirectory)..\scripts\hydrate-dotnet-templates.ps1;$(_DotnetTemplatesNupkg)"
           Outputs="$(IntermediateOutputPath)dotnet-templates\.hydrated">
 
     <Error Condition="'$(SourceItemTemplatesPackageId)' == ''"
            Text="SourceItemTemplatesPackageId must be set (the upstream NuGet template package id, e.g. Microsoft.Azure.Functions.Worker.ItemTemplates)." />
     <Error Condition="'$(SourceItemTemplatesVersion)' == ''"
            Text="SourceItemTemplatesVersion must be set (the upstream NuGet template package version, e.g. 4.0.5569)." />
+    <Error Condition="!Exists('$(_DotnetTemplatesNupkg)')"
+           Text="Upstream template nupkg not found at '$(_DotnetTemplatesNupkg)'. Restore should have downloaded it via the &lt;PackageDownload&gt; item; run a full restore before pack." />
 
     <PropertyGroup>
       <_DotnetTemplatesHive>$(IntermediateOutputPath)dotnet-templates\hive</_DotnetTemplatesHive>
@@ -58,12 +63,11 @@
       <_DotnetTemplatesIndex>$(_DotnetTemplatesOutDir)\dotnet-templates.json</_DotnetTemplatesIndex>
       <_DotnetTemplatesSource>$(_DotnetTemplatesOutDir)\source.json</_DotnetTemplatesSource>
       <_DotnetTemplatesScript>$(MSBuildThisFileDirectory)..\scripts\hydrate-dotnet-templates.ps1</_DotnetTemplatesScript>
-      <_DotnetTemplatesSourceArg Condition="'$(DotnetTemplatesNuGetSource)' != ''"> -NuGetSource &quot;$(DotnetTemplatesNuGetSource)&quot;</_DotnetTemplatesSourceArg>
     </PropertyGroup>
 
     <MakeDir Directories="$(_DotnetTemplatesOutDir)" />
 
-    <Exec Command="pwsh -NoProfile -ExecutionPolicy Bypass -File &quot;$(_DotnetTemplatesScript)&quot; -PackageId &quot;$(SourceItemTemplatesPackageId)&quot; -PackageVersion &quot;$(SourceItemTemplatesVersion)&quot; -HiveRoot &quot;$(_DotnetTemplatesHive)&quot; -OutputTemplates &quot;$(_DotnetTemplatesIndex)&quot; -OutputSource &quot;$(_DotnetTemplatesSource)&quot;$(_DotnetTemplatesSourceArg)"
+    <Exec Command="pwsh -NoProfile -ExecutionPolicy Bypass -File &quot;$(_DotnetTemplatesScript)&quot; -PackageId &quot;$(SourceItemTemplatesPackageId)&quot; -PackageVersion &quot;$(SourceItemTemplatesVersion)&quot; -LocalNupkgPath &quot;$(_DotnetTemplatesNupkg)&quot; -HiveRoot &quot;$(_DotnetTemplatesHive)&quot; -OutputTemplates &quot;$(_DotnetTemplatesIndex)&quot; -OutputSource &quot;$(_DotnetTemplatesSource)&quot;"
           ConsoleToMSBuild="true" />
 
     <Error Condition="!Exists('$(_DotnetTemplatesIndex)')"

--- a/eng/scripts/hydrate-dotnet-templates.ps1
+++ b/eng/scripts/hydrate-dotnet-templates.ps1
@@ -10,8 +10,11 @@
     Implements the build-time hydrate step from
     `proposed/templates-workload-spec.md` §6.3:
 
-      1. `dotnet new install <pkg>::<version>` against a build-scoped hive
-         (controlled by setting DOTNET_CLI_HOME to -HiveRoot).
+      1. `dotnet new install <LocalNupkgPath>` against a build-scoped hive
+         (controlled by setting DOTNET_CLI_HOME to -HiveRoot). The nupkg
+         is provided locally — restored into the global packages folder
+         by the <PackageDownload> item in the csproj — so no network
+         access is needed at hydrate time.
       2. Read `<hive>/.templateengine/dotnetcli/<sdkVer>/templatecache.json`
          (the templating engine's fully-hydrated cache of every installed
          template — Identity, GroupIdentity, Classifications, DefaultName,
@@ -38,10 +41,20 @@
 
 .PARAMETER PackageId
     Upstream NuGet template package id
-    (e.g. Microsoft.Azure.Functions.Worker.ItemTemplates).
+    (e.g. Microsoft.Azure.Functions.Worker.ItemTemplates). Used for the
+    sourcePackage.id field in the emitted dotnet-templates.json and
+    source.json, and for locating the installed nupkg in the hive
+    fallback path.
 
 .PARAMETER PackageVersion
-    Upstream NuGet template package version to pin (e.g. 4.0.5569).
+    Upstream NuGet template package version (e.g. 4.0.5569). Used for
+    the sourcePackage.version field.
+
+.PARAMETER LocalNupkgPath
+    Absolute path to the upstream NuGet template package on disk,
+    restored by the csproj's <PackageDownload> item. Passed directly to
+    `dotnet new install` so the install never touches the network and
+    re-read for per-template host descriptions.
 
 .PARAMETER HiveRoot
     Build-scoped directory used as DOTNET_CLI_HOME. The template engine
@@ -53,46 +66,40 @@
 
 .PARAMETER OutputSource
     Path to the generated source.json (§6.3 step 4).
-
-.PARAMETER NuGetSource
-    Optional --add-source argument forwarded to dotnet new install (e.g. a
-    pre-staged local feed in CI). When omitted, dotnet new uses its
-    configured feeds (NuGet.org by default).
 #>
 [CmdletBinding()]
 param(
     [Parameter(Mandatory=$true)] [string]$PackageId,
     [Parameter(Mandatory=$true)] [string]$PackageVersion,
+    [Parameter(Mandatory=$true)] [string]$LocalNupkgPath,
     [Parameter(Mandatory=$true)] [string]$HiveRoot,
     [Parameter(Mandatory=$true)] [string]$OutputTemplates,
-    [Parameter(Mandatory=$true)] [string]$OutputSource,
-    [string]$NuGetSource
+    [Parameter(Mandatory=$true)] [string]$OutputSource
 )
 
 $ErrorActionPreference = 'Stop'
-
-# Treat sentinel placeholders the build pipeline may emit as missing so we
-# don't pass them through to `dotnet new install --add-source`.
-if ($NuGetSource -and ($NuGetSource -match '^\s*$' -or $NuGetSource -eq '*Undefined*')) {
-    $NuGetSource = $null
-}
 
 function Resolve-FullPath([string]$path) {
     if ([System.IO.Path]::IsPathRooted($path)) { return [System.IO.Path]::GetFullPath($path) }
     return [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $path))
 }
 
+$LocalNupkgPath  = Resolve-FullPath $LocalNupkgPath
 $HiveRoot        = Resolve-FullPath $HiveRoot
 $OutputTemplates = Resolve-FullPath $OutputTemplates
 $OutputSource    = Resolve-FullPath $OutputSource
 
+if (-not (Test-Path -LiteralPath $LocalNupkgPath -PathType Leaf)) {
+    throw "Local nupkg not found at '$LocalNupkgPath'. The csproj's <PackageDownload> item should have restored it; ensure restore ran before pack."
+}
+
 Write-Host "hydrate-dotnet-templates:"
 Write-Host "  packageId       : $PackageId"
 Write-Host "  packageVersion  : $PackageVersion"
+Write-Host "  localNupkgPath  : $LocalNupkgPath"
 Write-Host "  hiveRoot        : $HiveRoot"
 Write-Host "  outputTemplates : $OutputTemplates"
 Write-Host "  outputSource    : $OutputSource"
-if ($NuGetSource) { Write-Host "  nugetSource     : $NuGetSource" }
 
 # ── 1. Set up a build-scoped hive ────────────────────────────────────────
 if (Test-Path -LiteralPath $HiveRoot) {
@@ -104,9 +111,10 @@ $env:DOTNET_CLI_HOME             = $HiveRoot
 $env:DOTNET_CLI_TELEMETRY_OPTOUT = '1'
 $env:DOTNET_NOLOGO               = '1'
 
-# ── 2. Install the upstream template pkg into that hive ──────────────────
-$installArgs = @('new', 'install', "$PackageId@$PackageVersion")
-if ($NuGetSource) { $installArgs += @('--add-source', $NuGetSource) }
+# ── 2. Install the upstream template pkg into that hive from disk ────────
+# Passing the absolute nupkg path makes `dotnet new install` resolve from
+# the local file directly, so no NuGet feed is consulted.
+$installArgs = @('new', 'install', $LocalNupkgPath)
 
 Write-Host "+ dotnet $($installArgs -join ' ')"
 & dotnet @installArgs | ForEach-Object {
@@ -114,7 +122,7 @@ Write-Host "+ dotnet $($installArgs -join ' ')"
     Write-Host $_
 }
 if ($LASTEXITCODE -ne 0) {
-    throw "dotnet new install failed (exit $LASTEXITCODE) for $PackageId::$PackageVersion."
+    throw "dotnet new install failed (exit $LASTEXITCODE) for $LocalNupkgPath."
 }
 
 # ── 3. Locate templatecache.json (path is SDK-versioned) ─────────────────
@@ -163,7 +171,7 @@ function Get-HostDescriptionByIdentity([string]$nupkgPath) {
         return $map
     }
 
-    $expandDir = Join-Path ([System.IO.Path]::GetDirectoryName($nupkgPath)) '_host_metadata_expanded'
+    $expandDir = Join-Path $HiveRoot '_host_metadata_expanded'
     if (Test-Path -LiteralPath $expandDir) { Remove-Item -LiteralPath $expandDir -Recurse -Force }
     New-Item -ItemType Directory -Path $expandDir -Force | Out-Null
 
@@ -211,24 +219,7 @@ function Get-HostDescriptionByIdentity([string]$nupkgPath) {
     return $map
 }
 
-$packagesDir = Join-Path $HiveRoot '.templateengine/packages'
-$installedNupkg = Get-ChildItem -LiteralPath $packagesDir -Filter "$PackageId.$PackageVersion.nupkg" -File -ErrorAction SilentlyContinue |
-    Select-Object -First 1
-if (-not $installedNupkg) {
-    # Some flows resolve a different concrete version (e.g. when caller
-    # passes "*" or omits version). Fall back to any nupkg matching the
-    # package id prefix.
-    $installedNupkg = Get-ChildItem -LiteralPath $packagesDir -Filter "$PackageId.*.nupkg" -File -ErrorAction SilentlyContinue |
-        Sort-Object Name -Descending |
-        Select-Object -First 1
-}
-
-$hostDescriptionsByIdentity = @{}
-if ($installedNupkg) {
-    $hostDescriptionsByIdentity = Get-HostDescriptionByIdentity $installedNupkg.FullName
-} else {
-    Write-Host "Host descriptions: no nupkg found under $packagesDir, projection will fall back to engine cache description (typically empty)."
-}
+$hostDescriptionsByIdentity = Get-HostDescriptionByIdentity $LocalNupkgPath
 
 # ── 4. Filter to Functions item templates ────────────────────────────────
 $entries = @($cache['TemplateInfo'] | Where-Object {

--- a/src/Workloads/Templates/DotNet/README.md
+++ b/src/Workloads/Templates/DotNet/README.md
@@ -55,17 +55,18 @@ dotnet pack ... /p:SourceItemTemplatesVersion=4.0.5569
 dotnet pack ... /p:SourceItemTemplatesPackageId=Microsoft.Azure.Functions.Worker.ItemTemplates
 ```
 
-The `HydrateDotnetTemplates` target (in
-`eng/build/Workloads.Templates.DotNet.targets`) runs
-`dotnet new install <pkg>@<version>` against a build-scoped template
-hive, reads the resulting `templatecache.json`, filters to Functions
-item templates (`Classifications` contains `Azure Function` and
-`tags.type == "item"`), strips `bind` / `derived` / `computed` /
-`generated` / implicit / disabled symbols, and projects the result
-into `dotnet-templates.json` (Templates Workload Spec §5.3.1). When
-the upstream pkg is staged behind a private feed, pass
-`/p:DotnetTemplatesNuGetSource=<feed-url-or-path>` to forward it as
-`dotnet new install --add-source`.
+The csproj's `<PackageDownload>` item pulls the upstream pkg into the
+global packages folder during restore, so the pack-time `HydrateDotnetTemplates`
+target (in `eng/build/Workloads.Templates.DotNet.targets`) never reaches
+the network. It runs `dotnet new install <local-nupkg-path>` against a
+build-scoped template hive, reads the resulting `templatecache.json`,
+filters to Functions item templates (`Classifications` contains
+`Azure Function` and `tags.type == "item"`), strips
+`bind` / `derived` / `computed` / `generated` / implicit / disabled
+symbols, and projects the result into `dotnet-templates.json` (Templates
+Workload Spec §5.3.1). If `Microsoft.Azure.Functions.Worker.ItemTemplates`
+is staged in a private feed, configure the feed in `NuGet.Config` so
+restore picks it up.
 
 The dev-only flag `/p:SkipHydrateDotnetTemplates=true` produces a
 pack with no catalog payload for offline iteration; it is **not** for

--- a/src/Workloads/Templates/DotNet/Workloads.Templates.DotNet.csproj
+++ b/src/Workloads/Templates/DotNet/Workloads.Templates.DotNet.csproj
@@ -17,6 +17,11 @@
     <None Include="workload.json" Pack="true" PackagePath="/" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Pre-fetch the upstream nupkg during restore so the hydrate step is offline. -->
+    <PackageDownload Include="$(SourceItemTemplatesPackageId)" Version="[$(SourceItemTemplatesVersion)]" />
+  </ItemGroup>
+
   <Import Project="..\..\..\..\eng\build\Workloads.Templates.DotNet.targets" />
 
 </Project>


### PR DESCRIPTION
Move the upstream Functions item-templates package download out of pack and into restore.

## Problem

The DotNet templates workload hydrate step ran `dotnet new install <id>@<version>` at pack time, which made an HTTP call to NuGet.org every build to fetch `Microsoft.Azure.Functions.Worker.ItemTemplates`. That broke any build environment without network access at pack time and made local iteration brittle.

## Fix

- Declare `<PackageDownload Include="$(SourceItemTemplatesPackageId)" Version="[$(SourceItemTemplatesVersion)]" />` in `Workloads.Templates.DotNet.csproj` so restore pulls the upstream nupkg into the global packages folder ([PackageDownload docs](https://learn.microsoft.com/en-us/nuget/consume-packages/packagedownload-functionality)).
- `HydrateDotnetTemplates` resolves the restored nupkg path via `[MSBuild]::NormalizePath($(NuGetPackageRoot), …)` and passes it directly to the hydrate script.
- `hydrate-dotnet-templates.ps1` now takes a required `-LocalNupkgPath` (replacing the old `-NuGetSource`). `dotnet new install <local-path>` resolves from the on-disk file without consulting a feed; the same path is reused to extract per-template host descriptions, replacing the `$HiveRoot/.templateengine/packages/` fallback search.
- Drop the `DotnetTemplatesNuGetSource` MSBuild knob — configure alternate feeds via `NuGet.Config` (the standard restore mechanism).

## Verification

Local `dotnet pack` against a clean GPF:

1. `dotnet restore` downloaded `microsoft.azure.functions.worker.itemtemplates/4.0.5584` into the GPF.
2. `dotnet pack --no-restore` ran `dotnet new install C:\Nuget\…\.nupkg` (resolved locally, no feed access in the log).
3. 36 templates filtered, projected, and written to `tools/any/content/dotnet-templates.json`; `source.json` written.
4. Re-running `dotnet pack` is a no-op (incremental check honoured); deleting the `.hydrated` marker triggers a clean rehydrate.

Built nupkg layout unchanged.