### PR TITLE
Inject IProcessEnvironment into ValidateHostWorkloadInitializationStep

### DIFF
--- a/src/Func/Commands/Start/Dashboard/Demo/DemoStartInitializationRunner.cs
+++ b/src/Func/Commands/Start/Dashboard/Demo/DemoStartInitializationRunner.cs
@@ -107,7 +107,7 @@ internal sealed class DemoStartInitializationRunner(
         [
             new ResolveProfileInitializationStep(_profileResolver),
             new ResolveConstraintsInitializationStep(),
-            new ValidateHostWorkloadInitializationStep(_hostWorkloadResolver, _workloadInstaller, _workloadPaths),
+            new ValidateHostWorkloadInitializationStep(_hostWorkloadResolver, _workloadInstaller, _workloadPaths, _processEnvironment),
             new ResolveFunctionsProjectInitializationStep(_projectResolver),
             new ResolveFunctionsWorkerInitializationStep(_workerResolverFactory, _workerInstaller),
             new ValidateExtensionBundleInitializationStep(

--- a/src/Func/Commands/Start/Initialization/Steps/ValidateHostWorkloadInitializationStep.cs
+++ b/src/Func/Commands/Start/Initialization/Steps/ValidateHostWorkloadInitializationStep.cs
@@ -12,7 +12,11 @@ namespace Azure.Functions.Cli.Commands.Start.Initialization;
 /// <summary>
 /// Validates that the requested host workload is available.
 /// </summary>
-internal sealed class ValidateHostWorkloadInitializationStep(IHostWorkloadResolver resolver, IWorkloadInstaller installer, IWorkloadPaths workloadPaths)
+internal sealed class ValidateHostWorkloadInitializationStep(
+    IHostWorkloadResolver resolver,
+    IWorkloadInstaller installer,
+    IWorkloadPaths workloadPaths,
+    IProcessEnvironment processEnvironment)
     : FuncStartInitializationStep
 {
     public const string StepId = "resolve_host_workload";
@@ -25,6 +29,7 @@ internal sealed class ValidateHostWorkloadInitializationStep(IHostWorkloadResolv
     private readonly IHostWorkloadResolver _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
     private readonly IWorkloadInstaller _installer = installer ?? throw new ArgumentNullException(nameof(installer));
     private readonly IWorkloadPaths _workloadPaths = workloadPaths ?? throw new ArgumentNullException(nameof(workloadPaths));
+    private readonly IProcessEnvironment _processEnvironment = processEnvironment ?? throw new ArgumentNullException(nameof(processEnvironment));
 
     public override string Id => StepId;
 
@@ -36,7 +41,7 @@ internal sealed class ValidateHostWorkloadInitializationStep(IHostWorkloadResolv
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        string? localContentRoot = Environment.GetEnvironmentVariable(HostContentRootEnvironmentVariable);
+        string? localContentRoot = _processEnvironment.Get(HostContentRootEnvironmentVariable);
         if (!string.IsNullOrWhiteSpace(localContentRoot))
         {
             ContentWorkloadInfo workload = CreateLocalContentWorkload(localContentRoot);

--- a/test/Func.Tests/Commands/HostWorkloadResolverTests.cs
+++ b/test/Func.Tests/Commands/HostWorkloadResolverTests.cs
@@ -188,7 +188,8 @@ public class HostWorkloadResolverTests
         var step = new ValidateHostWorkloadInitializationStep(
             resolver,
             Substitute.For<IWorkloadInstaller>(),
-            CreateWorkloadPaths());
+            CreateWorkloadPaths(),
+            Substitute.For<IProcessEnvironment>());
         StartInitializationStepContext context = NewStepContext(step, offline: true);
 
         GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
@@ -211,7 +212,8 @@ public class HostWorkloadResolverTests
         var step = new ValidateHostWorkloadInitializationStep(
             resolver,
             Substitute.For<IWorkloadInstaller>(),
-            CreateWorkloadPaths());
+            CreateWorkloadPaths(),
+            Substitute.For<IProcessEnvironment>());
         StartInitializationStepContext context = NewStepContext(step, offline: false);
 
         StartInitializationStepResult result = await step.ExecuteAsync(context, CancellationToken.None);


### PR DESCRIPTION
## Problem

`ValidateHostWorkloadInitializationStep.ExecuteAsync` read `FUNC_HOST_CONTENT_ROOT` directly via `Environment.GetEnvironmentVariable`. When that variable is set in the test process (or a CI agent), the step short-circuited before reaching the mocked `IHostWorkloadResolver`, breaking two unit tests:

- `ValidateStep_InstallRequiredAndOffline_ThrowsGracefulException`
- `ValidateStep_InstallRequiredAndOnline_AddsInstallStep`

This also violates the AGENTS.md rule against calling `Environment.*` directly from business logic.

## Fix

Thread the existing `IProcessEnvironment` seam (`src/Func/Common/`) through the step, the same way sibling init steps (`PrepareProjectHostRunInitializationStep`, `EnsureAzuriteInitializationStep`) already do. The two affected tests now construct the step with a substituted `IProcessEnvironment`, which returns `null` from `Get` by default and makes them deterministic regardless of ambient env.

## Verification

```
FUNC_HOST_CONTENT_ROOT=/tmp/anything dotnet test test/Func.Tests/Func.Tests.csproj --filter "FullyQualifiedName~HostWorkloadResolverTests"
# Before: 2 failed / 10 passed
# After:  12 passed
```

Full `Func.Tests` project: 942 passed, 0 failed.