### PR TITLE
fix(python-worker): resolve worker payload at restore time

### DIFF
--- a/src/Workloads/Workers/Python/Directory.Version.props
+++ b/src/Workloads/Workers/Python/Directory.Version.props
@@ -16,7 +16,7 @@
   <PropertyGroup>
     <WorkerVersion>4.43.0</WorkerVersion>
     <VersionPrefix>$(WorkerVersion)</VersionPrefix>
-    <VersionSuffix>preview.1</VersionSuffix>
+    <VersionSuffix>preview.2</VersionSuffix>
   </PropertyGroup>
 
 </Project>

--- a/src/Workloads/Workers/Python/Workloads.Workers.Python.csproj
+++ b/src/Workloads/Workers/Python/Workloads.Workers.Python.csproj
@@ -19,15 +19,19 @@
 
   <ItemGroup>
     <!--
-      TODO: Decouple from the upstream worker's precise package layout.
-      The plan is to include the PythonWorker package's assets normally (let
-      it wire up its content/None items via its build targets), then have a
-      target here transform those items and repack them under tools/any/. For
-      now we glob the restored package payload directly, which is brittle if
-      the upstream layout changes.is project.
+      TODO: Decouple from the upstream worker's precise package layout. We glob
+      the restored package payload directly, which is brittle if the upstream
+      layout changes.
+
+      GeneratePathProperty exposes $(PkgMicrosoft_Azure_Functions_PythonWorker)
+      pointing at the restored package root. IncludeAssets=none keeps the
+      package's build targets and tools/ files from affecting this project, and
+      keeps payload resolution restore-time (so `dotnet pack` with `no-build`,
+      which CI uses, still produces populated nupkgs).
     -->
-    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" VersionOverride="$(WorkerVersion)">
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" GeneratePathProperty="true" VersionOverride="$(WorkerVersion)">
       <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>none</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 
@@ -35,10 +39,19 @@
     <None Include="workload.json" Pack="true" PackagePath="/" />
   </ItemGroup>
 
-  <Target Name="IncludePythonWorkerContentInPack" AfterTargets="AssignTargetPaths" BeforeTargets="_GetPackageFiles">
+  <Target Name="IncludePythonWorkerContentInPack" BeforeTargets="_GetPackageFiles">
+    <Error Condition="'$(PkgMicrosoft_Azure_Functions_PythonWorker)' == ''"
+           Text="Microsoft.Azure.Functions.PythonWorker package path not resolved. Run 'dotnet restore' first." />
     <ItemGroup>
-      <None Update="@(None)" TargetPath="%(RecursiveDir)%(Filename)%(Extension)" Pack="true" PackagePath="tools/any/"
-         Condition="$([System.String]::new('%(None.TargetPath)').StartsWith('workers/python/'))" />
+      <_PythonWorkerFile Include="$(PkgMicrosoft_Azure_Functions_PythonWorker)/tools/**/*" />
+    </ItemGroup>
+    <Error Condition="'@(_PythonWorkerFile)' == ''"
+           Text="Python worker payload was empty under '$(PkgMicrosoft_Azure_Functions_PythonWorker)/tools/'. Refusing to pack an empty workload." />
+    <ItemGroup>
+      <None Include="@(_PythonWorkerFile)"
+            TargetPath="%(RecursiveDir)%(Filename)%(Extension)"
+            Pack="true"
+            PackagePath="tools/any/" />
     </ItemGroup>
   </Target>
 

--- a/src/Workloads/Workers/Python/release_notes.md
+++ b/src/Workloads/Workers/Python/release_notes.md
@@ -1,4 +1,8 @@
 # Azure.Functions.Cli.Workloads.Workers.Python
 
