### PR TITLE
Fall back to stable templates when project bundle channel workload is missing

### DIFF
--- a/src/Func/Commands/Workload/WorkloadSearchCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadSearchCommand.cs
@@ -165,7 +165,7 @@ internal sealed class WorkloadSearchCommand : FuncCliCommand
 
         _interaction.WriteHint(countLine);
         _interaction.WriteHint("Run 'func workload install <alias | package id>' to install one (stable by default).");
-        _interaction.WriteHint("When several versions or channels exist, pass --version (-v) to install a specific version.");
+        _interaction.WriteHint("When several versions or channels exist, pass --version (-v) to install a specific one.");
     }
 
     private static string DisplayNameOrPackageId(CatalogSearchResult result)

--- a/src/Func/Commands/Workload/WorkloadSearchCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadSearchCommand.cs
@@ -164,7 +164,8 @@ internal sealed class WorkloadSearchCommand : FuncCliCommand
         }
 
         _interaction.WriteHint(countLine);
-        _interaction.WriteHint("Run 'func workload install <alias>' to install one.");
+        _interaction.WriteHint("Run 'func workload install <alias | package id>' to install one (stable by default).");
+        _interaction.WriteHint("When several versions or channels exist, pass --version (-v) to pick a specific one.");
     }
 
     private static string DisplayNameOrPackageId(CatalogSearchResult result)

--- a/src/Func/Commands/Workload/WorkloadSearchCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadSearchCommand.cs
@@ -165,7 +165,7 @@ internal sealed class WorkloadSearchCommand : FuncCliCommand
 
         _interaction.WriteHint(countLine);
         _interaction.WriteHint("Run 'func workload install <alias | package id>' to install one (stable by default).");
-        _interaction.WriteHint("When several versions or channels exist, pass --version (-v) to pick a specific one.");
+        _interaction.WriteHint("When several versions or channels exist, pass --version (-v) to install a specific version.");
     }
 
     private static string DisplayNameOrPackageId(CatalogSearchResult result)

--- a/src/Func/Templates/NewCommandRenderer.cs
+++ b/src/Func/Templates/NewCommandRenderer.cs
@@ -44,12 +44,9 @@ internal sealed class NewCommandRenderer(IInteractionService interaction)
 
         _interaction.WriteWarning(
             $"No '{channelName}' templates workload installed for bundle '{bundleId}'; using stable templates instead.");
-        _interaction.WriteLine("Templates may differ from what your bundle ships. Install the matching workload:");
+        _interaction.WriteLine("Templates may differ from what your bundle ships.");
         _interaction.WriteLine(l => l
-            .Muted("  ")
-            .Code($"func workload install {alias} --version <version>-{channelName}.1"));
-        _interaction.WriteLine(l => l
-            .Muted("Find available versions with: ")
+            .Muted("Find a matching workload with: ")
             .Code($"func workload search {alias} --prerelease"));
     }
 

--- a/src/Func/Templates/NewCommandRenderer.cs
+++ b/src/Func/Templates/NewCommandRenderer.cs
@@ -40,17 +40,17 @@ internal sealed class NewCommandRenderer(IInteractionService interaction)
     public void RenderTemplatesChannelFallback(string stack, string bundleId, BundleChannel projectChannel)
     {
         string channelName = projectChannel.ToDisplayString();
-        string suggestedPkg = TemplatesWorkloadConstants.GetPackageId(stack);
+        string alias = $"{stack.ToLowerInvariant()}-templates";
 
         _interaction.WriteWarning(
             $"No '{channelName}' templates workload installed for bundle '{bundleId}'; using stable templates instead.");
         _interaction.WriteLine("Templates may differ from what your bundle ships. Install the matching workload:");
         _interaction.WriteLine(l => l
             .Muted("  ")
-            .Code($"func workload install {suggestedPkg} --version <version>-{channelName}.1"));
+            .Code($"func workload install {alias}@<version>-{channelName}.1"));
         _interaction.WriteLine(l => l
             .Muted("Find available versions with: ")
-            .Code($"func workload search {suggestedPkg} --prerelease"));
+            .Code($"func workload search {alias} --prerelease"));
     }
 
     /// <summary>

