### PR TITLE
Hide durable/blob/eventgridblob templates from func new list

### DIFF
--- a/src/Templates.V2/V2EngineProvider.cs
+++ b/src/Templates.V2/V2EngineProvider.cs
@@ -65,6 +65,11 @@ internal sealed class V2EngineProvider : ITemplateEngineProvider
         List<FunctionTemplateInfo> projected = [];
         foreach (NewTemplate template in payload.Templates)
         {
+            if (V2HiddenTemplates.IsHidden(template.Id ?? string.Empty))
+            {
+                continue;
+            }
+
             FunctionTemplateInfo? info = V2TemplateProjection.Project(template, payload, context.Stack);
             if (info is not null && MatchesLanguage(info, context.Language))
             {

--- a/src/Templates.V2/V2HiddenTemplates.cs
+++ b/src/Templates.V2/V2HiddenTemplates.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Templates.V2;
+
+/// <summary>
+/// Template ids the V2 provider suppresses from <c>func new</c> listings and
+/// the interactive picker. Apply is intentionally not filtered so callers who
+/// already know the id can still pass <c>--template &lt;id&gt;</c>.
+/// </summary>
+internal static class V2HiddenTemplates
+{
+    internal static readonly HashSet<string> Ids = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // TypeScript
+        "BlobTrigger-TypeScript",
+        "EventGridBlobTrigger-TypeScript",
+        "DurableFunctionsEntity-TypeScript",
+        "DurableFunctionsOrchestrator-TypeScript",
+
+        // JavaScript
+        "DurableFunctionsEntity-JavaScript",
+        "DurableFunctionsOrchestrator-JavaScript",
+    };
+
+    public static bool IsHidden(string templateId) =>
+        !string.IsNullOrWhiteSpace(templateId) && Ids.Contains(templateId);
+}

--- a/src/Templates.V2/V2HiddenTemplates.cs
+++ b/src/Templates.V2/V2HiddenTemplates.cs
@@ -21,6 +21,10 @@ internal static class V2HiddenTemplates
         // JavaScript
         "DurableFunctionsEntity-JavaScript",
         "DurableFunctionsOrchestrator-JavaScript",
+
+        // Python
+        "DurableFunctionsEntityTrigger-Python",
+        "DurableFunctionsOrchestration-Python",
     };
 
     public static bool IsHidden(string templateId) =>

--- a/src/Workloads/Stacks/Python/Templates/function_app.py
+++ b/src/Workloads/Stacks/Python/Templates/function_app.py
@@ -1,4 +1,7 @@
-import azure.functions as func
+import datetime
+import json
 import logging
 
-app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+import azure.functions as func
+
+app = func.FunctionApp(http_auth_level=func.AuthLevel.FUNCTION)

--- a/test/Func.Tests/Templates/V2/V2EngineProviderTests.cs
+++ b/test/Func.Tests/Templates/V2/V2EngineProviderTests.cs
@@ -80,6 +80,26 @@ public class V2EngineProviderTests : IDisposable
         Assert.Empty(typescriptOnly);
     }
 
