### PR TITLE
feat(workloads): add Java stack workload (#5320)

### DIFF
--- a/Azure.Functions.Cli.slnx
+++ b/Azure.Functions.Cli.slnx
@@ -18,6 +18,7 @@
   <Folder Name="/src/Workloads/Stacks/">
     <Project Path="src/Workloads/Stacks/DotNet/Workloads.DotNet.csproj" />
     <Project Path="src/Workloads/Stacks/Go/Workloads.Go.csproj" />
+    <Project Path="src/Workloads/Stacks/Java/Workloads.Java.csproj" />
     <Project Path="src/Workloads/Stacks/Node/Workloads.Node.csproj" />
     <Project Path="src/Workloads/Stacks/PowerShell/Workloads.PowerShell.csproj" />
     <Project Path="src/Workloads/Stacks/Python/Workloads.Python.csproj" />
@@ -47,6 +48,7 @@
   <Folder Name="/test/Workloads/Stacks/">
     <Project Path="test/Workloads/Stacks/DotNet.Tests/Workloads.DotNet.Tests.csproj" />
     <Project Path="test/Workloads/Stacks/Go.Tests/Workloads.Go.Tests.csproj" />
+    <Project Path="test/Workloads/Stacks/Java.Tests/Workloads.Java.Tests.csproj" />
     <Project Path="test/Workloads/Stacks/Node.Tests/Workloads.Node.Tests.csproj" />
     <Project Path="test/Workloads/Stacks/PowerShell.Tests/Workloads.PowerShell.Tests.csproj" />
     <Project Path="test/Workloads/Stacks/Python.Tests/Workloads.Python.Tests.csproj" />

--- a/eng/ci/release/official-release.workload.java.yml
+++ b/eng/ci/release/official-release.workload.java.yml
@@ -1,0 +1,18 @@
+parameters:
+- name: public
+  displayName: Publish to nuget.org?
+  type: boolean
+  default: false
+
+# Release has no triggers outside of pipeline
+trigger: none
+pr: none
+
+extends:
+  template: /eng/ci/templates/pipelines/release-packages.yml@self
+  parameters:
+    public: ${{ parameters.public }}
+    folder: workloads/java
+    projects: |
+      $(Build.SourcesDirectory)/src/Workloads/Stacks/Java/Workloads.Java.csproj
+      $(Build.SourcesDirectory)/test/Workloads/Stacks/Java.Tests/Workloads.Java.Tests.csproj

--- a/src/Workloads/Stacks/Java/Directory.Version.props
+++ b/src/Workloads/Stacks/Java/Directory.Version.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionSuffix>preview.1</VersionSuffix>
+  </PropertyGroup>
+</Project>

--- a/src/Workloads/Stacks/Java/JavaFunctionsProject.cs
+++ b/src/Workloads/Stacks/Java/JavaFunctionsProject.cs
@@ -1,0 +1,280 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Diagnostics;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Workers;
+
+namespace Azure.Functions.Cli.Workloads.Java;
+
+/// <summary>
+/// Java Functions project. Before the host runs, builds the user's Maven module
+/// with <c>mvn clean package</c> so the Azure Functions Maven plugin stages the
+/// app under <c>target/azure-functions/&lt;appName&gt;</c>, then points the host
+/// startup directory at that staged output.
+/// </summary>
+internal sealed class JavaFunctionsProject : FunctionsProject
+{
+    private const string StagedAppRootRelativePath = "target/azure-functions";
+    private const string HostJsonFileName = "host.json";
+
+    private readonly WorkingDirectory _workingDirectory;
+    private readonly FunctionsWorkerReference _workerReference;
+
+    public JavaFunctionsProject(WorkingDirectory workingDirectory)
+    {
+        _workingDirectory = workingDirectory ?? throw new ArgumentNullException(nameof(workingDirectory));
+
+        // The Java worker's worker.config.json declares language "java", which matches the
+        // workload id, so no runtime override is needed (unlike the Go worker's "native").
+        _workerReference = FunctionsWorkerReference.FromWorkload("java");
+    }
+
+    // Internal seams so tests can stub the Maven discovery/build without spawning real processes.
+    internal Func<string, CancellationToken, Task<string?>> ResolveMavenCommand { get; set; } = DefaultResolveMavenCommandAsync;
+
+    internal Func<string, string, Action<string>, Action<string>, CancellationToken, Task<int>> RunMavenPackage { get; set; } = DefaultRunMavenPackageAsync;
+
+    public override WorkingDirectory WorkingDirectory => _workingDirectory;
+
+    public override string StackName => "java";
+
+    public override string StackDisplayName => "Java";
+
+    public override bool SupportsExtensionBundles => true;
+
+    public override FunctionsWorkerReference WorkerReference => _workerReference;
+
+    public override async Task PrepareForHostRunAsync(FunctionsProjectHostRunContext context, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        string root = _workingDirectory.Info.FullName;
+
+        if (!context.SkipBuild)
+        {
+            string? mavenCommand = await ResolveMavenCommand(root, cancellationToken).ConfigureAwait(false);
+            if (mavenCommand is null)
+            {
+                throw new GracefulException(
+                    "Could not find Apache Maven. Install Maven 3.6 or later (https://maven.apache.org/install.html) "
+                    + "and ensure 'mvn' is on your PATH, or add a Maven wrapper ('mvnw') to the project.",
+                    isUserError: true);
+            }
+
+            context.Reporter.ReportStatus("Running mvn clean package");
+            int exitCode = await RunMavenPackage(
+                root,
+                mavenCommand,
+                line => context.Reporter.WriteLog(line, FunctionsProjectReportSeverity.Info),
+                line => context.Reporter.WriteLog(line, FunctionsProjectReportSeverity.Error),
+                cancellationToken).ConfigureAwait(false);
+            if (exitCode != 0)
+            {
+                throw new GracefulException(
+                    $"'mvn clean package' failed (exit {exitCode}).",
+                    isUserError: true);
+            }
+        }
+
+        DirectoryInfo? stagedApp = LocateStagedApp(root);
+        if (stagedApp is null)
+        {
+            throw new GracefulException(
+                $"No built Functions app was found under '{StagedAppRootRelativePath}'. "
+                + "Run 'mvn clean package' to build the project before starting the host.",
+                isUserError: true);
+        }
+
+        // The Maven plugin stages a self-contained app (host.json, the function jar, and
+        // generated function.json metadata) under target/azure-functions/<appName>. The host
+        // runs from there, not the project root.
+        context.StartupDirectory = stagedApp;
+    }
+
+    // Finds the staged Functions app produced by the Azure Functions Maven plugin. The plugin
+    // writes it to target/azure-functions/<appName>; when several exist (e.g. a timestamped
+    // appName across builds), the most recently written one wins.
+    private static DirectoryInfo? LocateStagedApp(string root)
+    {
+        var stagedRoot = new DirectoryInfo(Path.Combine(root, "target", "azure-functions"));
+        if (!stagedRoot.Exists)
+        {
+            return null;
+        }
+
+        return stagedRoot.EnumerateDirectories()
+            .Where(dir => File.Exists(Path.Combine(dir.FullName, HostJsonFileName)))
+            .OrderByDescending(dir => dir.LastWriteTimeUtc)
+            .FirstOrDefault();
+    }
+
+    private static Task<string?> DefaultResolveMavenCommandAsync(string root, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Prefer a project-local Maven wrapper when present.
+        string wrapperName = OperatingSystem.IsWindows() ? "mvnw.cmd" : "mvnw";
+        string wrapperPath = Path.Combine(root, wrapperName);
+        if (File.Exists(wrapperPath))
+        {
+            return Task.FromResult<string?>(wrapperPath);
+        }
+
+        // Otherwise fall back to Maven on PATH.
+        string[] candidates = OperatingSystem.IsWindows()
+            ? ["mvn.cmd", "mvn.bat", "mvn.exe"]
+            : ["mvn"];
+        return Task.FromResult(FindExecutableOnPath(candidates));
+    }
+
+    private static string? FindExecutableOnPath(string[] candidates)
+    {
+        string? pathValue = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrEmpty(pathValue))
+        {
+            return null;
+        }
+
+        foreach (string directory in pathValue.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            foreach (string candidate in candidates)
+            {
+                string fullPath = Path.Combine(directory, candidate);
+                if (File.Exists(fullPath))
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static Task<int> DefaultRunMavenPackageAsync(
+        string workingDirectory,
+        string mavenCommand,
+        Action<string> onOutputLine,
+        Action<string> onErrorLine,
+        CancellationToken cancellationToken)
+        => RunProcessAsync(workingDirectory, mavenCommand, ["clean", "package", "-DskipTests"], onOutputLine, onErrorLine, cancellationToken);
+
+    // Streams each line of stdout and stderr to the callbacks as the process produces them,
+    // waits for exit, and returns the exit code. Mirrors the Go stack's live-streaming runner.
+    private static async Task<int> RunProcessAsync(
+        string workingDirectory,
+        string fileName,
+        string[] arguments,
+        Action<string> onOutputLine,
+        Action<string> onErrorLine,
+        CancellationToken cancellationToken)
+    {
+        bool wrapInCmd = OperatingSystem.IsWindows() && IsBatchScript(fileName);
+
+        var psi = new ProcessStartInfo
+        {
+            // On Windows, Maven's launcher is a batch script (mvn.cmd / mvnw.cmd). CreateProcess can't
+            // run a .cmd/.bat directly, so it must go through cmd.exe, otherwise it exits 1 with no
+            // output. Real executables, and the shell-script launchers on Linux/macOS, start directly.
+            FileName = wrapInCmd ? "cmd.exe" : fileName,
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        if (wrapInCmd)
+        {
+            psi.ArgumentList.Add("/c");
+            psi.ArgumentList.Add(fileName);
+        }
+
+        foreach (string argument in arguments)
+        {
+            psi.ArgumentList.Add(argument);
+        }
+
+        using var process = new Process { StartInfo = psi };
+
+        // stdout and stderr are delivered on separate thread-pool threads, so each stream gets its own
+        // completion signal, and each line callback is invoked only from its own stream's thread.
+        TaskCompletionSource stdoutComplete = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource stderrComplete = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data is null)
+            {
+                stdoutComplete.TrySetResult();
+            }
+            else
+            {
+                onOutputLine(e.Data);
+            }
+        };
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data is null)
+            {
+                stderrComplete.TrySetResult();
+            }
+            else
+            {
+                onErrorLine(e.Data);
+            }
+        };
+
+        try
+        {
+            if (!process.Start())
+            {
+                onErrorLine($"Failed to start '{fileName}' process.");
+                return -1;
+            }
+
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+
+            // WaitForExitAsync does not guarantee the async stream readers have drained, so wait for the
+            // trailing (null Data) sentinel on both streams to ensure every line has been delivered.
+            await stdoutComplete.Task.ConfigureAwait(false);
+            await stderrComplete.Task.ConfigureAwait(false);
+
+            return process.ExitCode;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            onErrorLine(ex.Message);
+            return -1;
+        }
+        finally
+        {
+            // On cancellation (Ctrl+C) or failure, don't leave the Maven build and its child JVM running.
+            KillProcess(process);
+        }
+    }
+
+    private static void KillProcess(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch (Exception)
+        {
+            // Best effort: the process may have already exited between the check and the kill.
+        }
+    }
+
+    internal static bool IsBatchScript(string fileName)
+        => fileName.EndsWith(".cmd", StringComparison.OrdinalIgnoreCase)
+        || fileName.EndsWith(".bat", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Workloads/Stacks/Java/JavaProjectFactory.cs
+++ b/src/Workloads/Stacks/Java/JavaProjectFactory.cs
@@ -1,0 +1,73 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Projects;
+using static Azure.Functions.Cli.Projects.ProjectCreationResults;
+
+namespace Azure.Functions.Cli.Workloads.Java;
+
+/// <summary>
+/// Creates Java Functions projects from Java-specific fingerprints
+/// (Maven <c>pom.xml</c>, Gradle build scripts, or a <c>src/main/java</c> tree).
+/// </summary>
+internal sealed class JavaProjectFactory : IFunctionsProjectFactory
+{
+    public Task<ProjectCreationResult> TryCreateProjectAsync(ProjectCreationContext context, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        DirectoryInfo workingDirectory = context.WorkingDirectory.Info;
+        if (!workingDirectory.Exists)
+        {
+            return Task.FromResult(NotCreated("directory does not exist"));
+        }
+
+        string? reason = TryGetReason(workingDirectory);
+        if (reason is null)
+        {
+            return Task.FromResult(NotCreated("no Java project fingerprint found"));
+        }
+
+        FunctionsProject project = new JavaFunctionsProject(context.WorkingDirectory);
+        return Task.FromResult(Created(project, reason));
+    }
+
+    private static string? TryGetReason(DirectoryInfo workingDirectory)
+    {
+        // Maven manifest: strongest and most common signal for Java Functions.
+        if (File.Exists(Path.Combine(workingDirectory.FullName, "pom.xml")))
+        {
+            return "found pom.xml";
+        }
+
+        // Gradle build scripts (Groovy or Kotlin DSL).
+        string? gradle = FirstExisting(workingDirectory, "build.gradle", "build.gradle.kts");
+        if (gradle is not null)
+        {
+            return $"found {gradle}";
+        }
+
+        // Fallback: a conventional Java source tree.
+        if (Directory.Exists(Path.Combine(workingDirectory.FullName, "src", "main", "java")))
+        {
+            return "found src/main/java";
+        }
+
+        return null;
+    }
+
+    private static string? FirstExisting(DirectoryInfo directory, params string[] fileNames)
+    {
+        foreach (string name in fileNames)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, name)))
+            {
+                return name;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Workloads/Stacks/Java/JavaProjectInitializer.cs
+++ b/src/Workloads/Stacks/Java/JavaProjectInitializer.cs
@@ -1,0 +1,135 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using System.Reflection;
+using System.Text.Json.Nodes;
+using Azure.Functions.Cli.Commands;
+using Azure.Functions.Cli.Projects;
+
+namespace Azure.Functions.Cli.Workloads.Java;
+
+/// <summary>
+/// Scaffolds a Maven-based Java Functions project (<c>pom.xml</c>, a sample HTTP
+/// trigger under <c>src/main/java/com/function</c>, <c>host.json</c>,
+/// <c>local.settings.json</c>, <c>.gitignore</c>, and <c>.funcignore</c>).
+/// </summary>
+internal sealed class JavaProjectInitializer : IProjectInitializer
+{
+    private const string ArtifactIdPlaceholder = "{ArtifactId}";
+    private const string FunctionAppNamePlaceholder = "{FunctionAppName}";
+    private const string DefaultArtifactId = "azure-functions-java";
+
+    private static readonly Assembly _assembly = typeof(JavaProjectInitializer).Assembly;
+
+    public string Stack => "java";
+
+    public string DisplayName => "Java";
+
+    public IReadOnlyDictionary<string, IReadOnlyList<string>> SupportedLanguageAliases { get; } =
+        new Dictionary<string, IReadOnlyList<string>>()
+        {
+            { "Java", [] }
+        };
+
+    public IReadOnlyList<string> SupportedLanguages => [.. SupportedLanguageAliases.Keys];
+
+    public Option<bool> NoBundleOption { get; private set; } = default!;
+
+    public Option<BundleChannel> BundlesChannelOption { get; private set; } = default!;
+
+    public IReadOnlyList<Option> GetInitOptions(IInitOptionRegistry registry)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+
+        NoBundleOption = registry.GetOrAdd(CommonInitOptions.NoBundle());
+
+        BundlesChannelOption = registry.GetOrAdd(CommonInitOptions.BundlesChannel());
+
+        return [NoBundleOption, BundlesChannelOption];
+    }
+
+    public Task InitializeAsync(InitContext context, ParseResult parseResult, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(parseResult);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        string root = context.WorkingDirectory.Info.FullName;
+        bool force = context.Force;
+        bool noBundle = parseResult.GetValue(NoBundleOption);
+        BundleChannel channel = parseResult.GetValue(BundlesChannelOption);
+        string artifactId = ResolveArtifactId(context);
+
+        ProjectFiles.WriteIfMissing(
+            Path.Combine(root, "pom.xml"),
+            ProjectFiles.ReadTemplate(_assembly, "pom.xml")
+                .Replace(ArtifactIdPlaceholder, artifactId)
+                .Replace(FunctionAppNamePlaceholder, artifactId),
+            force);
+
+        ProjectFiles.WriteIfMissing(
+            Path.Combine(root, "src", "main", "java", "com", "function", "Function.java"),
+            ProjectFiles.ReadTemplate(_assembly, "Function.java"),
+            force);
+
+        ProjectFiles.WriteIfMissing(
+            Path.Combine(root, "local.settings.json"),
+            ProjectFiles.ReadTemplate(_assembly, "local.settings.json"),
+            force);
+
+        ProjectFiles.WriteIfMissing(
+            Path.Combine(root, ".gitignore"),
+            ProjectFiles.ReadTemplate(_assembly, "gitignore"),
+            force);
+
+        ProjectFiles.WriteIfMissing(
+            Path.Combine(root, ".funcignore"),
+            ProjectFiles.ReadTemplate(_assembly, "funcignore"),
+            force);
+
+        // Always lay down the base host.json so the project is valid even
+        // with --no-bundles. MergeHostJson below layers extensionBundle on top.
+        ProjectFiles.WriteIfMissing(
+            Path.Combine(root, "host.json"),
+            ProjectFiles.MinimalHostJson,
+            force);
+
+        if (!noBundle)
+        {
+            ProjectFiles.MergeHostJson(
+                Path.Combine(root, "host.json"),
+                host => EnsureExtensionBundle(host, channel));
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static void EnsureExtensionBundle(JsonObject host, BundleChannel channel)
+    {
+        // Only fill in when missing so an existing user-customised bundle is preserved.
+        // A forced re-init recreates host.json above, so the default bundle is written then.
+        if (host.ContainsKey("extensionBundle"))
+        {
+            return;
+        }
+
+        host["extensionBundle"] = new JsonObject
+        {
+            ["id"] = ExtensionBundle.IdFor(channel),
+            ["version"] = ExtensionBundle.DefaultVersionRange,
+        };
+    }
+
+    private static string ResolveArtifactId(InitContext context)
+    {
+        string raw = !string.IsNullOrWhiteSpace(context.ProjectName)
+            ? context.ProjectName!
+            : context.WorkingDirectory.Info.Name;
+
+        IEnumerable<char> chars = raw.Trim().ToLowerInvariant().Replace(' ', '-')
+            .Where(c => char.IsLetterOrDigit(c) || c is '-' or '_');
+        string sanitized = new([.. chars]);
+        return string.IsNullOrEmpty(sanitized) ? DefaultArtifactId : sanitized;
+    }
+}

--- a/src/Workloads/Stacks/Java/JavaWorkload.cs
+++ b/src/Workloads/Stacks/Java/JavaWorkload.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Workloads;
+using Microsoft.Extensions.DependencyInjection;
+
+[assembly: CliWorkload<Azure.Functions.Cli.Workloads.Java.JavaWorkload>()]
+
+namespace Azure.Functions.Cli.Workloads.Java;
+
+/// <summary>
+/// Entry-point for the Java workload. Registers Java-specific services: the
+/// project initializer (<c>func init --stack java</c>) and the project factory
+/// (language detection for <c>func new</c> / <c>func start</c>).
+/// </summary>
+public sealed class JavaWorkload : Workload
+{
+    public override string DisplayName => "Java Stack";
+
+    public override string Description => "Azure Functions CLI tooling for Java projects.";
+
+    public override void Configure(FunctionsCliBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        builder.Services.AddSingleton<IProjectInitializer, JavaProjectInitializer>();
+        builder.AddProjectFactory(new JavaProjectFactory());
+    }
+}

--- a/src/Workloads/Stacks/Java/README.md
+++ b/src/Workloads/Stacks/Java/README.md
@@ -1,0 +1,31 @@
+# Azure Functions CLI – Java workload
+
+This workload extends the Azure Functions CLI (`func`) with Java project
+support: `func init --stack java` scaffolding (a Maven project), language
+detection for existing projects, and a `func start` flow that builds the
+project with Maven before launching the host.
+
+## Install
+
+```bash
+func workload install Azure.Functions.Cli.Workloads.Java
+# or by alias
+func workload install java
+```
+
+The Java worker payload ships separately in the `java-worker` workload and is
+acquired automatically the first time you run `func start`.
+
+## Prerequisites
+
+- JDK 21 (set `JAVA_HOME`)
+- Apache Maven 3.6+ (`mvn` on `PATH`, or a `mvnw` wrapper in the project)
+
+## Status
+
+Preview.
+
+## Links
+
+- [Azure Functions CLI](https://github.com/Azure/azure-functions-core-tools)
+- [Workload spec](https://github.com/Azure/azure-functions-core-tools/blob/docs/proposed/workload-spec.md)

--- a/src/Workloads/Stacks/Java/Templates/Function.java
+++ b/src/Workloads/Stacks/Java/Templates/Function.java
@@ -1,0 +1,47 @@
+package com.function;
+
+import com.microsoft.azure.functions.ExecutionContext;
+import com.microsoft.azure.functions.HttpMethod;
+import com.microsoft.azure.functions.HttpRequestMessage;
+import com.microsoft.azure.functions.HttpResponseMessage;
+import com.microsoft.azure.functions.HttpStatus;
+import com.microsoft.azure.functions.annotation.AuthorizationLevel;
+import com.microsoft.azure.functions.annotation.FunctionName;
+import com.microsoft.azure.functions.annotation.HttpTrigger;
+
+import java.util.Optional;
+
+/**
+ * Azure Functions with HTTP Trigger.
+ */
+public class Function {
+    /**
+     * This function listens at endpoint "/api/HttpExample". Two ways to invoke it using "curl" command in bash:
+     * 1. curl -d "HTTP Body" {your host}/api/HttpExample
+     * 2. curl "{your host}/api/HttpExample?name=HTTP%20Query"
+     */
+    @FunctionName("HttpExample")
+    public HttpResponseMessage run(
+            @HttpTrigger(
+                name = "req",
+                methods = {HttpMethod.GET, HttpMethod.POST},
+                authLevel = AuthorizationLevel.ANONYMOUS)
+                HttpRequestMessage<Optional<String>> request,
+            final ExecutionContext context) {
+        context.getLogger().info("Java HTTP trigger processed a request.");
+
+        // Parse query parameter
+        final String query = request.getQueryParameters().get("name");
+        final String name = request.getBody().orElse(query);
+
+        if (name == null) {
+            return request.createResponseBuilder(HttpStatus.BAD_REQUEST)
+                    .body("Please pass a name on the query string or in the request body")
+                    .build();
+        } else {
+            return request.createResponseBuilder(HttpStatus.OK)
+                    .body("Hello, " + name)
+                    .build();
+        }
+    }
+}

--- a/src/Workloads/Stacks/Java/Templates/funcignore
+++ b/src/Workloads/Stacks/Java/Templates/funcignore
@@ -1,0 +1,8 @@
+.git*
+.vscode
+.idea
+local.settings.json
+src
+pom.xml
+target/*.jar
+!target/azure-functions

--- a/src/Workloads/Stacks/Java/Templates/gitignore
+++ b/src/Workloads/Stacks/Java/Templates/gitignore
@@ -1,0 +1,37 @@
+# Build output
+target/
+bin/
+obj/
+
+# Compiled class files
+*.class
+
+# Log files
+*.log
+
+# Package files
+*.jar
+*.war
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# Maven
+.mvn/timing.properties
+.mvn/wrapper/maven-wrapper.jar
+
+# Azure Functions
+local.settings.json
+
+# IDEs
+.idea/
+*.iml
+.vscode/
+.settings/
+.project
+.classpath
+
+# OS
+.DS_Store
+Thumbs.db

--- a/src/Workloads/Stacks/Java/Templates/local.settings.json
+++ b/src/Workloads/Stacks/Java/Templates/local.settings.json
@@ -1,0 +1,7 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "java",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true"
+  }
+}

--- a/src/Workloads/Stacks/Java/Templates/pom.xml
+++ b/src/Workloads/Stacks/Java/Templates/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.function</groupId>
+    <artifactId>{ArtifactId}</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Azure Java Functions</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>21</maven.compiler.release>
+        <azure.functions.maven.plugin.version>1.42.0</azure.functions.maven.plugin.version>
+        <azure.functions.java.library.version>3.1.0</azure.functions.java.library.version>
+        <functionAppName>{FunctionAppName}</functionAppName>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.microsoft.azure.functions</groupId>
+            <artifactId>azure-functions-java-library</artifactId>
+            <version>${azure.functions.java.library.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-functions-maven-plugin</artifactId>
+                <version>${azure.functions.maven.plugin.version}</version>
+                <configuration>
+                    <appName>${functionAppName}</appName>
+                    <resourceGroup>java-functions-group</resourceGroup>
+                    <region>eastus</region>
+                    <!-- Flex Consumption on Linux is the default deployment SKU. -->
+                    <pricingTier>Flex Consumption</pricingTier>
+                    <runtime>
+                        <os>linux</os>
+                        <javaVersion>21</javaVersion>
+                    </runtime>
+                    <appSettings>
+                        <property>
+                            <name>FUNCTIONS_EXTENSION_VERSION</name>
+                            <value>~4</value>
+                        </property>
+                    </appSettings>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>package-functions</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/Workloads/Stacks/Java/Workloads.Java.csproj
+++ b/src/Workloads/Stacks/Java/Workloads.Java.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Title>Java Stack</Title>
+    <Description>Azure Functions CLI tooling for Java projects.</Description>
+    <PackAsWorkload>true</PackAsWorkload>
+    <WorkloadKind>workload</WorkloadKind>
+    <WorkloadAlias>java</WorkloadAlias>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Azure.Functions.Cli.Workloads.Java.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(SrcRoot)Abstractions/Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Templates/**" />
+  </ItemGroup>
+
+</Project>

--- a/src/Workloads/Stacks/Java/release_notes.md
+++ b/src/Workloads/Stacks/Java/release_notes.md
@@ -1,0 +1,8 @@
+# Azure.Functions.Cli.Workloads.Java
+
+## 1.0.0-preview.1
+
+- Initial release of the Java stack workload: `func init --stack java`
+  scaffolds a Maven-based Java Functions project, project detection claims
+  Maven/Gradle Java projects, and `func start` builds with Maven before
+  launching the host.

--- a/test/Workloads/Stacks/Java.Tests/JavaFunctionsProjectTests.cs
+++ b/test/Workloads/Stacks/Java.Tests/JavaFunctionsProjectTests.cs
@@ -1,0 +1,197 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Projects;
+using Xunit;
+
+namespace Azure.Functions.Cli.Workloads.Java.Tests;
+
+public class JavaFunctionsProjectTests : IDisposable
+{
+    private readonly DirectoryInfo _projectDir;
+
+    public JavaFunctionsProjectTests()
+    {
+        _projectDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "func-java-project-" + Guid.NewGuid().ToString("N")));
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (_projectDir.Exists)
+            {
+                _projectDir.Delete(recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    [Fact]
+    public async Task PrepareForHostRun_builds_with_maven_and_points_startup_at_staged_app()
+    {
+        string? observedRoot = null;
+        JavaFunctionsProject project = CreateProject((root, _, _, _, _) =>
+        {
+            observedRoot = root;
+            CreateStagedApp();
+            return Task.FromResult(0);
+        });
+
+        FunctionsProjectHostRunContext context = CreateContext();
+        await project.PrepareForHostRunAsync(context, default);
+
+        Assert.Equal(_projectDir.FullName, observedRoot);
+        Assert.Equal(
+            Path.Combine(_projectDir.FullName, "target", "azure-functions", "app"),
+            context.StartupDirectory.FullName);
+    }
+
+    [Fact]
+    public async Task PrepareForHostRun_streams_build_output_to_reporter()
+    {
+        JavaFunctionsProject project = CreateProject((_, _, onOut, onErr, _) =>
+        {
+            onOut("[INFO] BUILD SUCCESS");
+            onErr("[WARNING] something");
+            CreateStagedApp();
+            return Task.FromResult(0);
+        });
+        var reporter = new CapturingReporter();
+        FunctionsProjectHostRunContext context = CreateContext();
+        context.Reporter = reporter;
+
+        await project.PrepareForHostRunAsync(context, default);
+
+        Assert.Contains(reporter.Logs, e => e.Severity == FunctionsProjectReportSeverity.Info && e.Line == "[INFO] BUILD SUCCESS");
+        Assert.Contains(reporter.Logs, e => e.Severity == FunctionsProjectReportSeverity.Error && e.Line == "[WARNING] something");
+    }
+
+    [Fact]
+    public async Task PrepareForHostRun_throws_graceful_on_nonzero_exit()
+    {
+        JavaFunctionsProject project = CreateProject((_, _, _, onErr, _) =>
+        {
+            onErr("[ERROR] BUILD FAILURE");
+            return Task.FromResult(1);
+        });
+        var reporter = new CapturingReporter();
+        FunctionsProjectHostRunContext context = CreateContext();
+        context.Reporter = reporter;
+
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => project.PrepareForHostRunAsync(context, default));
+
+        Assert.True(ex.IsUserError);
+        Assert.Contains("mvn clean package", ex.Message);
+        Assert.Contains("exit 1", ex.Message);
+        Assert.Contains(reporter.Logs, e => e.Severity == FunctionsProjectReportSeverity.Error && e.Line == "[ERROR] BUILD FAILURE");
+    }
+
+    [Fact]
+    public async Task PrepareForHostRun_skips_build_when_SkipBuild_and_uses_existing_staged_app()
+    {
+        CreateStagedApp();
+        bool invoked = false;
+        JavaFunctionsProject project = CreateProject((_, _, _, _, _) =>
+        {
+            invoked = true;
+            return Task.FromResult(0);
+        });
+
+        FunctionsProjectHostRunContext context = CreateContext(skipBuild: true);
+        await project.PrepareForHostRunAsync(context, default);
+
+        Assert.False(invoked);
+        Assert.Equal(
+            Path.Combine(_projectDir.FullName, "target", "azure-functions", "app"),
+            context.StartupDirectory.FullName);
+    }
+
+    [Fact]
+    public async Task PrepareForHostRun_throws_graceful_when_maven_not_found()
+    {
+        JavaFunctionsProject project = CreateProject((_, _, _, _, _) => Task.FromResult(0));
+        project.ResolveMavenCommand = (_, _) => Task.FromResult<string?>(null);
+
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => project.PrepareForHostRunAsync(CreateContext(), default));
+
+        Assert.True(ex.IsUserError);
+        Assert.Contains("Could not find Apache Maven", ex.Message);
+    }
+
+    [Fact]
+    public async Task PrepareForHostRun_throws_graceful_when_no_staged_app_produced()
+    {
+        // Build "succeeds" but produces no staged app under target/azure-functions.
+        JavaFunctionsProject project = CreateProject((_, _, _, _, _) => Task.FromResult(0));
+
+        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
+            () => project.PrepareForHostRunAsync(CreateContext(), default));
+
+        Assert.True(ex.IsUserError);
+        Assert.Contains("No built Functions app", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("mvn.cmd", true)]
+    [InlineData("mvnw.CMD", true)]
+    [InlineData("build.bat", true)]
+    [InlineData("mvn", false)]
+    [InlineData("go", false)]
+    public void IsBatchScript_DetectsWindowsBatchLaunchers(string fileName, bool expected)
+    {
+        Assert.Equal(expected, JavaFunctionsProject.IsBatchScript(fileName));
+    }
+
+    private DirectoryInfo CreateStagedApp(string appName = "app")
+    {
+        DirectoryInfo dir = Directory.CreateDirectory(
+            Path.Combine(_projectDir.FullName, "target", "azure-functions", appName));
+        File.WriteAllText(Path.Combine(dir.FullName, "host.json"), "{}");
+        return dir;
+    }
+
+    private JavaFunctionsProject CreateProject(Func<string, string, Action<string>, Action<string>, CancellationToken, Task<int>> runner)
+        => new(WorkingDirectory.FromExplicit(_projectDir.FullName))
+        {
+            ResolveMavenCommand = (_, _) => Task.FromResult<string?>("mvn"),
+            RunMavenPackage = runner,
+        };
+
+    private FunctionsProjectHostRunContext CreateContext(bool skipBuild = false)
+        => new(_projectDir, "java", new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase), skipBuild);
+
+    private sealed class CapturingReporter : IFunctionsProjectHostRunReporter
+    {
+        private readonly List<(string Line, FunctionsProjectReportSeverity Severity)> _logs = [];
+        private readonly object _gate = new();
+
+        public IReadOnlyList<(string Line, FunctionsProjectReportSeverity Severity)> Logs
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _logs.ToArray();
+                }
+            }
+        }
+
+        public void ReportStatus(string message)
+        {
+        }
+
+        public void WriteLog(string line, FunctionsProjectReportSeverity severity = FunctionsProjectReportSeverity.Info)
+        {
+            lock (_gate)
+            {
+                _logs.Add((line, severity));
+            }
+        }
+    }
+}

--- a/test/Workloads/Stacks/Java.Tests/JavaProjectFactoryTests.cs
+++ b/test/Workloads/Stacks/Java.Tests/JavaProjectFactoryTests.cs
@@ -1,0 +1,185 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Workers;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Functions.Cli.Workloads.Java.Tests;
+
+public class JavaProjectFactoryTests : IDisposable
+{
+    private readonly DirectoryInfo _projectDir;
+    private readonly IFunctionsWorkerResolver _workerResolver = Substitute.For<IFunctionsWorkerResolver>();
+
+    public JavaProjectFactoryTests()
+    {
+        _projectDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "func-java-resolver-" + Guid.NewGuid().ToString("N")));
+        _workerResolver.ResolveWorkerAsync(Arg.Any<FunctionsWorkerId>(), Arg.Any<CancellationToken>())
+            .Returns(FunctionsWorkerResolutionResults.Resolved(CreateWorker("java", "java")));
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (_projectDir.Exists)
+            {
+                _projectDir.Delete(recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    [Fact]
+    public async Task Empty_directory_does_not_match()
+    {
+        ProjectCreationResult result = await new JavaProjectFactory().TryCreateProjectAsync(CreateContext(), default);
+
+        ProjectCreationResult.NotCreated notCreated = Assert.IsType<ProjectCreationResult.NotCreated>(result);
+        Assert.Equal("no Java project fingerprint found", notCreated.Reason);
+    }
+
+    [Theory]
+    [InlineData("pom.xml", "<project/>")]
+    [InlineData("build.gradle", "plugins {}")]
+    [InlineData("build.gradle.kts", "plugins {}")]
+    public async Task Fingerprint_without_host_json_creates_project(string fileName, string contents)
+    {
+        WriteFile(fileName, contents);
+
+        ProjectCreationResult result = await new JavaProjectFactory().TryCreateProjectAsync(CreateContext(), default);
+
+        Assert.IsType<ProjectCreationResult.Created>(result);
+    }
+
+    [Fact]
+    public async Task Source_tree_creates_project()
+    {
+        Directory.CreateDirectory(Path.Combine(_projectDir.FullName, "src", "main", "java"));
+
+        ProjectCreationResult result = await new JavaProjectFactory().TryCreateProjectAsync(CreateContext(), default);
+
+        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
+        Assert.Equal("found src/main/java", created.Reason);
+    }
+
+    [Fact]
+    public async Task Foreign_python_directory_does_not_match()
+    {
+        WriteFile("host.json", "{}");
+        WriteFile("requirements.txt", string.Empty);
+
+        ProjectCreationResult result = await new JavaProjectFactory().TryCreateProjectAsync(CreateContext(), default);
+
+        Assert.IsType<ProjectCreationResult.NotCreated>(result);
+    }
+
+    [Fact]
+    public async Task Foreign_node_directory_does_not_match()
+    {
+        WriteFile("host.json", "{}");
+        WriteFile("package.json", "{}");
+
+        ProjectCreationResult result = await new JavaProjectFactory().TryCreateProjectAsync(CreateContext(), default);
+
+        Assert.IsType<ProjectCreationResult.NotCreated>(result);
+    }
+
+    [Theory]
+    [InlineData("pom.xml", "<project/>")]
+    [InlineData("build.gradle", "plugins {}")]
+    public async Task Match_for_each_fingerprint(string fileName, string contents)
+    {
+        WriteFile("host.json", "{}");
+        WriteFile(fileName, contents);
+
+        ProjectCreationResult result = await new JavaProjectFactory().TryCreateProjectAsync(CreateContext(), default);
+
+        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
+        Assert.Equal("java", created.Project.StackName);
+        Assert.Equal("Java", created.Project.StackDisplayName);
+        IFunctionsWorker worker = await ResolveWorkerAsync(created.Project);
+        Assert.Equal("java", worker.WorkerRuntime);
+        Assert.NotNull(created.Reason);
+    }
+
+    [Fact]
+    public async Task Pom_takes_precedence_over_gradle_and_sources()
+    {
+        WriteFile("host.json", "{}");
+        WriteFile("pom.xml", "<project/>");
+        WriteFile("build.gradle", "plugins {}");
+        Directory.CreateDirectory(Path.Combine(_projectDir.FullName, "src", "main", "java"));
+
+        ProjectCreationResult result = await new JavaProjectFactory().TryCreateProjectAsync(CreateContext(), default);
+
+        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
+        Assert.Equal("found pom.xml", created.Reason);
+    }
+
+    [Fact]
+    public async Task Host_json_only_does_not_match()
+    {
+        WriteFile("host.json", "{}");
+
+        ProjectCreationResult result = await new JavaProjectFactory().TryCreateProjectAsync(CreateContext(), default);
+
+        Assert.IsType<ProjectCreationResult.NotCreated>(result);
+    }
+
+    [Fact]
+    public async Task MatchingDirectory_WhenWorkerNotResolved_WorkerReferenceReportsFailure()
+    {
+        WriteFile("pom.xml", "<project/>");
+        FunctionsWorkerResolutionFailure failure = FunctionsWorkerResolutionFailures.NotInstalled(
+            new FunctionsWorkerId("java"),
+            "missing java worker");
+        _workerResolver.ResolveWorkerAsync(Arg.Any<FunctionsWorkerId>(), Arg.Any<CancellationToken>())
+            .Returns(FunctionsWorkerResolutionResults.NotResolved(failure));
+
+        ProjectCreationResult result = await new JavaProjectFactory().TryCreateProjectAsync(CreateContext(), default);
+
+        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
+        FunctionsWorkerResolutionResult workerResult = await created.Project.WorkerReference.ResolveWorkerAsync(
+            new FunctionsWorkerResolutionContext(_workerResolver),
+            default);
+        FunctionsWorkerResolutionResult.NotResolved notResolved = Assert.IsType<FunctionsWorkerResolutionResult.NotResolved>(workerResult);
+        Assert.Same(failure, notResolved.Failure);
+    }
+
+    [Fact]
+    public async Task NullContext_throws()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => new JavaProjectFactory().TryCreateProjectAsync(null!, default));
+    }
+
+    private void WriteFile(string name, string contents)
+        => File.WriteAllText(Path.Combine(_projectDir.FullName, name), contents);
+
+    private ProjectCreationContext CreateContext()
+        => new(WorkingDirectory.FromExplicit(_projectDir.FullName));
+
+    private async Task<IFunctionsWorker> ResolveWorkerAsync(FunctionsProject project)
+    {
+        FunctionsWorkerResolutionResult result = await project.WorkerReference.ResolveWorkerAsync(
+            new FunctionsWorkerResolutionContext(_workerResolver),
+            default);
+        FunctionsWorkerResolutionResult.Resolved resolved = Assert.IsType<FunctionsWorkerResolutionResult.Resolved>(result);
+        return resolved.Worker;
+    }
+
+    private static IFunctionsWorker CreateWorker(string workerId, string workerRuntime)
+        => new TestFunctionsWorker(new FunctionsWorkerId(workerId), workerRuntime, "worker.config.json", "1.0.0");
+
+    private sealed record TestFunctionsWorker(
+        FunctionsWorkerId Id,
+        string WorkerRuntime,
+        string WorkerConfigPath,
+        string Version) : IFunctionsWorker;
+}

--- a/test/Workloads/Stacks/Java.Tests/JavaProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/Java.Tests/JavaProjectInitializerTests.cs
@@ -1,0 +1,180 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Commands;
+using Azure.Functions.Cli.Projects;
+using Xunit;
+
+namespace Azure.Functions.Cli.Workloads.Java.Tests;
+
+public class JavaProjectInitializerTests : IDisposable
+{
+    private readonly DirectoryInfo _projectDir;
+
+    public JavaProjectInitializerTests()
+    {
+        _projectDir = Directory.CreateDirectory(
+            Path.Combine(Path.GetTempPath(), "func-java-init-" + Guid.NewGuid().ToString("N")));
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (_projectDir.Exists)
+            {
+                _projectDir.Delete(recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    [Fact]
+    public void Stack_IsJava()
+    {
+        Assert.Equal("java", new JavaProjectInitializer().Stack);
+    }
+
+    [Fact]
+    public void GetInitOptions_ContainsBundleOptions()
+    {
+        RootCommand root = [];
+        IReadOnlyList<Option> options = new JavaProjectInitializer().GetInitOptions(new InitOptionRegistry(root));
+        IReadOnlyList<string> names = [.. options.Select(o => o.Name)];
+
+        Assert.Contains("--no-bundles", names);
+        Assert.Contains("--bundles-channel", names);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WritesExpectedFiles()
+    {
+        await RunAsync(projectName: "my-java-app", force: false);
+
+        string pom = File.ReadAllText(Path.Combine(_projectDir.FullName, "pom.xml"));
+        Assert.Contains("<artifactId>my-java-app</artifactId>", pom);
+        Assert.Contains("azure-functions-java-library", pom);
+        Assert.Contains("azure-functions-maven-plugin", pom);
+        Assert.Contains("<functionAppName>my-java-app</functionAppName>", pom);
+        Assert.Contains("<pricingTier>Flex Consumption</pricingTier>", pom);
+        Assert.Contains("<javaVersion>21</javaVersion>", pom);
+
+        string functionJava = File.ReadAllText(
+            Path.Combine(_projectDir.FullName, "src", "main", "java", "com", "function", "Function.java"));
+        Assert.Contains("package com.function;", functionJava);
+        Assert.Contains("@FunctionName", functionJava);
+
+        Assert.True(File.Exists(Path.Combine(_projectDir.FullName, ".funcignore")));
+        Assert.True(File.Exists(Path.Combine(_projectDir.FullName, ".gitignore")));
+
+        using var settings = JsonDocument.Parse(File.ReadAllText(Path.Combine(_projectDir.FullName, "local.settings.json")));
+        Assert.Equal("java", settings.RootElement.GetProperty("Values").GetProperty("FUNCTIONS_WORKER_RUNTIME").GetString());
+    }
+
+    [Fact]
+    public async Task InitializeAsync_FallsBackToDirectoryNameForArtifactId()
+    {
+        await RunAsync(projectName: null, force: false);
+
+        string pom = File.ReadAllText(Path.Combine(_projectDir.FullName, "pom.xml"));
+        Assert.Matches(@"<artifactId>\S+</artifactId>", pom);
+        Assert.DoesNotContain("{ArtifactId}", pom);
+        Assert.DoesNotContain("{FunctionAppName}", pom);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_AppendsExtensionBundle_IntoExistingHostJson()
+    {
+        File.WriteAllText(Path.Combine(_projectDir.FullName, "host.json"), "{ \"version\": \"2.0\" }");
+
+        await RunAsync(projectName: "my-java-app", force: false);
+
+        var root = JsonNode.Parse(File.ReadAllText(Path.Combine(_projectDir.FullName, "host.json")));
+        Assert.NotNull(root);
+        Assert.Equal("2.0", root!["version"]!.GetValue<string>());
+        JsonNode? bundle = root["extensionBundle"];
+        Assert.NotNull(bundle);
+        Assert.Equal("Microsoft.Azure.Functions.ExtensionBundle", bundle!["id"]!.GetValue<string>());
+        Assert.Equal("[4.*, 5.0.0)", bundle["version"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task InitializeAsync_LeavesExistingExtensionBundleUntouched()
+    {
+        const string custom = "{\"version\":\"2.0\",\"extensionBundle\":{\"id\":\"custom\",\"version\":\"1.0.0\"}}";
+        File.WriteAllText(Path.Combine(_projectDir.FullName, "host.json"), custom);
+
+        await RunAsync(projectName: "my-java-app", force: false);
+
+        JsonNode? bundle = JsonNode.Parse(File.ReadAllText(Path.Combine(_projectDir.FullName, "host.json")))!["extensionBundle"];
+        Assert.Equal("custom", bundle!["id"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task InitializeAsync_BundlesChannel_Preview_WritesPreviewBundleId()
+    {
+        await RunAsync(projectName: "my-java-app", force: false, args: ["--bundles-channel", "Preview"]);
+
+        var root = JsonNode.Parse(File.ReadAllText(Path.Combine(_projectDir.FullName, "host.json")));
+        Assert.Equal(
+            "Microsoft.Azure.Functions.ExtensionBundle.Preview",
+            root!["extensionBundle"]!["id"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task InitializeAsync_NoBundle_WritesMinimalHostJsonWithoutExtensionBundle()
+    {
+        await RunAsync(projectName: "my-java-app", force: false, args: ["--no-bundles"]);
+
+        string hostJsonPath = Path.Combine(_projectDir.FullName, "host.json");
+        Assert.True(File.Exists(hostJsonPath), "host.json should be created even with --no-bundles");
+        string content = File.ReadAllText(hostJsonPath);
+        Assert.Contains("\"version\"", content);
+        Assert.DoesNotContain("extensionBundle", content);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_IsIdempotent_WithoutForce()
+    {
+        await RunAsync(projectName: "my-java-app", force: false);
+        string functionPath = Path.Combine(_projectDir.FullName, "src", "main", "java", "com", "function", "Function.java");
+        const string userEdit = "package com.function;\npublic class Function {}\n";
+        File.WriteAllText(functionPath, userEdit);
+
+        await RunAsync(projectName: "my-java-app", force: false);
+
+        Assert.Equal(userEdit, File.ReadAllText(functionPath));
+    }
+
+    [Fact]
+    public async Task InitializeAsync_ForceOverwrites()
+    {
+        await RunAsync(projectName: "my-java-app", force: false);
+        string pomPath = Path.Combine(_projectDir.FullName, "pom.xml");
+        File.WriteAllText(pomPath, "stale");
+
+        await RunAsync(projectName: "my-java-app", force: true);
+
+        Assert.Contains("azure-functions-maven-plugin", File.ReadAllText(pomPath));
+    }
+
+    private Task RunAsync(string? projectName, bool force, string[]? args = null)
+    {
+        var initializer = new JavaProjectInitializer();
+        var context = new InitContext(
+            WorkingDirectory.FromExplicit(_projectDir.FullName),
+            ProjectName: projectName,
+            Language: null,
+            Force: force);
+        var root = new RootCommand();
+        initializer.GetInitOptions(new InitOptionRegistry(root));
+
+        return initializer.InitializeAsync(context, root.Parse(args ?? []));
+    }
+}

--- a/test/Workloads/Stacks/Java.Tests/JavaWorkloadTests.cs
+++ b/test/Workloads/Stacks/Java.Tests/JavaWorkloadTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Workloads;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Functions.Cli.Workloads.Java.Tests;
+
+public class JavaWorkloadTests
+{
+    [Fact]
+    public void Configure_RegistersProjectInitializer()
+    {
+        ServiceCollection services = new();
+        FunctionsCliBuilder builder = Substitute.For<FunctionsCliBuilder>();
+        builder.Services.Returns(services);
+
+        new JavaWorkload().Configure(builder);
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        IProjectInitializer initializer = provider.GetRequiredService<IProjectInitializer>();
+        Assert.IsType<JavaProjectInitializer>(initializer);
+        Assert.Equal("java", initializer.Stack);
+        Assert.Equal("Java", Assert.Single(initializer.SupportedLanguages));
+    }
+
+    [Fact]
+    public void Configure_NullBuilder_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new JavaWorkload().Configure(null!));
+    }
+
+    [Fact]
+    public void Configure_AddsProjectFactory()
+    {
+        ServiceCollection services = new();
+        FunctionsCliBuilder builder = Substitute.For<FunctionsCliBuilder>();
+        builder.Services.Returns(services);
+
+        new JavaWorkload().Configure(builder);
+
+        builder.Received(1).AddProjectFactory(Arg.Any<JavaProjectFactory>());
+    }
+
+    [Fact]
+    public void DisplayName_And_Description_AreSet()
+    {
+        var workload = new JavaWorkload();
+
+        Assert.Equal("Java Stack", workload.DisplayName);
+        Assert.False(string.IsNullOrWhiteSpace(workload.Description));
+    }
+}

--- a/test/Workloads/Stacks/Java.Tests/Workloads.Java.Tests.csproj
+++ b/test/Workloads/Stacks/Java.Tests/Workloads.Java.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(SrcRoot)Workloads/Stacks/Java/Workloads.Java.csproj" />
+    <ProjectReference Include="$(SrcRoot)Abstractions/Abstractions.csproj" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## What this does

This adds the Java stack workload with alias `java`. It wires Java into `func init`, `func new`, and `func start`. It pairs with the Java worker in #5470. The two are separate packages so they can merge in either order, though worker first is the natural order since the stack pulls in the worker on the first `func start`.

## What is in it

The new code lives under `src/Workloads/Stacks/Java`.

- `JavaWorkload` is the entry point and registers the initializer and the project factory
- `JavaProjectInitializer` handles `func init --stack java`. It scaffolds a Maven project with a `pom.xml`, a sample HTTP trigger at `src/main/java/com/function/Function.java`, a `host.json` with the extension bundle, a `local.settings.json`, a `.gitignore`, and a `.funcignore`. It also contributes the shared `--no-bundles` and `--bundles-channel` options
- `JavaProjectFactory` claims a directory as Java when it sees a `pom.xml`, a Gradle build file, or a `src/main/java` tree
- `JavaFunctionsProject` runs `mvn clean package` before the host starts, then points the host at the staged `target/azure-functions/<app>` output. `func start --no-build` reuses an existing build

I also added the test project with 33 unit tests, registered both projects in `Azure.Functions.Cli.slnx`, and added the release pipeline at `eng/ci/release/official-release.workload.java.yml`.

## Scaffold defaults

The generated `pom.xml` targets Java 21, uses the latest `azure-functions-maven-plugin` 1.42.0, and defaults to Flex Consumption on Linux for deployment. It keeps `azure-functions-java-library` at 3.1.0.

## How I tested it

The build is clean with no warnings and all 33 tests pass. `dotnet pack` produces a valid nupkg with a `workload.json` whose kind is workload and an entry point that points at `JavaWorkload`.

I ran the whole thing end to end with a real `func` build.

- `func init --stack java` scaffolds the project with the expected `pom.xml` (Java 21, plugin 1.42.0, Flex Consumption on Linux), the sample function, and the settings files
- `mvn clean package` on JDK 21 builds and stages `target/azure-functions/<app>` the way `JavaFunctionsProject` expects
- `func start` resolves the project as Java, pulls in the worker, host, and bundles, and the HTTP trigger returns a 200 locally
- I deployed to a real Flex Consumption Linux app in Azure with `mvn azure-functions:deploy`. The app came up as Flex Consumption running Java 21 and the endpoint returned a 200 with the expected greeting. I deleted the app afterward

## Notes

`func start` needs JDK 21 with `JAVA_HOME` set, and Maven on the path or a `mvnw` wrapper in the project. If Maven is missing or the build fails the stack surfaces a clear error.

`func new` template listing goes through the repo wide `ITemplateProvider` contribution point, which isn't implemented for any stack yet. This workload registers the same way the Go and Python stacks do.

## Definition of done

- [x] `func init --stack java` produces a valid Maven project, verified end to end and it builds with `mvn package`
- [x] The stack registers through the workload model and shows up in `func --help` and the workload list once installed
- [x] The workload manifest matches the schema with kind workload and an entry point
- [x] The stack workload nupkg builds and the release pipeline is wired

Closes #5320
