### PR TITLE
Add PowerShell worker workload

### DIFF
--- a/Azure.Functions.Cli.slnx
+++ b/Azure.Functions.Cli.slnx
@@ -30,6 +30,7 @@
   <Folder Name="/src/Workloads/Workers/">
     <Project Path="src/Workloads/Workers/Go/Workloads.Workers.Go.csproj" />
     <Project Path="src/Workloads/Workers/Node/Workloads.Workers.Node.csproj" />
+    <Project Path="src/Workloads/Workers/PowerShell/Workloads.Workers.PowerShell.csproj" />
     <Project Path="src/Workloads/Workers/Python/Workloads.Workers.Python.csproj" />
   </Folder>
   <Folder Name="/test/">

--- a/eng/build/Packages.props
+++ b/eng/build/Packages.props
@@ -42,6 +42,8 @@
        documentation aid. -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.13.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" Version="4.0.4759" />
+    <PackageVersion Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.6" Version="4.0.4778" />
     <PackageVersion Include="Microsoft.Azure.Functions.PythonWorker" Version="4.43.0" />
   </ItemGroup>
 

--- a/eng/ci/release/official-release.workload.powershell-worker.yml
+++ b/eng/ci/release/official-release.workload.powershell-worker.yml
@@ -1,0 +1,17 @@
+parameters:
+- name: public
+  displayName: Publish to nuget.org?
+  type: boolean
+  default: false
+
+# Release has no triggers outside of pipeline
+trigger: none
+pr: none
+
+extends:
+  template: /eng/ci/templates/pipelines/release-packages.yml@self
+  parameters:
+    public: ${{ parameters.public }}
+    folder: workloads/powershell-worker
+    projects: |
+      $(Build.SourcesDirectory)/src/Workloads/Workers/PowerShell/Workloads.Workers.PowerShell.csproj

--- a/src/Workloads/Workers/PowerShell/Directory.Version.props
+++ b/src/Workloads/Workers/PowerShell/Directory.Version.props
@@ -1,0 +1,25 @@
+<Project>
+
+  <!--
+    Workload pkg versioning. This is a content-only workload (no workload
+    code or assemblies), so the pkg version maps 1:1 to the worker payload
+    version it carries:
+      $(WorkerVersion) - the PowerShell worker package version. Mirrors the
+                         Microsoft.Azure.Functions.PowerShellWorker.PS7.x
+                         versions pulled in at pack time. All per-version
+                         packages share the same version number.
+
+    Unlike the bundles workload, there is no channel axis: the upstream
+    PowerShellWorker NuGets don't ship preview/experimental SKUs, so the
+    workload pkg version is just $(WorkerVersion).
+  -->
+
+  <PropertyGroup>
+    <WorkerVersion>4.0.4778</WorkerVersion>
+    <WorkerVersionPS74>4.0.4759</WorkerVersionPS74>
+    <WorkerVersionPS76>4.0.4778</WorkerVersionPS76>
+    <VersionPrefix>$(WorkerVersion)</VersionPrefix>
+    <VersionSuffix>preview.1</VersionSuffix>
+  </PropertyGroup>
+
+</Project>

--- a/src/Workloads/Workers/PowerShell/README.DEV.md
+++ b/src/Workloads/Workers/PowerShell/README.DEV.md
@@ -1,0 +1,38 @@
+# Azure Functions CLI – PowerShell worker workload (dev notes)
+
+Repo-only notes for contributors. Not packaged into the nupkg.
+
+## Version scheme
+
+The workload pkg version maps 1:1 to the PowerShell worker payload it carries.
+One prop in `Directory.Version.props` drives `$(VersionPrefix)`:
+
+| Prop                   | Meaning                                                                            |
+|------------------------|------------------------------------------------------------------------------------|
+| `$(WorkerVersionPS74)` | `Microsoft.Azure.Functions.PowerShellWorker.PS7.4` version.                        |
+| `$(WorkerVersionPS76)` | `Microsoft.Azure.Functions.PowerShellWorker.PS7.6` version.                        |
+| `$(WorkerVersion)`     | Workload package version. Set to the highest of the per-PS-version pins.           |
+
+The per-version packages may not always share the same version number, so each
+is pinned independently. Bump both whenever the upstream worker packages are
+bumped. `VersionOverride` ensures each reference stays pinned.
+
+Unlike the bundles workload, there is no channel axis: the upstream
+PowerShellWorker NuGets don't ship preview/experimental SKUs.
+
+## Pack details
+
+Worker assets are pulled at pack time from the restored per-version NuGet
+packages and merged into a single `tools/any/` layout:
+
+```
+tools/any/
+├── worker.config.json        (shared, from either package)
+├── 7.4/                      (from PS7.4 package)
+│   └── Microsoft.Azure.Functions.PowerShellWorker.dll + deps
+└── 7.6/                      (from PS7.6 package)
+    └── Microsoft.Azure.Functions.PowerShellWorker.dll + deps
+```
+
+The host resolves the correct subdirectory at runtime via
+`%FUNCTIONS_WORKER_RUNTIME_VERSION%`.

