### PR TITLE
Fix Python worker startup deadlock on Windows (host stdio handle inheritance)

### DIFF
--- a/src/Workloads/Host/Interop/INativeHandleApi.cs
+++ b/src/Workloads/Host/Interop/INativeHandleApi.cs
@@ -1,0 +1,27 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workloads.Host.Interop;
+
+/// <summary>
+/// Thin seam over the Win32 handle-flag APIs so that handle-inheritance logic can be unit
+/// tested without touching real operating system handles.
+/// </summary>
+internal interface INativeHandleApi
+{
+    /// <summary>
+    /// Reads the flags (including the inheritable flag) for the given handle.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> if the handle is valid and its flags were read; otherwise <see langword="false"/>.
+    /// </returns>
+    public bool TryGetHandleFlags(nint handle, out uint flags);
+
+    /// <summary>
+    /// Clears the inheritable flag on the given handle so child processes cannot inherit it.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> if the flag was cleared; otherwise <see langword="false"/>.
+    /// </returns>
+    public bool TryDisableInheritance(nint handle);
+}

--- a/src/Workloads/Host/Interop/Win32NativeHandleApi.cs
+++ b/src/Workloads/Host/Interop/Win32NativeHandleApi.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace Azure.Functions.Cli.Workloads.Host.Interop;
+
+/// <summary>
+/// Windows implementation of <see cref="INativeHandleApi"/> backed by the kernel32 handle APIs.
+/// </summary>
+[SupportedOSPlatform("windows")]
+internal sealed partial class Win32NativeHandleApi : INativeHandleApi
+{
+    private const uint HandleFlagInherit = 0x1;
+
+    public bool TryGetHandleFlags(nint handle, out uint flags) => GetHandleInformation(handle, out flags);
+
+    public bool TryDisableInheritance(nint handle) => SetHandleInformation(handle, HandleFlagInherit, 0);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool GetHandleInformation(nint hObject, out uint lpdwFlags);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool SetHandleInformation(nint hObject, uint dwMask, uint dwFlags);
+}