--- a/src/Func/Templates/NewCommandRenderer.cs
+++ b/src/Func/Templates/NewCommandRenderer.cs
@@ -41,14 +41,16 @@ internal sealed class NewCommandRenderer(IInteractionService interaction)
     {
         string channelName = projectChannel.ToDisplayString();
         string suggestedPkg = TemplatesWorkloadConstants.GetPackageId(stack);
-        string suggestedVer = $"<version>-{channelName}.1";
 
         _interaction.WriteWarning(
             $"No '{channelName}' templates workload installed for bundle '{bundleId}'; using stable templates instead.");
+        _interaction.WriteLine("Templates may differ from what your bundle ships. Install the matching workload:");
         _interaction.WriteLine(l => l
-            .Muted("Templates may differ from what your bundle ships. Install the matching workload with: ")
-            .Code($"func workload install {suggestedPkg} --version {suggestedVer}")
-            .Muted("."));
+            .Muted("  ")
+            .Code($"func workload install {suggestedPkg} --version <version>-{channelName}.1"));
+        _interaction.WriteLine(l => l
+            .Muted("Find available versions with: ")
+            .Code($"func workload search {suggestedPkg} --prerelease"));
     }
 
     /// <summary>

--- a/src/Func/Templates/NewCommandRenderer.cs
+++ b/src/Func/Templates/NewCommandRenderer.cs
@@ -47,7 +47,7 @@ internal sealed class NewCommandRenderer(IInteractionService interaction)
         _interaction.WriteLine("Templates may differ from what your bundle ships. Install the matching workload:");
         _interaction.WriteLine(l => l
             .Muted("  ")
-            .Code($"func workload install {alias}@<version>-{channelName}.1"));
+            .Code($"func workload install {alias} --version <version>-{channelName}.1"));
         _interaction.WriteLine(l => l
             .Muted("Find available versions with: ")
             .Code($"func workload search {alias} --prerelease"));

--- a/src/Func/Templates/NewCommandRenderer.cs
+++ b/src/Func/Templates/NewCommandRenderer.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Bundles;
 using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Projects;
 
 namespace Azure.Functions.Cli.Templates;
 
@@ -27,6 +29,25 @@ internal sealed class NewCommandRenderer(IInteractionService interaction)
         _interaction.WriteLine(l => l
             .Muted("Install a templates workload: ")
             .Code("func workload install Azure.Functions.Cli.Workloads.Templates.<stack>")
+            .Muted("."));
+    }
+
+    /// <summary>
+    /// Renders the warning surfaced when the project's bundle channel
+    /// (preview / experimental) has no matching installed templates workload
+    /// and the runner has fallen back to the stable workload (issue #5369).
+    /// </summary>
+    public void RenderTemplatesChannelFallback(string stack, string bundleId, BundleChannel projectChannel)
+    {
+        string channelName = projectChannel.ToDisplayString();
+        string suggestedPkg = TemplatesWorkloadConstants.GetPackageId(stack);
+        string suggestedVer = $"<version>-{channelName}.1";
+
+        _interaction.WriteWarning(
+            $"No '{channelName}' templates workload installed for bundle '{bundleId}'; using stable templates instead.");
+        _interaction.WriteLine(l => l
+            .Muted("Templates may differ from what your bundle ships. Install the matching workload with: ")
+            .Code($"func workload install {suggestedPkg} --version {suggestedVer}")
             .Muted("."));
     }
 

--- a/src/Func/Templates/NewCommandRunner.cs
+++ b/src/Func/Templates/NewCommandRunner.cs
@@ -88,6 +88,11 @@ internal sealed class NewCommandRunner
 
         ResolvedContext resolved = outcome.Context!;
 
+        if (resolved.UsedStableFallback)
+        {
+            _renderer.RenderTemplatesChannelFallback(resolved.Stack, resolved.BundleId!, resolved.Channel);
+        }
+
         // Steps 11a / 11b: extension-bundle presence + min-bundle gate.
         // DotNet doesn't ship a templates-workload.json, so the gate is a
         // no-op for it; Node and Python carry one.
