### PR TITLE
Default func setup to stable bundle; honor host.json channel

### DIFF
--- a/src/Func/Bundles/BundleHelpers.cs
+++ b/src/Func/Bundles/BundleHelpers.cs
@@ -51,6 +51,37 @@ internal static class BundleHelpers
         };
 
     /// <summary>
+    /// Returns the NuGet prerelease label that identifies <paramref name="channel"/>,
+    /// or <c>null</c> for the stable channel (whose versions carry no prerelease label).
+    /// </summary>
+    /// <param name="channel">The channel to convert.</param>
+    /// <returns>The prerelease label, or <c>null</c> for stable.</returns>
+    public static string? ToPrereleaseLabel(this BundleChannel channel) =>
+        channel switch
+        {
+            BundleChannel.Stable => null,
+            BundleChannel.Preview => PreviewLabel,
+            BundleChannel.Experimental => ExperimentalLabel,
+            _ => throw new ArgumentOutOfRangeException(nameof(channel), channel, null)
+        };
+
+    /// <summary>
+    /// Determines whether <paramref name="version"/> belongs to <paramref name="channel"/>.
+    /// Stable matches only released versions; preview and experimental match prerelease
+    /// versions whose label identifies that channel.
+    /// </summary>
+    /// <param name="version">The nuget package version.</param>
+    /// <param name="channel">The channel to test against.</param>
+    /// <returns>True when the version belongs to the channel.</returns>
+    public static bool MatchesChannel(NuGetVersion version, BundleChannel channel)
+    {
+        ArgumentNullException.ThrowIfNull(version);
+        return channel == BundleChannel.Stable
+            ? !version.IsPrerelease
+            : version.IsPrerelease && GetBundleChannel(version) == channel;
+    }
+
+    /// <summary>
     /// Gets the channel label for a given bundle ID.
     /// </summary>
     /// <param name="bundleId">The bundle ID.</param>

--- a/src/Func/Commands/InitCommand.cs
+++ b/src/Func/Commands/InitCommand.cs
@@ -4,6 +4,7 @@
 using System.CommandLine;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Azure.Functions.Cli.Bundles;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Configuration;
 using Azure.Functions.Cli.Console;
@@ -56,6 +57,8 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
     private readonly IWorkloadHintRenderer _hintRenderer;
     private readonly ILocalSettingsProvider _localSettingsProvider;
     private readonly IFunctionsProjectResolver _projectResolver;
+    private readonly IHostJsonBundleSectionReader _bundleSectionReader;
+    private readonly InstalledBundleScanner _bundleScanner;
     private readonly IReadOnlyList<IProjectInitializer> _initializers;
 
     public InitCommand(
@@ -63,6 +66,8 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
         IWorkloadHintRenderer hintRenderer,
         ILocalSettingsProvider localSettingsProvider,
         IFunctionsProjectResolver projectResolver,
+        IHostJsonBundleSectionReader bundleSectionReader,
+        InstalledBundleScanner bundleScanner,
         IEnumerable<IProjectInitializer> initializers)
         : base("init", "Initialize a new Azure Functions project.")
     {
@@ -70,12 +75,16 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
         ArgumentNullException.ThrowIfNull(hintRenderer);
         ArgumentNullException.ThrowIfNull(localSettingsProvider);
         ArgumentNullException.ThrowIfNull(projectResolver);
+        ArgumentNullException.ThrowIfNull(bundleSectionReader);
+        ArgumentNullException.ThrowIfNull(bundleScanner);
         ArgumentNullException.ThrowIfNull(initializers);
 
         _interaction = interaction;
         _hintRenderer = hintRenderer;
         _localSettingsProvider = localSettingsProvider;
         _projectResolver = projectResolver;
+        _bundleSectionReader = bundleSectionReader;
+        _bundleScanner = bundleScanner;
         _initializers = initializers.ToList();
 
         StackOption.Description = BuildStackOptionDescription(_initializers);
@@ -332,7 +341,33 @@ internal class InitCommand : FuncCliCommand, IBuiltInCommand
             .Code(initializer.Stack)
             .Muted("."));
 
+        await WarnIfBundleChannelNotInstalledAsync(workingDirectory.Info, cancellationToken);
+
         return 0;
+    }
+
+    // A fresh scaffold may pin a preview/experimental bundle channel (via `-c`).
+    // Warn when no bundle workload for that channel is installed, pointing at
+    // workload search so `func start` doesn't later fail to resolve the bundle.
+    private async Task WarnIfBundleChannelNotInstalledAsync(DirectoryInfo projectDirectory, CancellationToken cancellationToken)
+    {
+        HostJsonBundleSection? bundle = await _bundleSectionReader.ReadAsync(projectDirectory, cancellationToken);
+        if (bundle is null
+            || !BundleHelpers.TryGetBundleChannel(bundle.Id, out BundleChannel channel)
+            || channel == BundleChannel.Stable)
+        {
+            return;
+        }
+
+        ScanResult scan = await _bundleScanner.ScanAsync(channel, cancellationToken);
+        if (scan.FilteredVersions.Count > 0)
+        {
+            return;
+        }
+
+        _interaction.WriteWarning(
+            $"This project targets the '{channel.ToDisplayString()}' extension bundle channel, but no matching bundle workload is installed. "
+            + "Find one with: func workload search bundles --prerelease");
     }
 
     private enum InitializationState

--- a/src/Func/Commands/Setup/SetupRenderer.cs
+++ b/src/Func/Commands/Setup/SetupRenderer.cs
@@ -79,6 +79,11 @@ internal sealed class SetupRenderer(IInteractionService interaction, SetupOutput
 
             payload["version"] = result.Version;
             payload["message"] = result.Message;
+            if (result.Warning is not null)
+            {
+                payload["warning"] = result.Warning;
+            }
+
             WriteEvent("dependency.result", payload);
             return;
         }
@@ -104,6 +109,11 @@ internal sealed class SetupRenderer(IInteractionService interaction, SetupOutput
             case SetupDependencyStatus.Failed:
                 _interaction.WriteError(result.Message);
                 break;
+        }
+
+        if (result.Warning is not null)
+        {
+            _interaction.WriteWarning(result.Warning);
         }
     }
 

