### PR TITLE
Split workload READMEs into consumer and dev variants

### DIFF
--- a/src/Workloads/Host/README.DEV.md
+++ b/src/Workloads/Host/README.DEV.md
@@ -1,0 +1,17 @@
+# Azure Functions CLI - Host workload (dev notes)
+
+Repo-only notes for contributors. Not packaged into the nupkg.
+
+## Pack details
+
+Release packaging should be performed with a RID-specific self-contained payload under `tools/any/` by passing
+`-p:PackRidSpecificHostWorkload=true -r <rid> -p:SelfContained=true`, which also suffixes the package id with the RID.
+The self-contained executable must be placed at `tools/any/Azure.Functions.Cli.Workloads.Host` on Unix-like platforms and
+`tools/any/Azure.Functions.Cli.Workloads.Host.exe` on Windows.
+
+## Local CLI/host iteration
+
+For local CLI/host iteration, set `FUNC_HOST_CONTENT_ROOT` to a built host
+content root that contains `Azure.Functions.Cli.Workloads.Host(.exe)` and
+`workers/workers.txt`. The CLI then skips workload resolution/installation and
+launches that local content root through the normal start pipeline.

--- a/src/Workloads/Host/README.md
+++ b/src/Workloads/Host/README.md
@@ -16,13 +16,7 @@ func workload install host
 
 Preview. The shell expects the Azure Functions CLI to prepare the process
 environment and command-line arguments before launch. It does not translate
-private CLI configuration into host settings. Local builds are
-framework-dependent by default.
-
-Release packaging should be performed with a RID-specific self-contained payload under `tools/any/` by passing
-`-p:PackRidSpecificHostWorkload=true -r <rid> -p:SelfContained=true`, which also suffixes the package id with the RID.
-The self-contained executable must be placed at `tools/any/Azure.Functions.Cli.Workloads.Host` on Unix-like platforms and
-`tools/any/Azure.Functions.Cli.Workloads.Host.exe` on Windows.
+private CLI configuration into host settings.
 
 ## Launch contract
 
@@ -34,11 +28,6 @@ The Azure Functions CLI is responsible for resolving the RID-specific workload p
 directory, overlaying prepared environment variables, and building host arguments before launching the workload process.
 The working directory and `AzureWebJobsScriptRoot` environment variable both point to the prepared function app startup
 directory.
-
-For local CLI/host iteration, set `FUNC_HOST_CONTENT_ROOT` to a built host
-content root that contains `Azure.Functions.Cli.Workloads.Host(.exe)` and
-`workers/workers.txt`. The CLI then skips workload resolution/installation and
-launches that local content root through the normal start pipeline.
 
 | Argument | Owner | Description |
 | --- | --- | --- |

--- a/src/Workloads/Templates/DotNet/README.DEV.md
+++ b/src/Workloads/Templates/DotNet/README.DEV.md
@@ -1,0 +1,64 @@
+# Azure Functions CLI: .NET templates workload (dev notes)
+
+Repo-only notes for contributors. Not packaged into the nupkg.
+
+## Versioning
+
+The workload pkg version is independent of the upstream
+`Microsoft.Azure.Functions.Worker.ItemTemplates` version and follows
+its own SemVer cadence. The DotNet workload has no extension-bundle
+channel (Templates Workload Spec §4.4.3), only the stable channel
+ships in v1.
+
+The exact pinned upstream version is in `tools/any/content/source.json`
+(written at pack time from `$(SourceItemTemplatesVersion)` in
+`Directory.Version.props`) and is also stamped into
+`dotnet-templates.json`'s `sourcePackage` field so consumers can
+verify the catalog and the pin agree.
+
+## Build-time pin selection
+
+The upstream NuGet package id and version are driven by two MSBuild
+properties in `Directory.Version.props`:
+
+```bash
+dotnet pack ... /p:SourceItemTemplatesVersion=4.0.5569
+dotnet pack ... /p:SourceItemTemplatesPackageId=Microsoft.Azure.Functions.Worker.ItemTemplates
+```
+
+The csproj's `<PackageDownload>` item pulls the upstream pkg into the
+global packages folder during restore, so the pack-time `HydrateDotnetTemplates`
+target (in `eng/build/Workloads.Templates.DotNet.targets`) never reaches
+the network. It runs `dotnet new install <local-nupkg-path>` against a
+build-scoped template hive, reads the resulting `templatecache.json`,
+filters to Functions item templates (`Classifications` contains
+`Azure Function` and `tags.type == "item"`), strips
+`bind` / `derived` / `computed` / `generated` / implicit / disabled
+symbols, and projects the result into `dotnet-templates.json` (Templates
+Workload Spec §5.3.1). If `Microsoft.Azure.Functions.Worker.ItemTemplates`
+is staged in a private feed, configure the feed in `NuGet.Config` so
+restore picks it up.
+
+The dev-only flag `/p:SkipHydrateDotnetTemplates=true` produces a
+pack with no catalog payload for offline iteration; it is **not** for
+release builds.
+
+## Layout
+
+The package places its metadata under `tools/any/content/`. After
+install:
+
+```
+<workload-home>/workloads/azure.functions.cli.workloads.templates.dotnet/<version>/
+  tools/any/content/
+    dotnet-templates.json   ← catalog + parameter index (spec §5.3.1)
+    source.json             ← NuGet pin: { kind, packageId, version }
+  workload.json
+```
+
+`tools/any/` is the canonical content-workload payload path. There are
+no per-template file directories on disk, `dotnet-templates.json`
+drives `func templates list` and `func new --template <id> --help`
+fully offline, and the upstream NuGet pin in `source.json` drives the
+CLI-managed dotnet template hive that scaffold (`dotnet new <id>`)
+resolves against (Templates Workload Spec §5.3, §6.3).

