### PR TITLE
Removed v1 templates from the template workloads

### DIFF
--- a/eng/build/Workloads/Workloads.Templates.targets
+++ b/eng/build/Workloads/Workloads.Templates.targets
@@ -8,14 +8,13 @@
       cdn (default)
         Downloads StaticContent files from the extension-bundle CDN for
         the channel selected by $(BundleChannel), filters
-        v1/templates/templates.json and/or v2/templates/templates.json by
+        v2/templates/templates.json by
         $(TemplatesStackLanguageFilter), and packs the result under
         tools/any/content/ of the workload nupkg. Skip the download with
         -p:SkipDownloadTemplates=true for dev / offline-only builds.
 
       static
         Packs files from $(MSBuildProjectDirectory)/content/v2/**/*.json
-        (and content/v1/**/*.json when $(IncludeV1Templates) is true)
         directly. No CDN access at pack time. Used when the templates
         workload owns its content in-repo (e.g. Node, see Templates
         Workload Spec §6.1, where the upstream bundle does not yet ship
@@ -26,7 +25,7 @@
 
     Per-csproj inputs:
       $(TemplatesContentSource)        cdn (default) | static. Picks the
-                                       source of the v1/v2 content.
+                                       source of the v2 content.
       $(BundleChannel)                 stable | preview | experimental.
                                        Same property the bundles workload
                                        uses; selects CDN id and bundle
@@ -41,18 +40,10 @@
                                        is static.
       $(TemplatesStackLanguageFilter)  Comma/semicolon allow-list of
                                        language values, matched
-                                       case-insensitively. Applied to v1
-                                       `metadata.language` and v2
-                                       top-level `language`. Required
-                                       when TemplatesContentSource=cdn
-                                       and any of $(IncludeV1Templates) /
+                                       case-insensitively. Applied to the
+                                       v2 top-level `language`. Required
+                                       when TemplatesContentSource=cdn and
                                        $(IncludeV2Templates) is true.
-      $(IncludeV1Templates)            true | false. Defaults true. Set
-                                       false for stacks that ship v2-only
-                                       (e.g. Python after the v2-only
-                                       cutover, Templates Workload Spec
-                                       §5.2 / §6.2). Also drops v1 from
-                                       static-mode packs.
       $(IncludeV2Templates)            true | false. Defaults true. Set
                                        false for stacks whose v2 content
                                        is not yet available.
@@ -81,7 +72,6 @@
   <PropertyGroup>
     <TemplatesContentSource Condition="'$(TemplatesContentSource)' == ''">cdn</TemplatesContentSource>
 
-    <IncludeV1Templates Condition="'$(IncludeV1Templates)' == ''">true</IncludeV1Templates>
     <IncludeV2Templates Condition="'$(IncludeV2Templates)' == ''">true</IncludeV2Templates>
   </PropertyGroup>
 
@@ -119,14 +109,13 @@
            Text="BundleChannel '$(BundleChannel)' is not one of stable|preview|experimental." />
     <Error Condition="'$(SourceBundleVersion)' == ''"
            Text="SourceBundleVersion must be set when TemplatesContentSource=cdn (the bundle version whose StaticContent the workload snapshots)." />
-    <Error Condition="'$(IncludeV1Templates)' != 'true' and '$(IncludeV2Templates)' != 'true'"
-           Text="At least one of IncludeV1Templates or IncludeV2Templates must be true; the templates workload would otherwise ship an empty payload." />
+    <Error Condition="'$(IncludeV2Templates)' != 'true'"
+           Text="IncludeV2Templates must be true; the templates workload would otherwise ship an empty payload." />
 
     <PropertyGroup>
       <_TplBaseUrl>https://cdn.functions.azure.com/public/ExtensionBundles/$(_BundleCdnId)/$(SourceBundleVersion)/StaticContent</_TplBaseUrl>
       <_TplDownloadedMarker>$(_TplStaging).downloaded</_TplDownloadedMarker>
       <_TplDownloadHash>$(_TplStaging).download.hash</_TplDownloadHash>
-      <_TplFilterV1Hash>$(_TplStaging).filter.v1.hash</_TplFilterV1Hash>
       <_TplFilterV2Hash>$(_TplStaging).filter.v2.hash</_TplFilterV2Hash>
     </PropertyGroup>
 
@@ -135,11 +124,7 @@
       forces a re-download (and re-filter) without a clean.
     -->
     <WriteLinesToFile File="$(_TplDownloadHash)"
-                      Lines="$(_TplBaseUrl)|v1=$(IncludeV1Templates)|v2=$(IncludeV2Templates)"
-                      Overwrite="true"
-                      WriteOnlyWhenDifferent="true" />
-    <WriteLinesToFile File="$(_TplFilterV1Hash)"
-                      Lines="$(TemplatesStackLanguageFilter)"
+                      Lines="$(_TplBaseUrl)|v2=$(IncludeV2Templates)"
                       Overwrite="true"
                       WriteOnlyWhenDifferent="true" />
     <WriteLinesToFile File="$(_TplFilterV2Hash)"
@@ -154,24 +139,6 @@
           BeforeTargets="GenerateNuspec;_GetPackageFiles"
           Inputs="$(MSBuildProjectFullPath);$(_TplDownloadHash)"
           Outputs="$(_TplDownloadedMarker)">
-    <DownloadFile Condition="'$(IncludeV1Templates)' == 'true'"
-                  SourceUrl="$(_TplBaseUrl)/v1/templates/templates.json"
-                  DestinationFolder="$(_TplStaging)v1/templates/"
-                  SkipUnchangedFiles="true" Retries="3" />
-    <DownloadFile Condition="'$(IncludeV1Templates)' == 'true'"
-                  SourceUrl="$(_TplBaseUrl)/v1/bindings/bindings.json"
-                  DestinationFolder="$(_TplStaging)v1/bindings/"
-                  SkipUnchangedFiles="true" Retries="3" />
-    <DownloadFile Condition="'$(IncludeV1Templates)' == 'true'"
-                  SourceUrl="$(_TplBaseUrl)/v1/resources/Resources.json"
-                  DestinationFolder="$(_TplStaging)v1/resources/"
-                  SkipUnchangedFiles="true" Retries="3" />
-    <DownloadFile Condition="'$(IncludeV1Templates)' == 'true'"
-                  SourceUrl="$(_TplBaseUrl)/v1/resources/Resources.%(_TplLocale.Identity).json"
-                  DestinationFolder="$(_TplStaging)v1/resources/"
-                  SkipUnchangedFiles="true" Retries="3"
-                  ContinueOnError="true" />
-
     <DownloadFile Condition="'$(IncludeV2Templates)' == 'true'"
                   SourceUrl="$(_TplBaseUrl)/v2/templates/templates.json"
                   DestinationFolder="$(_TplStaging)v2/templates/"
@@ -193,20 +160,6 @@
     <Touch Files="$(_TplDownloadedMarker)" AlwaysCreate="true" />
   </Target>
 
-  <Target Name="FilterTemplatesByLanguage"
-          DependsOnTargets="DownloadTemplatesContent"
-          Condition="'$(SkipDownloadTemplates)' != 'true' and '$(TemplatesContentSource)' == 'cdn' and '$(IncludeV1Templates)' == 'true'"
-          BeforeTargets="_GetPackageFiles"
-          Inputs="$(_TplDownloadedMarker);$(_TplFilterV1Hash)"
-          Outputs="$(_TplStaging).filtered.v1">
-    <Error Condition="'$(TemplatesStackLanguageFilter)' == ''"
-           Text="TemplatesStackLanguageFilter must be set (e.g. 'JavaScript;TypeScript' for Node, 'Python' for Python)." />
-
-    <Exec Command="pwsh -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)../../scripts/filter-templates.ps1&quot; -Path &quot;$(_TplStaging)v1/templates/templates.json&quot; -Languages &quot;$(TemplatesStackLanguageFilter)&quot; -Mode v1" />
-
-    <Touch Files="$(_TplStaging).filtered.v1" AlwaysCreate="true" />
-  </Target>
-
   <Target Name="FilterTemplatesByLanguageV2"
           DependsOnTargets="DownloadTemplatesContent"
           Condition="'$(SkipDownloadTemplates)' != 'true' and '$(TemplatesContentSource)' == 'cdn' and '$(IncludeV2Templates)' == 'true'"
@@ -216,7 +169,7 @@
     <Error Condition="'$(TemplatesStackLanguageFilter)' == ''"
            Text="TemplatesStackLanguageFilter must be set (e.g. 'JavaScript;TypeScript' for Node, 'Python' for Python)." />
 
-    <Exec Command="pwsh -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)../../scripts/filter-templates.ps1&quot; -Path &quot;$(_TplStaging)v2/templates/templates.json&quot; -Languages &quot;$(TemplatesStackLanguageFilter)&quot; -Mode v2" />
+    <Exec Command="pwsh -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)../../scripts/filter-templates.ps1&quot; -Path &quot;$(_TplStaging)v2/templates/templates.json&quot; -Languages &quot;$(TemplatesStackLanguageFilter)&quot;" />
 
     <Touch Files="$(_TplStaging).filtered.v2" AlwaysCreate="true" />
   </Target>
@@ -245,13 +198,10 @@
   </Target>
 
   <Target Name="_AddTemplatesToPack"
-          DependsOnTargets="FilterTemplatesByLanguage;FilterTemplatesByLanguageV2;GenerateTemplatesWorkloadJson"
+          DependsOnTargets="FilterTemplatesByLanguageV2;GenerateTemplatesWorkloadJson"
           Condition="'$(SkipDownloadTemplates)' != 'true' and '$(TemplatesContentSource)' == 'cdn'"
           BeforeTargets="_GetPackageFiles">
     <ItemGroup>
-      <None Condition="'$(IncludeV1Templates)' == 'true'"
-            Include="$(_TplStaging)v1/**/*.json"
-            Pack="true" PackagePath="tools/any/content/v1/" Visible="false" />
       <None Condition="'$(IncludeV2Templates)' == 'true'"
             Include="$(_TplStaging)v2/**/*.json"
             Pack="true" PackagePath="tools/any/content/v2/" Visible="false" />
@@ -261,7 +211,7 @@
   </Target>
 
   <!--
-    Static-mode pack: pull v1/v2 content from `$(MSBuildProjectDirectory)/content/`
+    Static-mode pack: pull v2 content from `$(MSBuildProjectDirectory)/content/`
     instead of downloading from the bundle CDN. The directory layout under
     content/ mirrors the nupkg layout under tools/any/content/.
 
@@ -320,14 +270,8 @@
           BeforeTargets="_GetPackageFiles">
     <Error Condition="!Exists('$(MSBuildProjectDirectory)/content/v2/templates/templates.json') and '$(IncludeV2Templates)' == 'true'"
            Text="TemplatesContentSource=static but $(MSBuildProjectDirectory)/content/v2/templates/templates.json is missing." />
-    <Error Condition="!Exists('$(MSBuildProjectDirectory)/content/v1/templates/templates.json') and '$(IncludeV1Templates)' == 'true'"
-           Text="TemplatesContentSource=static but $(MSBuildProjectDirectory)/content/v1/templates/templates.json is missing." />
 
     <ItemGroup>
-      <None Condition="'$(IncludeV1Templates)' == 'true'"
-            Include="$(MSBuildProjectDirectory)/content/v1/**/*.json"
-            Pack="true" PackagePath="tools/any/content/v1/" Visible="false" />
-
       <!--
         v2 content with per-channel filter ON: pack the bundles/resources
         from the repo but the templates.json from the obj/-staged filtered
@@ -359,7 +303,7 @@
   <Target Name="_WarnSkipDownloadTemplatesOnPack"
           Condition="'$(SkipDownloadTemplates)' == 'true'"
           BeforeTargets="GenerateNuspec">
-    <Warning Text="SkipDownloadTemplates=true: the $(MSBuildProjectName) pack will ship without any templates payload (no v1/v2 JSON, no templates-workload.json). Intended for offline dev builds only; do not use for release packs." />
+    <Warning Text="SkipDownloadTemplates=true: the $(MSBuildProjectName) pack will ship without any templates payload (no v2 JSON, no templates-workload.json). Intended for offline dev builds only; do not use for release packs." />
   </Target>
 
 </Project>

--- a/eng/scripts/filter-templates.ps1
+++ b/eng/scripts/filter-templates.ps1
@@ -5,19 +5,13 @@
 
 .DESCRIPTION
     Reads the templates.json file at -Path (expected to be a JSON array of
-    template objects from a Functions extension bundle's StaticContent
-    subtree), keeps only entries whose language matches one of the values
-    in -Languages, and writes the filtered array back to -Path.
-
-    -Mode v1 (default) reads `metadata.language` on each entry (v1 schema:
-    `Template[]`).
-    -Mode v2 reads top-level `language` on each entry (v2 schema:
-    `NewTemplate[]`).
+    v2 template objects from a Functions extension bundle's StaticContent
+    subtree), keeps only entries whose top-level `language` matches one of
+    the values in -Languages, and writes the filtered array back to -Path.
 
     Matching is case-insensitive (PowerShell `-contains` semantics) so the
     same allow-list — e.g. `Python` or `JavaScript;TypeScript` — applies
