### PR TITLE
Add `import logging` to Python function_app.py template

### DIFF
--- a/src/Workloads/Stacks/Python/Templates/function_app.py
+++ b/src/Workloads/Stacks/Python/Templates/function_app.py
@@ -1,3 +1,4 @@
 import azure.functions as func
+import logging
 
 app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)

--- a/src/Workloads/Stacks/Python/release_notes.md
+++ b/src/Workloads/Stacks/Python/release_notes.md
@@ -7,3 +7,4 @@
 - Honor an activated venv via `$VIRTUAL_ENV` and reuse pre-existing `venv`, `env`, or `.virtualenv` folders before falling back to creating `.venv`.
 - Point the host at the venv interpreter via `languageWorkers__python__defaultExecutablePath` and surface the detected Python major.minor as `FUNCTIONS_WORKER_RUNTIME_VERSION` so the worker sees the user's installed packages.
 - Fix Python worker startup on macOS/Linux by using `__` delimiter in `languageWorkers__python__defaultExecutablePath` (mirrors #5212 for `workerDirectory`).
+- Add `import logging` to the scaffolded `function_app.py` so sample HTTP handlers can call `logging.info(...)` without an extra import.


### PR DESCRIPTION
The scaffolded `function_app.py` for the Python stack was missing `import logging`, so users adding a sample HTTP handler with `logging.info(...)` had to add the import themselves.

## Changes

- `src/Workloads/Stacks/Python/Templates/function_app.py`: add `import logging`.
- `src/Workloads/Stacks/Python/release_notes.md`: note the fix.