### PR TITLE
fix: add lazy first-use install for npm RFC #868 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ apt-get update && apt-get install libicu-dev  -y
 
 npm can be used on all platforms. On unix platforms, you may need to specify `--unsafe-perm` if you are running npm with sudo. That's due to npm behavior of post install script.
 
+> **Note:** [npm RFC #868](https://github.com/npm/rfcs/pull/868) will block install scripts (like `postinstall`) by default in a future npm version. If the install script is skipped, the Azure Functions Core Tools binary will be downloaded automatically the first time you run `func`. No extra configuration is needed. If you want the binary installed at `npm install` time with a newer npm, add `azure-functions-core-tools` to the `allowScripts` field in your `package.json`.
+
 Alternatively, you can install the CLI manually by downloading the latest release from the GitHub repo:
 
 1. Download the latest release for your platform from [here](https://github.com/Azure/azure-functions-core-tools/releases).

--- a/eng/tools/publish-tools/npm/lib/main.js
+++ b/eng/tools/publish-tools/npm/lib/main.js
@@ -1,10 +1,27 @@
 #! /usr/bin/env node
 
 const path = require('path');
-const spawn = require('child_process').spawn;
+const fs = require('fs');
+const { spawn, spawnSync } = require('child_process');
 const args = process.argv;
 
+function installIfNeeded() {
+    const bin = path.resolve(path.join(path.dirname(__filename), '..', 'bin'));
+    const funcBin = path.join(bin, process.platform === 'win32' ? 'func.exe' : 'func');
+
+    if (!fs.existsSync(funcBin)) {
+        console.log('Azure Functions Core Tools binary not found. Running first-time setup...');
+        const installScript = path.resolve(path.join(path.dirname(__filename), 'install.js'));
+        const result = spawnSync(process.execPath, [installScript], { stdio: 'inherit' });
+        if (result.status !== 0) {
+            process.exit(result.status || 1);
+        }
+    }
+}
+
 function main() {
+    installIfNeeded();
+
     const bin = path.resolve(path.join(path.dirname(__filename), '..', 'bin'));
     const funcProc = spawn(bin + '/func', args.slice(2), {
         stdio: [process.stdin, process.stdout, process.stderr, 'pipe']


### PR DESCRIPTION
## Summary

Fixes #5258.

[npm RFC #868](https://github.com/npm/rfcs/pull/868) will block `postinstall` scripts by default in a future npm release (already the behavior in pnpm, Yarn Berry, Bun, and Deno). This would cause silent install failures where `func` is unusable because the binary was never downloaded.

## Changes

### `eng/tools/publish-tools/npm/lib/main.js`
Added an `installIfNeeded()` function that runs before spawning `func`. It checks whether the platform binary (`bin/func` or `bin/func.exe`) exists, and if not, runs `install.js` synchronously via `spawnSync` so the binary is downloaded on first use.

### `README.md`
Added a note in the npm install section explaining:
- The new lazy first-use install behavior when `postinstall` is blocked
- How to opt back in to install-time download with `allowScripts` for newer npm

## Behavior

| Scenario | Before | After |
|---|---|---|
| Older npm (postinstall allowed) | Binary downloaded at `npm install` ✅ | Binary downloaded at `npm install` ✅ |
| Newer npm (postinstall blocked) | Binary missing, confusing runtime error ❌ | Binary downloaded on first `func` run ✅ |
| User sets `allowScripts` | N/A | Binary downloaded at `npm install` ✅ |