--- a/src/Workloads/Templates/DotNet/README.md
+++ b/src/Workloads/Templates/DotNet/README.md
@@ -2,38 +2,26 @@
 
 This package ships function-scaffold templates for .NET Azure Functions
 projects, consumed by the `func` CLI's `func new` command. It is a
-**content workload** (Workload Spec §3; Templates Workload Spec §4.1):
-the package carries metadata files only, with no entry-point assembly
-and no runtime services. `func new` resolves the install directory by
-package id and reads the catalog directly.
+content workload: the package carries metadata files only, with no
+entry-point assembly and no runtime services. `func new` resolves the
+install directory by package id and reads the catalog directly.
 
 Unlike the Node and Python templates workloads, the .NET workload does
 **not** carry per-template source files. The template content itself
-lives in the upstream
-`Microsoft.Azure.Functions.Worker.ItemTemplates` NuGet package; this
-workload ships a fully-hydrated **catalog + parameter index**
-(`dotnet-templates.json`) generated at workload build time from each
-upstream `template.json`, plus a **pin** (`source.json`) recording the
-exact upstream version (Templates Workload Spec §5.3, §6.3). At
+lives in the upstream `Microsoft.Azure.Functions.Worker.ItemTemplates`
+NuGet package; this workload ships a fully-hydrated **catalog +
+parameter index** (`dotnet-templates.json`) plus a **pin**
+(`source.json`) recording the exact upstream version. At
 `func workload install` time, the CLI provisions the pinned NuGet
 package into the dotnet template hive; at `func new <id>` time the
 CLI shells out to `dotnet new` against that offline-provisioned hive.
 
-The workload pkg version is independent of the upstream
-`Microsoft.Azure.Functions.Worker.ItemTemplates` version and follows
-its own SemVer cadence. The DotNet workload has no extension-bundle
-channel (Templates Workload Spec §4.4.3) — only the stable channel
-ships in v1.
+The DotNet workload has no extension-bundle channel; only the stable
+channel ships in v1:
 
 | Channel | Workload pkg version | Upstream NuGet pin                                |
 |---------|----------------------|---------------------------------------------------|
 | stable  | `1.0.0`              | `Microsoft.Azure.Functions.Worker.ItemTemplates`  |
-
-The exact pinned upstream version is in `tools/any/content/source.json`
-(written at pack time from `$(SourceItemTemplatesVersion)` in
-`Directory.Version.props`) and is also stamped into
-`dotnet-templates.json`'s `sourcePackage` field so consumers can
-verify the catalog and the pin agree.
 
 ## Install
 
