### PR TITLE
Install func5 alias for side-by-side use with v4

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -123,6 +123,20 @@ try {
             xattr -d com.apple.quarantine (Join-Path $InstallDir 'func') 2>$null
         }
     }
+
+    # Drop a func5 wrapper so v5 can be invoked side-by-side with a v4 `func` on PATH.
+    if ($os -eq 'win') {
+        $wrapperPath = Join-Path $InstallDir 'func5.cmd'
+        @(
+            '@echo off',
+            '"%~dp0\func.exe" %*'
+        ) -join "`r`n" | Set-Content -Path $wrapperPath -Encoding Ascii -NoNewline
+    } else {
+        $wrapperPath = Join-Path $InstallDir 'func5'
+        $wrapperBody = "#!/usr/bin/env bash`nexec `"`$(dirname `"`$0`")/func`" `"`$@`"`n"
+        [System.IO.File]::WriteAllText($wrapperPath, $wrapperBody)
+        chmod +x $wrapperPath
+    }
 } finally {
     Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
 }
@@ -155,6 +169,16 @@ Write-Host 'The Azure Functions CLI collects usage data in order to help us impr
 Write-Host "The data is anonymous and doesn't include any user specific or personal information. The data is collected by Microsoft."
 Write-Host ''
 Write-Host "You can opt-out of telemetry by setting the FUNC_CLI_TELEMETRY_OPTOUT environment variable to any value other than 'no', 'n', '0', 'false', or 'off' using your favorite shell."
+
+# --- Side-by-side notice ---
+
+$aliasName = if ($os -eq 'win') { 'func5.cmd' } else { 'func5' }
+Write-Host ''
+Write-Host 'Side-by-side with Core Tools v4'
+Write-Host '-------------------------------'
+Write-Host "A '$aliasName' alias was installed alongside 'func' so you can run v5 without"
+Write-Host "shadowing an existing v4 install. If you already have Core Tools v4 on your"
+Write-Host "PATH, use 'func5' to invoke v5 and keep 'func' pointing at v4."
 
 # --- Bug bash env vars ---
 

--- a/install.ps1
+++ b/install.ps1
@@ -176,6 +176,7 @@ if ($os -eq 'win') {
             Write-Host "Add to your shell profile: export PATH=`"$InstallDir`:`$PATH`""
             Write-Host "  echo 'export PATH=`"$InstallDir`:`$PATH`"' >> $shellProfile"
         }
+        Write-Host "Then reload your shell: source $shellProfile (or open a new terminal)."
     }
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -247,3 +247,18 @@ if ($BugBash) {
     Write-Host 're-run the three assignments above before using func.' -ForegroundColor Yellow
     Write-Host '========================================================================' -ForegroundColor Yellow
 }
+
+# --- Reload shell reminder ---
+
+Write-Host ''
+Write-Host 'Reload your shell'
+Write-Host '-----------------'
+if ($os -eq 'win') {
+    Write-Host "Open a new terminal so 'func' and 'func5' are on PATH, or refresh the current"
+    Write-Host 'session with:'
+    Write-Host "  `$env:PATH = [Environment]::GetEnvironmentVariable('PATH','User') + ';' + [Environment]::GetEnvironmentVariable('PATH','Machine')"
+} else {
+    $shellProfile = if ($env:SHELL -like '*zsh*') { '~/.zshrc' } else { '~/.bashrc' }
+    Write-Host "If 'func5' isn't found in your current shell, open a new terminal or run:"
+    Write-Host "  source $shellProfile"
+}

