### PR TITLE
build: define PREVIEW constant, use for prerelease check

### DIFF
--- a/eng/build/Version.props
+++ b/eng/build/Version.props
@@ -22,6 +22,9 @@
 
     <!-- Major.Minor.Patch -> Major.Minor.0.0 -->
     <AssemblyVersion>$(VersionPrefix.Substring(0, $(VersionPrefix.LastIndexOf('.')))).0.0</AssemblyVersion>
+
+    <!-- Define a constant for preview builds. -->
+    <DefineConstants Condition="'$(VersionSuffix)' != ''">$(DefineConstants);PREVIEW</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(CI)' != 'true'">

--- a/src/Func/Common/AssemblyCliVersionProvider.cs
+++ b/src/Func/Common/AssemblyCliVersionProvider.cs
@@ -28,4 +28,10 @@ internal sealed class AssemblyCliVersionProvider : ICliVersionProvider
     public string Version { get; }
 
     public string InformationalVersion { get; }
+
+#if PREVIEW
+    public bool IsPrerelease => true;
+#else
+    public bool IsPrerelease => false;
+#endif
 }

--- a/src/Func/Common/ICliVersionProvider.cs
+++ b/src/Func/Common/ICliVersionProvider.cs
@@ -21,4 +21,9 @@ internal interface ICliVersionProvider
     /// (e.g. <c>"5.0.0+abc1234"</c>).
     /// </summary>
     public string InformationalVersion { get; }
+
+    /// <summary>
+    /// Indicates if the version is a prerelease.
+    /// </summary>
+    public bool IsPrerelease { get; }
 }

--- a/src/Func/Workloads/Catalog/WorkloadCatalogOptionsSetup.cs
+++ b/src/Func/Workloads/Catalog/WorkloadCatalogOptionsSetup.cs
@@ -27,8 +27,11 @@ internal sealed class WorkloadCatalogOptionsSetup(
     private static readonly HashSet<string> _falseEnvironmentValues =
         new(StringComparer.OrdinalIgnoreCase) { "0", "false", "f", "n", "no", "off" };
 
-    private readonly IProcessEnvironment _processEnvironment = processEnvironment ?? throw new ArgumentNullException(nameof(processEnvironment));
-    private readonly ICliVersionProvider _cliVersionProvider = cliVersionProvider ?? throw new ArgumentNullException(nameof(cliVersionProvider));
+    private readonly IProcessEnvironment _processEnvironment = processEnvironment
+        ?? throw new ArgumentNullException(nameof(processEnvironment));
+
+    private readonly ICliVersionProvider _cliVersionProvider = cliVersionProvider
+        ?? throw new ArgumentNullException(nameof(cliVersionProvider));
 
     public void Configure(WorkloadCatalogOptions options)
     {
@@ -62,11 +65,6 @@ internal sealed class WorkloadCatalogOptionsSetup(
             }
         }
 
-        // Auto-detect: a prerelease CLI build resolves prerelease workload
-        // packages by default. SemVer prerelease suffixes are delimited with
-        // '-' (e.g. "5.0.0-preview.1"), so the presence of a dash in the
-        // informational version is a reliable, build-agnostic signal.
-        string informational = _cliVersionProvider.InformationalVersion;
-        return !string.IsNullOrEmpty(informational) && informational.Contains('-');
+        return _cliVersionProvider.IsPrerelease;
     }
 }

--- a/test/Func.Tests/Workloads/Catalog/WorkloadCatalogTests.cs
+++ b/test/Func.Tests/Workloads/Catalog/WorkloadCatalogTests.cs
@@ -426,6 +426,7 @@ public sealed class WorkloadCatalogTests
         ICliVersionProvider provider = Substitute.For<ICliVersionProvider>();
         provider.InformationalVersion.Returns(informational);
         provider.Version.Returns(informational.Split('-', '+')[0]);
+        provider.IsPrerelease.Returns(informational.Contains('-'));
         return provider;
     }
 }


### PR DESCRIPTION
1. Add a `PREVIEW` build constant when VersionSuffix is non-empty **before** any CI-suffixes are injected.
    - CI builds for a stable version, like `5.0.0-ci.DATE.REV` will **not** be PREVIEW.
2. Switch to using that constant for prerelease check at runtime.
   - Behavior will be consistent between local, CI, and release-time builds.