### PR TITLE
build: migrate templates to workloads sdk

### DIFF
--- a/src/Workloads/Templates/DotNet/Workloads.Templates.DotNet.csproj
+++ b/src/Workloads/Templates/DotNet/Workloads.Templates.DotNet.csproj
@@ -4,18 +4,11 @@
     <TargetFramework>net10.0</TargetFramework>
     <Title>.NET Function Templates</Title>
     <Description>.NET function templates for the func CLI. Resolves templates from Microsoft.Azure.Functions.Worker.ItemTemplates at func new time.</Description>
-    <PackageType>FuncCliWorkload</PackageType>
-    <PackageTags>kind:content alias:dotnet-templates func-workload</PackageTags>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <PackAsWorkload>true</PackAsWorkload>
+    <WorkloadKind>content</WorkloadKind>
+    <WorkloadAlias>dotnet-templates</WorkloadAlias>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
-    <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="workload.json" Pack="true" PackagePath="/" />
-  </ItemGroup>
 
   <ItemGroup>
     <!-- Pre-fetch the upstream nupkg during restore so the hydrate step is offline. -->

--- a/src/Workloads/Templates/DotNet/workload.json
+++ b/src/Workloads/Templates/DotNet/workload.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
-  "kind": "content",
-  "displayName": ".NET Function Templates",
-  "description": "Function-scaffold templates for .NET Azure Functions projects. Templates are resolved from Microsoft.Azure.Functions.Worker.ItemTemplates at func new time."
-}

--- a/src/Workloads/Templates/Node/Workloads.Templates.Node.csproj
+++ b/src/Workloads/Templates/Node/Workloads.Templates.Node.csproj
@@ -4,13 +4,11 @@
     <TargetFramework>net10.0</TargetFramework>
     <Title>Node.js Function Templates</Title>
     <Description>Node.js function templates for the func CLI. Compatible with Microsoft.Azure.Functions.ExtensionBundle (minBundle:$(MinBundleVersionRange)).</Description>
-    <PackageType>FuncCliWorkload</PackageType>
-    <PackageTags>kind:content alias:node-templates func-workload minBundle:$(MinBundleVersionRange)</PackageTags>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <PackageTags>minBundle:$(MinBundleVersionRange)</PackageTags>
+    <PackAsWorkload>true</PackAsWorkload>
+    <WorkloadKind>content</WorkloadKind>
+    <WorkloadAlias>node-templates</WorkloadAlias>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
-    <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>
 
     <!--
       Static content source: the v2 Node templates ship as in-repo content
@@ -30,10 +28,6 @@
     <IncludeV2Templates>true</IncludeV2Templates>
     <FilterTemplatesByBundleChannel>true</FilterTemplatesByBundleChannel>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="workload.json" Pack="true" PackagePath="/" />
-  </ItemGroup>
 
   <Import Project="$(EngBuildRoot)Workloads/Workloads.Templates.targets" />
 

--- a/src/Workloads/Templates/Node/workload.json
+++ b/src/Workloads/Templates/Node/workload.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
-  "kind": "content",
-  "displayName": "Node.js Function Templates",
-  "description": "Function-scaffold templates for Node.js Azure Functions projects."
-}

--- a/src/Workloads/Templates/Python/Workloads.Templates.Python.csproj
+++ b/src/Workloads/Templates/Python/Workloads.Templates.Python.csproj
@@ -4,13 +4,11 @@
     <TargetFramework>net10.0</TargetFramework>
     <Title>Python Function Templates</Title>
     <Description>Python function templates for the func CLI. Compatible with Microsoft.Azure.Functions.ExtensionBundle (minBundle:$(MinBundleVersionRange)).</Description>
-    <PackageType>FuncCliWorkload</PackageType>
-    <PackageTags>kind:content alias:python-templates func-workload minBundle:$(MinBundleVersionRange)</PackageTags>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <PackageTags>minBundle:$(MinBundleVersionRange)</PackageTags>
+    <PackAsWorkload>true</PackAsWorkload>
+    <WorkloadKind>content</WorkloadKind>
+    <WorkloadAlias>python-templates</WorkloadAlias>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
-    <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>
 
     <TemplatesStackLanguageFilter>Python</TemplatesStackLanguageFilter>
     <IncludeV1Templates>false</IncludeV1Templates>

--- a/src/Workloads/Templates/Python/workload.json
+++ b/src/Workloads/Templates/Python/workload.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
-  "kind": "content",
-  "displayName": "Python Function Templates",
-  "description": "Function-scaffold templates for Python Azure Functions projects (v2 programming model)."
-}


### PR DESCRIPTION
migrate the following projects to workloads sdk

```
Workloads.Templates.Dotnet.csproj
Workloads.Templates.Node.csproj
Workloads.Templates.Python.csproj
```