### PR TITLE
Add debug-workloads script for fast local workload iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,51 @@ export PATH="$PATH:$(pwd)/out/bin/Func/debug"
 func <command>
 ```
 
+### Run Locally with Workloads
+
+One-time bootstrap (per workload you want to test, into ./.debug-workloads/):
+
+```bash
+dotnet build src/Func/Func.csproj
+dotnet build src/Workloads/Stacks/Node/Workloads.Node.csproj \
+ -t:DeployForDebug -p:FuncCliEnsureWorkloadInstalled=true
+```
+
+That packs the workload, runs func workload install against `./.debug-workloads/`, and drops the freshly built DLL+PDB into the install dir.
+
+Inner loop (after editing workload source, no re-install, no pack):
+
+```bash
+dotnet build src/Workloads/Stacks/Node/Workloads.Node.csproj -t:DeployForDebug
+```
+
+> Just copies the new DLL+PDB over the installed one.
+
+Run the CLI against that home:
+
+```bash
+export FUNC_CLI_WORKLOADS_HOME="$PWD/.debug-workloads"
+./out/bin/Func/debug/func <args>
+```
+
+#### One-shot script
+
+`eng/scripts/debug-workloads.ps1` wraps the above for every workload in the repo, so you can bootstrap a full home in one command:
+
+```bash
+pwsh ./eng/scripts/debug-workloads.ps1                  # all workloads
+pwsh ./eng/scripts/debug-workloads.ps1 -Project Node    # just one
+pwsh ./eng/scripts/debug-workloads.ps1 -Clean           # wipe + reinstall
+```
+
+Inner loop with the script (sub-second, copy-only):
+
+```bash
+pwsh ./eng/scripts/debug-workloads.ps1 -Project Node -SkipFuncBuild
+```
+
+Reach for the `build-workloads` skill instead when what you're testing is `func workload install` itself (feed resolution, manifest behaviour, etc.). Otherwise the script above is faster because it skips the NuGet feed.
+
 ### Publish a Self-Contained Build
 
 ```bash

--- a/docs/building-a-workload.md
+++ b/docs/building-a-workload.md
@@ -438,8 +438,18 @@ loads.
 
 The auto-install mode only installs the workload you picked. For end-to-end
 runs (`func start`) you also need a host and the matching language worker
-installed, since workload installs are not transitive today. Two recipes:
+installed, since workload installs are not transitive today. Three recipes:
 
+- **Everything in one go (recommended)**: `eng/scripts/debug-workloads.ps1`
+  drives `DeployForDebug` for every workload in the repo, installing into
+  `.debug-workloads/` so VS Code F5 finds them.
+  ```bash
+  pwsh ./eng/scripts/debug-workloads.ps1            # all 12 workloads
+  pwsh ./eng/scripts/debug-workloads.ps1 -Project Node   # iterate on one
+  pwsh ./eng/scripts/debug-workloads.ps1 -Clean     # wipe + reinstall
+  ```
+  After the first run, subsequent runs are copy-only (sub-second per
+  workload).
 - **Single language, file-based**: pack and install just what you need.
   ```bash
   dotnet pack src/Workloads/Host/Workloads.Host.csproj                -c Debug -o /tmp/funcpkgs
@@ -449,8 +459,9 @@ installed, since workload installs are not transitive today. Two recipes:
   ./out/bin/Func/debug/func workload install /tmp/funcpkgs/Azure.Functions.Cli.Workloads.Workers.Node.*.nupkg
   ```
 - **All workloads via a local feed**: see the `build-workloads` skill in
-  `.github/skills/build-workloads/`. Pack-and-pushes every workload to a
-  Dockerized NuGet feed; install with `func workload install <alias> --source <feed>`.
+  `.github/skills/build-workloads/`. Use this when what you're testing is
+  `func workload install` itself (feed resolution, manifest behaviour, etc.).
+  Otherwise the script above is faster.
 
 Once bootstrapped, every F5 redeploys only the workload you're iterating on
 and leaves the rest of the home untouched.