--- a/src/Workloads/Workers/PowerShell/README.md
+++ b/src/Workloads/Workers/PowerShell/README.md
@@ -1,0 +1,16 @@
+# Azure Functions CLI – PowerShell worker workload
+
+Content workload that ships the PowerShell language worker payload consumed by the
+Azure Functions CLI host.
+
+## Install
+
+```bash
+func workload install Azure.Functions.Cli.Workloads.Workers.PowerShell
+# or by alias
+func workload install powershell-worker
+```
+
+## Status
+
+Preview.

--- a/src/Workloads/Workers/PowerShell/Workloads.Workers.PowerShell.csproj
+++ b/src/Workloads/Workers/PowerShell/Workloads.Workers.PowerShell.csproj
@@ -1,0 +1,57 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Title>PowerShell Worker</Title>
+    <Description>Azure Functions CLI content workload that ships the PowerShell language worker.</Description>
+    <PackAsWorkload>true</PackAsWorkload>
+    <WorkloadKind>content</WorkloadKind>
+    <WorkloadAlias>powershell-worker</WorkloadAlias>
+    <PackageTags>func-worker</PackageTags>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);IncludePowerShellWorkerContentInPack</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!--
+      The PowerShell worker ships one NuGet per supported PS version. Each
+      package carries:
+        - A shared worker.config.json at contentFiles/any/any/workers/powershell/
+        - Version-specific DLLs under contentFiles/any/any/workers/powershell/<ver>/
+
+      We reference all supported versions and merge their content into a single
+      tools/any/ layout so the host can resolve the correct version at runtime
+      via %FUNCTIONS_WORKER_RUNTIME_VERSION%.
+
+      GeneratePathProperty exposes $(PkgMicrosoft_Azure_Functions_PowerShellWorker_PS7_4)
+      etc. IncludeAssets=none prevents upstream build targets from affecting this project.
+    -->
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" GeneratePathProperty="true" VersionOverride="$(WorkerVersionPS74)">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>none</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.6" GeneratePathProperty="true" VersionOverride="$(WorkerVersionPS76)">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>none</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <Target Name="IncludePowerShellWorkerContentInPack">
+    <Error Condition="'$(PkgMicrosoft_Azure_Functions_PowerShellWorker_PS7_4)' == ''"
+           Text="Microsoft.Azure.Functions.PowerShellWorker.PS7.4 package path not resolved. Run 'dotnet restore' first." />
+    <Error Condition="'$(PkgMicrosoft_Azure_Functions_PowerShellWorker_PS7_6)' == ''"
+           Text="Microsoft.Azure.Functions.PowerShellWorker.PS7.6 package path not resolved. Run 'dotnet restore' first." />
+    <ItemGroup>
+      <!-- PS 7.4 content (worker.config.json + 7.4/ subdirectory) -->
+      <_PS74WorkerFile Include="$(PkgMicrosoft_Azure_Functions_PowerShellWorker_PS7_4)/contentFiles/any/any/workers/powershell/**/*" />
+      <TfmSpecificPackageFile Include="@(_PS74WorkerFile)" TargetPath="%(RecursiveDir)%(Filename)%(Extension)"
+        Pack="true" PackagePath="tools/any/" />
+
+      <!-- PS 7.6 content (7.6/ subdirectory; worker.config.json is identical, deduped by NuGet) -->
+      <_PS76WorkerFile Include="$(PkgMicrosoft_Azure_Functions_PowerShellWorker_PS7_6)/contentFiles/any/any/workers/powershell/**/*" />
+      <TfmSpecificPackageFile Include="@(_PS76WorkerFile)" TargetPath="%(RecursiveDir)%(Filename)%(Extension)"
+        Pack="true" PackagePath="tools/any/" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Workloads/Workers/PowerShell/release_notes.md
+++ b/src/Workloads/Workers/PowerShell/release_notes.md
@@ -1,0 +1,4 @@
+# Azure.Functions.Cli.Workloads.Workers.PowerShell
+
+## 4.0.4778-preview.1
+


### PR DESCRIPTION
## Issue

Resolves #5321 

## What's Changed

Add the content workload that ships the PowerShell language worker payload (PS 7.4 + 7.6). This mirrors the existing Python/Node/Go worker workloads.

Design: single workload bundles all supported PS versions because the host resolves the correct worker subdirectory at runtime via `%FUNCTIONS_WORKER_RUNTIME_VERSION%`. Users install once and get all versions.

- Workloads.Workers.PowerShell.csproj (content workload, alias powershell-worker)
- References Microsoft.Azure.Functions.PowerShellWorker.PS7.4 (4.0.4781) and PS7.6 (4.0.4778), merging both into tools/any/
- Directory.Version.props with per-PS-version pins
- Release pipeline (official-release.workload.powershell-worker.yml)
- Central PackageVersion entries in eng/build/Packages.props
- Solution file entry under /src/Workloads/Workers/
