### PR TITLE
fix: apply prerelease-aware range check when resolving installed workers

### DIFF
--- a/src/Directory.Version.props
+++ b/src/Directory.Version.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>5.0.0</VersionPrefix>
-    <VersionSuffix>preview.1</VersionSuffix>
+    <VersionSuffix>preview.2</VersionSuffix>
     <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>
 

--- a/src/Func/Workers/DefaultFunctionsWorkerContentResolver.cs
+++ b/src/Func/Workers/DefaultFunctionsWorkerContentResolver.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Workloads;
+using Azure.Functions.Cli.Workloads.Catalog;
+using Microsoft.Extensions.Options;
 using NuGet.Versioning;
 
 namespace Azure.Functions.Cli.Workers;
@@ -9,12 +11,17 @@ namespace Azure.Functions.Cli.Workers;
 /// <summary>
 /// Default worker resolver for content workload payloads.
 /// </summary>
-internal sealed class DefaultFunctionsWorkerContentResolver(IWorkerConfigFileSystem workerConfigFileSystem) : IFunctionsWorkerContentResolver
+internal sealed class DefaultFunctionsWorkerContentResolver(
+    IWorkerConfigFileSystem workerConfigFileSystem,
+    IOptions<WorkloadCatalogOptions> catalogOptions) : IFunctionsWorkerContentResolver
 {
     private const string WorkerConfigFileName = "worker.config.json";
 
     private readonly IWorkerConfigFileSystem _workerConfigFileSystem = workerConfigFileSystem
         ?? throw new ArgumentNullException(nameof(workerConfigFileSystem));
+
+    private readonly WorkloadCatalogOptions _catalogOptions = catalogOptions?.Value
+        ?? throw new ArgumentNullException(nameof(catalogOptions));
 
     public FunctionsWorkerResolutionResult ResolveWorker(
         FunctionsWorkerId workerId,
@@ -69,8 +76,9 @@ internal sealed class DefaultFunctionsWorkerContentResolver(IWorkerConfigFileSys
         return FunctionsWorkerResolutionResults.Resolved(resolvedWorker);
     }
 
-    private static bool SatisfiesConstraint(NuGetVersion version, VersionRange? constraint)
-        => constraint is null || constraint.Satisfies(version);
+    private bool SatisfiesConstraint(NuGetVersion version, VersionRange? constraint)
+        => constraint is null
+            || WorkloadVersionRanges.SatisfiesRange(constraint, version, _catalogOptions.IncludePrerelease);
 
     private static FunctionsWorkerResolutionResult NotInstalled(FunctionsWorkerId workerId)
         => NotInstalledResult(

--- a/src/Func/Workloads/Catalog/WorkloadCatalog.cs
+++ b/src/Func/Workloads/Catalog/WorkloadCatalog.cs
@@ -109,25 +109,6 @@ internal sealed class WorkloadCatalog(IOptions<WorkloadCatalogOptions> options, 
         return best;
     }
 
-    // NuGet's VersionRange.Satisfies rejects prerelease candidates when the
-    // range itself has no prerelease in its bounds (e.g. a range pinned to
-    // "[3.13.0]" rejects "3.13.0-preview.1" even though both share the same
-    // numeric version). When prerelease is enabled, re-check the candidate's
-    // numeric portion against the range so prerelease versions whose numeric
-    // version is inside the bounds are accepted.
     private static bool SatisfiesRange(VersionRange range, NuGetVersion candidate, bool includePrerelease)
-    {
-        if (range.Satisfies(candidate))
-        {
-            return true;
-        }
-
-        if (!includePrerelease || !candidate.IsPrerelease)
-        {
-            return false;
-        }
-
-        var numeric = new NuGetVersion(candidate.Major, candidate.Minor, candidate.Patch, candidate.Revision);
-        return range.Satisfies(numeric);
-    }
+        => WorkloadVersionRanges.SatisfiesRange(range, candidate, includePrerelease);
 }

--- a/src/Func/Workloads/Catalog/WorkloadVersionRanges.cs
+++ b/src/Func/Workloads/Catalog/WorkloadVersionRanges.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using NuGet.Versioning;
+
+namespace Azure.Functions.Cli.Workloads.Catalog;
+
+/// <summary>
+/// Helpers for evaluating <see cref="VersionRange"/> against <see cref="NuGetVersion"/>
+/// candidates in a way that accounts for NuGet's prerelease handling.
+/// </summary>
+internal static class WorkloadVersionRanges
+{
+    /// <summary>
+    /// Returns whether <paramref name="candidate"/> satisfies <paramref name="range"/>,
+    /// honoring <paramref name="includePrerelease"/>.
+    /// </summary>
+    /// <remarks>
+    /// NuGet's <see cref="VersionRange.Satisfies(NuGetVersion)"/> rejects prerelease
+    /// candidates when the range itself has no prerelease in its bounds (for example,
+    /// a range pinned to <c>[3.13.0]</c> rejects <c>3.13.0-preview.1</c> even though
+    /// both share the same numeric version). When prerelease is enabled, re-check the
+    /// candidate's numeric portion against the range so prerelease versions whose
+    /// numeric version is inside the bounds are accepted.
+    /// </remarks>
+    public static bool SatisfiesRange(VersionRange range, NuGetVersion candidate, bool includePrerelease)
+    {
+        ArgumentNullException.ThrowIfNull(range);
+        ArgumentNullException.ThrowIfNull(candidate);
+
+        if (range.Satisfies(candidate))
+        {
+            return true;
+        }
+
+        if (!includePrerelease || !candidate.IsPrerelease)
+        {
+            return false;
+        }
+
+        var numeric = new NuGetVersion(candidate.Major, candidate.Minor, candidate.Patch, candidate.Revision);
+        return range.Satisfies(numeric);
+    }
+}

--- a/src/Func/release_notes.md
+++ b/src/Func/release_notes.md
@@ -2,3 +2,5 @@
 
 #### Changes
 
+- Fix `func start` failing to resolve installed prerelease worker workloads against built-in profile ranges (e.g. `node [3.13.0]` now accepts `3.13.0-preview.1`). (#5286)
+

--- a/test/Func.Tests/Workers/DefaultFunctionsWorkerInstallerTests.cs
+++ b/test/Func.Tests/Workers/DefaultFunctionsWorkerInstallerTests.cs
@@ -7,6 +7,7 @@ using Azure.Functions.Cli.Workloads.Catalog;
 using Azure.Functions.Cli.Workloads.Discovery;
 using Azure.Functions.Cli.Workloads.Install;
 using Azure.Functions.Cli.Workloads.Storage;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using NuGet.Configuration;
 using NuGet.Versioning;
@@ -181,7 +182,7 @@ public class DefaultFunctionsWorkerInstallerTests
     [Fact]
     public void Ctor_NullDependencies_Throw()
     {
-        var contentResolver = new DefaultFunctionsWorkerContentResolver(_fileSystem);
+        var contentResolver = new DefaultFunctionsWorkerContentResolver(_fileSystem, Options.Create(new WorkloadCatalogOptions()));
 
         Assert.Throws<ArgumentNullException>(() => new DefaultFunctionsWorkerInstaller(null!, _workloadInstaller, _workloadPaths, contentResolver));
         Assert.Throws<ArgumentNullException>(() => new DefaultFunctionsWorkerInstaller(_workloadCatalog, null!, _workloadPaths, contentResolver));
@@ -191,7 +192,7 @@ public class DefaultFunctionsWorkerInstallerTests
 
     private DefaultFunctionsWorkerInstaller CreateInstaller()
     {
-        var contentResolver = new DefaultFunctionsWorkerContentResolver(_fileSystem);
+        var contentResolver = new DefaultFunctionsWorkerContentResolver(_fileSystem, Options.Create(new WorkloadCatalogOptions()));
         return new DefaultFunctionsWorkerInstaller(_workloadCatalog, _workloadInstaller, _workloadPaths, contentResolver);
     }
 

--- a/test/Func.Tests/Workers/DefaultFunctionsWorkerResolverTests.cs
+++ b/test/Func.Tests/Workers/DefaultFunctionsWorkerResolverTests.cs
@@ -3,6 +3,8 @@
 
 using Azure.Functions.Cli.Workers;
 using Azure.Functions.Cli.Workloads;
+using Azure.Functions.Cli.Workloads.Catalog;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using NuGet.Versioning;
 using Xunit;
@@ -264,7 +266,52 @@ public class DefaultFunctionsWorkerResolverTests
     [Fact]
     public void ContentResolverCtor_NullWorkerConfigFileSystem_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => new DefaultFunctionsWorkerContentResolver(null!));
+        Assert.Throws<ArgumentNullException>(
+            () => new DefaultFunctionsWorkerContentResolver(null!, Options.Create(new WorkloadCatalogOptions())));
+    }
+
+    [Fact]
+    public void ContentResolverCtor_NullCatalogOptions_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new DefaultFunctionsWorkerContentResolver(_fileSystem, null!));
+    }
+
+    [Fact]
+    public async Task ResolveWorkerAsync_ExactStableRange_ResolvesPrereleaseInstalled_WhenIncludePrereleaseTrue()
+    {
+        // Repro for issue #5286: built-in profile pins worker to exact stable [3.13.0]
+        // but the catalog/installer only has 3.13.0-preview.1 installed. The resolver
+        // must accept the prerelease when prerelease is enabled.
+        ContentWorkloadInfo preview = CreateContentWorkload(NodeWorkerPackageId, "3.13.0-preview.1");
+        UseContentWorkloads(preview);
+
+        DefaultFunctionsWorkerResolver resolver = CreateResolver(
+            new Dictionary<string, VersionRange> { ["node"] = VersionRange.Parse("[3.13.0]") },
+            includePrerelease: true);
+
+        FunctionsWorkerResolutionResult result = await resolver.ResolveWorkerAsync(
+            new FunctionsWorkerId("node"),
+            CancellationToken.None);
+
+        FunctionsWorkerResolutionResult.Resolved resolved = Assert.IsType<FunctionsWorkerResolutionResult.Resolved>(result);
+        Assert.Equal("3.13.0-preview.1", resolved.Worker.Version);
+    }
+
+    [Fact]
+    public async Task ResolveWorkerAsync_ExactStableRange_RejectsPrereleaseInstalled_WhenIncludePrereleaseFalse()
+    {
+        ContentWorkloadInfo preview = CreateContentWorkload(NodeWorkerPackageId, "3.13.0-preview.1");
+        UseContentWorkloads(preview);
+
+        DefaultFunctionsWorkerResolver resolver = CreateResolver(
+            new Dictionary<string, VersionRange> { ["node"] = VersionRange.Parse("[3.13.0]") },
+            includePrerelease: false);
+
+        FunctionsWorkerResolutionResult result = await resolver.ResolveWorkerAsync(
+            new FunctionsWorkerId("node"),
+            CancellationToken.None);
+
+        Assert.IsType<FunctionsWorkerResolutionResult.NotResolved>(result);
     }
 
     private void UseContentWorkloads(params ContentWorkloadInfo[] workloads)
