### PR TITLE
fix(azurite): surface managed Azurite data directory with reset guidance (#5263)

### DIFF
--- a/src/Func/Commands/Start/Azurite/AzuriteBlobFailureDetector.cs
+++ b/src/Func/Commands/Start/Azurite/AzuriteBlobFailureDetector.cs
@@ -1,0 +1,65 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite;
+
+/// <summary>
+/// Watches host output for a 500 (Internal Server Error) coming from the CLI's
+/// managed Azurite instance. The signal is a server error paired with the
+/// <c>Azurite-Blob</c> server header, which only the local emulator emits, so
+/// pairing the two avoids firing on unrelated 500s. State is rolling because
+/// the two markers usually arrive on separate host log lines within one
+/// <c>RequestFailedException</c> dump.
+/// </summary>
+internal sealed class AzuriteBlobFailureDetector
+{
+    private const string ServerErrorMarker = "Internal Server Error";
+    private const string AzuriteMarker = "Azurite-Blob";
+
+    // How many lines a seen server error stays "hot" waiting for the
+    // Azurite-Blob header before we assume the two are unrelated. Generous
+    // because the exception dump can carry many header lines in between.
+    private const int ServerErrorWindow = 40;
+
+    private int _serverErrorCountdown;
+
+    /// <summary>
+    /// True once a managed-Azurite 500 has been observed. Latches on and never
+    /// resets, so callers act on it exactly once.
+    /// </summary>
+    public bool Detected { get; private set; }
+
+    /// <summary>
+    /// Feeds one piece of host output to the detector. Returns <c>true</c> only
+    /// on the transition into the detected state so callers can act once.
+    /// </summary>
+    public bool Observe(string? text)
+    {
+        if (Detected || string.IsNullOrEmpty(text))
+        {
+            return false;
+        }
+
+        bool hasServerError = text.Contains(ServerErrorMarker, StringComparison.OrdinalIgnoreCase);
+        bool hasAzurite = text.Contains(AzuriteMarker, StringComparison.OrdinalIgnoreCase);
+
+        // Same line carries both, or a recent server error is now followed by
+        // the Azurite-Blob header.
+        if (hasAzurite && (hasServerError || _serverErrorCountdown > 0))
+        {
+            Detected = true;
+            return true;
+        }
+
+        if (hasServerError)
+        {
+            _serverErrorCountdown = ServerErrorWindow;
+        }
+        else if (_serverErrorCountdown > 0)
+        {
+            _serverErrorCountdown--;
+        }
+
+        return false;
+    }
+}

--- a/src/Func/Commands/Start/Azurite/AzuriteFailureDetectingHostEventStream.cs
+++ b/src/Func/Commands/Start/Azurite/AzuriteFailureDetectingHostEventStream.cs
@@ -1,0 +1,80 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Runtime.CompilerServices;
+using Azure.Functions.Cli.Hosting.Events;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite;
+
+/// <summary>
+/// Wraps the host event stream and watches for a 500 from the CLI's managed
+/// Azurite instance. Host entries flow through untouched. On the first
+/// detection it injects a single warning entry with reset guidance so the
+/// failure is visible live, and flips <see cref="Detected"/> so the caller can
+/// repeat the guidance in the end-of-run summary. Only installed when the CLI
+/// launched Azurite, so it stays inert for user-managed or disabled emulators.
+/// </summary>
+internal sealed class AzuriteFailureDetectingHostEventStream : IHostEventStream, IHostEventStreamLifecycle
+{
+    private const string GuidanceCategory = "Azurite";
+
+    private readonly IHostEventStream _inner;
+    private readonly string _guidanceMessage;
+    private readonly TimeProvider _timeProvider;
+    private readonly AzuriteBlobFailureDetector _detector = new();
+
+    public AzuriteFailureDetectingHostEventStream(IHostEventStream inner, string guidanceMessage, TimeProvider? timeProvider = null)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        _guidanceMessage = guidanceMessage ?? throw new ArgumentNullException(nameof(guidanceMessage));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    /// <summary>True once a managed-Azurite 500 has been detected in host output.</summary>
+    public bool Detected => _detector.Detected;
+
+    public async IAsyncEnumerable<HostLogEntry> ReadAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        await foreach (HostLogEntry entry in _inner.ReadAsync(cancellationToken))
+        {
+            yield return entry;
+
+            if (!_detector.Detected && Observe(entry))
+            {
+                yield return CreateGuidanceEntry();
+            }
+        }
+    }
+
+    public Task RequestShutdownAsync(CancellationToken cancellationToken)
+        => _inner is IHostEventStreamLifecycle lifecycle ? lifecycle.RequestShutdownAsync(cancellationToken) : Task.CompletedTask;
+
+    public Task<int> WaitForExitAsync(CancellationToken cancellationToken)
+        => _inner is IHostEventStreamLifecycle lifecycle ? lifecycle.WaitForExitAsync(cancellationToken) : Task.FromResult(0);
+
+    public ValueTask DisposeAsync() => _inner.DisposeAsync();
+
+    private bool Observe(HostLogEntry entry)
+    {
+        // Markers can be in the formatted message or, when the host attaches
+        // the RequestFailedException, in its dump.
+        bool detected = _detector.Observe(entry.Message);
+        if (!detected && entry.Exception is { } exception)
+        {
+            detected = _detector.Observe(exception.ToString());
+        }
+
+        return detected;
+    }
+
+    private HostLogEntry CreateGuidanceEntry()
+        => new(
+            _timeProvider.GetUtcNow(),
+            GuidanceCategory,
+            LogLevel.Warning,
+            default,
+            _guidanceMessage,
+            Exception: null,
+            HostLogEntry.EmptyAttributes);
+}

