### PR TITLE
[vnext] Bump dotnet templates version to 4.0.5590

### DIFF
--- a/src/Workloads/Templates/DotNet/Directory.Version.props
+++ b/src/Workloads/Templates/DotNet/Directory.Version.props
@@ -27,7 +27,7 @@
     <VersionPrefix>$(TemplatesVersion)</VersionPrefix>
 
     <SourceItemTemplatesPackageId>Microsoft.Azure.Functions.Worker.ItemTemplates</SourceItemTemplatesPackageId>
-    <SourceItemTemplatesVersion>4.0.5584</SourceItemTemplatesVersion>
+    <SourceItemTemplatesVersion>4.0.5590</SourceItemTemplatesVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Picks up the latest released azure-functions-templates NuGet packages, bumping `SourceItemTemplatesVersion` from 4.0.5584 to 4.0.5590.