### PR TITLE
build: infer bundle channel from properties

### DIFF
--- a/eng/build/Workloads.Templates.SourceBundleVersion.props
+++ b/eng/build/Workloads.Templates.SourceBundleVersion.props
@@ -23,4 +23,17 @@
     <LatestExtensionBundleVersion>4.35.0</LatestExtensionBundleVersion>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <BundleChannel Condition="'$(BundleChannel)' == ''">stable</BundleChannel>
+    <_BundleCdnId Condition="'$(BundleChannel)' == 'stable'">Microsoft.Azure.Functions.ExtensionBundle</_BundleCdnId>
+    <_BundleCdnId Condition="'$(BundleChannel)' == 'preview'">Microsoft.Azure.Functions.ExtensionBundle.Preview</_BundleCdnId>
+    <_BundleCdnId Condition="'$(BundleChannel)' == 'experimental'">Microsoft.Azure.Functions.ExtensionBundle.Experimental</_BundleCdnId>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(BundleVersion)' == ''">
+    <BundleVersion Condition="'$(BundleChannel)' == 'stable'">4.35.0</BundleVersion>
+    <BundleVersion Condition="'$(BundleChannel)' == 'preview'">4.42.0</BundleVersion>
+    <BundleVersion Condition="'$(BundleChannel)' == 'experimental'">4.60.0</BundleVersion>
+  </PropertyGroup>
+
 </Project>

--- a/src/Workloads/Tools/ExtensionBundles/Directory.Version.props
+++ b/src/Workloads/Tools/ExtensionBundles/Directory.Version.props
@@ -22,20 +22,15 @@
       experimental  -> 4.35.0-experimental
   -->
 
+  <PropertyGroup Condition="'$(BundleChannel)' == '' AND '$(PublicReleaseTag)' != ''">
+    <BundleChannel>$([System.Text.RegularExpressions.Regex]::Match($(BUILD_SOURCEBRANCHNAME), '^v[^-]+(?:-([^.]+))').Groups[1].Value)</BundleChannel>
+  </PropertyGroup>
+
   <Import Project="$(EngBuildRoot)Workloads.Templates.SourceBundleVersion.props" />
 
   <PropertyGroup>
-    <BundleVersion Condition="'$(BundleVersion)' == ''">$(LatestExtensionBundleVersion)</BundleVersion>
-    <BundleChannel>stable</BundleChannel>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(BundleChannel)' == 'stable'">
     <VersionPrefix>$(BundleVersion)</VersionPrefix>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(BundleChannel)' != 'stable'">
-    <VersionPrefix>$(BundleVersion)</VersionPrefix>
-    <VersionSuffix>$(BundleChannel).1</VersionSuffix>
+    <VersionSuffix Condition="'$(BundleChannel)' != 'stable'">$(BundleChannel).1</VersionSuffix>
   </PropertyGroup>
 
 </Project>

--- a/src/Workloads/Tools/ExtensionBundles/DownloadDefaultBundle.targets
+++ b/src/Workloads/Tools/ExtensionBundles/DownloadDefaultBundle.targets
@@ -26,26 +26,26 @@
     bundle drop we own, instead of whatever happens to be on the CDN.
   -->
 
-  <PropertyGroup>
-    <_BundleCdnId Condition="'$(BundleChannel)' == 'stable'">Microsoft.Azure.Functions.ExtensionBundle</_BundleCdnId>
-    <_BundleCdnId Condition="'$(BundleChannel)' == 'preview'">Microsoft.Azure.Functions.ExtensionBundle.Preview</_BundleCdnId>
-    <_BundleCdnId Condition="'$(BundleChannel)' == 'experimental'">Microsoft.Azure.Functions.ExtensionBundle.Experimental</_BundleCdnId>
-  </PropertyGroup>
-
-  <Target Name="DownloadDefaultBundle"
-          Condition="'$(SkipDefaultBundleDownload)' != 'true'"
-          BeforeTargets="GenerateNuspec;_GetPackageFiles"
-          Inputs="$(MSBuildProjectFullPath)"
-          Outputs="$(IntermediateOutputPath)bundle\.extracted">
-    <Error Condition="'$(_BundleCdnId)' == ''"
-           Text="BundleChannel '$(BundleChannel)' is not one of stable|preview|experimental." />
+  <Target Name="_DownloadBundleProperties">
+    <Error Condition="'$(_BundleCdnId)' == ''" Text="BundleChannel '$(BundleChannel)' is not one of stable|preview|experimental." />
     <PropertyGroup>
       <_BundleCdnZipUrl>https://cdn.functions.azure.com/public/ExtensionBundles/$(_BundleCdnId)/$(BundleVersion)/$(_BundleCdnId).$(BundleVersion).zip</_BundleCdnZipUrl>
-      <_BundleStaging>$(IntermediateOutputPath)bundle\</_BundleStaging>
+      <_BundleStaging>$(IntermediateOutputPath)bundle/$(BundleChannel)</_BundleStaging>
       <_BundleZipName>$(_BundleCdnId).$(BundleVersion).zip</_BundleZipName>
       <_BundleZipPath>$(IntermediateOutputPath)$(_BundleZipName)</_BundleZipPath>
       <_BundleMarker>$(_BundleStaging).extracted</_BundleMarker>
+      <_BundleHash>$(_BundleStaging).hash</_BundleHash>
     </PropertyGroup>
+
+    <WriteLinesToFile File="$(_BundleHash)" Lines="$(_BundleCdnZipUrl)" WriteOnlyWhenDifferent="true" />
+  </Target>
+
+  <Target Name="DownloadDefaultBundle"
+          DependsOnTargets="_DownloadBundleProperties"
+          Condition="'$(SkipDefaultBundleDownload)' != 'true'"
+          BeforeTargets="GenerateNuspec;_GetPackageFiles"
+          Inputs="@(MSBuildAllProjects);$(_BundleHash)"
+          Outputs="$(_BundleMarker)">
     <MakeDir Directories="$(_BundleStaging)" />
     <DownloadFile SourceUrl="$(_BundleCdnZipUrl)"
                   DestinationFolder="$(IntermediateOutputPath)"


### PR DESCRIPTION
Refactors the bundle msbuild targets to:

1. Allow for setting bundle channel as a property, which will update the VersionPrefix and VersionSuffix
2. Infer bundle channel in CI based on the tag it is being built for.
3. Update bundle CDN download to invalidate its inputs/outputs when bundle channel & version changes.