### PR TITLE
Remove IInteractionService from Azurite orchestrator

### DIFF
--- a/src/Func/Commands/Start/Azurite/Orchestration/ManagedAzuriteOrchestrator.cs
+++ b/src/Func/Commands/Start/Azurite/Orchestration/ManagedAzuriteOrchestrator.cs
@@ -3,7 +3,6 @@
 
 using System.Text;
 using Azure.Functions.Cli.Commands.Start.Azurite.Launching;
-using Azure.Functions.Cli.Console;
 using Microsoft.Extensions.Logging;
 
 namespace Azure.Functions.Cli.Commands.Start.Azurite.Orchestration;
@@ -20,7 +19,6 @@ internal sealed class ManagedAzuriteOrchestrator : IManagedAzuriteOrchestrator
     private readonly IDockerAvailabilityProbe _dockerProbe;
     private readonly IAzuriteLauncher _launcher;
     private readonly IAzuriteManagedPathsProvider _pathsProvider;
-    private readonly IInteractionService _interaction;
     private readonly ILogger<ManagedAzuriteOrchestrator> _logger;
 
     public ManagedAzuriteOrchestrator(
@@ -30,7 +28,6 @@ internal sealed class ManagedAzuriteOrchestrator : IManagedAzuriteOrchestrator
         IDockerAvailabilityProbe dockerProbe,
         IAzuriteLauncher launcher,
         IAzuriteManagedPathsProvider pathsProvider,
-        IInteractionService interaction,
         ILogger<ManagedAzuriteOrchestrator> logger)
     {
         _classifier = classifier ?? throw new ArgumentNullException(nameof(classifier));
@@ -39,7 +36,6 @@ internal sealed class ManagedAzuriteOrchestrator : IManagedAzuriteOrchestrator
         _dockerProbe = dockerProbe ?? throw new ArgumentNullException(nameof(dockerProbe));
         _launcher = launcher ?? throw new ArgumentNullException(nameof(launcher));
         _pathsProvider = pathsProvider ?? throw new ArgumentNullException(nameof(pathsProvider));
-        _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -147,7 +143,6 @@ internal sealed class ManagedAzuriteOrchestrator : IManagedAzuriteOrchestrator
                 endpoints,
                 AzuriteLaunchMode.Native,
                 executable.FilePath,
-                executable.Version,
                 progress,
                 cancellationToken);
         }
@@ -167,7 +162,6 @@ internal sealed class ManagedAzuriteOrchestrator : IManagedAzuriteOrchestrator
             endpoints,
             AzuriteLaunchMode.Docker,
             executablePath: null,
-            executableVersion: docker.Version,
             progress,
             cancellationToken);
     }
@@ -177,14 +171,11 @@ internal sealed class ManagedAzuriteOrchestrator : IManagedAzuriteOrchestrator
         AzuriteEndpointTuple endpoints,
         AzuriteLaunchMode mode,
         string? executablePath,
