### PR TITLE
Replace deprecated url.parse() in npm install script

### DIFF
--- a/eng/tools/publish-tools/npm/lib/install.js
+++ b/eng/tools/publish-tools/npm/lib/install.js
@@ -1,7 +1,6 @@
 #! /usr/bin/env node
 
 const extract = require('extract-zip');
-const url = require('url');
 const { HttpsProxyAgent } = require('https-proxy-agent');
 const https = require('https');
 const version = require('../package.json').version;
@@ -49,7 +48,8 @@ const fileName = 'Azure.Functions.Cli.' + platform + '.' + version + '.zip';
 const endpoint = 'https://cdn.functions.azure.com/public/' + consolidatedBuildId + '/' + fileName;
 
 console.log('attempting to GET %j', endpoint);
-const options = url.parse(endpoint);
+const requestUrl = new URL(endpoint);
+const options = {};
 
 // npm config preceed system environment
 // https://github.com/npm/npm/blob/19397ad523434656af3d3765e80e22d7e6305f48/lib/config/reg-client.js#L7-L8
@@ -75,7 +75,7 @@ if (proxy) {
     options.agent = new HttpsProxyAgent(proxy);
 }
 
-https.get(options, response => {
+https.get(requestUrl, options, response => {
     const bar = new ProgressBar('[:bar] Downloading Azure Functions Core Tools', {
         total: Number(response.headers['content-length']),
         width: 18


### PR DESCRIPTION
Fixes #5366.

The npm install script builds the download request options with url.parse().
That call is deprecated (DEP0169) and prints a warning on every npm install
of the package.

This change uses the WHATWG URL API instead. The endpoint is parsed with
new URL() and passed as the first argument to https.get(), and the options
object (which carries the proxy agent when one is configured) is passed as
the second argument. The behavior is the same, including the proxy code path.

Tested locally: the script passes node --check, the download request reaches
the server, and the proxy agent is still used when set.
