### PR TITLE
build(vnext): pack per-RID python worker

### DIFF
--- a/src/Workloads/Workers/Python/Build.Inner.targets
+++ b/src/Workloads/Workers/Python/Build.Inner.targets
@@ -1,0 +1,16 @@
+<Project>
+
+  <PropertyGroup>
+    <BeforePack>$(BeforePack);ValidatePackWithRuntimeIdentifier</BeforePack>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(RuntimeIdentifier)' != ''">
+    <PackageId>$(AssemblyName).$(RuntimeIdentifier)</PackageId>
+    <PackageTags>$(PackageTags) rid:$(RuntimeIdentifier)</PackageTags>
+  </PropertyGroup>
+
+  <Target Name="ValidatePackWithRuntimeIdentifier" Condition="'$(RuntimeIdentifier)' == ''">
+    <Error Text="RuntimeIdentifier is required when packing the python worker workload. Pass -r &lt;rid&gt; when packing the python worker workload." />
+  </Target>
+
+</Project>

--- a/src/Workloads/Workers/Python/Build.Outer.targets
+++ b/src/Workloads/Workers/Python/Build.Outer.targets
@@ -1,0 +1,35 @@
+<Project>
+
+  <!--
+    These targets enable multi-TFM style building and packing for the host workload.
+    We want to pack the host workload SEPARATELY for multiple runtime identifiers as self contained.
+    The default behavior is to pack all into a single nupkg, we want one per RID.
+    To do this we customize build and pack targets:
+    1. For build, dispatch a unique inner build per RID plus a RID-less build for tests.
+    2. For pack, dispatch a unique inner pack per RID (no RID-less here).
+  -->
+
+  <PropertyGroup>
+    <!-- Enable roll-forward to latest patch.  This allows one restore operation
+         to apply to all of the self-contained publish operations. -->
+    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
+  </PropertyGroup>
+
+  <Target Name="_ResolveInnerProjects">
+    <ItemGroup>
+      <!-- Transform RuntimeIdentifiers property to item -->
+      <_RuntimeIdentifiersToDispatch Include="$(RuntimeIdentifiers)" />
+
+      <!-- Transform _RuntimeIdentifiersToDispatch items to project items to pass to MSBuild task -->
+      <_ProjectsForDispatch Include="@(_RuntimeIdentifiersToDispatch->'$(MSBuildProjectFullPath)')">
+        <!-- Delay setting SelfContained until now to avoid RuntimeIdentifier being set prematurely. -->
+        <AdditionalProperties>RuntimeIdentifier=%(_RuntimeIdentifiersToDispatch.Identity)</AdditionalProperties>
+      </_ProjectsForDispatch>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="Pack" DependsOnTargets="_ResolveInnerProjects">
+    <MSBuild Projects="@(_ProjectsForDispatch)" Targets="Pack" BuildInParallel="true"/>
+  </Target>
+
+</Project>

--- a/src/Workloads/Workers/Python/Workloads.Workers.Python.csproj
+++ b/src/Workloads/Workers/Python/Workloads.Workers.Python.csproj
@@ -1,15 +1,20 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project>
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Title>Python Worker</Title>
     <Description>Azure Functions CLI content workload that ships the Python language worker.</Description>
+
+    <!-- No win-arm64 for python worker. -->
+    <RuntimeIdentifiers>win-x64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <PackageType>FuncCliWorkload</PackageType>
     <PackageTags>kind:content alias:python-worker func-worker func-workload</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <NoWarn>$(NoWarn);NU5128;NU5100;NU5123</NoWarn>
+    <PackAllRids>$(CI)</PackAllRids>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,15 +24,10 @@
       it wire up its content/None items via its build targets), then have a
       target here transform those items and repack them under tools/any/. For
       now we glob the restored package payload directly, which is brittle if
-      the upstream layout changes.
-
-      GeneratePathProperty exposes $(PkgMicrosoft_Azure_Functions_PythonWorker)
-      pointing at the restored package root. IncludeAssets=none keeps the
-      package's build targets and tools/ files from affecting this project.
+      the upstream layout changes.is project.
     -->
-    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" GeneratePathProperty="true" VersionOverride="$(WorkerVersion)">
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" VersionOverride="$(WorkerVersion)">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>none</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 
@@ -35,16 +35,20 @@
     <None Include="workload.json" Pack="true" PackagePath="/" />
   </ItemGroup>
 
-  <Target Name="IncludePythonWorkerContentInPack" BeforeTargets="_GetPackageFiles">
-    <Error Condition="'$(PkgMicrosoft_Azure_Functions_PythonWorker)' == ''"
-           Text="Microsoft.Azure.Functions.PythonWorker package path not resolved. Run 'dotnet restore' first." />
+  <Target Name="IncludePythonWorkerContentInPack" AfterTargets="AssignTargetPaths" BeforeTargets="_GetPackageFiles">
     <ItemGroup>
-      <_PythonWorkerFile Include="$(PkgMicrosoft_Azure_Functions_PythonWorker)/tools/**/*" />
-      <None Include="@(_PythonWorkerFile)"
-            TargetPath="%(RecursiveDir)%(Filename)%(Extension)"
-            Pack="true"
-            PackagePath="tools/any/" />
+      <None Update="@(None)" TargetPath="%(RecursiveDir)%(Filename)%(Extension)" Pack="true" PackagePath="tools/any/"
+         Condition="$([System.String]::new('%(None.TargetPath)').StartsWith('workers/python/'))" />
     </ItemGroup>
   </Target>
+
+  <!--
+    In CI, we want to build and pack the host workload for each runtime identifier.
+    We use 'PackAllRids' as an intermediate property so local dev can still pack with -p:PackAllRids=true
+    (and not needing to set the full CI=true).
+  -->
+  <Import Project="Build.Inner.targets" Condition="'$(RuntimeIdentifier)' != ''" />
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+  <Import Project="Build.Outer.targets" Condition="$(PackAllRids) AND '$(RuntimeIdentifier)' == ''" />
 
 </Project>


### PR DESCRIPTION
- Packs a per-RID nupkg for Python Worker workload.
- Refactors how python files are mapped into nupkg
- When RID is present, copies only those RID files.

This PR does not include the changes to support installing a RID specific python worker at setup time.