### PR TITLE
build: add Workload.Publish.targets for local dev simplicity

### DIFF
--- a/eng/build/Workloads/Workload.Publish.targets
+++ b/eng/build/Workloads/Workload.Publish.targets
@@ -1,0 +1,47 @@
+<Project>
+
+  <!--
+  Publish a workload to a directory layout matching the NuGet package structure:
+    $(PublishDir)/workload.json
+    $(PublishDir)/tools/any/  (or tools/$(RuntimeIdentifier)/ for RID-specific builds)
+  -->
+
+  <!--
+  Include workload.json in the publish output root.
+  -->
+  <Target Name="_PublishWorkloadMetadata" DependsOnTargets="GenerateWorkloadJson" BeforeTargets="ComputeFilesToPublish">
+    <ItemGroup>
+      <ResolvedFileToPublish Include="$(_WorkloadJsonFile)" RelativePath="workload.json" CopyToPublishDirectory="PreserveNewest" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+  Include the workload's runtime assemblies and copy-local dependencies in the publish output.
+  Mirrors _IncludeWorkloadCopyLocal from Workload.Pack.targets, targeting publish output instead of NuGet package paths.
+  -->
+  <Target Name="_TrimUnifiedAssembliesForPublish" Condition="'$(WorkloadKind)' == 'workload'"
+    AfterTargets="ComputeResolvedFilesToPublishList" BeforeTargets="ComputeFilesToPublish">
+
+    <PropertyGroup>
+      <_WorkloadRidPath Condition="'$(RuntimeIdentifier)' == ''">any</_WorkloadRidPath>
+      <_WorkloadRidPath Condition="'$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier)</_WorkloadRidPath>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_PackageResolveFileToPublish Include="@(ResolvedFileToPublish)" Condition="'%(ResolvedFileToPublish.NuGetPackageId)' != ''" />
+    </ItemGroup>
+
+    <ResolveWorkloadCopyLocal Items="@(_PackageResolveFileToPublish)" UnifiedItems="@(_WorkloadUnifiedItems)">
+      <Output TaskParameter="WorkloadCopyLocal" ItemName="_WorkloadPublishCopyLocal" />
+    </ResolveWorkloadCopyLocal>
+
+    <ItemGroup>
+      <ResolvedFileToPublish Remove="@(_PackageResolveFileToPublish)" />
+      <ResolvedFileToPublish Remove="$(ProjectDepsFilePath)" />
+      <ResolvedFileToPublish Update="@(ResolvedFileToPublish)" Condition="'%(ResolvedFileToPublish.Filename)' == '$(TargetName)'"
+        RelativePath="tools/$(_WorkloadRidPath)/%(Filename)%(Extension)" />
+      <ResolvedFileToPublish Include="@(_WorkloadPublishCopyLocal)" RelativePath="tools/$(_WorkloadRidPath)/%(_WorkloadPublishCopyLocal.TargetPath)" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/eng/build/Workloads/Workload.targets
+++ b/eng/build/Workloads/Workload.targets
@@ -4,7 +4,7 @@
     <_AllowedWorkloadKind Include="workload;content;meta;rid-pointer" />
 
     <!-- This project contains tasks we need. Hook here to ensure it is built. -->
-    <ProjectReference Include="$(SrcRoot)Workloads/Sdk/Workloads.Sdk.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="$(SrcRoot)Workloads/Sdk/Workloads.Sdk.csproj" ReferenceOutputAssembly="false" Private="false" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -28,6 +28,12 @@
     <_WorkloadJsonCacheFile Condition="'$(_WorkloadJsonCacheFile)' == ''">$(IntermediateOutputPath)workload.json.cache</_WorkloadJsonCacheFile>
     <_WorkloadJsonFile Condition="'$(_WorkloadJsonFile)' == ''">$(IntermediateOutputPath)workload.json</_WorkloadJsonFile>
   </PropertyGroup>
+
+  <Target Name="_EnsureAbstractionsPrivate" BeforeTargets="AssignProjectConfiguration">
+    <ItemGroup>
+      <ProjectReference Update="@(ProjectReference)" Private="false" Condition="'%(Filename)%(Extension)' == 'Abstractions.csproj'" />
+    </ItemGroup>
+  </Target>
 
   <!-- Perform early validation of the workload. -->
   <Target Name="_ValidateWorkload" BeforeTargets="BeforeBuild">
@@ -100,5 +106,6 @@
 
   <Import Project="$(MSBuildThisFileDirectory)Workload.UnifiedAssemblies.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Workload.Pack.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)Workload.Publish.targets" />
 
 </Project>


### PR DESCRIPTION
Add `dotnet publish` support to workloads to simplify local dev. This will publish the workload in the layout expected by func cli and what would be packaged in the nupkg. This is a step towards local dev leveraging `dotnet publish -c debug -o {my_workload_dir}`. More changes will be needed before that is supported, but it is a step towards that.

No workloads are publishable yet, but if you were to enable publishing on `Workload.Dotnet.csproj` you would get:

```
 {publish_dir}/
 ├── workload.json
 └── tools/
     └── any/
         ├── Azure.Functions.Cli.Workloads.DotNet.dll
         └── Azure.Functions.Cli.Workloads.DotNet.pdb
```