### PR TITLE
Install scripts: prefer gh CLI when available to avoid GitHub rate limits

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -40,6 +40,47 @@ $ErrorActionPreference = 'Stop'
 $repo = $Source
 $apiBase = "https://api.github.com/repos/$repo"
 
+# --- GitHub CLI detection ---
+
+# Prefer 'gh' when available and authenticated so the GitHub API calls below run
+# against the user's authenticated quota (5000/hr) instead of the anonymous
+# 60/hr limit that customers have been hitting from shared NAT egress.
+$useGh = $false
+if (Get-Command gh -ErrorAction SilentlyContinue) {
+    & gh auth status *> $null
+    if ($LASTEXITCODE -eq 0) { $useGh = $true }
+}
+
+if ($useGh) {
+    Write-Host "Using GitHub CLI ('gh') for release metadata and asset download (authenticated, higher rate limit)."
+} else {
+    Write-Host "Using anonymous GitHub API requests. If you hit a rate limit, install and 'gh auth login' the GitHub CLI: https://cli.github.com"
+}
+
+function Get-GitHubReleases {
+    if ($useGh) {
+        return & gh api "/repos/$repo/releases?per_page=50" | ConvertFrom-Json
+    }
+    return Invoke-RestMethod -Uri "$apiBase/releases?per_page=50"
+}
+
+function Get-GitHubReleaseByTag([string] $Tag) {
+    if ($useGh) {
+        return & gh api "/repos/$repo/releases/tags/$Tag" | ConvertFrom-Json
+    }
+    return Invoke-RestMethod -Uri "$apiBase/releases/tags/$Tag"
+}
+
+function Get-GitHubReleaseAsset([string] $Tag, [string] $AssetName, [string] $OutFile) {
+    if ($useGh) {
+        & gh release download $Tag --repo $repo --pattern $AssetName --output $OutFile --clobber
+        if ($LASTEXITCODE -ne 0) { throw "gh release download failed with exit code $LASTEXITCODE" }
+        return
+    }
+    $downloadUrl = "https://github.com/$repo/releases/download/$Tag/$AssetName"
+    Invoke-WebRequest -Uri $downloadUrl -OutFile $OutFile
+}
+
 # --- Detect platform ---
 
 if ($IsWindows -or $env:OS -eq 'Windows_NT') {
@@ -67,7 +108,7 @@ $assetName = "func-$os-$archStr.$ext"
 if (-not $Version) {
     $label = if ($Prerelease) { 'latest 5.x pre-release' } else { 'latest 5.x stable release' }
     Write-Host "Resolving $label..."
-    $releases = Invoke-RestMethod -Uri "$apiBase/releases?per_page=50"
+    $releases = Get-GitHubReleases
     $release = $releases |
         Where-Object { $_.tag_name -match '^v?5\.' -and ($Prerelease -or -not $_.prerelease) } |
         Select-Object -First 1
@@ -90,7 +131,7 @@ if (-not $Version) {
     $Version = $release.tag_name
 } else {
     if ($Version -notlike 'v*') { $Version = "v$Version" }
-    $release = Invoke-RestMethod -Uri "$apiBase/releases/tags/$Version"
+    $release = Get-GitHubReleaseByTag -Tag $Version
 }
 
 Write-Host "Installing func CLI $Version ($os-$archStr)..."
@@ -106,13 +147,12 @@ if ((Test-Path $funcPath) -and -not $Force) {
 
 # --- Download and extract ---
 
-$downloadUrl = "https://github.com/$repo/releases/download/$Version/$assetName"
 $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "func-cli-install-$(Get-Random)"
 New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
 
 try {
     $downloadPath = Join-Path $tempDir $assetName
-    Invoke-WebRequest -Uri $downloadUrl -OutFile $downloadPath
+    Get-GitHubReleaseAsset -Tag $Version -AssetName $assetName -OutFile $downloadPath
     New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
 
     if ($ext -eq 'zip') {

--- a/install.sh
+++ b/install.sh
@@ -41,6 +41,22 @@ esac
 
 ASSET_NAME="func-${OS}-${ARCH}.tar.gz"
 
+# --- GitHub CLI detection ---
+
+# Prefer 'gh' when available and authenticated so the GitHub API calls below run
+# against the user's authenticated quota (5000/hr) instead of the anonymous
+# 60/hr limit that customers have been hitting from shared NAT egress.
+USE_GH="false"
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+    USE_GH="true"
+fi
+
+if [ "$USE_GH" = "true" ]; then
+    echo "Using GitHub CLI ('gh') for release metadata and asset download (authenticated, higher rate limit)."
+else
+    echo "Using anonymous GitHub API requests. If you hit a rate limit, install and 'gh auth login' the GitHub CLI: https://cli.github.com"
+fi
+
 # --- Resolve version ---
 
 if [ -z "$VERSION" ]; then
@@ -51,7 +67,11 @@ if [ -z "$VERSION" ]; then
     fi
 
     # GitHub API returns releases newest-first. Extract tag_name + prerelease pairs, then filter.
-    RELEASES_JSON=$(curl -sSL "${API_BASE}/releases?per_page=50")
+    if [ "$USE_GH" = "true" ]; then
+        RELEASES_JSON=$(gh api "/repos/${REPO}/releases?per_page=50")
+    else
+        RELEASES_JSON=$(curl -sSL "${API_BASE}/releases?per_page=50")
+    fi
     VERSION=$(echo "$RELEASES_JSON" \
         | tr ',' '\n' \
         | grep -E '"tag_name"|"prerelease"' \
@@ -115,7 +135,11 @@ DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${ASSET_NA
 TEMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TEMP_DIR"' EXIT
 
-curl -sSL -o "${TEMP_DIR}/${ASSET_NAME}" "$DOWNLOAD_URL"
+if [ "$USE_GH" = "true" ]; then
+    gh release download "$VERSION" --repo "$REPO" --pattern "$ASSET_NAME" --output "${TEMP_DIR}/${ASSET_NAME}" --clobber
+else
+    curl -sSL -o "${TEMP_DIR}/${ASSET_NAME}" "$DOWNLOAD_URL"
+fi
 mkdir -p "$INSTALL_DIR"
 tar -xzf "${TEMP_DIR}/${ASSET_NAME}" -C "$INSTALL_DIR"
 


### PR DESCRIPTION
## What

`install.ps1` and `install.sh` now prefer the GitHub CLI (`gh`) when it is installed and authenticated, falling back to the existing anonymous `Invoke-RestMethod` / `curl` calls otherwise.

## Why

Both scripts hit the GitHub REST API to resolve the latest 5.x release tag and (`install.ps1`) to look up a specific tag, then download the release asset. Anonymous requests share the 60/hr per-IP rate limit, which customers behind shared NAT egress have been hitting in waves. Routing through `gh` uses the user's authenticated 5000/hr quota and removes the failure mode.

## How

- Detect `gh` via `Get-Command` / `command -v` plus `gh auth status` returning 0.
- When available:
  - Metadata: `gh api "/repos/$repo/releases?per_page=50"` and `gh api "/repos/$repo/releases/tags/$Version"` (parsed via `ConvertFrom-Json` in PowerShell; the bash parser is unchanged since the JSON shape is identical).
  - Download: `gh release download $Version --repo $repo --pattern $assetName --output $path --clobber`.
- Otherwise fall through to the existing `Invoke-RestMethod` / `Invoke-WebRequest` / `curl` calls unchanged.
- Each script prints a one-line note at startup indicating which path is active, so users hitting rate limits know to install + `gh auth login`.

## Fallback behavior

No change when `gh` is missing or unauthenticated. The `curl` / `Invoke-WebRequest` paths run exactly as before.

## Validation

- `bash -n install.sh`
- `pwsh -NoProfile -Command "[scriptblock]::Create((Get-Content -Raw ./install.ps1)) | Out-Null"`

(Supersedes #5280, which was auto-closed when its head branch was renamed.)