### PR TITLE
feat(update): add IReleaseFeed + GitHubReleaseFeed

### DIFF
--- a/eng/build/Packages.props
+++ b/eng/build/Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="NuGet.Packaging" Version="6.13.2" />
     <PackageVersion Include="NuGet.Protocol" Version="6.13.2" />
     <PackageVersion Include="System.CommandLine" Version="2.0.6" />
+    <PackageVersion Include="Semver" Version="3.0.0" />
     <PackageVersion Include="Spectre.Console" Version="0.49.1" />
   </ItemGroup>
   <!-- telemetry -->

--- a/src/Func/Func.csproj
+++ b/src/Func/Func.csproj
@@ -45,6 +45,7 @@
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" />
     <PackageReference Include="NuGet.Versioning" />
+    <PackageReference Include="Semver" />
   </ItemGroup>
 
   <!--

--- a/src/Func/Update/GitHubReleaseDtos.cs
+++ b/src/Func/Update/GitHubReleaseDtos.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Text.Json.Serialization;
+
+namespace Azure.Functions.Cli.Update;
+
+/// <summary>
+/// JSON shape returned by
+/// <c>GET https://api.github.com/repos/&lt;owner&gt;/&lt;repo&gt;/releases</c>.
+/// Only the fields the update pipeline consumes are modelled.
+/// </summary>
+internal sealed record GitHubRelease(
+    [property: JsonPropertyName("tag_name")] string TagName,
+    [property: JsonPropertyName("prerelease")] bool IsPrerelease,
+    [property: JsonPropertyName("assets")] IReadOnlyList<GitHubAsset> Assets);
+
+/// <summary>
+/// A downloadable artifact attached to a <see cref="GitHubRelease"/>.
+/// </summary>
+internal sealed record GitHubAsset(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("browser_download_url")] string DownloadUrl,
+    [property: JsonPropertyName("size")] long Size);

