### PR TITLE
Update create-workload skill to match SDK-based workload patterns

### DIFF
--- a/.github/skills/create-workload/SKILL.md
+++ b/.github/skills/create-workload/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-workload
-description: 'Use when adding a new func CLI workload (e.g. Node, Python, Java). Scaffolds the source project, test project, solution entry, CI pipelines, and docs.'
+description: 'Use when adding a new func CLI workload (e.g. Node, Python, Java). Scaffolds the source project, test project, solution entry, CI release pipeline, and docs.'
 ---
 
 # Create a New Workload
@@ -29,15 +29,14 @@ Create the following files:
 - [ ] `Workloads.<Name>.csproj`
   ```xml
   <Project Sdk="Microsoft.NET.Sdk">
+
     <PropertyGroup>
       <TargetFramework>net10.0</TargetFramework>
-      <Title><Name></Title>
+      <Title><Name> Stack</Title>
       <Description>Azure Functions CLI tooling for <Name> projects.</Description>
-      <PackageType>FuncCliWorkload</PackageType>
-      <PackageTags>kind:workload alias:<name> func-workload</PackageTags>
-      <IncludeBuildOutput>false</IncludeBuildOutput>
-      <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
-      <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>
+      <PackAsWorkload>true</PackAsWorkload>
+      <WorkloadKind>workload</WorkloadKind>
+      <WorkloadAlias><name></WorkloadAlias>
     </PropertyGroup>
 
     <ItemGroup>
@@ -45,25 +44,18 @@ Create the following files:
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="$(SrcRoot)Abstractions/Abstractions.csproj">
-        <PrivateAssets>all</PrivateAssets>
-        <ExcludeAssets>runtime</ExcludeAssets>
-      </ProjectReference>
+      <ProjectReference Include="$(SrcRoot)Abstractions/Abstractions.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
-      <None Include="workload.json" Pack="true" PackagePath="/" />
-      <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="tools/any/" Visible="false" />
-    </ItemGroup>
   </Project>
   ```
-  - `PackageType=FuncCliWorkload` is required for catalog discovery.
-  - `Title` is the feed-UI display name; `Description` is the one-line summary. The `Workload` class's `DisplayName` / `Description` overrides serve the same purpose for the running CLI.
-  - `PackageTags` should include exactly one `kind:<workload|content|meta>` tag matching `workload.json`'s `kind` field, plus one or more `alias:<name>` tags so users can install by short name. `func-workload` is recommended for generic feed UI discoverability.
-  - `IncludeBuildOutput=false` plus the explicit `tools/any/` pack item is what makes the loader find the workload assembly.
-  - `SuppressDependenciesWhenPacking=true` plus `PrivateAssets=all` / `ExcludeAssets=runtime` on Abstractions keep the workload self-contained: the CLI provides Abstractions (and the other host-shared contract assemblies) at runtime. Apply the same `PrivateAssets=all` rule to **every** future `<PackageReference>`.
-  - The csproj above only packs the workload's own assembly. As soon as the workload pulls in transitive managed dependencies, you'll need to pack the `dotnet publish` output (workload `.dll`, `.deps.json`, transitive deps, optional `runtimes/`). The upcoming `Workload.Sdk` package will provide that pack target. See `docs/proposed/workload-package-layout.md` §5 and §9.
-  - Csproj/assembly name must be `Azure.Functions.Cli.Workloads.<Name>` (set via the project filename and matched in the package id).
+  - `PackAsWorkload=true` triggers the SDK build targets in `eng/build/Workloads/` that handle packaging, `workload.json` generation, dependency filtering, and pack layout. Do **not** manually set `PackageType`, `PackageTags`, `IncludeBuildOutput`, or `SuppressDependenciesWhenPacking` — the SDK targets set all of these from `WorkloadKind` and `WorkloadAlias`.
+  - `WorkloadKind` must be one of: `workload`, `content`, `meta`, `rid-pointer`. Stack workloads use `workload`.
+  - `WorkloadAlias` is the short name users pass to `func workload install <alias>`.
+  - `Title` is the feed-UI display name; `Description` is the one-line summary.
+  - The Abstractions reference does **not** need `PrivateAssets`/`ExcludeAssets` — the SDK targets (`Workload.Pack.targets`) automatically exclude unified CLI assemblies from the package via the `ResolveWorkloadCopyLocal` task.
+  - If the workload embeds template files, add `<EmbeddedResource Include="Templates/**" />`.
+  - Csproj/assembly name is `Azure.Functions.Cli.Workloads.<Name>` (derived from the project filename by `eng/build/Engineering.props`).
 - [ ] `Directory.Version.props`, the workload's version:
   ```xml
   <Project>
@@ -82,30 +74,25 @@ Create the following files:
   - Initial scaffold of the <Name> workload (entry point + stub project initializer).
   ```
 - [ ] `README.md` next to the csproj. `Release.props` auto-includes it as `<PackageReadmeFile>` (and the Functions icon as `<PackageIcon>`), so both surface on NuGet feeds. Describe the workload's purpose, supported languages, and any prerequisites.