@@ -43,54 +31,7 @@ func workload install Azure.Functions.Cli.Workloads.Templates.DotNet@1.0.0
 func workload install dotnet-templates@1.0.0
 ```
 
-Multiple templates versions coexist via `--force` (Workload Spec §4.6).
-
-## Build-time pin selection
-
-The upstream NuGet package id and version are driven by two MSBuild
-properties in `Directory.Version.props`:
-
-```bash
-dotnet pack ... /p:SourceItemTemplatesVersion=4.0.5569
-dotnet pack ... /p:SourceItemTemplatesPackageId=Microsoft.Azure.Functions.Worker.ItemTemplates
-```
-
-The csproj's `<PackageDownload>` item pulls the upstream pkg into the
-global packages folder during restore, so the pack-time `HydrateDotnetTemplates`
-target (in `eng/build/Workloads.Templates.DotNet.targets`) never reaches
-the network. It runs `dotnet new install <local-nupkg-path>` against a
-build-scoped template hive, reads the resulting `templatecache.json`,
-filters to Functions item templates (`Classifications` contains
-`Azure Function` and `tags.type == "item"`), strips
-`bind` / `derived` / `computed` / `generated` / implicit / disabled
-symbols, and projects the result into `dotnet-templates.json` (Templates
-Workload Spec §5.3.1). If `Microsoft.Azure.Functions.Worker.ItemTemplates`
-is staged in a private feed, configure the feed in `NuGet.Config` so
-restore picks it up.
-
-The dev-only flag `/p:SkipHydrateDotnetTemplates=true` produces a
-pack with no catalog payload for offline iteration; it is **not** for
-release builds.
-
-## Layout
-
-The package places its metadata under `tools/any/content/`. After
-install:
-
-```
-<workload-home>/workloads/azure.functions.cli.workloads.templates.dotnet/<version>/
-  tools/any/content/
-    dotnet-templates.json   ← catalog + parameter index (spec §5.3.1)
-    source.json             ← NuGet pin: { kind, packageId, version }
-  workload.json
-```
-
-`tools/any/` is the canonical content-workload payload path. There are
-no per-template file directories on disk — `dotnet-templates.json`
-drives `func templates list` and `func new --template <id> --help`
-fully offline, and the upstream NuGet pin in `source.json` drives the
-CLI-managed dotnet template hive that scaffold (`dotnet new <id>`)
-resolves against (Templates Workload Spec §5.3, §6.3).
+Multiple templates versions coexist via `--force`.
 
 ## Links
 

--- a/src/Workloads/Templates/Node/README.DEV.md
+++ b/src/Workloads/Templates/Node/README.DEV.md
@@ -1,0 +1,85 @@
+# Azure Functions CLI: Node templates workload (dev notes)
+
+Repo-only notes for contributors. Not packaged into the nupkg.
+
+## Template source
+
+The Node templates workload **does not** snapshot content from the
+extension-bundle CDN, the upstream bundle's
+`StaticContent/v2/templates/templates.json` does not yet publish Node
+entries (only Python). The Node v2 template content is therefore
+authored statically in this repo under
+`src/Workloads/Templates/Node/content/v2/`. See Templates Workload
+Spec §6.1.
+
+## Versioning
+
+The workload pkg version is independent of the source bundle version
+(Templates Workload Spec §4.4.1). The channel a workload was built
+from is encoded in the pkg version's prerelease label, and that
+channel maps 1:1 to an extension-bundle id (Templates Workload Spec
+§4.4.2).
+
+## Per-channel template subsetting
+
+Per-channel template subsetting is **on** by default for the Node
+workload. At pack time the build fetches `bin/extensions.json` from
+the latest **listed** bundle of `$(TemplatesChannel)` (resolved from
+the channel's CDN `index.json`) using HTTP Range requests (~10 KB
+rather than the full 150 MB bundle) and drops any template whose
+required bindings aren't present in that channel's bundle. The mapping
+of templates to required bindings is committed in
+`src/Workloads/Templates/Node/content/v2/templates/_bindings.json`.
+See Templates Workload Spec §4.3 / §6.1. Snapshot at the time of
+writing: stable `4.32.0` → 31 of 33 (no `mcpPromptTrigger`),
+preview `4.42.0` → 33 of 33, experimental `4.6.0` → 31 of 33.
+
+## Bundle compatibility (sources of truth)
+
+The minimum compatible extension-bundle version is recorded in two
+locations that both derive from the single `$(MinBundleVersionRange)`
+MSBuild property, so they cannot drift:
+
+- `tools/any/content/templates-workload.json`, CLI-owned sibling
+  manifest. Authoritative. Generated at pack time by the
+  `GenerateTemplatesWorkloadJson` target.
+- Nuspec `minBundle:[4.0.0,)` tag, discoverable via
+  `func workload search` / `list`.
+
+## Build-time channel selection
+
+The workload pkg version's prerelease label is driven by
+`$(TemplatesChannel)` in `Directory.Version.props`:
+
+```bash
+dotnet pack ... /p:TemplatesChannel=preview
+dotnet pack ... /p:TemplatesChannel=experimental
+```
+
+For Node, channel does **not** select a CDN source, `$(TemplatesContentSource)`
+is `static` and the content always comes from `content/v2/` in this
+repo. `$(SourceBundleVersion)` is unused for Node.
+
+## Layout
+
+The package places the template payload under `tools/any/content/v2/`,
+following the v2 template-engine schema layout (Templates Workload
+Spec §5.2):
+
+```
+<workload-home>/workloads/azure.functions.cli.workloads.templates.node/<version>/
+  tools/any/content/
+    templates-workload.json     ← min-bundle sibling manifest
+    v2/
+      bindings/userPrompts.json
+      resources/Resources.json
+      templates/templates.json  ← NewTemplate[] (jobs/actions DSL)
+  workload.json
+```
+
+Each `NewTemplate` entry carries its per-template file contents
+**inline** in a `files: { <filename>: <contents> }` map; the
+`WriteToFile` action writes the file to
+`src/functions/$(FUNCTION_NAME_INPUT).<js|ts>` after the engine
+substitutes the `$(FUNCTION_NAME_INPUT)` token (Templates Workload
+Spec §5.2 / §5.4).

--- a/src/Workloads/Templates/Node/README.md
+++ b/src/Workloads/Templates/Node/README.md
@@ -3,24 +3,12 @@
 This package ships function-scaffold templates for Node.js Azure
 Functions projects (**v2 template-engine schema, Node v4 programming
 model**), consumed by the `func` CLI's `func new` command. It is a
-**content workload** (Workload Spec §3; Templates Workload Spec §4.1):
-the package carries template files only, with no entry-point assembly
-and no runtime services. `func new` resolves the install directory by
-package id and reads the template payload directly.
+content workload: the package carries template files only, with no
+entry-point assembly and no runtime services. `func new` resolves the
+install directory by package id and reads the template payload directly.
 
-> **Template source.** The Node templates workload **does not** snapshot
-> content from the extension-bundle CDN — the upstream bundle's
-> `StaticContent/v2/templates/templates.json` does not yet publish Node
-> entries (only Python). The Node v2 template content is therefore
-> authored statically in this repo under
-> `src/Workloads/Templates/Node/content/v2/`. See Templates Workload
-> Spec §6.1.
-
-The workload pkg version is independent of the source bundle version
-(Templates Workload Spec §4.4.1). The channel a workload was built
-from is encoded in the pkg version's prerelease label, and that
-channel maps 1:1 to an extension-bundle id (Templates Workload Spec
-§4.4.2):
+The channel a workload was built from is encoded in the pkg version's
+prerelease label, and that channel maps 1:1 to an extension-bundle id:
 
 | Channel       | Workload pkg version   | Bundle id                                                          |
 |---------------|------------------------|--------------------------------------------------------------------|
@@ -30,35 +18,15 @@ channel maps 1:1 to an extension-bundle id (Templates Workload Spec
 
 The bundle id is the value `func new` expects in the project's
 `host.json` `extensionBundle.id` at scaffold time. Channel selection
-at `func new` is implicit — derived from the project's `host.json`
+at `func new` is implicit, derived from the project's `host.json`
 bundle id.
-
-> **Per-channel template subsetting** is **on** by default for the
-> Node workload. At pack time the build fetches `bin/extensions.json`
-> from the latest **listed** bundle of `$(TemplatesChannel)`
-> (resolved from the channel's CDN `index.json`) using HTTP Range
-> requests (~10 KB rather than the full 150 MB bundle) and drops any
-> template whose required bindings aren't present in that channel's
-> bundle. The mapping of templates to required bindings is committed
-> in `src/Workloads/Templates/Node/content/v2/templates/_bindings.json`.
-> See Templates Workload Spec §4.3 / §6.1. Snapshot at the time of
-> writing: stable `4.32.0` → 31 of 33 (no `mcpPromptTrigger`),
-> preview `4.42.0` → 33 of 33, experimental `4.6.0` → 31 of 33.
 
 ## Bundle compatibility
 
 This workload declares a minimum compatible extension-bundle version
 (`[4.0.0,)`). `func new` validates the project's resolved bundle
 version against this constraint and surfaces incompatibilities as a
-warning or error (Templates Workload Spec §4.4.4). The constraint is
-recorded in two locations that both derive from the single
-`$(MinBundleVersionRange)` MSBuild property, so they cannot drift:
-
-- `tools/any/content/templates-workload.json` — CLI-owned sibling
-  manifest. Authoritative. Generated at pack time by the
-  `GenerateTemplatesWorkloadJson` target.
-- Nuspec `minBundle:[4.0.0,)` tag — discoverable via
-  `func workload search` / `list`.
+warning or error.
 
 ## Install
 
@@ -76,45 +44,7 @@ func workload install node-templates@1.0.0-preview
 func workload install node-templates@1.0.0-experimental
 ```
 
