### PR TITLE
Fix npm postinstall silently swallowing extraction errors

### DIFF
--- a/eng/tools/publish-tools/npm/lib/install.js
+++ b/eng/tools/publish-tools/npm/lib/install.js
@@ -116,6 +116,9 @@ https.get(options, response => {
                             fs.chmodSync(`${installPath}/in-proc6/func`, 0o755);
                         }
                     }
+                }).catch(err => {
+                    console.error(chalk.red('Error extracting zip file: ' + err.message));
+                    process.exit(1);
                 });
             });
         });


### PR DESCRIPTION
## Summary

Add `.catch()` handler to the `extract()` Promise in the npm postinstall script so that zip extraction failures are reported to stderr and cause a non-zero exit code.

## Problem

On Node.js v24 (and potentially other environments where extraction fails), the `extract()` Promise rejection in `eng/tools/publish-tools/npm/lib/install.js` was unhandled. This caused `npm install -g azure-functions-core-tools@4` to report success even though the binary was never extracted from the zip file. Users would then get ENOENT errors when trying to run `func`.

## Fix

Added a `.catch()` handler to the `extract()` Promise that:
1. Logs the extraction error to stderr (using chalk for red formatting)
2. Exits the process with code 1

This ensures npm correctly reports a failed installation when extraction fails.