### PR TITLE
Wire `func start`/`func run` for PowerShell Stack

### DIFF
--- a/src/Workloads/Stacks/PowerShell/PowerShellFunctionsProject.cs
+++ b/src/Workloads/Stacks/PowerShell/PowerShellFunctionsProject.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Workers;
+
+namespace Azure.Functions.Cli.Workloads.PowerShell;
+
+/// <summary>
+/// PowerShell Functions project. PowerShell is an interpreted language with no
+/// compile step, so <see cref="PrepareForHostRunAsync"/> is a no-op. The host
+/// worker handles module resolution at runtime via <c>requirements.psd1</c> and
+/// the <c>Modules</c> folder.
+/// </summary>
+internal sealed class PowerShellFunctionsProject : FunctionsProject
+{
+    private readonly WorkingDirectory _workingDirectory;
+    private readonly FunctionsWorkerReference _workerReference;
+
+    public PowerShellFunctionsProject(WorkingDirectory workingDirectory)
+    {
+        _workingDirectory = workingDirectory ?? throw new ArgumentNullException(nameof(workingDirectory));
+        _workerReference = FunctionsWorkerReference.FromWorkload("powershell");
+    }
+
+    public override WorkingDirectory WorkingDirectory => _workingDirectory;
+
+    public override string StackName => "powershell";
+
+    public override string StackDisplayName => "PowerShell";
+
+    public override bool SupportsExtensionBundles => true;
+
+    public override FunctionsWorkerReference WorkerReference => _workerReference;
+}

