### PR TITLE
Stream Node npm output live during host-run preparation

### DIFF
--- a/src/Workloads/Stacks/Node/NodeFunctionsProject.cs
+++ b/src/Workloads/Stacks/Node/NodeFunctionsProject.cs
@@ -30,8 +30,9 @@ internal sealed class NodeFunctionsProject : FunctionsProject
 
     // Internal seam so tests can stub npm invocations without spawning real
     // processes. Args is forwarded as a single argv list to keep tests
-    // simple to assert against (e.g. ["install"], ["run", "build"]).
-    internal Func<string, IReadOnlyList<string>, CancellationToken, Task<(int ExitCode, string Stderr)>> RunNpm { get; set; } = DefaultRunNpm;
+    // simple to assert against (e.g. ["install"], ["run", "build"]). stdout and
+    // stderr lines are streamed to the callbacks as the process produces them.
+    internal Func<string, IReadOnlyList<string>, Action<string>, Action<string>, CancellationToken, Task<int>> RunNpm { get; set; } = DefaultRunNpm;
 
     public override WorkingDirectory WorkingDirectory => _workingDirectory;
 
@@ -99,29 +100,30 @@ internal sealed class NodeFunctionsProject : FunctionsProject
     {
         reporter.ReportStatus($"Running {display}");
 
-        (int exitCode, string stderr) = await RunNpm(root, args, cancellationToken).ConfigureAwait(false);
-
-        WriteLogLines(reporter, stderr, exitCode == 0 ? FunctionsProjectReportSeverity.Info : FunctionsProjectReportSeverity.Error);
+        // Stream stdout as informational and stderr as error output as the process produces it, so the
+        // build/restore progress shows up live under the spinner instead of appearing all at once on exit.
+        int exitCode = await RunNpm(
+            root,
+            args,
+            line => reporter.WriteLog(line, FunctionsProjectReportSeverity.Info),
+            line => reporter.WriteLog(line, FunctionsProjectReportSeverity.Error),
+            cancellationToken).ConfigureAwait(false);
 
         if (exitCode != 0)
         {
+            // Output has already been streamed live through the callbacks above, so the message points the
+            // user there instead of repeating it.
             throw new GracefulException(
-                $"'{display}' failed (exit {exitCode}). {stderr?.Trim()}",
+                $"'{display}' failed (exit {exitCode}).",
                 isUserError: true);
         }
     }
 
-    private static void WriteLogLines(IFunctionsProjectHostRunReporter reporter, string output, FunctionsProjectReportSeverity severity)
-    {
-        foreach (string line in output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
-        {
-            reporter.WriteLog(line, severity);
-        }
-    }
-
-    private static async Task<(int ExitCode, string Stderr)> DefaultRunNpm(
+    private static async Task<int> DefaultRunNpm(
         string workingDirectory,
         IReadOnlyList<string> args,
+        Action<string> onOutputLine,
+        Action<string> onErrorLine,
         CancellationToken cancellationToken)
     {
         try
@@ -151,23 +153,92 @@ internal sealed class NodeFunctionsProject : FunctionsProject
                 psi.ArgumentList.Add(arg);
             }
 
-            using var process = Process.Start(psi);
-            if (process is null)
-            {
-                return (-1, "Failed to start 'npm' process.");
-            }
-
-            // Drain stdout and stderr in parallel: if either pipe buffer (~64KB) fills
-            // while we're only reading the other, npm blocks on write and we deadlock.
-            Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
-            Task<string> stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
-            await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
-            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
-            return (process.ExitCode, await stderrTask.ConfigureAwait(false));
+            return await RunProcessStreamingAsync(psi, onOutputLine, onErrorLine, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            return (-1, ex.Message);
+            onErrorLine(ex.Message);
+            return -1;
+        }
+    }
+
+    // Streams each line of stdout and stderr to the supplied callbacks as the process produces them, waits
+    // for exit, and returns the exit code. Mirrors the live-streaming process core used by the .NET stack.
+    private static async Task<int> RunProcessStreamingAsync(
+        ProcessStartInfo startInfo,
+        Action<string> onOutputLine,
+        Action<string> onErrorLine,
+        CancellationToken cancellationToken)
+    {
+        using var process = new Process { StartInfo = startInfo };
+
+        // stdout and stderr are delivered on separate thread-pool threads, so each stream gets its own
+        // completion signal; each line callback is invoked only from its own stream's thread.
+        TaskCompletionSource stdoutComplete = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource stderrComplete = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data is null)
+            {
+                stdoutComplete.TrySetResult();
+            }
+            else
+            {
+                onOutputLine(e.Data);
+            }
+        };
+
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data is null)
+            {
+                stderrComplete.TrySetResult();
+            }
+            else
+            {
+                onErrorLine(e.Data);
+            }
+        };
+
+        if (!process.Start())
+        {
+            onErrorLine("Failed to start 'npm' process.");
+            return -1;
+        }
+
+        try
+        {
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+
+            // WaitForExitAsync does not guarantee the async stream readers have drained, so wait for the
+            // trailing (null Data) sentinel on both streams to ensure every line has been delivered.
+            await stdoutComplete.Task.ConfigureAwait(false);
+            await stderrComplete.Task.ConfigureAwait(false);
+
+            return process.ExitCode;
+        }
+        finally
+        {
+            KillProcess(process);
+        }
+    }
+
+    private static void KillProcess(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch (Exception)
+        {
+            // Best effort: don't mask the original outcome if the process has already exited.
         }
     }
 }