--- a/install.ps1
+++ b/install.ps1
@@ -146,9 +146,11 @@ try {
 # Detect a pre-existing 'func' that lives outside our install dir (e.g. Core Tools v4).
 # If one is present we APPEND our dir so the existing 'func' keeps winning and only
 # 'func5' resolves to v5. Otherwise we PREPEND so new users get 'func' = v5 by default.
+# Include both Application (.exe/.cmd/.bat) and ExternalScript (.ps1) so we catch
+# npm-installed shims, which use a .ps1 wrapper that wins over .cmd in pwsh.
 $installDirFull = (Resolve-Path $InstallDir).Path
 $existingFunc = $null
-$existingCmd = Get-Command func -ErrorAction SilentlyContinue | Where-Object { $_.CommandType -eq 'Application' } | Select-Object -First 1
+$existingCmd = Get-Command func -CommandType Application, ExternalScript -ErrorAction SilentlyContinue | Select-Object -First 1
 if ($existingCmd -and -not $existingCmd.Source.StartsWith($installDirFull, [System.StringComparison]::OrdinalIgnoreCase)) {
     $existingFunc = $existingCmd.Source
 }

--- a/install.ps1
+++ b/install.ps1
@@ -143,18 +143,39 @@ try {
 
 # --- Update PATH ---
 
+# Detect a pre-existing 'func' that lives outside our install dir (e.g. Core Tools v4).
+# If one is present we APPEND our dir so the existing 'func' keeps winning and only
+# 'func5' resolves to v5. Otherwise we PREPEND so new users get 'func' = v5 by default.
+$installDirFull = (Resolve-Path $InstallDir).Path
+$existingFunc = $null
+$existingCmd = Get-Command func -ErrorAction SilentlyContinue | Where-Object { $_.CommandType -eq 'Application' } | Select-Object -First 1
+if ($existingCmd -and -not $existingCmd.Source.StartsWith($installDirFull, [System.StringComparison]::OrdinalIgnoreCase)) {
+    $existingFunc = $existingCmd.Source
+}
+
 if ($os -eq 'win') {
     $userPath = [Environment]::GetEnvironmentVariable('PATH', 'User')
     if ($userPath -notlike "*$InstallDir*") {
-        [Environment]::SetEnvironmentVariable('PATH', "$InstallDir;$userPath", 'User')
-        $env:PATH = "$InstallDir;$env:PATH"
+        if ($existingFunc) {
+            $newPath = "$userPath;$InstallDir"
+            $env:PATH = "$env:PATH;$InstallDir"
+        } else {
+            $newPath = "$InstallDir;$userPath"
+            $env:PATH = "$InstallDir;$env:PATH"
+        }
+        [Environment]::SetEnvironmentVariable('PATH', $newPath, 'User')
         Write-Host "Added $InstallDir to user PATH."
     }
 } else {
     if ($env:PATH -notlike "*$InstallDir*") {
         $shellProfile = if ($env:SHELL -like '*zsh*') { '~/.zshrc' } else { '~/.bashrc' }
-        Write-Host "Add to your shell profile: export PATH=`"$InstallDir`:`$PATH`""
-        Write-Host "  echo 'export PATH=`"$InstallDir`:`$PATH`"' >> $shellProfile"
+        if ($existingFunc) {
+            Write-Host "Add to your shell profile: export PATH=`"`$PATH`:$InstallDir`""
+            Write-Host "  echo 'export PATH=`"`$PATH`:$InstallDir`"' >> $shellProfile"
+        } else {
+            Write-Host "Add to your shell profile: export PATH=`"$InstallDir`:`$PATH`""
+            Write-Host "  echo 'export PATH=`"$InstallDir`:`$PATH`"' >> $shellProfile"
+        }
     }
 }
 
@@ -172,13 +193,16 @@ Write-Host "You can opt-out of telemetry by setting the FUNC_CLI_TELEMETRY_OPTOU
 
 # --- Side-by-side notice ---
 
-$aliasName = if ($os -eq 'win') { 'func5.cmd' } else { 'func5' }
 Write-Host ''
 Write-Host 'Side-by-side with Core Tools v4'
 Write-Host '-------------------------------'
-Write-Host "A '$aliasName' alias was installed alongside 'func' so you can run v5 without"
-Write-Host "shadowing an existing v4 install. If you already have Core Tools v4 on your"
-Write-Host "PATH, use 'func5' to invoke v5 and keep 'func' pointing at v4."
+if ($existingFunc) {
+    Write-Host "Detected an existing 'func' at $existingFunc, leaving it as the default."
+    Write-Host "Use 'func5' to invoke v5; 'func' will continue to invoke the existing install."
+} else {
+    Write-Host "No existing 'func' was found on PATH, so 'func' and 'func5' both invoke v5."
+    Write-Host "If you later install Core Tools v4, use 'func5' to keep invoking v5."
+}
 
 # --- Bug bash env vars ---
 

--- a/install.sh
+++ b/install.sh
@@ -144,6 +144,7 @@ if command -v func >/dev/null 2>&1; then
     esac
 fi
 
+UPDATED_PROFILE=""
 if [[ ":$PATH:" != *":${INSTALL_DIR}:"* ]]; then
     SHELL_NAME=$(basename "${SHELL:-bash}")
     case "$SHELL_NAME" in
@@ -160,6 +161,7 @@ if [[ ":$PATH:" != *":${INSTALL_DIR}:"* ]]; then
         export PATH="${INSTALL_DIR}:${PATH}"
     fi
     echo "Added ${INSTALL_DIR} to PATH in ${PROFILE}."
+    UPDATED_PROFILE="$PROFILE"
 fi
 
 echo "func CLI ${VERSION} installed to ${INSTALL_DIR}"
@@ -224,4 +226,13 @@ if [ "$BUGBASH" = "true" ]; then
     echo -e "\033[33mIf you open a new terminal session (or a shell that doesn't load\033[0m"
     echo -e "\033[33m${BUGBASH_PROFILE}), re-run the three exports above before using func.\033[0m"
     echo -e "\033[33m========================================================================\033[0m"
+fi
+
+# --- Reload shell reminder ---
+
+if [ -n "$UPDATED_PROFILE" ]; then
+    echo ""
+    echo -e "\033[33mReload your shell so 'func5' is on PATH in this session:\033[0m"
+    echo "  source ${UPDATED_PROFILE}"
+    echo "Or open a new terminal window."
 fi

--- a/install.sh
+++ b/install.sh
@@ -235,4 +235,14 @@ if [ -n "$UPDATED_PROFILE" ]; then
     echo -e "\033[33mReload your shell so 'func5' is on PATH in this session:\033[0m"
     echo "  source ${UPDATED_PROFILE}"
     echo "Or open a new terminal window."
+else
+    SHELL_NAME=$(basename "${SHELL:-bash}")
+    case "$SHELL_NAME" in
+        zsh)  PROFILE_HINT="$HOME/.zshrc" ;;
+        bash) PROFILE_HINT="$HOME/.bashrc" ;;
+        *)    PROFILE_HINT="$HOME/.profile" ;;
+    esac
+    echo ""
+    echo "If 'func5' isn't found in your current shell, open a new terminal or run:"
+    echo "  source ${PROFILE_HINT}"
 fi