--- a/src/Workloads/Stacks/PowerShell/PowerShellFunctionsProject.cs
+++ b/src/Workloads/Stacks/PowerShell/PowerShellFunctionsProject.cs
@@ -15,18 +15,20 @@ namespace Azure.Functions.Cli.Workloads.PowerShell;
 /// </summary>
 internal sealed class PowerShellFunctionsProject : FunctionsProject
 {
+    internal const string WorkloadId = "powershell";
+
     private readonly WorkingDirectory _workingDirectory;
     private readonly FunctionsWorkerReference _workerReference;
 
     public PowerShellFunctionsProject(WorkingDirectory workingDirectory)
     {
         _workingDirectory = workingDirectory ?? throw new ArgumentNullException(nameof(workingDirectory));
-        _workerReference = FunctionsWorkerReference.FromWorkload("powershell");
+        _workerReference = FunctionsWorkerReference.FromWorkload(WorkloadId);
     }
 
     public override WorkingDirectory WorkingDirectory => _workingDirectory;
 
-    public override string StackName => "powershell";
+    public override string StackName => WorkloadId;
 
     public override string StackDisplayName => "PowerShell";
 

--- a/src/Workloads/Stacks/PowerShell/PowerShellProjectFactory.cs
+++ b/src/Workloads/Stacks/PowerShell/PowerShellProjectFactory.cs
@@ -1,0 +1,69 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Workers;
+using static Azure.Functions.Cli.Projects.ProjectCreationResults;
+
+namespace Azure.Functions.Cli.Workloads.PowerShell;
+
+/// <summary>
+/// Creates PowerShell Functions projects from PowerShell-specific fingerprints.
+/// </summary>
+internal sealed class PowerShellProjectFactory : IFunctionsProjectFactory
+{
+    private static readonly FunctionsWorkerId _workerId = new("powershell");
+
+    public Task<ProjectCreationResult> TryCreateProjectAsync(ProjectCreationContext context, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        DirectoryInfo workingDirectory = context.WorkingDirectory.Info;
+        if (!workingDirectory.Exists)
+        {
+            return Task.FromResult(NotCreated("directory does not exist"));
+        }
+
+        string? reason = TryGetReason(workingDirectory);
+        if (reason is null)
+        {
+            return Task.FromResult(NotCreated("no PowerShell project fingerprint found"));
+        }
+
+        FunctionsProject project = new PowerShellFunctionsProject(context.WorkingDirectory);
+        return Task.FromResult(Created(project, reason));
+    }
+
+    private static string? TryGetReason(DirectoryInfo workingDirectory)
+    {
+        string root = workingDirectory.FullName;
+
+        // profile.ps1 is the strongest signal for a PowerShell Functions project.
+        if (File.Exists(Path.Combine(root, "profile.ps1")))
+        {
+            return "found profile.ps1";
+        }
+
+        // requirements.psd1 declares managed dependencies for PowerShell Functions.
+        if (File.Exists(Path.Combine(root, "requirements.psd1")))
+        {
+            return "found requirements.psd1";
+        }
+
+        // Fallback: any *.ps1 at the project root.
+        if (Directory.EnumerateFiles(root, "*.ps1", SearchOption.TopDirectoryOnly).Any())
+        {
+            return "found *.ps1 file";
+        }
+
+        // A Modules folder is a common PowerShell Functions convention.
+        if (Directory.Exists(Path.Combine(root, "Modules")))
+        {
+            return "found Modules folder";
+        }
+
+        return null;
+    }
+}

--- a/src/Workloads/Stacks/PowerShell/PowerShellProjectFactory.cs
+++ b/src/Workloads/Stacks/PowerShell/PowerShellProjectFactory.cs
@@ -3,7 +3,6 @@
 
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Projects;
-using Azure.Functions.Cli.Workers;
 using static Azure.Functions.Cli.Projects.ProjectCreationResults;
 
 namespace Azure.Functions.Cli.Workloads.PowerShell;
@@ -13,8 +12,6 @@ namespace Azure.Functions.Cli.Workloads.PowerShell;
 /// </summary>
 internal sealed class PowerShellProjectFactory : IFunctionsProjectFactory
 {
-    private static readonly FunctionsWorkerId _workerId = new("powershell");
-
     public Task<ProjectCreationResult> TryCreateProjectAsync(ProjectCreationContext context, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(context);

--- a/src/Workloads/Stacks/PowerShell/PowerShellProjectFactory.cs
+++ b/src/Workloads/Stacks/PowerShell/PowerShellProjectFactory.cs
@@ -49,8 +49,10 @@ internal sealed class PowerShellProjectFactory : IFunctionsProjectFactory
             return "found requirements.psd1";
         }
 
-        // Fallback: any *.ps1 at the project root.
-        if (Directory.EnumerateFiles(root, "*.ps1", SearchOption.TopDirectoryOnly).Any())
+        // Fallback: any *.ps1 at the project root. Filter by exact extension
+        // because on Windows the 3-char pattern also matches .ps1xml files.
+        if (Directory.EnumerateFiles(root, "*.ps1", SearchOption.TopDirectoryOnly)
+                .Any(f => Path.GetExtension(f).Equals(".ps1", StringComparison.OrdinalIgnoreCase)))
         {
             return "found *.ps1 file";
         }

--- a/src/Workloads/Stacks/PowerShell/PowerShellWorkload.cs
+++ b/src/Workloads/Stacks/PowerShell/PowerShellWorkload.cs
@@ -11,7 +11,7 @@ namespace Azure.Functions.Cli.Workloads.PowerShell;
 
 /// <summary>
 /// Entry-point for the PowerShell workload. Registers PowerShell-specific
-/// services (project initializer today; project factory / commands later).
+/// services (project initializer, project factory).
 /// </summary>
 public sealed class PowerShellWorkload : Workload
 {
@@ -23,5 +23,6 @@ public sealed class PowerShellWorkload : Workload
     {
         ArgumentNullException.ThrowIfNull(builder);
         builder.Services.AddSingleton<IProjectInitializer, PowerShellProjectInitializer>();
+        builder.AddProjectFactory(new PowerShellProjectFactory());
     }
 }

--- a/test/Workloads/Stacks/PowerShell.Tests/PowerShellFunctionsProjectTests.cs
+++ b/test/Workloads/Stacks/PowerShell.Tests/PowerShellFunctionsProjectTests.cs
@@ -1,0 +1,116 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Workers;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Functions.Cli.Workloads.PowerShell.Tests;
+
+public class PowerShellFunctionsProjectTests : IDisposable
+{
+    private readonly DirectoryInfo _projectDir;
+    private readonly IFunctionsWorkerResolver _workerResolver = Substitute.For<IFunctionsWorkerResolver>();
+
+    public PowerShellFunctionsProjectTests()
+    {
+        _projectDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "func-ps-project-" + Guid.NewGuid().ToString("N")));
+        _workerResolver.ResolveWorkerAsync(Arg.Any<FunctionsWorkerId>(), Arg.Any<CancellationToken>())
+            .Returns(FunctionsWorkerResolutionResults.Resolved(CreateWorker("powershell", "powershell")));
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (_projectDir.Exists)
+            {
+                _projectDir.Delete(recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    [Fact]
+    public void StackName_is_powershell()
+    {
+        PowerShellFunctionsProject project = CreateProject();
+
+        Assert.Equal("powershell", project.StackName);
+    }
+
+    [Fact]
+    public void StackDisplayName_is_PowerShell()
+    {
+        PowerShellFunctionsProject project = CreateProject();
+
+        Assert.Equal("PowerShell", project.StackDisplayName);
+    }
+
+    [Fact]
+    public void SupportsExtensionBundles_is_true()
+    {
+        PowerShellFunctionsProject project = CreateProject();
+
+        Assert.True(project.SupportsExtensionBundles);
+    }
+
+    [Fact]
+    public async Task WorkerReference_resolves_powershell_worker()
+    {
+        PowerShellFunctionsProject project = CreateProject();
+
+        FunctionsWorkerResolutionResult result = await project.WorkerReference.ResolveWorkerAsync(
+            new FunctionsWorkerResolutionContext(_workerResolver),
+            default);
+
+        FunctionsWorkerResolutionResult.Resolved resolved = Assert.IsType<FunctionsWorkerResolutionResult.Resolved>(result);
+        Assert.Equal("powershell", resolved.Worker.WorkerRuntime);
+    }
+
+    [Fact]
+    public async Task PrepareForHostRunAsync_is_noop()
+    {
+        PowerShellFunctionsProject project = CreateProject();
+        FunctionsProjectHostRunContext context = new(
+            _projectDir,
+            "powershell",
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+
+        // Should complete without side-effects.
+        await project.PrepareForHostRunAsync(context, default);
+
+        Assert.Equal(_projectDir.FullName, context.StartupDirectory.FullName);
+    }
+
+    [Fact]
+    public async Task PrepareForHostRunAsync_NullContext_throws()
+    {
+        PowerShellFunctionsProject project = CreateProject();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => project.PrepareForHostRunAsync(null!, default));
+    }
+
+    [Fact]
+    public void Constructor_NullWorkingDirectory_throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new PowerShellFunctionsProject(null!));
+    }
+
+    private PowerShellFunctionsProject CreateProject()
+        => new(WorkingDirectory.FromExplicit(_projectDir.FullName));
+
+    private static IFunctionsWorker CreateWorker(string workerId, string workerRuntime)
+        => new TestFunctionsWorker(new FunctionsWorkerId(workerId), workerRuntime, "worker.config.json", "1.0.0");
+
+    private sealed record TestFunctionsWorker(
+        FunctionsWorkerId Id,
+        string WorkerRuntime,
+        string WorkerConfigPath,
+        string Version) : IFunctionsWorker;
+}

--- a/test/Workloads/Stacks/PowerShell.Tests/PowerShellProjectFactoryTests.cs
+++ b/test/Workloads/Stacks/PowerShell.Tests/PowerShellProjectFactoryTests.cs
@@ -1,0 +1,173 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Workers;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Functions.Cli.Workloads.PowerShell.Tests;
+
+public class PowerShellProjectFactoryTests : IDisposable
+{
+    private readonly DirectoryInfo _projectDir;
+    private readonly IFunctionsWorkerResolver _workerResolver = Substitute.For<IFunctionsWorkerResolver>();
+
+    public PowerShellProjectFactoryTests()
+    {
+        _projectDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "func-ps-resolver-" + Guid.NewGuid().ToString("N")));
+        _workerResolver.ResolveWorkerAsync(Arg.Any<FunctionsWorkerId>(), Arg.Any<CancellationToken>())
+            .Returns(FunctionsWorkerResolutionResults.Resolved(CreateWorker("powershell", "powershell")));
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (_projectDir.Exists)
+            {
+                _projectDir.Delete(recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    [Fact]
+    public async Task Empty_directory_does_not_match()
+    {
+        ProjectCreationResult result = await new PowerShellProjectFactory().TryCreateProjectAsync(CreateContext(), default);
+
+        ProjectCreationResult.NotCreated notCreated = Assert.IsType<ProjectCreationResult.NotCreated>(result);
+        Assert.Equal("no PowerShell project fingerprint found", notCreated.Reason);
+    }
+
+    [Theory]
+    [InlineData("profile.ps1", "# profile")]
+    [InlineData("requirements.psd1", "@{}")]
+    [InlineData("run.ps1", "param($Request)")]
+    public async Task Fingerprint_creates_project(string fileName, string contents)
+    {
+        WriteFile(fileName, contents);
+
+        ProjectCreationResult result = await new PowerShellProjectFactory().TryCreateProjectAsync(CreateContext(), default);
+
+        Assert.IsType<ProjectCreationResult.Created>(result);
+    }
+
+    [Fact]
+    public async Task Modules_folder_creates_project()
+    {
+        Directory.CreateDirectory(Path.Combine(_projectDir.FullName, "Modules"));
+
+        ProjectCreationResult result = await new PowerShellProjectFactory().TryCreateProjectAsync(CreateContext(), default);
+
+        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
+        Assert.Equal("found Modules folder", created.Reason);
+    }
+
+    [Fact]
+    public async Task Profile_takes_precedence_over_other_signals()
+    {
+        WriteFile("profile.ps1", "# profile");
+        WriteFile("requirements.psd1", "@{}");
+        WriteFile("run.ps1", "param($Request)");
+
+        ProjectCreationResult result = await new PowerShellProjectFactory().TryCreateProjectAsync(CreateContext(), default);
+
+        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
+        Assert.Equal("found profile.ps1", created.Reason);
+    }
+
+    [Fact]
+    public async Task Foreign_python_directory_does_not_match()
+    {
+        WriteFile("requirements.txt", string.Empty);
+        WriteFile("function_app.py", "import azure.functions");
+
+        ProjectCreationResult result = await new PowerShellProjectFactory().TryCreateProjectAsync(CreateContext(), default);
+
+        Assert.IsType<ProjectCreationResult.NotCreated>(result);
+    }
+
+    [Fact]
+    public async Task Foreign_node_directory_does_not_match()
+    {
+        WriteFile("package.json", "{}");
+        WriteFile("index.js", "module.exports = async function() {}");
+
+        ProjectCreationResult result = await new PowerShellProjectFactory().TryCreateProjectAsync(CreateContext(), default);
+
+        Assert.IsType<ProjectCreationResult.NotCreated>(result);
+    }
+
+    [Theory]
+    [InlineData("profile.ps1", "# profile", "found profile.ps1")]
+    [InlineData("requirements.psd1", "@{}", "found requirements.psd1")]
+    public async Task Match_for_each_fingerprint_sets_correct_stack(string fileName, string contents, string expectedReason)
+    {
+        WriteFile(fileName, contents);
+
+        ProjectCreationResult result = await new PowerShellProjectFactory().TryCreateProjectAsync(CreateContext(), default);
+
+        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
+        Assert.Equal("powershell", created.Project.StackName);
+        Assert.Equal("PowerShell", created.Project.StackDisplayName);
+        Assert.Equal(expectedReason, created.Reason);
+        IFunctionsWorker worker = await ResolveWorkerAsync(created.Project);
+        Assert.Equal("powershell", worker.WorkerRuntime);
+    }
+
+    [Fact]
+    public async Task MatchingDirectory_WhenWorkerNotResolved_WorkerReferenceReportsFailure()
+    {
+        WriteFile("profile.ps1", "# profile");
+        FunctionsWorkerResolutionFailure failure = FunctionsWorkerResolutionFailures.NotInstalled(
+            new FunctionsWorkerId("powershell"),
+            "missing powershell worker");
+        _workerResolver.ResolveWorkerAsync(Arg.Any<FunctionsWorkerId>(), Arg.Any<CancellationToken>())
+            .Returns(FunctionsWorkerResolutionResults.NotResolved(failure));
+
+        ProjectCreationResult result = await new PowerShellProjectFactory().TryCreateProjectAsync(CreateContext(), default);
+
+        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
+        FunctionsWorkerResolutionResult workerResult = await created.Project.WorkerReference.ResolveWorkerAsync(
+            new FunctionsWorkerResolutionContext(_workerResolver),
+            default);
+        FunctionsWorkerResolutionResult.NotResolved notResolved = Assert.IsType<FunctionsWorkerResolutionResult.NotResolved>(workerResult);
+        Assert.Same(failure, notResolved.Failure);
+    }
+
+    [Fact]
+    public async Task NullContext_throws()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => new PowerShellProjectFactory().TryCreateProjectAsync(null!, default));
+    }
+
+    private void WriteFile(string name, string contents)
+        => File.WriteAllText(Path.Combine(_projectDir.FullName, name), contents);
+
+    private ProjectCreationContext CreateContext()
+        => new(WorkingDirectory.FromExplicit(_projectDir.FullName));
+
+    private async Task<IFunctionsWorker> ResolveWorkerAsync(FunctionsProject project)
+    {
+        FunctionsWorkerResolutionResult result = await project.WorkerReference.ResolveWorkerAsync(
+            new FunctionsWorkerResolutionContext(_workerResolver),
+            default);
+        FunctionsWorkerResolutionResult.Resolved resolved = Assert.IsType<FunctionsWorkerResolutionResult.Resolved>(result);
+        return resolved.Worker;
+    }
+
+    private static IFunctionsWorker CreateWorker(string workerId, string workerRuntime)
+        => new TestFunctionsWorker(new FunctionsWorkerId(workerId), workerRuntime, "worker.config.json", "1.0.0");
+
+    private sealed record TestFunctionsWorker(
+        FunctionsWorkerId Id,
+        string WorkerRuntime,
+        string WorkerConfigPath,
+        string Version) : IFunctionsWorker;
+}

