### PR TITLE
feat(workloads): add Java worker workload (#5319)

### DIFF
--- a/Azure.Functions.Cli.slnx
+++ b/Azure.Functions.Cli.slnx
@@ -29,6 +29,7 @@
   </Folder>
   <Folder Name="/src/Workloads/Workers/">
     <Project Path="src/Workloads/Workers/Go/Workloads.Workers.Go.csproj" />
+    <Project Path="src/Workloads/Workers/Java/Workloads.Workers.Java.csproj" />
     <Project Path="src/Workloads/Workers/Node/Workloads.Workers.Node.csproj" />
     <Project Path="src/Workloads/Workers/PowerShell/Workloads.Workers.PowerShell.csproj" />
     <Project Path="src/Workloads/Workers/Python/Workloads.Workers.Python.csproj" />

--- a/eng/build/Packages.props
+++ b/eng/build/Packages.props
@@ -42,6 +42,7 @@
        pkg version. Keep these central pins in sync with those props as a
        documentation aid. -->
   <ItemGroup>
+    <PackageVersion Include="Microsoft.Azure.Functions.JavaWorker" Version="2.19.4" />
     <PackageVersion Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.13.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" Version="4.0.4759" />
     <PackageVersion Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.6" Version="4.0.4778" />

--- a/eng/ci/release/official-release.workload.java-worker.yml
+++ b/eng/ci/release/official-release.workload.java-worker.yml
@@ -1,0 +1,17 @@
+parameters:
+- name: public
+  displayName: Publish to nuget.org?
+  type: boolean
+  default: false
+
+# Release has no triggers outside of pipeline
+trigger: none
+pr: none
+
+extends:
+  template: /eng/ci/templates/pipelines/release-packages.yml@self
+  parameters:
+    public: ${{ parameters.public }}
+    folder: workloads/java-worker
+    projects: |
+      $(Build.SourcesDirectory)/src/Workloads/Workers/Java/Workloads.Workers.Java.csproj

--- a/src/Workloads/Workers/Java/Directory.Version.props
+++ b/src/Workloads/Workers/Java/Directory.Version.props
@@ -1,0 +1,22 @@
+<Project>
+
+  <!--
+    Workload pkg versioning. This is a content-only workload (no workload
+    code or assemblies), so the pkg version maps 1:1 to the worker payload
+    version it carries:
+      $(WorkerVersion) - the Java worker package version. Mirrors the
+                         Microsoft.Azure.Functions.JavaWorker version
+                         pulled in at pack time. Bare three-part SemVer.
+
+    Unlike the bundles workload, there is no channel axis: the upstream
+    JavaWorker NuGet doesn't ship preview/experimental SKUs, so the
+    workload pkg version is just $(WorkerVersion).
+  -->
+
+  <PropertyGroup>
+    <WorkerVersion>2.19.4</WorkerVersion>
+    <VersionPrefix>$(WorkerVersion)</VersionPrefix>
+    <VersionSuffix>preview.1</VersionSuffix>
+  </PropertyGroup>
+
+</Project>

--- a/src/Workloads/Workers/Java/README.DEV.md
+++ b/src/Workloads/Workers/Java/README.DEV.md
@@ -1,0 +1,26 @@
+# Azure Functions CLI – Java worker workload (dev notes)
+
+Repo-only notes for contributors. Not packaged into the nupkg.
+
+## Version scheme
+
+The workload pkg version maps 1:1 to the Java worker payload it carries.
+One prop in `Directory.Version.props` drives `$(VersionPrefix)`:
+
+| Prop               | Meaning                                                                  |
+|--------------------|--------------------------------------------------------------------------|
+| `$(WorkerVersion)` | `Microsoft.Azure.Functions.JavaWorker` version. Bare three-part SemVer. |
+
+Bump `$(WorkerVersion)` whenever the upstream worker package is bumped.
+`$(WorkerVersion)` also pins the restored
+`Microsoft.Azure.Functions.JavaWorker` pkg via `VersionOverride`, so the
+two versions cannot drift.
+
+Unlike the bundles workload, there is no channel axis: the upstream
+JavaWorker NuGet doesn't ship preview/experimental SKUs.
+
+## Pack details
+
+Worker assets are pulled at pack time from the restored
+`Microsoft.Azure.Functions.JavaWorker` NuGet package and packed under
+`tools/any/` in the resulting workload NuGet.

--- a/src/Workloads/Workers/Java/README.md
+++ b/src/Workloads/Workers/Java/README.md
@@ -1,0 +1,16 @@
+# Azure Functions CLI – Java worker workload
+
+Content workload that ships the Java language worker payload consumed by the
+Azure Functions CLI host.
+
+## Install
+
+```bash
+func workload install Azure.Functions.Cli.Workloads.Workers.Java
+# or by alias
+func workload install java-worker
+```
+
+## Status
+
+Preview.

--- a/src/Workloads/Workers/Java/Workloads.Workers.Java.csproj
+++ b/src/Workloads/Workers/Java/Workloads.Workers.Java.csproj
@@ -1,0 +1,44 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Title>Java Worker</Title>
+    <Description>Azure Functions CLI content workload that ships the Java language worker.</Description>
+    <PackAsWorkload>true</PackAsWorkload>
+    <WorkloadKind>content</WorkloadKind>
+    <WorkloadAlias>java-worker</WorkloadAlias>
+    <PackageTags>func-worker</PackageTags>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);IncludeJavaWorkerContentInPack</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!--
+      TODO: Decouple from the upstream worker's precise package layout.
+      The plan is to include the JavaWorker package's assets normally (let
+      it wire up its content/None items via its build targets), then have a
+      target here transform those items and repack them under tools/any/. For
+      now we glob the restored package payload directly, which is brittle if
+      the upstream layout changes.
+
+      GeneratePathProperty exposes $(PkgMicrosoft_Azure_Functions_JavaWorker)
+      pointing at the restored package root. IncludeAssets=none keeps the
+      package's build targets and contentFiles from affecting this project.
+    -->
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" GeneratePathProperty="true" VersionOverride="$(WorkerVersion)">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>none</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <Target Name="IncludeJavaWorkerContentInPack">
+    <Error Condition="'$(PkgMicrosoft_Azure_Functions_JavaWorker)' == ''"
+           Text="Microsoft.Azure.Functions.JavaWorker package path not resolved. Run 'dotnet restore' first." />
+    <ItemGroup>
+      <_JavaWorkerFile Include="$(PkgMicrosoft_Azure_Functions_JavaWorker)/contentFiles/any/any/workers/java/**/*" />
+      <TfmSpecificPackageFile Include="@(_JavaWorkerFile)" TargetPath="%(RecursiveDir)%(Filename)%(Extension)"
+        Pack="true" PackagePath="tools/any/" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Workloads/Workers/Java/release_notes.md
+++ b/src/Workloads/Workers/Java/release_notes.md
@@ -1,0 +1,6 @@
+# Azure.Functions.Cli.Workloads.Workers.Java
+
+## 2.19.4
+
+- Initial release of the Java worker workload. Ships the
+  `Microsoft.Azure.Functions.JavaWorker` payload as a content workload.


