### PR TITLE
fix: correct func startup binding

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -19,3 +19,5 @@
 - Bumped https-proxy-agent dependency (#5335)
 - Updated target framework to .NET 10 (#4850)
 - Fix Flex Health Check to use `defaultHostName` instead of `enabledHostNames` (#5462)
+- Changed `func start` to bind to the IPv4 loopback address (`127.0.0.1`) by default instead of `0.0.0.0`, and added an opt-in `--address` flag (and `Host.LocalHttpAddress` setting in `local.settings.json`) to override the bind address (#5484)
+  - **Potential breaking change:** the host now binds to `127.0.0.1` by default, so it is only reachable from the local machine. Setups that relied on binding to `0.0.0.0` — for example reaching the host from outside a Docker container via a published port — will no longer connect. Workaround: start the host with `func start --address 0.0.0.0` (or set `"LocalHttpAddress": "0.0.0.0"` under `Host` in `local.settings.json`) to restore the previous behavior.

--- a/src/Cli/func/Actions/HostActions/StartHostAction.cs
+++ b/src/Cli/func/Actions/HostActions/StartHostAction.cs
@@ -217,7 +217,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 defaultBuilder
                 .UseKestrel(options =>
                 {
-                    options.Listen(IPAddress.Any, listenAddress.Port, listenOptins =>
+                    options.Listen(IPAddress.Loopback, listenAddress.Port, listenOptins =>
                     {
                         listenOptins.UseHttps(certificate);
                     });
@@ -921,7 +921,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
             X509Certificate2 cert = UseHttps
                 ? await SecurityHelpers.GetOrCreateCertificate(CertPath, CertPassword)
                 : null;
-            return (new Uri($"{protocol}://0.0.0.0:{Port}"), new Uri($"{protocol}://localhost:{Port}"), cert);
+            return (new Uri($"{protocol}://127.0.0.1:{Port}"), new Uri($"{protocol}://localhost:{Port}"), cert);
         }
 
         private void EnsureWorkerRuntimeIsSet()

--- a/src/Cli/func/Actions/HostActions/StartHostAction.cs
+++ b/src/Cli/func/Actions/HostActions/StartHostAction.cs
@@ -39,6 +39,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
     {
         private const int DefaultPort = 7071;
         private const int DefaultTimeout = 20;
+        private const string DefaultAddress = "127.0.0.1";
         private readonly ISecretsManager _secretsManager;
         private readonly IProcessManager _processManager;
         private readonly KeyVaultReferencesManager _keyVaultReferencesManager;
@@ -52,6 +53,8 @@ namespace Azure.Functions.Cli.Actions.HostActions
         }
 
         public int Port { get; set; }
+
+        public string Address { get; set; }
 
         public string CorsOrigins { get; set; }
 
@@ -95,6 +98,12 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 .WithDescription($"Local port to listen on. Default: {DefaultPort}")
                 .SetDefault(hostSettings.LocalHttpPort == default(int) ? DefaultPort : hostSettings.LocalHttpPort)
                 .Callback(p => Port = p);
+
+            Parser
+                .Setup<string>("address")
+                .WithDescription($"Local IP address to bind to. Default: {DefaultAddress}")
+                .SetDefault(string.IsNullOrWhiteSpace(hostSettings.LocalHttpAddress) ? DefaultAddress : hostSettings.LocalHttpAddress)
+                .Callback(a => Address = a);
 
             Parser
                 .Setup<string>("cors")
@@ -217,7 +226,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 defaultBuilder
                 .UseKestrel(options =>
                 {
-                    options.Listen(IPAddress.Loopback, listenAddress.Port, listenOptins =>
+                    options.Listen(ResolveBindAddress(), listenAddress.Port, listenOptins =>
                     {
                         listenOptins.UseHttps(certificate);
                     });
@@ -918,10 +927,21 @@ namespace Azure.Functions.Cli.Actions.HostActions
         private async Task<(Uri ListenUri, Uri BaseUri, X509Certificate2 Cert)> Setup()
         {
             var protocol = UseHttps ? "https" : "http";
+            var bindEndpoint = new IPEndPoint(ResolveBindAddress(), Port);
             X509Certificate2 cert = UseHttps
                 ? await SecurityHelpers.GetOrCreateCertificate(CertPath, CertPassword)
                 : null;
-            return (new Uri($"{protocol}://127.0.0.1:{Port}"), new Uri($"{protocol}://localhost:{Port}"), cert);
+            return (new Uri($"{protocol}://{bindEndpoint}"), new Uri($"{protocol}://localhost:{Port}"), cert);
+        }
+
+        internal IPAddress ResolveBindAddress()
+        {
+            if (!IPAddress.TryParse(Address, out IPAddress address))
+            {
+                throw new CliException($"Invalid --address value '{Address}'. Expected an IP address, for example 127.0.0.1 or 0.0.0.0.");
+            }
+
+            return address;
         }
 
         private void EnsureWorkerRuntimeIsSet()

--- a/src/Cli/func/Common/HostStartSettings.cs
+++ b/src/Cli/func/Common/HostStartSettings.cs
@@ -10,6 +10,9 @@ namespace Azure.Functions.Cli.Common
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public int LocalHttpPort { get; set; }
 
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string LocalHttpAddress { get; set; }
+
         [JsonProperty("CORS", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string Cors { get; set; }
 

--- a/test/Cli/Func.UnitTests/ActionsTests/StartHostActionTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/StartHostActionTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.IO.Abstractions;
+using System.Net;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -590,6 +591,61 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests
             {
                 Environment.SetEnvironmentVariable(envVar, original);
             }
+        }
+
+        [Fact]
+        public void ParseArgs_NoAddressAndNoConfig_DefaultsToLoopback()
+        {
+            var secretsManager = new Mock<ISecretsManager>();
+            secretsManager.Setup(s => s.GetHostStartSettings()).Returns(new HostStartSettings());
+
+            var action = new StartHostAction(secretsManager.Object, Mock.Of<IProcessManager>());
+            action.ParseArgs(Array.Empty<string>());
+
+            action.Address.Should().Be("127.0.0.1");
+            action.ResolveBindAddress().Should().Be(IPAddress.Loopback);
+        }
+
+        [Fact]
+        public void ParseArgs_ExplicitAddress_OverridesDefault()
+        {
+            var secretsManager = new Mock<ISecretsManager>();
+            secretsManager.Setup(s => s.GetHostStartSettings()).Returns(new HostStartSettings());
+
+            var action = new StartHostAction(secretsManager.Object, Mock.Of<IProcessManager>());
+            action.ParseArgs(["--address", "0.0.0.0"]);
+
+            action.Address.Should().Be("0.0.0.0");
+            action.ResolveBindAddress().Should().Be(IPAddress.Any);
+        }
+
+        [Fact]
+        public void ParseArgs_ConfigAddress_UsedWhenNoFlag()
+        {
+            var secretsManager = new Mock<ISecretsManager>();
+            secretsManager.Setup(s => s.GetHostStartSettings())
+                .Returns(new HostStartSettings { LocalHttpAddress = "0.0.0.0" });
+
+            var action = new StartHostAction(secretsManager.Object, Mock.Of<IProcessManager>());
+            action.ParseArgs(Array.Empty<string>());
+
+            action.Address.Should().Be("0.0.0.0");
+            action.ResolveBindAddress().Should().Be(IPAddress.Any);
+        }
+
+        [Fact]
+        public void ResolveBindAddress_InvalidAddress_ThrowsCliException()
+        {
+            var secretsManager = new Mock<ISecretsManager>();
+            secretsManager.Setup(s => s.GetHostStartSettings()).Returns(new HostStartSettings());
+
+            var action = new StartHostAction(secretsManager.Object, Mock.Of<IProcessManager>())
+            {
+                Address = "not-an-ip"
+            };
+
+            Action act = () => action.ResolveBindAddress();
+            act.Should().Throw<CliException>().WithMessage("*not-an-ip*");
         }
     }
 }


### PR DESCRIPTION
## Summary

Updates `func start` local host binding and makes the bind address configurable.

Changes in `src/Cli/func/Actions/HostActions/StartHostAction.cs` (and `src/Cli/func/Common/HostStartSettings.cs`):
- **Default binding**: both the HTTP path (`Setup()`) and the HTTPS path (Kestrel `Listen`) bind to the IPv4 loopback address (`127.0.0.1` / `IPAddress.Loopback`).
- **New opt-in `--address` flag**: lets you specify the local IP address to bind to. When unset it defaults to `127.0.0.1`.
- **New `local.settings.json` setting**: `Host.LocalHttpAddress` provides the same override via config.
- **Precedence**: `--address` flag → `Host.LocalHttpAddress` → `127.0.0.1`.

The address is resolved once via a shared `ResolveBindAddress()` helper that validates the value and throws a clear `CliException` on invalid input. It feeds both binding paths (the listen URI is built through an `IPEndPoint` so IPv6 values are bracketed correctly). `BaseUri` and displayed function URLs remain `localhost`, so normal local development output is unchanged.

## Notes

- Default behavior is localhost-only; broadening the bind address is strictly opt-in.
- No change to IPv6 defaults.
- Existing localhost-based workflows and tests (which connect via `http://localhost:{port}`) are unaffected.
- `NetworkHelpers` and unrelated build assets are untouched.

## Validation

- `dotnet build` of `src/Cli/func` succeeds with 0 warnings / 0 errors.
- 4 new unit tests in `StartHostActionTests.cs` cover the default, the `--address` override, the config-supplied value, and invalid-input handling — all pass.