### PR TITLE
Improve setup-local-cli skill: CI=true, drop quickstart env var, dual-shell snippets

### DIFF
--- a/.github/skills/setup-local-cli/SKILL.md
+++ b/.github/skills/setup-local-cli/SKILL.md
@@ -1,13 +1,17 @@
 ---
 name: setup-local-cli
-description: 'Use when a contributor wants a ready-to-use local v5 CLI build: publishes func for the host RID to artifacts/func-cli, refreshes the local workloads feed, and prints a paste-ready shell snippet that aliases f5 to the binary and exports the workload + quickstart manifest env vars.'
+description: 'Use when a contributor wants a ready-to-use local v5 CLI build: publishes func for the host RID to artifacts/func-cli, refreshes the local workloads feed, and prints paste-ready bash and PowerShell snippets that alias f5 to the binary and export the workloads feed env var.'
 ---
 
 # Set Up the Local v5 CLI for Hand Testing
 
 Contributors iterating on v5 want to drive the CLI from a real shell, not
 `dotnet run`. This skill builds everything needed for that loop in one go and
-hands back a single line to paste.
+hands back a snippet per shell to paste.
+
+Both the CLI publish and the delegated `build-workloads` invocation run with
+`CI=true` so contributors get the same `FileVersion`, workload version suffix,
+and warnings-as-errors behaviour that customers see in official builds.
 
 What it produces:
 
@@ -16,9 +20,17 @@ What it produces:
 2. A clean local NuGet feed at `http://localhost:5555/v3/index.json` populated
    with every workload package in the repo (delegates to the `build-workloads`
    skill).
-3. A one-line snippet the user pastes in their own shell, of the form:
+3. Two paste-ready snippets, one per shell. Pick the one for the shell you
+   want to run `f5` from:
+
+   Bash / zsh:
    ```
-   alias f5="<repo>/artifacts/func-cli/func" && export FUNC_CLI_WORKLOADS_SOURCE="http://localhost:5555/v3/index.json" && export FUNC_CLI_QUICKSTART_MANIFEST_URL="https://raw.githubusercontent.com/Azure/azure-functions-templates/dev/Functions.Templates/Template-Manifest/manifest.json"
+   alias f5="<repo>/artifacts/func-cli/func" && export FUNC_CLI_WORKLOADS_SOURCE="http://localhost:5555/v3/index.json"
+   ```
+
+   PowerShell:
+   ```
+   function f5 { & "<repo>/artifacts/func-cli/func" @args }; $env:FUNC_CLI_WORKLOADS_SOURCE = "http://localhost:5555/v3/index.json"
    ```
 
 Use this skill when the user says things like:
@@ -37,14 +49,13 @@ pwsh ./.github/skills/setup-local-cli/scripts/setup-local-cli.ps1
 
 Flags worth knowing (see script header for the full list):
 
-- `-Configuration <Debug|Release>` — default `Release`.
-- `-Rid <rid>` — override the auto-detected host RID
+- `-Configuration <Debug|Release>`, default `Release`.
+- `-Rid <rid>`, override the auto-detected host RID
   (`osx-arm64`, `osx-x64`, `linux-x64`, `linux-arm64`, `win-x64`, `win-arm64`).
