### PR TITLE
feat(func setup): resolve python worker per-RID

### DIFF
--- a/src/Func/Commands/Setup/SetupFeatureCatalog.cs
+++ b/src/Func/Commands/Setup/SetupFeatureCatalog.cs
@@ -54,6 +54,12 @@ internal static class SetupFeatureCatalog
             return true;
         }
 
+        if (id.StartsWith(PythonWorkerWorkloadPackage.PackageIdPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            feature = "python";
+            return true;
+        }
+
         if (string.Equals(id, IInstalledBundleWorkloads.BundleWorkloadPackageId, StringComparison.OrdinalIgnoreCase))
         {
             feature = RuntimeFeature;

--- a/src/Func/Commands/Setup/SetupRunner.cs
+++ b/src/Func/Commands/Setup/SetupRunner.cs
@@ -900,7 +900,10 @@ internal sealed record SetupDependency(
             _ => stack,
         };
 
-    private static string SetupRunnerWorkerPackageId(string runtime) => WorkerPackagePrefix + runtime;
+    private static string SetupRunnerWorkerPackageId(string runtime)
+        => string.Equals(runtime, "python", StringComparison.OrdinalIgnoreCase)
+            ? PythonWorkerWorkloadPackage.CurrentPackageId
+            : WorkerPackagePrefix + runtime;
 
     private static string? SetupRunnerRangeText(VersionRange? range)
         => range is null ? null : range.OriginalString ?? range.ToString();

--- a/src/Func/Commands/Setup/SetupRunner.cs
+++ b/src/Func/Commands/Setup/SetupRunner.cs
@@ -427,6 +427,14 @@ internal sealed class SetupRunner(
 
             if (runtimeFeature.InstallWorker)
             {
+                if (TryDetectUnsupportedWorkerRid(runtimeFeature.Name, out string unsupportedMessage))
+                {
+                    failures.Add(SetupDependencyResult.Failed(
+                        SetupDependency.Worker(runtimeFeature.Name, versionRange: null),
+                        unsupportedMessage));
+                    continue;
+                }
+
                 VersionRange? workerRange = null;
                 profileScope.Profile?.WorkerVersionRanges.TryGetValue(runtimeFeature.ProfileRuntime, out workerRange);
                 dependencies.Add(SetupDependency.Worker(runtimeFeature.Name, workerRange));
@@ -739,6 +747,26 @@ internal sealed class SetupRunner(
         {
             runtimeFeatures.Add(new SetupRuntimeFeature(name, profileRuntime, installWorker));
         }
+    }
+
+    // Reject runtimes whose worker workload isn't published for the current RID
+    // before we hit the catalog, so users get a clear "no python worker for
+    // win-arm64" message instead of an opaque "package not found".
+    private static bool TryDetectUnsupportedWorkerRid(string runtimeName, out string message)
+    {
+        if (string.Equals(runtimeName, "python", StringComparison.OrdinalIgnoreCase)
+            && !PythonWorkerWorkloadPackage.IsCurrentRuntimeSupported())
+        {
+            string currentRid = WorkloadRuntimeIdentifier.Current;
+            string supported = string.Join(", ", PythonWorkerWorkloadPackage.SupportedRuntimeIdentifiers
+                .OrderBy(r => r, StringComparer.OrdinalIgnoreCase));
+            message = $"No python worker is published for runtime identifier '{currentRid}'. "
+                + $"Supported runtimes: {supported}.";
+            return true;
+        }
+
+        message = string.Empty;
+        return false;
     }
 
     private static string NormalizeFeature(string value)

--- a/src/Func/Workloads/Catalog/CatalogSearchResult.cs
+++ b/src/Func/Workloads/Catalog/CatalogSearchResult.cs
@@ -30,6 +30,14 @@ internal sealed record CatalogSearchResult(
     /// <c>func workload search --stack</c> keeps only <c>kind:workload</c> entries.
     /// </summary>
     public string? Kind { get; init; }
+
+    /// <summary>
+    /// Lowercased value parsed from the <c>rid:&lt;rid&gt;</c> NuGet tag, set on
+    /// per-RID workload packages (host, python worker). <see langword="null"/>
+    /// for single-RID packages. Lets the alias resolver pick the variant that
+    /// matches the current platform when an alias spans multiple per-RID packs.
+    /// </summary>
+    public string? Rid { get; init; }
 }
 
 /// <summary>

--- a/src/Func/Workloads/Catalog/NuGetProtocolSourceClient.cs
+++ b/src/Func/Workloads/Catalog/NuGetProtocolSourceClient.cs
@@ -202,6 +202,7 @@ internal class NuGetProtocolSourceClient(SourceRepository repository)
                 Source: source)
             {
                 Kind = ParseKind(tagsString),
+                Rid = ParseRid(tagsString),
             });
         }
 
@@ -254,26 +255,35 @@ internal class NuGetProtocolSourceClient(SourceRepository repository)
     // returning null when the tag is absent means callers can distinguish
     // "not declared" from a typo'd value.
     private static string? ParseKind(string? tags)
+        => ParseLastTagValue(tags, WorkloadInstaller.KindTagPrefix);
+
+    // Last rid:<value> tag wins, same as kind. Per-RID workload packs (host,
+    // python worker) carry exactly one `rid:` tag matching the runtime they
+    // target; single-RID packs omit it.
+    private static string? ParseRid(string? tags)
+        => ParseLastTagValue(tags, WorkloadInstaller.RidTagPrefix);
+
+    private static string? ParseLastTagValue(string? tags, string prefix)
     {
         if (string.IsNullOrWhiteSpace(tags))
         {
             return null;
         }
 
-        string? kind = null;
+        string? lastValue = null;
         foreach (string token in tags.Split([' ', ','], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
         {
-            if (token.StartsWith(WorkloadInstaller.KindTagPrefix, StringComparison.OrdinalIgnoreCase))
+            if (token.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
             {
-                string value = token[WorkloadInstaller.KindTagPrefix.Length..].Trim();
+                string value = token[prefix.Length..].Trim();
                 if (value.Length > 0)
                 {
-                    kind = value.ToLowerInvariant();
+                    lastValue = value.ToLowerInvariant();
                 }
             }
         }
 
-        return kind;
+        return lastValue;
     }
 
     // Hits without a `packageTypes` array fall through (kept): V3 search

--- a/src/Func/Workloads/HostWorkloadPackage.cs
+++ b/src/Func/Workloads/HostWorkloadPackage.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Runtime.InteropServices;
-
 namespace Azure.Functions.Cli.Workloads;
 
 internal static class HostWorkloadPackage
@@ -11,23 +9,8 @@ internal static class HostWorkloadPackage
 
     public static string CurrentPackageId => FromRuntimeIdentifier(CurrentRuntimeIdentifier);
 
-    public static string CurrentRuntimeIdentifier
-    {
-        get
-        {
-            string runtimeIdentifier = RuntimeInformation.RuntimeIdentifier;
-            if (string.IsNullOrWhiteSpace(runtimeIdentifier))
-            {
-                throw new InvalidOperationException("Unable to determine the current runtime identifier for the host workload package.");
-            }
-
-            return runtimeIdentifier.Trim();
-        }
-    }
+    public static string CurrentRuntimeIdentifier => WorkloadRuntimeIdentifier.Current;
 
     public static string FromRuntimeIdentifier(string runtimeIdentifier)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(runtimeIdentifier);
-        return PackageIdPrefix + runtimeIdentifier.Trim().ToLowerInvariant();
-    }
+        => WorkloadRuntimeIdentifier.Qualify(PackageIdPrefix, runtimeIdentifier);
 }

--- a/src/Func/Workloads/Install/WorkloadInstaller.cs
+++ b/src/Func/Workloads/Install/WorkloadInstaller.cs
@@ -41,6 +41,14 @@ internal sealed class WorkloadInstaller(
     public const string KindTagPrefix = "kind:";
 
     /// <summary>
+    /// NuGet-tag prefix that pins a per-RID workload package to the runtime
+    /// identifier it targets (e.g. <c>rid:win-x64</c>). Lets alias resolution
+    /// pick the variant matching the current platform when an alias spans
+    /// multiple per-RID packs (host, python worker).
+    /// </summary>
+    public const string RidTagPrefix = "rid:";
+
+    /// <summary>
     /// Package-type name a workload package must declare in its .nuspec so
     /// the installer can refuse arbitrary .nupkgs. Mirrors dotnet's
     /// <c>DotnetTool</c> convention.
@@ -297,8 +305,10 @@ internal sealed class WorkloadInstaller(
         // Spec §6.1 step 2 (default flow): query the catalog for packages
         // declaring `alias:<aliasOrId>` and pick the unique match. Zero
         // matches falls back to treating the input as a literal package id.
-        // Multiple distinct package ids is an error; the user must re-run
-        // with --exact <packageId>.
+        // When an alias spans multiple per-RID packs (host, python worker),
+        // disambiguate by the `rid:` tag using the current runtime identifier.
+        // Multiple distinct package ids that don't disambiguate is an error;
+        // the user must re-run with --exact <packageId>.
         const int aliasSearchTake = 50;
 
         var query = new CatalogSearchQuery
@@ -310,34 +320,65 @@ internal sealed class WorkloadInstaller(
         };
 
         IReadOnlyList<CatalogSearchResult> hits = await _catalog.SearchAsync(query, cancellationToken);
-        IReadOnlyList<string> matchedIds = FilterByAlias(hits, aliasOrId);
+        IReadOnlyList<CatalogSearchResult> aliasMatches = FilterByAlias(hits, aliasOrId);
 
         // Some feeds (BaGet, older NuGet implementations) tokenize the `q=`
         // term in ways that drop hyphenated aliases like `node-worker`. When
         // the targeted query returns nothing, retry with an empty filter:
         // the `packageType=FuncCliWorkload` constraint keeps the result set
         // bounded to workload packages, which we then filter client-side.
-        if (matchedIds.Count == 0 && hits.Count == 0)
+        if (aliasMatches.Count == 0 && hits.Count == 0)
         {
             IReadOnlyList<CatalogSearchResult> all = await _catalog.SearchAsync(
                 query with { Filter = null },
                 cancellationToken);
-            matchedIds = FilterByAlias(all, aliasOrId);
+            aliasMatches = FilterByAlias(all, aliasOrId);
         }
+
+        IReadOnlyList<string> matchedIds = DistinctPackageIds(aliasMatches);
 
         if (matchedIds.Count > 1)
         {
+            // Per-RID disambiguation: if every match carries a `rid:` tag,
+            // pick the one matching the current runtime identifier. This is
+            // what makes `func workload install host` and
+            // `func workload install python-worker` resolve to the user's
+            // platform without forcing them to spell out the full RID.
+            if (aliasMatches.All(m => m.Rid is not null))
+            {
+                string currentRid = WorkloadRuntimeIdentifier.Current.ToLowerInvariant();
+                IReadOnlyList<string> ridMatches = DistinctPackageIds(
+                    aliasMatches.Where(m => string.Equals(m.Rid, currentRid, StringComparison.OrdinalIgnoreCase)));
+
+                if (ridMatches.Count == 1)
+                {
+                    return ridMatches[0];
+                }
+
+                if (ridMatches.Count == 0)
+                {
+                    IReadOnlyList<string> supported = aliasMatches
+                        .Select(m => m.Rid!)
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .OrderBy(r => r, StringComparer.OrdinalIgnoreCase)
+                        .ToArray();
+                    throw new WorkloadPackageNotFoundException(
+                        $"No '{aliasOrId}' workload is published for runtime identifier '{currentRid}'. "
+                        + $"Published runtimes: {string.Join(", ", supported)}.");
+                }
+            }
+
             throw new AmbiguousPackageMatchException(aliasOrId, matchedIds);
         }
 
         return matchedIds.Count == 1 ? matchedIds[0] : aliasOrId;
     }
 
-    private static IReadOnlyList<string> FilterByAlias(IReadOnlyList<CatalogSearchResult> hits, string alias) =>
-        [.. hits
-            .Where(r => r.Aliases.Any(a => string.Equals(a, alias, StringComparison.OrdinalIgnoreCase)))
-            .Select(r => r.PackageId)
-            .Distinct(StringComparer.OrdinalIgnoreCase)];
+    private static IReadOnlyList<CatalogSearchResult> FilterByAlias(IReadOnlyList<CatalogSearchResult> hits, string alias) =>
+        [.. hits.Where(r => r.Aliases.Any(a => string.Equals(a, alias, StringComparison.OrdinalIgnoreCase)))];
+
+    private static IReadOnlyList<string> DistinctPackageIds(IEnumerable<CatalogSearchResult> hits) =>
+        [.. hits.Select(r => r.PackageId).Distinct(StringComparer.OrdinalIgnoreCase)];
 
     private async Task<ResolvedPackage> ResolveCatalogPackageAsync(
         string packageId,

--- a/src/Func/Workloads/PythonWorkerWorkloadPackage.cs
+++ b/src/Func/Workloads/PythonWorkerWorkloadPackage.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workloads;
+
+/// <summary>
+/// Per-RID variant of the python worker content workload. The upstream
+/// <c>Microsoft.Azure.Functions.PythonWorker</c> NuGet ships native binaries
+/// for every platform, so we repack one workload nupkg per RID and resolve
+/// the current platform's package id here. Mirrors <see cref="HostWorkloadPackage"/>.
+/// </summary>
+internal static class PythonWorkerWorkloadPackage
+{
+    internal const string PackageIdPrefix = "Azure.Functions.Cli.Workloads.Workers.Python.";
+
+    public static string CurrentPackageId => FromRuntimeIdentifier(WorkloadRuntimeIdentifier.Current);
+
+    public static string FromRuntimeIdentifier(string runtimeIdentifier)
+        => WorkloadRuntimeIdentifier.Qualify(PackageIdPrefix, runtimeIdentifier);
+}

--- a/src/Func/Workloads/PythonWorkerWorkloadPackage.cs
+++ b/src/Func/Workloads/PythonWorkerWorkloadPackage.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Collections.Frozen;
+
 namespace Azure.Functions.Cli.Workloads;
 
 /// <summary>
@@ -13,8 +15,27 @@ internal static class PythonWorkerWorkloadPackage
 {
     internal const string PackageIdPrefix = "Azure.Functions.Cli.Workloads.Workers.Python.";
 
+    /// <summary>
+    /// RIDs we publish a python worker pack for. Must match the
+    /// <c>_CliRuntimeIdentifiers</c> set in
+    /// <c>src/Workloads/Workers/Python/Workloads.Workers.Python.csproj</c>.
+    /// The upstream PythonWorker package has no <c>win-arm64</c> assets.
+    /// </summary>
+    public static readonly FrozenSet<string> SupportedRuntimeIdentifiers =
+        new[] { "win-x64", "linux-x64", "linux-arm64", "osx-x64", "osx-arm64" }
+            .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
     public static string CurrentPackageId => FromRuntimeIdentifier(WorkloadRuntimeIdentifier.Current);
+
+    public static bool IsSupported(string runtimeIdentifier)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(runtimeIdentifier);
+        return SupportedRuntimeIdentifiers.Contains(runtimeIdentifier.Trim());
+    }
+
+    public static bool IsCurrentRuntimeSupported() => IsSupported(WorkloadRuntimeIdentifier.Current);
 
     public static string FromRuntimeIdentifier(string runtimeIdentifier)
         => WorkloadRuntimeIdentifier.Qualify(PackageIdPrefix, runtimeIdentifier);
 }
+

--- a/src/Func/Workloads/WorkloadRuntimeIdentifier.cs
+++ b/src/Func/Workloads/WorkloadRuntimeIdentifier.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Runtime.InteropServices;
+
+namespace Azure.Functions.Cli.Workloads;
+
+/// <summary>
+/// Resolves the runtime identifier (RID) the current process is running on
+/// and exposes helpers that append it to a per-RID workload package id.
+/// Per-RID workload packages (host, python worker) follow the convention
+/// <c>&lt;baseId&gt;.&lt;rid&gt;</c>, e.g. <c>Azure.Functions.Cli.Workloads.Host.win-x64</c>.
+/// </summary>
+internal static class WorkloadRuntimeIdentifier
+{
+    public static string Current
+    {
+        get
+        {
+            string runtimeIdentifier = RuntimeInformation.RuntimeIdentifier;
+            if (string.IsNullOrWhiteSpace(runtimeIdentifier))
+            {
+                throw new InvalidOperationException("Unable to determine the current runtime identifier for per-RID workload packages.");
+            }
+
+            return runtimeIdentifier.Trim();
+        }
+    }
+
+    /// <summary>
+    /// Returns <paramref name="packageIdPrefix"/> + the given RID, lowercased.
+    /// The prefix is expected to already end with a trailing '.'.
+    /// </summary>
+    public static string Qualify(string packageIdPrefix, string runtimeIdentifier)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageIdPrefix);
+        ArgumentException.ThrowIfNullOrWhiteSpace(runtimeIdentifier);
+        return packageIdPrefix + runtimeIdentifier.Trim().ToLowerInvariant();
+    }
+}

--- a/src/Func/release_notes.md
+++ b/src/Func/release_notes.md
@@ -6,4 +6,5 @@
 - `func start --no-build`: now actually skips compilation steps in stack workloads. Node skips `npm run build` (still runs `npm install` when `node_modules` is missing), Go skips `go build` (trusts the existing `bin/<module>` binary), Python is a no-op (no build step). Was previously parsed and ignored.
 - `func start`: `local.settings.json` Values no longer overwrite environment variables already set in the current shell, matching v4 behavior. Skipped keys are logged as warnings, along with empty keys. Empty string values are preserved so the host can see an intentional clear.
 - `func new`: sanitize the function-name token when rendering v2 templates so names like `HttpTrigger-Python` produce valid Python/Node identifiers instead of `SyntaxError` (#5202).
+- `func setup --features python` now installs only the python worker build for the current RID (#5247), matching the host workload resolution.
 - <entry>

--- a/src/Func/release_notes.md
+++ b/src/Func/release_notes.md
@@ -7,4 +7,5 @@
 - `func start`: `local.settings.json` Values no longer overwrite environment variables already set in the current shell, matching v4 behavior. Skipped keys are logged as warnings, along with empty keys. Empty string values are preserved so the host can see an intentional clear.
 - `func new`: sanitize the function-name token when rendering v2 templates so names like `HttpTrigger-Python` produce valid Python/Node identifiers instead of `SyntaxError` (#5202).
 - `func setup --features python` now installs only the python worker build for the current RID (#5247), matching the host workload resolution.
+- `func workload install <alias>` now resolves to the per-RID workload pack for the current platform when an alias spans multiple per-RID packs (e.g. `host`, `python-worker`). Installing by full package id still installs that exact package. Running `func setup` for Python on `win-arm64` now reports a clear unsupported-runtime error instead of failing later in the install flow.
 - <entry>

--- a/test/Func.Tests/Commands/Setup/SetupFeatureCatalogTests.cs
+++ b/test/Func.Tests/Commands/Setup/SetupFeatureCatalogTests.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Commands.Setup;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Commands.Setup;
+
+public sealed class SetupFeatureCatalogTests
+{
+    [Theory]
+    [InlineData("Azure.Functions.Cli.Workloads.Host.win-x64", SetupFeatureCatalog.HostFeature)]
+    [InlineData("azure.functions.cli.workloads.host.linux-x64", SetupFeatureCatalog.HostFeature)]
+    [InlineData("Azure.Functions.Cli.Workloads.Workers.Python.win-x64", "python")]
+    [InlineData("azure.functions.cli.workloads.workers.python.osx-arm64", "python")]
+    [InlineData("Azure.Functions.Cli.Workloads.Workers.Node", "node")]
+    [InlineData("Azure.Functions.Cli.Workloads.Templates.Python", "python")]
+    [InlineData("Azure.Functions.Cli.Workloads.Python", "python")]
+    public void TryGetFeatureForPackageId_ReturnsExpectedFeature(string packageId, string expectedFeature)
+    {
+        bool matched = SetupFeatureCatalog.TryGetFeatureForPackageId(packageId, out string feature);
+
+        Assert.True(matched);
+        Assert.Equal(expectedFeature, feature);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("SomeOther.Package")]
+    public void TryGetFeatureForPackageId_ReturnsFalse_ForUnknownIds(string? packageId)
+    {
+        bool matched = SetupFeatureCatalog.TryGetFeatureForPackageId(packageId, out string feature);
+
+        Assert.False(matched);
+        Assert.Equal(string.Empty, feature);
+    }
+}

--- a/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
+++ b/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
@@ -626,6 +626,132 @@ public sealed class WorkloadInstallerTests : IDisposable
         public void Report(WorkloadInstallProgress value) => sink.Add(value);
     }
 
+    [Fact]
+    public async Task InstallFromCatalog_AliasResolution_DisambiguatesByCurrentRid_WhenAllMatchesAreRidTagged()
+    {
+        // When an alias spans multiple per-RID packs (host, python worker),
+        // the resolver should pick the variant tagged with the current
+        // runtime identifier instead of throwing ambiguity.
+        string nupkg = BuildNupkg();
+        string currentRid = WorkloadRuntimeIdentifier.Current.ToLowerInvariant();
+        string targetId = $"Azure.Functions.Cli.Workloads.Workers.Python.{currentRid}";
+        var source = new PackageSource("https://example/v3/index.json", "test");
+        var resolved = NewResolved(targetId, "1.0.0");
+
+        _catalog.SearchAsync(
+                Arg.Is<CatalogSearchQuery>(q => q.Filter == "python-worker"),
+                Arg.Any<CancellationToken>())
+            .Returns(new List<CatalogSearchResult>
+            {
+                new("azure.functions.cli.workloads.workers.python.win-x64", NuGetVersion.Parse("1.0.0"),
+                    Title: null, Description: null, Aliases: ["python-worker"], Source: source) { Rid = "win-x64" },
+                new("azure.functions.cli.workloads.workers.python.linux-x64", NuGetVersion.Parse("1.0.0"),
+                    Title: null, Description: null, Aliases: ["python-worker"], Source: source) { Rid = "linux-x64" },
+                new(targetId.ToLowerInvariant(), NuGetVersion.Parse("1.0.0"),
+                    Title: null, Description: null, Aliases: ["python-worker"], Source: source) { Rid = currentRid },
+            });
+        _catalog.ResolveLatestVersionAsync(
+                targetId.ToLowerInvariant(), true, null, true, null, Arg.Any<CancellationToken>())
+            .Returns(resolved);
+        _catalog.DownloadAsync(resolved, Arg.Any<CancellationToken>())
+            .Returns(_ => File.OpenRead(nupkg));
+
+        WorkloadInstaller installer = NewInstaller();
+        WorkloadInstallResult result = await installer.InstallFromCatalogAsync(
+            "python-worker", version: null, source: null,
+            includePrerelease: true, exact: false, force: false);
+
+        Assert.NotNull(result);
+        await _catalog.Received(1).ResolveLatestVersionAsync(
+            targetId.ToLowerInvariant(), true, null, true, null, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InstallFromCatalog_AliasResolution_ThrowsClearError_WhenNoPackageForCurrentRid()
+    {
+        // If the alias only matches per-RID packs and none of them target the
+        // current runtime (e.g. python on win-arm64), surface a clear "no
+        // package for this RID" message listing what is published instead of
+        // a generic "package not found" or alias ambiguity error.
+        var source = new PackageSource("https://example/v3/index.json", "test");
+
+        _catalog.SearchAsync(
+                Arg.Is<CatalogSearchQuery>(q => q.Filter == "python-worker"),
+                Arg.Any<CancellationToken>())
+            .Returns(new List<CatalogSearchResult>
+            {
+                new("azure.functions.cli.workloads.workers.python.osx-x64", NuGetVersion.Parse("1.0.0"),
+                    Title: null, Description: null, Aliases: ["python-worker"], Source: source) { Rid = "osx-x64" },
+                new("azure.functions.cli.workloads.workers.python.linux-x64", NuGetVersion.Parse("1.0.0"),
+                    Title: null, Description: null, Aliases: ["python-worker"], Source: source) { Rid = "linux-x64" },
+            });
+
+        WorkloadInstaller installer = NewInstaller();
+        WorkloadPackageNotFoundException ex = await Assert.ThrowsAsync<WorkloadPackageNotFoundException>(
+            () => installer.InstallFromCatalogAsync(
+                "python-worker", version: null, source: null,
+                includePrerelease: true, exact: false, force: false));
+
+        Assert.Contains("python-worker", ex.Message);
+        Assert.Contains("linux-x64", ex.Message);
+        Assert.Contains("osx-x64", ex.Message);
+    }
+
+    [Fact]
+    public async Task InstallFromCatalog_AliasResolution_StillAmbiguous_WhenMatchesLackRidTag()
+    {
+        // Two unrelated packages declaring the same alias without any `rid:`
+        // tag must still throw ambiguity. RID disambiguation only kicks in
+        // when every match is RID-tagged.
+        var source = new PackageSource("https://example/v3/index.json", "test");
+
+        _catalog.SearchAsync(
+                Arg.Is<CatalogSearchQuery>(q => q.Filter == "shared-alias"),
+                Arg.Any<CancellationToken>())
+            .Returns(new List<CatalogSearchResult>
+            {
+                new("pkg.one", NuGetVersion.Parse("1.0.0"),
+                    Title: null, Description: null, Aliases: ["shared-alias"], Source: source),
+                new("pkg.two", NuGetVersion.Parse("1.0.0"),
+                    Title: null, Description: null, Aliases: ["shared-alias"], Source: source),
+            });
+
+        WorkloadInstaller installer = NewInstaller();
+        await Assert.ThrowsAsync<AmbiguousPackageMatchException>(
+            () => installer.InstallFromCatalogAsync(
+                "shared-alias", version: null, source: null,
+                includePrerelease: true, exact: false, force: false));
+    }
+
+    [Fact]
+    public async Task InstallFromCatalog_ExplicitPackageId_BypassesAliasResolution()
+    {
+        // The user can always install a specific per-RID pack by its full id;
+        // alias resolution must not rewrite it. exact:true short-circuits the
+        // alias search entirely, but we also cover exact:false: passing a real
+        // package id (not an alias) should resolve to that id.
+        string nupkg = BuildNupkg();
+        string explicitId = "Azure.Functions.Cli.Workloads.Workers.Python.win-x64";
+        var resolved = NewResolved(explicitId, "1.0.0");
+
+        _catalog.SearchAsync(Arg.Any<CatalogSearchQuery>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+        _catalog.ResolveLatestVersionAsync(
+                explicitId, true, null, true, null, Arg.Any<CancellationToken>())
+            .Returns(resolved);
+        _catalog.DownloadAsync(resolved, Arg.Any<CancellationToken>())
+            .Returns(_ => File.OpenRead(nupkg));
+
+        WorkloadInstaller installer = NewInstaller();
+        WorkloadInstallResult result = await installer.InstallFromCatalogAsync(
+            explicitId, version: null, source: null,
+            includePrerelease: true, exact: true, force: false);
+
+        Assert.NotNull(result);
+        await _catalog.Received(1).ResolveLatestVersionAsync(
+            explicitId, true, null, true, null, Arg.Any<CancellationToken>());
+    }
+
     private static WorkloadEntry ExistingEntry(string id, string version) => new()
     {
         PackageId = id,

--- a/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
+++ b/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
@@ -675,15 +675,21 @@ public sealed class WorkloadInstallerTests : IDisposable
         // a generic "package not found" or alias ambiguity error.
         var source = new PackageSource("https://example/v3/index.json", "test");
 
+        // Use two RIDs that definitely aren't the current host so we exercise
+        // the "no pack for current RID" branch on every test environment.
+        string currentRid = WorkloadRuntimeIdentifier.Current.ToLowerInvariant();
+        string ridA = currentRid == "fake-rid-a" ? "fake-rid-c" : "fake-rid-a";
+        string ridB = currentRid == "fake-rid-b" ? "fake-rid-d" : "fake-rid-b";
+
         _catalog.SearchAsync(
                 Arg.Is<CatalogSearchQuery>(q => q.Filter == "python-worker"),
                 Arg.Any<CancellationToken>())
             .Returns(new List<CatalogSearchResult>
             {
-                new("azure.functions.cli.workloads.workers.python.osx-x64", NuGetVersion.Parse("1.0.0"),
-                    Title: null, Description: null, Aliases: ["python-worker"], Source: source) { Rid = "osx-x64" },
-                new("azure.functions.cli.workloads.workers.python.linux-x64", NuGetVersion.Parse("1.0.0"),
-                    Title: null, Description: null, Aliases: ["python-worker"], Source: source) { Rid = "linux-x64" },
+                new($"azure.functions.cli.workloads.workers.python.{ridA}", NuGetVersion.Parse("1.0.0"),
+                    Title: null, Description: null, Aliases: ["python-worker"], Source: source) { Rid = ridA },
+                new($"azure.functions.cli.workloads.workers.python.{ridB}", NuGetVersion.Parse("1.0.0"),
+                    Title: null, Description: null, Aliases: ["python-worker"], Source: source) { Rid = ridB },
             });
 
         WorkloadInstaller installer = NewInstaller();
@@ -693,8 +699,8 @@ public sealed class WorkloadInstallerTests : IDisposable
                 includePrerelease: true, exact: false, force: false));
 
         Assert.Contains("python-worker", ex.Message);
-        Assert.Contains("linux-x64", ex.Message);
-        Assert.Contains("osx-x64", ex.Message);
+        Assert.Contains(ridA, ex.Message);
+        Assert.Contains(ridB, ex.Message);
     }
 
     [Fact]

--- a/test/Func.Tests/Workloads/PythonWorkerWorkloadPackageTests.cs
+++ b/test/Func.Tests/Workloads/PythonWorkerWorkloadPackageTests.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Workloads;
+
+public sealed class PythonWorkerWorkloadPackageTests
+{
+    [Theory]
+    [InlineData("win-x64", "Azure.Functions.Cli.Workloads.Workers.Python.win-x64")]
+    [InlineData("LINUX-X64", "Azure.Functions.Cli.Workloads.Workers.Python.linux-x64")]
+    [InlineData(" osx-arm64 ", "Azure.Functions.Cli.Workloads.Workers.Python.osx-arm64")]
+    public void FromRuntimeIdentifier_AppendsLowercasedRid(string runtimeIdentifier, string expected)
+    {
+        Assert.Equal(expected, PythonWorkerWorkloadPackage.FromRuntimeIdentifier(runtimeIdentifier));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void FromRuntimeIdentifier_RejectsBlankRid(string runtimeIdentifier)
+    {
+        Assert.Throws<ArgumentException>(() => PythonWorkerWorkloadPackage.FromRuntimeIdentifier(runtimeIdentifier));
+    }
+
+    [Fact]
+    public void FromRuntimeIdentifier_RejectsNullRid()
+    {
+        Assert.Throws<ArgumentNullException>(() => PythonWorkerWorkloadPackage.FromRuntimeIdentifier(null!));
+    }
+
+    [Fact]
+    public void CurrentPackageId_StartsWithPrefix()
+    {
+        Assert.StartsWith(PythonWorkerWorkloadPackage.PackageIdPrefix, PythonWorkerWorkloadPackage.CurrentPackageId);
+    }
+}

--- a/test/Func.Tests/Workloads/PythonWorkerWorkloadPackageTests.cs
+++ b/test/Func.Tests/Workloads/PythonWorkerWorkloadPackageTests.cs
@@ -36,4 +36,18 @@ public sealed class PythonWorkerWorkloadPackageTests
     {
         Assert.StartsWith(PythonWorkerWorkloadPackage.PackageIdPrefix, PythonWorkerWorkloadPackage.CurrentPackageId);
     }
+
+    [Theory]
+    [InlineData("win-x64", true)]
+    [InlineData("linux-x64", true)]
+    [InlineData("linux-arm64", true)]
+    [InlineData("osx-x64", true)]
+    [InlineData("osx-arm64", true)]
+    [InlineData("WIN-X64", true)]
+    [InlineData("win-arm64", false)]
+    [InlineData("freebsd-x64", false)]
+    public void IsSupported_MatchesPublishedRids(string runtimeIdentifier, bool expected)
+    {
+        Assert.Equal(expected, PythonWorkerWorkloadPackage.IsSupported(runtimeIdentifier));
+    }
 }


### PR DESCRIPTION
resolves #5247

## Summary

Wires `func setup --features python` and `func workload install` to behave per-RID, mirroring the existing host workload pattern. Builds on PR #5255 (per-RID python worker packing).

### `func setup --features python`
Selects `Azure.Functions.Cli.Workloads.Workers.Python.<current-rid>` instead of a single `*.tools` pack, so only the worker build for the user's platform is downloaded. On `win-arm64` (where the Python worker is not published), setup now fails fast with a clear unsupported-runtime message instead of running through to a confusing install failure.

### `func workload install`
- `func workload install <full-package-id>`: unchanged, installs that exact package.
- `func workload install <alias>` (e.g. `host`, `python-worker`): resolves to the per-RID pack tagged with the current runtime identifier. If the alias only matches per-RID packs and none target the current platform, throws `WorkloadPackageNotFoundException` listing the RIDs that are published. Aliases that match non-RID-tagged packages still throw `AmbiguousPackageMatchException` as before.

### Internals
- New `WorkloadRuntimeIdentifier` shared helper (single source of truth for "current RID"); `HostWorkloadPackage` now delegates to it.
- New `PythonWorkerWorkloadPackage` with `CurrentPackageId`, `SupportedRuntimeIdentifiers`, `IsSupported`.
- `CatalogSearchResult` now carries the `rid:` tag parsed from V3 search hits, and `WorkloadInstaller.ResolveAliasOrIdAsync` uses it to disambiguate alias matches.
- `SetupFeatureCatalog` recognizes per-RID python worker ids.

## Tests
- New `WorkloadInstallerTests` cases for alias→RID disambiguation, no-pack-for-current-RID error, and explicit-id bypass.
- `PythonWorkerWorkloadPackageTests` covers `IsSupported` across published RIDs.
- `SetupFeatureCatalogTests` covers per-RID Python id mapping.
- Full `Func.Tests` suite: 1150 passed.