### PR TITLE
Add PowerShell templates workload

### DIFF
--- a/Azure.Functions.Cli.slnx
+++ b/Azure.Functions.Cli.slnx
@@ -25,6 +25,7 @@
   <Folder Name="/src/Workloads/Templates/">
     <Project Path="src/Workloads/Templates/DotNet/Workloads.Templates.DotNet.csproj" />
     <Project Path="src/Workloads/Templates/Node/Workloads.Templates.Node.csproj" />
+    <Project Path="src/Workloads/Templates/PowerShell/Workloads.Templates.PowerShell.csproj" />
     <Project Path="src/Workloads/Templates/Python/Workloads.Templates.Python.csproj" />
   </Folder>
   <Folder Name="/src/Workloads/Workers/">

--- a/eng/ci/release/official-release.workload.templates.powershell.yml
+++ b/eng/ci/release/official-release.workload.templates.powershell.yml
@@ -1,0 +1,17 @@
+parameters:
+- name: public
+  displayName: Publish to nuget.org?
+  type: boolean
+  default: false
+
+# Release has no triggers outside of pipeline
+trigger: none
+pr: none
+
+extends:
+  template: /eng/ci/templates/pipelines/release-packages.yml@self
+  parameters:
+    public: ${{ parameters.public }}
+    folder: workloads/templates/powershell
+    projects: |
+      $(Build.SourcesDirectory)/src/Workloads/Templates/PowerShell/Workloads.Templates.PowerShell.csproj

--- a/src/Workloads/Templates/PowerShell/README.DEV.md
+++ b/src/Workloads/Templates/PowerShell/README.DEV.md
@@ -1,0 +1,71 @@
+# Azure Functions CLI: PowerShell templates workload (dev notes)
+
+Repo-only notes for contributors. Not packaged into the nupkg.
+
+## Versioning
+
+The workload pkg version is independent of the source bundle version
+(Templates Workload Spec §4.4.1). The channel a workload was built
+from is encoded in the pkg version's prerelease label, and that
+channel maps 1:1 to an extension-bundle id (Templates Workload Spec
+§4.4.2).
+
+## Bundle compatibility (sources of truth)
+
+The minimum compatible extension-bundle version is recorded in three
+locations that all derive from the single `$(MinBundleVersionRange)`
+MSBuild property, so they cannot drift:
+
+- `tools/any/content/templates-workload.json`, CLI-owned sibling
+  manifest. Authoritative. Generated at pack time by the
+  `GenerateTemplatesWorkloadJson` target.
+- Nuspec `minBundle:[4.0.0,)` tag, discoverable via
+  `func workload search` / `list`.
+- Nuspec `<description>` sentence, surfaced by `func workload list`.
+
+## Build-time channel selection
+
+The source bundle id used at pack time is driven by
+`$(BundleChannel)` in `Directory.Version.props`, the same property
+the bundles workload uses. In CI it is inferred from the git tag
+(e.g. `templates-powershell/v1.0.1-preview.1` → `preview`); locally you
+can pass it directly:
+
+```bash
+dotnet pack ... /p:BundleChannel=preview
+dotnet pack ... /p:BundleChannel=experimental
+```
+
+`$(SourceBundleVersion)` selects the bundle version whose
+`StaticContent/v2` subtree is snapshotted at build time. It defaults
+to the channel-resolved `$(BundleVersion)` from the shared
+`Workloads.Templates.SourceBundleVersion.props` and is recorded as
+build provenance only; it does not derive the templates pkg version
+(Templates Workload Spec §4.4.1).
+
+## Layout
+
+The package places the template payload under `tools/any/content/`,
+matching the upstream extension bundle's `StaticContent/v2/` subtree
+with the `StaticContent/` wrapper stripped (Templates Workload Spec
+§5.2). PowerShell ships only the templates matching language filter
+`PowerShell`:
+
+```
+<workload-home>/workloads/azure.functions.cli.workloads.templates.powershell/<version>/
+  tools/any/content/
+    templates-workload.json      ← min-bundle sibling manifest
+    v2/                          ← v2 programming model
+      bindings/userPrompts.json
+      resources/Resources.json
+      resources/Resources.<locale>.json
+      templates/templates.json   ← NewTemplate[] (jobs/actions)
+  workload.json
+```
+
+Template files are carried **inline** inside each `NewTemplate`
+entry's `files: { <filename>: <contents> }` map; there are no separate
+per-template file directories on disk (Templates Workload Spec §5.2).
+v2 templates reference prompt ids defined in `v2/bindings/userPrompts.json`
+via `paramId` references inside `jobs[].inputs[]`. `tools/any/` is the
+canonical content-workload payload path.

