### PR TITLE
Address install.ps1 review feedback from #5294

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ If a v4 `func` is already on PATH (e.g., from npm), the installer leaves it as t
 
 ### Options
 
-Pass flags to the installer using the patterns below. Run `Get-Help install.ps1` (PowerShell) or `install.sh --help` (Bash) for the full list (includes `-WhatIf` / `--dry-run`, `-Verbose`, `-SkipPath`, `-KeepArchive`).
+Pass flags to the installer using the patterns below. The PowerShell script also supports `-WhatIf` to preview changes without writing anything, plus the standard `-Verbose`, `-SkipPath`, and `-KeepArchive` switches; the Bash script exposes the same via `--dry-run`, `--verbose`, `--skip-path`, `--keep-archive`, and prints the full list with `--help`.
 
 | Option | PowerShell | Bash |
 |--------|-----------|------|
 | Include pre-releases | `iex "& { $(irm https://aka.ms/func-cli/install.ps1) } -Prerelease"` | `curl -sSL https://aka.ms/func-cli/install.sh \| bash -s -- --prerelease` |
 | Specific version | `iex "& { $(irm https://aka.ms/func-cli/install.ps1) } -Version 5.0.0"` | `curl -sSL https://aka.ms/func-cli/install.sh \| bash -s -- --version 5.0.0` |
 | Custom install dir | `iex "& { $(irm https://aka.ms/func-cli/install.ps1) } -InstallPath ~/my-tools"` | `curl -sSL https://aka.ms/func-cli/install.sh \| bash -s -- --install-path ~/my-tools` |
-| Show help | `Get-Help install.ps1` (after saving locally) or `install.ps1 -?` | `curl -sSL https://aka.ms/func-cli/install.sh \| bash -s -- --help` |
+| Preview without writing | `iex "& { $(irm https://aka.ms/func-cli/install.ps1) } -WhatIf"` | `curl -sSL https://aka.ms/func-cli/install.sh \| bash -s -- --dry-run` |
 
 The Bash script also still honours the legacy environment variables (`VERSION`, `PRERELEASE=true`, `INSTALL_DIR`, `FORCE=true`, `SOURCE`) for back-compat. Flags take precedence.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Pass flags to the installer using the patterns below. The PowerShell script also
 | Specific version | `iex "& { $(irm https://aka.ms/func-cli/install.ps1) } -Version 5.0.0"` | `curl -sSL https://aka.ms/func-cli/install.sh \| bash -s -- --version 5.0.0` |
 | Custom install dir | `iex "& { $(irm https://aka.ms/func-cli/install.ps1) } -InstallPath ~/my-tools"` | `curl -sSL https://aka.ms/func-cli/install.sh \| bash -s -- --install-path ~/my-tools` |
 | Preview without writing | `iex "& { $(irm https://aka.ms/func-cli/install.ps1) } -WhatIf"` | `curl -sSL https://aka.ms/func-cli/install.sh \| bash -s -- --dry-run` |
+| Show help | `iex "& { $(irm https://aka.ms/func-cli/install.ps1) } -Help"` | `curl -sSL https://aka.ms/func-cli/install.sh \| bash -s -- --help` |
 
 The Bash script also still honours the legacy environment variables (`VERSION`, `PRERELEASE=true`, `INSTALL_DIR`, `FORCE=true`, `SOURCE`) for back-compat. Flags take precedence.
 

--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ If a v4 `func` is already on PATH (e.g., from npm), the installer leaves it as t
 
 ### Options
 
