### PR TITLE
Convert release notes to Keep a Changelog format

### DIFF
--- a/.github/skills/create-workload/SKILL.md
+++ b/.github/skills/create-workload/SKILL.md
@@ -77,7 +77,16 @@ Create the following files:
   ```markdown
   # Azure.Functions.Cli.Workloads.<Name>
 
-  ## 1.0.0-preview.1
+  All notable changes to this package are documented here.
+
+  The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+  and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+  ## [Unreleased]
+
+  ## [1.0.0-preview.1]
+
+  ### Added
 
   - Initial scaffold of the <Name> workload (entry point + stub project initializer).
   ```

--- a/docs/building-a-workload.md
+++ b/docs/building-a-workload.md
@@ -141,7 +141,16 @@ And a `release_notes.md`:
 ```markdown
 # Azure.Functions.Cli.Workloads.Node
 
-## 1.0.0-preview.1
+All notable changes to this package are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0-preview.1]
+
+### Added
 
 - Initial scaffold of the Node.js workload (entry point + stub project initializer).
 ```

--- a/src/Abstractions/release_notes.md
+++ b/src/Abstractions/release_notes.md
@@ -1,6 +1,14 @@
-# Azure Functions CLI Abstractions 1.0.0
+# Azure Functions CLI Abstractions
 
-#### Changes
+All notable changes to this package are documented here.
 
-- Added `FunctionsProject.Language` virtual property so workloads can report the detected project language to the CLI (used by `func init` adopt mode). (#5300)
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [1.0.0]
+
+### Added
+
+- `FunctionsProject.Language` virtual property so workloads can report the detected project language to the CLI (used by `func init` adopt mode). (#5300)

--- a/src/Func/release_notes.md
+++ b/src/Func/release_notes.md
@@ -1,10 +1,21 @@
-# Azure Functions CLI 5.0.0
+# Azure Functions CLI
 
-#### Changes
+All notable changes to this package are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [5.0.0]
+
+### Changed
 
 - `func init` now adopts an existing project's language (writes `stack.language` to `.func/config.json`) using the runtime project resolver. (#5300)
 - `func init` heals a `.func/config.json` that has `stack.runtime` but no `stack.language` on a multi-language stack, instead of refusing with "pass --force". Other top-level keys (profiles, etc.) are preserved. (#5300)
 - Clarified the `func new` "missing language" hint to mention both scaffolding and adopting an existing project. (#5300)
-- Fix `func start` failing to resolve installed prerelease worker workloads against built-in profile ranges (e.g. `node [3.13.0]` now accepts `3.13.0-preview.1`). (#5286)
-- Fix `func new` printing the "Cannot determine language" error three times when `stack.language` is missing from `.func/config.json`. (#5306)
 
+### Fixed
+
+- `func start` failing to resolve installed prerelease worker workloads against built-in profile ranges (e.g. `node [3.13.0]` now accepts `3.13.0-preview.1`). (#5286)
+- `func new` printing the "Cannot determine language" error three times when `stack.language` is missing from `.func/config.json`. (#5306)

--- a/src/Workloads/Host/release_notes.md
+++ b/src/Workloads/Host/release_notes.md
@@ -1,4 +1,14 @@
 # Azure.Functions.Cli.Workloads.Host
 
-## 1.0.0-preview.1
+All notable changes to this package are documented here.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0-preview.1]
+
+### Added
+
+- Initial preview release.

--- a/src/Workloads/Stacks/DotNet/release_notes.md
+++ b/src/Workloads/Stacks/DotNet/release_notes.md
@@ -1,8 +1,20 @@
 # Azure.Functions.Cli.Workloads.DotNet
 
-## 1.0.0-preview.2
+All notable changes to this package are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0-preview.2]
+
+### Changed
 
 - `func init` adopt mode now reports the project language to the CLI so it gets written to `.func/config.json`.
 
-## 1.0.0-preview.1
+## [1.0.0-preview.1]
 
+### Added
+
+- Initial preview release.

--- a/src/Workloads/Stacks/Go/release_notes.md
+++ b/src/Workloads/Stacks/Go/release_notes.md
@@ -1,4 +1,14 @@
 # Azure.Functions.Cli.Workloads.Go
 
-## 1.0.0-preview.1
+All notable changes to this package are documented here.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0-preview.1]
+
+### Added
+
+- Initial preview release.

--- a/src/Workloads/Stacks/Node/release_notes.md
+++ b/src/Workloads/Stacks/Node/release_notes.md
@@ -1,8 +1,20 @@
 # Azure.Functions.Cli.Workloads.Node
 
-## 1.0.0-preview.2
+All notable changes to this package are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0-preview.2]
+
+### Changed
 
 - `func init` adopt mode now reports the project language (JavaScript or TypeScript) to the CLI so it gets written to `.func/config.json`.
 
-## 1.0.0-preview.1
+## [1.0.0-preview.1]
 
+### Added
+
+- Initial preview release.

--- a/src/Workloads/Stacks/Python/release_notes.md
+++ b/src/Workloads/Stacks/Python/release_notes.md
@@ -1,4 +1,14 @@
 # Azure.Functions.Cli.Workloads.Python
 
-## 1.0.0-preview.1
+All notable changes to this package are documented here.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0-preview.1]
+
+### Added
+
+- Initial preview release.

--- a/src/Workloads/Templates/DotNet/release_notes.md
+++ b/src/Workloads/Templates/DotNet/release_notes.md
@@ -1,4 +1,14 @@
 # Azure.Functions.Cli.Workloads.Templates.DotNet
 
-## 1.0.1
+All notable changes to this package are documented here.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.1]
+
+### Added
+
+- Initial release.

--- a/src/Workloads/Templates/Node/release_notes.md
+++ b/src/Workloads/Templates/Node/release_notes.md
@@ -1,4 +1,14 @@
 # Azure.Functions.Cli.Workloads.Templates.Node
 
-## 1.0.1
+All notable changes to this package are documented here.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.1]
+
+### Added
+
+- Initial release.

--- a/src/Workloads/Templates/Python/release_notes.md
+++ b/src/Workloads/Templates/Python/release_notes.md
@@ -1,4 +1,14 @@
 # Azure.Functions.Cli.Workloads.Templates.Python
 
-## 1.0.1
+All notable changes to this package are documented here.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.1]
+
+### Added
+
+- Initial release.

