### PR TITLE
feat: resolve relative paths from workload.json

### DIFF
--- a/src/Func/Commands/Workload/WorkloadListCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadListCommand.cs
@@ -229,7 +229,7 @@ internal sealed class WorkloadListCommand : FuncCliCommand
                     e.PackageVersion,
                     e.Aliases ?? [],
                     info?.DisplayName ?? GetDisplayName(e),
-                    info?.Description ?? (e.Description ?? string.Empty),
+                    info?.Description ?? e.Description ?? string.Empty,
                     Loaded: loaded);
             })];
     }

--- a/src/Func/Workloads/Loading/WorkloadLoader.cs
+++ b/src/Func/Workloads/Loading/WorkloadLoader.cs
@@ -46,26 +46,26 @@ internal sealed class WorkloadLoader(IWorkloadPaths paths) : IWorkloadLoader
                 "Only kind=workload entries should reach the loader. This is a CLI bug.");
 
         string installPath = _paths.GetInstallDirectory(entry.PackageId, entry.PackageVersion);
-        string contentRoot = Path.GetFullPath(Path.Combine(installPath, "tools", "any"));
-        string assemblyPath = Path.GetFullPath(Path.Combine(contentRoot, entryPoint.AssemblyPath));
+        string assemblyPath = ResolveAssemblyPath(installPath, entryPoint.AssemblyPath, entry.PackageId);
+        string contentRoot = Path.GetDirectoryName(assemblyPath)!;
 
         // Defense-in-depth: the metadata reader already rejects rooted paths
         // and `..` segments, but the on-disk registry stores the same value
         // and could be tampered with. Refuse anything resolving outside
-        // the content root.
-        string contentRootWithSeparator = contentRoot.EndsWith(Path.DirectorySeparatorChar)
-            ? contentRoot
-            : contentRoot + Path.DirectorySeparatorChar;
-        if (!assemblyPath.StartsWith(contentRootWithSeparator, StringComparison.Ordinal))
+        // the install directory (where workload.json lives).
+        string installPathWithSeparator = installPath.EndsWith(Path.DirectorySeparatorChar)
+            ? installPath
+            : installPath + Path.DirectorySeparatorChar;
+        if (!assemblyPath.StartsWith(installPathWithSeparator, StringComparison.Ordinal))
         {
             throw new InvalidWorkloadException(
-                $"[{entry.PackageId}] Could not load workload: assembly path '{entryPoint.AssemblyPath}' resolves outside the package content root '{contentRoot}'.");
+                $"[{entry.PackageId}] Could not load workload: assembly path '{entryPoint.AssemblyPath}' resolves outside the install directory '{installPath}'.");
         }
 
         if (!File.Exists(assemblyPath))
         {
             throw new InvalidWorkloadException(
-                $"[{entry.PackageId}] Could not load workload: assembly '{entryPoint.AssemblyPath}' was not found at '{contentRoot}'.");
+                $"[{entry.PackageId}] Could not load workload: assembly '{entryPoint.AssemblyPath}' was not found at '{installPath}'.");
         }
 
         WorkloadLoadContext loadContext = new(entry.PackageId, assemblyPath);
@@ -91,5 +91,29 @@ internal sealed class WorkloadLoader(IWorkloadPaths paths) : IWorkloadLoader
             DisplayName: instance.DisplayName,
             Description: instance.Description,
             LoadContext: loadContext);
+    }
+
+    /// <summary>
+    /// Resolves the entry-point assembly path, first relative to the install directory
+    /// (where workload.json lives), then falling back to the legacy tools/any/ subdirectory.
+    /// </summary>
+    private static string ResolveAssemblyPath(string installPath, string relativeAssemblyPath, string packageId)
+    {
+        // Try resolving directly relative to the install root (workload.json location).
+        string candidate = Path.GetFullPath(Path.Combine(installPath, relativeAssemblyPath));
+        if (File.Exists(candidate))
+        {
+            return candidate;
+        }
+
+        // Fall back to legacy tools/any/ layout.
+        string legacyCandidate = Path.GetFullPath(Path.Combine(installPath, "tools", "any", relativeAssemblyPath));
+        if (File.Exists(legacyCandidate))
+        {
+            return legacyCandidate;
+        }
+
+        // Return the primary candidate so the caller produces a clear error message.
+        return candidate;
     }
 }

--- a/test/Func.Tests/Workloads/Loading/WorkloadLoaderTests.cs
+++ b/test/Func.Tests/Workloads/Loading/WorkloadLoaderTests.cs
@@ -186,24 +186,138 @@ public class WorkloadLoaderTests
     }
 
     [Fact]