-- [ ] `workload.json`, the entry-point manifest packed at the package root. `assemblyPath` is relative to `tools/any/` (bare filename; no leading `/`, no `..`); `type` is the FQN of the `Workload` subclass:
-  ```json
-  {
-    "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
-    "kind": "workload",
-    "entryPoint": {
-      "assemblyPath": "Azure.Functions.Cli.Workloads.<Name>.dll",
-      "type": "Azure.Functions.Cli.Workloads.<Name>.<Name>Workload"
-    }
-  }
-  ```
-- [ ] `<Name>Workload.cs`, subclass of `Workloads.Workload`:
+- [ ] `<Name>Workload.cs`, the workload entry-point class. The file **must** include the assembly-level `CliWorkload<T>` attribute that the SDK uses to discover the entry point during packaging:
   ```csharp
+  // Copyright (c) .NET Foundation. All rights reserved.
+  // Licensed under the MIT License. See LICENSE in the project root for license information.
+
+  using Azure.Functions.Cli.Projects;
   using Azure.Functions.Cli.Workloads;
   using Microsoft.Extensions.DependencyInjection;
+
+  [assembly: CliWorkload<Azure.Functions.Cli.Workloads.<Name>.<Name>Workload>()]
 
   namespace Azure.Functions.Cli.Workloads.<Name>;
 
   /// <summary>
   /// Entry-point for the <Name> workload.
   /// </summary>
-  public sealed class <Name>Workload : Workloads.Workload
+  public sealed class <Name>Workload : Workload
   {
-      public override string DisplayName => "<Name>";
+      public override string DisplayName => "<Name> Stack";
 
       public override string Description => "Azure Functions CLI tooling for <Name> projects.";
 
@@ -116,17 +103,43 @@ Create the following files:
       }
   }
   ```
-  - Must be `public sealed` and have a parameterless constructor (the loader activates it by reflection).
-  - Use expression-bodied `=>` overrides; do not redeclare package id or version on the class — the csproj and `Directory.Version.props` are the single source of truth.
+  - Must be `public sealed` with a parameterless constructor (the loader activates it by reflection).
+  - The `[assembly: CliWorkload<T>()]` attribute is **required** — the `ResolveWorkloadEntry` MSBuild task scans the compiled assembly for this attribute to auto-generate `workload.json`. Do **not** create a manual `workload.json` file.
+  - Use expression-bodied `=>` overrides; do not redeclare package id or version on the class.
+  - Register additional services in `Configure` as needed: `IQuickstartProvider` for post-init guidance, `IFunctionsProjectFactory` via `builder.AddProjectFactory(...)` for project detection, custom commands via `builder.RegisterCommand<T>()`.
 - [ ] At least one provider, typically `<Name>ProjectInitializer.cs` implementing `IProjectInitializer`:
   ```csharp
+  // Copyright (c) .NET Foundation. All rights reserved.
+  // Licensed under the MIT License. See LICENSE in the project root for license information.
+
+  using System.CommandLine;
+  using Azure.Functions.Cli.Commands;
+  using Azure.Functions.Cli.Projects;
+
+  namespace Azure.Functions.Cli.Workloads.<Name>;
+
+  /// <summary>
+  /// Scaffolds a <Name> Functions project.
+  /// </summary>
   internal sealed class <Name>ProjectInitializer : IProjectInitializer
   {
       public string Stack => "<name>";
 
-      public IReadOnlyList<string> SupportedLanguages { get; } = ["<Language>"];
+      public string DisplayName => "<Name>";
 
-      public IReadOnlyList<Option> GetInitOptions(IInitOptionRegistry registry) => [];
+      public IReadOnlyList<string> SupportedLanguages => [.. SupportedLanguageAliases.Keys];
+
+      public IReadOnlyDictionary<string, IReadOnlyList<string>> SupportedLanguageAliases { get; } =
+          new Dictionary<string, IReadOnlyList<string>>()
+          {
+              { "<Language>", [] }
+          };
+
+      public IReadOnlyList<Option> GetInitOptions(IInitOptionRegistry registry)
+      {
+          ArgumentNullException.ThrowIfNull(registry);
+          return [];
+      }
 
       public Task InitializeAsync(
           InitContext context,
@@ -148,21 +161,25 @@ Mirror the source path under `test/Workloads/`: grouped workloads use
 `test/Workloads/<kind>/<Name>.Tests/`, and ungrouped workloads use
 `test/Workloads/<Name>.Tests/`.
 
-- [ ] `Workloads.<Name>.Tests.csproj`, assembly name `Azure.Functions.Cli.Workloads.<Name>.Tests`:
+- [ ] `Workloads.<Name>.Tests.csproj`:
   ```xml
   <Project Sdk="Microsoft.NET.Sdk">
