### PR TITLE
Bump templates to 1.0.1 and clear release notes

### DIFF
--- a/src/Func/release_notes.md
+++ b/src/Func/release_notes.md
@@ -2,10 +2,3 @@
 
 #### Changes
 
-- `func setup` now installs the matching stack workload (Node, Python, Go, DotNet) for the project's worker runtime, detected from `local.settings.json` or selected via prompt / `--features`.
-- `func start --no-build`: now actually skips compilation steps in stack workloads. Node skips `npm run build` (still runs `npm install` when `node_modules` is missing), Go skips `go build` (trusts the existing `bin/<module>` binary), Python is a no-op (no build step). Was previously parsed and ignored.
-- `func start`: `local.settings.json` Values no longer overwrite environment variables already set in the current shell, matching v4 behavior. Skipped keys are logged as warnings, along with empty keys. Empty string values are preserved so the host can see an intentional clear.
-- `func new`: sanitize the function-name token when rendering v2 templates so names like `HttpTrigger-Python` produce valid Python/Node identifiers instead of `SyntaxError` (#5202).
-- `func setup --features python` now installs only the python worker build for the current RID (#5247), matching the host workload resolution.
-- `func workload install <alias>` now resolves to the per-RID workload pack for the current platform when an alias spans multiple per-RID packs (e.g. `host`, `python-worker`). Installing by full package id still installs that exact package. Running `func setup` for Python on `win-arm64` now reports a clear unsupported-runtime error instead of failing later in the install flow.
-- <entry>

--- a/src/Workloads/Host/release_notes.md
+++ b/src/Workloads/Host/release_notes.md
@@ -2,4 +2,3 @@
 
 ## 1.0.0-preview.1
 
-- Initial scaffold of the Host content workload with a minimal host shell.

--- a/src/Workloads/Stacks/DotNet/release_notes.md
+++ b/src/Workloads/Stacks/DotNet/release_notes.md
@@ -2,4 +2,3 @@
 
 ## 1.0.0-preview.1
 
-- Initial scaffold of the .NET workload (entry point + stub project initializer).

--- a/src/Workloads/Stacks/Go/release_notes.md
+++ b/src/Workloads/Stacks/Go/release_notes.md
@@ -2,8 +2,3 @@
 
 ## 1.0.0-preview.1
 
-- Initial scaffold of the Go workload (entry point + stub project initializer).
-- Run `go build` before host start so the Go worker can launch the project binary.
-- Validate the Go toolchain (Go 1.24+) with a clear install hint when missing or too old, and emit the binary as `bin/app` (`bin\app.exe` on Windows) to match the Go worker's `defaultExecutablePath`.
-- Run `go mod tidy` before `go build` on `func start` so the version-less scaffold (and any drifted `go.sum`) resolves to the latest Go worker SDK release.
-- Scaffold `main.go` with an HTTP-triggered "hello" function instead of an empty `main`, so a fresh `func init` is runnable end to end.

--- a/src/Workloads/Stacks/Node/release_notes.md
+++ b/src/Workloads/Stacks/Node/release_notes.md
@@ -2,5 +2,3 @@
 
 ## 1.0.0-preview.1
 
-- Initial scaffold of the Node workload (entry point + stub project initializer).
-- Run `npm install` and `npm run build` (when a `build` script is declared) before host start.

--- a/src/Workloads/Stacks/Python/release_notes.md
+++ b/src/Workloads/Stacks/Python/release_notes.md
@@ -2,9 +2,3 @@
 
 ## 1.0.0-preview.1
 
-- Initial scaffold of the Python workload (entry point + stub project initializer).
-- Create a `.venv` (if missing), run `pip install -r requirements.txt`, and set `PYTHON_ISOLATE_WORKER_DEPENDENCIES=1` before host start.
-- Honor an activated venv via `$VIRTUAL_ENV` and reuse pre-existing `venv`, `env`, or `.virtualenv` folders before falling back to creating `.venv`.
-- Point the host at the venv interpreter via `languageWorkers__python__defaultExecutablePath` and surface the detected Python major.minor as `FUNCTIONS_WORKER_RUNTIME_VERSION` so the worker sees the user's installed packages.
-- Fix Python worker startup on macOS/Linux by using `__` delimiter in `languageWorkers__python__defaultExecutablePath` (mirrors #5212 for `workerDirectory`).
-- Add `import logging` to the scaffolded `function_app.py` so sample HTTP handlers can call `logging.info(...)` without an extra import.

--- a/src/Workloads/Templates/Directory.Version.props
+++ b/src/Workloads/Templates/Directory.Version.props
@@ -34,7 +34,7 @@
   <Import Project="$(EngBuildRoot)Workloads.Templates.SourceBundleVersion.props" />
 
   <PropertyGroup>
-    <TemplatesVersion>1.0.0</TemplatesVersion>
+    <TemplatesVersion>1.0.1</TemplatesVersion>
     <TemplatesChannel>stable</TemplatesChannel>
     <SourceBundleVersion Condition="'$(SourceBundleVersion)' == ''">$(LatestExtensionBundleVersion)</SourceBundleVersion>
     <MinBundleVersionRange Condition="'$(MinBundleVersionRange)' == ''">[4.0.0,)</MinBundleVersionRange>

--- a/src/Workloads/Templates/DotNet/Directory.Version.props
+++ b/src/Workloads/Templates/DotNet/Directory.Version.props
@@ -23,7 +23,7 @@
   -->
 
   <PropertyGroup>
-    <TemplatesVersion>1.0.0</TemplatesVersion>
+    <TemplatesVersion>1.0.1</TemplatesVersion>
     <VersionPrefix>$(TemplatesVersion)</VersionPrefix>
 
     <SourceItemTemplatesPackageId>Microsoft.Azure.Functions.Worker.ItemTemplates</SourceItemTemplatesPackageId>

--- a/src/Workloads/Templates/DotNet/release_notes.md
+++ b/src/Workloads/Templates/DotNet/release_notes.md
@@ -1,5 +1,4 @@
 # Azure.Functions.Cli.Workloads.Templates.DotNet
 
-## 1.0.0
+## 1.0.1
 
-- Initial scaffold of the .NET templates workload (index + NuGet pin).

--- a/src/Workloads/Templates/Node/release_notes.md
+++ b/src/Workloads/Templates/Node/release_notes.md
@@ -1,6 +1,4 @@
 # Azure.Functions.Cli.Workloads.Templates.Node
 
-## 1.0.0
+## 1.0.1
 
-- Function names containing characters that are not valid JavaScript/TypeScript identifiers (e.g. `HttpTrigger-Node`) are now sanitized before being emitted as `function` declarations and handler references, so generated sources parse cleanly (#5202).
-- Initial scaffold of the Node.js templates workload (v2 template-engine schema, Node v4 programming model). 33 templates statically authored in-repo under `content/v2/`. No CDN download of templates at pack time. **Per-channel template subsetting** is on: pack fetches `bin/extensions.json` from the active channel's latest listed bundle (CDN `index.json` + HTTP-Range zip extraction; only listed versions consumed) and filters the template set against the committed `_bindings.json` map (Templates Workload Spec §4.3 / §6.1). Cross-reference at this revision: stable 4.32.0 → 31/33, preview 4.42.0 → 33/33, experimental 4.6.0 → 31/33 (McpPromptTrigger JS+TS dropped where `mcpPromptTrigger` binding isn't yet shipped).

--- a/src/Workloads/Templates/Python/release_notes.md
+++ b/src/Workloads/Templates/Python/release_notes.md
@@ -1,6 +1,4 @@
 # Azure.Functions.Cli.Workloads.Templates.Python
 
-## 1.0.0
+## 1.0.1
 
-- Initial scaffold of the Python templates workload (v2 programming model only). v1 (legacy) programming-model templates are not shipped — users on v1 should migrate to v2 (see Templates Workload Spec §7.1).
-- Function names containing characters that are not valid Python identifiers (e.g. `HttpTrigger-Python`) are now sanitized before being emitted as `def` declarations, so generated `function_app.py` parses cleanly (#5202).

--- a/src/Workloads/Workers/Go/release_notes.md
+++ b/src/Workloads/Workers/Go/release_notes.md
@@ -2,7 +2,3 @@
 
 ## 1.0.0-preview.1
 
-- Adopt single-axis `$(WorkerVersion)` version scheme. Manually maintained
-  (no upstream Go worker NuGet) and drives the workload pkg version.
-  Matches the Node and Python worker workload version layout. Ships as a
-  preview while the Go worker integration stabilises.

--- a/src/Workloads/Workers/Node/release_notes.md
+++ b/src/Workloads/Workers/Node/release_notes.md
@@ -2,10 +2,3 @@
 
 ## 3.13.0
 
-- Adopt single-axis version scheme: `$(WorkerVersion)` mirrors
-  `Microsoft.Azure.Functions.NodeJsWorker`. Workload pkg version tracks the
-  worker payload version 1:1.
-
-## 1.0.0-preview.1
-
-- Initial scaffold of the Node worker content workload.

--- a/src/Workloads/Workers/Python/release_notes.md
+++ b/src/Workloads/Workers/Python/release_notes.md
@@ -2,10 +2,3 @@
 
 ## 4.43.0
 
-- Adopt single-axis version scheme: `$(WorkerVersion)` mirrors
-  `Microsoft.Azure.Functions.PythonWorker`. Workload pkg version tracks the
-  worker payload version 1:1.
-
-## 1.0.0-preview.1
-
-- Initial scaffold of the Python worker content workload.


### PR DESCRIPTION
Bumps the templates workloads to 1.0.1 and clears all workload release notes ahead of the next release.

## Versions
- **Templates (Node, Python, DotNet)**: `1.0.0` → `1.0.1`
- **ExtensionBundles**: stays at `4.35.0`. No payload change since the [v4.35.0 tag](https://github.com/Azure/azure-functions-core-tools/releases/tag/bug-bash%2Fbundles%2Fv4.35.0); only #5160 touched it, a non-stable-channel prerelease label format tweak (`4.35.0-preview` → `4.35.0-preview.1`).

## What changed in the templates workloads since [v1.0.0](https://github.com/Azure/azure-functions-core-tools/releases/tag/bug-bash%2Ftemplates%2Fv1.0.0)

**Node + Python**
- #5227: `workload.json` Title/Description refresh
- #5243: Sanitize function-name token in V2 template engine (CLI engine fix; Node/Python templates are the consumers)

**DotNet**
- #5227: Same `workload.json` refresh
- #5254: Restore upstream nupkg via `PackageDownload` (build mechanism)
- #5197 + #5272: Bump `SourceItemTemplatesVersion` (upstream pin) `4.0.5584` → `4.0.5590`

Patch is the right bump: no new templates, no new options, no new binding coverage.

## Release notes
All workload `release_notes.md` files cleared for the next release cycle.