--- a/src/Func/Update/GitHubReleaseFeed.cs
+++ b/src/Func/Update/GitHubReleaseFeed.cs
@@ -1,0 +1,177 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Azure.Functions.Cli.Common;
+using Microsoft.Extensions.Logging;
+using Semver;
+
+namespace Azure.Functions.Cli.Update;
+
+/// <summary>
+/// <see cref="IReleaseFeed"/> backed by the public GitHub releases API. SemVer
+/// classification (stable vs prerelease) is driven by the release tag's
+/// SemVer prerelease label, not GitHub's <c>prerelease</c> boolean, so that
+/// <c>func update</c> agrees with the existing install scripts.
+/// </summary>
+internal sealed class GitHubReleaseFeed(
+    IHttpClientFactory httpClientFactory,
+    ILogger<GitHubReleaseFeed> logger,
+    IProcessEnvironment processEnvironment) : IReleaseFeed
+{
+    /// <summary>Named <see cref="HttpClient"/> identifier; registered alongside this service.</summary>
+    internal const string HttpClientName = "github";
+
+    private const string ReleasesPath = "repos/Azure/azure-functions-core-tools/releases?per_page=100";
+    private const string GitHubTokenEnvVar = "GITHUB_TOKEN";
+
+    private readonly IHttpClientFactory _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+    private readonly ILogger<GitHubReleaseFeed> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly IProcessEnvironment _processEnvironment = processEnvironment ?? throw new ArgumentNullException(nameof(processEnvironment));
+
+    public async Task<Release?> GetLatestAsync(bool includePrerelease, CancellationToken cancellationToken)
+    {
+        IReadOnlyList<Release> releases = await FetchReleasesAsync(cancellationToken);
+
+        return releases
+            .Where(r => includePrerelease || !r.IsPrerelease)
+            .OrderByDescending(r => r.Version, SemVersion.PrecedenceComparer)
+            .FirstOrDefault();
+    }
+
+    public async Task<Release?> GetVersionAsync(SemVersion version, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(version);
+
+        IReadOnlyList<Release> releases = await FetchReleasesAsync(cancellationToken);
+
+        return releases.FirstOrDefault(r => SemVersion.PrecedenceComparer.Equals(r.Version, version));
+    }
+
+    private async Task<IReadOnlyList<Release>> FetchReleasesAsync(CancellationToken cancellationToken)
+    {
+        using HttpClient client = _httpClientFactory.CreateClient(HttpClientName);
+        using var request = new HttpRequestMessage(HttpMethod.Get, ReleasesPath);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+        request.Headers.TryAddWithoutValidation("X-GitHub-Api-Version", "2022-11-28");
+
+        string? token = _processEnvironment.Get(GitHubTokenEnvVar);
+        if (!string.IsNullOrEmpty(token))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        }
+
+        using HttpResponseMessage response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+
+        EnsureSuccessOrThrowGraceful(response);
+
+        await using Stream stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+
+        GitHubRelease[]? raw;
+        try
+        {
+            raw = await JsonSerializer.DeserializeAsync(
+                stream,
+                UpdateJsonContext.Default.GitHubReleaseArray,
+                cancellationToken);
+        }
+        catch (JsonException ex)
+        {
+            throw new GracefulException(
+                "Could not parse the GitHub releases response. The API shape may have changed.",
+                ex);
+        }
+
+        if (raw is null || raw.Length == 0)
+        {
+            return [];
+        }
+
+        var parsed = new List<Release>(raw.Length);
+        foreach (GitHubRelease entry in raw)
+        {
+            if (TryParse(entry, out Release? release))
+            {
+                parsed.Add(release);
+            }
+        }
+
+        return parsed;
+    }
+
+    private bool TryParse(GitHubRelease entry, out Release release)
+    {
+        // Strip a single leading 'v' if present, then require strict SemVer 2.0.
+        // Tags that don't parse strictly (e.g. legacy "release-2024-01") are
+        // skipped rather than throwing; func update simply ignores them.
+        string raw = entry.TagName;
+        string stripped = raw.StartsWith('v') ? raw[1..] : raw;
+
+        if (!SemVersion.TryParse(stripped, SemVersionStyles.Strict, out SemVersion? version))
+        {
+            _logger.LogDebug("Skipping release with unparseable tag {Tag}.", raw);
+            release = null!;
+            return false;
+        }
+
+        IReadOnlyList<ReleaseAsset> assets = entry.Assets is { Count: > 0 }
+            ? [.. entry.Assets.Select(a => new ReleaseAsset(a.Name, a.DownloadUrl, a.Size, Sha256: null))]
+            : [];
+
+        release = new Release(
+            Version: version,
+            IsPrerelease: version.IsPrerelease,
+            TagName: raw,
+            Assets: assets);
+        return true;
+    }
+
+    private static void EnsureSuccessOrThrowGraceful(HttpResponseMessage response)
+    {
+        if (response.IsSuccessStatusCode)
+        {
+            return;
+        }
+
+        if (response.StatusCode == HttpStatusCode.Forbidden && IsRateLimited(response))
+        {
+            throw new GracefulException(
+                "GitHub API rate limit reached. Set the GITHUB_TOKEN environment variable "
+                + "to use an authenticated request (raises the limit from 60 to 5000 req/hr).",
+                isUserError: true);
+        }
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            throw new GracefulException(
+                "GitHub returned 404 while listing func releases. The releases endpoint may have moved.",
+                isUserError: true);
+        }
+
+        if ((int)response.StatusCode >= 500)
+        {
+            throw new GracefulException(
+                $"GitHub returned {(int)response.StatusCode} while listing releases. Try again later.",
+                isUserError: true);
+        }
+
+        throw new GracefulException(
+            $"Unexpected response ({(int)response.StatusCode} {response.ReasonPhrase}) from GitHub releases.",
+            isUserError: true);
+    }
+
+    private static bool IsRateLimited(HttpResponseMessage response)
+    {
+        if (!response.Headers.TryGetValues("X-RateLimit-Remaining", out IEnumerable<string>? values))
+        {
+            return false;
+        }
+
+        string? first = values.FirstOrDefault();
+        return first is not null
+            && int.TryParse(first, out int remaining)
+            && remaining == 0;
+    }
+}

