### PR TITLE
fix(func new): render resolution failures exactly once

### DIFF
--- a/src/Func/Templates/NewCommandRunner.cs
+++ b/src/Func/Templates/NewCommandRunner.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.CommandLine;
+using System.Diagnostics;
 using Azure.Functions.Cli.Bundles;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Configuration;
@@ -411,6 +412,14 @@ internal sealed class NewCommandRunner
             case ResolutionFailureKind.MissingLanguage:
                 _renderer.RenderMissingLanguage(failure.Stack!, failure.ProjectPath!);
                 break;
+
+            default:
+                // Guard against silently swallowing a future ResolutionFailureKind.
+                // Without this, a new enum value would return null from the caller
+                // with no user-visible error, reintroducing the class of bug this
+                // refactor exists to prevent.
+                throw new UnreachableException(
+                    $"Unhandled {nameof(ResolutionFailureKind)}: {failure.Kind}.");
         }
     }
 

--- a/src/Func/Templates/NewCommandRunner.cs
+++ b/src/Func/Templates/NewCommandRunner.cs
@@ -78,11 +78,14 @@ internal sealed class NewCommandRunner
     {
         ArgumentNullException.ThrowIfNull(invocation);
 
-        ResolvedContext? resolved = await ResolveContextAsync(invocation, cancellationToken);
-        if (resolved is null)
+        ResolutionOutcome outcome = await ResolveContextAsync(invocation, cancellationToken);
+        if (outcome.Failure is { } executeFailure)
         {
+            RenderResolutionFailure(executeFailure);
             return 1;
         }
+
+        ResolvedContext resolved = outcome.Context!;
 
         // Steps 11a / 11b: extension-bundle presence + min-bundle gate.
         // DotNet doesn't ship a templates-workload.json, so the gate is a
@@ -161,11 +164,14 @@ internal sealed class NewCommandRunner
     {
         ArgumentNullException.ThrowIfNull(invocation);
 
-        ResolvedContext? resolved = await ResolveContextAsync(invocation, cancellationToken);
-        if (resolved is null)
+        ResolutionOutcome outcome = await ResolveContextAsync(invocation, cancellationToken);
+        if (outcome.Failure is { } listFailure)
         {
+            RenderResolutionFailure(listFailure);
             return 1;
         }
+
+        ResolvedContext resolved = outcome.Context!;
 
         IReadOnlyList<FunctionTemplateInfo> templates = await ListTemplatesAsync(resolved, cancellationToken);
         if (templates.Count == 0)
@@ -212,6 +218,13 @@ internal sealed class NewCommandRunner
     /// overload on the execute path to map user-supplied values back to
     /// the v2 paramId the engine resolves against.
     /// </summary>
+    /// <remarks>
+    /// Pre-parse / hydration callers are best-effort: when resolution fails
+    /// they return <c>null</c> silently. Rendering the failure is the job of
+    /// the execute / list entry-points, which call <see cref="ResolveContextAsync"/>
+    /// themselves; rendering here too would surface the same error twice
+    /// (or three times, once #5304's third call site lands) for one invocation.
+    /// </remarks>
     public async Task<IReadOnlyList<HydratedTemplateOption>?> HydrateOptionsForTemplateWithIdsAsync(
         NewInvocation invocation,
         string templateId,
@@ -220,8 +233,8 @@ internal sealed class NewCommandRunner
         ArgumentNullException.ThrowIfNull(invocation);
         ArgumentException.ThrowIfNullOrWhiteSpace(templateId);
 
-        ResolvedContext? resolved = await ResolveContextAsync(invocation, cancellationToken);
-        if (resolved is null)
+        ResolutionOutcome outcome = await ResolveContextAsync(invocation, cancellationToken);
+        if (outcome.Context is not { } resolved)
         {
             return null;
         }
@@ -238,7 +251,7 @@ internal sealed class NewCommandRunner
         return _optionHydrator.HydrateWithIds(template);
     }
 
-    private async Task<ResolvedContext?> ResolveContextAsync(
+    private async Task<ResolutionOutcome> ResolveContextAsync(
         NewInvocation invocation,
         CancellationToken cancellationToken)
     {
@@ -259,8 +272,7 @@ internal sealed class NewCommandRunner
 
         if (projectResult is not ProjectResolutionResult.Resolved resolved)
         {
-            _renderer.RenderProjectRequired();
-            return null;
+            return ResolutionOutcome.Fail(new ResolutionFailure(ResolutionFailureKind.ProjectRequired));
         }
 
         string stack = resolved.Project.StackName;
@@ -283,30 +295,15 @@ internal sealed class NewCommandRunner
                 invocation.WorkingDirectory.Info, cancellationToken);
             if (section is null || string.IsNullOrWhiteSpace(section.Id))
             {
-                _interaction.WriteError(
-                    "Cannot resolve templates: host.json declares no extension bundle.");
-                _interaction.WriteLine(l => l
-                    .Muted("Configure ")
-                    .Code("extensionBundle.id")
-                    .Muted(" in host.json or run ")
-                    .Code("func init")
-                    .Muted(" with a stack that declares one."));
-                return null;
+                return ResolutionOutcome.Fail(new ResolutionFailure(ResolutionFailureKind.HostJsonBundleMissing));
             }
 
             bundleId = section.Id;
             if (!BundleHelpers.TryGetBundleChannel(bundleId, out channel))
             {
-                _interaction.WriteError($"Unrecognized extension bundle id '{bundleId}'.");
-                _interaction.WriteLine(l => l
-                    .Muted("Use one of: ")
-                    .Code(BundleHelpers.StableBundleId)
-                    .Muted(", ")
-                    .Code(BundleHelpers.PreviewBundleId)
-                    .Muted(", or ")
-                    .Code(BundleHelpers.ExperimentalBundleId)
-                    .Muted("."));
-                return null;
+                return ResolutionOutcome.Fail(new ResolutionFailure(
+                    ResolutionFailureKind.UnrecognisedBundleId,
+                    BundleId: bundleId));
             }
 
             IReadOnlyList<InstalledTemplatesWorkload> allRows =
@@ -318,24 +315,16 @@ internal sealed class NewCommandRunner
         {
             if (channel is BundleChannel.Unknown)
             {
-                _renderer.RenderNoTemplatesWorkloadInstalled(stack);
+                return ResolutionOutcome.Fail(new ResolutionFailure(
+                    ResolutionFailureKind.NoTemplatesWorkloadInstalled,
+                    Stack: stack));
             }
-            else
-            {
-                string channelName = channel.ToDisplayString();
-                string suggestedPkg = TemplatesWorkloadConstants.GetPackageId(stack);
-                string suggestedVer = channel == BundleChannel.Stable
-                    ? "<version>"
-                    : $"<version>-{channelName}.1";
-                _interaction.WriteError(
-                    $"No installed templates workload matches this project's bundle channel " +
-                    $"({bundleId} -> channel '{channelName}').");
-                _interaction.WriteLine(l => l
-                    .Muted("Install one with: ")
-                    .Code($"func workload install {suggestedPkg} --version {suggestedVer}")
-                    .Muted("."));
-            }
-            return null;
+
+            return ResolutionOutcome.Fail(new ResolutionFailure(
+                ResolutionFailureKind.NoTemplatesWorkloadForChannel,
+                Stack: stack,
+                BundleId: bundleId,
+                Channel: channel));
         }
 
         // Step 5: language resolution via IOptionsMonitor<StackOptions>.
@@ -344,17 +333,85 @@ internal sealed class NewCommandRunner
         string? language = ResolveLanguage(stack, stackOptionsBound);
         if (language is null)
         {
-            _renderer.RenderMissingLanguage(stack, projectDirectory);
-            return null;
+            return ResolutionOutcome.Fail(new ResolutionFailure(
+                ResolutionFailureKind.MissingLanguage,
+                Stack: stack,
+                ProjectPath: projectDirectory));
         }
 
-        return new ResolvedContext(
+        return ResolutionOutcome.Succeed(new ResolvedContext(
             invocation.WorkingDirectory,
             stack,
             language,
             workload,
             bundleId,
-            channel);
+            channel));
+    }
+
+    /// <summary>
+    /// Renders a single <see cref="ResolutionFailure"/>. Centralizing the
+    /// render here keeps <see cref="ResolveContextAsync"/> side-effect free:
+    /// each <see cref="ExecuteAsync"/> / <see cref="ListAsync"/> entry-point
+    /// renders the failure at most once, regardless of how many internal
+    /// resolution passes a caller adds (pre-parse / hydration paths run the
+    /// same resolver but consume the outcome silently).
+    /// </summary>
+    private void RenderResolutionFailure(ResolutionFailure failure)
+    {
+        switch (failure.Kind)
+        {
+            case ResolutionFailureKind.ProjectRequired:
+                _renderer.RenderProjectRequired();
+                break;
+
+            case ResolutionFailureKind.HostJsonBundleMissing:
+                _interaction.WriteError(
+                    "Cannot resolve templates: host.json declares no extension bundle.");
+                _interaction.WriteLine(l => l
+                    .Muted("Configure ")
+                    .Code("extensionBundle.id")
+                    .Muted(" in host.json or run ")
+                    .Code("func init")
+                    .Muted(" with a stack that declares one."));
+                break;
+
+            case ResolutionFailureKind.UnrecognisedBundleId:
+                _interaction.WriteError($"Unrecognized extension bundle id '{failure.BundleId}'.");
+                _interaction.WriteLine(l => l
+                    .Muted("Use one of: ")
+                    .Code(BundleHelpers.StableBundleId)
+                    .Muted(", ")
+                    .Code(BundleHelpers.PreviewBundleId)
+                    .Muted(", or ")
+                    .Code(BundleHelpers.ExperimentalBundleId)
+                    .Muted("."));
+                break;
+
+            case ResolutionFailureKind.NoTemplatesWorkloadInstalled:
+                _renderer.RenderNoTemplatesWorkloadInstalled(failure.Stack!);
+                break;
+
+            case ResolutionFailureKind.NoTemplatesWorkloadForChannel:
+                {
+                    string channelName = failure.Channel.ToDisplayString();
+                    string suggestedPkg = TemplatesWorkloadConstants.GetPackageId(failure.Stack!);
+                    string suggestedVer = failure.Channel == BundleChannel.Stable
+                        ? "<version>"
+                        : $"<version>-{channelName}.1";
+                    _interaction.WriteError(
+                        $"No installed templates workload matches this project's bundle channel " +
+                        $"({failure.BundleId} -> channel '{channelName}').");
+                    _interaction.WriteLine(l => l
+                        .Muted("Install one with: ")
+                        .Code($"func workload install {suggestedPkg} --version {suggestedVer}")
+                        .Muted("."));
+                    break;
+                }
+
+            case ResolutionFailureKind.MissingLanguage:
+                _renderer.RenderMissingLanguage(failure.Stack!, failure.ProjectPath!);
+                break;
+        }
     }
 
     private async Task<int> EnforceBundleGatesAsync(
@@ -650,6 +707,40 @@ internal sealed class NewCommandRunner
         InstalledTemplatesWorkload Workload,
         string? BundleId,
         BundleChannel Channel);
+
+    private enum ResolutionFailureKind
+    {
+        ProjectRequired,
+        HostJsonBundleMissing,
+        UnrecognisedBundleId,
+        NoTemplatesWorkloadInstalled,
+        NoTemplatesWorkloadForChannel,
+        MissingLanguage,
+    }
+
+    private sealed record ResolutionFailure(
+        ResolutionFailureKind Kind,
+        string? Stack = null,
+        string? ProjectPath = null,
+        string? BundleId = null,
+        BundleChannel Channel = BundleChannel.Unknown);
+
+    private readonly struct ResolutionOutcome
+    {
+        private ResolutionOutcome(ResolvedContext? context, ResolutionFailure? failure)
+        {
+            Context = context;
+            Failure = failure;
+        }
+
+        public ResolvedContext? Context { get; }
+
+        public ResolutionFailure? Failure { get; }
+
+        public static ResolutionOutcome Succeed(ResolvedContext context) => new(context, null);
+
+        public static ResolutionOutcome Fail(ResolutionFailure failure) => new(null, failure);
+    }
 }
 
 /// <summary>

--- a/src/Func/release_notes.md
+++ b/src/Func/release_notes.md
@@ -3,4 +3,5 @@
 #### Changes
 
 - Fix `func start` failing to resolve installed prerelease worker workloads against built-in profile ranges (e.g. `node [3.13.0]` now accepts `3.13.0-preview.1`). (#5286)
+- Fix `func new` printing the "Cannot determine language" error three times when `stack.language` is missing from `.func/config.json`. (#5306)
 

--- a/test/Func.Tests/Templates/NewCommandRunnerTests.cs
+++ b/test/Func.Tests/Templates/NewCommandRunnerTests.cs
@@ -1,0 +1,128 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Bundles;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Configuration;
+using Azure.Functions.Cli.Profiles;
+using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Templates;
+using Azure.Functions.Cli.Workers;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Functions.Cli.Tests.Templates;
+
+public class NewCommandRunnerTests
+{
+    [Fact]
+    public async Task ExecuteAsync_MissingLanguageOnMultiLanguageStack_RendersErrorExactlyOnce()
+    {
+        // Repro of https://github.com/Azure/azure-functions-core-tools/issues/5304:
+        // when `.func/config.json` is missing `stack.language` on a
+        // multi-language stack (dotnet), the missing-language error should
+        // surface exactly once for one `func new -t ...` invocation.
+        TestInteractionService interaction = new();
+        NewCommandRunner runner = BuildRunnerForMissingLanguage(interaction);
+
+        WorkingDirectory wd = new(new DirectoryInfo(Path.GetTempPath()), WasExplicit: false);
+        NewInvocation invocation = new(
+            WorkingDirectory: wd,
+            RequestedTemplate: "HttpTrigger",
+            RequestedFunctionName: null,
+            Force: false,
+            NonInteractive: true);
+
+        int exitCode = await runner.ExecuteAsync(invocation, CancellationToken.None);
+
+        Assert.Equal(1, exitCode);
+        int hits = interaction.Lines.Count(l => l.Contains("Cannot determine language for stack"));
+        Assert.True(hits == 1, $"expected the missing-language error to be rendered exactly once, but it was rendered {hits} times. Output:\n{interaction.AllOutput}");
+    }
+
+    [Fact]
+    public async Task ListAsync_MissingLanguageOnMultiLanguageStack_RendersErrorExactlyOnce()
+    {
+        TestInteractionService interaction = new();
+        NewCommandRunner runner = BuildRunnerForMissingLanguage(interaction);
+
+        WorkingDirectory wd = new(new DirectoryInfo(Path.GetTempPath()), WasExplicit: false);
+        NewInvocation invocation = new(
+            WorkingDirectory: wd,
+            RequestedTemplate: null,
+            RequestedFunctionName: null,
+            Force: false,
+            NonInteractive: true);
+
+        int exitCode = await runner.ListAsync(invocation, CancellationToken.None);
+
+        Assert.Equal(1, exitCode);
+        int hits = interaction.Lines.Count(l => l.Contains("Cannot determine language for stack"));
+        Assert.True(hits == 1, $"expected the missing-language error to be rendered exactly once, but it was rendered {hits} times. Output:\n{interaction.AllOutput}");
+    }
+
+    private static NewCommandRunner BuildRunnerForMissingLanguage(TestInteractionService interaction)
+    {
+        // Project resolver returns a multi-language dotnet project.
+        IFunctionsProjectResolver projectResolver = Substitute.For<IFunctionsProjectResolver>();
+        WorkingDirectory wd = new(new DirectoryInfo(Path.GetTempPath()), WasExplicit: false);
+        projectResolver
+            .ResolveProjectAsync(Arg.Any<ProjectResolutionContext>(), Arg.Any<CancellationToken>())
+            .Returns(ProjectResolutionResults.Resolved(new FakeDotNetProject(wd), "fake"));
+
+        // Profile resolver: no-op (returns whatever default Substitute provides).
+        IProfileResolver profileResolver = Substitute.For<IProfileResolver>();
+
+        // StackOptions: Language is null/empty, simulating the missing
+        // `stack.language` config we want the runner to surface.
+        IOptionsMonitor<StackOptions> stackOptions = Substitute.For<IOptionsMonitor<StackOptions>>();
+        stackOptions.Get(Arg.Any<string>()).Returns(new StackOptions { Runtime = "dotnet", Language = null });
+
+        // Installed templates workloads: return one row so the orchestrator
+        // gets past the "no workload installed" gate and reaches the
+        // language-resolution step that emits the error under test.
+        IInstalledTemplatesWorkloads installedTemplates = Substitute.For<IInstalledTemplatesWorkloads>();
+        installedTemplates
+            .ListInstalledAsync("dotnet", Arg.Any<CancellationToken>())
+            .Returns(new List<InstalledTemplatesWorkload>
+            {
+                new("dotnet", "1.0.0", Path.GetTempPath()),
+            });
+
+        // No project initializers registered: multi-language stack
+        // (initializer has > 1 SupportedLanguages or no entry), so the
+        // single-language fallback in ResolveLanguage cannot fire and the
+        // missing-language branch is taken.
+        return new NewCommandRunner(
+            interaction,
+            projectResolver,
+            profileResolver,
+            stackOptions,
+            projectInitializers: Array.Empty<IProjectInitializer>(),
+            installedTemplates,
+            new TemplateEngineProviderRegistry([]),
+            new TemplateOptionHydrator(Array.Empty<IProjectInitializer>()),
+            new TemplatePicker(interaction),
+            new NewCommandRenderer(interaction),
+            Substitute.For<IHostJsonBundleSectionReader>(),
+            Substitute.For<IExtensionBundleResolver>());
+    }
+
+    private sealed class FakeDotNetProject(WorkingDirectory workingDirectory) : FunctionsProject
+    {
+        private readonly WorkingDirectory _workingDirectory = workingDirectory;
+        private readonly FunctionsWorkerReference _workerReference =
+            FunctionsWorkerReference.FromWorkerInfo(".NET", "dotnet-isolated", "/tmp/worker.config.json", "1.0.0");
+
+        public override WorkingDirectory WorkingDirectory => _workingDirectory;
+
+        public override string StackName => "dotnet";
+
+        public override string StackDisplayName => ".NET";
+
+        public override bool SupportsExtensionBundles => false;
+
+        public override FunctionsWorkerReference WorkerReference => _workerReference;
+    }
+}


### PR DESCRIPTION
Resolves #5304

## Problem

When `.func/config.json` is missing `stack.language` on a multi-language stack (e.g. `dotnet`), running `func5 new -t Http` printed the same "Cannot determine language" error three times in a single invocation.

The root cause is that `NewCommandRunner.ResolveContextAsync` mixed resolution with rendering: every failure branch called `_renderer.RenderXxx(...)` (or `_interaction.WriteError`) inline and then returned `null`. Any caller that runs the resolver more than once (directly, or through a pre-parse / hydration pass) therefore prints the same error N times.

## Fix

Split resolution from rendering:

- `ResolveContextAsync` now returns a `ResolutionOutcome` (success carrying `ResolvedContext`, or a `ResolutionFailure` record carrying the failure kind + minimum metadata).
- All inline `_renderer` / `_interaction` calls inside the resolver are removed.
- `ExecuteAsync` and `ListAsync` each render the failure exactly once via a new `RenderResolutionFailure(failure)` helper.

This makes the duplication structurally impossible from a single entry-point call. Future pre-parse / hydration callers can now run the resolver silently and let the actual execute/list call render once.

## Tests

- New `NewCommandRunnerTests` exercises the missing-language path via both `ExecuteAsync` and `ListAsync` and asserts the error is rendered exactly once.
- Full suite: 1151 tests pass, clean build (0 warnings).

## Out of scope

- The upstream `func init` adoption gap (where the language was never persisted to begin with) is being fixed in #5300.