### PR TITLE
build: infer bundle channel for templates workloads

### DIFF
--- a/eng/build/Workloads.Templates.SourceBundleVersion.props
+++ b/eng/build/Workloads.Templates.SourceBundleVersion.props
@@ -1,27 +1,21 @@
 <Project>
 
   <!--
-    Source bundle version for the Templates workload — the
-    Microsoft.Azure.Functions.ExtensionBundle release that the templates
-    workloads snapshot StaticContent from at build time.
+    Shared channel/version mapping for any workload that snapshots from
+    or ships an extension bundle (the Templates workloads and the
+    ExtensionBundles workload).
 
-      $(LatestExtensionBundleVersion)
-        Bare three-part SemVer of the bundle release this build targets.
-
-    Primary consumer:
-      - src/Workloads/Templates/Directory.Version.props
-        ($(SourceBundleVersion) defaults to it).
-
-    The bundles workload also imports this file and defaults
-    $(BundleVersion) to the same value so the bundle it ships matches
-    the snapshot the templates workloads were built against. Bumping
-    this property re-points both in lockstep, so the bundles workload
-    and the templates workloads can't drift across a bundle release.
+      $(BundleChannel)   stable (default) | preview | experimental.
+                         Selects $(_BundleCdnId) and the channel-pinned
+                         $(BundleVersion) below.
+      $(_BundleCdnId)    The CDN package id for the channel.
+      $(BundleVersion)   The bundle version this build targets for the
+                         channel. Bumping a value here re-points the
+                         bundles workload (which ships that bundle) and
+                         the bundle-backed templates workloads (which
+                         snapshot StaticContent from it) in lockstep, so
+                         they can't drift across a bundle release.
   -->
-
-  <PropertyGroup>
-    <LatestExtensionBundleVersion>4.35.0</LatestExtensionBundleVersion>
-  </PropertyGroup>
 
   <PropertyGroup>
     <BundleChannel Condition="'$(BundleChannel)' == ''">stable</BundleChannel>

--- a/eng/build/Workloads.Templates.targets
+++ b/eng/build/Workloads.Templates.targets
@@ -7,7 +7,7 @@
 
       cdn (default)
         Downloads StaticContent files from the extension-bundle CDN for
-        the channel selected by $(TemplatesChannel), filters
+        the channel selected by $(BundleChannel), filters
         v1/templates/templates.json and/or v2/templates/templates.json by
         $(TemplatesStackLanguageFilter), and packs the result under
         tools/any/content/ of the workload nupkg. Skip the download with
@@ -17,7 +17,7 @@
         Packs files from $(MSBuildProjectDirectory)/content/v2/**/*.json
         (and content/v1/**/*.json when $(IncludeV1Templates) is true)
         directly. No CDN access at pack time. Used when the templates