--- a/src/Workloads/Tools/ExtensionBundles/release_notes.md
+++ b/src/Workloads/Tools/ExtensionBundles/release_notes.md
@@ -1,0 +1,8 @@
+# Azure.Functions.Cli.Workloads.ExtensionBundles
+
+All notable changes to this package are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/src/Workloads/Workers/Go/release_notes.md
+++ b/src/Workloads/Workers/Go/release_notes.md
@@ -1,4 +1,14 @@
 # Azure.Functions.Cli.Workloads.Workers.Go
 
-## 1.0.0-preview.1
+All notable changes to this package are documented here.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0-preview.1]
+
+### Added
+
+- Initial preview release.

--- a/src/Workloads/Workers/Node/release_notes.md
+++ b/src/Workloads/Workers/Node/release_notes.md
@@ -1,4 +1,14 @@
 # Azure.Functions.Cli.Workloads.Workers.Node
 
-## 3.13.0
+All notable changes to this package are documented here.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [3.13.0]
+
+### Added
+
+- Initial release.

--- a/src/Workloads/Workers/Python/release_notes.md
+++ b/src/Workloads/Workers/Python/release_notes.md
@@ -1,5 +1,14 @@
 # Azure.Functions.Cli.Workloads.Workers.Python
 
-## 4.43.0-preview.2
+All notable changes to this package are documented here.
 
-- fix: address per-RID content files missing in nupkg (#5285)
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [4.43.0-preview.2]
+
+### Fixed
+
+- Per-RID content files missing in nupkg. (#5285)


### PR DESCRIPTION
Migrates every `release_notes.md` in the repo to the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) model so each package has a consistent, scannable history with an `## [Unreleased]` section ready for new entries.

### Changes

- All 14 `release_notes.md` files (`src/Func`, `src/Abstractions`, and every workload under `src/Workloads/**`) updated with:
  - Standard header explaining the format + SemVer link.
  - `## [Unreleased]` section.
  - Existing entries preserved, grouped under `### Added` / `### Changed` / `### Fixed`.
  - Seed entry added to previously empty/stub files.
- `docs/building-a-workload.md` and `.github/skills/create-workload/SKILL.md` examples updated to match.

MSBuild integration is unchanged: `eng/build/Release.props` still points `ReleaseNotesFile` at `release_notes.md` and `Release.targets` inlines the file verbatim into `PackageReleaseNotes`. Verified by packing `Abstractions` successfully.