### PR TITLE
Skip worker version validation when Packages.props unchanged

### DIFF
--- a/eng/ci/templates/official/steps/prebuild-common.yml
+++ b/eng/ci/templates/official/steps/prebuild-common.yml
@@ -21,9 +21,21 @@ steps:
 
 - template: /eng/ci/templates/steps/restore-nuget.yml@self
 
+- pwsh: |
+    $diff = git diff --name-only origin/main...HEAD
+    if ($diff -match 'eng/build/Packages\.props') {
+      Write-Output "Packages.props changed, running worker version validation..."
+      Write-Output "##vso[task.setvariable variable=runWorkerValidation]true"
+    } else {
+      Write-Output "Packages.props not changed, skipping worker version validation."
+      Write-Output "##vso[task.setvariable variable=runWorkerValidation]false"
+    }
+  displayName: 'Check if worker validation needed'
+
 - pwsh: ./eng/scripts/validate-worker-versions.ps1
   displayName: 'Validate worker versions'
-  condition: ne(variables['skipWorkerVersionValidation'], 'true')
+  condition: and(ne(variables['skipWorkerVersionValidation'], 'true'), eq(variables['runWorkerValidation'], 'true'))
+
 
 - pwsh: ./eng/scripts/check-vulnerabilities.ps1
   displayName: "Check for security vulnerabilities"

--- a/eng/ci/templates/public/jobs/build-cli.yml
+++ b/eng/ci/templates/public/jobs/build-cli.yml
@@ -19,8 +19,20 @@ jobs:
 
   - template: /eng/ci/templates/steps/restore-nuget.yml@self
 
+  - pwsh: |
+      $diff = git diff --name-only origin/main...HEAD
+      if ($diff -match 'eng/build/Packages\.props') {
+        Write-Output "Packages.props changed, running worker version validation..."
+        Write-Output "##vso[task.setvariable variable=runWorkerValidation]true"
+      } else {
+        Write-Output "Packages.props not changed, skipping worker version validation."
+        Write-Output "##vso[task.setvariable variable=runWorkerValidation]false"
+      }
+    displayName: 'Check if worker validation needed'
+
   - pwsh: ./eng/scripts/validate-worker-versions.ps1
     displayName: 'Validate worker versions'
+    condition: eq(variables['runWorkerValidation'], 'true')
 
   - pwsh: ./eng/scripts/check-vulnerabilities.ps1
     displayName: 'Check for security vulnerabilities'


### PR DESCRIPTION
## Problem

The `validate-worker-versions.ps1` step calls GitHub API on every PR build to fetch worker version files from the host repo. On shared CI agents, this frequently hits the unauthenticated rate limit (60 req/hr), causing 429 errors and build failures even for PRs that don't touch versioning.

## Solution

Suggested by Naren - Add a pre-check step that diffs against `origin/main` to see if `eng/build/Packages.props` was modified. The worker version validation only runs when that file changed — which is the only case where versions could be out of sync.

This eliminates unnecessary GitHub API calls for the vast majority of PR builds.

## Changes

- `eng/ci/templates/public/jobs/build-cli.yml` — added diff check + condition
- `eng/ci/templates/official/steps/prebuild-common.yml` — added diff check + condition