--- a/eng/build/WorkloadDebug.targets
+++ b/eng/build/WorkloadDebug.targets
@@ -37,10 +37,11 @@
       <!-- func workload install normalises the package id to lowercase on disk. -->
       <_DeployForDebugPackageIdLower>$(PackageId.ToLowerInvariant())</_DeployForDebugPackageIdLower>
       <_DeployForDebugTargetDir>$(_DeployForDebugHome)/workloads/$(_DeployForDebugPackageIdLower)/$(PackageVersion)/tools/any</_DeployForDebugTargetDir>
+      <_DeployForDebugInstallVersionDir>$(_DeployForDebugHome)/workloads/$(_DeployForDebugPackageIdLower)/$(PackageVersion)</_DeployForDebugInstallVersionDir>
       <_DeployForDebugFuncDll>$(RepoRoot)out/bin/Func/debug/func.dll</_DeployForDebugFuncDll>
       <_DeployForDebugPackOutput>$(_DeployForDebugHome)/.pack-cache</_DeployForDebugPackOutput>
       <_DeployForDebugNupkg>$(_DeployForDebugPackOutput)/$(PackageId).$(PackageVersion).nupkg</_DeployForDebugNupkg>
-      <_DeployForDebugNeedsInstall Condition="!Exists('$(_DeployForDebugTargetDir)')">true</_DeployForDebugNeedsInstall>
+      <_DeployForDebugNeedsInstall Condition="!Exists('$(_DeployForDebugInstallVersionDir)')">true</_DeployForDebugNeedsInstall>
     </PropertyGroup>
 
     <!--
@@ -49,7 +50,7 @@
       install via `func workload install`).
     -->
     <Error Condition="'$(_DeployForDebugNeedsInstall)' == 'true' AND '$(FuncCliEnsureWorkloadInstalled)' != 'true'"
-           Text="DeployForDebug: '$(PackageId)' $(PackageVersion) is not installed at '$(_DeployForDebugTargetDir)'. Either rerun with -p:FuncCliEnsureWorkloadInstalled=true to auto-install (the &quot;auto-install&quot; VS Code launch config does this), or run `func workload install &lt;nupkg-or-id&gt;` against the same home first." />
+           Text="DeployForDebug: '$(PackageId)' $(PackageVersion) is not installed at '$(_DeployForDebugInstallVersionDir)'. Either rerun with -p:FuncCliEnsureWorkloadInstalled=true to auto-install (the &quot;auto-install&quot; VS Code launch config does this), or run `func workload install &lt;nupkg-or-id&gt;` against the same home first." />
 
     <Error Condition="'$(_DeployForDebugNeedsInstall)' == 'true' AND '$(FuncCliEnsureWorkloadInstalled)' == 'true' AND !Exists('$(_DeployForDebugFuncDll)')"
            Text="DeployForDebug: '$(PackageId)' isn't installed yet and func.dll wasn't found at '$(_DeployForDebugFuncDll)'. Build Func.csproj first." />
@@ -63,14 +64,14 @@
           Command='dotnet "$(_DeployForDebugFuncDll)" workload install "$(_DeployForDebugNupkg)" --force'
           EnvironmentVariables="FUNC_CLI_WORKLOADS_HOME=$(_DeployForDebugHome)" />
 
-    <Error Condition="'$(_DeployForDebugNeedsInstall)' == 'true' AND '$(FuncCliEnsureWorkloadInstalled)' == 'true' AND !Exists('$(_DeployForDebugTargetDir)')"
-           Text="DeployForDebug: install of '$(_DeployForDebugNupkg)' didn't produce '$(_DeployForDebugTargetDir)'. Check the func workload install output above." />
+    <Error Condition="'$(_DeployForDebugNeedsInstall)' == 'true' AND '$(FuncCliEnsureWorkloadInstalled)' == 'true' AND !Exists('$(_DeployForDebugInstallVersionDir)')"
+           Text="DeployForDebug: install of '$(_DeployForDebugNupkg)' didn't produce '$(_DeployForDebugInstallVersionDir)'. Check the func workload install output above." />
 
     <Message Condition="'$(PackageType)' == 'FuncCliWorkload' AND '$(_DeployForDebugNeedsInstall)' != 'true'"
              Importance="High"
-             Text="DeployForDebug: '$(PackageId)' $(PackageVersion) already installed at $(_DeployForDebugTargetDir)." />
+             Text="DeployForDebug: '$(PackageId)' $(PackageVersion) already installed at $(_DeployForDebugInstallVersionDir)." />
 
