### PR TITLE
fix(workload): show one row per channel in `workload search` --prerelease

### DIFF
--- a/src/Func/Commands/Workload/WorkloadSearchCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadSearchCommand.cs
@@ -6,6 +6,7 @@ using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Workloads.Catalog;
 using Microsoft.Extensions.Options;
+using NuGet.Versioning;
 
 namespace Azure.Functions.Cli.Commands.Workload;
 
@@ -24,6 +25,11 @@ internal sealed class WorkloadSearchCommand : FuncCliCommand
     // workload (the only kind `func init --stack` can target). Mirrors the
     // `kind:workload` PackageTag stack csprojs emit.
     private const string StackKind = "workload";
+
+    // Label used for non-prerelease versions when grouping search results by
+    // release channel. Versions without a prerelease label all collapse to
+    // this single bucket so the stable channel renders as one row.
+    private const string StableChannel = "stable";
 
     private readonly IInteractionService _interaction;
     private readonly IWorkloadCatalog _catalog;
@@ -109,12 +115,24 @@ internal sealed class WorkloadSearchCommand : FuncCliCommand
             results = [.. results.Where(r => string.Equals(r.Kind, StackKind, StringComparison.OrdinalIgnoreCase))];
         }
 
+        // Track the number of distinct packages the catalog returned before
+        // we expand into per-channel rows, so the "more may be available"
+        // hint stays anchored to the search page size rather than the
+        // post-expansion row count.
+        int packageCount = results.Count;
+
+        if (effectivePrerelease && results.Count > 0)
+        {
+            results = await ExpandResultsByChannelAsync(results, cancellationToken);
+        }
+
         if (json)
         {
             _interaction.WriteJson(results.Select(r => new
             {
                 packageId = r.PackageId,
                 latestVersion = r.LatestVersion.ToNormalizedString(),
+                channel = r.Channel,
                 title = r.Title,
                 description = r.Description,
                 aliases = r.Aliases,
@@ -141,24 +159,102 @@ internal sealed class WorkloadSearchCommand : FuncCliCommand
             WriteCard(card, result);
         }
 
-        WriteFooter(results.Count);
+        WriteFooter(results.Count, packageCount);
         return 0;
+    }
+
+    /// <summary>
+    /// Returns the channel a version belongs to. Non-prerelease versions all
+    /// fall in <c>stable</c>; prerelease versions take the first release
+    /// label (e.g. <c>4.42.0-preview.1</c> → <c>preview</c>,
+    /// <c>5.0.0-experimental</c> → <c>experimental</c>). Any post-dash label
+    /// becomes its own channel, so the command isn't limited to a hard-coded
+    /// preview/experimental list.
+    /// </summary>
+    internal static string GetChannel(NuGetVersion version)
+    {
+        ArgumentNullException.ThrowIfNull(version);
+        if (!version.IsPrerelease)
+        {
+            return StableChannel;
+        }
+
+        foreach (string label in version.ReleaseLabels)
+        {
+            if (!string.IsNullOrWhiteSpace(label))
+            {
+                return label.ToLowerInvariant();
+            }
+        }
+
+        return StableChannel;
+    }
+
+    /// <summary>
+    /// Expands each search hit into one row per release channel, fetching
+    /// the full version list per package and picking the latest version in
+    /// each channel. Preserves the original package ordering returned by
+    /// the catalog; within a package, channels are sorted by latest version
+    /// descending so the newest channel renders first.
+    /// </summary>
+    private async Task<IReadOnlyList<CatalogSearchResult>> ExpandResultsByChannelAsync(
+        IReadOnlyList<CatalogSearchResult> results,
+        CancellationToken cancellationToken)
+    {
+        CatalogSearchResult[][] perPackage = await Task.WhenAll(results.Select(r => ExpandSingleAsync(r, cancellationToken)));
+        return [.. perPackage.SelectMany(x => x)];
+    }
+
+    private async Task<CatalogSearchResult[]> ExpandSingleAsync(CatalogSearchResult result, CancellationToken cancellationToken)
+    {
+        IReadOnlyList<NuGetVersion> versions;
+        try
+        {
+            versions = await _catalog.ListVersionsAsync(result.PackageId, result.Source.Source, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            // Version listing failures shouldn't drop the package from
+            // search output, the user can still see and install the row
+            // they already had. Fall back to the original hit, just
+            // tagged with the channel of the version we already know.
+            return [result with { Channel = GetChannel(result.LatestVersion) }];
+        }
+
+        if (versions.Count == 0)
+        {
+            return [result with { Channel = GetChannel(result.LatestVersion) }];
+        }
+
+        return [.. versions
+            .GroupBy(GetChannel, StringComparer.OrdinalIgnoreCase)
+            .Select(g => result with { LatestVersion = g.Max()!, Channel = g.Key })
+            .OrderByDescending(r => r.LatestVersion)];
     }
 
     private static void WriteCard(WorkloadCardWriter card, CatalogSearchResult result)
     {
         card.WriteHeading(DisplayNameOrPackageId(result));
         card.WriteField("Version", result.LatestVersion.ToNormalizedString());
+        if (!string.IsNullOrEmpty(result.Channel))
+        {
+            card.WriteField("Channel", result.Channel);
+        }
+
         card.WriteField("Package ID", result.PackageId);
         card.WriteAliases(result.Aliases);
         card.WriteDescription(result.Description);
     }
 
-    private void WriteFooter(int count)
+    private void WriteFooter(int count, int packageCount)
     {
         _interaction.WriteBlankLine();
         string countLine = $"Showing {count} {(count == 1 ? "result" : "results")}.";
-        if (count >= DefaultTake)
+        if (packageCount >= DefaultTake)
         {
             countLine += " More may be available, refine your query.";
         }

--- a/src/Func/Workloads/Catalog/CatalogSearchResult.cs
+++ b/src/Func/Workloads/Catalog/CatalogSearchResult.cs
@@ -38,6 +38,15 @@ internal sealed record CatalogSearchResult(
     /// matches the current platform when an alias spans multiple per-RID packs.
     /// </summary>
     public string? Rid { get; init; }
+
+    /// <summary>
+    /// Release channel this row represents (e.g. <c>stable</c>, <c>preview</c>,
+    /// <c>experimental</c>). Set when <c>func workload search</c> expands a
+    /// single package into one row per channel so users can install a
+    /// non-latest channel. <see langword="null"/> when channel grouping was
+    /// not requested.
+    /// </summary>
+    public string? Channel { get; init; }
 }
 
 /// <summary>

--- a/src/Func/Workloads/Catalog/IWorkloadCatalog.cs
+++ b/src/Func/Workloads/Catalog/IWorkloadCatalog.cs
@@ -90,6 +90,21 @@ internal interface IWorkloadCatalog
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Lists every version of <paramref name="packageId"/> visible on the
+    /// configured source, including prerelease versions. Used by
+    /// <c>func workload search</c> to surface the latest version of each
+    /// release channel (stable, preview, experimental, ...) instead of just
+    /// the single highest version.
+    /// </summary>
+    /// <param name="packageId">NuGet package id; case-insensitive.</param>
+    /// <param name="source">Optional <c>--source</c> override.</param>
+    /// <param name="cancellationToken">Cancellation propagated to the underlying request.</param>
+    public Task<IReadOnlyList<NuGetVersion>> ListVersionsAsync(
+        string packageId,
+        string? source = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Downloads the <c>.nupkg</c> for <paramref name="package"/> to a temp
     /// file and returns an open read stream over it. The caller owns the
     /// returned stream; closing it removes the temp file.

--- a/src/Func/Workloads/Catalog/WorkloadCatalog.cs
+++ b/src/Func/Workloads/Catalog/WorkloadCatalog.cs
@@ -69,6 +69,13 @@ internal sealed class WorkloadCatalog(IOptions<WorkloadCatalogOptions> options, 
     }
 
     /// <inheritdoc />
+    public Task<IReadOnlyList<NuGetVersion>> ListVersionsAsync(string packageId, string? source = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+        return ResolveClient(source).ListVersionsAsync(packageId, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public Task<Stream> DownloadAsync(ResolvedPackage package, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(package);

--- a/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
+++ b/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
@@ -824,6 +824,13 @@ public sealed class SetupRunnerTests : IDisposable
         public Task<Stream> DownloadAsync(ResolvedPackage package, CancellationToken cancellationToken = default)
             => Task.FromResult<Stream>(new MemoryStream());
 
+        public Task<IReadOnlyList<NuGetVersion>> ListVersionsAsync(string packageId, string? source = null, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult<IReadOnlyList<NuGetVersion>>(
+                _latest.TryGetValue(packageId, out NuGetVersion? version) ? [version] : []);
+        }
+
         private ResolvedPackage? CreateResolved(string packageId, NuGetVersion? version)
             => version is null ? null : new ResolvedPackage(packageId.ToLowerInvariant(), version, _source);
     }

--- a/test/Func.Tests/Commands/Workload/WorkloadSearchCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadSearchCommandTests.cs
@@ -277,10 +277,134 @@ public class WorkloadSearchCommandTests
         Assert.Contains("\"aliases\":[\"python\"]", jsonLine);
     }
 
+    [Fact]
+    public async Task Search_Prerelease_ExpandsResultsByChannel()
+    {
+        // Search returns the highest prerelease per package, we expand into
+        // one row per channel by listing every version of the package.
+        StubSearch(
+            new CatalogSearchResult(
+                "func.workload.bundles",
+                NuGetVersion.Parse("4.42.0-preview.1"),
+                Title: "Extension Bundles",
+                Description: "Bundles",
+                Aliases: ["bundles"],
+                Source: _stubSource));
+        StubVersions(
+            "func.workload.bundles",
+            NuGetVersion.Parse("4.35.0"),
+            NuGetVersion.Parse("4.40.0-experimental.2"),
+            NuGetVersion.Parse("4.42.0-preview.1"));
+
+        var cmd = new WorkloadSearchCommand(_interaction, _catalog, _testCatalogOptions);
+        int exit = await InvokeAsync(cmd, "--prerelease");
+
+        Assert.Equal(0, exit);
+        // One card per channel. Channel-label line is emitted on expansion
+        // so users can tell which row matches `--version` for which channel.
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("Version:") && l.EndsWith("4.42.0-preview.1"));
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("Version:") && l.EndsWith("4.40.0-experimental.2"));
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("Version:") && l.EndsWith("4.35.0"));
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("Channel:") && l.EndsWith("preview"));
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("Channel:") && l.EndsWith("experimental"));
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("Channel:") && l.EndsWith("stable"));
+        Assert.Contains("HINT: Showing 3 results.", _interaction.Lines);
+    }
+
+    [Fact]
+    public async Task Search_Prerelease_PicksLatestPerChannel()
+    {
+        StubSearch(
+            new CatalogSearchResult(
+                "pkg",
+                NuGetVersion.Parse("2.0.0-preview.5"),
+                Title: "Pkg",
+                Description: null,
+                Aliases: [],
+                Source: _stubSource));
+        StubVersions(
+            "pkg",
+            NuGetVersion.Parse("1.5.0"),
+            NuGetVersion.Parse("2.0.0"),
+            NuGetVersion.Parse("2.0.0-preview.1"),
+            NuGetVersion.Parse("2.0.0-preview.5"),
+            NuGetVersion.Parse("2.1.0-preview.2"));
+
+        var cmd = new WorkloadSearchCommand(_interaction, _catalog, _testCatalogOptions);
+        await InvokeAsync(cmd, "--prerelease");
+
+        // Latest stable wins out over earlier stable, latest preview wins
+        // out over earlier prereleases on the same channel.
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("Version:") && l.EndsWith("2.1.0-preview.2"));
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("Version:") && l.EndsWith("2.0.0"));
+        Assert.DoesNotContain(_interaction.Lines, l => l.StartsWith("Version:") && l.EndsWith("2.0.0-preview.5"));
+        Assert.DoesNotContain(_interaction.Lines, l => l.StartsWith("Version:") && l.EndsWith("1.5.0"));
+    }
+
+    [Fact]
+    public async Task Search_NoPrerelease_DoesNotExpand()
+    {
+        StubSearch(
+            new CatalogSearchResult(
+                "pkg",
+                NuGetVersion.Parse("1.0.0"),
+                Title: "Pkg",
+                Description: null,
+                Aliases: [],
+                Source: _stubSource));
+
+        var cmd = new WorkloadSearchCommand(_interaction, _catalog, _testCatalogOptions);
+        await InvokeAsync(cmd);
+
+        // ListVersionsAsync is not called when prerelease is off, the
+        // server-side search filter already gives us the stable row.
+        await _catalog.DidNotReceiveWithAnyArgs().ListVersionsAsync(default!, default, default);
+        Assert.DoesNotContain(_interaction.Lines, l => l.StartsWith("Channel:"));
+    }
+
+    [Fact]
+    public async Task Search_Prerelease_ListVersionsFailure_FallsBackToOriginalRow()
+    {
+        StubSearch(
+            new CatalogSearchResult(
+                "pkg",
+                NuGetVersion.Parse("1.0.0-preview"),
+                Title: "Pkg",
+                Description: null,
+                Aliases: [],
+                Source: _stubSource));
+        _catalog.ListVersionsAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns<Task<IReadOnlyList<NuGetVersion>>>(_ => throw new InvalidOperationException("feed down"));
+
+        var cmd = new WorkloadSearchCommand(_interaction, _catalog, _testCatalogOptions);
+        int exit = await InvokeAsync(cmd, "--prerelease");
+
+        Assert.Equal(0, exit);
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("Version:") && l.EndsWith("1.0.0-preview"));
+        Assert.Contains(_interaction.Lines, l => l.StartsWith("Channel:") && l.EndsWith("preview"));
+    }
+
+    [Theory]
+    [InlineData("1.0.0", "stable")]
+    [InlineData("1.0.0-preview.1", "preview")]
+    [InlineData("4.42.0-experimental.2", "experimental")]
+    [InlineData("1.0.0-alpha", "alpha")]
+    [InlineData("1.0.0-rc.1+build.5", "rc")]
+    public void GetChannel_ParsesPrereleaseLabel(string version, string expectedChannel)
+    {
+        Assert.Equal(expectedChannel, WorkloadSearchCommand.GetChannel(NuGetVersion.Parse(version)));
+    }
+
     private void StubSearch(params CatalogSearchResult[] results)
     {
         _catalog.SearchAsync(Arg.Any<CatalogSearchQuery>(), Arg.Any<CancellationToken>())
             .Returns(results);
+    }
+
+    private void StubVersions(string packageId, params NuGetVersion[] versions)
+    {
+        _catalog.ListVersionsAsync(packageId, Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<NuGetVersion>)versions);
     }
 
     private static Task<int> InvokeAsync(WorkloadSearchCommand cmd, params string[] args)