@@ -173,6 +178,11 @@ internal sealed class NewCommandRunner
         }
 
         ResolvedContext resolved = outcome.Context!;
+
+        if (resolved.UsedStableFallback)
+        {
+            _renderer.RenderTemplatesChannelFallback(resolved.Stack, resolved.BundleId!, resolved.Channel);
+        }
 
         IReadOnlyList<FunctionTemplateInfo> templates = await ListTemplatesAsync(resolved, cancellationToken);
         if (templates.Count == 0)
@@ -282,6 +292,7 @@ internal sealed class NewCommandRunner
         InstalledTemplatesWorkload? workload;
         string? bundleId = null;
         BundleChannel channel = BundleChannel.Unknown;
+        bool usedStableFallback = false;
         if (string.Equals(stack, "dotnet", StringComparison.OrdinalIgnoreCase))
         {
             IReadOnlyList<InstalledTemplatesWorkload> allRows =
@@ -310,6 +321,20 @@ internal sealed class NewCommandRunner
             IReadOnlyList<InstalledTemplatesWorkload> allRows =
                 await _installedTemplatesWorkloads.ListInstalledAsync(stack, cancellationToken);
             workload = TemplatesChannelMapper.PickChannelMatched(allRows, channel);
+
+            // Issue #5369: when the project asks for a non-stable channel
+            // (preview / experimental) and no matching workload is installed,
+            // fall back to the stable templates workload if one exists rather
+            // than hard-failing. The warning is emitted by Execute / List so
+            // pre-parse hydration paths stay silent.
+            if (workload is null && channel != BundleChannel.Stable)
+            {
+                workload = TemplatesChannelMapper.PickChannelMatched(allRows, BundleChannel.Stable);
+                if (workload is not null)
+                {
+                    usedStableFallback = true;
+                }
+            }
         }
 
         if (workload is null)
@@ -346,7 +371,8 @@ internal sealed class NewCommandRunner
             language,
             workload,
             bundleId,
-            channel));
+            channel,
+            usedStableFallback));
     }
 
     /// <summary>
@@ -715,7 +741,8 @@ internal sealed class NewCommandRunner
         string Language,
         InstalledTemplatesWorkload Workload,
         string? BundleId,
-        BundleChannel Channel);
+        BundleChannel Channel,
+        bool UsedStableFallback);
 
     private enum ResolutionFailureKind
     {

--- a/test/Func.Tests/Commands/Workload/WorkloadSearchCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadSearchCommandTests.cs
@@ -104,7 +104,7 @@ public class WorkloadSearchCommandTests
         Assert.Contains(_interaction.Lines, l => l.StartsWith("Description:") && l.EndsWith("Python workload"));
         Assert.Contains("HINT: Showing 1 result.", _interaction.Lines);
         Assert.Contains("HINT: Run 'func workload install <alias | package id>' to install one (stable by default).", _interaction.Lines);
-        Assert.Contains("HINT: When several versions or channels exist, pass --version (-v) to pick a specific one.", _interaction.Lines);
+        Assert.Contains("HINT: When several versions or channels exist, pass --version (-v) to install a specific version.", _interaction.Lines);
     }
 
     [Fact]

--- a/test/Func.Tests/Commands/Workload/WorkloadSearchCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadSearchCommandTests.cs
@@ -104,7 +104,7 @@ public class WorkloadSearchCommandTests
         Assert.Contains(_interaction.Lines, l => l.StartsWith("Description:") && l.EndsWith("Python workload"));
         Assert.Contains("HINT: Showing 1 result.", _interaction.Lines);
         Assert.Contains("HINT: Run 'func workload install <alias | package id>' to install one (stable by default).", _interaction.Lines);
-        Assert.Contains("HINT: When several versions or channels exist, pass --version (-v) to install a specific version.", _interaction.Lines);
+        Assert.Contains("HINT: When several versions or channels exist, pass --version (-v) to install a specific one.", _interaction.Lines);
     }
 
     [Fact]