--- a/src/Func/Commands/Setup/SetupRunner.cs
+++ b/src/Func/Commands/Setup/SetupRunner.cs
@@ -7,6 +7,7 @@ using Azure.Functions.Cli.Configuration;
 using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Hosting.FirstRun;
 using Azure.Functions.Cli.Profiles;
+using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Workloads;
 using Azure.Functions.Cli.Workloads.Catalog;
 using Azure.Functions.Cli.Workloads.Discovery;
@@ -405,6 +406,9 @@ internal sealed class SetupRunner(
         List<SetupDependency> dependencies = [];
         List<SetupDependencyResult> failures = [];
 
+        HostJsonBundleSection? hostJsonBundle = await _hostJsonBundleSectionReader.ReadAsync(workingDirectory, cancellationToken);
+        BundleChannel bundleChannel = ResolveBundleChannel(hostJsonBundle);
+
         dependencies.Add(SetupDependency.Host(profileScope.Profile?.HostVersionRange));
 
         foreach (SetupRuntimeFeature runtimeFeature in featurePlan.RuntimeFeatures)
@@ -443,53 +447,54 @@ internal sealed class SetupRunner(
 
             if (SetupDependency.SupportsTemplates(runtimeFeature.Name))
             {
-                dependencies.Add(SetupDependency.Templates(runtimeFeature.Name));
+                // Script stacks ship per-channel templates that track the bundle
+                // channel; dotnet templates don't use bundles, so they stay channel-less.
+                BundleChannel? templatesChannel = IsDotNetRuntime(runtimeFeature.Name) ? null : bundleChannel;
+                dependencies.Add(SetupDependency.Templates(runtimeFeature.Name, templatesChannel));
             }
         }
 
         if (featurePlan.IncludeExtensionBundle)
         {
-            SetupDependencyResult? failure = null;
-            SetupDependency? bundleDependency = await TryCreateBundleDependencyAsync(workingDirectory, profileScope, cancellationToken);
+            SetupDependency? bundleDependency = CreateBundleDependency(hostJsonBundle, bundleChannel, profileScope);
             if (bundleDependency is null)
             {
-                var dependency = SetupDependency.Bundle(BundleHelpers.StableBundleId, versionRange: null, rangeText: null);
-                failure = SetupDependencyResult.Failed(
+                var dependency = SetupDependency.Bundle(BundleHelpers.StableBundleId, versionRange: null, rangeText: null, BundleChannel.Stable);
+                failures.Add(SetupDependencyResult.Failed(
                     dependency,
-                    "The host.json extensionBundle range and profile extensionBundle range do not overlap.");
+                    "The host.json extensionBundle range and profile extensionBundle range do not overlap."));
             }
             else
             {
                 dependencies.Add(bundleDependency);
-            }
-
-            if (failure is not null)
-            {
-                failures.Add(failure);
             }
         }
 
         return new SetupDependencyPlan(dependencies, failures);
     }
 
-    private async Task<SetupDependency?> TryCreateBundleDependencyAsync(
-        DirectoryInfo workingDirectory,
-        SetupProfileScope profileScope,
-        CancellationToken cancellationToken)
+    private static BundleChannel ResolveBundleChannel(HostJsonBundleSection? hostJsonBundle)
+        => hostJsonBundle is not null && BundleHelpers.TryGetBundleChannel(hostJsonBundle.Id, out BundleChannel channel)
+            ? channel
+            : BundleChannel.Stable;
+
+    private static SetupDependency? CreateBundleDependency(
+        HostJsonBundleSection? hostJsonBundle,
+        BundleChannel channel,
+        SetupProfileScope profileScope)
     {
-        HostJsonBundleSection? hostJsonBundle = await _hostJsonBundleSectionReader.ReadAsync(workingDirectory, cancellationToken);
         VersionRange? profileRange = profileScope.Profile?.ExtensionBundleVersionRange;
         string? profileRangeText = RangeText(profileRange);
 
         if (hostJsonBundle is null)
         {
-            return SetupDependency.Bundle(BundleHelpers.StableBundleId, profileRange, profileRangeText);
+            return SetupDependency.Bundle(BundleHelpers.StableBundleId, profileRange, profileRangeText, channel);
         }
 
         VersionRange? effectiveRange = VersionRangeIntersection.Intersect(hostJsonBundle.Version, profileRangeText);
         return effectiveRange is null
             ? null
-            : SetupDependency.Bundle(hostJsonBundle.Id, effectiveRange, RangeText(effectiveRange));
+            : SetupDependency.Bundle(hostJsonBundle.Id, effectiveRange, RangeText(effectiveRange), channel);
     }
 
     private async Task<SetupDependencyResult> EnsureDependencyAsync(
@@ -537,25 +542,30 @@ internal sealed class SetupRunner(
         }
 
         ResolvedPackage package = resolution.Package!;
+        string? channelWarning = resolution.Warning;
         dependency = dependency with { ResolvedPackageId = package.PackageId };
-        InstalledCandidate? exactInstalled = GetInstalledCandidates(installed, dependency, options.IncludePrerelease)
-            .FirstOrDefault(candidate => candidate.Version.Equals(package.Version));
+
+        // Match the exact resolved version directly: the version string already
+        // encodes the channel, so this stays correct when a channeled dependency
+        // fell back to the stable channel (where the installed version's channel
+        // no longer equals dependency.Channel).
+        bool exactInstalled = IsExactVersionInstalled(installed, dependency, package.Version);
 
         string targetVersion = package.Version.ToNormalizedString();
-        if (exactInstalled is not null)
+        if (exactInstalled)
         {
             return SetupDependencyResult.Satisfied(
                 dependency,
                 package.PackageId,
                 targetVersion,
-                $"{dependency.DisplayName} {targetVersion} is already installed.");
+                $"{dependency.DisplayName} {targetVersion} is already installed.") with { Warning = channelWarning };
         }
 
         if (options.Check)
         {
             return SetupDependencyResult.Failed(
                 dependency,
-                $"{dependency.DisplayName} {targetVersion} is not installed.");
+                $"{dependency.DisplayName} {targetVersion} is not installed.") with { Warning = channelWarning };
         }
 
         try
