### PR TITLE
docs: add v5 GA plan

### DIFF
--- a/proposed/v5-ga-plan.md
+++ b/proposed/v5-ga-plan.md
@@ -1,0 +1,328 @@
+# Azure Functions CLI v5: Path to GA
+
+Everything we need to GA the v5 CLI, grouped by area. Each bullet is an
+independently shippable work item (one issue / one PR scope).
+
+---
+
+## Workloads: Language workers & templates
+
+### PowerShell
+
+- Powershell stack workload
+- PowerShell worker workload
+- PowerShell templates workload
+
+### Java
+
+- Java stack workload
+- Java worker workload
+- Java templates workload
+
+### Go
+
+- Go templates workload
+
+### Quickstart
+
+- Extract `func quickstart` content from thin CLI into a workload
+- Quickstart workload publish pipeline (CI + feed)
+
+### Worker package layout
+
+- Host package per-RID layout cleanup (drop `.{rid}` suffix)
+- Python worker per-RID layout cleanup (drop `.{rid}` suffix)
+- Document the per-RID worker package convention
+
+## Workloads: Optional / advanced
+
+### Durable
+
+- `func durable get-history`
+- `func durable get-instances`
+- `func durable get-runtime-status`
+- `func durable purge-history`
+- `func durable raise-event`
+- `func durable rewind`
+- `func durable start-new`
+- `func durable terminate`
+- `func durable delete-task-hub`
+- Durable workload packaging + CI
+
+### Kubernetes / KEDA
+
+- `func kubernetes deploy`
+- `func kubernetes delete`
+- `func keda install`
+- `func keda remove`
+- KEDA scaler config generation helpers
+- Kubernetes workload packaging + CI
+
+### Azure Container Apps
+
+- Drop support in v5
+
+## Workloads: Ownership migration
+
+Move each workload to its source-of-truth repo so it ships with the thing it
+wraps.
+
+- Move .NET templates workload to templates repo
+- Move Node templates workload to templates repo
+- Move Python templates workload to templates repo
+- Move Node worker workload to node-worker repo
+- Move Python worker workload to python-worker repo
+- Move Java worker workload to java-worker repo
+- Move PowerShell worker workload to pwsh-worker repo
+- Move Host workload to host repo?
+- Document workload publisher onboarding (per-repo CI + feed publishing)
+
+---
+
+## Commands: Local development parity (from `main`)
+
+### `func settings`
+
+- `func settings add`
+- `func settings list`
+- `func settings delete`
+- `func settings encrypt`
+- `func settings decrypt`
+
+### `func extensions`
+
+- `func extensions install`
+- `func extensions sync`
+
+### Misc
+
+- `func templates list`: surface installed template metadata
+- `func logs`: host log streaming
+- `func azurite` lifecycle polish (start / stop / status UX)
+
+## Commands: `func pack`
+
+- `func pack` (custom / generic)
+- `func pack dotnet`
+- `func pack node`
+- `func pack python`
+- `func pack powershell`
+- `func pack go`
+- Pack options + validation helpers (shared)
+
+## Commands: Diagnostics (`func doctor`)
+
+- `func doctor` core scaffold
+- `func doctor`: dotnet SDK check
+- `func doctor`: workload manifest health check
+- `func doctor`: Azurite availability check
+- `func doctor`: port conflict check
+- `func doctor`: workload package cache check
+
+## Commands: CLI configuration (`func cli settings`)
+
+- Storage location + schema decision
+- `func cli settings get`
+- `func cli settings set`
+- `func cli settings unset`
+- `func cli settings list`
+
+## Commands: `func azure` group
+
+Need to discuss if we want a func azure workload or to invest in a better story for using az cli and azd instead
+
+- ADR: `func azure` group home (thin CLI vs workload)
+- `func azure login` / auth strategy (DefaultAzureCredential vs az shell-out)
+- `func azure publish` (function app publish)
+- `func azure fetch-app-settings`
+- `func azure add-storage-account-setting`
+- `func azure list-functions`
+- `func azure log-stream`
+
+---
+
+## Infrastructure: Templating
+
+- ADR: templating engine location (separate package vs per-workload vs
+  shared library). Blocks Go/durable/k8s workloads.
+- Prototype the chosen templating engine approach
+
+## Infrastructure: Profiles CDN
+
+- Pick CDN + path scheme
+- Publishing pipeline
+- Versioning + cache-bust strategy
+- Switch `func setup` / profile commands to CDN
+
+## Infrastructure: Schema store
+
+- Publish `workload.json` schema
+- Publish `workloads.json` schema
+- Publish profile config schema
+- Audit vnext for other authored configs and publish them
+- Add `$schema` references in samples and docs
+
+## Infrastructure: CI / ADO pipelines
+
+- Dedicated ADO **public-build** pipeline for vnext (stop depending on the
+  `main` branch pipeline)
+- Dedicated ADO **official/signed-build** pipeline for vnext
+- vnext PR validation triggers (branch + path filters)
+- Document vnext pipeline ownership + GA rollover plan (what happens when
+  vnext becomes main)
+
+---
+
+## Distribution: Installer
+
+- Installer E2E: Windows x64
+- Installer E2E: Windows arm64
+- Installer E2E: macOS x64
+- Installer E2E: macOS arm64
+- Installer E2E: Linux x64
+- Installer E2E: Linux arm64
+
+## Distribution: Package channels
+
+- Homebrew formula update for v5
+- npm package policy decision (deprecation pointer vs full install)
+- npm package implementation per chosen policy
+- winget manifest
+- Chocolatey package
+- Scoop manifest
+- apt repo (or document install.sh as the apt path)
+- rpm repo (or document install.sh as the rpm path)
+
+## Distribution: Signing
+
+- Authenticode signing for Windows binaries in release pipeline
+- macOS notarization for published archive
+- Document signature verification for users
+
+## Distribution: Updates
+
+- `func --version` opt-in new-version-available check
+- `func update` command (or documented installer re-run pointer)
+  - Currently in progress
+
+---
+
+## Telemetry & diagnostics
+
+- Telemetry vendor / pipeline decision
+- Telemetry opt-in/opt-out wiring via `func cli settings`
+- Honor `DO_NOT_TRACK`
+- Per-command timing + outcome instrumentation
+- PII scrubbing helpers
+- Crash reporting: unhandled exception capture
+- Crash reporting: stack scrubbing
+- `--verbose` audit across all commands
+- Consistent log scope IDs per command
+
+---
+
+## Docs: External
+
+- learn.microsoft.com Functions Core Tools refresh for v5
+- Rebrand user-facing strings to "Azure Functions CLI"
+- Update Azure Functions docs sample snippets to v5
+
+## Docs: In-repo
+
+- README rewrite for v5
+- CONTRIBUTING refresh
+- repo-structure.md refresh
+- building-a-workload.md refresh
+- v4 → v5 command map (in-repo)
+
+## Docs: UX
+
+- `--help` audit: every command has a one-line description
+- `--help` audit: every option has a one-line description
+- Error messages include next-step hints
+- `func completion bash`
+- `func completion zsh`
+- `func completion pwsh`
+- `func completion fish`
+
+---
+
+## Quality
+
+- E2E CI: install → init → start → publish for .NET
+- E2E CI: Node
+- E2E CI: Python
+- E2E CI: PowerShell
+- E2E CI: Java
+- E2E CI: Go
+- Performance budget: define cold-start target
+- Performance budget: enforce in CI
+
+---
+
+## Migration & v4 deprecation
+
+- v4 → v5 migration guide content
+- v4 → v5 command map (companion to in-repo docs item)
+- v4 → v5 behavior diffs catalog
+- v4 → v5 known gaps page
+- `func --version` v4-detected migration pointer
+- `local.settings.json` schema compatibility audit
+- `host.json` schema compatibility audit
+- Document any breaking schema changes
+- v4 deprecation timeline (public announcement)
+- v4 security-only support window decision
+- v4 archive / sunset date decision
+
+---
+
+## Hardening
+
+### Security
+
+- Token handling review
+- Workload package signature verification
+- NuGet feed pinning
+- Supply-chain audit
+
+### Localization
+
+- Decision (in-scope for GA or defer)
+- Implementation (if in-scope)
+
+### Accessibility
+
+- NO_COLOR audit
+- Non-TTY audit
+- Screen-reader friendliness via `IInteractionService`
+
+---
+
+## Release process
+
+- Switch default branch (vnext → main, or rename)
+- Cut `v5.0.0` tag
+- Comprehensive v5.0.0 release notes (full delta from v4 latest)
+- Issue templates refresh
+- Triage process documented
+- Post-GA 30-day SLA decision + comms
+
+---
+
+## Cross-cutting / not yet bucketed
+
+- Third-party command extensibility (plugin model beyond workloads)
+- Extension bundles management UX: dedicated `func bundles` group?
+- Workload feed strategy: public NuGet only vs dedicated feed (affects
+  offline / airgapped story)
+
+---
+
+## Open questions
+
+1. Templating engine location (blocks Go/durable/k8s workloads).
+2. Workload ownership migration sequencing (templates first, then workers,
+   or all at once?).
+3. `func azure` group: thin CLI or workload?
+4. Telemetry vendor / pipeline.
+5. Distribution package matrix: GA-required vs post-GA.