-        workload owns its content in-repo (e.g. Node — see Templates
+        workload owns its content in-repo (e.g. Node, see Templates
         Workload Spec §6.1, where the upstream bundle does not yet ship
         v2 Node templates).
 
@@ -27,7 +27,11 @@
     Per-csproj inputs:
       $(TemplatesContentSource)        cdn (default) | static. Picks the
                                        source of the v1/v2 content.
-      $(TemplatesChannel)              stable | preview | experimental.
+      $(BundleChannel)                 stable | preview | experimental.
+                                       Same property the bundles workload
+                                       uses; selects CDN id and bundle
+                                       version via the shared
+                                       Workloads.Templates.SourceBundleVersion.props.
       $(SourceBundleVersion)           Bundle version snapshotted at pack
                                        time when TemplatesContentSource=cdn.
                                        Build-provenance only; does not
@@ -46,7 +50,7 @@
       $(IncludeV1Templates)            true | false. Defaults true. Set
                                        false for stacks that ship v2-only
                                        (e.g. Python after the v2-only
-                                       cutover — Templates Workload Spec
+                                       cutover, Templates Workload Spec
                                        §5.2 / §6.2). Also drops v1 from
                                        static-mode packs.
       $(IncludeV2Templates)            true | false. Defaults true. Set
@@ -56,7 +60,7 @@
                                        compatibility with. Drives the
                                        generated templates-workload.json,
                                        the nuspec `minBundle:` tag, and
-                                       the csproj <Description> sentence —
+                                       the csproj <Description> sentence,
                                        single source of truth for spec
                                        §4.4.4.
 
@@ -64,26 +68,33 @@
       stable       -> Microsoft.Azure.Functions.ExtensionBundle
       preview      -> Microsoft.Azure.Functions.ExtensionBundle.Preview
       experimental -> Microsoft.Azure.Functions.ExtensionBundle.Experimental
+    Resolved into $(_BundleCdnId) by the shared SourceBundleVersion props.
 
-    All intermediate staging lives under $(IntermediateOutputPath)templates\
-    (i.e. obj\<config>\<tfm>\templates\). $(IntermediateOutputPath) is not
-    populated during property evaluation, only when targets execute, so
-    every path that derives from it is built inline in target attributes
-    or inside target bodies — never in a top-level <PropertyGroup>.
+    All intermediate staging lives under
+    $(IntermediateOutputPath)templates/$(BundleChannel)/, so per-channel
+    builds in the same obj/ dir don't collide. $(IntermediateOutputPath)
+    is not populated during property evaluation, only when targets
+    execute, so the staging paths are computed inside the
+    _TemplatesProperties target rather than a top-level <PropertyGroup>.
   -->
 
   <PropertyGroup>
     <TemplatesContentSource Condition="'$(TemplatesContentSource)' == ''">cdn</TemplatesContentSource>
 
-    <_TplCdnId Condition="'$(TemplatesChannel)' == 'stable'">Microsoft.Azure.Functions.ExtensionBundle</_TplCdnId>
-    <_TplCdnId Condition="'$(TemplatesChannel)' == 'preview'">Microsoft.Azure.Functions.ExtensionBundle.Preview</_TplCdnId>
-    <_TplCdnId Condition="'$(TemplatesChannel)' == 'experimental'">Microsoft.Azure.Functions.ExtensionBundle.Experimental</_TplCdnId>
-
     <IncludeV1Templates Condition="'$(IncludeV1Templates)' == ''">true</IncludeV1Templates>
     <IncludeV2Templates Condition="'$(IncludeV2Templates)' == ''">true</IncludeV2Templates>
-
-    <_TplBaseUrl>https://cdn.functions.azure.com/public/ExtensionBundles/$(_TplCdnId)/$(SourceBundleVersion)/StaticContent</_TplBaseUrl>
   </PropertyGroup>
+
+  <!--
+    Shared staging-path setup used by every templates target in both
+    cdn and static modes. Lives in its own target so $(IntermediateOutputPath)
+    is bound by the time it runs.
+  -->
+  <Target Name="_TemplatesProperties">
+    <PropertyGroup>
+      <_TplStaging>$(IntermediateOutputPath)templates/$(BundleChannel)/</_TplStaging>
+    </PropertyGroup>
+  </Target>
 
   <ItemGroup>
     <!--
@@ -95,90 +106,127 @@
     <_TplLocale Include="cs-CZ;de-DE;es-ES;fr-FR;hu-HU;it-IT;ja-JP;ko-KR;nl-NL;pl-PL;pt-BR;pt-PT;ru-RU;sv-SE;tr-TR;zh-CN;zh-TW" />
   </ItemGroup>
 
-  <Target Name="DownloadTemplatesContent"
-          Condition="'$(SkipDownloadTemplates)' != 'true' and '$(TemplatesContentSource)' == 'cdn'"
-          BeforeTargets="GenerateNuspec;_GetPackageFiles"
-          Inputs="$(MSBuildProjectFullPath)"
-          Outputs="$(IntermediateOutputPath)templates\.downloaded">
-    <Error Condition="'$(_TplCdnId)' == ''"
-           Text="TemplatesChannel '$(TemplatesChannel)' is not one of stable|preview|experimental." />
+  <!--
+    CDN-mode setup: computes the base URL and writes a hash file that
+    captures every input that should invalidate the download (URL +
+    Include flags + language filter). Mirrors the bundles workload's
+    _DownloadBundleProperties pattern from #5364.
+  -->
+  <Target Name="_DownloadTemplatesProperties"
+          DependsOnTargets="_TemplatesProperties"
+          Condition="'$(SkipDownloadTemplates)' != 'true' and '$(TemplatesContentSource)' == 'cdn'">
+    <Error Condition="'$(_BundleCdnId)' == ''"
+           Text="BundleChannel '$(BundleChannel)' is not one of stable|preview|experimental." />
     <Error Condition="'$(SourceBundleVersion)' == ''"
            Text="SourceBundleVersion must be set when TemplatesContentSource=cdn (the bundle version whose StaticContent the workload snapshots)." />
     <Error Condition="'$(IncludeV1Templates)' != 'true' and '$(IncludeV2Templates)' != 'true'"
            Text="At least one of IncludeV1Templates or IncludeV2Templates must be true; the templates workload would otherwise ship an empty payload." />
 
+    <PropertyGroup>
+      <_TplBaseUrl>https://cdn.functions.azure.com/public/ExtensionBundles/$(_BundleCdnId)/$(SourceBundleVersion)/StaticContent</_TplBaseUrl>
+      <_TplDownloadedMarker>$(_TplStaging).downloaded</_TplDownloadedMarker>
+      <_TplDownloadHash>$(_TplStaging).download.hash</_TplDownloadHash>
+      <_TplFilterV1Hash>$(_TplStaging).filter.v1.hash</_TplFilterV1Hash>
+      <_TplFilterV2Hash>$(_TplStaging).filter.v2.hash</_TplFilterV2Hash>
+    </PropertyGroup>
+
+    <!--
+      Hash captures URL + per-version include flags so toggling them
+      forces a re-download (and re-filter) without a clean.
+    -->
+    <WriteLinesToFile File="$(_TplDownloadHash)"
+                      Lines="$(_TplBaseUrl)|v1=$(IncludeV1Templates)|v2=$(IncludeV2Templates)"
+                      Overwrite="true"
+                      WriteOnlyWhenDifferent="true" />
+    <WriteLinesToFile File="$(_TplFilterV1Hash)"
+                      Lines="$(TemplatesStackLanguageFilter)"
+                      Overwrite="true"
+                      WriteOnlyWhenDifferent="true" />
+    <WriteLinesToFile File="$(_TplFilterV2Hash)"
+                      Lines="$(TemplatesStackLanguageFilter)"
+                      Overwrite="true"
+                      WriteOnlyWhenDifferent="true" />
+  </Target>
+
+  <Target Name="DownloadTemplatesContent"
+          DependsOnTargets="_DownloadTemplatesProperties"
+          Condition="'$(SkipDownloadTemplates)' != 'true' and '$(TemplatesContentSource)' == 'cdn'"
+          BeforeTargets="GenerateNuspec;_GetPackageFiles"
+          Inputs="$(MSBuildProjectFullPath);$(_TplDownloadHash)"
+          Outputs="$(_TplDownloadedMarker)">
     <DownloadFile Condition="'$(IncludeV1Templates)' == 'true'"
                   SourceUrl="$(_TplBaseUrl)/v1/templates/templates.json"
-                  DestinationFolder="$(IntermediateOutputPath)templates\v1\templates\"
+                  DestinationFolder="$(_TplStaging)v1/templates/"
                   SkipUnchangedFiles="true" Retries="3" />
     <DownloadFile Condition="'$(IncludeV1Templates)' == 'true'"
                   SourceUrl="$(_TplBaseUrl)/v1/bindings/bindings.json"
-                  DestinationFolder="$(IntermediateOutputPath)templates\v1\bindings\"
+                  DestinationFolder="$(_TplStaging)v1/bindings/"
                   SkipUnchangedFiles="true" Retries="3" />
     <DownloadFile Condition="'$(IncludeV1Templates)' == 'true'"
                   SourceUrl="$(_TplBaseUrl)/v1/resources/Resources.json"
-                  DestinationFolder="$(IntermediateOutputPath)templates\v1\resources\"
+                  DestinationFolder="$(_TplStaging)v1/resources/"
                   SkipUnchangedFiles="true" Retries="3" />
     <DownloadFile Condition="'$(IncludeV1Templates)' == 'true'"
                   SourceUrl="$(_TplBaseUrl)/v1/resources/Resources.%(_TplLocale.Identity).json"
-                  DestinationFolder="$(IntermediateOutputPath)templates\v1\resources\"
+                  DestinationFolder="$(_TplStaging)v1/resources/"
                   SkipUnchangedFiles="true" Retries="3"
                   ContinueOnError="true" />
 
     <DownloadFile Condition="'$(IncludeV2Templates)' == 'true'"
                   SourceUrl="$(_TplBaseUrl)/v2/templates/templates.json"
-                  DestinationFolder="$(IntermediateOutputPath)templates\v2\templates\"
+                  DestinationFolder="$(_TplStaging)v2/templates/"
                   SkipUnchangedFiles="true" Retries="3" />
     <DownloadFile Condition="'$(IncludeV2Templates)' == 'true'"
                   SourceUrl="$(_TplBaseUrl)/v2/bindings/userPrompts.json"
-                  DestinationFolder="$(IntermediateOutputPath)templates\v2\bindings\"
+                  DestinationFolder="$(_TplStaging)v2/bindings/"
                   SkipUnchangedFiles="true" Retries="3" />
     <DownloadFile Condition="'$(IncludeV2Templates)' == 'true'"
                   SourceUrl="$(_TplBaseUrl)/v2/resources/Resources.json"
-                  DestinationFolder="$(IntermediateOutputPath)templates\v2\resources\"
+                  DestinationFolder="$(_TplStaging)v2/resources/"
                   SkipUnchangedFiles="true" Retries="3" />
     <DownloadFile Condition="'$(IncludeV2Templates)' == 'true'"
                   SourceUrl="$(_TplBaseUrl)/v2/resources/Resources.%(_TplLocale.Identity).json"
-                  DestinationFolder="$(IntermediateOutputPath)templates\v2\resources\"
+                  DestinationFolder="$(_TplStaging)v2/resources/"
                   SkipUnchangedFiles="true" Retries="3"
                   ContinueOnError="true" />
 
-    <Touch Files="$(IntermediateOutputPath)templates\.downloaded" AlwaysCreate="true" />
+    <Touch Files="$(_TplDownloadedMarker)" AlwaysCreate="true" />
   </Target>
 
   <Target Name="FilterTemplatesByLanguage"
           DependsOnTargets="DownloadTemplatesContent"
           Condition="'$(SkipDownloadTemplates)' != 'true' and '$(TemplatesContentSource)' == 'cdn' and '$(IncludeV1Templates)' == 'true'"
           BeforeTargets="_GetPackageFiles"
-          Inputs="$(IntermediateOutputPath)templates\.downloaded"
-          Outputs="$(IntermediateOutputPath)templates\.filtered.v1">
+          Inputs="$(_TplDownloadedMarker);$(_TplFilterV1Hash)"
+          Outputs="$(_TplStaging).filtered.v1">
     <Error Condition="'$(TemplatesStackLanguageFilter)' == ''"
            Text="TemplatesStackLanguageFilter must be set (e.g. 'JavaScript;TypeScript' for Node, 'Python' for Python)." />
 
-    <Exec Command="pwsh -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)..\scripts\filter-templates.ps1&quot; -Path &quot;$(IntermediateOutputPath)templates\v1\templates\templates.json&quot; -Languages &quot;$(TemplatesStackLanguageFilter)&quot; -Mode v1" />
+    <Exec Command="pwsh -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)../scripts/filter-templates.ps1&quot; -Path &quot;$(_TplStaging)v1/templates/templates.json&quot; -Languages &quot;$(TemplatesStackLanguageFilter)&quot; -Mode v1" />
 
-    <Touch Files="$(IntermediateOutputPath)templates\.filtered.v1" AlwaysCreate="true" />
+    <Touch Files="$(_TplStaging).filtered.v1" AlwaysCreate="true" />
   </Target>
 
   <Target Name="FilterTemplatesByLanguageV2"
           DependsOnTargets="DownloadTemplatesContent"
           Condition="'$(SkipDownloadTemplates)' != 'true' and '$(TemplatesContentSource)' == 'cdn' and '$(IncludeV2Templates)' == 'true'"
           BeforeTargets="_GetPackageFiles"
-          Inputs="$(IntermediateOutputPath)templates\.downloaded"
-          Outputs="$(IntermediateOutputPath)templates\.filtered.v2">
+          Inputs="$(_TplDownloadedMarker);$(_TplFilterV2Hash)"
+          Outputs="$(_TplStaging).filtered.v2">
     <Error Condition="'$(TemplatesStackLanguageFilter)' == ''"
            Text="TemplatesStackLanguageFilter must be set (e.g. 'JavaScript;TypeScript' for Node, 'Python' for Python)." />
 
-    <Exec Command="pwsh -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)..\scripts\filter-templates.ps1&quot; -Path &quot;$(IntermediateOutputPath)templates\v2\templates\templates.json&quot; -Languages &quot;$(TemplatesStackLanguageFilter)&quot; -Mode v2" />
+    <Exec Command="pwsh -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)../scripts/filter-templates.ps1&quot; -Path &quot;$(_TplStaging)v2/templates/templates.json&quot; -Languages &quot;$(TemplatesStackLanguageFilter)&quot; -Mode v2" />
 
-    <Touch Files="$(IntermediateOutputPath)templates\.filtered.v2" AlwaysCreate="true" />
+    <Touch Files="$(_TplStaging).filtered.v2" AlwaysCreate="true" />
   </Target>
 
   <Target Name="GenerateTemplatesWorkloadJson"
+          DependsOnTargets="_TemplatesProperties"
           Condition="'$(SkipDownloadTemplates)' != 'true'"
           BeforeTargets="_GetPackageFiles"
           Inputs="$(MSBuildProjectFullPath)"
-          Outputs="$(IntermediateOutputPath)templates\templates-workload.json">
+          Outputs="$(_TplStaging)templates-workload.json">
     <Error Condition="'$(MinBundleVersionRange)' == ''"
            Text="MinBundleVersionRange must be set (the NuGet range the templates workload declares compatibility with)." />
 
@@ -189,8 +237,8 @@
       Description sentence are both driven by $(MinBundleVersionRange), so
       the three locations cannot drift.
     -->
-    <MakeDir Directories="$(IntermediateOutputPath)templates\" />
-    <WriteLinesToFile File="$(IntermediateOutputPath)templates\templates-workload.json"
+    <MakeDir Directories="$(_TplStaging)" />
+    <WriteLinesToFile File="$(_TplStaging)templates-workload.json"
                       Lines="{ &quot;%24schema&quot;: &quot;https://aka.ms/func-workloads/templates/v1/templates-workload.json/schema.json&quot;, &quot;minBundleVersion&quot;: &quot;$(MinBundleVersionRange)&quot; }"
                       Overwrite="true"
                       Encoding="UTF-8" />
@@ -202,12 +250,12 @@
           BeforeTargets="_GetPackageFiles">
     <ItemGroup>
       <None Condition="'$(IncludeV1Templates)' == 'true'"
-            Include="$(IntermediateOutputPath)templates\v1\**\*.json"
+            Include="$(_TplStaging)v1/**/*.json"
             Pack="true" PackagePath="tools/any/content/v1/" Visible="false" />
       <None Condition="'$(IncludeV2Templates)' == 'true'"
-            Include="$(IntermediateOutputPath)templates\v2\**\*.json"
+            Include="$(_TplStaging)v2/**/*.json"
             Pack="true" PackagePath="tools/any/content/v2/" Visible="false" />
-      <None Include="$(IntermediateOutputPath)templates\templates-workload.json"
+      <None Include="$(_TplStaging)templates-workload.json"
             Pack="true" PackagePath="tools/any/content/" Visible="false" />
     </ItemGroup>
   </Target>
@@ -219,7 +267,7 @@
 
     Per-channel subsetting (opt in via $(FilterTemplatesByBundleChannel)=true):
       When enabled, the v2 templates.json is filtered against the active
-      $(TemplatesChannel)'s authoritative bundle. The build:
+      $(BundleChannel)'s authoritative bundle. The build:
         1. Reads index.json from the channel's CDN to find the latest
            listed 4.x bundle version.
         2. Extracts bin/extensions.json from that bundle via HTTP Range
@@ -227,9 +275,9 @@
         3. Filters content/v2/templates/templates.json by
            content/v2/templates/_bindings.json, dropping any entry whose
            required binding(s) aren't in the channel's extensions.json.
-      The filtered file is staged at $(IntermediateOutputPath)templates\v2\templates\templates.json
+      The filtered file is staged at $(_TplStaging)v2/templates/templates.json
       and packed in place of the source file. _bindings.json itself is
-      excluded from the pack — it is a build-time-only manifest.
+      excluded from the pack, it is a build-time-only manifest.
 
       When disabled (default), every channel ships every static template.
   -->
@@ -238,12 +286,13 @@
   </PropertyGroup>
 
   <Target Name="FetchBundleExtensionsForChannel"
+          DependsOnTargets="_TemplatesProperties"
           Condition="'$(TemplatesContentSource)' == 'static' and '$(FilterTemplatesByBundleChannel)' == 'true' and '$(IncludeV2Templates)' == 'true'"
           BeforeTargets="_GetPackageFiles"
           Inputs="$(MSBuildProjectFullPath)"
-          Outputs="$(IntermediateOutputPath)templates/bundle/extensions.json">
-    <Error Condition="'$(TemplatesChannel)' == ''"
-           Text="FilterTemplatesByBundleChannel=true requires TemplatesChannel to be set (stable | preview | experimental)." />
+          Outputs="$(_TplStaging)bundle/extensions.json">
+    <Error Condition="'$(BundleChannel)' == ''"
+           Text="FilterTemplatesByBundleChannel=true requires BundleChannel to be set (stable | preview | experimental)." />
     <!--
       Paths passed to `<Exec>` are substituted into the shell command
       verbatim, so they must use the platform-neutral forward-slash form
@@ -251,18 +300,18 @@
       backslashes are literal filename characters, not path separators,
       and the staged file ends up at the wrong path.
     -->
-    <Exec Command="pwsh -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)../scripts/fetch-bundle-extensions-json.ps1&quot; -Channel &quot;$(TemplatesChannel)&quot; -OutputPath &quot;$(IntermediateOutputPath)templates/bundle/extensions.json&quot; -VersionOut &quot;$(IntermediateOutputPath)templates/bundle/version.txt&quot;" />
+    <Exec Command="pwsh -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)../scripts/fetch-bundle-extensions-json.ps1&quot; -Channel &quot;$(BundleChannel)&quot; -OutputPath &quot;$(_TplStaging)bundle/extensions.json&quot; -VersionOut &quot;$(_TplStaging)bundle/version.txt&quot;" />
   </Target>
 
   <Target Name="FilterStaticTemplatesByBundleChannel"
           DependsOnTargets="FetchBundleExtensionsForChannel"
           Condition="'$(TemplatesContentSource)' == 'static' and '$(FilterTemplatesByBundleChannel)' == 'true' and '$(IncludeV2Templates)' == 'true'"
           BeforeTargets="_GetPackageFiles"
-          Inputs="$(MSBuildProjectDirectory)/content/v2/templates/templates.json;$(MSBuildProjectDirectory)/content/v2/templates/_bindings.json;$(IntermediateOutputPath)templates/bundle/extensions.json"
-          Outputs="$(IntermediateOutputPath)templates/v2/templates/templates.json">
+          Inputs="$(MSBuildProjectDirectory)/content/v2/templates/templates.json;$(MSBuildProjectDirectory)/content/v2/templates/_bindings.json;$(_TplStaging)bundle/extensions.json"
+          Outputs="$(_TplStaging)v2/templates/templates.json">
     <Error Condition="!Exists('$(MSBuildProjectDirectory)/content/v2/templates/_bindings.json')"
            Text="FilterTemplatesByBundleChannel=true requires content/v2/templates/_bindings.json (per-template binding-requirements map)." />
-    <Exec Command="pwsh -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)../scripts/filter-node-templates-by-bundle.ps1&quot; -TemplatesPath &quot;$(MSBuildProjectDirectory)/content/v2/templates/templates.json&quot; -BindingsMapPath &quot;$(MSBuildProjectDirectory)/content/v2/templates/_bindings.json&quot; -ExtensionsJsonPath &quot;$(IntermediateOutputPath)templates/bundle/extensions.json&quot; -OutputPath &quot;$(IntermediateOutputPath)templates/v2/templates/templates.json&quot; -ChannelLabel &quot;$(TemplatesChannel)&quot;" />
+    <Exec Command="pwsh -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)../scripts/filter-node-templates-by-bundle.ps1&quot; -TemplatesPath &quot;$(MSBuildProjectDirectory)/content/v2/templates/templates.json&quot; -BindingsMapPath &quot;$(MSBuildProjectDirectory)/content/v2/templates/_bindings.json&quot; -ExtensionsJsonPath &quot;$(_TplStaging)bundle/extensions.json&quot; -OutputPath &quot;$(_TplStaging)v2/templates/templates.json&quot; -ChannelLabel &quot;$(BundleChannel)&quot;" />
   </Target>
 
   <Target Name="_AddStaticTemplatesToPack"
@@ -290,7 +339,7 @@
             Exclude="$(MSBuildProjectDirectory)/content/v2/templates/templates.json;$(MSBuildProjectDirectory)/content/v2/templates/_bindings.json"
             Pack="true" PackagePath="tools/any/content/v2/" Visible="false" />
       <None Condition="'$(IncludeV2Templates)' == 'true' and '$(FilterTemplatesByBundleChannel)' == 'true'"
-            Include="$(IntermediateOutputPath)templates/v2/templates/templates.json"
+            Include="$(_TplStaging)v2/templates/templates.json"
             Pack="true" PackagePath="tools/any/content/v2/templates/" Visible="false" />
 
       <!--
@@ -302,7 +351,7 @@
             Exclude="$(MSBuildProjectDirectory)/content/v2/templates/_bindings.json"
             Pack="true" PackagePath="tools/any/content/v2/" Visible="false" />
 
-      <None Include="$(IntermediateOutputPath)templates\templates-workload.json"
+      <None Include="$(_TplStaging)templates-workload.json"
             Pack="true" PackagePath="tools/any/content/" Visible="false" />
     </ItemGroup>
   </Target>

--- a/src/Workloads/Templates/Directory.Version.props
+++ b/src/Workloads/Templates/Directory.Version.props
@@ -6,7 +6,7 @@
     Directory.Version.props because it does not snapshot from an
     extension bundle (see proposed/templates-workload-spec.md §4.4.3).
 
-      $(TemplatesVersion)         workload pkg version. Bare three-part SemVer.
+      $(VersionPrefix)            workload pkg version. Bare three-part SemVer.
       $(BundleChannel)            stable | preview | experimental. Single
                                   channel concept shared with the bundles
                                   workload. Selects the source bundle id at
@@ -29,10 +29,10 @@
                                   so the three storage locations cannot
                                   drift (Templates Workload Spec §4.4.4).
 
-    Derived $(VersionPrefix):
-      stable        -> 1.0.0
-      preview       -> 1.0.0-preview
-      experimental  -> 1.0.0-experimental
+    Derived workload pkg version:
+      stable        -> 1.0.1
+      preview       -> 1.0.1-preview
+      experimental  -> 1.0.1-experimental
   -->
 
   <PropertyGroup Condition="'$(BundleChannel)' == '' AND '$(PublicReleaseTag)' != ''">
@@ -42,14 +42,11 @@
   <Import Project="$(EngBuildRoot)Workloads.Templates.SourceBundleVersion.props" />
 
   <PropertyGroup>
-    <TemplatesVersion>1.0.1</TemplatesVersion>
+    <VersionPrefix>1.0.1</VersionPrefix>
+    <VersionSuffix Condition="'$(BundleChannel)' != 'stable'">$(BundleChannel)</VersionSuffix>
+
     <SourceBundleVersion Condition="'$(SourceBundleVersion)' == ''">$(BundleVersion)</SourceBundleVersion>
     <MinBundleVersionRange Condition="'$(MinBundleVersionRange)' == ''">[4.0.0,)</MinBundleVersionRange>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <VersionPrefix Condition="'$(BundleChannel)' == 'stable'">$(TemplatesVersion)</VersionPrefix>
-    <VersionPrefix Condition="'$(BundleChannel)' != 'stable'">$(TemplatesVersion)-$(BundleChannel)</VersionPrefix>
   </PropertyGroup>
 
 </Project>

--- a/src/Workloads/Templates/Directory.Version.props
+++ b/src/Workloads/Templates/Directory.Version.props
@@ -7,13 +7,17 @@
     extension bundle (see proposed/templates-workload-spec.md §4.4.3).
 
       $(TemplatesVersion)         workload pkg version. Bare three-part SemVer.
-      $(TemplatesChannel)         stable | preview | experimental. Selects the
-                                  source bundle id at build time and the
-                                  workload pkg's prerelease label.
+      $(BundleChannel)            stable | preview | experimental. Single
+                                  channel concept shared with the bundles
+                                  workload. Selects the source bundle id at
+                                  build time and the workload pkg's
+                                  prerelease label. Inferred from the git
+                                  tag in CI; defaults to stable otherwise.
       $(SourceBundleVersion)      bundle version snapshotted at build time.
-                                  Defaults to $(LatestExtensionBundleVersion)
-                                  so a bundle bump propagates from one file
-                                  (eng/build/Workloads.Templates.SourceBundleVersion.props).
+                                  Defaults to $(BundleVersion) (the
+                                  channel-resolved bundle version from
+                                  eng/build/Workloads.Templates.SourceBundleVersion.props)
+                                  so a bundle bump propagates from one file.
                                   Recorded as build provenance only; not
                                   used to derive the templates pkg version
                                   (Templates Workload Spec §4.4.1).
@@ -31,21 +35,21 @@
       experimental  -> 1.0.0-experimental
   -->
 
+  <PropertyGroup Condition="'$(BundleChannel)' == '' AND '$(PublicReleaseTag)' != ''">
+    <BundleChannel>$([System.Text.RegularExpressions.Regex]::Match($(BUILD_SOURCEBRANCHNAME), '^v[^-]+(?:-([^.]+))').Groups[1].Value)</BundleChannel>
+  </PropertyGroup>
+
   <Import Project="$(EngBuildRoot)Workloads.Templates.SourceBundleVersion.props" />
 
   <PropertyGroup>
     <TemplatesVersion>1.0.1</TemplatesVersion>
-    <TemplatesChannel>stable</TemplatesChannel>
-    <SourceBundleVersion Condition="'$(SourceBundleVersion)' == ''">$(LatestExtensionBundleVersion)</SourceBundleVersion>
+    <SourceBundleVersion Condition="'$(SourceBundleVersion)' == ''">$(BundleVersion)</SourceBundleVersion>
     <MinBundleVersionRange Condition="'$(MinBundleVersionRange)' == ''">[4.0.0,)</MinBundleVersionRange>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TemplatesChannel)' == 'stable'">