@@ -280,10 +327,13 @@ public class DefaultFunctionsWorkerResolverTests
             });
     }
 
-    private DefaultFunctionsWorkerResolver CreateResolver(IReadOnlyDictionary<string, VersionRange>? workerVersionRanges = null)
-        => new(_workloads, CreateContentResolver(), workerVersionRanges);
+    private DefaultFunctionsWorkerResolver CreateResolver(
+        IReadOnlyDictionary<string, VersionRange>? workerVersionRanges = null,
+        bool includePrerelease = false)
+        => new(_workloads, CreateContentResolver(includePrerelease), workerVersionRanges);
 
-    private DefaultFunctionsWorkerContentResolver CreateContentResolver() => new(_fileSystem);
+    private DefaultFunctionsWorkerContentResolver CreateContentResolver(bool includePrerelease = false)
+        => new(_fileSystem, Options.Create(new WorkloadCatalogOptions { IncludePrerelease = includePrerelease }));
 
     private static ContentWorkloadInfo CreateContentWorkload(string packageId, string packageVersion, IReadOnlyList<string>? aliases = null)
     {


### PR DESCRIPTION
Resolves #5286

## The bug

On `func 5.0.0-preview.1`, applying any built-in profile (`flex`, `linux-premium`, `windows-consumption`, etc.) and running `func start` fails at the `resolve_worker` step:

```
Installed Azure Functions worker workloads for 'node' do not satisfy version range '[3.13.0]'.
```

The built-in profiles pin workers to exact stable ranges (e.g. node `[3.13.0]`), but the v5 preview catalog only ships `3.13.0-preview.1`. Per SemVer / NuGet, `3.13.0-preview.1 < 3.13.0`, so `VersionRange.Satisfies` rejects the installed prerelease worker.

## Why #5257 didn't catch this

PR #5257 fixed the same NuGet quirk in `WorkloadCatalog.SatisfiesRange` (catalog / network search path) but missed `DefaultFunctionsWorkerContentResolver.SatisfiesConstraint`, which runs against already-installed worker workloads on `func start`. That path still called `range.Satisfies(version)` directly.

## The fix

1. Extracted the prerelease-aware satisfaction logic from `WorkloadCatalog` into a shared internal helper `WorkloadVersionRanges.SatisfiesRange` (in `Workloads.Catalog`).
2. `WorkloadCatalog` now delegates to it.
3. `DefaultFunctionsWorkerContentResolver` now takes `IOptions<WorkloadCatalogOptions>` and uses the helper, so it honors the same `IncludePrerelease` flag that auto-enables on prerelease CLI builds (from `WorkloadCatalogOptionsSetup` introduced in #5257).

Net effect on a `5.0.0-preview.1` install: `[3.13.0]` accepts the installed `3.13.0-preview.1` worker, profiles become usable locally again.

## Tests

* New `DefaultFunctionsWorkerResolverTests`:
  * `ResolveWorkerAsync_ExactStableRange_ResolvesPrereleaseInstalled_WhenIncludePrereleaseTrue` (regression test for #5286)
  * `ResolveWorkerAsync_ExactStableRange_RejectsPrereleaseInstalled_WhenIncludePrereleaseFalse`
* Updated null-arg ctor tests for the new `IOptions<WorkloadCatalogOptions>` dependency.
* Full `Func.Tests`: **1174/1174 green**.

## Docs

No user-facing doc changes required; the bug-bash README guidance from #5257 still applies and continues to work.