-        string? executableVersion,
         IProgress<string>? progress,
         CancellationToken cancellationToken)
     {
         AzuriteManagedPaths paths = _pathsProvider.GetPaths();
         await _pathsProvider.EnsureCreatedAsync(paths, cancellationToken);
-
-        WriteStartBanner(mode, executablePath, executableVersion, endpoints, paths);
 
         AzuriteLaunchRequest launchRequest = new(
             mode: mode,
@@ -213,7 +204,7 @@ internal sealed class ManagedAzuriteOrchestrator : IManagedAzuriteOrchestrator
         switch (poll.Kind)
         {
             case PollOutcomeKind.Ready:
-                _interaction.WriteSuccess($"Azurite ready ({poll.Elapsed.TotalSeconds:0.0}s).");
+                progress?.Report($"Azurite ready ({poll.Elapsed.TotalSeconds:0.0}s)");
                 return new ManagedAzuriteResult.Started(process, mode, endpoints);
 
             case PollOutcomeKind.ProcessExited:
@@ -369,46 +360,6 @@ internal sealed class ManagedAzuriteOrchestrator : IManagedAzuriteOrchestrator
 
         await SafeDisposeAsync(process);
     }
-
-    private void WriteStartBanner(
-        AzuriteLaunchMode mode,
-        string? executablePath,
-        string? executableVersion,
-        AzuriteEndpointTuple endpoints,
-        AzuriteManagedPaths paths)
-    {
-        string modeLabel = mode == AzuriteLaunchMode.Native ? "native" : "Docker";
-        _interaction.WriteLine(l =>
-        {
-            l.Plain("Starting Azurite (").Emphasis(modeLabel).Plain(") for AzureWebJobsStorage...");
-        });
-
-        if (mode == AzuriteLaunchMode.Native && !string.IsNullOrEmpty(executablePath))
-        {
-            _interaction.WriteLine(l => l.Muted("  Executable: ").Path(executablePath));
-        }
-        else if (mode == AzuriteLaunchMode.Docker)
-        {
-            _interaction.WriteLine(l => l.Muted("  Image: ").Path(AzuriteDockerImage.Default));
-        }
-
-        if (!string.IsNullOrEmpty(executableVersion))
-        {
-            _interaction.WriteLine(l => l.Muted("  Version: ").Plain(executableVersion));
-        }
-
-        _interaction.WriteLine(l => l.Muted("  Data: ").Path(paths.DataDirectory));
-        _interaction.WriteLine(l => l.Muted("  Logs: ").Path(paths.LogFilePath));
-        _interaction.WriteLine(l => l
-            .Muted("  Endpoints: blob ")
-            .Plain(FormatEndpoint(endpoints.BlobEndpoint))
-            .Muted(", queue ")
-            .Plain(FormatEndpoint(endpoints.QueueEndpoint))
-            .Muted(", table ")
-            .Plain(FormatEndpoint(endpoints.TableEndpoint)));
-    }
-
-    private static string FormatEndpoint(Uri uri) => $"{uri.Host}:{uri.Port}";
 
     private static AzuriteEndpointTuple DefaultEndpoints()
     {

--- a/test/Func.Tests/Commands/Start/Azurite/Orchestration/ManagedAzuriteOrchestratorTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/Orchestration/ManagedAzuriteOrchestratorTests.cs
@@ -6,7 +6,6 @@ using System.Runtime.CompilerServices;
 using Azure.Functions.Cli.Commands.Start.Azurite;
 using Azure.Functions.Cli.Commands.Start.Azurite.Launching;
 using Azure.Functions.Cli.Commands.Start.Azurite.Orchestration;
-using Azure.Functions.Cli.Console;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using Xunit;
@@ -24,7 +23,6 @@ public class ManagedAzuriteOrchestratorTests
     private readonly IDockerAvailabilityProbe _dockerProbe = Substitute.For<IDockerAvailabilityProbe>();
     private readonly IAzuriteLauncher _launcher = Substitute.For<IAzuriteLauncher>();
     private readonly IAzuriteManagedPathsProvider _paths = Substitute.For<IAzuriteManagedPathsProvider>();
-    private readonly IInteractionService _interaction = Substitute.For<IInteractionService>();
 
     public ManagedAzuriteOrchestratorTests()
     {
@@ -37,7 +35,7 @@ public class ManagedAzuriteOrchestratorTests
 
     private ManagedAzuriteOrchestrator CreateSut() => new(
         _classifier, _probe, _locator, _dockerProbe, _launcher, _paths,
-        _interaction, NullLogger<ManagedAzuriteOrchestrator>.Instance);
+        NullLogger<ManagedAzuriteOrchestrator>.Instance);
 
     private static ManagedAzuriteRequest Request(bool disabled = false, TimeSpan? timeout = null) =>
         new(Conn, ProjectRoot, disabled, timeout ?? TimeSpan.FromSeconds(5));
@@ -286,6 +284,7 @@ public class ManagedAzuriteOrchestratorTests
         Assert.Contains(messages, m => m.Contains("checking for an existing Azurite endpoint", StringComparison.OrdinalIgnoreCase));
         Assert.Contains(messages, m => m.Contains("looking for a local Azurite installation", StringComparison.OrdinalIgnoreCase));
         Assert.Contains(messages, m => m.Contains("starting Azurite (native)", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(messages, m => m.Contains("Azurite ready", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]


### PR DESCRIPTION
Replaced IInteractionService with IProgress<string> for all user-facing output in ManagedAzuriteOrchestrator. Removed WriteStartBanner and updated tests to assert on progress messages instead of interaction service calls. Cleans up dependencies and streamlines progress reporting.