--- a/proposed/v5-ga-plan.md
+++ b/proposed/v5-ga-plan.md
@@ -131,6 +131,12 @@ Implement func doctor command.
   - Azurite availability check
   - port conflict check
   - workload package cache check
+- Integrate with [`azure-functions-skills`](https://github.com/Azure/azure-functions-skills):
+  the skills repo already ships a doctor command that runs LLM-driven
+  skills to validate config + code (~53% of incoming ICMs could be
+  prevented by keeping these skills current). Decide whether
+  `func doctor` shells out to the skills runtime, or whether the skills'
+  doctor calls into `func doctor` for the deterministic checks.
 
 ### Schema store
 

--- a/proposed/v5-ga-plan.md
+++ b/proposed/v5-ga-plan.md
@@ -1,72 +1,117 @@
 # Azure Functions CLI v5: Path to GA
 
-Everything we need to GA the v5 CLI, grouped by area. Each bullet is an
-independently shippable work item (one issue / one PR scope).
+Everything we need to GA the v5 CLI, organized by milestone. Each bullet
+is one issue / one PR scope (unless explicitly informational).
 
 ---
 
-## Workloads: Language workers & templates
+## Milestone 1 (Now: August)
 
-### PowerShell
+GitHub milestone: [v5 Milestone 1](https://github.com/Azure/azure-functions-core-tools/milestone/104)
 
-- Powershell stack workload
-- PowerShell worker workload
-- PowerShell templates workload
+Themes: release CI + profiles integration, tech debt cleanup, parity
+(Java + PowerShell), quickstart-as-workload, `func update`.
 
-### Java
+- Implement Java worker workload (#5319)
+- Implement Java stack workload (#5320)
+- Implement PowerShell worker workload (#5321)
+- Implement PowerShell stack workload (#5322)
+- Implement PowerShell templates workload (#5323)
+- Extract `func quickstart` content from the core CLI into a workload (#5324)
+- Create quickstart workload release pipeline (#5325)
+- Drop `.{rid}` suffix from workload packages (host + python) (#5326)
+- Implement Go templates workload (#5327)
+- Design: v4 + v5 release story (parallel release, workload alignment,
+  distribution channels, rollback) (#5328)
+- Design: profile updates as part of release pipelines (#5329)
+- Refactor templates engine out of the core CLI (#5330)
+- Set up dedicated ADO pipelines for vnext (#5331)
+- Stand up profiles CDN (#5332)
+- Implement `func update` command (#5333)
 
-- Java stack workload
-- Java worker workload
-- Java templates workload
+---
 
-### Go
+## Milestone 2
 
-- Go templates workload
+Themes: parity (durable + pack + custom handlers), CLI settings / config, tooling story.
 
-### Quickstart
+### Parity: Durable
 
-- Extract `func quickstart` content from thin CLI into a workload
-- Quickstart workload publish pipeline (CI + feed)
+- Implement durable workload
+- Setup durable workload CI/CD
 
-### Worker package layout
+### Parity: `func pack`
 
-- Host package per-RID layout cleanup (drop `.{rid}` suffix)
-- Python worker per-RID layout cleanup (drop `.{rid}` suffix)
-- Document the per-RID worker package convention
+- Design: new `func pack` experience & AZ CLI integration
 
-## Workloads: Optional / advanced
+### CLI settings / config
 
-### Durable
+- Design: figure out the settings story (local settings json / .env / app.settings etc.)
 
-- `func durable get-history`
-- `func durable get-instances`
-- `func durable get-runtime-status`
-- `func durable purge-history`
-- `func durable raise-event`
-- `func durable rewind`
-- `func durable start-new`
-- `func durable terminate`
-- `func durable delete-task-hub`
-- Durable workload packaging + CI
+### Tooling integrations
 
-### Kubernetes / KEDA
+External tools that embed or invoke `func`. For each: confirm v5 compat,
+ship updates, document the integration contract so it doesn't silently
+break on a CLI change.
 
-- `func kubernetes deploy`
-- `func kubernetes delete`
-- `func keda install`
-- `func keda remove`
-- KEDA scaler config generation helpers
-- Kubernetes workload packaging + CI
+#### VS Code (Azure Functions extension)
 
-### Azure Container Apps
+- Audit current `func` invocation sites in the extension
+- Update extension to detect + prefer v5 install
+- Coordinate release of extension version that supports v5
+- Document the CLI-to-extension contract (commands, JSON output shapes,
+  exit codes the extension depends on)
 
-- Drop support in v5
+#### Visual Studio (Azure Functions tooling)
 
-## Workloads: Ownership migration
+- Audit current `func` invocation sites
+- Update VS tooling to support v5
+- Coordinate release with the VS tooling team
+- Document the CLI-to-VS contract
 
-Move each workload to its source-of-truth repo so it ships with the thing it
-wraps.
+#### Azure CLI (`az functionapp` integrations)
 
+- Audit `az` codepaths that shell out to `func`
+- Update `az` to support v5
+- Coordinate release with the `az` team
+
+#### Rider (JetBrains Azure Toolkit)
+
+- Audit Rider plugin `func` invocation sites
+- Update plugin to support v5
+- Coordinate release with the JetBrains plugin owners
+
+#### IntelliJ (JetBrains Azure Toolkit)
+
+- Audit IntelliJ plugin `func` invocation sites
+- Update plugin to support v5
+- Coordinate release with the JetBrains plugin owners
+
+#### Tooling: shared
+
+- Stable, documented CLI contract for tooling consumers (output shapes,
+  exit codes, version-detection command)
+- Breaking-change communication channel for tooling owners
+- Pre-release / preview CLI builds available to tooling teams for
+  validation before GA
+
+---
+
+## Milestone 3
+
+Themes: Kubernetes/KEDA decision, workload ownership migration, `func
+doctor`, schema store publishing.
+
+### Investigate Kubernetes / KEDA usage in v4
+
+- Pull telemetry on `func kubernetes` + `func keda` usage in v4
+- Decision: ship a v5 Kubernetes/KEDA workload, or drop?
+- If shipping: open implementation issues (kubernetes deploy/delete,
+  keda install/remove, scaler helpers, workload packaging + CI)
+
+### Workload ownership + migration to owner repos
+
+- Document workload publisher onboarding (per-repo CI + feed publishing)
 - Move .NET templates workload to templates repo
 - Move Node templates workload to templates repo
 - Move Python templates workload to templates repo
@@ -74,143 +119,34 @@ wraps.
 - Move Python worker workload to python-worker repo
 - Move Java worker workload to java-worker repo
 - Move PowerShell worker workload to pwsh-worker repo
-- Move Host workload to host repo?
-- Document workload publisher onboarding (per-repo CI + feed publishing)
+- Move Host workload to host repo
 
----
+### `func doctor`
 
-## Commands: Local development parity (from `main`)
+Implement func doctor command.
 
-### `func settings`
+- Some troubleshoot area ideas:
+  - dotnet SDK check
+  - workload manifest health check
+  - Azurite availability check
+  - port conflict check
+  - workload package cache check
 
-- `func settings add`
-- `func settings list`
-- `func settings delete`
-- `func settings encrypt`
-- `func settings decrypt`
+### Schema store
 
-### `func extensions`
-
-- `func extensions install`
-- `func extensions sync`
-
-### Misc
-
-- `func templates list`: surface installed template metadata
-- `func logs`: host log streaming
-- `func azurite` lifecycle polish (start / stop / status UX)
-
-## Commands: `func pack`
-
-- `func pack` (custom / generic)
-- `func pack dotnet`
-- `func pack node`
-- `func pack python`
-- `func pack powershell`
-- `func pack go`
-- Pack options + validation helpers (shared)
-
-## Commands: Diagnostics (`func doctor`)
-
-- `func doctor` core scaffold
-- `func doctor`: dotnet SDK check
-- `func doctor`: workload manifest health check
-- `func doctor`: Azurite availability check
-- `func doctor`: port conflict check
-- `func doctor`: workload package cache check
-
-## Commands: CLI configuration (`func cli settings`)
-
-- Storage location + schema decision
-- `func cli settings get`
-- `func cli settings set`
-- `func cli settings unset`
-- `func cli settings list`
-
-## Commands: `func azure` group
-
-Need to discuss if we want a func azure workload or to invest in a better story for using az cli and azd instead
-
-- ADR: `func azure` group home (thin CLI vs workload)
-- `func azure login` / auth strategy (DefaultAzureCredential vs az shell-out)
-- `func azure publish` (function app publish)
-- `func azure fetch-app-settings`
-- `func azure add-storage-account-setting`
-- `func azure list-functions`
-- `func azure log-stream`
-
----
-
-## Infrastructure: Templating
-
-- ADR: templating engine location (separate package vs per-workload vs
-  shared library). Blocks Go/durable/k8s workloads.
-- Prototype the chosen templating engine approach
-
-## Infrastructure: Profiles CDN
-
-- Pick CDN + path scheme
-- Publishing pipeline
-- Versioning + cache-bust strategy
-- Switch `func setup` / profile commands to CDN
-
-## Infrastructure: Schema store
+Publish all defined schemas in the new CLI.
 
 - Publish `workload.json` schema
 - Publish `workloads.json` schema
-- Publish profile config schema
+- Publish profile schema
+- Publish .func/config.json schema
 - Audit vnext for other authored configs and publish them
 - Add `$schema` references in samples and docs
 
-## Infrastructure: CI / ADO pipelines
-
-- Dedicated ADO **public-build** pipeline for vnext (stop depending on the
-  `main` branch pipeline)
-- Dedicated ADO **official/signed-build** pipeline for vnext
-- vnext PR validation triggers (branch + path filters)
-- Document vnext pipeline ownership + GA rollover plan (what happens when
-  vnext becomes main)
-
----
-
-## Distribution: Installer
-
-- Installer E2E: Windows x64
-- Installer E2E: Windows arm64
-- Installer E2E: macOS x64
-- Installer E2E: macOS arm64
-- Installer E2E: Linux x64
-- Installer E2E: Linux arm64
-
-## Distribution: Package channels
-
-- Homebrew formula update for v5
-- npm package policy decision (deprecation pointer vs full install)
-- npm package implementation per chosen policy
-- winget manifest
-- Chocolatey package
-- Scoop manifest
-- apt repo (or document install.sh as the apt path)
-- rpm repo (or document install.sh as the rpm path)
-
-## Distribution: Signing
-
-- Authenticode signing for Windows binaries in release pipeline
-- macOS notarization for published archive
-- Document signature verification for users
-
-## Distribution: Updates
-
-- `func --version` opt-in new-version-available check
-- `func update` command (or documented installer re-run pointer)
-  - Currently in progress
-
----
-
-## Telemetry & diagnostics
+### Telemetry & diagnostics
 
 - Telemetry vendor / pipeline decision
-- Telemetry opt-in/opt-out wiring via `func cli settings`
+- Telemetry opt-in/opt-out wiring
 - Honor `DO_NOT_TRACK`
 - Per-command timing + outcome instrumentation
 - PII scrubbing helpers
@@ -221,21 +157,27 @@ Need to discuss if we want a func azure workload or to invest in a better story 
 
 ---
 
-## Docs: External
+## Future milestones / backlog
+
+Not yet assigned to a milestone. Grouped by area for easy sorting.
+
+### Docs
+
+#### External
 
 - learn.microsoft.com Functions Core Tools refresh for v5
 - Rebrand user-facing strings to "Azure Functions CLI"
 - Update Azure Functions docs sample snippets to v5
 
-## Docs: In-repo
+#### In-Repo
 
 - README rewrite for v5
 - CONTRIBUTING refresh
 - repo-structure.md refresh
 - building-a-workload.md refresh
-- v4 → v5 command map (in-repo)
+- v4 -> v5 command map (in-repo)
 
-## Docs: UX
+#### UX
 
 - `--help` audit: every command has a one-line description
 - `--help` audit: every option has a one-line description
@@ -245,27 +187,41 @@ Need to discuss if we want a func azure workload or to invest in a better story 
 - `func completion pwsh`
 - `func completion fish`
 
----
+### Quality
 
-## Quality
+E2E testing and performance.
 
-- E2E CI: install → init → start → publish for .NET
-- E2E CI: Node
-- E2E CI: Python
-- E2E CI: PowerShell
-- E2E CI: Java
-- E2E CI: Go
+- E2E testing
 - Performance budget: define cold-start target
 - Performance budget: enforce in CI
 
----
+### Parity Audit
 
-## Migration & v4 deprecation
+#### Languages (audit matrix)
 
-- v4 → v5 migration guide content
-- v4 → v5 command map (companion to in-repo docs item)
-- v4 → v5 behavior diffs catalog
-- v4 → v5 known gaps page
+- Living parity matrix doc (per-language v4 vs v5)
+- .NET in-proc parity audit
+- .NET isolated parity audit
+- Node parity audit
+- Python parity audit
+- PowerShell parity audit
+- Java parity audit
+- Go parity audit
+
+#### Tools / extensions
+
+- Extension bundles parity audit
+- KEDA / Kubernetes tooling parity audit
+- Azure Container Apps tooling parity audit
+- Custom handlers parity audit
+- Worker indexing model parity (v4 -> v5)
+
+### Migration & v4 deprecation
+
+- v4 -> v5 migration guide content
+- v4 -> v5 command map (companion to in-repo docs)
+- v4 -> v5 behavior diffs catalog
+- v4 -> v5 known gaps page
 - `func --version` v4-detected migration pointer
 - `local.settings.json` schema compatibility audit
 - `host.json` schema compatibility audit
@@ -274,16 +230,13 @@ Need to discuss if we want a func azure workload or to invest in a better story 
 - v4 security-only support window decision
 - v4 archive / sunset date decision
 
----
-
-## Hardening
-
 ### Security
 
 - Token handling review
 - Workload package signature verification
 - NuGet feed pinning
 - Supply-chain audit
+- Threat modeling
 
 ### Localization
 
@@ -296,11 +249,9 @@ Need to discuss if we want a func azure workload or to invest in a better story 
 - Non-TTY audit
 - Screen-reader friendliness via `IInteractionService`
 
----
+### Release process (GA cutover)
 
-## Release process
-
-- Switch default branch (vnext → main, or rename)
+- Switch default branch (vnext -> main, or rename)
 - Cut `v5.0.0` tag
 - Comprehensive v5.0.0 release notes (full delta from v4 latest)
 - Issue templates refresh
@@ -309,20 +260,52 @@ Need to discuss if we want a func azure workload or to invest in a better story 
 
 ---
 
-## Cross-cutting / not yet bucketed
+## Release Process Notes
 
-- Third-party command extensibility (plugin model beyond workloads)
-- Extension bundles management UX: dedicated `func bundles` group?
-- Workload feed strategy: public NuGet only vs dedicated feed (affects
-  offline / airgapped story)
+Everything related to shipping v5 to users. Most of these are
+informational (decisions, channel coverage, comms) rather than discrete
+issues. Pulled out into issues only when they need active work.
 
----
+### Distribution: installer (info)
 
-## Open questions
+Installer scripts already exist (`install.sh`, `install.ps1`). Coverage
+to validate before GA: Windows x64, Windows arm64, macOS x64, macOS arm64,
+Linux x64, Linux arm64.
 
-1. Templating engine location (blocks Go/durable/k8s workloads).
-2. Workload ownership migration sequencing (templates first, then workers,
-   or all at once?).
-3. `func azure` group: thin CLI or workload?
-4. Telemetry vendor / pipeline.
-5. Distribution package matrix: GA-required vs post-GA.
+### Distribution: package channels (info)
+
+Channels to make a per-channel decision on before GA:
+
+- Homebrew
+- npm (keep / deprecation-pointer / drop)
+- winget
+- Chocolatey
+- Scoop
+- apt
+- rpm
+
+### Distribution: signing (info)
+
+- Authenticode signing for Windows binaries in release pipeline
+- macOS notarization for the published archive
+- Documented signature verification for users
+
+#### Release story
+
+- v4 + v5 parallel cadence + branding split
+- Side-by-side install story across channels
+- Bug-fix backport policy v5 -> v4 during parallel window
+- Coordinated release notes across v4 and v5
+- Define rollback per distribution channel
+- Per-channel rollback playbook (npm, brew, winget, choco, scoop, apt,
+  rpm, installer scripts, CDN profiles)
+- Workload rollback story (unlist/yank without breaking older CLIs)
+- Profiles rollback (pinned previous-version URLs + CDN cache purge)
+- Incident comms template
+- Base CLI / workload version compatibility matrix
+- Coordinated release tagging across owner repos
+- Aggregate workload release notes into CLI release notes
+- Cross-repo release readiness checklist
+- Channel-by-channel release-day checklist
+- Cross-channel version-bump automation
+- Release-day per-channel status tracker

--- a/proposed/v5-ga-plan.md
+++ b/proposed/v5-ga-plan.md
@@ -37,63 +37,30 @@ Themes: parity (durable + pack + custom handlers), CLI settings / config, toolin
 
 ### Parity: Durable
 
-- Implement durable workload
-- Setup durable workload CI/CD
+- Implement durable workload (#5340)
+- Setup durable workload CI/CD (#5341)
 
 ### Parity: `func pack`
 
-- Design: new `func pack` experience & AZ CLI integration
+- Design: new `func pack` experience & AZ CLI integration (#5342)
 
 ### CLI settings / config
 
-- Design: figure out the settings story (local settings json / .env / app.settings etc.)
+- Design: figure out the settings story (local settings json / .env / app.settings etc.) (#5343)
 
-### Tooling integrations
+### Tooling: notify partner teams (#5344)
 
-External tools that embed or invoke `func`. For each: confirm v5 compat,
-ship updates, document the integration contract so it doesn't silently
-break on a CLI change.
+Reach out to teams that ship tools embedding `func` so they have a head
+start migrating from v4 and can raise concerns before GA. We're not
+asking them to release anything; this is awareness + intake. Reference
+doc: https://aka.ms/func-cli.
 
-#### VS Code (Azure Functions extension)
-
-- Audit current `func` invocation sites in the extension
-- Update extension to detect + prefer v5 install
-- Coordinate release of extension version that supports v5
-- Document the CLI-to-extension contract (commands, JSON output shapes,
-  exit codes the extension depends on)
-
-#### Visual Studio (Azure Functions tooling)
-
-- Audit current `func` invocation sites
-- Update VS tooling to support v5
-- Coordinate release with the VS tooling team
-- Document the CLI-to-VS contract
-
-#### Azure CLI (`az functionapp` integrations)
-
-- Audit `az` codepaths that shell out to `func`
-- Update `az` to support v5
-- Coordinate release with the `az` team
-
-#### Rider (JetBrains Azure Toolkit)
-
-- Audit Rider plugin `func` invocation sites
-- Update plugin to support v5
-- Coordinate release with the JetBrains plugin owners
-
-#### IntelliJ (JetBrains Azure Toolkit)
-
-- Audit IntelliJ plugin `func` invocation sites
-- Update plugin to support v5
-- Coordinate release with the JetBrains plugin owners
-
-#### Tooling: shared
-
-- Stable, documented CLI contract for tooling consumers (output shapes,
-  exit codes, version-detection command)
-- Breaking-change communication channel for tooling owners
-- Pre-release / preview CLI builds available to tooling teams for
-  validation before GA
+- Notify VS Code Azure Functions extension team + capture feedback
+- Notify Visual Studio Azure Functions tooling team + capture feedback
+- Notify Azure CLI (`az functionapp`) team + capture feedback
+- Notify Rider Azure Toolkit team + capture feedback
+- Notify IntelliJ Azure Toolkit team + capture feedback
+- Triage any concerns raised into follow-up issues before GA
 
 ---
 
@@ -102,14 +69,14 @@ break on a CLI change.
 Themes: Kubernetes/KEDA decision, workload ownership migration, `func
 doctor`, schema store publishing.
 
-### Investigate Kubernetes / KEDA usage in v4
+### Investigate Kubernetes / KEDA usage in v4 (#5345)
 
 - Pull telemetry on `func kubernetes` + `func keda` usage in v4
 - Decision: ship a v5 Kubernetes/KEDA workload, or drop?
 - If shipping: open implementation issues (kubernetes deploy/delete,
   keda install/remove, scaler helpers, workload packaging + CI)
 
-### Workload ownership + migration to owner repos
+### Workload ownership + migration to owner repos (#5346)
 
 - Document workload publisher onboarding (per-repo CI + feed publishing)
 - Move .NET templates workload to templates repo
@@ -121,7 +88,7 @@ doctor`, schema store publishing.
 - Move PowerShell worker workload to pwsh-worker repo
 - Move Host workload to host repo
 
-### `func doctor`
+### `func doctor` (#5347)
 
 Implement func doctor command.
 
@@ -138,7 +105,7 @@ Implement func doctor command.
   `func doctor` shells out to the skills runtime, or whether the skills'
   doctor calls into `func doctor` for the deterministic checks.
 
-### Schema store
+### Schema store (#5348)
 
 Publish all defined schemas in the new CLI.
 
@@ -149,7 +116,7 @@ Publish all defined schemas in the new CLI.
 - Audit vnext for other authored configs and publish them
 - Add `$schema` references in samples and docs
 
-### Telemetry & diagnostics
+### Telemetry & diagnostics (#5349)
 
 - Telemetry vendor / pipeline decision
 - Telemetry opt-in/opt-out wiring
@@ -167,7 +134,7 @@ Publish all defined schemas in the new CLI.
 
 Not yet assigned to a milestone. Grouped by area for easy sorting.
 
-### Docs
+### Docs (epic: #5350)
 
 #### External
 
@@ -185,9 +152,9 @@ Not yet assigned to a milestone. Grouped by area for easy sorting.
 
 #### UX
 
-- `--help` audit: every command has a one-line description
-- `--help` audit: every option has a one-line description
-- Error messages include next-step hints
+- `--help` audit: every command has a one-line description (#5351)
+- `--help` audit: every option has a one-line description (#5351)
+- Error messages include next-step hints (#5352)
 - `func completion bash`
 - `func completion zsh`
 - `func completion pwsh`
@@ -197,11 +164,11 @@ Not yet assigned to a milestone. Grouped by area for easy sorting.
 
 E2E testing and performance.
 
-- E2E testing
-- Performance budget: define cold-start target
-- Performance budget: enforce in CI
+- E2E testing (#5353)
+- Performance budget: define cold-start target (#5354)
+- Performance budget: enforce in CI (#5354)
 
-### Parity Audit
+### Parity Audit (epic: #5355)
 
 #### Languages (audit matrix)
 
@@ -224,19 +191,19 @@ E2E testing and performance.
 
 ### Migration & v4 deprecation
 
-- v4 -> v5 migration guide content
-- v4 -> v5 command map (companion to in-repo docs)
-- v4 -> v5 behavior diffs catalog
-- v4 -> v5 known gaps page
-- `func --version` v4-detected migration pointer
-- `local.settings.json` schema compatibility audit
-- `host.json` schema compatibility audit
-- Document any breaking schema changes
-- v4 deprecation timeline (public announcement)
-- v4 security-only support window decision
-- v4 archive / sunset date decision
+- v4 -> v5 migration guide content (#5356)
+- v4 -> v5 command map (companion to in-repo docs) (#5356)
+- v4 -> v5 behavior diffs catalog (#5356)
+- v4 -> v5 known gaps page (#5356)
+- `func --version` v4-detected migration pointer (#5357)
+- `local.settings.json` schema compatibility audit (#5358)
+- `host.json` schema compatibility audit (#5358)
+- Document any breaking schema changes (#5358)
+- v4 deprecation timeline (public announcement) (#5359)
+- v4 security-only support window decision (#5359)
+- v4 archive / sunset date decision (#5359)
 
-### Security
+### Security (#5360)
 
 - Token handling review
 - Workload package signature verification
@@ -244,18 +211,18 @@ E2E testing and performance.
 - Supply-chain audit
 - Threat modeling
 
-### Localization
+### Localization (#5361)
 
 - Decision (in-scope for GA or defer)
 - Implementation (if in-scope)
 
-### Accessibility
+### Accessibility (#5362)
 
 - NO_COLOR audit
 - Non-TTY audit
 - Screen-reader friendliness via `IInteractionService`
 
-### Release process (GA cutover)
+### Release process (GA cutover) (#5363)
 
 - Switch default branch (vnext -> main, or rename)
 - Cut `v5.0.0` tag


### PR DESCRIPTION
Adds `proposed/v5-ga-plan.md`: a working list of everything we need to GA the v5 CLI, grouped by area. Each bullet is intended to be one issue / PR scope.

Open as draft for review and discussion. The 'Open questions' section at the bottom captures the things I want to resolve before we start picking up items.

Source: drafted in a Copilot CLI session, mirrored here for review.