-Multiple templates versions coexist via `--force` (Workload Spec §4.6).
-
-## Build-time channel selection
-
-The workload pkg version's prerelease label is driven by
-`$(TemplatesChannel)` in `Directory.Version.props`:
-
-```bash
-dotnet pack ... /p:TemplatesChannel=preview
-dotnet pack ... /p:TemplatesChannel=experimental
-```
-
-For Node, channel does **not** select a CDN source — `$(TemplatesContentSource)`
-is `static` and the content always comes from `content/v2/` in this
-repo. `$(SourceBundleVersion)` is unused for Node.
-
-## Layout
-
-The package places the template payload under `tools/any/content/v2/`,
-following the v2 template-engine schema layout (Templates Workload
-Spec §5.2):
-
-```
-<workload-home>/workloads/azure.functions.cli.workloads.templates.node/<version>/
-  tools/any/content/
-    templates-workload.json     ← min-bundle sibling manifest
-    v2/
-      bindings/userPrompts.json
-      resources/Resources.json
-      templates/templates.json  ← NewTemplate[] (jobs/actions DSL)
-  workload.json
-```
-
-Each `NewTemplate` entry carries its per-template file contents
-**inline** in a `files: { <filename>: <contents> }` map; the
-`WriteToFile` action writes the file to
-`src/functions/$(FUNCTION_NAME_INPUT).<js|ts>` after the engine
-substitutes the `$(FUNCTION_NAME_INPUT)` token (Templates Workload
-Spec §5.2 / §5.4).
+Multiple templates versions coexist via `--force`.
 
 ## Links
 

