### PR TITLE
fix: keep workload load context alive

### DIFF
--- a/src/Func/Workloads/Loading/WorkloadLoader.cs
+++ b/src/Func/Workloads/Loading/WorkloadLoader.cs
@@ -68,8 +68,8 @@ internal sealed class WorkloadLoader(IWorkloadPaths paths) : IWorkloadLoader
                 $"[{entry.PackageId}] Could not load workload: assembly '{entryPoint.AssemblyPath}' was not found at '{contentRoot}'.");
         }
 
-        Assembly assembly = new WorkloadLoadContext(entry.PackageId, assemblyPath)
-            .LoadFromAssemblyPath(assemblyPath);
+        WorkloadLoadContext loadContext = new(entry.PackageId, assemblyPath);
+        Assembly assembly = loadContext.LoadFromAssemblyPath(assemblyPath);
 
         Type? type = assembly.GetType(entryPoint.Type, throwOnError: false) ?? throw new InvalidWorkloadException(
                 $"[{entry.PackageId}] Could not load workload: type '{entryPoint.Type}' was not found in '{entryPoint.AssemblyPath}' (install path: '{installPath}').");
@@ -81,7 +81,6 @@ internal sealed class WorkloadLoader(IWorkloadPaths paths) : IWorkloadLoader
         }
 
         var instance = (Workload)Activator.CreateInstance(type)!;
-
         return new RuntimeWorkloadInfo(
             Instance: instance,
             PackageId: entry.PackageId,
@@ -90,6 +89,7 @@ internal sealed class WorkloadLoader(IWorkloadPaths paths) : IWorkloadLoader
             InstallDirectory: installPath,
             ContentRoot: contentRoot,
             DisplayName: instance.DisplayName,
-            Description: instance.Description);
+            Description: instance.Description,
+            LoadContext: loadContext);
     }
 }

--- a/src/Func/Workloads/WorkloadInfo.cs
+++ b/src/Func/Workloads/WorkloadInfo.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Workloads.Loading;
+
 namespace Azure.Functions.Cli.Workloads;
 
 /// <summary>
@@ -35,6 +37,10 @@ internal abstract record WorkloadInfo(
 /// <param name="ContentRoot">Directory containing package payload files.</param>
 /// <param name="DisplayName">Human-readable name for <c>func workload list</c>.</param>
 /// <param name="Description">One-line workload description.</param>
+/// <param name="LoadContext">The assembly load context used to load the workload.</param>
+/// <remarks>
+/// The <see cref="LoadContext"/> must be kept in memory as long as the workload is in use.
+/// </remarks>
 internal sealed record RuntimeWorkloadInfo(
     Workload Instance,
     string PackageId,
@@ -43,7 +49,8 @@ internal sealed record RuntimeWorkloadInfo(
     string InstallDirectory,
     string ContentRoot,
     string DisplayName,
-    string Description)
+    string Description,
+    WorkloadLoadContext LoadContext)
     : WorkloadInfo(WorkloadKind.Workload, PackageId, PackageVersion, Aliases, InstallDirectory, ContentRoot, DisplayName, Description);
 
 /// <summary>

--- a/test/Func.Tests/Commands/Workload/WorkloadListCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadListCommandTests.cs
@@ -335,7 +335,8 @@ public class WorkloadListCommandTests
             AppContext.BaseDirectory,
             AppContext.BaseDirectory,
             instance.DisplayName,
-            instance.Description);
+            instance.Description,
+            LoadContext: null!);
 
     private static Task<int> InvokeAsync(WorkloadListCommand cmd, params string[] args)
         => InvokeAsync(cmd, includeRootVerbose: false, args);

--- a/test/Func.Tests/TestWorkloads.cs
+++ b/test/Func.Tests/TestWorkloads.cs
@@ -23,7 +23,8 @@ internal static class TestWorkloads
             InstallDirectory: AppContext.BaseDirectory,
             ContentRoot: AppContext.BaseDirectory,
             DisplayName: instance.DisplayName,
-            Description: instance.Description);
+            Description: instance.Description,
+            LoadContext: null!);
     }
 
     public static ContentWorkloadInfo CreateContentInfo(string packageId = "Test.Content.A", string version = "1.0.0")


### PR DESCRIPTION
## Changes

Update the workload loading mechanism to track and expose the `WorkloadLoadContext` used for dynamically loading assemblies. This ensures that the custom assembly load context is retained for the lifetime of the workload, which allows for further assembly loads by the workload.

**Enhancements to workload loading and tracking:**

* The `RuntimeWorkloadInfo` record now includes a `LoadContext` property, referencing the `WorkloadLoadContext` used to load the workload assembly. This property is documented as necessary to keep in memory as long as the workload is in use. [[1]](diffhunk://#diff-68fd4bfd72309d3029e7a190725eb48aade574cbda87b822cad5c6571635b87dR40-R43) [[2]](diffhunk://#diff-68fd4bfd72309d3029e7a190725eb48aade574cbda87b822cad5c6571635b87dL46-R53)
* The `LoadEntry` method in `WorkloadLoader.cs` has been updated to create and retain a `WorkloadLoadContext` instance, passing it to the new `LoadContext` property of `RuntimeWorkloadInfo`. [[1]](diffhunk://#diff-5f98f43c450c8bf76e6474c83b732af3a4fa3a2ac9dc11152aefe38b88464de0L71-R72) [[2]](diffhunk://#diff-5f98f43c450c8bf76e6474c83b732af3a4fa3a2ac9dc11152aefe38b88464de0L93-R93)
* Added the appropriate namespace import to `WorkloadInfo.cs` for access to `WorkloadLoadContext`.

## Context

Today the `WorkloadLoadContext` immediately goes out of scope and is garbage collected before the workload runs. Any new type-loads the workload performs will then fail with an `InvalidOperationException` due to its ALC being GC'd.