+    [Fact]
+    public async Task ListTemplatesAsync_Omits_Hidden_Templates()
+    {
+        WriteHiddenFixturePayload(_installDir);
+
+        IInstalledTemplatesWorkloads installed = Substitute.For<IInstalledTemplatesWorkloads>();
+        installed.ListInstalledAsync("node", Arg.Any<CancellationToken>())
+            .Returns([new InstalledTemplatesWorkload("node", "1.0.0", _installDir)]);
+
+        var provider = new V2EngineProvider(installed);
+        IReadOnlyList<FunctionTemplateInfo> templates = await provider.ListTemplatesAsync(
+            new TemplateListContext(new Cli.Common.WorkingDirectory(new DirectoryInfo(_workloadHome), false), "node", null),
+            CancellationToken.None);
+
+        // BlobTrigger-TypeScript and DurableFunctionsOrchestrator-JavaScript
+        // are on the hidden list; only the HTTP trigger should remain.
+        Assert.Single(templates);
+        Assert.Equal("HttpTrigger-JavaScript", templates[0].Id);
+    }
+
     private static void WriteFixturePayload(string installDir)
     {
         string v2 = Path.Combine(installDir, "tools", "any", "content", "v2");
@@ -119,5 +139,45 @@ public class V2EngineProviderTests : IDisposable
         File.WriteAllText(Path.Combine(v2, "resources", "Resources.json"), """
         { "HttpTrigger_description": "An HTTP-triggered function." }
         """);
+    }
+
+    private static void WriteHiddenFixturePayload(string installDir)
+    {
+        string v2 = Path.Combine(installDir, "tools", "any", "content", "v2");
+        Directory.CreateDirectory(Path.Combine(v2, "templates"));
+        Directory.CreateDirectory(Path.Combine(v2, "bindings"));
+        Directory.CreateDirectory(Path.Combine(v2, "resources"));
+
+        File.WriteAllText(Path.Combine(v2, "templates", "templates.json"), """
+        [
+          {
+            "id": "HttpTrigger-JavaScript",
+            "name": "HTTP trigger",
+            "language": "javascript",
+            "jobs": [ { "type": "CreateNewApp", "inputs": [ { "paramId": "trigger-functionName", "assignTo": "$(FUNCTION_NAME_INPUT)", "defaultValue": "HttpTrigger" } ] } ],
+            "actions": [ { "type": "WriteToFile", "filePath": "src/functions/$(FUNCTION_NAME_INPUT).js", "fileContent": "// generated" } ]
+          },
+          {
+            "id": "BlobTrigger-TypeScript",
+            "name": "Blob trigger",
+            "language": "typescript",
+            "jobs": [ { "type": "CreateNewApp", "inputs": [ { "paramId": "trigger-functionName", "assignTo": "$(FUNCTION_NAME_INPUT)", "defaultValue": "BlobTrigger" } ] } ],
+            "actions": [ { "type": "WriteToFile", "filePath": "src/functions/$(FUNCTION_NAME_INPUT).ts", "fileContent": "// generated" } ]
+          },
+          {
+            "id": "DurableFunctionsOrchestrator-JavaScript",
+            "name": "Durable Functions orchestrator",
+            "language": "javascript",
+            "jobs": [ { "type": "CreateNewApp", "inputs": [ { "paramId": "trigger-functionName", "assignTo": "$(FUNCTION_NAME_INPUT)", "defaultValue": "DurableFunctionsOrchestrator" } ] } ],
+            "actions": [ { "type": "WriteToFile", "filePath": "src/functions/$(FUNCTION_NAME_INPUT).js", "fileContent": "// generated" } ]
+          }
+        ]
+        """);
+
+        File.WriteAllText(Path.Combine(v2, "bindings", "userPrompts.json"), """
+        [ { "id": "trigger-functionName", "label": "Function name", "defaultValue": "HttpTrigger" } ]
+        """);
+
+        File.WriteAllText(Path.Combine(v2, "resources", "Resources.json"), "{}");
     }
 }


### PR DESCRIPTION
Hides templates that aren't yet ready for v5 from `func new`, and updates the Python init scaffold.

## Hidden templates (V2HiddenTemplates)

- **TypeScript:** `BlobTrigger-TypeScript`, `EventGridBlobTrigger-TypeScript`, `DurableFunctionsEntity-TypeScript`, `DurableFunctionsOrchestrator-TypeScript`
- **JavaScript:** `DurableFunctionsEntity-JavaScript`, `DurableFunctionsOrchestrator-JavaScript`
- **Python:** `DurableFunctionsEntityTrigger-Python`, `DurableFunctionsOrchestration-Python`

Filtering is in `V2EngineProvider.ListTemplatesAsync` only. `ApplyAsync` is untouched, so `--template <id>` still works if anyone needs to scaffold one explicitly.

## Python `func init` scaffold (`function_app.py`)

- Default `http_auth_level` flipped from `ANONYMOUS` to `FUNCTION`.
- Added `datetime`, `json`, `logging` imports so the generated app is closer to what most triggers need out of the box.

## Test plan

- New `ListTemplatesAsync_Omits_Hidden_Templates` test in `V2EngineProviderTests` (4/4 pass).
- Existing Python init tests still pass (54/54).