+## 4.43.0-preview.2
+
+- Fix empty per-RID nupkgs shipped under `--no-build`. Resolve the worker payload at restore time via `GeneratePathProperty` and add an empty-payload guard. (#5284)
+
 ## 4.43.0
 


### PR DESCRIPTION
## Problem

The `Workloads.Workers.Python` per-RID nupkgs published by CI shipped empty: each `.nupkg` was ~29 KB and contained only `workload.json`, `README.md`, and the icon — no Python worker payload.

## Root cause

#5255 ("build(vnext): pack per-RID python worker") changed `IncludePythonWorkerContentInPack` to rely on the SDK auto-populating `@(None)` items from `Microsoft.Azure.Functions.PythonWorker` assets, then filter them by `TargetPath.StartsWith('workers/python/')`.

That population only happens as part of the SDK's build-time resolve chain (`ResolvePackageDependencies` → `AssignTargetPaths`). CI runs:

```yaml
# eng/ci/templates/jobs/build.yml
arguments: -c ${{ parameters.configuration }} -v m -o $(pack_dir) --no-build ${{ parameters.build_args }}
```

`--no-build` becomes the global property `NoBuild=true`, which is inherited by the per-RID MSBuild dispatch in `Build.Outer.targets`. With `NoBuild=true`, the SDK skips the resolve chain → `@(None)` is never populated from the upstream package → the `Update` is a no-op → every per-RID nupkg ships empty.

Reproduced locally with the exact CI flow:

```bash
dotnet restore … -p:PackAllRids=true
dotnet build   … --no-restore -p:PackAllRids=true       # RID-less, fine
dotnet pack    … --no-build -p:PackAllRids=true -o out/
# → 5 nupkgs, ~29 KB each, no python worker payload
```

### Why Host doesn't have this problem

`Workloads.Host` assembles its payload from on-disk build output via a plain glob:

```xml
<HostWorkloadPayloadInput Include="$(OutputPath)**/*" Exclude="$(OutputPath)**/*.pdb" />
…
<TfmSpecificPackageFile Include="$(HostWorkloadPayloadRoot)**/*" PackagePath="tools/any/…" />
```

That's independent of the SDK resolve chain, so `--no-build` doesn't break it. Host also has a `_DispatchInnerBuilds` hook in `Build.Outer.targets` that fans `Build` out per RID up front, plus an explicit `Error Condition="'@(HostWorkloadPayloadInput)' == ''"` guard so an empty payload fails loudly instead of shipping silently.

## Fix

`src/Workloads/Workers/Python/Workloads.Workers.Python.csproj`:

1. Re-add `GeneratePathProperty="true"` + `IncludeAssets="none"` on the `Microsoft.Azure.Functions.PythonWorker` `PackageReference` so the package path is exposed at restore time without the SDK trying to flow assets through `@(None)`.
2. Replace the `<None Update="@(None)" …>` filter with an explicit `Include` glob of `$(PkgMicrosoft_Azure_Functions_PythonWorker)/tools/**/*`, mirroring the pre-#5255 behavior. Restore-time path resolution survives `--no-build`.
3. Add a `<Error Condition="'@(_PythonWorkerFile)' == ''" …>` guard so a future regression that produces an empty payload fails the pack instead of silently shipping empty nupkgs (matching Host's existing safety check).

## Verification

With this fix and the exact CI flow:

```bash
dotnet restore … -p:PackAllRids=true
dotnet build   … --no-restore -p:PackAllRids=true
dotnet pack    … --no-build -p:PackAllRids=true -o out/
```

Produces 5 per-RID nupkgs each ~292 MB containing the full Python worker payload. Plain local `dotnet pack` (without `PackAllRids`) still produces the single fat RID-less nupkg as before.

## Follow-up (not in this PR)

Each per-RID nupkg currently contains *all* platforms' workers under `tools/any/<pyver>/<OS>/<arch>/`, so the per-RID split is bytes-cloned 5× with no payload trimming. Filtering the glob by RID (e.g. `linux-x64` → `**/LINUX/X64/**`) would actually deliver on #5255's intent. Tracking separately.