-    <ItemGroup Condition="'$(PackageType)' == 'FuncCliWorkload'">
+    <ItemGroup Condition="'$(PackageType)' == 'FuncCliWorkload' AND '$(IncludeBuildOutput)' != 'false'">
       <_DeployForDebugPayload Include="$(TargetPath)" />
       <_DeployForDebugPayload Include="$(TargetDir)$(TargetName).pdb" Condition="Exists('$(TargetDir)$(TargetName).pdb')" />
     </ItemGroup>

--- a/eng/scripts/debug-workloads.ps1
+++ b/eng/scripts/debug-workloads.ps1
@@ -1,0 +1,185 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Fast local inner loop for testing the func CLI with workloads, without
+    standing up a NuGet feed.
+
+.DESCRIPTION
+    Builds func once, then invokes the `DeployForDebug` MSBuild target on one
+    or more workload csprojs. `DeployForDebug` (eng/build/WorkloadDebug.targets)
+    packs + installs the workload on first use, and after that just copies the
+    freshly built DLL+PDB into the workload's install dir, so subsequent runs
+    are sub-second.
+
+    The resolved workloads home (default `<repo>/.debug-workloads`) is the same
+    one the VS Code launch profiles use, so you can pre-stage with this script
+    and then hit F5.
+
+    Use the build-workloads skill instead when what you're testing is
+    `func workload install/uninstall/list` or feed resolution itself; this
+    script bypasses the feed entirely.
+
+.PARAMETER Project
+    Workload(s) to deploy. Accepts a csproj path, a short name matching the
+    csproj filename without extension (e.g. `Workloads.Node`), or the last
+    folder segment (e.g. `Node`, `Workers.Node`). Omit to deploy every workload
+    discovered in Azure.Functions.Cli.slnx under src/Workloads/.
+
+.PARAMETER WorkloadsHome
+    Workloads home directory to deploy into. Default: `<repo>/.debug-workloads`.
+    The VS Code launch profiles read from the same path.
+
+.PARAMETER Configuration
+    Build configuration. Default: Debug (matches func.dll location used by
+    DeployForDebug for the first-install step).
+
+.PARAMETER Clean
+    Wipe the workloads home before deploying. Forces every workload to go
+    through the pack + install path again.
+
+.PARAMETER SkipFuncBuild
+    Skip the initial `dotnet build` of Func.csproj. Use when you know func.dll
+    is already current (e.g. you just built it from VS Code).
+
+.EXAMPLE
+    ./eng/scripts/debug-workloads.ps1
+    Deploys every workload into .debug-workloads/ (pack + install on first
+    run, copy-only thereafter).
+
+.EXAMPLE
+    ./eng/scripts/debug-workloads.ps1 -Project Node
+    Iterates on just the Node stack workload.
+
+.EXAMPLE
+    ./eng/scripts/debug-workloads.ps1 -Clean
+    Fresh start: wipes the home and reinstalls every workload.
+#>
+[CmdletBinding()]
+param(
+    [string[]] $Project,
+    [string] $WorkloadsHome,
+    [ValidateSet('Debug', 'Release')]
+    [string] $Configuration = 'Debug',
+    [switch] $Clean,
+    [switch] $SkipFuncBuild
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
+$slnxFile = Join-Path $repoRoot 'Azure.Functions.Cli.slnx'
+$funcCsproj = Join-Path $repoRoot 'src/Func/Func.csproj'
+
+if (-not $WorkloadsHome) { $WorkloadsHome = Join-Path $repoRoot '.debug-workloads' }
+$WorkloadsHome = [System.IO.Path]::GetFullPath($WorkloadsHome)
+
+function Invoke-Native {
+    param([Parameter(Mandatory)] [string] $File, [string[]] $Arguments)
+    & $File @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$File $($Arguments -join ' ') exited with code $LASTEXITCODE"
+    }
+}
+
+function Get-AllWorkloadProjects {
+    if (-not (Test-Path $slnxFile)) { throw "Solution file not found: $slnxFile" }
+    [xml] $slnx = Get-Content -Raw $slnxFile
+    $projects = $slnx.SelectNodes('//Project') |
+        ForEach-Object { $_.GetAttribute('Path') } |
+        Where-Object { $_ -and ($_ -replace '\\', '/').StartsWith('src/Workloads/') } |
+        Sort-Object -Unique
+    if (-not $projects) { throw "No workload projects found under src/Workloads/ in $slnxFile" }
+    $projects | ForEach-Object { Join-Path $repoRoot ($_ -replace '\\', '/') }
+}
+
+function Resolve-WorkloadProject {
+    param([Parameter(Mandatory)] [string] $Spec, [Parameter(Mandatory)] [string[]] $AllProjects)
+
+    if (Test-Path -LiteralPath $Spec -PathType Leaf) {
+        return (Resolve-Path -LiteralPath $Spec).Path
+    }
+
+    # Match by csproj filename (e.g. "Workloads.Node") or trailing path
+    # segment ("Node", "Workers/Node", "Stacks/Node"). Case-insensitive.
+    $normalized = ($Spec -replace '\\', '/').TrimEnd('/').ToLowerInvariant()
+    $hits = $AllProjects | Where-Object {
+        $proj = ($_ -replace '\\', '/').ToLowerInvariant()
+        $leaf = [System.IO.Path]::GetFileNameWithoutExtension($proj)
+        $leaf -eq $normalized -or $proj.EndsWith("/$normalized.csproj") -or $proj -like "*/$normalized/*.csproj"
+    }
+
+    if (-not $hits) {
+        $available = ($AllProjects | ForEach-Object { [System.IO.Path]::GetFileNameWithoutExtension($_) }) -join ', '
+        throw "No workload project matched '$Spec'. Available: $available"
+    }
+    if (@($hits).Count -gt 1) {
+        throw "Ambiguous workload spec '$Spec' matched: $($hits -join ', ')"
+    }
+    return @($hits)[0]
+}
+
+if ($Clean -and (Test-Path -LiteralPath $WorkloadsHome)) {
+    Write-Host "Cleaning workloads home: $WorkloadsHome" -ForegroundColor Cyan
+    Remove-Item -Recurse -Force -LiteralPath $WorkloadsHome
+}
+
+if (-not $SkipFuncBuild) {
+    Write-Host "Building func ($Configuration)..." -ForegroundColor Cyan
+    Invoke-Native -File 'dotnet' -Arguments @(
+        'build', $funcCsproj,
+        '-c', $Configuration,
+        '/clp:NoSummary',
+        '/v:m'
+    )
+}
+
+$allProjects = Get-AllWorkloadProjects
+if ($Project) {
+    $targets = @()
+    foreach ($spec in $Project) {
+        $targets += Resolve-WorkloadProject -Spec $spec -AllProjects $allProjects
+    }
+} else {
+    $targets = @($allProjects)
+}
+
+Write-Host "Deploying $(@($targets).Count) workload(s) to $WorkloadsHome" -ForegroundColor Cyan
+
+$failed = @()
+foreach ($proj in $targets) {
+    $name = [System.IO.Path]::GetFileNameWithoutExtension($proj)
+    Write-Host ""
+    Write-Host "==> $name" -ForegroundColor Cyan
+    try {
+        Invoke-Native -File 'dotnet' -Arguments @(
+            'build', $proj,
+            '-c', $Configuration,
+            '-t:DeployForDebug',
+            "-p:FuncCliWorkloadsHome=$WorkloadsHome",
+            '-p:FuncCliEnsureWorkloadInstalled=true',
+            '/clp:NoSummary',
+            '/v:m'
+        )
+    } catch {
+        Write-Warning "Failed to deploy $name : $_"
+        $failed += $name
+    }
+}
+
+Write-Host ""
+if ($failed.Count -gt 0) {
+    Write-Host "Failed: $($failed -join ', ')" -ForegroundColor Red
+    exit 1
+}
+
+$funcExe = if ($IsWindows) { 'func.exe' } else { 'func' }
+$funcPath = Join-Path $repoRoot "out/bin/Func/$($Configuration.ToLowerInvariant())/$funcExe"
+
+Write-Host "Done." -ForegroundColor Green
+Write-Host ""
+Write-Host "To drive the CLI against this home from your shell:" -ForegroundColor Cyan
+Write-Host "  export FUNC_CLI_WORKLOADS_HOME=`"$WorkloadsHome`""
+Write-Host "  $funcPath <args>"
+Write-Host ""
+Write-Host "Or hit F5 in VS Code with the `"Run func cli (debug workload)`" profile." -ForegroundColor DarkGray

