### PR TITLE
Bump safe NuGet deps and ignore host-pinned packages in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,12 @@ updates:
       - dependency-name: "Microsoft.Azure.Functions.PowerShellWorker.*"
       - dependency-name: "Microsoft.Azure.Functions.PythonWorker"
       - dependency-name: "Microsoft.Azure.WebJobs.Script.WebHost"
+      # These packages are transitive dependencies of the host and must stay
+      # pinned to the versions that ship with it. Only bump them when the
+      # host version is upgraded.
+      - dependency-name: "Azure.Identity"
+      - dependency-name: "Azure.Security.KeyVault.Secrets"
+      - dependency-name: "Microsoft.Identity.Client"
       # We intentionally stay on Microsoft.ApplicationInsights 2.x and do
       # not plan to move to v3.
       - dependency-name: "Microsoft.ApplicationInsights"

--- a/eng/build/Packages.props
+++ b/eng/build/Packages.props
@@ -14,7 +14,7 @@
   </ItemGroup>
   <!-- func -->
   <ItemGroup>
-    <PackageVersion Include="Autofac" Version="9.1.0" />
+    <PackageVersion Include="Autofac" Version="9.3.0" />
     <PackageVersion Include="Azure.Identity" Version="1.17.1" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageVersion Include="AccentedCommandLineParser" Version="2.0.1" />
@@ -22,10 +22,10 @@
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Azure.DurableTask.AzureStorage.Internal" Version="1.4.0" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="4.1051.300" />
-    <PackageVersion Include="Microsoft.Build" Version="17.11.48" />
+    <PackageVersion Include="Microsoft.Build" Version="18.7.1" />
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.84.2" />
     <PackageVersion Include="NuGet.Packaging" Version="5.11.7" />
-    <PackageVersion Include="YamlDotNet" Version="6.1.2" />
+    <PackageVersion Include="YamlDotNet" Version="18.1.0" />
   </ItemGroup>
   <!-- workers -->
   <ItemGroup>
@@ -45,10 +45,10 @@
   <ItemGroup>
     <PackageVersion Include="Azure.Data.Tables" Version="12.9.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.22.1" />
-    <PackageVersion Include="Azure.Storage.Queues" Version="12.27.0" />
+    <PackageVersion Include="Azure.Storage.Queues" Version="12.27.1" />
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageVersion Include="Moq" Version="4.8.2" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="NSubstitute" Version="3.1.0" />
     <PackageVersion Include="Octokit" Version="0.29.0" />
     <PackageVersion Include="RichardSzalay.MockHttp" Version="5.0.0" />

--- a/src/Cli/func/Kubernetes/KubernetesHelper.cs
+++ b/src/Cli/func/Kubernetes/KubernetesHelper.cs
@@ -571,7 +571,7 @@ namespace Azure.Functions.Cli.Kubernetes
                 {
                     var yaml = new SerializerBuilder()
                         .DisableAliases()
-                        .WithNamingConvention(new CamelCaseNamingConvention())
+                        .WithNamingConvention(CamelCaseNamingConvention.Instance)
                         .WithEventEmitter(e => new QuoteNumbersEventEmitter(e))
                         .Build();
                     var writer = new StringWriter();
@@ -832,6 +832,7 @@ namespace Azure.Functions.Cli.Kubernetes
             public override void Emit(ScalarEventInfo eventInfo, IEmitter emitter)
             {
                 if (eventInfo.Source.Type == typeof(string) &&
+                    eventInfo.Source.Value is not null &&
                     (double.TryParse(eventInfo.Source.Value.ToString(), out _) ||
                      bool.TryParse(eventInfo.Source.Value.ToString(), out _)))
                 {


### PR DESCRIPTION
## Summary

Upgrades NuGet packages that are **not** transitive dependencies of the host, and configures dependabot to stop opening PRs for host-pinned packages.

### Package upgrades

| Package | Old | New | Category |
|---------|-----|-----|----------|
| Autofac | 9.1.0 | 9.3.0 | CLI-only (DI container) |
| Microsoft.Build | 17.11.48 | 18.7.1 | CLI-only (project parsing) — **major bump** |
| YamlDotNet | 6.1.2 | 18.1.0 | CLI-only (Kubernetes helper) — **major bump** |
| Azure.Storage.Queues | 12.27.0 | 12.27.1 | Test dep |
| Moq | 4.8.2 | 4.20.72 | Test dep |

### Breaking change fixes

- **YamlDotNet**: `CamelCaseNamingConvention` constructor is obsolete in v18 — switched to `CamelCaseNamingConvention.Instance` singleton pattern.
- **Microsoft.Build**: No breaking changes — the `Construction` API we use (`ProjectRootElement`, `ProjectItemElement`) is unchanged.

### Dependabot ignore rules

Added ignore entries for packages that are transitive dependencies of `Microsoft.Azure.WebJobs.Script.WebHost` and must stay pinned to the versions the host ships with:

- `Azure.Identity` (host declares dep on 1.17.1)
- `Azure.Security.KeyVault.Secrets` (host declares dep on 4.6.0)
- `Microsoft.Identity.Client` (transitive via Azure.Identity)

These should only be bumped when the host version itself is upgraded.

### Supersedes

This PR covers the safe subset of #5453 plus the major bumps from #5454 and #5455. All three can be closed after this merges.

### Validation

- `dotnet restore` ✅
- `dotnet build` (full solution) ✅ — 0 warnings, 0 errors