### PR DESCRIPTION
resolves #5370

## Problem
`func workload search` collapses results to one row per package (the highest version returned by the V3 search endpoint), so users only ever see the latest channel's build. With `--prerelease`, the stable row was hidden behind a newer `-preview` / `-experimental` version, and there was no way to discover the right `--version` for a non-default channel.

## Fix
When `--prerelease` is on, expand each search hit into one row per release channel by listing all versions of the package and picking the latest per channel. A `Channel:` field is rendered on each card (and surfaced in `--json` as `channel`) so it's obvious which row maps to which install target.

Channels are derived from the prerelease label: no label → `stable`, otherwise the first dot-separated label segment (so `4.42.0-preview.1` → `preview`, `5.0.0-experimental.2` → `experimental`, `1.0.0-rc.1` → `rc`, etc.). Per the issue's follow-up note, the command isn't restricted to a hard-coded `preview`/`experimental` allow-list; any post-dash label is its own channel.

Behaviour without `--prerelease` is unchanged: one stable row per package, no extra version listing call.

Other notes:
- `IWorkloadCatalog.ListVersionsAsync` is a new primitive that delegates to the existing source-client implementation.
- The "more may be available, refine your query" hint is now anchored to the package count returned by the catalog (the actual paging unit), not the post-expansion row count.
- Version listing per package runs in parallel (`Task.WhenAll`). A listing failure for one package falls back to the original search row instead of dropping it.

## Tests
- New unit coverage for channel expansion (latest-per-channel selection, no expansion without `--prerelease`, fallback when version listing fails, channel parsing).
- All 1201 existing tests pass.