### PR DESCRIPTION
## What this does

This adds the Java worker workload so the v5 `func` CLI can host Java function apps. It's a content workload that ships the `Microsoft.Azure.Functions.JavaWorker` payload under `tools/any/`. I modeled it on the existing Node worker because Java is portable the same way, so there are no per-RID variants.

This is just the worker package. The stack workload that wires up `func init`, `func new`, and `func start` is in #5471.

## What is in it

- `src/Workloads/Workers/Java`, the content workload project with alias `java-worker`, version props pinned to worker 2.19.4, and consumer and dev READMEs
- A pack step that repacks the upstream worker payload (`azure-functions-java-worker.jar`, `worker.config.json`, `annotationLib/`, `agent/`) into `tools/any/`
- The project registered in `Azure.Functions.Cli.slnx`
- `Microsoft.Azure.Functions.JavaWorker` 2.19.4 pinned in `eng/build/Packages.props`
- The official release pipeline at `eng/ci/release/official-release.workload.java-worker.yml`

## How I tested it

`dotnet pack` produces a valid workload nupkg. It carries `packageType=FuncCliWorkload`, the tags `func-worker func-workload kind:content alias:java-worker`, an empty dependencies list, and an auto generated `workload.json` whose kind is content with no entry point. The worker payload lands under `tools/any/`.

I also ran the full flow with a real `func` build. `func start` on a Java project resolves the worker package `Azure.Functions.Cli.Workloads.Workers.java` and launches the host, and the sample HTTP function returns a 200. `java` was already in `supportedRuntimes` across every profile in `BuiltInProfiles.json`, so I didn't need to touch the base CLI. Worker resolution is generic and case insensitive, so the runtime `java` maps straight to this package.

## Notes

I used the alias `java-worker` rather than `java` to stay consistent with the other workers (`node-worker`, `python-worker`, `go-worker`, `powershell-worker`) and to avoid colliding with the `java` stack alias. The install command is `func workload install java-worker`.

## Definition of done

- [x] Worker workload nupkg builds and publishes through the workloads pipeline
- [x] CI is wired up, the unified public build compiles the solution and the official release pipeline is added
- [x] `func workload install java-worker` installs a portable package that works on Windows, macOS, and Linux
- [x] The worker resolves for `func start` since `worker.config.json` sits at `tools/any/` and `java` is in the profile `supportedRuntimes`
- [x] The workload manifest matches the content workload schema

Closes #5319