--- a/eng/scripts/debug-workloads.ps1
+++ b/eng/scripts/debug-workloads.ps1
@@ -119,6 +119,18 @@ function Resolve-WorkloadProject {
     return @($hits)[0]
 }
 
+function Get-WorkloadRid {
+    param([Parameter(Mandatory)] [string] $Csproj)
+    # Host and Workers.Python override PackageId with `.<rid>` (matching what
+    # `func workload install` resolves from the feed for real users), so they
+    # have to be packed with -r <rid>. Detect that by looking for a
+    # <RuntimeIdentifiers> element in the csproj.
+    [xml] $proj = Get-Content -Raw $Csproj
+    $rids = $proj.SelectNodes('//RuntimeIdentifiers') | Select-Object -First 1
+    if (-not $rids -or [string]::IsNullOrWhiteSpace($rids.InnerText)) { return $null }
+    return [System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier
+}
+
 if ($Clean -and (Test-Path -LiteralPath $WorkloadsHome)) {
     Write-Host "Cleaning workloads home: $WorkloadsHome" -ForegroundColor Cyan
     Remove-Item -Recurse -Force -LiteralPath $WorkloadsHome
@@ -152,7 +164,7 @@ foreach ($proj in $targets) {
     Write-Host ""
     Write-Host "==> $name" -ForegroundColor Cyan
     try {
-        Invoke-Native -File 'dotnet' -Arguments @(
+        $buildArgs = @(
             'build', $proj,
             '-c', $Configuration,
             '-t:DeployForDebug',
@@ -161,6 +173,12 @@ foreach ($proj in $targets) {
             '/clp:NoSummary',
             '/v:m'
         )
+        $rid = Get-WorkloadRid -Csproj $proj
+        if ($rid) {
+            Write-Host "    (RID-aware workload, packing as -r $rid -p:PackAllRids=true)" -ForegroundColor DarkGray
+            $buildArgs += @('-r', $rid, '-p:PackAllRids=true')
+        }
+        Invoke-Native -File 'dotnet' -Arguments $buildArgs
     } catch {
         Write-Warning "Failed to deploy $name : $_"
         $failed += $name


### PR DESCRIPTION
## What

A faster local loop for testing the `func` CLI with workloads, without standing up BaGet.

### New: `eng/scripts/debug-workloads.ps1`

Wraps the `DeployForDebug` MSBuild target across one or every workload in the repo:

```bash
pwsh ./eng/scripts/debug-workloads.ps1                # all 12 workloads → ./.debug-workloads/
pwsh ./eng/scripts/debug-workloads.ps1 -Project Node  # one
pwsh ./eng/scripts/debug-workloads.ps1 -Clean         # wipe + reinstall
pwsh ./eng/scripts/debug-workloads.ps1 -Project Node -SkipFuncBuild  # sub-second copy-only inner loop
```

First run packs + installs each workload (~30s for all 12 on a warm cache); subsequent runs just copy fresh DLL+PDBs into the install dir.

### Bug fix: `eng/build/WorkloadDebug.targets`

Discovered while testing `-All`. Two related issues with content-only workloads (Host):

1. Post-install assertion checked `tools/any/` instead of the workload's version dir, so a successful Host install wrongly errored.
2. The DLL/PDB copy step ran for content-only packages, dropping an orphan DLL into `tools/any/` that nothing reads.

Both fixed by checking the version dir for install success and gating the copy on `IncludeBuildOutput != false`. The existing F5 launch profile for the Host stack would have hit the same bug.

### Docs

Updated `README.md` ("Run Locally with Workloads") and `docs/building-a-workload.md` to point at the new script. The `build-workloads` skill remains the right tool when what you're testing is `func workload install` itself.

## Verified

- All 12 workloads deploy cleanly into a fresh home.
- Re-running on one workload is copy-only (sub-second).
- Host workload (content-only) installs cleanly with no orphan files.