-    cleanly to both v1 (`metadata.language: "Python"`) and v2
-    (`language: "python"`).
+    against the v2 `language` field (`language: "python"`).
 
     Used at templates-workload pack time to drop entries that don't belong
     to the current per-stack workload. See
@@ -30,11 +24,6 @@
     Comma- or semicolon-separated allow-list of language values
     (e.g. "JavaScript,TypeScript" for Node; "Python" for Python).
     Matching is case-insensitive.
-
-.PARAMETER Mode
-    Programming-model schema selector. `v1` reads `metadata.language`
-    (legacy `Template[]`). `v2` reads top-level `language`
-    (`NewTemplate[]`). Defaults to `v1` for backwards compatibility.
 #>
 [CmdletBinding()]
 param(
@@ -42,11 +31,7 @@ param(
     [string]$Path,
 
     [Parameter(Mandatory=$true)]
-    [string]$Languages,
-
-    [Parameter(Mandatory=$false)]
-    [ValidateSet('v1','v2')]
-    [string]$Mode = 'v1'
+    [string]$Languages
 )
 
 $ErrorActionPreference = 'Stop'
@@ -71,10 +56,7 @@ if ($all -isnot [System.Collections.IEnumerable] -or $all -is [string]) {
 }
 
 $beforeCount = @($all).Count
-$kept = switch ($Mode) {
-    'v1' { @($all | Where-Object { $allow -contains $_.metadata.language }) }
-    'v2' { @($all | Where-Object { $allow -contains $_.language }) }
-}
+$kept = @($all | Where-Object { $allow -contains $_.language })
 $afterCount = $kept.Count
 
 # ConvertTo-Json drops the array wrapper for 0- and 1-element collections.
@@ -92,4 +74,4 @@ else {
 $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
 [System.IO.File]::WriteAllText($Path, $json + "`n", $utf8NoBom)
 
-Write-Host "filter-templates ($Mode): $Path  kept $afterCount of $beforeCount entries (languages: $($allow -join ', '))."
+Write-Host "filter-templates: $Path  kept $afterCount of $beforeCount entries (languages: $($allow -join ', '))."

--- a/src/Workloads/Templates/Node/Workloads.Templates.Node.csproj
+++ b/src/Workloads/Templates/Node/Workloads.Templates.Node.csproj
@@ -24,7 +24,6 @@
       Templates Workload Spec §4.4.2.
     -->
     <TemplatesContentSource>static</TemplatesContentSource>
-    <IncludeV1Templates>false</IncludeV1Templates>
     <IncludeV2Templates>true</IncludeV2Templates>
     <FilterTemplatesByBundleChannel>true</FilterTemplatesByBundleChannel>
   </PropertyGroup>

--- a/src/Workloads/Templates/Python/README.DEV.md
+++ b/src/Workloads/Templates/Python/README.DEV.md
@@ -4,10 +4,10 @@ Repo-only notes for contributors. Not packaged into the nupkg.
 
 ## Programming model scope
 
-v1 (legacy) programming model templates are **not** shipped in the v5
-Python templates workload (Templates Workload Spec §5.2 / §6.2 / §7.1).
-Users still authoring against the v1 programming model should migrate
-to v2 or stay on v4 tooling.
+The Python templates workload ships v2 programming model templates
+only (Templates Workload Spec §5.2 / §6.2 / §7.1). Users still
+authoring against the legacy programming model should migrate to v2 or
+stay on v4 tooling.
 
 ## Versioning
 

--- a/src/Workloads/Templates/Python/Workloads.Templates.Python.csproj
+++ b/src/Workloads/Templates/Python/Workloads.Templates.Python.csproj
@@ -11,7 +11,6 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
 
     <TemplatesStackLanguageFilter>Python</TemplatesStackLanguageFilter>
-    <IncludeV1Templates>false</IncludeV1Templates>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #5377

Removed v1 templates from the template workloads

Files changed (5):

 -  eng/build/Workloads/Workloads.Templates.targets : removed IncludeV1Templates property/default, the four v1 CDN DownloadFile tasks, the v1 FilterTemplatesByLanguage target, the v1 filter hash, and v1 pack items in both cdn and static modes; simplified the empty-payload guard to require IncludeV2Templates=true; rewrote header/doc comments to v2-only.
 -  eng/scripts/filter-templates.ps1 : dropped the -Mode param and the v1 metadata.language branch; always filters on the v2 top-level language field.
 -  Workloads.Templates.Node.csproj  and  Workloads.Templates.Python.csproj : removed the dead  <IncludeV1Templates>false</IncludeV1Templates>  lines.
 -  Python/README.DEV.md : reworded the v1 programming-model note.

DotNet template workload intentionally untouched (out of scope; its "v1" references are workload package version 1.0.0, not template v1).

Verified:

 - Node static pack → nupkg contains only content/v2 (no v1 folder).
 - Python CDN pack → only v2 files downloaded, v2 filter ran (kept 18/18), 0 v1 entries in nupkg.
 - filter-templates.ps1 parses and works (case-insensitive v2 language filter).
 - Release build clean under TreatWarningsAsErrors; 78/78 Func.Tests Templates tests pass.
 
### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