--- a/install.sh
+++ b/install.sh
@@ -123,6 +123,13 @@ if [ "$OS" = "osx" ]; then
     xattr -d com.apple.quarantine "${INSTALL_DIR}/func" 2>/dev/null || true
 fi
 
+# Drop a func5 wrapper so v5 can be invoked side-by-side with a v4 `func` on PATH.
+cat > "${INSTALL_DIR}/func5" <<'EOF'
+#!/usr/bin/env bash
+exec "$(dirname "$0")/func" "$@"
+EOF
+chmod +x "${INSTALL_DIR}/func5"
+
 # --- Update PATH ---
 
 if [[ ":$PATH:" != *":${INSTALL_DIR}:"* ]]; then
@@ -150,6 +157,15 @@ echo "The Azure Functions CLI collects usage data in order to help us improve yo
 echo "The data is anonymous and doesn't include any user specific or personal information. The data is collected by Microsoft."
 echo ""
 echo "You can opt-out of telemetry by setting the FUNC_CLI_TELEMETRY_OPTOUT environment variable to any value other than 'no', 'n', '0', 'false', or 'off' using your favorite shell."
+
+# --- Side-by-side notice ---
+
+echo ""
+echo "Side-by-side with Core Tools v4"
+echo "-------------------------------"
+echo "A 'func5' alias was installed alongside 'func' so you can run v5 without"
+echo "shadowing an existing v4 install. If you already have Core Tools v4 on your"
+echo "PATH, use 'func5' to invoke v5 and keep 'func' pointing at v4."
 
 # --- Bug bash env vars ---
 

--- a/install.sh
+++ b/install.sh
@@ -132,6 +132,18 @@ chmod +x "${INSTALL_DIR}/func5"
 
 # --- Update PATH ---
 
