### PR TITLE
fix: explain best-effort catch blocks (#5449)

### DIFF
--- a/src/Func/Quickstart/ManifestCache.cs
+++ b/src/Func/Quickstart/ManifestCache.cs
@@ -78,8 +78,17 @@ internal sealed class ManifestCache(IOptions<QuickstartManifestOptions> options)
         }
         catch
         {
-            // Best-effort cleanup of the unique temp file.
-            try { File.Delete(tempPath); } catch { }
+            // Best-effort cleanup of the unique temp file before rethrowing the original failure.
+            try
+            {
+                File.Delete(tempPath);
+            }
+            catch
+            {
+                // Ignore: the temp file is uniquely named so a leftover is harmless, and we
+                // must not mask the original write/move exception being rethrown below.
+            }
+
             throw;
         }
     }

--- a/src/Templates.DotNet/DefaultDotnetTemplateRunner.cs
+++ b/src/Templates.DotNet/DefaultDotnetTemplateRunner.cs
@@ -67,7 +67,16 @@ internal sealed class DefaultDotnetTemplateRunner : IDotnetTemplateRunner
         }
         catch (OperationCanceledException)
         {
-            try { process.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+            try
+            {
+                process.Kill(entireProcessTree: true);
+            }
+            catch
+            {
+                // Ignore: the process may have already exited, and a failed kill must not
+                // mask the cancellation being rethrown below.
+            }
+
             throw;
         }
 

--- a/src/Templates.DotNet/ItemTemplateHiveProvisioner.cs
+++ b/src/Templates.DotNet/ItemTemplateHiveProvisioner.cs
@@ -110,7 +110,16 @@ internal sealed class ItemTemplateHiveProvisioner(IItemTemplateHivePathProvider 
         }
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
         {
-            try { process.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+            try
+            {
+                process.Kill(entireProcessTree: true);
+            }
+            catch
+            {
+                // Ignore: the process may have already exited on timeout, and a failed kill
+                // must not mask the timeout error thrown below.
+            }
+
             throw new InvalidOperationException(
                 $"Provisioning the dotnet item-template hive timed out after {_installTimeout.TotalMinutes:0} minutes. Check your network and try again.");
         }


### PR DESCRIPTION
## What this does

This cleans up the empty and near-empty catch blocks called out in the issue. Our coding standard only allows swallowing an exception on a genuine best-effort cleanup path, and the catch has to include a comment saying why losing the exception is fine. All three cases here are real best-effort cleanup, so I added the missing explanations rather than changing behavior.

## Changes

- `src/Func/Quickstart/ManifestCache.cs`, the inner `catch` around the temp-file delete was empty. The temp file is uniquely named so a leftover is harmless, and swallowing here avoids masking the original write or move error that gets rethrown right after
- `src/Templates.DotNet/ItemTemplateHiveProvisioner.cs`, the `catch` around `process.Kill` on timeout only had a bare `/* best-effort */`. I expanded it to say the process may already have exited and a failed kill must not hide the timeout error thrown next
- `src/Templates.DotNet/DefaultDotnetTemplateRunner.cs`, same idea for the kill on cancellation

There are no behavior changes here, only comments and a bit of formatting around the existing cleanup.

## How I tested it

I built `Templates.DotNet` and `Func` with no warnings and no errors. I also grepped `src` for any remaining empty catch blocks and there are none left. The change is comment only so it doesn't touch runtime behavior.

## Acceptance criteria

- [x] No empty catch blocks without explanatory comments
- [x] Any catches that were hiding real errors are fixed with proper handling, none were, all three are genuine best-effort cleanup
- [x] Build passes and the change is comment only so tests are unaffected

Closes #5449