-    <VersionPrefix>$(TemplatesVersion)</VersionPrefix>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TemplatesChannel)' != 'stable'">
-    <VersionPrefix>$(TemplatesVersion)-$(TemplatesChannel)</VersionPrefix>
+  <PropertyGroup>
+    <VersionPrefix Condition="'$(BundleChannel)' == 'stable'">$(TemplatesVersion)</VersionPrefix>
+    <VersionPrefix Condition="'$(BundleChannel)' != 'stable'">$(TemplatesVersion)-$(BundleChannel)</VersionPrefix>
   </PropertyGroup>
 
 </Project>

--- a/src/Workloads/Templates/DotNet/Directory.Version.props
+++ b/src/Workloads/Templates/DotNet/Directory.Version.props
@@ -7,8 +7,7 @@
     Microsoft.Azure.Functions.Worker.ItemTemplates NuGet pin (which
     is exposed below and written into content/source.json at pack time).
 
-      $(TemplatesVersion)               Workload pkg version (3-part SemVer).
-                                        Drives $(VersionPrefix).
+      $(VersionPrefix)                  Workload pkg version (3-part SemVer).
       $(SourceItemTemplatesPackageId)   Upstream NuGet template package id
                                         that the workload hydrates from at
                                         build time (Templates Workload Spec
@@ -23,8 +22,7 @@
   -->
 
   <PropertyGroup>
-    <TemplatesVersion>1.0.1</TemplatesVersion>
-    <VersionPrefix>$(TemplatesVersion)</VersionPrefix>
+    <VersionPrefix>1.0.1</VersionPrefix>
 
     <SourceItemTemplatesPackageId>Microsoft.Azure.Functions.Worker.ItemTemplates</SourceItemTemplatesPackageId>
     <SourceItemTemplatesVersion>4.0.5590</SourceItemTemplatesVersion>

--- a/src/Workloads/Templates/Node/README.DEV.md
+++ b/src/Workloads/Templates/Node/README.DEV.md
@@ -24,7 +24,7 @@ channel maps 1:1 to an extension-bundle id (Templates Workload Spec
 
 Per-channel template subsetting is **on** by default for the Node
 workload. At pack time the build fetches `bin/extensions.json` from
-the latest **listed** bundle of `$(TemplatesChannel)` (resolved from
+the latest **listed** bundle of `$(BundleChannel)` (resolved from
 the channel's CDN `index.json`) using HTTP Range requests (~10 KB
 rather than the full 150 MB bundle) and drops any template whose
 required bindings aren't present in that channel's bundle. The mapping
@@ -49,11 +49,14 @@ MSBuild property, so they cannot drift:
 ## Build-time channel selection
 
 The workload pkg version's prerelease label is driven by
-`$(TemplatesChannel)` in `Directory.Version.props`:
+`$(BundleChannel)` in `Directory.Version.props`, the same property
+the bundles workload uses. In CI it is inferred from the git tag
+(e.g. `templates-node/v1.0.1-preview.1` → `preview`); locally you
+can pass it directly:
 
 ```bash
-dotnet pack ... /p:TemplatesChannel=preview
-dotnet pack ... /p:TemplatesChannel=experimental
+dotnet pack ... /p:BundleChannel=preview
+dotnet pack ... /p:BundleChannel=experimental
 ```
 
 For Node, channel does **not** select a CDN source, `$(TemplatesContentSource)`

--- a/src/Workloads/Templates/Node/Workloads.Templates.Node.csproj
+++ b/src/Workloads/Templates/Node/Workloads.Templates.Node.csproj
@@ -19,7 +19,7 @@
 
       FilterTemplatesByBundleChannel=true makes pack also fetch
       bin/extensions.json from the latest listed bundle of
-      $(TemplatesChannel) (CDN index.json + HTTP-Range zip extraction)
+      $(BundleChannel) (CDN index.json + HTTP-Range zip extraction)
       and subset templates.json against content/v2/templates/_bindings.json
       so the published nupkg only carries templates whose extension
       dependencies are present in the active channel's bundle. See

--- a/src/Workloads/Templates/Python/README.DEV.md
+++ b/src/Workloads/Templates/Python/README.DEV.md
@@ -33,17 +33,22 @@ MSBuild property, so they cannot drift:
 ## Build-time channel selection
 
 The source bundle id used at pack time is driven by
-`$(TemplatesChannel)` in `Directory.Version.props`:
+`$(BundleChannel)` in `Directory.Version.props`, the same property
+the bundles workload uses. In CI it is inferred from the git tag
+(e.g. `templates-python/v1.0.1-preview.1` → `preview`); locally you
+can pass it directly:
 
 ```bash
-dotnet pack ... /p:TemplatesChannel=preview
-dotnet pack ... /p:TemplatesChannel=experimental
+dotnet pack ... /p:BundleChannel=preview
+dotnet pack ... /p:BundleChannel=experimental
 ```
 
 `$(SourceBundleVersion)` selects the bundle version whose
-`StaticContent/v2` subtree is snapshotted at build time. It is
-recorded as build provenance only; it does not derive the templates
-pkg version (Templates Workload Spec §4.4.1).
+`StaticContent/v2` subtree is snapshotted at build time. It defaults
+to the channel-resolved `$(BundleVersion)` from the shared
+`Workloads.Templates.SourceBundleVersion.props` and is recorded as
+build provenance only; it does not derive the templates pkg version
+(Templates Workload Spec §4.4.1).
 
 ## Layout
 

--- a/src/Workloads/Tools/ExtensionBundles/Directory.Version.props
+++ b/src/Workloads/Tools/ExtensionBundles/Directory.Version.props
@@ -6,8 +6,8 @@
     version it carries:
       $(BundleVersion)  - the bundle payload version. Drives the CDN URL
                           and the user-facing version in func logs. Bare
-                          three-part SemVer. Defaults to
-                          $(LatestExtensionBundleVersion) from
+                          three-part SemVer. Defaults to the channel's
+                          pinned value in
                           eng/build/Workloads.Templates.SourceBundleVersion.props
                           so the bundle this workload ships always matches
                           the snapshot the templates workloads were built


### PR DESCRIPTION
Applies the [#5364](https://github.com/Azure/azure-functions-core-tools/pull/5364) pattern (channel inferred from properties, per-channel defaults, hash-based invalidation) to the Node and Python templates workloads.

Drops the separate `$(TemplatesChannel)` MSBuild property and reuses `$(BundleChannel)`, so a single channel concept drives both the bundles workload and any workload that snapshots from a bundle. The runtime `TemplatesChannelMapper` (CLI-side) is a different concept and is intentionally left alone.

### Changes

- **`src/Workloads/Templates/Directory.Version.props`** — infers `$(BundleChannel)` from `BUILD_SOURCEBRANCHNAME` when `PublicReleaseTag` is set (same regex as bundles); defaults `$(SourceBundleVersion)` to the channel-resolved `$(BundleVersion)` from the shared `Workloads.Templates.SourceBundleVersion.props`. `$(VersionPrefix)` keeps the existing `1.0.1` / `1.0.1-preview` / `1.0.1-experimental` shape.
- **`eng/build/Workloads.Templates.targets`** — drops the duplicate `_TplCdnId` block and reuses `$(_BundleCdnId)` from the shared props. Splits staging setup into `_TemplatesProperties` (always runs, computes per-channel staging path) and `_DownloadTemplatesProperties` (CDN-only, computes URL and writes hash files capturing URL + `IncludeV1/V2Templates` flags + `TemplatesStackLanguageFilter`). All staging moves under `obj/<config>/<tfm>/templates/$(BundleChannel)/` so channel-switching builds don't collide.
- Doc/comment updates in the Node csproj and both `README.DEV.md` files.

### Verification

- `dotnet pack` for Node templates (static mode) stable and preview channels — both produce correctly versioned nupkgs and filter against the right bundle.
- `dotnet pack` for Python templates (cdn mode) stable channel — downloads from the stable bundle and packs cleanly.
- Existing test suite: 1192/1192 passing.

resolves no open issue.