### PR TITLE
build: use relative path for workload.json

### DIFF
--- a/eng/build/Workloads/Workload.Pack.targets
+++ b/eng/build/Workloads/Workload.Pack.targets
@@ -86,19 +86,14 @@
   Will resolve both runtime (packages) and reference copy-local paths.
   Will trim out all unified (CLI-controlled) assemblies.
   -->
-  <Target Name="_IncludeWorkloadCopyLocal" DependsOnTargets="ResolveReferences" Condition="'$(WorkloadKind)' == 'workload'">
-    <PropertyGroup>
-      <_WorkloadRidPath Condition="'$(RuntimeIdentifier)' == ''">any</_WorkloadRidPath>
-      <_WorkloadRidPath Condition="'$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier)</_WorkloadRidPath>
-    </PropertyGroup>
-
+  <Target Name="_IncludeWorkloadCopyLocal" DependsOnTargets="ResolveReferences;_SetWorkloadProperties" Condition="'$(WorkloadKind)' == 'workload'">
     <ResolveWorkloadCopyLocal Items="@(RuntimeCopyLocalItems);@(ReferenceCopyLocalPaths)" UnifiedItems="@(_WorkloadUnifiedItems)">
       <Output TaskParameter="WorkloadCopyLocal" ItemName="_WorkloadCopyLocal" />
     </ResolveWorkloadCopyLocal>
 
     <ItemGroup>
-      <TfmSpecificPackageFile Include="$(TargetPath)" PackagePath="tools/$(_WorkloadRidPath)/" />
-      <TfmSpecificPackageFile Include="@(_WorkloadCopyLocal)" PackagePath="tools/$(_WorkloadRidPath)/%(_WorkloadCopyLocal.TargetPath)" />
+      <TfmSpecificPackageFile Include="$(TargetPath)" PackagePath="$(_WorkloadPackageContentRoot)" />
+      <TfmSpecificPackageFile Include="@(_WorkloadCopyLocal)" PackagePath="$(_WorkloadPackageContentRoot)%(_WorkloadCopyLocal.TargetPath)" />
     </ItemGroup>
   </Target>
 

--- a/eng/build/Workloads/Workload.targets
+++ b/eng/build/Workloads/Workload.targets
@@ -24,7 +24,8 @@
     <WorkloadKind Condition="'$(RuntimeIdentifiers)' != '' AND '$(RuntimeIdentifier)' == ''">rid-pointer</WorkloadKind>
 
     <!-- When NoBuild is true, assume assemblies will already exist as needed. -->
-    <_ResolveWorkloadEntryPointDependsOn Condition="'$(NoBuild)' != 'true'">Build</_ResolveWorkloadEntryPointDependsOn>
+    <_ResolveWorkloadEntryPointDependsOn>_SetWorkloadProperties</_ResolveWorkloadEntryPointDependsOn>
+    <_ResolveWorkloadEntryPointDependsOn Condition="'$(NoBuild)' != 'true'">Build;$(_ResolveWorkloadEntryPointDependsOn)</_ResolveWorkloadEntryPointDependsOn>
     <_WorkloadJsonCacheFile Condition="'$(_WorkloadJsonCacheFile)' == ''">$(IntermediateOutputPath)workload.json.cache</_WorkloadJsonCacheFile>
     <_WorkloadJsonFile Condition="'$(_WorkloadJsonFile)' == ''">$(IntermediateOutputPath)workload.json</_WorkloadJsonFile>
   </PropertyGroup>
@@ -41,11 +42,19 @@
     <Error Condition="!@(_AllowedWorkloadKind->AnyHaveMetadataValue('Identity', '$(WorkloadKind)'))" Text="Invalid WorkloadKind '$(WorkloadKind)'. Valid values are: @(_AllowedWorkloadKind)." />
   </Target>
 
+  <Target Name="_SetWorkloadProperties">
+    <PropertyGroup>
+      <_WorkloadRidPath Condition="'$(RuntimeIdentifier)' == ''">any</_WorkloadRidPath>
+      <_WorkloadRidPath Condition="'$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier)</_WorkloadRidPath>
+      <_WorkloadPackageContentRoot>tools/$(_WorkloadRidPath)/</_WorkloadPackageContentRoot>
+    </PropertyGroup>
+  </Target>
+
   <!-- Resolve the entry point for the workload when it is a 'workload' kind. -->
   <Target Name="_ResolveWorkloadEntryPoint" Condition="'$(WorkloadKind)' == 'workload'" 
     DependsOnTargets="$(_ResolveWorkloadEntryPointDependsOn)">
     <PropertyGroup>
-      <WorkloadEntryPointAssembly Condition="'$(WorkloadEntryPointAssembly)' == ''">$(TargetFileName)</WorkloadEntryPointAssembly>
+      <WorkloadEntryPointAssembly Condition="'$(WorkloadEntryPointAssembly)' == ''">$(_WorkloadPackageContentRoot)$(TargetFileName)</WorkloadEntryPointAssembly>
     </PropertyGroup>
 
     <ResolveWorkloadEntry AssemblyPath="$(TargetPath)" Condition="'$(WorkloadEntryPointType)' == ''">


### PR DESCRIPTION
update workload sdk to emit workload.json with package-relative path for the entry point assembly.

before
```
{
  "entryPoint": {
    "assemblyPath": "Azure.Functions.Cli.Workloads.DotNet.dll",
    "type": "Azure.Functions.Cli.Workloads.DotNet.DotNetWorkload"
  }
}
```

after:
```
{
  "entryPoint": {
    "assemblyPath": "tools/any/Azure.Functions.Cli.Workloads.DotNet.dll",
    "type": "Azure.Functions.Cli.Workloads.DotNet.DotNetWorkload"
  }
}
```