### PR TITLE
build: move workload stacks to sdk

### DIFF
--- a/src/Workloads/Stacks/Go/GoWorkload.cs
+++ b/src/Workloads/Stacks/Go/GoWorkload.cs
@@ -2,7 +2,10 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Workloads;
 using Microsoft.Extensions.DependencyInjection;
+
+[assembly: CliWorkload<Azure.Functions.Cli.Workloads.Go.GoWorkload>()]
 
 namespace Azure.Functions.Cli.Workloads.Go;
 

--- a/src/Workloads/Stacks/Go/Workloads.Go.csproj
+++ b/src/Workloads/Stacks/Go/Workloads.Go.csproj
@@ -4,11 +4,9 @@
     <TargetFramework>net10.0</TargetFramework>
     <Title>Go Stack</Title>
     <Description>Azure Functions CLI tooling for Go projects.</Description>
-    <PackageType>FuncCliWorkload</PackageType>
-    <PackageTags>kind:workload alias:go func-workload</PackageTags>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
-    <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>
+    <PackAsWorkload>true</PackAsWorkload>
+    <WorkloadKind>workload</WorkloadKind>
+    <WorkloadAlias>go</WorkloadAlias>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,15 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(SrcRoot)Abstractions/Abstractions.csproj">
-      <PrivateAssets>all</PrivateAssets>
-      <ExcludeAssets>runtime</ExcludeAssets>
-    </ProjectReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="workload.json" Pack="true" PackagePath="/" />
-    <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="tools/any/" Visible="false" />
+    <ProjectReference Include="$(SrcRoot)Abstractions/Abstractions.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Workloads/Stacks/Go/workload.json
+++ b/src/Workloads/Stacks/Go/workload.json
@@ -1,8 +1,0 @@
-{
-  "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
-  "kind": "workload",
-  "entryPoint": {
-    "assemblyPath": "Azure.Functions.Cli.Workloads.Go.dll",
-    "type": "Azure.Functions.Cli.Workloads.Go.GoWorkload"
-  }
-}

--- a/src/Workloads/Stacks/Node/NodeWorkload.cs
+++ b/src/Workloads/Stacks/Node/NodeWorkload.cs
@@ -6,6 +6,8 @@ using Azure.Functions.Cli.Quickstart;
 using Azure.Functions.Cli.Workloads;
 using Microsoft.Extensions.DependencyInjection;
 
+[assembly: CliWorkload<Azure.Functions.Cli.Workloads.Node.NodeWorkload>()]
+
 namespace Azure.Functions.Cli.Workloads.Node;
 
 /// <summary>

--- a/src/Workloads/Stacks/Node/Workloads.Node.csproj
+++ b/src/Workloads/Stacks/Node/Workloads.Node.csproj
@@ -4,11 +4,9 @@
     <TargetFramework>net10.0</TargetFramework>
     <Title>Node.js Stack</Title>
     <Description>Azure Functions CLI tooling for Node.js projects.</Description>
-    <PackageType>FuncCliWorkload</PackageType>
-    <PackageTags>kind:workload alias:node func-workload</PackageTags>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
-    <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>
+    <PackAsWorkload>true</PackAsWorkload>
+    <WorkloadKind>workload</WorkloadKind>
+    <WorkloadAlias>node</WorkloadAlias>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,15 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(SrcRoot)Abstractions/Abstractions.csproj">
-      <PrivateAssets>all</PrivateAssets>
-      <ExcludeAssets>runtime</ExcludeAssets>
-    </ProjectReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="workload.json" Pack="true" PackagePath="/" />
-    <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="tools/any/" Visible="false" />
+    <ProjectReference Include="$(SrcRoot)Abstractions/Abstractions.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Workloads/Stacks/Node/workload.json
+++ b/src/Workloads/Stacks/Node/workload.json
@@ -1,8 +1,0 @@
-{
-  "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
-  "kind": "workload",
-  "entryPoint": {
-    "assemblyPath": "Azure.Functions.Cli.Workloads.Node.dll",
-    "type": "Azure.Functions.Cli.Workloads.Node.NodeWorkload"
-  }
-}

--- a/src/Workloads/Stacks/Python/PythonWorkload.cs
+++ b/src/Workloads/Stacks/Python/PythonWorkload.cs
@@ -3,7 +3,10 @@
 
 using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Quickstart;
+using Azure.Functions.Cli.Workloads;
 using Microsoft.Extensions.DependencyInjection;
+
+[assembly: CliWorkload<Azure.Functions.Cli.Workloads.Python.PythonWorkload>()]
 
 namespace Azure.Functions.Cli.Workloads.Python;
 

--- a/src/Workloads/Stacks/Python/Workloads.Python.csproj
+++ b/src/Workloads/Stacks/Python/Workloads.Python.csproj
@@ -4,11 +4,9 @@
     <TargetFramework>net10.0</TargetFramework>
     <Title>Python Stack</Title>
     <Description>Azure Functions CLI tooling for Python projects.</Description>
-    <PackageType>FuncCliWorkload</PackageType>
-    <PackageTags>kind:workload alias:python func-workload</PackageTags>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
-    <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>
+    <PackAsWorkload>true</PackAsWorkload>
+    <WorkloadKind>workload</WorkloadKind>
+    <WorkloadAlias>python</WorkloadAlias>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,15 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(SrcRoot)Abstractions/Abstractions.csproj">
-      <PrivateAssets>all</PrivateAssets>
-      <ExcludeAssets>runtime</ExcludeAssets>
-    </ProjectReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="workload.json" Pack="true" PackagePath="/" />
-    <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="tools/any/" Visible="false" />
+    <ProjectReference Include="$(SrcRoot)Abstractions/Abstractions.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Workloads/Stacks/Python/workload.json
+++ b/src/Workloads/Stacks/Python/workload.json
@@ -1,8 +1,0 @@
-{
-  "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
-  "kind": "workload",
-  "entryPoint": {
-    "assemblyPath": "Azure.Functions.Cli.Workloads.Python.dll",
-    "type": "Azure.Functions.Cli.Workloads.Python.PythonWorkload"
-  }
-}


### PR DESCRIPTION
Migrate the following projects to Workloads SDK

```
Workloads.Go.csproj
Workloads.Node.csproj
Workloads.Python.csproj
```