--- a/src/Workloads/Templates/Python/README.DEV.md
+++ b/src/Workloads/Templates/Python/README.DEV.md
@@ -1,0 +1,72 @@
+# Azure Functions CLI: Python templates workload (dev notes)
+
+Repo-only notes for contributors. Not packaged into the nupkg.
+
+## Programming model scope
+
+v1 (legacy) programming model templates are **not** shipped in the v5
+Python templates workload (Templates Workload Spec §5.2 / §6.2 / §7.1).
+Users still authoring against the v1 programming model should migrate
+to v2 or stay on v4 tooling.
+
+## Versioning
+
+The workload pkg version is independent of the source bundle version
+(Templates Workload Spec §4.4.1). The channel a workload was built
+from is encoded in the pkg version's prerelease label, and that
+channel maps 1:1 to an extension-bundle id (Templates Workload Spec
+§4.4.2).
+
+## Bundle compatibility (sources of truth)
+
+The minimum compatible extension-bundle version is recorded in three
+locations that all derive from the single `$(MinBundleVersionRange)`
+MSBuild property, so they cannot drift:
+
+- `tools/any/content/templates-workload.json`, CLI-owned sibling
+  manifest. Authoritative. Generated at pack time by the
+  `GenerateTemplatesWorkloadJson` target.
+- Nuspec `minBundle:[4.0.0,)` tag, discoverable via
+  `func workload search` / `list`.
+- Nuspec `<description>` sentence, surfaced by `func workload list`.
+
+## Build-time channel selection
+
+The source bundle id used at pack time is driven by
+`$(TemplatesChannel)` in `Directory.Version.props`:
+
+```bash
+dotnet pack ... /p:TemplatesChannel=preview
+dotnet pack ... /p:TemplatesChannel=experimental
+```
+
+`$(SourceBundleVersion)` selects the bundle version whose
+`StaticContent/v2` subtree is snapshotted at build time. It is
+recorded as build provenance only; it does not derive the templates
+pkg version (Templates Workload Spec §4.4.1).
+
+## Layout
+
+The package places the template payload under `tools/any/content/`,
+matching the upstream extension bundle's `StaticContent/v2/` subtree
+with the `StaticContent/` wrapper stripped (Templates Workload Spec
+§5.2). Python ships only the v2 programming-model subtree:
+
+```
+<workload-home>/workloads/azure.functions.cli.workloads.templates.python/<version>/
+  tools/any/content/
+    templates-workload.json      ← min-bundle sibling manifest
+    v2/                          ← v2 programming model
+      bindings/userPrompts.json
+      resources/Resources.json
+      resources/Resources.<locale>.json
+      templates/templates.json   ← NewTemplate[] (jobs/actions)
+  workload.json
+```
+
+Template files are carried **inline** inside each `NewTemplate`
+entry's `files: { <filename>: <contents> }` map; there are no separate
+per-template file directories on disk (Templates Workload Spec §5.2).
+v2 templates reference prompt ids defined in `v2/bindings/userPrompts.json`
+via `paramId` references inside `jobs[].inputs[]`. `tools/any/` is the
+canonical content-workload payload path.

--- a/src/Workloads/Templates/Python/README.md
+++ b/src/Workloads/Templates/Python/README.md
@@ -2,22 +2,13 @@
 
 This package ships function-scaffold templates for Python Azure
 Functions projects (**v2 programming model only**), consumed by the
-`func` CLI's `func new` command. It is a **content workload**
-(Workload Spec §3; Templates Workload Spec §4.1): the package carries
-template files only, with no entry-point assembly and no runtime
-services. `func new` resolves the install directory by package id and
-reads the template payload directly.
+`func` CLI's `func new` command. It is a content workload: the package
+carries template files only, with no entry-point assembly and no
+runtime services. `func new` resolves the install directory by package
+id and reads the template payload directly.
 
-> **v1 (legacy) programming model templates are not shipped** in the
-> v5 Python templates workload (Templates Workload Spec §5.2 / §6.2
-> / §7.1). Users still authoring against the v1 programming model
-> should migrate to v2 or stay on v4 tooling.
-
-The workload pkg version is independent of the source bundle version
-(Templates Workload Spec §4.4.1). The channel a workload was built
-from is encoded in the pkg version's prerelease label, and that
-channel maps 1:1 to an extension-bundle id (Templates Workload Spec
-§4.4.2):
+The channel a workload was built from is encoded in the pkg version's
+prerelease label, and that channel maps 1:1 to an extension-bundle id:
 
 | Channel       | Workload pkg version   | Bundle id                                                          |
 |---------------|------------------------|--------------------------------------------------------------------|
