### PR TITLE
build: add channel iteration suffix to templates workload

### DIFF
--- a/src/Workloads/Templates/Directory.Version.props
+++ b/src/Workloads/Templates/Directory.Version.props
@@ -31,8 +31,8 @@
 
     Derived workload pkg version:
       stable        -> 1.0.1
-      preview       -> 1.0.1-preview
-      experimental  -> 1.0.1-experimental
+      preview       -> 1.0.1-preview.1
+      experimental  -> 1.0.1-experimental.1
   -->
 
   <PropertyGroup Condition="'$(BundleChannel)' == '' AND '$(PublicReleaseTag)' != ''">
@@ -43,7 +43,7 @@
 
   <PropertyGroup>
     <VersionPrefix>1.0.1</VersionPrefix>
-    <VersionSuffix Condition="'$(BundleChannel)' != 'stable'">$(BundleChannel)</VersionSuffix>
+    <VersionSuffix Condition="'$(BundleChannel)' != 'stable'">$(BundleChannel).1</VersionSuffix>
 
     <SourceBundleVersion Condition="'$(SourceBundleVersion)' == ''">$(BundleVersion)</SourceBundleVersion>
     <MinBundleVersionRange Condition="'$(MinBundleVersionRange)' == ''">[4.0.0,)</MinBundleVersionRange>


### PR DESCRIPTION
Templates is the only channel-aware workload missing the `.N` iteration suffix. Bundles already uses this pattern (`$(BundleChannel).2` -> `4.42.0-preview.2`); this brings templates in line.

### Change

```xml
<VersionSuffix Condition="'$(BundleChannel)' != 'stable'">$(BundleChannel).1</VersionSuffix>
```

### Resulting versions

| Tag | Pkg version |
|---|---|
| `python-templates/v1.0.1-preview` | `1.0.1-preview.1` |
| `python-templates/v1.0.1-experimental` | `1.0.1-experimental.1` |
| `node-templates/v1.0.1-preview` | `1.0.1-preview.1` |
| `node-templates/v1.0.1-experimental` | `1.0.1-experimental.1` |

Bump the `.1` to `.2` (etc.) in a follow-up PR for each new preview/experimental iteration, same workflow as bundles.

DotNet templates workload is unaffected (no channel axis).