--- a/src/Workloads/Templates/PowerShell/README.md
+++ b/src/Workloads/Templates/PowerShell/README.md
@@ -1,0 +1,53 @@
+# Azure Functions CLI: PowerShell templates workload
+
+This package ships function-scaffold templates for PowerShell Azure
+Functions projects, consumed by the `func` CLI's `func new` command. It
+is a content workload: the package carries template files only, with no
+entry-point assembly and no runtime services. `func new` resolves the
+install directory by package id and reads the template payload directly.
+
+The channel a workload was built from is encoded in the pkg version's
+prerelease label, and that channel maps 1:1 to an extension-bundle id:
+
+| Channel       | Workload pkg version   | Bundle id                                                          |
+|---------------|------------------------|--------------------------------------------------------------------|
+| stable        | `1.0.0`                | `Microsoft.Azure.Functions.ExtensionBundle`                        |
+| preview       | `1.0.0-preview`        | `Microsoft.Azure.Functions.ExtensionBundle.Preview`                |
+| experimental  | `1.0.0-experimental`   | `Microsoft.Azure.Functions.ExtensionBundle.Experimental`           |
+
+The bundle id is both the upstream extension bundle the workload's
+templates were snapshotted from and the value `func new` expects in
+the project's `host.json` `extensionBundle.id` at scaffold time.
+Channel selection at `func new` is implicit, derived from the
+project's `host.json` bundle id.
+
+## Bundle compatibility
+
+This workload declares a minimum compatible extension-bundle version
+(`[4.0.0,)`). `func new` validates the project's resolved bundle
+version against this constraint and surfaces incompatibilities as a
+warning or error.
+
+## Install
+
+```bash
+func workload install Azure.Functions.Cli.Workloads.Templates.PowerShell@1.0.0
+# or by alias
+func workload install powershell-templates@1.0.0
+```
+
+Preview / experimental channels resolve via the matching prerelease
+label:
+
+```bash
+func workload install powershell-templates@1.0.0-preview
+func workload install powershell-templates@1.0.0-experimental
+```
+
+Multiple templates versions coexist via `--force`.
+
+## Links
+
+- [Azure Functions CLI](https://github.com/Azure/azure-functions-core-tools)
+- [Workload spec](https://github.com/Azure/azure-functions-core-tools/blob/docs/proposed/workload-spec.md)
+- [Templates workload spec](https://github.com/Azure/azure-functions-core-tools/blob/docs/proposed/templates-workload-spec.md)

--- a/src/Workloads/Templates/PowerShell/Workloads.Templates.PowerShell.csproj
+++ b/src/Workloads/Templates/PowerShell/Workloads.Templates.PowerShell.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Title>PowerShell Function Templates</Title>
+    <Description>PowerShell function templates for the func CLI. Compatible with Microsoft.Azure.Functions.ExtensionBundle (minBundle:$(MinBundleVersionRange)).</Description>
+    <PackageTags>minBundle:$(MinBundleVersionRange)</PackageTags>
+    <PackAsWorkload>true</PackAsWorkload>
+    <WorkloadKind>content</WorkloadKind>
+    <WorkloadAlias>powershell-templates</WorkloadAlias>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+
+    <TemplatesStackLanguageFilter>PowerShell</TemplatesStackLanguageFilter>
+  </PropertyGroup>
+
+  <Import Project="$(EngBuildRoot)Workloads/Workloads.Templates.targets" />
+
+</Project>

--- a/src/Workloads/Templates/PowerShell/release_notes.md
+++ b/src/Workloads/Templates/PowerShell/release_notes.md
@@ -1,0 +1,4 @@
+# Azure.Functions.Cli.Workloads.Templates.PowerShell
+
+## 1.0.1
+


### PR DESCRIPTION
## Summary

Scaffolds the PowerShell templates content workload that downloads PowerShell function templates from the extension-bundle CDN at pack time, filtered by the `PowerShell` language. The workload uses the same CDN-mode pipeline as the Python templates workload.

## Changes

- Add `src/Workloads/Templates/PowerShell/` with csproj, README, and release notes
- Add CI release pipeline (`official-release.workload.templates.powershell.yml`)
- Register project in `Azure.Functions.Cli.slnx`

## How it works

The workload shares `src/Workloads/Templates/Directory.Version.props` (v1.0.1) and imports `Workloads.Templates.targets` which handles CDN download, language filtering (`TemplatesStackLanguageFilter=PowerShell`), and pack layout. At pack time, it snapshots v2 templates from the extension bundle's `StaticContent/v2/` subtree, keeping only entries with `language: PowerShell` (HTTP, timer, queue, blob triggers).

Install alias: `func workload install powershell-templates`

## Validation

- ✅ Full solution build: 0 warnings, 0 errors
- ✅ All 1,541 tests pass

Closes #5323