@@ -26,9 +17,9 @@ channel maps 1:1 to an extension-bundle id (Templates Workload Spec
 | experimental  | `1.0.0-experimental`   | `Microsoft.Azure.Functions.ExtensionBundle.Experimental`           |
 
 The bundle id is both the upstream extension bundle the workload's
-templates were snapshotted from at build time and the value `func new`
-expects in the project's `host.json` `extensionBundle.id` at scaffold
-time. Channel selection at `func new` is implicit — derived from the
+templates were snapshotted from and the value `func new` expects in
+the project's `host.json` `extensionBundle.id` at scaffold time.
+Channel selection at `func new` is implicit, derived from the
 project's `host.json` bundle id.
 
 ## Bundle compatibility
@@ -36,16 +27,7 @@ project's `host.json` bundle id.
 This workload declares a minimum compatible extension-bundle version
 (`[4.0.0,)`). `func new` validates the project's resolved bundle
 version against this constraint and surfaces incompatibilities as a
-warning or error (Templates Workload Spec §4.4.4). The constraint is
-recorded in three locations that all derive from the single
-`$(MinBundleVersionRange)` MSBuild property, so they cannot drift:
-
-- `tools/any/content/templates-workload.json` — CLI-owned sibling
-  manifest. Authoritative. Generated at pack time by the
-  `GenerateTemplatesWorkloadJson` target.
-- Nuspec `minBundle:[4.0.0,)` tag — discoverable via
-  `func workload search` / `list`.
-- Nuspec `<description>` sentence — surfaced by `func workload list`.
+warning or error.
 
 ## Install
 
@@ -63,48 +45,7 @@ func workload install python-templates@1.0.0-preview
 func workload install python-templates@1.0.0-experimental
 ```
 
-Multiple templates versions coexist via `--force` (Workload Spec §4.6).
-
-## Build-time channel selection
-
-The source bundle id used at pack time is driven by
-`$(TemplatesChannel)` in `Directory.Version.props`:
-
-```bash
-dotnet pack ... /p:TemplatesChannel=preview
-dotnet pack ... /p:TemplatesChannel=experimental
-```
-
-`$(SourceBundleVersion)` selects the bundle version whose
-`StaticContent/v2` subtree is snapshotted at build time. It is
-recorded as build provenance only; it does not derive the templates
-pkg version (Templates Workload Spec §4.4.1).
-
-## Layout
-
-The package places the template payload under `tools/any/content/`,
-matching the upstream extension bundle's `StaticContent/v2/` subtree
-with the `StaticContent/` wrapper stripped (Templates Workload Spec
-§5.2). Python ships only the v2 programming-model subtree:
-
-```
-<workload-home>/workloads/azure.functions.cli.workloads.templates.python/<version>/
-  tools/any/content/
-    templates-workload.json      ← min-bundle sibling manifest
-    v2/                          ← v2 programming model
-      bindings/userPrompts.json
-      resources/Resources.json
-      resources/Resources.<locale>.json
-      templates/templates.json   ← NewTemplate[] (jobs/actions)
-  workload.json
-```
-
-Template files are carried **inline** inside each `NewTemplate`
-entry's `files: { <filename>: <contents> }` map; there are no separate
-per-template file directories on disk (Templates Workload Spec §5.2).
-v2 templates reference prompt ids defined in `v2/bindings/userPrompts.json`
-via `paramId` references inside `jobs[].inputs[]`. `tools/any/` is the
-canonical content-workload payload path.
+Multiple templates versions coexist via `--force`.
 
 ## Links
 

--- a/src/Workloads/Tools/ExtensionBundles/README.DEV.md
+++ b/src/Workloads/Tools/ExtensionBundles/README.DEV.md
@@ -1,0 +1,30 @@
+# Azure Functions CLI – Extension Bundles workload (dev notes)
+
+Repo-only notes for contributors. Not packaged into the nupkg.
+
+## Build-time channel selection
+
+The CDN bundle id used at pack time is driven by `$(BundleChannel)` in
+`Directory.Version.props`:
+
+```bash
+dotnet pack ... /p:BundleChannel=preview
+dotnet pack ... /p:BundleChannel=experimental
+```
+
+## Layout
+
+The package places the bundle payload under `tools/any/<BundleVersion>/`
+so the on-disk layout matches what the host's `ExtensionBundleManager`
+expects to probe (`<downloadPath>/<version>/...`). After install:
+
+```
+<workload-home>/workloads/azure.functions.cli.workloads.extensionbundles/<version>/
+  tools/any/
+    <BundleVersion>/         ← extension bundle root (bin/, extensions.json, ...)
+  workload.json
+```
+
+The CLI bundle resolver sets `downloadPath` to `<install>/tools/any/`
+and the host walks the `<BundleVersion>/` child for the requested version.
+`tools/any/` is the canonical content-workload payload path.

--- a/src/Workloads/Tools/ExtensionBundles/README.md
+++ b/src/Workloads/Tools/ExtensionBundles/README.md
@@ -1,10 +1,10 @@
 # Azure Functions CLI – Extension Bundles workload
 
 This package ships the Azure Functions extension bundle payload for the
-`func` CLI. It is a **content workload** (Workload Spec §3, §5.3): the
-package carries files only, with no entry-point assembly and no runtime
-services. `func start` resolves the install directory by package id and
-reads the bundle layout directly.
+`func` CLI. It is a content workload: the package carries files only,
+with no entry-point assembly and no runtime services. `func start`
+resolves the install directory by package id and reads the bundle
+layout directly.
 
 The bundle payload version is encoded directly in the workload pkg
 version (1:1 mapping; this is a content-only workload, so there is no
@@ -27,34 +27,7 @@ func workload install Azure.Functions.Cli.Workloads.ExtensionBundles@4.35.0
 func workload install bundles@4.35.0
 ```
 
-Multiple bundle versions coexist via `--force` (Workload Spec §4.6).
-
-## Build-time channel selection
-
-The CDN bundle id used at pack time is driven by `$(BundleChannel)` in
-`Directory.Version.props`:
-
-```bash
-dotnet pack ... /p:BundleChannel=preview
-dotnet pack ... /p:BundleChannel=experimental
-```
-
-## Layout
-
-The package places the bundle payload under `tools/any/<BundleVersion>/`
-so the on-disk layout matches what the host's `ExtensionBundleManager`
-expects to probe (`<downloadPath>/<version>/...`). After install:
-
-```
-<workload-home>/workloads/azure.functions.cli.workloads.extensionbundles/<version>/
-  tools/any/
-    <BundleVersion>/         ← extension bundle root (bin/, extensions.json, ...)
-  workload.json
-```
-
-The CLI bundle resolver sets `downloadPath` to `<install>/tools/any/`
-and the host walks the `<BundleVersion>/` child for the requested version.
-`tools/any/` is the canonical content-workload payload path.
+Multiple bundle versions coexist via `--force`.
 
 ## Links
 

--- a/src/Workloads/Workers/Go/README.DEV.md
+++ b/src/Workloads/Workers/Go/README.DEV.md
@@ -1,0 +1,21 @@
+# Azure Functions CLI – Go worker workload (dev notes)
+
+Repo-only notes for contributors. Not packaged into the nupkg.
+
+## Version scheme
+
+Mirrors the Node and Python worker workloads: a single `$(WorkerVersion)`
+(three-part SemVer) drives `$(VersionPrefix)`. Go has no upstream worker
+NuGet, so `$(WorkerVersion)` is maintained manually in
+`Directory.Version.props` alongside any change to the static
+`worker.config.json` payload.
+
+Ships as a NuGet prerelease (`1.0.0-preview.1`) via `$(VersionSuffix)`
+while the Go worker integration stabilises. `func workload install` won't
+pick up prereleases without an explicit version pin or `--prerelease`.
+
+## Pack details
+
+Go has no upstream worker NuGet; the workload ships a static native
+`worker.config.json` under `tools/any/` that points the host at a user-built Go
+executable (`bin/app`).

--- a/src/Workloads/Workers/Go/README.md
+++ b/src/Workloads/Workers/Go/README.md
@@ -1,7 +1,8 @@
 # Azure Functions CLI – Go worker workload
 
 Content workload that ships the Go worker assets (a static `worker.config.json`
-plus any supporting files) consumed by the Azure Functions CLI host.
+plus any supporting files) consumed by the Azure Functions CLI host. The host
+launches a user-built Go executable (`bin/app`) at runtime.
 
 ## Install
 