-    public void Load_Throws_WhenAssemblyPathEscapesContentRoot()
-    {
-        // The metadata reader rejects rooted paths and `..` segments at parse
-        // time, but the registry persists the same value and could be tampered
-        // with on disk. Pin the loader's defense-in-depth check.
-        var loader = new WorkloadLoader(StubPaths());
-        var entry = FixtureEntry(FixturePackageId, assemblyFileOverride: "../../../escape.dll");
-
-        var ex = Assert.Throws<InvalidWorkloadException>(() => loader.Load([entry]));
-
-        Assert.StartsWith($"[{FixturePackageId}]", ex.Message);
-        Assert.Contains("outside the package content root", ex.Message);
-    }
-
-    [Fact]
     public void Ctor_NullPaths_Throws()
     {
         Assert.Throws<ArgumentNullException>(() => new WorkloadLoader(null!));
+    }
+
+    [Fact]
+    public void Load_ResolvesAssembly_FromInstallRootDirectly()
+    {
+        // Simulates the new publish layout where the DLL lives directly relative
+        // to the install root (where workload.json is), without tools/any/.
+        string tempDir = Path.Combine(Path.GetTempPath(), $"wl-loader-test-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            CopyFixtureToDirectory(FixtureAssemblyFile, tempDir);
+
+            var paths = Substitute.For<IWorkloadPaths>();
+            paths.WorkloadsRoot.Returns(tempDir);
+            paths.GetInstallDirectory(Arg.Any<string>(), Arg.Any<string>()).Returns(tempDir);
+
+            var loader = new WorkloadLoader(paths);
+            var entry = FixtureEntry(FixturePackageId);
+
+            var loaded = loader.Load([entry]);
+
+            var item = Assert.Single(loaded);
+            Assert.Equal(FixtureTypeName, item.Instance.GetType().FullName);
+            Assert.Equal(tempDir, item.ContentRoot);
+            UnloadAndRelease(item.LoadContext);
+        }
+        finally
+        {
+            TryDeleteDirectory(tempDir);
+        }
+    }
+
+    [Fact]
+    public void Load_ResolvesAssembly_FromSubdirectoryRelativeToInstallRoot()
+    {
+        // Assembly path includes a subdirectory (e.g. "lib/MyWorkload.dll")
+        // resolved relative to the install root.
+        string tempDir = Path.Combine(Path.GetTempPath(), $"wl-loader-test-{Guid.NewGuid():N}");
+        try
+        {
+            string subDir = Path.Combine(tempDir, "lib");
+            Directory.CreateDirectory(subDir);
+            CopyFixtureToDirectory(FixtureAssemblyFile, subDir);
+
+            var paths = Substitute.For<IWorkloadPaths>();
+            paths.WorkloadsRoot.Returns(tempDir);
+            paths.GetInstallDirectory(Arg.Any<string>(), Arg.Any<string>()).Returns(tempDir);
+
+            var loader = new WorkloadLoader(paths);
+            var entry = FixtureEntry(FixturePackageId, assemblyFileOverride: $"lib/{FixtureAssemblyFile}");
+
+            var loaded = loader.Load([entry]);
+
+            var item = Assert.Single(loaded);
+            Assert.Equal(FixtureTypeName, item.Instance.GetType().FullName);
+            Assert.Equal(subDir, item.ContentRoot);
+            UnloadAndRelease(item.LoadContext);
+        }
+        finally
+        {
+            TryDeleteDirectory(tempDir);
+        }
+    }
+
+    [Fact]
+    public void Load_PrefersInstallRoot_OverToolsAny()
+    {
+        // When the assembly exists both at the install root and under tools/any/,
+        // the install root takes precedence.
+        string tempDir = Path.Combine(Path.GetTempPath(), $"wl-loader-test-{Guid.NewGuid():N}");
+        try
+        {
+            string toolsAny = Path.Combine(tempDir, "tools", "any");
+            Directory.CreateDirectory(toolsAny);
+            CopyFixtureToDirectory(FixtureAssemblyFile, tempDir);
+            CopyFixtureToDirectory(FixtureAssemblyFile, toolsAny);
+
+            var paths = Substitute.For<IWorkloadPaths>();
+            paths.WorkloadsRoot.Returns(tempDir);
+            paths.GetInstallDirectory(Arg.Any<string>(), Arg.Any<string>()).Returns(tempDir);
+
+            var loader = new WorkloadLoader(paths);
+            var entry = FixtureEntry(FixturePackageId);
+
+            var loaded = loader.Load([entry]);
+
+            var item = Assert.Single(loaded);
+            Assert.Equal(FixtureTypeName, item.Instance.GetType().FullName);
+            // ContentRoot is the directory of the resolved assembly — should be the install root.
+            Assert.Equal(tempDir, item.ContentRoot);
+            UnloadAndRelease(item.LoadContext);
+        }
+        finally
+        {
+            TryDeleteDirectory(tempDir);
+        }
+    }
+
+    [Fact]
+    public void Load_Throws_WhenSubdirectoryPathEscapesInstallRoot()
+    {
+        // Relative paths that escape the install directory must be rejected,
+        // even when they point to valid files on disk.
+        string tempDir = Path.Combine(Path.GetTempPath(), $"wl-loader-test-{Guid.NewGuid():N}");
+        try
+        {
+            string nested = Path.Combine(tempDir, "inner");
+            Directory.CreateDirectory(nested);
+
+            // Place the DLL one level above the "install directory" to simulate escape.
+            CopyFixtureToDirectory(FixtureAssemblyFile, tempDir);
+
+            var paths = Substitute.For<IWorkloadPaths>();
+            paths.WorkloadsRoot.Returns(nested);
+            paths.GetInstallDirectory(Arg.Any<string>(), Arg.Any<string>()).Returns(nested);
+
+            var loader = new WorkloadLoader(paths);
+            var entry = FixtureEntry(FixturePackageId, assemblyFileOverride: $"../{FixtureAssemblyFile}");
+
+            var ex = Assert.Throws<InvalidWorkloadException>(() => loader.Load([entry]));
+
+            Assert.StartsWith($"[{FixturePackageId}]", ex.Message);
+            Assert.Contains("outside the install directory", ex.Message);
+        }
+        finally
+        {
+            TryDeleteDirectory(tempDir);
+        }
     }
 
     private static IWorkloadPaths StubPaths()