--- a/src/Func/Commands/Start/Azurite/EnsureAzuriteInitializationStep.cs
+++ b/src/Func/Commands/Start/Azurite/EnsureAzuriteInitializationStep.cs
@@ -70,7 +70,8 @@ internal sealed class EnsureAzuriteInitializationStep(
 
             case ManagedAzuriteResult.Started started:
                 context.State.ManagedAzurite = ManagedAzuriteHandle.Owning(started.Process, started.Mode);
-                return StartInitializationStepResult.Completed($"Started managed Azurite ({started.Mode}).");
+                return StartInitializationStepResult.Completed(
+                    $"Started managed Azurite ({started.Mode}). Data directory: {started.Paths.DataDirectory}");
 
             case ManagedAzuriteResult.Failed failed:
                 throw new GracefulException(failed.UserMessage, isUserError: true, verboseMessage: failed.VerboseDetail);

--- a/src/Func/Commands/Start/Azurite/EnsureAzuriteInitializationStep.cs
+++ b/src/Func/Commands/Start/Azurite/EnsureAzuriteInitializationStep.cs
@@ -70,6 +70,7 @@ internal sealed class EnsureAzuriteInitializationStep(
 
             case ManagedAzuriteResult.Started started:
                 context.State.ManagedAzurite = ManagedAzuriteHandle.Owning(started.Process, started.Mode);
+                context.State.AzuritePaths = started.Paths;
                 return StartInitializationStepResult.Completed(
                     $"Started managed Azurite ({started.Mode}). Data directory: {started.Paths.DataDirectory}");
 

--- a/src/Func/Commands/Start/Azurite/Orchestration/ManagedAzuriteOrchestrator.cs
+++ b/src/Func/Commands/Start/Azurite/Orchestration/ManagedAzuriteOrchestrator.cs
@@ -205,7 +205,11 @@ internal sealed class ManagedAzuriteOrchestrator : IManagedAzuriteOrchestrator
         {
             case PollOutcomeKind.Ready:
                 progress?.Report($"Azurite ready ({poll.Elapsed.TotalSeconds:0.0}s)");
-                return new ManagedAzuriteResult.Started(process, mode, endpoints);
+                _logger.LogInformation(
+                    "Managed Azurite data directory: {DataDirectory}. Log file: {LogFilePath}.",
+                    paths.DataDirectory,
+                    paths.LogFilePath);
+                return new ManagedAzuriteResult.Started(process, mode, endpoints, paths);
 
             case PollOutcomeKind.ProcessExited:
                 await SafeDisposeAsync(process);
@@ -439,7 +443,10 @@ internal sealed class ManagedAzuriteOrchestrator : IManagedAzuriteOrchestrator
         }
 
         sb.AppendLine();
-        sb.Append($"Log file: {paths.LogFilePath}");
+        sb.AppendLine($"Data directory: {paths.DataDirectory}");
+        sb.AppendLine($"Log file: {paths.LogFilePath}");
+        sb.AppendLine();
+        sb.Append("To reset Azurite state, delete the data directory above, then run 'func start' again.");
         if (!string.IsNullOrWhiteSpace(stderrTail))
         {
             sb.AppendLine();
@@ -461,7 +468,10 @@ internal sealed class ManagedAzuriteOrchestrator : IManagedAzuriteOrchestrator
         sb.AppendLine($"  Queue: {endpoints.QueueEndpoint}");
         sb.AppendLine($"  Table: {endpoints.TableEndpoint}");
         sb.AppendLine();
-        sb.Append($"Log file: {paths.LogFilePath}");
+        sb.AppendLine($"Data directory: {paths.DataDirectory}");
+        sb.AppendLine($"Log file: {paths.LogFilePath}");
+        sb.AppendLine();
+        sb.Append("To reset Azurite state, delete the data directory above, then run 'func start' again.");
         return sb.ToString();
     }
 

--- a/src/Func/Commands/Start/Azurite/Orchestration/ManagedAzuriteResult.cs
+++ b/src/Func/Commands/Start/Azurite/Orchestration/ManagedAzuriteResult.cs
@@ -33,9 +33,10 @@ internal abstract record ManagedAzuriteResult
     /// <summary>
     /// The CLI launched Azurite. <paramref name="Process"/> is the running
     /// handle; the caller is responsible for disposing it when the host run
-    /// ends.
+    /// ends. <paramref name="Paths"/> carries the managed data directory and
+    /// log file so callers can surface them for reset guidance.
     /// </summary>
-    public sealed record Started(IAzuriteProcess Process, AzuriteLaunchMode Mode, AzuriteEndpointTuple Endpoints) : ManagedAzuriteResult;
+    public sealed record Started(IAzuriteProcess Process, AzuriteLaunchMode Mode, AzuriteEndpointTuple Endpoints, AzuriteManagedPaths Paths) : ManagedAzuriteResult;
 
     /// <summary>
     /// Azurite cannot be made ready. <paramref name="UserMessage"/> is

--- a/src/Func/Commands/Start/Initialization/StartInitializationResult.cs
+++ b/src/Func/Commands/Start/Initialization/StartInitializationResult.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Commands.Start.Azurite;
 using Azure.Functions.Cli.Commands.Start.Azurite.Orchestration;
 using Azure.Functions.Cli.Hosting.Dashboard;
 using Azure.Functions.Cli.Hosting.Events;
@@ -22,4 +23,5 @@ internal sealed record StartInitializationResult(
     IFunctionsWorker Worker,
     FunctionsProjectHostRunContext HostRunContext,
     StartInitializationProfileInfo? Profile = null,
-    ManagedAzuriteHandle? ManagedAzurite = null);
+    ManagedAzuriteHandle? ManagedAzurite = null,
+    AzuriteManagedPaths? AzuritePaths = null);

--- a/src/Func/Commands/Start/Initialization/StartInitializationState.cs
+++ b/src/Func/Commands/Start/Initialization/StartInitializationState.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Commands.Start.Azurite;
 using Azure.Functions.Cli.Commands.Start.Azurite.Orchestration;
 using Azure.Functions.Cli.Hosting.Dashboard;
 using Azure.Functions.Cli.Hosting.Events;
@@ -52,6 +53,13 @@ internal sealed class StartInitializationState
     /// </summary>
     public ManagedAzuriteHandle? ManagedAzurite { get; set; }
 
+    /// <summary>
+    /// On-disk paths for the managed Azurite instance the CLI launched, or
+    /// null when Azurite is user-managed, disabled, or non-local. Lets the
+    /// host run surface reset guidance if the emulator returns a 500.
+    /// </summary>
+    public AzuriteManagedPaths? AzuritePaths { get; set; }
+
     public StartInitializationResult ToResult(StartInitializationContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -75,7 +83,8 @@ internal sealed class StartInitializationState
             worker,
             hostRunContext,
             CreateProfileInfo(),
-            ManagedAzurite);
+            ManagedAzurite,
+            AzuritePaths);
     }
 
     private StartInitializationProfileInfo? CreateProfileInfo()

