### PR TITLE
build: migrate ext bundle to workload sdk

### DIFF
--- a/src/Workloads/ExtensionBundles/Workloads.ExtensionBundles.csproj
+++ b/src/Workloads/ExtensionBundles/Workloads.ExtensionBundles.csproj
@@ -4,18 +4,10 @@
     <TargetFramework>net10.0</TargetFramework>
     <Title>Extension Bundles</Title>
     <Description>Azure Functions CLI extension bundle payload, delivered as a content workload for the func CLI.</Description>
-    <PackageType>FuncCliWorkload</PackageType>
-    <PackageTags>kind:content alias:bundles func-workload func-tool</PackageTags>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
-    <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>
+    <PackAsWorkload>true</PackAsWorkload>
+    <WorkloadKind>content</WorkloadKind>
+    <WorkloadAlias>bundles</WorkloadAlias>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="workload.json" Pack="true" PackagePath="/" />
-  </ItemGroup>
 
   <Import Project="DownloadDefaultBundle.targets" />
 

--- a/src/Workloads/ExtensionBundles/workload.json
+++ b/src/Workloads/ExtensionBundles/workload.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
-  "kind": "content"
-}


### PR DESCRIPTION
migrate `Workloads.ExtensionBundles.csproj` to workload sdk