@@ -212,7 +326,7 @@ public class WorkloadLoaderTests
         // Fixture dlls land at <BaseDirectory>/tools/any/<file> via test
         // project copies, so returning BaseDirectory as the install directory
         // lines up with a registry entry of AssemblyPath = "<file>" without
-        // having to materialise a <pkgid>/<version>/tools/any tree.
+        // having to materialize a <package_id>/<version>/tools/any tree.
         var paths = Substitute.For<IWorkloadPaths>();
         paths.WorkloadsRoot.Returns(AppContext.BaseDirectory);
         paths.GetInstallDirectory(Arg.Any<string>(), Arg.Any<string>())
@@ -244,4 +358,56 @@ public class WorkloadLoaderTests
             Type = SdkFixtureTypeName,
         },
     };
+
+    /// <summary>
+    /// Copies the fixture assembly (and its deps.json / runtimeconfig.json) from the
+    /// test output's tools/any/ directory into the specified target directory.
+    /// </summary>
+    private static void CopyFixtureToDirectory(string assemblyFileName, string targetDir)
+    {
+        string sourceDir = Path.Combine(AppContext.BaseDirectory, "tools", "any");
+        string baseName = Path.GetFileNameWithoutExtension(assemblyFileName);
+
+        foreach (string ext in new[] { ".dll", ".deps.json", ".runtimeconfig.json", ".pdb" })
+        {
+            string source = Path.Combine(sourceDir, baseName + ext);
+            if (File.Exists(source))
+            {
+                File.Copy(source, Path.Combine(targetDir, baseName + ext), overwrite: true);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Unloads a collectible <see cref="WorkloadLoadContext"/> and waits for the GC
+    /// to release file handles so temp directories can be deleted on Windows.
+    /// </summary>
+    private static void UnloadAndRelease(WorkloadLoadContext context)
+    {
+        context.Unload();
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+    }
+
+    /// <summary>
+    /// Best-effort cleanup of temp directories. On Windows, collectible ALC file
+    /// handles may linger briefly after unload; swallow access errors so test
+    /// assertions are not masked by cleanup failures.
+    /// </summary>
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            Directory.Delete(path, recursive: true);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // File still locked by the OS after ALC unload; acceptable in tests.
+        }
+        catch (IOException)
+        {
+            // Same — lingering handle.
+        }
+    }
 }


### PR DESCRIPTION
- allow for `workload.json` entry point to be a relative path from `workload.json` itself.
- retains legacy behavior of resolving relative to `/tools/any` if relative to `workload.json` is not found

This change is in preparation to update the SDK to emit `workload.json` with the relative path of `tools/any/workload.dll`. Or for a RID-specific package to be `tools/<rid>/workload.dll`.