### PR TITLE
Tag-driven channel + version for bundles and templates workloads

### DIFF
--- a/eng/build/Release.props
+++ b/eng/build/Release.props
@@ -46,7 +46,16 @@
     <!-- Only set public release if this is a release tag or a release branch -->
     <!-- tag must be 'v{Version}', '{name}-v{Version}', or '{name}/v{Version}' for a match -->
     <!-- release branch must be refs/heads/release/* -->
-    <PublicReleaseTag Condition="$([System.Text.RegularExpressions.Regex]::IsMatch($(BUILD_SOURCEBRANCH), `refs/tags/(?:.*[-/])?v.*`))">$(BUILD_SOURCEBRANCHNAME)</PublicReleaseTag>
+    <!--
+      PublicReleaseTag is the full tag name (e.g. 'v4.0.0', 'host-v4.20.0',
+      'bundles/v4.35.0-preview.1'). We strip the 'refs/tags/' prefix from
+      BUILD_SOURCEBRANCH rather than using BUILD_SOURCEBRANCHNAME, which
+      only returns the last path segment and would drop the workload
+      prefix from slash-namespaced tags ('v4.35.0-preview.1' instead of
+      'bundles/v4.35.0-preview.1'). The full tag is needed so the GitHub
+      release link in release notes resolves correctly.
+    -->
+    <PublicReleaseTag Condition="$([System.Text.RegularExpressions.Regex]::IsMatch($(BUILD_SOURCEBRANCH), `refs/tags/(?:.*[-/])?v.*`))">$(BUILD_SOURCEBRANCH.Substring(10))</PublicReleaseTag>
     <PublicRelease>false</PublicRelease>
     <PublicRelease Condition="'$(PublicReleaseTag)' != ''">true</PublicRelease>
     <PublicRelease Condition="'$(BUILD_SOURCEBRANCH)' != '' AND $(BUILD_SOURCEBRANCH.StartsWith('refs/heads/release/'))">true</PublicRelease>

--- a/eng/ci/release/official-release.workload.bundles.yml
+++ b/eng/ci/release/official-release.workload.bundles.yml
@@ -15,3 +15,7 @@ extends:
     folder: workloads/bundles
     projects: |
       $(Build.SourcesDirectory)/src/Workloads/Tools/ExtensionBundles/Workloads.ExtensionBundles.csproj
+    tagSpec:
+      tagPrefix: bundles
+      allowChannels: true
+    build_args: -p:BundleVersion=$(ReleaseTagVersion) -p:BundleChannel=$(ReleaseTagChannel) -p:VersionSuffix=$(ReleaseTagSuffix)

--- a/eng/ci/release/official-release.workload.templates.dotnet.yml
+++ b/eng/ci/release/official-release.workload.templates.dotnet.yml
@@ -15,3 +15,7 @@ extends:
     folder: workloads/templates/dotnet
     projects: |
       $(Build.SourcesDirectory)/src/Workloads/Templates/DotNet/Workloads.Templates.DotNet.csproj
+    tagSpec:
+      tagPrefix: templates-dotnet
+      allowChannels: false
+    build_args: -p:TemplatesVersion=$(ReleaseTagVersion)

--- a/eng/ci/release/official-release.workload.templates.node.yml
+++ b/eng/ci/release/official-release.workload.templates.node.yml
@@ -15,3 +15,7 @@ extends:
     folder: workloads/templates/node
     projects: |
       $(Build.SourcesDirectory)/src/Workloads/Templates/Node/Workloads.Templates.Node.csproj
+    tagSpec:
+      tagPrefix: templates-node
+      allowChannels: true
+    build_args: -p:TemplatesVersion=$(ReleaseTagVersion) -p:TemplatesChannel=$(ReleaseTagChannel) -p:VersionSuffix=$(ReleaseTagSuffix)

--- a/eng/ci/release/official-release.workload.templates.python.yml
+++ b/eng/ci/release/official-release.workload.templates.python.yml
@@ -15,3 +15,7 @@ extends:
     folder: workloads/templates/python
     projects: |
       $(Build.SourcesDirectory)/src/Workloads/Templates/Python/Workloads.Templates.Python.csproj
+    tagSpec:
+      tagPrefix: templates-python
+      allowChannels: true
+    build_args: -p:TemplatesVersion=$(ReleaseTagVersion) -p:TemplatesChannel=$(ReleaseTagChannel) -p:VersionSuffix=$(ReleaseTagSuffix)

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -13,6 +13,13 @@ parameters:
 - name: build_args
   type: string
   default: ''
+- name: tagSpec
+  # Optional. When set with a tagPrefix, a parse-workload-tag step runs
+  # before Restore and exposes ReleaseTagVersion / ReleaseTagChannel /
+  # ReleaseTagSuffix to subsequent steps. Shape:
+  # { tagPrefix: string, allowChannels: boolean (default true) }
+  type: object
+  default: {}
 
 jobs:
 - job: build
@@ -44,6 +51,15 @@ jobs:
     - template: /eng/ci/templates/steps/setup-dependencies.yml@self
       parameters:
         sign: ${{ parameters.sign }}
+
+    - ${{ if parameters.tagSpec.tagPrefix }}:
+      - template: /eng/ci/templates/steps/parse-workload-tag.yml@self
+        parameters:
+          tagPrefix: ${{ parameters.tagSpec.tagPrefix }}
+          ${{ if ne(parameters.tagSpec.allowChannels, false) }}:
+            allowChannels: true
+          ${{ else }}:
+            allowChannels: false
 
     - task: DotNetCoreCLI@2
       displayName: Restore

--- a/eng/ci/templates/jobs/validate-workload-tag.yml
+++ b/eng/ci/templates/jobs/validate-workload-tag.yml
@@ -1,0 +1,36 @@
+parameters:
+- name: tagPrefix
+  type: string
+- name: allowChannels
+  type: boolean
+  default: true
+
+jobs:
+- job: ValidateTag
+  displayName: Validate ${{ parameters.tagPrefix }} tag
+  templateContext:
+    type: validationJob
+
+  steps:
+  - checkout: none
+
+  - pwsh: |
+      $source = "$(Build.SourceBranch)"
+      $prefix = '${{ parameters.tagPrefix }}'
+      $allowChannels = [System.Boolean]::Parse('${{ parameters.allowChannels }}')
+
+      if ($allowChannels) {
+        $pattern = "^refs/tags/$([regex]::Escape($prefix))/v(\d+\.\d+\.\d+)(?:-(preview|experimental)\.(\d+))?$"
+        $expected = "refs/tags/$prefix/v<major>.<minor>.<patch>[-(preview|experimental).<n>]"
+      } else {
+        $pattern = "^refs/tags/$([regex]::Escape($prefix))/v(\d+\.\d+\.\d+)$"
+        $expected = "refs/tags/$prefix/v<major>.<minor>.<patch>"
+      }
+
+      if ($source -notmatch $pattern) {
+        Write-Host "##vso[task.logissue type=error]Invalid release tag '$source' for workload '$prefix'. Expected: $expected"
+        exit 1
+      }
+
+      Write-Host "Tag '$source' matches the '$prefix' release format."
+    displayName: Validate workload tag format

--- a/eng/ci/templates/pipelines/release-packages.yml
+++ b/eng/ci/templates/pipelines/release-packages.yml
@@ -6,6 +6,17 @@ parameters:
 - name: public
   type: boolean
   default: false
+- name: tagSpec
+  # Optional. When set with a tagPrefix, the pipeline validates the queued
+  # tag and parses it into ReleaseTagVersion / ReleaseTagChannel /
+  # ReleaseTagSuffix pipeline variables. The wrapping release yml is
+  # expected to map those to the workload's MSBuild props via build_args.
+  # Shape: { tagPrefix: string, allowChannels: boolean (default true) }
+  type: object
+  default: {}
+- name: build_args
+  type: string
+  default: ''
 
 resources:
   repositories:
@@ -40,6 +51,14 @@ extends:
       - template: /eng/ci/templates/jobs/validate-release-ref.yml@self
         parameters:
           failOnInvalidRef: ${{ parameters.public }}
+      - ${{ if parameters.tagSpec.tagPrefix }}:
+        - template: /eng/ci/templates/jobs/validate-workload-tag.yml@self
+          parameters:
+            tagPrefix: ${{ parameters.tagSpec.tagPrefix }}
+            ${{ if ne(parameters.tagSpec.allowChannels, false) }}:
+              allowChannels: true
+            ${{ else }}:
+              allowChannels: false
 
     - stage: Build
       dependsOn: Validate
@@ -52,7 +71,8 @@ extends:
           sign: true
           artifacts: ['pack']
           projects: ${{ parameters.projects }}
-          build_args: -p:IsReleaseCI=true
+          tagSpec: ${{ parameters.tagSpec }}
+          build_args: -p:IsReleaseCI=true ${{ parameters.build_args }}
 
     - stage: Release
       dependsOn: Build

--- a/eng/ci/templates/steps/parse-workload-tag.yml
+++ b/eng/ci/templates/steps/parse-workload-tag.yml
@@ -1,0 +1,50 @@
+parameters:
+- name: tagPrefix
+  type: string
+- name: allowChannels
+  type: boolean
+  default: true
+
+# Parses the git tag the release pipeline was queued against and sets
+# pipeline variables consumed by the workload's MSBuild props via
+# -p:... in build_args:
+#   $(ReleaseTagVersion)  three-part SemVer parsed from the tag
+#   $(ReleaseTagChannel)  stable | preview | experimental (always
+#                         stable when allowChannels=false)
+#   $(ReleaseTagSuffix)   prerelease suffix (e.g. preview.1); empty
+#                         when channel is stable
+#
+# Tag format:
+#   <prefix>/v<major>.<minor>.<patch>                       (stable)
+#   <prefix>/v<major>.<minor>.<patch>-(preview|experimental).<n>
+steps:
+- pwsh: |
+    $source = "$(Build.SourceBranch)"
+    $prefix = '${{ parameters.tagPrefix }}'
+    $allowChannels = [System.Boolean]::Parse('${{ parameters.allowChannels }}')
+
+    if ($allowChannels) {
+      $pattern = "^refs/tags/$([regex]::Escape($prefix))/v(\d+\.\d+\.\d+)(?:-(preview|experimental)\.(\d+))?$"
+    } else {
+      $pattern = "^refs/tags/$([regex]::Escape($prefix))/v(\d+\.\d+\.\d+)$"
+    }
+
+    $match = [regex]::Match($source, $pattern)
+    if (-not $match.Success) {
+      Write-Host "##vso[task.logissue type=error]Invalid release tag '$source' for workload '$prefix'."
+      exit 1
+    }
+
+    $version = $match.Groups[1].Value
+    $channel = 'stable'
+    $suffix = ''
+    if ($allowChannels -and $match.Groups[2].Success) {
+      $channel = $match.Groups[2].Value
+      $suffix = "$channel.$($match.Groups[3].Value)"
+    }
+
+    Write-Host "Parsed tag: version=$version channel=$channel suffix=$suffix"
+    Write-Host "##vso[task.setvariable variable=ReleaseTagVersion]$version"
+    Write-Host "##vso[task.setvariable variable=ReleaseTagChannel]$channel"
+    Write-Host "##vso[task.setvariable variable=ReleaseTagSuffix]$suffix"
+  displayName: Parse workload tag (${{ parameters.tagPrefix }})

--- a/src/Workloads/Templates/Directory.Version.props
+++ b/src/Workloads/Templates/Directory.Version.props
@@ -32,6 +32,12 @@
                                  Recorded as build provenance only; not
                                  used to derive the templates pkg version
                                  (Templates Workload Spec §4.4.1).
+                                 NOTE: preview / experimental templates
+                                 releases that need to snapshot from a
+                                 non-stable bundle version must pass
+                                 -p:SourceBundleVersion=... at pipeline-
+                                 queue time; the tag does not carry it
+                                 today.
       $(MinBundleVersionRange)   NuGet version range the workload pkg
                                  declares it is compatible with. Feeds
                                  the nuspec `minBundle:` tag, the
@@ -87,6 +93,17 @@
   <Target Name="_ValidateTemplatesStableLockstep" BeforeTargets="GenerateNuspec;_GetPackageFiles;Build">
     <Error Condition="'$(TemplatesChannel)' == 'stable' AND '$(TemplatesVersion)' != '$(StableTemplatesVersion)'"
            Text="Stable templates release: TemplatesVersion ('$(TemplatesVersion)') must match StableTemplatesVersion ('$(StableTemplatesVersion)'). Bump src/Workloads/Templates/Directory.Version.props on vnext first, then re-tag." />
+  </Target>
+  <!--
+    Stable templates release must snapshot from the stable bundle baseline
+    on vnext ($(LatestExtensionBundleVersion)). Preview / experimental
+    tags are exempt so they can snapshot from a different bundle version
+    when needed (operator overrides with -p:SourceBundleVersion=... at
+    pipeline-queue time).
+  -->
+  <Target Name="_ValidateTemplatesStableSourceBundleLockstep" BeforeTargets="GenerateNuspec;_GetPackageFiles;Build">
+    <Error Condition="'$(TemplatesChannel)' == 'stable' AND '$(SourceBundleVersion)' != '$(LatestExtensionBundleVersion)'"
+           Text="Stable templates release: SourceBundleVersion ('$(SourceBundleVersion)') must match LatestExtensionBundleVersion ('$(LatestExtensionBundleVersion)'). Bump eng/build/Workloads.Templates.SourceBundleVersion.props on vnext first, then re-tag." />
   </Target>
 
 </Project>

--- a/src/Workloads/Templates/Directory.Version.props
+++ b/src/Workloads/Templates/Directory.Version.props
@@ -6,36 +6,58 @@
     Directory.Version.props because it does not snapshot from an
     extension bundle (see proposed/templates-workload-spec.md §4.4.3).
 
-      $(TemplatesVersion)         workload pkg version. Bare three-part SemVer.
-      $(TemplatesChannel)         stable | preview | experimental. Selects the
-                                  source bundle id at build time and the
-                                  workload pkg's prerelease label.
-      $(SourceBundleVersion)      bundle version snapshotted at build time.
-                                  Defaults to $(LatestExtensionBundleVersion)
-                                  so a bundle bump propagates from one file
-                                  (eng/build/Workloads.Templates.SourceBundleVersion.props).
-                                  Recorded as build provenance only; not
-                                  used to derive the templates pkg version
-                                  (Templates Workload Spec §4.4.1).
-      $(MinBundleVersionRange)    NuGet version range the workload pkg
-                                  declares it is compatible with. Feeds the
-                                  nuspec `minBundle:` tag, the workload.json
-                                  description sentence, and the generated
-                                  templates-workload.json sibling manifest,
-                                  so the three storage locations cannot
-                                  drift (Templates Workload Spec §4.4.4).
+    Properties (overridable via -p:... from the release pipeline):
+      $(StableTemplatesVersion)  Source of truth on vnext for the stable
+                                 templates line. Bumping this property is
+                                 the lockstep gate for a stable release:
+                                 PR the bump to vnext, then tag
+                                 templates-node/vX.Y.Z (or python).
+      $(TemplatesVersion)        Effective workload pkg version. Defaults
+                                 to $(StableTemplatesVersion). The release
+                                 pipeline overrides via -p:TemplatesVersion
+                                 (parsed from the tag) so preview /
+                                 experimental tags can ship a different
+                                 version line.
+      $(TemplatesChannel)        stable | preview | experimental. Selects
+                                 the source bundle id at build time and
+                                 the workload pkg's prerelease label.
+                                 Default stable.
+      $(VersionSuffix)           Optional prerelease label (e.g.
+                                 preview.1, experimental.2). Default
+                                 unset.
+      $(SourceBundleVersion)     Bundle version snapshotted at build time.
+                                 Defaults to $(LatestExtensionBundleVersion)
+                                 so a bundle bump propagates from one file
+                                 (eng/build/Workloads.Templates.SourceBundleVersion.props).
+                                 Recorded as build provenance only; not
+                                 used to derive the templates pkg version
+                                 (Templates Workload Spec §4.4.1).
+      $(MinBundleVersionRange)   NuGet version range the workload pkg
+                                 declares it is compatible with. Feeds
+                                 the nuspec `minBundle:` tag, the
+                                 workload.json description sentence, and
+                                 the generated templates-workload.json
+                                 sibling manifest, so the three storage
+                                 locations cannot drift (Templates
+                                 Workload Spec §4.4.4).
+
+    Release model: vnext carries only the stable line. The release
+    pipeline parses the git tag and passes -p:TemplatesVersion /
+    -p:TemplatesChannel / -p:VersionSuffix. Stable releases must match
+    $(StableTemplatesVersion); preview / experimental may drift.
 
     Derived $(VersionPrefix):
-      stable        -> 1.0.0
-      preview       -> 1.0.0-preview
-      experimental  -> 1.0.0-experimental
+      stable        -> 1.0.1
+      preview       -> 1.0.1  (+ VersionSuffix preview.N)
+      experimental  -> 1.0.1  (+ VersionSuffix experimental.N)
   -->
 
   <Import Project="$(EngBuildRoot)Workloads.Templates.SourceBundleVersion.props" />
 
   <PropertyGroup>
-    <TemplatesVersion>1.0.1</TemplatesVersion>
-    <TemplatesChannel>stable</TemplatesChannel>
+    <StableTemplatesVersion>1.0.1</StableTemplatesVersion>
+    <TemplatesChannel Condition="'$(TemplatesChannel)' == ''">stable</TemplatesChannel>
+    <TemplatesVersion Condition="'$(TemplatesVersion)' == ''">$(StableTemplatesVersion)</TemplatesVersion>
     <SourceBundleVersion Condition="'$(SourceBundleVersion)' == ''">$(LatestExtensionBundleVersion)</SourceBundleVersion>
     <MinBundleVersionRange Condition="'$(MinBundleVersionRange)' == ''">[4.0.0,)</MinBundleVersionRange>
   </PropertyGroup>
@@ -45,7 +67,26 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TemplatesChannel)' != 'stable'">
-    <VersionPrefix>$(TemplatesVersion)-$(TemplatesChannel)</VersionPrefix>
+    <VersionPrefix>$(TemplatesVersion)</VersionPrefix>
+    <VersionSuffix Condition="'$(VersionSuffix)' == ''">$(TemplatesChannel).1</VersionSuffix>
   </PropertyGroup>
+
+  <Target Name="_ValidateTemplatesChannel" BeforeTargets="GenerateNuspec;_GetPackageFiles;Build">
+    <Error Condition="'$(TemplatesChannel)' != 'stable' AND '$(TemplatesChannel)' != 'preview' AND '$(TemplatesChannel)' != 'experimental'"
+           Text="TemplatesChannel '$(TemplatesChannel)' is not one of stable|preview|experimental." />
+  </Target>
+
+  <!--
+    Stable templates release must match the version checked in to vnext
+    ($(StableTemplatesVersion)). To ship a new stable line: PR the bump
+    here on vnext first, then tag templates-node/vX.Y.Z (or python).
+
+    Preview / experimental tags are exempt so they can ship ahead of the
+    stable line without a flip-flop PR.
+  -->
+  <Target Name="_ValidateTemplatesStableLockstep" BeforeTargets="GenerateNuspec;_GetPackageFiles;Build">
+    <Error Condition="'$(TemplatesChannel)' == 'stable' AND '$(TemplatesVersion)' != '$(StableTemplatesVersion)'"
+           Text="Stable templates release: TemplatesVersion ('$(TemplatesVersion)') must match StableTemplatesVersion ('$(StableTemplatesVersion)'). Bump src/Workloads/Templates/Directory.Version.props on vnext first, then re-tag." />
+  </Target>
 
 </Project>

--- a/src/Workloads/Templates/DotNet/Directory.Version.props
+++ b/src/Workloads/Templates/DotNet/Directory.Version.props
@@ -7,27 +7,55 @@
     Microsoft.Azure.Functions.Worker.ItemTemplates NuGet pin (which
     is exposed below and written into content/source.json at pack time).
 
-      $(TemplatesVersion)               Workload pkg version (3-part SemVer).
-                                        Drives $(VersionPrefix).
+    Properties (overridable via -p:... from the release pipeline):
+      $(StableTemplatesVersion)         Source of truth on vnext for the
+                                        DotNet templates workload version.
+                                        Bumping this property is the
+                                        lockstep gate for a release: PR
+                                        the bump to vnext, then tag
+                                        templates-dotnet/vX.Y.Z.
+      $(TemplatesVersion)               Effective workload pkg version
+                                        (3-part SemVer). Defaults to
+                                        $(StableTemplatesVersion). The
+                                        release pipeline overrides via
+                                        -p:TemplatesVersion (parsed from
+                                        the tag); the lockstep target
+                                        below enforces they match.
       $(SourceItemTemplatesPackageId)   Upstream NuGet template package id
                                         that the workload hydrates from at
                                         build time (Templates Workload Spec
                                         §6.3 step 1).
       $(SourceItemTemplatesVersion)     Upstream NuGet template package
                                         version. Drives the dotnet new
-                                        install during the hydrate step and
-                                        is written into content/source.json
-                                        so the CLI core knows which pkg to
-                                        provision into the dotnet template
-                                        hive at func workload install time.
+                                        install during the hydrate step
+                                        and is written into
+                                        content/source.json so the CLI
+                                        core knows which pkg to provision
+                                        into the dotnet template hive at
+                                        func workload install time.
+
+    DotNet has no preview / experimental channel today. The tag namespace
+    is stable-only (templates-dotnet/vX.Y.Z).
   -->
 
   <PropertyGroup>
-    <TemplatesVersion>1.0.1</TemplatesVersion>
+    <StableTemplatesVersion>1.0.1</StableTemplatesVersion>
+    <TemplatesVersion Condition="'$(TemplatesVersion)' == ''">$(StableTemplatesVersion)</TemplatesVersion>
     <VersionPrefix>$(TemplatesVersion)</VersionPrefix>
 
     <SourceItemTemplatesPackageId>Microsoft.Azure.Functions.Worker.ItemTemplates</SourceItemTemplatesPackageId>
     <SourceItemTemplatesVersion>4.0.5590</SourceItemTemplatesVersion>
   </PropertyGroup>
+
+  <!--
+    Stable releases (the only kind for templates-dotnet today) must match
+    the version checked in to vnext ($(StableTemplatesVersion)). To ship
+    a new version: PR the bump here on vnext first, then tag
+    templates-dotnet/vX.Y.Z.
+  -->
+  <Target Name="_ValidateTemplatesDotNetStableLockstep" BeforeTargets="GenerateNuspec;_GetPackageFiles;Build">
+    <Error Condition="'$(TemplatesVersion)' != '$(StableTemplatesVersion)'"
+           Text="templates-dotnet release: TemplatesVersion ('$(TemplatesVersion)') must match StableTemplatesVersion ('$(StableTemplatesVersion)'). Bump src/Workloads/Templates/DotNet/Directory.Version.props on vnext first, then re-tag." />
+  </Target>
 
 </Project>

--- a/src/Workloads/Tools/ExtensionBundles/Directory.Version.props
+++ b/src/Workloads/Tools/ExtensionBundles/Directory.Version.props
@@ -1,32 +1,45 @@
 <Project>
 
   <!--
-    Workload pkg versioning. This is a content-only workload (no workload
-    code or assemblies), so the pkg version maps 1:1 to the bundle payload
-    version it carries:
-      $(BundleVersion)  - the bundle payload version. Drives the CDN URL
-                          and the user-facing version in func logs. Bare
-                          three-part SemVer. Defaults to
-                          $(LatestExtensionBundleVersion) from
-                          eng/build/Workloads.Templates.SourceBundleVersion.props
-                          so the bundle this workload ships always matches
-                          the snapshot the templates workloads were built
-                          against (one-line bump for both).
-      $(BundleChannel)  - stable | preview | experimental. Selects the CDN
-                          bundle id (see DownloadDefaultBundle.targets) and
-                          the workload pkg's prerelease label.
+    Workload pkg versioning. Bundles is a content-only workload (no
+    workload code or assemblies), so the pkg version maps 1:1 to the
+    bundle payload version it carries.
+
+    Properties (overridable via -p:... from the release pipeline):
+      $(BundleVersion)  Bundle payload version. Drives the CDN URL and
+                        the user-facing version in func logs. Bare
+                        three-part SemVer. Defaults to
+                        $(LatestExtensionBundleVersion) from
+                        eng/build/Workloads.Templates.SourceBundleVersion.props
+                        so the bundle this workload ships always matches
+                        the snapshot the templates workloads were built
+                        against (one-line bump for both).
+      $(BundleChannel)  stable | preview | experimental. Selects the CDN
+                        bundle id (see DownloadDefaultBundle.targets) and
+                        the workload pkg's prerelease label. Default
+                        stable.
+      $(VersionSuffix)  Optional prerelease label (e.g. preview.1,
+                        experimental.2). When unset and channel != stable,
+                        falls back to $(BundleChannel).1 for local builds.
+
+    Release model: vnext carries only the stable line. The release
+    pipeline parses the git tag (e.g. bundles/v4.35.0-preview.1) and
+    passes -p:BundleVersion / -p:BundleChannel / -p:VersionSuffix.
+    Stable releases must match $(LatestExtensionBundleVersion) (enforced
+    by the lockstep target below); preview / experimental may drift so
+    the bundles workload can ship a new bundle line ahead of templates.
 
     Derived $(VersionPrefix):
       stable        -> 4.35.0
-      preview       -> 4.35.0-preview
-      experimental  -> 4.35.0-experimental
+      preview       -> 4.35.0  (+ VersionSuffix preview.N)
+      experimental  -> 4.35.0  (+ VersionSuffix experimental.N)
   -->
 
   <Import Project="$(EngBuildRoot)Workloads.Templates.SourceBundleVersion.props" />
 
   <PropertyGroup>
+    <BundleChannel Condition="'$(BundleChannel)' == ''">stable</BundleChannel>
     <BundleVersion Condition="'$(BundleVersion)' == ''">$(LatestExtensionBundleVersion)</BundleVersion>
-    <BundleChannel>stable</BundleChannel>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(BundleChannel)' == 'stable'">
@@ -35,7 +48,29 @@
 
   <PropertyGroup Condition="'$(BundleChannel)' != 'stable'">
     <VersionPrefix>$(BundleVersion)</VersionPrefix>
-    <VersionSuffix>$(BundleChannel).1</VersionSuffix>
+    <VersionSuffix Condition="'$(VersionSuffix)' == ''">$(BundleChannel).1</VersionSuffix>
   </PropertyGroup>
+
+  <Target Name="_ValidateBundleChannel" BeforeTargets="GenerateNuspec;_GetPackageFiles;Build">
+    <Error Condition="'$(BundleChannel)' != 'stable' AND '$(BundleChannel)' != 'preview' AND '$(BundleChannel)' != 'experimental'"
+           Text="BundleChannel '$(BundleChannel)' is not one of stable|preview|experimental." />
+  </Target>
+
+  <!--
+    Stable bundles release must match the bundle version checked in to
+    vnext (via $(LatestExtensionBundleVersion)). This keeps the bundles
+    workload and the templates workloads on the same bundle snapshot for
+    any commit shipped through a stable tag. To ship a new stable bundle
+    line: PR the bump to eng/build/Workloads.Templates.SourceBundleVersion.props
+    on vnext first, then tag bundles/vX.Y.Z.
+
+    Preview / experimental tags are intentionally exempt: those channels
+    exist so the bundles workload can ship a new bundle line ahead of
+    the templates baseline.
+  -->
+  <Target Name="_ValidateBundleStableLockstep" BeforeTargets="GenerateNuspec;_GetPackageFiles;Build">
+    <Error Condition="'$(BundleChannel)' == 'stable' AND '$(BundleVersion)' != '$(LatestExtensionBundleVersion)'"
+           Text="Stable bundles release: BundleVersion ('$(BundleVersion)') must match LatestExtensionBundleVersion ('$(LatestExtensionBundleVersion)'). Bump eng/build/Workloads.Templates.SourceBundleVersion.props on vnext first, then re-tag." />
+  </Target>
 
 </Project>

--- a/src/Workloads/Tools/ExtensionBundles/DownloadDefaultBundle.targets
+++ b/src/Workloads/Tools/ExtensionBundles/DownloadDefaultBundle.targets
@@ -13,13 +13,20 @@
     pack of a developer build, or a PR build whose $(BundleVersion) is
     not yet published to the CDN).
 
-    The CDN bundle id is selected from $(BundleChannel):
+    The CDN bundle id is selected from $(BundleChannel) (validated by
+    Directory.Version.props):
       stable        -> Microsoft.Azure.Functions.ExtensionBundle
       preview       -> Microsoft.Azure.Functions.ExtensionBundle.Preview
       experimental  -> Microsoft.Azure.Functions.ExtensionBundle.Experimental
 
     The CDN URL always carries the bare $(BundleVersion); the workload pkg's
     own prerelease label (preview/experimental.N) is not part of the URL.
+
+    Release model: the bundles release pipeline parses the git tag (e.g.
+    bundles/v4.35.0-preview.1) and supplies BundleChannel + BundleVersion
+    via -p:. See src/Workloads/Tools/ExtensionBundles/Directory.Version.props
+    for the full release model and the stable-only lockstep with
+    $(LatestExtensionBundleVersion).
 
     TODO: switch the pack-time payload source from the public CDN to the
     bundle CI build artifacts so the workload always ships the exact
@@ -37,8 +44,6 @@
           BeforeTargets="GenerateNuspec;_GetPackageFiles"
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(IntermediateOutputPath)bundle\.extracted">
-    <Error Condition="'$(_BundleCdnId)' == ''"
-           Text="BundleChannel '$(BundleChannel)' is not one of stable|preview|experimental." />
     <PropertyGroup>
       <_BundleCdnZipUrl>https://cdn.functions.azure.com/public/ExtensionBundles/$(_BundleCdnId)/$(BundleVersion)/$(_BundleCdnId).$(BundleVersion).zip</_BundleCdnZipUrl>
       <_BundleStaging>$(IntermediateOutputPath)bundle\</_BundleStaging>


### PR DESCRIPTION
## What

Make the bundles and three templates release pipelines drive package version (and channel, where applicable) from the git tag the pipeline was queued against. `vnext` carries only the **stable** line; preview/experimental ship via **tag only**, no flip-flop PR required.

Related: proposed release-process doc on the `docs` branch (#5313).

## Tag → release mapping

| Workload          | Tag examples                                                              | Channels                       |
| ----------------- | ------------------------------------------------------------------------- | ------------------------------ |
| bundles           | `bundles/v4.35.0`, `bundles/v4.35.0-preview.1`, `...-experimental.1`      | stable / preview / experimental|
| templates-node    | `templates-node/v1.0.1`, `templates-node/v1.0.1-preview.1`                | stable / preview / experimental|
| templates-python  | `templates-python/v1.0.1[-(preview\|experimental).N]`                     | stable / preview / experimental|
| templates-dotnet  | `templates-dotnet/v1.0.1`                                                 | stable only (no channel)       |

Tag regex: `^refs/tags/<prefix>/v(\d+\.\d+\.\d+)(?:-(preview|experimental)\.(\d+))?$`

## Stable lockstep

Stable releases must match the version checked in to `vnext`. This is the existing **bundles/templates lockstep guarantee**, enforced as MSBuild Error targets:

- **Bundles**: `BundleVersion` must equal `$(LatestExtensionBundleVersion)`.
- **Templates Node/Python (bundle-backed)**: `TemplatesVersion` must equal `$(StableTemplatesVersion)` **and** `SourceBundleVersion` must equal `$(LatestExtensionBundleVersion)` (Node and Python both snapshot from the bundle at pack time, so they share the same baseline as the bundles workload).
- **Templates DotNet**: `TemplatesVersion` must equal `$(StableTemplatesVersion)`.

To ship a new stable line: PR the bump on `vnext`, then tag.

Preview/experimental tags are exempt so those channels can ship a version line (and, for templates, a non-stable bundle snapshot) ahead of `vnext`'s stable baseline.

## How the pipeline change works

Opt-in via a new structured `tagSpec` parameter on the shared `release-packages.yml` + `build.yml`. Default is `{}`, so all other workload pipelines (host, workers, etc.) keep working unchanged.

- New `eng/ci/templates/jobs/validate-workload-tag.yml` — runs in the Validate stage when `tagSpec.tagPrefix` is set; regex-enforces the tag format and fails fast.
- New `eng/ci/templates/steps/parse-workload-tag.yml` — prepended in the Build job; parses the tag and sets `ReleaseTagVersion` / `ReleaseTagChannel` / `ReleaseTagSuffix` pipeline variables.
- Each release yml maps those variables to its workload's MSBuild props via `build_args`, e.g.:
  ```yaml
  # bundles
  build_args: -p:BundleVersion=$(ReleaseTagVersion) -p:BundleChannel=$(ReleaseTagChannel) -p:VersionSuffix=$(ReleaseTagSuffix)
  # templates-node / templates-python
  build_args: -p:TemplatesVersion=$(ReleaseTagVersion) -p:TemplatesChannel=$(ReleaseTagChannel) -p:VersionSuffix=$(ReleaseTagSuffix)
  # templates-dotnet (no channel)
  build_args: -p:TemplatesVersion=$(ReleaseTagVersion)
  ```

## Known limitation (templates preview/experimental + non-stable bundle)

Templates Node/Python snapshot StaticContent from the bundle CDN at pack time. `TemplatesChannel=preview` flips the CDN bundle id to the preview channel, but `SourceBundleVersion` still defaults to `$(LatestExtensionBundleVersion)` (the stable bundle version on `vnext`). When a preview/experimental templates release needs to snapshot from a **different** bundle version (e.g. `4.36.0` published only on the preview CDN), the operator must additionally pass `-p:SourceBundleVersion=...` at pipeline-queue time. Encoding the source bundle version into the templates tag itself is a follow-up design decision and out of scope for this PR.

## Drive-by fix

`eng/build/Release.props`: `PublicReleaseTag` now derives from `BUILD_SOURCEBRANCH` (stripping `refs/tags/`) rather than `BUILD_SOURCEBRANCHNAME`, which only returns the last path segment. Without this, the GitHub release-notes link for slash-namespaced tags (`bundles/v4.35.0-preview.1` etc.) would drop the workload prefix and resolve to a non-existent tag. Behaviour unchanged for existing dash-namespaced (`host-v...`) and bare (`v...`) tags.

## Validations

- `dotnet pack` exercised across all four workloads × applicable channels; produced `.nupkg` versions match expectations (e.g. `Azure.Functions.Cli.Workloads.ExtensionBundles.4.36.0-preview.1.nupkg`, `Azure.Functions.Cli.Workloads.Templates.Node.1.0.1-preview.1.nupkg` pulling from the preview CDN at `-p:SourceBundleVersion=4.36.0`).
- All three stable lockstep Error targets verified to fire when intentionally mismatched (`BundleVersion`, `TemplatesVersion`, `SourceBundleVersion`).
- Invalid channel name fires the channel-validation error.
- Full `CI=true dotnet build -c Release` is clean (0 warnings, 0 errors). `Func.Tests` suite all green (1192 tests).

## Out of scope

- Versioning model for other workloads (host, workers, stacks).
- Encoding the source bundle version into the templates tag (see "Known limitation" above).
- Switching the bundle payload source from CDN to bundle CI artifacts (existing `TODO` in `DownloadDefaultBundle.targets`).