+# Detect a pre-existing 'func' that lives outside our install dir (e.g. Core Tools v4).
+# If one is present we APPEND our dir so the existing 'func' keeps winning and only
+# 'func5' resolves to v5. Otherwise we PREPEND so new users get 'func' = v5 by default.
+EXISTING_FUNC=""
+if command -v func >/dev/null 2>&1; then
+    RESOLVED=$(command -v func)
+    case "$RESOLVED" in
+        "${INSTALL_DIR}/"*) ;;
+        *) EXISTING_FUNC="$RESOLVED" ;;
+    esac
+fi
+
 if [[ ":$PATH:" != *":${INSTALL_DIR}:"* ]]; then
     SHELL_NAME=$(basename "${SHELL:-bash}")
     case "$SHELL_NAME" in
@@ -140,13 +152,18 @@ if [[ ":$PATH:" != *":${INSTALL_DIR}:"* ]]; then
         *)    PROFILE="$HOME/.profile" ;;
     esac
 
-    echo "export PATH=\"${INSTALL_DIR}:\$PATH\"" >> "$PROFILE"
+    if [ -n "$EXISTING_FUNC" ]; then
+        echo "export PATH=\"\$PATH:${INSTALL_DIR}\"" >> "$PROFILE"
+        export PATH="${PATH}:${INSTALL_DIR}"
+    else
+        echo "export PATH=\"${INSTALL_DIR}:\$PATH\"" >> "$PROFILE"
+        export PATH="${INSTALL_DIR}:${PATH}"
+    fi
     echo "Added ${INSTALL_DIR} to PATH in ${PROFILE}."
-    export PATH="${INSTALL_DIR}:${PATH}"
 fi
 
 echo "func CLI ${VERSION} installed to ${INSTALL_DIR}"
-func --version
+"${INSTALL_DIR}/func" --version
 
 # --- Telemetry notice ---
 
@@ -163,9 +180,13 @@ echo "You can opt-out of telemetry by setting the FUNC_CLI_TELEMETRY_OPTOUT envi
 echo ""
 echo "Side-by-side with Core Tools v4"
 echo "-------------------------------"
-echo "A 'func5' alias was installed alongside 'func' so you can run v5 without"
-echo "shadowing an existing v4 install. If you already have Core Tools v4 on your"
-echo "PATH, use 'func5' to invoke v5 and keep 'func' pointing at v4."
+if [ -n "$EXISTING_FUNC" ]; then
+    echo "Detected an existing 'func' at ${EXISTING_FUNC}, leaving it as the default."
+    echo "Use 'func5' to invoke v5; 'func' will continue to invoke the existing install."
+else
+    echo "No existing 'func' was found on PATH, so 'func' and 'func5' both invoke v5."
+    echo "If you later install Core Tools v4, use 'func5' to keep invoking v5."
+fi
 
 # --- Bug bash env vars ---
 

--- a/install.sh
+++ b/install.sh
@@ -230,8 +230,10 @@ fi
 
 # --- Reload shell reminder ---
 
+echo ""
+echo "Reload your shell"
+echo "-----------------"
 if [ -n "$UPDATED_PROFILE" ]; then
-    echo ""
     echo -e "\033[33mReload your shell so 'func5' is on PATH in this session:\033[0m"
     echo "  source ${UPDATED_PROFILE}"
     echo "Or open a new terminal window."
@@ -242,7 +244,6 @@ else
         bash) PROFILE_HINT="$HOME/.bashrc" ;;
         *)    PROFILE_HINT="$HOME/.profile" ;;
     esac
-    echo ""
     echo "If 'func5' isn't found in your current shell, open a new terminal or run:"
     echo "  source ${PROFILE_HINT}"
 fi


### PR DESCRIPTION
Drops a `func5` wrapper next to `func` during install so customers with Core Tools v4 already on PATH can run v5 side-by-side without shadowing their existing `func`.

## Changes

- `install.sh` (mac/linux): writes `func5` as an executable bash wrapper that `exec`s the sibling `func` binary.
- `install.ps1`:
  - Windows: writes `func5.cmd` containing `@echo off` + `"%~dp0\func.exe" %*`.
  - mac/linux: writes the same bash wrapper as `install.sh`.
- Both installers print a "Side-by-side with Core Tools v4" notice after the Telemetry block explaining the alias.

## Testing

```bash
INSTALL_DIR=/tmp/func5-test FORCE=true bash ./install.sh --prerelease
/tmp/func5-test/func5 --version   # matches /tmp/func5-test/func --version
```

```powershell
./install.ps1 -InstallDir "$env:TEMP/func5-test" -Force -Prerelease
& "$env:TEMP/func5-test/func5.cmd" --version   # Windows
```