--- a/test/Func.Tests/Commands/Workload/WorkloadSearchCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadSearchCommandTests.cs
@@ -103,7 +103,8 @@ public class WorkloadSearchCommandTests
         Assert.Contains(_interaction.Lines, l => l.StartsWith("Alias:") && l.EndsWith("python"));
         Assert.Contains(_interaction.Lines, l => l.StartsWith("Description:") && l.EndsWith("Python workload"));
         Assert.Contains("HINT: Showing 1 result.", _interaction.Lines);
-        Assert.Contains("HINT: Run 'func workload install <alias>' to install one.", _interaction.Lines);
+        Assert.Contains("HINT: Run 'func workload install <alias | package id>' to install one (stable by default).", _interaction.Lines);
+        Assert.Contains("HINT: When several versions or channels exist, pass --version (-v) to pick a specific one.", _interaction.Lines);
     }
 
     [Fact]

--- a/test/Func.Tests/Templates/NewCommandRunnerTests.cs
+++ b/test/Func.Tests/Templates/NewCommandRunnerTests.cs
@@ -62,6 +62,62 @@ public class NewCommandRunnerTests
         Assert.True(hits == 1, $"expected the missing-language error to be rendered exactly once, but it was rendered {hits} times. Output:\n{interaction.AllOutput}");
     }
 
+    [Fact]
+    public async Task ListAsync_ProjectChannelMissingWorkload_FallsBackToStableAndWarns()
+    {
+        // Repro of https://github.com/Azure/azure-functions-core-tools/issues/5369:
+        // project declares the preview extension bundle but only a stable
+        // templates workload is installed. The runner should fall back to the
+        // stable workload, emit a warning, and not hard-fail.
+        TestInteractionService interaction = new();
+        NewCommandRunner runner = BuildRunnerForChannelFallback(
+            interaction,
+            bundleId: BundleHelpers.PreviewBundleId,
+            installedVersions: ["1.0.0"]);
+
+        WorkingDirectory wd = new(new DirectoryInfo(Path.GetTempPath()), WasExplicit: false);
+        NewInvocation invocation = new(
+            WorkingDirectory: wd,
+            RequestedTemplate: null,
+            RequestedFunctionName: null,
+            Force: false,
+            NonInteractive: true);
+
+        int exitCode = await runner.ListAsync(invocation, CancellationToken.None);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains(interaction.Lines, l =>
+            l.Contains("WARNING") && l.Contains("preview") && l.Contains(BundleHelpers.PreviewBundleId));
+        Assert.DoesNotContain(interaction.Lines, l =>
+            l.Contains("No installed templates workload matches"));
+    }
+
+    [Fact]
+    public async Task ListAsync_ProjectChannelMissingAndNoStable_StillHardFails()
+    {
+        // Counterpart to the fallback test: when neither the project's
+        // channel nor stable is installed, the original hard-fail message
+        // still surfaces.
+        TestInteractionService interaction = new();
+        NewCommandRunner runner = BuildRunnerForChannelFallback(
+            interaction,
+            bundleId: BundleHelpers.PreviewBundleId,
+            installedVersions: ["1.0.0-experimental.1"]);
+
+        WorkingDirectory wd = new(new DirectoryInfo(Path.GetTempPath()), WasExplicit: false);
+        NewInvocation invocation = new(
+            WorkingDirectory: wd,
+            RequestedTemplate: null,
+            RequestedFunctionName: null,
+            Force: false,
+            NonInteractive: true);
+
+        int exitCode = await runner.ListAsync(invocation, CancellationToken.None);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains(interaction.Lines, l => l.Contains("No installed templates workload matches"));
+    }
+
     private static NewCommandRunner BuildRunnerForMissingLanguage(TestInteractionService interaction)
     {
         // Project resolver returns a multi-language dotnet project.
@@ -109,6 +165,47 @@ public class NewCommandRunnerTests
             Substitute.For<IExtensionBundleResolver>());
     }
 
