### PR TITLE
fix: warn when key vault references fail to resolve

### DIFF
--- a/src/Cli/func/Common/KeyVaultReferencesManager.cs
+++ b/src/Cli/func/Common/KeyVaultReferencesManager.cs
@@ -22,9 +22,16 @@ namespace Azure.Functions.Cli.Common
         {
             foreach (var key in settings.Keys.ToList())
             {
+                ParseSecretResult parseResult = null;
                 try
                 {
-                    var keyVaultValue = GetSecretValue(key, settings[key]);
+                    parseResult = ParseSecret(key, settings[key]);
+                    if (parseResult == null)
+                    {
+                        continue;
+                    }
+
+                    var keyVaultValue = GetSecretValue(parseResult);
                     if (keyVaultValue != null)
                     {
                         settings[key] = keyVaultValue;
@@ -34,23 +41,21 @@ namespace Azure.Functions.Cli.Common
                 {
                     // Do not block StartHostAction if secret cannot be resolved: instead, skip it
                     // and attempt to resolve other secrets
+                    if (parseResult != null)
+                    {
+                        ColoredConsole.WriteLine(WarningColor($"Unable to resolve the Key Vault reference for setting: {key}"));
+                    }
+
                     continue;
                 }
             }
         }
 
-        private string GetSecretValue(string key, string value)
+        protected virtual string GetSecretValue(ParseSecretResult parseResult)
         {
-            var result = ParseSecret(key, value);
-
-            if (result != null)
-            {
-                var client = GetSecretClient(result.Uri);
-                var secret = client.GetSecret(result.Name, result.Version);
-                return secret.Value.Value;
-            }
-
-            return null;
+            var client = GetSecretClient(parseResult.Uri);
+            var secret = client.GetSecret(parseResult.Name, parseResult.Version);
+            return secret.Value.Value;
         }
 
         internal ParseSecretResult ParseSecret(string key, string value)

--- a/test/Cli/Func.UnitTests/CommonTests/KeyVaultReferencesManagerTests.cs
+++ b/test/Cli/Func.UnitTests/CommonTests/KeyVaultReferencesManagerTests.cs
@@ -42,6 +42,62 @@ namespace Azure.Functions.Cli.UnitTests.CommonTests
             exception.Should().BeNull();
         }
 
+        [Fact]
+        public void ResolveKeyVaultReferencesEmitsWarningWhenParsedReferenceFailsToResolve()
+        {
+            // Arrange
+            const string failedKey = "FailedSecret";
+            const string failedReference = "@Microsoft.KeyVault(VaultName=testvault;SecretName=throwsecret)";
+            const string resolvedKey = "ResolvedSecret";
+            const string resolvedValue = "resolved-value";
+            var manager = new TestKeyVaultReferencesManager(secretName =>
+            {
+                if (secretName == "throwsecret")
+                {
+                    throw new InvalidOperationException("Could not resolve secret");
+                }
+
+                return resolvedValue;
+            });
+            _settings = new Dictionary<string, string>
+            {
+                { failedKey, failedReference },
+                { resolvedKey, "@Microsoft.KeyVault(VaultName=testvault;SecretName=resolvedsecret)" },
+            };
+
+            // Act
+            var outputString = CaptureConsoleOutput(() => manager.ResolveKeyVaultReferences(_settings));
+
+            // Assert
+            outputString.Should().Contain($"Unable to resolve the Key Vault reference for setting: {failedKey}");
+            outputString.Should().NotContain(failedReference);
+            outputString.Should().NotContain("throwsecret");
+            outputString.Should().NotContain(resolvedValue);
+            _settings[failedKey].Should().Be(failedReference);
+            _settings[resolvedKey].Should().Be(resolvedValue);
+        }
+
+        [Fact]
+        public void ResolveKeyVaultReferencesDoesNotEmitResolutionWarningForUnparseableReferences()
+        {
+            // Arrange
+            const string key = "UnparseableSecret";
+            const string reference = "@Microsoft.KeyVault(VaultName=testvault;)";
+            var manager = new TestKeyVaultReferencesManager(_ => throw new InvalidOperationException("Should not resolve"));
+            _settings = new Dictionary<string, string>
+            {
+                { key, reference },
+            };
+
+            // Act
+            var outputString = CaptureConsoleOutput(() => manager.ResolveKeyVaultReferences(_settings));
+
+            // Assert
+            outputString.Should().Contain($"Unable to parse the Key Vault reference for setting: {key}");
+            outputString.Should().NotContain($"Unable to resolve the Key Vault reference for setting: {key}");
+            outputString.Should().NotContain(reference);
+        }
+
         [Theory]
         [InlineData("test", null, false)]
         [InlineData("test", "@Microsoft.KeyVault()", true)]
@@ -52,19 +108,10 @@ namespace Azure.Functions.Cli.UnitTests.CommonTests
         [InlineData("test", "@Microsoft-KeyVault()", false)] // hyphen instead of dot
         public void ParseSecretEmitsWarningWithUnsuccessfullyMatchedKeyVaultReferences(string key, string value, bool attemptedKeyVaultReference)
         {
-            // Arrange
-            var output = new StringBuilder();
-            var console = Substitute.For<IConsoleWriter>();
-            console.WriteLine(Arg.Do<object>(o => output.AppendLine(o?.ToString()))).Returns(console);
-            console.Write(Arg.Do<object>(o => output.Append(o.ToString()))).Returns(console);
-            ColoredConsole.Out = console;
-            ColoredConsole.Error = console;
-
             // Act
-            _keyVaultReferencesManager.ParseSecret(key, value);
+            var outputString = CaptureConsoleOutput(() => _keyVaultReferencesManager.ParseSecret(key, value));
 
             // Assert
-            var outputString = output.ToString();
             if (attemptedKeyVaultReference)
             {
                 outputString.Should().Contain($"Unable to parse the Key Vault reference for setting: {key}");
@@ -120,6 +167,44 @@ namespace Azure.Functions.Cli.UnitTests.CommonTests
 
             // Assert
             Assert.Equal(expectedValue, result);
+        }
+
+        private static string CaptureConsoleOutput(Action action)
+        {
+            var output = new StringBuilder();
+            var console = Substitute.For<IConsoleWriter>();
+            console.WriteLine(Arg.Do<object>(o => output.AppendLine(o?.ToString()))).Returns(console);
+            console.Write(Arg.Do<object>(o => output.Append(o?.ToString()))).Returns(console);
+
+            var oldOut = ColoredConsole.Out;
+            var oldErr = ColoredConsole.Error;
+            try
+            {
+                ColoredConsole.Out = console;
+                ColoredConsole.Error = console;
+                action();
+                return output.ToString();
+            }
+            finally
+            {
+                ColoredConsole.Out = oldOut;
+                ColoredConsole.Error = oldErr;
+            }
+        }
+
+        private class TestKeyVaultReferencesManager : KeyVaultReferencesManager
+        {
+            private readonly Func<string, string> _getSecretValue;
+
+            public TestKeyVaultReferencesManager(Func<string, string> getSecretValue)
+            {
+                _getSecretValue = getSecretValue;
+            }
+
+            protected override string GetSecretValue(ParseSecretResult parseResult)
+            {
+                return _getSecretValue(parseResult.Name);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #4845.

## Summary

Key Vault references in local settings were already non-blocking, but resolution failures were silently skipped after parsing succeeded. This changes `ResolveKeyVaultReferences` to parse each setting first, then emit a warning when a parseable Key Vault reference cannot be resolved. The warning includes only the setting name so it does not expose the Key Vault reference, secret name, version, or resolved value.

The existing parse-warning behavior is preserved for malformed Key Vault references, and non-Key-Vault settings continue to be ignored without warning.

## Validation

- `git diff --check`
- Parent static check confirmed the broad non-blocking catch remains in place and the warning path is gated on a parsed Key Vault reference.
- `dotnet test test/Cli/Func.UnitTests/Azure.Functions.Cli.UnitTests.csproj --filter FullyQualifiedName~KeyVaultReferencesManagerTests --no-restore` could not run locally because `dotnet` is not installed in this environment.
