### PR TITLE
fix(vnext/python-worker): address per-RID content files missing in nupkg

### DIFF
--- a/src/Workloads/Workers/Python/Directory.Version.props
+++ b/src/Workloads/Workers/Python/Directory.Version.props
@@ -16,7 +16,7 @@
   <PropertyGroup>
     <WorkerVersion>4.43.0</WorkerVersion>
     <VersionPrefix>$(WorkerVersion)</VersionPrefix>
-    <VersionSuffix>preview.1</VersionSuffix>
+    <VersionSuffix>preview.2</VersionSuffix>
   </PropertyGroup>
 
 </Project>

--- a/src/Workloads/Workers/Python/Workloads.Workers.Python.csproj
+++ b/src/Workloads/Workers/Python/Workloads.Workers.Python.csproj
@@ -35,7 +35,7 @@
     <None Include="workload.json" Pack="true" PackagePath="/" />
   </ItemGroup>
 
-  <Target Name="IncludePythonWorkerContentInPack" AfterTargets="AssignTargetPaths" BeforeTargets="_GetPackageFiles">
+  <Target Name="IncludePythonWorkerContentInPack" DependsOnTargets="AssignTargetPaths" BeforeTargets="_GetPackageFiles">
     <ItemGroup>
       <None Update="@(None)" TargetPath="%(RecursiveDir)%(Filename)%(Extension)" Pack="true" PackagePath="tools/any/"
          Condition="$([System.String]::new('%(None.TargetPath)').StartsWith('workers/python/'))" />

--- a/src/Workloads/Workers/Python/release_notes.md
+++ b/src/Workloads/Workers/Python/release_notes.md
@@ -1,4 +1,5 @@
 # Azure.Functions.Cli.Workloads.Workers.Python
 
-## 4.43.0
+## 4.43.0-preview.2
 
+- fix: address per-RID content files missing in nupkg (#5285)


### PR DESCRIPTION
Fix per-RID content files missing from python worker nupkg. The root issue is on a `dotnet pack -no-build`, `AssignTargetPaths` is not invoked and so the PythonWorker targets don't populate the `@(None)` item group. Fix is to ensure `AssignTargetPaths` runs.