--- a/test/Workloads/Stacks/Node.Tests/NodeFunctionsProjectTests.cs
+++ b/test/Workloads/Stacks/Node.Tests/NodeFunctionsProjectTests.cs
@@ -34,10 +34,10 @@ public class NodeFunctionsProjectTests : IDisposable
     public async Task PrepareForHostRun_without_package_json_is_noop()
     {
         bool invoked = false;
-        NodeFunctionsProject project = CreateProject((_, _, _) =>
+        NodeFunctionsProject project = CreateProject((_, _, _, _, _) =>
         {
             invoked = true;
-            return Task.FromResult((0, string.Empty));
+            return Task.FromResult(0);
         });
 
         await project.PrepareForHostRunAsync(CreateContext(), default);
@@ -50,10 +50,10 @@ public class NodeFunctionsProjectTests : IDisposable
     {
         WritePackageJson("""{ "name": "x", "version": "1.0.0" }""");
         var commands = new List<IReadOnlyList<string>>();
-        NodeFunctionsProject project = CreateProject((_, args, _) =>
+        NodeFunctionsProject project = CreateProject((_, args, _, _, _) =>
         {
             commands.Add(args);
-            return Task.FromResult((0, string.Empty));
+            return Task.FromResult(0);
         });
 
         await project.PrepareForHostRunAsync(CreateContext(), default);
@@ -68,10 +68,10 @@ public class NodeFunctionsProjectTests : IDisposable
         WritePackageJson("""{ "name": "x", "version": "1.0.0" }""");
         Directory.CreateDirectory(Path.Combine(_projectDir.FullName, "node_modules"));
         var commands = new List<IReadOnlyList<string>>();
-        NodeFunctionsProject project = CreateProject((_, args, _) =>
+        NodeFunctionsProject project = CreateProject((_, args, _, _, _) =>
         {
             commands.Add(args);
-            return Task.FromResult((0, string.Empty));
+            return Task.FromResult(0);
         });
 
         await project.PrepareForHostRunAsync(CreateContext(), default);
@@ -85,10 +85,10 @@ public class NodeFunctionsProjectTests : IDisposable
         WritePackageJson("""{ "name": "x", "scripts": { "build": "tsc" } }""");
         Directory.CreateDirectory(Path.Combine(_projectDir.FullName, "node_modules"));
         var commands = new List<IReadOnlyList<string>>();
-        NodeFunctionsProject project = CreateProject((_, args, _) =>
+        NodeFunctionsProject project = CreateProject((_, args, _, _, _) =>
         {
             commands.Add(args);
-            return Task.FromResult((0, string.Empty));
+            return Task.FromResult(0);
         });
 
         await project.PrepareForHostRunAsync(CreateContext(), default);
@@ -98,17 +98,45 @@ public class NodeFunctionsProjectTests : IDisposable
     }
 
     [Fact]
+    public async Task PrepareForHostRun_streams_output_to_reporter()
+    {
+        WritePackageJson("""{ "name": "x", "version": "1.0.0" }""");
+        NodeFunctionsProject project = CreateProject((_, _, onOut, onErr, _) =>
+        {
+            onOut("added 42 packages");
+            onErr("npm warn deprecated");
+            return Task.FromResult(0);
+        });
+        var reporter = new CapturingReporter();
+        FunctionsProjectHostRunContext context = CreateContext();
+        context.Reporter = reporter;
+
+        await project.PrepareForHostRunAsync(context, default);
+
+        Assert.Contains(reporter.Logs, e => e.Severity == FunctionsProjectReportSeverity.Info && e.Line == "added 42 packages");
+        Assert.Contains(reporter.Logs, e => e.Severity == FunctionsProjectReportSeverity.Error && e.Line == "npm warn deprecated");
+    }
+
+    [Fact]
     public async Task PrepareForHostRun_throws_graceful_on_install_failure()
     {
         WritePackageJson("""{ "name": "x" }""");
-        NodeFunctionsProject project = CreateProject((_, _, _) => Task.FromResult((1, "ENOENT")));
+        NodeFunctionsProject project = CreateProject((_, _, _, onErr, _) =>
+        {
+            onErr("ENOENT");
+            return Task.FromResult(1);
+        });
+        var reporter = new CapturingReporter();
+        FunctionsProjectHostRunContext context = CreateContext();
+        context.Reporter = reporter;
 
         GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => project.PrepareForHostRunAsync(CreateContext(), default));
+            () => project.PrepareForHostRunAsync(context, default));
 
         Assert.True(ex.IsUserError);
-        Assert.Contains("npm install", ex.Message);
-        Assert.Contains("ENOENT", ex.Message);
+        Assert.Contains("install", ex.Message);
+        Assert.Contains("exit 1", ex.Message);
+        Assert.Contains(reporter.Logs, e => e.Severity == FunctionsProjectReportSeverity.Error && e.Line == "ENOENT");
     }
 
     [Fact]
@@ -117,10 +145,10 @@ public class NodeFunctionsProjectTests : IDisposable
         WritePackageJson("""{ "name": "x", "scripts": { "build": "tsc" } }""");
         Directory.CreateDirectory(Path.Combine(_projectDir.FullName, "node_modules"));
         var commands = new List<IReadOnlyList<string>>();
-        NodeFunctionsProject project = CreateProject((_, args, _) =>
+        NodeFunctionsProject project = CreateProject((_, args, _, _, _) =>
         {
             commands.Add(args);
-            return Task.FromResult((0, string.Empty));
+            return Task.FromResult(0);
         });
 
         await project.PrepareForHostRunAsync(CreateContext(skipBuild: true), default);
@@ -133,10 +161,10 @@ public class NodeFunctionsProjectTests : IDisposable
     {
         WritePackageJson("""{ "name": "x", "scripts": { "build": "tsc" } }""");
         var commands = new List<IReadOnlyList<string>>();
-        NodeFunctionsProject project = CreateProject((_, args, _) =>
+        NodeFunctionsProject project = CreateProject((_, args, _, _, _) =>
         {
             commands.Add(args);
-            return Task.FromResult((0, string.Empty));
+            return Task.FromResult(0);
         });
 
         await project.PrepareForHostRunAsync(CreateContext(skipBuild: true), default);
@@ -145,7 +173,7 @@ public class NodeFunctionsProjectTests : IDisposable
         Assert.Equal(new[] { "install" }, commands[0]);
     }
 
-    private NodeFunctionsProject CreateProject(Func<string, IReadOnlyList<string>, CancellationToken, Task<(int, string)>> runner)
+    private NodeFunctionsProject CreateProject(Func<string, IReadOnlyList<string>, Action<string>, Action<string>, CancellationToken, Task<int>> runner)
         => new(WorkingDirectory.FromExplicit(_projectDir.FullName))
         {
             RunNpm = runner,
@@ -158,4 +186,33 @@ public class NodeFunctionsProjectTests : IDisposable
         => new(_projectDir, "node", new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
         }, skipBuild);
+
+    private sealed class CapturingReporter : IFunctionsProjectHostRunReporter
+    {
+        private readonly List<(string Line, FunctionsProjectReportSeverity Severity)> _logs = [];
+        private readonly object _gate = new();
+
+        public IReadOnlyList<(string Line, FunctionsProjectReportSeverity Severity)> Logs
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _logs.ToArray();
+                }
+            }
+        }
+
+        public void ReportStatus(string message)
+        {
+        }
+
+        public void WriteLog(string line, FunctionsProjectReportSeverity severity = FunctionsProjectReportSeverity.Info)
+        {
+            lock (_gate)
+            {
+                _logs.Add((line, severity));
+            }
+        }
+    }
 }


### PR DESCRIPTION
### Issue describing the changes in this PR

Follow-up to #5246 (which added live build/prepare log streaming for .NET and fixed #5217). This brings the same live-streaming experience to the **Node** stack.

## Summary

When `func start` prepares a Node project for the host run (`npm install`, `npm run build`), the CLI previously buffered the process output and only flushed it (stderr) after the process exited. This PR streams stdout (informational) and stderr (error) line-by-line to the host-run reporter as npm produces it, so build/restore progress shows up live under the spinner and collapses to a checklist line on success / retains the failing step's log tail on failure — matching the .NET behavior.

## What changed

- `NodeFunctionsProject`: the `RunNpm` seam now streams stdout/stderr to `Action<string>` callbacks and returns the exit code, instead of returning buffered `(int, string)`. Output is wired to `reporter.WriteLog(line, Info/Error)` live.
- Added a streaming process core (`OutputDataReceived`/`ErrorDataReceived` + completion sentinels + `WaitForExitAsync` + best-effort kill), mirroring `DotnetCliRunner`.
- On non-zero exit, `GracefulException` no longer embeds stderr (already streamed live).
- Tests updated to the new seam signature; failure-path tests assert the exit code in the message and the streamed error line via a `CapturingReporter`. New test covers live streaming to the reporter.

No live-streaming changes to Python/Go here — those are separate follow-up PRs.