--- a/src/Workloads/Host/Program.cs
+++ b/src/Workloads/Host/Program.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Workloads.Host.Interop;
+using Azure.Functions.Cli.Workloads.Host.Startup;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using DotnetHost = Microsoft.Extensions.Hosting.Host;
@@ -12,6 +14,11 @@ internal static class Program
     public static async Task<int> Main(string[] args)
     {
         SetHostEnvironmentVariables();
+
+        if (OperatingSystem.IsWindows())
+        {
+            new ChildProcessHandleSanitizer(new Win32NativeHandleApi()).DisableInheritanceOnOpenHandles();
+        }
 
         HostApplicationBuilder builder = DotnetHost.CreateEmptyApplicationBuilder(null);
         builder.Services.AddSingleton<HostShell>();

--- a/src/Workloads/Host/Startup/ChildProcessHandleSanitizer.cs
+++ b/src/Workloads/Host/Startup/ChildProcessHandleSanitizer.cs
@@ -1,0 +1,62 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads.Host.Interop;
+
+namespace Azure.Functions.Cli.Workloads.Host.Startup;
+
+/// <summary>
+/// Strips the inheritable flag from every handle this process currently owns so that language
+/// workers spawned later cannot inherit the host's redirected stdio pipe handles.
+/// </summary>
+/// <remarks>
+/// The CLI launches the host with redirected stdin/stdout/stderr, so the host's pipe handles
+/// (and the C runtime's duplicates of them) are marked inheritable. The Functions host spawns
+/// each language worker with <c>bInheritHandles = TRUE</c> because it redirects the worker's
+/// streams, which leaks those host pipe handles into the worker. A leaked, shared, synchronous
+/// stdout pipe handle deadlocks CPython startup, which seeks stdout (<c>fflush</c>) during
+/// interpreter initialization. Clearing inheritance before any worker launches prevents the
+/// leak; .NET re-enables inheritance on the specific worker handles transiently while it starts
+/// each worker, so worker stdio still works.
+/// </remarks>
+internal sealed class ChildProcessHandleSanitizer(INativeHandleApi nativeHandleApi)
+{
+    private const uint HandleFlagInherit = 0x1;
+
+    // Win32 handles are multiples of four. The host owns only a handful of low-valued handles
+    // at startup (before any worker launches), so scanning a small fixed window is sufficient.
+    private const int MaxHandleValue = 0x10000;
+
+    private readonly INativeHandleApi _nativeHandleApi = nativeHandleApi ?? throw new ArgumentNullException(nameof(nativeHandleApi));
+
+    /// <summary>
+    /// Disables handle inheritance on the host's currently open handles.
+    /// </summary>
+    /// <returns>
+    /// The number of handles whose inheritable flag was cleared.
+    /// </returns>
+    public int DisableInheritanceOnOpenHandles()
+    {
+        int disabledCount = 0;
+        for (int value = 4; value <= MaxHandleValue; value += 4)
+        {
+            nint handle = value;
+            if (!_nativeHandleApi.TryGetHandleFlags(handle, out uint flags))
+            {
+                continue;
+            }
+
+            if ((flags & HandleFlagInherit) == 0)
+            {
+                continue;
+            }
+
+            if (_nativeHandleApi.TryDisableInheritance(handle))
+            {
+                disabledCount++;
+            }
+        }
+
+        return disabledCount;
+    }
+}

--- a/test/Workloads/Host.Tests/ChildProcessHandleSanitizerTests.cs
+++ b/test/Workloads/Host.Tests/ChildProcessHandleSanitizerTests.cs
@@ -1,0 +1,78 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads.Host.Interop;
+using Azure.Functions.Cli.Workloads.Host.Startup;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Functions.Cli.Workloads.Host.Tests;
+
+public sealed class ChildProcessHandleSanitizerTests
+{
+    private const uint HandleFlagInherit = 0x1;
+    private const uint HandleFlagProtectFromClose = 0x2;
+
+    [Fact]
+    public void Constructor_NullNativeHandleApi_Throws()
+        => Assert.Throws<ArgumentNullException>(() => new ChildProcessHandleSanitizer(null!));
+
+    [Fact]
+    public void DisableInheritanceOnOpenHandles_ClearsInheritOnlyOnInheritableHandles()
+    {
+        INativeHandleApi nativeHandleApi = Substitute.For<INativeHandleApi>();
+        nativeHandleApi.TryDisableInheritance(Arg.Any<nint>()).Returns(true);
+
+        ConfigureHandle(nativeHandleApi, 0x10, HandleFlagInherit);
+        ConfigureHandle(nativeHandleApi, 0x20, HandleFlagInherit);
+        ConfigureHandle(nativeHandleApi, 0x30, HandleFlagProtectFromClose);
+
+        var sanitizer = new ChildProcessHandleSanitizer(nativeHandleApi);
+
+        int disabledCount = sanitizer.DisableInheritanceOnOpenHandles();
+
+        Assert.Equal(2, disabledCount);
+        nativeHandleApi.Received(1).TryDisableInheritance((nint)0x10);
+        nativeHandleApi.Received(1).TryDisableInheritance((nint)0x20);
+        nativeHandleApi.DidNotReceive().TryDisableInheritance((nint)0x30);
+    }
+
+    [Fact]
+    public void DisableInheritanceOnOpenHandles_HandleThatFailsToClear_IsAttemptedButNotCounted()
+    {
+        INativeHandleApi nativeHandleApi = Substitute.For<INativeHandleApi>();
+        nativeHandleApi.TryDisableInheritance(Arg.Any<nint>()).Returns(true);
+        nativeHandleApi.TryDisableInheritance((nint)0x20).Returns(false);
+
+        ConfigureHandle(nativeHandleApi, 0x10, HandleFlagInherit);
+        ConfigureHandle(nativeHandleApi, 0x20, HandleFlagInherit);
+
+        var sanitizer = new ChildProcessHandleSanitizer(nativeHandleApi);
+
+        int disabledCount = sanitizer.DisableInheritanceOnOpenHandles();
+
+        Assert.Equal(1, disabledCount);
+        nativeHandleApi.Received(1).TryDisableInheritance((nint)0x20);
+    }
+
+    [Fact]
+    public void DisableInheritanceOnOpenHandles_NoInheritableHandles_ClearsNothing()
+    {
+        INativeHandleApi nativeHandleApi = Substitute.For<INativeHandleApi>();
+
+        var sanitizer = new ChildProcessHandleSanitizer(nativeHandleApi);
+
+        int disabledCount = sanitizer.DisableInheritanceOnOpenHandles();
+
+        Assert.Equal(0, disabledCount);
+        nativeHandleApi.DidNotReceive().TryDisableInheritance(Arg.Any<nint>());
+    }
+
+    private static void ConfigureHandle(INativeHandleApi nativeHandleApi, int handleValue, uint flags)
+        => nativeHandleApi.TryGetHandleFlags((nint)handleValue, out Arg.Any<uint>())
+            .Returns(call =>
+            {
+                call[1] = flags;
+                return true;
+            });
+}


### PR DESCRIPTION
## Problem

Python language workers deadlock on startup on Windows under the v5 host. The worker process hangs during CPython interpreter initialization and never connects, so `func start` stalls indefinitely.

## Root cause

The CLI launches the Functions host (`Workloads.Host`) with redirected `stdin`/`stdout`/`stderr`. Inherited std handles stay marked **inheritable** inside the host, and the C runtime keeps additional inheritable duplicates of them. When the host spawns a language worker it redirects the worker's streams, which forces `bInheritHandles = TRUE`, so the worker **inherits the host's stdio pipe handles**.

A leaked, shared, **synchronous** stdout pipe handle deadlocks CPython init: interpreter startup performs an `fflush(stdout)` → `lseek` (`NtQueryInformationFile`) on the shared file object, which blocks on the host's own synchronous I/O against the *same* kernel `FILE_OBJECT`. Confirmed via an elevated `SystemExtendedHandleInformation` scan showing the worker's `stdout` handle and several host handles pointing at one shared file object.

Only Python is affected because only CPython seeks `stdout` during initialization; Node/Go/.NET workers do not.

## Fix

Clear `HANDLE_FLAG_INHERIT` from the host's open handles at startup, **before any worker launches**. .NET re-marks the specific worker std handles inheritable transiently while starting each worker, so worker stdio still works. The sweep is Windows-only and runs once in `Program.Main`.

- `INativeHandleApi` / `Win32NativeHandleApi` — thin source-generated (`LibraryImport`) seam over `GetHandleInformation`/`SetHandleInformation` so the logic is unit-testable.
- `ChildProcessHandleSanitizer` — OS-agnostic sweep that disables inheritance on currently open handles.

## Validation

- Reproduced the original deadlock (py-spy native stack stuck in `fflush` → `lseek` → `NtQueryInformationFile` during `Py_InitializeFromConfig`), then confirmed the fix lets the Python worker start normally on a real venv project.
- New unit tests for `ChildProcessHandleSanitizer`; full `Workloads.Host.Tests` suite passes (44 tests), Release build clean (0 warnings).