### PR TITLE
ci: add branchClassification.yml

### DIFF
--- a/.azuredevops/policies/branchClassification.yml
+++ b/.azuredevops/policies/branchClassification.yml
@@ -1,0 +1,15 @@
+name: branch_classification
+resource: repository
+disabled: false
+where:
+configuration:
+  branchClassificationSettings:
+    defaultClassification: nonproduction
+    ruleset:
+      - name: prod-branches
+        branchNames:
+          - main
+          - vnext
+          - in-proc
+          - release/*
+        classification: production


### PR DESCRIPTION
Adds `branchClassification.yml` to customize how 1ES classifies our branches so that `vnext` can be considered production (and allow for releases based off that branch). This needs to go into the default branch (main).