+    private static NewCommandRunner BuildRunnerForChannelFallback(
+        TestInteractionService interaction,
+        string bundleId,
+        IReadOnlyList<string> installedVersions)
+    {
+        IFunctionsProjectResolver projectResolver = Substitute.For<IFunctionsProjectResolver>();
+        WorkingDirectory wd = new(new DirectoryInfo(Path.GetTempPath()), WasExplicit: false);
+        projectResolver
+            .ResolveProjectAsync(Arg.Any<ProjectResolutionContext>(), Arg.Any<CancellationToken>())
+            .Returns(ProjectResolutionResults.Resolved(new FakeNodeProject(wd), "fake"));
+
+        IProfileResolver profileResolver = Substitute.For<IProfileResolver>();
+
+        IOptionsMonitor<StackOptions> stackOptions = Substitute.For<IOptionsMonitor<StackOptions>>();
+        stackOptions.Get(Arg.Any<string>()).Returns(new StackOptions { Runtime = "node", Language = "javascript" });
+
+        IInstalledTemplatesWorkloads installedTemplates = Substitute.For<IInstalledTemplatesWorkloads>();
+        installedTemplates
+            .ListInstalledAsync("node", Arg.Any<CancellationToken>())
+            .Returns(installedVersions.Select(v => new InstalledTemplatesWorkload("node", v, Path.GetTempPath())).ToList());
+
+        IHostJsonBundleSectionReader hostJsonReader = Substitute.For<IHostJsonBundleSectionReader>();
+        hostJsonReader
+            .ReadAsync(Arg.Any<DirectoryInfo>(), Arg.Any<CancellationToken>())
+            .Returns(new HostJsonBundleSection(bundleId, "[4.*, 5.0.0)"));
+
+        return new NewCommandRunner(
+            interaction,
+            projectResolver,
+            profileResolver,
+            stackOptions,
+            projectInitializers: Array.Empty<IProjectInitializer>(),
+            installedTemplates,
+            new TemplateEngineProviderRegistry([]),
+            new TemplateOptionHydrator(Array.Empty<IProjectInitializer>()),
+            new TemplatePicker(interaction),
+            new NewCommandRenderer(interaction),
+            hostJsonReader,
+            Substitute.For<IExtensionBundleResolver>());
+    }
+
     private sealed class FakeDotNetProject(WorkingDirectory workingDirectory) : FunctionsProject
     {
         private readonly WorkingDirectory _workingDirectory = workingDirectory;
@@ -122,6 +219,23 @@ public class NewCommandRunnerTests
         public override string StackDisplayName => ".NET";
 
         public override bool SupportsExtensionBundles => false;
+
+        public override FunctionsWorkerReference WorkerReference => _workerReference;
+    }
+
+    private sealed class FakeNodeProject(WorkingDirectory workingDirectory) : FunctionsProject
+    {
+        private readonly WorkingDirectory _workingDirectory = workingDirectory;
+        private readonly FunctionsWorkerReference _workerReference =
+            FunctionsWorkerReference.FromWorkerInfo("Node.js", "node", "/tmp/worker.config.json", "1.0.0");
+
+        public override WorkingDirectory WorkingDirectory => _workingDirectory;
+
+        public override string StackName => "node";
+
+        public override string StackDisplayName => "Node.js";
+
+        public override bool SupportsExtensionBundles => true;
 
         public override FunctionsWorkerReference WorkerReference => _workerReference;
     }


### PR DESCRIPTION
Resolves #5369.

When `func new` runs in a project whose extension bundle is `Preview` or `Experimental` and no channel-matched templates workload is installed, the command used to hard-fail. This change makes the resolution degrade gracefully:

1. Prefer the channel-matched templates workload.
2. If none is installed and a stable one is, fall back to it and emit a warning explaining the mismatch plus the `func workload install ... --version <version>-<channel>.1` hint.
3. If nothing is installed at all, surface the existing hard-fail message unchanged.

The warning fires from `Execute` / `List` only, so pre-parse hydration paths stay silent and we don't double-render.

### Tests
- `ListAsync_ProjectChannelMissingWorkload_FallsBackToStableAndWarns`
- `ListAsync_ProjectChannelMissingAndNoStable_StillHardFails`
- Existing template tests still green (77/77).