### PR TITLE
Improve setup hints and add go to flex profile

### DIFF
--- a/src/Func/Commands/Setup/SetupRunner.cs
+++ b/src/Func/Commands/Setup/SetupRunner.cs
@@ -58,9 +58,8 @@ internal sealed class SetupRunner(
             SetupFeaturePlan? featurePlan = await ResolveFeaturesAsync(options, cancellationToken);
             if (featurePlan is null)
             {
-                // The interactive default-features prompt was confirmed with no
-                // selection. Treat that as a clean opt-out, not a failure: the
-                // user explicitly chose to leave without installing anything.
+                // No stacks were offered to install (every supported stack is
+                // already installed). Treat that as a clean no-op, not a failure.
                 renderer.SetupSkippedNoSelection();
                 await TryMarkFirstRunCompleteAsync(cancellationToken);
                 return new SetupRunResult(0);
@@ -179,8 +178,8 @@ internal sealed class SetupRunner(
 
         if (requestedFeatures is null)
         {
-            // Interactive default-features prompt confirmed with no selection;
-            // the caller treats this as a graceful exit.
+            // Interactive prompt had nothing to offer (every supported stack
+            // is already installed); the caller treats this as a graceful exit.
             return null;
         }
 
@@ -293,14 +292,11 @@ internal sealed class SetupRunner(
             }
 
             IReadOnlyList<string> picked = await _interaction.PromptForMultiSelectionAsync(
-                "Select stacks to install (SPACE to toggle, ENTER to confirm; ENTER with no selection exits):",
+                "Select stacks to install (SPACE to toggle, ENTER to confirm; CTRL+C to cancel):",
                 choices.PromptChoices,
                 cancellationToken);
 
-            // No selection = user opted out. Signal that with null so the
-            // caller can exit cleanly instead of falling through to a default
-            // they did not ask for.
-            return picked.Count > 0 ? picked : null;
+            return picked;
         }
 
         return ["runtime"];

--- a/src/Func/Console/SpectreInteractionService.cs
+++ b/src/Func/Console/SpectreInteractionService.cs
@@ -329,14 +329,12 @@ internal class SpectreInteractionService : IInteractionService
             return [];
         }
 
-        // NotRequired() lets the user press ENTER with nothing selected to exit
-        // the prompt cleanly. Callers treat an empty result as "no selection",
-        // which (for `func setup`) is the documented escape hatch from the
-        // stack picker.
+        // The prompt requires at least one selection; users cancel with CTRL+C
+        // (which surfaces as OperationCanceledException up the call stack).
         List<MultiSelectionChoice> selected = await new MultiSelectionPrompt<MultiSelectionChoice>()
             .Title(title)
-            .NotRequired()
-            .InstructionsText("[grey](press [blue]<space>[/] to toggle, [green]<enter>[/] to confirm; [green]<enter>[/] with no selection exits)[/]")
+            .Required()
+            .InstructionsText("[grey](press [blue]<space>[/] to toggle, [green]<enter>[/] to confirm; [red]<ctrl+c>[/] to cancel)[/]")
             .UseConverter(static choice => choice.Label)
             .AddChoices(choiceList)
             .ShowAsync(_stderr, cancellationToken);

--- a/src/Func/Profiles/BuiltInProfiles.json
+++ b/src/Func/Profiles/BuiltInProfiles.json
@@ -28,7 +28,8 @@
         "java",
         "powershell",
         "dotnet-isolated",
-        "custom"
+        "custom",
+        "go"
       ]
     },
     "linux-premium": {

--- a/src/Func/Profiles/BuiltInProfiles.json
+++ b/src/Func/Profiles/BuiltInProfiles.json
@@ -23,13 +23,13 @@
         }
       },
       "supportedRuntimes": [
+        "go",
         "node",
         "python",
         "java",
         "powershell",
         "dotnet-isolated",
-        "custom",
-        "go"
+        "custom"
       ]
     },
     "linux-premium": {

--- a/src/Func/Projects/FunctionsProjectResolver.cs
+++ b/src/Func/Projects/FunctionsProjectResolver.cs
@@ -37,6 +37,7 @@ internal sealed class FunctionsProjectResolver(IEnumerable<WorkloadProjectFactor
             }
         }
 
-        return ProjectResolutionResults.NotResolved("No installed workload recognized this directory as an Azure Functions project.");
+        return ProjectResolutionResults.NotResolved(
+            "No installed workload recognized this directory as an Azure Functions project. Run 'func setup' to install a stack.");
     }
 }

--- a/src/Func/Projects/FunctionsProjectResolver.cs
+++ b/src/Func/Projects/FunctionsProjectResolver.cs
@@ -38,6 +38,6 @@ internal sealed class FunctionsProjectResolver(IEnumerable<WorkloadProjectFactor
         }
 
         return ProjectResolutionResults.NotResolved(
-            "No installed workload recognized this directory as an Azure Functions project. Run 'func setup' to install a stack.");
+            "No installed workload recognized this directory as an Azure Functions project. Run 'func setup' to set up your local environment for your chosen stack.");
     }
 }