@@ -11,20 +12,10 @@ func workload install Azure.Functions.Cli.Workloads.Workers.Go
 func workload install go-worker
 ```
 
-## Version scheme
-
-Mirrors the Node and Python worker workloads: a single `$(WorkerVersion)`
-(three-part SemVer) drives `$(VersionPrefix)`. Go has no upstream worker
-NuGet, so `$(WorkerVersion)` is maintained manually in
-`Directory.Version.props` alongside any change to the static
-`worker.config.json` payload.
-
-Ships as a NuGet prerelease (`1.0.0-preview.1`) via `$(VersionSuffix)`
-while the Go worker integration stabilises. `func workload install` won't
-pick up prereleases without an explicit version pin or `--prerelease`.
+Ships as a NuGet prerelease while the Go worker integration stabilises.
+`func workload install` won't pick it up without an explicit version pin or
+`--prerelease`.
 
 ## Status
 
-Preview. Go has no upstream worker NuGet; the workload ships a static native
-`worker.config.json` under `tools/any/` that points the host at a user-built Go
-executable (`bin/app`).
+Preview.

--- a/src/Workloads/Workers/Node/README.DEV.md
+++ b/src/Workloads/Workers/Node/README.DEV.md
@@ -1,0 +1,26 @@
+# Azure Functions CLI – Node.js worker workload (dev notes)
+
+Repo-only notes for contributors. Not packaged into the nupkg.
+
+## Version scheme
+
+The workload pkg version maps 1:1 to the Node.js worker payload it carries.
+One prop in `Directory.Version.props` drives `$(VersionPrefix)`:
+
+| Prop               | Meaning                                                                   |
+|--------------------|---------------------------------------------------------------------------|
+| `$(WorkerVersion)` | `Microsoft.Azure.Functions.NodeJsWorker` version. Bare three-part SemVer. |
+
+Bump `$(WorkerVersion)` whenever the upstream worker package is bumped.
+`$(WorkerVersion)` also pins the restored
+`Microsoft.Azure.Functions.NodeJsWorker` pkg via `VersionOverride`, so the
+two versions cannot drift.
+
+Unlike the bundles workload, there is no channel axis: the upstream
+NodeJsWorker NuGet doesn't ship preview/experimental SKUs.
+
+## Pack details
+
+Worker assets are pulled at pack time from the restored
+`Microsoft.Azure.Functions.NodeJsWorker` NuGet package and packed under
+`tools/any/` in the resulting workload NuGet.

--- a/src/Workloads/Workers/Node/README.md
+++ b/src/Workloads/Workers/Node/README.md
@@ -11,25 +11,6 @@ func workload install Azure.Functions.Cli.Workloads.Workers.Node
 func workload install node-worker
 ```
 
