### PR TITLE
fix: add Git Bash func5 wrapper to Windows installer

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -313,11 +313,17 @@ try {
             }
         }
 
-        # Drop a func5 wrapper so v5 can be invoked side-by-side with a v4 'func' on PATH.
+        # Drop func5 wrappers so v5 can be invoked side-by-side with a v4 'func' on PATH.
         if ($os -eq 'win') {
-            $wrapperPath = Join-Path $InstallPath 'func5.cmd'
+            # cmd.exe / PowerShell wrapper
+            $cmdWrapperPath = Join-Path $InstallPath 'func5.cmd'
             @('@echo off', '"%~dp0\func.exe" %*') -join "`r`n" |
-                Set-Content -Path $wrapperPath -Encoding Ascii -NoNewline
+                Set-Content -Path $cmdWrapperPath -Encoding Ascii -NoNewline
+
+            # Extensionless wrapper for Git Bash / MSYS2 shells
+            $bashWrapperPath = Join-Path $InstallPath 'func5'
+            $bashBody = "#!/usr/bin/env bash`nexec `"`$(dirname `"`$0`")/func.exe`" `"`$@`"`n"
+            [System.IO.File]::WriteAllText($bashWrapperPath, $bashBody)
         } else {
             $wrapperPath = Join-Path $InstallPath 'func5'
             $body = "#!/usr/bin/env bash`nexec `"`$(dirname `"`$0`")/func`" `"`$@`"`n"


### PR DESCRIPTION
### Issue describing the changes in this PR

Fixes #5397

`install.ps1` already creates `func5.cmd` for cmd.exe/PowerShell and persists the install directory to the Windows User PATH. However, Git Bash (MSYS/MINGW) does not resolve `.cmd` files as bare commands, so `func5` was unavailable there.

This PR adds an extensionless `func5` bash wrapper alongside `func5.cmd` on Windows installs:

```bash
#!/usr/bin/env bash
exec "$(dirname "$0")/func.exe" "$@"
```

### Pull request checklist

* [x] My changes **do not** require documentation changes
* [x] My changes **do not** need to be backported to a previous version
* [x] My changes **should not** be added to the release notes for the next release
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

- **cmd.exe PATH issue** (part 1 of #5397): Already resolved — `install.ps1` uses `[Environment]::SetEnvironmentVariable('PATH', ..., 'User')` to persist the install dir system-wide.
- **Git Bash issue** (part 2 of #5397): Fixed by this PR — an extensionless `func5` script is now created that execs `func.exe` directly.
- No changes to `install.sh` (non-Windows already works correctly).