### PR TITLE
fix(run): always tear down host process on every exit path

### DIFF
--- a/src/Func/Commands/Start/Dashboard/DashboardPipeline.cs
+++ b/src/Func/Commands/Start/Dashboard/DashboardPipeline.cs
@@ -59,13 +59,28 @@ internal sealed class DashboardPipeline(
         catch (OperationCanceledException) when (pipelineCts.IsCancellationRequested)
         {
             exitReason = "sigint";
-            if (_source is IHostEventStreamLifecycle lifecycle)
-            {
-                await lifecycle.RequestShutdownAsync(CancellationToken.None);
-            }
         }
         finally
         {
+            // Belt-and-braces: every exit path (clean source completion,
+            // sigint, or an unexpected exception from a renderer / sink)
+            // must signal the underlying host to shut down. RequestShutdown
+            // is idempotent and a no-op once the process has already
+            // exited.
+            if (_source is IHostEventStreamLifecycle lifecycle)
+            {
+                try
+                {
+                    await lifecycle.RequestShutdownAsync(CancellationToken.None);
+                }
+                catch
+                {
+                    // Best effort. The owning command will dispose the
+                    // stream which kills the process tree if shutdown
+                    // signalling failed.
+                }
+            }
+
             if (_renderer is IDashboardShutdownRequester requester && shutdownHandler is not null)
             {
                 requester.ShutdownRequested -= shutdownHandler;

--- a/src/Func/Commands/Start/Dashboard/DashboardPipeline.cs
+++ b/src/Func/Commands/Start/Dashboard/DashboardPipeline.cs
@@ -62,11 +62,7 @@ internal sealed class DashboardPipeline(
         }
         finally
         {
-            // Belt-and-braces: every exit path (clean source completion,
-            // sigint, or an unexpected exception from a renderer / sink)
-            // must signal the underlying host to shut down. RequestShutdown
-            // is idempotent and a no-op once the process has already
-            // exited.
+            // Signal shutdown on every exit path; StartCommand's await using disposes the stream as a fallback.
             if (_source is IHostEventStreamLifecycle lifecycle)
             {
                 try
@@ -75,9 +71,7 @@ internal sealed class DashboardPipeline(
                 }
                 catch
                 {
-                    // Best effort. The owning command will dispose the
-                    // stream which kills the process tree if shutdown
-                    // signalling failed.
+                    // Best effort.
                 }
             }
 

--- a/src/Func/Commands/Start/Dashboard/Demo/DemoEventSource.cs
+++ b/src/Func/Commands/Start/Dashboard/Demo/DemoEventSource.cs
@@ -90,6 +90,8 @@ internal sealed class DemoEventSource(TimeProvider? timeProvider = null) : IHost
 
     private TimeSpan Scale(TimeSpan ts) => TimeSpan.FromMilliseconds(ts.TotalMilliseconds * SpeedMultiplier);
 
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
     private static IEnumerable<(TimeSpan Delay, HostLogEntry Entry)> BuildTimeline(
         int burstCount,
         (string Name, string Trigger, string? Route, string[] Methods)[] extras)

--- a/src/Func/Commands/Start/Dashboard/Demo/DemoStartInitializationRunner.cs
+++ b/src/Func/Commands/Start/Dashboard/Demo/DemoStartInitializationRunner.cs
@@ -103,10 +103,7 @@ internal sealed class DemoStartInitializationRunner(
         }
         catch
         {
-            // If a step (or ToResult) fails after the host was started, the
-            // caller never gets a chance to take ownership of the event
-            // stream. Tear it down here so the spawned host process doesn't
-            // outlive `func run`.
+            // Ensure the host process doesn't outlive a failed startup before the caller takes ownership.
             if (state.EventStream is { } eventStream)
             {
                 try
@@ -115,7 +112,7 @@ internal sealed class DemoStartInitializationRunner(
                 }
                 catch
                 {
-                    // Best effort: keep the original failure primary.
+                    // Best effort.
                 }
             }
 

--- a/src/Func/Commands/Start/Dashboard/Demo/DemoStartInitializationRunner.cs
+++ b/src/Func/Commands/Start/Dashboard/Demo/DemoStartInitializationRunner.cs
@@ -96,9 +96,31 @@ internal sealed class DemoStartInitializationRunner(
         };
         await EmitAsync(renderer, new StartInitializationStartedEvent(Now(), state.ProfileName), cancellationToken);
 
-        await RunStepsAsync(CreateSteps(), context, state, renderer, cancellationToken);
+        try
+        {
+            await RunStepsAsync(CreateSteps(), context, state, renderer, cancellationToken);
+            return state.ToResult(context);
+        }
+        catch
+        {
+            // If a step (or ToResult) fails after the host was started, the
+            // caller never gets a chance to take ownership of the event
+            // stream. Tear it down here so the spawned host process doesn't
+            // outlive `func run`.
+            if (state.EventStream is { } eventStream)
+            {
+                try
+                {
+                    await eventStream.DisposeAsync();
+                }
+                catch
+                {
+                    // Best effort: keep the original failure primary.
+                }
+            }
 
-        return state.ToResult(context);
+            throw;
+        }
     }
 
     private StartInitializationStepCollection CreateSteps()

--- a/src/Func/Commands/Start/Host/HostProcessEventStream.cs
+++ b/src/Func/Commands/Start/Host/HostProcessEventStream.cs
@@ -19,6 +19,7 @@ internal sealed class HostProcessEventStream : IHostEventStream, IHostEventStrea
     private readonly Task _stdoutTask;
     private readonly Task _stderrTask;
     private int _shutdownRequested;
+    private int _disposed;
 
     public HostProcessEventStream(
         IHostProcess process,
@@ -80,6 +81,41 @@ internal sealed class HostProcessEventStream : IHostEventStream, IHostEventStrea
 
     public Task<int> WaitForExitAsync(CancellationToken cancellationToken)
         => _exitTask.WaitAsync(cancellationToken);
+
+    /// <summary>
+    /// Ensures the host process is shut down (gracefully if it cooperates,
+    /// killed otherwise) before returning. Idempotent and best-effort, so
+    /// it's safe to call from <c>await using</c> on every code path,
+    /// including ones that already drove the pipeline to completion.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            await RequestShutdownAsync(CancellationToken.None);
+        }
+        catch
+        {
+            // RequestShutdownAsync is best-effort during disposal; the
+            // process is killed below regardless. Swallowing here keeps the
+            // outer failure (which is why we're disposing) primary.
+            try
+            {
+                _process.KillTree();
+            }
+            catch
+            {
+                // Process may already be gone; nothing more we can do.
+            }
+
+            await _process.DisposeAsync();
+        }
+    }
 
     private void WriteProcessStarted(HostProcessLaunchInfo launchInfo)
     {

--- a/src/Func/Commands/Start/Host/HostProcessEventStream.cs
+++ b/src/Func/Commands/Start/Host/HostProcessEventStream.cs
@@ -83,10 +83,7 @@ internal sealed class HostProcessEventStream : IHostEventStream, IHostEventStrea
         => _exitTask.WaitAsync(cancellationToken);
 
     /// <summary>
-    /// Ensures the host process is shut down (gracefully if it cooperates,
-    /// killed otherwise) before returning. Idempotent and best-effort, so
-    /// it's safe to call from <c>await using</c> on every code path,
-    /// including ones that already drove the pipeline to completion.
+    /// Idempotent, best-effort shutdown safe to call from <c>await using</c> on any exit path.
     /// </summary>
     public async ValueTask DisposeAsync()
     {
@@ -101,16 +98,14 @@ internal sealed class HostProcessEventStream : IHostEventStream, IHostEventStrea
         }
         catch
         {
-            // RequestShutdownAsync is best-effort during disposal; the
-            // process is killed below regardless. Swallowing here keeps the
-            // outer failure (which is why we're disposing) primary.
+            // Graceful shutdown failed; force-kill below.
             try
             {
                 _process.KillTree();
             }
             catch
             {
-                // Process may already be gone; nothing more we can do.
+                // Process already gone.
             }
 
             await _process.DisposeAsync();

--- a/src/Func/Commands/Start/Host/HostProcessEventStream.cs
+++ b/src/Func/Commands/Start/Host/HostProcessEventStream.cs
@@ -98,7 +98,7 @@ internal sealed class HostProcessEventStream : IHostEventStream, IHostEventStrea
         }
         catch
         {
-            // Graceful shutdown failed; force-kill below.
+            // Graceful shutdown failed; force-kill and let _exitTask complete so it doesn't go unobserved.
             try
             {
                 _process.KillTree();
@@ -108,7 +108,15 @@ internal sealed class HostProcessEventStream : IHostEventStream, IHostEventStrea
                 // Process already gone.
             }
 
-            await _process.DisposeAsync();
+            // _exitTask drains stdout/stderr and disposes _process in its finally block.
+            try
+            {
+                await _exitTask;
+            }
+            catch
+            {
+                // _exitTask may fault after KillTree; we only need it to finish, not succeed.
+            }
         }
     }
 

--- a/src/Func/Commands/Start/Initialization/StartInitializationLogEventStream.cs
+++ b/src/Func/Commands/Start/Initialization/StartInitializationLogEventStream.cs
@@ -28,6 +28,8 @@ internal sealed class StartInitializationLogEventStream(IEnumerable<StartInitial
         }
     }
 
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
     private static IReadOnlyList<HostLogEntry> BuildEntries(IEnumerable<StartInitializationEvent> initializationEvents)
     {
         ArgumentNullException.ThrowIfNull(initializationEvents);

--- a/src/Func/Commands/Start/StartCommand.cs
+++ b/src/Func/Commands/Start/StartCommand.cs
@@ -210,11 +210,17 @@ internal sealed class StartCommand : FuncCliCommand, IBuiltInCommand
             initializationEvents = [.. initializationRenderer.Events];
         }
 
+        // The init runner already started the host process. Take ownership of
+        // the event stream here so any failure between this point and
+        // pipeline completion (renderer construction, log-file sink, summary
+        // emission, etc.) still tears the host PID down.
+        await using IHostEventStream hostEventStream = initializationResult.EventStream;
+
         var state = new DashboardState();
 
         IDashboardRenderer renderer = CreateRenderer(mode, initializationResult.RunInfo);
 
-        IHostEventStream dashboardEventStream = _eventStreamFactory.Create(mode, initializationEvents, initializationResult.EventStream);
+        IHostEventStream dashboardEventStream = _eventStreamFactory.Create(mode, initializationEvents, hostEventStream);
         var pipeline = new DashboardPipeline(state, dashboardEventStream, renderer, eventSink);
         FunctionsProjectHostRunOutcome? outcome = null;
         // Stop any managed Azurite instance the orchestrator launched when

--- a/src/Func/Commands/Start/StartCommand.cs
+++ b/src/Func/Commands/Start/StartCommand.cs
@@ -210,10 +210,7 @@ internal sealed class StartCommand : FuncCliCommand, IBuiltInCommand
             initializationEvents = [.. initializationRenderer.Events];
         }
 
-        // The init runner already started the host process. Take ownership of
-        // the event stream here so any failure between this point and
-        // pipeline completion (renderer construction, log-file sink, summary
-        // emission, etc.) still tears the host PID down.
+        // Take ownership of the host stream now so any failure before pipeline completion still tears the process down.
         await using IHostEventStream hostEventStream = initializationResult.EventStream;
 
         var state = new DashboardState();

--- a/src/Func/Hosting/Events/CompositeHostEventStream.cs
+++ b/src/Func/Hosting/Events/CompositeHostEventStream.cs
@@ -36,6 +36,27 @@ internal sealed class CompositeHostEventStream : IHostEventStream, IHostEventStr
     public Task<int> WaitForExitAsync(CancellationToken cancellationToken)
         => _lifecycle?.WaitForExitAsync(cancellationToken) ?? Task.FromResult(0);
 
+    public async ValueTask DisposeAsync()
+    {
+        List<Exception>? failures = null;
+        foreach (IHostEventStream source in _sources)
+        {
+            try
+            {
+                await source.DisposeAsync();
+            }
+            catch (Exception ex)
+            {
+                (failures ??= []).Add(ex);
+            }
+        }
+
+        if (failures is { Count: > 0 })
+        {
+            throw new AggregateException(failures);
+        }
+    }
+
     private static IHostEventStream[] CopySources(IEnumerable<IHostEventStream> sources)
     {
         ArgumentNullException.ThrowIfNull(sources);

--- a/src/Func/Hosting/Events/IHostEventStream.cs
+++ b/src/Func/Hosting/Events/IHostEventStream.cs
@@ -9,7 +9,7 @@ namespace Azure.Functions.Cli.Hosting.Events;
 /// the future, a transport-backed source bridging the real host (gRPC, OTLP,
 /// or similar). The abstraction is intentionally transport-neutral.
 /// </summary>
-internal interface IHostEventStream
+internal interface IHostEventStream : IAsyncDisposable
 {
     /// <summary>
     /// Reads records as they arrive. Completes when the source signals end

--- a/src/Func/Hosting/Events/InMemoryHostEventStream.cs
+++ b/src/Func/Hosting/Events/InMemoryHostEventStream.cs
@@ -38,6 +38,12 @@ internal sealed class InMemoryHostEventStream : IHostEventStream
 
     public void Complete() => _channel.Writer.TryComplete();
 
+    public ValueTask DisposeAsync()
+    {
+        _channel.Writer.TryComplete();
+        return ValueTask.CompletedTask;
+    }
+
     public async IAsyncEnumerable<HostLogEntry> ReadAsync([EnumeratorCancellation] CancellationToken cancellationToken)
     {
         while (await _channel.Reader.WaitToReadAsync(cancellationToken))

--- a/test/Func.Tests/Commands/HostProcessEventStreamTests.cs
+++ b/test/Func.Tests/Commands/HostProcessEventStreamTests.cs
@@ -64,6 +64,39 @@ public class HostProcessEventStreamTests
         Assert.True(process.Disposed);
     }
 
+    [Fact]
+    public async Task DisposeAsync_KillsBlockingProcessTree()
+    {
+        var process = new BlockingHostProcess();
+        var stream = new HostProcessEventStream(
+            process,
+            new LineHostProcessOutputParser(),
+            CreateLaunchInfo(),
+            TimeSpan.Zero);
+
+        await stream.DisposeAsync();
+
+        Assert.True(process.StandardInputDisposed);
+        Assert.True(process.KillTreeCalled);
+        Assert.True(process.Disposed);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_IsIdempotent()
+    {
+        var process = new BlockingHostProcess();
+        var stream = new HostProcessEventStream(
+            process,
+            new LineHostProcessOutputParser(),
+            CreateLaunchInfo(),
+            TimeSpan.Zero);
+
+        await stream.DisposeAsync();
+        await stream.DisposeAsync();
+
+        Assert.Equal(1, process.KillTreeCallCount);
+    }
+
     private static async Task<HostLogEntry[]> ReadAllAsync(IHostEventStream stream)
     {
         List<HostLogEntry> entries = [];
@@ -137,6 +170,8 @@ public class HostProcessEventStreamTests
 
         public bool KillTreeCalled { get; private set; }
 
+        public int KillTreeCallCount { get; private set; }
+
         public bool Disposed { get; private set; }
 
         public void Start()
@@ -149,6 +184,7 @@ public class HostProcessEventStreamTests
         public void KillTree()
         {
             KillTreeCalled = true;
+            KillTreeCallCount++;
             _exit.TrySetResult();
         }
 

--- a/test/Func.Tests/Commands/StartCommandTests.cs
+++ b/test/Func.Tests/Commands/StartCommandTests.cs
@@ -449,5 +449,7 @@ public class StartCommandTests : IDisposable
 
         public Task<int> WaitForExitAsync(CancellationToken cancellationToken)
             => Task.FromResult(exitCode);
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 }

--- a/test/Func.Tests/Commands/StartDashboardEventStreamFactoryTests.cs
+++ b/test/Func.Tests/Commands/StartDashboardEventStreamFactoryTests.cs
@@ -114,5 +114,7 @@ public class StartDashboardEventStreamFactoryTests
 
         public Task<int> WaitForExitAsync(CancellationToken cancellationToken)
             => Task.FromResult(exitCode);
+
+        public ValueTask DisposeAsync() => _inner.DisposeAsync();
     }
 }

--- a/test/Func.Tests/Hosting/Dashboard/DashboardPipelineTests.cs
+++ b/test/Func.Tests/Hosting/Dashboard/DashboardPipelineTests.cs
@@ -109,9 +109,7 @@ public class DashboardPipelineTests
         var renderer = new ThrowingRenderer();
         var pipeline = new DashboardPipeline(state, source, renderer);
 
-        // Push an entry the renderer will choke on so ReadAsync throws a
-        // non-OperationCanceledException — the path that previously left
-        // the host PID running because shutdown only ran from the OCE catch.
+        // Triggers a non-OCE throw from the renderer, the path that previously skipped shutdown.
         source.PushEntry(new HostLogEntry(
             DateTimeOffset.UnixEpoch,
             "Function.HttpTrigger1",

--- a/test/Func.Tests/Hosting/Dashboard/DashboardPipelineTests.cs
+++ b/test/Func.Tests/Hosting/Dashboard/DashboardPipelineTests.cs
@@ -101,6 +101,46 @@ public class DashboardPipelineTests
         Assert.Contains("invocation_completed HttpTrigger1 invocation-1 failed duration_ms=42", output);
     }
 
+    [Fact]
+    public async Task RunAsync_WhenRendererThrows_StillShutsDownHostAndRethrows()
+    {
+        var state = new DashboardState();
+        var source = new NeverEndingLifecycleEventStream();
+        var renderer = new ThrowingRenderer();
+        var pipeline = new DashboardPipeline(state, source, renderer);
+
+        // Push an entry the renderer will choke on so ReadAsync throws a
+        // non-OperationCanceledException — the path that previously left
+        // the host PID running because shutdown only ran from the OCE catch.
+        source.PushEntry(new HostLogEntry(
+            DateTimeOffset.UnixEpoch,
+            "Function.HttpTrigger1",
+            LogLevel.Information,
+            default,
+            "trigger",
+            Exception: null,
+            HostLogEntry.EmptyAttributes));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => pipeline.RunAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5)));
+
+        Assert.True(source.ShutdownRequested);
+    }
+
+    private sealed class ThrowingRenderer : IDashboardRenderer
+    {
+        public Task OnStartAsync(DashboardState state, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+
+        public Task OnEventAsync(HostLogEntry entry, IReadOnlyList<DashboardEvent> events, CancellationToken cancellationToken)
+            => throw new InvalidOperationException("renderer blew up");
+
+        public Task OnSummaryAsync(SummaryEvent summary, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
     private sealed class NeverEndingEventStream : IHostEventStream
     {
         public async IAsyncEnumerable<HostLogEntry> ReadAsync([EnumeratorCancellation] CancellationToken cancellationToken)
@@ -108,35 +148,19 @@ public class DashboardPipelineTests
             await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
             yield break;
         }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
     private sealed class CompletedLifecycleEventStream(int exitCode) : IHostEventStream, IHostEventStreamLifecycle
     {
         public bool WaitForExitCalled { get; private set; }
 
-        public async IAsyncEnumerable<HostLogEntry> ReadAsync([EnumeratorCancellation] CancellationToken cancellationToken)
-        {
-            await Task.CompletedTask;
-            yield break;
-        }
-
-        public Task RequestShutdownAsync(CancellationToken cancellationToken)
-            => Task.CompletedTask;
-
-        public Task<int> WaitForExitAsync(CancellationToken cancellationToken)
-        {
-            WaitForExitCalled = true;
-            return Task.FromResult(exitCode);
-        }
-    }
-
-    private sealed class NeverEndingLifecycleEventStream : IHostEventStream, IHostEventStreamLifecycle
-    {
         public bool ShutdownRequested { get; private set; }
 
         public async IAsyncEnumerable<HostLogEntry> ReadAsync([EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            await Task.CompletedTask;
             yield break;
         }
 
@@ -147,7 +171,36 @@ public class DashboardPipelineTests
         }
 
         public Task<int> WaitForExitAsync(CancellationToken cancellationToken)
+        {
+            WaitForExitCalled = true;
+            return Task.FromResult(exitCode);
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class NeverEndingLifecycleEventStream : IHostEventStream, IHostEventStreamLifecycle
+    {
+        private readonly InMemoryHostEventStream _inner = new();
+
+        public bool ShutdownRequested { get; private set; }
+
+        public void PushEntry(HostLogEntry entry) => _inner.Write(entry);
+
+        public IAsyncEnumerable<HostLogEntry> ReadAsync(CancellationToken cancellationToken)
+            => _inner.ReadAsync(cancellationToken);
+
+        public Task RequestShutdownAsync(CancellationToken cancellationToken)
+        {
+            ShutdownRequested = true;
+            _inner.Complete();
+            return Task.CompletedTask;
+        }
+
+        public Task<int> WaitForExitAsync(CancellationToken cancellationToken)
             => Task.FromResult(99);
+
+        public ValueTask DisposeAsync() => _inner.DisposeAsync();
     }
 
     private sealed class ShutdownRequestingRenderer : IDashboardRenderer, IDashboardShutdownRequester

--- a/test/Func.Tests/Hosting/Events/CompositeHostEventStreamTests.cs
+++ b/test/Func.Tests/Hosting/Events/CompositeHostEventStreamTests.cs
@@ -1,0 +1,64 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Runtime.CompilerServices;
+using Azure.Functions.Cli.Hosting.Events;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Hosting.Events;
+
+public class CompositeHostEventStreamTests
+{
+    [Fact]
+    public async Task DisposeAsync_DisposesEveryChildStream()
+    {
+        var first = new TrackingEventStream();
+        var second = new TrackingEventStream();
+        var third = new TrackingEventStream();
+        var composite = new CompositeHostEventStream([first, second, third]);
+
+        await composite.DisposeAsync();
+
+        Assert.True(first.Disposed);
+        Assert.True(second.Disposed);
+        Assert.True(third.Disposed);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DisposesRemainingChildrenEvenWhenOneThrows()
+    {
+        var first = new TrackingEventStream();
+        var second = new TrackingEventStream { ThrowOnDispose = true };
+        var third = new TrackingEventStream();
+        var composite = new CompositeHostEventStream([first, second, third]);
+
+        await Assert.ThrowsAsync<AggregateException>(async () => await composite.DisposeAsync());
+
+        Assert.True(first.Disposed);
+        Assert.True(third.Disposed);
+    }
+
+    private sealed class TrackingEventStream : IHostEventStream
+    {
+        public bool Disposed { get; private set; }
+
+        public bool ThrowOnDispose { get; init; }
+
+        public async IAsyncEnumerable<HostLogEntry> ReadAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Disposed = true;
+            if (ThrowOnDispose)
+            {
+                throw new InvalidOperationException("boom");
+            }
+
+            return ValueTask.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Problem

After `func run` exits, the spawned `Azure.Functions.Cli.Workloads.Host` process can sometimes survive and stay visible in Activity Monitor. It's hard to reproduce because the happy paths (clean source completion, Ctrl+C handled in the OCE catch) do clean up correctly; the host also has a stdin-EOF fallback that catches abrupt CLI exits.

The real leaks are on the CLI side, in the ownership chain between starting the host PID and the dashboard pipeline taking over.

## Leak paths fixed

1. **`HostProcessEventStream` was never deterministically disposed.** It implemented `IHostEventStream` (no `IAsyncDisposable`) and only disposed the wrapped `Process` from the `finally` of `CompleteWhenProcessExitsAsync`, which only runs after the process actually exits. So a stuck host kept itself alive.
2. **`StartCommand` had a window after init returned the started host stream and before the pipeline began.** Anything that threw in that window (renderer construction, log-file sink open, recording-renderer disposal, summary emit) skipped all teardown.  `await using ManagedAzuriteHandle? azurite` covered Azurite; nothing covered the host.
3. **`DashboardPipeline.RunAsync` only called `RequestShutdownAsync` from the `OperationCanceledException` catch.** A non-OCE exception (renderer crashing inside `OnEventAsync`, event sink IO error, etc.) propagated without ever signalling the host. The `finally` only disposed the renderer.

## What this PR does

- **`IHostEventStream` now extends `IAsyncDisposable`.** All five implementations (`HostProcessEventStream`, `CompositeHostEventStream`, `InMemoryHostEventStream`, `DemoEventSource`, `StartInitializationLogEventStream`) get the method.
- **`HostProcessEventStream.DisposeAsync`** is idempotent and routes through `RequestShutdownAsync` so disposal closes stdin, waits the shutdown timeout, then `KillTree`s on timeout. Best-effort: a thrown `RequestShutdownAsync` falls through to a direct `KillTree` + `Process.Dispose` so the OS handle is released no matter what.
- **`CompositeHostEventStream.DisposeAsync`** forwards to every child; failures from one child don't stop the rest, then surface as an `AggregateException`.
- **`StartCommand.ExecuteAsync`** `await using`s the host event stream the moment the init runner returns it, before any renderer / sink / pipeline construction. Now every throw path between init and pipeline completion tears the host PID down.
- **`DashboardPipeline.RunAsync`** always signals shutdown via `RequestShutdownAsync` in `finally`. Belt-and-braces over the StartCommand-level `await using`; idempotent, so the existing OCE path is unchanged behaviorally.
- **`DemoStartInitializationRunner.RunAsync`** disposes `state.EventStream` if any step (or `ToResult`) throws after the host has been started. Today `StartHostInitializationStep` is last, but this defends against future step additions.

## Tests

- New `HostProcessEventStreamTests`: `DisposeAsync_KillsBlockingProcessTree`, `DisposeAsync_IsIdempotent`.
- New `DashboardPipelineTests.RunAsync_WhenRendererThrows_StillShutsDownHostAndRethrows` — proves the non-OCE leak path is closed.
- New `CompositeHostEventStreamTests` covering forward-to-children and exception aggregation.
- All 1,175 `Func.Tests` pass. Release build clean (0 warnings, `CI=true`).

## Out of scope

- Initialization-runner Azurite leak when a step after `EnsureAzuriteInitializationStep` fails. Not currently triggerable (host start is last) and orthogonal to this fix; will be a follow-up.
- Host workload changes: stdin-EOF monitor and Ctrl+C handling already cover their side of the contract.