--- a/src/Func/Commands/Start/StartCommand.cs
+++ b/src/Func/Commands/Start/StartCommand.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine;
 using System.Globalization;
+using Azure.Functions.Cli.Commands.Start.Azurite;
 using Azure.Functions.Cli.Commands.Start.Azurite.Orchestration;
 using Azure.Functions.Cli.Commands.Start.Initialization;
 using Azure.Functions.Cli.Commands.Start.Initialization.Rendering;
@@ -217,7 +218,20 @@ internal sealed class StartCommand : FuncCliCommand, IBuiltInCommand
 
         IDashboardRenderer renderer = CreateRenderer(mode, initializationResult.RunInfo);
 
-        IHostEventStream dashboardEventStream = _eventStreamFactory.Create(mode, initializationEvents, hostEventStream);
+        // When the CLI launched Azurite, watch host output for a 500 from the
+        // emulator and surface data-directory reset guidance (live and in the
+        // end-of-run summary). Inert for user-managed or disabled Azurite.
+        IHostEventStream hostStreamForDashboard = hostEventStream;
+        AzuriteFailureDetectingHostEventStream? azuriteFailureDetector = null;
+        string? azuriteResetGuidance = null;
+        if (initializationResult.AzuritePaths is { } azuritePaths)
+        {
+            azuriteResetGuidance = BuildAzuriteResetGuidance(azuritePaths);
+            azuriteFailureDetector = new AzuriteFailureDetectingHostEventStream(hostEventStream, azuriteResetGuidance);
+            hostStreamForDashboard = azuriteFailureDetector;
+        }
+
+        IHostEventStream dashboardEventStream = _eventStreamFactory.Create(mode, initializationEvents, hostStreamForDashboard);
         var pipeline = new DashboardPipeline(state, dashboardEventStream, renderer, eventSink);
         FunctionsProjectHostRunOutcome? outcome = null;
         // Stop any managed Azurite instance the orchestrator launched when