--- a/test/Workloads/Stacks/PowerShell.Tests/PowerShellProjectFactoryTests.cs
+++ b/test/Workloads/Stacks/PowerShell.Tests/PowerShellProjectFactoryTests.cs
@@ -103,6 +103,16 @@ public class PowerShellProjectFactoryTests : IDisposable
         Assert.IsType<ProjectCreationResult.NotCreated>(result);
     }
 
+    [Fact]
+    public async Task Ps1xml_file_alone_does_not_match()
+    {
+        WriteFile("MyModule.Format.ps1xml", "<Configuration />");
+
+        ProjectCreationResult result = await new PowerShellProjectFactory().TryCreateProjectAsync(CreateContext(), default);
+
+        Assert.IsType<ProjectCreationResult.NotCreated>(result);
+    }
+
     [Theory]
     [InlineData("profile.ps1", "# profile", "found profile.ps1")]
     [InlineData("requirements.psd1", "@{}", "found requirements.psd1")]

--- a/test/Workloads/Stacks/PowerShell.Tests/PowerShellWorkloadTests.cs
+++ b/test/Workloads/Stacks/PowerShell.Tests/PowerShellWorkloadTests.cs
@@ -28,6 +28,18 @@ public class PowerShellWorkloadTests
     }
 
     [Fact]