+
     <PropertyGroup>
       <TargetFramework>net10.0</TargetFramework>
-      <AssemblyName>Azure.Functions.Cli.Workloads.<Name>.Tests</AssemblyName>
     </PropertyGroup>
 
     <ItemGroup>
       <ProjectReference Include="$(SrcRoot)Workloads/<kind>/<Name>/Workloads.<Name>.csproj" />
+      <ProjectReference Include="$(SrcRoot)Abstractions/Abstractions.csproj" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     </ItemGroup>
+
   </Project>
   ```
   - Omit the `<kind>/` segment in the `ProjectReference` for ungrouped workloads.
-  - Don't add a redundant `ProjectReference` to `Abstractions`; it flows through the workload reference.
+  - The `Abstractions` and `Microsoft.Extensions.DependencyInjection` references are needed for DI-based contract tests that verify `Configure(FunctionsCliBuilder)` registrations.
+  - Common test dependencies (xUnit, NSubstitute, AwesomeAssertions) are pulled in by `test/Directory.Build.props` — do not redeclare them.
 - [ ] `<Name>WorkloadTests.cs`, contract tests for the workload (initializer is registered via `Configure`, `DisplayName` / `Description` are set).
 - [ ] `<Name>ProjectInitializerTests.cs`, unit tests for the initializer (`Stack`, `SupportedLanguages`, `InitializeAsync` throws `NotImplementedException` for stubs).
 
@@ -184,29 +201,36 @@ Mirror the source path under `test/Workloads/`: grouped workloads use
   ```
   For ungrouped workloads, use `/src/Workloads/` and `/test/Workloads/` as the solution folders.
 
-### 4. CI pipelines
+### 4. CI release pipeline
 
-All workloads share a single job template, `eng/ci/templates/jobs/build-workload.yml`, parameterised by `WorkloadProjectName`. Each workload only needs two thin pipeline files; do not introduce per-workload job/step templates.
+Build and test are handled by the unified `eng/ci/public-build.yml` which builds the entire solution — no per-workload build pipelines are needed. Each workload only needs a **release pipeline** for publishing to NuGet.
 