-Pass flags to the installer using the patterns below. Run with `-Help` / `--help` for the full list (includes `-DryRun`, `-Verbose`, `-SkipPath`, `-KeepArchive`).
+Pass flags to the installer using the patterns below. Run `Get-Help install.ps1` (PowerShell) or `install.sh --help` (Bash) for the full list (includes `-WhatIf` / `--dry-run`, `-Verbose`, `-SkipPath`, `-KeepArchive`).
 
 | Option | PowerShell | Bash |
 |--------|-----------|------|
 | Include pre-releases | `iex "& { $(irm https://aka.ms/func-cli/install.ps1) } -Prerelease"` | `curl -sSL https://aka.ms/func-cli/install.sh \| bash -s -- --prerelease` |
 | Specific version | `iex "& { $(irm https://aka.ms/func-cli/install.ps1) } -Version 5.0.0"` | `curl -sSL https://aka.ms/func-cli/install.sh \| bash -s -- --version 5.0.0` |
 | Custom install dir | `iex "& { $(irm https://aka.ms/func-cli/install.ps1) } -InstallPath ~/my-tools"` | `curl -sSL https://aka.ms/func-cli/install.sh \| bash -s -- --install-path ~/my-tools` |
-| Show help | `iex "& { $(irm https://aka.ms/func-cli/install.ps1) } -Help"` | `curl -sSL https://aka.ms/func-cli/install.sh \| bash -s -- --help` |
+| Show help | `Get-Help install.ps1` (after saving locally) or `install.ps1 -?` | `curl -sSL https://aka.ms/func-cli/install.sh \| bash -s -- --help` |
 
 The Bash script also still honours the legacy environment variables (`VERSION`, `PRERELEASE=true`, `INSTALL_DIR`, `FORCE=true`, `SOURCE`) for back-compat. Flags take precedence.
 

--- a/install.ps1
+++ b/install.ps1
@@ -35,9 +35,7 @@
     Keep the downloaded archive and temp directory after install.
 
 .PARAMETER Help
-    Show help text. Provided because PowerShell's built-in -? and Get-Help
-    require the script to exist as a file on disk, which the documented
-    `irm | iex` install flow doesn't satisfy.
+    Show help text.
 #>
 
 [CmdletBinding(SupportsShouldProcess)]

--- a/install.ps1
+++ b/install.ps1
@@ -61,7 +61,7 @@ $Script:InvokedFromFile = -not [string]::IsNullOrEmpty($PSCommandPath)
 
 function Exit-Script {
     param([int] $Code = 0)
-    if ($Script:InvokedFromFile) { exit $Code } else { return }
+    if ($Script:InvokedFromFile) { exit $Code } else { return $Code }
 }
 
 # --- Logging ---

--- a/install.ps1
+++ b/install.ps1
@@ -32,6 +32,11 @@
 
 .PARAMETER KeepArchive
     Keep the downloaded archive and temp directory after install.
+
+.PARAMETER Help
+    Show help text. Provided because PowerShell's built-in -? and Get-Help
+    require the script to exist as a file on disk, which the documented
+    `irm | iex` install flow doesn't satisfy.
 #>
 
 [CmdletBinding(SupportsShouldProcess)]
@@ -43,7 +48,8 @@ param(
     [switch] $Prerelease,
     [switch] $Force,
     [switch] $SkipPath,
-    [switch] $KeepArchive
+    [switch] $KeepArchive,
+    [switch] $Help
 )
 
 $ErrorActionPreference = 'Stop'
@@ -82,6 +88,45 @@ function Write-Message {
         'Warning' { Write-Warning $Message }
         'Error'   { Write-Error $Message }
     }
