### PR TITLE
build(vnext/bundles): remove extra folder and files from bundle nupkg

### DIFF
--- a/eng/ci/release/official-release.workload.bundles.yml
+++ b/eng/ci/release/official-release.workload.bundles.yml
@@ -3,6 +3,15 @@ parameters:
   displayName: Publish to nuget.org?
   type: boolean
   default: false
+- name: channel
+  displayName: Bundle channel
+  type: string
+  default: inferred
+  values:
+    - inferred
+    - stable
+    - preview
+    - experimental
 
 # Release has no triggers outside of pipeline
 trigger: none
@@ -15,3 +24,5 @@ extends:
     folder: workloads/bundles
     projects: |
       $(Build.SourcesDirectory)/src/Workloads/Tools/ExtensionBundles/Workloads.ExtensionBundles.csproj
+    ${{ if ne(parameters.channel, 'inferred') }}:
+      build_args: -p:BundleChannel=${{ parameters.channel }}

--- a/eng/ci/templates/pipelines/release-packages.yml
+++ b/eng/ci/templates/pipelines/release-packages.yml
@@ -6,6 +6,9 @@ parameters:
 - name: public
   type: boolean
   default: false
+- name: build_args
+  type: string
+  default: ""
 
 resources:
   repositories:
@@ -52,7 +55,7 @@ extends:
           sign: true
           artifacts: ['pack']
           projects: ${{ parameters.projects }}
-          build_args: -p:IsReleaseCI=true
+          build_args: -p:IsReleaseCI=true ${{ parameters.build_args }}
 
     - stage: Release
       dependsOn: Build

--- a/src/Workloads/Tools/ExtensionBundles/Directory.Version.props
+++ b/src/Workloads/Tools/ExtensionBundles/Directory.Version.props
@@ -30,7 +30,7 @@
 
   <PropertyGroup>
     <VersionPrefix>$(BundleVersion)</VersionPrefix>
-    <VersionSuffix Condition="'$(BundleChannel)' != 'stable'">$(BundleChannel).1</VersionSuffix>
+    <VersionSuffix Condition="'$(BundleChannel)' != 'stable'">$(BundleChannel).2</VersionSuffix>
   </PropertyGroup>
 
 </Project>

--- a/src/Workloads/Tools/ExtensionBundles/DownloadDefaultBundle.targets
+++ b/src/Workloads/Tools/ExtensionBundles/DownloadDefaultBundle.targets
@@ -60,8 +60,7 @@
           DependsOnTargets="DownloadDefaultBundle"
           BeforeTargets="_GetPackageFiles">
     <ItemGroup>
-      <None Include="$(IntermediateOutputPath)bundle\**\*"
-            Exclude="$(IntermediateOutputPath)bundle\.extracted"
+      <None Include="$(IntermediateOutputPath)bundle\$(BundleChannel)\**\*"
             Pack="true"
             PackagePath="tools/any/$(BundleVersion)/"
             Visible="false" />


### PR DESCRIPTION
The recent change to bundle packaging introduced a new folder to the nupkg layout due to globbing. This PR addresses that, removing the extra folder.