@@ -589,12 +599,12 @@ internal sealed class SetupRunner(
                     dependency,
                     installResult.Entry.PackageId,
                     installedVersion,
-                    $"{dependency.DisplayName} {installedVersion} is already installed.")
+                    $"{dependency.DisplayName} {installedVersion} is already installed.") with { Warning = channelWarning }
                 : SetupDependencyResult.Installed(
                     dependency,
                     installResult.Entry.PackageId,
                     installedVersion,
-                    $"Installed {dependency.DisplayName} {installedVersion}.");
+                    $"Installed {dependency.DisplayName} {installedVersion}.") with { Warning = channelWarning };
         }
         catch (WorkloadPackageNotFoundException ex)
         {
@@ -626,6 +636,11 @@ internal sealed class SetupRunner(
     {
         try
         {
+            if (dependency.Channel is { } channel)
+            {
+                return await ResolveChannelFromCatalogAsync(dependency, channel, source, cancellationToken);
+            }
+
             ResolvedPackage? package = dependency.VersionRange is null
                 ? await _workloadCatalog.ResolveLatestVersionAsync(
                     dependency.PackageId,
@@ -643,8 +658,7 @@ internal sealed class SetupRunner(
 
             if (package is null)
             {
-                string range = dependency.RangeText is null ? string.Empty : $" in range '{dependency.RangeText}'";
-                return CatalogResolution.Missing($"No {dependency.DisplayName} workload version{range} is available from the configured workload catalog.");
+                return CatalogResolution.Missing(NoVersionMessage(dependency));
             }
 
             return CatalogResolution.Resolved(package);
@@ -665,6 +679,59 @@ internal sealed class SetupRunner(
         }
     }
 
+    // Resolves a bundle or templates dependency on its declared channel. When the
+    // requested channel has nothing published we fall back to the stable channel
+    // (with a warning) so setup still provisions a working workload rather than failing.
+    private async Task<CatalogResolution> ResolveChannelFromCatalogAsync(
+        SetupDependency dependency,
+        BundleChannel channel,
+        string? source,
+        CancellationToken cancellationToken)
+    {
+        ResolvedPackage? package = await _workloadCatalog.ResolveLatestVersionOnChannelAsync(
+            dependency.PackageId,
+            channel.ToPrereleaseLabel(),
+            dependency.VersionRange,
+            source,
+            cancellationToken);
+
+        if (package is not null)
+        {
+            return CatalogResolution.Resolved(package);
+        }
+
+        if (channel != BundleChannel.Stable)
+        {
+            ResolvedPackage? stable = await _workloadCatalog.ResolveLatestVersionOnChannelAsync(
+                dependency.PackageId,
+                BundleChannel.Stable.ToPrereleaseLabel(),
+                dependency.VersionRange,
+                source,
+                cancellationToken);
+
+            if (stable is not null)
+            {
+                return CatalogResolution.Resolved(stable, ChannelFallbackWarning(dependency, channel));
+            }
+        }
+
+        return CatalogResolution.Missing(NoVersionMessage(dependency));
+    }
+
+    private static string ChannelFallbackWarning(SetupDependency dependency, BundleChannel channel)
+    {
+        string suggestion = dependency.SearchAlias is { } alias
+            ? $" Find a matching workload with: func workload search {alias} --prerelease"
+            : string.Empty;
+        return $"No '{channel.ToDisplayString()}' {dependency.DisplayName} is available; using stable instead.{suggestion}";
+    }
+
+    private static string NoVersionMessage(SetupDependency dependency)
+    {
+        string range = dependency.RangeText is null ? string.Empty : $" in range '{dependency.RangeText}'";
+        return $"No {dependency.DisplayName} workload version{range} is available from the configured workload catalog.";
+    }
+
     private static IReadOnlyList<InstalledCandidate> GetInstalledCandidates(
         IReadOnlyList<WorkloadEntry> installed,
         SetupDependency dependency,
@@ -674,8 +741,21 @@ internal sealed class SetupRunner(
         foreach (WorkloadEntry entry in installed)
         {
             if (!MatchesDependency(entry, dependency)
-                || !NuGetVersion.TryParse(entry.PackageVersion, out NuGetVersion? version)
-                || (!includePrerelease && version.IsPrerelease))
+                || !NuGetVersion.TryParse(entry.PackageVersion, out NuGetVersion? version))
+            {
+                continue;
+            }
+
+            // A channeled dependency only counts an installed version that belongs
+            // to the same channel; otherwise fall back to the prerelease toggle.
+            if (dependency.Channel is { } channel)
+            {
+                if (!BundleHelpers.MatchesChannel(version, channel))
+                {
+                    continue;
+                }
+            }
+            else if (!includePrerelease && version.IsPrerelease)
             {
                 continue;
             }
@@ -684,6 +764,21 @@ internal sealed class SetupRunner(
         }
 
         return candidates;
+    }
+
+    private static bool IsExactVersionInstalled(IReadOnlyList<WorkloadEntry> installed, SetupDependency dependency, NuGetVersion version)
+    {
+        foreach (WorkloadEntry entry in installed)
+        {
+            if (MatchesDependency(entry, dependency)
+                && NuGetVersion.TryParse(entry.PackageVersion, out NuGetVersion? installedVersion)
+                && installedVersion.Equals(version))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool MatchesDependency(WorkloadEntry entry, SetupDependency dependency)
@@ -791,9 +886,9 @@ internal sealed class SetupRunner(
         => string.Equals(runtime, DotNetFeature, StringComparison.OrdinalIgnoreCase)
             || string.Equals(runtime, DotNetProfileRuntime, StringComparison.OrdinalIgnoreCase);
 
-    private sealed record CatalogResolution(ResolvedPackage? Package, string? FailureMessage, bool PackageMissing)
+    private sealed record CatalogResolution(ResolvedPackage? Package, string? FailureMessage, bool PackageMissing, string? Warning = null)
     {
-        public static CatalogResolution Resolved(ResolvedPackage package) => new(package, FailureMessage: null, PackageMissing: false);
+        public static CatalogResolution Resolved(ResolvedPackage package, string? warning = null) => new(package, FailureMessage: null, PackageMissing: false, warning);
 
         public static CatalogResolution Failed(string failureMessage) => new(Package: null, failureMessage, PackageMissing: false);
 
@@ -828,7 +923,8 @@ internal sealed record SetupDependency(
     VersionRange? VersionRange,
     string? RangeText,
     string? ResolvedPackageId,
-    bool Optional = false)
+    bool Optional = false,
+    BundleChannel? Channel = null)
 {
     private const string WorkerPackagePrefix = "Azure.Functions.Cli.Workloads.Workers.";
     private const string StackPackagePrefix = "Azure.Functions.Cli.Workloads.";
@@ -875,7 +971,7 @@ internal sealed record SetupDependency(
             ResolvedPackageId: null,
             Optional: true);
 
-    public static SetupDependency Bundle(string bundleId, VersionRange? versionRange, string? rangeText)
+    public static SetupDependency Bundle(string bundleId, VersionRange? versionRange, string? rangeText, BundleChannel channel)
         => new(
             SetupDependencyKind.ExtensionBundle,
             bundleId,
@@ -883,7 +979,8 @@ internal sealed record SetupDependency(
             IInstalledBundleWorkloads.BundleWorkloadPackageId,
             versionRange,
             rangeText,
-            ResolvedPackageId: null);
+            ResolvedPackageId: null,
+            Channel: channel);
 
     public static SetupDependency Stack(string stack)
         => new(
@@ -900,7 +997,7 @@ internal sealed record SetupDependency(
 
     public static IReadOnlyList<string> Stacks => [.. _stacks];
 
-    public static SetupDependency Templates(string stack)
+    public static SetupDependency Templates(string stack, BundleChannel? channel)
         => new(
             SetupDependencyKind.Templates,
             stack,
@@ -909,10 +1006,20 @@ internal sealed record SetupDependency(
             VersionRange: null,
             RangeText: null,
             ResolvedPackageId: null,
-            Optional: true);
+            Optional: true,
+            Channel: channel);
 
     public static bool SupportsTemplates(string stack)
         => !string.IsNullOrWhiteSpace(stack) && _templates.Contains(stack.Trim());
+
+    // Workload search alias for the channel-fallback hint. Only the channeled
+    // dependency kinds (bundle, templates) need one.
+    public string? SearchAlias => Kind switch
+    {
+        SetupDependencyKind.ExtensionBundle => "bundles",
+        SetupDependencyKind.Templates => $"{Name}-templates",
+        _ => null,
+    };
 
     private static string StackPackageSuffix(string stack)
         => stack.Trim().ToLowerInvariant() switch
@@ -958,7 +1065,8 @@ internal sealed record SetupDependencyResult(
     SetupDependencyStatus Status,
     string? PackageId,
     string? Version,
-    string Message)
+    string Message,
+    string? Warning = null)
 {
     public static SetupDependencyResult Satisfied(SetupDependency dependency, string packageId, string version, string message)
         => new(dependency, SetupDependencyStatus.Satisfied, packageId, version, message);

--- a/src/Func/Workloads/Catalog/IWorkloadCatalog.cs
+++ b/src/Func/Workloads/Catalog/IWorkloadCatalog.cs
@@ -75,6 +75,31 @@ internal interface IWorkloadCatalog
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Returns the highest version of <paramref name="packageId"/> on a single
+    /// release channel, or <c>null</c> when no version matches. The stable
+    /// channel (<paramref name="prereleaseLabel"/> is <c>null</c>) selects only
+    /// released versions; any other value selects prerelease versions whose
+    /// first label equals it (e.g. <c>preview</c>, <c>experimental</c>).
+    /// </summary>
+    /// <remarks>
+    /// Unlike the other resolve methods, the channel fully determines prerelease
+    /// handling, so this ignores the catalog's configured prerelease default.
+    /// </remarks>
+    /// <param name="packageId">NuGet package id; case-insensitive.</param>
+    /// <param name="prereleaseLabel">
+    /// Prerelease label identifying the channel, or <c>null</c> for the stable channel.
+    /// </param>
+    /// <param name="versionRange">Optional range the selected version must satisfy.</param>
+    /// <param name="source">Optional <c>--source</c> override.</param>
+    /// <param name="cancellationToken">Cancellation propagated to the underlying request.</param>
+    public Task<ResolvedPackage?> ResolveLatestVersionOnChannelAsync(
+        string packageId,
+        string? prereleaseLabel,
+        VersionRange? versionRange = null,
+        string? source = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Resolves an exact <paramref name="version"/> of <paramref name="packageId"/>
     /// against the configured source. Returns <c>null</c> when the source does
     /// not advertise that version. Used by <c>install --version</c>.

--- a/src/Func/Workloads/Catalog/WorkloadCatalog.cs
+++ b/src/Func/Workloads/Catalog/WorkloadCatalog.cs
@@ -59,6 +59,18 @@ internal sealed class WorkloadCatalog(IOptions<WorkloadCatalogOptions> options, 
     }
 
     /// <inheritdoc />
+    public async Task<ResolvedPackage?> ResolveLatestVersionOnChannelAsync(string packageId, string? prereleaseLabel, VersionRange? versionRange = null,
+        string? source = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+        bool includePrerelease = prereleaseLabel is not null;
+
+        return await ResolveMatchingVersionAsync(packageId, source, cancellationToken,
+            versions => SelectLatest(versions, candidate => MatchesChannel(candidate, prereleaseLabel)
+                && (versionRange is null || SatisfiesRange(versionRange, candidate, includePrerelease))));
+    }
+
+    /// <inheritdoc />
     public async Task<ResolvedPackage?> ResolveVersionAsync(string packageId, NuGetVersion version, string? source = null, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
@@ -118,4 +130,9 @@ internal sealed class WorkloadCatalog(IOptions<WorkloadCatalogOptions> options, 
 
     private static bool SatisfiesRange(VersionRange range, NuGetVersion candidate, bool includePrerelease)
         => WorkloadVersionRanges.SatisfiesRange(range, candidate, includePrerelease);
+
+    private static bool MatchesChannel(NuGetVersion candidate, string? prereleaseLabel)
+        => prereleaseLabel is null
+            ? !candidate.IsPrerelease
+            : candidate.IsPrerelease && string.Equals(candidate.ReleaseLabels.FirstOrDefault(), prereleaseLabel, StringComparison.OrdinalIgnoreCase);
 }

--- a/src/Workloads/Tools/ExtensionBundles/README.md
+++ b/src/Workloads/Tools/ExtensionBundles/README.md
@@ -19,6 +19,20 @@ separate workload code to version).
 The prerelease label, when present, names the channel. `func` always
 reports the 3-part bundle version (`4.35.0`) in user-facing logs.
 
+## Channel selection in `func setup` and `func init`
+
+`func setup` installs the **stable** bundle by default. When a project's
+`host.json` opts into a channel via `extensionBundle.id` (the `.Preview` or
+`.Experimental` id above), setup installs the matching channel for both the
+bundle and the script-stack templates (Node, Python). If that channel has
+nothing published, setup falls back to the stable channel and prints a
+warning rather than failing; the warning points at
+`func workload search bundles --prerelease` so you can see what is available.
+
+`func init -s <stack> -c preview|experimental` scaffolds a `host.json` pinned
+to the chosen channel. If no bundle workload for that channel is installed, it
+prints a hint to run `func workload search bundles --prerelease`.
+
 ## Install
 
 ```bash

--- a/test/Func.Tests/Bundles/BundleHelpersTests.cs
+++ b/test/Func.Tests/Bundles/BundleHelpersTests.cs
@@ -158,6 +158,50 @@ public class BundleHelpersTests
         Assert.Throws<ArgumentOutOfRangeException>(() => ((BundleChannel)99).ToDisplayString());
     }
 
+    // --- ToPrereleaseLabel ---
+
+    [Fact]
+    public void ToPrereleaseLabel_Stable_ReturnsNull()
+    {
+        Assert.Null(BundleChannel.Stable.ToPrereleaseLabel());
+    }
+
+    [Theory]
+    [InlineData(BundleChannel.Preview, "preview")]
+    [InlineData(BundleChannel.Experimental, "experimental")]
+    public void ToPrereleaseLabel_PrereleaseChannel_ReturnsLabel(BundleChannel channel, string expected)
+    {
+        Assert.Equal(expected, channel.ToPrereleaseLabel());
+    }
+
+    [Theory]
+    [InlineData(BundleChannel.Unknown)]
+    [InlineData((BundleChannel)99)]
+    public void ToPrereleaseLabel_InvalidChannel_Throws(BundleChannel channel)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => channel.ToPrereleaseLabel());
+    }
+
+    // --- MatchesChannel ---
+
+    [Theory]
+    [InlineData("1.5.0", BundleChannel.Stable, true)]
+    [InlineData("2.0.0-preview.1", BundleChannel.Stable, false)]
+    [InlineData("2.0.0-preview.1", BundleChannel.Preview, true)]
+    [InlineData("2.0.0-experimental.1", BundleChannel.Preview, false)]
+    [InlineData("2.0.0-experimental.2", BundleChannel.Experimental, true)]
+    [InlineData("1.5.0", BundleChannel.Preview, false)]
+    public void MatchesChannel_ReturnsExpected(string version, BundleChannel channel, bool expected)
+    {
+        Assert.Equal(expected, BundleHelpers.MatchesChannel(NuGetVersion.Parse(version), channel));
+    }
+
+    [Fact]
+    public void MatchesChannel_NullVersion_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => BundleHelpers.MatchesChannel(null!, BundleChannel.Stable));
+    }
+
     // --- GetBundleChannel(NuGetVersion) null guard ---
 
     [Fact]

--- a/test/Func.Tests/Commands/InitCommandTests.cs
+++ b/test/Func.Tests/Commands/InitCommandTests.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine;
 using System.Text.Json;
+using Azure.Functions.Cli.Bundles;
 using Azure.Functions.Cli.Commands;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Configuration;
@@ -20,6 +21,8 @@ public class InitCommandTests
     private readonly RecordingWorkloadHintRenderer _hintRenderer;
     private readonly ILocalSettingsProvider _localSettings;
     private readonly IFunctionsProjectResolver _projectResolver;
+    private readonly IHostJsonBundleSectionReader _bundleReader;
+    private readonly IInstalledBundleWorkloads _installedBundles;
 
     public InitCommandTests()
     {
@@ -31,10 +34,18 @@ public class InitCommandTests
         _projectResolver
             .ResolveProjectAsync(Arg.Any<ProjectResolutionContext>(), Arg.Any<CancellationToken>())
             .Returns(ProjectResolutionResults.NotResolved("no project"));
+        _bundleReader = Substitute.For<IHostJsonBundleSectionReader>();
+        _bundleReader
+            .ReadAsync(Arg.Any<DirectoryInfo>(), Arg.Any<CancellationToken>())
+            .Returns((HostJsonBundleSection?)null);
+        _installedBundles = Substitute.For<IInstalledBundleWorkloads>();
+        _installedBundles
+            .ListInstalledAsync(Arg.Any<CancellationToken>())
+            .Returns([]);
     }
 
     private InitCommand CreateCommand(IEnumerable<IProjectInitializer> initializers) =>
-        new(_interaction, _hintRenderer, _localSettings, _projectResolver, initializers);
+        new(_interaction, _hintRenderer, _localSettings, _projectResolver, _bundleReader, new InstalledBundleScanner(_installedBundles), initializers);
 
     [Fact]
     public void InitCommand_HasExpectedOptions()
@@ -148,6 +159,80 @@ public class InitCommandTests
             {
                 Directory.Delete(newDir, recursive: true);
             }
+        }
+    }
+
+    [Fact]
+    public async Task InitCommand_PreviewChannelBundle_NoInstalledBundle_WarnsWithSearchHint()
+    {
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+
+        try
+        {
+            _bundleReader.ReadAsync(Arg.Any<DirectoryInfo>(), Arg.Any<CancellationToken>())
+                .Returns(new HostJsonBundleSection(BundleHelpers.PreviewBundleId, "[4.0.0, 5.0.0)"));
+
+            var initializer = new FakeProjectInitializer("python");
+            int exitCode = await RunInitAsync(newDir, initializer, language: "python", stack: "python");
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(
+                _interaction.Lines,
+                line => line.Contains("func workload search bundles --prerelease", StringComparison.Ordinal));
+        }
+        finally
+        {
+            CleanupDirectory(newDir);
+        }
+    }
+
+    [Fact]
+    public async Task InitCommand_PreviewChannelBundle_InstalledBundle_DoesNotWarn()
+    {
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+
+        try
+        {
+            _bundleReader.ReadAsync(Arg.Any<DirectoryInfo>(), Arg.Any<CancellationToken>())
+                .Returns(new HostJsonBundleSection(BundleHelpers.PreviewBundleId, "[4.0.0, 5.0.0)"));
+            _installedBundles.ListInstalledAsync(Arg.Any<CancellationToken>())
+                .Returns(new InstalledBundleWorkload[] { new("4.11.0-preview.1", newDir) });
+
+            var initializer = new FakeProjectInitializer("python");
+            int exitCode = await RunInitAsync(newDir, initializer, language: "python", stack: "python");
+
+            Assert.Equal(0, exitCode);
+            Assert.DoesNotContain(
+                _interaction.Lines,
+                line => line.Contains("func workload search bundles --prerelease", StringComparison.Ordinal));
+        }
+        finally
+        {
+            CleanupDirectory(newDir);
+        }
+    }
+
+    [Fact]
+    public async Task InitCommand_StableChannelBundle_DoesNotWarn()
+    {
+        var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
+
+        try
+        {
+            _bundleReader.ReadAsync(Arg.Any<DirectoryInfo>(), Arg.Any<CancellationToken>())
+                .Returns(new HostJsonBundleSection(BundleHelpers.StableBundleId, "[4.0.0, 5.0.0)"));
+
+            var initializer = new FakeProjectInitializer("python");
+            int exitCode = await RunInitAsync(newDir, initializer, language: "python", stack: "python");
+
+            Assert.Equal(0, exitCode);
+            Assert.DoesNotContain(
+                _interaction.Lines,
+                line => line.Contains("func workload search bundles --prerelease", StringComparison.Ordinal));
+        }
+        finally
+        {
+            CleanupDirectory(newDir);
         }
     }
 
@@ -558,7 +643,7 @@ public class InitCommandTests
 
             var interactive = new InteractiveTestInteractionService();
             var dotnet = new FakeProjectInitializer("dotnet", workerRuntimeAliases: ["dotnet-isolated"]);
-            var command = new InitCommand(interactive, _hintRenderer, _localSettings, _projectResolver, [dotnet]);
+            var command = new InitCommand(interactive, _hintRenderer, _localSettings, _projectResolver, _bundleReader, new InstalledBundleScanner(_installedBundles), [dotnet]);
             var root = new RootCommand { command };
 
             int exitCode = await root.Parse(["init", newDir, "--stack", "dotnet-isolated"]).InvokeAsync();
@@ -722,7 +807,7 @@ public class InitCommandTests
 
             var interactive = new InteractiveTestInteractionService();
             var python = new FakeProjectInitializer("python");
-            var command = new InitCommand(interactive, _hintRenderer, _localSettings, _projectResolver, [python]);
+            var command = new InitCommand(interactive, _hintRenderer, _localSettings, _projectResolver, _bundleReader, new InstalledBundleScanner(_installedBundles), [python]);
             var root = new RootCommand { command };
 
             int exitCode = await root.Parse(["init", newDir]).InvokeAsync();

--- a/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
+++ b/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
@@ -512,6 +512,151 @@ public sealed class SetupRunnerTests : IDisposable
     }
 
     [Fact]
+    public async Task RunAsync_StableProject_IgnoresPrereleaseBundle_EvenWithIncludePrerelease()
+    {
+        FakeCatalog catalog = Catalog()
+            .WithLatest(_hostPackageId, "4.1.0")
+            .WithVersions(IInstalledBundleWorkloads.BundleWorkloadPackageId, "4.10.0", "4.20.0-preview.1");
+        SetupRunner runner = CreateRunner(catalog);
+
+        SetupRunResult result = await runner.RunAsync(Options(includePrerelease: true), CancellationToken.None);
+
+        Assert.Equal(0, result.ExitCode);
+        await _installer.Received(1).InstallFromCatalogAsync(
+            Arg.Is<string>(id => string.Equals(id, IInstalledBundleWorkloads.BundleWorkloadPackageId, StringComparison.OrdinalIgnoreCase)),
+            Arg.Is<NuGetVersion>(version => version.ToNormalizedString() == "4.10.0"),
+            Arg.Any<string?>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+        await _installer.DidNotReceive().InstallFromCatalogAsync(
+            Arg.Any<string>(),
+            Arg.Is<NuGetVersion>(version => version.ToNormalizedString() == "4.20.0-preview.1"),
+            Arg.Any<string?>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunAsync_HostJsonPreviewBundle_InstallsPreviewBundleAndTemplates()
+    {
+        const string nodeStack = "Azure.Functions.Cli.Workloads.Node";
+        const string nodeTemplates = "Azure.Functions.Cli.Workloads.Templates.Node";
+        _bundleReader.ReadAsync(Arg.Any<DirectoryInfo>(), Arg.Any<CancellationToken>())
+            .Returns(new HostJsonBundleSection(BundleHelpers.PreviewBundleId, "[4.0.0, 5.0.0)"));
+        FakeCatalog catalog = Catalog()
+            .WithLatest(_hostPackageId, "4.1.0")
+            .WithVersions(IInstalledBundleWorkloads.BundleWorkloadPackageId, "4.10.0", "4.11.0-preview.1")
+            .WithLatest(WorkerPackage("node"), "1.0.0")
+            .WithLatest(nodeStack, "1.0.0")
+            .WithVersions(nodeTemplates, "1.0.0", "1.1.0-preview.1");
+        SetupRunner runner = CreateRunner(catalog);
+
+        SetupRunResult result = await runner.RunAsync(Options(features: ["node"]), CancellationToken.None);
+
+        Assert.Equal(0, result.ExitCode);
+        await _installer.Received(1).InstallFromCatalogAsync(
+            Arg.Is<string>(id => string.Equals(id, IInstalledBundleWorkloads.BundleWorkloadPackageId, StringComparison.OrdinalIgnoreCase)),
+            Arg.Is<NuGetVersion>(version => version.ToNormalizedString() == "4.11.0-preview.1"),
+            Arg.Any<string?>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+        await _installer.Received(1).InstallFromCatalogAsync(
+            Arg.Is<string>(id => string.Equals(id, nodeTemplates, StringComparison.OrdinalIgnoreCase)),
+            Arg.Is<NuGetVersion>(version => version.ToNormalizedString() == "1.1.0-preview.1"),
+            Arg.Any<string?>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunAsync_HostJsonPreviewBundle_NoPreviewPublished_FallsBackToStableWithWarning()
+    {
+        _bundleReader.ReadAsync(Arg.Any<DirectoryInfo>(), Arg.Any<CancellationToken>())
+            .Returns(new HostJsonBundleSection(BundleHelpers.PreviewBundleId, "[4.0.0, 5.0.0)"));
+        FakeCatalog catalog = Catalog()
+            .WithLatest(_hostPackageId, "4.1.0")
+            .WithVersions(IInstalledBundleWorkloads.BundleWorkloadPackageId, "4.10.0");
+        SetupRunner runner = CreateRunner(catalog);
+
+        SetupRunResult result = await runner.RunAsync(Options(), CancellationToken.None);
+
+        Assert.Equal(0, result.ExitCode);
+        await _installer.Received(1).InstallFromCatalogAsync(
+            Arg.Is<string>(id => string.Equals(id, IInstalledBundleWorkloads.BundleWorkloadPackageId, StringComparison.OrdinalIgnoreCase)),
+            Arg.Is<NuGetVersion>(version => version.ToNormalizedString() == "4.10.0"),
+            Arg.Any<string?>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+        Assert.Contains(
+            _interaction.Lines,
+            line => line.Contains("func workload search bundles --prerelease", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task RunAsync_HostJsonExperimentalBundle_InstallsExperimentalBundle()
+    {
+        _bundleReader.ReadAsync(Arg.Any<DirectoryInfo>(), Arg.Any<CancellationToken>())
+            .Returns(new HostJsonBundleSection(BundleHelpers.ExperimentalBundleId, "[4.0.0, 5.0.0)"));
+        FakeCatalog catalog = Catalog()
+            .WithLatest(_hostPackageId, "4.1.0")
+            .WithVersions(IInstalledBundleWorkloads.BundleWorkloadPackageId, "4.10.0", "4.12.0-experimental.3");
+        SetupRunner runner = CreateRunner(catalog);
+
+        SetupRunResult result = await runner.RunAsync(Options(), CancellationToken.None);
+
+        Assert.Equal(0, result.ExitCode);
+        await _installer.Received(1).InstallFromCatalogAsync(
+            Arg.Is<string>(id => string.Equals(id, IInstalledBundleWorkloads.BundleWorkloadPackageId, StringComparison.OrdinalIgnoreCase)),
+            Arg.Is<NuGetVersion>(version => version.ToNormalizedString() == "4.12.0-experimental.3"),
+            Arg.Any<string?>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunAsync_PreviewBundleFallbackAlreadyInstalled_CheckPasses()
+    {
+        _bundleReader.ReadAsync(Arg.Any<DirectoryInfo>(), Arg.Any<CancellationToken>())
+            .Returns(new HostJsonBundleSection(BundleHelpers.PreviewBundleId, "[4.0.0, 5.0.0)"));
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>())
+            .Returns([
+                Entry(_hostPackageId, "4.1.0", aliases: ["host"], kind: WorkloadKind.Content),
+                Entry(IInstalledBundleWorkloads.BundleWorkloadPackageId, "4.10.0", kind: WorkloadKind.Content),
+            ]);
+        FakeCatalog catalog = Catalog()
+            .WithLatest(_hostPackageId, "4.1.0")
+            .WithVersions(IInstalledBundleWorkloads.BundleWorkloadPackageId, "4.10.0");
+        SetupRunner runner = CreateRunner(catalog);
+
+        SetupRunResult result = await runner.RunAsync(Options(check: true), CancellationToken.None);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.DoesNotContain(_interaction.Lines, line => line.Contains("extension bundle", StringComparison.Ordinal)
+            && line.Contains("not installed", StringComparison.Ordinal));
+        Assert.Contains(
+            _interaction.Lines,
+            line => line.Contains("func workload search bundles --prerelease", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task RunAsync_FeatureWithoutStackMapping_DoesNotInstallStack()
     {
         string workerPackageId = WorkerPackage("java");
@@ -741,6 +886,7 @@ public sealed class SetupRunnerTests : IDisposable
         private readonly PackageSource _source = new("https://example.test/v3/index.json");
         private readonly Dictionary<string, CatalogSearchResult> _aliases = new(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<string, NuGetVersion> _latest = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, List<NuGetVersion>> _versions = new(StringComparer.OrdinalIgnoreCase);
 
         public int ResolveLatestCallCount { get; private set; }
 
@@ -760,12 +906,25 @@ public sealed class SetupRunnerTests : IDisposable
                 _source);
             _aliases[alias] = result;
             _latest[packageId] = parsed;
+            AddVersion(packageId, parsed);
             return this;
         }
 
         public FakeCatalog WithLatest(string packageId, string version)
         {
-            _latest[packageId] = NuGetVersion.Parse(version);
+            var parsed = NuGetVersion.Parse(version);
+            _latest[packageId] = parsed;
+            AddVersion(packageId, parsed);
+            return this;
+        }
+
+        public FakeCatalog WithVersions(string packageId, params string[] versions)
+        {
+            foreach (string version in versions)
+            {
+                AddVersion(packageId, NuGetVersion.Parse(version));
+            }
+
             return this;
         }
 
@@ -811,6 +970,30 @@ public sealed class SetupRunnerTests : IDisposable
             return Task.FromResult(CreateResolved(packageId, version));
         }
 
+        public Task<ResolvedPackage?> ResolveLatestVersionOnChannelAsync(
+            string packageId,
+            string? prereleaseLabel,
+            VersionRange? versionRange = null,
+            string? source = null,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ResolveLatestCallCount++;
+            ResolveSources.Add(source);
+
+            NuGetVersion? selected = null;
+            if (_versions.TryGetValue(packageId, out List<NuGetVersion>? candidates))
+            {
+                selected = candidates
+                    .Where(v => MatchesLabel(v, prereleaseLabel))
+                    .Where(v => versionRange is null || WorkloadVersionRanges.SatisfiesRange(versionRange, v, prereleaseLabel is not null))
+                    .OrderByDescending(v => v)
+                    .FirstOrDefault();
+            }
+
+            return Task.FromResult(CreateResolved(packageId, selected));
+        }
+
         public Task<ResolvedPackage?> ResolveVersionAsync(
             string packageId,
             NuGetVersion version,
@@ -829,6 +1012,25 @@ public sealed class SetupRunnerTests : IDisposable
             cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult<IReadOnlyList<NuGetVersion>>(
                 _latest.TryGetValue(packageId, out NuGetVersion? version) ? [version] : []);
+        }
+
+        private static bool MatchesLabel(NuGetVersion version, string? prereleaseLabel)
+            => prereleaseLabel is null
+                ? !version.IsPrerelease
+                : version.IsPrerelease && string.Equals(version.ReleaseLabels.FirstOrDefault(), prereleaseLabel, StringComparison.OrdinalIgnoreCase);
+
+        private void AddVersion(string packageId, NuGetVersion version)
+        {
+            if (!_versions.TryGetValue(packageId, out List<NuGetVersion>? list))
+            {
+                list = [];
+                _versions[packageId] = list;
+            }
+
+            if (!list.Contains(version))
+            {
+                list.Add(version);
+            }
         }
 
         private ResolvedPackage? CreateResolved(string packageId, NuGetVersion? version)

--- a/test/Func.Tests/TestParser.cs
+++ b/test/Func.Tests/TestParser.cs
@@ -82,6 +82,8 @@ internal static class TestParser
         services.AddSingleton(Substitute.For<Cli.Projects.IFunctionsProjectResolver>());
         services.AddSingleton(Substitute.For<Cli.Workloads.Storage.IWorkloadPaths>());
         services.AddSingleton(Substitute.For<Cli.Bundles.IHostJsonBundleSectionReader>());
+        services.AddSingleton(Substitute.For<Cli.Bundles.IInstalledBundleWorkloads>());
+        services.AddSingleton<Cli.Bundles.InstalledBundleScanner>();
         services.AddSingleton(Substitute.For<Cli.Bundles.IExtensionBundleResolver>());
         services.AddSingleton(Substitute.For<IStartInitializationRunner>());
 

--- a/test/Func.Tests/Workloads/Catalog/WorkloadCatalogTests.cs
+++ b/test/Func.Tests/Workloads/Catalog/WorkloadCatalogTests.cs
@@ -272,6 +272,68 @@ public sealed class WorkloadCatalogTests
     }
 
     [Fact]
+    public async Task ResolveLatestVersionOnChannelAsync_StableChannel_ExcludesPrerelease()
+    {
+        WorkloadCatalog catalog = NewCatalog(
+            (_defaultSource, BuildClient(_defaultSource, versions: [V("1.0.0"), V("2.0.0-preview.1"), V("1.5.0")])));
+
+        ResolvedPackage? resolved = await catalog.ResolveLatestVersionOnChannelAsync("alpha", prereleaseLabel: null);
+
+        Assert.NotNull(resolved);
+        Assert.Equal(V("1.5.0"), resolved!.Version);
+    }
+
+    [Fact]
+    public async Task ResolveLatestVersionOnChannelAsync_PreviewChannel_PicksHighestPreview()
+    {
+        WorkloadCatalog catalog = NewCatalog(
+            (_defaultSource, BuildClient(_defaultSource, versions:
+                [V("1.0.0"), V("2.0.0-preview.1"), V("2.0.0-preview.3"), V("2.0.0-experimental.1")])));
+
+        ResolvedPackage? resolved = await catalog.ResolveLatestVersionOnChannelAsync("alpha", prereleaseLabel: "preview");
+
+        Assert.NotNull(resolved);
+        Assert.Equal(V("2.0.0-preview.3"), resolved!.Version);
+    }
+
+    [Fact]
+    public async Task ResolveLatestVersionOnChannelAsync_ExperimentalChannel_PicksExperimental()
+    {
+        WorkloadCatalog catalog = NewCatalog(
+            (_defaultSource, BuildClient(_defaultSource, versions:
+                [V("1.0.0"), V("2.0.0-preview.1"), V("2.5.0-experimental.2")])));
+
+        ResolvedPackage? resolved = await catalog.ResolveLatestVersionOnChannelAsync("alpha", prereleaseLabel: "experimental");
+
+        Assert.NotNull(resolved);
+        Assert.Equal(V("2.5.0-experimental.2"), resolved!.Version);
+    }
+
+    [Fact]
+    public async Task ResolveLatestVersionOnChannelAsync_PreviewChannel_NoPreviewPublished_ReturnsNull()
+    {
+        WorkloadCatalog catalog = NewCatalog(
+            (_defaultSource, BuildClient(_defaultSource, versions: [V("1.0.0"), V("2.0.0")])));
+
+        ResolvedPackage? resolved = await catalog.ResolveLatestVersionOnChannelAsync("alpha", prereleaseLabel: "preview");
+
+        Assert.Null(resolved);
+    }
+
+    [Fact]
+    public async Task ResolveLatestVersionOnChannelAsync_PreviewChannel_RespectsRange()
+    {
+        WorkloadCatalog catalog = NewCatalog(
+            (_defaultSource, BuildClient(_defaultSource, versions: [V("4.10.0-preview.1"), V("4.20.0-preview.1")])));
+        var range = VersionRange.Parse("[4.0.0, 4.15.0)");
+
+        ResolvedPackage? resolved = await catalog.ResolveLatestVersionOnChannelAsync("alpha", prereleaseLabel: "preview", versionRange: range);
+
+        Assert.NotNull(resolved);
+        Assert.Equal(V("4.10.0-preview.1"), resolved!.Version);
+    }
+
+    [Fact]
     public async Task ResolveVersionAsync_ReturnsResolvedPackage_WhenSourceHasVersion()
     {
         WorkloadCatalog catalog = NewCatalog(


### PR DESCRIPTION
resolves #5374

## What

`func setup` now installs the latest **stable** extension bundle by default. Preview/experimental bundles (and matching node/python templates) are only installed when the project's `host.json` opts into that channel via `extensionBundle.id`.

## Behavior

- **Setup, stable by default:** a prerelease CLI (or `--prerelease`) no longer pulls a preview/experimental bundle unless `host.json` asks for it.
- **Channel applies to templates too:** node/python template workloads track the bundle channel (dotnet templates stay channel-less, since they don't use bundles).
- **Graceful fallback:** when `host.json` pins preview/experimental but that channel has nothing published, setup falls back to stable and warns instead of failing.
- **Init discovery hint:** `func init -s <stack> -c preview|experimental` warns when no matching-channel bundle workload is installed and points at `func workload search bundles --prerelease`.

## Tests

- 1217 Func.Tests pass; added coverage for channel resolution, stable fallback + warning, the `--check` fallback-already-installed case, and init detection.
- Release build clean under `TreatWarningsAsErrors=true`.

## Docs

- Added a channel-selection section to `src/Workloads/Tools/ExtensionBundles/README.md`.