+    public void Configure_AddsProjectFactory()
+    {
+        ServiceCollection services = new();
+        FunctionsCliBuilder builder = Substitute.For<FunctionsCliBuilder>();
+        builder.Services.Returns(services);
+
+        new PowerShellWorkload().Configure(builder);
+
+        builder.Received(1).AddProjectFactory(Arg.Any<PowerShellProjectFactory>());
+    }
+
+    [Fact]
     public void Configure_NullBuilder_Throws()
     {
         Assert.Throws<ArgumentNullException>(() => new PowerShellWorkload().Configure(null!));


### PR DESCRIPTION
### Issue describing the changes in this PR

resolves #5480

**Wire PowerShell workload with `func run`/`func start`**

Adds project factory and project class so the PowerShell workload participates in project resolution during `func start`/`func run`.

### Changes

- **`PowerShellProjectFactory`** — fingerprints PowerShell projects (`profile.ps1`, `requirements.psd1`, `*.ps1`, `Modules/` folder)
- **`PowerShellFunctionsProject`** — `FunctionsProject` implementation (interpreted, no build step needed)
- **`PowerShellWorkload.Configure`** — registers the factory via `AddProjectFactory`
- Tests for all new classes

### Notes

PowerShell is an interpreted language so `PrepareForHostRunAsync` is a no-op — the host worker handles module resolution at runtime via `requirements.psd1` and the `Modules` folder.

### Testing
Local E2E testing was performed. Full end-to-end verified:

✅ resolve_project complete: PowerShell — factory fingerprints profile.ps1
✅ resolve_worker complete: powershell 4.0.4778 — worker resolved from installed workload
✅ resolve_bundle complete: Bundle ... 4.35.0 — extension bundles loaded
✅ HttpTrigger loaded at http://localhost:7071/api/HttpTrigger
✅ curl returned Hello from PowerShell Functions!
The PowerShell workload is fully wired with func start.