### PR TITLE
Fix experimental bundle version (4.60.0 → 4.6.0)

### DIFF
--- a/eng/build/Workloads.Templates.SourceBundleVersion.props
+++ b/eng/build/Workloads.Templates.SourceBundleVersion.props
@@ -33,7 +33,7 @@
   <PropertyGroup Condition="'$(BundleVersion)' == ''">
     <BundleVersion Condition="'$(BundleChannel)' == 'stable'">4.35.0</BundleVersion>
     <BundleVersion Condition="'$(BundleChannel)' == 'preview'">4.42.0</BundleVersion>
-    <BundleVersion Condition="'$(BundleChannel)' == 'experimental'">4.60.0</BundleVersion>
+    <BundleVersion Condition="'$(BundleChannel)' == 'experimental'">4.6.0</BundleVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## What

Change the experimental channel `BundleVersion` from `4.60.0` to `4.6.0` in `eng/build/Workloads.Templates.SourceBundleVersion.props`.

## Why

The experimental release pipeline is failing in `dotnet pack` for `Workloads.ExtensionBundles`:

```
error MSB3923: Failed to download file
"https://cdn.functions.azure.com/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle.Experimental/4.60.0/Microsoft.Azure.Functions.ExtensionBundle.Experimental.4.60.0.zip".
Response status code does not indicate success: 404 (The specified blob does not exist.).
```

`4.60.0` was never published to the CDN. The latest published experimental bundle is `4.6.0`:

```
GET https://cdn.functions.azure.com/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle.Experimental/index.json
→ ["4.0.0","4.1.0","4.2.0","4.3.0","4.4.0","4.5.0","4.6.0"]
```

Looks like a slipped decimal when the value was last bumped.