### PR TITLE
Revert "Set sentinel APPLICATIONINSIGHTS_CONNECTION_STRING in e2e tests (#4924)"

### DIFF
--- a/test/Cli/Func.E2ETests/BaseE2ETests.cs
+++ b/test/Cli/Func.E2ETests/BaseE2ETests.cs
@@ -48,20 +48,6 @@ namespace Azure.Functions.Cli.E2ETests
             // offline behavior pass the `--offline` flag, which still takes precedence.
             Environment.SetEnvironmentVariable(Azure.Functions.Cli.Common.Constants.FunctionsCoreToolsOffline, "false");
 
-            // Provide a sentinel Application Insights connection string. The dotnet-isolated
-            // worker template writes `host.json` with `telemetryMode: "OpenTelemetry"`, which
-            // causes the Azure Monitor exporter inside the worker to validate
-            // APPLICATIONINSIGHTS_CONNECTION_STRING at DI build time. With no value set, the
-            // worker process exits with 0xDEAD before responding to the host, the host
-            // exhausts its restart retries, and `func start` exits -1. The all-zeros key is
-            // the documented sentinel; it satisfies the parser without enabling telemetry.
-            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")))
-            {
-                Environment.SetEnvironmentVariable(
-                    "APPLICATIONINSIGHTS_CONNECTION_STRING",
-                    "InstrumentationKey=00000000-0000-0000-0000-000000000000");
-            }
-
             Directory.CreateDirectory(WorkingDirectory);
             return Task.CompletedTask;
         }

--- a/test/Cli/Func.E2ETests/Fixtures/BaseFunctionAppFixture.cs
+++ b/test/Cli/Func.E2ETests/Fixtures/BaseFunctionAppFixture.cs
@@ -75,20 +75,6 @@ namespace Azure.Functions.Cli.E2ETests.Fixtures
             // BaseE2ETests; fixture-backed tests don't go through that path.
             Environment.SetEnvironmentVariable(Azure.Functions.Cli.Common.Constants.FunctionsCoreToolsOffline, "false");
 
-            // Provide a sentinel Application Insights connection string. The dotnet-isolated
-            // worker template writes `host.json` with `telemetryMode: "OpenTelemetry"`, which
-            // causes the Azure Monitor exporter inside the worker to validate
-            // APPLICATIONINSIGHTS_CONNECTION_STRING at DI build time. With no value set, the
-            // worker process exits with 0xDEAD before responding to the host, the host
-            // exhausts its restart retries, and `func start` exits -1. The all-zeros key is
-            // the documented sentinel; it satisfies the parser without enabling telemetry.
-            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")))
-            {
-                Environment.SetEnvironmentVariable(
-                    "APPLICATIONINSIGHTS_CONNECTION_STRING",
-                    "InstrumentationKey=00000000-0000-0000-0000-000000000000");
-            }
-
             var workerRuntime = WorkerRuntimeLanguageHelper.GetRuntimeMoniker(WorkerRuntime);
             var initArgs = new List<string> { ".", "--worker-runtime", workerRuntime }
                 .Concat(TargetFramework != null


### PR DESCRIPTION

This reverts https://github.com/Azure/azure-functions-core-tools/pull/4924 (8a37e15b01d5643c26c8dc87a098478de061872b)

### Issue describing the changes in this PR

Partially resolves https://github.com/Azure/azure-functions-core-tools/issues/5460.
`main` has already been updated to use a newer version of `azure-functions-templates` (in https://github.com/Azure/azure-functions-core-tools/pull/5271 and others) which contains the corrected templates, but that has not flowed into a stable release yet.

The only purpose the original change served was to hide that the templates didn't work by default, and should be removed to prevent possible regressions.

### Pull request checklist

* [X] My changes **do not** require documentation changes
* [X] My changes **do not** need to be backported to a previous version
* [X] My changes **should not** be added to the release notes for the next release
* [X] I have added all required tests (Unit tests, E2E tests)