-- `-Port <int>` — host port for the workloads feed (default `5555`).
-- `-QuickstartManifestUrl <url>` — override the templates manifest URL.
-- `-SkipWorkloads` — skip the feed teardown + rebuild (the feed is already up
+- `-Port <int>`, host port for the workloads feed (default `5555`).
+- `-SkipWorkloads`, skip the feed teardown and rebuild (the feed is already up
   and current).
-- `-SkipCli` — skip the CLI publish (an existing
+- `-SkipCli`, skip the CLI publish (an existing
   `artifacts/func-cli/func` is fine).
 
 The script is the source of truth. If a flag is in the script but missing

--- a/.github/skills/setup-local-cli/scripts/setup-local-cli.ps1
+++ b/.github/skills/setup-local-cli/scripts/setup-local-cli.ps1
@@ -2,12 +2,16 @@
 <#
 .SYNOPSIS
     Build and publish func for the current OS/arch, stand up the local
-    workloads feed, and print a paste-ready shell snippet that aliases f5 to
-    the built binary and exports the workload + quickstart manifest env vars.
+    workloads feed, and print paste-ready shell snippets that alias f5 to
+    the built binary and export the workloads feed env var.
 
 .DESCRIPTION
     End-to-end local-loop setup so a contributor can iterate on the v5 CLI
     in their own terminal. See SKILL.md next to this script.
+
+    Both the CLI publish and the delegated build-workloads invocation run
+    with CI=true so contributors get the same FileVersion, workload
+    version suffix, and warnings-as-errors behaviour that customers see.
 
 .PARAMETER Configuration
     Build configuration for both the CLI publish and the workloads pack.
@@ -19,10 +23,6 @@
 
 .PARAMETER Port
     Host port for the local workloads feed. Default: 5555.
-
-.PARAMETER QuickstartManifestUrl
-    URL the CLI should load templates from. Default: the dev branch of
-    azure-functions-templates.
 
 .PARAMETER SkipWorkloads
     Skip the workloads-feed build/publish (assumes the feed is already up).
@@ -36,7 +36,6 @@ param(
     [string] $Configuration = 'Release',
     [string] $Rid,
     [int] $Port = 5555,
-    [string] $QuickstartManifestUrl = 'https://raw.githubusercontent.com/Azure/azure-functions-templates/dev/Functions.Templates/Template-Manifest/manifest.json',
     [switch] $SkipWorkloads,
     [switch] $SkipCli
 )
@@ -64,11 +63,17 @@ function Get-HostRid {
 
 if (-not $Rid) { $Rid = Get-HostRid }
 
+# Run both the CLI publish and the workloads build with CI=true so contributors
+# get the same FileVersion, workload version suffix, and warnings-as-errors
+# behaviour as the official CI/release builds (see eng/build/Version.props,
+# eng/build/Version.targets, eng/build/Release.props, eng/build/Engineering.props).
+$env:CI = 'true'
+
 if (-not $SkipCli) {
     if (Test-Path $cliOutDir) { Remove-Item -Recurse -Force $cliOutDir }
     New-Item -ItemType Directory -Path $cliOutDir | Out-Null
 
-    Write-Host "Publishing func ($Rid, $Configuration) to $cliOutDir ..." -ForegroundColor Cyan
+    Write-Host "Publishing func ($Rid, $Configuration, CI=true) to $cliOutDir ..." -ForegroundColor Cyan
     & dotnet publish $cliProject -c $Configuration -r $Rid -o $cliOutDir --nologo
     if ($LASTEXITCODE -ne 0) { throw "dotnet publish failed with exit code $LASTEXITCODE" }
 }
@@ -99,14 +104,18 @@ if (-not $SkipWorkloads) {
 }
 
 $feedUrl = "http://localhost:$Port/v3/index.json"
-$snippet = "alias f5=`"$funcPath`" && export FUNC_CLI_WORKLOADS_SOURCE=`"$feedUrl`" && export FUNC_CLI_QUICKSTART_MANIFEST_URL=`"$QuickstartManifestUrl`""
+$bashSnippet = "alias f5=`"$funcPath`" && export FUNC_CLI_WORKLOADS_SOURCE=`"$feedUrl`""
+$pwshSnippet = "function f5 { & `"$funcPath`" @args }; `$env:FUNC_CLI_WORKLOADS_SOURCE = `"$feedUrl`""
 
 Write-Host ""
-Write-Host "func binary:        $funcPath" -ForegroundColor Green
-Write-Host "Workloads feed:     $feedUrl" -ForegroundColor Green
-Write-Host "Quickstart manifest: $QuickstartManifestUrl" -ForegroundColor Green
+Write-Host "func binary:    $funcPath" -ForegroundColor Green
+Write-Host "Workloads feed: $feedUrl" -ForegroundColor Green
 Write-Host ""
-Write-Host "Paste this in your shell to use the CLI as 'f5':" -ForegroundColor Yellow
+Write-Host "Paste the snippet for your shell to use the CLI as 'f5':" -ForegroundColor Yellow
 Write-Host ""
-Write-Host $snippet
+Write-Host "Bash / zsh:" -ForegroundColor Yellow
+Write-Host $bashSnippet
+Write-Host ""
+Write-Host "PowerShell:" -ForegroundColor Yellow
+Write-Host $pwshSnippet
 Write-Host ""


### PR DESCRIPTION
Three surgical updates to the `setup-local-cli` skill.

## Changes

1. **Force `CI=true` for the CLI publish and `build-workloads` invocation.** Sets `$env:CI = 'true'` inside the script so contributors get the same `FileVersion` (`$(VersionPrefix).$(BuildNumber)` instead of the `42.42.42.4242` placeholder), the CI-style version suffix on workload nupkgs, and `TreatWarningsAsErrors` + `NU1904`-as-error that customers see (see `eng/build/Version.props`, `eng/build/Version.targets`, `eng/build/Release.props`, `eng/build/Engineering.props`). `build-workloads.ps1` itself is unchanged; the env var is just inherited.

2. **Drop `FUNC_CLI_QUICKSTART_MANIFEST_URL` plumbing.** The CLI no longer needs it. Removed the `-QuickstartManifestUrl` parameter, the `export FUNC_CLI_QUICKSTART_MANIFEST_URL=...` line from the printed snippet, and the `Quickstart manifest:` summary line. `SKILL.md` updated to match (synopsis, sample snippet, flag list).

3. **Print both a bash/zsh and a PowerShell snippet.** Windows contributors can now use the skill too. The script always emits both blocks under `Bash / zsh:` and `PowerShell:` headings so the contributor picks the right one regardless of which shell they ran the script from. `SKILL.md` sample shows both.

## Verification

Ran `pwsh ./.github/skills/setup-local-cli/scripts/setup-local-cli.ps1 -SkipWorkloads` on macOS (osx-arm64). Publish completed, snippet block rendered cleanly for both shells, and `func --version` on the published binary reports a real version string rather than `42.42.42.4242`.

No changes to `build-workloads.ps1`, CI pipelines, or the published feed.