-## Version scheme
-
-The workload pkg version maps 1:1 to the Node.js worker payload it carries.
-One prop in `Directory.Version.props` drives `$(VersionPrefix)`:
-
-| Prop               | Meaning                                                                   |
-|--------------------|---------------------------------------------------------------------------|
-| `$(WorkerVersion)` | `Microsoft.Azure.Functions.NodeJsWorker` version. Bare three-part SemVer. |
-
-Bump `$(WorkerVersion)` whenever the upstream worker package is bumped.
-`$(WorkerVersion)` also pins the restored
-`Microsoft.Azure.Functions.NodeJsWorker` pkg via `VersionOverride`, so the
-two versions cannot drift.
-
-Unlike the bundles workload, there is no channel axis: the upstream
-NodeJsWorker NuGet doesn't ship preview/experimental SKUs.
-
 ## Status
 
-Preview. Worker assets are pulled at pack time from the restored
-`Microsoft.Azure.Functions.NodeJsWorker` NuGet package and packed under
-`tools/any/` in the resulting workload NuGet.
+Preview.

--- a/src/Workloads/Workers/Python/README.DEV.md
+++ b/src/Workloads/Workers/Python/README.DEV.md
@@ -1,0 +1,26 @@
+# Azure Functions CLI – Python worker workload (dev notes)
+
+Repo-only notes for contributors. Not packaged into the nupkg.
+
+## Version scheme
+
+The workload pkg version maps 1:1 to the Python worker payload it carries.
+One prop in `Directory.Version.props` drives `$(VersionPrefix)`:
+
+| Prop               | Meaning                                                                   |
+|--------------------|---------------------------------------------------------------------------|
+| `$(WorkerVersion)` | `Microsoft.Azure.Functions.PythonWorker` version. Bare three-part SemVer. |
+
+Bump `$(WorkerVersion)` whenever the upstream worker package is bumped.
+`$(WorkerVersion)` also pins the restored
+`Microsoft.Azure.Functions.PythonWorker` pkg via `VersionOverride`, so the
+two versions cannot drift.
+
+Unlike the bundles workload, there is no channel axis: the upstream
+PythonWorker NuGet doesn't ship preview/experimental SKUs.
+
+## Pack details
+
+Worker assets are pulled at pack time from the restored
+`Microsoft.Azure.Functions.PythonWorker` NuGet package (its `tools/` payload)
+and packed under `tools/any/` in the resulting workload NuGet.

--- a/src/Workloads/Workers/Python/README.md
+++ b/src/Workloads/Workers/Python/README.md
@@ -11,25 +11,6 @@ func workload install Azure.Functions.Cli.Workloads.Workers.Python
 func workload install python-worker
 ```
 
-## Version scheme
-
-The workload pkg version maps 1:1 to the Python worker payload it carries.
-One prop in `Directory.Version.props` drives `$(VersionPrefix)`:
-
-| Prop               | Meaning                                                                   |
-|--------------------|---------------------------------------------------------------------------|
-| `$(WorkerVersion)` | `Microsoft.Azure.Functions.PythonWorker` version. Bare three-part SemVer. |
-
-Bump `$(WorkerVersion)` whenever the upstream worker package is bumped.
-`$(WorkerVersion)` also pins the restored
-`Microsoft.Azure.Functions.PythonWorker` pkg via `VersionOverride`, so the
-two versions cannot drift.
-
-Unlike the bundles workload, there is no channel axis: the upstream
-PythonWorker NuGet doesn't ship preview/experimental SKUs.
-
 ## Status
 
-Preview. Worker assets are pulled at pack time from the restored
-`Microsoft.Azure.Functions.PythonWorker` NuGet package (its `tools/` payload)
-and packed under `tools/any/` in the resulting workload NuGet.
+Preview.


### PR DESCRIPTION
## What

Trim each workload `README.md` to consumer-facing content (description, install, runtime/integration contracts, links) and move pack-time / dev-only detail (MSBuild props, `Directory.Version.props`, `/p:Foo=…`, pack target names, spec section refs, internal pack layout) into a sibling `README.DEV.md`.

`README.DEV.md` is not packaged. `eng/build/Release.props` only adds `$(ReadmeFile)` (which defaults to `README.md`) to the nupkg, so the new file stays in the repo for contributors.

## Why

The packaged readme is what nuget.org shows on the package's Readme tab (e.g. [Workers.Python](https://www.nuget.org/packages/Azure.Functions.Cli.Workloads.Workers.Python.osx-arm64/4.43.0-preview.1#readme-body-tab)). Sections like "Version scheme" (about `$(WorkerVersion)`) and the pack-internal "Status" paragraphs are noise for consumers and should live with the source.

## Files

Each workload that had dev/pack content was split:

- `src/Workloads/Workers/{Python,Node,Go}/README{,.DEV}.md`
- `src/Workloads/Host/README{,.DEV}.md`
- `src/Workloads/Templates/{Node,Python,DotNet}/README{,.DEV}.md`
- `src/Workloads/Tools/ExtensionBundles/README{,.DEV}.md`

Skipped:

- `src/Workloads/Stacks/{Go,Node,Python,DotNet}/README.md`: consumer-only content already, nothing to move.
- `src/Abstractions/`: no `README.md` exists.

## Verification

Packed `Workloads.Workers.Python` locally and confirmed the top-level `README.md` in the nupkg is the slim 318-byte consumer version and `README.DEV.md` is not included.