### PR TITLE
Bump dotnet templates version to 4.0.5590

### DIFF
--- a/eng/build/Templates.targets
+++ b/eng/build/Templates.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <TemplatesVersion>4.0.5584</TemplatesVersion>
+    <TemplatesVersion>4.0.5590</TemplatesVersion>
     <TemplatesJsonVersion>3.1.1648</TemplatesJsonVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Picks up the latest released `azure-functions-templates` NuGet packages, bumping `TemplatesVersion` in `eng/build/Templates.targets` from `4.0.5584` to `4.0.5590`.