--- a/src/Func/Update/IReleaseFeed.cs
+++ b/src/Func/Update/IReleaseFeed.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Semver;
+
+namespace Azure.Functions.Cli.Update;
+
+/// <summary>
+/// Abstraction over the source of func CLI releases. The production
+/// implementation queries the public GitHub releases API; tests substitute it
+/// with an in-memory feed.
+/// </summary>
+internal interface IReleaseFeed
+{
+    /// <summary>
+    /// Returns the SemVer-max release on the requested channel, or
+    /// <c>null</c> when the channel has no releases.
+    /// </summary>
+    /// <param name="includePrerelease">
+    /// <c>false</c> to consider only stable releases (no SemVer prerelease label);
+    /// <c>true</c> to consider stable and prerelease releases together.
+    /// </param>
+    public Task<Release?> GetLatestAsync(bool includePrerelease, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Returns the release whose tag parses to the requested
+    /// <paramref name="version"/>, or <c>null</c> when no such release exists.
+    /// Used by <c>func update --version X.Y.Z</c>.
+    /// </summary>
+    public Task<Release?> GetVersionAsync(SemVersion version, CancellationToken cancellationToken);
+}

--- a/src/Func/Update/Release.cs
+++ b/src/Func/Update/Release.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Semver;
+
+namespace Azure.Functions.Cli.Update;
+
+/// <summary>
+/// A published func CLI release as seen by the update pipeline. Parsed from a
+/// GitHub release; the version comes from the release tag and drives both
+/// channel classification and "newer than current" comparisons.
+/// </summary>
+internal sealed record Release(
+    SemVersion Version,
+    bool IsPrerelease,
+    string TagName,
+    IReadOnlyList<ReleaseAsset> Assets);
+
+/// <summary>
+/// A single downloadable artifact attached to a <see cref="Release"/>. The next
+/// PR in the update chain matches one of these by RID.
+/// </summary>
+/// <remarks>
+/// <see cref="Sha256"/> is plumbed nullable because the canonical hash source
+/// hasn't been pinned down yet (see PR open questions). The install-script
+/// team owns confirming it; this field is wired so downloaders can adopt it
+/// without a record-shape change.
+/// </remarks>
+internal sealed record ReleaseAsset(
+    string Name,
+    string DownloadUrl,
+    long Size,
+    string? Sha256);

--- a/src/Func/Update/UpdateJsonContext.cs
+++ b/src/Func/Update/UpdateJsonContext.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Text.Json.Serialization;
+
+namespace Azure.Functions.Cli.Update;
+
+/// <summary>
+/// Source-generated <see cref="JsonSerializerContext"/> for GitHub releases
+/// deserialization. Keeps JSON reflection-free (AOT/trim-friendly), matching
+/// the pattern used by other JSON-consuming subsystems in this CLI.
+/// </summary>
+[JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
+[JsonSerializable(typeof(GitHubRelease[]))]
+internal sealed partial class UpdateJsonContext : JsonSerializerContext;

--- a/test/Func.Tests/Func.Tests.csproj
+++ b/test/Func.Tests/Func.Tests.csproj
@@ -10,6 +10,10 @@
     <ProjectReference Include="$(SrcRoot)Func/Func.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="Update/Fixtures/releases.json" LogicalName="Azure.Functions.Cli.Tests.Update.Fixtures.releases.json" />
+  </ItemGroup>
+
   <!-- Test fixtures: built and copied to output as content; loaded via reflection. -->
   <ItemGroup>
     <ProjectReference Include="../Fixtures/Workloads.Tests.Fixtures.*/Workloads.Tests.Fixtures.*.csproj">

--- a/test/Func.Tests/Update/Fixtures/releases.json
+++ b/test/Func.Tests/Update/Fixtures/releases.json
@@ -1,0 +1,50 @@
+[
+  {
+    "tag_name": "v5.0.0-preview.2",
+    "prerelease": true,
+    "published_at": "2025-01-15T00:00:00Z",
+    "assets": [
+      {
+        "name": "Azure.Functions.Cli.osx-arm64.5.0.0-preview.2.zip",
+        "browser_download_url": "https://example.test/v5.0.0-preview.2/osx-arm64.zip",
+        "size": 12345678
+      }
+    ]
+  },
+  {
+    "tag_name": "v5.0.0-preview.1",
+    "prerelease": true,
+    "published_at": "2025-03-01T00:00:00Z",
+    "assets": []
+  },
+  {
+    "tag_name": "v5.0.0",
+    "prerelease": false,
+    "published_at": "2024-12-01T00:00:00Z",
+    "assets": [
+      {
+        "name": "Azure.Functions.Cli.osx-arm64.5.0.0.zip",
+        "browser_download_url": "https://example.test/v5.0.0/osx-arm64.zip",
+        "size": 23456789
+      }
+    ]
+  },
+  {
+    "tag_name": "5.1.0",
+    "prerelease": false,
+    "published_at": "2025-02-10T00:00:00Z",
+    "assets": []
+  },
+  {
+    "tag_name": "v4.9.0",
+    "prerelease": false,
+    "published_at": "2024-06-01T00:00:00Z",
+    "assets": []
+  },
+  {
+    "tag_name": "release-2024-01",
+    "prerelease": false,
+    "published_at": "2024-01-15T00:00:00Z",
+    "assets": []
+  }
+]

--- a/test/Func.Tests/Update/GitHubReleaseFeedTests.cs
+++ b/test/Func.Tests/Update/GitHubReleaseFeedTests.cs
@@ -1,0 +1,216 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Update;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Semver;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Update;
+
+public sealed class GitHubReleaseFeedTests
+{
+    private const string FixtureResource = "Azure.Functions.Cli.Tests.Update.Fixtures.releases.json";
+
+    [Fact]
+    public async Task GetLatestAsync_StableOnly_PrefersSemVerMaxStableIgnoringNewerPrereleases()
+    {
+        GitHubReleaseFeed feed = CreateFeed(out _, RespondWithFixture());
+
+        Release? latest = await feed.GetLatestAsync(includePrerelease: false, CancellationToken.None);
+
+        Assert.NotNull(latest);
+        Assert.Equal("5.1.0", latest!.Version.ToString());
+        Assert.False(latest.IsPrerelease);
+    }
+
+    [Fact]
+    public async Task GetLatestAsync_IncludingPrereleases_ReturnsSemVerMaxAcrossAll()
+    {
+        GitHubReleaseFeed feed = CreateFeed(out _, RespondWithFixture());
+
+        Release? latest = await feed.GetLatestAsync(includePrerelease: true, CancellationToken.None);
+
+        Assert.NotNull(latest);
+
+        // 5.1.0 (stable) > 5.0.0-preview.2 > 5.0.0-preview.1 > 5.0.0 (stable) > 4.9.0
+        // per SemVer precedence: 5.1.0 wins.
+        Assert.Equal("5.1.0", latest!.Version.ToString());
+    }
+
+    [Fact]
+    public async Task GetLatestAsync_TagWithoutLeadingV_ParsesAndIsSelectable()
+    {
+        // The fixture's "5.1.0" entry has no leading "v"; it must still be picked
+        // up by GetLatestAsync(false). Covered together with case 1's assertion,
+        // but expressed separately so a regression surfaces with clear intent.
+        GitHubReleaseFeed feed = CreateFeed(out _, RespondWithFixture());
+
+        Release? latest = await feed.GetLatestAsync(includePrerelease: false, CancellationToken.None);
+
+        Assert.NotNull(latest);
+        Assert.Equal("5.1.0", latest!.TagName);
+    }
+
+    [Fact]
+    public async Task GetLatestAsync_UnparseableTag_IsSkippedSilently()
+    {
+        // The fixture contains "release-2024-01" which is not strict SemVer 2.0.
+        // It must be ignored without throwing.
+        GitHubReleaseFeed feed = CreateFeed(out _, RespondWithFixture());
+
+        Release? latest = await feed.GetLatestAsync(includePrerelease: false, CancellationToken.None);
+
+        Assert.NotNull(latest);
+        Assert.NotEqual("release-2024-01", latest!.TagName);
+    }
+
+    [Fact]
+    public async Task GetVersionAsync_ExactMatch_ReturnsRelease()
+    {
+        GitHubReleaseFeed feed = CreateFeed(out _, RespondWithFixture());
+        var target = SemVersion.Parse("5.0.0-preview.1", SemVersionStyles.Strict);
+
+        Release? result = await feed.GetVersionAsync(target, CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal("v5.0.0-preview.1", result!.TagName);
+        Assert.True(result.IsPrerelease);
+    }
+
+    [Fact]
+    public async Task GetVersionAsync_NoMatch_ReturnsNull()
+    {
+        GitHubReleaseFeed feed = CreateFeed(out _, RespondWithFixture());
+        var target = SemVersion.Parse("99.0.0", SemVersionStyles.Strict);
+
+        Release? result = await feed.GetVersionAsync(target, CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task FetchReleases_GitHubTokenSet_AddsBearerAuthorizationHeader()
+    {
+        IProcessEnvironment env = Substitute.For<IProcessEnvironment>();
+        env.Get("GITHUB_TOKEN").Returns("ghp_test-token-123");
+
+        var handler = new StubHttpMessageHandler(RespondWithFixture());
+        GitHubReleaseFeed feed = CreateFeed(handler, env);
+
+        await feed.GetLatestAsync(includePrerelease: false, CancellationToken.None);
+
+        Assert.NotNull(handler.LastRequest);
+        Assert.NotNull(handler.LastRequest!.Headers.Authorization);
+        Assert.Equal("Bearer", handler.LastRequest.Headers.Authorization!.Scheme);
+        Assert.Equal("ghp_test-token-123", handler.LastRequest.Headers.Authorization.Parameter);
+    }
+
+    [Fact]
+    public async Task FetchReleases_NoGitHubToken_OmitsAuthorizationHeader()
+    {
+        IProcessEnvironment env = Substitute.For<IProcessEnvironment>();
+        env.Get("GITHUB_TOKEN").Returns((string?)null);
+
+        var handler = new StubHttpMessageHandler(RespondWithFixture());
+        GitHubReleaseFeed feed = CreateFeed(handler, env);
+
+        await feed.GetLatestAsync(includePrerelease: false, CancellationToken.None);
+
+        Assert.NotNull(handler.LastRequest);
+        Assert.Null(handler.LastRequest!.Headers.Authorization);
+    }
+
+    [Fact]
+    public async Task FetchReleases_RateLimited_ThrowsGracefulMentioningGitHubToken()
+    {
+        var handler = new StubHttpMessageHandler((_, _) =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.Forbidden)
+            {
+                Content = new StringContent("rate limit exceeded"),
+            };
+            response.Headers.Add("X-RateLimit-Remaining", "0");
+            return response;
+        });
+
+        GitHubReleaseFeed feed = CreateFeed(handler, Substitute.For<IProcessEnvironment>());
+
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => feed.GetLatestAsync(includePrerelease: false, CancellationToken.None));
+
+        Assert.Contains("GITHUB_TOKEN", ex.Message, StringComparison.Ordinal);
+        Assert.True(ex.IsUserError);
+    }
+
+    [Fact]
+    public async Task FetchReleases_ServerError_ThrowsGraceful()
+    {
+        var handler = new StubHttpMessageHandler((_, _) =>
+            new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+
+        GitHubReleaseFeed feed = CreateFeed(handler, Substitute.For<IProcessEnvironment>());
+
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => feed.GetLatestAsync(includePrerelease: false, CancellationToken.None));
+
+        Assert.Contains("503", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetLatestAsync_PreCancelledToken_ThrowsOperationCanceled()
+    {
+        var handler = new StubHttpMessageHandler(RespondWithFixture());
+        GitHubReleaseFeed feed = CreateFeed(handler, Substitute.For<IProcessEnvironment>());
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAsync<TaskCanceledException>(
+            () => feed.GetLatestAsync(includePrerelease: false, cts.Token));
+    }
+
+    private static Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> RespondWithFixture()
+    {
+        byte[] body = LoadFixture();
+        return (_, _) => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(body)
+            {
+                Headers = { ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json") },
+            },
+        };
+    }
+
+    private static byte[] LoadFixture()
+    {
+        using Stream? stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(FixtureResource)
+            ?? throw new InvalidOperationException($"Embedded fixture '{FixtureResource}' not found.");
+        using var ms = new MemoryStream();
+        stream.CopyTo(ms);
+        return ms.ToArray();
+    }
+
+    private static GitHubReleaseFeed CreateFeed(out StubHttpMessageHandler handler, Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> responder)
+    {
+        handler = new StubHttpMessageHandler(responder);
+        return CreateFeed(handler, Substitute.For<IProcessEnvironment>());
+    }
+
+    private static GitHubReleaseFeed CreateFeed(StubHttpMessageHandler handler, IProcessEnvironment env)
+    {
+        IHttpClientFactory factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient(GitHubReleaseFeed.HttpClientName).Returns(_ => new HttpClient(handler, disposeHandler: false)
+        {
+            BaseAddress = new Uri("https://api.github.com/"),
+        });
+
+        return new GitHubReleaseFeed(factory, NullLogger<GitHubReleaseFeed>.Instance, env);
+    }
+}

--- a/test/Func.Tests/Update/StubHttpMessageHandler.cs
+++ b/test/Func.Tests/Update/StubHttpMessageHandler.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Tests.Update;
+
+/// <summary>
+/// <see cref="HttpMessageHandler"/> that lets each test inspect the outgoing
+/// request and program the response in one place. Captures the last seen
+/// request so tests can assert on headers and URL after invocation.
+/// </summary>
+internal sealed class StubHttpMessageHandler(Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> responder)
+    : HttpMessageHandler
+{
+    private readonly Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> _responder = responder ?? throw new ArgumentNullException(nameof(responder));
+
+    public HttpRequestMessage? LastRequest { get; private set; }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        LastRequest = request;
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(_responder(request, cancellationToken));
+    }
+}


### PR DESCRIPTION
Stacked on #5292. PR #2 in the `func update` chain.

Adds the GitHub-releases data source the update pipeline will consume. No RID matching, no download, no command wiring; those land in subsequent PRs.

## What's in

- `IReleaseFeed` interface with `GetLatestAsync(bool includePrerelease, ct)` and `GetVersionAsync(SemVersion, ct)`.
- `Release` + `ReleaseAsset` internal records.
- `GitHubReleaseFeed` impl backed by `IHttpClientFactory` (named `"github"`), primary-ctor DI, `ILogger<>`, and the existing `IProcessEnvironment` seam for `GITHUB_TOKEN`.
- DTOs + source-gen `UpdateJsonContext` (matches the `QuickstartJsonContext` pattern; AOT/trim-friendly).
- Pin `Semver` 3.0.0 in `eng/build/Packages.props` (the library the spec calls for).
- 11 unit tests with stub `HttpMessageHandler` + trimmed real-shape fixture JSON.

## Design notes

- **Classification follows the SemVer label on the release tag, not GitHub's `prerelease` boolean** (per spec). A release is stable iff `SemVersion.Prerelease.Count == 0`; everything else is prerelease.
- Tags are parsed by stripping a single leading `v` and then `SemVersion.Parse(value, SemVersionStyles.Strict)`. Unparseable tags (e.g. legacy `release-2024-01`) are skipped with `LogDebug` instead of throwing.
- "Latest" within a channel is the max by `SemVersion.PrecedenceComparer`, not GitHub's `published_at`. The fixture deliberately inverts `published_at` ordering so the test exercises the SemVer logic.
- `User-Agent` already comes from the global `HttpClientDefaults`, so it's not duplicated here.
- `Authorization: Bearer <token>` added per-request when `IProcessEnvironment.Get("GITHUB_TOKEN")` returns a non-empty value. Tests substitute the env seam, so no real env mutation is needed.
- Error mapping (narrow catches): 403 + `X-RateLimit-Remaining: 0` → `GracefulException` mentioning `GITHUB_TOKEN`; 404 / 5xx → `GracefulException`; `JsonException` → `GracefulException` (bug-class, not user error). Cancellation and network failures surface unwrapped per repo convention.

## What's explicitly out (lands in later PRs)

- DI registration (`UpdateServices.cs` + `Program.cs` change). Nothing consumes the feed yet; registering it now would be dead code. Lands with the consuming PR.
- RID-based asset selection (`RidResolver`), download, SHA-256 validation, `UpdateCommand.ExecuteAsync` wiring, install-method detection, update notifier.

## Open questions

1. **SHA-256 source.** Spec says the install scripts verify SHA-256 against a published hash. Where does the canonical hash live today (release notes body? a separate JSON file in the assets list)? `ReleaseAsset.Sha256` is plumbed nullable; the install-script team needs to confirm before the downloader PR populates it.
2. **Pagination.** v1 fetches a single page of 100. The repo has ~50 releases historically. Open follow-up if we ever cross 100 and want `GetVersionAsync` to stay exhaustive.

## Test plan

- `dotnet build -c Release` clean (CI is `TreatWarningsAsErrors`).
- `dotnet test test/Func.Tests/Func.Tests.csproj`: 11 new tests pass, 1184 pre-existing tests pass, 1 unrelated `CompactRendererFunctionBrowserTests` flake (requires real TTY; reproduces on `main`).

## Test coverage table

| # | Scenario |
|---|----------|
| 1 | `GetLatestAsync(false)` returns latest stable, ignoring newer prereleases |
| 2 | `GetLatestAsync(true)` returns SemVer-max across all |
| 3 | Tag without leading `v` parses correctly |
| 4 | Unparseable tag skipped, no throw |
| 5 | `GetVersionAsync` exact match |
| 6 | `GetVersionAsync` returns null when not found |
| 7 | `Authorization: Bearer <token>` set when `GITHUB_TOKEN` present |
| 8 | `Authorization` absent when `GITHUB_TOKEN` unset |
| 9 | HTTP 403 + rate-limit → `GracefulException` mentions `GITHUB_TOKEN` |
| 10 | HTTP 503 → `GracefulException` |
| 11 | Pre-cancelled `CancellationToken` → `TaskCanceledException` |

Refs #5292.