-- [ ] `eng/ci/workloads/<name>/public-build.yml`, 1ES Unofficial template:
-  - Extends the 1ES unofficial template and references the shared job template:
-    ```yaml
-    extends:
-      template: ...1ESPipelineTemplates/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
-      parameters:
-        ...
-        stages:
-          - stage: BuildAndTest
-            jobs:
-              - template: /eng/ci/templates/jobs/build-workload.yml@self
-                parameters:
-                  WorkloadProjectName: <Name>
-    ```
-  - Path filters scope triggers to `src/Abstractions/**`, `src/Workloads/<kind>/<Name>/**`, `test/Workloads/<kind>/<Name>.Tests/**`, `eng/ci/templates/jobs/build-workload.yml`, and the pipeline file itself. Omit the `<kind>/` segment for ungrouped workloads.
-- [ ] `eng/ci/workloads/<name>/official-build.yml`, 1ES Official template:
-  - Same shape, but extends the Official template, sets `pr: none`, and adds `release/*` to its branch triggers (and to path filters as needed). The shared template handles build + test + pack.
+- [ ] `eng/ci/release/official-release.workload.<name>.yml`:
+  ```yaml
+  parameters:
+  - name: public
+    displayName: Publish to nuget.org?
+    type: boolean
+    default: false
 
-Use `eng/ci/workloads/python/{public,official}-build.yml` as the reference.
+  # Release has no triggers outside of pipeline
+  trigger: none
+  pr: none
+
+  extends:
+    template: /eng/ci/templates/pipelines/release-packages.yml@self
+    parameters:
+      public: ${{ parameters.public }}
+      folder: workloads/<name>
+      projects: |
+        $(Build.SourcesDirectory)/src/Workloads/<kind>/<Name>/Workloads.<Name>.csproj
+        $(Build.SourcesDirectory)/test/Workloads/<kind>/<Name>.Tests/Workloads.<Name>.Tests.csproj
+  ```
+  - The `release-packages.yml` shared template handles: restore → build → test → sign → pack → release to NuGet staging feed (with optional nuget.org publish).
+  - The `folder` parameter determines the partner drop path (`azure-functions/workloads/<name>/`).
+  - Omit the `<kind>/` segment in project paths for ungrouped workloads.
+
+Use `eng/ci/release/official-release.workload.python.yml` as the reference.
 
 ### 5. Documentation
 
@@ -224,8 +248,8 @@ dotnet test
 A correctly built workload package should:
 
 - Have package id `Azure.Functions.Cli.Workloads.<Name>` and `packageType=FuncCliWorkload`.
-- Carry tags `kind:workload alias:<name>` (plus optional extra `alias:` entries and `func-workload`).
-- Contain `workload.json` at the package root.
-- Contain the workload assembly at `tools/any/Azure.Functions.Cli.Workloads.<Name>.dll`.
+- Carry tags `func-workload;kind:workload;alias:<name>` (auto-set by `Workload.Pack.targets`).
+- Contain an auto-generated `workload.json` at the package root (generated by the `WriteWorkloadJson` MSBuild task from the `[assembly: CliWorkload<T>()]` attribute).
+- Contain the workload assembly (and its non-unified transitive deps) under `tools/any/`.
 - Have an empty `<dependencies>` element in its `.nuspec`.
-- Not contain Abstractions or any of the other host-shared contract assemblies.
+- Not contain Abstractions or any other unified CLI assemblies (excluded by the `ResolveWorkloadCopyLocal` task).


### PR DESCRIPTION
Aligns the `create-workload` skill with the current workload infrastructure that uses the Workloads SDK build targets.

## Key changes

| Aspect | Old (manual) | New (SDK-driven) |
|--------|-------------|------------------|
| **Csproj** | Manual `PackageType`, `PackageTags`, `IncludeBuildOutput`, `SuppressDependenciesWhenPacking` | `PackAsWorkload=true`, `WorkloadKind`, `WorkloadAlias` |
| **workload.json** | Hand-written, checked into source | Auto-generated by `WriteWorkloadJson` MSBuild task from `[assembly: CliWorkload<T>()]` |
| **Abstractions ref** | `PrivateAssets=all` + `ExcludeAssets=runtime` | Plain reference (SDK targets handle exclusion via `ResolveWorkloadCopyLocal`) |
| **Entry point** | No assembly attribute mentioned | `[assembly: CliWorkload<T>()]` required |
| **Initializer template** | Minimal (`Stack`, `SupportedLanguages`) | Full shape (`DisplayName`, `SupportedLanguageAliases`, proper usings) |
| **CI** | Per-workload `public-build.yml` + `official-build.yml` | Unified build; only a release pipeline per workload |
| **Test project** | No DI refs, explicit `AssemblyName` | Includes Abstractions + DI for contract tests, omits redundant `AssemblyName` |