@@ -247,6 +261,14 @@ internal sealed class StartCommand : FuncCliCommand, IBuiltInCommand
             {
                 await CompleteProjectHostRunAsync(initializationResult, outcome);
             }
+
+            // Repeat the managed-Azurite reset guidance after the dashboard has
+            // torn down so it is the last thing the user sees when the emulator
+            // returned a 500 during the run.
+            if (azuriteFailureDetector?.Detected == true && azuriteResetGuidance is not null)
+            {
+                _interaction.WriteWarning(azuriteResetGuidance);
+            }
         }
     }
 
@@ -270,6 +292,11 @@ internal sealed class StartCommand : FuncCliCommand, IBuiltInCommand
             _interaction.WriteWarning($"Project cleanup failed: {ex.Message}");
         }
     }
+
+    private static string BuildAzuriteResetGuidance(AzuriteManagedPaths paths)
+        => $"Managed Azurite returned a 500 (Internal Server Error), which usually means its data directory is "
+            + $"corrupted or in a bad state. Delete '{paths.DataDirectory}' to reset Azurite, then run 'func start' again. "
+            + $"Azurite debug log: '{paths.LogFilePath}'.";
 
     private HostStartupOptions GetHostStartupOptions(DirectoryInfo projectDirectory)
         => ProjectDirectoryResolver.IsProjectDirectory(projectDirectory)