+}
+
+# --- Help ---
+
+# We expose a custom -Help switch because PowerShell's built-in -? and
+# Get-Help both need the script to exist as a file PowerShell can resolve
+# by path. The documented install flow is `irm <url> | iex`, where the
+# script body is piped through Invoke-Expression and never lands on disk,
+# so neither built-in works there.
+if ($Help) {
+    Write-Message @"
+Azure Functions CLI installer
+
+DESCRIPTION:
+    Downloads and installs the func CLI for the current platform from GitHub Releases.
+
+PARAMETERS:
+    -InstallPath <string>       Directory to install the CLI (default: `$HOME\.azure-functions)
+    -Version <string>           Specific version to install (default: latest 5.x stable)
+    -Source <string>            GitHub repo to fetch releases from (default: Azure/azure-functions-core-tools)
+    -Prerelease                 Include pre-release versions when resolving latest
+    -Force                      Overwrite an existing installation
+    -SkipPath                   Do not update PATH or shell profile
+    -KeepArchive                Keep the downloaded archive after install
+    -WhatIf                     Show what would happen without making changes (built-in)
+    -Help                       Show this help message
+
+GITHUB ACTIONS:
+    When GITHUB_ACTIONS=true, the install dir is also appended to `$env:GITHUB_PATH so
+    func is available in subsequent workflow steps.
+
+EXAMPLES:
+    irm https://aka.ms/func-cli/install.ps1 | iex
+    iex "& { `$(irm https://aka.ms/func-cli/install.ps1) } -Prerelease"
+    iex "& { `$(irm https://aka.ms/func-cli/install.ps1) } -InstallPath C:\tools\func"
+    iex "& { `$(irm https://aka.ms/func-cli/install.ps1) } -Help"
+"@
+    Exit-Script 0
+    return
 }
 
 if (-not $InstallPath) { $InstallPath = $Script:DefaultInstallDir }

--- a/install.ps1
+++ b/install.ps1
@@ -36,9 +36,6 @@
 
 .PARAMETER DryRun
     Show what would happen without making changes.
-
-.PARAMETER Help
-    Show help text.
 #>
 
 [CmdletBinding()]
@@ -51,8 +48,7 @@ param(
     [switch] $Force,
     [switch] $SkipPath,
     [switch] $KeepArchive,
-    [switch] $DryRun,
-    [switch] $Help
+    [switch] $DryRun
 )
 
 $ErrorActionPreference = 'Stop'
@@ -91,45 +87,6 @@ function Write-Message {
         'Warning' { Write-Warning $Message }
         'Error'   { Write-Error $Message }
     }
-}
-
-# --- Help ---
-
-if ($Help) {
-    Write-Message @"
-Azure Functions CLI installer
-
-DESCRIPTION:
-    Downloads and installs the func CLI for the current platform from GitHub Releases.
-
-PARAMETERS:
-    -InstallPath <string>       Directory to install the CLI (default: `$HOME\.azure-functions)
-    -Version <string>           Specific version to install (default: latest 5.x stable)
-    -Source <string>            GitHub repo to fetch releases from (default: Azure/azure-functions-core-tools)
-    -Prerelease                 Include pre-release versions when resolving latest
-    -Force                      Overwrite an existing installation
-    -SkipPath                   Do not update PATH or shell profile
-    -KeepArchive                Keep the downloaded archive after install
-    -DryRun                     Show what would happen without making changes
-    -Help                       Show this help message
-
-GITHUB ACTIONS:
-    When GITHUB_ACTIONS=true, the install dir is also appended to `$env:GITHUB_PATH so
-    func is available in subsequent workflow steps.
-
-EXAMPLES:
-    .\install.ps1
-    .\install.ps1 -InstallPath C:\tools\func
-    .\install.ps1 -Version 5.0.0 -Force
-    .\install.ps1 -Prerelease
-
-    # Piped execution:
-    iex "& { `$(irm https://aka.ms/func-cli/install.ps1) }"
-    iex "& { `$(irm https://aka.ms/func-cli/install.ps1) } -Prerelease"
-    iex "& { `$(irm https://aka.ms/func-cli/install.ps1) } -InstallPath C:\tools\func"
-"@
-    Exit-Script 0
-    return
 }
 
 if (-not $InstallPath) { $InstallPath = $Script:DefaultInstallDir }

--- a/install.ps1
+++ b/install.ps1
@@ -33,12 +33,9 @@
 
 .PARAMETER KeepArchive
     Keep the downloaded archive and temp directory after install.
-
-.PARAMETER DryRun
-    Show what would happen without making changes.
 #>
 
-[CmdletBinding()]
+[CmdletBinding(SupportsShouldProcess)]
 param(
     [Alias('InstallDir')]
     [string] $InstallPath = "",
@@ -47,8 +44,7 @@ param(
     [switch] $Prerelease,
     [switch] $Force,
     [switch] $SkipPath,
-    [switch] $KeepArchive,
-    [switch] $DryRun
+    [switch] $KeepArchive
 )
 
 $ErrorActionPreference = 'Stop'
@@ -260,10 +256,7 @@ New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
 try {
     $downloadPath = Join-Path $tempDir $assetName
 
-    if ($DryRun) {
-        Write-Message "[DRY RUN] Would download $assetName from release $Version to $downloadPath"
-        Write-Message "[DRY RUN] Would extract to $InstallPath"
-    } else {
+    if ($PSCmdlet.ShouldProcess($InstallPath, "Download $assetName from release $Version and install func CLI")) {
         Write-Message "Downloading $assetName..."
         Get-GitHubReleaseAsset -Tag $Version -AssetName $assetName -OutFile $downloadPath
         New-Item -ItemType Directory -Path $InstallPath -Force | Out-Null
@@ -313,20 +306,20 @@ $pathProfilePath = $null
 
 if ($SkipPath) {
     Write-Message 'Skipping PATH update (-SkipPath).'
-} elseif ($DryRun) {
-    Write-Message "[DRY RUN] Would add $InstallPath to PATH"
 } elseif ($os -eq 'win') {
     $userPath = [Environment]::GetEnvironmentVariable('PATH', 'User')
     if ($userPath -notlike "*$InstallPath*") {
-        if ($existingFunc) {
-            $newPath = "$userPath;$InstallPath"
-            $env:PATH = "$env:PATH;$InstallPath"
-        } else {
-            $newPath = "$InstallPath;$userPath"
-            $env:PATH = "$InstallPath;$env:PATH"
+        if ($PSCmdlet.ShouldProcess('User PATH environment variable', "Add $InstallPath")) {
+            if ($existingFunc) {
+                $newPath = "$userPath;$InstallPath"
+                $env:PATH = "$env:PATH;$InstallPath"
+            } else {
+                $newPath = "$InstallPath;$userPath"
+                $env:PATH = "$InstallPath;$env:PATH"
+            }
+            [Environment]::SetEnvironmentVariable('PATH', $newPath, 'User')
+            $pathUpdated = $true
         }
-        [Environment]::SetEnvironmentVariable('PATH', $newPath, 'User')
-        $pathUpdated = $true
     }
 } else {
     if ($env:PATH -notlike "*$InstallPath*") {
@@ -336,23 +329,22 @@ if ($SkipPath) {
         } else {
             "export PATH=`"$InstallPath`:`$PATH`""
         }
-        Add-Content -Path $pathProfilePath -Value "`n# Added by Azure Functions CLI installer`n$exportLine"
-        $pathUpdated = $true
+        if ($PSCmdlet.ShouldProcess($pathProfilePath, "Append PATH export for $InstallPath")) {
+            Add-Content -Path $pathProfilePath -Value "`n# Added by Azure Functions CLI installer`n$exportLine"
+            $pathUpdated = $true
+        }
     }
 }
 
 # GitHub Actions: make func available in subsequent workflow steps.
 if ($env:GITHUB_ACTIONS -eq 'true' -and $env:GITHUB_PATH) {
-    if ($DryRun) {
-        Write-Message "[DRY RUN] Would append $InstallPath to `$env:GITHUB_PATH"
-    } else {
+    if ($PSCmdlet.ShouldProcess('$env:GITHUB_PATH', "Append $InstallPath")) {
         Add-Content -Path $env:GITHUB_PATH -Value $InstallPath
         Write-Message "Appended $InstallPath to `$env:GITHUB_PATH for subsequent workflow steps."
     }
 }
 
-if ($DryRun) {
-    Write-Message "[DRY RUN] func CLI $Version would be installed to $InstallPath" -Level Success
+if ($WhatIfPreference) {
     Exit-Script 0; return
 }
 
@@ -388,7 +380,7 @@ if ($existingFunc) {
 
 # --- Reload shell reminder ---
 
-if (-not $SkipPath -and -not $DryRun) {
+if (-not $SkipPath -and -not $WhatIfPreference) {
     if ($os -eq 'win') {
         Write-Message ''
         Write-Message 'Reload shell'

--- a/install.ps1
+++ b/install.ps1
@@ -10,8 +10,7 @@
     PATH so 'func' / 'func5' are available in new terminals.
 
     Piped usage:
-        iex "& { $(irm https://aka.ms/func-cli/install.ps1) }"
-        iex "& { $(irm https://aka.ms/func-cli/install.ps1) } -Prerelease"
+        irm https://aka.ms/func-cli/install.ps1 | iex
 
 .PARAMETER InstallPath
     Directory to install the CLI. Defaults to $HOME\.azure-functions.

--- a/install.ps1
+++ b/install.ps1
@@ -11,6 +11,7 @@
 
     Piped usage:
         irm https://aka.ms/func-cli/install.ps1 | iex
+        iex "& { $(irm https://aka.ms/func-cli/install.ps1) } -Prerelease"
 
 .PARAMETER InstallPath
     Directory to install the CLI. Defaults to $HOME\.azure-functions.


### PR DESCRIPTION
Addresses feedback from @jviau on #5294.

Three accepted, one investigated-and-kept (with rationale):

1. **~~Drop custom `-Help` switch~~ — investigated, kept.** Initially dropped on the assumption that `-?` / `Get-Help` cover it, but empirical testing against `https://aka.ms/func-cli/install.ps1` showed both built-ins require the script to exist as a file PowerShell can resolve by path:
   - `iex "& { $(irm <url>) } -?"` → `Cannot process argument because the value of argument "helpTarget" is null`
   - `Get-Help <url>` → `could not find ... in a help file`
   - `Get-Help` on a scriptblock built from `irm` content → `script block cannot be evaluated without input`
   - Save-to-disk + `Get-Help ./install.ps1` → works (control)

   Since the documented install flow is `irm | iex` (no file on disk), the custom `-Help` switch is the only thing that actually works there. Restored it with an inline comment explaining why it's not redundant.

2. **Replace `-DryRun` with built-in `-WhatIf`.** Added `[CmdletBinding(SupportsShouldProcess)]` and gated the side-effectful operations (download/extract, wrapper write, PATH mutation, GitHub Actions PATH append) with `$PSCmdlet.ShouldProcess(...)`. PowerShell now emits the standard `What if:` lines; `-Confirm` comes along for free. `install.sh` keeps `--dry-run` (no equivalent built-in in bash).

3. **Restore the simple `irm | iex` example in `.DESCRIPTION`.** Most users will paste the plain pipe form; the `iex "& { ... } -Flag"` pattern remains documented in the README options table for flag cases.

4. **Return the exit code from `Exit-Script`.** When invoked via `iex`, `Exit-Script` returns instead of calling `exit` (so the user's session survives). Now it returns the code as well so callers can still observe the status.

README also picked up a new "Preview without writing" row (`-WhatIf` / `--dry-run`) since that's now the documented dry-run path.

Verified:
- `bash -n install.sh` clean.
- `Get-Command ./install.ps1 -Syntax` shows `-Help`, `-WhatIf`, `-Confirm`; no `-DryRun`.
- `-WhatIf` run prints `What if:` lines and writes nothing.
- `-Help` prints the help block and exits 0.
- Full install (`-Prerelease -Force -SkipPath -InstallPath /tmp/...`) succeeds end-to-end and prints the side-by-side notice.