--- a/src/Func/Workloads/WorkloadHintRenderer.cs
+++ b/src/Func/Workloads/WorkloadHintRenderer.cs
@@ -74,7 +74,7 @@ internal sealed class WorkloadHintRenderer(IInteractionService interaction) : IW
             $"Auto-selecting '{hint.RequestedStack}' (the only installed workload).");
         _interaction.WriteLine(l => l
             .Muted("Install more with ")
-            .Command("func workload install")
+            .Command("func setup")
             .Muted(" or run ")
             .Command("func workload search")
             .Muted(" to discover available stacks."));

--- a/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
+++ b/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
@@ -612,41 +612,6 @@ public sealed class SetupRunnerTests : IDisposable
     }
 
     [Fact]
-    public async Task RunAsync_InteractiveEmptySelection_ExitsCleanlyWithSkippedHint()
-    {
-        FakeCatalog catalog = Catalog().WithLatest(_hostPackageId, "4.1.0");
-        EmptyPickInteractionService interactive = new();
-        SetupRunner runner = new(
-            interactive,
-            _store,
-            catalog,
-            _installer,
-            _profileCatalog,
-            new TestOptionsMonitor<ProjectProfileOptions>(new ProjectProfileOptions()),
-            new TestOptionsMonitor<UserProfilePreferenceOptions>(new UserProfilePreferenceOptions()),
-            new FakeCliConfigurationProvider(new Dictionary<string, string?>()),
-            _bundleReader);
-
-        SetupRunResult result = await runner.RunAsync(
-            new SetupCommandOptions(
-                new DirectoryInfo(_tempDir),
-                Features: [],
-                ProfileNames: [],
-                Source: null,
-                SetupInstallPolicy.LatestCompatible,
-                IncludePrerelease: false,
-                NonInteractive: false,
-                AssumeYes: true,
-                Check: false,
-                SetupOutputMode.Plain),
-            CancellationToken.None);
-
-        Assert.Equal(0, result.ExitCode);
-        Assert.Contains(interactive.Lines, line => line.StartsWith("HINT:", StringComparison.Ordinal) && line.Contains("No stacks selected", StringComparison.Ordinal));
-        await _installer.DidNotReceiveWithAnyArgs().InstallFromCatalogAsync(default!, default, default, default, default, default, default, default);
-    }
-
-    [Fact]
     public async Task RunAsync_InteractiveEmptyFolder_RendersInstalledStacksAsStaticLines_AboveThePrompt()
     {
         const string nodeStack = "Azure.Functions.Cli.Workloads.Node";
@@ -714,42 +679,6 @@ public sealed class SetupRunnerTests : IDisposable
             firstRunStore);
 
         SetupRunResult result = await runner.RunAsync(Options(), CancellationToken.None);
-
-        Assert.Equal(0, result.ExitCode);
-        await firstRunStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task RunAsync_MarksFirstRunComplete_WhenInteractiveSelectionEmpty()
-    {
-        IFirstRunStateStore firstRunStore = Substitute.For<IFirstRunStateStore>();
-        EmptyPickInteractionService interactive = new();
-        FakeCatalog catalog = Catalog().WithLatest(_hostPackageId, "4.1.0");
-        SetupRunner runner = new(
-            interactive,
-            _store,
-            catalog,
-            _installer,
-            _profileCatalog,
-            new TestOptionsMonitor<ProjectProfileOptions>(new ProjectProfileOptions()),
-            new TestOptionsMonitor<UserProfilePreferenceOptions>(new UserProfilePreferenceOptions()),
-            new FakeCliConfigurationProvider(new Dictionary<string, string?>()),
-            _bundleReader,
-            firstRunStore);
-
-        SetupRunResult result = await runner.RunAsync(
-            new SetupCommandOptions(
-                new DirectoryInfo(_tempDir),
-                Features: [],
-                ProfileNames: [],
-                Source: null,
-                SetupInstallPolicy.LatestCompatible,
-                IncludePrerelease: false,
-                NonInteractive: false,
-                AssumeYes: true,
-                Check: false,
-                SetupOutputMode.Plain),
-            CancellationToken.None);
 
         Assert.Equal(0, result.ExitCode);
         await firstRunStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
@@ -945,18 +874,6 @@ public sealed class SetupRunnerTests : IDisposable
             MultiSelectionChoice? first = picks.FirstOrDefault(c => string.Equals(c.Value, "node", StringComparison.OrdinalIgnoreCase))
                 ?? picks.FirstOrDefault();
             return Task.FromResult<IReadOnlyList<string>>(first is null ? [] : [first.Value]);
-        }
-    }
-
-    private sealed class EmptyPickInteractionService : TestInteractionService
-    {
-        public override bool IsInteractive => true;
-
-        public override Task<IReadOnlyList<string>> PromptForMultiSelectionAsync(string title, IEnumerable<MultiSelectionChoice> choices, CancellationToken cancellationToken = default)
-        {
-            var picks = choices.ToList();
-            base.PromptForMultiSelectionAsync(title, picks, cancellationToken).GetAwaiter().GetResult();
-            return Task.FromResult<IReadOnlyList<string>>([]);
         }
     }
 


### PR DESCRIPTION
Small UX cleanups around setup messaging and the flex profile.

- Project resolution failure now suggests `func setup` so users have a concrete next step instead of just being told no workload matched.
- Auto-selected sole-workload hint points at `func setup` instead of the lower-level `func workload install`.
- Add `go` to the flex profile's `supportedRuntimes` (it was already listed under workers but missing from the supported runtimes list).