--- a/test/Func.Tests/Commands/Start/Azurite/AzuriteBlobFailureDetectorTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/AzuriteBlobFailureDetectorTests.cs
@@ -1,0 +1,113 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Commands.Start.Azurite;
+
+namespace Azure.Functions.Cli.Tests.Commands.Start.Azurite;
+
+public class AzuriteBlobFailureDetectorTests
+{
+    [Fact]
+    public void SingleLine_WithServerError_And_AzuriteHeader_Detects()
+    {
+        var detector = new AzuriteBlobFailureDetector();
+
+        bool transitioned = detector.Observe("Status: 500 (Internal Server Error) Server: Azurite-Blob/3.35.0");
+
+        transitioned.Should().BeTrue();
+        detector.Detected.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ServerError_ThenAzuriteHeader_WithinWindow_Detects()
+    {
+        var detector = new AzuriteBlobFailureDetector();
+
+        detector.Observe("Status: 500 (Internal Server Error)").Should().BeFalse();
+        detector.Observe("Headers:").Should().BeFalse();
+        bool transitioned = detector.Observe("Server: Azurite-Blob/3.35.0");
+
+        transitioned.Should().BeTrue();
+        detector.Detected.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ServerError_WithoutAzurite_DoesNotDetect()
+    {
+        var detector = new AzuriteBlobFailureDetector();
+
+        detector.Observe("Status: 500 (Internal Server Error)");
+        detector.Observe("Server: SomeOtherService/1.0");
+
+        detector.Detected.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AzuriteHeader_WithoutServerError_DoesNotDetect()
+    {
+        var detector = new AzuriteBlobFailureDetector();
+
+        detector.Observe("Server: Azurite-Blob/3.35.0");
+
+        detector.Detected.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AzuriteHeader_FarAfterServerError_DoesNotDetect()
+    {
+        var detector = new AzuriteBlobFailureDetector();
+
+        detector.Observe("Status: 500 (Internal Server Error)");
+        for (int i = 0; i < 45; i++)
+        {
+            detector.Observe($"unrelated host log line {i}");
+        }
+
+        detector.Observe("Server: Azurite-Blob/3.35.0");
+
+        detector.Detected.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Observe_ReturnsTrue_OnlyOnTransition()
+    {
+        var detector = new AzuriteBlobFailureDetector();
+
+        detector.Observe("500 (Internal Server Error) from Azurite-Blob/3.35.0").Should().BeTrue();
+        detector.Observe("500 (Internal Server Error) from Azurite-Blob/3.35.0").Should().BeFalse();
+    }
+
+    [Fact]
+    public void NullOrEmpty_IsIgnored()
+    {
+        var detector = new AzuriteBlobFailureDetector();
+
+        detector.Observe(null).Should().BeFalse();
+        detector.Observe(string.Empty).Should().BeFalse();
+        detector.Detected.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Detects_RepresentativeRequestFailedExceptionBlock()
+    {
+        var detector = new AzuriteBlobFailureDetector();
+        string[] block =
+        [
+            "There was an error performing a write operation on the Blob Storage Secret Repository.",
+            "Azure.RequestFailedException: Service request failed.",
+            "Status: 500 (Internal Server Error)",
+            "Headers:",
+            "Server: Azurite-Blob/3.35.0",
+            "x-ms-error-code: InternalError",
+        ];
+
+        bool detectedDuringBlock = false;
+        foreach (string line in block)
+        {
+            detectedDuringBlock |= detector.Observe(line);
+        }
+
+        detectedDuringBlock.Should().BeTrue();
+        detector.Detected.Should().BeTrue();
+    }
+}

--- a/test/Func.Tests/Commands/Start/Azurite/AzuriteFailureDetectingHostEventStreamTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/AzuriteFailureDetectingHostEventStreamTests.cs
@@ -1,0 +1,70 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Commands.Start.Azurite;
+using Azure.Functions.Cli.Hosting.Events;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Functions.Cli.Tests.Commands.Start.Azurite;
+
+public class AzuriteFailureDetectingHostEventStreamTests
+{
+    private const string Guidance = "Delete the Azurite data directory to reset it.";
+
+    [Fact]
+    public async Task PassesEntriesThrough_AndInjectsGuidanceOnce_OnDetection()
+    {
+        var inner = new InMemoryHostEventStream();
+        inner.Write(Entry("Status: 500 (Internal Server Error)"));
+        inner.Write(Entry("Server: Azurite-Blob/3.35.0"));
+        inner.Write(Entry("Server: Azurite-Blob/3.35.0"));
+        inner.Complete();
+
+        await using var stream = new AzuriteFailureDetectingHostEventStream(inner, Guidance);
+        List<HostLogEntry> observed = await DrainAsync(stream);
+
+        // Three host entries pass through plus exactly one injected guidance entry.
+        observed.Should().HaveCount(4);
+        HostLogEntry guidance = observed.Should().ContainSingle(e => e.Message == Guidance).Which;
+        guidance.Level.Should().Be(LogLevel.Warning);
+        guidance.Category.Should().Be("Azurite");
+        stream.Detected.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task BenignOutput_PassesThrough_WithoutInjection()
+    {
+        var inner = new InMemoryHostEventStream();
+        inner.Write(Entry("Now listening on: http://0.0.0.0:7071"));
+        inner.Write(Entry("Worker process started."));
+        inner.Complete();
+
+        await using var stream = new AzuriteFailureDetectingHostEventStream(inner, Guidance);
+        List<HostLogEntry> observed = await DrainAsync(stream);
+
+        observed.Should().HaveCount(2);
+        observed.Should().NotContain(e => e.Message == Guidance);
+        stream.Detected.Should().BeFalse();
+    }
+
+    private static async Task<List<HostLogEntry>> DrainAsync(IHostEventStream stream)
+    {
+        List<HostLogEntry> entries = [];
+        await foreach (HostLogEntry entry in stream.ReadAsync(CancellationToken.None))
+        {
+            entries.Add(entry);
+        }
+
+        return entries;
+    }
+
+    private static HostLogEntry Entry(string message)
+        => new(
+            DateTimeOffset.UtcNow,
+            "Host.Process",
+            LogLevel.Information,
+            default,
+            message,
+            Exception: null,
+            HostLogEntry.EmptyAttributes);
+}

--- a/test/Func.Tests/Commands/Start/Azurite/Orchestration/ManagedAzuriteOrchestratorTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/Orchestration/ManagedAzuriteOrchestratorTests.cs
@@ -155,6 +155,7 @@ public class ManagedAzuriteOrchestratorTests
         var started = result.Should().BeOfType<ManagedAzuriteResult.Started>().Subject;
         started.Mode.Should().Be(AzuriteLaunchMode.Native);
         started.Process.Should().BeSameAs(fake);
+        started.Paths.DataDirectory.Should().Be(Path.Combine(Path.GetTempPath(), "azurite-data"));
         await _launcher.Received(1).StartAsync(
             Arg.Is<AzuriteLaunchRequest>(r => r.Mode == AzuriteLaunchMode.Native && r.ExecutablePath == "/usr/bin/azurite"),
             Arg.Any<CancellationToken>());
@@ -215,8 +216,10 @@ public class ManagedAzuriteOrchestratorTests
             progress: null,
             CancellationToken.None);
 
-        result.Should().BeOfType<ManagedAzuriteResult.Failed>()
-            .Which.UserMessage.Should().Contain("did not become ready");
+        var failed = result.Should().BeOfType<ManagedAzuriteResult.Failed>().Subject;
+        failed.UserMessage.Should().Contain("did not become ready");
+        failed.UserMessage.Should().Contain("Data directory:");
+        failed.UserMessage.Should().Contain("delete the data directory");
         fake.StopCalled.Should().BeTrue("Orchestrator must stop the process on timeout.");
     }
 
@@ -236,6 +239,8 @@ public class ManagedAzuriteOrchestratorTests
         var failed = result.Should().BeOfType<ManagedAzuriteResult.Failed>().Subject;
         failed.UserMessage.Should().Contain("Azurite exited before it was ready");
         failed.UserMessage.Should().Contain("ENOENT");
+        failed.UserMessage.Should().Contain("Data directory:");
+        failed.UserMessage.Should().Contain("delete the data directory");
     }
 
     [Fact]


### PR DESCRIPTION
## What this does

This finishes #5263. When the CLI manages Azurite and the host hits a 500 from it, the CLI now surfaces its own actionable error with the data directory, a reset step, and the Azurite debug log path. It also prints the managed Azurite data directory at startup so users can find it without digging through `ps`.

## What is in it

Two parts.

First, surfacing the data directory. The startup step reports the data directory when the CLI starts Azurite, and the orchestrator failure messages include it with reset guidance.

Second, the 500 detection. A small detector watches host output for a server error paired with the `Azurite-Blob` server header, which only the local emulator emits, so it never fires on an unrelated 500. It only runs when the CLI launched Azurite. On the first hit it injects a live warning with the data directory, a delete-to-reset step, and the debug log path, and it repeats the same guidance in the end-of-run summary. For user-managed or disabled Azurite it stays inert.

## How I tested it

Unit tests cover the detector signal (same-line and cross-line pairing, no false positive on a plain 500, fires once) and the stream decorator (host entries pass through, guidance injected once). The full suite is green at 1259 tests with no warnings.

I also ran it end to end against a real host. I isolated `FUNC_CLI_HOME` to a temp directory, ran func start once so the CLI launched managed Azurite and seeded its data dir, corrupted the data dir so a secrets write returns a 500, then ran func start again. The real host output was:

```
[error] There was an error performing a write operation on the Blob Storage Secret Repository.
        Azure.RequestFailedException: Service request failed.
        Status: 500 (Internal Server Error)
        Server: Azurite-Blob/3.35.0
[warn]  Managed Azurite returned a 500 (Internal Server Error), which usually means its data
        directory is corrupted or in a bad state. Delete '<data-dir>' to reset Azurite, then
        re-run func start. Azurite debug log: '<log-path>'.
```

So the detector caught the real 500 (server error plus the `Azurite-Blob` header), the guidance rendered live right after the error, and the data directory and log path were correct. The live surface is validated end to end. The summary surface is covered by the unit tests. In the E2E the broken host hung on the failing write instead of exiting cleanly, so I did not capture the summary line in that run.

## Notes

While setting up the test I hit a real orphaned managed Azurite from a prior failed func start, still holding the ports and pointing at the default data dir, which the CLI silently reused. That is the #5264 scenario, tracked separately.

## Definition of done

- [x] When the host hits a 5xx from managed Azurite, the CLI surfaces its own error with the data directory, a reset step, and the debug log path
- [x] The managed Azurite data directory is printed at startup
- [x] Unit tested, and the 500 path validated end to end against a real host

Closes #5263
