### PR TITLE
fix(in-proc): correct func startup binding

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -207,7 +207,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 defaultBuilder
                 .UseKestrel(options =>
                 {
-                    options.Listen(IPAddress.Any, listenAddress.Port, listenOptins =>
+                    options.Listen(IPAddress.Loopback, listenAddress.Port, listenOptins =>
                     {
                         listenOptins.UseHttps(certificate);
                     });
@@ -600,7 +600,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
             X509Certificate2 cert = UseHttps
                 ? await SecurityHelpers.GetOrCreateCertificate(CertPath, CertPassword)
                 : null;
-            return (new Uri($"{protocol}://0.0.0.0:{Port}"), new Uri($"{protocol}://localhost:{Port}"), cert);
+            return (new Uri($"{protocol}://127.0.0.1:{Port}"), new Uri($"{protocol}://localhost:{Port}"), cert);
         }
 
         private void EnsureWorkerRuntimeIsSet()

--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -40,6 +40,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
     {
         private const int DefaultPort = 7071;
         private const int DefaultTimeout = 20;
+        private const string DefaultAddress = "127.0.0.1";
         private const string Net6FrameworkDescriptionPrefix = ".NET 6.0";
         private const string WindowsExecutableName = "func.exe";
         private const string LinuxExecutableName = "func";
@@ -50,6 +51,8 @@ namespace Azure.Functions.Cli.Actions.HostActions
         private readonly KeyVaultReferencesManager _keyVaultReferencesManager;
 
         public int Port { get; set; }
+
+        public string Address { get; set; }
 
         public string CorsOrigins { get; set; }
 
@@ -96,6 +99,12 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 .WithDescription($"Local port to listen on. Default: {DefaultPort}")
                 .SetDefault(hostSettings.LocalHttpPort == default(int) ? DefaultPort : hostSettings.LocalHttpPort)
                 .Callback(p => Port = p);
+
+            Parser
+                .Setup<string>("address")
+                .WithDescription($"Local IP address to bind to. Default: {DefaultAddress}")
+                .SetDefault(string.IsNullOrWhiteSpace(hostSettings.LocalHttpAddress) ? DefaultAddress : hostSettings.LocalHttpAddress)
+                .Callback(a => Address = a);
 
             Parser
                 .Setup<string>("cors")
@@ -207,7 +216,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 defaultBuilder
                 .UseKestrel(options =>
                 {
-                    options.Listen(IPAddress.Loopback, listenAddress.Port, listenOptins =>
+                    options.Listen(ResolveBindAddress(), listenAddress.Port, listenOptins =>
                     {
                         listenOptins.UseHttps(certificate);
                     });
@@ -597,10 +606,21 @@ namespace Azure.Functions.Cli.Actions.HostActions
         private async Task<(Uri listenUri, Uri baseUri, X509Certificate2 cert)> Setup()
         {
             var protocol = UseHttps ? "https" : "http";
+            var bindEndpoint = new IPEndPoint(ResolveBindAddress(), Port);
             X509Certificate2 cert = UseHttps
                 ? await SecurityHelpers.GetOrCreateCertificate(CertPath, CertPassword)
                 : null;
-            return (new Uri($"{protocol}://127.0.0.1:{Port}"), new Uri($"{protocol}://localhost:{Port}"), cert);
+            return (new Uri($"{protocol}://{bindEndpoint}"), new Uri($"{protocol}://localhost:{Port}"), cert);
+        }
+
+        internal IPAddress ResolveBindAddress()
+        {
+            if (!IPAddress.TryParse(Address, out var address))
+            {
+                throw new CliException($"Invalid --address value '{Address}'. Expected an IP address, for example 127.0.0.1 or 0.0.0.0.");
+            }
+
+            return address;
         }
 
         private void EnsureWorkerRuntimeIsSet()

--- a/src/Azure.Functions.Cli/Common/HostStartSettings.cs
+++ b/src/Azure.Functions.Cli/Common/HostStartSettings.cs
@@ -7,6 +7,9 @@ namespace Azure.Functions.Cli.Common
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public int LocalHttpPort { get; set; }
 
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string LocalHttpAddress { get; set; }
+
         [JsonProperty("CORS", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string Cors { get; set; }
 

--- a/test/Azure.Functions.Cli.Tests/ActionsTests/StartHostActionTests.cs
+++ b/test/Azure.Functions.Cli.Tests/ActionsTests/StartHostActionTests.cs
@@ -3,11 +3,13 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
+using System.Net;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Azure.Functions.Cli.Actions.HostActions;
 using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Interfaces;
 using Colors.Net;
 using FluentAssertions;
 using NSubstitute;
@@ -167,6 +169,57 @@ namespace Azure.Functions.Cli.Tests.ActionsTests
             await StartHostAction.CheckNonOptionalSettings(new Dictionary<string, string>(), "x:\\", false);
             output.ToString().Should().Contain("Warning: Cannot find value named 'blah'");
             output.ToString().Should().Contain("Warning: 'connection' property in 'x:\\folder2\\function.json' is empty.");
+        }
+
+        [Fact]
+        public void ParseArgs_NoAddressAndNoConfig_DefaultsToLoopback()
+        {
+            var action = CreateStartHostAction(new HostStartSettings());
+
+            action.ParseArgs(Array.Empty<string>());
+
+            action.Address.Should().Be("127.0.0.1");
+            action.ResolveBindAddress().Should().Be(IPAddress.Loopback);
+        }
+
+        [Fact]
+        public void ParseArgs_ExplicitAddress_OverridesDefault()
+        {
+            var action = CreateStartHostAction(new HostStartSettings());
+
+            action.ParseArgs(new[] { "--address", "0.0.0.0" });
+
+            action.Address.Should().Be("0.0.0.0");
+            action.ResolveBindAddress().Should().Be(IPAddress.Any);
+        }
+
+        [Fact]
+        public void ParseArgs_ConfigAddress_UsedWhenNoFlag()
+        {
+            var action = CreateStartHostAction(new HostStartSettings { LocalHttpAddress = "0.0.0.0" });
+
+            action.ParseArgs(Array.Empty<string>());
+
+            action.Address.Should().Be("0.0.0.0");
+        }
+
+        [Fact]
+        public void ResolveBindAddress_InvalidAddress_ThrowsCliException()
+        {
+            var action = CreateStartHostAction(new HostStartSettings());
+            action.Address = "not-an-ip";
+
+            Action resolve = () => action.ResolveBindAddress();
+
+            resolve.Should().Throw<CliException>();
+        }
+
+        private static StartHostAction CreateStartHostAction(HostStartSettings hostStartSettings)
+        {
+            var secretsManager = Substitute.For<ISecretsManager>();
+            secretsManager.GetHostStartSettings().Returns(hostStartSettings);
+            var processManager = Substitute.For<IProcessManager>();
+            return new StartHostAction(secretsManager, processManager);
         }
 
         private IFileSystem GetFakeFileSystem(IEnumerable<(string folder, string functionJsonContent)> list)


### PR DESCRIPTION
## Summary
Binds the local `func start` host to IPv4 loopback (`127.0.0.1`) by default instead of the IPv4 wildcard (`0.0.0.0`) on the **in-proc** branch, and makes the bind address configurable via a new opt-in `--address` flag.

Changes in `src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs`:

1. **HTTPS (Kestrel `Listen`)** — now binds to the resolved address (`ResolveBindAddress()`) instead of the hard-coded wildcard.
2. **HTTP (`Setup()` listen URI)** — the ListenUri is built from an `IPEndPoint` for the resolved address (handles IPv6 bracketing); `BaseUri` stays `localhost`, so displayed function URLs are unchanged.

### Opt-in `--address` flag
- New `--address` CLI flag and `local.settings.json` `Host.LocalHttpAddress` setting, both defaulting to `127.0.0.1`.
- `HostStartSettings.LocalHttpAddress` added; `StartHostAction` gains an `Address` property, a `DefaultAddress` const, and an `internal ResolveBindAddress()` helper that parses the address and throws `CliException` on an invalid value.
- Default behavior is unchanged: when no flag/setting is provided, the host binds to `127.0.0.1`.
- Adds 4 unit tests: default-to-loopback, explicit `--address` override, config-setting used when no flag, and invalid-address throws.

This mirrors #5484 on `main`, applied to the in-proc `src/Azure.Functions.Cli/` layout. Base branch is `in-proc`.

## IPv6
No IPv6 change by default. The host previously bound IPv4-only and continues to default to IPv4 loopback; the `IPEndPoint`-based ListenUri correctly brackets IPv6 addresses if one is supplied via `--address`.

## Cross-platform
`127.0.0.1` is IPv4 loopback on Windows/macOS/Linux with no per-OS difference. Clients connecting to `localhost` still reach the host.

## Validation
`dotnet build -c Debug` on `src/Azure.Functions.Cli` succeeds with 0 errors. The 4 new `StartHostActionTests` address tests pass. Remaining warnings are pre-existing baseline warnings unrelated to this change.