### PR TITLE
test: switch to AwesomeAssertions and idiomatic chaining

### DIFF
--- a/docs/adding-a-command.md
+++ b/docs/adding-a-command.md
@@ -152,7 +152,6 @@ Create a test file in `test/Func.Tests/Commands/`:
 // test/Func.Tests/Commands/DeployCommandTests.cs
 
 using Azure.Functions.Cli.Commands;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands;
 

--- a/eng/build/Packages.props
+++ b/eng/build/Packages.props
@@ -57,6 +57,7 @@
 
   <!-- test projects -->
   <ItemGroup>
+    <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/src/Abstractions/Commands/InitContext.cs
+++ b/src/Abstractions/Commands/InitContext.cs
@@ -3,7 +3,6 @@
 
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Projects;
-using Azure.Functions.Cli.Workloads;
 
 namespace Azure.Functions.Cli.Commands;
 

--- a/src/Abstractions/Projects/IProjectInitializer.cs
+++ b/src/Abstractions/Projects/IProjectInitializer.cs
@@ -4,7 +4,6 @@
 using System.CommandLine;
 using System.Text.RegularExpressions;
 using Azure.Functions.Cli.Commands;
-using Azure.Functions.Cli.Workloads;
 
 namespace Azure.Functions.Cli.Projects;
 

--- a/src/Func/Bundles/BundleHelpers.cs
+++ b/src/Func/Bundles/BundleHelpers.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Diagnostics.CodeAnalysis;
 using Azure.Functions.Cli.Projects;
 using NuGet.Versioning;
 

--- a/src/Func/Commands/Start/Azurite/AzuriteExecutableLocator.cs
+++ b/src/Func/Commands/Start/Azurite/AzuriteExecutableLocator.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Azure.Functions.Cli;
 using Azure.Functions.Cli.Commands.Start.Azurite.Processes;
 
 namespace Azure.Functions.Cli.Commands.Start.Azurite;

--- a/src/Func/Commands/Start/Azurite/Launching/DockerAzuriteCommandBuilder.cs
+++ b/src/Func/Commands/Start/Azurite/Launching/DockerAzuriteCommandBuilder.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Globalization;
-using System.IO;
 
 namespace Azure.Functions.Cli.Commands.Start.Azurite.Launching;
 

--- a/src/Func/Commands/Start/Dashboard/Rendering/CompactDashboardShortcutLabels.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/CompactDashboardShortcutLabels.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Azure.Functions.Cli;
-
 namespace Azure.Functions.Cli.Hosting.Dashboard.Rendering;
 
 /// <summary>

--- a/src/Func/Commands/Start/Dashboard/Rendering/CompactRenderer.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/CompactRenderer.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Globalization;
-using System.Runtime.CompilerServices;
-using Azure.Functions.Cli;
 using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Console.Theme;
 using Azure.Functions.Cli.Hosting.Events;

--- a/src/Func/Commands/Start/Dashboard/Rendering/Initialization/IStartInitializationRenderer.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/Initialization/IStartInitializationRenderer.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Azure.Functions.Cli.Commands.Start.Initialization;
-
 namespace Azure.Functions.Cli.Commands.Start.Initialization.Rendering;
 
 /// <summary>

--- a/src/Func/Commands/Start/Dashboard/Rendering/Initialization/JsonStartInitializationRenderer.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/Initialization/JsonStartInitializationRenderer.cs
@@ -4,7 +4,6 @@
 using System.Buffers;
 using System.Globalization;
 using System.Text.Json;
-using Azure.Functions.Cli.Commands.Start.Initialization;
 using Azure.Functions.Cli.Hosting.Events;
 using Azure.Functions.Cli.Projects;
 

--- a/src/Func/Commands/Start/Dashboard/Rendering/Initialization/PlainStartInitializationRenderer.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/Initialization/PlainStartInitializationRenderer.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Azure.Functions.Cli.Commands.Start.Initialization;
 using Azure.Functions.Cli.Console;
 
 namespace Azure.Functions.Cli.Commands.Start.Initialization.Rendering;

--- a/src/Func/Commands/Start/Dashboard/Rendering/Initialization/RecordingStartInitializationRenderer.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/Initialization/RecordingStartInitializationRenderer.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Azure.Functions.Cli.Commands.Start.Initialization;
-
 namespace Azure.Functions.Cli.Commands.Start.Initialization.Rendering;
 
 /// <summary>

--- a/src/Func/Commands/Start/Dashboard/Rendering/JsonRenderer.cs
+++ b/src/Func/Commands/Start/Dashboard/Rendering/JsonRenderer.cs
@@ -3,7 +3,6 @@
 
 using System.Buffers;
 using System.Globalization;
-using System.Text;
 using System.Text.Json;
 using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Hosting.Events;

--- a/src/Func/Commands/Start/Initialization/StartInitializationState.cs
+++ b/src/Func/Commands/Start/Initialization/StartInitializationState.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Commands.Start.Azurite.Orchestration;
-using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Hosting.Dashboard;
 using Azure.Functions.Cli.Hosting.Events;
 using Azure.Functions.Cli.Profiles;

--- a/src/Func/Commands/Workload/WorkloadPruneCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadPruneCommand.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.CommandLine;
-using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Workloads.Install;
 using Azure.Functions.Cli.Workloads.Storage;

--- a/src/Func/Hosting/BuiltInCommands.cs
+++ b/src/Func/Hosting/BuiltInCommands.cs
@@ -5,13 +5,10 @@ using Azure.Functions.Cli.Commands;
 using Azure.Functions.Cli.Commands.Profile;
 using Azure.Functions.Cli.Commands.Quickstart;
 using Azure.Functions.Cli.Commands.Setup;
-using Azure.Functions.Cli.Commands.Start.Initialization;
 using Azure.Functions.Cli.Commands.Update;
 using Azure.Functions.Cli.Commands.Workload;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Hosting.Dashboard.Rendering;
-using Azure.Functions.Cli.Projects;
-using Azure.Functions.Cli.Workers;
 using Azure.Functions.Cli.Workloads;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/src/Func/Hosting/CliHostFactory.cs
+++ b/src/Func/Hosting/CliHostFactory.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Azure.Functions.Cli;
 using Azure.Functions.Cli.Bundles;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Commands.Start.Azurite;

--- a/src/Func/Hosting/WorkloadStorageRegistration.cs
+++ b/src/Func/Hosting/WorkloadStorageRegistration.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Common;
-using Azure.Functions.Cli.Workloads;
 using Azure.Functions.Cli.Workloads.Discovery;
 using Azure.Functions.Cli.Workloads.Loading;
 using Azure.Functions.Cli.Workloads.Storage;

--- a/src/Func/NewCommandArgPreparer.cs
+++ b/src/Func/NewCommandArgPreparer.cs
@@ -3,9 +3,6 @@
 
 using System.CommandLine;
 using Azure.Functions.Cli.Commands;
-using Azure.Functions.Cli.Common;
-using Azure.Functions.Cli.Templates;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Azure.Functions.Cli;
 

--- a/src/Func/Quickstart/HttpTemplateFetcher.cs
+++ b/src/Func/Quickstart/HttpTemplateFetcher.cs
@@ -3,7 +3,6 @@
 
 using System.IO.Compression;
 using System.Net;
-using System.Net.Http;
 using Azure.Functions.Cli.Common;
 using Microsoft.Extensions.Logging;
 

--- a/src/Func/Templates/TemplateOptionHydrator.cs
+++ b/src/Func/Templates/TemplateOptionHydrator.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.CommandLine;
-using System.CommandLine.Parsing;
 using System.Text;
 using System.Text.RegularExpressions;
 using Azure.Functions.Cli.Projects;

--- a/src/Func/Workloads/Catalog/WorkloadCatalogOptions.cs
+++ b/src/Func/Workloads/Catalog/WorkloadCatalogOptions.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Azure.Functions.Cli.Common;
-
 namespace Azure.Functions.Cli.Workloads.Catalog;
 
 /// <summary>

--- a/src/Func/Workloads/Storage/WorkloadJsonContext.cs
+++ b/src/Func/Workloads/Storage/WorkloadJsonContext.cs
@@ -3,7 +3,6 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Azure.Functions.Cli.Workloads;
 
 namespace Azure.Functions.Cli.Workloads.Storage;
 

--- a/src/Workloads/Host/Logging/HostStructuredEventWriter.cs
+++ b/src/Workloads/Host/Logging/HostStructuredEventWriter.cs
@@ -3,7 +3,6 @@
 
 using System.Buffers;
 using System.Collections;
-using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using System.Text.Json;

--- a/src/Workloads/Host/Logging/HostStructuredLoggerProvider.cs
+++ b/src/Workloads/Host/Logging/HostStructuredLoggerProvider.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Collections;
 using System.Globalization;
 using Microsoft.Extensions.Logging;
 

--- a/src/Workloads/Host/Logging/RawHostLogCaptureProvider.cs
+++ b/src/Workloads/Host/Logging/RawHostLogCaptureProvider.cs
@@ -3,7 +3,6 @@
 
 using System.Buffers;
 using System.Collections;
-using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
 using Microsoft.Extensions.Configuration;

--- a/src/Workloads/Stacks/Go/GoProjectFactory.cs
+++ b/src/Workloads/Stacks/Go/GoProjectFactory.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Workers;
 using static Azure.Functions.Cli.Projects.ProjectCreationResults;

--- a/src/Workloads/Stacks/Node/NodeProjectFactory.cs
+++ b/src/Workloads/Stacks/Node/NodeProjectFactory.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Text.Json;
-using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Workers;
 using static Azure.Functions.Cli.Projects.ProjectCreationResults;

--- a/src/Workloads/Stacks/Python/PythonProjectFactory.cs
+++ b/src/Workloads/Stacks/Python/PythonProjectFactory.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Workers;
 using static Azure.Functions.Cli.Projects.ProjectCreationResults;

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -10,6 +10,7 @@
   <!-- Enforce common packages for all test projects -->
   <!-- Intentionally use != false condition, so an explicit false value will skip the packages -->
   <ItemGroup Condition="'$(IsTestProject)' != 'false'">
+    <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">
@@ -17,6 +18,9 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NSubstitute" />
+
+    <Using Include="AwesomeAssertions" />
+    <Using Include="Xunit" />
   </ItemGroup>
 
 </Project>

--- a/test/Fixtures/Workloads.Tests.Fixtures.Default/StubWorkload.cs
+++ b/test/Fixtures/Workloads.Tests.Fixtures.Default/StubWorkload.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Azure.Functions.Cli.Workloads;
-
 namespace Azure.Functions.Cli.Workloads.Tests.Fixtures.Default;
 
 public sealed class StubWorkload : Workloads.Workload

--- a/test/Fixtures/Workloads.Tests.Fixtures.Sdk/StubWorkload.cs
+++ b/test/Fixtures/Workloads.Tests.Fixtures.Sdk/StubWorkload.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Azure.Functions.Cli.Workloads;
-
 namespace Azure.Functions.Cli.Workloads.Tests.Fixtures.Sdk;
 
 /// <summary>

--- a/test/Fixtures/Workloads.Tests.Fixtures.WithCommand/StubWorkload.cs
+++ b/test/Fixtures/Workloads.Tests.Fixtures.WithCommand/StubWorkload.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Commands;
-using Azure.Functions.Cli.Workloads;
 
 namespace Azure.Functions.Cli.Workloads.Tests.Fixtures.WithCommand;
 

--- a/test/Func.Tests/Bundles/BundleHelpersTests.cs
+++ b/test/Func.Tests/Bundles/BundleHelpersTests.cs
@@ -3,7 +3,6 @@
 
 using Azure.Functions.Cli.Projects;
 using NuGet.Versioning;
-using Xunit;
 
 namespace Azure.Functions.Cli.Bundles.Tests;
 
@@ -16,7 +15,7 @@ public class BundleHelpersTests
     public void GetBundleChannel_StableVersion_ReturnsStable(string version)
     {
         var v = NuGetVersion.Parse(version);
-        Assert.Equal(BundleChannel.Stable, BundleHelpers.GetBundleChannel(v));
+        BundleHelpers.GetBundleChannel(v).Should().Be(BundleChannel.Stable);
     }
 
     [Theory]
@@ -27,7 +26,7 @@ public class BundleHelpersTests
     public void GetBundleChannel_PreviewLabel_ReturnsPreview(string version)
     {
         var v = NuGetVersion.Parse(version);
-        Assert.Equal(BundleChannel.Preview, BundleHelpers.GetBundleChannel(v));
+        BundleHelpers.GetBundleChannel(v).Should().Be(BundleChannel.Preview);
     }
 
     [Theory]
@@ -38,7 +37,7 @@ public class BundleHelpersTests
     public void GetBundleChannel_ExperimentalLabel_ReturnsExperimental(string version)
     {
         var v = NuGetVersion.Parse(version);
-        Assert.Equal(BundleChannel.Experimental, BundleHelpers.GetBundleChannel(v));
+        BundleHelpers.GetBundleChannel(v).Should().Be(BundleChannel.Experimental);
     }
 
     [Theory]
@@ -50,7 +49,7 @@ public class BundleHelpersTests
     public void GetBundleChannel_UnknownPrereleaseLabel_ReturnsStable(string version)
     {
         var v = NuGetVersion.Parse(version);
-        Assert.Equal(BundleChannel.Stable, BundleHelpers.GetBundleChannel(v));
+        BundleHelpers.GetBundleChannel(v).Should().Be(BundleChannel.Stable);
     }
 
     [Fact]
@@ -58,7 +57,7 @@ public class BundleHelpersTests
     {
         // Only the first release label is checked; "preview" is first here.
         var v = NuGetVersion.Parse("5.0.0-preview.experimental.1");
-        Assert.Equal(BundleChannel.Preview, BundleHelpers.GetBundleChannel(v));
+        BundleHelpers.GetBundleChannel(v).Should().Be(BundleChannel.Preview);
     }
 
     [Fact]
@@ -66,7 +65,7 @@ public class BundleHelpersTests
     {
         // Only the first release label is checked; "experimental" is first here.
         var v = NuGetVersion.Parse("5.0.0-experimental.preview.1");
-        Assert.Equal(BundleChannel.Experimental, BundleHelpers.GetBundleChannel(v));
+        BundleHelpers.GetBundleChannel(v).Should().Be(BundleChannel.Experimental);
     }
 
     // --- GetBundleChannel(string bundleId) ---
@@ -74,19 +73,22 @@ public class BundleHelpersTests
     [Fact]
     public void GetBundleChannelByBundleId_StableId_ReturnsStable()
     {
-        Assert.Equal(BundleChannel.Stable, BundleHelpers.GetBundleChannel(BundleHelpers.StableBundleId));
+        BundleHelpers.GetBundleChannel(BundleHelpers.StableBundleId)
+            .Should().Be(BundleChannel.Stable);
     }
 
     [Fact]
     public void GetBundleChannelByBundleId_PreviewId_ReturnsPreview()
     {
-        Assert.Equal(BundleChannel.Preview, BundleHelpers.GetBundleChannel(BundleHelpers.PreviewBundleId));
+        BundleHelpers.GetBundleChannel(BundleHelpers.PreviewBundleId)
+            .Should().Be(BundleChannel.Preview);
     }
 
     [Fact]
     public void GetBundleChannelByBundleId_ExperimentalId_ReturnsExperimental()
     {
-        Assert.Equal(BundleChannel.Experimental, BundleHelpers.GetBundleChannel(BundleHelpers.ExperimentalBundleId));
+        BundleHelpers.GetBundleChannel(BundleHelpers.ExperimentalBundleId)
+            .Should().Be(BundleChannel.Experimental);
     }
 
     [Theory]
@@ -97,7 +99,7 @@ public class BundleHelpersTests
     {
         // Should not throw — case-insensitive matching.
         var channel = BundleHelpers.GetBundleChannel(bundleId);
-        Assert.Equal(expectedChannel, channel);
+        channel.Should().Be(expectedChannel);
     }
 
     [Theory]
@@ -106,7 +108,8 @@ public class BundleHelpersTests
     [InlineData("Microsoft.Azure.Functions.ExtensionBundle.Unknown")]
     public void GetBundleChannelByBundleId_InvalidId_Throws(string bundleId)
     {
-        Assert.Throws<ArgumentException>(() => BundleHelpers.GetBundleChannel(bundleId));
+        FluentActions.Invoking(() => BundleHelpers.GetBundleChannel(bundleId))
+            .Should().ThrowExactly<ArgumentException>();
     }
 
     // --- TryGetBundleChannel ---
@@ -118,8 +121,8 @@ public class BundleHelpersTests
     public void TryGetBundleChannel_KnownId_ReturnsTrueWithChannel(string bundleId, BundleChannel expected)
     {
         var result = BundleHelpers.TryGetBundleChannel(bundleId, out var channel);
-        Assert.True(result);
-        Assert.Equal(expected, channel);
+        result.Should().BeTrue();
+        channel.Should().Be(expected);
     }
 
     [Theory]
@@ -127,7 +130,7 @@ public class BundleHelpersTests
     [InlineData("MICROSOFT.AZURE.FUNCTIONS.EXTENSIONBUNDLE.PREVIEW")]
     public void TryGetBundleChannel_CaseInsensitive_ReturnsTrue(string bundleId)
     {
-        Assert.True(BundleHelpers.TryGetBundleChannel(bundleId, out _));
+        BundleHelpers.TryGetBundleChannel(bundleId, out _).Should().BeTrue();
     }
 
     [Theory]
@@ -136,8 +139,8 @@ public class BundleHelpersTests
     public void TryGetBundleChannel_UnknownId_ReturnsFalseWithUnknown(string bundleId)
     {
         var result = BundleHelpers.TryGetBundleChannel(bundleId, out var channel);
-        Assert.False(result);
-        Assert.Equal(BundleChannel.Unknown, channel);
+        result.Should().BeFalse();
+        channel.Should().Be(BundleChannel.Unknown);
     }
 
     // --- ToDisplayString ---
@@ -149,13 +152,14 @@ public class BundleHelpersTests
     [InlineData(BundleChannel.Experimental, "experimental")]
     public void ToDisplayString_ReturnsExpected(BundleChannel channel, string expected)
     {
-        Assert.Equal(expected, channel.ToDisplayString());
+        channel.ToDisplayString().Should().Be(expected);
     }
 
     [Fact]
     public void ToDisplayString_InvalidChannel_Throws()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => ((BundleChannel)99).ToDisplayString());
+        FluentActions.Invoking(() => ((BundleChannel)99).ToDisplayString())
+            .Should().ThrowExactly<ArgumentOutOfRangeException>();
     }
 
     // --- ToPrereleaseLabel ---
@@ -163,7 +167,7 @@ public class BundleHelpersTests
     [Fact]
     public void ToPrereleaseLabel_Stable_ReturnsNull()
     {
-        Assert.Null(BundleChannel.Stable.ToPrereleaseLabel());
+        BundleChannel.Stable.ToPrereleaseLabel().Should().BeNull();
     }
 
     [Theory]
@@ -171,7 +175,7 @@ public class BundleHelpersTests
     [InlineData(BundleChannel.Experimental, "experimental")]
     public void ToPrereleaseLabel_PrereleaseChannel_ReturnsLabel(BundleChannel channel, string expected)
     {
-        Assert.Equal(expected, channel.ToPrereleaseLabel());
+        channel.ToPrereleaseLabel().Should().Be(expected);
     }
 
     [Theory]
@@ -179,7 +183,8 @@ public class BundleHelpersTests
     [InlineData((BundleChannel)99)]
     public void ToPrereleaseLabel_InvalidChannel_Throws(BundleChannel channel)
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => channel.ToPrereleaseLabel());
+        FluentActions.Invoking(() => channel.ToPrereleaseLabel())
+            .Should().ThrowExactly<ArgumentOutOfRangeException>();
     }
 
     // --- MatchesChannel ---
@@ -193,13 +198,14 @@ public class BundleHelpersTests
     [InlineData("1.5.0", BundleChannel.Preview, false)]
     public void MatchesChannel_ReturnsExpected(string version, BundleChannel channel, bool expected)
     {
-        Assert.Equal(expected, BundleHelpers.MatchesChannel(NuGetVersion.Parse(version), channel));
+        BundleHelpers.MatchesChannel(NuGetVersion.Parse(version), channel).Should().Be(expected);
     }
 
     [Fact]
     public void MatchesChannel_NullVersion_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => BundleHelpers.MatchesChannel(null!, BundleChannel.Stable));
+        FluentActions.Invoking(() => BundleHelpers.MatchesChannel(null!, BundleChannel.Stable))
+            .Should().ThrowExactly<ArgumentNullException>();
     }
 
     // --- GetBundleChannel(NuGetVersion) null guard ---
@@ -207,6 +213,7 @@ public class BundleHelpersTests
     [Fact]
     public void GetBundleChannelByVersion_Null_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => BundleHelpers.GetBundleChannel((NuGetVersion)null!));
+        FluentActions.Invoking(() => BundleHelpers.GetBundleChannel((NuGetVersion)null!))
+            .Should().ThrowExactly<ArgumentNullException>();
     }
 }

--- a/test/Func.Tests/Bundles/BundleHintBuilderTests.cs
+++ b/test/Func.Tests/Bundles/BundleHintBuilderTests.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Xunit;
-
 namespace Azure.Functions.Cli.Bundles.Tests;
 
 public class BundleHintBuilderTests
@@ -17,11 +15,11 @@ public class BundleHintBuilderTests
             highestVersionSatisfyingHostJsonOnly: "3.36.0",
             profileName: "stable");
 
-        Assert.Contains("[3.*, 4.0.0)", hint);
-        Assert.Contains("[4.*, 5.0.0)", hint);
-        Assert.Contains("stable", hint);
-        Assert.Contains("3.36.0", hint);
-        Assert.Contains("Widen", hint);
+        hint.Should().Contain("[3.*, 4.0.0)");
+        hint.Should().Contain("[4.*, 5.0.0)");
+        hint.Should().Contain("stable");
+        hint.Should().Contain("3.36.0");
+        hint.Should().Contain("Widen");
     }
 
     [Fact]
@@ -33,10 +31,10 @@ public class BundleHintBuilderTests
             ["4.10.0", "4.20.0"],
             suggestedVersion: "4.10.0");
 
-        Assert.Contains("4.10.0", hint);
-        Assert.Contains("4.20.0", hint);
-        Assert.Contains("[4.22.0, 5.0.0)", hint);
-        Assert.Contains($"func workload install {IInstalledBundleWorkloads.BundleWorkloadPackageId}@4.10.0 --force", hint);
+        hint.Should().Contain("4.10.0");
+        hint.Should().Contain("4.20.0");
+        hint.Should().Contain("[4.22.0, 5.0.0)");
+        hint.Should().Contain($"func workload install {IInstalledBundleWorkloads.BundleWorkloadPackageId}@4.10.0 --force");
     }
 
     [Fact]
@@ -48,8 +46,8 @@ public class BundleHintBuilderTests
             [],
             suggestedVersion: null);
 
-        Assert.Contains("No bundle workload is installed.", hint);
-        Assert.Contains("@<version>", hint);
+        hint.Should().Contain("No bundle workload is installed.");
+        hint.Should().Contain("@<version>");
     }
 
     [Fact]
@@ -57,8 +55,8 @@ public class BundleHintBuilderTests
     {
         string hint = BundleHintBuilder.WorkloadMissing();
 
-        Assert.Contains($"func workload install {IInstalledBundleWorkloads.BundleWorkloadPackageId}", hint);
-        Assert.DoesNotContain("func setup", hint);
+        hint.Should().Contain($"func workload install {IInstalledBundleWorkloads.BundleWorkloadPackageId}");
+        hint.Should().NotContain("func setup");
     }
 
     [Fact]
@@ -66,8 +64,8 @@ public class BundleHintBuilderTests
     {
         string hint = BundleHintBuilder.WorkloadMissing(workerRuntime: "go");
 
-        Assert.Contains("func workload install", hint);
-        Assert.Contains("func setup --features go", hint);
+        hint.Should().Contain("func workload install");
+        hint.Should().Contain("func setup --features go");
     }
 
     [Fact]
@@ -75,8 +73,8 @@ public class BundleHintBuilderTests
     {
         string hint = BundleHintBuilder.WorkloadMissing(workerRuntime: "ruby");
 
-        Assert.Contains("func workload install", hint);
-        Assert.DoesNotContain("func setup", hint);
+        hint.Should().Contain("func workload install");
+        hint.Should().NotContain("func setup");
     }
 
     [Fact]
@@ -89,7 +87,7 @@ public class BundleHintBuilderTests
             suggestedVersion: "4.10.0",
             workerRuntime: "node");
 
-        Assert.Contains("func setup --features node", hint);
+        hint.Should().Contain("func setup --features node");
     }
 
     [Fact]
@@ -104,6 +102,6 @@ public class BundleHintBuilderTests
             highestVersionSatisfyingHostJsonOnly: "3.36.0",
             profileName: "stable");
 
-        Assert.DoesNotContain("func setup", hint);
+        hint.Should().NotContain("func setup");
     }
 }

--- a/test/Func.Tests/Bundles/ExtensionBundleResolverTests.cs
+++ b/test/Func.Tests/Bundles/ExtensionBundleResolverTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.Extensions.Logging.Abstractions;
-using Xunit;
 
 namespace Azure.Functions.Cli.Bundles.Tests;
 
@@ -16,10 +15,10 @@ public class ExtensionBundleResolverTests
         ExtensionBundleResolution result = await Build([Row("4.10.0"), Row("4.22.0")])
             .ResolveAsync(Context(host: "[4.0.0, 5.0.0)"));
 
-        ExtensionBundleResolution.Resolved resolved = Assert.IsType<ExtensionBundleResolution.Resolved>(result);
-        Assert.Equal("4.22.0", resolved.Version);
-        Assert.Equal(BundleId, resolved.BundleId);
-        Assert.EndsWith(Path.Combine("tools", "any"), resolved.Path);
+        ExtensionBundleResolution.Resolved resolved = result.Should().BeOfType<ExtensionBundleResolution.Resolved>().Subject;
+        resolved.Version.Should().Be("4.22.0");
+        resolved.BundleId.Should().Be(BundleId);
+        resolved.Path.Should().EndWith(Path.Combine("tools", "any"));
     }
 
     [Fact]
@@ -28,8 +27,8 @@ public class ExtensionBundleResolverTests
         ExtensionBundleResolution result = await Build([Row("4.10.0"), Row("4.22.0"), Row("5.1.0")])
             .ResolveAsync(Context(host: "[4.0.0, 6.0.0)", profile: "[4.15.0, 5.0.0)"));
 
-        ExtensionBundleResolution.Resolved resolved = Assert.IsType<ExtensionBundleResolution.Resolved>(result);
-        Assert.Equal("4.22.0", resolved.Version);
+        result.Should().BeOfType<ExtensionBundleResolution.Resolved>()
+            .Which.Version.Should().Be("4.22.0");
     }
 
     [Fact]
@@ -38,9 +37,9 @@ public class ExtensionBundleResolverTests
         ExtensionBundleResolution result = await Build([Row("3.30.0"), Row("4.10.0")])
             .ResolveAsync(Context(host: "[3.*, 4.0.0)", profile: "[4.*, 5.0.0)"));
 
-        ExtensionBundleResolution.EmptyIntersection empty = Assert.IsType<ExtensionBundleResolution.EmptyIntersection>(result);
-        Assert.Equal("3.30.0", empty.HighestVersionSatisfyingHostJsonOnly);
-        Assert.Contains("[3.*, 4.0.0)", empty.Hint);
+        ExtensionBundleResolution.EmptyIntersection empty = result.Should().BeOfType<ExtensionBundleResolution.EmptyIntersection>().Subject;
+        empty.HighestVersionSatisfyingHostJsonOnly.Should().Be("3.30.0");
+        empty.Hint.Should().Contain("[3.*, 4.0.0)");
     }
 
     [Fact]
@@ -49,9 +48,9 @@ public class ExtensionBundleResolverTests
         ExtensionBundleResolution result = await Build([Row("4.10.0")])
             .ResolveAsync(Context(host: "[5.0.0, 6.0.0)"));
 
-        ExtensionBundleResolution.NoCompatibleInstall none = Assert.IsType<ExtensionBundleResolution.NoCompatibleInstall>(result);
-        Assert.Contains("4.10.0", none.Hint);
-        Assert.Contains("func workload install", none.Hint);
+        ExtensionBundleResolution.NoCompatibleInstall none = result.Should().BeOfType<ExtensionBundleResolution.NoCompatibleInstall>().Subject;
+        none.Hint.Should().Contain("4.10.0");
+        none.Hint.Should().Contain("func workload install");
     }
 
     [Fact]
@@ -59,8 +58,8 @@ public class ExtensionBundleResolverTests
     {
         ExtensionBundleResolution result = await Build([]).ResolveAsync(Context(host: "[4.0.0, 5.0.0)"));
 
-        ExtensionBundleResolution.WorkloadMissing missing = Assert.IsType<ExtensionBundleResolution.WorkloadMissing>(result);
-        Assert.Contains("func workload install", missing.Hint);
+        ExtensionBundleResolution.WorkloadMissing missing = result.Should().BeOfType<ExtensionBundleResolution.WorkloadMissing>().Subject;
+        missing.Hint.Should().Contain("func workload install");
     }
 
     [Fact]
@@ -68,8 +67,8 @@ public class ExtensionBundleResolverTests
     {
         ExtensionBundleResolution result = await Build([]).ResolveAsync(Context(host: "[4.0.0, 5.0.0)", workerRuntime: "go"));
 
-        ExtensionBundleResolution.WorkloadMissing missing = Assert.IsType<ExtensionBundleResolution.WorkloadMissing>(result);
-        Assert.Contains("func setup --features go", missing.Hint);
+        ExtensionBundleResolution.WorkloadMissing missing = result.Should().BeOfType<ExtensionBundleResolution.WorkloadMissing>().Subject;
+        missing.Hint.Should().Contain("func setup --features go");
     }
 
     [Fact]
@@ -78,8 +77,8 @@ public class ExtensionBundleResolverTests
         ExtensionBundleResolution result = await Build([Row("4.10.0")])
             .ResolveAsync(Context(host: "[5.0.0, 6.0.0)", workerRuntime: "node"));
 
-        ExtensionBundleResolution.NoCompatibleInstall none = Assert.IsType<ExtensionBundleResolution.NoCompatibleInstall>(result);
-        Assert.Contains("func setup --features node", none.Hint);
+        ExtensionBundleResolution.NoCompatibleInstall none = result.Should().BeOfType<ExtensionBundleResolution.NoCompatibleInstall>().Subject;
+        none.Hint.Should().Contain("func setup --features node");
     }
 
     [Fact]
@@ -88,9 +87,9 @@ public class ExtensionBundleResolverTests
         var telemetry = new RecordingTelemetry();
         await Build([Row("4.22.0")], telemetry).ResolveAsync(Context(host: "[4.0.0, 5.0.0)"));
 
-        BundleResolveEvent evt = Assert.Single(telemetry.Events);
-        Assert.Equal(BundleResolveReason.Ok, evt.Reason);
-        Assert.Equal("4.22.0", evt.ResolvedVersion);
+        BundleResolveEvent evt = telemetry.Events.Should().ContainSingle().Subject;
+        evt.Reason.Should().Be(BundleResolveReason.Ok);
+        evt.ResolvedVersion.Should().Be("4.22.0");
     }
 
     [Fact]
@@ -99,8 +98,8 @@ public class ExtensionBundleResolverTests
         var telemetry = new RecordingTelemetry();
         await Build([], telemetry).ResolveAsync(Context(host: "[4.0.0, 5.0.0)"));
 
-        BundleResolveEvent evt = Assert.Single(telemetry.Events);
-        Assert.Equal(BundleResolveReason.WorkloadMissing, evt.Reason);
+        BundleResolveEvent evt = telemetry.Events.Should().ContainSingle().Subject;
+        evt.Reason.Should().Be(BundleResolveReason.WorkloadMissing);
     }
 
     [Fact]
@@ -109,8 +108,8 @@ public class ExtensionBundleResolverTests
         var telemetry = new RecordingTelemetry();
         await Build([Row("4.22.0")], telemetry).ResolveAsync(Context(host: "[3.*, 4.0.0)", profile: "[4.*, 5.0.0)"));
 
-        BundleResolveEvent evt = Assert.Single(telemetry.Events);
-        Assert.Equal(BundleResolveReason.EmptyIntersection, evt.Reason);
+        BundleResolveEvent evt = telemetry.Events.Should().ContainSingle().Subject;
+        evt.Reason.Should().Be(BundleResolveReason.EmptyIntersection);
     }
 
     [Fact]
@@ -119,8 +118,8 @@ public class ExtensionBundleResolverTests
         var telemetry = new RecordingTelemetry();
         await Build([Row("3.0.0")], telemetry).ResolveAsync(Context(host: "[5.0.0, 6.0.0)"));
 
-        BundleResolveEvent evt = Assert.Single(telemetry.Events);
-        Assert.Equal(BundleResolveReason.NoCompatibleInstall, evt.Reason);
+        BundleResolveEvent evt = telemetry.Events.Should().ContainSingle().Subject;
+        evt.Reason.Should().Be(BundleResolveReason.NoCompatibleInstall);
     }
 
     private static ExtensionBundleResolver Build(IReadOnlyList<InstalledBundleWorkload> rows, IBundleResolveTelemetry? telemetry = null)

--- a/test/Func.Tests/Bundles/ExtensionBundleResolverTests.cs
+++ b/test/Func.Tests/Bundles/ExtensionBundleResolverTests.cs
@@ -58,8 +58,8 @@ public class ExtensionBundleResolverTests
     {
         ExtensionBundleResolution result = await Build([]).ResolveAsync(Context(host: "[4.0.0, 5.0.0)"));
 
-        ExtensionBundleResolution.WorkloadMissing missing = result.Should().BeOfType<ExtensionBundleResolution.WorkloadMissing>().Subject;
-        missing.Hint.Should().Contain("func workload install");
+        result.Should().BeOfType<ExtensionBundleResolution.WorkloadMissing>()
+            .Which.Hint.Should().Contain("func workload install");
     }
 
     [Fact]
@@ -67,8 +67,8 @@ public class ExtensionBundleResolverTests
     {
         ExtensionBundleResolution result = await Build([]).ResolveAsync(Context(host: "[4.0.0, 5.0.0)", workerRuntime: "go"));
 
-        ExtensionBundleResolution.WorkloadMissing missing = result.Should().BeOfType<ExtensionBundleResolution.WorkloadMissing>().Subject;
-        missing.Hint.Should().Contain("func setup --features go");
+        result.Should().BeOfType<ExtensionBundleResolution.WorkloadMissing>()
+            .Which.Hint.Should().Contain("func setup --features go");
     }
 
     [Fact]
@@ -77,8 +77,8 @@ public class ExtensionBundleResolverTests
         ExtensionBundleResolution result = await Build([Row("4.10.0")])
             .ResolveAsync(Context(host: "[5.0.0, 6.0.0)", workerRuntime: "node"));
 
-        ExtensionBundleResolution.NoCompatibleInstall none = result.Should().BeOfType<ExtensionBundleResolution.NoCompatibleInstall>().Subject;
-        none.Hint.Should().Contain("func setup --features node");
+        result.Should().BeOfType<ExtensionBundleResolution.NoCompatibleInstall>()
+            .Which.Hint.Should().Contain("func setup --features node");
     }
 
     [Fact]
@@ -98,8 +98,7 @@ public class ExtensionBundleResolverTests
         var telemetry = new RecordingTelemetry();
         await Build([], telemetry).ResolveAsync(Context(host: "[4.0.0, 5.0.0)"));
 
-        BundleResolveEvent evt = telemetry.Events.Should().ContainSingle().Subject;
-        evt.Reason.Should().Be(BundleResolveReason.WorkloadMissing);
+        telemetry.Events.Should().ContainSingle().Which.Reason.Should().Be(BundleResolveReason.WorkloadMissing);
     }
 
     [Fact]
@@ -108,8 +107,7 @@ public class ExtensionBundleResolverTests
         var telemetry = new RecordingTelemetry();
         await Build([Row("4.22.0")], telemetry).ResolveAsync(Context(host: "[3.*, 4.0.0)", profile: "[4.*, 5.0.0)"));
 
-        BundleResolveEvent evt = telemetry.Events.Should().ContainSingle().Subject;
-        evt.Reason.Should().Be(BundleResolveReason.EmptyIntersection);
+        telemetry.Events.Should().ContainSingle().Which.Reason.Should().Be(BundleResolveReason.EmptyIntersection);
     }
 
     [Fact]
@@ -118,8 +116,7 @@ public class ExtensionBundleResolverTests
         var telemetry = new RecordingTelemetry();
         await Build([Row("3.0.0")], telemetry).ResolveAsync(Context(host: "[5.0.0, 6.0.0)"));
 
-        BundleResolveEvent evt = telemetry.Events.Should().ContainSingle().Subject;
-        evt.Reason.Should().Be(BundleResolveReason.NoCompatibleInstall);
+        telemetry.Events.Should().ContainSingle().Which.Reason.Should().Be(BundleResolveReason.NoCompatibleInstall);
     }
 
     private static ExtensionBundleResolver Build(IReadOnlyList<InstalledBundleWorkload> rows, IBundleResolveTelemetry? telemetry = null)

--- a/test/Func.Tests/Bundles/InstalledBundleScannerTests.cs
+++ b/test/Func.Tests/Bundles/InstalledBundleScannerTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using NuGet.Versioning;
-using Xunit;
 
 namespace Azure.Functions.Cli.Bundles.Tests;
 
@@ -16,8 +15,8 @@ public class InstalledBundleScannerTests
     public async Task NoRows_ReportsZeroTotal()
     {
         ScanResult result = await Build([]).ScanAsync(StableId);
-        Assert.Equal(0, result.TotalInstalledRows);
-        Assert.Empty(result.FilteredVersions);
+        result.TotalInstalledRows.Should().Be(0);
+        result.FilteredVersions.Should().BeEmpty();
     }
 
     [Fact]
@@ -31,10 +30,10 @@ public class InstalledBundleScannerTests
             Row("4.24.0", "/d"),
         ]).ScanAsync(StableId);
 
-        Assert.Equal(4, result.TotalInstalledRows);
-        Assert.Equal(2, result.FilteredVersions.Count);
-        Assert.Equal(NuGetVersion.Parse("4.24.0"), result.FilteredVersions[0].Version);
-        Assert.Equal(NuGetVersion.Parse("4.22.0"), result.FilteredVersions[1].Version);
+        result.TotalInstalledRows.Should().Be(4);
+        result.FilteredVersions.Count.Should().Be(2);
+        result.FilteredVersions[0].Version.Should().Be(NuGetVersion.Parse("4.24.0"));
+        result.FilteredVersions[1].Version.Should().Be(NuGetVersion.Parse("4.22.0"));
     }
 
     [Fact]
@@ -48,8 +47,8 @@ public class InstalledBundleScannerTests
             Row("4.25.0-beta", "/d"),
         ]).ScanAsync(PreviewId);
 
-        Assert.Single(result.FilteredVersions);
-        Assert.Equal(NuGetVersion.Parse("4.23.0-preview"), result.FilteredVersions[0].Version);
+        result.FilteredVersions.Should().ContainSingle();
+        result.FilteredVersions[0].Version.Should().Be(NuGetVersion.Parse("4.23.0-preview"));
     }
 
     [Fact]
@@ -63,9 +62,9 @@ public class InstalledBundleScannerTests
             Row("4.25.0-experimental.2", "/d"),
         ]).ScanAsync(ExperimentalId);
 
-        Assert.Equal(2, result.FilteredVersions.Count);
-        Assert.Equal(NuGetVersion.Parse("4.25.0-experimental.2"), result.FilteredVersions[0].Version);
-        Assert.Equal(NuGetVersion.Parse("4.24.0-experimental.1"), result.FilteredVersions[1].Version);
+        result.FilteredVersions.Count.Should().Be(2);
+        result.FilteredVersions[0].Version.Should().Be(NuGetVersion.Parse("4.25.0-experimental.2"));
+        result.FilteredVersions[1].Version.Should().Be(NuGetVersion.Parse("4.24.0-experimental.1"));
     }
 
     [Fact]
@@ -73,7 +72,7 @@ public class InstalledBundleScannerTests
     {
         ScanResult result = await Build([Row("4.35.0", "/install/dir")]).ScanAsync(StableId);
 
-        Assert.Equal(Path.Combine("/install/dir", "tools", "any"), result.FilteredVersions[0].Path);
+        result.FilteredVersions[0].Path.Should().Be(Path.Combine("/install/dir", "tools", "any"));
     }
 
     [Fact]
@@ -85,8 +84,8 @@ public class InstalledBundleScannerTests
             Row("4.22.0", "/y"),
         ]).ScanAsync(StableId);
 
-        Assert.Single(result.FilteredVersions);
-        Assert.Equal(NuGetVersion.Parse("4.22.0"), result.FilteredVersions[0].Version);
+        result.FilteredVersions.Should().ContainSingle();
+        result.FilteredVersions[0].Version.Should().Be(NuGetVersion.Parse("4.22.0"));
     }
 
     [Fact]
@@ -99,8 +98,8 @@ public class InstalledBundleScannerTests
             Row("4.10.0", "/c"),
         ]).ScanAsync(StableId);
 
-        Assert.Equal(NuGetVersion.Parse("4.30.0"), result.FilteredVersions[0].Version);
-        Assert.Equal(NuGetVersion.Parse("4.10.0"), result.FilteredVersions[2].Version);
+        result.FilteredVersions[0].Version.Should().Be(NuGetVersion.Parse("4.30.0"));
+        result.FilteredVersions[2].Version.Should().Be(NuGetVersion.Parse("4.10.0"));
     }
 
     private static InstalledBundleScanner Build(IReadOnlyList<InstalledBundleWorkload> rows)

--- a/test/Func.Tests/Bundles/InstalledBundleWorkloadsTests.cs
+++ b/test/Func.Tests/Bundles/InstalledBundleWorkloadsTests.cs
@@ -69,7 +69,6 @@ public class InstalledBundleWorkloadsTests
 
         IReadOnlyList<InstalledBundleWorkload> result = await new InstalledBundleWorkloads(store, paths).ListInstalledAsync();
 
-        InstalledBundleWorkload row = result.Should().ContainSingle().Subject;
-        row.InstallDirectory.Should().Be("/home/.func/workloads/bundles/4.35.0");
+        result.Should().ContainSingle().Which.InstallDirectory.Should().Be("/home/.func/workloads/bundles/4.35.0");
     }
 }

--- a/test/Func.Tests/Bundles/InstalledBundleWorkloadsTests.cs
+++ b/test/Func.Tests/Bundles/InstalledBundleWorkloadsTests.cs
@@ -4,7 +4,6 @@
 using Azure.Functions.Cli.Workloads;
 using Azure.Functions.Cli.Workloads.Storage;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Bundles.Tests;
 
@@ -26,9 +25,9 @@ public class InstalledBundleWorkloadsTests
 
         IReadOnlyList<InstalledBundleWorkload> result = await new InstalledBundleWorkloads(store, paths).ListInstalledAsync();
 
-        Assert.Equal(2, result.Count);
-        Assert.Contains(result, r => r.PackageVersion == "4.35.0");
-        Assert.Contains(result, r => r.PackageVersion == "4.36.0");
+        result.Count.Should().Be(2);
+        result.Should().Contain(r => r.PackageVersion == "4.35.0");
+        result.Should().Contain(r => r.PackageVersion == "4.36.0");
     }
 
     [Fact]
@@ -48,7 +47,7 @@ public class InstalledBundleWorkloadsTests
         ]);
         paths.GetInstallDirectory(Arg.Any<string>(), Arg.Any<string>()).Returns("/x");
 
-        Assert.Empty(await new InstalledBundleWorkloads(store, paths).ListInstalledAsync());
+        (await new InstalledBundleWorkloads(store, paths).ListInstalledAsync()).Should().BeEmpty();
     }
 
     [Fact]
@@ -70,7 +69,7 @@ public class InstalledBundleWorkloadsTests
 
         IReadOnlyList<InstalledBundleWorkload> result = await new InstalledBundleWorkloads(store, paths).ListInstalledAsync();
 
-        InstalledBundleWorkload row = Assert.Single(result);
-        Assert.Equal("/home/.func/workloads/bundles/4.35.0", row.InstallDirectory);
+        InstalledBundleWorkload row = result.Should().ContainSingle().Subject;
+        row.InstallDirectory.Should().Be("/home/.func/workloads/bundles/4.35.0");
     }
 }

--- a/test/Func.Tests/Bundles/ValidateExtensionBundleInitializationStepTests.cs
+++ b/test/Func.Tests/Bundles/ValidateExtensionBundleInitializationStepTests.cs
@@ -12,7 +12,6 @@ using Azure.Functions.Cli.Workers;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using NuGet.Versioning;
-using Xunit;
 
 namespace Azure.Functions.Cli.Bundles.Tests;
 
@@ -46,8 +45,8 @@ public class ValidateExtensionBundleInitializationStepTests : IDisposable
 
         StartInitializationStepResult result = await step.ExecuteAsync(context, CancellationToken.None);
 
-        Assert.Equal("No extension bundle declared", result.Message);
-        Assert.Empty(context.State.BundleEnvVarsForHost);
+        result.Message.Should().Be("No extension bundle declared");
+        context.State.BundleEnvVarsForHost.Should().BeEmpty();
         await resolver.DidNotReceiveWithAnyArgs().ResolveAsync(default!, default);
     }
 
@@ -61,7 +60,7 @@ public class ValidateExtensionBundleInitializationStepTests : IDisposable
 
         StartInitializationStepResult result = await step.ExecuteAsync(context, CancellationToken.None);
 
-        Assert.Equal("No extension bundle declared", result.Message);
+        result.Message.Should().Be("No extension bundle declared");
         await resolver.DidNotReceiveWithAnyArgs().ResolveAsync(default!, default);
     }
 
@@ -77,10 +76,9 @@ public class ValidateExtensionBundleInitializationStepTests : IDisposable
         ValidateExtensionBundleInitializationStep step = NewStep(resolver);
         StartInitializationStepContext context = NewContext();
 
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => step.ExecuteAsync(context, CancellationToken.None));
-        Assert.Equal("MISSING-HINT", ex.Message);
-        Assert.True(ex.IsUserError);
+        GracefulException ex = (await FluentActions.Awaiting(() => step.ExecuteAsync(context, CancellationToken.None)).Should().ThrowAsync<GracefulException>()).Which;
+        ex.Message.Should().Be("MISSING-HINT");
+        ex.IsUserError.Should().BeTrue();
     }
 
     [Fact]
@@ -102,10 +100,10 @@ public class ValidateExtensionBundleInitializationStepTests : IDisposable
 
         StartInitializationStepResult result = await step.ExecuteAsync(context, CancellationToken.None);
 
-        Assert.Equal("Bundle Microsoft.Azure.Functions.ExtensionBundle 4.35.0", result.Message);
-        Assert.Equal("/install/4.35.0/tools/any", context.State.BundleDownloadPath);
-        Assert.Equal("/install/4.35.0/tools/any", context.State.BundleEnvVarsForHost[DownloadPathEnvVar]);
-        Assert.Equal("false", context.State.BundleEnvVarsForHost[EnsureLatestEnvVar]);
+        result.Message.Should().Be("Bundle Microsoft.Azure.Functions.ExtensionBundle 4.35.0");
+        context.State.BundleDownloadPath.Should().Be("/install/4.35.0/tools/any");
+        context.State.BundleEnvVarsForHost[DownloadPathEnvVar].Should().Be("/install/4.35.0/tools/any");
+        context.State.BundleEnvVarsForHost[EnsureLatestEnvVar].Should().Be("false");
     }
 
     [Fact]
@@ -149,10 +147,9 @@ public class ValidateExtensionBundleInitializationStepTests : IDisposable
         ValidateExtensionBundleInitializationStep step = NewStep(resolver);
         StartInitializationStepContext context = NewContext();
 
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => step.ExecuteAsync(context, CancellationToken.None));
-        Assert.Equal("RESOLVER-HINT", ex.Message);
-        Assert.True(ex.IsUserError);
+        GracefulException ex = (await FluentActions.Awaiting(() => step.ExecuteAsync(context, CancellationToken.None)).Should().ThrowAsync<GracefulException>()).Which;
+        ex.Message.Should().Be("RESOLVER-HINT");
+        ex.IsUserError.Should().BeTrue();
     }
 
     [Fact]
@@ -194,11 +191,10 @@ public class ValidateExtensionBundleInitializationStepTests : IDisposable
         ValidateExtensionBundleInitializationStep step = NewStep(resolver);
         StartInitializationStepContext context = NewContext();
 
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => step.ExecuteAsync(context, CancellationToken.None));
+        GracefulException ex = (await FluentActions.Awaiting(() => step.ExecuteAsync(context, CancellationToken.None)).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.True(ex.IsUserError);
-        Assert.Contains("host.json is not valid JSON", ex.Message);
+        ex.IsUserError.Should().BeTrue();
+        ex.Message.Should().Contain("host.json is not valid JSON");
         await resolver.DidNotReceiveWithAnyArgs().ResolveAsync(default!, default);
     }
 
@@ -210,11 +206,10 @@ public class ValidateExtensionBundleInitializationStepTests : IDisposable
         ValidateExtensionBundleInitializationStep step = NewStep(resolver);
         StartInitializationStepContext context = NewContext();
 
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => step.ExecuteAsync(context, CancellationToken.None));
+        GracefulException ex = (await FluentActions.Awaiting(() => step.ExecuteAsync(context, CancellationToken.None)).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.True(ex.IsUserError);
-        Assert.Contains("host.json extensionBundle must include", ex.Message);
+        ex.IsUserError.Should().BeTrue();
+        ex.Message.Should().Contain("host.json extensionBundle must include");
         await resolver.DidNotReceiveWithAnyArgs().ResolveAsync(default!, default);
     }
 

--- a/test/Func.Tests/Bundles/VersionRangeIntersectionTests.cs
+++ b/test/Func.Tests/Bundles/VersionRangeIntersectionTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using NuGet.Versioning;
-using Xunit;
 
 namespace Azure.Functions.Cli.Bundles.Tests;
 
@@ -12,35 +11,35 @@ public class VersionRangeIntersectionTests
     public void NullProfile_ReturnsHostRangeUnchanged()
     {
         VersionRange? result = VersionRangeIntersection.Intersect("[4.0.0, 5.0.0)", null);
-        Assert.NotNull(result);
-        Assert.True(result.Satisfies(NuGetVersion.Parse("4.22.0")));
-        Assert.False(result.Satisfies(NuGetVersion.Parse("5.0.0")));
+        result.Should().NotBeNull();
+        result.Satisfies(NuGetVersion.Parse("4.22.0")).Should().BeTrue();
+        result.Satisfies(NuGetVersion.Parse("5.0.0")).Should().BeFalse();
     }
 
     [Fact]
     public void OverlappingRanges_ReturnsTighterIntersection()
     {
         VersionRange? result = VersionRangeIntersection.Intersect("[4.0.0, 5.0.0)", "[4.10.0, 6.0.0)");
-        Assert.NotNull(result);
-        Assert.True(result.Satisfies(NuGetVersion.Parse("4.22.0")));
-        Assert.False(result.Satisfies(NuGetVersion.Parse("4.5.0")));
-        Assert.False(result.Satisfies(NuGetVersion.Parse("5.0.0")));
+        result.Should().NotBeNull();
+        result.Satisfies(NuGetVersion.Parse("4.22.0")).Should().BeTrue();
+        result.Satisfies(NuGetVersion.Parse("4.5.0")).Should().BeFalse();
+        result.Satisfies(NuGetVersion.Parse("5.0.0")).Should().BeFalse();
     }
 
     [Fact]
     public void DisjointRanges_ReturnsNull()
     {
-        Assert.Null(VersionRangeIntersection.Intersect("[4.0.0, 5.0.0)", "[5.0.0, 6.0.0)"));
+        VersionRangeIntersection.Intersect("[4.0.0, 5.0.0)", "[5.0.0, 6.0.0)").Should().BeNull();
     }
 
     [Fact]
     public void NestedRanges_ReturnsInnerRange()
     {
         VersionRange? result = VersionRangeIntersection.Intersect("[1.0.0, 9.0.0)", "[4.0.0, 5.0.0)");
-        Assert.NotNull(result);
-        Assert.True(result.Satisfies(NuGetVersion.Parse("4.5.0")));
-        Assert.False(result.Satisfies(NuGetVersion.Parse("5.0.0")));
-        Assert.False(result.Satisfies(NuGetVersion.Parse("3.9.0")));
+        result.Should().NotBeNull();
+        result.Satisfies(NuGetVersion.Parse("4.5.0")).Should().BeTrue();
+        result.Satisfies(NuGetVersion.Parse("5.0.0")).Should().BeFalse();
+        result.Satisfies(NuGetVersion.Parse("3.9.0")).Should().BeFalse();
     }
 
     [Fact]
@@ -55,13 +54,13 @@ public class VersionRangeIntersectionTests
         ];
 
         NuGetVersion? best = VersionRangeIntersection.FindBest(candidates, VersionRange.Parse("[4.0.0, 5.0.0)"));
-        Assert.Equal(NuGetVersion.Parse("4.22.0"), best);
+        best.Should().Be(NuGetVersion.Parse("4.22.0"));
     }
 
     [Fact]
     public void FindBest_NoneMatching_ReturnsNull()
     {
         NuGetVersion[] candidates = [NuGetVersion.Parse("3.0.0"), NuGetVersion.Parse("5.0.0")];
-        Assert.Null(VersionRangeIntersection.FindBest(candidates, VersionRange.Parse("[4.0.0, 5.0.0)")));
+        VersionRangeIntersection.FindBest(candidates, VersionRange.Parse("[4.0.0, 5.0.0)")).Should().BeNull();
     }
 }

--- a/test/Func.Tests/Commands/HelpCommandTests.cs
+++ b/test/Func.Tests/Commands/HelpCommandTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Commands;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands;
 
@@ -25,9 +24,9 @@ public class HelpCommandTests
     {
         var exitCode = _helpCommand.ShowGeneralHelp();
 
-        Assert.Equal(0, exitCode);
-        Assert.Contains("Azure Functions CLI", _interaction.AllOutput);
-        Assert.Contains("Usage", _interaction.AllOutput);
+        exitCode.Should().Be(0);
+        _interaction.AllOutput.Should().Contain("Azure Functions CLI");
+        _interaction.AllOutput.Should().Contain("Usage");
     }
 
     [Fact]
@@ -36,8 +35,8 @@ public class HelpCommandTests
         _helpCommand.ShowGeneralHelp();
 
         var output = _interaction.AllOutput;
-        Assert.Contains("version", output);
-        Assert.Contains("help", output);
+        output.Should().Contain("version");
+        output.Should().Contain("help");
     }
 
     [Fact]
@@ -45,8 +44,8 @@ public class HelpCommandTests
     {
         var exitCode = _helpCommand.ShowCommandHelp("version");
 
-        Assert.Equal(0, exitCode);
-        Assert.Contains("version", _interaction.AllOutput);
+        exitCode.Should().Be(0);
+        _interaction.AllOutput.Should().Contain("version");
     }
 
     [Fact]
@@ -54,8 +53,8 @@ public class HelpCommandTests
     {
         var exitCode = _helpCommand.ShowCommandHelp("nonexistent");
 
-        Assert.Equal(1, exitCode);
-        Assert.Contains("Unknown command", _interaction.AllOutput);
+        exitCode.Should().Be(1);
+        _interaction.AllOutput.Should().Contain("Unknown command");
     }
 
     [Fact]
@@ -69,7 +68,7 @@ public class HelpCommandTests
         _helpCommand.RenderCommandHelp(installCommand);
 
         var output = _interaction.AllOutput;
-        Assert.Contains("func workload install", output);
-        Assert.DoesNotContain("func install ", output);
+        output.Should().Contain("func workload install");
+        output.Should().NotContain("func install ");
     }
 }

--- a/test/Func.Tests/Commands/HostProcessEventStreamTests.cs
+++ b/test/Func.Tests/Commands/HostProcessEventStreamTests.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using Azure.Functions.Cli.Commands.Start.Host;
 using Azure.Functions.Cli.Hosting.Events;
 using Microsoft.Extensions.Logging;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands;
 
@@ -30,18 +29,18 @@ public class HostProcessEventStreamTests
         HostLogEntry[] entries = await ReadAllAsync(stream);
         int exitCode = await stream.WaitForExitAsync(CancellationToken.None);
 
-        Assert.Equal(23, exitCode);
-        Assert.True(process.Disposed);
-        Assert.Equal(3, entries.Length);
-        Assert.Equal("Host.Process", entries[0].Category);
-        Assert.Equal(LogLevel.Information, entries[0].Level);
-        Assert.Contains("http://localhost:7071", entries[0].Message);
-        Assert.Equal(HostProcessStreamNames.Cli, entries[0].GetAttribute<string>(HostLogAttributeKeys.Stream));
-        Assert.Contains(entries, entry =>
+        exitCode.Should().Be(23);
+        process.Disposed.Should().BeTrue();
+        entries.Length.Should().Be(3);
+        entries[0].Category.Should().Be("Host.Process");
+        entries[0].Level.Should().Be(LogLevel.Information);
+        entries[0].Message.Should().Contain("http://localhost:7071");
+        entries[0].GetAttribute<string>(HostLogAttributeKeys.Stream).Should().Be(HostProcessStreamNames.Cli);
+        entries.Should().Contain(entry =>
             entry.Message == "stdout line"
             && entry.Level == LogLevel.Information
             && entry.GetAttribute<string>(HostLogAttributeKeys.Stream) == HostProcessStreamNames.StandardOutput);
-        Assert.Contains(entries, entry =>
+        entries.Should().Contain(entry =>
             entry.Message == "stderr line"
             && entry.Level == LogLevel.Error
             && entry.GetAttribute<string>(HostLogAttributeKeys.Stream) == HostProcessStreamNames.StandardError);
@@ -59,9 +58,9 @@ public class HostProcessEventStreamTests
 
         await stream.RequestShutdownAsync(CancellationToken.None);
 
-        Assert.True(process.StandardInputDisposed);
-        Assert.True(process.KillTreeCalled);
-        Assert.True(process.Disposed);
+        process.StandardInputDisposed.Should().BeTrue();
+        process.KillTreeCalled.Should().BeTrue();
+        process.Disposed.Should().BeTrue();
     }
 
     [Fact]
@@ -76,9 +75,9 @@ public class HostProcessEventStreamTests
 
         await stream.DisposeAsync();
 
-        Assert.True(process.StandardInputDisposed);
-        Assert.True(process.KillTreeCalled);
-        Assert.True(process.Disposed);
+        process.StandardInputDisposed.Should().BeTrue();
+        process.KillTreeCalled.Should().BeTrue();
+        process.Disposed.Should().BeTrue();
     }
 
     [Fact]
@@ -94,7 +93,7 @@ public class HostProcessEventStreamTests
         await stream.DisposeAsync();
         await stream.DisposeAsync();
 
-        Assert.Equal(1, process.KillTreeCallCount);
+        process.KillTreeCallCount.Should().Be(1);
     }
 
     private static async Task<HostLogEntry[]> ReadAllAsync(IHostEventStream stream)

--- a/test/Func.Tests/Commands/HostProcessOutputParserTests.cs
+++ b/test/Func.Tests/Commands/HostProcessOutputParserTests.cs
@@ -5,7 +5,6 @@ using Azure.Functions.Cli.Commands.Start.Host;
 using Azure.Functions.Cli.Hosting.Events;
 using Microsoft.Extensions.Logging;
 using System.Text.Json;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands;
 
@@ -18,10 +17,10 @@ public class HostProcessOutputParserTests
 
         HostLogEntry entry = parser.ParseLine(HostProcessStreamNames.StandardOutput, "Host started", DateTimeOffset.UnixEpoch);
 
-        Assert.Equal("Host.Process", entry.Category);
-        Assert.Equal(LogLevel.Information, entry.Level);
-        Assert.Equal("Host started", entry.Message);
-        Assert.Equal(HostProcessStreamNames.StandardOutput, entry.GetAttribute<string>(HostLogAttributeKeys.Stream));
+        entry.Category.Should().Be("Host.Process");
+        entry.Level.Should().Be(LogLevel.Information);
+        entry.Message.Should().Be("Host started");
+        entry.GetAttribute<string>(HostLogAttributeKeys.Stream).Should().Be(HostProcessStreamNames.StandardOutput);
     }
 
     [Fact]
@@ -31,9 +30,9 @@ public class HostProcessOutputParserTests
 
         HostLogEntry entry = parser.ParseLine(HostProcessStreamNames.StandardError, "Host failed", DateTimeOffset.UnixEpoch);
 
-        Assert.Equal(LogLevel.Error, entry.Level);
-        Assert.Equal("Host failed", entry.Message);
-        Assert.Equal(HostProcessStreamNames.StandardError, entry.GetAttribute<string>(HostLogAttributeKeys.Stream));
+        entry.Level.Should().Be(LogLevel.Error);
+        entry.Message.Should().Be("Host failed");
+        entry.GetAttribute<string>(HostLogAttributeKeys.Stream).Should().Be(HostProcessStreamNames.StandardError);
     }
 
     [Fact]
@@ -73,27 +72,27 @@ public class HostProcessOutputParserTests
             Minify(line),
             DateTimeOffset.UnixEpoch);
 
-        Assert.Equal(DateTimeOffset.Parse("2026-05-26T12:00:00.0000000+00:00"), entry.Timestamp);
-        Assert.Equal("Function.HttpTrigger1.User", entry.Category);
-        Assert.Equal(LogLevel.Warning, entry.Level);
-        Assert.Equal(42, entry.EventId.Id);
-        Assert.Equal("UserLog", entry.EventId.Name);
-        Assert.Equal("hello from user code", entry.Message);
-        Assert.Equal("HttpTrigger1", entry.GetAttribute<string>(HostLogAttributeKeys.FunctionName));
-        Assert.Equal(HostProcessStreamNames.StandardOutput, entry.GetAttribute<string>(HostLogAttributeKeys.Stream));
-        Assert.Equal(12.5, entry.GetAttribute<double>(HostLogAttributeKeys.DurationMs));
-        Assert.Equal(202, entry.GetAttribute<int>(HostLogAttributeKeys.HttpStatusCode));
+        entry.Timestamp.Should().Be(DateTimeOffset.Parse("2026-05-26T12:00:00.0000000+00:00"));
+        entry.Category.Should().Be("Function.HttpTrigger1.User");
+        entry.Level.Should().Be(LogLevel.Warning);
+        entry.EventId.Id.Should().Be(42);
+        entry.EventId.Name.Should().Be("UserLog");
+        entry.Message.Should().Be("hello from user code");
+        entry.GetAttribute<string>(HostLogAttributeKeys.FunctionName).Should().Be("HttpTrigger1");
+        entry.GetAttribute<string>(HostLogAttributeKeys.Stream).Should().Be(HostProcessStreamNames.StandardOutput);
+        entry.GetAttribute<double>(HostLogAttributeKeys.DurationMs).Should().Be(12.5);
+        entry.GetAttribute<int>(HostLogAttributeKeys.HttpStatusCode).Should().Be(202);
         string[]? methods = entry.GetAttribute<string[]>(HostLogAttributeKeys.FunctionHttpMethods);
-        Assert.NotNull(methods);
-        Assert.Equal(["get", "post"], methods);
-        Assert.Equal("boom", entry.Exception?.Message);
-        Assert.NotNull(entry.ExceptionDetails);
-        Assert.Equal("System.InvalidOperationException", entry.ExceptionDetails.Type);
-        Assert.Equal("remote stack", entry.ExceptionDetails.Stack);
-        Assert.NotNull(entry.ExceptionDetails.InnerException);
-        Assert.Equal("Worker.UserException", entry.ExceptionDetails.InnerException.Type);
-        Assert.Equal("inner boom", entry.ExceptionDetails.InnerException.Message);
-        Assert.Equal("inner stack", entry.ExceptionDetails.InnerException.Stack);
+        methods.Should().NotBeNull();
+        methods.Should().Equal(["get", "post"]);
+        (entry.Exception?.Message).Should().Be("boom");
+        entry.ExceptionDetails.Should().NotBeNull();
+        entry.ExceptionDetails.Type.Should().Be("System.InvalidOperationException");
+        entry.ExceptionDetails.Stack.Should().Be("remote stack");
+        entry.ExceptionDetails.InnerException.Should().NotBeNull();
+        entry.ExceptionDetails.InnerException.Type.Should().Be("Worker.UserException");
+        entry.ExceptionDetails.InnerException.Message.Should().Be("inner boom");
+        entry.ExceptionDetails.InnerException.Stack.Should().Be("inner stack");
     }
 
     [Fact]
@@ -116,11 +115,11 @@ public class HostProcessOutputParserTests
             Minify(line),
             DateTimeOffset.UnixEpoch);
 
-        Assert.Equal("HttpTrigger1", entry.GetAttribute<string>(HostLogAttributeKeys.FunctionName));
-        Assert.Equal("11111111-1111-1111-1111-111111111111", entry.GetAttribute<string>(HostLogAttributeKeys.FunctionInvocationId));
-        Assert.Equal(CliEventKinds.InvocationCompleted, entry.GetAttribute<string>(HostLogAttributeKeys.CliEventKind));
-        Assert.Equal("succeeded", entry.GetAttribute<string>(HostLogAttributeKeys.FunctionResult));
-        Assert.Equal(123.45, entry.GetAttribute<double>(HostLogAttributeKeys.DurationMs));
+        entry.GetAttribute<string>(HostLogAttributeKeys.FunctionName).Should().Be("HttpTrigger1");
+        entry.GetAttribute<string>(HostLogAttributeKeys.FunctionInvocationId).Should().Be("11111111-1111-1111-1111-111111111111");
+        entry.GetAttribute<string>(HostLogAttributeKeys.CliEventKind).Should().Be(CliEventKinds.InvocationCompleted);
+        entry.GetAttribute<string>(HostLogAttributeKeys.FunctionResult).Should().Be("succeeded");
+        entry.GetAttribute<double>(HostLogAttributeKeys.DurationMs).Should().Be(123.45);
     }
 
     [Fact]
@@ -133,11 +132,11 @@ public class HostProcessOutputParserTests
             "warn: Microsoft.Azure.WebJobs.Hosting.OptionsLoggingService[12]",
             DateTimeOffset.UnixEpoch);
 
-        Assert.Equal(LogLevel.Warning, entry.Level);
-        Assert.Equal("Microsoft.Azure.WebJobs.Hosting.OptionsLoggingService", entry.Category);
-        Assert.Equal(12, entry.EventId.Id);
-        Assert.Equal(string.Empty, entry.Message);
-        Assert.Equal(HostProcessStreamNames.StandardOutput, entry.GetAttribute<string>(HostLogAttributeKeys.Stream));
+        entry.Level.Should().Be(LogLevel.Warning);
+        entry.Category.Should().Be("Microsoft.Azure.WebJobs.Hosting.OptionsLoggingService");
+        entry.EventId.Id.Should().Be(12);
+        entry.Message.Should().Be(string.Empty);
+        entry.GetAttribute<string>(HostLogAttributeKeys.Stream).Should().Be(HostProcessStreamNames.StandardOutput);
     }
 
     [Fact]
@@ -154,15 +153,15 @@ public class HostProcessOutputParserTests
             "      Executed 'Functions.HttpTrigger1' (Failed, Id=abc123, Duration=7ms)",
             DateTimeOffset.UnixEpoch);
 
-        Assert.Equal(LogLevel.Error, entry.Level);
-        Assert.Equal("Function.HttpTrigger1.User", entry.Category);
-        Assert.Equal(3, entry.EventId.Id);
-        Assert.Equal("Executed 'Functions.HttpTrigger1' (Failed, Id=abc123, Duration=7ms)", entry.Message);
-        Assert.Equal("HttpTrigger1", entry.GetAttribute<string>(HostLogAttributeKeys.FunctionName));
-        Assert.Equal("abc123", entry.GetAttribute<string>(HostLogAttributeKeys.FunctionInvocationId));
-        Assert.Equal(CliEventKinds.InvocationCompleted, entry.GetAttribute<string>(HostLogAttributeKeys.CliEventKind));
-        Assert.Equal("failed", entry.GetAttribute<string>(HostLogAttributeKeys.FunctionResult));
-        Assert.Equal(7, entry.GetAttribute<double>(HostLogAttributeKeys.DurationMs));
+        entry.Level.Should().Be(LogLevel.Error);
+        entry.Category.Should().Be("Function.HttpTrigger1.User");
+        entry.EventId.Id.Should().Be(3);
+        entry.Message.Should().Be("Executed 'Functions.HttpTrigger1' (Failed, Id=abc123, Duration=7ms)");
+        entry.GetAttribute<string>(HostLogAttributeKeys.FunctionName).Should().Be("HttpTrigger1");
+        entry.GetAttribute<string>(HostLogAttributeKeys.FunctionInvocationId).Should().Be("abc123");
+        entry.GetAttribute<string>(HostLogAttributeKeys.CliEventKind).Should().Be(CliEventKinds.InvocationCompleted);
+        entry.GetAttribute<string>(HostLogAttributeKeys.FunctionResult).Should().Be("failed");
+        entry.GetAttribute<double>(HostLogAttributeKeys.DurationMs).Should().Be(7);
     }
 
     [Theory]
@@ -175,9 +174,9 @@ public class HostProcessOutputParserTests
 
         HostLogEntry entry = parser.ParseLine(HostProcessStreamNames.StandardOutput, line, DateTimeOffset.UnixEpoch);
 
-        Assert.Equal("Host.Process", entry.Category);
-        Assert.Equal(line, entry.Message);
-        Assert.Equal(HostProcessStreamNames.StandardOutput, entry.GetAttribute<string>(HostLogAttributeKeys.Stream));
+        entry.Category.Should().Be("Host.Process");
+        entry.Message.Should().Be(line);
+        entry.GetAttribute<string>(HostLogAttributeKeys.Stream).Should().Be(HostProcessStreamNames.StandardOutput);
     }
 
     private static string Minify(string json)

--- a/test/Func.Tests/Commands/HostProcessStartInfoFactoryTests.cs
+++ b/test/Func.Tests/Commands/HostProcessStartInfoFactoryTests.cs
@@ -7,7 +7,6 @@ using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Hosting.Dashboard.Rendering;
 using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Workloads;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands;
 
@@ -48,22 +47,22 @@ public class HostProcessStartInfoFactoryTests : IDisposable
 
         HostProcessLaunchInfo launchInfo = factory.Create(context);
 
-        Assert.Equal(Path.Combine(_contentRoot.FullName, GetExecutableName()), launchInfo.StartInfo.FileName);
-        Assert.Equal(_startupDirectory.FullName, launchInfo.StartInfo.WorkingDirectory);
-        Assert.False(launchInfo.StartInfo.UseShellExecute);
-        Assert.True(launchInfo.StartInfo.RedirectStandardInput);
-        Assert.True(launchInfo.StartInfo.RedirectStandardOutput);
-        Assert.True(launchInfo.StartInfo.RedirectStandardError);
-        Assert.Equal(HostProcessStartInfoFactory.DefaultPort, launchInfo.Port);
-        Assert.Equal(new Uri("http://0.0.0.0:7071"), launchInfo.ListenUri);
-        Assert.Equal(new Uri("http://localhost:7071"), launchInfo.LocalBaseUri);
-        Assert.Equal(["--enable-auth", "--urls", "http://0.0.0.0:7071"], launchInfo.StartInfo.ArgumentList);
-        Assert.Equal("custom-value", launchInfo.StartInfo.Environment["CUSTOM_ENV"]);
-        Assert.Equal(_startupDirectory.FullName, launchInfo.StartInfo.Environment[HostProcessStartInfoFactory.ScriptRootEnvironmentVariable]);
-        Assert.Equal("Development", launchInfo.StartInfo.Environment[HostProcessStartInfoFactory.AzureFunctionsEnvironmentVariable]);
-        Assert.Equal("localhost:7071", launchInfo.StartInfo.Environment[HostProcessStartInfoFactory.WebsiteHostnameEnvironmentVariable]);
-        Assert.Equal("true", launchInfo.StartInfo.Environment[HostProcessStartInfoFactory.AspNetCoreSuppressStatusMessagesEnvironmentVariable]);
-        Assert.Equal("None", launchInfo.StartInfo.Environment[HostProcessStartInfoFactory.HostingLifetimeLogLevelEnvironmentVariable]);
+        launchInfo.StartInfo.FileName.Should().Be(Path.Combine(_contentRoot.FullName, GetExecutableName()));
+        launchInfo.StartInfo.WorkingDirectory.Should().Be(_startupDirectory.FullName);
+        launchInfo.StartInfo.UseShellExecute.Should().BeFalse();
+        launchInfo.StartInfo.RedirectStandardInput.Should().BeTrue();
+        launchInfo.StartInfo.RedirectStandardOutput.Should().BeTrue();
+        launchInfo.StartInfo.RedirectStandardError.Should().BeTrue();
+        launchInfo.Port.Should().Be(HostProcessStartInfoFactory.DefaultPort);
+        launchInfo.ListenUri.Should().Be(new Uri("http://0.0.0.0:7071"));
+        launchInfo.LocalBaseUri.Should().Be(new Uri("http://localhost:7071"));
+        launchInfo.StartInfo.ArgumentList.Should().Equal(["--enable-auth", "--urls", "http://0.0.0.0:7071"]);
+        launchInfo.StartInfo.Environment["CUSTOM_ENV"].Should().Be("custom-value");
+        launchInfo.StartInfo.Environment[HostProcessStartInfoFactory.ScriptRootEnvironmentVariable].Should().Be(_startupDirectory.FullName);
+        launchInfo.StartInfo.Environment[HostProcessStartInfoFactory.AzureFunctionsEnvironmentVariable].Should().Be("Development");
+        launchInfo.StartInfo.Environment[HostProcessStartInfoFactory.WebsiteHostnameEnvironmentVariable].Should().Be("localhost:7071");
+        launchInfo.StartInfo.Environment[HostProcessStartInfoFactory.AspNetCoreSuppressStatusMessagesEnvironmentVariable].Should().Be("true");
+        launchInfo.StartInfo.Environment[HostProcessStartInfoFactory.HostingLifetimeLogLevelEnvironmentVariable].Should().Be("None");
     }
 
     [Fact]
@@ -78,10 +77,10 @@ public class HostProcessStartInfoFactoryTests : IDisposable
 
         HostProcessLaunchInfo launchInfo = factory.Create(context);
 
-        Assert.Equal(9090, launchInfo.Port);
-        Assert.Equal(new Uri("http://0.0.0.0:9090"), launchInfo.ListenUri);
-        Assert.Equal(new Uri("http://localhost:9090"), launchInfo.LocalBaseUri);
-        Assert.Equal(["--urls", "http://0.0.0.0:9090"], launchInfo.StartInfo.ArgumentList);
+        launchInfo.Port.Should().Be(9090);
+        launchInfo.ListenUri.Should().Be(new Uri("http://0.0.0.0:9090"));
+        launchInfo.LocalBaseUri.Should().Be(new Uri("http://localhost:9090"));
+        launchInfo.StartInfo.ArgumentList.Should().Equal(["--urls", "http://0.0.0.0:9090"]);
     }
 
     [Theory]
@@ -92,9 +91,9 @@ public class HostProcessStartInfoFactoryTests : IDisposable
         var factory = new HostProcessStartInfoFactory();
         HostProcessStartContext context = CreateContext(port: port, enableAuth: false);
 
-        var exception = Assert.Throws<GracefulException>(() => factory.Create(context));
+        var exception = FluentActions.Invoking(() => factory.Create(context)).Should().ThrowExactly<GracefulException>().Which;
 
-        Assert.Contains("--port", exception.Message);
+        exception.Message.Should().Contain("--port");
     }
 
     private HostProcessStartContext CreateContext(

--- a/test/Func.Tests/Commands/HostWorkloadResolverTests.cs
+++ b/test/Func.Tests/Commands/HostWorkloadResolverTests.cs
@@ -12,7 +12,6 @@ using Azure.Functions.Cli.Workloads.Storage;
 using NSubstitute;
 using NuGet.Versioning;
 using PackageSource = NuGet.Configuration.PackageSource;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands;
 
@@ -44,10 +43,10 @@ public class HostWorkloadResolverTests
 
         HostWorkloadResolution result = await resolver.ResolveAsync(context, CancellationToken.None);
 
-        HostWorkloadResolution.Installed installed = Assert.IsType<HostWorkloadResolution.Installed>(result);
-        Assert.Same(selectedHost, installed.Workload);
-        Assert.Equal("4.1000.0", installed.HostVersion);
-        Assert.False(installed.ExplicitlyRequested);
+        HostWorkloadResolution.Installed installed = result.Should().BeOfType<HostWorkloadResolution.Installed>().Subject;
+        installed.Workload.Should().BeSameAs(selectedHost);
+        installed.HostVersion.Should().Be("4.1000.0");
+        installed.ExplicitlyRequested.Should().BeFalse();
     }
 
     [Fact]
@@ -61,8 +60,8 @@ public class HostWorkloadResolverTests
 
         HostWorkloadResolution result = await resolver.ResolveAsync(context, CancellationToken.None);
 
-        HostWorkloadResolution.Installed installed = Assert.IsType<HostWorkloadResolution.Installed>(result);
-        Assert.Same(selectedHost, installed.Workload);
+        HostWorkloadResolution.Installed installed = result.Should().BeOfType<HostWorkloadResolution.Installed>().Subject;
+        installed.Workload.Should().BeSameAs(selectedHost);
     }
 
     [Fact]
@@ -76,8 +75,8 @@ public class HostWorkloadResolverTests
 
         HostWorkloadResolution result = await resolver.ResolveAsync(context, CancellationToken.None);
 
-        HostWorkloadResolution.Installed installed = Assert.IsType<HostWorkloadResolution.Installed>(result);
-        Assert.Same(currentRidHost, installed.Workload);
+        HostWorkloadResolution.Installed installed = result.Should().BeOfType<HostWorkloadResolution.Installed>().Subject;
+        installed.Workload.Should().BeSameAs(currentRidHost);
     }
 
     [Fact]
@@ -89,10 +88,9 @@ public class HostWorkloadResolverTests
             ProfileHostVersionRange: VersionRange.Parse("[1.8.1, 4.1048.200)"),
             Offline: false);
 
-        HostWorkloadResolutionException ex = await Assert.ThrowsAsync<HostWorkloadResolutionException>(
-            () => resolver.ResolveAsync(context, CancellationToken.None));
+        HostWorkloadResolutionException ex = (await FluentActions.Awaiting(() => resolver.ResolveAsync(context, CancellationToken.None)).Should().ThrowAsync<HostWorkloadResolutionException>()).Which;
 
-        Assert.Contains("outside profile host range", ex.Message);
+        ex.Message.Should().Contain("outside profile host range");
     }
 
     [Fact]
@@ -108,9 +106,9 @@ public class HostWorkloadResolverTests
 
         HostWorkloadResolution result = await resolver.ResolveAsync(context, CancellationToken.None);
 
-        HostWorkloadResolution.Installed installed = Assert.IsType<HostWorkloadResolution.Installed>(result);
-        Assert.True(installed.ExplicitlyRequested);
-        Assert.Same(requestedHost, installed.Workload);
+        HostWorkloadResolution.Installed installed = result.Should().BeOfType<HostWorkloadResolution.Installed>().Subject;
+        installed.ExplicitlyRequested.Should().BeTrue();
+        installed.Workload.Should().BeSameAs(requestedHost);
     }
 
     [Fact]
@@ -124,9 +122,9 @@ public class HostWorkloadResolverTests
 
         HostWorkloadResolution result = await resolver.ResolveAsync(context, CancellationToken.None);
 
-        HostWorkloadResolution.InstallRequired installRequired = Assert.IsType<HostWorkloadResolution.InstallRequired>(result);
-        Assert.Equal("4.1000.0", installRequired.HostVersion);
-        Assert.Equal(_hostPackageId, installRequired.PackageId);
+        HostWorkloadResolution.InstallRequired installRequired = result.Should().BeOfType<HostWorkloadResolution.InstallRequired>().Subject;
+        installRequired.HostVersion.Should().Be("4.1000.0");
+        installRequired.PackageId.Should().Be(_hostPackageId);
     }
 
     [Fact]
@@ -148,9 +146,9 @@ public class HostWorkloadResolverTests
 
         HostWorkloadResolution result = await resolver.ResolveAsync(context, CancellationToken.None);
 
-        HostWorkloadResolution.InstallRequired installRequired = Assert.IsType<HostWorkloadResolution.InstallRequired>(result);
-        Assert.Equal("4.1048.199", installRequired.HostVersion);
-        Assert.Equal(_hostPackageId, installRequired.PackageId);
+        HostWorkloadResolution.InstallRequired installRequired = result.Should().BeOfType<HostWorkloadResolution.InstallRequired>().Subject;
+        installRequired.HostVersion.Should().Be("4.1048.199");
+        installRequired.PackageId.Should().Be(_hostPackageId);
     }
 
     [Fact]
@@ -164,8 +162,8 @@ public class HostWorkloadResolverTests
 
         HostWorkloadResolution result = await resolver.ResolveAsync(context, CancellationToken.None);
 
-        HostWorkloadResolution.InstallRequired installRequired = Assert.IsType<HostWorkloadResolution.InstallRequired>(result);
-        Assert.Equal("[1.8.1, 4.1048.200)", installRequired.HostVersion);
+        HostWorkloadResolution.InstallRequired installRequired = result.Should().BeOfType<HostWorkloadResolution.InstallRequired>().Subject;
+        installRequired.HostVersion.Should().Be("[1.8.1, 4.1048.200)");
         await _workloadCatalog.DidNotReceive().SearchAsync(Arg.Any<CatalogSearchQuery>(), Arg.Any<CancellationToken>());
         await _workloadCatalog.DidNotReceive().ResolveLatestVersionInRangeAsync(
             Arg.Any<string>(),
@@ -192,11 +190,10 @@ public class HostWorkloadResolverTests
             Substitute.For<IProcessEnvironment>());
         StartInitializationStepContext context = NewStepContext(step, offline: true);
 
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => step.ExecuteAsync(context, CancellationToken.None));
+        GracefulException ex = (await FluentActions.Awaiting(() => step.ExecuteAsync(context, CancellationToken.None)).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.Contains("--offline", ex.Message);
-        Assert.Equal("4.1000.0", context.State.HostVersion);
+        ex.Message.Should().Contain("--offline");
+        context.State.HostVersion.Should().Be("4.1000.0");
     }
 
     [Fact]
@@ -218,8 +215,8 @@ public class HostWorkloadResolverTests
 
         StartInitializationStepResult result = await step.ExecuteAsync(context, CancellationToken.None);
 
-        Assert.Equal("No compatible host installed", result.Message);
-        Assert.IsType<InstallHostWorkloadInitializationStep>(context.DrainNextSteps().Single());
+        result.Message.Should().Be("No compatible host installed");
+        context.DrainNextSteps().Single().Should().BeOfType<InstallHostWorkloadInitializationStep>();
     }
 
     [Fact]
@@ -242,10 +239,10 @@ public class HostWorkloadResolverTests
 
         StartInitializationStepResult result = await step.ExecuteAsync(context, CancellationToken.None);
 
-        Assert.Equal("Installed host 4.1000.0", result.Message);
-        Assert.Equal("4.1000.0", context.State.HostVersion);
-        Assert.NotNull(context.State.HostWorkload);
-        Assert.Equal(_hostPackageId, context.State.HostWorkload.PackageId);
+        result.Message.Should().Be("Installed host 4.1000.0");
+        context.State.HostVersion.Should().Be("4.1000.0");
+        context.State.HostWorkload.Should().NotBeNull();
+        context.State.HostWorkload.PackageId.Should().Be(_hostPackageId);
         await installer.Received(1).InstallFromCatalogAsync(
             packageId: _hostPackageId,
             version: Arg.Is<NuGetVersion?>(version => version != null && version.ToNormalizedString() == "4.1000.0"),
@@ -274,11 +271,10 @@ public class HostWorkloadResolverTests
         var step = new InstallHostWorkloadInitializationStep(installer, CreateWorkloadPaths(), _hostPackageId, "4.1000.0");
         StartInitializationStepContext context = NewStepContext(step, offline: false);
 
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => step.ExecuteAsync(context, CancellationToken.None));
+        GracefulException ex = (await FluentActions.Awaiting(() => step.ExecuteAsync(context, CancellationToken.None)).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.True(ex.IsUserError);
-        Assert.Equal("missing host", ex.Message);
+        ex.IsUserError.Should().BeTrue();
+        ex.Message.Should().Be("missing host");
     }
 
     private void UseContentWorkloads(params ContentWorkloadInfo[] workloads)

--- a/test/Func.Tests/Commands/HostWorkloadResolverTests.cs
+++ b/test/Func.Tests/Commands/HostWorkloadResolverTests.cs
@@ -60,8 +60,7 @@ public class HostWorkloadResolverTests
 
         HostWorkloadResolution result = await resolver.ResolveAsync(context, CancellationToken.None);
 
-        HostWorkloadResolution.Installed installed = result.Should().BeOfType<HostWorkloadResolution.Installed>().Subject;
-        installed.Workload.Should().BeSameAs(selectedHost);
+        result.Should().BeOfType<HostWorkloadResolution.Installed>().Which.Workload.Should().BeSameAs(selectedHost);
     }
 
     [Fact]
@@ -75,8 +74,7 @@ public class HostWorkloadResolverTests
 
         HostWorkloadResolution result = await resolver.ResolveAsync(context, CancellationToken.None);
 
-        HostWorkloadResolution.Installed installed = result.Should().BeOfType<HostWorkloadResolution.Installed>().Subject;
-        installed.Workload.Should().BeSameAs(currentRidHost);
+        result.Should().BeOfType<HostWorkloadResolution.Installed>().Which.Workload.Should().BeSameAs(currentRidHost);
     }
 
     [Fact]
@@ -162,8 +160,8 @@ public class HostWorkloadResolverTests
 
         HostWorkloadResolution result = await resolver.ResolveAsync(context, CancellationToken.None);
 
-        HostWorkloadResolution.InstallRequired installRequired = result.Should().BeOfType<HostWorkloadResolution.InstallRequired>().Subject;
-        installRequired.HostVersion.Should().Be("[1.8.1, 4.1048.200)");
+        result.Should().BeOfType<HostWorkloadResolution.InstallRequired>()
+            .Which.HostVersion.Should().Be("[1.8.1, 4.1048.200)");
         await _workloadCatalog.DidNotReceive().SearchAsync(Arg.Any<CatalogSearchQuery>(), Arg.Any<CancellationToken>());
         await _workloadCatalog.DidNotReceive().ResolveLatestVersionInRangeAsync(
             Arg.Any<string>(),

--- a/test/Func.Tests/Commands/InitCommandTests.cs
+++ b/test/Func.Tests/Commands/InitCommandTests.cs
@@ -339,8 +339,7 @@ public class InitCommandTests
 
             exitCode.Should().Be(1);
 
-            WorkloadHint hint = _hintRenderer.Hints.Should().ContainSingle().Subject;
-            hint.Kind.Should().Be(WorkloadHintKind.NoWorkloadsInstalled);
+            _hintRenderer.Hints.Should().ContainSingle().Which.Kind.Should().Be(WorkloadHintKind.NoWorkloadsInstalled);
         }
         finally
         {
@@ -384,8 +383,7 @@ public class InitCommandTests
             python.WasInvoked.Should().BeFalse();
             node.WasInvoked.Should().BeFalse();
 
-            WorkloadHint hint = _hintRenderer.Hints.Should().ContainSingle().Subject;
-            hint.Kind.Should().Be(WorkloadHintKind.AmbiguousStackChoice);
+            _hintRenderer.Hints.Should().ContainSingle().Which.Kind.Should().Be(WorkloadHintKind.AmbiguousStackChoice);
         }
         finally
         {

--- a/test/Func.Tests/Commands/InitCommandTests.cs
+++ b/test/Func.Tests/Commands/InitCommandTests.cs
@@ -11,7 +11,6 @@ using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Workers;
 using Azure.Functions.Cli.Workloads;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands;
 
@@ -53,10 +52,10 @@ public class InitCommandTests
         var cmd = CreateCommand([]);
         var optionNames = cmd.Options.Select(o => o.Name).ToList();
 
-        Assert.Contains("--stack", optionNames);
-        Assert.Contains("--name", optionNames);
-        Assert.Contains("--language", optionNames);
-        Assert.Contains("--force", optionNames);
+        optionNames.Should().Contain("--stack");
+        optionNames.Should().Contain("--name");
+        optionNames.Should().Contain("--language");
+        optionNames.Should().Contain("--force");
     }
 
     [Fact]
@@ -65,8 +64,8 @@ public class InitCommandTests
         var cmd = CreateCommand([]);
         string description = cmd.StackOption.Description ?? string.Empty;
 
-        Assert.Contains("Set up a stack", description);
-        Assert.Contains("func setup --features", description);
+        description.Should().Contain("Set up a stack");
+        description.Should().Contain("func setup --features");
     }
 
     [Fact]
@@ -76,7 +75,7 @@ public class InitCommandTests
             [new FakeProjectInitializer("Python"), new FakeProjectInitializer("dotnet"), new FakeProjectInitializer("node")]);
         string description = cmd.StackOption.Description ?? string.Empty;
 
-        Assert.Contains("Supported values: dotnet, node, python.", description);
+        description.Should().Contain("Supported values: dotnet, node, python.");
     }
 
     [Fact]
@@ -84,7 +83,7 @@ public class InitCommandTests
     {
         var cmd = CreateCommand([]);
 
-        Assert.Contains("func workload search --stack", cmd.GetHelpFooterHint() ?? string.Empty);
+        (cmd.GetHelpFooterHint() ?? string.Empty).Should().Contain("func workload search --stack");
     }
 
     [Fact]
@@ -93,15 +92,15 @@ public class InitCommandTests
         var root = TestParser.CreateRoot(_interaction);
         var names = root.Subcommands.Select(c => c.Name).ToList();
 
-        Assert.Contains("init", names);
+        names.Should().Contain("init");
     }
 
     [Fact]
     public void InitCommand_HasPathArgument()
     {
         var cmd = CreateCommand([]);
-        Assert.Single(cmd.Arguments);
-        Assert.Equal("path", cmd.Arguments[0].Name);
+        cmd.Arguments.Should().ContainSingle();
+        cmd.Arguments[0].Name.Should().Be("path");
     }
 
     [Fact]
@@ -110,7 +109,7 @@ public class InitCommandTests
         // Even when --stack is missing, InitCommand creates the target
         // directory before validating (directory creation is unconditional).
         var newDir = Path.Combine(Path.GetTempPath(), $"func-init-{Guid.NewGuid():N}");
-        Assert.False(Directory.Exists(newDir));
+        Directory.Exists(newDir).Should().BeFalse();
 
         try
         {
@@ -120,8 +119,8 @@ public class InitCommandTests
             var exitCode = await result.InvokeAsync();
 
             // No --stack provided → exit 1, but directory was still created.
-            Assert.Equal(1, exitCode);
-            Assert.True(Directory.Exists(newDir));
+            exitCode.Should().Be(1);
+            Directory.Exists(newDir).Should().BeTrue();
         }
         finally
         {
@@ -142,16 +141,16 @@ public class InitCommandTests
             var initializer = new FakeProjectInitializer("python");
             int exitCode = await RunInitAsync(newDir, initializer, language: "python", stack: "python");
 
-            Assert.Equal(0, exitCode);
-            Assert.True(initializer.WasInvoked);
+            exitCode.Should().Be(0);
+            initializer.WasInvoked.Should().BeTrue();
 
             string configPath = Path.Combine(newDir, ".func", "config.json");
-            Assert.True(File.Exists(configPath), $"Expected .func/config.json at {configPath}.");
+            File.Exists(configPath).Should().BeTrue($"Expected .func/config.json at {configPath}.");
 
             using var doc = JsonDocument.Parse(File.ReadAllText(configPath));
             JsonElement stack = doc.RootElement.GetProperty("stack");
-            Assert.Equal("python", stack.GetProperty("runtime").GetString());
-            Assert.Equal("python", stack.GetProperty("language").GetString());
+            stack.GetProperty("runtime").GetString().Should().Be("python");
+            stack.GetProperty("language").GetString().Should().Be("python");
         }
         finally
         {
@@ -175,10 +174,8 @@ public class InitCommandTests
             var initializer = new FakeProjectInitializer("python");
             int exitCode = await RunInitAsync(newDir, initializer, language: "python", stack: "python");
 
-            Assert.Equal(0, exitCode);
-            Assert.Contains(
-                _interaction.Lines,
-                line => line.Contains("func workload search bundles --prerelease", StringComparison.Ordinal));
+            exitCode.Should().Be(0);
+            _interaction.Lines.Should().Contain(line => line.Contains("func workload search bundles --prerelease", StringComparison.Ordinal));
         }
         finally
         {
@@ -201,10 +198,8 @@ public class InitCommandTests
             var initializer = new FakeProjectInitializer("python");
             int exitCode = await RunInitAsync(newDir, initializer, language: "python", stack: "python");
 
-            Assert.Equal(0, exitCode);
-            Assert.DoesNotContain(
-                _interaction.Lines,
-                line => line.Contains("func workload search bundles --prerelease", StringComparison.Ordinal));
+            exitCode.Should().Be(0);
+            _interaction.Lines.Should().NotContain(line => line.Contains("func workload search bundles --prerelease", StringComparison.Ordinal));
         }
         finally
         {
@@ -225,10 +220,8 @@ public class InitCommandTests
             var initializer = new FakeProjectInitializer("python");
             int exitCode = await RunInitAsync(newDir, initializer, language: "python", stack: "python");
 
-            Assert.Equal(0, exitCode);
-            Assert.DoesNotContain(
-                _interaction.Lines,
-                line => line.Contains("func workload search bundles --prerelease", StringComparison.Ordinal));
+            exitCode.Should().Be(0);
+            _interaction.Lines.Should().NotContain(line => line.Contains("func workload search bundles --prerelease", StringComparison.Ordinal));
         }
         finally
         {
@@ -253,9 +246,9 @@ public class InitCommandTests
 
             // Folder is already a Functions project (.func/config.json present);
             // command refuses without --force, initializer never runs.
-            Assert.Equal(1, exitCode);
-            Assert.False(initializer.WasInvoked);
-            Assert.Equal(existingContent, File.ReadAllText(configPath));
+            exitCode.Should().Be(1);
+            initializer.WasInvoked.Should().BeFalse();
+            File.ReadAllText(configPath).Should().Be(existingContent);
         }
         finally
         {
@@ -276,13 +269,13 @@ public class InitCommandTests
             var initializer = new FakeProjectInitializer("dotnet");
             int exitCode = await RunInitAsync(newDir, initializer, language: null, stack: "dotnet");
 
-            Assert.Equal(0, exitCode);
+            exitCode.Should().Be(0);
 
             string configPath = Path.Combine(newDir, ".func", "config.json");
             using var doc = JsonDocument.Parse(File.ReadAllText(configPath));
             JsonElement stack = doc.RootElement.GetProperty("stack");
-            Assert.Equal("dotnet", stack.GetProperty("runtime").GetString());
-            Assert.False(stack.TryGetProperty("language", out _));
+            stack.GetProperty("runtime").GetString().Should().Be("dotnet");
+            stack.TryGetProperty("language", out _).Should().BeFalse();
         }
         finally
         {
@@ -344,10 +337,10 @@ public class InitCommandTests
         {
             int exitCode = await RunInitAsync(newDir, initializers: []);
 
-            Assert.Equal(1, exitCode);
+            exitCode.Should().Be(1);
 
-            WorkloadHint hint = Assert.Single(_hintRenderer.Hints);
-            Assert.Equal(WorkloadHintKind.NoWorkloadsInstalled, hint.Kind);
+            WorkloadHint hint = _hintRenderer.Hints.Should().ContainSingle().Subject;
+            hint.Kind.Should().Be(WorkloadHintKind.NoWorkloadsInstalled);
         }
         finally
         {
@@ -364,12 +357,12 @@ public class InitCommandTests
             var initializer = new FakeProjectInitializer("python");
             int exitCode = await RunInitAsync(newDir, initializer, language: null, stack: "ruby");
 
-            Assert.Equal(1, exitCode);
-            Assert.False(initializer.WasInvoked);
+            exitCode.Should().Be(1);
+            initializer.WasInvoked.Should().BeFalse();
 
-            WorkloadHint hint = Assert.Single(_hintRenderer.Hints);
-            Assert.Equal(WorkloadHintKind.NoMatchingStack, hint.Kind);
-            Assert.Equal("ruby", hint.RequestedStack);
+            WorkloadHint hint = _hintRenderer.Hints.Should().ContainSingle().Subject;
+            hint.Kind.Should().Be(WorkloadHintKind.NoMatchingStack);
+            hint.RequestedStack.Should().Be("ruby");
         }
         finally
         {
@@ -387,12 +380,12 @@ public class InitCommandTests
             var node = new FakeProjectInitializer("node");
             int exitCode = await RunInitAsync(newDir, [python, node]);
 
-            Assert.Equal(1, exitCode);
-            Assert.False(python.WasInvoked);
-            Assert.False(node.WasInvoked);
+            exitCode.Should().Be(1);
+            python.WasInvoked.Should().BeFalse();
+            node.WasInvoked.Should().BeFalse();
 
-            WorkloadHint hint = Assert.Single(_hintRenderer.Hints);
-            Assert.Equal(WorkloadHintKind.AmbiguousStackChoice, hint.Kind);
+            WorkloadHint hint = _hintRenderer.Hints.Should().ContainSingle().Subject;
+            hint.Kind.Should().Be(WorkloadHintKind.AmbiguousStackChoice);
         }
         finally
         {
@@ -409,13 +402,13 @@ public class InitCommandTests
             var initializer = new FakeProjectInitializer("python");
             int exitCode = await RunInitAsync(newDir, initializer, language: null);
 
-            Assert.Equal(0, exitCode);
-            Assert.True(initializer.WasInvoked);
+            exitCode.Should().Be(0);
+            initializer.WasInvoked.Should().BeTrue();
             AssertConfigJsonHasShape(newDir, expectedStack: "python", expectedLanguage: null);
 
-            WorkloadHint hint = Assert.Single(_hintRenderer.Hints);
-            Assert.Equal(WorkloadHintKind.AutoSelectedSoleWorkload, hint.Kind);
-            Assert.Equal("python", hint.RequestedStack);
+            WorkloadHint hint = _hintRenderer.Hints.Should().ContainSingle().Subject;
+            hint.Kind.Should().Be(WorkloadHintKind.AutoSelectedSoleWorkload);
+            hint.RequestedStack.Should().Be("python");
         }
         finally
         {
@@ -432,12 +425,12 @@ public class InitCommandTests
             var initializer = new FakeProjectInitializer("python");
             int exitCode = await RunInitAsync(newDir, initializer, language: "python", stack: "python");
 
-            Assert.Equal(0, exitCode);
-            Assert.True(initializer.WasInvoked);
+            exitCode.Should().Be(0);
+            initializer.WasInvoked.Should().BeTrue();
             AssertConfigJsonHasShape(newDir, expectedStack: "python", expectedLanguage: "python");
 
             // No hint rendered when --stack matched directly.
-            Assert.Empty(_hintRenderer.Hints);
+            _hintRenderer.Hints.Should().BeEmpty();
         }
         finally
         {
@@ -464,12 +457,12 @@ public class InitCommandTests
             var initializer = new FakeProjectInitializer("python");
             int exitCode = await RunInitAsync(newDir, initializer, language: null, stack: "python");
 
-            Assert.Equal(0, exitCode);
+            exitCode.Should().Be(0);
             // Scaffolding is skipped: existing files survive untouched and the
             // initializer is not invoked.
-            Assert.False(initializer.WasInvoked);
-            Assert.Equal(existingContent, File.ReadAllText(hostPath));
-            Assert.True(File.Exists(userFile));
+            initializer.WasInvoked.Should().BeFalse();
+            File.ReadAllText(hostPath).Should().Be(existingContent);
+            File.Exists(userFile).Should().BeTrue();
             AssertConfigJsonHasShape(newDir, expectedStack: "python", expectedLanguage: null);
         }
         finally
@@ -492,9 +485,9 @@ public class InitCommandTests
             var initializer = new FakeProjectInitializer("python");
             int exitCode = await RunInitAsync(newDir, initializer, language: null, stack: "python");
 
-            Assert.Equal(1, exitCode);
-            Assert.False(initializer.WasInvoked);
-            Assert.Equal("{}", File.ReadAllText(Path.Combine(newDir, ".func", "config.json")));
+            exitCode.Should().Be(1);
+            initializer.WasInvoked.Should().BeFalse();
+            File.ReadAllText(Path.Combine(newDir, ".func", "config.json")).Should().Be("{}");
         }
         finally
         {
@@ -515,8 +508,8 @@ public class InitCommandTests
             var initializer = new FakeProjectInitializer("python");
             int exitCode = await RunInitAsync(newDir, initializer, language: null, stack: "python", force: true);
 
-            Assert.Equal(0, exitCode);
-            Assert.True(initializer.WasInvoked);
+            exitCode.Should().Be(0);
+            initializer.WasInvoked.Should().BeTrue();
         }
         finally
         {
@@ -544,11 +537,11 @@ public class InitCommandTests
             var initializer = new FakeProjectInitializer("python");
             int exitCode = await RunInitAsync(newDir, initializer, language: null, stack: "python", force: true);
 
-            Assert.Equal(0, exitCode);
-            Assert.False(File.Exists(Path.Combine(newDir, "package.json")));
-            Assert.False(File.Exists(Path.Combine(newDir, "requirements.txt")));
-            Assert.False(Directory.Exists(Path.Combine(newDir, "node_modules")));
-            Assert.True(File.Exists(Path.Combine(newDir, ".git", "HEAD")));
+            exitCode.Should().Be(0);
+            File.Exists(Path.Combine(newDir, "package.json")).Should().BeFalse();
+            File.Exists(Path.Combine(newDir, "requirements.txt")).Should().BeFalse();
+            Directory.Exists(Path.Combine(newDir, "node_modules")).Should().BeFalse();
+            File.Exists(Path.Combine(newDir, ".git", "HEAD")).Should().BeTrue();
         }
         finally
         {
@@ -568,8 +561,8 @@ public class InitCommandTests
             var initializer = new FakeProjectInitializer("python");
             int exitCode = await RunInitAsync(newDir, initializer, language: null, stack: "python", force: true);
 
-            Assert.Equal(0, exitCode);
-            Assert.Contains(_interaction.Lines, l => l.StartsWith("WARNING:") && l.Contains("--force will delete"));
+            exitCode.Should().Be(0);
+            _interaction.Lines.Should().Contain(l => l.StartsWith("WARNING:") && l.Contains("--force will delete"));
         }
         finally
         {
@@ -593,8 +586,8 @@ public class InitCommandTests
             var dotnet = new FakeProjectInitializer("dotnet", workerRuntimeAliases: ["dotnet-isolated"]);
             int exitCode = await RunInitAsync(newDir, [dotnet], language: null, stack: null);
 
-            Assert.Equal(0, exitCode);
-            Assert.False(dotnet.WasInvoked);
+            exitCode.Should().Be(0);
+            dotnet.WasInvoked.Should().BeFalse();
             AssertConfigJsonHasShape(newDir, expectedStack: "dotnet", expectedLanguage: null);
         }
         finally
@@ -619,8 +612,8 @@ public class InitCommandTests
             var dotnet = new FakeProjectInitializer("dotnet", workerRuntimeAliases: ["dotnet-isolated"]);
             int exitCode = await RunInitAsync(newDir, dotnet, language: null, stack: "dotnet");
 
-            Assert.Equal(0, exitCode);
-            Assert.False(dotnet.WasInvoked);
+            exitCode.Should().Be(0);
+            dotnet.WasInvoked.Should().BeFalse();
             AssertConfigJsonHasShape(newDir, expectedStack: "dotnet", expectedLanguage: null);
         }
         finally
@@ -648,8 +641,8 @@ public class InitCommandTests
 
             int exitCode = await root.Parse(["init", newDir, "--stack", "dotnet-isolated"]).InvokeAsync();
 
-            Assert.Equal(0, exitCode);
-            Assert.False(dotnet.WasInvoked);
+            exitCode.Should().Be(0);
+            dotnet.WasInvoked.Should().BeFalse();
             AssertConfigJsonHasShape(newDir, expectedStack: "dotnet", expectedLanguage: null);
         }
         finally
@@ -674,8 +667,8 @@ public class InitCommandTests
             var python = new FakeProjectInitializer("python");
             int exitCode = await RunInitAsync(newDir, [python], language: null, stack: null);
 
-            Assert.Equal(0, exitCode);
-            Assert.False(python.WasInvoked);
+            exitCode.Should().Be(0);
+            python.WasInvoked.Should().BeFalse();
             AssertConfigJsonHasShape(newDir, expectedStack: "python", expectedLanguage: null);
         }
         finally
@@ -701,10 +694,10 @@ public class InitCommandTests
             var python = new FakeProjectInitializer("python");
             int exitCode = await RunInitAsync(newDir, [python], language: null, stack: null);
 
-            Assert.Equal(1, exitCode);
-            Assert.False(python.WasInvoked);
-            Assert.False(File.Exists(Path.Combine(newDir, ".func", "config.json")));
-            Assert.Contains(_interaction.Lines, l =>
+            exitCode.Should().Be(1);
+            python.WasInvoked.Should().BeFalse();
+            File.Exists(Path.Combine(newDir, ".func", "config.json")).Should().BeFalse();
+            _interaction.Lines.Should().Contain(l =>
                 l.StartsWith("ERROR:")
                 && l.Contains("'ruby' stack is not installed")
                 && l.Contains("func setup --features <stack>"));
@@ -729,11 +722,11 @@ public class InitCommandTests
             var node = new FakeProjectInitializer("node");
             int exitCode = await RunInitAsync(newDir, [python, node], language: null, stack: "node");
 
-            Assert.Equal(1, exitCode);
-            Assert.False(python.WasInvoked);
-            Assert.False(node.WasInvoked);
-            Assert.False(File.Exists(Path.Combine(newDir, ".func", "config.json")));
-            Assert.Contains(_interaction.Lines, l => l.Contains("conflicts") && l.Contains("python") && l.Contains("node"));
+            exitCode.Should().Be(1);
+            python.WasInvoked.Should().BeFalse();
+            node.WasInvoked.Should().BeFalse();
+            File.Exists(Path.Combine(newDir, ".func", "config.json")).Should().BeFalse();
+            _interaction.Lines.Should().Contain(l => l.Contains("conflicts") && l.Contains("python") && l.Contains("node"));
         }
         finally
         {
@@ -754,8 +747,8 @@ public class InitCommandTests
             var python = new FakeProjectInitializer("python");
             int exitCode = await RunInitAsync(newDir, python, language: null, stack: "python");
 
-            Assert.Equal(0, exitCode);
-            Assert.False(python.WasInvoked);
+            exitCode.Should().Be(0);
+            python.WasInvoked.Should().BeFalse();
             AssertConfigJsonHasShape(newDir, expectedStack: "python", expectedLanguage: null);
         }
         finally
@@ -781,10 +774,10 @@ public class InitCommandTests
             var python = new FakeProjectInitializer("python");
             int exitCode = await RunInitAsync(newDir, python, language: null);
 
-            Assert.Equal(1, exitCode);
-            Assert.False(python.WasInvoked);
-            Assert.False(File.Exists(Path.Combine(newDir, ".func", "config.json")));
-            Assert.Contains(_interaction.Lines, l =>
+            exitCode.Should().Be(1);
+            python.WasInvoked.Should().BeFalse();
+            File.Exists(Path.Combine(newDir, ".func", "config.json")).Should().BeFalse();
+            _interaction.Lines.Should().Contain(l =>
                 l.StartsWith("ERROR:") && l.Contains("Couldn't detect the project's stack"));
         }
         finally
@@ -812,10 +805,10 @@ public class InitCommandTests
 
             int exitCode = await root.Parse(["init", newDir]).InvokeAsync();
 
-            Assert.Equal(0, exitCode);
-            Assert.False(python.WasInvoked);
+            exitCode.Should().Be(0);
+            python.WasInvoked.Should().BeFalse();
             AssertConfigJsonHasShape(newDir, expectedStack: "python", expectedLanguage: null);
-            Assert.Contains(interactive.Lines, l =>
+            interactive.Lines.Should().Contain(l =>
                 l.StartsWith("SELECT:") && l.Contains("Adopting an existing project"));
         }
         finally
@@ -839,10 +832,10 @@ public class InitCommandTests
             var python = new FakeProjectInitializer("python");
             int exitCode = await RunInitAsync(newDir, [python], language: null, stack: "ruby");
 
-            Assert.Equal(1, exitCode);
-            Assert.False(python.WasInvoked);
-            Assert.False(File.Exists(Path.Combine(newDir, ".func", "config.json")));
-            Assert.Contains(_interaction.Lines, l =>
+            exitCode.Should().Be(1);
+            python.WasInvoked.Should().BeFalse();
+            File.Exists(Path.Combine(newDir, ".func", "config.json")).Should().BeFalse();
+            _interaction.Lines.Should().Contain(l =>
                 l.StartsWith("ERROR:")
                 && l.Contains("'ruby' stack is not installed")
                 && l.Contains("func setup --features <stack>"));
@@ -868,8 +861,8 @@ public class InitCommandTests
             var node = new FakeProjectInitializer("node");
             int exitCode = await RunInitAsync(newDir, node, language: null, stack: "node", force: true);
 
-            Assert.Equal(0, exitCode);
-            Assert.True(node.WasInvoked);
+            exitCode.Should().Be(0);
+            node.WasInvoked.Should().BeTrue();
             AssertConfigJsonHasShape(newDir, expectedStack: "node", expectedLanguage: null);
         }
         finally
@@ -893,27 +886,27 @@ public class InitCommandTests
     private static void AssertConfigJsonHasShape(string directory, string? expectedStack, string? expectedLanguage)
     {
         string configPath = Path.Combine(directory, ".func", "config.json");
-        Assert.True(File.Exists(configPath), $"Expected .func/config.json at {configPath}.");
+        File.Exists(configPath).Should().BeTrue($"Expected .func/config.json at {configPath}.");
 
         using var doc = JsonDocument.Parse(File.ReadAllText(configPath));
         if (expectedStack is null)
         {
-            Assert.False(doc.RootElement.TryGetProperty("stack", out _));
+            doc.RootElement.TryGetProperty("stack", out _).Should().BeFalse();
         }
         else
         {
-            Assert.Equal(expectedStack, doc.RootElement.GetProperty("stack").GetProperty("runtime").GetString());
+            doc.RootElement.GetProperty("stack").GetProperty("runtime").GetString().Should().Be(expectedStack);
         }
         if (expectedLanguage is null)
         {
             if (doc.RootElement.TryGetProperty("stack", out JsonElement stack))
             {
-                Assert.False(stack.TryGetProperty("language", out _));
+                stack.TryGetProperty("language", out _).Should().BeFalse();
             }
         }
         else
         {
-            Assert.Equal(expectedLanguage, doc.RootElement.GetProperty("stack").GetProperty("language").GetString());
+            doc.RootElement.GetProperty("stack").GetProperty("language").GetString().Should().Be(expectedLanguage);
         }
     }
 
@@ -934,9 +927,9 @@ public class InitCommandTests
             var initializer = new FakeProjectInitializer("node", ["JavaScript", "TypeScript"]);
             int exitCode = await RunInitAsync(newDir, initializer, language: "python", stack: "node");
 
-            Assert.Equal(1, exitCode);
-            Assert.False(initializer.WasInvoked);
-            Assert.Contains(_interaction.Lines, l => l.Contains("not supported", StringComparison.OrdinalIgnoreCase));
+            exitCode.Should().Be(1);
+            initializer.WasInvoked.Should().BeFalse();
+            _interaction.Lines.Should().Contain(l => l.Contains("not supported", StringComparison.OrdinalIgnoreCase));
         }
         finally
         {
@@ -953,7 +946,7 @@ public class InitCommandTests
             var initializer = new FakeProjectInitializer("python", ["Python"]);
             int exitCode = await RunInitAsync(newDir, initializer, language: null, stack: "python");
 
-            Assert.Equal(0, exitCode);
+            exitCode.Should().Be(0);
 
             // With a single supported language, the stack runtime implies the
             // language; the config skips the redundant 'language' field.
@@ -974,9 +967,9 @@ public class InitCommandTests
             var initializer = new FakeProjectInitializer("node", ["JavaScript", "TypeScript"]);
             int exitCode = await RunInitAsync(newDir, initializer, language: null, stack: "node");
 
-            Assert.Equal(1, exitCode);
-            Assert.False(initializer.WasInvoked);
-            Assert.Contains(_interaction.Lines, l => l.Contains("--language", StringComparison.Ordinal));
+            exitCode.Should().Be(1);
+            initializer.WasInvoked.Should().BeFalse();
+            _interaction.Lines.Should().Contain(l => l.Contains("--language", StringComparison.Ordinal));
         }
         finally
         {
@@ -999,8 +992,8 @@ public class InitCommandTests
         var cmd = CreateCommand([first, second]);
 
         int matches = cmd.Options.Count(o => o.Name == "--no-bundles");
-        Assert.Equal(1, matches);
-        Assert.Same(first.ContributedOptions[0], second.ContributedOptions[0]);
+        matches.Should().Be(1);
+        second.ContributedOptions[0].Should().BeSameAs(first.ContributedOptions[0]);
     }
 
     [Fact]
@@ -1031,8 +1024,8 @@ public class InitCommandTests
                 stack: "python",
                 extraArgs: ["--no-bundles"]);
 
-            Assert.Equal(0, exitCode);
-            Assert.True(observed);
+            exitCode.Should().Be(0);
+            observed.Should().BeTrue();
         }
         finally
         {
@@ -1050,12 +1043,12 @@ public class InitCommandTests
             "python",
             optionFactory: r => [r.GetOrAdd(new Option<string>("--no-bundles"))]);
 
-        var ex = Assert.Throws<InvalidOperationException>(() =>
-            CreateCommand([first, second]));
+        var ex = FluentActions.Invoking(() =>
+            CreateCommand([first, second])).Should().ThrowExactly<InvalidOperationException>().Which;
 
-        Assert.Contains("python", ex.Message);
-        Assert.Contains("node", ex.Message);
-        Assert.Contains("--no-bundles", ex.Message);
+        ex.Message.Should().Contain("python");
+        ex.Message.Should().Contain("node");
+        ex.Message.Should().Contain("--no-bundles");
     }
 
     [Fact]
@@ -1069,12 +1062,12 @@ public class InitCommandTests
             "go",
             optionFactory: r => [r.GetOrAdd(new Option<string>("--clean", "-c"))]);
 
-        var ex = Assert.Throws<InvalidOperationException>(() =>
-            CreateCommand([first, second]));
+        var ex = FluentActions.Invoking(() =>
+            CreateCommand([first, second])).Should().ThrowExactly<InvalidOperationException>().Which;
 
-        Assert.Contains("-c", ex.Message);
-        Assert.Contains("--clean", ex.Message);
-        Assert.Contains("--bundles-channel", ex.Message);
+        ex.Message.Should().Contain("-c");
+        ex.Message.Should().Contain("--clean");
+        ex.Message.Should().Contain("--bundles-channel");
     }
 
     [Fact]
@@ -1101,8 +1094,8 @@ public class InitCommandTests
 
             int exitCode = await RunInitAsync(newDir, dotnet, language: null, stack: "dotnet");
 
-            Assert.Equal(0, exitCode);
-            Assert.False(dotnet.WasInvoked);
+            exitCode.Should().Be(0);
+            dotnet.WasInvoked.Should().BeFalse();
             AssertConfigJsonHasShape(newDir, expectedStack: "dotnet", expectedLanguage: "c#");
         }
         finally
@@ -1128,7 +1121,7 @@ public class InitCommandTests
 
             int exitCode = await RunInitAsync(newDir, dotnet, language: null, stack: "dotnet");
 
-            Assert.Equal(0, exitCode);
+            exitCode.Should().Be(0);
             AssertConfigJsonHasShape(newDir, expectedStack: "dotnet", expectedLanguage: null);
         }
         finally
@@ -1161,7 +1154,7 @@ public class InitCommandTests
 
             int exitCode = await RunInitAsync(newDir, dotnet, language: "F#", stack: "dotnet");
 
-            Assert.Equal(0, exitCode);
+            exitCode.Should().Be(0);
             AssertConfigJsonHasShape(newDir, expectedStack: "dotnet", expectedLanguage: "f#");
         }
         finally
@@ -1198,13 +1191,13 @@ public class InitCommandTests
 
             int exitCode = await RunInitAsync(newDir, dotnet, language: null, stack: null);
 
-            Assert.Equal(0, exitCode);
-            Assert.False(dotnet.WasInvoked);
+            exitCode.Should().Be(0);
+            dotnet.WasInvoked.Should().BeFalse();
             AssertConfigJsonHasShape(newDir, expectedStack: "dotnet", expectedLanguage: "c#");
 
             using var doc = JsonDocument.Parse(File.ReadAllText(Path.Combine(newDir, ".func", "config.json")));
-            Assert.True(doc.RootElement.TryGetProperty("profiles", out JsonElement profiles));
-            Assert.True(profiles.GetProperty("keep").GetBoolean());
+            doc.RootElement.TryGetProperty("profiles", out JsonElement profiles).Should().BeTrue();
+            profiles.GetProperty("keep").GetBoolean().Should().BeTrue();
         }
         finally
         {
@@ -1230,9 +1223,9 @@ public class InitCommandTests
 
             int exitCode = await RunInitAsync(newDir, python, language: null, stack: null);
 
-            Assert.Equal(1, exitCode);
-            Assert.False(python.WasInvoked);
-            Assert.Contains(_interaction.Lines, l => l.Contains("already contains a Functions project", StringComparison.OrdinalIgnoreCase));
+            exitCode.Should().Be(1);
+            python.WasInvoked.Should().BeFalse();
+            _interaction.Lines.Should().Contain(l => l.Contains("already contains a Functions project", StringComparison.OrdinalIgnoreCase));
         }
         finally
         {
@@ -1256,8 +1249,8 @@ public class InitCommandTests
 
             int exitCode = await RunInitAsync(newDir, dotnet, language: null, stack: null);
 
-            Assert.Equal(1, exitCode);
-            Assert.False(dotnet.WasInvoked);
+            exitCode.Should().Be(1);
+            dotnet.WasInvoked.Should().BeFalse();
         }
         finally
         {

--- a/test/Func.Tests/Commands/NewCommandTests.cs
+++ b/test/Func.Tests/Commands/NewCommandTests.cs
@@ -5,7 +5,6 @@ using System.CommandLine;
 using Azure.Functions.Cli.Commands;
 using Azure.Functions.Cli.Templates;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands;
 
@@ -38,11 +37,11 @@ public class NewCommandTests
         var cmd = new NewCommand(_runner);
         var optionNames = cmd.Options.Select(o => o.Name).ToList();
 
-        Assert.Contains("--name", optionNames);
-        Assert.Contains("--template", optionNames);
-        Assert.Contains("--force", optionNames);
-        Assert.Contains("--non-interactive", optionNames);
-        Assert.Contains("--list", optionNames);
+        optionNames.Should().Contain("--name");
+        optionNames.Should().Contain("--template");
+        optionNames.Should().Contain("--force");
+        optionNames.Should().Contain("--non-interactive");
+        optionNames.Should().Contain("--list");
     }
 
     [Fact]
@@ -51,15 +50,15 @@ public class NewCommandTests
         var root = TestParser.CreateRoot(_interaction);
         var names = root.Subcommands.Select(c => c.Name).ToList();
 
-        Assert.Contains("new", names);
+        names.Should().Contain("new");
     }
 
     [Fact]
     public void NewCommand_HasPathArgument()
     {
         var cmd = new NewCommand(_runner);
-        Assert.Single(cmd.Arguments);
-        Assert.Equal("path", cmd.Arguments[0].Name);
+        cmd.Arguments.Should().ContainSingle();
+        cmd.Arguments[0].Name.Should().Be("path");
     }
 
     // Single-dash typos like `-name` must surface as unrecognized options, not "needs a project".
@@ -72,9 +71,7 @@ public class NewCommandTests
             new[] { "new", "--template", "HttpTrigger-Python", "-name", "ttpt" },
             new ParserConfiguration { EnablePosixBundling = false });
 
-        Assert.Contains(
-            result.Errors,
-            e => e.Message.Contains("Unrecognized option '-name'", System.StringComparison.Ordinal));
+        result.Errors.Should().Contain(e => e.Message.Contains("Unrecognized option '-name'", System.StringComparison.Ordinal));
     }
 }
 

--- a/test/Func.Tests/Commands/PackCommandTests.cs
+++ b/test/Func.Tests/Commands/PackCommandTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Commands;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands;
 
@@ -15,7 +14,7 @@ public class PackCommandTests
     {
         var command = new PackCommand(_interaction);
 
-        Assert.True(command.Hidden);
+        command.Hidden.Should().BeTrue();
     }
 
     [Fact]
@@ -26,10 +25,10 @@ public class PackCommandTests
 
         var exitCode = await parseResult.InvokeAsync();
 
-        Assert.NotEqual(0, exitCode);
-        Assert.Contains("not supported yet", _interaction.AllOutput);
-        Assert.Contains("v4", _interaction.AllOutput);
-        Assert.Contains("functions-run-local", _interaction.AllOutput);
+        exitCode.Should().NotBe(0);
+        _interaction.AllOutput.Should().Contain("not supported yet");
+        _interaction.AllOutput.Should().Contain("v4");
+        _interaction.AllOutput.Should().Contain("functions-run-local");
     }
 
     [Fact]
@@ -40,7 +39,7 @@ public class PackCommandTests
 
         var exitCode = await parseResult.InvokeAsync();
 
-        Assert.NotEqual(0, exitCode);
-        Assert.Contains("not supported yet", _interaction.AllOutput);
+        exitCode.Should().NotBe(0);
+        _interaction.AllOutput.Should().Contain("not supported yet");
     }
 }

--- a/test/Func.Tests/Commands/PathArgumentTests.cs
+++ b/test/Func.Tests/Commands/PathArgumentTests.cs
@@ -3,7 +3,6 @@
 
 using System.CommandLine;
 using Azure.Functions.Cli.Commands;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands;
 
@@ -22,10 +21,10 @@ public class PathArgumentTests
 
         var workingDirectory = parseResult.GetValue(cmd.PathArgument!);
 
-        Assert.NotNull(workingDirectory);
-        Assert.True(workingDirectory!.WasExplicit);
-        Assert.Equal("/tmp/some-project", workingDirectory.OriginalPath);
-        Assert.EndsWith("some-project", workingDirectory.Info.Name);
+        workingDirectory.Should().NotBeNull();
+        workingDirectory!.WasExplicit.Should().BeTrue();
+        workingDirectory.OriginalPath.Should().Be("/tmp/some-project");
+        workingDirectory.Info.Name.Should().EndWith("some-project");
     }
 
     [Fact]
@@ -36,10 +35,10 @@ public class PathArgumentTests
 
         var workingDirectory = parseResult.GetValue(cmd.PathArgument!);
 
-        Assert.NotNull(workingDirectory);
-        Assert.False(workingDirectory!.WasExplicit);
-        Assert.Null(workingDirectory.OriginalPath);
-        Assert.Equal(Directory.GetCurrentDirectory(), workingDirectory.Info.FullName);
+        workingDirectory.Should().NotBeNull();
+        workingDirectory!.WasExplicit.Should().BeFalse();
+        workingDirectory.OriginalPath.Should().BeNull();
+        workingDirectory.Info.FullName.Should().Be(Directory.GetCurrentDirectory());
     }
 
     [Fact]
@@ -48,7 +47,7 @@ public class PathArgumentTests
         var cmd = new TestableCommand();
         var parseResult = cmd.Parse(["--bogus"]);
 
-        Assert.NotEmpty(parseResult.Errors);
+        parseResult.Errors.Should().NotBeEmpty();
     }
 
     private sealed class TestableCommand : FuncCliCommand

--- a/test/Func.Tests/Commands/Profile/ProfileCommandTests.cs
+++ b/test/Func.Tests/Commands/Profile/ProfileCommandTests.cs
@@ -2,14 +2,12 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.Text.Json;
 using Azure.Functions.Cli.Commands;
 using Azure.Functions.Cli.Commands.Profile;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Profiles;
 using Microsoft.Extensions.Options;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands.Profile;
 
@@ -39,10 +37,10 @@ public sealed class ProfileCommandTests : IDisposable
         var root = TestParser.CreateRoot(_interaction);
         Command? profileCommand = root.Subcommands.SingleOrDefault(c => c.Name == "profile");
 
-        Assert.NotNull(profileCommand);
-        Assert.Contains(profileCommand!.Subcommands, c => c.Name == "list");
-        Assert.Contains(profileCommand.Subcommands, c => c.Name == "show");
-        Assert.Contains(profileCommand.Subcommands, c => c.Name == "set");
+        profileCommand.Should().NotBeNull();
+        profileCommand!.Subcommands.Should().Contain(c => c.Name == "list");
+        profileCommand.Subcommands.Should().Contain(c => c.Name == "show");
+        profileCommand.Subcommands.Should().Contain(c => c.Name == "set");
     }
 
     [Fact]
@@ -56,12 +54,12 @@ public sealed class ProfileCommandTests : IDisposable
 
         int exit = await InvokeAsync(command, _tempDir);
 
-        Assert.Equal(0, exit);
-        Assert.Contains("  Project profiles    my-preview (default), flex", _interaction.Lines);
-        Assert.Contains("TABLE: [Name, Source, Host Version, Extension Bundle, Status]", _interaction.Lines);
-        Assert.Contains("  ROW: [flex, built-in, [4.0.0, 5.0.0), [3.0.0, 5.0.0), stable]", _interaction.Lines);
-        Assert.Contains("  ROW: [my-preview, user, [4.1.0, 5.0.0), -, stable]", _interaction.Lines);
-        Assert.Contains("  ROW: [staging, project, [4.0.0, 5.0.0), [3.0.0, 5.0.0), stable]", _interaction.Lines);
+        exit.Should().Be(0);
+        _interaction.Lines.Should().Contain("  Project profiles    my-preview (default), flex");
+        _interaction.Lines.Should().Contain("TABLE: [Name, Source, Host Version, Extension Bundle, Status]");
+        _interaction.Lines.Should().Contain("  ROW: [flex, built-in, [4.0.0, 5.0.0), [3.0.0, 5.0.0), stable]");
+        _interaction.Lines.Should().Contain("  ROW: [my-preview, user, [4.1.0, 5.0.0), -, stable]");
+        _interaction.Lines.Should().Contain("  ROW: [staging, project, [4.0.0, 5.0.0), [3.0.0, 5.0.0), stable]");
     }
 
     [Fact]
@@ -74,9 +72,9 @@ public sealed class ProfileCommandTests : IDisposable
 
         int exit = await InvokeAsync(command, "--source", "built-in", _tempDir);
 
-        Assert.Equal(0, exit);
-        string row = Assert.Single(_interaction.Lines, l => l.StartsWith("  ROW:"));
-        Assert.Equal("  ROW: [flex, built-in, [4.0.0, 5.0.0), -, stable]", row);
+        exit.Should().Be(0);
+        string row = _interaction.Lines.Should().ContainSingle(l => l.StartsWith("  ROW:")).Which;
+        row.Should().Be("  ROW: [flex, built-in, [4.0.0, 5.0.0), -, stable]");
     }
 
     [Fact]
@@ -88,12 +86,12 @@ public sealed class ProfileCommandTests : IDisposable
 
         int exit = await InvokeAsync(command, "--json", _tempDir);
 
-        Assert.Equal(0, exit);
-        Assert.DoesNotContain(_interaction.Lines, l => l.StartsWith("TABLE:"));
+        exit.Should().Be(0);
+        _interaction.Lines.Should().NotContain(l => l.StartsWith("TABLE:"));
         string json = _interaction.Lines.Single(l => l.StartsWith("JSON:"));
-        Assert.Contains("\"defaultProfile\":\"flex\"", json);
-        Assert.Contains("\"name\":\"flex\"", json);
-        Assert.Contains("\"source\":\"built-in\"", json);
+        json.Should().Contain("\"defaultProfile\":\"flex\"");
+        json.Should().Contain("\"name\":\"flex\"");
+        json.Should().Contain("\"source\":\"built-in\"");
     }
 
     [Fact]
@@ -113,13 +111,13 @@ public sealed class ProfileCommandTests : IDisposable
 
         int exit = await InvokeAsync(command, "staging", _tempDir);
 
-        Assert.Equal(0, exit);
-        Assert.Contains("  Name    staging", _interaction.Lines);
-        Assert.Contains("  Source    project", _interaction.Lines);
-        Assert.Contains("  Host version    [4.0.0, 5.0.0)", _interaction.Lines);
-        Assert.Contains("  Extension bundle    [3.0.0, 5.0.0)", _interaction.Lines);
-        Assert.Contains("  Workers    node [4.0.0]", _interaction.Lines);
-        Assert.Contains("  Supported runtimes    node", _interaction.Lines);
+        exit.Should().Be(0);
+        _interaction.Lines.Should().Contain("  Name    staging");
+        _interaction.Lines.Should().Contain("  Source    project");
+        _interaction.Lines.Should().Contain("  Host version    [4.0.0, 5.0.0)");
+        _interaction.Lines.Should().Contain("  Extension bundle    [3.0.0, 5.0.0)");
+        _interaction.Lines.Should().Contain("  Workers    node [4.0.0]");
+        _interaction.Lines.Should().Contain("  Supported runtimes    node");
     }
 
     [Fact]
@@ -131,10 +129,10 @@ public sealed class ProfileCommandTests : IDisposable
 
         int exit = await InvokeAsync(command, "staging", "--raw", _tempDir);
 
-        Assert.Equal(0, exit);
-        Assert.Contains("  Name    staging", _interaction.Lines);
-        Assert.Contains("  Extends    flex", _interaction.Lines);
-        Assert.Contains("  Host version    -", _interaction.Lines);
+        exit.Should().Be(0);
+        _interaction.Lines.Should().Contain("  Name    staging");
+        _interaction.Lines.Should().Contain("  Extends    flex");
+        _interaction.Lines.Should().Contain("  Host version    -");
     }
 
     [Fact]
@@ -143,10 +141,9 @@ public sealed class ProfileCommandTests : IDisposable
         ProfileShowCommand command = CreateShowCommand(
             Source(ProfileSourceKind.BuiltIn, Profile("flex", hostRange: "[4.0.0, 5.0.0)")));
 
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => InvokeAsync(command, "missing", _tempDir));
+        GracefulException ex = (await FluentActions.Awaiting(() => InvokeAsync(command, "missing", _tempDir)).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.Contains("Profile 'missing' was not found.", ex.Message);
+        ex.Message.Should().Contain("Profile 'missing' was not found.");
     }
 
     [Fact]
@@ -158,14 +155,14 @@ public sealed class ProfileCommandTests : IDisposable
 
         int exit = await InvokeAsync(command, "flex", _tempDir);
 
-        Assert.Equal(0, exit);
-        Assert.Contains("SUCCESS: Profile 'flex' set as this project's default.", _interaction.Lines);
-        Assert.Contains("HINT: Added 'flex' to this project's profiles list.", _interaction.Lines);
+        exit.Should().Be(0);
+        _interaction.Lines.Should().Contain("SUCCESS: Profile 'flex' set as this project's default.");
+        _interaction.Lines.Should().Contain("HINT: Added 'flex' to this project's profiles list.");
         using JsonDocument document = ReadProjectConfig();
         JsonElement root = document.RootElement;
-        Assert.Equal("flex", root.GetProperty("defaultProfile").GetString());
-        JsonElement profile = Assert.Single(root.GetProperty("profiles").EnumerateArray());
-        Assert.Equal("flex", profile.GetString());
+        root.GetProperty("defaultProfile").GetString().Should().Be("flex");
+        JsonElement profile = root.GetProperty("profiles").EnumerateArray().Should().ContainSingle().Subject;
+        profile.GetString().Should().Be("flex");
     }
 
     [Fact]
@@ -186,14 +183,14 @@ public sealed class ProfileCommandTests : IDisposable
 
         int exit = await InvokeAsync(command, "staging", _tempDir);
 
-        Assert.Equal(0, exit);
+        exit.Should().Be(0);
         using JsonDocument document = ReadProjectConfig();
         JsonElement root = document.RootElement;
-        Assert.Equal("node", root.GetProperty("stack").GetProperty("runtime").GetString());
-        Assert.Equal("staging", root.GetProperty("defaultProfile").GetString());
+        root.GetProperty("stack").GetProperty("runtime").GetString().Should().Be("node");
+        root.GetProperty("defaultProfile").GetString().Should().Be("staging");
         string?[] profiles = [.. root.GetProperty("profiles").EnumerateArray().Select(p => p.GetString())];
         string?[] expectedProfiles = ["flex", "staging"];
-        Assert.Equal(expectedProfiles, profiles);
+        profiles.Should().Equal(expectedProfiles);
     }
 
     [Fact]
@@ -205,13 +202,13 @@ public sealed class ProfileCommandTests : IDisposable
 
         int exit = await InvokeAsync(command, "flex", _tempDir);
 
-        Assert.Equal(0, exit);
-        Assert.DoesNotContain(_interaction.Lines, l => l.StartsWith("HINT: Added", StringComparison.Ordinal));
+        exit.Should().Be(0);
+        _interaction.Lines.Should().NotContain(l => l.StartsWith("HINT: Added", StringComparison.Ordinal));
         using JsonDocument document = ReadProjectConfig();
         JsonElement root = document.RootElement;
-        JsonElement profile = Assert.Single(root.GetProperty("profiles").EnumerateArray());
-        Assert.Equal("FLEX", profile.GetString());
-        Assert.Equal("FLEX", root.GetProperty("defaultProfile").GetString());
+        JsonElement profile = root.GetProperty("profiles").EnumerateArray().Should().ContainSingle().Subject;
+        profile.GetString().Should().Be("FLEX");
+        root.GetProperty("defaultProfile").GetString().Should().Be("FLEX");
     }
 
     [Fact]
@@ -220,11 +217,10 @@ public sealed class ProfileCommandTests : IDisposable
         ProfileSetCommand command = CreateSetCommand(
             Source(ProfileSourceKind.BuiltIn, Profile("flex")));
 
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => InvokeAsync(command, "missing", _tempDir));
+        GracefulException ex = (await FluentActions.Awaiting(() => InvokeAsync(command, "missing", _tempDir)).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.Contains("Profile 'missing' was not found.", ex.Message);
-        Assert.False(_fileSystem.Exists(ProjectConfigPath()));
+        ex.Message.Should().Contain("Profile 'missing' was not found.");
+        _fileSystem.Exists(ProjectConfigPath()).Should().BeFalse();
     }
 
     [Fact]
@@ -233,12 +229,11 @@ public sealed class ProfileCommandTests : IDisposable
         ProfileSetCommand command = CreateSetCommand(
             Source(ProfileSourceKind.BuiltIn, Profile("flex")));
 
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => InvokeAsync(command, "flex", _tempDir));
+        GracefulException ex = (await FluentActions.Awaiting(() => InvokeAsync(command, "flex", _tempDir)).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.Contains("Project not initialized.", ex.Message);
-        Assert.Contains("Run 'func init'", ex.Message);
-        Assert.False(_fileSystem.Exists(ProjectConfigPath()));
+        ex.Message.Should().Contain("Project not initialized.");
+        ex.Message.Should().Contain("Run 'func init'");
+        _fileSystem.Exists(ProjectConfigPath()).Should().BeFalse();
     }
 
     [Fact]
@@ -248,10 +243,9 @@ public sealed class ProfileCommandTests : IDisposable
         ProfileSetCommand command = CreateSetCommand(
             Source(ProfileSourceKind.BuiltIn, Profile("flex")));
 
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => InvokeAsync(command, "flex", _tempDir));
+        GracefulException ex = (await FluentActions.Awaiting(() => InvokeAsync(command, "flex", _tempDir)).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.Contains("contains invalid JSON", ex.Message);
+        ex.Message.Should().Contain("contains invalid JSON");
     }
 
     private ProfileListCommand CreateListCommand(ProjectProfileOptions options, params IProfileSource[] sources)

--- a/test/Func.Tests/Commands/Profile/ProfileCommandTests.cs
+++ b/test/Func.Tests/Commands/Profile/ProfileCommandTests.cs
@@ -161,8 +161,7 @@ public sealed class ProfileCommandTests : IDisposable
         using JsonDocument document = ReadProjectConfig();
         JsonElement root = document.RootElement;
         root.GetProperty("defaultProfile").GetString().Should().Be("flex");
-        JsonElement profile = root.GetProperty("profiles").EnumerateArray().Should().ContainSingle().Subject;
-        profile.GetString().Should().Be("flex");
+        root.GetProperty("profiles").EnumerateArray().Should().ContainSingle().Which.GetString().Should().Be("flex");
     }
 
     [Fact]
@@ -206,8 +205,7 @@ public sealed class ProfileCommandTests : IDisposable
         _interaction.Lines.Should().NotContain(l => l.StartsWith("HINT: Added", StringComparison.Ordinal));
         using JsonDocument document = ReadProjectConfig();
         JsonElement root = document.RootElement;
-        JsonElement profile = root.GetProperty("profiles").EnumerateArray().Should().ContainSingle().Subject;
-        profile.GetString().Should().Be("FLEX");
+        root.GetProperty("profiles").EnumerateArray().Should().ContainSingle().Which.GetString().Should().Be("FLEX");
         root.GetProperty("defaultProfile").GetString().Should().Be("FLEX");
     }
 

--- a/test/Func.Tests/Commands/PublishCommandTests.cs
+++ b/test/Func.Tests/Commands/PublishCommandTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Commands;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands;
 
@@ -15,7 +14,7 @@ public class PublishCommandTests
     {
         var command = new PublishCommand(_interaction);
 
-        Assert.True(command.Hidden);
+        command.Hidden.Should().BeTrue();
     }
 
     [Fact]
@@ -26,10 +25,10 @@ public class PublishCommandTests
 
         var exitCode = await parseResult.InvokeAsync();
 
-        Assert.NotEqual(0, exitCode);
-        Assert.Contains("not supported in v5", _interaction.AllOutput);
-        Assert.Contains("az functionapp deployment", _interaction.AllOutput);
-        Assert.Contains("functions-run-local", _interaction.AllOutput);
+        exitCode.Should().NotBe(0);
+        _interaction.AllOutput.Should().Contain("not supported in v5");
+        _interaction.AllOutput.Should().Contain("az functionapp deployment");
+        _interaction.AllOutput.Should().Contain("functions-run-local");
     }
 
     [Fact]
@@ -40,7 +39,7 @@ public class PublishCommandTests
 
         var exitCode = await parseResult.InvokeAsync();
 
-        Assert.NotEqual(0, exitCode);
-        Assert.Contains("not supported in v5", _interaction.AllOutput);
+        exitCode.Should().NotBe(0);
+        _interaction.AllOutput.Should().Contain("not supported in v5");
     }
 }

--- a/test/Func.Tests/Commands/Quickstart/QuickstartCommandTests.cs
+++ b/test/Func.Tests/Commands/Quickstart/QuickstartCommandTests.cs
@@ -1,11 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Azure.Functions.Cli.Commands;
 using Azure.Functions.Cli.Commands.Quickstart;
 using Azure.Functions.Cli.Quickstart;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands.Quickstart;
 
@@ -30,14 +28,14 @@ public class QuickstartCommandTests
 
         var optionNames = cmd.Options.Select(o => o.Name).ToList();
 
-        Assert.Contains("--stack", optionNames);
-        Assert.Contains("--language", optionNames);
-        Assert.Contains("--template", optionNames);
-        Assert.Contains("--resource", optionNames);
-        Assert.Contains("--iac", optionNames);
-        Assert.Contains("--search", optionNames);
-        Assert.Contains("--fetch", optionNames);
-        Assert.Contains("--force", optionNames);
+        optionNames.Should().Contain("--stack");
+        optionNames.Should().Contain("--language");
+        optionNames.Should().Contain("--template");
+        optionNames.Should().Contain("--resource");
+        optionNames.Should().Contain("--iac");
+        optionNames.Should().Contain("--search");
+        optionNames.Should().Contain("--fetch");
+        optionNames.Should().Contain("--force");
     }
 
     [Fact]
@@ -46,8 +44,8 @@ public class QuickstartCommandTests
         QuickstartCommand cmd = CreateCommand();
         string description = cmd.StackOption.Description ?? string.Empty;
 
-        Assert.Contains("Set up a stack", description);
-        Assert.Contains("func setup --features", description);
+        description.Should().Contain("Set up a stack");
+        description.Should().Contain("func setup --features");
     }
 
     [Fact]
@@ -59,7 +57,7 @@ public class QuickstartCommandTests
             QuickstartTestHelpers.CreateProvider(stack: "node"));
         string description = cmd.StackOption.Description ?? string.Empty;
 
-        Assert.Contains("Supported values: dotnet, node, python.", description);
+        description.Should().Contain("Supported values: dotnet, node, python.");
     }
 
     [Fact]
@@ -67,7 +65,7 @@ public class QuickstartCommandTests
     {
         QuickstartCommand cmd = CreateCommand();
 
-        Assert.Contains("func workload search --stack", cmd.GetHelpFooterHint() ?? string.Empty);
+        (cmd.GetHelpFooterHint() ?? string.Empty).Should().Contain("func workload search --stack");
     }
 
     [Fact]
@@ -77,8 +75,8 @@ public class QuickstartCommandTests
 
         var subcommandNames = cmd.Subcommands.Select(c => c.Name).ToList();
 
-        Assert.Contains("list", subcommandNames);
-        Assert.Contains("info", subcommandNames);
+        subcommandNames.Should().Contain("list");
+        subcommandNames.Should().Contain("info");
     }
 
     [Fact]
@@ -86,8 +84,8 @@ public class QuickstartCommandTests
     {
         QuickstartCommand cmd = CreateCommand();
 
-        Assert.Single(cmd.Arguments);
-        Assert.Equal("path", cmd.Arguments[0].Name);
+        cmd.Arguments.Should().ContainSingle();
+        cmd.Arguments[0].Name.Should().Be("path");
     }
 
     [Fact]
@@ -96,6 +94,6 @@ public class QuickstartCommandTests
         var root = TestParser.CreateRoot(_interaction);
         var names = root.Subcommands.Select(c => c.Name).ToList();
 
-        Assert.Contains("quickstart", names);
+        names.Should().Contain("quickstart");
     }
 }

--- a/test/Func.Tests/Commands/Quickstart/QuickstartInfoCommandTests.cs
+++ b/test/Func.Tests/Commands/Quickstart/QuickstartInfoCommandTests.cs
@@ -5,7 +5,6 @@ using System.CommandLine;
 using Azure.Functions.Cli.Commands.Quickstart;
 using Azure.Functions.Cli.Quickstart;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands.Quickstart;
 
@@ -21,15 +20,15 @@ public class QuickstartInfoCommandTests
     public void QuickstartInfoCommand_HasJsonOption()
     {
         QuickstartInfoCommand cmd = CreateCommand();
-        Assert.Contains(cmd.Options, o => o.Name == "--json");
+        cmd.Options.Should().Contain(o => o.Name == "--json");
     }
 
     [Fact]
     public void QuickstartInfoCommand_HasTemplateIdArgument()
     {
         QuickstartInfoCommand cmd = CreateCommand();
-        Assert.Single(cmd.Arguments);
-        Assert.Equal("id", cmd.Arguments[0].Name);
+        cmd.Arguments.Should().ContainSingle();
+        cmd.Arguments[0].Name.Should().Be("id");
     }
 
     [Fact]
@@ -40,8 +39,8 @@ public class QuickstartInfoCommandTests
 
         int exit = await InvokeAsync(CreateCommand(), "nonexistent");
 
-        Assert.Equal(1, exit);
-        Assert.Contains(_interaction.Lines, l => l.Contains("not found"));
+        exit.Should().Be(1);
+        _interaction.Lines.Should().Contain(l => l.Contains("not found"));
     }
 
     [Fact]
@@ -57,11 +56,11 @@ public class QuickstartInfoCommandTests
 
         int exit = await InvokeAsync(CreateCommand(), "http-py");
 
-        Assert.Equal(0, exit);
-        Assert.DoesNotContain(_interaction.Lines, l => l.StartsWith("JSON:"));
-        Assert.Contains(_interaction.Lines, l => l.Contains("http-py"));
-        Assert.Contains(_interaction.Lines, l => l.Contains("Python"));
-        Assert.Contains(_interaction.Lines, l => l.Contains("http"));
+        exit.Should().Be(0);
+        _interaction.Lines.Should().NotContain(l => l.StartsWith("JSON:"));
+        _interaction.Lines.Should().Contain(l => l.Contains("http-py"));
+        _interaction.Lines.Should().Contain(l => l.Contains("Python"));
+        _interaction.Lines.Should().Contain(l => l.Contains("http"));
     }
 
     [Fact]
@@ -77,13 +76,13 @@ public class QuickstartInfoCommandTests
 
         int exit = await InvokeAsync(CreateCommand(), "http-py", "--json");
 
-        Assert.Equal(0, exit);
+        exit.Should().Be(0);
         string jsonLine = _interaction.Lines.Single(l => l.StartsWith("JSON:"));
-        Assert.Contains("\"id\":\"http-py\"", jsonLine);
-        Assert.Contains("\"name\":\"HTTP Trigger\"", jsonLine);
-        Assert.Contains("\"language\":\"Python\"", jsonLine);
-        Assert.Contains("\"resource\":\"http\"", jsonLine);
-        Assert.Contains("\"iac\":\"bicep\"", jsonLine);
+        jsonLine.Should().Contain("\"id\":\"http-py\"");
+        jsonLine.Should().Contain("\"name\":\"HTTP Trigger\"");
+        jsonLine.Should().Contain("\"language\":\"Python\"");
+        jsonLine.Should().Contain("\"resource\":\"http\"");
+        jsonLine.Should().Contain("\"iac\":\"bicep\"");
     }
 
     [Fact]
@@ -97,9 +96,9 @@ public class QuickstartInfoCommandTests
 
         int exit = await InvokeAsync(CreateCommand(), "http-py", "--json");
 
-        Assert.Equal(0, exit);
+        exit.Should().Be(0);
         string jsonLine = _interaction.Lines.Single(l => l.StartsWith("JSON:"));
-        Assert.Contains("\"language\":\"FSharp\"", jsonLine);
+        jsonLine.Should().Contain("\"language\":\"FSharp\"");
     }
 
     [Fact]
@@ -115,9 +114,9 @@ public class QuickstartInfoCommandTests
 
         int exit = await InvokeAsync(CreateCommand(), "http-py", "--json");
 
-        Assert.Equal(0, exit);
+        exit.Should().Be(0);
         string jsonLine = _interaction.Lines.Single(l => l.StartsWith("JSON:"));
-        Assert.Contains("\"iac\":\"none\"", jsonLine);
+        jsonLine.Should().Contain("\"iac\":\"none\"");
     }
 
     [Fact]
@@ -133,8 +132,8 @@ public class QuickstartInfoCommandTests
 
         int exit = await InvokeAsync(CreateCommand(), "HTTP-PY");
 
-        Assert.Equal(0, exit);
-        Assert.Contains(_interaction.Lines, l => l.Contains("http-py"));
+        exit.Should().Be(0);
+        _interaction.Lines.Should().Contain(l => l.Contains("http-py"));
     }
 
     // --- helpers ---

--- a/test/Func.Tests/Commands/Quickstart/QuickstartListCommandTests.cs
+++ b/test/Func.Tests/Commands/Quickstart/QuickstartListCommandTests.cs
@@ -5,7 +5,6 @@ using System.CommandLine;
 using Azure.Functions.Cli.Commands.Quickstart;
 using Azure.Functions.Cli.Quickstart;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands.Quickstart;
 
@@ -24,12 +23,12 @@ public class QuickstartListCommandTests
         QuickstartListCommand cmd = CreateCommand();
         var optionNames = cmd.Options.Select(o => o.Name).ToList();
 
-        Assert.Contains("--stack", optionNames);
-        Assert.Contains("--language", optionNames);
-        Assert.Contains("--resource", optionNames);
-        Assert.Contains("--iac", optionNames);
-        Assert.Contains("--search", optionNames);
-        Assert.Contains("--json", optionNames);
+        optionNames.Should().Contain("--stack");
+        optionNames.Should().Contain("--language");
+        optionNames.Should().Contain("--resource");
+        optionNames.Should().Contain("--iac");
+        optionNames.Should().Contain("--search");
+        optionNames.Should().Contain("--json");
     }
 
     [Fact]
@@ -39,8 +38,8 @@ public class QuickstartListCommandTests
         Option<string?> stackOption = cmd.StackOption;
         string description = stackOption.Description ?? string.Empty;
 
-        Assert.Contains("Set up a stack", description);
-        Assert.Contains("func setup --features", description);
+        description.Should().Contain("Set up a stack");
+        description.Should().Contain("func setup --features");
     }
 
     [Fact]
@@ -52,7 +51,7 @@ public class QuickstartListCommandTests
             QuickstartTestHelpers.CreateProvider(stack: "node"));
         string description = cmd.StackOption.Description ?? string.Empty;
 
-        Assert.Contains("Supported values: dotnet, node, python.", description);
+        description.Should().Contain("Supported values: dotnet, node, python.");
     }
 
     [Fact]
@@ -60,7 +59,7 @@ public class QuickstartListCommandTests
     {
         QuickstartListCommand cmd = CreateCommand();
 
-        Assert.Contains("func workload search --stack", cmd.GetHelpFooterHint() ?? string.Empty);
+        (cmd.GetHelpFooterHint() ?? string.Empty).Should().Contain("func workload search --stack");
     }
 
     [Fact]
@@ -71,7 +70,7 @@ public class QuickstartListCommandTests
 
         int exit = await InvokeAsync(CreateCommand(), "--stack", "missing");
 
-        Assert.Equal(1, exit);
+        exit.Should().Be(1);
     }
 
     [Fact]
@@ -86,9 +85,9 @@ public class QuickstartListCommandTests
 
         int exit = await InvokeAsync(CreateCommand());
 
-        Assert.Equal(0, exit);
-        Assert.Contains("TABLE: [ID, Name, Description]", _interaction.Lines);
-        Assert.DoesNotContain(_interaction.Lines, l => l.StartsWith("JSON:"));
+        exit.Should().Be(0);
+        _interaction.Lines.Should().Contain("TABLE: [ID, Name, Description]");
+        _interaction.Lines.Should().NotContain(l => l.StartsWith("JSON:"));
     }
 
     [Fact]
@@ -102,12 +101,12 @@ public class QuickstartListCommandTests
 
         int exit = await InvokeAsync(CreateCommand(), "--json");
 
-        Assert.Equal(0, exit);
-        Assert.DoesNotContain(_interaction.Lines, l => l.StartsWith("TABLE:"));
+        exit.Should().Be(0);
+        _interaction.Lines.Should().NotContain(l => l.StartsWith("TABLE:"));
         string jsonLine = _interaction.Lines.Single(l => l.StartsWith("JSON:"));
-        Assert.Contains("\"id\":\"http-py\"", jsonLine);
-        Assert.Contains("\"name\":\"HTTP Trigger\"", jsonLine);
-        Assert.Contains("\"description\":\"A Python HTTP trigger\"", jsonLine);
+        jsonLine.Should().Contain("\"id\":\"http-py\"");
+        jsonLine.Should().Contain("\"name\":\"HTTP Trigger\"");
+        jsonLine.Should().Contain("\"description\":\"A Python HTTP trigger\"");
     }
 
     [Fact]
@@ -121,9 +120,9 @@ public class QuickstartListCommandTests
 
         int exit = await InvokeAsync(CreateCommand(), "--json");
 
-        Assert.Equal(0, exit);
+        exit.Should().Be(0);
         string jsonLine = _interaction.Lines.Single(l => l.StartsWith("JSON:"));
-        Assert.Contains("\"description\":\"\"", jsonLine);
+        jsonLine.Should().Contain("\"description\":\"\"");
     }
 
     [Fact]
@@ -136,8 +135,8 @@ public class QuickstartListCommandTests
 
         int exit = await InvokeAsync(CreateCommand());
 
-        Assert.Equal(0, exit);
-        Assert.Contains(_interaction.Lines, l => l.Contains("No templates match"));
+        exit.Should().Be(0);
+        _interaction.Lines.Should().Contain(l => l.Contains("No templates match"));
     }
 
     [Fact]
@@ -155,7 +154,7 @@ public class QuickstartListCommandTests
 
         int exit = await InvokeAsync(CreateCommand(), "--language", "unknown");
 
-        Assert.Equal(1, exit);
+        exit.Should().Be(1);
     }
 
     // --- helpers ---

--- a/test/Func.Tests/Commands/Setup/SetupCommandTests.cs
+++ b/test/Func.Tests/Commands/Setup/SetupCommandTests.cs
@@ -2,15 +2,11 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.CommandLine;
-using System.CommandLine.Invocation;
-using Azure.Functions.Cli;
 using Azure.Functions.Cli.Commands;
 using Azure.Functions.Cli.Commands.Setup;
 using Azure.Functions.Cli.Common;
-using Azure.Functions.Cli.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands.Setup;
 
@@ -39,16 +35,16 @@ public sealed class SetupCommandTests : IDisposable
         var cmd = new SetupCommand(Substitute.For<ISetupRunner>(), Microsoft.Extensions.Options.Options.Create(new Azure.Functions.Cli.Workloads.Catalog.WorkloadCatalogOptions()));
         IReadOnlyList<string> optionNames = cmd.Options.Select(o => o.Name).ToArray();
 
-        Assert.Contains("--features", optionNames);
-        Assert.Contains("--profile", optionNames);
-        Assert.Contains("--profiles", optionNames);
-        Assert.Contains("--install-policy", optionNames);
-        Assert.Contains("--source", optionNames);
-        Assert.Contains("--prerelease", optionNames);
-        Assert.Contains("--non-interactive", optionNames);
-        Assert.Contains("--yes", optionNames);
-        Assert.Contains("--check", optionNames);
-        Assert.Contains("--output", optionNames);
+        optionNames.Should().Contain("--features");
+        optionNames.Should().Contain("--profile");
+        optionNames.Should().Contain("--profiles");
+        optionNames.Should().Contain("--install-policy");
+        optionNames.Should().Contain("--source");
+        optionNames.Should().Contain("--prerelease");
+        optionNames.Should().Contain("--non-interactive");
+        optionNames.Should().Contain("--yes");
+        optionNames.Should().Contain("--check");
+        optionNames.Should().Contain("--output");
     }
 
     [Fact]
@@ -57,8 +53,8 @@ public sealed class SetupCommandTests : IDisposable
         var cmd = new SetupCommand(Substitute.For<ISetupRunner>(), Microsoft.Extensions.Options.Options.Create(new Azure.Functions.Cli.Workloads.Catalog.WorkloadCatalogOptions()));
         string description = cmd.FeaturesOption.Description ?? string.Empty;
 
-        Assert.Contains("dotnet", description);
-        Assert.DoesNotContain("dotnet-isolated", description);
+        description.Should().Contain("dotnet");
+        description.Should().NotContain("dotnet-isolated");
     }
 
     [Fact]
@@ -66,7 +62,7 @@ public sealed class SetupCommandTests : IDisposable
     {
         var root = TestParser.CreateRoot(_interaction);
 
-        Assert.Contains(root.Subcommands, command => command.Name == "setup");
+        root.Subcommands.Should().Contain(command => command.Name == "setup");
     }
 
     [Fact]
@@ -87,7 +83,7 @@ public sealed class SetupCommandTests : IDisposable
 
         int exitCode = await result.InvokeAsync(new InvocationConfiguration { EnableDefaultExceptionHandler = false });
 
-        Assert.Equal(0, exitCode);
+        exitCode.Should().Be(0);
         await setupRunner.Received(1).RunAsync(
             Arg.Is<SetupCommandOptions>(options =>
                 options.WorkingDirectory.FullName == new DirectoryInfo(_tempDir).FullName
@@ -109,10 +105,9 @@ public sealed class SetupCommandTests : IDisposable
         var root = TestParser.CreateRoot(_interaction);
         ParseResult result = root.Parse($"setup \"{_tempDir}\" --install-policy always");
 
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => result.InvokeAsync(new InvocationConfiguration { EnableDefaultExceptionHandler = false }));
+        GracefulException ex = (await FluentActions.Awaiting(() => result.InvokeAsync(new InvocationConfiguration { EnableDefaultExceptionHandler = false })).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.Contains("--install-policy", ex.Message);
-        Assert.Contains("always", ex.Message);
+        ex.Message.Should().Contain("--install-policy");
+        ex.Message.Should().Contain("always");
     }
 }

--- a/test/Func.Tests/Commands/Setup/SetupFeatureCatalogTests.cs
+++ b/test/Func.Tests/Commands/Setup/SetupFeatureCatalogTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Commands.Setup;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands.Setup;
 
@@ -20,8 +19,8 @@ public sealed class SetupFeatureCatalogTests
     {
         bool matched = SetupFeatureCatalog.TryGetFeatureForPackageId(packageId, out string feature);
 
-        Assert.True(matched);
-        Assert.Equal(expectedFeature, feature);
+        matched.Should().BeTrue();
+        feature.Should().Be(expectedFeature);
     }
 
     [Theory]
@@ -33,7 +32,7 @@ public sealed class SetupFeatureCatalogTests
     {
         bool matched = SetupFeatureCatalog.TryGetFeatureForPackageId(packageId, out string feature);
 
-        Assert.False(matched);
-        Assert.Equal(string.Empty, feature);
+        matched.Should().BeFalse();
+        feature.Should().Be(string.Empty);
     }
 }

--- a/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
+++ b/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
@@ -17,7 +17,6 @@ using Microsoft.Extensions.Options;
 using NSubstitute;
 using NuGet.Configuration;
 using NuGet.Versioning;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands.Setup;
 
@@ -75,7 +74,7 @@ public sealed class SetupRunnerTests : IDisposable
 
         SetupRunResult result = await runner.RunAsync(Options(), CancellationToken.None);
 
-        Assert.Equal(0, result.ExitCode);
+        result.ExitCode.Should().Be(0);
         await _installer.Received(1).InstallFromCatalogAsync(
             Arg.Is<string>(id => string.Equals(id, _hostPackageId, StringComparison.OrdinalIgnoreCase)),
             Arg.Is<NuGetVersion>(version => version.ToNormalizedString() == "4.1.0"),
@@ -111,7 +110,7 @@ public sealed class SetupRunnerTests : IDisposable
 
         SetupRunResult result = await runner.RunAsync(Options(), CancellationToken.None);
 
-        Assert.Equal(0, result.ExitCode);
+        result.ExitCode.Should().Be(0);
 
         await _installer.Received(1).InstallFromCatalogAsync(
             Arg.Is<string>(id => string.Equals(id, _hostPackageId, StringComparison.OrdinalIgnoreCase)),
@@ -165,7 +164,7 @@ public sealed class SetupRunnerTests : IDisposable
             Options(features: ["dotnet"], source: source, includePrerelease: true),
             CancellationToken.None);
 
-        Assert.Equal(0, result.ExitCode);
+        result.ExitCode.Should().Be(0);
         await _installer.Received(1).InstallFromCatalogAsync(
             Arg.Is<string>(id => string.Equals(id, _dotNetStackPackageId, StringComparison.OrdinalIgnoreCase)),
             Arg.Is<NuGetVersion>(version => version.ToNormalizedString() == "1.0.0"),
@@ -214,8 +213,8 @@ public sealed class SetupRunnerTests : IDisposable
 
         SetupRunResult result = await runner.RunAsync(Options(features: ["dotnet"], profiles: ["flex"]), CancellationToken.None);
 
-        Assert.Equal(0, result.ExitCode);
-        Assert.DoesNotContain(_interaction.Lines, line => line.Contains("does not support runtime", StringComparison.OrdinalIgnoreCase));
+        result.ExitCode.Should().Be(0);
+        _interaction.Lines.Should().NotContain(line => line.Contains("does not support runtime", StringComparison.OrdinalIgnoreCase));
     }
 
     [Theory]
@@ -232,24 +231,22 @@ public sealed class SetupRunnerTests : IDisposable
             Options(features: [requestedFeature], outputMode: SetupOutputMode.Json),
             CancellationToken.None);
 
-        Assert.Equal(0, result.ExitCode);
+        result.ExitCode.Should().Be(0);
         using var started = JsonDocument.Parse(_interaction.Lines[0]);
         JsonElement root = started.RootElement;
         string[] features = [.. root.GetProperty("features").EnumerateArray().Select(feature => feature.GetString()!)];
         string[] workerRuntimes = [.. root.GetProperty("worker_runtimes").EnumerateArray().Select(runtime => runtime.GetString()!)];
 
-        Assert.Equal(["dotnet"], features);
-        Assert.Empty(workerRuntimes);
-        Assert.DoesNotContain(_interaction.Lines, line => line.Contains("dotnet-isolated", StringComparison.OrdinalIgnoreCase));
-        string stackLine = Assert.Single(
-            _interaction.Lines,
-            line => line.Contains("\"type\":\"dependency.detected\"", StringComparison.OrdinalIgnoreCase)
-                && line.Contains("\"dependency_type\":\"stack\"", StringComparison.OrdinalIgnoreCase));
+        features.Should().Equal(["dotnet"]);
+        workerRuntimes.Should().BeEmpty();
+        _interaction.Lines.Should().NotContain(line => line.Contains("dotnet-isolated", StringComparison.OrdinalIgnoreCase));
+        string stackLine = _interaction.Lines.Should().ContainSingle(line => line.Contains("\"type\":\"dependency.detected\"", StringComparison.OrdinalIgnoreCase)
+                && line.Contains("\"dependency_type\":\"stack\"", StringComparison.OrdinalIgnoreCase)).Which;
         using var stackEvent = JsonDocument.Parse(stackLine);
         JsonElement stackRoot = stackEvent.RootElement;
 
-        Assert.Equal("dotnet", stackRoot.GetProperty("name").GetString());
-        Assert.Equal(_dotNetStackPackageId, stackRoot.GetProperty("package_id").GetString(), ignoreCase: true);
+        stackRoot.GetProperty("name").GetString().Should().Be("dotnet");
+        stackRoot.GetProperty("package_id").GetString().Should().BeEquivalentTo(_dotNetStackPackageId);
     }
 
     [Theory]
@@ -271,9 +268,9 @@ public sealed class SetupRunnerTests : IDisposable
 
         SetupRunResult result = await runner.RunAsync(Options(features: [requestedFeature], profiles: ["flex"]), CancellationToken.None);
 
-        Assert.Equal(1, result.ExitCode);
-        Assert.Contains(_interaction.Lines, line => line.Contains("does not support runtime 'dotnet'", StringComparison.OrdinalIgnoreCase));
-        Assert.DoesNotContain(_interaction.Lines, line => line.Contains("dotnet-isolated", StringComparison.OrdinalIgnoreCase));
+        result.ExitCode.Should().Be(1);
+        _interaction.Lines.Should().Contain(line => line.Contains("does not support runtime 'dotnet'", StringComparison.OrdinalIgnoreCase));
+        _interaction.Lines.Should().NotContain(line => line.Contains("dotnet-isolated", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
@@ -295,15 +292,15 @@ public sealed class SetupRunnerTests : IDisposable
             Options(features: ["dotnet"], profiles: ["flex"], outputMode: SetupOutputMode.Json),
             CancellationToken.None);
 
-        Assert.Equal(1, result.ExitCode);
-        string failureLine = Assert.Single(_interaction.Lines, line => line.Contains("\"status\":\"failed\"", StringComparison.OrdinalIgnoreCase));
+        result.ExitCode.Should().Be(1);
+        string failureLine = _interaction.Lines.Should().ContainSingle(line => line.Contains("\"status\":\"failed\"", StringComparison.OrdinalIgnoreCase)).Which;
         using var failure = JsonDocument.Parse(failureLine);
         JsonElement root = failure.RootElement;
 
-        Assert.Equal("runtime", root.GetProperty("dependency_type").GetString());
-        Assert.Equal("dotnet", root.GetProperty("name").GetString());
-        Assert.False(root.TryGetProperty("package_id", out _));
-        Assert.DoesNotContain("dotnet-isolated", failureLine, StringComparison.OrdinalIgnoreCase);
+        root.GetProperty("dependency_type").GetString().Should().Be("runtime");
+        root.GetProperty("name").GetString().Should().Be("dotnet");
+        root.TryGetProperty("package_id", out _).Should().BeFalse();
+        failureLine.Should().NotContainEquivalentOf("dotnet-isolated");
     }
 
     [Fact]
@@ -315,10 +312,10 @@ public sealed class SetupRunnerTests : IDisposable
 
         SetupRunResult result = await runner.RunAsync(Options(features: ["host"], source: source), CancellationToken.None);
 
-        Assert.Equal(0, result.ExitCode);
-        Assert.Empty(catalog.SearchSources);
-        Assert.NotEmpty(catalog.ResolveSources);
-        Assert.All(catalog.ResolveSources, actual => Assert.Equal(source, actual));
+        result.ExitCode.Should().Be(0);
+        catalog.SearchSources.Should().BeEmpty();
+        catalog.ResolveSources.Should().NotBeEmpty();
+        catalog.ResolveSources.Should().AllSatisfy(actual => actual.Should().Be(source));
         await _installer.Received(1).InstallFromCatalogAsync(
             Arg.Is<string>(id => string.Equals(id, _hostPackageId, StringComparison.OrdinalIgnoreCase)),
             Arg.Is<NuGetVersion>(version => version.ToNormalizedString() == "4.1.0"),
@@ -340,8 +337,8 @@ public sealed class SetupRunnerTests : IDisposable
 
         SetupRunResult result = await runner.RunAsync(Options(features: ["host"]), CancellationToken.None);
 
-        Assert.Equal(0, result.ExitCode);
-        Assert.Empty(catalog.SearchSources);
+        result.ExitCode.Should().Be(0);
+        catalog.SearchSources.Should().BeEmpty();
         await _installer.Received(1).InstallFromCatalogAsync(
             Arg.Is<string>(id => string.Equals(id, _hostPackageId, StringComparison.OrdinalIgnoreCase)),
             Arg.Is<NuGetVersion>(version => version.ToNormalizedString() == "4.1.0"),
@@ -363,8 +360,8 @@ public sealed class SetupRunnerTests : IDisposable
 
         SetupRunResult result = await runner.RunAsync(Options(features: ["host"], installPolicy: SetupInstallPolicy.IfNeeded), CancellationToken.None);
 
-        Assert.Equal(0, result.ExitCode);
-        Assert.Equal(0, catalog.ResolveLatestCallCount);
+        result.ExitCode.Should().Be(0);
+        catalog.ResolveLatestCallCount.Should().Be(0);
         await _installer.DidNotReceive().InstallFromCatalogAsync(
             Arg.Any<string>(),
             Arg.Any<NuGetVersion?>(),
@@ -386,8 +383,8 @@ public sealed class SetupRunnerTests : IDisposable
 
         SetupRunResult result = await runner.RunAsync(Options(features: ["host"], check: true), CancellationToken.None);
 
-        Assert.Equal(1, result.ExitCode);
-        Assert.Contains(_interaction.Lines, line => line.Contains("4.1.0") && line.Contains("not installed"));
+        result.ExitCode.Should().Be(1);
+        _interaction.Lines.Should().Contain(line => line.Contains("4.1.0") && line.Contains("not installed"));
         await _installer.DidNotReceive().InstallFromCatalogAsync(
             Arg.Any<string>(),
             Arg.Any<NuGetVersion?>(),
@@ -414,14 +411,12 @@ public sealed class SetupRunnerTests : IDisposable
                 outputMode: SetupOutputMode.Json),
             CancellationToken.None);
 
-        Assert.Equal(0, result.ExitCode);
+        result.ExitCode.Should().Be(0);
         string[] eventTypes = [.. _interaction.Lines
             .Select(line => JsonDocument.Parse(line).RootElement.GetProperty("type").GetString()!)
         ];
 
-        Assert.Equal(
-            ["setup.started", "profile.started", "dependency.detected", "dependency.result", "profile.completed", "setup.completed"],
-            eventTypes);
+        eventTypes.Should().Equal(["setup.started", "profile.started", "dependency.detected", "dependency.result", "profile.completed", "setup.completed"]);
     }
 
     [Fact]
@@ -453,8 +448,8 @@ public sealed class SetupRunnerTests : IDisposable
                 check: true),
             CancellationToken.None);
 
-        Assert.Equal(1, result.ExitCode);
-        Assert.Contains(_interaction.Lines, line => line.Contains("does not support runtime 'node'"));
+        result.ExitCode.Should().Be(1);
+        _interaction.Lines.Should().Contain(line => line.Contains("does not support runtime 'node'"));
     }
 
     [Fact]
@@ -471,7 +466,7 @@ public sealed class SetupRunnerTests : IDisposable
 
         SetupRunResult result = await runner.RunAsync(Options(features: ["node"]), CancellationToken.None);
 
-        Assert.Equal(0, result.ExitCode);
+        result.ExitCode.Should().Be(0);
         await _installer.Received(1).InstallFromCatalogAsync(
             Arg.Is<string>(id => string.Equals(id, nodeStack, StringComparison.OrdinalIgnoreCase)),
             Arg.Any<NuGetVersion?>(),
@@ -499,7 +494,7 @@ public sealed class SetupRunnerTests : IDisposable
 
         SetupRunResult result = await runner.RunAsync(Options(features: ["node"]), CancellationToken.None);
 
-        Assert.Equal(0, result.ExitCode);
+        result.ExitCode.Should().Be(0);
         await _installer.Received(1).InstallFromCatalogAsync(
             Arg.Is<string>(id => string.Equals(id, nodeTemplates, StringComparison.OrdinalIgnoreCase)),
             Arg.Any<NuGetVersion?>(),
@@ -521,7 +516,7 @@ public sealed class SetupRunnerTests : IDisposable
 
         SetupRunResult result = await runner.RunAsync(Options(includePrerelease: true), CancellationToken.None);
 
-        Assert.Equal(0, result.ExitCode);
+        result.ExitCode.Should().Be(0);
         await _installer.Received(1).InstallFromCatalogAsync(
             Arg.Is<string>(id => string.Equals(id, IInstalledBundleWorkloads.BundleWorkloadPackageId, StringComparison.OrdinalIgnoreCase)),
             Arg.Is<NuGetVersion>(version => version.ToNormalizedString() == "4.10.0"),
@@ -559,7 +554,7 @@ public sealed class SetupRunnerTests : IDisposable
 
         SetupRunResult result = await runner.RunAsync(Options(features: ["node"]), CancellationToken.None);
 
-        Assert.Equal(0, result.ExitCode);
+        result.ExitCode.Should().Be(0);
         await _installer.Received(1).InstallFromCatalogAsync(
             Arg.Is<string>(id => string.Equals(id, IInstalledBundleWorkloads.BundleWorkloadPackageId, StringComparison.OrdinalIgnoreCase)),
             Arg.Is<NuGetVersion>(version => version.ToNormalizedString() == "4.11.0-preview.1"),
@@ -592,7 +587,7 @@ public sealed class SetupRunnerTests : IDisposable
 
         SetupRunResult result = await runner.RunAsync(Options(), CancellationToken.None);
 
-        Assert.Equal(0, result.ExitCode);
+        result.ExitCode.Should().Be(0);
         await _installer.Received(1).InstallFromCatalogAsync(
             Arg.Is<string>(id => string.Equals(id, IInstalledBundleWorkloads.BundleWorkloadPackageId, StringComparison.OrdinalIgnoreCase)),
             Arg.Is<NuGetVersion>(version => version.ToNormalizedString() == "4.10.0"),
@@ -602,9 +597,7 @@ public sealed class SetupRunnerTests : IDisposable
             Arg.Any<bool>(),
             Arg.Any<IProgress<WorkloadInstallProgress>?>(),
             Arg.Any<CancellationToken>());
-        Assert.Contains(
-            _interaction.Lines,
-            line => line.Contains("func workload search bundles --prerelease", StringComparison.Ordinal));
+        _interaction.Lines.Should().Contain(line => line.Contains("func workload search bundles --prerelease", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -619,7 +612,7 @@ public sealed class SetupRunnerTests : IDisposable
 
         SetupRunResult result = await runner.RunAsync(Options(), CancellationToken.None);
 
-        Assert.Equal(0, result.ExitCode);
+        result.ExitCode.Should().Be(0);
         await _installer.Received(1).InstallFromCatalogAsync(
             Arg.Is<string>(id => string.Equals(id, IInstalledBundleWorkloads.BundleWorkloadPackageId, StringComparison.OrdinalIgnoreCase)),
             Arg.Is<NuGetVersion>(version => version.ToNormalizedString() == "4.12.0-experimental.3"),
@@ -648,12 +641,10 @@ public sealed class SetupRunnerTests : IDisposable
 
         SetupRunResult result = await runner.RunAsync(Options(check: true), CancellationToken.None);
 
-        Assert.Equal(0, result.ExitCode);
-        Assert.DoesNotContain(_interaction.Lines, line => line.Contains("extension bundle", StringComparison.Ordinal)
+        result.ExitCode.Should().Be(0);
+        _interaction.Lines.Should().NotContain(line => line.Contains("extension bundle", StringComparison.Ordinal)
             && line.Contains("not installed", StringComparison.Ordinal));
-        Assert.Contains(
-            _interaction.Lines,
-            line => line.Contains("func workload search bundles --prerelease", StringComparison.Ordinal));
+        _interaction.Lines.Should().Contain(line => line.Contains("func workload search bundles --prerelease", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -668,7 +659,7 @@ public sealed class SetupRunnerTests : IDisposable
 
         SetupRunResult result = await runner.RunAsync(Options(features: ["java"]), CancellationToken.None);
 
-        Assert.Equal(0, result.ExitCode);
+        result.ExitCode.Should().Be(0);
         await _installer.DidNotReceive().InstallFromCatalogAsync(
             Arg.Is<string>(id => id.StartsWith("Azure.Functions.Cli.Workloads.", StringComparison.OrdinalIgnoreCase)
                 && !id.StartsWith("Azure.Functions.Cli.Workloads.Workers.", StringComparison.OrdinalIgnoreCase)
@@ -720,8 +711,8 @@ public sealed class SetupRunnerTests : IDisposable
                 SetupOutputMode.Plain),
             CancellationToken.None);
 
-        Assert.Equal(0, result.ExitCode);
-        Assert.Contains(interactive.Lines, line => line.StartsWith("MULTISELECT:", StringComparison.Ordinal));
+        result.ExitCode.Should().Be(0);
+        interactive.Lines.Should().Contain(line => line.StartsWith("MULTISELECT:", StringComparison.Ordinal));
         await _installer.Received(1).InstallFromCatalogAsync(
             Arg.Is<string>(id => string.Equals(id, nodeStack, StringComparison.OrdinalIgnoreCase)),
             Arg.Any<NuGetVersion?>(),
@@ -741,7 +732,7 @@ public sealed class SetupRunnerTests : IDisposable
 
         SetupRunResult result = await runner.RunAsync(Options(features: ["host"]), CancellationToken.None);
 
-        Assert.Equal(0, result.ExitCode);
+        result.ExitCode.Should().Be(0);
         await _installer.DidNotReceive().InstallFromCatalogAsync(
             Arg.Is<string>(id => id.StartsWith("Azure.Functions.Cli.Workloads.Node", StringComparison.OrdinalIgnoreCase)
                 || id.StartsWith("Azure.Functions.Cli.Workloads.Python", StringComparison.OrdinalIgnoreCase)
@@ -797,11 +788,11 @@ public sealed class SetupRunnerTests : IDisposable
         // Installed stacks render as static "fake checkbox" lines above the
         // prompt with the uninstall hint, and are kept out of the multi-select
         // entirely so the user can't toggle them.
-        Assert.Contains(interactive.Lines, line => line.Contains("Already installed", StringComparison.Ordinal)
+        interactive.Lines.Should().Contain(line => line.Contains("Already installed", StringComparison.Ordinal)
             && line.Contains("func workload uninstall", StringComparison.Ordinal));
-        Assert.Contains(interactive.Lines, line => line.Contains("[✓] node", StringComparison.Ordinal));
-        Assert.DoesNotContain(interactive.Lines, line => line.StartsWith("MULTISELECT:", StringComparison.Ordinal) && line.Contains("node", StringComparison.Ordinal));
-        Assert.DoesNotContain(interactive.MultiSelectionChoices.SelectMany(g => g), c => c.Value == "node");
+        interactive.Lines.Should().Contain(line => line.Contains("[✓] node", StringComparison.Ordinal));
+        interactive.Lines.Should().NotContain(line => line.StartsWith("MULTISELECT:", StringComparison.Ordinal) && line.Contains("node", StringComparison.Ordinal));
+        interactive.MultiSelectionChoices.SelectMany(g => g).Should().NotContain(c => c.Value == "node");
     }
 
     [Fact]
@@ -825,7 +816,7 @@ public sealed class SetupRunnerTests : IDisposable
 
         SetupRunResult result = await runner.RunAsync(Options(), CancellationToken.None);
 
-        Assert.Equal(0, result.ExitCode);
+        result.ExitCode.Should().Be(0);
         await firstRunStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
     }
 

--- a/test/Func.Tests/Commands/Start/Azurite/AzureWebJobsStorageClassifierTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/AzureWebJobsStorageClassifierTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Commands.Start.Azurite;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands.Start.Azurite;
 
@@ -21,8 +20,8 @@ public class AzureWebJobsStorageClassifierTests
     {
         var result = _classifier.Classify(value);
 
-        Assert.Equal(AzureWebJobsStorageClassification.NotLocal, result.Classification);
-        Assert.Null(result.Endpoints);
+        result.Classification.Should().Be(AzureWebJobsStorageClassification.NotLocal);
+        result.Endpoints.Should().BeNull();
     }
 
     [Fact]
@@ -30,8 +29,8 @@ public class AzureWebJobsStorageClassifierTests
     {
         var result = _classifier.Classify("UseDevelopmentStorage=true");
 
-        Assert.Equal(AzureWebJobsStorageClassification.ManageableAzurite, result.Classification);
-        Assert.Null(result.Endpoints);
+        result.Classification.Should().Be(AzureWebJobsStorageClassification.ManageableAzurite);
+        result.Endpoints.Should().BeNull();
     }
 
     [Fact]
@@ -39,7 +38,7 @@ public class AzureWebJobsStorageClassifierTests
     {
         var result = _classifier.Classify("usedevelopmentstorage=TRUE");
 
-        Assert.Equal(AzureWebJobsStorageClassification.ManageableAzurite, result.Classification);
+        result.Classification.Should().Be(AzureWebJobsStorageClassification.ManageableAzurite);
     }
 
     [Fact]
@@ -48,7 +47,7 @@ public class AzureWebJobsStorageClassifierTests
         var result = _classifier.Classify(
             "UseDevelopmentStorage=true;DevelopmentStorageProxyUri=http://127.0.0.1");
 
-        Assert.Equal(AzureWebJobsStorageClassification.UserConfiguredAzurite, result.Classification);
+        result.Classification.Should().Be(AzureWebJobsStorageClassification.UserConfiguredAzurite);
     }
 
     [Fact]
@@ -63,12 +62,12 @@ public class AzureWebJobsStorageClassifierTests
 
         var result = _classifier.Classify(cs);
 
-        Assert.Equal(AzureWebJobsStorageClassification.ManageableAzurite, result.Classification);
-        Assert.NotNull(result.Endpoints);
-        Assert.Equal("devstoreaccount1", result.Endpoints!.AccountName);
-        Assert.Equal(10000, result.Endpoints.BlobEndpoint.Port);
-        Assert.Equal(10001, result.Endpoints.QueueEndpoint.Port);
-        Assert.Equal(10002, result.Endpoints.TableEndpoint.Port);
+        result.Classification.Should().Be(AzureWebJobsStorageClassification.ManageableAzurite);
+        result.Endpoints.Should().NotBeNull();
+        result.Endpoints!.AccountName.Should().Be("devstoreaccount1");
+        result.Endpoints.BlobEndpoint.Port.Should().Be(10000);
+        result.Endpoints.QueueEndpoint.Port.Should().Be(10001);
+        result.Endpoints.TableEndpoint.Port.Should().Be(10002);
     }
 
     [Fact]
@@ -83,8 +82,8 @@ public class AzureWebJobsStorageClassifierTests
 
         var result = _classifier.Classify(cs);
 
-        Assert.Equal(AzureWebJobsStorageClassification.ManageableAzurite, result.Classification);
-        Assert.Equal(20000, result.Endpoints!.BlobEndpoint.Port);
+        result.Classification.Should().Be(AzureWebJobsStorageClassification.ManageableAzurite);
+        result.Endpoints!.BlobEndpoint.Port.Should().Be(20000);
     }
 
     [Fact]
@@ -99,7 +98,7 @@ public class AzureWebJobsStorageClassifierTests
 
         var result = _classifier.Classify(cs);
 
-        Assert.Equal(AzureWebJobsStorageClassification.UserConfiguredAzurite, result.Classification);
+        result.Classification.Should().Be(AzureWebJobsStorageClassification.UserConfiguredAzurite);
     }
 
     [Fact]
@@ -114,9 +113,9 @@ public class AzureWebJobsStorageClassifierTests
 
         var result = _classifier.Classify(cs);
 
-        Assert.Equal(AzureWebJobsStorageClassification.UserConfiguredAzurite, result.Classification);
-        Assert.NotNull(result.Endpoints);
-        Assert.Equal("account1", result.Endpoints!.AccountName);
+        result.Classification.Should().Be(AzureWebJobsStorageClassification.UserConfiguredAzurite);
+        result.Endpoints.Should().NotBeNull();
+        result.Endpoints!.AccountName.Should().Be("account1");
     }
 
     [Fact]
@@ -131,7 +130,7 @@ public class AzureWebJobsStorageClassifierTests
 
         var result = _classifier.Classify(cs);
 
-        Assert.Equal(AzureWebJobsStorageClassification.UserConfiguredAzurite, result.Classification);
+        result.Classification.Should().Be(AzureWebJobsStorageClassification.UserConfiguredAzurite);
     }
 
     [Fact]
@@ -143,8 +142,8 @@ public class AzureWebJobsStorageClassifierTests
 
         var result = _classifier.Classify(cs);
 
-        Assert.Equal(AzureWebJobsStorageClassification.UserConfiguredAzurite, result.Classification);
-        Assert.Null(result.Endpoints);
+        result.Classification.Should().Be(AzureWebJobsStorageClassification.UserConfiguredAzurite);
+        result.Endpoints.Should().BeNull();
     }
 
     [Fact]
@@ -155,7 +154,7 @@ public class AzureWebJobsStorageClassifierTests
 
         var result = _classifier.Classify(cs);
 
-        Assert.Equal(AzureWebJobsStorageClassification.NotLocal, result.Classification);
+        result.Classification.Should().Be(AzureWebJobsStorageClassification.NotLocal);
     }
 
     [Fact]
@@ -165,7 +164,7 @@ public class AzureWebJobsStorageClassifierTests
 
         var result = _classifier.Classify(cs);
 
-        Assert.Equal(AzureWebJobsStorageClassification.NotLocal, result.Classification);
+        result.Classification.Should().Be(AzureWebJobsStorageClassification.NotLocal);
     }
 
     [Fact]
@@ -179,7 +178,7 @@ public class AzureWebJobsStorageClassifierTests
 
         var result = _classifier.Classify(cs);
 
-        Assert.Equal(AzureWebJobsStorageClassification.NotLocal, result.Classification);
+        result.Classification.Should().Be(AzureWebJobsStorageClassification.NotLocal);
     }
 
     [Fact]
@@ -191,7 +190,7 @@ public class AzureWebJobsStorageClassifierTests
 
         var result = _classifier.Classify(cs);
 
-        Assert.Equal(AzureWebJobsStorageClassification.NotLocal, result.Classification);
+        result.Classification.Should().Be(AzureWebJobsStorageClassification.NotLocal);
     }
 
     [Fact]
@@ -203,7 +202,7 @@ public class AzureWebJobsStorageClassifierTests
 
         var result = _classifier.Classify(cs);
 
-        Assert.Equal(AzureWebJobsStorageClassification.ManageableAzurite, result.Classification);
+        result.Classification.Should().Be(AzureWebJobsStorageClassification.ManageableAzurite);
     }
 
     [Fact]
@@ -215,8 +214,8 @@ public class AzureWebJobsStorageClassifierTests
 
         var result = _classifier.Classify(cs);
 
-        Assert.Equal(AzureWebJobsStorageClassification.ManageableAzurite, result.Classification);
-        Assert.Equal("devstoreaccount1", result.Endpoints!.AccountName);
+        result.Classification.Should().Be(AzureWebJobsStorageClassification.ManageableAzurite);
+        result.Endpoints!.AccountName.Should().Be("devstoreaccount1");
     }
 
     [Fact]
@@ -229,7 +228,7 @@ public class AzureWebJobsStorageClassifierTests
 
         var result = _classifier.Classify(cs);
 
-        Assert.Equal(AzureWebJobsStorageClassification.ManageableAzurite, result.Classification);
+        result.Classification.Should().Be(AzureWebJobsStorageClassification.ManageableAzurite);
     }
 
     [Theory]
@@ -241,7 +240,7 @@ public class AzureWebJobsStorageClassifierTests
     [InlineData("foo.localhost")]
     [InlineData("account1.blob.localhost")]
     public void IsLocalHost_RecognizesLocalHosts(string host)
-        => Assert.True(AzureWebJobsStorageClassifier.IsLocalHost(host));
+        => AzureWebJobsStorageClassifier.IsLocalHost(host).Should().BeTrue();
 
     [Theory]
     [InlineData("myaccount.blob.core.windows.net")]
@@ -249,7 +248,7 @@ public class AzureWebJobsStorageClassifierTests
     [InlineData("")]
     [InlineData("10.0.0.1")]
     public void IsLocalHost_RejectsNonLocalHosts(string host)
-        => Assert.False(AzureWebJobsStorageClassifier.IsLocalHost(host));
+        => AzureWebJobsStorageClassifier.IsLocalHost(host).Should().BeFalse();
 
     [Fact]
     public void Classify_LocalhostByName_IsManageable()
@@ -260,7 +259,7 @@ public class AzureWebJobsStorageClassifierTests
 
         var result = _classifier.Classify(cs);
 
-        Assert.Equal(AzureWebJobsStorageClassification.ManageableAzurite, result.Classification);
+        result.Classification.Should().Be(AzureWebJobsStorageClassification.ManageableAzurite);
     }
 
     [Fact]
@@ -273,7 +272,7 @@ public class AzureWebJobsStorageClassifierTests
 
         var result = _classifier.Classify(cs);
 
-        Assert.Equal(AzureWebJobsStorageClassification.UserConfiguredAzurite, result.Classification);
+        result.Classification.Should().Be(AzureWebJobsStorageClassification.UserConfiguredAzurite);
     }
 
     [Fact]
@@ -281,6 +280,6 @@ public class AzureWebJobsStorageClassifierTests
     {
         var result = _classifier.Classify("garbage-without-equals");
 
-        Assert.Equal(AzureWebJobsStorageClassification.NotLocal, result.Classification);
+        result.Classification.Should().Be(AzureWebJobsStorageClassification.NotLocal);
     }
 }

--- a/test/Func.Tests/Commands/Start/Azurite/AzuriteExecutableLocatorTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/AzuriteExecutableLocatorTests.cs
@@ -1,11 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Azure.Functions.Cli;
 using Azure.Functions.Cli.Commands.Start.Azurite;
 using Azure.Functions.Cli.Commands.Start.Azurite.Processes;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands.Start.Azurite;
 
@@ -36,8 +34,7 @@ public class AzuriteExecutableLocatorTests
     {
         AzuriteExecutableLocator sut = CreateSut();
 
-        await Assert.ThrowsAsync<ArgumentNullException>(
-            () => sut.FindAsync(null!, CancellationToken.None));
+        await FluentActions.Awaiting(() => sut.FindAsync(null!, CancellationToken.None)).Should().ThrowAsync<ArgumentNullException>();
     }
 
     [Fact]
@@ -53,10 +50,10 @@ public class AzuriteExecutableLocatorTests
 
         AzuriteExecutable? result = await CreateSut().FindAsync(ProjectRoot, CancellationToken.None);
 
-        Assert.NotNull(result);
-        Assert.Equal(projectLocal, result!.FilePath);
-        Assert.Equal(AzuriteExecutableSource.ProjectLocal, result.Source);
-        Assert.Equal("3.30.0", result.Version);
+        result.Should().NotBeNull();
+        result!.FilePath.Should().Be(projectLocal);
+        result.Source.Should().Be(AzuriteExecutableSource.ProjectLocal);
+        result.Version.Should().Be("3.30.0");
     }
 
     [Fact]
@@ -72,9 +69,9 @@ public class AzuriteExecutableLocatorTests
 
         AzuriteExecutable? result = await CreateSut().FindAsync(ProjectRoot, CancellationToken.None);
 
-        Assert.NotNull(result);
-        Assert.Equal(projectLocal, result!.FilePath);
-        Assert.Equal(AzuriteExecutableSource.ProjectLocal, result.Source);
+        result.Should().NotBeNull();
+        result!.FilePath.Should().Be(projectLocal);
+        result.Source.Should().Be(AzuriteExecutableSource.ProjectLocal);
     }
 
     [Fact]
@@ -91,9 +88,9 @@ public class AzuriteExecutableLocatorTests
 
         AzuriteExecutable? result = await CreateSut().FindAsync(ProjectRoot, CancellationToken.None);
 
-        Assert.NotNull(result);
-        Assert.Equal(match, result!.FilePath);
-        Assert.Equal(AzuriteExecutableSource.Path, result.Source);
+        result.Should().NotBeNull();
+        result!.FilePath.Should().Be(match);
+        result.Source.Should().Be(AzuriteExecutableSource.Path);
     }
 
     [Fact]
@@ -116,8 +113,8 @@ public class AzuriteExecutableLocatorTests
 
         AzuriteExecutable? result = await CreateSut().FindAsync(ProjectRoot, CancellationToken.None);
 
-        Assert.NotNull(result);
-        Assert.Equal(cmd, result!.FilePath);
+        result.Should().NotBeNull();
+        result!.FilePath.Should().Be(cmd);
     }
 
     [Fact]
@@ -134,8 +131,8 @@ public class AzuriteExecutableLocatorTests
 
         AzuriteExecutable? result = await CreateSut().FindAsync(ProjectRoot, CancellationToken.None);
 
-        Assert.NotNull(result);
-        Assert.Equal(match, result!.FilePath);
+        result.Should().NotBeNull();
+        result!.FilePath.Should().Be(match);
 
         // Ensure we never asked about .cmd/.exe variants on Unix.
         _hostEnv.DidNotReceive().ExecutableExists(Arg.Is<string>(p =>
@@ -151,7 +148,7 @@ public class AzuriteExecutableLocatorTests
 
         AzuriteExecutable? result = await CreateSut().FindAsync(ProjectRoot, CancellationToken.None);
 
-        Assert.Null(result);
+        result.Should().BeNull();
         await _processRunner.DidNotReceiveWithAnyArgs().RunAsync(default!, default);
     }
 
@@ -172,9 +169,9 @@ public class AzuriteExecutableLocatorTests
 
         AzuriteExecutable? result = await CreateSut().FindAsync(ProjectRoot, CancellationToken.None);
 
-        Assert.NotNull(result);
-        Assert.Equal(projectLocal, result!.FilePath);
-        Assert.Null(result.Version);
+        result.Should().NotBeNull();
+        result!.FilePath.Should().Be(projectLocal);
+        result.Version.Should().BeNull();
     }
 
     [Fact]
@@ -189,8 +186,8 @@ public class AzuriteExecutableLocatorTests
 
         AzuriteExecutable? result = await CreateSut().FindAsync(ProjectRoot, CancellationToken.None);
 
-        Assert.NotNull(result);
-        Assert.Null(result!.Version);
+        result.Should().NotBeNull();
+        result!.Version.Should().BeNull();
     }
 
     [Fact]
@@ -204,8 +201,8 @@ public class AzuriteExecutableLocatorTests
 
         AzuriteExecutable? result = await CreateSut().FindAsync(ProjectRoot, CancellationToken.None);
 
-        Assert.NotNull(result);
-        Assert.Equal("Azurite-Blob 3.30.0 (build 20250101)", result!.Version);
+        result.Should().NotBeNull();
+        result!.Version.Should().Be("Azurite-Blob 3.30.0 (build 20250101)");
     }
 
     [Fact]
@@ -215,7 +212,6 @@ public class AzuriteExecutableLocatorTests
         using CancellationTokenSource cts = new();
         cts.Cancel();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(
-            () => CreateSut().FindAsync(ProjectRoot, cts.Token));
+        await FluentActions.Awaiting(() => CreateSut().FindAsync(ProjectRoot, cts.Token)).Should().ThrowAsync<OperationCanceledException>();
     }
 }

--- a/test/Func.Tests/Commands/Start/Azurite/AzuriteManagedPathsProviderTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/AzuriteManagedPathsProviderTests.cs
@@ -3,7 +3,6 @@
 
 using Azure.Functions.Cli.Commands.Start.Azurite;
 using Azure.Functions.Cli.Configuration;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands.Start.Azurite;
 
@@ -19,8 +18,8 @@ public class AzuriteManagedPathsProviderTests
         AzuriteManagedPaths paths = provider.GetPaths();
 
         string expectedRoot = Path.Combine(configurationPaths.Home, "azurite");
-        Assert.Equal(Path.Combine(expectedRoot, "data"), paths.DataDirectory);
-        Assert.Equal(Path.Combine(expectedRoot, "azurite.log"), paths.LogFilePath);
+        paths.DataDirectory.Should().Be(Path.Combine(expectedRoot, "data"));
+        paths.LogFilePath.Should().Be(Path.Combine(expectedRoot, "azurite.log"));
     }
 
     [Fact]
@@ -32,8 +31,8 @@ public class AzuriteManagedPathsProviderTests
         var provider = new AzuriteManagedPathsProvider(configurationPaths);
         AzuriteManagedPaths paths = provider.GetPaths();
 
-        Assert.False(Directory.Exists(paths.DataDirectory));
-        Assert.False(Directory.Exists(Path.GetDirectoryName(paths.LogFilePath)!));
+        Directory.Exists(paths.DataDirectory).Should().BeFalse();
+        Directory.Exists(Path.GetDirectoryName(paths.LogFilePath)!).Should().BeFalse();
     }
 
     [Fact]
@@ -47,13 +46,13 @@ public class AzuriteManagedPathsProviderTests
 
         await provider.EnsureCreatedAsync(paths, CancellationToken.None);
 
-        Assert.True(Directory.Exists(paths.DataDirectory));
-        Assert.True(Directory.Exists(Path.GetDirectoryName(paths.LogFilePath)!));
+        Directory.Exists(paths.DataDirectory).Should().BeTrue();
+        Directory.Exists(Path.GetDirectoryName(paths.LogFilePath)!).Should().BeTrue();
     }
 
     [Fact]
     public void Constructor_NullConfigurationPaths_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => new AzuriteManagedPathsProvider(null!));
+        FluentActions.Invoking(() => new AzuriteManagedPathsProvider(null!)).Should().ThrowExactly<ArgumentNullException>();
     }
 }

--- a/test/Func.Tests/Commands/Start/Azurite/AzuriteProbeTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/AzuriteProbeTests.cs
@@ -58,8 +58,7 @@ public class AzuriteProbeTests : IAsyncLifetime
             handler = inner;
         }
 
-        var sockets = handler.Should().BeOfType<SocketsHttpHandler>().Subject;
-        sockets.UseProxy.Should().BeFalse();
+        handler.Should().BeOfType<SocketsHttpHandler>().Which.UseProxy.Should().BeFalse();
     }
 
     [Fact]

--- a/test/Func.Tests/Commands/Start/Azurite/AzuriteProbeTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/AzuriteProbeTests.cs
@@ -2,13 +2,10 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Net;
-using System.Net.Http;
 using System.Net.Sockets;
 using System.Text;
 using Azure.Functions.Cli.Commands.Start.Azurite;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging.Abstractions;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands.Start.Azurite;
 
@@ -61,8 +58,8 @@ public class AzuriteProbeTests : IAsyncLifetime
             handler = inner;
         }
 
-        var sockets = Assert.IsType<SocketsHttpHandler>(handler);
-        Assert.False(sockets.UseProxy);
+        var sockets = handler.Should().BeOfType<SocketsHttpHandler>().Subject;
+        sockets.UseProxy.Should().BeFalse();
     }
 
     [Fact]
@@ -92,10 +89,10 @@ public class AzuriteProbeTests : IAsyncLifetime
 
         var result = await probe.ProbeAsync(endpoints, CancellationToken.None);
 
-        Assert.Equal(AzuriteProbeStatus.Ready, result.Status);
-        Assert.All(result.Endpoints, o =>
-            Assert.Equal(AzuriteEndpointStatus.Ready, o.Status));
-        Assert.Contains(result.Endpoints, o => o.RequestId == "abc-123");
+        result.Status.Should().Be(AzuriteProbeStatus.Ready);
+        result.Endpoints.Should().AllSatisfy(o =>
+            o.Status.Should().Be(AzuriteEndpointStatus.Ready));
+        result.Endpoints.Should().Contain(o => o.RequestId == "abc-123");
     }
 
     [Fact]
@@ -110,8 +107,8 @@ public class AzuriteProbeTests : IAsyncLifetime
 
         var outcome = await ProbeSingleAsync(uri);
 
-        Assert.Equal(AzuriteEndpointStatus.Ready, outcome.Status);
-        Assert.Equal("AuthenticationFailed", outcome.ErrorCode);
+        outcome.Status.Should().Be(AzuriteEndpointStatus.Ready);
+        outcome.ErrorCode.Should().Be("AuthenticationFailed");
     }
 
     [Fact]
@@ -128,7 +125,7 @@ public class AzuriteProbeTests : IAsyncLifetime
 
         var outcome = await ProbeSingleAsync(uri);
 
-        Assert.Equal(AzuriteEndpointStatus.Ready, outcome.Status);
+        outcome.Status.Should().Be(AzuriteEndpointStatus.Ready);
     }
 
     [Fact]
@@ -146,9 +143,9 @@ public class AzuriteProbeTests : IAsyncLifetime
 
         var result = await probe.ProbeAsync(endpoints, CancellationToken.None);
 
-        Assert.Equal(AzuriteProbeStatus.PortConflict, result.Status);
-        Assert.All(result.Endpoints, o =>
-            Assert.Equal(AzuriteEndpointStatus.PortConflict, o.Status));
+        result.Status.Should().Be(AzuriteProbeStatus.PortConflict);
+        result.Endpoints.Should().AllSatisfy(o =>
+            o.Status.Should().Be(AzuriteEndpointStatus.PortConflict));
     }
 
     [Fact]
@@ -164,9 +161,9 @@ public class AzuriteProbeTests : IAsyncLifetime
 
         var result = await probe.ProbeAsync(endpoints, CancellationToken.None);
 
-        Assert.Equal(AzuriteProbeStatus.NotListening, result.Status);
-        Assert.All(result.Endpoints, o =>
-            Assert.Equal(AzuriteEndpointStatus.NotListening, o.Status));
+        result.Status.Should().Be(AzuriteProbeStatus.NotListening);
+        result.Endpoints.Should().AllSatisfy(o =>
+            o.Status.Should().Be(AzuriteEndpointStatus.NotListening));
     }
 
     [Fact]
@@ -192,12 +189,12 @@ public class AzuriteProbeTests : IAsyncLifetime
 
         var result = await probe.ProbeAsync(endpoints, CancellationToken.None);
 
-        Assert.Equal(AzuriteProbeStatus.Partial, result.Status);
+        result.Status.Should().Be(AzuriteProbeStatus.Partial);
 
         var byService = result.Endpoints.ToDictionary(o => o.Service);
-        Assert.Equal(AzuriteEndpointStatus.Ready, byService[AzuriteService.Blob].Status);
-        Assert.Equal(AzuriteEndpointStatus.Ready, byService[AzuriteService.Queue].Status);
-        Assert.Equal(AzuriteEndpointStatus.NotListening, byService[AzuriteService.Table].Status);
+        byService[AzuriteService.Blob].Status.Should().Be(AzuriteEndpointStatus.Ready);
+        byService[AzuriteService.Queue].Status.Should().Be(AzuriteEndpointStatus.Ready);
+        byService[AzuriteService.Table].Status.Should().Be(AzuriteEndpointStatus.NotListening);
     }
 
     [Fact]
@@ -216,12 +213,12 @@ public class AzuriteProbeTests : IAsyncLifetime
 
         var result = await probe.ProbeAsync(endpoints, CancellationToken.None);
 
-        Assert.Equal(AzuriteProbeStatus.Partial, result.Status);
+        result.Status.Should().Be(AzuriteProbeStatus.Partial);
 
         var byService = result.Endpoints.ToDictionary(o => o.Service);
-        Assert.Equal(AzuriteEndpointStatus.NotListening, byService[AzuriteService.Blob].Status);
-        Assert.Equal(AzuriteEndpointStatus.PortConflict, byService[AzuriteService.Queue].Status);
-        Assert.Equal(AzuriteEndpointStatus.PortConflict, byService[AzuriteService.Table].Status);
+        byService[AzuriteService.Blob].Status.Should().Be(AzuriteEndpointStatus.NotListening);
+        byService[AzuriteService.Queue].Status.Should().Be(AzuriteEndpointStatus.PortConflict);
+        byService[AzuriteService.Table].Status.Should().Be(AzuriteEndpointStatus.PortConflict);
     }
 
     [Fact]
@@ -237,8 +234,7 @@ public class AzuriteProbeTests : IAsyncLifetime
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => probe.ProbeAsync(endpoints, cts.Token));
+        await FluentActions.Awaiting(() => probe.ProbeAsync(endpoints, cts.Token)).Should().ThrowAsync<OperationCanceledException>();
     }
 
     private async Task<AzuriteEndpointProbeOutcome> ProbeSingleAsync(Uri uri)

--- a/test/Func.Tests/Commands/Start/Azurite/AzuriteServiceCollectionExtensionsTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/AzuriteServiceCollectionExtensionsTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Azure.Functions.Cli;
 using Azure.Functions.Cli.Commands.Start.Azurite;
 using Azure.Functions.Cli.Commands.Start.Azurite.Launching;
 using Azure.Functions.Cli.Commands.Start.Azurite.Orchestration;
@@ -9,7 +8,6 @@ using Azure.Functions.Cli.Configuration;
 using Azure.Functions.Cli.Console;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands.Start.Azurite;
 
@@ -19,23 +17,23 @@ public class AzuriteServiceCollectionExtensionsTests
     public void AddAzuriteProbe_ResolvesIAzuriteProbe()
     {
         IServiceProvider provider = BaseServices().AddAzuriteProbe().BuildServiceProvider();
-        Assert.NotNull(provider.GetRequiredService<IAzuriteProbe>());
+        provider.GetRequiredService<IAzuriteProbe>().Should().NotBeNull();
     }
 
     [Fact]
     public void AddAzuriteManagedPaths_ResolvesPathsProviderAndClock()
     {
         IServiceProvider provider = BaseServices().AddAzuriteManagedPaths().BuildServiceProvider();
-        Assert.NotNull(provider.GetRequiredService<IAzuriteManagedPathsProvider>());
-        Assert.NotNull(provider.GetRequiredService<IClock>());
+        provider.GetRequiredService<IAzuriteManagedPathsProvider>().Should().NotBeNull();
+        provider.GetRequiredService<IClock>().Should().NotBeNull();
     }
 
     [Fact]
     public void AddAzuriteDiscovery_ResolvesLocatorAndDockerProbe()
     {
         IServiceProvider provider = BaseServices().AddAzuriteDiscovery().BuildServiceProvider();
-        Assert.NotNull(provider.GetRequiredService<IAzuriteExecutableLocator>());
-        Assert.NotNull(provider.GetRequiredService<IDockerAvailabilityProbe>());
+        provider.GetRequiredService<IAzuriteExecutableLocator>().Should().NotBeNull();
+        provider.GetRequiredService<IDockerAvailabilityProbe>().Should().NotBeNull();
     }
 
     [Fact]
@@ -43,7 +41,7 @@ public class AzuriteServiceCollectionExtensionsTests
     {
         IServiceCollection services = BaseServices().AddAzuriteDiscovery().AddAzuriteLauncher();
         IServiceProvider provider = services.BuildServiceProvider();
-        Assert.NotNull(provider.GetRequiredService<IAzuriteLauncher>());
+        provider.GetRequiredService<IAzuriteLauncher>().Should().NotBeNull();
     }
 
     [Fact]
@@ -51,13 +49,13 @@ public class AzuriteServiceCollectionExtensionsTests
     {
         IServiceProvider provider = BaseServices().AddManagedAzurite().BuildServiceProvider();
 
-        Assert.NotNull(provider.GetRequiredService<IManagedAzuriteOrchestrator>());
-        Assert.NotNull(provider.GetRequiredService<IAzureWebJobsStorageClassifier>());
-        Assert.NotNull(provider.GetRequiredService<IAzuriteProbe>());
-        Assert.NotNull(provider.GetRequiredService<IAzuriteExecutableLocator>());
-        Assert.NotNull(provider.GetRequiredService<IDockerAvailabilityProbe>());
-        Assert.NotNull(provider.GetRequiredService<IAzuriteLauncher>());
-        Assert.NotNull(provider.GetRequiredService<IAzuriteManagedPathsProvider>());
+        provider.GetRequiredService<IManagedAzuriteOrchestrator>().Should().NotBeNull();
+        provider.GetRequiredService<IAzureWebJobsStorageClassifier>().Should().NotBeNull();
+        provider.GetRequiredService<IAzuriteProbe>().Should().NotBeNull();
+        provider.GetRequiredService<IAzuriteExecutableLocator>().Should().NotBeNull();
+        provider.GetRequiredService<IDockerAvailabilityProbe>().Should().NotBeNull();
+        provider.GetRequiredService<IAzuriteLauncher>().Should().NotBeNull();
+        provider.GetRequiredService<IAzuriteManagedPathsProvider>().Should().NotBeNull();
     }
 
     private static IServiceCollection BaseServices()

--- a/test/Func.Tests/Commands/Start/Azurite/DockerAvailabilityProbeTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/DockerAvailabilityProbeTests.cs
@@ -4,7 +4,6 @@
 using Azure.Functions.Cli.Commands.Start.Azurite;
 using Azure.Functions.Cli.Commands.Start.Azurite.Processes;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands.Start.Azurite;
 
@@ -42,8 +41,8 @@ public class DockerAvailabilityProbeTests
 
         DockerAvailability result = await CreateSut().ProbeAsync(CancellationToken.None);
 
-        Assert.Equal(DockerAvailabilityStatus.Available, result.Status);
-        Assert.Equal("Docker version 24.0.7, build afdd53b", result.Version);
+        result.Status.Should().Be(DockerAvailabilityStatus.Available);
+        result.Version.Should().Be("Docker version 24.0.7, build afdd53b");
     }
 
     [Fact]
@@ -54,8 +53,8 @@ public class DockerAvailabilityProbeTests
 
         DockerAvailability result = await CreateSut().ProbeAsync(CancellationToken.None);
 
-        Assert.Equal(DockerAvailabilityStatus.ExecutableNotFound, result.Status);
-        Assert.Null(result.Version);
+        result.Status.Should().Be(DockerAvailabilityStatus.ExecutableNotFound);
+        result.Version.Should().BeNull();
 
         await _processRunner.DidNotReceive().RunAsync(
             Arg.Is<ProcessRunRequest>(r => IsInfoCall(r)),
@@ -72,9 +71,9 @@ public class DockerAvailabilityProbeTests
 
         DockerAvailability result = await CreateSut().ProbeAsync(CancellationToken.None);
 
-        Assert.Equal(DockerAvailabilityStatus.DaemonUnavailable, result.Status);
-        Assert.Contains("Cannot connect to the Docker daemon.", result.Reason);
-        Assert.Equal("Docker version 24.0.7", result.Version);
+        result.Status.Should().Be(DockerAvailabilityStatus.DaemonUnavailable);
+        result.Reason.Should().Contain("Cannot connect to the Docker daemon.");
+        result.Version.Should().Be("Docker version 24.0.7");
     }
 
     [Fact]
@@ -87,8 +86,8 @@ public class DockerAvailabilityProbeTests
 
         DockerAvailability result = await CreateSut().ProbeAsync(CancellationToken.None);
 
-        Assert.Equal(DockerAvailabilityStatus.CommandFailed, result.Status);
-        Assert.Contains("docker info", result.Reason);
+        result.Status.Should().Be(DockerAvailabilityStatus.CommandFailed);
+        result.Reason.Should().Contain("docker info");
     }
 
     [Fact]
@@ -97,7 +96,6 @@ public class DockerAvailabilityProbeTests
         using CancellationTokenSource cts = new();
         cts.Cancel();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(
-            () => CreateSut().ProbeAsync(cts.Token));
+        await FluentActions.Awaiting(() => CreateSut().ProbeAsync(cts.Token)).Should().ThrowAsync<OperationCanceledException>();
     }
 }

--- a/test/Func.Tests/Commands/Start/Azurite/Launching/AzuriteLaunchRequestTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/Launching/AzuriteLaunchRequestTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Commands.Start.Azurite.Launching;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands.Start.Azurite.Launching;
 
@@ -11,75 +10,75 @@ public class AzuriteLaunchRequestTests
     [Fact]
     public void Constructor_NativeMode_WithoutExecutablePath_Throws()
     {
-        var ex = Assert.Throws<ArgumentException>(() => new AzuriteLaunchRequest(
+        var ex = FluentActions.Invoking(() => new AzuriteLaunchRequest(
             mode: AzuriteLaunchMode.Native,
             blobPort: 10000,
             queuePort: 10001,
             tablePort: 10002,
             dataPath: "/tmp/data",
-            logPath: "/tmp/log/azurite.log"));
+            logPath: "/tmp/log/azurite.log")).Should().ThrowExactly<ArgumentException>().Which;
 
-        Assert.Equal("executablePath", ex.ParamName);
+        ex.ParamName.Should().Be("executablePath");
     }
 
     [Fact]
     public void Constructor_DockerMode_WithoutImage_Throws()
     {
-        var ex = Assert.Throws<ArgumentException>(() => new AzuriteLaunchRequest(
+        var ex = FluentActions.Invoking(() => new AzuriteLaunchRequest(
             mode: AzuriteLaunchMode.Docker,
             blobPort: 10000,
             queuePort: 10001,
             tablePort: 10002,
             dataPath: "/tmp/data",
             logPath: "/tmp/log/azurite.log",
-            containerName: "func-azurite-test"));
+            containerName: "func-azurite-test")).Should().ThrowExactly<ArgumentException>().Which;
 
-        Assert.Equal("dockerImage", ex.ParamName);
+        ex.ParamName.Should().Be("dockerImage");
     }
 
     [Fact]
     public void Constructor_DockerMode_WithoutContainerName_Throws()
     {
-        var ex = Assert.Throws<ArgumentException>(() => new AzuriteLaunchRequest(
+        var ex = FluentActions.Invoking(() => new AzuriteLaunchRequest(
             mode: AzuriteLaunchMode.Docker,
             blobPort: 10000,
             queuePort: 10001,
             tablePort: 10002,
             dataPath: "/tmp/data",
             logPath: "/tmp/log/azurite.log",
-            dockerImage: AzuriteDockerImage.Default));
+            dockerImage: AzuriteDockerImage.Default)).Should().ThrowExactly<ArgumentException>().Which;
 
-        Assert.Equal("containerName", ex.ParamName);
+        ex.ParamName.Should().Be("containerName");
     }
 
     [Fact]
     public void Constructor_MissingDataPath_Throws()
     {
-        var ex = Assert.Throws<ArgumentException>(() => new AzuriteLaunchRequest(
+        var ex = FluentActions.Invoking(() => new AzuriteLaunchRequest(
             mode: AzuriteLaunchMode.Native,
             blobPort: 10000,
             queuePort: 10001,
             tablePort: 10002,
             dataPath: string.Empty,
             logPath: "/tmp/log/azurite.log",
-            executablePath: "/usr/local/bin/azurite"));
+            executablePath: "/usr/local/bin/azurite")).Should().ThrowExactly<ArgumentException>().Which;
 
-        Assert.Equal("dataPath", ex.ParamName);
+        ex.ParamName.Should().Be("dataPath");
     }
 
     [Fact]
     public void Constructor_MissingLogPath_Throws()
     {
-        var ex = Assert.Throws<ArgumentException>(() => new AzuriteLaunchRequest(
+        var ex = FluentActions.Invoking(() => new AzuriteLaunchRequest(
             mode: AzuriteLaunchMode.Native,
             blobPort: 10000,
             queuePort: 10001,
             tablePort: 10002,
             dataPath: "/tmp/data",
             logPath: string.Empty,
-            executablePath: "/usr/local/bin/azurite"));
+            executablePath: "/usr/local/bin/azurite")).Should().ThrowExactly<ArgumentException>().Which;
 
-        Assert.Equal("logPath", ex.ParamName);
+        ex.ParamName.Should().Be("logPath");
     }
 
     [Fact]
@@ -94,13 +93,13 @@ public class AzuriteLaunchRequestTests
             logPath: "/var/log/azurite.log",
             executablePath: "/usr/local/bin/azurite");
 
-        Assert.Equal(AzuriteLaunchMode.Native, request.Mode);
-        Assert.Equal("/usr/local/bin/azurite", request.ExecutablePath);
-        Assert.Null(request.DockerImage);
-        Assert.Null(request.ContainerName);
-        Assert.Equal(20000, request.BlobPort);
-        Assert.Equal(20001, request.QueuePort);
-        Assert.Equal(20002, request.TablePort);
+        request.Mode.Should().Be(AzuriteLaunchMode.Native);
+        request.ExecutablePath.Should().Be("/usr/local/bin/azurite");
+        request.DockerImage.Should().BeNull();
+        request.ContainerName.Should().BeNull();
+        request.BlobPort.Should().Be(20000);
+        request.QueuePort.Should().Be(20001);
+        request.TablePort.Should().Be(20002);
     }
 
     [Fact]
@@ -116,9 +115,9 @@ public class AzuriteLaunchRequestTests
             dockerImage: AzuriteDockerImage.Default,
             containerName: "func-azurite-abc");
 
-        Assert.Equal(AzuriteLaunchMode.Docker, request.Mode);
-        Assert.Equal(AzuriteDockerImage.Default, request.DockerImage);
-        Assert.Equal("func-azurite-abc", request.ContainerName);
-        Assert.Null(request.ExecutablePath);
+        request.Mode.Should().Be(AzuriteLaunchMode.Docker);
+        request.DockerImage.Should().Be(AzuriteDockerImage.Default);
+        request.ContainerName.Should().Be("func-azurite-abc");
+        request.ExecutablePath.Should().BeNull();
     }
 }

--- a/test/Func.Tests/Commands/Start/Azurite/Launching/AzuriteLauncherTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/Launching/AzuriteLauncherTests.cs
@@ -1,10 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.IO;
 using System.Runtime.InteropServices;
 using Azure.Functions.Cli.Commands.Start.Azurite.Launching;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands.Start.Azurite.Launching;
 
@@ -48,11 +46,11 @@ public class AzuriteLauncherTests
         }
 
         var process = new System.Diagnostics.Process { StartInfo = psi };
-        Assert.True(process.Start(), "Failed to start sentinel process.");
+        process.Start().Should().BeTrue("Failed to start sentinel process.");
 
         await using IAzuriteProcess handle = new AzuriteProcess(process, AzuriteLaunchMode.Native);
 
-        Assert.True(handle.ProcessId > 0);
+        (handle.ProcessId > 0).Should().BeTrue();
 
         using var readCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         string? firstLine = null;
@@ -62,7 +60,7 @@ public class AzuriteLauncherTests
             break;
         }
 
-        Assert.Equal("started", firstLine?.Trim());
+        (firstLine?.Trim()).Should().Be("started");
 
         await handle.StopAsync(CancellationToken.None);
 
@@ -71,12 +69,12 @@ public class AzuriteLauncherTests
 
         // Force-killed processes return a non-zero exit code on Unix and an
         // OS-specific code on Windows. Either way, the process must have exited.
-        Assert.NotEqual(0, exitCode);
+        exitCode.Should().NotBe(0);
 
         // Verify request shape validation still passes for the parallel
         // happy-path AzuriteLaunchRequest. (Keeps the launch-request type
         // exercised even though we routed around the launcher.)
-        Assert.Equal(AzuriteLaunchMode.Native, request.Mode);
+        request.Mode.Should().Be(AzuriteLaunchMode.Native);
     }
 
     [Fact]
@@ -94,11 +92,10 @@ public class AzuriteLauncherTests
             logPath: Path.Combine(Path.GetTempPath(), "azurite-test.log"),
             executablePath: missingPath);
 
-        var ex = await Assert.ThrowsAsync<AzuriteLaunchException>(
-            () => launcher.StartAsync(request, CancellationToken.None));
+        var ex = (await FluentActions.Awaiting(() => launcher.StartAsync(request, CancellationToken.None)).Should().ThrowAsync<AzuriteLaunchException>()).Which;
 
-        Assert.Equal(AzuriteLaunchMode.Native, ex.Mode);
-        Assert.Equal(missingPath, ex.FileName);
+        ex.Mode.Should().Be(AzuriteLaunchMode.Native);
+        ex.FileName.Should().Be(missingPath);
     }
 
     [Fact]
@@ -121,7 +118,7 @@ public class AzuriteLauncherTests
         }
 
         var process = new System.Diagnostics.Process { StartInfo = psi };
-        Assert.True(process.Start());
+        process.Start().Should().BeTrue();
         int pid = process.Id;
 
         IAzuriteProcess handle = new AzuriteProcess(process, AzuriteLaunchMode.Native);
@@ -129,7 +126,7 @@ public class AzuriteLauncherTests
 
         // Give the OS a moment to reap.
         await Task.Delay(200);
-        Assert.False(IsProcessAlive(pid));
+        IsProcessAlive(pid).Should().BeFalse();
     }
 
     private static (string FileName, string CommandText) GetEchoSleepSentinel()

--- a/test/Func.Tests/Commands/Start/Azurite/Launching/DockerAzuriteCommandBuilderTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/Launching/DockerAzuriteCommandBuilderTests.cs
@@ -1,9 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.IO;
 using Azure.Functions.Cli.Commands.Start.Azurite.Launching;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands.Start.Azurite.Launching;
 
@@ -24,7 +22,7 @@ public class DockerAzuriteCommandBuilderTests
 
         var (fileName, args) = DockerAzuriteCommandBuilder.Build(request);
 
-        Assert.Equal("docker", fileName);
+        fileName.Should().Be("docker");
 
         string expectedLogDir = Path.GetDirectoryName("/var/log/azurite/azurite.log")!;
         string[] expected =
@@ -52,7 +50,7 @@ public class DockerAzuriteCommandBuilderTests
             "--debug", "/logs/azurite.log",
         ];
 
-        Assert.Equal(expected, args);
+        args.Should().Equal(expected);
     }
 
     [Fact]
@@ -70,9 +68,9 @@ public class DockerAzuriteCommandBuilderTests
 
         var (_, args) = DockerAzuriteCommandBuilder.Build(request);
 
-        Assert.Contains("127.0.0.1:21000:10000", args);
-        Assert.Contains("127.0.0.1:21001:10001", args);
-        Assert.Contains("127.0.0.1:21002:10002", args);
+        args.Should().Contain("127.0.0.1:21000:10000");
+        args.Should().Contain("127.0.0.1:21001:10001");
+        args.Should().Contain("127.0.0.1:21002:10002");
     }
 
     [Fact]
@@ -93,8 +91,8 @@ public class DockerAzuriteCommandBuilderTests
 
         var (_, args) = DockerAzuriteCommandBuilder.Build(request);
 
-        Assert.Contains($"{logDir}:/logs", args);
-        Assert.DoesNotContain(logPath + ":/logs", args);
+        args.Should().Contain($"{logDir}:/logs");
+        args.Should().NotContain(logPath + ":/logs");
     }
 
     [Fact]
@@ -112,8 +110,8 @@ public class DockerAzuriteCommandBuilderTests
 
         var (_, args) = DockerAzuriteCommandBuilder.Build(request);
 
-        Assert.Contains(AzuriteDockerImage.Default, args);
-        Assert.Equal("mcr.microsoft.com/azure-storage/azurite:3.35.0", AzuriteDockerImage.Default);
+        args.Should().Contain(AzuriteDockerImage.Default);
+        AzuriteDockerImage.Default.Should().Be("mcr.microsoft.com/azure-storage/azurite:3.35.0");
     }
 
     [Fact]
@@ -131,7 +129,7 @@ public class DockerAzuriteCommandBuilderTests
 
         var (fileName, _) = DockerAzuriteCommandBuilder.Build(request, dockerCommand: "/usr/local/bin/podman");
 
-        Assert.Equal("/usr/local/bin/podman", fileName);
+        fileName.Should().Be("/usr/local/bin/podman");
     }
 
     [Fact]
@@ -146,6 +144,6 @@ public class DockerAzuriteCommandBuilderTests
             logPath: "/d/azurite.log",
             executablePath: "/azurite");
 
-        Assert.Throws<ArgumentException>(() => DockerAzuriteCommandBuilder.Build(request));
+        FluentActions.Invoking(() => DockerAzuriteCommandBuilder.Build(request)).Should().ThrowExactly<ArgumentException>();
     }
 }

--- a/test/Func.Tests/Commands/Start/Azurite/Launching/NativeAzuriteCommandBuilderTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/Launching/NativeAzuriteCommandBuilderTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Commands.Start.Azurite.Launching;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands.Start.Azurite.Launching;
 
@@ -22,7 +21,7 @@ public class NativeAzuriteCommandBuilderTests
 
         var (fileName, args) = NativeAzuriteCommandBuilder.Build(request);
 
-        Assert.Equal("/usr/local/bin/azurite", fileName);
+        fileName.Should().Be("/usr/local/bin/azurite");
 
         string[] expected =
         [
@@ -40,7 +39,7 @@ public class NativeAzuriteCommandBuilderTests
             "--debug", "/var/log/azurite.log",
         ];
 
-        Assert.Equal(expected, args);
+        args.Should().Equal(expected);
     }
 
     [Fact]
@@ -57,9 +56,9 @@ public class NativeAzuriteCommandBuilderTests
 
         var (_, args) = NativeAzuriteCommandBuilder.Build(request);
 
-        Assert.Contains("20000", args);
-        Assert.Contains("30000", args);
-        Assert.Contains("40000", args);
+        args.Should().Contain("20000");
+        args.Should().Contain("30000");
+        args.Should().Contain("40000");
     }
 
     [Fact]
@@ -75,6 +74,6 @@ public class NativeAzuriteCommandBuilderTests
             dockerImage: AzuriteDockerImage.Default,
             containerName: "func-azurite-x");
 
-        Assert.Throws<ArgumentException>(() => NativeAzuriteCommandBuilder.Build(request));
+        FluentActions.Invoking(() => NativeAzuriteCommandBuilder.Build(request)).Should().ThrowExactly<ArgumentException>();
     }
 }

--- a/test/Func.Tests/Commands/Start/Azurite/Orchestration/ManagedAzuriteOrchestratorTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/Orchestration/ManagedAzuriteOrchestratorTests.cs
@@ -8,7 +8,6 @@ using Azure.Functions.Cli.Commands.Start.Azurite.Launching;
 using Azure.Functions.Cli.Commands.Start.Azurite.Orchestration;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands.Start.Azurite.Orchestration;
 
@@ -74,7 +73,7 @@ public class ManagedAzuriteOrchestratorTests
 
         ManagedAzuriteResult result = await sut.EnsureReadyAsync(Request(disabled: true), progress: null, CancellationToken.None);
 
-        Assert.IsType<ManagedAzuriteResult.Disabled>(result);
+        result.Should().BeOfType<ManagedAzuriteResult.Disabled>();
         await _probe.DidNotReceive().ProbeAsync(Arg.Any<AzuriteEndpointTuple>(), Arg.Any<CancellationToken>());
         await _locator.DidNotReceive().FindAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
         await _launcher.DidNotReceive().StartAsync(Arg.Any<AzuriteLaunchRequest>(), Arg.Any<CancellationToken>());
@@ -87,7 +86,7 @@ public class ManagedAzuriteOrchestratorTests
 
         ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), progress: null, CancellationToken.None);
 
-        Assert.IsType<ManagedAzuriteResult.Disabled>(result);
+        result.Should().BeOfType<ManagedAzuriteResult.Disabled>();
         await _probe.DidNotReceive().ProbeAsync(Arg.Any<AzuriteEndpointTuple>(), Arg.Any<CancellationToken>());
     }
 
@@ -99,7 +98,7 @@ public class ManagedAzuriteOrchestratorTests
 
         ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), progress: null, CancellationToken.None);
 
-        Assert.IsType<ManagedAzuriteResult.UserManaged>(result);
+        result.Should().BeOfType<ManagedAzuriteResult.UserManaged>();
         await _launcher.DidNotReceive().StartAsync(Arg.Any<AzuriteLaunchRequest>(), Arg.Any<CancellationToken>());
     }
 
@@ -111,9 +110,9 @@ public class ManagedAzuriteOrchestratorTests
 
         ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), progress: null, CancellationToken.None);
 
-        var failed = Assert.IsType<ManagedAzuriteResult.Failed>(result);
-        Assert.Contains("cannot start this configuration automatically", failed.UserMessage);
-        Assert.Contains("Start Azurite", failed.UserMessage);
+        var failed = result.Should().BeOfType<ManagedAzuriteResult.Failed>().Subject;
+        failed.UserMessage.Should().Contain("cannot start this configuration automatically");
+        failed.UserMessage.Should().Contain("Start Azurite");
     }
 
     [Fact]
@@ -124,7 +123,7 @@ public class ManagedAzuriteOrchestratorTests
 
         ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), progress: null, CancellationToken.None);
 
-        Assert.IsType<ManagedAzuriteResult.UserManaged>(result);
+        result.Should().BeOfType<ManagedAzuriteResult.UserManaged>();
         await _launcher.DidNotReceive().StartAsync(Arg.Any<AzuriteLaunchRequest>(), Arg.Any<CancellationToken>());
     }
 
@@ -136,8 +135,8 @@ public class ManagedAzuriteOrchestratorTests
 
         ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), progress: null, CancellationToken.None);
 
-        var failed = Assert.IsType<ManagedAzuriteResult.Failed>(result);
-        Assert.Contains("another process is using the Azurite ports", failed.UserMessage);
+        var failed = result.Should().BeOfType<ManagedAzuriteResult.Failed>().Subject;
+        failed.UserMessage.Should().Contain("another process is using the Azurite ports");
     }
 
     [Fact]
@@ -153,9 +152,9 @@ public class ManagedAzuriteOrchestratorTests
 
         ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), progress: null, CancellationToken.None);
 
-        var started = Assert.IsType<ManagedAzuriteResult.Started>(result);
-        Assert.Equal(AzuriteLaunchMode.Native, started.Mode);
-        Assert.Same(fake, started.Process);
+        var started = result.Should().BeOfType<ManagedAzuriteResult.Started>().Subject;
+        started.Mode.Should().Be(AzuriteLaunchMode.Native);
+        started.Process.Should().BeSameAs(fake);
         await _launcher.Received(1).StartAsync(
             Arg.Is<AzuriteLaunchRequest>(r => r.Mode == AzuriteLaunchMode.Native && r.ExecutablePath == "/usr/bin/azurite"),
             Arg.Any<CancellationToken>());
@@ -176,8 +175,8 @@ public class ManagedAzuriteOrchestratorTests
 
         ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), progress: null, CancellationToken.None);
 
-        var started = Assert.IsType<ManagedAzuriteResult.Started>(result);
-        Assert.Equal(AzuriteLaunchMode.Docker, started.Mode);
+        var started = result.Should().BeOfType<ManagedAzuriteResult.Started>().Subject;
+        started.Mode.Should().Be(AzuriteLaunchMode.Docker);
         await _launcher.Received(1).StartAsync(
             Arg.Is<AzuriteLaunchRequest>(r => r.Mode == AzuriteLaunchMode.Docker),
             Arg.Any<CancellationToken>());
@@ -194,10 +193,10 @@ public class ManagedAzuriteOrchestratorTests
 
         ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), progress: null, CancellationToken.None);
 
-        var failed = Assert.IsType<ManagedAzuriteResult.Failed>(result);
-        Assert.Contains("Azurite is not running", failed.UserMessage);
-        Assert.Contains("npm install -g azurite", failed.UserMessage);
-        Assert.Contains("Docker Desktop", failed.UserMessage);
+        var failed = result.Should().BeOfType<ManagedAzuriteResult.Failed>().Subject;
+        failed.UserMessage.Should().Contain("Azurite is not running");
+        failed.UserMessage.Should().Contain("npm install -g azurite");
+        failed.UserMessage.Should().Contain("Docker Desktop");
         await _launcher.DidNotReceive().StartAsync(Arg.Any<AzuriteLaunchRequest>(), Arg.Any<CancellationToken>());
     }
 
@@ -217,9 +216,9 @@ public class ManagedAzuriteOrchestratorTests
             progress: null,
             CancellationToken.None);
 
-        var failed = Assert.IsType<ManagedAzuriteResult.Failed>(result);
-        Assert.Contains("did not become ready", failed.UserMessage);
-        Assert.True(fake.StopCalled, "Orchestrator must stop the process on timeout.");
+        var failed = result.Should().BeOfType<ManagedAzuriteResult.Failed>().Subject;
+        failed.UserMessage.Should().Contain("did not become ready");
+        fake.StopCalled.Should().BeTrue("Orchestrator must stop the process on timeout.");
     }
 
     [Fact]
@@ -235,9 +234,9 @@ public class ManagedAzuriteOrchestratorTests
 
         ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), progress: null, CancellationToken.None);
 
-        var failed = Assert.IsType<ManagedAzuriteResult.Failed>(result);
-        Assert.Contains("Azurite exited before it was ready", failed.UserMessage);
-        Assert.Contains("ENOENT", failed.UserMessage);
+        var failed = result.Should().BeOfType<ManagedAzuriteResult.Failed>().Subject;
+        failed.UserMessage.Should().Contain("Azurite exited before it was ready");
+        failed.UserMessage.Should().Contain("ENOENT");
     }
 
     [Fact]
@@ -260,7 +259,7 @@ public class ManagedAzuriteOrchestratorTests
         await Task.Delay(100);
         cts.Cancel();
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => resultTask);
+        await FluentActions.Awaiting(() => resultTask).Should().ThrowAsync<OperationCanceledException>();
     }
 
     [Fact]
@@ -279,12 +278,12 @@ public class ManagedAzuriteOrchestratorTests
 
         ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), progress, CancellationToken.None);
 
-        Assert.IsType<ManagedAzuriteResult.Started>(result);
-        Assert.Contains(messages, m => m.Contains("checking AzureWebJobsStorage configuration", StringComparison.OrdinalIgnoreCase));
-        Assert.Contains(messages, m => m.Contains("checking for an existing Azurite endpoint", StringComparison.OrdinalIgnoreCase));
-        Assert.Contains(messages, m => m.Contains("looking for a local Azurite installation", StringComparison.OrdinalIgnoreCase));
-        Assert.Contains(messages, m => m.Contains("starting Azurite (native)", StringComparison.OrdinalIgnoreCase));
-        Assert.Contains(messages, m => m.Contains("Azurite ready", StringComparison.OrdinalIgnoreCase));
+        result.Should().BeOfType<ManagedAzuriteResult.Started>();
+        messages.Should().Contain(m => m.Contains("checking AzureWebJobsStorage configuration", StringComparison.OrdinalIgnoreCase));
+        messages.Should().Contain(m => m.Contains("checking for an existing Azurite endpoint", StringComparison.OrdinalIgnoreCase));
+        messages.Should().Contain(m => m.Contains("looking for a local Azurite installation", StringComparison.OrdinalIgnoreCase));
+        messages.Should().Contain(m => m.Contains("starting Azurite (native)", StringComparison.OrdinalIgnoreCase));
+        messages.Should().Contain(m => m.Contains("Azurite ready", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
@@ -301,9 +300,9 @@ public class ManagedAzuriteOrchestratorTests
 
         ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), progress, CancellationToken.None);
 
-        Assert.IsType<ManagedAzuriteResult.Failed>(result);
-        Assert.Contains(messages, m => m.Contains("looking for a local Azurite installation", StringComparison.OrdinalIgnoreCase));
-        Assert.Contains(messages, m => m.Contains("checking Docker availability", StringComparison.OrdinalIgnoreCase));
+        result.Should().BeOfType<ManagedAzuriteResult.Failed>();
+        messages.Should().Contain(m => m.Contains("looking for a local Azurite installation", StringComparison.OrdinalIgnoreCase));
+        messages.Should().Contain(m => m.Contains("checking Docker availability", StringComparison.OrdinalIgnoreCase));
     }
 
     private sealed class CapturingProgress(List<string> messages) : IProgress<string>

--- a/test/Func.Tests/Commands/Start/Azurite/Orchestration/ManagedAzuriteOrchestratorTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/Orchestration/ManagedAzuriteOrchestratorTests.cs
@@ -135,8 +135,8 @@ public class ManagedAzuriteOrchestratorTests
 
         ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), progress: null, CancellationToken.None);
 
-        var failed = result.Should().BeOfType<ManagedAzuriteResult.Failed>().Subject;
-        failed.UserMessage.Should().Contain("another process is using the Azurite ports");
+        result.Should().BeOfType<ManagedAzuriteResult.Failed>()
+            .Which.UserMessage.Should().Contain("another process is using the Azurite ports");
     }
 
     [Fact]
@@ -175,8 +175,7 @@ public class ManagedAzuriteOrchestratorTests
 
         ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), progress: null, CancellationToken.None);
 
-        var started = result.Should().BeOfType<ManagedAzuriteResult.Started>().Subject;
-        started.Mode.Should().Be(AzuriteLaunchMode.Docker);
+        result.Should().BeOfType<ManagedAzuriteResult.Started>().Which.Mode.Should().Be(AzuriteLaunchMode.Docker);
         await _launcher.Received(1).StartAsync(
             Arg.Is<AzuriteLaunchRequest>(r => r.Mode == AzuriteLaunchMode.Docker),
             Arg.Any<CancellationToken>());
@@ -216,8 +215,8 @@ public class ManagedAzuriteOrchestratorTests
             progress: null,
             CancellationToken.None);
 
-        var failed = result.Should().BeOfType<ManagedAzuriteResult.Failed>().Subject;
-        failed.UserMessage.Should().Contain("did not become ready");
+        result.Should().BeOfType<ManagedAzuriteResult.Failed>()
+            .Which.UserMessage.Should().Contain("did not become ready");
         fake.StopCalled.Should().BeTrue("Orchestrator must stop the process on timeout.");
     }
 

--- a/test/Func.Tests/Commands/Start/Azurite/Processes/ProcessRunnerTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/Processes/ProcessRunnerTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Commands.Start.Azurite.Processes;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands.Start.Azurite.Processes;
 
@@ -31,10 +30,10 @@ public class ProcessRunnerTests
             new ProcessRunRequest(fileName, args, WorkingDirectory: null, _defaultTimeout),
             CancellationToken.None);
 
-        Assert.False(outcome.ExecutableNotFound);
-        Assert.False(outcome.TimedOut);
-        Assert.Equal(0, outcome.ExitCode);
-        Assert.Contains("hello", outcome.StandardOutput);
+        outcome.ExecutableNotFound.Should().BeFalse();
+        outcome.TimedOut.Should().BeFalse();
+        outcome.ExitCode.Should().Be(0);
+        outcome.StandardOutput.Should().Contain("hello");
     }
 
     [Fact]
@@ -46,9 +45,9 @@ public class ProcessRunnerTests
             new ProcessRunRequest(fileName, args, WorkingDirectory: null, _defaultTimeout),
             CancellationToken.None);
 
-        Assert.Equal(7, outcome.ExitCode);
-        Assert.False(outcome.TimedOut);
-        Assert.False(outcome.ExecutableNotFound);
+        outcome.ExitCode.Should().Be(7);
+        outcome.TimedOut.Should().BeFalse();
+        outcome.ExecutableNotFound.Should().BeFalse();
     }
 
     [Fact]
@@ -62,8 +61,8 @@ public class ProcessRunnerTests
                 Timeout: _defaultTimeout),
             CancellationToken.None);
 
-        Assert.True(outcome.ExecutableNotFound);
-        Assert.Null(outcome.ExitCode);
+        outcome.ExecutableNotFound.Should().BeTrue();
+        outcome.ExitCode.Should().BeNull();
     }
 
     [Fact]
@@ -77,7 +76,7 @@ public class ProcessRunnerTests
             new ProcessRunRequest(fileName, args, WorkingDirectory: null, Timeout: TimeSpan.FromMilliseconds(250)),
             CancellationToken.None);
 
-        Assert.True(outcome.TimedOut);
-        Assert.Null(outcome.ExitCode);
+        outcome.TimedOut.Should().BeTrue();
+        outcome.ExitCode.Should().BeNull();
     }
 }

--- a/test/Func.Tests/Commands/Start/Initialization/PrepareProjectHostRunInitializationStepTests.cs
+++ b/test/Func.Tests/Commands/Start/Initialization/PrepareProjectHostRunInitializationStepTests.cs
@@ -10,7 +10,6 @@ using Azure.Functions.Cli.Hosting.Dashboard.Rendering;
 using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Workers;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands.Start.Initialization;
 
@@ -44,7 +43,7 @@ public class PrepareProjectHostRunInitializationStepTests : IDisposable
 
         await NewStep().ExecuteAsync(context, CancellationToken.None);
 
-        Assert.Equal("MyValue", context.State.HostRunContext!.EnvironmentVariables["MyKey"]);
+        context.State.HostRunContext!.EnvironmentVariables["MyKey"].Should().Be("MyValue");
         _interaction.DidNotReceiveWithAnyArgs().WriteWarning(default!);
     }
 
@@ -56,7 +55,7 @@ public class PrepareProjectHostRunInitializationStepTests : IDisposable
 
         await NewStep().ExecuteAsync(context, CancellationToken.None);
 
-        Assert.False(context.State.HostRunContext!.EnvironmentVariables.ContainsKey(string.Empty));
+        context.State.HostRunContext!.EnvironmentVariables.ContainsKey(string.Empty).Should().BeFalse();
         _interaction.Received(1).WriteWarning(Arg.Is<string>(m => m.Contains("empty key", StringComparison.OrdinalIgnoreCase)));
     }
 
@@ -68,8 +67,8 @@ public class PrepareProjectHostRunInitializationStepTests : IDisposable
 
         await NewStep().ExecuteAsync(context, CancellationToken.None);
 
-        Assert.True(context.State.HostRunContext!.EnvironmentVariables.TryGetValue("ClearMe", out string? value));
-        Assert.Equal(string.Empty, value);
+        context.State.HostRunContext!.EnvironmentVariables.TryGetValue("ClearMe", out string? value).Should().BeTrue();
+        value.Should().Be(string.Empty);
         _interaction.DidNotReceiveWithAnyArgs().WriteWarning(default!);
     }
 
@@ -82,7 +81,7 @@ public class PrepareProjectHostRunInitializationStepTests : IDisposable
 
         await NewStep().ExecuteAsync(context, CancellationToken.None);
 
-        Assert.False(context.State.HostRunContext!.EnvironmentVariables.ContainsKey("MyKey"));
+        context.State.HostRunContext!.EnvironmentVariables.ContainsKey("MyKey").Should().BeFalse();
         _interaction.Received(1).WriteWarning(Arg.Is<string>(m => m.Contains("MyKey") && m.Contains("already set", StringComparison.OrdinalIgnoreCase)));
     }
 
@@ -95,8 +94,8 @@ public class PrepareProjectHostRunInitializationStepTests : IDisposable
 
         await NewStep().ExecuteAsync(context, CancellationToken.None);
 
-        Assert.False(context.State.HostRunContext!.EnvironmentVariables.ContainsKey("MYKEY"));
-        Assert.False(context.State.HostRunContext!.EnvironmentVariables.ContainsKey("MyKey"));
+        context.State.HostRunContext!.EnvironmentVariables.ContainsKey("MYKEY").Should().BeFalse();
+        context.State.HostRunContext!.EnvironmentVariables.ContainsKey("MyKey").Should().BeFalse();
     }
 
     [Fact]
@@ -108,7 +107,7 @@ public class PrepareProjectHostRunInitializationStepTests : IDisposable
 
         await NewStep().ExecuteAsync(context, CancellationToken.None);
 
-        Assert.Equal("valueA", context.State.HostRunContext!.EnvironmentVariables["KeyA"]);
+        context.State.HostRunContext!.EnvironmentVariables["KeyA"].Should().Be("valueA");
         _interaction.DidNotReceiveWithAnyArgs().WriteWarning(default!);
     }
 
@@ -121,7 +120,7 @@ public class PrepareProjectHostRunInitializationStepTests : IDisposable
 
         await NewStep().ExecuteAsync(context, CancellationToken.None);
 
-        Assert.False(context.State.HostRunContext!.EnvironmentVariables.ContainsKey("KeyB"));
+        context.State.HostRunContext!.EnvironmentVariables.ContainsKey("KeyB").Should().BeFalse();
         _interaction.Received(1).WriteWarning(Arg.Is<string>(s => s.Contains("KeyB")));
     }
 
@@ -140,9 +139,9 @@ public class PrepareProjectHostRunInitializationStepTests : IDisposable
         await NewStep().ExecuteAsync(context, CancellationToken.None);
 
         IDictionary<string, string> env = context.State.HostRunContext!.EnvironmentVariables;
-        Assert.Equal("fromHost", env["HostKey"]);
-        Assert.Equal("fromBundle", env["BundleKey"]);
-        Assert.False(env.ContainsKey("MyKey"));
+        env["HostKey"].Should().Be("fromHost");
+        env["BundleKey"].Should().Be("fromBundle");
+        env.ContainsKey("MyKey").Should().BeFalse();
     }
 
     [Fact]
@@ -155,15 +154,15 @@ public class PrepareProjectHostRunInitializationStepTests : IDisposable
 
         await NewStep().ExecuteAsync(context, CancellationToken.None);
 
-        Assert.NotNull(context.State.HostRunContext!.Reporter);
-        Assert.Contains(renderer.Events, ev => ev is StartInitializationProgressEvent progress
+        context.State.HostRunContext!.Reporter.Should().NotBeNull();
+        renderer.Events.Any(ev => ev is StartInitializationProgressEvent progress
             && progress.StepId == PrepareProjectHostRunInitializationStep.StepId
             && double.IsNaN(progress.Percent)
-            && progress.Message == "running npm install");
-        Assert.Contains(renderer.Events, ev => ev is StartInitializationLogEvent log
+            && progress.Message == "running npm install").Should().BeTrue();
+        renderer.Events.Any(ev => ev is StartInitializationLogEvent log
             && log.StepId == PrepareProjectHostRunInitializationStep.StepId
             && log.Line == "npm install output"
-            && log.Severity == FunctionsProjectReportSeverity.Warning);
+            && log.Severity == FunctionsProjectReportSeverity.Warning).Should().BeTrue();
     }
 
     [Fact]
@@ -177,14 +176,14 @@ public class PrepareProjectHostRunInitializationStepTests : IDisposable
         reporter.WriteLog("build output", FunctionsProjectReportSeverity.Error);
         await reporter.CompleteAsync();
 
-        Assert.Contains(renderer.Events, ev => ev is StartInitializationProgressEvent progress
+        renderer.Events.Any(ev => ev is StartInitializationProgressEvent progress
             && progress.StepId == "adapter_step"
             && double.IsNaN(progress.Percent)
-            && progress.Message == "building");
-        Assert.Contains(renderer.Events, ev => ev is StartInitializationLogEvent log
+            && progress.Message == "building").Should().BeTrue();
+        renderer.Events.Any(ev => ev is StartInitializationLogEvent log
             && log.StepId == "adapter_step"
             && log.Line == "build output"
-            && log.Severity == FunctionsProjectReportSeverity.Error);
+            && log.Severity == FunctionsProjectReportSeverity.Error).Should().BeTrue();
     }
 
     private void SetLocalSettings(Dictionary<string, string> values)

--- a/test/Func.Tests/Commands/StartCommandTests.cs
+++ b/test/Func.Tests/Commands/StartCommandTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.CommandLine;
-using Azure.Functions.Cli;
 using Azure.Functions.Cli.Commands;
 using Azure.Functions.Cli.Commands.Start.Initialization;
 using Azure.Functions.Cli.Commands.Start.Initialization.Rendering;
@@ -16,7 +15,6 @@ using Azure.Functions.Cli.Workers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands;
 
@@ -57,19 +55,19 @@ public class StartCommandTests : IDisposable
 
         var optionNames = cmd.Options.Select(o => o.Name).ToList();
 
-        Assert.Contains("--port", optionNames);
-        Assert.Contains("--cors", optionNames);
-        Assert.Contains("--cors-credentials", optionNames);
-        Assert.Contains("--functions", optionNames);
-        Assert.Contains("--no-build", optionNames);
-        Assert.Contains("--enable-auth", optionNames);
-        Assert.Contains("--profile", optionNames);
-        Assert.Contains("--host-version", optionNames);
-        Assert.Contains("--offline", optionNames);
-        Assert.Contains("--output", optionNames);
-        Assert.Contains("--no-tui", optionNames);
-        Assert.Contains("--log-file", optionNames);
-        Assert.Contains("--demo", optionNames);
+        optionNames.Should().Contain("--port");
+        optionNames.Should().Contain("--cors");
+        optionNames.Should().Contain("--cors-credentials");
+        optionNames.Should().Contain("--functions");
+        optionNames.Should().Contain("--no-build");
+        optionNames.Should().Contain("--enable-auth");
+        optionNames.Should().Contain("--profile");
+        optionNames.Should().Contain("--host-version");
+        optionNames.Should().Contain("--offline");
+        optionNames.Should().Contain("--output");
+        optionNames.Should().Contain("--no-tui");
+        optionNames.Should().Contain("--log-file");
+        optionNames.Should().Contain("--demo");
     }
 
     [Fact]
@@ -78,8 +76,8 @@ public class StartCommandTests : IDisposable
         var root = TestParser.CreateRoot(_interaction);
         var runCommand = root.Subcommands.SingleOrDefault(c => c.Name == "run");
 
-        Assert.NotNull(runCommand);
-        Assert.Contains("start", runCommand!.Aliases);
+        runCommand.Should().NotBeNull();
+        runCommand!.Aliases.Should().Contain("start");
     }
 
     [Fact]
@@ -90,8 +88,8 @@ public class StartCommandTests : IDisposable
         var result = root.Parse($"run \"{nonExistent}\"");
 
         var config = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
-        var ex = await Assert.ThrowsAsync<GracefulException>(() => result.InvokeAsync(config));
-        Assert.Contains("does not exist", ex.Message);
+        var ex = (await FluentActions.Awaiting(() => result.InvokeAsync(config)).Should().ThrowAsync<GracefulException>()).Which;
+        ex.Message.Should().Contain("does not exist");
     }
 
     [Fact]
@@ -104,9 +102,9 @@ public class StartCommandTests : IDisposable
         // Disable the default exception handler so GracefulException propagates,
         // matching production wiring.
         var config = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
-        var ex = await Assert.ThrowsAsync<GracefulException>(() => result.InvokeAsync(config));
-        Assert.Contains("does not exist", ex.Message);
-        Assert.Contains(nonExistent, ex.Message);
+        var ex = (await FluentActions.Awaiting(() => result.InvokeAsync(config)).Should().ThrowAsync<GracefulException>()).Which;
+        ex.Message.Should().Contain("does not exist");
+        ex.Message.Should().Contain(nonExistent);
     }
 
     [Fact]
@@ -116,9 +114,9 @@ public class StartCommandTests : IDisposable
         var result = root.Parse($"start \"{_tempDir}\" --output=bogus");
 
         var config = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
-        var ex = await Assert.ThrowsAsync<GracefulException>(() => result.InvokeAsync(config));
-        Assert.Contains("--output", ex.Message);
-        Assert.Contains("bogus", ex.Message);
+        var ex = (await FluentActions.Awaiting(() => result.InvokeAsync(config)).Should().ThrowAsync<GracefulException>()).Which;
+        ex.Message.Should().Contain("--output");
+        ex.Message.Should().Contain("bogus");
     }
 
     [Fact]
@@ -146,7 +144,7 @@ public class StartCommandTests : IDisposable
 
         int exitCode = await result.InvokeAsync(new InvocationConfiguration { EnableDefaultExceptionHandler = false });
 
-        Assert.Equal(0, exitCode);
+        exitCode.Should().Be(0);
         await _initializationRunner.Received(1).RunAsync(
             Arg.Is<StartInitializationContext>(context =>
                 context.Options.WorkingDirectory.Info.FullName == new DirectoryInfo(_tempDir).FullName
@@ -191,7 +189,7 @@ public class StartCommandTests : IDisposable
 
         int exitCode = await result.InvokeAsync(new InvocationConfiguration { EnableDefaultExceptionHandler = false });
 
-        Assert.Equal(0, exitCode);
+        exitCode.Should().Be(0);
         await _initializationRunner.Received(1).RunAsync(
             Arg.Is<StartInitializationContext>(context => context.Options.DemoMode),
             Arg.Any<IStartInitializationRenderer>(),
@@ -223,7 +221,7 @@ public class StartCommandTests : IDisposable
 
         int exitCode = await result.InvokeAsync(new InvocationConfiguration { EnableDefaultExceptionHandler = false });
 
-        Assert.Equal(0, exitCode);
+        exitCode.Should().Be(0);
         options.Received(1).Get(new DirectoryInfo(_tempDir).FullName);
         await _initializationRunner.Received(1).RunAsync(
             Arg.Is<StartInitializationContext>(context =>
@@ -258,7 +256,7 @@ public class StartCommandTests : IDisposable
 
         int exitCode = await result.InvokeAsync(new InvocationConfiguration { EnableDefaultExceptionHandler = false });
 
-        Assert.Equal(0, exitCode);
+        exitCode.Should().Be(0);
         options.DidNotReceive().Get(Arg.Any<string>());
         await _initializationRunner.Received(1).RunAsync(
             Arg.Is<StartInitializationContext>(context => context.Options.Port == 9092),
@@ -290,13 +288,13 @@ public class StartCommandTests : IDisposable
 
         int exitCode = await result.InvokeAsync(new InvocationConfiguration { EnableDefaultExceptionHandler = false });
 
-        Assert.Equal(0, exitCode);
-        TestFunctionsProject project = Assert.IsType<TestFunctionsProject>(initializationResult.Project);
-        FunctionsProjectHostRunCompletionContext completion = Assert.Single(project.CompletionContexts);
-        Assert.Same(initializationResult.HostRunContext, completion.RunContext);
+        exitCode.Should().Be(0);
+        TestFunctionsProject project = initializationResult.Project.Should().BeOfType<TestFunctionsProject>().Subject;
+        FunctionsProjectHostRunCompletionContext completion = project.CompletionContexts.Should().ContainSingle().Subject;
+        completion.RunContext.Should().BeSameAs(initializationResult.HostRunContext);
         FunctionsProjectHostRunOutcome.Completed completed =
-            Assert.IsType<FunctionsProjectHostRunOutcome.Completed>(completion.Outcome);
-        Assert.Equal(0, completed.ExitCode);
+            completion.Outcome.Should().BeOfType<FunctionsProjectHostRunOutcome.Completed>().Subject;
+        completed.ExitCode.Should().Be(0);
     }
 
     [Fact]
@@ -322,12 +320,12 @@ public class StartCommandTests : IDisposable
 
         int exitCode = await result.InvokeAsync(new InvocationConfiguration { EnableDefaultExceptionHandler = false });
 
-        Assert.Equal(11, exitCode);
-        TestFunctionsProject project = Assert.IsType<TestFunctionsProject>(initializationResult.Project);
-        FunctionsProjectHostRunCompletionContext completion = Assert.Single(project.CompletionContexts);
+        exitCode.Should().Be(11);
+        TestFunctionsProject project = initializationResult.Project.Should().BeOfType<TestFunctionsProject>().Subject;
+        FunctionsProjectHostRunCompletionContext completion = project.CompletionContexts.Should().ContainSingle().Subject;
         FunctionsProjectHostRunOutcome.Completed completed =
-            Assert.IsType<FunctionsProjectHostRunOutcome.Completed>(completion.Outcome);
-        Assert.Equal(11, completed.ExitCode);
+            completion.Outcome.Should().BeOfType<FunctionsProjectHostRunOutcome.Completed>().Subject;
+        completed.ExitCode.Should().Be(11);
     }
 
     [Fact]
@@ -358,8 +356,8 @@ public class StartCommandTests : IDisposable
 
         int exitCode = await result.InvokeAsync(new InvocationConfiguration { EnableDefaultExceptionHandler = false });
 
-        Assert.Equal(0, exitCode);
-        Assert.Contains("WARNING: Project cleanup failed: cleanup failed", _interaction.Lines);
+        exitCode.Should().Be(0);
+        _interaction.Lines.Should().Contain("WARNING: Project cleanup failed: cleanup failed");
     }
 
     private static StartInitializationResult CreateInitializationResult(IHostEventStream eventStream, TestFunctionsProject? project = null)

--- a/test/Func.Tests/Commands/StartDashboardEventStreamFactoryTests.cs
+++ b/test/Func.Tests/Commands/StartDashboardEventStreamFactoryTests.cs
@@ -5,7 +5,6 @@ using Azure.Functions.Cli.Commands.Start.Initialization;
 using Azure.Functions.Cli.Hosting.Dashboard.Rendering;
 using Azure.Functions.Cli.Hosting.Events;
 using Microsoft.Extensions.Logging;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands;
 
@@ -39,13 +38,13 @@ public class StartDashboardEventStreamFactoryTests
         IHostEventStream stream = factory.Create(OutputMode.Compact, initializationEvents, hostStream);
         HostLogEntry[] entries = await ReadAllAsync(stream);
 
-        Assert.Equal(2, entries.Length);
-        Assert.Equal("[startup]", entries[0].Category);
-        Assert.Equal("Resolve profile: None (no profile applied)", entries[0].Message);
-        Assert.Equal(LogLevel.Information, entries[0].Level);
-        Assert.Equal("start_initialization_step_completed", entries[0].GetAttribute<string>(HostLogAttributeKeys.CliEventKind));
-        Assert.Equal("Host.Startup", entries[1].Category);
-        Assert.Equal("Host ready", entries[1].Message);
+        entries.Length.Should().Be(2);
+        entries[0].Category.Should().Be("[startup]");
+        entries[0].Message.Should().Be("Resolve profile: None (no profile applied)");
+        entries[0].Level.Should().Be(LogLevel.Information);
+        entries[0].GetAttribute<string>(HostLogAttributeKeys.CliEventKind).Should().Be("start_initialization_step_completed");
+        entries[1].Category.Should().Be("Host.Startup");
+        entries[1].Message.Should().Be("Host ready");
     }
 
     [Theory]
@@ -66,7 +65,7 @@ public class StartDashboardEventStreamFactoryTests
 
         IHostEventStream stream = factory.Create(outputMode, initializationEvents, hostStream);
 
-        Assert.Same(hostStream, stream);
+        stream.Should().BeSameAs(hostStream);
     }
 
     [Fact]
@@ -78,10 +77,10 @@ public class StartDashboardEventStreamFactoryTests
 
         IHostEventStream stream = factory.Create(OutputMode.Compact, [], hostStream);
 
-        var lifecycle = Assert.IsAssignableFrom<IHostEventStreamLifecycle>(stream);
-        Assert.Equal(13, await lifecycle.WaitForExitAsync(CancellationToken.None));
+        var lifecycle = stream.Should().BeAssignableTo<IHostEventStreamLifecycle>().Subject;
+        (await lifecycle.WaitForExitAsync(CancellationToken.None)).Should().Be(13);
         await lifecycle.RequestShutdownAsync(CancellationToken.None);
-        Assert.True(hostStream.ShutdownRequested);
+        hostStream.ShutdownRequested.Should().BeTrue();
     }
 
     private static async Task<HostLogEntry[]> ReadAllAsync(IHostEventStream stream)

--- a/test/Func.Tests/Commands/StartInitializationTests.cs
+++ b/test/Func.Tests/Commands/StartInitializationTests.cs
@@ -26,7 +26,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using NuGet.Versioning;
 using Spectre.Console;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands;
 
@@ -71,11 +70,11 @@ public class StartInitializationTests : IDisposable
 
         StartInitializationResult result = await runner.RunAsync(context, renderer, CancellationToken.None);
 
-        Assert.Equal(".NET", result.RunInfo.StackName);
-        Assert.Equal("4.834.0", result.HostVersion);
-        Assert.False(result.BundleRequired);
-        Assert.IsType<DemoEventSource>(result.EventStream);
-        Assert.Contains(renderer.Events, static ev =>
+        result.RunInfo.StackName.Should().Be(".NET");
+        result.HostVersion.Should().Be("4.834.0");
+        result.BundleRequired.Should().BeFalse();
+        result.EventStream.Should().BeOfType<DemoEventSource>();
+        renderer.Events.Any(static ev =>
             ev is StartInitializationStepStartedEvent
             {
                 Step:
@@ -83,13 +82,13 @@ public class StartInitializationTests : IDisposable
                     Id: InstallHostWorkloadInitializationStep.StepId,
                     DisplayKind: StartInitializationDisplayKind.Progress,
                 },
-            });
-        Assert.Contains(renderer.Events, static ev =>
+            }).Should().BeTrue();
+        renderer.Events.Any(static ev =>
             ev is StartInitializationProgressEvent
             {
                 StepId: InstallHostWorkloadInitializationStep.StepId,
                 Percent: 100,
-            });
+            }).Should().BeTrue();
     }
 
     [Fact]
@@ -114,9 +113,9 @@ public class StartInitializationTests : IDisposable
         int installStartedIndex = FindStartedStepIndex(renderer.Events, InstallHostWorkloadInitializationStep.StepId);
         int stackStartedIndex = FindStartedStepIndex(renderer.Events, ResolveFunctionsProjectInitializationStep.StepId);
 
-        Assert.True(validationCompletedIndex >= 0);
-        Assert.True(installStartedIndex > validationCompletedIndex);
-        Assert.True(stackStartedIndex > installStartedIndex);
+        (validationCompletedIndex >= 0).Should().BeTrue();
+        (installStartedIndex > validationCompletedIndex).Should().BeTrue();
+        (stackStartedIndex > installStartedIndex).Should().BeTrue();
     }
 
     [Fact]
@@ -142,12 +141,12 @@ public class StartInitializationTests : IDisposable
         int prepareStartedIndex = FindStartedStepIndex(renderer.Events, PrepareProjectHostRunInitializationStep.StepId);
         int startHostStartedIndex = FindStartedStepIndex(renderer.Events, StartHostInitializationStep.StepId);
 
-        Assert.True(prepareStartedIndex >= 0);
-        Assert.True(startHostStartedIndex > prepareStartedIndex);
-        Assert.Same(project, result.Project);
-        Assert.Same(result.HostRunContext, project.PreparedContexts.Single());
-        Assert.Equal(startupDirectory.FullName, result.HostRunContext.StartupDirectory.FullName);
-        Assert.Equal("dotnet-isolated", result.HostRunContext.WorkerRuntime);
+        (prepareStartedIndex >= 0).Should().BeTrue();
+        (startHostStartedIndex > prepareStartedIndex).Should().BeTrue();
+        result.Project.Should().BeSameAs(project);
+        project.PreparedContexts.Single().Should().BeSameAs(result.HostRunContext);
+        result.HostRunContext.StartupDirectory.FullName.Should().Be(startupDirectory.FullName);
+        result.HostRunContext.WorkerRuntime.Should().Be("dotnet-isolated");
     }
 
     [Fact]
@@ -191,9 +190,9 @@ public class StartInitializationTests : IDisposable
         StartInitializationResult result = await runner.RunAsync(context, renderer, CancellationToken.None);
 
         IDictionary<string, string> env = result.HostRunContext.EnvironmentVariables;
-        Assert.Equal("yes", env["FROM_LOCAL"]);
-        Assert.Equal("node", env["FUNCTIONS_WORKER_RUNTIME"]);
-        Assert.Equal(workerDir, env["languageWorkers__node__workerDirectory"]);
+        env["FROM_LOCAL"].Should().Be("yes");
+        env["FUNCTIONS_WORKER_RUNTIME"].Should().Be("node");
+        env["languageWorkers__node__workerDirectory"].Should().Be(workerDir);
     }
 
     [Fact]
@@ -233,7 +232,7 @@ public class StartInitializationTests : IDisposable
 
         StartInitializationResult result = await runner.RunAsync(context, renderer, CancellationToken.None);
 
-        Assert.Same(eventStream, result.EventStream);
+        result.EventStream.Should().BeSameAs(eventStream);
         await hostProcessRunner.Received(1).StartAsync(
             Arg.Is<HostProcessStartContext>(startContext =>
                 ReferenceEquals(startContext.HostWorkload, hostWorkload)
@@ -293,14 +292,14 @@ public class StartInitializationTests : IDisposable
 
         StartInitializationResult result = await runner.RunAsync(context, renderer, CancellationToken.None);
 
-        Assert.Equal("local-dev", result.HostVersion);
-        Assert.Same(eventStream, result.EventStream);
-        Assert.NotNull(capturedStartContext);
+        result.HostVersion.Should().Be("local-dev");
+        result.EventStream.Should().BeSameAs(eventStream);
+        capturedStartContext.Should().NotBeNull();
         HostProcessStartContext startContext = capturedStartContext!;
-        Assert.Equal(contentRoot, startContext.HostWorkload.ContentRoot);
-        Assert.Equal("Azure.Functions.Cli.Workloads.Host.local", startContext.HostWorkload.PackageId);
-        Assert.Contains("host", startContext.HostWorkload.Aliases);
-        Assert.Equal(-1, FindStartedStepIndex(renderer.Events, InstallHostWorkloadInitializationStep.StepId));
+        startContext.HostWorkload.ContentRoot.Should().Be(contentRoot);
+        startContext.HostWorkload.PackageId.Should().Be("Azure.Functions.Cli.Workloads.Host.local");
+        startContext.HostWorkload.Aliases.Should().Contain("host");
+        FindStartedStepIndex(renderer.Events, InstallHostWorkloadInitializationStep.StepId).Should().Be(-1);
     }
 
     [Fact]
@@ -322,15 +321,14 @@ public class StartInitializationTests : IDisposable
             demoMode: false);
         var renderer = new RecordingStartInitializationRenderer();
 
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => runner.RunAsync(context, renderer, CancellationToken.None));
+        GracefulException ex = (await FluentActions.Awaiting(() => runner.RunAsync(context, renderer, CancellationToken.None)).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.Contains(ValidateHostWorkloadInitializationStep.HostContentRootEnvironmentVariable, ex.Message);
-        Assert.Contains("host executable was not found", ex.Message);
-        Assert.Contains(renderer.Events, ev => ev is StartInitializationStepFailedEvent failed
+        ex.Message.Should().Contain(ValidateHostWorkloadInitializationStep.HostContentRootEnvironmentVariable);
+        ex.Message.Should().Contain("host executable was not found");
+        renderer.Events.Any(ev => ev is StartInitializationStepFailedEvent failed
             && failed.StepId == ValidateHostWorkloadInitializationStep.StepId
             && failed.Message is not null
-            && failed.Message.Contains("host executable was not found", StringComparison.Ordinal));
+            && failed.Message.Contains("host executable was not found", StringComparison.Ordinal)).Should().BeTrue();
     }
 
     [Fact]
@@ -382,8 +380,8 @@ public class StartInitializationTests : IDisposable
 
         StartInitializationResult result = await runner.RunAsync(context, renderer, CancellationToken.None);
 
-        Assert.Equal("flex", result.RunInfo.ProfileName);
-        Assert.Equal("4.1000.0", result.HostVersion);
+        result.RunInfo.ProfileName.Should().Be("flex");
+        result.HostVersion.Should().Be("4.1000.0");
         await hostWorkloadResolver.Received(1).ResolveAsync(
             Arg.Is<HostWorkloadResolutionContext>(hostContext =>
                 ReferenceEquals(hostContext.ProfileHostVersionRange, hostRange)),
@@ -443,9 +441,9 @@ public class StartInitializationTests : IDisposable
             renderer,
             CancellationToken.None);
 
-        Assert.Equal("node", result.Worker.WorkerRuntime);
-        Assert.Equal("3.13.0", result.Worker.Version);
-        Assert.Same(installedWorker, result.Worker);
+        result.Worker.WorkerRuntime.Should().Be("node");
+        result.Worker.Version.Should().Be("3.13.0");
+        result.Worker.Should().BeSameAs(installedWorker);
         await workerResolver.Received(1).ResolveWorkerAsync(workerId, Arg.Any<CancellationToken>());
         await workerInstaller.Received(1)
             .InstallAsync(workerId, Arg.Is<IReadOnlyDictionary<string, VersionRange>>(ranges => HasWorkerRange(ranges, workerRange)), Arg.Any<CancellationToken>());
@@ -489,10 +487,9 @@ public class StartInitializationTests : IDisposable
             demoSpeedMultiplier: 0.001,
             demoAutoExit: true);
 
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => runner.RunAsync(context, new RecordingStartInitializationRenderer(), CancellationToken.None));
+        GracefulException ex = (await FluentActions.Awaiting(() => runner.RunAsync(context, new RecordingStartInitializationRenderer(), CancellationToken.None)).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.Contains("does not support the detected runtime 'node'", ex.Message);
+        ex.Message.Should().Contain("does not support the detected runtime 'node'");
     }
 
     [Fact]
@@ -514,10 +511,9 @@ public class StartInitializationTests : IDisposable
             demoSpeedMultiplier: 0.001,
             demoAutoExit: true);
 
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => runner.RunAsync(context, new RecordingStartInitializationRenderer(), CancellationToken.None));
+        GracefulException ex = (await FluentActions.Awaiting(() => runner.RunAsync(context, new RecordingStartInitializationRenderer(), CancellationToken.None)).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.Contains(workerFailure.Message, ex.Message);
+        ex.Message.Should().Contain(workerFailure.Message);
         await projectResolver.Received(1).ResolveProjectAsync(
             Arg.Any<ProjectResolutionContext>(),
             Arg.Any<CancellationToken>());
@@ -547,14 +543,14 @@ public class StartInitializationTests : IDisposable
 
         string[] lines = Encoding.UTF8.GetString(stream.ToArray()).Split('\n', StringSplitOptions.RemoveEmptyEntries);
 
-        Assert.Equal(2, lines.Length);
+        lines.Length.Should().Be(2);
         using var started = JsonDocument.Parse(lines[0]);
-        Assert.Equal("start_initialization_started", started.RootElement.GetProperty("kind").GetString());
-        Assert.Equal("none", started.RootElement.GetProperty("profile").GetString());
+        started.RootElement.GetProperty("kind").GetString().Should().Be("start_initialization_started");
+        started.RootElement.GetProperty("profile").GetString().Should().Be("none");
         using var progress = JsonDocument.Parse(lines[1]);
-        Assert.Equal("start_initialization_progress", progress.RootElement.GetProperty("kind").GetString());
-        Assert.Equal(customStepId, progress.RootElement.GetProperty("step").GetString());
-        Assert.Equal(50, progress.RootElement.GetProperty("percent").GetDouble());
+        progress.RootElement.GetProperty("kind").GetString().Should().Be("start_initialization_progress");
+        progress.RootElement.GetProperty("step").GetString().Should().Be(customStepId);
+        progress.RootElement.GetProperty("percent").GetDouble().Should().Be(50);
     }
 
     [Fact]
@@ -571,15 +567,15 @@ public class StartInitializationTests : IDisposable
 
         string[] lines = Encoding.UTF8.GetString(stream.ToArray()).Split('\n', StringSplitOptions.RemoveEmptyEntries);
 
-        Assert.Equal(2, lines.Length);
+        lines.Length.Should().Be(2);
         using var log = JsonDocument.Parse(lines[0]);
-        Assert.Equal("start_initialization_log", log.RootElement.GetProperty("kind").GetString());
-        Assert.Equal("prepare", log.RootElement.GetProperty("step").GetString());
-        Assert.Equal("npm output", log.RootElement.GetProperty("line").GetString());
-        Assert.Equal("warning", log.RootElement.GetProperty("severity").GetString());
+        log.RootElement.GetProperty("kind").GetString().Should().Be("start_initialization_log");
+        log.RootElement.GetProperty("step").GetString().Should().Be("prepare");
+        log.RootElement.GetProperty("line").GetString().Should().Be("npm output");
+        log.RootElement.GetProperty("severity").GetString().Should().Be("warning");
         using var failed = JsonDocument.Parse(lines[1]);
-        Assert.Equal("start_initialization_step_failed", failed.RootElement.GetProperty("kind").GetString());
-        Assert.Equal("build failed", failed.RootElement.GetProperty("message").GetString());
+        failed.RootElement.GetProperty("kind").GetString().Should().Be("start_initialization_step_failed");
+        failed.RootElement.GetProperty("message").GetString().Should().Be("build failed");
     }
 
     [Fact]
@@ -591,7 +587,7 @@ public class StartInitializationTests : IDisposable
 
         await renderer.OnEventAsync(logEvent, CancellationToken.None);
 
-        Assert.Contains("[init] prepare  npm output", interaction.Lines);
+        interaction.Lines.Should().Contain("[init] prepare  npm output");
     }
 
     [Fact]
@@ -641,12 +637,12 @@ public class StartInitializationTests : IDisposable
         JsonElement root = document.RootElement;
         JsonElement profileDetails = root.GetProperty("profile_details");
 
-        Assert.Equal("start_initialization_completed", root.GetProperty("kind").GetString());
-        Assert.Equal("node", root.GetProperty("worker_runtime").GetString());
-        Assert.Equal("flex", profileDetails.GetProperty("name").GetString());
-        Assert.Equal("[1.8.1, 4.1048.200)", profileDetails.GetProperty("host_version_range").GetString());
-        Assert.Equal("[3.13.0]", profileDetails.GetProperty("worker_version_ranges").GetProperty("node").GetString());
-        Assert.Equal("warning", profileDetails.GetProperty("diagnostics")[0].GetProperty("severity").GetString());
+        root.GetProperty("kind").GetString().Should().Be("start_initialization_completed");
+        root.GetProperty("worker_runtime").GetString().Should().Be("node");
+        profileDetails.GetProperty("name").GetString().Should().Be("flex");
+        profileDetails.GetProperty("host_version_range").GetString().Should().Be("[1.8.1, 4.1048.200)");
+        profileDetails.GetProperty("worker_version_ranges").GetProperty("node").GetString().Should().Be("[3.13.0]");
+        profileDetails.GetProperty("diagnostics")[0].GetProperty("severity").GetString().Should().Be("warning");
     }
 
     [Fact]
@@ -707,14 +703,14 @@ public class StartInitializationTests : IDisposable
         string output = writer.ToString();
         string completedIcon = console.Profile.Capabilities.Unicode ? "\u2713" : "[x]";
 
-        Assert.Contains("Azure Functions CLI", output);
-        Assert.Contains("5.0.0-test", output);
-        Assert.Contains(completedIcon, output);
-        Assert.Contains("Resolve profile...", output);
-        Assert.Contains("Install host workload", output);
-        Assert.Contains(" 50%", output);
-        Assert.DoesNotContain("\u001b[2J", output);
-        Assert.Contains("Preparing download", output);
+        output.Should().Contain("Azure Functions CLI");
+        output.Should().Contain("5.0.0-test");
+        output.Should().Contain(completedIcon);
+        output.Should().Contain("Resolve profile...");
+        output.Should().Contain("Install host workload");
+        output.Should().Contain(" 50%");
+        output.Should().NotContain("\u001b[2J");
+        output.Should().Contain("Preparing download");
     }
 
     [Fact]
@@ -736,11 +732,11 @@ public class StartInitializationTests : IDisposable
         await WaitForOutputAsync(writer, output => output.Contains("entry 12", StringComparison.Ordinal));
         string runningOutput = writer.ToString();
 
-        Assert.Contains("running npm install", runningOutput);
-        Assert.DoesNotContain("entry 01", runningOutput);
-        Assert.DoesNotContain("entry 02", runningOutput);
-        Assert.Contains("entry 03", runningOutput);
-        Assert.Contains("entry 12", runningOutput);
+        runningOutput.Should().Contain("running npm install");
+        runningOutput.Should().NotContain("entry 01");
+        runningOutput.Should().NotContain("entry 02");
+        runningOutput.Should().Contain("entry 03");
+        runningOutput.Should().Contain("entry 12");
 
         await renderer.OnEventAsync(new StartInitializationStepCompletedEvent(DateTimeOffset.UnixEpoch, "prepare", "ready"), CancellationToken.None);
         await WaitForOutputAsync(writer, output => output.Contains("ready", StringComparison.Ordinal));
@@ -748,12 +744,12 @@ public class StartInitializationTests : IDisposable
         await renderer.DisposeAsync();
 
         string completedOutput = writer.ToString();
-        Assert.Contains("ready", completedOutput);
+        completedOutput.Should().Contain("ready");
 
         // On success the log area collapses entirely. The old collapsed summary row was the only place a
         // line count was followed by an ellipsis ("N lines…"), so its absence guards the full collapse.
         string ellipsis = console.Profile.Capabilities.Unicode ? "\u2026" : "...";
-        Assert.DoesNotContain($"lines{ellipsis}", completedOutput);
+        completedOutput.Should().NotContain($"lines{ellipsis}");
     }
 
     [Fact]
@@ -776,8 +772,8 @@ public class StartInitializationTests : IDisposable
         await renderer.DisposeAsync();
 
         string output = writer.ToString();
-        Assert.Contains("3 lines", output);
-        Assert.Contains("line 3", output);
+        output.Should().Contain("3 lines");
+        output.Should().Contain("line 3");
     }
 
     [Fact]
@@ -801,8 +797,8 @@ public class StartInitializationTests : IDisposable
         string output = writer.ToString();
 
         // No single rendered line should reach the untruncated length, so the full run never appears.
-        Assert.DoesNotContain(longLine, output);
-        Assert.Contains(ellipsis, output);
+        output.Should().NotContain(longLine);
+        output.Should().Contain(ellipsis);
     }
 
     [Fact]
@@ -823,9 +819,9 @@ public class StartInitializationTests : IDisposable
 
         string output = writer.ToString();
 
-        Assert.Contains("build failed", output);
-        Assert.Contains("error tail", output);
-        Assert.DoesNotContain("1 lines", output);
+        output.Should().Contain("build failed");
+        output.Should().Contain("error tail");
+        output.Should().NotContain("1 lines");
     }
 
     [Fact]
@@ -842,7 +838,7 @@ public class StartInitializationTests : IDisposable
 
             await renderer.OnEventAsync(startedEvent, CancellationToken.None);
 
-            Assert.DoesNotContain("\u001b[2J", writer.ToString());
+            writer.ToString().Should().NotContain("\u001b[2J");
         }
         finally
         {
@@ -876,8 +872,8 @@ public class StartInitializationTests : IDisposable
                 renderedFrameCount = spinner.Frames.Distinct().Count(frame => output.Contains(frame, StringComparison.Ordinal));
             }
 
-            Assert.True(renderedFrameCount >= 2, $"Expected multiple spinner frames, but saw {renderedFrameCount}. Output: {output}");
-            Assert.DoesNotContain("\r\u001b[2K", output);
+            (renderedFrameCount >= 2).Should().BeTrue($"Expected multiple spinner frames, but saw {renderedFrameCount}. Output: {output}");
+            output.Should().NotContain("\r\u001b[2K");
         }
         finally
         {
@@ -924,13 +920,13 @@ public class StartInitializationTests : IDisposable
 
             await Task.Delay(300);
 
-            Assert.True(statusIndex >= 0, $"Expected status output before prompt. Output: {outputDuringPrompt}");
-            Assert.True(promptIndex > statusIndex, $"Expected prompt to render after status output. Output: {outputDuringPrompt}");
-            Assert.DoesNotContain("\r\u001b[2K", outputDuringPrompt[statusIndex..promptIndex]);
-            Assert.Equal(outputDuringPrompt, writer.ToString());
+            (statusIndex >= 0).Should().BeTrue($"Expected status output before prompt. Output: {outputDuringPrompt}");
+            (promptIndex > statusIndex).Should().BeTrue($"Expected prompt to render after status output. Output: {outputDuringPrompt}");
+            outputDuringPrompt[statusIndex..promptIndex].Should().NotContain("\r\u001b[2K");
+            writer.ToString().Should().Be(outputDuringPrompt);
 
             promptResult.SetResult(true);
-            Assert.True(await confirmTask);
+            (await confirmTask).Should().BeTrue();
             await WaitForOutputAsync(writer, output => output.Length > outputDuringPrompt.Length);
         }
         finally
@@ -1033,7 +1029,7 @@ public class StartInitializationTests : IDisposable
             await Task.Delay(100);
         }
 
-        Assert.True(predicate(output), $"Expected output condition was not met. Output: {output}");
+        predicate(output).Should().BeTrue($"Expected output condition was not met. Output: {output}");
     }
 
     private static DemoStartInitializationRunner CreateRunner(

--- a/test/Func.Tests/Commands/VersionCheckerTests.cs
+++ b/test/Func.Tests/Commands/VersionCheckerTests.cs
@@ -3,7 +3,6 @@
 
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Configuration;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands;
 
@@ -17,7 +16,7 @@ public class VersionCheckerTests
 
         // Should not throw — returns null on cancellation
         var result = await VersionChecker.CheckForUpdateAsync(cts.Token);
-        Assert.Null(result);
+        result.Should().BeNull();
     }
 
     [Fact]
@@ -29,7 +28,7 @@ public class VersionCheckerTests
         // Result can be null (offline/current) or a version string — both are valid
         if (result is not null)
         {
-            Assert.True(Version.TryParse(result, out _), $"Expected valid version, got: {result}");
+            Version.TryParse(result, out _).Should().BeTrue($"Expected valid version, got: {result}");
         }
     }
 
@@ -46,7 +45,7 @@ public class VersionCheckerTests
 
             string? result = await VersionChecker.CheckForUpdateAsync(paths, CancellationToken.None);
 
-            Assert.Equal("9999.0.0", result);
+            result.Should().Be("9999.0.0");
         }
         finally
         {

--- a/test/Func.Tests/Commands/VersionCommandTests.cs
+++ b/test/Func.Tests/Commands/VersionCommandTests.cs
@@ -4,7 +4,6 @@
 using Azure.Functions.Cli.Commands;
 using Azure.Functions.Cli.Common;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands;
 
@@ -29,9 +28,9 @@ public class VersionCommandTests
 
         var exitCode = await parseResult.InvokeAsync();
 
-        Assert.Equal(0, exitCode);
-        Assert.Single(_interaction.Lines);
-        Assert.Contains("5.0.0", _interaction.Lines[0]);
+        exitCode.Should().Be(0);
+        _interaction.Lines.Should().ContainSingle();
+        _interaction.Lines[0].Should().Contain("5.0.0");
     }
 
     [Fact]
@@ -39,8 +38,8 @@ public class VersionCommandTests
     {
         var provider = new AssemblyCliVersionProvider();
 
-        Assert.False(string.IsNullOrWhiteSpace(provider.Version));
-        Assert.Contains("5.0.0", provider.Version);
+        string.IsNullOrWhiteSpace(provider.Version).Should().BeFalse();
+        provider.Version.Should().Contain("5.0.0");
     }
 
     [Fact]
@@ -50,9 +49,9 @@ public class VersionCommandTests
 
         var exitCode = command.ExecuteDetailed();
 
-        Assert.Equal(0, exitCode);
-        Assert.Contains(_interaction.Lines, l => l.Contains("Azure Functions CLI"));
-        Assert.Contains("Version", _interaction.AllOutput);
-        Assert.Contains("Runtime", _interaction.AllOutput);
+        exitCode.Should().Be(0);
+        _interaction.Lines.Should().Contain(l => l.Contains("Azure Functions CLI"));
+        _interaction.AllOutput.Should().Contain("Version");
+        _interaction.AllOutput.Should().Contain("Runtime");
     }
 }

--- a/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
@@ -13,7 +13,6 @@ using Azure.Functions.Cli.Workloads.Storage;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using NuGet.Versioning;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands.Workload;
 
@@ -36,11 +35,11 @@ public class WorkloadInstallCommandTests
     public void Install_HasExpectedArgsAndOptions()
     {
         var cmd = NewInstall();
-        Assert.Single(cmd.Arguments, a => a.Name == "id");
-        Assert.Contains(cmd.Options, o => o.Name == "--force");
-        Assert.Contains(cmd.Options, o => o.Name == "--version");
-        Assert.Contains(cmd.Options, o => o.Name == "--source");
-        Assert.Contains(cmd.Options, o => o.Name == "--prerelease");
+        cmd.Arguments.Should().ContainSingle(a => a.Name == "id");
+        cmd.Options.Should().Contain(o => o.Name == "--force");
+        cmd.Options.Should().Contain(o => o.Name == "--version");
+        cmd.Options.Should().Contain(o => o.Name == "--source");
+        cmd.Options.Should().Contain(o => o.Name == "--prerelease");
     }
 
     [Fact]
@@ -51,7 +50,7 @@ public class WorkloadInstallCommandTests
         var cmd = NewInstall();
         int exit = await InvokeAsync(cmd, "Test.Workload");
 
-        Assert.Equal(0, exit);
+        exit.Should().Be(0);
         await _installer.Received(1).InstallFromCatalogAsync(
             "Test.Workload", null, null, (bool?)null, false, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
     }
@@ -71,7 +70,7 @@ public class WorkloadInstallCommandTests
             "--exact",
             "--force");
 
-        Assert.Equal(0, exit);
+        exit.Should().Be(0);
         await _installer.Received(1).InstallFromCatalogAsync(
             "Test.Workload",
             Arg.Is<NuGetVersion>(v => v != null && v.ToNormalizedString() == "2.0.0-beta.1"),
@@ -91,7 +90,7 @@ public class WorkloadInstallCommandTests
         var cmd = NewInstall();
         int exit = await InvokeAsync(cmd, "Test.Workload", "-v", "1.2.3", "-f");
 
-        Assert.Equal(0, exit);
+        exit.Should().Be(0);
         await _installer.Received(1).InstallFromCatalogAsync(
             "Test.Workload",
             Arg.Is<NuGetVersion>(v => v != null && v.ToNormalizedString() == "1.2.3"),
@@ -111,7 +110,7 @@ public class WorkloadInstallCommandTests
         var cmd = NewInstall();
         int exit = await InvokeAsync(cmd, "test.workload", "-e");
 
-        Assert.Equal(0, exit);
+        exit.Should().Be(0);
         await _installer.Received(1).InstallFromCatalogAsync(
             "test.workload", null, null, (bool?)null, true, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
     }
@@ -126,7 +125,7 @@ public class WorkloadInstallCommandTests
         var cmd = NewInstall();
         int exit = await InvokeAsync(cmd, "Test.Workload", "--source", "/tmp/local-feed");
 
-        Assert.Equal(0, exit);
+        exit.Should().Be(0);
         await _installer.Received(1).InstallFromCatalogAsync(
             "Test.Workload", null, "/tmp/local-feed", (bool?)null, false, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
     }
@@ -140,8 +139,8 @@ public class WorkloadInstallCommandTests
 
         ParseResult parse = root.Parse([cmd.Name, "Test.Workload", "--version", "not-semver"]);
 
-        Assert.NotEmpty(parse.Errors);
-        Assert.Contains(parse.Errors, e => e.Message.Contains("not a valid semver"));
+        parse.Errors.Should().NotBeEmpty();
+        parse.Errors.Should().Contain(e => e.Message.Contains("not a valid semver"));
     }
 
     [Fact]
@@ -153,7 +152,7 @@ public class WorkloadInstallCommandTests
 
         ParseResult parse = root.Parse([cmd.Name]);
 
-        Assert.NotEmpty(parse.Errors);
+        parse.Errors.Should().NotBeEmpty();
     }
 
     [Fact]
@@ -165,8 +164,8 @@ public class WorkloadInstallCommandTests
 
         ParseResult parse = root.Parse([cmd.Name, "   "]);
 
-        Assert.NotEmpty(parse.Errors);
-        Assert.Contains(parse.Errors, e => e.Message.Contains("workload id is required"));
+        parse.Errors.Should().NotBeEmpty();
+        parse.Errors.Should().Contain(e => e.Message.Contains("workload id is required"));
     }
 
     [Fact]
@@ -177,10 +176,8 @@ public class WorkloadInstallCommandTests
         var cmd = NewInstall();
         int exit = await InvokeAsync(cmd, "Test.Workload");
 
-        Assert.Equal(0, exit);
-        Assert.Contains(
-            _interaction.Lines,
-            l => l.StartsWith("WARNING:")
+        exit.Should().Be(0);
+        _interaction.Lines.Should().Contain(l => l.StartsWith("WARNING:")
                 && l.Contains("already installed")
                 && l.Contains("test.workload"));
     }
@@ -204,10 +201,8 @@ public class WorkloadInstallCommandTests
         var cmd = NewInstall();
         int exit = await InvokeAsync(cmd, "test.content");
 
-        Assert.Equal(0, exit);
-        Assert.Contains(
-            _interaction.Lines,
-            l => l.StartsWith("SUCCESS:")
+        exit.Should().Be(0);
+        _interaction.Lines.Should().Contain(l => l.StartsWith("SUCCESS:")
                 && l.Contains("content at")
                 && l.Contains("api.nuget.org"));
     }
@@ -222,11 +217,10 @@ public class WorkloadInstallCommandTests
                 "myalias", new[] { "Pkg.A", "Pkg.B" }));
 
         var cmd = NewInstall();
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => InvokeAsync(cmd, "myalias"));
-        Assert.Contains("myalias", ex.Message);
-        Assert.Contains("--exact", ex.Message);
-        Assert.True(ex.IsUserError);
+        GracefulException ex = (await FluentActions.Awaiting(() => InvokeAsync(cmd, "myalias")).Should().ThrowAsync<GracefulException>()).Which;
+        ex.Message.Should().Contain("myalias");
+        ex.Message.Should().Contain("--exact");
+        ex.IsUserError.Should().BeTrue();
     }
 
     [Fact]
@@ -238,10 +232,9 @@ public class WorkloadInstallCommandTests
             .Throws(new WorkloadPackageNotFoundException("not on any source"));
 
         var cmd = NewInstall();
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => InvokeAsync(cmd, "Test.Workload"));
-        Assert.Contains("not on any source", ex.Message);
-        Assert.True(ex.IsUserError);
+        GracefulException ex = (await FluentActions.Awaiting(() => InvokeAsync(cmd, "Test.Workload")).Should().ThrowAsync<GracefulException>()).Which;
+        ex.Message.Should().Contain("not on any source");
+        ex.IsUserError.Should().BeTrue();
     }
 
     [Fact]
@@ -253,10 +246,9 @@ public class WorkloadInstallCommandTests
             .Throws(new InvalidWorkloadException("bad package"));
 
         var cmd = NewInstall();
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => InvokeAsync(cmd, "Test.Workload"));
-        Assert.Equal("bad package", ex.Message);
-        Assert.True(ex.IsUserError);
+        GracefulException ex = (await FluentActions.Awaiting(() => InvokeAsync(cmd, "Test.Workload")).Should().ThrowAsync<GracefulException>()).Which;
+        ex.Message.Should().Be("bad package");
+        ex.IsUserError.Should().BeTrue();
     }
 
     [Fact]
@@ -269,11 +261,10 @@ public class WorkloadInstallCommandTests
                 "Workload 'x' version '1' is already installed at '/p' but is missing from the registry."));
 
         var cmd = NewInstall();
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => InvokeAsync(cmd, "Test.Workload"));
-        Assert.Contains("missing from the registry", ex.Message);
-        Assert.Contains("--force", ex.Message);
-        Assert.True(ex.IsUserError);
+        GracefulException ex = (await FluentActions.Awaiting(() => InvokeAsync(cmd, "Test.Workload")).Should().ThrowAsync<GracefulException>()).Which;
+        ex.Message.Should().Contain("missing from the registry");
+        ex.Message.Should().Contain("--force");
+        ex.IsUserError.Should().BeTrue();
     }
 
     [Fact]
@@ -285,8 +276,7 @@ public class WorkloadInstallCommandTests
             .Throws(new NullReferenceException("oops"));
 
         var cmd = NewInstall();
-        await Assert.ThrowsAsync<NullReferenceException>(
-            () => InvokeAsync(cmd, "Test.Workload"));
+        await FluentActions.Awaiting(() => InvokeAsync(cmd, "Test.Workload")).Should().ThrowAsync<NullReferenceException>();
     }
 
     [Fact]
@@ -309,7 +299,7 @@ public class WorkloadInstallCommandTests
             var cmd = NewInstall();
             int exit = await InvokeAsync(cmd, tempPkg);
 
-            Assert.Equal(0, exit);
+            exit.Should().Be(0);
             await _installer.Received(1).InstallFromPackageAsync(
                 tempPkg, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
             await _installer.DidNotReceiveWithAnyArgs().InstallFromCatalogAsync(
@@ -337,11 +327,11 @@ public class WorkloadInstallCommandTests
         var cmd = NewInstall();
         int exit = await InvokeAsync(cmd, "Test.Workload");
 
-        Assert.Equal(1, exit);
+        exit.Should().Be(1);
         await _installer.DidNotReceive().InstallFromCatalogAsync(
             Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
             Arg.Any<bool?>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
-        Assert.Contains(_interaction.Lines, l =>
+        _interaction.Lines.Should().Contain(l =>
             l.StartsWith("HINT:") && l.Contains("func workload update test"));
     }
 
@@ -361,8 +351,8 @@ public class WorkloadInstallCommandTests
         var cmd = NewInstall();
         int exit = await InvokeAsync(cmd, "alias1");
 
-        Assert.Equal(1, exit);
-        Assert.Contains(_interaction.Lines, l =>
+        exit.Should().Be(1);
+        _interaction.Lines.Should().Contain(l =>
             l.StartsWith("HINT:") && l.Contains("alias1") && l.Contains("1.2.3"));
     }
 
@@ -382,8 +372,8 @@ public class WorkloadInstallCommandTests
         var cmd = NewInstall();
         int exit = await InvokeAsync(cmd, "Test.Workload");
 
-        Assert.Equal(1, exit);
-        Assert.Contains(_interaction.Lines, l =>
+        exit.Should().Be(1);
+        _interaction.Lines.Should().Contain(l =>
             l.StartsWith("HINT:") && l.Contains("Test.Workload") && l.Contains("1.2.3"));
     }
 
@@ -404,7 +394,7 @@ public class WorkloadInstallCommandTests
         var cmd = NewInstall();
         int exit = await InvokeAsync(cmd, "alias1", "--exact");
 
-        Assert.Equal(0, exit);
+        exit.Should().Be(0);
         await _installer.Received(1).InstallFromCatalogAsync(
             "alias1", null, null, (bool?)null, true, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
     }
@@ -426,7 +416,7 @@ public class WorkloadInstallCommandTests
         var cmd = NewInstall();
         int exit = await InvokeAsync(cmd, "Test.Workload", "--force");
 
-        Assert.Equal(0, exit);
+        exit.Should().Be(0);
         await _installer.Received(1).InstallFromCatalogAsync(
             "Test.Workload", null, null, (bool?)null, false, true, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
         await _store.DidNotReceive().GetWorkloadsAsync(Arg.Any<CancellationToken>());
@@ -463,13 +453,13 @@ public class WorkloadInstallCommandTests
         var cmd = NewInstall();
         int exit = await InvokeAsync(cmd, "Test.Workload");
 
-        Assert.Equal(0, exit);
-        Assert.NotNull(captured);
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("PROGRESS:", StringComparison.Ordinal) && l.Contains("Installing workload 'Test.Workload'", StringComparison.Ordinal));
-        Assert.Contains(_interaction.Lines, l => l == "PROGRESS: Resolving workload 'Test.Workload'");
-        Assert.Contains(_interaction.Lines, l => l == "PROGRESS: Downloading 'test.workload' 1.0.0");
-        Assert.Contains(_interaction.Lines, l => l == "PROGRESS: Extracting workload 'test.workload' 1.0.0");
-        Assert.Contains(_interaction.Lines, l => l == "PROGRESS: Registering workload 'test.workload' 1.0.0");
+        exit.Should().Be(0);
+        captured.Should().NotBeNull();
+        _interaction.Lines.Should().Contain(l => l.StartsWith("PROGRESS:", StringComparison.Ordinal) && l.Contains("Installing workload 'Test.Workload'", StringComparison.Ordinal));
+        _interaction.Lines.Should().Contain(l => l == "PROGRESS: Resolving workload 'Test.Workload'");
+        _interaction.Lines.Should().Contain(l => l == "PROGRESS: Downloading 'test.workload' 1.0.0");
+        _interaction.Lines.Should().Contain(l => l == "PROGRESS: Extracting workload 'test.workload' 1.0.0");
+        _interaction.Lines.Should().Contain(l => l == "PROGRESS: Registering workload 'test.workload' 1.0.0");
     }
 
     private void StubCatalogResult(bool alreadyInstalled = false, string packageId = "test.workload") =>
@@ -519,7 +509,7 @@ public class WorkloadInstallNextStepsHintTests
 
         await InvokeAsync(NewInstall(), packageId);
 
-        Assert.Contains(_interaction.Lines, l =>
+        _interaction.Lines.Should().Contain(l =>
             l.StartsWith("HINT:", StringComparison.Ordinal)
             && l.Contains("Next steps:", StringComparison.Ordinal)
             && l.Contains($"func setup --features {expectedFeature}", StringComparison.Ordinal));
@@ -532,7 +522,7 @@ public class WorkloadInstallNextStepsHintTests
 
         await InvokeAsync(NewInstall(), IInstalledBundleWorkloads.BundleWorkloadPackageId);
 
-        Assert.Contains(_interaction.Lines, l =>
+        _interaction.Lines.Should().Contain(l =>
             l.StartsWith("HINT:", StringComparison.Ordinal)
             && l.Contains("func setup --features runtime", StringComparison.Ordinal));
     }
@@ -545,7 +535,7 @@ public class WorkloadInstallNextStepsHintTests
 
         await InvokeAsync(NewInstall(), hostPackageId);
 
-        Assert.Contains(_interaction.Lines, l =>
+        _interaction.Lines.Should().Contain(l =>
             l.StartsWith("HINT:", StringComparison.Ordinal)
             && l.Contains("func setup --features host", StringComparison.Ordinal));
     }
@@ -557,7 +547,7 @@ public class WorkloadInstallNextStepsHintTests
 
         await InvokeAsync(NewInstall(), "Third.Party.Workload");
 
-        Assert.DoesNotContain(_interaction.Lines, l =>
+        _interaction.Lines.Should().NotContain(l =>
             l.StartsWith("HINT:", StringComparison.Ordinal) && l.Contains("Next steps:", StringComparison.Ordinal));
     }
 
@@ -568,7 +558,7 @@ public class WorkloadInstallNextStepsHintTests
 
         await InvokeAsync(NewInstall(), "Azure.Functions.Cli.Workloads.Workers.go");
 
-        Assert.DoesNotContain(_interaction.Lines, l =>
+        _interaction.Lines.Should().NotContain(l =>
             l.StartsWith("HINT:", StringComparison.Ordinal) && l.Contains("Next steps:", StringComparison.Ordinal));
     }
 
@@ -581,7 +571,7 @@ public class WorkloadInstallNextStepsHintTests
 
         await InvokeAsync(cmd, "Azure.Functions.Cli.Workloads.Workers.go");
 
-        Assert.DoesNotContain(nonInteractive.Lines, l =>
+        nonInteractive.Lines.Should().NotContain(l =>
             l.StartsWith("HINT:", StringComparison.Ordinal) && l.Contains("Next steps:", StringComparison.Ordinal));
     }
 

--- a/test/Func.Tests/Commands/Workload/WorkloadListCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadListCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Functions.Cli.Commands.Workload;
 using Azure.Functions.Cli.Workloads;
 using Azure.Functions.Cli.Workloads.Storage;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands.Workload;
 
@@ -20,9 +19,9 @@ public class WorkloadListCommandTests
         var cmd = new WorkloadListCommand(_interaction, Provider(), Substitute.For<IWorkloadStore>());
         int exit = await InvokeAsync(cmd);
 
-        Assert.Equal(0, exit);
-        Assert.Contains("HINT: No workloads installed.", _interaction.Lines);
-        Assert.DoesNotContain(_interaction.Lines, l => l.StartsWith("TABLE:"));
+        exit.Should().Be(0);
+        _interaction.Lines.Should().Contain("HINT: No workloads installed.");
+        _interaction.Lines.Should().NotContain(l => l.StartsWith("TABLE:"));
     }
 
     [Fact]
@@ -40,9 +39,9 @@ public class WorkloadListCommandTests
         var cmd = new WorkloadListCommand(_interaction, Provider(workloads), Substitute.For<IWorkloadStore>());
         int exit = await InvokeAsync(cmd);
 
-        Assert.Equal(0, exit);
-        Assert.Contains("TABLE: [Alias, Display Name, Version]", _interaction.Lines);
-        Assert.Contains("  ROW: [dotnet, .NET, 1.0.0]", _interaction.Lines);
+        exit.Should().Be(0);
+        _interaction.Lines.Should().Contain("TABLE: [Alias, Display Name, Version]");
+        _interaction.Lines.Should().Contain("  ROW: [dotnet, .NET, 1.0.0]");
     }
 
     [Fact]
@@ -59,10 +58,10 @@ public class WorkloadListCommandTests
         await InvokeAsync(cmd);
 
         var rows = _interaction.Lines.Where(l => l.StartsWith("  ROW:")).ToList();
-        Assert.Equal(3, rows.Count);
-        Assert.Contains(".NET", rows[0]);
-        Assert.Contains("Node.js", rows[1]);
-        Assert.Contains("Python", rows[2]);
+        rows.Count.Should().Be(3);
+        rows[0].Should().Contain(".NET");
+        rows[1].Should().Contain("Node.js");
+        rows[2].Should().Contain("Python");
     }
 
     [Fact]
@@ -81,8 +80,8 @@ public class WorkloadListCommandTests
         await InvokeAsync(cmd);
 
         string rowLine = _interaction.Lines.Single(l => l.StartsWith("  ROW:"));
-        Assert.StartsWith("  ROW: [, ", rowLine);
-        Assert.DoesNotContain(", -, ", rowLine);
+        rowLine.Should().StartWith("  ROW: [, ");
+        rowLine.Should().NotContain(", -, ");
     }
 
     [Fact]
@@ -98,10 +97,8 @@ public class WorkloadListCommandTests
         var cmd = new WorkloadListCommand(_interaction, Provider(workloads), Substitute.For<IWorkloadStore>());
         int exit = await InvokeAsync(cmd);
 
-        Assert.Equal(0, exit);
-        Assert.Contains(
-            "  ROW: [, Azure.Functions.Cli.Workloads.Host, 4.0.0]",
-            _interaction.Lines);
+        exit.Should().Be(0);
+        _interaction.Lines.Should().Contain("  ROW: [, Azure.Functions.Cli.Workloads.Host, 4.0.0]");
     }
 
     [Fact]
@@ -119,13 +116,13 @@ public class WorkloadListCommandTests
         var cmd = new WorkloadListCommand(_interaction, Provider(workloads), Substitute.For<IWorkloadStore>());
         int exit = await InvokeAsync(cmd, includeRootVerbose: true, "--verbose");
 
-        Assert.Equal(0, exit);
-        Assert.DoesNotContain(_interaction.Lines, l => l.StartsWith("TABLE:"));
-        Assert.Contains(".NET Development Stack", _interaction.Lines);
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("Version:") && l.EndsWith("1.0.0"));
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("Package ID:") && l.EndsWith("Azure.Functions.Cli.Workloads.Dotnet"));
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("Alias:") && l.EndsWith("dotnet"));
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("Description:") && l.EndsWith("C# / F# workload."));
+        exit.Should().Be(0);
+        _interaction.Lines.Should().NotContain(l => l.StartsWith("TABLE:"));
+        _interaction.Lines.Should().Contain(".NET Development Stack");
+        _interaction.Lines.Should().Contain(l => l.StartsWith("Version:") && l.EndsWith("1.0.0"));
+        _interaction.Lines.Should().Contain(l => l.StartsWith("Package ID:") && l.EndsWith("Azure.Functions.Cli.Workloads.Dotnet"));
+        _interaction.Lines.Should().Contain(l => l.StartsWith("Alias:") && l.EndsWith("dotnet"));
+        _interaction.Lines.Should().Contain(l => l.StartsWith("Description:") && l.EndsWith("C# / F# workload."));
     }
 
     [Fact]
@@ -146,7 +143,7 @@ public class WorkloadListCommandTests
 
         // Card now puts description inline next to its label, so the full
         // string lands at the end of that line verbatim.
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("Description:") && l.EndsWith(longDescription));
+        _interaction.Lines.Should().Contain(l => l.StartsWith("Description:") && l.EndsWith(longDescription));
     }
 
     [Fact]
@@ -164,9 +161,7 @@ public class WorkloadListCommandTests
         var cmd = new WorkloadListCommand(_interaction, Provider(workloads), Substitute.For<IWorkloadStore>());
         await InvokeAsync(cmd, includeRootVerbose: true, "--verbose");
 
-        Assert.Contains(
-            _interaction.Lines,
-            l => l.StartsWith("Aliases:") && l.EndsWith("dotnet, dotnet-isolated"));
+        _interaction.Lines.Should().Contain(l => l.StartsWith("Aliases:") && l.EndsWith("dotnet, dotnet-isolated"));
     }
 
     [Fact]
@@ -181,7 +176,7 @@ public class WorkloadListCommandTests
         var cmd = new WorkloadListCommand(_interaction, Provider(workloads), Substitute.For<IWorkloadStore>());
         await InvokeAsync(cmd);
 
-        Assert.Contains("HINT: 2 workloads installed.", _interaction.Lines);
+        _interaction.Lines.Should().Contain("HINT: 2 workloads installed.");
     }
 
     [Fact]
@@ -195,7 +190,7 @@ public class WorkloadListCommandTests
         var cmd = new WorkloadListCommand(_interaction, Provider(workloads), Substitute.For<IWorkloadStore>());
         await InvokeAsync(cmd);
 
-        Assert.Contains("HINT: 1 workload installed.", _interaction.Lines);
+        _interaction.Lines.Should().Contain("HINT: 1 workload installed.");
     }
 
     [Fact]
@@ -213,13 +208,13 @@ public class WorkloadListCommandTests
         var cmd = new WorkloadListCommand(_interaction, Provider(workloads), Substitute.For<IWorkloadStore>());
         int exit = await InvokeAsync(cmd, "--json");
 
-        Assert.Equal(0, exit);
-        Assert.DoesNotContain(_interaction.Lines, l => l.StartsWith("TABLE:"));
+        exit.Should().Be(0);
+        _interaction.Lines.Should().NotContain(l => l.StartsWith("TABLE:"));
         string jsonLine = _interaction.Lines.Single(l => l.StartsWith("JSON:"));
-        Assert.Contains("\"packageId\":\"Azure.Functions.Cli.Workloads.Dotnet\"", jsonLine);
-        Assert.Contains("\"packageVersion\":\"1.0.0\"", jsonLine);
+        jsonLine.Should().Contain("\"packageId\":\"Azure.Functions.Cli.Workloads.Dotnet\"");
+        jsonLine.Should().Contain("\"packageVersion\":\"1.0.0\"");
         // Loaded view omits the Loaded flag (null on the row, so JSON drops it).
-        Assert.DoesNotContain("\"loaded\"", jsonLine);
+        jsonLine.Should().NotContain("\"loaded\"");
     }
 
     [Fact]
@@ -256,17 +251,17 @@ public class WorkloadListCommandTests
         var cmd = new WorkloadListCommand(_interaction, Provider(loaded), store);
         int exit = await InvokeAsync(cmd, "--all-versions");
 
-        Assert.Equal(0, exit);
-        Assert.DoesNotContain(_interaction.Lines, l => l.StartsWith("TABLE:"));
+        exit.Should().Be(0);
+        _interaction.Lines.Should().NotContain(l => l.StartsWith("TABLE:"));
         // Header shows display name + alias in parentheses.
-        Assert.Contains(".NET (a)", _interaction.Lines);
+        _interaction.Lines.Should().Contain(".NET (a)");
         // Highest version first, marked as loaded.
         int loadedIndex = _interaction.Lines.ToList().FindIndex(l => l.Contains("2.0.0"));
         int olderIndex = _interaction.Lines.ToList().FindIndex(l => l.Contains("1.0.0"));
-        Assert.True(loadedIndex < olderIndex);
-        Assert.Contains("(loaded)", _interaction.Lines[loadedIndex]);
-        Assert.DoesNotContain("(loaded)", _interaction.Lines[olderIndex]);
-        Assert.Contains("HINT: 1 workload, 2 versions installed.", _interaction.Lines);
+        (loadedIndex < olderIndex).Should().BeTrue();
+        _interaction.Lines[loadedIndex].Should().Contain("(loaded)");
+        _interaction.Lines[olderIndex].Should().NotContain("(loaded)");
+        _interaction.Lines.Should().Contain("HINT: 1 workload, 2 versions installed.");
     }
 
     [Fact]
@@ -290,16 +285,16 @@ public class WorkloadListCommandTests
         await InvokeAsync(cmd, "--all-versions", "--json");
 
         string jsonLine = _interaction.Lines.Single(l => l.StartsWith("JSON:"));
-        Assert.Contains("\"loaded\":true", jsonLine);
-        Assert.Contains("\"loaded\":false", jsonLine);
+        jsonLine.Should().Contain("\"loaded\":true");
+        jsonLine.Should().Contain("\"loaded\":false");
     }
 
     [Fact]
     public async Task List_HasJsonAndAllVersionsOptions()
     {
         var cmd = new WorkloadListCommand(_interaction, Provider(), Substitute.For<IWorkloadStore>());
-        Assert.Contains(cmd.Options, o => o.Name == "--json");
-        Assert.Contains(cmd.Options, o => o.Name == "--all-versions");
+        cmd.Options.Should().Contain(o => o.Name == "--json");
+        cmd.Options.Should().Contain(o => o.Name == "--all-versions");
         await Task.CompletedTask;
     }
 

--- a/test/Func.Tests/Commands/Workload/WorkloadPruneCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadPruneCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Functions.Cli.Commands.Workload;
 using Azure.Functions.Cli.Workloads.Install;
 using Azure.Functions.Cli.Workloads.Storage;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands.Workload;
 
@@ -20,8 +19,8 @@ public class WorkloadPruneCommandTests
     public void Prune_HasExpectedArgsAndOptions()
     {
         var cmd = new WorkloadPruneCommand(_interaction, _installer, _store);
-        Assert.Single(cmd.Arguments, a => a.Name == "id");
-        Assert.Contains(cmd.Options, o => o.Name == "--exact");
+        cmd.Arguments.Should().ContainSingle(a => a.Name == "id");
+        cmd.Options.Should().Contain(o => o.Name == "--exact");
     }
 
     [Fact]
@@ -32,8 +31,8 @@ public class WorkloadPruneCommandTests
         var cmd = new WorkloadPruneCommand(_interaction, _installer, _store);
         int exit = await InvokeAsync(cmd);
 
-        Assert.Equal(0, exit);
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("HINT:") && l.Contains("No workloads installed"));
+        exit.Should().Be(0);
+        _interaction.Lines.Should().Contain(l => l.StartsWith("HINT:") && l.Contains("No workloads installed"));
         await _installer.DidNotReceive().UninstallAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
@@ -50,8 +49,8 @@ public class WorkloadPruneCommandTests
         var cmd = new WorkloadPruneCommand(_interaction, _installer, _store);
         int exit = await InvokeAsync(cmd);
 
-        Assert.Equal(0, exit);
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("HINT:") && l.Contains("Nothing to prune"));
+        exit.Should().Be(0);
+        _interaction.Lines.Should().Contain(l => l.StartsWith("HINT:") && l.Contains("Nothing to prune"));
         await _installer.DidNotReceive().UninstallAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
@@ -71,7 +70,7 @@ public class WorkloadPruneCommandTests
         var cmd = new WorkloadPruneCommand(_interaction, _installer, _store);
         int exit = await InvokeAsync(cmd);
 
-        Assert.Equal(0, exit);
+        exit.Should().Be(0);
         await _installer.Received(1).UninstallAsync("Pkg.A", "1.5.0", Arg.Any<CancellationToken>());
         await _installer.Received(1).UninstallAsync("Pkg.A", "1.0.0", Arg.Any<CancellationToken>());
         await _installer.DidNotReceive().UninstallAsync("Pkg.A", "2.0.0", Arg.Any<CancellationToken>());
@@ -93,7 +92,7 @@ public class WorkloadPruneCommandTests
         var cmd = new WorkloadPruneCommand(_interaction, _installer, _store);
         int exit = await InvokeAsync(cmd, "Pkg.A");
 
-        Assert.Equal(0, exit);
+        exit.Should().Be(0);
         await _installer.Received(1).UninstallAsync("Pkg.A", "1.0.0", Arg.Any<CancellationToken>());
         await _installer.DidNotReceive().UninstallAsync("Pkg.B", Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
@@ -112,7 +111,7 @@ public class WorkloadPruneCommandTests
         var cmd = new WorkloadPruneCommand(_interaction, _installer, _store);
         int exit = await InvokeAsync(cmd, "a");
 
-        Assert.Equal(0, exit);
+        exit.Should().Be(0);
         await _installer.Received(1).UninstallAsync("Pkg.A", "1.0.0", Arg.Any<CancellationToken>());
     }
 
@@ -128,8 +127,8 @@ public class WorkloadPruneCommandTests
         var cmd = new WorkloadPruneCommand(_interaction, _installer, _store);
         int exit = await InvokeAsync(cmd, "a", "--exact");
 
-        Assert.Equal(0, exit);
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("WARNING:") && l.Contains("'a' is not installed"));
+        exit.Should().Be(0);
+        _interaction.Lines.Should().Contain(l => l.StartsWith("WARNING:") && l.Contains("'a' is not installed"));
         await _installer.DidNotReceive().UninstallAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
@@ -140,7 +139,7 @@ public class WorkloadPruneCommandTests
         var cmd = new WorkloadPruneCommand(_interaction, _installer, _store);
         int exit = await InvokeAsync(cmd, "   ");
 
-        Assert.NotEqual(0, exit);
+        exit.Should().NotBe(0);
         await _store.DidNotReceive().GetWorkloadsAsync(Arg.Any<CancellationToken>());
     }
 

--- a/test/Func.Tests/Commands/Workload/WorkloadSearchCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadSearchCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Functions.Cli.Commands.Workload;
 using Azure.Functions.Cli.Workloads.Catalog;
 using NSubstitute;
 using NuGet.Versioning;
-using Xunit;
 using PackageSource = NuGet.Configuration.PackageSource;
 
 namespace Azure.Functions.Cli.Tests.Commands.Workload;
@@ -25,10 +24,10 @@ public class WorkloadSearchCommandTests
     public void Search_HasExpectedArgsAndOptions()
     {
         var cmd = new WorkloadSearchCommand(_interaction, _catalog, _testCatalogOptions);
-        Assert.Single(cmd.Arguments, a => a.Name == "query");
-        Assert.Contains(cmd.Options, o => o.Name == "--source");
-        Assert.Contains(cmd.Options, o => o.Name == "--prerelease");
-        Assert.Contains(cmd.Options, o => o.Name == "--stack");
+        cmd.Arguments.Should().ContainSingle(a => a.Name == "query");
+        cmd.Options.Should().Contain(o => o.Name == "--source");
+        cmd.Options.Should().Contain(o => o.Name == "--prerelease");
+        cmd.Options.Should().Contain(o => o.Name == "--stack");
     }
 
     [Fact]
@@ -60,12 +59,12 @@ public class WorkloadSearchCommandTests
         var cmd = new WorkloadSearchCommand(_interaction, _catalog, _testCatalogOptions);
         int exit = await InvokeAsync(cmd, "--stack");
 
-        Assert.Equal(0, exit);
+        exit.Should().Be(0);
         // Stack workload's display name appears as a card heading.
-        Assert.Contains("Python", _interaction.Lines);
+        _interaction.Lines.Should().Contain("Python");
         // Filtered-out packages don't appear anywhere.
-        Assert.DoesNotContain(_interaction.Lines, l => l.Contains("workloads.host"));
-        Assert.DoesNotContain(_interaction.Lines, l => l.Contains("workloads.nokind"));
+        _interaction.Lines.Should().NotContain(l => l.Contains("workloads.host"));
+        _interaction.Lines.Should().NotContain(l => l.Contains("workloads.nokind"));
     }
 
     [Fact]
@@ -76,8 +75,8 @@ public class WorkloadSearchCommandTests
         var cmd = new WorkloadSearchCommand(_interaction, _catalog, _testCatalogOptions);
         int exit = await InvokeAsync(cmd);
 
-        Assert.Equal(0, exit);
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("WARNING:") && l.Contains("No workloads found"));
+        exit.Should().Be(0);
+        _interaction.Lines.Should().Contain(l => l.StartsWith("WARNING:") && l.Contains("No workloads found"));
     }
 
     [Fact]
@@ -95,16 +94,16 @@ public class WorkloadSearchCommandTests
         var cmd = new WorkloadSearchCommand(_interaction, _catalog, _testCatalogOptions);
         int exit = await InvokeAsync(cmd);
 
-        Assert.Equal(0, exit);
-        Assert.DoesNotContain(_interaction.Lines, l => l.StartsWith("TABLE:"));
-        Assert.Contains("Python", _interaction.Lines);
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("Version:") && l.EndsWith("1.2.3"));
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("Package ID:") && l.EndsWith("func.workload.python"));
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("Alias:") && l.EndsWith("python"));
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("Description:") && l.EndsWith("Python workload"));
-        Assert.Contains("HINT: Showing 1 result.", _interaction.Lines);
-        Assert.Contains("HINT: Run 'func workload install <alias | package id>' to install one (stable by default).", _interaction.Lines);
-        Assert.Contains("HINT: When several versions or channels exist, pass --version (-v) to install a specific one.", _interaction.Lines);
+        exit.Should().Be(0);
+        _interaction.Lines.Should().NotContain(l => l.StartsWith("TABLE:"));
+        _interaction.Lines.Should().Contain("Python");
+        _interaction.Lines.Should().Contain(l => l.StartsWith("Version:") && l.EndsWith("1.2.3"));
+        _interaction.Lines.Should().Contain(l => l.StartsWith("Package ID:") && l.EndsWith("func.workload.python"));
+        _interaction.Lines.Should().Contain(l => l.StartsWith("Alias:") && l.EndsWith("python"));
+        _interaction.Lines.Should().Contain(l => l.StartsWith("Description:") && l.EndsWith("Python workload"));
+        _interaction.Lines.Should().Contain("HINT: Showing 1 result.");
+        _interaction.Lines.Should().Contain("HINT: Run 'func workload install <alias | package id>' to install one (stable by default).");
+        _interaction.Lines.Should().Contain("HINT: When several versions or channels exist, pass --version (-v) to install a specific one.");
     }
 
     [Fact]
@@ -122,9 +121,7 @@ public class WorkloadSearchCommandTests
         var cmd = new WorkloadSearchCommand(_interaction, _catalog, _testCatalogOptions);
         await InvokeAsync(cmd);
 
-        Assert.Contains(
-            _interaction.Lines,
-            l => l.StartsWith("Aliases:") && l.EndsWith("dotnet, dotnet-isolated"));
+        _interaction.Lines.Should().Contain(l => l.StartsWith("Aliases:") && l.EndsWith("dotnet, dotnet-isolated"));
     }
 
     [Fact]
@@ -143,12 +140,12 @@ public class WorkloadSearchCommandTests
         await InvokeAsync(cmd);
 
         // Title missing: heading falls back to package id.
-        Assert.Contains("no.alias.pkg", _interaction.Lines);
+        _interaction.Lines.Should().Contain("no.alias.pkg");
         // Alias line present, value empty.
         string aliasLine = _interaction.Lines.Single(l => l.StartsWith("Alias:"));
-        Assert.Equal("Alias:", aliasLine.TrimEnd());
+        aliasLine.TrimEnd().Should().Be("Alias:");
         // No description -> placeholder shown on the Description: line.
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("Description:") && l.EndsWith("(no description)"));
+        _interaction.Lines.Should().Contain(l => l.StartsWith("Description:") && l.EndsWith("(no description)"));
     }
 
     [Fact]
@@ -163,9 +160,9 @@ public class WorkloadSearchCommandTests
 
         int firstHeading = _interaction.Lines.ToList().FindIndex(l => l == "A");
         int secondHeading = _interaction.Lines.ToList().FindIndex(l => l == "B");
-        Assert.InRange(firstHeading, 0, secondHeading - 1);
+        firstHeading.Should().BeInRange(0, secondHeading - 1);
         // Blank line separator between cards.
-        Assert.Equal(string.Empty, _interaction.Lines[secondHeading - 1]);
+        _interaction.Lines[secondHeading - 1].Should().Be(string.Empty);
     }
 
     [Fact]
@@ -186,7 +183,7 @@ public class WorkloadSearchCommandTests
 
         // Card layout keeps the description on its own Description: line and
         // emits the full string verbatim rather than truncating it.
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("Description:") && l.EndsWith(longDesc));
+        _interaction.Lines.Should().Contain(l => l.StartsWith("Description:") && l.EndsWith(longDesc));
     }
 
     [Fact]
@@ -206,9 +203,7 @@ public class WorkloadSearchCommandTests
         var cmd = new WorkloadSearchCommand(_interaction, _catalog, _testCatalogOptions);
         await InvokeAsync(cmd);
 
-        Assert.Contains(
-            "HINT: Showing 20 results. More may be available, refine your query.",
-            _interaction.Lines);
+        _interaction.Lines.Should().Contain("HINT: Showing 20 results. More may be available, refine your query.");
     }
 
     [Fact]
@@ -225,12 +220,12 @@ public class WorkloadSearchCommandTests
             "--source", "https://example/v3/index.json",
             "--prerelease");
 
-        Assert.Equal(0, exit);
-        Assert.NotNull(captured);
-        Assert.Equal("python", captured!.Filter);
-        Assert.True(captured.IncludePrerelease);
-        Assert.Equal("https://example/v3/index.json", captured.Source);
-        Assert.Equal(20, captured.Take);
+        exit.Should().Be(0);
+        captured.Should().NotBeNull();
+        captured!.Filter.Should().Be("python");
+        captured.IncludePrerelease.Should().BeTrue();
+        captured.Source.Should().Be("https://example/v3/index.json");
+        captured.Take.Should().Be(20);
     }
 
     [Fact]
@@ -245,12 +240,12 @@ public class WorkloadSearchCommandTests
         var cmd = new WorkloadSearchCommand(_interaction, _catalog, _testCatalogOptions);
         int exit = await InvokeAsync(cmd);
 
-        Assert.Equal(0, exit);
-        Assert.NotNull(captured);
-        Assert.Null(captured!.Filter);
-        Assert.False(captured.IncludePrerelease);
-        Assert.Null(captured.Source);
-        Assert.Equal(20, captured.Take);
+        exit.Should().Be(0);
+        captured.Should().NotBeNull();
+        captured!.Filter.Should().BeNull();
+        captured.IncludePrerelease.Should().BeFalse();
+        captured.Source.Should().BeNull();
+        captured.Take.Should().Be(20);
     }
 
     [Fact]
@@ -268,14 +263,14 @@ public class WorkloadSearchCommandTests
         var cmd = new WorkloadSearchCommand(_interaction, _catalog, _testCatalogOptions);
         int exit = await InvokeAsync(cmd, "--json");
 
-        Assert.Equal(0, exit);
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("JSON:"));
-        Assert.DoesNotContain(_interaction.Lines, l => l.StartsWith("TABLE:"));
-        Assert.DoesNotContain(_interaction.Lines, l => l.StartsWith("Version:"));
+        exit.Should().Be(0);
+        _interaction.Lines.Should().Contain(l => l.StartsWith("JSON:"));
+        _interaction.Lines.Should().NotContain(l => l.StartsWith("TABLE:"));
+        _interaction.Lines.Should().NotContain(l => l.StartsWith("Version:"));
         string jsonLine = _interaction.Lines.Single(l => l.StartsWith("JSON:"));
-        Assert.Contains("\"packageId\":\"func.workload.python\"", jsonLine);
-        Assert.Contains("\"latestVersion\":\"1.2.3\"", jsonLine);
-        Assert.Contains("\"aliases\":[\"python\"]", jsonLine);
+        jsonLine.Should().Contain("\"packageId\":\"func.workload.python\"");
+        jsonLine.Should().Contain("\"latestVersion\":\"1.2.3\"");
+        jsonLine.Should().Contain("\"aliases\":[\"python\"]");
     }
 
     [Fact]
@@ -300,16 +295,16 @@ public class WorkloadSearchCommandTests
         var cmd = new WorkloadSearchCommand(_interaction, _catalog, _testCatalogOptions);
         int exit = await InvokeAsync(cmd, "--prerelease");
 
-        Assert.Equal(0, exit);
+        exit.Should().Be(0);
         // One card per channel. Channel-label line is emitted on expansion
         // so users can tell which row matches `--version` for which channel.
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("Version:") && l.EndsWith("4.42.0-preview.1"));
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("Version:") && l.EndsWith("4.40.0-experimental.2"));
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("Version:") && l.EndsWith("4.35.0"));
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("Channel:") && l.EndsWith("preview"));
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("Channel:") && l.EndsWith("experimental"));
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("Channel:") && l.EndsWith("stable"));
-        Assert.Contains("HINT: Showing 3 results.", _interaction.Lines);
+        _interaction.Lines.Should().Contain(l => l.StartsWith("Version:") && l.EndsWith("4.42.0-preview.1"));
+        _interaction.Lines.Should().Contain(l => l.StartsWith("Version:") && l.EndsWith("4.40.0-experimental.2"));
+        _interaction.Lines.Should().Contain(l => l.StartsWith("Version:") && l.EndsWith("4.35.0"));
+        _interaction.Lines.Should().Contain(l => l.StartsWith("Channel:") && l.EndsWith("preview"));
+        _interaction.Lines.Should().Contain(l => l.StartsWith("Channel:") && l.EndsWith("experimental"));
+        _interaction.Lines.Should().Contain(l => l.StartsWith("Channel:") && l.EndsWith("stable"));
+        _interaction.Lines.Should().Contain("HINT: Showing 3 results.");
     }
 
     [Fact]
@@ -336,10 +331,10 @@ public class WorkloadSearchCommandTests
 
         // Latest stable wins out over earlier stable, latest preview wins
         // out over earlier prereleases on the same channel.
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("Version:") && l.EndsWith("2.1.0-preview.2"));
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("Version:") && l.EndsWith("2.0.0"));
-        Assert.DoesNotContain(_interaction.Lines, l => l.StartsWith("Version:") && l.EndsWith("2.0.0-preview.5"));
-        Assert.DoesNotContain(_interaction.Lines, l => l.StartsWith("Version:") && l.EndsWith("1.5.0"));
+        _interaction.Lines.Should().Contain(l => l.StartsWith("Version:") && l.EndsWith("2.1.0-preview.2"));
+        _interaction.Lines.Should().Contain(l => l.StartsWith("Version:") && l.EndsWith("2.0.0"));
+        _interaction.Lines.Should().NotContain(l => l.StartsWith("Version:") && l.EndsWith("2.0.0-preview.5"));
+        _interaction.Lines.Should().NotContain(l => l.StartsWith("Version:") && l.EndsWith("1.5.0"));
     }
 
     [Fact]
@@ -360,7 +355,7 @@ public class WorkloadSearchCommandTests
         // ListVersionsAsync is not called when prerelease is off, the
         // server-side search filter already gives us the stable row.
         await _catalog.DidNotReceiveWithAnyArgs().ListVersionsAsync(default!, default, default);
-        Assert.DoesNotContain(_interaction.Lines, l => l.StartsWith("Channel:"));
+        _interaction.Lines.Should().NotContain(l => l.StartsWith("Channel:"));
     }
 
     [Fact]
@@ -380,9 +375,9 @@ public class WorkloadSearchCommandTests
         var cmd = new WorkloadSearchCommand(_interaction, _catalog, _testCatalogOptions);
         int exit = await InvokeAsync(cmd, "--prerelease");
 
-        Assert.Equal(0, exit);
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("Version:") && l.EndsWith("1.0.0-preview"));
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("Channel:") && l.EndsWith("preview"));
+        exit.Should().Be(0);
+        _interaction.Lines.Should().Contain(l => l.StartsWith("Version:") && l.EndsWith("1.0.0-preview"));
+        _interaction.Lines.Should().Contain(l => l.StartsWith("Channel:") && l.EndsWith("preview"));
     }
 
     [Theory]
@@ -393,7 +388,7 @@ public class WorkloadSearchCommandTests
     [InlineData("1.0.0-rc.1+build.5", "rc")]
     public void GetChannel_ParsesPrereleaseLabel(string version, string expectedChannel)
     {
-        Assert.Equal(expectedChannel, WorkloadSearchCommand.GetChannel(NuGetVersion.Parse(version)));
+        WorkloadSearchCommand.GetChannel(NuGetVersion.Parse(version)).Should().Be(expectedChannel);
     }
 
     private void StubSearch(params CatalogSearchResult[] results)

--- a/test/Func.Tests/Commands/Workload/WorkloadUninstallCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadUninstallCommandTests.cs
@@ -8,7 +8,6 @@ using Azure.Functions.Cli.Workloads;
 using Azure.Functions.Cli.Workloads.Install;
 using Azure.Functions.Cli.Workloads.Storage;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands.Workload;
 
@@ -26,8 +25,8 @@ public class WorkloadUninstallCommandTests
         var cmd = NewCommand();
         int exit = await InvokeAsync(cmd, "Test.Workload");
 
-        Assert.Equal(0, exit);
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("WARNING:") && l.Contains("not installed"));
+        exit.Should().Be(0);
+        _interaction.Lines.Should().Contain(l => l.StartsWith("WARNING:") && l.Contains("not installed"));
         await _installer.DidNotReceive().UninstallAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
@@ -42,9 +41,9 @@ public class WorkloadUninstallCommandTests
         var cmd = NewCommand();
         int exit = await InvokeAsync(cmd, "Test.Workload");
 
-        Assert.Equal(0, exit);
+        exit.Should().Be(0);
         await _installer.Received(1).UninstallAsync("Test.Workload", "1.0.0", Arg.Any<CancellationToken>());
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("SUCCESS:") && l.Contains("1.0.0"));
+        _interaction.Lines.Should().Contain(l => l.StartsWith("SUCCESS:") && l.Contains("1.0.0"));
     }
 
     [Fact]
@@ -53,11 +52,10 @@ public class WorkloadUninstallCommandTests
         StubInstalled(("Test.Workload", "1.0.0"), ("Test.Workload", "2.0.0"));
 
         var cmd = NewCommand();
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => InvokeAsync(cmd, "Test.Workload"));
+        GracefulException ex = (await FluentActions.Awaiting(() => InvokeAsync(cmd, "Test.Workload")).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.Contains("Multiple versions", ex.Message);
-        Assert.Contains("--all-versions", ex.Message);
+        ex.Message.Should().Contain("Multiple versions");
+        ex.Message.Should().Contain("--all-versions");
     }
 
     [Fact]
@@ -80,11 +78,10 @@ public class WorkloadUninstallCommandTests
         StubInstalled(("Test.Workload", "1.0.0"));
 
         var cmd = NewCommand();
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => InvokeAsync(cmd, "Test.Workload", "--version", "9.9.9"));
+        GracefulException ex = (await FluentActions.Awaiting(() => InvokeAsync(cmd, "Test.Workload", "--version", "9.9.9")).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.Contains("9.9.9", ex.Message);
-        Assert.Contains("Installed versions: 1.0.0", ex.Message);
+        ex.Message.Should().Contain("9.9.9");
+        ex.Message.Should().Contain("Installed versions: 1.0.0");
     }
 
     [Fact]
@@ -138,8 +135,8 @@ public class WorkloadUninstallCommandTests
 
         ParseResult parse = root.Parse([cmd.Name, "Test.Workload", "--all-versions", "--version", "1.0.0"]);
 
-        Assert.NotEmpty(parse.Errors);
-        Assert.Contains(parse.Errors, e => e.Message.Contains("--all-versions and --version"));
+        parse.Errors.Should().NotBeEmpty();
+        parse.Errors.Should().Contain(e => e.Message.Contains("--all-versions and --version"));
     }
 
     [Fact]
@@ -151,8 +148,8 @@ public class WorkloadUninstallCommandTests
 
         ParseResult parse = root.Parse([cmd.Name, "   "]);
 
-        Assert.NotEmpty(parse.Errors);
-        Assert.Contains(parse.Errors, e => e.Message.Contains("workload id is required"));
+        parse.Errors.Should().NotBeEmpty();
+        parse.Errors.Should().Contain(e => e.Message.Contains("workload id is required"));
     }
 
     [Fact]
@@ -165,7 +162,7 @@ public class WorkloadUninstallCommandTests
         var cmd = NewCommand();
         int exit = await InvokeAsync(cmd, "test.workload");
 
-        Assert.Equal(0, exit);
+        exit.Should().Be(0);
         await _installer.Received(1).UninstallAsync("Test.Workload", "1.0.0", Arg.Any<CancellationToken>());
     }
 
@@ -179,7 +176,7 @@ public class WorkloadUninstallCommandTests
         var cmd = NewCommand();
         int exit = await InvokeAsync(cmd, "stub");
 
-        Assert.Equal(0, exit);
+        exit.Should().Be(0);
         await _installer.Received(1).UninstallAsync("Test.Workload", "1.0.0", Arg.Any<CancellationToken>());
     }
 
@@ -193,7 +190,7 @@ public class WorkloadUninstallCommandTests
         var cmd = NewCommand();
         int exit = await InvokeAsync(cmd, "STUB");
 
-        Assert.Equal(0, exit);
+        exit.Should().Be(0);
         await _installer.Received(1).UninstallAsync("Test.Workload", "1.0.0", Arg.Any<CancellationToken>());
     }
 
@@ -205,12 +202,11 @@ public class WorkloadUninstallCommandTests
             (PackageId: "Second.Workload", Version: "1.0.0", Aliases: new[] { "shared" }));
 
         var cmd = NewCommand();
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => InvokeAsync(cmd, "shared"));
+        GracefulException ex = (await FluentActions.Awaiting(() => InvokeAsync(cmd, "shared")).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.Contains("matches multiple installed workloads", ex.Message);
-        Assert.Contains("First.Workload", ex.Message);
-        Assert.Contains("Second.Workload", ex.Message);
+        ex.Message.Should().Contain("matches multiple installed workloads");
+        ex.Message.Should().Contain("First.Workload");
+        ex.Message.Should().Contain("Second.Workload");
     }
 
     [Fact]
@@ -225,8 +221,8 @@ public class WorkloadUninstallCommandTests
         var cmd = NewCommand();
         int exit = await InvokeAsync(cmd, "shared", "--exact");
 
-        Assert.Equal(0, exit);
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("WARNING:") && l.Contains("not installed"));
+        exit.Should().Be(0);
+        _interaction.Lines.Should().Contain(l => l.StartsWith("WARNING:") && l.Contains("not installed"));
         await _installer.DidNotReceive().UninstallAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
@@ -244,7 +240,7 @@ public class WorkloadUninstallCommandTests
         var cmd = NewCommand();
         int exit = await InvokeAsync(cmd, "First.Workload", "-e");
 
-        Assert.Equal(0, exit);
+        exit.Should().Be(0);
         await _installer.Received(1).UninstallAsync("First.Workload", "1.0.0", Arg.Any<CancellationToken>());
     }
 

--- a/test/Func.Tests/Commands/Workload/WorkloadUpdateCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadUpdateCommandTests.cs
@@ -4,15 +4,12 @@
 using System.CommandLine;
 using Azure.Functions.Cli.Commands.Workload;
 using Azure.Functions.Cli.Common;
-using Azure.Functions.Cli.Workloads;
 using Azure.Functions.Cli.Workloads.Catalog;
-using Azure.Functions.Cli.Workloads.Discovery;
 using Azure.Functions.Cli.Workloads.Install;
 using Azure.Functions.Cli.Workloads.Storage;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using NuGet.Versioning;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Commands.Workload;
 
@@ -29,13 +26,13 @@ public class WorkloadUpdateCommandTests
     public void Update_HasExpectedArgsAndOptions()
     {
         var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store, _testCatalogOptions);
-        Assert.Single(cmd.Arguments, a => a.Name == "id");
-        Assert.Contains(cmd.Options, o => o.Name == "--version");
-        Assert.Contains(cmd.Options, o => o.Name == "--all");
-        Assert.Contains(cmd.Options, o => o.Name == "--major");
-        Assert.Contains(cmd.Options, o => o.Name == "--source");
-        Assert.Contains(cmd.Options, o => o.Name == "--prerelease");
-        Assert.Contains(cmd.Options, o => o.Name == "--exact");
+        cmd.Arguments.Should().ContainSingle(a => a.Name == "id");
+        cmd.Options.Should().Contain(o => o.Name == "--version");
+        cmd.Options.Should().Contain(o => o.Name == "--all");
+        cmd.Options.Should().Contain(o => o.Name == "--major");
+        cmd.Options.Should().Contain(o => o.Name == "--source");
+        cmd.Options.Should().Contain(o => o.Name == "--prerelease");
+        cmd.Options.Should().Contain(o => o.Name == "--exact");
     }
 
     [Fact]
@@ -47,7 +44,7 @@ public class WorkloadUpdateCommandTests
 
         ParseResult parse = root.Parse([cmd.Name]);
 
-        Assert.NotEmpty(parse.Errors);
+        parse.Errors.Should().NotBeEmpty();
     }
 
     [Fact]
@@ -59,7 +56,7 @@ public class WorkloadUpdateCommandTests
 
         ParseResult parse = root.Parse([cmd.Name, "test.workload", "--all"]);
 
-        Assert.NotEmpty(parse.Errors);
+        parse.Errors.Should().NotBeEmpty();
     }
 
     [Fact]
@@ -71,8 +68,8 @@ public class WorkloadUpdateCommandTests
 
         ParseResult parse = root.Parse([cmd.Name, "--all", "--version", "1.0.0"]);
 
-        Assert.NotEmpty(parse.Errors);
-        Assert.Contains(parse.Errors, e => e.Message.Contains("--version cannot be combined with --all"));
+        parse.Errors.Should().NotBeEmpty();
+        parse.Errors.Should().Contain(e => e.Message.Contains("--version cannot be combined with --all"));
     }
 
     [Fact]
@@ -84,8 +81,8 @@ public class WorkloadUpdateCommandTests
 
         ParseResult parse = root.Parse([cmd.Name, "--all", "--exact"]);
 
-        Assert.NotEmpty(parse.Errors);
-        Assert.Contains(parse.Errors, e => e.Message.Contains("--exact cannot be combined with --all"));
+        parse.Errors.Should().NotBeEmpty();
+        parse.Errors.Should().Contain(e => e.Message.Contains("--exact cannot be combined with --all"));
     }
 
     [Fact]
@@ -97,7 +94,7 @@ public class WorkloadUpdateCommandTests
 
         ParseResult parse = root.Parse([cmd.Name, "   "]);
 
-        Assert.NotEmpty(parse.Errors);
+        parse.Errors.Should().NotBeEmpty();
     }
 
     [Fact]
@@ -109,8 +106,8 @@ public class WorkloadUpdateCommandTests
 
         ParseResult parse = root.Parse([cmd.Name, "Test.Workload", "--version", "not-semver"]);
 
-        Assert.NotEmpty(parse.Errors);
-        Assert.Contains(parse.Errors, e => e.Message.Contains("not a valid semver"));
+        parse.Errors.Should().NotBeEmpty();
+        parse.Errors.Should().Contain(e => e.Message.Contains("not a valid semver"));
     }
 
     [Fact]
@@ -128,10 +125,8 @@ public class WorkloadUpdateCommandTests
         var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store, _testCatalogOptions);
         int exit = await InvokeAsync(cmd, "Test.Workload");
 
-        Assert.Equal(0, exit);
-        Assert.Contains(
-            _interaction.Lines,
-            l => l.StartsWith("SUCCESS:")
+        exit.Should().Be(0);
+        _interaction.Lines.Should().Contain(l => l.StartsWith("SUCCESS:")
                 && l.Contains("Updated workload")
                 && l.Contains("test.workload")
                 && l.Contains("from 1.0.0 to 1.1.0"));
@@ -152,10 +147,8 @@ public class WorkloadUpdateCommandTests
         var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store, _testCatalogOptions);
         int exit = await InvokeAsync(cmd, "Test.Workload");
 
-        Assert.Equal(0, exit);
-        Assert.Contains(
-            _interaction.Lines,
-            l => l.Contains("already at the latest")
+        exit.Should().Be(0);
+        _interaction.Lines.Should().Contain(l => l.Contains("already at the latest")
                 && l.Contains("test.workload")
                 && l.Contains("1.0.0"));
     }
@@ -180,7 +173,7 @@ public class WorkloadUpdateCommandTests
             "--source", "https://example/v3/index.json",
             "--prerelease");
 
-        Assert.Equal(0, exit);
+        exit.Should().Be(0);
         await _installer.Received(1).UpdateAsync(
             "Test.Workload",
             Arg.Is<NuGetVersion>(v => v != null && v.ToNormalizedString() == "1.0.0"),
@@ -200,11 +193,10 @@ public class WorkloadUpdateCommandTests
             .Throws(new InvalidOperationException("Workload 'test.workload' is not installed."));
 
         var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store, _testCatalogOptions);
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => InvokeAsync(cmd, "Test.Workload"));
+        GracefulException ex = (await FluentActions.Awaiting(() => InvokeAsync(cmd, "Test.Workload")).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.Contains("not installed", ex.Message);
-        Assert.True(ex.IsUserError);
+        ex.Message.Should().Contain("not installed");
+        ex.IsUserError.Should().BeTrue();
     }
 
     [Fact]
@@ -216,10 +208,9 @@ public class WorkloadUpdateCommandTests
             .Throws(new WorkloadPackageNotFoundException("nope"));
 
         var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store, _testCatalogOptions);
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => InvokeAsync(cmd, "Test.Workload"));
+        GracefulException ex = (await FluentActions.Awaiting(() => InvokeAsync(cmd, "Test.Workload")).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.True(ex.IsUserError);
+        ex.IsUserError.Should().BeTrue();
     }
 
     [Fact]
@@ -231,8 +222,8 @@ public class WorkloadUpdateCommandTests
         var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store, _testCatalogOptions);
         int exit = await InvokeAsync(cmd, "--all");
 
-        Assert.Equal(0, exit);
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("HINT:") && l.Contains("No workloads installed"));
+        exit.Should().Be(0);
+        _interaction.Lines.Should().Contain(l => l.StartsWith("HINT:") && l.Contains("No workloads installed"));
         await _installer.DidNotReceive().UpdateAsync(
             Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
             Arg.Any<bool?>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
@@ -267,15 +258,15 @@ public class WorkloadUpdateCommandTests
         var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store, _testCatalogOptions);
         int exit = await InvokeAsync(cmd, "--all");
 
-        Assert.Equal(0, exit);
+        exit.Should().Be(0);
         await _installer.Received(1).UpdateAsync(
             "a.workload", Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
             Arg.Any<bool?>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
         await _installer.Received(1).UpdateAsync(
             "b.workload", Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
             Arg.Any<bool?>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("SUCCESS:") && l.Contains("a.workload"));
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("WARNING:") && l.Contains("b.workload"));
+        _interaction.Lines.Should().Contain(l => l.StartsWith("SUCCESS:") && l.Contains("a.workload"));
+        _interaction.Lines.Should().Contain(l => l.StartsWith("WARNING:") && l.Contains("b.workload"));
     }
 
     [Fact]
@@ -303,9 +294,9 @@ public class WorkloadUpdateCommandTests
         var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store, _testCatalogOptions);
         int exit = await InvokeAsync(cmd, "--all");
 
-        Assert.Equal(1, exit);
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("ERROR:") && l.Contains("a.workload"));
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("SUCCESS:") && l.Contains("b.workload"));
+        exit.Should().Be(1);
+        _interaction.Lines.Should().Contain(l => l.StartsWith("ERROR:") && l.Contains("a.workload"));
+        _interaction.Lines.Should().Contain(l => l.StartsWith("SUCCESS:") && l.Contains("b.workload"));
     }
 
     [Fact]
@@ -324,10 +315,8 @@ public class WorkloadUpdateCommandTests
         var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store, _testCatalogOptions);
         int exit = await InvokeAsync(cmd, "Test.Workload");
 
-        Assert.Equal(0, exit);
-        Assert.Contains(
-            _interaction.Lines,
-            l => l.StartsWith("HINT:")
+        exit.Should().Be(0);
+        _interaction.Lines.Should().Contain(l => l.StartsWith("HINT:")
                 && l.Contains("No version of 'test.workload'")
                 && l.Contains("--source"));
     }
@@ -356,7 +345,7 @@ public class WorkloadUpdateCommandTests
         var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store, _testCatalogOptions);
         int exit = await InvokeAsync(cmd, "demo");
 
-        Assert.Equal(0, exit);
+        exit.Should().Be(0);
         await _installer.Received(1).UpdateAsync(
             "test.workload",
             Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
@@ -382,10 +371,9 @@ public class WorkloadUpdateCommandTests
             .Throws(new InvalidOperationException("Workload 'demo' is not installed."));
 
         var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store, _testCatalogOptions);
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => InvokeAsync(cmd, "demo", "--exact"));
+        GracefulException ex = (await FluentActions.Awaiting(() => InvokeAsync(cmd, "demo", "--exact")).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.Contains("not installed", ex.Message);
+        ex.Message.Should().Contain("not installed");
         await _installer.DidNotReceive().UpdateAsync(
             "test.workload",
             Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
@@ -402,13 +390,12 @@ public class WorkloadUpdateCommandTests
         });
 
         var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store, _testCatalogOptions);
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => InvokeAsync(cmd, "shared"));
+        GracefulException ex = (await FluentActions.Awaiting(() => InvokeAsync(cmd, "shared")).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.Contains("matches multiple installed workloads", ex.Message);
-        Assert.Contains("a.workload", ex.Message);
-        Assert.Contains("b.workload", ex.Message);
-        Assert.True(ex.IsUserError);
+        ex.Message.Should().Contain("matches multiple installed workloads");
+        ex.Message.Should().Contain("a.workload");
+        ex.Message.Should().Contain("b.workload");
+        ex.IsUserError.Should().BeTrue();
         await _installer.DidNotReceive().UpdateAsync(
             Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
             Arg.Any<bool?>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());

--- a/test/Func.Tests/Common/DirectoryGuardTests.cs
+++ b/test/Func.Tests/Common/DirectoryGuardTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Common;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Common;
 
@@ -29,7 +28,7 @@ public class DirectoryGuardTests : IDisposable
     {
         bool result = DirectoryGuard.HasNonGitContent(new DirectoryInfo(_tempDir));
 
-        Assert.False(result);
+        result.Should().BeFalse();
     }
 
     [Fact]
@@ -39,7 +38,7 @@ public class DirectoryGuardTests : IDisposable
 
         bool result = DirectoryGuard.HasNonGitContent(new DirectoryInfo(_tempDir));
 
-        Assert.False(result);
+        result.Should().BeFalse();
     }
 
     [Fact]
@@ -49,7 +48,7 @@ public class DirectoryGuardTests : IDisposable
 
         bool result = DirectoryGuard.HasNonGitContent(new DirectoryInfo(_tempDir));
 
-        Assert.True(result);
+        result.Should().BeTrue();
     }
 
     [Fact]
@@ -59,7 +58,7 @@ public class DirectoryGuardTests : IDisposable
 
         bool result = DirectoryGuard.HasNonGitContent(new DirectoryInfo(_tempDir));
 
-        Assert.True(result);
+        result.Should().BeTrue();
     }
 
     [Fact]
@@ -78,11 +77,11 @@ public class DirectoryGuardTests : IDisposable
         DirectoryGuard.ClearExceptGit(new DirectoryInfo(_tempDir));
 
         // Assert
-        Assert.True(Directory.Exists(gitDir));
-        Assert.True(File.Exists(Path.Combine(gitDir, "HEAD")));
-        Assert.False(File.Exists(Path.Combine(_tempDir, "host.json")));
-        Assert.False(File.Exists(Path.Combine(_tempDir, "local.settings.json")));
-        Assert.False(Directory.Exists(Path.Combine(_tempDir, "src")));
+        Directory.Exists(gitDir).Should().BeTrue();
+        File.Exists(Path.Combine(gitDir, "HEAD")).Should().BeTrue();
+        File.Exists(Path.Combine(_tempDir, "host.json")).Should().BeFalse();
+        File.Exists(Path.Combine(_tempDir, "local.settings.json")).Should().BeFalse();
+        Directory.Exists(Path.Combine(_tempDir, "src")).Should().BeFalse();
     }
 
     [Fact]
@@ -94,18 +93,18 @@ public class DirectoryGuardTests : IDisposable
 
         DirectoryGuard.ClearExceptGit(new DirectoryInfo(_tempDir));
 
-        Assert.False(File.Exists(filePath));
+        File.Exists(filePath).Should().BeFalse();
     }
 
     [Fact]
     public void HasNonGitContent_ThrowsOnNull()
     {
-        Assert.Throws<ArgumentNullException>(() => DirectoryGuard.HasNonGitContent(null!));
+        FluentActions.Invoking(() => DirectoryGuard.HasNonGitContent(null!)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
     public void ClearExceptGit_ThrowsOnNull()
     {
-        Assert.Throws<ArgumentNullException>(() => DirectoryGuard.ClearExceptGit(null!));
+        FluentActions.Invoking(() => DirectoryGuard.ClearExceptGit(null!)).Should().ThrowExactly<ArgumentNullException>();
     }
 }

--- a/test/Func.Tests/Common/FuncHomeResolverTests.cs
+++ b/test/Func.Tests/Common/FuncHomeResolverTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Abstractions.Common;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Common;
 
@@ -18,7 +17,7 @@ public class FuncHomeResolverTests
 
         string resolved = WithEnv(null, FuncHomeResolver.Resolve);
 
-        Assert.Equal(expected, resolved);
+        resolved.Should().Be(expected);
     }
 
     [Theory]
@@ -32,7 +31,7 @@ public class FuncHomeResolverTests
 
         string resolved = WithEnv(blank, FuncHomeResolver.Resolve);
 
-        Assert.Equal(expected, resolved);
+        resolved.Should().Be(expected);
     }
 
     [Fact]
@@ -42,7 +41,7 @@ public class FuncHomeResolverTests
 
         string resolved = WithEnv(custom, FuncHomeResolver.Resolve);
 
-        Assert.Equal(Path.GetFullPath(custom), resolved);
+        resolved.Should().Be(Path.GetFullPath(custom));
     }
 
     [Fact]
@@ -52,7 +51,7 @@ public class FuncHomeResolverTests
 
         string resolved = WithEnv(relative, FuncHomeResolver.Resolve);
 
-        Assert.Equal(Path.GetFullPath(relative), resolved);
+        resolved.Should().Be(Path.GetFullPath(relative));
     }
 
     private static string WithEnv(string? value, Func<string> action)

--- a/test/Func.Tests/Common/WorkingDirectoryTests.cs
+++ b/test/Func.Tests/Common/WorkingDirectoryTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Common;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Common;
 
@@ -28,8 +27,8 @@ public class WorkingDirectoryTests : IDisposable
     {
         var workingDirectory = WorkingDirectory.FromCwd();
 
-        Assert.False(workingDirectory.WasExplicit);
-        Assert.Equal(Directory.GetCurrentDirectory(), workingDirectory.Info.FullName);
+        workingDirectory.WasExplicit.Should().BeFalse();
+        workingDirectory.Info.FullName.Should().Be(Directory.GetCurrentDirectory());
     }
 
     [Fact]
@@ -37,31 +36,31 @@ public class WorkingDirectoryTests : IDisposable
     {
         var workingDirectory = WorkingDirectory.FromExplicit(_tempDir);
 
-        Assert.True(workingDirectory.WasExplicit);
-        Assert.Equal(_tempDir, workingDirectory.Info.FullName);
+        workingDirectory.WasExplicit.Should().BeTrue();
+        workingDirectory.Info.FullName.Should().Be(_tempDir);
     }
 
     [Fact]
     public void Exists_ReflectsDirectoryState()
     {
         var workingDirectory = WorkingDirectory.FromExplicit(_tempDir);
-        Assert.False(workingDirectory.Exists);
+        workingDirectory.Exists.Should().BeFalse();
 
         Directory.CreateDirectory(_tempDir);
         workingDirectory.Info.Refresh();
-        Assert.True(workingDirectory.Exists);
+        workingDirectory.Exists.Should().BeTrue();
     }
 
     [Fact]
     public void CreateIfNotExists_CreatesMissingDirectory()
     {
         var workingDirectory = WorkingDirectory.FromExplicit(_tempDir);
-        Assert.False(workingDirectory.Exists);
+        workingDirectory.Exists.Should().BeFalse();
 
         workingDirectory.CreateIfNotExists();
 
-        Assert.True(Directory.Exists(_tempDir));
-        Assert.True(workingDirectory.Exists);
+        Directory.Exists(_tempDir).Should().BeTrue();
+        workingDirectory.Exists.Should().BeTrue();
     }
 
     [Fact]
@@ -73,6 +72,6 @@ public class WorkingDirectoryTests : IDisposable
         workingDirectory.CreateIfNotExists();
         workingDirectory.CreateIfNotExists();
 
-        Assert.True(Directory.Exists(_tempDir));
+        Directory.Exists(_tempDir).Should().BeTrue();
     }
 }

--- a/test/Func.Tests/Configuration/LocalSettingsConfigurationProviderTests.cs
+++ b/test/Func.Tests/Configuration/LocalSettingsConfigurationProviderTests.cs
@@ -3,7 +3,6 @@
 
 using Azure.Functions.Cli.Configuration;
 using Microsoft.Extensions.Configuration;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Configuration;
 
@@ -40,11 +39,11 @@ public sealed class LocalSettingsConfigurationProviderTests : IDisposable
             .Add(new LocalSettingsConfigurationSource(_dir, new LocalSettingsProvider()))
             .Build();
 
-        Assert.Equal("node", configuration["stack:runtime"]);
-        Assert.Equal("7073", configuration["HostStartup:Port"]);
-        Assert.Equal("*", configuration["HostStartup:Cors"]);
-        Assert.Equal("True", configuration["HostStartup:CorsCredentials"]);
-        Assert.Null(configuration["AzureWebJobsStorage"]);
+        configuration["stack:runtime"].Should().Be("node");
+        configuration["HostStartup:Port"].Should().Be("7073");
+        configuration["HostStartup:Cors"].Should().Be("*");
+        configuration["HostStartup:CorsCredentials"].Should().Be("True");
+        configuration["AzureWebJobsStorage"].Should().BeNull();
     }
 
     [Fact]
@@ -63,7 +62,7 @@ public sealed class LocalSettingsConfigurationProviderTests : IDisposable
         StackOptions options = new();
         new StackOptionsSetup(configuration).Configure(options);
 
-        Assert.Equal("python", options.Runtime);
+        options.Runtime.Should().Be("python");
     }
 
     [Fact]
@@ -90,7 +89,7 @@ public sealed class LocalSettingsConfigurationProviderTests : IDisposable
         StackOptions options = new();
         new StackOptionsSetup(configuration).Configure(options);
 
-        Assert.Equal("project", options.Runtime);
+        options.Runtime.Should().Be("project");
     }
 
     [Fact]
@@ -113,7 +112,7 @@ public sealed class LocalSettingsConfigurationProviderTests : IDisposable
         StackOptions options = new();
         new StackOptionsSetup(configuration).Configure(options);
 
-        Assert.Equal("local", options.Runtime);
+        options.Runtime.Should().Be("local");
     }
 
     [Fact]
@@ -127,7 +126,7 @@ public sealed class LocalSettingsConfigurationProviderTests : IDisposable
 
         setup.Configure(_dir.FullName, options);
 
-        Assert.Equal("custom-runtime", options.Runtime);
+        options.Runtime.Should().Be("custom-runtime");
     }
 
     [Fact]
@@ -141,7 +140,7 @@ public sealed class LocalSettingsConfigurationProviderTests : IDisposable
 
         setup.Configure(_dir.FullName, options);
 
-        Assert.Equal(7074, options.Port);
+        options.Port.Should().Be(7074);
     }
 
     [Fact]
@@ -154,9 +153,9 @@ public sealed class LocalSettingsConfigurationProviderTests : IDisposable
 
         IConfiguration configuration = configurationProvider.GetProjectConfiguration(_dir);
 
-        Assert.Equal("project-profile", configuration["profiles:0"]);
-        Assert.Null(configuration["defaultProfile"]);
-        Assert.Equal("node", configuration["stack:runtime"]);
+        configuration["profiles:0"].Should().Be("project-profile");
+        configuration["defaultProfile"].Should().BeNull();
+        configuration["stack:runtime"].Should().Be("node");
     }
 
     [Fact]
@@ -169,7 +168,7 @@ public sealed class LocalSettingsConfigurationProviderTests : IDisposable
 
         IConfiguration configuration = configurationProvider.GetEffectiveConfiguration(_dir);
 
-        Assert.Equal("project", configuration["stack:runtime"]);
+        configuration["stack:runtime"].Should().Be("project");
     }
 
     [Fact]
@@ -182,8 +181,8 @@ public sealed class LocalSettingsConfigurationProviderTests : IDisposable
         WriteProjectConfig("""{"defaultProfile":"linux-premium"}""");
         IConfiguration secondConfiguration = configurationProvider.GetProjectConfiguration(_dir);
 
-        Assert.Same(firstConfiguration, secondConfiguration);
-        Assert.Equal("flex", secondConfiguration["defaultProfile"]);
+        secondConfiguration.Should().BeSameAs(firstConfiguration);
+        secondConfiguration["defaultProfile"].Should().Be("flex");
     }
 
     private void WriteSettings(string contents)

--- a/test/Func.Tests/Configuration/LocalSettingsProviderTests.cs
+++ b/test/Func.Tests/Configuration/LocalSettingsProviderTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Configuration;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Configuration;
 
@@ -18,9 +17,9 @@ public sealed class LocalSettingsProviderTests : IDisposable
     {
         LocalSettingsSnapshot snapshot = _provider.Get(_dir);
 
-        Assert.Empty(snapshot.Values);
-        Assert.Null(snapshot.WorkerRuntime);
-        Assert.Null(snapshot.Host);
+        snapshot.Values.Should().BeEmpty();
+        snapshot.WorkerRuntime.Should().BeNull();
+        snapshot.Host.Should().BeNull();
     }
 
     [Fact]
@@ -44,13 +43,13 @@ public sealed class LocalSettingsProviderTests : IDisposable
 
         LocalSettingsSnapshot snapshot = _provider.Get(_dir);
 
-        Assert.Equal("python", snapshot.WorkerRuntime);
-        Assert.Equal("UseDevelopmentStorage=true", snapshot.Values["AzureWebJobsStorage"]);
-        Assert.False(snapshot.Values.ContainsKey("IgnoredNumber"));
-        Assert.NotNull(snapshot.Host);
-        Assert.Equal(7072, snapshot.Host!.LocalHttpPort);
-        Assert.Equal("http://localhost,http://example", snapshot.Host.Cors);
-        Assert.True(snapshot.Host.CorsCredentials);
+        snapshot.WorkerRuntime.Should().Be("python");
+        snapshot.Values["AzureWebJobsStorage"].Should().Be("UseDevelopmentStorage=true");
+        snapshot.Values.ContainsKey("IgnoredNumber").Should().BeFalse();
+        snapshot.Host.Should().NotBeNull();
+        snapshot.Host!.LocalHttpPort.Should().Be(7072);
+        snapshot.Host.Cors.Should().Be("http://localhost,http://example");
+        snapshot.Host.CorsCredentials.Should().BeTrue();
     }
 
     [Fact]
@@ -60,8 +59,8 @@ public sealed class LocalSettingsProviderTests : IDisposable
 
         LocalSettingsSnapshot snapshot = _provider.Get(_dir);
 
-        Assert.Empty(snapshot.Values);
-        Assert.Null(snapshot.WorkerRuntime);
+        snapshot.Values.Should().BeEmpty();
+        snapshot.WorkerRuntime.Should().BeNull();
     }
 
     [Fact]
@@ -73,14 +72,14 @@ public sealed class LocalSettingsProviderTests : IDisposable
         WriteSettings("""{"Values":{"FUNCTIONS_WORKER_RUNTIME":"node"}}""");
         LocalSettingsSnapshot second = _provider.Get(_dir);
 
-        Assert.Same(first, second);
-        Assert.Equal("python", second.WorkerRuntime);
+        second.Should().BeSameAs(first);
+        second.WorkerRuntime.Should().Be("python");
     }
 
     [Fact]
     public void Get_NullDirectory_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => _provider.Get(null!));
+        FluentActions.Invoking(() => _provider.Get(null!)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     private void WriteSettings(string contents)

--- a/test/Func.Tests/Hosting/CliHostFactoryTests.cs
+++ b/test/Func.Tests/Hosting/CliHostFactoryTests.cs
@@ -2,14 +2,12 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Text.Json;
-using Azure.Functions.Cli;
 using Azure.Functions.Cli.Hosting;
 using Azure.Functions.Cli.Workloads;
 using Azure.Functions.Cli.Workloads.Storage;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Hosting;
 
@@ -51,7 +49,7 @@ public sealed class CliHostFactoryTests : IDisposable
         HostApplicationBuilder builder = CliHostFactory.CreateBuilder(interaction);
         using ServiceProvider provider = builder.Services.BuildServiceProvider();
 
-        Assert.NotNull(provider.GetRequiredService<IPlatform>());
+        provider.GetRequiredService<IPlatform>().Should().NotBeNull();
     }
 
     [Fact]
@@ -65,8 +63,8 @@ public sealed class CliHostFactoryTests : IDisposable
         using IHost host = await StartHostAsync(interaction);
         var rootCommand = Parser.CreateCommand(host.Services);
 
-        Assert.Contains(rootCommand.Subcommands, c => string.Equals(c.Name, "hello-from-workload", StringComparison.Ordinal));
-        Assert.DoesNotContain(interaction.Lines, l => l.StartsWith("WARNING:", StringComparison.Ordinal));
+        rootCommand.Subcommands.Should().Contain(c => string.Equals(c.Name, "hello-from-workload", StringComparison.Ordinal));
+        interaction.Lines.Should().NotContain(l => l.StartsWith("WARNING:", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -83,10 +81,10 @@ public sealed class CliHostFactoryTests : IDisposable
         using IHost host = await StartHostAsync(interaction);
 
         IWorkloadProvider provider = host.Services.GetRequiredService<IWorkloadProvider>();
-        Assert.Single(provider.GetRuntimeWorkloads());
-        Assert.Equal(2, provider.GetContentWorkloads().Count);
-        Assert.Equal(3, provider.GetWorkloads().Count);
-        Assert.All(provider.GetContentWorkloads(), w => Assert.Equal(w.PackageId, w.DisplayName));
+        provider.GetRuntimeWorkloads().Should().ContainSingle();
+        provider.GetContentWorkloads().Count.Should().Be(2);
+        provider.GetWorkloads().Count.Should().Be(3);
+        provider.GetContentWorkloads().Should().AllSatisfy(w => w.DisplayName.Should().Be(w.PackageId));
     }
 
     [Fact]
@@ -100,14 +98,12 @@ public sealed class CliHostFactoryTests : IDisposable
         using IHost host = await StartHostAsync(interaction);
         var rootCommand = Parser.CreateCommand(host.Services);
 
-        Assert.Contains(
-            interaction.Lines,
-            l => l.StartsWith("WARNING:", StringComparison.Ordinal)
+        interaction.Lines.Should().Contain(l => l.StartsWith("WARNING:", StringComparison.Ordinal)
                  && l.Contains("throwing.fixture@1.0.0", StringComparison.Ordinal)
                  && l.Contains("Boom from ThrowingWorkload", StringComparison.Ordinal));
 
         // Built-ins must still be there: a single misbehaving workload cannot brick the CLI.
-        Assert.Contains(rootCommand.Subcommands, c => string.Equals(c.Name, "version", StringComparison.OrdinalIgnoreCase));
+        rootCommand.Subcommands.Should().Contain(c => string.Equals(c.Name, "version", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
@@ -122,9 +118,9 @@ public sealed class CliHostFactoryTests : IDisposable
         var rootCommand = Parser.CreateCommand(host.Services);
 
         var workloads = host.Services.GetRequiredService<IWorkloadProvider>().GetWorkloads();
-        Assert.Empty(workloads);
-        Assert.DoesNotContain(rootCommand.Subcommands, c => string.Equals(c.Name, "hello-from-workload", StringComparison.Ordinal));
-        Assert.DoesNotContain(interaction.Lines, l => l.StartsWith("WARNING:", StringComparison.Ordinal));
+        workloads.Should().BeEmpty();
+        rootCommand.Subcommands.Should().NotContain(c => string.Equals(c.Name, "hello-from-workload", StringComparison.Ordinal));
+        interaction.Lines.Should().NotContain(l => l.StartsWith("WARNING:", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -157,11 +153,11 @@ public sealed class CliHostFactoryTests : IDisposable
             var rootCommand = Parser.CreateCommand(host.Services);
 
             // The registered WorkloadPathsOptions wins: the staged workload's command is present.
-            Assert.Contains(rootCommand.Subcommands, c => string.Equals(c.Name, "hello-from-workload", StringComparison.Ordinal));
+            rootCommand.Subcommands.Should().Contain(c => string.Equals(c.Name, "hello-from-workload", StringComparison.Ordinal));
 
             // And the bound IWorkloadPaths reflects the override, not IConfiguration.
             var paths = host.Services.GetRequiredService<IWorkloadPaths>();
-            Assert.Equal(Path.GetFullPath(_home), paths.Home);
+            paths.Home.Should().Be(Path.GetFullPath(_home));
         }
         finally
         {

--- a/test/Func.Tests/Hosting/Dashboard/DashboardPipelineTests.cs
+++ b/test/Func.Tests/Hosting/Dashboard/DashboardPipelineTests.cs
@@ -6,7 +6,6 @@ using Azure.Functions.Cli.Hosting.Dashboard;
 using Azure.Functions.Cli.Hosting.Dashboard.Rendering;
 using Azure.Functions.Cli.Hosting.Events;
 using Microsoft.Extensions.Logging;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Hosting.Dashboard;
 
@@ -26,10 +25,10 @@ public class DashboardPipelineTests
 
         int exitCode = await runTask.WaitAsync(TimeSpan.FromSeconds(5));
 
-        Assert.Equal(0, exitCode);
-        Assert.NotNull(renderer.Summary);
-        Assert.Equal("sigint", renderer.Summary.ExitReason);
-        Assert.True(renderer.Disposed);
+        exitCode.Should().Be(0);
+        renderer.Summary.Should().NotBeNull();
+        renderer.Summary.ExitReason.Should().Be("sigint");
+        renderer.Disposed.Should().BeTrue();
     }
 
     [Fact]
@@ -42,10 +41,10 @@ public class DashboardPipelineTests
 
         int exitCode = await pipeline.RunAsync(CancellationToken.None);
 
-        Assert.Equal(42, exitCode);
-        Assert.True(source.WaitForExitCalled);
-        Assert.NotNull(renderer.Summary);
-        Assert.Equal("source_completed", renderer.Summary.ExitReason);
+        exitCode.Should().Be(42);
+        source.WaitForExitCalled.Should().BeTrue();
+        renderer.Summary.Should().NotBeNull();
+        renderer.Summary.ExitReason.Should().Be("source_completed");
     }
 
     [Fact]
@@ -62,10 +61,10 @@ public class DashboardPipelineTests
 
         int exitCode = await runTask.WaitAsync(TimeSpan.FromSeconds(5));
 
-        Assert.Equal(0, exitCode);
-        Assert.True(source.ShutdownRequested);
-        Assert.NotNull(renderer.Summary);
-        Assert.Equal("sigint", renderer.Summary.ExitReason);
+        exitCode.Should().Be(0);
+        source.ShutdownRequested.Should().BeTrue();
+        renderer.Summary.Should().NotBeNull();
+        renderer.Summary.ExitReason.Should().Be("sigint");
     }
 
     [Fact]
@@ -96,9 +95,9 @@ public class DashboardPipelineTests
         int exitCode = await pipeline.RunAsync(CancellationToken.None);
 
         string output = writer.ToString();
-        Assert.Equal(0, exitCode);
-        Assert.Contains("[error] Function.HttpTrigger1: Invocation failed", output);
-        Assert.Contains("invocation_completed HttpTrigger1 invocation-1 failed duration_ms=42", output);
+        exitCode.Should().Be(0);
+        output.Should().Contain("[error] Function.HttpTrigger1: Invocation failed");
+        output.Should().Contain("invocation_completed HttpTrigger1 invocation-1 failed duration_ms=42");
     }
 
     [Fact]
@@ -119,10 +118,9 @@ public class DashboardPipelineTests
             Exception: null,
             HostLogEntry.EmptyAttributes));
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
-            () => pipeline.RunAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5)));
+        await FluentActions.Awaiting(() => pipeline.RunAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5))).Should().ThrowAsync<InvalidOperationException>();
 
-        Assert.True(source.ShutdownRequested);
+        source.ShutdownRequested.Should().BeTrue();
     }
 
     private sealed class ThrowingRenderer : IDashboardRenderer

--- a/test/Func.Tests/Hosting/Dashboard/DashboardStateTests.cs
+++ b/test/Func.Tests/Hosting/Dashboard/DashboardStateTests.cs
@@ -4,7 +4,6 @@
 using Azure.Functions.Cli.Hosting.Dashboard;
 using Azure.Functions.Cli.Hosting.Events;
 using Microsoft.Extensions.Logging;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Hosting.Dashboard;
 
@@ -27,10 +26,10 @@ public class DashboardStateTests
 
         IReadOnlyList<DashboardEvent> events = state.Observe(entry);
 
-        var ev = Assert.Single(events.OfType<HostStateChangedEvent>());
-        Assert.Equal(HostLifecycleState.Starting, ev.From);
-        Assert.Equal(HostLifecycleState.Ready, ev.To);
-        Assert.Equal(1241.0, ev.DurationMs);
+        var ev = events.OfType<HostStateChangedEvent>().Should().ContainSingle().Subject;
+        ev.From.Should().Be(HostLifecycleState.Starting);
+        ev.To.Should().Be(HostLifecycleState.Ready);
+        ev.DurationMs.Should().Be(1241.0);
     }
 
     [Fact]
@@ -52,12 +51,12 @@ public class DashboardStateTests
 
         IReadOnlyList<DashboardEvent> events = state.Observe(entry);
 
-        Assert.Single(events.OfType<FunctionDiscoveredEvent>());
+        events.OfType<FunctionDiscoveredEvent>().Should().ContainSingle();
         DashboardSnapshot snap = state.Snapshot();
-        var fn = Assert.Single(snap.Functions);
-        Assert.Equal("HttpTrigger1", fn.Name);
-        Assert.Equal("http", fn.TriggerType);
-        Assert.Equal(["GET", "POST"], fn.HttpMethods);
+        var fn = snap.Functions.Should().ContainSingle().Subject;
+        fn.Name.Should().Be("HttpTrigger1");
+        fn.TriggerType.Should().Be("http");
+        fn.HttpMethods.Should().Equal(["GET", "POST"]);
     }
 
     [Fact]
@@ -77,8 +76,8 @@ public class DashboardStateTests
                 [HostLogAttributeKeys.FunctionInvocationId] = "id-1",
             }));
 
-        Assert.Equal(FunctionStatus.Active, state.Snapshot().Functions[0].Status);
-        Assert.Equal(1, state.Snapshot().ActiveInvocationCount);
+        state.Snapshot().Functions[0].Status.Should().Be(FunctionStatus.Active);
+        state.Snapshot().ActiveInvocationCount.Should().Be(1);
 
         IReadOnlyList<DashboardEvent> events = state.Observe(MakeEntry(
             "Function.HttpTrigger1",
@@ -93,13 +92,13 @@ public class DashboardStateTests
                 [HostLogAttributeKeys.DurationMs] = 12.0,
             }));
 
-        Assert.Single(events.OfType<InvocationCompletedEvent>());
+        events.OfType<InvocationCompletedEvent>().Should().ContainSingle();
         DashboardSnapshot snap = state.Snapshot();
-        Assert.Equal(1, snap.TotalInvocations);
-        Assert.Equal(1, snap.SucceededInvocations);
-        Assert.Equal(0, snap.FailedInvocations);
-        Assert.Equal(0, snap.ActiveInvocationCount);
-        Assert.Equal(FunctionStatus.Ready, snap.Functions[0].Status);
+        snap.TotalInvocations.Should().Be(1);
+        snap.SucceededInvocations.Should().Be(1);
+        snap.FailedInvocations.Should().Be(0);
+        snap.ActiveInvocationCount.Should().Be(0);
+        snap.Functions[0].Status.Should().Be(FunctionStatus.Ready);
     }
 
     [Fact]
@@ -128,21 +127,21 @@ public class DashboardStateTests
             exception: new InvalidOperationException("placeholder"),
             exceptionDetails: exceptionDetails));
 
-        var completed = Assert.Single(events.OfType<InvocationCompletedEvent>());
-        Assert.Equal("Microsoft.Azure.WebJobs.Host.FunctionInvocationException", completed.ErrorType);
-        Assert.Equal("Exception while executing function", completed.ErrorMessage);
-        Assert.Equal("Worker.UserException", completed.Error?.InnerException?.Type);
-        Assert.Equal("inner boom", completed.Error?.InnerException?.Message);
+        var completed = events.OfType<InvocationCompletedEvent>().Should().ContainSingle().Subject;
+        completed.ErrorType.Should().Be("Microsoft.Azure.WebJobs.Host.FunctionInvocationException");
+        completed.ErrorMessage.Should().Be("Exception while executing function");
+        (completed.Error?.InnerException?.Type).Should().Be("Worker.UserException");
+        (completed.Error?.InnerException?.Message).Should().Be("inner boom");
 
         DashboardSnapshot snap = state.Snapshot();
-        Assert.Equal(FunctionStatus.Error, snap.Functions[0].Status);
-        Assert.Equal(1, snap.Functions[0].TotalErrors);
-        Assert.Equal(1, snap.FailedInvocations);
+        snap.Functions[0].Status.Should().Be(FunctionStatus.Error);
+        snap.Functions[0].TotalErrors.Should().Be(1);
+        snap.FailedInvocations.Should().Be(1);
         const string ExpectedLastErrorMessage =
             "Microsoft.Azure.WebJobs.Host.FunctionInvocationException: Exception while executing function" +
             " ---> Worker.UserException: inner boom";
-        Assert.Equal(ExpectedLastErrorMessage, snap.Functions[0].LastErrorMessage);
-        Assert.True(snap.ErrorCount > 0);
+        snap.Functions[0].LastErrorMessage.Should().Be(ExpectedLastErrorMessage);
+        (snap.ErrorCount > 0).Should().BeTrue();
     }
 
     [Fact]
@@ -160,7 +159,7 @@ public class DashboardStateTests
                 [HostLogAttributeKeys.HostState] = "recycling",
             }));
 
-        Assert.Single(state.Snapshot().Functions); // not yet cleared
+        state.Snapshot().Functions.Should().ContainSingle(); // not yet cleared
 
         state.Observe(MakeEntry(
             "Host.Lifecycle",
@@ -172,7 +171,7 @@ public class DashboardStateTests
                 [HostLogAttributeKeys.HostState] = "ready",
             }));
 
-        Assert.Empty(state.Snapshot().Functions);
+        state.Snapshot().Functions.Should().BeEmpty();
     }
 
     [Fact]
@@ -195,10 +194,10 @@ public class DashboardStateTests
 
         SummaryEvent summary = state.BuildSummary("sigint", DateTimeOffset.UtcNow);
 
-        Assert.Equal("sigint", summary.ExitReason);
-        Assert.Equal(1, summary.FunctionCount);
-        Assert.Equal(1, summary.TotalInvocations);
-        Assert.Equal(1, summary.SucceededInvocations);
+        summary.ExitReason.Should().Be("sigint");
+        summary.FunctionCount.Should().Be(1);
+        summary.TotalInvocations.Should().Be(1);
+        summary.SucceededInvocations.Should().Be(1);
     }
 
     private static HostLogEntry DiscoverHttp(string name) => MakeEntry(

--- a/test/Func.Tests/Hosting/Dashboard/Demo/DemoEventSourceTests.cs
+++ b/test/Func.Tests/Hosting/Dashboard/Demo/DemoEventSourceTests.cs
@@ -3,7 +3,6 @@
 
 using Azure.Functions.Cli.Hosting.Dashboard.Demo;
 using Azure.Functions.Cli.Hosting.Events;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Hosting.Dashboard.Demo;
 
@@ -26,12 +25,12 @@ public class DemoEventSourceTests
 
         HashSet<string> distinctNames = await CollectDistinctDiscoveredNames(source);
 
-        Assert.Equal(5, distinctNames.Count);
-        Assert.Contains("HttpTrigger1", distinctNames);
-        Assert.Contains("QueueProcessor", distinctNames);
-        Assert.Contains("TimerCleanup", distinctNames);
-        Assert.Contains("HttpTriggerOrders", distinctNames);
-        Assert.Contains("BlobIngest", distinctNames);
+        distinctNames.Count.Should().Be(5);
+        distinctNames.Should().Contain("HttpTrigger1");
+        distinctNames.Should().Contain("QueueProcessor");
+        distinctNames.Should().Contain("TimerCleanup");
+        distinctNames.Should().Contain("HttpTriggerOrders");
+        distinctNames.Should().Contain("BlobIngest");
     }
 
     [Theory]
@@ -51,11 +50,11 @@ public class DemoEventSourceTests
 
         HashSet<string> distinctNames = await CollectDistinctDiscoveredNames(source);
 
-        Assert.Equal(functionCount, distinctNames.Count);
+        distinctNames.Count.Should().Be(functionCount);
         // Sequential extras start at HttpExtra1.
         for (int i = 1; i <= functionCount - 5; i++)
         {
-            Assert.Contains($"HttpExtra{i}", distinctNames);
+            distinctNames.Should().Contain($"HttpExtra{i}");
         }
     }
 
@@ -75,7 +74,7 @@ public class DemoEventSourceTests
 
         HashSet<string> distinctNames = await CollectDistinctDiscoveredNames(source);
 
-        Assert.Equal(5, distinctNames.Count);
+        distinctNames.Count.Should().Be(5);
     }
 
     private static async Task<HashSet<string>> CollectDistinctDiscoveredNames(DemoEventSource source)

--- a/test/Func.Tests/Hosting/Dashboard/FunctionPaletteTests.cs
+++ b/test/Func.Tests/Hosting/Dashboard/FunctionPaletteTests.cs
@@ -4,7 +4,6 @@
 using System.Reflection;
 using Azure.Functions.Cli.Hosting.Dashboard;
 using Spectre.Console;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Hosting.Dashboard;
 
@@ -18,7 +17,7 @@ public class FunctionPaletteTests
         var first = palette.GetColorFor("HttpTrigger1");
         var second = palette.GetColorFor("HttpTrigger1");
 
-        Assert.Equal(first, second);
+        second.Should().Be(first);
     }
 
     [Fact]
@@ -27,7 +26,7 @@ public class FunctionPaletteTests
         var a = new FunctionPalette();
         var b = new FunctionPalette();
 
-        Assert.Equal(a.GetColorFor("Login"), b.GetColorFor("Login"));
+        b.GetColorFor("Login").Should().Be(a.GetColorFor("Login"));
     }
 
     [Fact]
@@ -43,7 +42,7 @@ public class FunctionPaletteTests
         }.Select(palette.GetColorFor).Distinct().ToList();
 
         // The expanded palette should provide useful variety for common apps.
-        Assert.True(colors.Count >= 8, $"Expected at least 8 distinct colors, got {colors.Count}: {string.Join(",", colors)}");
+        (colors.Count >= 8).Should().BeTrue($"Expected at least 8 distinct colors, got {colors.Count}: {string.Join(",", colors)}");
     }
 
     [Fact]
@@ -51,9 +50,9 @@ public class FunctionPaletteTests
     {
         string[] colors = GetPaletteColors();
 
-        Assert.True(colors.Length >= 32, $"Expected at least 32 palette entries, got {colors.Length}.");
-        Assert.Equal(colors.Length, colors.Distinct(StringComparer.OrdinalIgnoreCase).Count());
-        Assert.DoesNotContain(colors, static color => color.Contains("red", StringComparison.OrdinalIgnoreCase));
+        (colors.Length >= 32).Should().BeTrue($"Expected at least 32 palette entries, got {colors.Length}.");
+        colors.Distinct(StringComparer.OrdinalIgnoreCase).Count().Should().Be(colors.Length);
+        colors.Should().NotContain(static color => color.Contains("red", StringComparison.OrdinalIgnoreCase));
 
         var writer = new StringWriter();
         IAnsiConsole console = AnsiConsole.Create(new AnsiConsoleSettings
@@ -68,7 +67,7 @@ public class FunctionPaletteTests
         {
             writer.GetStringBuilder().Clear();
             console.Write(new Markup($"[{color}]sample[/]"));
-            Assert.Equal("sample", writer.ToString());
+            writer.ToString().Should().Be("sample");
         }
     }
 

--- a/test/Func.Tests/Hosting/Dashboard/Rendering/CompactFunctionBrowserBuilderTests.cs
+++ b/test/Func.Tests/Hosting/Dashboard/Rendering/CompactFunctionBrowserBuilderTests.cs
@@ -6,7 +6,6 @@ using Azure.Functions.Cli.Hosting.Dashboard;
 using Azure.Functions.Cli.Hosting.Dashboard.Rendering;
 using Spectre.Console;
 using Spectre.Console.Rendering;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Hosting.Dashboard.Rendering;
 
@@ -19,7 +18,7 @@ public class CompactFunctionBrowserBuilderTests
 
         int totalRows = builder.GetTotalRows(functionCount: 5);
 
-        Assert.Equal(3, totalRows);
+        totalRows.Should().Be(3);
     }
 
     [Fact]
@@ -40,9 +39,9 @@ public class CompactFunctionBrowserBuilderTests
             selectedIndex: 0);
 
         string output = Render(renderable);
-        Assert.Contains("Functions (2)", output);
-        Assert.Contains("HttpTrigger (3)", output);
-        Assert.Contains("QueueProcessor", output);
+        output.Should().Contain("Functions (2)");
+        output.Should().Contain("HttpTrigger (3)");
+        output.Should().Contain("QueueProcessor");
     }
 
     [Fact]
@@ -53,8 +52,8 @@ public class CompactFunctionBrowserBuilderTests
         IRenderable renderable = builder.Build([], totalRows: 1, visibleRows: 1, rowOffset: 0, selectedIndex: 0);
 
         string output = Render(renderable);
-        Assert.Contains("Functions (0)", output);
-        Assert.Contains("No functions loaded yet", output);
+        output.Should().Contain("Functions (0)");
+        output.Should().Contain("No functions loaded yet");
     }
 
     private static FunctionInfo CreateFunction(string name, FunctionStatus status, int activeInvocations)

--- a/test/Func.Tests/Hosting/Dashboard/Rendering/CompactFunctionSearchBuilderTests.cs
+++ b/test/Func.Tests/Hosting/Dashboard/Rendering/CompactFunctionSearchBuilderTests.cs
@@ -6,7 +6,6 @@ using Azure.Functions.Cli.Hosting.Dashboard;
 using Azure.Functions.Cli.Hosting.Dashboard.Rendering;
 using Spectre.Console;
 using Spectre.Console.Rendering;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Hosting.Dashboard.Rendering;
 
@@ -24,7 +23,7 @@ public class CompactFunctionSearchBuilderTests
 
         FunctionInfo[] matches = builder.GetMatches(functions, " ");
 
-        Assert.Same(functions, matches);
+        matches.Should().BeSameAs(functions);
     }
 
     [Fact]
@@ -40,8 +39,8 @@ public class CompactFunctionSearchBuilderTests
 
         FunctionInfo[] matches = builder.GetMatches(functions, "ord");
 
-        Assert.Single(matches);
-        Assert.Equal("QueueProcessor", matches[0].Name);
+        matches.Should().ContainSingle();
+        matches[0].Name.Should().Be("QueueProcessor");
     }
 
     [Fact]
@@ -52,8 +51,8 @@ public class CompactFunctionSearchBuilderTests
         IRenderable renderable = builder.Build("missing", [], visibleRows: 3, rowOffset: 0, selectedIndex: 0);
 
         string output = Render(renderable);
-        Assert.Contains("Search functions", output);
-        Assert.Contains("No functions match \"missing\"", output);
+        output.Should().Contain("Search functions");
+        output.Should().Contain("No functions match \"missing\"");
     }
 
     private static FunctionInfo CreateFunction(string name, string triggerType, string? route)

--- a/test/Func.Tests/Hosting/Dashboard/Rendering/CompactInputControllerTests.cs
+++ b/test/Func.Tests/Hosting/Dashboard/Rendering/CompactInputControllerTests.cs
@@ -5,7 +5,6 @@ using Azure.Functions.Cli.Console.Theme;
 using Azure.Functions.Cli.Hosting.Dashboard;
 using Azure.Functions.Cli.Hosting.Dashboard.Rendering;
 using Microsoft.Extensions.Logging;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Hosting.Dashboard.Rendering;
 
@@ -25,9 +24,9 @@ public class CompactInputControllerTests
             logScrollStep: 3,
             maxLogScrollOffset: 200);
 
-        Assert.True(result.Handled);
-        Assert.True(state.HelpOpen);
-        Assert.False(state.FunctionBrowserOpen);
+        result.Handled.Should().BeTrue();
+        state.HelpOpen.Should().BeTrue();
+        state.FunctionBrowserOpen.Should().BeFalse();
     }
 
     [Fact]
@@ -49,9 +48,9 @@ public class CompactInputControllerTests
             logScrollStep: 3,
             maxLogScrollOffset: 200);
 
-        Assert.True(result.Handled);
-        Assert.False(state.FunctionSearchOpen);
-        Assert.Equal("QueueProcessor", state.ActiveFunctionFilter);
+        result.Handled.Should().BeTrue();
+        state.FunctionSearchOpen.Should().BeFalse();
+        state.ActiveFunctionFilter.Should().Be("QueueProcessor");
     }
 
     [Fact]
@@ -68,9 +67,9 @@ public class CompactInputControllerTests
             logScrollStep: 3,
             maxLogScrollOffset: 200);
 
-        Assert.True(result.Handled);
-        Assert.True(result.ClearLogsRequested);
-        Assert.Equal(0, state.LogScrollOffset);
+        result.Handled.Should().BeTrue();
+        result.ClearLogsRequested.Should().BeTrue();
+        state.LogScrollOffset.Should().Be(0);
     }
 
     [Fact]
@@ -87,8 +86,8 @@ public class CompactInputControllerTests
             logScrollStep: 3,
             maxLogScrollOffset: 200);
 
-        Assert.True(result.Handled);
-        Assert.Equal(LogLevel.Warning, state.MinimumLogLevel);
+        result.Handled.Should().BeTrue();
+        state.MinimumLogLevel.Should().Be(LogLevel.Warning);
     }
 
     [Fact]
@@ -113,9 +112,9 @@ public class CompactInputControllerTests
             logScrollStep: 3,
             maxLogScrollOffset: 200);
 
-        Assert.True(upResult.Handled);
-        Assert.True(downResult.Handled);
-        Assert.Equal(2, state.LogScrollOffset);
+        upResult.Handled.Should().BeTrue();
+        downResult.Handled.Should().BeTrue();
+        state.LogScrollOffset.Should().Be(2);
     }
 
     [Fact]
@@ -140,9 +139,9 @@ public class CompactInputControllerTests
             logScrollStep: 3,
             maxLogScrollOffset: 200);
 
-        Assert.True(pageUpResult.Handled);
-        Assert.True(pageDownResult.Handled);
-        Assert.Equal(2, state.LogScrollOffset);
+        pageUpResult.Handled.Should().BeTrue();
+        pageDownResult.Handled.Should().BeTrue();
+        state.LogScrollOffset.Should().Be(2);
     }
 
     private static CompactInputController CreateController()

--- a/test/Func.Tests/Hosting/Dashboard/Rendering/CompactLogComponentsTests.cs
+++ b/test/Func.Tests/Hosting/Dashboard/Rendering/CompactLogComponentsTests.cs
@@ -8,7 +8,6 @@ using Azure.Functions.Cli.Hosting.Events;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
 using Spectre.Console.Rendering;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Hosting.Dashboard.Rendering;
 
@@ -25,10 +24,10 @@ public class CompactLogComponentsTests
 
         CompactLogLine[] lines = buffer.Snapshot();
 
-        Assert.Equal(2, lines.Length);
-        Assert.Equal("Second", lines[0].FunctionName);
-        Assert.Equal("Third", lines[1].FunctionName);
-        Assert.True(lines[1].IsError);
+        lines.Length.Should().Be(2);
+        lines[0].FunctionName.Should().Be("Second");
+        lines[1].FunctionName.Should().Be("Third");
+        lines[1].IsError.Should().BeTrue();
     }
 
     [Fact]
@@ -49,10 +48,10 @@ public class CompactLogComponentsTests
 
         CompactLogLine line = formatter.Format(entry, [], listenUri: null)!;
 
-        Assert.Equal("HttpTrigger1", line.FunctionName);
-        Assert.False(line.IsError);
-        Assert.Equal(LogLevel.Warning, line.Level);
-        Assert.Contains("Queue depth is high", Render(line.Renderable));
+        line.FunctionName.Should().Be("HttpTrigger1");
+        line.IsError.Should().BeFalse();
+        line.Level.Should().Be(LogLevel.Warning);
+        Render(line.Renderable).Should().Contain("Queue depth is high");
     }
 
     [Fact]
@@ -73,7 +72,7 @@ public class CompactLogComponentsTests
 
         CompactLogLine line = formatter.Format(entry, [], listenUri: null)!;
 
-        Assert.True(line.RenderRows(width: 80).Count > 1);
+        (line.RenderRows(width: 80).Count > 1).Should().BeTrue();
     }
 
     [Fact]
@@ -102,12 +101,12 @@ public class CompactLogComponentsTests
 
         CompactLogLine line = formatter.Format(entry, events, listenUri: null)!;
 
-        Assert.Equal("HttpTrigger1", line.FunctionName);
-        Assert.True(line.IsError);
-        Assert.Equal(LogLevel.Error, line.Level);
+        line.FunctionName.Should().Be("HttpTrigger1");
+        line.IsError.Should().BeTrue();
+        line.Level.Should().Be(LogLevel.Error);
         string output = Render(line.Renderable);
-        Assert.Contains("InvalidOperationException", output);
-        Assert.Contains("Boom", output);
+        output.Should().Contain("InvalidOperationException");
+        output.Should().Contain("Boom");
     }
 
     [Fact]
@@ -134,13 +133,13 @@ public class CompactLogComponentsTests
         CompactLogLine line = formatter.Format(entry, [], listenUri: null)!;
 
         string output = RenderRows(line);
-        Assert.Null(line.FunctionName);
-        Assert.True(line.IsError);
-        Assert.Equal(LogLevel.Error, line.Level);
-        Assert.DoesNotContain("Grpc", output);
-        Assert.Contains("Language Worker Process exited.", output);
-        Assert.Contains("Microsoft.Azure.WebJobs.Script.Workers.WorkerProcessExitException", output);
-        Assert.Contains("A connection string was not found.", output);
+        line.FunctionName.Should().BeNull();
+        line.IsError.Should().BeTrue();
+        line.Level.Should().Be(LogLevel.Error);
+        output.Should().NotContain("Grpc");
+        output.Should().Contain("Language Worker Process exited.");
+        output.Should().Contain("Microsoft.Azure.WebJobs.Script.Workers.WorkerProcessExitException");
+        output.Should().Contain("A connection string was not found.");
     }
 
     [Fact]
@@ -161,8 +160,8 @@ public class CompactLogComponentsTests
 
         CompactLogLine? line = formatter.Format(entry, [], listenUri: null);
 
-        Assert.NotNull(line);
-        Assert.Contains("A connection string was not found.", RenderRows(line));
+        line.Should().NotBeNull();
+        RenderRows(line).Should().Contain("A connection string was not found.");
     }
 
     [Fact]
@@ -180,7 +179,7 @@ public class CompactLogComponentsTests
 
         CompactLogLine? line = formatter.Format(entry, [], listenUri: null);
 
-        Assert.Null(line);
+        line.Should().BeNull();
     }
 
     [Fact]
@@ -202,9 +201,9 @@ public class CompactLogComponentsTests
         CompactLogLine line = formatter.Format(entry, [], listenUri: null)!;
 
         string output = RenderRows(line);
-        Assert.Null(line.FunctionName);
-        Assert.Contains("Initialization", output);
-        Assert.Contains("Resolving host workload", output);
+        line.FunctionName.Should().BeNull();
+        output.Should().Contain("Initialization");
+        output.Should().Contain("Resolving host workload");
     }
 
     [Fact]
@@ -223,9 +222,9 @@ public class CompactLogComponentsTests
         CompactLogLine line = formatter.Format(entry, [], listenUri: null)!;
 
         string output = RenderRows(line);
-        Assert.Null(line.FunctionName);
-        Assert.DoesNotContain("Initialization", output);
-        Assert.Contains("Reading host configuration", output);
+        line.FunctionName.Should().BeNull();
+        output.Should().NotContain("Initialization");
+        output.Should().Contain("Reading host configuration");
     }
 
     private static string Render(IRenderable renderable)

--- a/test/Func.Tests/Hosting/Dashboard/Rendering/CompactRendererFunctionBrowserTests.cs
+++ b/test/Func.Tests/Hosting/Dashboard/Rendering/CompactRendererFunctionBrowserTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Reflection;
-using Azure.Functions.Cli;
 using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Console.Theme;
 using Azure.Functions.Cli.Hosting.Dashboard;
@@ -12,7 +11,6 @@ using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Spectre.Console;
 using Spectre.Console.Rendering;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Hosting.Dashboard.Rendering;
 
@@ -28,10 +26,10 @@ public class CompactRendererFunctionBrowserTests
         Render(console, writer, InvokePrivate<IRenderable>(renderer, "BuildHeader", snapshot));
 
         string output = writer.ToString();
-        Assert.Contains("⚡ Azure Functions CLI", output);
-        Assert.Contains("Host: 4.834.0", output);
-        Assert.Contains("Profile: flex", output);
-        Assert.Contains("Stack: .NET", output);
+        output.Should().Contain("⚡ Azure Functions CLI");
+        output.Should().Contain("Host: 4.834.0");
+        output.Should().Contain("Profile: flex");
+        output.Should().Contain("Stack: .NET");
     }
 
     [Fact]
@@ -43,12 +41,12 @@ public class CompactRendererFunctionBrowserTests
         Render(console, writer, InvokePrivate<IRenderable>(renderer, "BuildFooter", snapshot, null));
 
         string output = writer.ToString();
-        Assert.Contains("12 functions", output);
-        Assert.Contains("↑/↓, PgUp/PgDn logs", output);
-        Assert.DoesNotContain("Fn+↑/↓", output);
-        Assert.DoesNotContain("Ctrl+U/D", output);
-        Assert.Contains("L:info", output);
-        Assert.Contains("q/Ctrl+C", output);
+        output.Should().Contain("12 functions");
+        output.Should().Contain("↑/↓, PgUp/PgDn logs");
+        output.Should().NotContain("Fn+↑/↓");
+        output.Should().NotContain("Ctrl+U/D");
+        output.Should().Contain("L:info");
+        output.Should().Contain("q/Ctrl+C");
     }
 
     [Fact]
@@ -61,7 +59,7 @@ public class CompactRendererFunctionBrowserTests
         Render(console, writer, InvokePrivate<IRenderable>(renderer, "BuildFooter", snapshot, null));
 
         string output = writer.ToString();
-        Assert.Contains("?/Esc close", output);
+        output.Should().Contain("?/Esc close");
     }
 
     [Fact]
@@ -74,26 +72,26 @@ public class CompactRendererFunctionBrowserTests
         Render(console, writer, InvokePrivate<IRenderable>(renderer, "BuildHeader", snapshot));
 
         string output = writer.ToString();
-        Assert.Contains("Help", output);
-        Assert.Contains("Available compact-mode controls", output);
-        Assert.Contains("Toggle this help panel", output);
-        Assert.Contains("Search functions by name", output);
-        Assert.Contains("Scroll logs line by line", output);
-        Assert.Contains("Clear visible log output", output);
-        Assert.Contains("Cycle the active function filter", output);
-        Assert.Contains("Toggle errors-only log view", output);
-        Assert.Contains("Set visible log level", output);
-        Assert.Contains("Scroll logs", output);
-        Assert.Contains("PgUp/PgDn", output);
-        Assert.DoesNotContain("Fn+↑/↓", output);
-        Assert.DoesNotContain("Ctrl+U/D", output);
-        Assert.DoesNotContain("Open the configured log file", output);
-        Assert.DoesNotContain("Coming soon", output);
-        Assert.DoesNotContain("c clear logs", output);
-        Assert.DoesNotContain("e errors only", output);
-        Assert.DoesNotContain("1/2/3 log level", output);
-        Assert.DoesNotContain("q quit", output);
-        Assert.DoesNotContain("/ search", output);
+        output.Should().Contain("Help");
+        output.Should().Contain("Available compact-mode controls");
+        output.Should().Contain("Toggle this help panel");
+        output.Should().Contain("Search functions by name");
+        output.Should().Contain("Scroll logs line by line");
+        output.Should().Contain("Clear visible log output");
+        output.Should().Contain("Cycle the active function filter");
+        output.Should().Contain("Toggle errors-only log view");
+        output.Should().Contain("Set visible log level");
+        output.Should().Contain("Scroll logs");
+        output.Should().Contain("PgUp/PgDn");
+        output.Should().NotContain("Fn+↑/↓");
+        output.Should().NotContain("Ctrl+U/D");
+        output.Should().NotContain("Open the configured log file");
+        output.Should().NotContain("Coming soon");
+        output.Should().NotContain("c clear logs");
+        output.Should().NotContain("e errors only");
+        output.Should().NotContain("1/2/3 log level");
+        output.Should().NotContain("q quit");
+        output.Should().NotContain("/ search");
     }
 
     [Fact]
@@ -106,8 +104,8 @@ public class CompactRendererFunctionBrowserTests
         Render(console, writer, InvokePrivate<IRenderable>(renderer, "BuildLayout"));
 
         string output = writer.ToString();
-        Assert.Contains("Help", output);
-        Assert.True(CountRenderedLines(output) <= console.Profile.Height);
+        output.Should().Contain("Help");
+        (CountRenderedLines(output) <= console.Profile.Height).Should().BeTrue();
     }
 
     [Fact]
@@ -121,10 +119,10 @@ public class CompactRendererFunctionBrowserTests
         Render(console, writer, InvokePrivate<IRenderable>(renderer, "BuildHeader", snapshot));
 
         string output = writer.ToString();
-        Assert.Contains("Search functions", output);
-        Assert.Contains("extra2", output);
-        Assert.Contains("HttpExtra2", output);
-        Assert.DoesNotContain("HttpExtra1 ", output);
+        output.Should().Contain("Search functions");
+        output.Should().Contain("extra2");
+        output.Should().Contain("HttpExtra2");
+        output.Should().NotContain("HttpExtra1 ");
     }
 
     [Fact]
@@ -138,8 +136,8 @@ public class CompactRendererFunctionBrowserTests
         Render(console, writer, InvokePrivate<IRenderable>(renderer, "BuildLayout"));
 
         string output = writer.ToString();
-        Assert.Contains("Search functions", output);
-        Assert.True(CountRenderedLines(output) <= console.Profile.Height);
+        output.Should().Contain("Search functions");
+        (CountRenderedLines(output) <= console.Profile.Height).Should().BeTrue();
     }
 
     [Fact]
@@ -152,11 +150,11 @@ public class CompactRendererFunctionBrowserTests
         Render(console, writer, InvokePrivate<IRenderable>(renderer, "BuildHeader", snapshot));
 
         string output = writer.ToString();
-        Assert.Contains("Functions (12)", output);
-        Assert.Contains("HttpExtra1", output);
-        Assert.Contains("HttpExtra7", output);
-        Assert.Contains("Up/Down navigate", output);
-        Assert.Contains("Enter filter", output);
+        output.Should().Contain("Functions (12)");
+        output.Should().Contain("HttpExtra1");
+        output.Should().Contain("HttpExtra7");
+        output.Should().Contain("Up/Down navigate");
+        output.Should().Contain("Enter filter");
     }
 
     [Fact]
@@ -168,15 +166,15 @@ public class CompactRendererFunctionBrowserTests
         Render(console, writer, InvokePrivate<IRenderable>(renderer, "BuildHeader", snapshot));
 
         string output = writer.ToString();
-        Assert.Contains("HttpExtra3", output);
-        Assert.Contains("◉ Active", output);
-        Assert.Contains("HttpExtra2", output);
-        Assert.Contains("✗ Error", output);
-        Assert.Contains("HttpExtra1", output);
-        Assert.Contains("+7 more", output);
-        Assert.Contains("press t to view all", output);
-        Assert.True(output.IndexOf("HttpExtra3", StringComparison.Ordinal) < output.IndexOf("HttpExtra2", StringComparison.Ordinal));
-        Assert.True(output.IndexOf("HttpExtra2", StringComparison.Ordinal) < output.IndexOf("HttpExtra1", StringComparison.Ordinal));
+        output.Should().Contain("HttpExtra3");
+        output.Should().Contain("◉ Active");
+        output.Should().Contain("HttpExtra2");
+        output.Should().Contain("✗ Error");
+        output.Should().Contain("HttpExtra1");
+        output.Should().Contain("+7 more");
+        output.Should().Contain("press t to view all");
+        (output.IndexOf("HttpExtra3", StringComparison.Ordinal) < output.IndexOf("HttpExtra2", StringComparison.Ordinal)).Should().BeTrue();
+        (output.IndexOf("HttpExtra2", StringComparison.Ordinal) < output.IndexOf("HttpExtra1", StringComparison.Ordinal)).Should().BeTrue();
     }
 
     [Fact]
@@ -188,9 +186,9 @@ public class CompactRendererFunctionBrowserTests
         Render(console, writer, InvokePrivate<IRenderable>(renderer, "BuildHeader", snapshot));
 
         string output = writer.ToString();
-        Assert.Contains("20 functions", output);
-        Assert.Contains("ready", output);
-        Assert.DoesNotContain("press t to view all", output);
+        output.Should().Contain("20 functions");
+        output.Should().Contain("ready");
+        output.Should().NotContain("press t to view all");
     }
 
     [Fact]
@@ -200,14 +198,14 @@ public class CompactRendererFunctionBrowserTests
         var state = BuildState(functionCount: 12);
         SetPrivate(renderer, "_state", state);
 
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('t', ConsoleKey.T)));
-        Assert.True((bool)GetPrivate(renderer, "_functionBrowserOpen")!);
+        InvokePrivate<bool>(renderer, "HandleKey", Key('t', ConsoleKey.T)).Should().BeTrue();
+        ((bool)GetPrivate(renderer, "_functionBrowserOpen")!).Should().BeTrue();
 
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('\0', ConsoleKey.DownArrow)));
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('\r', ConsoleKey.Enter)));
+        InvokePrivate<bool>(renderer, "HandleKey", Key('\0', ConsoleKey.DownArrow)).Should().BeTrue();
+        InvokePrivate<bool>(renderer, "HandleKey", Key('\r', ConsoleKey.Enter)).Should().BeTrue();
 
-        Assert.False((bool)GetPrivate(renderer, "_functionBrowserOpen")!);
-        Assert.Equal("HttpExtra2", GetPrivate(renderer, "_activeFunctionFilter"));
+        ((bool)GetPrivate(renderer, "_functionBrowserOpen")!).Should().BeFalse();
+        GetPrivate(renderer, "_activeFunctionFilter").Should().Be("HttpExtra2");
     }
 
     [Fact]
@@ -217,14 +215,14 @@ public class CompactRendererFunctionBrowserTests
         SetPrivate(renderer, "_state", BuildState(functionCount: 12));
         SetPrivate(renderer, "_functionBrowserOpen", true);
 
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('?', ConsoleKey.Oem2)));
+        InvokePrivate<bool>(renderer, "HandleKey", Key('?', ConsoleKey.Oem2)).Should().BeTrue();
 
-        Assert.True((bool)GetPrivate(renderer, "_helpOpen")!);
-        Assert.False((bool)GetPrivate(renderer, "_functionBrowserOpen")!);
+        ((bool)GetPrivate(renderer, "_helpOpen")!).Should().BeTrue();
+        ((bool)GetPrivate(renderer, "_functionBrowserOpen")!).Should().BeFalse();
 
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('?', ConsoleKey.Oem2)));
+        InvokePrivate<bool>(renderer, "HandleKey", Key('?', ConsoleKey.Oem2)).Should().BeTrue();
 
-        Assert.False((bool)GetPrivate(renderer, "_helpOpen")!);
+        ((bool)GetPrivate(renderer, "_helpOpen")!).Should().BeFalse();
     }
 
     [Fact]
@@ -234,9 +232,9 @@ public class CompactRendererFunctionBrowserTests
         SetPrivate(renderer, "_state", BuildState(functionCount: 12));
         SetPrivate(renderer, "_helpOpen", true);
 
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('\u001b', ConsoleKey.Escape)));
+        InvokePrivate<bool>(renderer, "HandleKey", Key('\u001b', ConsoleKey.Escape)).Should().BeTrue();
 
-        Assert.False((bool)GetPrivate(renderer, "_helpOpen")!);
+        ((bool)GetPrivate(renderer, "_helpOpen")!).Should().BeFalse();
     }
 
     [Fact]
@@ -246,9 +244,9 @@ public class CompactRendererFunctionBrowserTests
         SetPrivate(renderer, "_state", BuildState(functionCount: 12));
         SetPrivate(renderer, "_activeFunctionFilter", "HttpExtra1");
 
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('a', ConsoleKey.A)));
+        InvokePrivate<bool>(renderer, "HandleKey", Key('a', ConsoleKey.A)).Should().BeTrue();
 
-        Assert.Null(GetPrivate(renderer, "_activeFunctionFilter"));
+        GetPrivate(renderer, "_activeFunctionFilter").Should().BeNull();
     }
 
     [Fact]
@@ -271,12 +269,12 @@ public class CompactRendererFunctionBrowserTests
         Render(console, writer, InvokePrivate<IRenderable>(renderer, "BuildLayout"));
 
         string output = writer.ToString();
-        Assert.Equal("HttpTrigger1", GetPrivate(renderer, "_activeFunctionFilter"));
-        Assert.Contains("Filter HttpTrigger1", output);
-        Assert.Contains("selected before recycle", output);
-        Assert.Contains("selected after recycle", output);
-        Assert.DoesNotContain("other before recycle", output);
-        Assert.DoesNotContain("other after recycle", output);
+        GetPrivate(renderer, "_activeFunctionFilter").Should().Be("HttpTrigger1");
+        output.Should().Contain("Filter HttpTrigger1");
+        output.Should().Contain("selected before recycle");
+        output.Should().Contain("selected after recycle");
+        output.Should().NotContain("other before recycle");
+        output.Should().NotContain("other after recycle");
     }
 
     [Fact]
@@ -288,14 +286,14 @@ public class CompactRendererFunctionBrowserTests
 
         Render(console, writer, InvokePrivate<IRenderable>(renderer, "BuildLayout"));
 
-        Assert.Contains("first compact log", writer.ToString());
+        writer.ToString().Should().Contain("first compact log");
 
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('c', ConsoleKey.C)));
+        InvokePrivate<bool>(renderer, "HandleKey", Key('c', ConsoleKey.C)).Should().BeTrue();
         Render(console, writer, InvokePrivate<IRenderable>(renderer, "BuildLayout"));
 
         string output = writer.ToString();
-        Assert.DoesNotContain("first compact log", output);
-        Assert.Contains("Waiting for events", output);
+        output.Should().NotContain("first compact log");
+        output.Should().Contain("Waiting for events");
     }
 
     [Fact]
@@ -309,24 +307,24 @@ public class CompactRendererFunctionBrowserTests
         Render(console, writer, InvokePrivate<IRenderable>(renderer, "BuildLayout"));
 
         string output = writer.ToString();
-        Assert.Contains("info compact log", output);
-        Assert.Contains("error compact log", output);
+        output.Should().Contain("info compact log");
+        output.Should().Contain("error compact log");
 
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('e', ConsoleKey.E)));
+        InvokePrivate<bool>(renderer, "HandleKey", Key('e', ConsoleKey.E)).Should().BeTrue();
         Render(console, writer, InvokePrivate<IRenderable>(renderer, "BuildLayout"));
 
         output = writer.ToString();
-        Assert.DoesNotContain("info compact log", output);
-        Assert.Contains("error compact log", output);
-        Assert.Contains("Errors only", output);
+        output.Should().NotContain("info compact log");
+        output.Should().Contain("error compact log");
+        output.Should().Contain("Errors only");
 
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('e', ConsoleKey.E)));
+        InvokePrivate<bool>(renderer, "HandleKey", Key('e', ConsoleKey.E)).Should().BeTrue();
         Render(console, writer, InvokePrivate<IRenderable>(renderer, "BuildLayout"));
 
         output = writer.ToString();
-        Assert.Contains("info compact log", output);
-        Assert.Contains("error compact log", output);
-        Assert.DoesNotContain("Errors only", output);
+        output.Should().Contain("info compact log");
+        output.Should().Contain("error compact log");
+        output.Should().NotContain("Errors only");
     }
 
     [Fact]
@@ -335,17 +333,17 @@ public class CompactRendererFunctionBrowserTests
         (CompactRenderer renderer, _, _) = NewRenderer();
         SetPrivate(renderer, "_state", BuildState(functionCount: 3));
 
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('f', ConsoleKey.F)));
-        Assert.Equal("HttpExtra1", GetPrivate(renderer, "_activeFunctionFilter"));
+        InvokePrivate<bool>(renderer, "HandleKey", Key('f', ConsoleKey.F)).Should().BeTrue();
+        GetPrivate(renderer, "_activeFunctionFilter").Should().Be("HttpExtra1");
 
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('f', ConsoleKey.F)));
-        Assert.Equal("HttpExtra2", GetPrivate(renderer, "_activeFunctionFilter"));
+        InvokePrivate<bool>(renderer, "HandleKey", Key('f', ConsoleKey.F)).Should().BeTrue();
+        GetPrivate(renderer, "_activeFunctionFilter").Should().Be("HttpExtra2");
 
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('f', ConsoleKey.F)));
-        Assert.Equal("HttpTrigger1", GetPrivate(renderer, "_activeFunctionFilter"));
+        InvokePrivate<bool>(renderer, "HandleKey", Key('f', ConsoleKey.F)).Should().BeTrue();
+        GetPrivate(renderer, "_activeFunctionFilter").Should().Be("HttpTrigger1");
 
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('f', ConsoleKey.F)));
-        Assert.Null(GetPrivate(renderer, "_activeFunctionFilter"));
+        InvokePrivate<bool>(renderer, "HandleKey", Key('f', ConsoleKey.F)).Should().BeTrue();
+        GetPrivate(renderer, "_activeFunctionFilter").Should().BeNull();
     }
 
     [Fact]
@@ -357,32 +355,32 @@ public class CompactRendererFunctionBrowserTests
         await renderer.OnEventAsync(Log("HttpTrigger1", "warning compact log", LogLevel.Warning), [], CancellationToken.None);
         await renderer.OnEventAsync(Log("HttpTrigger1", "error compact log", LogLevel.Error), [], CancellationToken.None);
 
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('2', ConsoleKey.D2)));
+        InvokePrivate<bool>(renderer, "HandleKey", Key('2', ConsoleKey.D2)).Should().BeTrue();
         Render(console, writer, InvokePrivate<IRenderable>(renderer, "BuildLayout"));
 
         string output = writer.ToString();
-        Assert.DoesNotContain("info compact log", output);
-        Assert.Contains("warning compact log", output);
-        Assert.Contains("error compact log", output);
-        Assert.Contains("L:warn", output);
+        output.Should().NotContain("info compact log");
+        output.Should().Contain("warning compact log");
+        output.Should().Contain("error compact log");
+        output.Should().Contain("L:warn");
 
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('3', ConsoleKey.D3)));
+        InvokePrivate<bool>(renderer, "HandleKey", Key('3', ConsoleKey.D3)).Should().BeTrue();
         Render(console, writer, InvokePrivate<IRenderable>(renderer, "BuildLayout"));
 
         output = writer.ToString();
-        Assert.DoesNotContain("info compact log", output);
-        Assert.DoesNotContain("warning compact log", output);
-        Assert.Contains("error compact log", output);
-        Assert.Contains("L:error", output);
+        output.Should().NotContain("info compact log");
+        output.Should().NotContain("warning compact log");
+        output.Should().Contain("error compact log");
+        output.Should().Contain("L:error");
 
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('1', ConsoleKey.D1)));
+        InvokePrivate<bool>(renderer, "HandleKey", Key('1', ConsoleKey.D1)).Should().BeTrue();
         Render(console, writer, InvokePrivate<IRenderable>(renderer, "BuildLayout"));
 
         output = writer.ToString();
-        Assert.Contains("info compact log", output);
-        Assert.Contains("warning compact log", output);
-        Assert.Contains("error compact log", output);
-        Assert.Contains("L:info", output);
+        output.Should().Contain("info compact log");
+        output.Should().Contain("warning compact log");
+        output.Should().Contain("error compact log");
+        output.Should().Contain("L:info");
     }
 
     [Fact]
@@ -393,9 +391,9 @@ public class CompactRendererFunctionBrowserTests
         bool requested = false;
         renderer.ShutdownRequested += () => requested = true;
 
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('q', ConsoleKey.Q)));
+        InvokePrivate<bool>(renderer, "HandleKey", Key('q', ConsoleKey.Q)).Should().BeTrue();
 
-        Assert.True(requested);
+        requested.Should().BeTrue();
     }
 
     [Fact]
@@ -404,7 +402,7 @@ public class CompactRendererFunctionBrowserTests
         (CompactRenderer renderer, _, _) = NewRenderer();
         SetPrivate(renderer, "_state", BuildState(functionCount: 3));
 
-        Assert.False(InvokePrivate<bool>(renderer, "HandleKey", Key('l', ConsoleKey.L)));
+        InvokePrivate<bool>(renderer, "HandleKey", Key('l', ConsoleKey.L)).Should().BeFalse();
     }
 
     [Fact]
@@ -420,33 +418,33 @@ public class CompactRendererFunctionBrowserTests
         Render(console, writer, InvokePrivate<IRenderable>(renderer, "BuildLayout"));
 
         string output = writer.ToString();
-        Assert.DoesNotContain("compact log 01", output);
-        Assert.Contains("compact log 20", output);
+        output.Should().NotContain("compact log 01");
+        output.Should().Contain("compact log 20");
 
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('\0', ConsoleKey.PageUp)));
+        InvokePrivate<bool>(renderer, "HandleKey", Key('\0', ConsoleKey.PageUp)).Should().BeTrue();
         Render(console, writer, InvokePrivate<IRenderable>(renderer, "BuildLayout"));
 
         output = writer.ToString();
-        Assert.Contains("compact log 01", output);
-        Assert.DoesNotContain("compact log 20", output);
-        Assert.Contains("Scrollback", output);
+        output.Should().Contain("compact log 01");
+        output.Should().NotContain("compact log 20");
+        output.Should().Contain("Scrollback");
 
         await renderer.OnEventAsync(Log("HttpTrigger1", "compact log 21"), [], CancellationToken.None);
         Render(console, writer, InvokePrivate<IRenderable>(renderer, "BuildLayout"));
 
         output = writer.ToString();
-        Assert.Contains("compact log 01", output);
-        Assert.DoesNotContain("compact log 21", output);
+        output.Should().Contain("compact log 01");
+        output.Should().NotContain("compact log 21");
 
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('\0', ConsoleKey.End)));
+        InvokePrivate<bool>(renderer, "HandleKey", Key('\0', ConsoleKey.End)).Should().BeTrue();
         Render(console, writer, InvokePrivate<IRenderable>(renderer, "BuildLayout"));
 
         output = writer.ToString();
-        Assert.DoesNotContain("compact log 01", output);
-        Assert.Contains("compact log 21", output);
+        output.Should().NotContain("compact log 01");
+        output.Should().Contain("compact log 21");
 
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('\0', ConsoleKey.PageUp)));
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('\0', ConsoleKey.PageDown)));
+        InvokePrivate<bool>(renderer, "HandleKey", Key('\0', ConsoleKey.PageUp)).Should().BeTrue();
+        InvokePrivate<bool>(renderer, "HandleKey", Key('\0', ConsoleKey.PageDown)).Should().BeTrue();
     }
 
     [Fact]
@@ -460,8 +458,8 @@ public class CompactRendererFunctionBrowserTests
         Render(console, writer, InvokePrivate<IRenderable>(renderer, "BuildLayout"));
 
         string output = writer.ToString();
-        Assert.Contains("Function", output);
-        Assert.True(CountRenderedLines(output) <= console.Profile.Height);
+        output.Should().Contain("Function");
+        (CountRenderedLines(output) <= console.Profile.Height).Should().BeTrue();
     }
 
     [Fact]
@@ -470,16 +468,16 @@ public class CompactRendererFunctionBrowserTests
         (CompactRenderer renderer, _, _) = NewRenderer();
         SetPrivate(renderer, "_state", BuildState(functionCount: 12));
 
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('/', ConsoleKey.Oem2)));
+        InvokePrivate<bool>(renderer, "HandleKey", Key('/', ConsoleKey.Oem2)).Should().BeTrue();
         foreach (char c in "extra2")
         {
-            Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key(c, CharToConsoleKey(c))));
+            InvokePrivate<bool>(renderer, "HandleKey", Key(c, CharToConsoleKey(c))).Should().BeTrue();
         }
 
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('\r', ConsoleKey.Enter)));
+        InvokePrivate<bool>(renderer, "HandleKey", Key('\r', ConsoleKey.Enter)).Should().BeTrue();
 
-        Assert.False((bool)GetPrivate(renderer, "_functionSearchOpen")!);
-        Assert.Equal("HttpExtra2", GetPrivate(renderer, "_activeFunctionFilter"));
+        ((bool)GetPrivate(renderer, "_functionSearchOpen")!).Should().BeFalse();
+        GetPrivate(renderer, "_activeFunctionFilter").Should().Be("HttpExtra2");
     }
 
     [Fact]
@@ -488,16 +486,16 @@ public class CompactRendererFunctionBrowserTests
         (CompactRenderer renderer, _, _) = NewRenderer();
         SetPrivate(renderer, "_state", BuildState(functionCount: 12));
 
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('/', ConsoleKey.Oem2)));
+        InvokePrivate<bool>(renderer, "HandleKey", Key('/', ConsoleKey.Oem2)).Should().BeTrue();
         foreach (char c in "extra")
         {
-            Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key(c, CharToConsoleKey(c))));
+            InvokePrivate<bool>(renderer, "HandleKey", Key(c, CharToConsoleKey(c))).Should().BeTrue();
         }
 
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('\0', ConsoleKey.DownArrow)));
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('\r', ConsoleKey.Enter)));
+        InvokePrivate<bool>(renderer, "HandleKey", Key('\0', ConsoleKey.DownArrow)).Should().BeTrue();
+        InvokePrivate<bool>(renderer, "HandleKey", Key('\r', ConsoleKey.Enter)).Should().BeTrue();
 
-        Assert.Equal("HttpExtra2", GetPrivate(renderer, "_activeFunctionFilter"));
+        GetPrivate(renderer, "_activeFunctionFilter").Should().Be("HttpExtra2");
     }
 
     [Fact]
@@ -507,12 +505,12 @@ public class CompactRendererFunctionBrowserTests
         SetPrivate(renderer, "_state", BuildState(functionCount: 12));
         SetPrivate(renderer, "_activeFunctionFilter", "HttpTrigger1");
 
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('/', ConsoleKey.Oem2)));
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('x', ConsoleKey.X)));
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('\u001b', ConsoleKey.Escape)));
+        InvokePrivate<bool>(renderer, "HandleKey", Key('/', ConsoleKey.Oem2)).Should().BeTrue();
+        InvokePrivate<bool>(renderer, "HandleKey", Key('x', ConsoleKey.X)).Should().BeTrue();
+        InvokePrivate<bool>(renderer, "HandleKey", Key('\u001b', ConsoleKey.Escape)).Should().BeTrue();
 
-        Assert.False((bool)GetPrivate(renderer, "_functionSearchOpen")!);
-        Assert.Equal("HttpTrigger1", GetPrivate(renderer, "_activeFunctionFilter"));
+        ((bool)GetPrivate(renderer, "_functionSearchOpen")!).Should().BeFalse();
+        GetPrivate(renderer, "_activeFunctionFilter").Should().Be("HttpTrigger1");
     }
 
     [Fact]
@@ -521,16 +519,16 @@ public class CompactRendererFunctionBrowserTests
         (CompactRenderer renderer, _, _) = NewRenderer();
         SetPrivate(renderer, "_state", BuildState(functionCount: 12));
 
-        Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key('/', ConsoleKey.Oem2)));
+        InvokePrivate<bool>(renderer, "HandleKey", Key('/', ConsoleKey.Oem2)).Should().BeTrue();
         foreach (char c in "zzz")
         {
-            Assert.True(InvokePrivate<bool>(renderer, "HandleKey", Key(c, CharToConsoleKey(c))));
+            InvokePrivate<bool>(renderer, "HandleKey", Key(c, CharToConsoleKey(c))).Should().BeTrue();
         }
 
-        Assert.False(InvokePrivate<bool>(renderer, "HandleKey", Key('\r', ConsoleKey.Enter)));
+        InvokePrivate<bool>(renderer, "HandleKey", Key('\r', ConsoleKey.Enter)).Should().BeFalse();
 
-        Assert.True((bool)GetPrivate(renderer, "_functionSearchOpen")!);
-        Assert.Null(GetPrivate(renderer, "_activeFunctionFilter"));
+        ((bool)GetPrivate(renderer, "_functionSearchOpen")!).Should().BeTrue();
+        GetPrivate(renderer, "_activeFunctionFilter").Should().BeNull();
     }
 
     [Fact]
@@ -542,9 +540,9 @@ public class CompactRendererFunctionBrowserTests
         Render(console, writer, InvokePrivate<IRenderable>(renderer, "BuildFooter", snapshot, null));
 
         string output = writer.ToString();
-        Assert.Contains("↑/↓, Fn+↑/↓ logs", output);
-        Assert.DoesNotContain("PgUp/PgDn", output);
-        Assert.DoesNotContain("Ctrl+U/D", output);
+        output.Should().Contain("↑/↓, Fn+↑/↓ logs");
+        output.Should().NotContain("PgUp/PgDn");
+        output.Should().NotContain("Ctrl+U/D");
     }
 
     [Fact]
@@ -557,9 +555,9 @@ public class CompactRendererFunctionBrowserTests
         Render(console, writer, InvokePrivate<IRenderable>(renderer, "BuildHeader", snapshot));
 
         string output = writer.ToString();
-        Assert.Contains("Fn+↑/↓", output);
-        Assert.DoesNotContain("PgUp/PgDn", output);
-        Assert.DoesNotContain("Ctrl+U/D", output);
+        output.Should().Contain("Fn+↑/↓");
+        output.Should().NotContain("PgUp/PgDn");
+        output.Should().NotContain("Ctrl+U/D");
     }
 
     [Fact]
@@ -573,9 +571,9 @@ public class CompactRendererFunctionBrowserTests
         string output = writer.ToString();
         int enterIndex = output.IndexOf("\u001b[?1049h\u001b[H", StringComparison.Ordinal);
         int exitIndex = output.IndexOf("\u001b[?1049l", StringComparison.Ordinal);
-        Assert.NotEqual(-1, enterIndex);
-        Assert.NotEqual(-1, exitIndex);
-        Assert.True(enterIndex < exitIndex);
+        enterIndex.Should().NotBe(-1);
+        exitIndex.Should().NotBe(-1);
+        (enterIndex < exitIndex).Should().BeTrue();
     }
 
     [Fact]
@@ -587,8 +585,8 @@ public class CompactRendererFunctionBrowserTests
         await renderer.OnSummaryAsync(CreateSummary(), CancellationToken.None);
 
         string output = writer.ToString();
-        Assert.DoesNotContain("\u001b[?1049h", output);
-        Assert.DoesNotContain("\u001b[?1049l", output);
+        output.Should().NotContain("\u001b[?1049h");
+        output.Should().NotContain("\u001b[?1049l");
     }
 
     [Fact]
@@ -600,8 +598,8 @@ public class CompactRendererFunctionBrowserTests
         await renderer.OnSummaryAsync(CreateSummary(), CancellationToken.None);
 
         string output = writer.ToString();
-        Assert.DoesNotContain("\u001b[?1049h", output);
-        Assert.DoesNotContain("\u001b[?1049l", output);
+        output.Should().NotContain("\u001b[?1049h");
+        output.Should().NotContain("\u001b[?1049l");
     }
 
     private static (CompactRenderer Renderer, IAnsiConsole Console, StringWriter Writer) NewRenderer(

--- a/test/Func.Tests/Hosting/Dashboard/Rendering/HttpRouteFormatterTests.cs
+++ b/test/Func.Tests/Hosting/Dashboard/Rendering/HttpRouteFormatterTests.cs
@@ -1,15 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.IO;
-using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Console.Theme;
 using Azure.Functions.Cli.Hosting.Dashboard;
 using Azure.Functions.Cli.Hosting.Dashboard.Rendering;
 using NSubstitute;
-using NSubstitute.Extensions;
 using Spectre.Console;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Hosting.Dashboard.Rendering;
 
@@ -30,7 +26,7 @@ public class HttpRouteFormatterTests
         string result = HttpRouteFormatter.FormatRouteMarkup(fn, "http://localhost:7071", _theme);
 
         const string url = "http://localhost:7071/api/hello";
-        Assert.Equal($"GET,POST [underline blue link={url}]{url}[/]", result);
+        result.Should().Be($"GET,POST [underline blue link={url}]{url}[/]");
     }
 
     [Fact]
@@ -40,7 +36,7 @@ public class HttpRouteFormatterTests
 
         string result = HttpRouteFormatter.FormatRouteMarkup(fn, "http://localhost:7071/", _theme);
 
-        Assert.Contains("[underline blue link=http://localhost:7071/api/orders]", result);
+        result.Should().Contain("[underline blue link=http://localhost:7071/api/orders]");
     }
 
     [Fact]
@@ -50,8 +46,8 @@ public class HttpRouteFormatterTests
 
         string result = HttpRouteFormatter.FormatRouteMarkup(fn, listenUri: null, _theme);
 
-        Assert.Equal("GET /api/hello", result);
-        Assert.DoesNotContain("[link=", result);
+        result.Should().Be("GET /api/hello");
+        result.Should().NotContain("[link=");
     }
 
     [Fact]
@@ -61,8 +57,8 @@ public class HttpRouteFormatterTests
 
         string result = HttpRouteFormatter.FormatRouteMarkup(fn, "http://localhost:7071", _theme);
 
-        Assert.Equal("my-queue", result);
-        Assert.DoesNotContain("[link=", result);
+        result.Should().Be("my-queue");
+        result.Should().NotContain("[link=");
     }
 
     [Fact]
@@ -72,8 +68,8 @@ public class HttpRouteFormatterTests
 
         string result = HttpRouteFormatter.FormatRouteMarkup(fn, "http://localhost:7071", _theme);
 
-        Assert.Equal("GET —", result);
-        Assert.DoesNotContain("[link=", result);
+        result.Should().Be("GET —");
+        result.Should().NotContain("[link=");
     }
 
     [Fact]
@@ -105,9 +101,9 @@ public class HttpRouteFormatterTests
         console.Markup(markup);
         string output = writer.ToString();
 
-        Assert.Contains("\u001b]8;", output);
-        Assert.Contains("http://localhost:7071/api/hello", output);
-        Assert.Contains("\u001b]8;;\u001b\\", output);
+        output.Should().Contain("\u001b]8;");
+        output.Should().Contain("http://localhost:7071/api/hello");
+        output.Should().Contain("\u001b]8;;\u001b\\");
     }
 
     private static FunctionInfo MakeFunction(string triggerType, string? route, IReadOnlyList<string> methods)

--- a/test/Func.Tests/Hosting/Dashboard/Rendering/JsonRendererTests.cs
+++ b/test/Func.Tests/Hosting/Dashboard/Rendering/JsonRendererTests.cs
@@ -7,7 +7,6 @@ using Azure.Functions.Cli.Hosting.Dashboard;
 using Azure.Functions.Cli.Hosting.Dashboard.Rendering;
 using Azure.Functions.Cli.Hosting.Events;
 using Microsoft.Extensions.Logging;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Hosting.Dashboard.Rendering;
 
@@ -33,13 +32,13 @@ public class JsonRendererTests
         await renderer.DisposeAsync();
 
         IReadOnlyList<JsonDocument> records = ReadAll(stream);
-        Assert.NotEmpty(records);
+        records.Should().NotBeEmpty();
 
         foreach (var doc in records)
         {
-            Assert.Equal(1, doc.RootElement.GetProperty("schema_version").GetInt32());
-            Assert.False(string.IsNullOrEmpty(doc.RootElement.GetProperty("kind").GetString()));
-            Assert.False(string.IsNullOrEmpty(doc.RootElement.GetProperty("timestamp").GetString()));
+            doc.RootElement.GetProperty("schema_version").GetInt32().Should().Be(1);
+            string.IsNullOrEmpty(doc.RootElement.GetProperty("kind").GetString()).Should().BeFalse();
+            string.IsNullOrEmpty(doc.RootElement.GetProperty("timestamp").GetString()).Should().BeFalse();
         }
     }
 
@@ -62,7 +61,7 @@ public class JsonRendererTests
         await renderer.DisposeAsync();
 
         IReadOnlyList<JsonDocument> records = ReadAll(stream);
-        Assert.Equal("summary", records[^1].RootElement.GetProperty("kind").GetString());
+        records[^1].RootElement.GetProperty("kind").GetString().Should().Be("summary");
     }
 
     [Fact]
@@ -84,9 +83,9 @@ public class JsonRendererTests
         await renderer.DisposeAsync();
 
         IReadOnlyList<JsonDocument> records = ReadAll(stream);
-        Assert.True(records.Count >= 3, $"Expected at least 3 records, got {records.Count}");
-        Assert.Equal("log", records[0].RootElement.GetProperty("kind").GetString());
-        Assert.Equal("host_state_changed", records[1].RootElement.GetProperty("kind").GetString());
+        (records.Count >= 3).Should().BeTrue($"Expected at least 3 records, got {records.Count}");
+        records[0].RootElement.GetProperty("kind").GetString().Should().Be("log");
+        records[1].RootElement.GetProperty("kind").GetString().Should().Be("host_state_changed");
     }
 
     [Fact]
@@ -127,21 +126,21 @@ public class JsonRendererTests
             .Single(doc => doc.RootElement.GetProperty("kind").GetString() == "log")
             .RootElement
             .GetProperty("exception");
-        Assert.Equal("Microsoft.Azure.WebJobs.Host.FunctionInvocationException", logException.GetProperty("type").GetString());
-        Assert.Equal("outer stack", logException.GetProperty("stack").GetString());
-        Assert.Equal("Worker.UserException", logException.GetProperty("inner_exception").GetProperty("type").GetString());
-        Assert.Equal("inner stack", logException.GetProperty("inner_exception").GetProperty("stack").GetString());
+        logException.GetProperty("type").GetString().Should().Be("Microsoft.Azure.WebJobs.Host.FunctionInvocationException");
+        logException.GetProperty("stack").GetString().Should().Be("outer stack");
+        logException.GetProperty("inner_exception").GetProperty("type").GetString().Should().Be("Worker.UserException");
+        logException.GetProperty("inner_exception").GetProperty("stack").GetString().Should().Be("inner stack");
 
         JsonElement eventError = records
             .Single(doc => doc.RootElement.GetProperty("kind").GetString() == "invocation_completed")
             .RootElement
             .GetProperty("error");
-        Assert.Equal("Microsoft.Azure.WebJobs.Host.FunctionInvocationException", eventError.GetProperty("type").GetString());
-        Assert.Equal("Exception while executing function", eventError.GetProperty("message").GetString());
-        Assert.Equal("outer stack", eventError.GetProperty("stack").GetString());
-        Assert.Equal("Worker.UserException", eventError.GetProperty("inner_exception").GetProperty("type").GetString());
-        Assert.Equal("inner boom", eventError.GetProperty("inner_exception").GetProperty("message").GetString());
-        Assert.Equal("inner stack", eventError.GetProperty("inner_exception").GetProperty("stack").GetString());
+        eventError.GetProperty("type").GetString().Should().Be("Microsoft.Azure.WebJobs.Host.FunctionInvocationException");
+        eventError.GetProperty("message").GetString().Should().Be("Exception while executing function");
+        eventError.GetProperty("stack").GetString().Should().Be("outer stack");
+        eventError.GetProperty("inner_exception").GetProperty("type").GetString().Should().Be("Worker.UserException");
+        eventError.GetProperty("inner_exception").GetProperty("message").GetString().Should().Be("inner boom");
+        eventError.GetProperty("inner_exception").GetProperty("stack").GetString().Should().Be("inner stack");
     }
 
     [Fact]
@@ -168,11 +167,11 @@ public class JsonRendererTests
         await renderer.OnEventAsync(entry, [], default);
         await renderer.DisposeAsync();
 
-        JsonElement exception = Assert.Single(ReadAll(stream))
+        JsonElement exception = ReadAll(stream).Should().ContainSingle().Subject
             .RootElement
             .GetProperty("exception");
-        Assert.Equal("Microsoft.Azure.WebJobs.Script.Workers.WorkerProcessExitException", exception.GetProperty("type").GetString());
-        Assert.Equal("A connection string was not found. Please set your connection string.", exception.GetProperty("message").GetString());
+        exception.GetProperty("type").GetString().Should().Be("Microsoft.Azure.WebJobs.Script.Workers.WorkerProcessExitException");
+        exception.GetProperty("message").GetString().Should().Be("A connection string was not found. Please set your connection string.");
     }
 
     private static (JsonRenderer renderer, MemoryStream stream) NewRenderer()

--- a/test/Func.Tests/Hosting/Dashboard/Rendering/OutputModeResolverTests.cs
+++ b/test/Func.Tests/Hosting/Dashboard/Rendering/OutputModeResolverTests.cs
@@ -4,7 +4,6 @@
 using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Hosting.Dashboard.Rendering;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Hosting.Dashboard.Rendering;
 
@@ -16,8 +15,8 @@ public class OutputModeResolverTests
         var interaction = Substitute.For<IInteractionService>();
         interaction.IsInteractive.Returns(true);
 
-        Assert.Equal(OutputMode.Json, OutputModeResolver.Resolve(OutputMode.Json, noTui: false, interaction));
-        Assert.Equal(OutputMode.Plain, OutputModeResolver.Resolve(OutputMode.Plain, noTui: false, interaction));
+        OutputModeResolver.Resolve(OutputMode.Json, noTui: false, interaction).Should().Be(OutputMode.Json);
+        OutputModeResolver.Resolve(OutputMode.Plain, noTui: false, interaction).Should().Be(OutputMode.Plain);
     }
 
     [Fact]
@@ -26,7 +25,7 @@ public class OutputModeResolverTests
         var interaction = Substitute.For<IInteractionService>();
         interaction.IsInteractive.Returns(true);
 
-        Assert.Equal(OutputMode.Plain, OutputModeResolver.Resolve(explicitMode: null, noTui: true, interaction));
+        OutputModeResolver.Resolve(explicitMode: null, noTui: true, interaction).Should().Be(OutputMode.Plain);
     }
 
     [Fact]
@@ -34,7 +33,7 @@ public class OutputModeResolverTests
     {
         var interaction = Substitute.For<IInteractionService>();
         interaction.IsInteractive.Returns(true);
-        Assert.Equal(OutputMode.Compact, OutputModeResolver.Resolve(null, noTui: false, interaction));
+        OutputModeResolver.Resolve(null, noTui: false, interaction).Should().Be(OutputMode.Compact);
     }
 
     [Fact]
@@ -42,7 +41,7 @@ public class OutputModeResolverTests
     {
         var interaction = Substitute.For<IInteractionService>();
         interaction.IsInteractive.Returns(false);
-        Assert.Equal(OutputMode.Plain, OutputModeResolver.Resolve(null, noTui: false, interaction));
+        OutputModeResolver.Resolve(null, noTui: false, interaction).Should().Be(OutputMode.Plain);
     }
 
     [Theory]
@@ -53,8 +52,8 @@ public class OutputModeResolverTests
     [InlineData("  compact  ", "compact")]
     public void TryParse_AcceptsKnownValues(string input, string expectedName)
     {
-        Assert.True(OutputModeResolver.TryParse(input, out var mode));
-        Assert.Equal(expectedName, mode.ToString().ToLowerInvariant());
+        OutputModeResolver.TryParse(input, out var mode).Should().BeTrue();
+        mode.ToString().ToLowerInvariant().Should().Be(expectedName);
     }
 
     [Theory]
@@ -63,6 +62,6 @@ public class OutputModeResolverTests
     [InlineData("dashboard")]
     public void TryParse_RejectsUnknownValues(string? input)
     {
-        Assert.False(OutputModeResolver.TryParse(input, out _));
+        OutputModeResolver.TryParse(input, out _).Should().BeFalse();
     }
 }

--- a/test/Func.Tests/Hosting/Dashboard/Rendering/PlainRendererTests.cs
+++ b/test/Func.Tests/Hosting/Dashboard/Rendering/PlainRendererTests.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.IO;
-using System.Text;
 using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Console.Theme;
 using Azure.Functions.Cli.Hosting.Dashboard;
@@ -10,7 +8,6 @@ using Azure.Functions.Cli.Hosting.Dashboard.Rendering;
 using Azure.Functions.Cli.Hosting.Events;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Hosting.Dashboard.Rendering;
 
@@ -29,9 +26,9 @@ public class PlainRendererTests
         const string expectedOsc8Open = "\u001b]8;;" + url + "\u001b\\";
         const string expectedOsc8Close = "\u001b]8;;\u001b\\";
 
-        Assert.Contains(expectedOsc8Open, output);
-        Assert.Contains(expectedOsc8Close, output);
-        Assert.Contains("GET,POST " + expectedOsc8Open + url + expectedOsc8Close, output);
+        output.Should().Contain(expectedOsc8Open);
+        output.Should().Contain(expectedOsc8Close);
+        output.Should().Contain("GET,POST " + expectedOsc8Open + url + expectedOsc8Close);
     }
 
     [Fact]
@@ -43,8 +40,8 @@ public class PlainRendererTests
         await PumpScenarioAsync(renderer);
 
         string output = writer.ToString();
-        Assert.Contains("GET,POST http://localhost:7071/api/hello", output);
-        Assert.DoesNotContain("\u001b]8;", output);
+        output.Should().Contain("GET,POST http://localhost:7071/api/hello");
+        output.Should().NotContain("\u001b]8;");
     }
 
     [Fact]
@@ -67,9 +64,9 @@ public class PlainRendererTests
         await renderer.OnEventAsync(entry, state.Observe(entry), default);
 
         string output = writer.ToString();
-        Assert.Contains("QueueProcessor", output);
-        Assert.Contains("my-queue", output);
-        Assert.DoesNotContain("\u001b]8;", output);
+        output.Should().Contain("QueueProcessor");
+        output.Should().Contain("my-queue");
+        output.Should().NotContain("\u001b]8;");
     }
 
     [Fact]
@@ -99,9 +96,9 @@ public class PlainRendererTests
         await renderer.OnEventAsync(entry, state.Observe(entry), default);
 
         string output = writer.ToString();
-        Assert.Contains("[invocation end]", output);
-        Assert.Contains("WorkerProcessExitException", output);
-        Assert.Equal(1, CountOccurrences(output, "A connection string was not found."));
+        output.Should().Contain("[invocation end]");
+        output.Should().Contain("WorkerProcessExitException");
+        CountOccurrences(output, "A connection string was not found.").Should().Be(1);
     }
 
     [Fact]
@@ -127,9 +124,9 @@ public class PlainRendererTests
         await renderer.OnEventAsync(entry, state.Observe(entry), default);
 
         string output = writer.ToString();
-        Assert.DoesNotContain("Grpc", output);
-        Assert.Contains("WorkerProcessExitException", output);
-        Assert.Contains("A connection string was not found.", output);
+        output.Should().NotContain("Grpc");
+        output.Should().Contain("WorkerProcessExitException");
+        output.Should().Contain("A connection string was not found.");
     }
 
     [Fact]
@@ -147,8 +144,8 @@ public class PlainRendererTests
         await renderer.OnEventAsync(entry, state.Observe(entry), default);
 
         string output = writer.ToString();
-        Assert.DoesNotContain("Grpc", output);
-        Assert.Contains("A connection string was not found.", output);
+        output.Should().NotContain("Grpc");
+        output.Should().Contain("A connection string was not found.");
     }
 
     private static async Task PumpScenarioAsync(PlainRenderer renderer)

--- a/test/Func.Tests/Hosting/DefaultFunctionsCliBuilderTests.cs
+++ b/test/Func.Tests/Hosting/DefaultFunctionsCliBuilderTests.cs
@@ -56,8 +56,7 @@ public class DefaultFunctionsCliBuilderTests
 
         var resolved = services.BuildServiceProvider().GetServices<FuncCliCommand>().ToList();
         var external = resolved.OfType<ExternalCommand>().Should().ContainSingle().Subject;
-        var source = external.Source.Should().BeOfType<GenericTestCommand>().Subject;
-        source.Payload.Value.Should().Be("from-di");
+        external.Source.Should().BeOfType<GenericTestCommand>().Which.Payload.Value.Should().Be("from-di");
     }
 
     [Fact]
@@ -96,8 +95,7 @@ public class DefaultFunctionsCliBuilderTests
 
         var resolved = services.BuildServiceProvider().GetServices<FuncCliCommand>().ToList();
         var external = resolved.OfType<ExternalCommand>().Should().ContainSingle().Subject;
-        var source = external.Source.Should().BeOfType<GenericTestCommand>().Subject;
-        source.Payload.Value.Should().Be("from-di");
+        external.Source.Should().BeOfType<GenericTestCommand>().Which.Payload.Value.Should().Be("from-di");
     }
 
     [Fact]

--- a/test/Func.Tests/Hosting/DefaultFunctionsCliBuilderTests.cs
+++ b/test/Func.Tests/Hosting/DefaultFunctionsCliBuilderTests.cs
@@ -7,7 +7,6 @@ using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Workloads;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Hosting;
 
@@ -19,13 +18,13 @@ public class DefaultFunctionsCliBuilderTests
         var services = new ServiceCollection();
         var builder = new DefaultFunctionsCliBuilder(services);
 
-        Assert.Same(services, builder.Services);
+        builder.Services.Should().BeSameAs(services);
     }
 
     [Fact]
     public void Ctor_NullServices_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => new DefaultFunctionsCliBuilder(null!));
+        FluentActions.Invoking(() => new DefaultFunctionsCliBuilder(null!)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
@@ -39,10 +38,10 @@ public class DefaultFunctionsCliBuilderTests
         builder.RegisterCommand(stub);
 
         var resolved = services.BuildServiceProvider().GetServices<FuncCliCommand>().ToList();
-        var external = Assert.Single(resolved.OfType<ExternalCommand>());
-        Assert.Same(workload, external.Workload);
-        Assert.Same(stub, external.Source);
-        Assert.Equal("hello", external.Name);
+        var external = resolved.OfType<ExternalCommand>().Should().ContainSingle().Subject;
+        external.Workload.Should().BeSameAs(workload);
+        external.Source.Should().BeSameAs(stub);
+        external.Name.Should().Be("hello");
     }
 
     [Fact]
@@ -56,9 +55,9 @@ public class DefaultFunctionsCliBuilderTests
         builder.RegisterCommand<GenericTestCommand>();
 
         var resolved = services.BuildServiceProvider().GetServices<FuncCliCommand>().ToList();
-        var external = Assert.Single(resolved.OfType<ExternalCommand>());
-        var source = Assert.IsType<GenericTestCommand>(external.Source);
-        Assert.Equal("from-di", source.Payload.Value);
+        var external = resolved.OfType<ExternalCommand>().Should().ContainSingle().Subject;
+        var source = external.Source.Should().BeOfType<GenericTestCommand>().Subject;
+        source.Payload.Value.Should().Be("from-di");
     }
 
     [Fact]
@@ -71,7 +70,7 @@ public class DefaultFunctionsCliBuilderTests
         builder.RegisterCommand<GenericTestCommand>();
 
         var sp = services.BuildServiceProvider();
-        Assert.Null(sp.GetService<GenericTestCommand>());
+        sp.GetService<GenericTestCommand>().Should().BeNull();
     }
 
     [Fact]
@@ -80,9 +79,9 @@ public class DefaultFunctionsCliBuilderTests
         var services = new ServiceCollection();
         var builder = new DefaultFunctionsCliBuilder(services, TestWorkloads.CreateInfo());
 
-        var ex = Assert.Throws<ArgumentException>(builder.RegisterCommand<AbstractFuncCommand>);
-        Assert.Contains("abstract command type", ex.Message);
-        Assert.Contains(nameof(AbstractFuncCommand), ex.Message);
+        var ex = FluentActions.Invoking(builder.RegisterCommand<AbstractFuncCommand>).Should().ThrowExactly<ArgumentException>().Which;
+        ex.Message.Should().Contain("abstract command type");
+        ex.Message.Should().Contain(nameof(AbstractFuncCommand));
     }
 
     [Fact]
@@ -96,9 +95,9 @@ public class DefaultFunctionsCliBuilderTests
         builder.RegisterCommand(typeof(GenericTestCommand));
 
         var resolved = services.BuildServiceProvider().GetServices<FuncCliCommand>().ToList();
-        var external = Assert.Single(resolved.OfType<ExternalCommand>());
-        var source = Assert.IsType<GenericTestCommand>(external.Source);
-        Assert.Equal("from-di", source.Payload.Value);
+        var external = resolved.OfType<ExternalCommand>().Should().ContainSingle().Subject;
+        var source = external.Source.Should().BeOfType<GenericTestCommand>().Subject;
+        source.Payload.Value.Should().Be("from-di");
     }
 
     [Fact]
@@ -111,7 +110,7 @@ public class DefaultFunctionsCliBuilderTests
         builder.RegisterCommand(typeof(GenericTestCommand));
 
         var sp = services.BuildServiceProvider();
-        Assert.Null(sp.GetService<GenericTestCommand>());
+        sp.GetService<GenericTestCommand>().Should().BeNull();
     }
 
     [Fact]
@@ -119,7 +118,7 @@ public class DefaultFunctionsCliBuilderTests
     {
         var builder = new DefaultFunctionsCliBuilder(new ServiceCollection(), TestWorkloads.CreateInfo());
 
-        Assert.Throws<ArgumentNullException>(() => builder.RegisterCommand((Type)null!));
+        FluentActions.Invoking(() => builder.RegisterCommand((Type)null!)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
@@ -127,9 +126,9 @@ public class DefaultFunctionsCliBuilderTests
     {
         var builder = new DefaultFunctionsCliBuilder(new ServiceCollection(), TestWorkloads.CreateInfo());
 
-        var ex = Assert.Throws<ArgumentException>(() => builder.RegisterCommand(typeof(string)));
-        Assert.Contains("not assignable", ex.Message);
-        Assert.Contains(nameof(FuncCommand), ex.Message);
+        var ex = FluentActions.Invoking(() => builder.RegisterCommand(typeof(string))).Should().ThrowExactly<ArgumentException>().Which;
+        ex.Message.Should().Contain("not assignable");
+        ex.Message.Should().Contain(nameof(FuncCommand));
     }
 
     [Fact]
@@ -137,9 +136,9 @@ public class DefaultFunctionsCliBuilderTests
     {
         var builder = new DefaultFunctionsCliBuilder(new ServiceCollection(), TestWorkloads.CreateInfo());
 
-        var ex = Assert.Throws<ArgumentException>(() => builder.RegisterCommand(typeof(AbstractFuncCommand)));
-        Assert.Contains("abstract command type", ex.Message);
-        Assert.Contains(nameof(AbstractFuncCommand), ex.Message);
+        var ex = FluentActions.Invoking(() => builder.RegisterCommand(typeof(AbstractFuncCommand))).Should().ThrowExactly<ArgumentException>().Which;
+        ex.Message.Should().Contain("abstract command type");
+        ex.Message.Should().Contain(nameof(AbstractFuncCommand));
     }
 
     [Fact]
@@ -147,7 +146,7 @@ public class DefaultFunctionsCliBuilderTests
     {
         var builder = new DefaultFunctionsCliBuilder(new ServiceCollection(), TestWorkloads.CreateInfo());
 
-        Assert.Throws<ArgumentNullException>(() => builder.RegisterCommand((FuncCommand)null!));
+        FluentActions.Invoking(() => builder.RegisterCommand((FuncCommand)null!)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
@@ -155,9 +154,8 @@ public class DefaultFunctionsCliBuilderTests
     {
         var builder = new DefaultFunctionsCliBuilder(new ServiceCollection());
 
-        var ex = Assert.Throws<InvalidOperationException>(
-            () => builder.RegisterCommand(new TestWorkloads.StubFuncCommand("oops")));
-        Assert.Contains("workload-scoped builder", ex.Message);
+        var ex = FluentActions.Invoking(() => builder.RegisterCommand(new TestWorkloads.StubFuncCommand("oops"))).Should().ThrowExactly<InvalidOperationException>().Which;
+        ex.Message.Should().Contain("workload-scoped builder");
     }
 
     [Fact]
@@ -165,7 +163,7 @@ public class DefaultFunctionsCliBuilderTests
     {
         var builder = new DefaultFunctionsCliBuilder(new ServiceCollection());
 
-        Assert.Throws<InvalidOperationException>(builder.RegisterCommand<GenericTestCommand>);
+        FluentActions.Invoking(builder.RegisterCommand<GenericTestCommand>).Should().ThrowExactly<InvalidOperationException>();
     }
 
     [Fact]
@@ -173,7 +171,7 @@ public class DefaultFunctionsCliBuilderTests
     {
         var builder = new DefaultFunctionsCliBuilder(new ServiceCollection());
 
-        Assert.Throws<InvalidOperationException>(() => builder.RegisterCommand(typeof(GenericTestCommand)));
+        FluentActions.Invoking(() => builder.RegisterCommand(typeof(GenericTestCommand))).Should().ThrowExactly<InvalidOperationException>();
     }
 
     [Fact]
@@ -186,9 +184,9 @@ public class DefaultFunctionsCliBuilderTests
 
         builder.AddProjectFactory(factory);
 
-        var registration = Assert.Single(services.BuildServiceProvider().GetServices<WorkloadProjectFactoryRegistration>());
-        Assert.Same(workload, registration.Workload);
-        Assert.Same(factory, registration.Factory);
+        var registration = services.BuildServiceProvider().GetServices<WorkloadProjectFactoryRegistration>().Should().ContainSingle().Subject;
+        registration.Workload.Should().BeSameAs(workload);
+        registration.Factory.Should().BeSameAs(factory);
     }
 
     [Fact]
@@ -196,7 +194,7 @@ public class DefaultFunctionsCliBuilderTests
     {
         var builder = new DefaultFunctionsCliBuilder(new ServiceCollection(), TestWorkloads.CreateInfo());
 
-        Assert.Throws<ArgumentNullException>(() => builder.AddProjectFactory(null!));
+        FluentActions.Invoking(() => builder.AddProjectFactory(null!)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
@@ -205,8 +203,8 @@ public class DefaultFunctionsCliBuilderTests
         var builder = new DefaultFunctionsCliBuilder(new ServiceCollection());
         var factory = Substitute.For<IFunctionsProjectFactory>();
 
-        var ex = Assert.Throws<InvalidOperationException>(() => builder.AddProjectFactory(factory));
-        Assert.Contains("workload-scoped builder", ex.Message);
+        var ex = FluentActions.Invoking(() => builder.AddProjectFactory(factory)).Should().ThrowExactly<InvalidOperationException>().Which;
+        ex.Message.Should().Contain("workload-scoped builder");
     }
 
     private sealed class GenericTestPayload(string value)

--- a/test/Func.Tests/Hosting/Events/CompositeHostEventStreamTests.cs
+++ b/test/Func.Tests/Hosting/Events/CompositeHostEventStreamTests.cs
@@ -3,7 +3,6 @@
 
 using System.Runtime.CompilerServices;
 using Azure.Functions.Cli.Hosting.Events;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Hosting.Events;
 
@@ -19,9 +18,9 @@ public class CompositeHostEventStreamTests
 
         await composite.DisposeAsync();
 
-        Assert.True(first.Disposed);
-        Assert.True(second.Disposed);
-        Assert.True(third.Disposed);
+        first.Disposed.Should().BeTrue();
+        second.Disposed.Should().BeTrue();
+        third.Disposed.Should().BeTrue();
     }
 
     [Fact]
@@ -32,10 +31,10 @@ public class CompositeHostEventStreamTests
         var third = new TrackingEventStream();
         var composite = new CompositeHostEventStream([first, second, third]);
 
-        await Assert.ThrowsAsync<AggregateException>(async () => await composite.DisposeAsync());
+        await FluentActions.Awaiting(async () => await composite.DisposeAsync()).Should().ThrowAsync<AggregateException>();
 
-        Assert.True(first.Disposed);
-        Assert.True(third.Disposed);
+        first.Disposed.Should().BeTrue();
+        third.Disposed.Should().BeTrue();
     }
 
     private sealed class TrackingEventStream : IHostEventStream

--- a/test/Func.Tests/Hosting/FirstRun/FileFirstRunStateStoreTests.cs
+++ b/test/Func.Tests/Hosting/FirstRun/FileFirstRunStateStoreTests.cs
@@ -4,7 +4,6 @@
 using Azure.Functions.Cli.Configuration;
 using Azure.Functions.Cli.Hosting.FirstRun;
 using Azure.Functions.Cli.Workloads.Storage;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Hosting.FirstRun;
 
@@ -39,7 +38,7 @@ public sealed class FileFirstRunStateStoreTests : IDisposable
     [Fact]
     public async Task IsFirstRunAsync_ReturnsTrue_WhenMarkerMissingAndNoWorkloads()
     {
-        Assert.True(await _store.IsFirstRunAsync());
+        (await _store.IsFirstRunAsync()).Should().BeTrue();
     }
 
     [Fact]
@@ -47,13 +46,13 @@ public sealed class FileFirstRunStateStoreTests : IDisposable
     {
         WriteEmptyWorkloadRegistry();
 
-        Assert.False(await _store.IsFirstRunAsync());
+        (await _store.IsFirstRunAsync()).Should().BeFalse();
     }
 
     [Fact]
     public async Task GetStateAsync_ReturnsNeverPrompted_WhenMarkerMissingAndNoWorkloads()
     {
-        Assert.Equal(FirstRunState.NeverPrompted, await _store.GetStateAsync());
+        (await _store.GetStateAsync()).Should().Be(FirstRunState.NeverPrompted);
     }
 
     [Fact]
@@ -61,7 +60,7 @@ public sealed class FileFirstRunStateStoreTests : IDisposable
     {
         await _store.MarkCompleteAsync(CancellationToken.None);
 
-        Assert.Equal(FirstRunState.MarkerWithoutWorkloads, await _store.GetStateAsync());
+        (await _store.GetStateAsync()).Should().Be(FirstRunState.MarkerWithoutWorkloads);
     }
 
     [Fact]
@@ -69,10 +68,10 @@ public sealed class FileFirstRunStateStoreTests : IDisposable
     {
         WriteEmptyWorkloadRegistry();
 
-        Assert.Equal(FirstRunState.WorkloadsInstalled, await _store.GetStateAsync());
+        (await _store.GetStateAsync()).Should().Be(FirstRunState.WorkloadsInstalled);
 
         await _store.MarkCompleteAsync(CancellationToken.None);
-        Assert.Equal(FirstRunState.WorkloadsInstalled, await _store.GetStateAsync());
+        (await _store.GetStateAsync()).Should().Be(FirstRunState.WorkloadsInstalled);
     }
 
     [Fact]
@@ -80,30 +79,30 @@ public sealed class FileFirstRunStateStoreTests : IDisposable
     {
         await _store.MarkCompleteAsync(CancellationToken.None);
 
-        Assert.False(await _store.IsFirstRunAsync());
-        Assert.True(File.Exists(Path.Combine(_tempHome, FileFirstRunStateStore.MarkerFileName)));
+        (await _store.IsFirstRunAsync()).Should().BeFalse();
+        File.Exists(Path.Combine(_tempHome, FileFirstRunStateStore.MarkerFileName)).Should().BeTrue();
     }
 
     [Fact]
     public async Task MarkCompleteAsync_CreatesHomeDirectory_WhenMissing()
     {
-        Assert.False(Directory.Exists(_tempHome));
+        Directory.Exists(_tempHome).Should().BeFalse();
 
         await _store.MarkCompleteAsync(CancellationToken.None);
 
-        Assert.True(Directory.Exists(_tempHome));
+        Directory.Exists(_tempHome).Should().BeTrue();
     }
 
     [Fact]
     public void Constructor_ThrowsArgumentNullException_ForNullPaths()
     {
-        Assert.Throws<ArgumentNullException>(() => new FileFirstRunStateStore(null!, _workloadPaths));
+        FluentActions.Invoking(() => new FileFirstRunStateStore(null!, _workloadPaths)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
     public void Constructor_ThrowsArgumentNullException_ForNullWorkloadPaths()
     {
-        Assert.Throws<ArgumentNullException>(() => new FileFirstRunStateStore(new CliConfigurationPathsOptions(_tempHome), null!));
+        FluentActions.Invoking(() => new FileFirstRunStateStore(new CliConfigurationPathsOptions(_tempHome), null!)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     private void WriteEmptyWorkloadRegistry()

--- a/test/Func.Tests/Hosting/FirstRun/FirstRunCoordinatorTests.cs
+++ b/test/Func.Tests/Hosting/FirstRun/FirstRunCoordinatorTests.cs
@@ -9,7 +9,6 @@ using Azure.Functions.Cli.Console.Theme;
 using Azure.Functions.Cli.Hosting.FirstRun;
 using NSubstitute;
 using Spectre.Console.Rendering;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Hosting.FirstRun;
 
@@ -32,8 +31,8 @@ public sealed class FirstRunCoordinatorTests
 
         int? result = await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
 
-        Assert.Null(result);
-        Assert.Equal(0, _interaction.ConfirmCalls);
+        result.Should().BeNull();
+        _interaction.ConfirmCalls.Should().Be(0);
         await _setupRunner.DidNotReceiveWithAnyArgs().RunAsync(default!, default);
         await _stateStore.DidNotReceiveWithAnyArgs().MarkCompleteAsync(default);
     }
@@ -46,8 +45,8 @@ public sealed class FirstRunCoordinatorTests
 
         int? result = await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
 
-        Assert.Null(result);
-        Assert.Equal(0, _interaction.ConfirmCalls);
+        result.Should().BeNull();
+        _interaction.ConfirmCalls.Should().Be(0);
         await _setupRunner.DidNotReceiveWithAnyArgs().RunAsync(default!, default);
         await _stateStore.DidNotReceiveWithAnyArgs().MarkCompleteAsync(default);
     }
@@ -67,8 +66,8 @@ public sealed class FirstRunCoordinatorTests
 
         int? result = await coordinator.EnsureFirstRunPromptedAsync(commandName, Parse(commandName), CancellationToken.None);
 
-        Assert.Null(result);
-        Assert.Equal(0, _interaction.ConfirmCalls);
+        result.Should().BeNull();
+        _interaction.ConfirmCalls.Should().Be(0);
         await _stateStore.DidNotReceiveWithAnyArgs().MarkCompleteAsync(default);
     }
 
@@ -83,8 +82,8 @@ public sealed class FirstRunCoordinatorTests
 
         int? result = await coordinator.EnsureFirstRunPromptedAsync("start", Parse($"start {token}"), CancellationToken.None);
 
-        Assert.Null(result);
-        Assert.Equal(0, _interaction.ConfirmCalls);
+        result.Should().BeNull();
+        _interaction.ConfirmCalls.Should().Be(0);
         await _stateStore.DidNotReceiveWithAnyArgs().MarkCompleteAsync(default);
     }
 
@@ -99,8 +98,8 @@ public sealed class FirstRunCoordinatorTests
 
         int? result = await coordinator.EnsureFirstRunPromptedAsync("unknown", Parse(string.Empty), CancellationToken.None);
 
-        Assert.Null(result);
-        Assert.Equal(1, _interaction.ConfirmCalls);
+        result.Should().BeNull();
+        _interaction.ConfirmCalls.Should().Be(1);
         await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
     }
 
@@ -111,8 +110,8 @@ public sealed class FirstRunCoordinatorTests
 
         int? result = await coordinator.EnsureFirstRunPromptedAsync("unknown", Parse("startt"), CancellationToken.None);
 
-        Assert.Null(result);
-        Assert.Equal(0, _interaction.ConfirmCalls);
+        result.Should().BeNull();
+        _interaction.ConfirmCalls.Should().Be(0);
         await _stateStore.DidNotReceiveWithAnyArgs().MarkCompleteAsync(default);
     }
 
@@ -129,9 +128,9 @@ public sealed class FirstRunCoordinatorTests
         // After a successful setup we always short-circuit the user's command,
         // regardless of which one they typed, because the workload loader
         // snapshot is stale until the next process.
-        Assert.Equal(0, result);
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("HINT:", StringComparison.Ordinal) && l.Contains("Re-run `func start`"));
-        Assert.Equal(1, _interaction.ConfirmCalls);
+        result.Should().Be(0);
+        _interaction.Lines.Should().Contain(l => l.StartsWith("HINT:", StringComparison.Ordinal) && l.Contains("Re-run `func start`"));
+        _interaction.ConfirmCalls.Should().Be(1);
         await _setupRunner.Received(1).RunAsync(Arg.Any<SetupCommandOptions>(), Arg.Any<CancellationToken>());
         await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
     }
@@ -144,8 +143,8 @@ public sealed class FirstRunCoordinatorTests
 
         int? result = await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
 
-        Assert.Null(result);
-        Assert.Equal(1, _interaction.ConfirmCalls);
+        result.Should().BeNull();
+        _interaction.ConfirmCalls.Should().Be(1);
         await _setupRunner.DidNotReceiveWithAnyArgs().RunAsync(default!, default);
         await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
     }
@@ -157,8 +156,7 @@ public sealed class FirstRunCoordinatorTests
         cts.Cancel();
         FirstRunCoordinator coordinator = CreateCoordinator();
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), cts.Token));
+        await FluentActions.Awaiting(() => coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), cts.Token)).Should().ThrowAsync<OperationCanceledException>();
 
         // Ctrl+C at the prompt should still write the marker so the user
         // is not re-prompted next time. The token passed to MarkCompleteAsync
@@ -178,8 +176,8 @@ public sealed class FirstRunCoordinatorTests
 
         int? result = await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
 
-        Assert.Null(result);
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("WARNING:", StringComparison.Ordinal) && l.Contains("boom"));
+        result.Should().BeNull();
+        _interaction.Lines.Should().Contain(l => l.StartsWith("WARNING:", StringComparison.Ordinal) && l.Contains("boom"));
         await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
     }
 
@@ -198,8 +196,8 @@ public sealed class FirstRunCoordinatorTests
 
         int? result = await coordinator.EnsureFirstRunPromptedAsync(commandName, Parse(commandName), CancellationToken.None);
 
-        Assert.Equal(0, result);
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("HINT:", StringComparison.Ordinal) && l.Contains($"Re-run `func {commandName}`"));
+        result.Should().Be(0);
+        _interaction.Lines.Should().Contain(l => l.StartsWith("HINT:", StringComparison.Ordinal) && l.Contains($"Re-run `func {commandName}`"));
         await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
     }
 
@@ -217,9 +215,9 @@ public sealed class FirstRunCoordinatorTests
         // empty parse result rather than parsing the sentinel as a token.
         int? result = await coordinator.EnsureFirstRunPromptedAsync(commandName, Parse(string.Empty), CancellationToken.None);
 
-        Assert.Equal(0, result);
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("HINT:", StringComparison.Ordinal) && l.Contains("Run `func <command>`"));
-        Assert.DoesNotContain(_interaction.Lines, l => l.Contains($"Re-run `func {commandName}`"));
+        result.Should().Be(0);
+        _interaction.Lines.Should().Contain(l => l.StartsWith("HINT:", StringComparison.Ordinal) && l.Contains("Run `func <command>`"));
+        _interaction.Lines.Should().NotContain(l => l.Contains($"Re-run `func {commandName}`"));
         await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
     }
 
@@ -231,7 +229,7 @@ public sealed class FirstRunCoordinatorTests
 
         int? result = await coordinator.EnsureFirstRunPromptedAsync("init", Parse("init"), CancellationToken.None);
 
-        Assert.Null(result);
+        result.Should().BeNull();
         await _setupRunner.DidNotReceiveWithAnyArgs().RunAsync(default!, default);
         await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
     }
@@ -246,7 +244,7 @@ public sealed class FirstRunCoordinatorTests
 
         int? result = await coordinator.EnsureFirstRunPromptedAsync("init", Parse("init"), CancellationToken.None);
 
-        Assert.Null(result);
+        result.Should().BeNull();
         await _stateStore.Received(1).MarkCompleteAsync(Arg.Any<CancellationToken>());
     }
 
@@ -258,9 +256,9 @@ public sealed class FirstRunCoordinatorTests
 
         int? result = await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
 
-        Assert.Null(result);
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("HINT:", StringComparison.Ordinal) && l.Contains("`func setup`"));
-        Assert.Equal(0, _interaction.ConfirmCalls);
+        result.Should().BeNull();
+        _interaction.Lines.Should().Contain(l => l.StartsWith("HINT:", StringComparison.Ordinal) && l.Contains("`func setup`"));
+        _interaction.ConfirmCalls.Should().Be(0);
         await _stateStore.DidNotReceiveWithAnyArgs().MarkCompleteAsync(default);
     }
 
@@ -272,8 +270,8 @@ public sealed class FirstRunCoordinatorTests
 
         int? result = await coordinator.EnsureFirstRunPromptedAsync("setup", Parse("setup"), CancellationToken.None);
 
-        Assert.Null(result);
-        Assert.DoesNotContain(_interaction.Lines, l => l.Contains("`func setup`"));
+        result.Should().BeNull();
+        _interaction.Lines.Should().NotContain(l => l.Contains("`func setup`"));
     }
 
     [Fact]
@@ -285,8 +283,8 @@ public sealed class FirstRunCoordinatorTests
 
         int? result = await coordinator.EnsureFirstRunPromptedAsync("start", Parse("start"), CancellationToken.None);
 
-        Assert.Null(result);
-        Assert.DoesNotContain(_interaction.Lines, l => l.Contains("`func setup`"));
+        result.Should().BeNull();
+        _interaction.Lines.Should().NotContain(l => l.Contains("`func setup`"));
     }
 
     private FirstRunCoordinator CreateCoordinator() => new(_interaction, _stateStore, _setupRunner);

--- a/test/Func.Tests/Hosting/FuncAliasNudgeTests.cs
+++ b/test/Func.Tests/Hosting/FuncAliasNudgeTests.cs
@@ -4,7 +4,6 @@
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Hosting;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Hosting;
 
@@ -18,7 +17,7 @@ public class FuncAliasNudgeTests
 
         new FuncAliasNudge(interaction, version).TryPrint(exitCode: 1, commandName: "init");
 
-        Assert.Contains(interaction.Lines, l => l.Contains("func5", StringComparison.Ordinal));
+        interaction.Lines.Should().Contain(l => l.Contains("func5", StringComparison.Ordinal));
     }
 
     [Theory]
@@ -31,7 +30,7 @@ public class FuncAliasNudgeTests
 
         new FuncAliasNudge(interaction, version).TryPrint(exitCode: 0, commandName: commandName);
 
-        Assert.Contains(interaction.Lines, l => l.Contains("func5", StringComparison.Ordinal));
+        interaction.Lines.Should().Contain(l => l.Contains("func5", StringComparison.Ordinal));
     }
 
     [Theory]
@@ -46,7 +45,7 @@ public class FuncAliasNudgeTests
 
         new FuncAliasNudge(interaction, version).TryPrint(exitCode: 0, commandName: commandName);
 
-        Assert.Empty(interaction.Lines);
+        interaction.Lines.Should().BeEmpty();
     }
 
     [Fact]
@@ -57,7 +56,7 @@ public class FuncAliasNudgeTests
 
         new FuncAliasNudge(interaction, version).TryPrint(exitCode: 1, commandName: "help");
 
-        Assert.Empty(interaction.Lines);
+        interaction.Lines.Should().BeEmpty();
     }
 
     [Fact]
@@ -68,7 +67,7 @@ public class FuncAliasNudgeTests
 
         new FuncAliasNudge(interaction, version).TryPrint(exitCode: 1, commandName: "help");
 
-        Assert.Empty(interaction.Lines);
+        interaction.Lines.Should().BeEmpty();
     }
 
     [Fact]
@@ -77,8 +76,8 @@ public class FuncAliasNudgeTests
         var interaction = new InteractiveTestInteractionService();
         ICliVersionProvider version = Substitute.For<ICliVersionProvider>();
 
-        Assert.Throws<ArgumentNullException>(() => new FuncAliasNudge(null!, version));
-        Assert.Throws<ArgumentNullException>(() => new FuncAliasNudge(interaction, null!));
+        FluentActions.Invoking(() => new FuncAliasNudge(null!, version)).Should().ThrowExactly<ArgumentNullException>();
+        FluentActions.Invoking(() => new FuncAliasNudge(interaction, null!)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     private static ICliVersionProvider Version(bool isPrerelease)

--- a/test/Func.Tests/Http/HttpClientDefaultsTests.cs
+++ b/test/Func.Tests/Http/HttpClientDefaultsTests.cs
@@ -3,7 +3,6 @@
 
 using Azure.Functions.Cli.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Http;
 
@@ -30,9 +29,9 @@ public sealed class HttpClientDefaultsTests
 
         await client.GetAsync("https://example.com");
 
-        Assert.NotNull(capturedUserAgent);
-        Assert.StartsWith("AzureFunctionsCli/", capturedUserAgent);
-        Assert.Contains("(", capturedUserAgent);
+        capturedUserAgent.Should().NotBeNull();
+        capturedUserAgent.Should().StartWith("AzureFunctionsCli/");
+        capturedUserAgent.Should().Contain("(");
     }
 
     [Fact]
@@ -56,8 +55,8 @@ public sealed class HttpClientDefaultsTests
 
         await client.GetAsync("https://example.com");
 
-        Assert.NotNull(capturedUserAgent);
-        Assert.StartsWith("AzureFunctionsCli/", capturedUserAgent);
+        capturedUserAgent.Should().NotBeNull();
+        capturedUserAgent.Should().StartWith("AzureFunctionsCli/");
     }
 
     [Fact]
@@ -81,9 +80,9 @@ public sealed class HttpClientDefaultsTests
 
         await client.GetAsync("https://example.com");
 
-        Assert.NotNull(capturedUserAgent);
+        capturedUserAgent.Should().NotBeNull();
         // Format: AzureFunctionsCli/{version} ({os})
-        Assert.Matches(@"^AzureFunctionsCli/\S+ \(.+\)$", capturedUserAgent);
+        capturedUserAgent.Should().MatchRegex(@"^AzureFunctionsCli/\S+ \(.+\)$");
     }
 
     private sealed class CapturingHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)

--- a/test/Func.Tests/ParserTests.cs
+++ b/test/Func.Tests/ParserTests.cs
@@ -6,7 +6,6 @@ using Azure.Functions.Cli.Commands;
 using Azure.Functions.Cli.Hosting;
 using Azure.Functions.Cli.Workloads;
 using Microsoft.Extensions.DependencyInjection;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests;
 
@@ -24,8 +23,8 @@ public class ParserTests
     {
         FuncRootCommand root = TestParser.CreateRoot(_interaction);
 
-        Assert.NotNull(root);
-        Assert.IsType<FuncRootCommand>(root);
+        root.Should().NotBeNull();
+        root.Should().BeOfType<FuncRootCommand>();
     }
 
     [Fact]
@@ -34,8 +33,8 @@ public class ParserTests
         FuncRootCommand root = TestParser.CreateRoot(_interaction);
         var names = root.Subcommands.Select(c => c.Name).ToList();
 
-        Assert.Contains("version", names);
-        Assert.Contains("help", names);
+        names.Should().Contain("version");
+        names.Should().Contain("help");
     }
 
     [Fact]
@@ -44,7 +43,7 @@ public class ParserTests
         FuncRootCommand root = TestParser.CreateRoot(_interaction);
         var optionNames = root.Options.Select(o => o.Name).ToList();
 
-        Assert.Contains("--verbose", optionNames);
+        optionNames.Should().Contain("--verbose");
     }
 
     [Fact]
@@ -53,7 +52,7 @@ public class ParserTests
         // -v is intentionally left free so subcommands can claim it.
         var root = (FuncRootCommand)TestParser.CreateRoot(_interaction);
 
-        Assert.DoesNotContain("-v", root.VerboseOption.Aliases);
+        root.VerboseOption.Aliases.Should().NotContain("-v");
     }
 
     [Theory]
@@ -64,7 +63,7 @@ public class ParserTests
         FuncRootCommand root = TestParser.CreateRoot(_interaction);
         ParseResult result = root.Parse(commandName);
 
-        Assert.Empty(result.Errors);
+        result.Errors.Should().BeEmpty();
     }
 
     // --- Workload command tracking ---
@@ -79,9 +78,9 @@ public class ParserTests
             builder => builder.RegisterCommand(new TestWorkloads.StubFuncCommand("workload-cmd", "wd")));
 
         ExternalCommand? added = root.Subcommands.OfType<ExternalCommand>().SingleOrDefault();
-        Assert.NotNull(added);
-        Assert.Equal("workload-cmd", added!.Name);
-        Assert.Same(workload, added.Workload);
+        added.Should().NotBeNull();
+        added!.Name.Should().Be("workload-cmd");
+        added.Workload.Should().BeSameAs(workload);
     }
 
     [Fact]
@@ -95,10 +94,10 @@ public class ParserTests
 
         // init is a built-in name; the workload registration is skipped.
         var initCommands = root.Subcommands.Where(c => c.Name == "init").ToList();
-        Assert.Single(initCommands);
-        Assert.IsNotType<ExternalCommand>(initCommands[0]);
+        initCommands.Should().ContainSingle();
+        initCommands[0].Should().NotBeOfType<ExternalCommand>();
 
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("WARNING:") && l.Contains("Wl.Bar") && l.Contains("'init'"));
+        _interaction.Lines.Should().Contain(l => l.StartsWith("WARNING:") && l.Contains("Wl.Bar") && l.Contains("'init'"));
     }
 
     [Fact]
@@ -117,8 +116,8 @@ public class ParserTests
 
         FuncRootCommand root = Parser.CreateCommand(services);
 
-        Assert.DoesNotContain(root.Subcommands, c => c.Name == "dup");
-        Assert.Contains(_interaction.Lines, l => l.StartsWith("WARNING:")
+        root.Subcommands.Should().NotContain(c => c.Name == "dup");
+        _interaction.Lines.Should().Contain(l => l.StartsWith("WARNING:")
             && l.Contains("Wl.A") && l.Contains("Wl.B") && l.Contains("'dup'"));
     }
 
@@ -130,9 +129,9 @@ public class ParserTests
             s.AddSingleton<FuncCliCommand, RogueFuncCliCommand>();
         });
 
-        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => Parser.CreateCommand(services));
-        Assert.Contains(nameof(RogueFuncCliCommand), ex.Message);
-        Assert.Contains("rogue", ex.Message);
+        InvalidOperationException ex = FluentActions.Invoking(() => Parser.CreateCommand(services)).Should().ThrowExactly<InvalidOperationException>().Which;
+        ex.Message.Should().Contain(nameof(RogueFuncCliCommand));
+        ex.Message.Should().Contain("rogue");
     }
 
     [Fact]
@@ -147,8 +146,8 @@ public class ParserTests
 
         int exit = await parseResult.InvokeAsync();
 
-        Assert.Equal(0, exit);
-        Assert.NotEmpty(_interaction.Lines);
+        exit.Should().Be(0);
+        _interaction.Lines.Should().NotBeEmpty();
     }
 
     private sealed class RogueFuncCliCommand : FuncCliCommand

--- a/test/Func.Tests/Profiles/BuiltInProfileSourceTests.cs
+++ b/test/Func.Tests/Profiles/BuiltInProfileSourceTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Profiles;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Profiles;
 
@@ -16,11 +15,9 @@ public class BuiltInProfileSourceTests
 
         ProfileSourceSnapshot snapshot = await source.LoadAsync(context, CancellationToken.None);
 
-        Assert.Equal(ProfileSourceKind.BuiltIn, snapshot.Source.Kind);
-        Assert.Equal(
-            ["flex", "linux-consumption", "linux-premium", "windows-consumption", "windows-dedicated"],
-            snapshot.Profiles.Keys.OrderBy(static p => p, StringComparer.Ordinal));
-        Assert.Equal("stable", snapshot.Profiles["flex"].Status);
-        Assert.Equal("deprecated", snapshot.Profiles["linux-consumption"].Status);
+        snapshot.Source.Kind.Should().Be(ProfileSourceKind.BuiltIn);
+        snapshot.Profiles.Keys.OrderBy(static p => p, StringComparer.Ordinal).Should().Equal(["flex", "linux-consumption", "linux-premium", "windows-consumption", "windows-dedicated"]);
+        snapshot.Profiles["flex"].Status.Should().Be("stable");
+        snapshot.Profiles["linux-consumption"].Status.Should().Be("deprecated");
     }
 }

--- a/test/Func.Tests/Profiles/ProfileDocumentParserTests.cs
+++ b/test/Func.Tests/Profiles/ProfileDocumentParserTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Profiles;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Profiles;
 
@@ -34,11 +33,11 @@ public class ProfileDocumentParserTests
         ProfileSourceSnapshot snapshot = _parser.ParseBuiltInRegistry(json, Source(ProfileSourceKind.BuiltIn));
 
         ProfileDefinition profile = snapshot.Profiles["flex"];
-        Assert.Equal(new DateTimeOffset(2025, 1, 2, 3, 4, 5, TimeSpan.Zero), snapshot.GeneratedAt);
-        Assert.Equal("[1.8.1, 4.1048.200)", profile.Host!.Version);
-        Assert.Equal("[3.0.0, 5.0.0)", profile.ExtensionBundle!.Version);
-        Assert.Equal("[3.13.0]", profile.Workers!["node"]!.Version);
-        Assert.Equal(["node", "python"], profile.SupportedRuntimes);
+        snapshot.GeneratedAt.Should().Be(new DateTimeOffset(2025, 1, 2, 3, 4, 5, TimeSpan.Zero));
+        profile.Host!.Version.Should().Be("[1.8.1, 4.1048.200)");
+        profile.ExtensionBundle!.Version.Should().Be("[3.0.0, 5.0.0)");
+        profile.Workers!["node"]!.Version.Should().Be("[3.13.0]");
+        profile.SupportedRuntimes.Should().Equal(["node", "python"]);
     }
 
     [Fact]
@@ -50,10 +49,9 @@ public class ProfileDocumentParserTests
             }
             """;
 
-        ProfileConfigurationException ex = Assert.Throws<ProfileConfigurationException>(
-            () => _parser.ParseBuiltInRegistry(json, Source(ProfileSourceKind.BuiltIn)));
+        ProfileConfigurationException ex = FluentActions.Invoking(() => _parser.ParseBuiltInRegistry(json, Source(ProfileSourceKind.BuiltIn))).Should().ThrowExactly<ProfileConfigurationException>().Which;
 
-        Assert.Contains(ProfileSchemas.BuiltInRegistryV1, ex.Message);
+        ex.Message.Should().Contain(ProfileSchemas.BuiltInRegistryV1);
     }
 
     [Fact]
@@ -65,11 +63,10 @@ public class ProfileDocumentParserTests
             }
             """;
 
-        ProfileConfigurationException ex = Assert.Throws<ProfileConfigurationException>(
-            () => _parser.ParseCustomProfiles(json, Source(ProfileSourceKind.Project)));
+        ProfileConfigurationException ex = FluentActions.Invoking(() => _parser.ParseCustomProfiles(json, Source(ProfileSourceKind.Project))).Should().ThrowExactly<ProfileConfigurationException>().Which;
 
-        Assert.Contains("unsupported schema", ex.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains(ProfileSchemas.CustomProfilesV1, ex.Message);
+        ex.Message.Should().ContainEquivalentOf("unsupported schema");
+        ex.Message.Should().Contain(ProfileSchemas.CustomProfilesV1);
     }
 
     [Fact]
@@ -83,11 +80,10 @@ public class ProfileDocumentParserTests
             }
             """;
 
-        ProfileConfigurationException ex = Assert.Throws<ProfileConfigurationException>(
-            () => _parser.ParseCustomProfiles(json, Source(ProfileSourceKind.Project)));
+        ProfileConfigurationException ex = FluentActions.Invoking(() => _parser.ParseCustomProfiles(json, Source(ProfileSourceKind.Project))).Should().ThrowExactly<ProfileConfigurationException>().Which;
 
-        Assert.Contains("invalid NuGet version range", ex.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("host.version", ex.Message);
+        ex.Message.Should().ContainEquivalentOf("invalid NuGet version range");
+        ex.Message.Should().Contain("host.version");
     }
 
     [Fact]
@@ -101,10 +97,9 @@ public class ProfileDocumentParserTests
             }
             """;
 
-        ProfileConfigurationException ex = Assert.Throws<ProfileConfigurationException>(
-            () => _parser.ParseCustomProfiles(json, Source(ProfileSourceKind.Project)));
+        ProfileConfigurationException ex = FluentActions.Invoking(() => _parser.ParseCustomProfiles(json, Source(ProfileSourceKind.Project))).Should().ThrowExactly<ProfileConfigurationException>().Which;
 
-        Assert.Contains("unsupported status", ex.Message, StringComparison.OrdinalIgnoreCase);
+        ex.Message.Should().ContainEquivalentOf("unsupported status");
     }
 
     [Fact]
@@ -123,7 +118,7 @@ public class ProfileDocumentParserTests
 
         ProfileSourceSnapshot snapshot = _parser.ParseCustomProfiles(json, Source(ProfileSourceKind.Project));
 
-        Assert.True(snapshot.Profiles.ContainsKey("flex"));
+        snapshot.Profiles.ContainsKey("flex").Should().BeTrue();
     }
 
     private static ProfileSourceInfo Source(ProfileSourceKind kind)

--- a/test/Func.Tests/Profiles/ProfileResolverTests.cs
+++ b/test/Func.Tests/Profiles/ProfileResolverTests.cs
@@ -6,7 +6,6 @@ using Azure.Functions.Cli.Profiles;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using NuGet.Versioning;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Profiles;
 
@@ -25,9 +24,9 @@ public class ProfileResolverTests
 
         ProfileResolution resolution = await resolver.ResolveAsync(Context(), CancellationToken.None);
 
-        Assert.IsType<ProfileResolution.None>(resolution);
-        Assert.Empty(resolution.Diagnostics);
-        Assert.Equal(0, source.LoadCount);
+        resolution.Should().BeOfType<ProfileResolution.None>();
+        resolution.Diagnostics.Should().BeEmpty();
+        source.LoadCount.Should().Be(0);
     }
 
     [Fact]
@@ -45,10 +44,10 @@ public class ProfileResolverTests
 
         ProfileResolution.Resolved resolution = await ResolveProfileAsync(resolver, requestedProfile: "flex");
 
-        Assert.Equal("flex", resolution.Profile.Name);
-        ProfileDiagnostic diagnostic = Assert.Single(resolution.Diagnostics);
-        Assert.Equal(ProfileDiagnosticSeverity.Warning, diagnostic.Severity);
-        Assert.Contains("not declared", diagnostic.Message, StringComparison.OrdinalIgnoreCase);
+        resolution.Profile.Name.Should().Be("flex");
+        ProfileDiagnostic diagnostic = resolution.Diagnostics.Should().ContainSingle().Subject;
+        diagnostic.Severity.Should().Be(ProfileDiagnosticSeverity.Warning);
+        diagnostic.Message.Should().ContainEquivalentOf("not declared");
     }
 
     [Fact]
@@ -68,8 +67,8 @@ public class ProfileResolverTests
 
         ProfileResolution.Resolved resolution = await ResolveProfileAsync(resolver);
 
-        Assert.Equal("linux-premium", resolution.Profile.Name);
-        Assert.True(resolution.Profile.HostVersionRange.Satisfies(NuGetVersion.Parse("2.5.0")));
+        resolution.Profile.Name.Should().Be("linux-premium");
+        resolution.Profile.HostVersionRange.Satisfies(NuGetVersion.Parse("2.5.0")).Should().BeTrue();
     }
 
     [Fact]
@@ -90,7 +89,7 @@ public class ProfileResolverTests
 
         ProfileResolution.Resolved resolution = await ResolveProfileAsync(resolver);
 
-        Assert.Equal("linux-premium", resolution.Profile.Name);
+        resolution.Profile.Name.Should().Be("linux-premium");
     }
 
     [Fact]
@@ -104,7 +103,7 @@ public class ProfileResolverTests
 
         ProfileResolution.Resolved resolution = await ResolveProfileAsync(resolver);
 
-        Assert.Equal("flex", resolution.Profile.Name);
+        resolution.Profile.Name.Should().Be("flex");
     }
 
     [Fact]
@@ -124,7 +123,7 @@ public class ProfileResolverTests
 
         ProfileResolution.Resolved resolution = await ResolveProfileAsync(resolver, canPrompt: true);
 
-        Assert.Equal("linux-premium", resolution.Profile.Name);
+        resolution.Profile.Name.Should().Be("linux-premium");
     }
 
     [Fact]
@@ -144,10 +143,10 @@ public class ProfileResolverTests
 
         ProfileResolution.Resolved resolution = await ResolveProfileAsync(resolver);
 
-        Assert.Equal("flex", resolution.Profile.Name);
-        ProfileDiagnostic diagnostic = Assert.Single(resolution.Diagnostics);
-        Assert.Equal(ProfileDiagnosticSeverity.Warning, diagnostic.Severity);
-        Assert.Contains("will be ignored", diagnostic.Message, StringComparison.OrdinalIgnoreCase);
+        resolution.Profile.Name.Should().Be("flex");
+        ProfileDiagnostic diagnostic = resolution.Diagnostics.Should().ContainSingle().Subject;
+        diagnostic.Severity.Should().Be(ProfileDiagnosticSeverity.Warning);
+        diagnostic.Message.Should().ContainEquivalentOf("will be ignored");
     }
 
     [Fact]
@@ -166,8 +165,8 @@ public class ProfileResolverTests
 
         ProfileResolution.Resolved resolution = await ResolveProfileAsync(resolver, canPrompt: true);
 
-        Assert.Equal("flex", resolution.Profile.Name);
-        Assert.Contains(_interaction.Lines, line => line.StartsWith("SELECT: Select an Azure Functions profile", StringComparison.Ordinal));
+        resolution.Profile.Name.Should().Be("flex");
+        _interaction.Lines.Should().Contain(line => line.StartsWith("SELECT: Select an Azure Functions profile", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -183,11 +182,10 @@ public class ProfileResolverTests
         ]);
         ProfileResolver resolver = CreateResolver(source);
 
-        ProfileConfigurationException ex = await Assert.ThrowsAsync<ProfileConfigurationException>(
-            () => resolver.ResolveAsync(Context(canPrompt: false), CancellationToken.None));
+        ProfileConfigurationException ex = (await FluentActions.Awaiting(() => resolver.ResolveAsync(Context(canPrompt: false), CancellationToken.None)).Should().ThrowAsync<ProfileConfigurationException>()).Which;
 
-        Assert.Contains("--profile", ex.Message);
-        Assert.Contains("defaultProfile", ex.Message);
+        ex.Message.Should().Contain("--profile");
+        ex.Message.Should().Contain("defaultProfile");
     }
 
     [Fact]
@@ -206,9 +204,9 @@ public class ProfileResolverTests
 
         ProfileResolution.Resolved resolution = await ResolveProfileAsync(resolver, requestedProfile: "shared");
 
-        Assert.Equal(ProfileSourceKind.Project, resolution.Profile.Source.Kind);
-        Assert.True(resolution.Profile.HostVersionRange.Satisfies(NuGetVersion.Parse("3.5.0")));
-        Assert.False(resolution.Profile.HostVersionRange.Satisfies(NuGetVersion.Parse("2.5.0")));
+        resolution.Profile.Source.Kind.Should().Be(ProfileSourceKind.Project);
+        resolution.Profile.HostVersionRange.Satisfies(NuGetVersion.Parse("3.5.0")).Should().BeTrue();
+        resolution.Profile.HostVersionRange.Satisfies(NuGetVersion.Parse("2.5.0")).Should().BeFalse();
     }
 
     [Fact]
@@ -237,12 +235,12 @@ public class ProfileResolverTests
 
         ProfileResolution.Resolved resolution = await ResolveProfileAsync(resolver, requestedProfile: "child");
 
-        Assert.True(resolution.Profile.HostVersionRange.Satisfies(NuGetVersion.Parse("2.0.0")));
-        Assert.True(resolution.Profile.ExtensionBundleVersionRange!.Satisfies(NuGetVersion.Parse("5.5.0")));
-        Assert.Equal(["node", "python"], resolution.Profile.SupportedRuntimes);
-        Assert.True(resolution.Profile.WorkerVersionRanges["node"].Satisfies(NuGetVersion.Parse("3.13.0")));
-        Assert.True(resolution.Profile.WorkerVersionRanges["go"].Satisfies(NuGetVersion.Parse("1.0.0")));
-        Assert.False(resolution.Profile.WorkerVersionRanges.ContainsKey("python"));
+        resolution.Profile.HostVersionRange.Satisfies(NuGetVersion.Parse("2.0.0")).Should().BeTrue();
+        resolution.Profile.ExtensionBundleVersionRange!.Satisfies(NuGetVersion.Parse("5.5.0")).Should().BeTrue();
+        resolution.Profile.SupportedRuntimes.Should().Equal(["node", "python"]);
+        resolution.Profile.WorkerVersionRanges["node"].Satisfies(NuGetVersion.Parse("3.13.0")).Should().BeTrue();
+        resolution.Profile.WorkerVersionRanges["go"].Satisfies(NuGetVersion.Parse("1.0.0")).Should().BeTrue();
+        resolution.Profile.WorkerVersionRanges.ContainsKey("python").Should().BeFalse();
     }
 
     [Fact]
@@ -254,10 +252,9 @@ public class ProfileResolverTests
         ]);
         ProfileResolver resolver = CreateResolver(source);
 
-        ProfileConfigurationException ex = await Assert.ThrowsAsync<ProfileConfigurationException>(
-            () => resolver.ResolveAsync(Context(requestedProfile: "a"), CancellationToken.None));
+        ProfileConfigurationException ex = (await FluentActions.Awaiting(() => resolver.ResolveAsync(Context(requestedProfile: "a"), CancellationToken.None)).Should().ThrowAsync<ProfileConfigurationException>()).Which;
 
-        Assert.Contains("Circular profile inheritance", ex.Message);
+        ex.Message.Should().Contain("Circular profile inheritance");
     }
 
     [Fact]
@@ -270,10 +267,10 @@ public class ProfileResolverTests
 
         ProfileResolution.Resolved resolution = await ResolveProfileAsync(resolver, requestedProfile: "linux-consumption");
 
-        ProfileDiagnostic diagnostic = Assert.Single(resolution.Diagnostics);
-        Assert.Equal(ProfileDiagnosticSeverity.Warning, diagnostic.Severity);
-        Assert.Contains("deprecated", diagnostic.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("https://example.test/deprecation", diagnostic.Message);
+        ProfileDiagnostic diagnostic = resolution.Diagnostics.Should().ContainSingle().Subject;
+        diagnostic.Severity.Should().Be(ProfileDiagnosticSeverity.Warning);
+        diagnostic.Message.Should().ContainEquivalentOf("deprecated");
+        diagnostic.Message.Should().Contain("https://example.test/deprecation");
     }
 
     private ProfileResolver CreateResolver(params IProfileSource[] sources)
@@ -293,7 +290,7 @@ public class ProfileResolverTests
             Context(requestedProfile, canPrompt),
             CancellationToken.None);
 
-        return Assert.IsType<ProfileResolution.Resolved>(resolution);
+        return resolution.Should().BeOfType<ProfileResolution.Resolved>().Subject;
     }
 
     private ProfileResolutionContext Context(string? requestedProfile = null, bool canPrompt = false)

--- a/test/Func.Tests/Profiles/ProjectProfileOptionsSetupTests.cs
+++ b/test/Func.Tests/Profiles/ProjectProfileOptionsSetupTests.cs
@@ -5,7 +5,6 @@ using System.Text;
 using Azure.Functions.Cli.Configuration;
 using Azure.Functions.Cli.Profiles;
 using Microsoft.Extensions.Configuration;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Profiles;
 
@@ -29,8 +28,8 @@ public sealed class ProjectProfileOptionsSetupTests : IDisposable
 
         setup.Configure(options);
 
-        Assert.Empty(options.Profiles);
-        Assert.Null(options.DefaultProfile);
+        options.Profiles.Should().BeEmpty();
+        options.DefaultProfile.Should().BeNull();
     }
 
     [Fact]
@@ -50,8 +49,8 @@ public sealed class ProjectProfileOptionsSetupTests : IDisposable
 
         setup.Configure(_dir.FullName, options);
 
-        Assert.Equal(["flex", "linux-premium"], options.Profiles);
-        Assert.Equal("linux-premium", options.DefaultProfile);
+        options.Profiles.Should().Equal(["flex", "linux-premium"]);
+        options.DefaultProfile.Should().Be("linux-premium");
     }
 
     [Fact]
@@ -71,8 +70,8 @@ public sealed class ProjectProfileOptionsSetupTests : IDisposable
 
         setup.Configure(_dir.FullName, options);
 
-        Assert.Empty(options.Profiles);
-        Assert.Null(options.DefaultProfile);
+        options.Profiles.Should().BeEmpty();
+        options.DefaultProfile.Should().BeNull();
     }
 
     [Fact]
@@ -87,9 +86,9 @@ public sealed class ProjectProfileOptionsSetupTests : IDisposable
         var setup = new ProjectProfileOptionsSetup(configuration);
         ProjectProfileOptions options = new();
 
-        ProfileConfigurationException ex = Assert.Throws<ProfileConfigurationException>(() => setup.Configure(options));
+        ProfileConfigurationException ex = FluentActions.Invoking(() => setup.Configure(options)).Should().ThrowExactly<ProfileConfigurationException>().Which;
 
-        Assert.Contains("more than once", ex.Message, StringComparison.OrdinalIgnoreCase);
+        ex.Message.Should().ContainEquivalentOf("more than once");
     }
 
     [Fact]
@@ -104,10 +103,10 @@ public sealed class ProjectProfileOptionsSetupTests : IDisposable
         var setup = new ProjectProfileOptionsSetup(configuration);
         ProjectProfileOptions options = new();
 
-        ProfileConfigurationException ex = Assert.Throws<ProfileConfigurationException>(() => setup.Configure(options));
+        ProfileConfigurationException ex = FluentActions.Invoking(() => setup.Configure(options)).Should().ThrowExactly<ProfileConfigurationException>().Which;
 
-        Assert.Contains("unsupported schema", ex.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains(ProfileSchemas.ProjectConfigV1, ex.Message);
+        ex.Message.Should().ContainEquivalentOf("unsupported schema");
+        ex.Message.Should().Contain(ProfileSchemas.ProjectConfigV1);
     }
 
     private void WriteProjectConfig(string contents)

--- a/test/Func.Tests/Profiles/UserProfilePreferenceOptionsSetupTests.cs
+++ b/test/Func.Tests/Profiles/UserProfilePreferenceOptionsSetupTests.cs
@@ -4,7 +4,6 @@
 using Azure.Functions.Cli.Configuration;
 using Azure.Functions.Cli.Profiles;
 using Microsoft.Extensions.Configuration;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Profiles;
 
@@ -30,7 +29,7 @@ public sealed class UserProfilePreferenceOptionsSetupTests : IDisposable
 
         setup.Configure(options);
 
-        Assert.Equal("flex", options.DefaultProfile);
+        options.DefaultProfile.Should().Be("flex");
     }
 
     [Fact]
@@ -45,7 +44,7 @@ public sealed class UserProfilePreferenceOptionsSetupTests : IDisposable
 
         setup.Configure(options);
 
-        Assert.Null(options.DefaultProfile);
+        options.DefaultProfile.Should().BeNull();
     }
 
     private void WriteUserConfig(string contents)

--- a/test/Func.Tests/Profiles/UserProfileSourceTests.cs
+++ b/test/Func.Tests/Profiles/UserProfileSourceTests.cs
@@ -4,7 +4,6 @@
 using Azure.Functions.Cli.Configuration;
 using Azure.Functions.Cli.Profiles;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Profiles;
 
@@ -23,9 +22,9 @@ public class UserProfileSourceTests
 
         ProfileSourceSnapshot snapshot = await source.LoadAsync(context, CancellationToken.None);
 
-        Assert.Equal(ProfileSourceKind.User, snapshot.Source.Kind);
-        Assert.Equal("~/.azure-functions/profiles.json", snapshot.Source.DisplayName);
-        Assert.Equal(expectedPath, snapshot.Source.Path);
+        snapshot.Source.Kind.Should().Be(ProfileSourceKind.User);
+        snapshot.Source.DisplayName.Should().Be("~/.azure-functions/profiles.json");
+        snapshot.Source.Path.Should().Be(expectedPath);
         await fileSystem.Received(1).ReadAllTextIfExistsAsync(expectedPath, CancellationToken.None);
     }
 }

--- a/test/Func.Tests/Projects/FunctionsProjectHostRunContextTests.cs
+++ b/test/Func.Tests/Projects/FunctionsProjectHostRunContextTests.cs
@@ -4,7 +4,6 @@
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Workers;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Projects;
 
@@ -20,8 +19,8 @@ public sealed class FunctionsProjectHostRunContextTests
             "dotnet-isolated",
             environmentVariables);
 
-        Assert.Equal("dotnet-isolated", context.WorkerRuntime);
-        Assert.Equal("dotnet-isolated", environmentVariables[FunctionsProjectHostRunContext.WorkerRuntimeEnvironmentVariable]);
+        context.WorkerRuntime.Should().Be("dotnet-isolated");
+        environmentVariables[FunctionsProjectHostRunContext.WorkerRuntimeEnvironmentVariable].Should().Be("dotnet-isolated");
     }
 
     [Fact]
@@ -34,10 +33,8 @@ public sealed class FunctionsProjectHostRunContextTests
 
         context.WorkerRuntime = "python";
 
-        Assert.Equal("python", context.WorkerRuntime);
-        Assert.Equal(
-            "python",
-            context.EnvironmentVariables[FunctionsProjectHostRunContext.WorkerRuntimeEnvironmentVariable]);
+        context.WorkerRuntime.Should().Be("python");
+        context.EnvironmentVariables[FunctionsProjectHostRunContext.WorkerRuntimeEnvironmentVariable].Should().Be("python");
     }
 
     [Fact]
@@ -50,7 +47,7 @@ public sealed class FunctionsProjectHostRunContextTests
 
         context.EnvironmentVariables.Remove(FunctionsProjectHostRunContext.WorkerRuntimeEnvironmentVariable);
 
-        Assert.Throws<InvalidOperationException>(() => context.WorkerRuntime);
+        FluentActions.Invoking(() => context.WorkerRuntime).Should().ThrowExactly<InvalidOperationException>();
     }
 
     [Fact]
@@ -61,7 +58,7 @@ public sealed class FunctionsProjectHostRunContextTests
             "dotnet-isolated",
             new Dictionary<string, string>());
 
-        Assert.Throws<ArgumentNullException>(() => context.StartupDirectory = null!);
+        FluentActions.Invoking(() => context.StartupDirectory = null!).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
@@ -72,8 +69,8 @@ public sealed class FunctionsProjectHostRunContextTests
             "dotnet-isolated",
             new Dictionary<string, string>());
 
-        Assert.NotNull(context.Reporter);
-        Assert.IsType<NullFunctionsProjectHostRunReporter>(context.Reporter);
+        context.Reporter.Should().NotBeNull();
+        context.Reporter.Should().BeOfType<NullFunctionsProjectHostRunReporter>();
     }
 
     [Fact]
@@ -84,7 +81,7 @@ public sealed class FunctionsProjectHostRunContextTests
             "dotnet-isolated",
             new Dictionary<string, string>());
 
-        Assert.Throws<ArgumentNullException>(() => context.Reporter = null!);
+        FluentActions.Invoking(() => context.Reporter = null!).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]

--- a/test/Func.Tests/Projects/FunctionsProjectResolverTests.cs
+++ b/test/Func.Tests/Projects/FunctionsProjectResolverTests.cs
@@ -55,8 +55,7 @@ public sealed class FunctionsProjectResolverTests
 
         ProjectResolutionResult result = await resolver.ResolveProjectAsync(CreateContext(), CancellationToken.None);
 
-        ProjectResolutionResult.Resolved resolved = result.Should().BeOfType<ProjectResolutionResult.Resolved>().Subject;
-        resolved.Project.Should().BeSameAs(firstProject);
+        result.Should().BeOfType<ProjectResolutionResult.Resolved>().Which.Project.Should().BeSameAs(firstProject);
         await second.DidNotReceive().TryCreateProjectAsync(Arg.Any<ProjectCreationContext>(), Arg.Any<CancellationToken>());
     }
 
@@ -89,8 +88,8 @@ public sealed class FunctionsProjectResolverTests
 
         ProjectResolutionResult result = await resolver.ResolveProjectAsync(CreateContext(), CancellationToken.None);
 
-        ProjectResolutionResult.NotResolved notResolved = result.Should().BeOfType<ProjectResolutionResult.NotResolved>().Subject;
-        notResolved.Message.Should().Contain("No installed workload recognized");
+        result.Should().BeOfType<ProjectResolutionResult.NotResolved>()
+            .Which.Message.Should().Contain("No installed workload recognized");
     }
 
     [Fact]

--- a/test/Func.Tests/Projects/FunctionsProjectResolverTests.cs
+++ b/test/Func.Tests/Projects/FunctionsProjectResolverTests.cs
@@ -6,7 +6,6 @@ using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Workers;
 using Azure.Functions.Cli.Workloads;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Projects;
 
@@ -23,9 +22,9 @@ public sealed class FunctionsProjectResolverTests
 
         ProjectResolutionResult result = await resolver.ResolveProjectAsync(CreateContext(), CancellationToken.None);
 
-        ProjectResolutionResult.Resolved resolved = Assert.IsType<ProjectResolutionResult.Resolved>(result);
-        Assert.Same(project, resolved.Project);
-        Assert.Equal("matched", resolved.Message);
+        ProjectResolutionResult.Resolved resolved = result.Should().BeOfType<ProjectResolutionResult.Resolved>().Subject;
+        resolved.Project.Should().BeSameAs(project);
+        resolved.Message.Should().Be("matched");
     }
 
     [Fact]
@@ -38,9 +37,9 @@ public sealed class FunctionsProjectResolverTests
 
         ProjectResolutionResult result = await resolver.ResolveProjectAsync(CreateContext(), CancellationToken.None);
 
-        ProjectResolutionResult.Resolved resolved = Assert.IsType<ProjectResolutionResult.Resolved>(result);
-        Assert.Same(project, resolved.Project);
-        Assert.Equal("matched second", resolved.Message);
+        ProjectResolutionResult.Resolved resolved = result.Should().BeOfType<ProjectResolutionResult.Resolved>().Subject;
+        resolved.Project.Should().BeSameAs(project);
+        resolved.Message.Should().Be("matched second");
         await second.Received(1).TryCreateProjectAsync(Arg.Any<ProjectCreationContext>(), Arg.Any<CancellationToken>());
     }
 
@@ -56,8 +55,8 @@ public sealed class FunctionsProjectResolverTests
 
         ProjectResolutionResult result = await resolver.ResolveProjectAsync(CreateContext(), CancellationToken.None);
 
-        ProjectResolutionResult.Resolved resolved = Assert.IsType<ProjectResolutionResult.Resolved>(result);
-        Assert.Same(firstProject, resolved.Project);
+        ProjectResolutionResult.Resolved resolved = result.Should().BeOfType<ProjectResolutionResult.Resolved>().Subject;
+        resolved.Project.Should().BeSameAs(firstProject);
         await second.DidNotReceive().TryCreateProjectAsync(Arg.Any<ProjectCreationContext>(), Arg.Any<CancellationToken>());
     }
 
@@ -76,9 +75,9 @@ public sealed class FunctionsProjectResolverTests
 
         ProjectResolutionResult result = await resolver.ResolveProjectAsync(CreateContext(), CancellationToken.None);
 
-        ProjectResolutionResult.NotResolved notResolved = Assert.IsType<ProjectResolutionResult.NotResolved>(result);
-        Assert.Equal("missing worker", notResolved.Message);
-        Assert.Same(failure, notResolved.Failure);
+        ProjectResolutionResult.NotResolved notResolved = result.Should().BeOfType<ProjectResolutionResult.NotResolved>().Subject;
+        notResolved.Message.Should().Be("missing worker");
+        notResolved.Failure.Should().BeSameAs(failure);
         await second.DidNotReceive().TryCreateProjectAsync(Arg.Any<ProjectCreationContext>(), Arg.Any<CancellationToken>());
     }
 
@@ -90,8 +89,8 @@ public sealed class FunctionsProjectResolverTests
 
         ProjectResolutionResult result = await resolver.ResolveProjectAsync(CreateContext(), CancellationToken.None);
 
-        ProjectResolutionResult.NotResolved notResolved = Assert.IsType<ProjectResolutionResult.NotResolved>(result);
-        Assert.Contains("No installed workload recognized", notResolved.Message);
+        ProjectResolutionResult.NotResolved notResolved = result.Should().BeOfType<ProjectResolutionResult.NotResolved>().Subject;
+        notResolved.Message.Should().Contain("No installed workload recognized");
     }
 
     [Fact]

--- a/test/Func.Tests/Quickstart/HttpTemplateFetcherTests.cs
+++ b/test/Func.Tests/Quickstart/HttpTemplateFetcherTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Quickstart;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Quickstart;
 
@@ -21,7 +20,7 @@ public class HttpTemplateFetcherTests
 
         string result = HttpTemplateFetcher.BuildArchiveUrl(entry);
 
-        Assert.Equal(expected, result);
+        result.Should().Be(expected);
     }
 
     [Fact]
@@ -31,8 +30,8 @@ public class HttpTemplateFetcherTests
 
         string result = HttpTemplateFetcher.BuildArchiveUrl(entry);
 
-        Assert.DoesNotContain("//archive", result);
-        Assert.Contains("/archive/refs/tags/v1.0.0.zip", result);
+        result.Should().NotContain("//archive");
+        result.Should().Contain("/archive/refs/tags/v1.0.0.zip");
     }
 
     [Fact]
@@ -40,9 +39,8 @@ public class HttpTemplateFetcherTests
     {
         QuickstartEntry entry = CreateEntry(repositoryUrl: "https://gitlab.com/org/repo");
 
-        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
-            () => HttpTemplateFetcher.BuildArchiveUrl(entry));
-        Assert.Contains("github.com", ex.Message);
+        InvalidOperationException ex = FluentActions.Invoking(() => HttpTemplateFetcher.BuildArchiveUrl(entry)).Should().ThrowExactly<InvalidOperationException>().Which;
+        ex.Message.Should().Contain("github.com");
     }
 
     [Fact]
@@ -55,8 +53,8 @@ public class HttpTemplateFetcherTests
         // Must contain exactly one occurrence of "refs/tags/"
         int firstIndex = result.IndexOf("refs/tags/", StringComparison.Ordinal);
         int secondIndex = result.IndexOf("refs/tags/", firstIndex + 1, StringComparison.Ordinal);
-        Assert.True(firstIndex >= 0, "URL should contain refs/tags/");
-        Assert.True(secondIndex < 0, "URL should not contain refs/tags/ twice");
+        (firstIndex >= 0).Should().BeTrue("URL should contain refs/tags/");
+        (secondIndex < 0).Should().BeTrue("URL should not contain refs/tags/ twice");
     }
 
     private static QuickstartEntry CreateEntry(

--- a/test/Func.Tests/Quickstart/QuickstartManifestServiceTests.cs
+++ b/test/Func.Tests/Quickstart/QuickstartManifestServiceTests.cs
@@ -6,7 +6,6 @@ using Azure.Functions.Cli.Quickstart;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Quickstart;
 
@@ -34,8 +33,8 @@ public sealed class QuickstartManifestServiceTests
 
         QuickstartManifest result = await service.GetManifestAsync();
 
-        Assert.Single(result.Entries);
-        Assert.Equal("http-python", result.Entries[0].Id);
+        result.Entries.Should().ContainSingle();
+        result.Entries[0].Id.Should().Be("http-python");
         cache.Received(1).WriteManifest(manifest);
         cache.Received(1).WriteMeta(Arg.Any<ManifestCacheMeta>());
     }
@@ -52,8 +51,8 @@ public sealed class QuickstartManifestServiceTests
 
         QuickstartManifest result = await service.GetManifestAsync();
 
-        Assert.Single(result.Entries);
-        Assert.Equal("cached-entry", result.Entries[0].Id);
+        result.Entries.Should().ContainSingle();
+        result.Entries[0].Id.Should().Be("cached-entry");
     }
 
     [Fact]
@@ -74,8 +73,8 @@ public sealed class QuickstartManifestServiceTests
 
         QuickstartManifest result = await service.GetManifestAsync();
 
-        Assert.Single(result.Entries);
-        Assert.Equal("fresh-entry", result.Entries[0].Id);
+        result.Entries.Should().ContainSingle();
+        result.Entries[0].Id.Should().Be("fresh-entry");
         cache.Received(1).WriteManifest(freshManifest);
     }
 
@@ -91,8 +90,8 @@ public sealed class QuickstartManifestServiceTests
 
         QuickstartManifest result = await service.GetManifestAsync();
 
-        Assert.Single(result.Entries);
-        Assert.Equal("existing-entry", result.Entries[0].Id);
+        result.Entries.Should().ContainSingle();
+        result.Entries[0].Id.Should().Be("existing-entry");
         cache.Received(1).WriteMeta(Arg.Is<ManifestCacheMeta>(m => m.ETag == "\"etag1\""));
     }
 
@@ -108,8 +107,8 @@ public sealed class QuickstartManifestServiceTests
 
         QuickstartManifest result = await service.GetManifestAsync();
 
-        Assert.Single(result.Entries);
-        Assert.Equal("stale-entry", result.Entries[0].Id);
+        result.Entries.Should().ContainSingle();
+        result.Entries[0].Id.Should().Be("stale-entry");
     }
 
     [Fact]
@@ -120,7 +119,7 @@ public sealed class QuickstartManifestServiceTests
         QuickstartManifestService service = CreateService(
             new HttpRequestException("Network unreachable"), cache);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetManifestAsync());
+        await FluentActions.Awaiting(() => service.GetManifestAsync()).Should().ThrowAsync<InvalidOperationException>();
     }
 
     [Fact]
@@ -138,8 +137,8 @@ public sealed class QuickstartManifestServiceTests
 
         QuickstartManifest result = await service.GetManifestAsync();
 
-        Assert.Single(result.Entries);
-        Assert.Equal("has-ref", result.Entries[0].Id);
+        result.Entries.Should().ContainSingle();
+        result.Entries[0].Id.Should().Be("has-ref");
     }
 
     [Fact]
@@ -157,8 +156,8 @@ public sealed class QuickstartManifestServiceTests
 
         QuickstartManifest result = await service.GetManifestAsync();
 
-        Assert.Single(result.Entries);
-        Assert.Equal("full-ref", result.Entries[0].Id);
+        result.Entries.Should().ContainSingle();
+        result.Entries[0].Id.Should().Be("full-ref");
     }
 
     [Fact]
@@ -176,8 +175,8 @@ public sealed class QuickstartManifestServiceTests
 
         QuickstartManifest result = await service.GetManifestAsync();
 
-        Assert.Single(result.Entries);
-        Assert.Equal("tagged", result.Entries[0].Id);
+        result.Entries.Should().ContainSingle();
+        result.Entries[0].Id.Should().Be("tagged");
     }
 
     [Fact]
@@ -200,8 +199,8 @@ public sealed class QuickstartManifestServiceTests
 
         QuickstartManifest result = await service.GetManifestAsync();
 
-        Assert.Single(result.Entries);
-        Assert.Equal("trusted", result.Entries[0].Id);
+        result.Entries.Should().ContainSingle();
+        result.Entries[0].Id.Should().Be("trusted");
     }
 
     [Fact]
@@ -220,7 +219,7 @@ public sealed class QuickstartManifestServiceTests
 
         QuickstartManifest result = await service.GetManifestAsync();
 
-        Assert.Equal(3, result.Entries.Count);
+        result.Entries.Count.Should().Be(3);
     }
 
     [Fact]
@@ -236,8 +235,8 @@ public sealed class QuickstartManifestServiceTests
 
         QuickstartManifest result = await service.GetManifestAsync();
 
-        Assert.Single(result.Entries);
-        Assert.Equal("cached", result.Entries[0].Id);
+        result.Entries.Should().ContainSingle();
+        result.Entries[0].Id.Should().Be("cached");
     }
 
     [Fact]
@@ -256,8 +255,8 @@ public sealed class QuickstartManifestServiceTests
 
             QuickstartManifest result = await service.GetManifestAsync();
 
-            Assert.Single(result.Entries);
-            Assert.Equal("local-entry", result.Entries[0].Id);
+            result.Entries.Should().ContainSingle();
+            result.Entries[0].Id.Should().Be("local-entry");
         }
         finally
         {
@@ -274,7 +273,7 @@ public sealed class QuickstartManifestServiceTests
         QuickstartManifestService service = CreateService(
             new HttpResponseMessage(HttpStatusCode.InternalServerError), cache);
 
-        await Assert.ThrowsAsync<FileNotFoundException>(() => service.GetManifestAsync());
+        await FluentActions.Awaiting(() => service.GetManifestAsync()).Should().ThrowAsync<FileNotFoundException>();
     }
 
     [Fact]
@@ -290,11 +289,10 @@ public sealed class QuickstartManifestServiceTests
             QuickstartManifestService service = CreateService(
                 new HttpResponseMessage(HttpStatusCode.InternalServerError), cache);
 
-            InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(
-                () => service.GetManifestAsync());
+            InvalidOperationException ex = (await FluentActions.Awaiting(() => service.GetManifestAsync()).Should().ThrowAsync<InvalidOperationException>()).Which;
 
-            Assert.Contains("empty or malformed", ex.Message);
-            Assert.IsType<System.Text.Json.JsonException>(ex.InnerException);
+            ex.Message.Should().Contain("empty or malformed");
+            ex.InnerException.Should().BeOfType<System.Text.Json.JsonException>();
         }
         finally
         {
@@ -316,8 +314,8 @@ public sealed class QuickstartManifestServiceTests
 
         QuickstartManifest result = await service.GetManifestAsync();
 
-        Assert.Single(result.Entries);
-        Assert.Equal("cdn-entry", result.Entries[0].Id);
+        result.Entries.Should().ContainSingle();
+        result.Entries[0].Id.Should().Be("cdn-entry");
     }
 
     private QuickstartManifestService CreateService(HttpResponseMessage response, IManifestCache cache)

--- a/test/Func.Tests/Quickstart/QuickstartManifestTests.cs
+++ b/test/Func.Tests/Quickstart/QuickstartManifestTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Quickstart;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Quickstart;
 
@@ -32,8 +31,8 @@ public sealed class QuickstartManifestTests
 
         IReadOnlyList<QuickstartEntry> results = manifest.Filter(language: "Python");
 
-        Assert.Single(results);
-        Assert.Equal("python-entry", results[0].Id);
+        results.Should().ContainSingle();
+        results[0].Id.Should().Be("python-entry");
     }
 
     [Fact]
@@ -43,7 +42,7 @@ public sealed class QuickstartManifestTests
 
         IReadOnlyList<QuickstartEntry> results = manifest.Filter(language: "python");
 
-        Assert.Single(results);
+        results.Should().ContainSingle();
     }
 
     [Fact]
@@ -57,8 +56,8 @@ public sealed class QuickstartManifestTests
 
         IReadOnlyList<QuickstartEntry> results = manifest.Filter(resource: "timer");
 
-        Assert.Single(results);
-        Assert.Equal("timer-entry", results[0].Id);
+        results.Should().ContainSingle();
+        results[0].Id.Should().Be("timer-entry");
     }
 
     [Fact]
@@ -72,8 +71,8 @@ public sealed class QuickstartManifestTests
 
         IReadOnlyList<QuickstartEntry> results = manifest.Filter(iac: "bicep");
 
-        Assert.Single(results);
-        Assert.Equal("bicep-entry", results[0].Id);
+        results.Should().ContainSingle();
+        results[0].Id.Should().Be("bicep-entry");
     }
 
     [Fact]
@@ -83,7 +82,7 @@ public sealed class QuickstartManifestTests
 
         IReadOnlyList<QuickstartEntry> results = manifest.Filter(search: "python");
 
-        Assert.Single(results);
+        results.Should().ContainSingle();
     }
 
     [Fact]
@@ -93,7 +92,7 @@ public sealed class QuickstartManifestTests
 
         IReadOnlyList<QuickstartEntry> results = manifest.Filter(search: "openai");
 
-        Assert.Single(results);
+        results.Should().ContainSingle();
     }
 
     [Fact]
@@ -103,7 +102,7 @@ public sealed class QuickstartManifestTests
 
         IReadOnlyList<QuickstartEntry> results = manifest.Filter(search: "Deploy with");
 
-        Assert.Single(results);
+        results.Should().ContainSingle();
     }
 
     [Fact]
@@ -113,7 +112,7 @@ public sealed class QuickstartManifestTests
 
         IReadOnlyList<QuickstartEntry> results = manifest.Filter(search: "terraform");
 
-        Assert.Single(results);
+        results.Should().ContainSingle();
     }
 
     [Fact]
@@ -128,8 +127,8 @@ public sealed class QuickstartManifestTests
 
         IReadOnlyList<QuickstartEntry> results = manifest.Filter(language: "Python", resource: "http");
 
-        Assert.Single(results);
-        Assert.Equal("match", results[0].Id);
+        results.Should().ContainSingle();
+        results[0].Id.Should().Be("match");
     }
 
     [Fact]
@@ -144,9 +143,9 @@ public sealed class QuickstartManifestTests
 
         IReadOnlyList<QuickstartEntry> results = manifest.Filter();
 
-        Assert.Equal("high-priority", results[0].Id);
-        Assert.Equal("mid-priority", results[1].Id);
-        Assert.Equal("low-priority", results[2].Id);
+        results[0].Id.Should().Be("high-priority");
+        results[1].Id.Should().Be("mid-priority");
+        results[2].Id.Should().Be("low-priority");
     }
 
     [Fact]
@@ -160,8 +159,8 @@ public sealed class QuickstartManifestTests
 
         IReadOnlyList<QuickstartEntry> results = manifest.Filter();
 
-        Assert.Equal(2, results.Count);
-        Assert.Equal("b", results[0].Id);
+        results.Count.Should().Be(2);
+        results[0].Id.Should().Be("b");
     }
 
     [Fact]
@@ -171,7 +170,7 @@ public sealed class QuickstartManifestTests
 
         IReadOnlyList<QuickstartEntry> results = manifest.Filter(language: "Go");
 
-        Assert.Empty(results);
+        results.Should().BeEmpty();
     }
 }
 

--- a/test/Func.Tests/Quickstart/QuickstartScaffolderTests.cs
+++ b/test/Func.Tests/Quickstart/QuickstartScaffolderTests.cs
@@ -4,7 +4,6 @@
 using Azure.Functions.Cli.Quickstart;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Quickstart;
 
@@ -48,45 +47,45 @@ public class QuickstartScaffolderTests : IDisposable
         await _scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None);
 
         // init → remote add → fetch → checkout → cat-file → rev-parse → rev-list = 7 calls
-        Assert.Equal(7, _gitRunner.Calls.Count);
+        _gitRunner.Calls.Count.Should().Be(7);
 
         // Call 1: git init <tempDir>
-        Assert.Contains("init", _gitRunner.Calls[0].Arguments);
+        _gitRunner.Calls[0].Arguments.Should().Contain("init");
 
         // Call 2: git -C <tempDir> remote add origin -- <url>
         IReadOnlyList<string> remoteArgs = _gitRunner.Calls[1].Arguments;
-        Assert.Contains("remote", remoteArgs);
-        Assert.Contains("add", remoteArgs);
-        Assert.Contains("origin", remoteArgs);
+        remoteArgs.Should().Contain("remote");
+        remoteArgs.Should().Contain("add");
+        remoteArgs.Should().Contain("origin");
 
         // Call 3: git -C <tempDir> fetch --depth 1 --no-tags origin refs/tags/v1.0.0:refs/tags/v1.0.0
         IReadOnlyList<string> fetchArgs = _gitRunner.Calls[2].Arguments;
-        Assert.Contains("fetch", fetchArgs);
-        Assert.Contains("--depth", fetchArgs);
-        Assert.Contains("--no-tags", fetchArgs);
-        Assert.Contains("refs/tags/v1.0.0:refs/tags/v1.0.0", fetchArgs);
+        fetchArgs.Should().Contain("fetch");
+        fetchArgs.Should().Contain("--depth");
+        fetchArgs.Should().Contain("--no-tags");
+        fetchArgs.Should().Contain("refs/tags/v1.0.0:refs/tags/v1.0.0");
 
         // Call 4: git -C <tempDir> checkout --detach refs/tags/v1.0.0
         IReadOnlyList<string> checkoutArgs = _gitRunner.Calls[3].Arguments;
-        Assert.Contains("checkout", checkoutArgs);
-        Assert.Contains("--detach", checkoutArgs);
-        Assert.Contains("refs/tags/v1.0.0", checkoutArgs);
+        checkoutArgs.Should().Contain("checkout");
+        checkoutArgs.Should().Contain("--detach");
+        checkoutArgs.Should().Contain("refs/tags/v1.0.0");
 
         // Call 5: git -C <tempDir> cat-file -t refs/tags/v1.0.0
         IReadOnlyList<string> catFileArgs = _gitRunner.Calls[4].Arguments;
-        Assert.Contains("cat-file", catFileArgs);
-        Assert.Contains("-t", catFileArgs);
-        Assert.Contains("refs/tags/v1.0.0", catFileArgs);
+        catFileArgs.Should().Contain("cat-file");
+        catFileArgs.Should().Contain("-t");
+        catFileArgs.Should().Contain("refs/tags/v1.0.0");
 
         // Call 6: git -C <tempDir> rev-parse HEAD
         IReadOnlyList<string> revParseArgs = _gitRunner.Calls[5].Arguments;
-        Assert.Contains("rev-parse", revParseArgs);
-        Assert.Contains("HEAD", revParseArgs);
+        revParseArgs.Should().Contain("rev-parse");
+        revParseArgs.Should().Contain("HEAD");
 
         // Call 7: git -C <tempDir> rev-list -n 1 refs/tags/v1.0.0
         IReadOnlyList<string> revListArgs = _gitRunner.Calls[6].Arguments;
-        Assert.Contains("rev-list", revListArgs);
-        Assert.Contains("refs/tags/v1.0.0", revListArgs);
+        revListArgs.Should().Contain("rev-list");
+        revListArgs.Should().Contain("refs/tags/v1.0.0");
     }
 
     [Fact]
@@ -94,9 +93,8 @@ public class QuickstartScaffolderTests : IDisposable
     {
         QuickstartEntry entry = CreateEntry(gitRef: "refs/heads/main");
 
-        ArgumentException ex = await Assert.ThrowsAsync<ArgumentException>(
-            () => _scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None));
-        Assert.Contains("not a tag ref", ex.Message);
+        ArgumentException ex = (await FluentActions.Awaiting(() => _scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None)).Should().ThrowAsync<ArgumentException>()).Which;
+        ex.Message.Should().Contain("not a tag ref");
     }
 
     [Fact]
@@ -104,9 +102,8 @@ public class QuickstartScaffolderTests : IDisposable
     {
         QuickstartEntry entry = CreateEntry(gitRef: "v1.0.0");
 
-        ArgumentException ex = await Assert.ThrowsAsync<ArgumentException>(
-            () => _scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None));
-        Assert.Contains("not a tag ref", ex.Message);
+        ArgumentException ex = (await FluentActions.Awaiting(() => _scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None)).Should().ThrowAsync<ArgumentException>()).Which;
+        ex.Message.Should().Contain("not a tag ref");
     }
 
     [Fact]
@@ -114,9 +111,8 @@ public class QuickstartScaffolderTests : IDisposable
     {
         QuickstartEntry entry = CreateEntry(gitRef: null);
 
-        ArgumentException ex = await Assert.ThrowsAsync<ArgumentException>(
-            () => _scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None));
-        Assert.Contains("no GitRef", ex.Message);
+        ArgumentException ex = (await FluentActions.Awaiting(() => _scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None)).Should().ThrowAsync<ArgumentException>()).Which;
+        ex.Message.Should().Contain("no GitRef");
     }
 
     [Fact]
@@ -124,9 +120,8 @@ public class QuickstartScaffolderTests : IDisposable
     {
         QuickstartEntry entry = CreateEntry(gitRef: "  ");
 
-        ArgumentException ex = await Assert.ThrowsAsync<ArgumentException>(
-            () => _scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None));
-        Assert.Contains("no GitRef", ex.Message);
+        ArgumentException ex = (await FluentActions.Awaiting(() => _scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None)).Should().ThrowAsync<ArgumentException>()).Which;
+        ex.Message.Should().Contain("no GitRef");
     }
 
     [Fact]
@@ -144,9 +139,8 @@ public class QuickstartScaffolderTests : IDisposable
             NullLogger<QuickstartScaffolder>.Instance);
         QuickstartEntry entry = CreateEntry();
 
-        InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None));
-        Assert.Contains("lightweight tag", ex.Message);
+        InvalidOperationException ex = (await FluentActions.Awaiting(() => scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None)).Should().ThrowAsync<InvalidOperationException>()).Which;
+        ex.Message.Should().Contain("lightweight tag");
     }
 
     [Fact]
@@ -156,8 +150,8 @@ public class QuickstartScaffolderTests : IDisposable
 
         await _scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None);
 
-        Assert.False(Directory.Exists(Path.Combine(_targetDir, ".git")));
-        Assert.False(Directory.Exists(Path.Combine(_targetDir, ".github")));
+        Directory.Exists(Path.Combine(_targetDir, ".git")).Should().BeFalse();
+        Directory.Exists(Path.Combine(_targetDir, ".github")).Should().BeFalse();
     }
 
     [Fact]
@@ -167,8 +161,8 @@ public class QuickstartScaffolderTests : IDisposable
 
         await _scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None);
 
-        Assert.True(File.Exists(Path.Combine(_targetDir, "host.json")));
-        Assert.True(File.Exists(Path.Combine(_targetDir, "function_app.py")));
+        File.Exists(Path.Combine(_targetDir, "host.json")).Should().BeTrue();
+        File.Exists(Path.Combine(_targetDir, "function_app.py")).Should().BeTrue();
     }
 
     [Fact]
@@ -178,8 +172,8 @@ public class QuickstartScaffolderTests : IDisposable
 
         await _scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None);
 
-        Assert.True(File.Exists(Path.Combine(_targetDir, "starter.txt")));
-        Assert.False(File.Exists(Path.Combine(_targetDir, "host.json")));
+        File.Exists(Path.Combine(_targetDir, "starter.txt")).Should().BeTrue();
+        File.Exists(Path.Combine(_targetDir, "host.json")).Should().BeFalse();
     }
 
     [Fact]
@@ -190,8 +184,8 @@ public class QuickstartScaffolderTests : IDisposable
         await _scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Auto, CancellationToken.None);
 
         // init → remote add → fetch → checkout → cat-file → rev-parse → rev-list = 7 calls
-        Assert.Equal(7, _gitRunner.Calls.Count);
-        Assert.Contains("init", _gitRunner.Calls[0].Arguments);
+        _gitRunner.Calls.Count.Should().Be(7);
+        _gitRunner.Calls[0].Arguments.Should().Contain("init");
     }
 
     [Fact]
@@ -211,10 +205,9 @@ public class QuickstartScaffolderTests : IDisposable
 
         // HTTP mode will fail because we didn't set up a real HttpClient,
         // but we can verify it didn't try git
-        await Assert.ThrowsAnyAsync<Exception>(
-            () => scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Auto, CancellationToken.None));
+        await FluentActions.Awaiting(() => scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Auto, CancellationToken.None)).Should().ThrowAsync<Exception>();
 
-        Assert.Empty(noGitRunner.Calls);
+        noGitRunner.Calls.Should().BeEmpty();
     }
 
     [Fact]
@@ -222,8 +215,7 @@ public class QuickstartScaffolderTests : IDisposable
     {
         QuickstartEntry entry = CreateEntry(gitRef: "--upload-pack=evil");
 
-        await Assert.ThrowsAsync<ArgumentException>(
-            () => _scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None));
+        await FluentActions.Awaiting(() => _scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None)).Should().ThrowAsync<ArgumentException>();
     }
 
     [Theory]
@@ -233,9 +225,8 @@ public class QuickstartScaffolderTests : IDisposable
     {
         QuickstartEntry entry = CreateEntry(folderPath: folderPath);
 
-        ArgumentException ex = await Assert.ThrowsAsync<ArgumentException>(
-            () => _scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None));
-        Assert.Contains("relative path", ex.Message);
+        ArgumentException ex = (await FluentActions.Awaiting(() => _scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None)).Should().ThrowAsync<ArgumentException>()).Which;
+        ex.Message.Should().Contain("relative path");
     }
 
     [Fact]
@@ -253,9 +244,8 @@ public class QuickstartScaffolderTests : IDisposable
             NullLogger<QuickstartScaffolder>.Instance);
         QuickstartEntry entry = CreateEntry(repositoryUrl: "https://gitlab.com/org/repo");
 
-        InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Http, CancellationToken.None));
-        Assert.Contains("github.com", ex.Message);
+        InvalidOperationException ex = (await FluentActions.Awaiting(() => scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Http, CancellationToken.None)).Should().ThrowAsync<InvalidOperationException>()).Which;
+        ex.Message.Should().Contain("github.com");
     }
 
     [Fact]
@@ -263,15 +253,13 @@ public class QuickstartScaffolderTests : IDisposable
     {
         QuickstartEntry entry = CreateEntry(folderPath: "../etc/passwd");
 
-        await Assert.ThrowsAsync<ArgumentException>(
-            () => _scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None));
+        await FluentActions.Awaiting(() => _scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None)).Should().ThrowAsync<ArgumentException>();
     }
 
     [Fact]
     public async Task ScaffoldAsync_NullEntry_ThrowsArgumentNullException()
     {
-        await Assert.ThrowsAsync<ArgumentNullException>(
-            () => _scaffolder.ScaffoldAsync(null!, _targetDir, FetchMode.Git, CancellationToken.None));
+        await FluentActions.Awaiting(() => _scaffolder.ScaffoldAsync(null!, _targetDir, FetchMode.Git, CancellationToken.None)).Should().ThrowAsync<ArgumentNullException>();
     }
 
     [Fact]
@@ -279,8 +267,7 @@ public class QuickstartScaffolderTests : IDisposable
     {
         QuickstartEntry entry = CreateEntry(folderPath: "nonexistent/path");
 
-        await Assert.ThrowsAsync<DirectoryNotFoundException>(
-            () => _scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None));
+        await FluentActions.Awaiting(() => _scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None)).Should().ThrowAsync<DirectoryNotFoundException>();
     }
 
     [Fact]
@@ -288,8 +275,7 @@ public class QuickstartScaffolderTests : IDisposable
     {
         QuickstartEntry entry = CreateEntry();
 
-        await Assert.ThrowsAsync<ArgumentNullException>(
-            () => _scaffolder.ScaffoldAsync(entry, null!, FetchMode.Git, CancellationToken.None));
+        await FluentActions.Awaiting(() => _scaffolder.ScaffoldAsync(entry, null!, FetchMode.Git, CancellationToken.None)).Should().ThrowAsync<ArgumentNullException>();
     }
 
     [Fact]
@@ -297,8 +283,7 @@ public class QuickstartScaffolderTests : IDisposable
     {
         QuickstartEntry entry = CreateEntry();
 
-        await Assert.ThrowsAsync<ArgumentException>(
-            () => _scaffolder.ScaffoldAsync(entry, "   ", FetchMode.Git, CancellationToken.None));
+        await FluentActions.Awaiting(() => _scaffolder.ScaffoldAsync(entry, "   ", FetchMode.Git, CancellationToken.None)).Should().ThrowAsync<ArgumentException>();
     }
 
     [Fact]
@@ -314,8 +299,7 @@ public class QuickstartScaffolderTests : IDisposable
         QuickstartEntry entry = CreateEntry();
 
         // init fails → GitRunnerException propagates directly (not wrapped)
-        await Assert.ThrowsAsync<GitRunnerException>(
-            () => scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None));
+        await FluentActions.Awaiting(() => scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None)).Should().ThrowAsync<GitRunnerException>();
     }
 
     [Fact]
@@ -324,8 +308,7 @@ public class QuickstartScaffolderTests : IDisposable
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => _scaffolder.ScaffoldAsync(CreateEntry(), _targetDir, FetchMode.Git, cts.Token));
+        await FluentActions.Awaiting(() => _scaffolder.ScaffoldAsync(CreateEntry(), _targetDir, FetchMode.Git, cts.Token)).Should().ThrowAsync<OperationCanceledException>();
     }
 
     [Fact]
@@ -342,11 +325,10 @@ public class QuickstartScaffolderTests : IDisposable
             NullLogger<QuickstartScaffolder>.Instance);
         QuickstartEntry entry = CreateEntry();
 
-        await Assert.ThrowsAsync<GitRunnerException>(
-            () => scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None));
+        await FluentActions.Awaiting(() => scaffolder.ScaffoldAsync(entry, _targetDir, FetchMode.Git, CancellationToken.None)).Should().ThrowAsync<GitRunnerException>();
 
         string[] tempDirsAfter = Directory.GetDirectories(Path.GetTempPath(), "func-quickstart-*");
-        Assert.Equal(tempDirsBefore.Length, tempDirsAfter.Length);
+        tempDirsAfter.Length.Should().Be(tempDirsBefore.Length);
     }
 
     private const string FakeCommitHash = "abc123def456";

--- a/test/Func.Tests/Quickstart/QuickstartUrlValidatorTests.cs
+++ b/test/Func.Tests/Quickstart/QuickstartUrlValidatorTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Quickstart;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Quickstart;
 
@@ -17,7 +16,7 @@ public sealed class QuickstartUrlValidatorTests
     [InlineData("https://github.com/microsoft/some-repo")]
     public void IsAllowed_AcceptsTrustedOrganizations(string url)
     {
-        Assert.True(QuickstartUrlValidator.IsAllowed(url));
+        QuickstartUrlValidator.IsAllowed(url).Should().BeTrue();
     }
 
     [Theory]
@@ -26,54 +25,54 @@ public sealed class QuickstartUrlValidatorTests
     [InlineData("   ")]
     public void IsAllowed_RejectsNullOrEmpty(string? url)
     {
-        Assert.False(QuickstartUrlValidator.IsAllowed(url));
+        QuickstartUrlValidator.IsAllowed(url).Should().BeFalse();
     }
 
     [Fact]
     public void IsAllowed_RejectsHttpScheme()
     {
-        Assert.False(QuickstartUrlValidator.IsAllowed("http://github.com/Azure/some-repo"));
+        QuickstartUrlValidator.IsAllowed("http://github.com/Azure/some-repo").Should().BeFalse();
     }
 
     [Fact]
     public void IsAllowed_RejectsNonGitHubHost()
     {
-        Assert.False(QuickstartUrlValidator.IsAllowed("https://gitlab.com/Azure/some-repo"));
+        QuickstartUrlValidator.IsAllowed("https://gitlab.com/Azure/some-repo").Should().BeFalse();
     }
 
     [Fact]
     public void IsAllowed_RejectsUntrustedOrganization()
     {
-        Assert.False(QuickstartUrlValidator.IsAllowed("https://github.com/random-user/some-repo"));
+        QuickstartUrlValidator.IsAllowed("https://github.com/random-user/some-repo").Should().BeFalse();
     }
 
     [Fact]
     public void IsAllowed_RejectsEmbeddedCredentials()
     {
-        Assert.False(QuickstartUrlValidator.IsAllowed("https://user:pass@github.com/Azure/some-repo"));
+        QuickstartUrlValidator.IsAllowed("https://user:pass@github.com/Azure/some-repo").Should().BeFalse();
     }
 
     [Fact]
     public void IsAllowed_RejectsInvalidUri()
     {
-        Assert.False(QuickstartUrlValidator.IsAllowed("not-a-url"));
+        QuickstartUrlValidator.IsAllowed("not-a-url").Should().BeFalse();
     }
 
     [Fact]
     public void IsAllowed_RejectsFileScheme()
     {
-        Assert.False(QuickstartUrlValidator.IsAllowed("file:///c:/manifests/test.json"));
+        QuickstartUrlValidator.IsAllowed("file:///c:/manifests/test.json").Should().BeFalse();
     }
 
     [Fact]
     public void IsAllowed_RejectsNonDefaultPort()
     {
-        Assert.False(QuickstartUrlValidator.IsAllowed("https://github.com:8080/Azure/some-repo"));
+        QuickstartUrlValidator.IsAllowed("https://github.com:8080/Azure/some-repo").Should().BeFalse();
     }
 
     [Fact]
     public void IsAllowed_RejectsOrgWithoutRepo()
     {
-        Assert.False(QuickstartUrlValidator.IsAllowed("https://github.com/Azure"));
+        QuickstartUrlValidator.IsAllowed("https://github.com/Azure").Should().BeFalse();
     }
 }

--- a/test/Func.Tests/Telemetry/CommandNameResolverTests.cs
+++ b/test/Func.Tests/Telemetry/CommandNameResolverTests.cs
@@ -4,7 +4,6 @@
 using System.CommandLine;
 using Azure.Functions.Cli.Commands;
 using Azure.Functions.Cli.Telemetry;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Telemetry;
 
@@ -15,8 +14,7 @@ public class CommandNameResolverTests
     {
         var rootCommand = new FuncRootCommand();
 
-        Assert.Throws<ArgumentNullException>(
-            () => CommandNameResolver.ResolveCommandName(null!, rootCommand));
+        FluentActions.Invoking(() => CommandNameResolver.ResolveCommandName(null!, rootCommand)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
@@ -25,8 +23,7 @@ public class CommandNameResolverTests
         var rootCommand = new FuncRootCommand();
         ParseResult parseResult = rootCommand.Parse([]);
 
-        Assert.Throws<ArgumentNullException>(
-            () => CommandNameResolver.ResolveCommandName(parseResult, null!));
+        FluentActions.Invoking(() => CommandNameResolver.ResolveCommandName(parseResult, null!)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
@@ -38,7 +35,7 @@ public class CommandNameResolverTests
 
         string name = CommandNameResolver.ResolveCommandName(parseResult, rootCommand);
 
-        Assert.Equal("help", name);
+        name.Should().Be("help");
     }
 
     [Fact]
@@ -50,7 +47,7 @@ public class CommandNameResolverTests
 
         string name = CommandNameResolver.ResolveCommandName(parseResult, rootCommand);
 
-        Assert.Equal("version", name);
+        name.Should().Be("version");
     }
 
     [Fact]
@@ -63,7 +60,7 @@ public class CommandNameResolverTests
 
         string name = CommandNameResolver.ResolveCommandName(parseResult, rootCommand);
 
-        Assert.Equal("init", name);
+        name.Should().Be("init");
     }
 
     [Fact]
@@ -78,7 +75,7 @@ public class CommandNameResolverTests
 
         string name = CommandNameResolver.ResolveCommandName(parseResult, rootCommand);
 
-        Assert.Equal("workload list", name);
+        name.Should().Be("workload list");
     }
 
     [Fact]
@@ -96,7 +93,7 @@ public class CommandNameResolverTests
 
         string name = CommandNameResolver.ResolveCommandName(parseResult, rootCommand);
 
-        Assert.Equal("workload remote add", name);
+        name.Should().Be("workload remote add");
     }
 
     [Fact]
@@ -111,7 +108,7 @@ public class CommandNameResolverTests
 
         string name = CommandNameResolver.ResolveCommandName(parseResult, rootCommand);
 
-        Assert.Equal("init", name);
+        name.Should().Be("init");
     }
 
     [Fact]
@@ -122,10 +119,10 @@ public class CommandNameResolverTests
         var rootCommand = new FuncRootCommand();
         ParseResult parseResult = rootCommand.Parse(["badcommand"]);
 
-        Assert.NotEmpty(parseResult.Errors);
+        parseResult.Errors.Should().NotBeEmpty();
 
         string name = CommandNameResolver.ResolveCommandName(parseResult, rootCommand);
 
-        Assert.Equal("unknown", name);
+        name.Should().Be("unknown");
     }
 }

--- a/test/Func.Tests/Telemetry/TelemetryTests.cs
+++ b/test/Func.Tests/Telemetry/TelemetryTests.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using Azure.Functions.Cli.Telemetry;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Telemetry;
 
@@ -14,8 +13,8 @@ public class TelemetryTests
     {
         // Default build has the all-zeros instrumentation key, so telemetry
         // is not configured.
-        Assert.False(CliTelemetry.TryGetConnectionString(out var connectionString));
-        Assert.Null(connectionString);
+        CliTelemetry.TryGetConnectionString(out var connectionString).Should().BeFalse();
+        connectionString.Should().BeNull();
     }
 
     [Theory]
@@ -29,7 +28,7 @@ public class TelemetryTests
 
         // We can't override the build-time key from a test, so we just
         // assert the helper agrees the opt-out wins regardless of key state.
-        Assert.False(CliTelemetry.TryGetConnectionString(out _));
+        CliTelemetry.TryGetConnectionString(out _).Should().BeFalse();
     }
 
     [Theory]
@@ -66,7 +65,7 @@ public class TelemetryTests
         // an opt-out, so we fail safe toward not collecting telemetry.
         using var optOut = new EnvVarScope(Azure.Functions.Cli.Common.Constants.TelemetryOptOutEnvVar, value);
 
-        Assert.False(CliTelemetry.TryGetConnectionString(out _));
+        CliTelemetry.TryGetConnectionString(out _).Should().BeFalse();
     }
 
     private sealed class EnvVarScope : IDisposable
@@ -101,11 +100,11 @@ public class TelemetryTests
         using var listener = SubscribeListener();
 
         using var activity = CliTelemetry.Trace.StartCommandActivity();
-        Assert.NotNull(activity);
+        activity.Should().NotBeNull();
 
-        Assert.Equal(ActivityExtensions.CommandActivityName, activity.OperationName);
-        Assert.Equal(ActivityKind.Internal, activity.Kind);
-        Assert.Null(activity.GetTagItem(TelemetryConventions.CliCommandName));
+        activity.OperationName.Should().Be(ActivityExtensions.CommandActivityName);
+        activity.Kind.Should().Be(ActivityKind.Internal);
+        activity.GetTagItem(TelemetryConventions.CliCommandName).Should().BeNull();
     }
 
     [Fact]
@@ -114,14 +113,14 @@ public class TelemetryTests
         using var listener = SubscribeListener();
 
         using var activity = CliTelemetry.Trace.StartCommandActivity();
-        Assert.NotNull(activity);
+        activity.Should().NotBeNull();
 
         activity.SetCommandName("workload install");
 
-        Assert.Equal("workload install", activity.DisplayName);
-        Assert.Equal("workload install", activity.GetTagItem(TelemetryConventions.CliCommandName));
+        activity.DisplayName.Should().Be("workload install");
+        activity.GetTagItem(TelemetryConventions.CliCommandName).Should().Be("workload install");
         // Operation name (fixed at creation) is left alone — only DisplayName moves.
-        Assert.Equal(ActivityExtensions.CommandActivityName, activity.OperationName);
+        activity.OperationName.Should().Be(ActivityExtensions.CommandActivityName);
     }
 
     [Fact]
@@ -132,13 +131,13 @@ public class TelemetryTests
         using var listener = SubscribeListener();
 
         using var activity = CliTelemetry.Trace.StartCommandActivity();
-        Assert.NotNull(activity);
+        activity.Should().NotBeNull();
 
         activity.SetCommandName("workload");
         activity.SetCommandName("workload install");
 
-        Assert.Equal("workload install", activity.DisplayName);
-        Assert.Equal("workload install", activity.GetTagItem(TelemetryConventions.CliCommandName));
+        activity.DisplayName.Should().Be("workload install");
+        activity.GetTagItem(TelemetryConventions.CliCommandName).Should().Be("workload install");
     }
 
     [Fact]
@@ -147,13 +146,13 @@ public class TelemetryTests
         using var listener = SubscribeListener();
 
         using var activity = CliTelemetry.Trace.StartCommandActivity();
-        Assert.NotNull(activity);
+        activity.Should().NotBeNull();
 
         var ex = new InvalidOperationException("boom");
         activity.Fail(ex);
 
-        Assert.Equal(ActivityStatusCode.Error, activity.Status);
-        Assert.Equal("boom", activity.StatusDescription);
+        activity.Status.Should().Be(ActivityStatusCode.Error);
+        activity.StatusDescription.Should().Be("boom");
     }
 
     [Fact]
@@ -162,11 +161,11 @@ public class TelemetryTests
         var resource = CliTelemetry.CreateResourceBuilder().Build();
         var attrs = resource.Attributes.ToDictionary(kv => kv.Key, kv => kv.Value);
 
-        Assert.Equal(CliTelemetry.SourceName, attrs["service.name"]);
-        Assert.Equal(CliTelemetry.CliVersion, attrs["service.version"]);
-        Assert.True(attrs.ContainsKey("os.type"));
-        Assert.True(attrs.ContainsKey("os.architecture"));
-        Assert.True(attrs.ContainsKey("process.runtime.description"));
+        attrs["service.name"].Should().Be(CliTelemetry.SourceName);
+        attrs["service.version"].Should().Be(CliTelemetry.CliVersion);
+        attrs.ContainsKey("os.type").Should().BeTrue();
+        attrs.ContainsKey("os.architecture").Should().BeTrue();
+        attrs.ContainsKey("process.runtime.description").Should().BeTrue();
     }
 
     private static ActivityListener SubscribeListener()

--- a/test/Func.Tests/Templates/DotNet/DotNetEngineProviderTests.cs
+++ b/test/Func.Tests/Templates/DotNet/DotNetEngineProviderTests.cs
@@ -166,8 +166,8 @@ public class DotNetEngineProviderTests : IDisposable
             new System.CommandLine.RootCommand().Parse(string.Empty),
             CancellationToken.None);
 
-        var failed = result.Should().BeOfType<TemplateApplicationResult.Failed>().Subject;
-        failed.Failure.Should().BeOfType<TemplateApplicationFailure.ProviderError>();
+        result.Should().BeOfType<TemplateApplicationResult.Failed>()
+            .Which.Failure.Should().BeOfType<TemplateApplicationFailure.ProviderError>();
     }
 
     [Fact]

--- a/test/Func.Tests/Templates/DotNet/DotNetEngineProviderTests.cs
+++ b/test/Func.Tests/Templates/DotNet/DotNetEngineProviderTests.cs
@@ -4,7 +4,6 @@
 using Azure.Functions.Cli.Templates;
 using Azure.Functions.Cli.Templates.DotNet;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Templates.DotNet;
 
@@ -37,7 +36,7 @@ public class DotNetEngineProviderTests : IDisposable
             new TemplateListContext(new Cli.Common.WorkingDirectory(new DirectoryInfo(_installDir), false), "dotnet", "csharp"),
             CancellationToken.None);
 
-        Assert.Empty(templates);
+        templates.Should().BeEmpty();
     }
 
     [Fact]
@@ -58,11 +57,11 @@ public class DotNetEngineProviderTests : IDisposable
 
         // Two records (C# + F# variants of HttpTrigger sharing groupIdentity)
         // collapse to a single FunctionTemplateInfo whose Languages list both.
-        var info = Assert.Single(templates);
-        Assert.Equal("http", info.Id);
-        Assert.Equal(EngineIds.DotNet, info.EngineId);
-        Assert.Contains("c#", info.Languages, StringComparer.OrdinalIgnoreCase);
-        Assert.Contains("f#", info.Languages, StringComparer.OrdinalIgnoreCase);
+        var info = templates.Should().ContainSingle().Subject;
+        info.Id.Should().Be("http");
+        info.EngineId.Should().Be(EngineIds.DotNet);
+        info.Languages.Should().Contain(x => string.Equals(x, "c#", StringComparison.OrdinalIgnoreCase));
+        info.Languages.Should().Contain(x => string.Equals(x, "f#", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
@@ -83,7 +82,7 @@ public class DotNetEngineProviderTests : IDisposable
             new TemplateListContext(new Cli.Common.WorkingDirectory(new DirectoryInfo(_installDir), false), "dotnet", "csharp"),
             CancellationToken.None);
 
-        Assert.Single(csharp);
+        csharp.Should().ContainSingle();
     }
 
     [Fact]
@@ -125,7 +124,7 @@ public class DotNetEngineProviderTests : IDisposable
             new System.CommandLine.RootCommand().Parse(string.Empty),
             CancellationToken.None);
 
-        Assert.IsType<TemplateApplicationResult.Created>(result);
+        result.Should().BeOfType<TemplateApplicationResult.Created>();
     }
 
     [Fact]
@@ -167,8 +166,8 @@ public class DotNetEngineProviderTests : IDisposable
             new System.CommandLine.RootCommand().Parse(string.Empty),
             CancellationToken.None);
 
-        var failed = Assert.IsType<TemplateApplicationResult.Failed>(result);
-        Assert.IsType<TemplateApplicationFailure.ProviderError>(failed.Failure);
+        var failed = result.Should().BeOfType<TemplateApplicationResult.Failed>().Subject;
+        failed.Failure.Should().BeOfType<TemplateApplicationFailure.ProviderError>();
     }
 
     [Fact]
@@ -211,8 +210,8 @@ public class DotNetEngineProviderTests : IDisposable
             new System.CommandLine.RootCommand().Parse(string.Empty),
             CancellationToken.None);
 
-        Assert.NotNull(capturedArgs);
-        Assert.Contains("--force", capturedArgs!);
+        capturedArgs.Should().NotBeNull();
+        capturedArgs!.Should().Contain("--force");
     }
 
     [Fact]
@@ -255,8 +254,8 @@ public class DotNetEngineProviderTests : IDisposable
             new System.CommandLine.RootCommand().Parse(string.Empty),
             CancellationToken.None);
 
-        Assert.NotNull(capturedArgs);
-        Assert.DoesNotContain("--force", capturedArgs!);
+        capturedArgs.Should().NotBeNull();
+        capturedArgs!.Should().NotContain("--force");
     }
 
     private static void WriteFixture(string installDir)

--- a/test/Func.Tests/Templates/NewCommandRendererTests.cs
+++ b/test/Func.Tests/Templates/NewCommandRendererTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Templates;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Templates;
 
@@ -22,9 +21,9 @@ public class NewCommandRendererTests
 
         renderer.RenderCatalogue("dotnet", "c#", templates);
 
-        Assert.Contains("TABLE: [NAME, TEMPLATE ID, DESCRIPTION]", interaction.Lines);
-        Assert.Contains("  ROW: [BlobTrigger, blob, blob desc]", interaction.Lines);
-        Assert.Contains("  ROW: [DurableFunctionsEntityClass, durableentityclass, entity desc]", interaction.Lines);
+        interaction.Lines.Should().Contain("TABLE: [NAME, TEMPLATE ID, DESCRIPTION]");
+        interaction.Lines.Should().Contain("  ROW: [BlobTrigger, blob, blob desc]");
+        interaction.Lines.Should().Contain("  ROW: [DurableFunctionsEntityClass, durableentityclass, entity desc]");
     }
 
     [Fact]
@@ -40,7 +39,7 @@ public class NewCommandRendererTests
 
         renderer.RenderCatalogue("dotnet", null, templates);
 
-        Assert.Contains("  ROW: [anonymous, anonymous, no display]", interaction.Lines);
+        interaction.Lines.Should().Contain("  ROW: [anonymous, anonymous, no display]");
     }
 
     [Fact]
@@ -54,9 +53,7 @@ public class NewCommandRendererTests
             "c#",
             [MakeTemplate(id: "http", displayName: "HttpTrigger", description: "")]);
 
-        Assert.Contains(
-            interaction.Lines,
-            l => l.Contains("func new --template <TEMPLATE_ID> --name <function-name>", System.StringComparison.Ordinal));
+        interaction.Lines.Should().Contain(l => l.Contains("func new --template <TEMPLATE_ID> --name <function-name>", System.StringComparison.Ordinal));
     }
 
     private static FunctionTemplateInfo MakeTemplate(string id, string displayName, string? description) =>

--- a/test/Func.Tests/Templates/NewCommandRunnerTests.cs
+++ b/test/Func.Tests/Templates/NewCommandRunnerTests.cs
@@ -10,7 +10,6 @@ using Azure.Functions.Cli.Templates;
 using Azure.Functions.Cli.Workers;
 using Microsoft.Extensions.Options;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Templates;
 
@@ -36,9 +35,9 @@ public class NewCommandRunnerTests
 
         int exitCode = await runner.ExecuteAsync(invocation, CancellationToken.None);
 
-        Assert.Equal(1, exitCode);
+        exitCode.Should().Be(1);
         int hits = interaction.Lines.Count(l => l.Contains("Cannot determine language for stack"));
-        Assert.True(hits == 1, $"expected the missing-language error to be rendered exactly once, but it was rendered {hits} times. Output:\n{interaction.AllOutput}");
+        (hits == 1).Should().BeTrue($"expected the missing-language error to be rendered exactly once, but it was rendered {hits} times. Output:\n{interaction.AllOutput}");
     }
 
     [Fact]
@@ -57,9 +56,9 @@ public class NewCommandRunnerTests
 
         int exitCode = await runner.ListAsync(invocation, CancellationToken.None);
 
-        Assert.Equal(1, exitCode);
+        exitCode.Should().Be(1);
         int hits = interaction.Lines.Count(l => l.Contains("Cannot determine language for stack"));
-        Assert.True(hits == 1, $"expected the missing-language error to be rendered exactly once, but it was rendered {hits} times. Output:\n{interaction.AllOutput}");
+        (hits == 1).Should().BeTrue($"expected the missing-language error to be rendered exactly once, but it was rendered {hits} times. Output:\n{interaction.AllOutput}");
     }
 
     [Fact]
@@ -85,10 +84,10 @@ public class NewCommandRunnerTests
 
         int exitCode = await runner.ListAsync(invocation, CancellationToken.None);
 
-        Assert.Equal(1, exitCode);
-        Assert.Contains(interaction.Lines, l =>
+        exitCode.Should().Be(1);
+        interaction.Lines.Should().Contain(l =>
             l.Contains("WARNING") && l.Contains("preview") && l.Contains(BundleHelpers.PreviewBundleId));
-        Assert.DoesNotContain(interaction.Lines, l =>
+        interaction.Lines.Should().NotContain(l =>
             l.Contains("No installed templates workload matches"));
     }
 
@@ -114,8 +113,8 @@ public class NewCommandRunnerTests
 
         int exitCode = await runner.ListAsync(invocation, CancellationToken.None);
 
-        Assert.Equal(1, exitCode);
-        Assert.Contains(interaction.Lines, l => l.Contains("No installed templates workload matches"));
+        exitCode.Should().Be(1);
+        interaction.Lines.Should().Contain(l => l.Contains("No installed templates workload matches"));
     }
 
     private static NewCommandRunner BuildRunnerForMissingLanguage(TestInteractionService interaction)

--- a/test/Func.Tests/Templates/TemplateEngineProviderRegistryTests.cs
+++ b/test/Func.Tests/Templates/TemplateEngineProviderRegistryTests.cs
@@ -3,7 +3,6 @@
 
 using Azure.Functions.Cli.Templates;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Templates;
 
@@ -14,9 +13,9 @@ public class TemplateEngineProviderRegistryTests
     {
         var registry = new TemplateEngineProviderRegistry([]);
 
-        Assert.Null(registry.TryGet(EngineIds.V2));
-        Assert.Null(registry.TryGet(EngineIds.DotNet));
-        Assert.Empty(registry.Providers);
+        registry.TryGet(EngineIds.V2).Should().BeNull();
+        registry.TryGet(EngineIds.DotNet).Should().BeNull();
+        registry.Providers.Should().BeEmpty();
     }
 
     [Fact]
@@ -26,8 +25,8 @@ public class TemplateEngineProviderRegistryTests
         ITemplateEngineProvider dotnet = FakeProvider(EngineIds.DotNet);
         var registry = new TemplateEngineProviderRegistry([v2, dotnet]);
 
-        Assert.Same(v2, registry.TryGet(EngineIds.V2));
-        Assert.Same(dotnet, registry.TryGet(EngineIds.DotNet));
+        registry.TryGet(EngineIds.V2).Should().BeSameAs(v2);
+        registry.TryGet(EngineIds.DotNet).Should().BeSameAs(dotnet);
     }
 
     [Fact]
@@ -36,8 +35,8 @@ public class TemplateEngineProviderRegistryTests
         ITemplateEngineProvider v2 = FakeProvider(EngineIds.V2);
         var registry = new TemplateEngineProviderRegistry([v2]);
 
-        Assert.Same(v2, registry.TryGet("V2"));
-        Assert.Same(v2, registry.TryGet("v2"));
+        registry.TryGet("V2").Should().BeSameAs(v2);
+        registry.TryGet("v2").Should().BeSameAs(v2);
     }
 
     [Fact]
@@ -46,7 +45,7 @@ public class TemplateEngineProviderRegistryTests
         ITemplateEngineProvider a = FakeProvider(EngineIds.V2);
         ITemplateEngineProvider b = FakeProvider(EngineIds.V2);
 
-        Assert.Throws<InvalidOperationException>(() => new TemplateEngineProviderRegistry([a, b]));
+        FluentActions.Invoking(() => new TemplateEngineProviderRegistry([a, b])).Should().ThrowExactly<InvalidOperationException>();
     }
 
     [Fact]
@@ -54,7 +53,7 @@ public class TemplateEngineProviderRegistryTests
     {
         ITemplateEngineProvider bad = FakeProvider(string.Empty);
 
-        Assert.Throws<InvalidOperationException>(() => new TemplateEngineProviderRegistry([bad]));
+        FluentActions.Invoking(() => new TemplateEngineProviderRegistry([bad])).Should().ThrowExactly<InvalidOperationException>();
     }
 
     private static ITemplateEngineProvider FakeProvider(string engineId)

--- a/test/Func.Tests/Templates/TemplateOptionHydratorTests.cs
+++ b/test/Func.Tests/Templates/TemplateOptionHydratorTests.cs
@@ -6,7 +6,6 @@ using System.Text.RegularExpressions;
 using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Templates;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Templates;
 
@@ -20,7 +19,7 @@ public class TemplateOptionHydratorTests
 
         IReadOnlyList<Option> options = hydrator.Hydrate(template);
 
-        Assert.Empty(options);
+        options.Should().BeEmpty();
     }
 
     [Fact]
@@ -40,11 +39,11 @@ public class TemplateOptionHydratorTests
 
         IReadOnlyList<Option> options = hydrator.Hydrate(TemplateWithPrompts([prompt]));
 
-        Option<string?> opt = Assert.IsType<Option<string?>>(Assert.Single(options));
-        Assert.Equal("--route", opt.Name);
-        Assert.Equal("Route template", opt.Description);
+        Option<string?> opt = options.Should().ContainSingle().Subject.Should().BeOfType<Option<string?>>().Subject;
+        opt.Name.Should().Be("--route");
+        opt.Description.Should().Be("Route template");
         // SCL exposes the factory; invoke it to confirm the default value.
-        Assert.NotNull(opt.DefaultValueFactory);
+        opt.DefaultValueFactory.Should().NotBeNull();
     }
 
     [Fact]
@@ -55,7 +54,7 @@ public class TemplateOptionHydratorTests
 
         IReadOnlyList<Option> options = hydrator.Hydrate(TemplateWithPrompts([prompt]));
 
-        Assert.Equal("--auth-level", options[0].Name);
+        options[0].Name.Should().Be("--auth-level");
     }
 
     [Theory]
@@ -71,7 +70,7 @@ public class TemplateOptionHydratorTests
 
         IReadOnlyList<Option> options = hydrator.Hydrate(TemplateWithPrompts([prompt]));
 
-        Assert.Equal(expectedOptionName, options[0].Name);
+        options[0].Name.Should().Be(expectedOptionName);
     }
 
     [Fact]
@@ -91,9 +90,9 @@ public class TemplateOptionHydratorTests
 
         IReadOnlyList<Option> options = hydrator.Hydrate(TemplateWithPrompts([prompt]));
 
-        Option<string?> opt = Assert.IsType<Option<string?>>(Assert.Single(options));
+        Option<string?> opt = options.Should().ContainSingle().Subject.Should().BeOfType<Option<string?>>().Subject;
         // SCL emits a validator for AcceptOnlyFromAmong; we just confirm the option exists with the expected name.
-        Assert.Equal("--auth-level", opt.Name);
+        opt.Name.Should().Be("--auth-level");
     }
 
     [Fact]
@@ -104,7 +103,7 @@ public class TemplateOptionHydratorTests
 
         IReadOnlyList<Option> options = hydrator.Hydrate(TemplateWithPrompts([prompt]));
 
-        Assert.IsType<Option<bool>>(Assert.Single(options));
+        options.Should().ContainSingle().Subject.Should().BeOfType<Option<bool>>();
     }
 
     [Fact]
@@ -115,7 +114,7 @@ public class TemplateOptionHydratorTests
 
         IReadOnlyList<Option> options = hydrator.Hydrate(TemplateWithPrompts([prompt]));
 
-        Assert.Equal("--ns", options[0].Name);
+        options[0].Name.Should().Be("--ns");
     }
 
     [Fact]
@@ -126,7 +125,7 @@ public class TemplateOptionHydratorTests
 
         IReadOnlyList<Option> options = hydrator.Hydrate(TemplateWithPrompts([prompt]));
 
-        Assert.Contains("-r", options[0].Aliases);
+        options[0].Aliases.Should().Contain("-r");
     }
 
     [Fact]
@@ -146,7 +145,7 @@ public class TemplateOptionHydratorTests
         // The hydrator wires a validator delegate that runs at parse time; we
         // confirm the option exists and is configured. End-to-end validation
         // is exercised once NewCommand actually parses a stage-B argv.
-        Assert.Single(options);
+        options.Should().ContainSingle();
     }
 
     private static FunctionTemplateInfo TemplateWithPrompts(

--- a/test/Func.Tests/Templates/TemplatesChannelMapperTests.cs
+++ b/test/Func.Tests/Templates/TemplatesChannelMapperTests.cs
@@ -3,7 +3,6 @@
 
 using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Templates;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Templates;
 
@@ -21,12 +20,12 @@ public class TemplatesChannelMapperTests
         ];
 
         InstalledTemplatesWorkload? stable = TemplatesChannelMapper.PickChannelMatched(rows, BundleChannel.Stable);
-        Assert.NotNull(stable);
-        Assert.Equal("1.1.0", stable.PackageVersion);
+        stable.Should().NotBeNull();
+        stable.PackageVersion.Should().Be("1.1.0");
 
         InstalledTemplatesWorkload? preview = TemplatesChannelMapper.PickChannelMatched(rows, BundleChannel.Preview);
-        Assert.NotNull(preview);
-        Assert.Equal("1.1.0-preview", preview.PackageVersion);
+        preview.Should().NotBeNull();
+        preview.PackageVersion.Should().Be("1.1.0-preview");
     }
 
     [Fact]
@@ -37,6 +36,6 @@ public class TemplatesChannelMapperTests
             new("node", "1.0.0", "/n/1.0.0"),
         ];
 
-        Assert.Null(TemplatesChannelMapper.PickChannelMatched(rows, BundleChannel.Experimental));
+        TemplatesChannelMapper.PickChannelMatched(rows, BundleChannel.Experimental).Should().BeNull();
     }
 }

--- a/test/Func.Tests/Templates/TemplatesWorkloadConstantsTests.cs
+++ b/test/Func.Tests/Templates/TemplatesWorkloadConstantsTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Templates;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Templates;
 
@@ -16,7 +15,7 @@ public class TemplatesWorkloadConstantsTests
     [InlineData("  python  ", "Azure.Functions.Cli.Workloads.Templates.Python")]
     public void GetPackageId_Title_Cases_The_Stack(string stack, string expected)
     {
-        Assert.Equal(expected, TemplatesWorkloadConstants.GetPackageId(stack));
+        TemplatesWorkloadConstants.GetPackageId(stack).Should().Be(expected);
     }
 
     [Theory]
@@ -25,6 +24,6 @@ public class TemplatesWorkloadConstantsTests
     [InlineData("   ")]
     public void GetPackageId_Empty_Stack_Throws(string? stack)
     {
-        Assert.Throws<ArgumentException>(() => TemplatesWorkloadConstants.GetPackageId(stack!));
+        FluentActions.Invoking(() => TemplatesWorkloadConstants.GetPackageId(stack!)).Should().ThrowExactly<ArgumentException>();
     }
 }

--- a/test/Func.Tests/Templates/TemplatesWorkloadManifestReaderTests.cs
+++ b/test/Func.Tests/Templates/TemplatesWorkloadManifestReaderTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Templates;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Templates;
 
@@ -24,7 +23,7 @@ public class TemplatesWorkloadManifestReaderTests : IDisposable
     [Fact]
     public void Missing_File_Returns_Null()
     {
-        Assert.Null(TemplatesWorkloadManifestReader.GetMinBundleVersion(_installDir));
+        TemplatesWorkloadManifestReader.GetMinBundleVersion(_installDir).Should().BeNull();
     }
 
     [Fact]
@@ -36,7 +35,7 @@ public class TemplatesWorkloadManifestReaderTests : IDisposable
             Path.Combine(contentDir, "templates-workload.json"),
             """{ "minBundleVersion": "[4.0.0, )" }""");
 
-        Assert.Equal("[4.0.0, )", TemplatesWorkloadManifestReader.GetMinBundleVersion(_installDir));
+        TemplatesWorkloadManifestReader.GetMinBundleVersion(_installDir).Should().Be("[4.0.0, )");
     }
 
     [Fact]
@@ -48,7 +47,7 @@ public class TemplatesWorkloadManifestReaderTests : IDisposable
             Path.Combine(contentDir, "templates-workload.json"),
             """{ "somethingElse": "ignored" }""");
 
-        Assert.Null(TemplatesWorkloadManifestReader.GetMinBundleVersion(_installDir));
+        TemplatesWorkloadManifestReader.GetMinBundleVersion(_installDir).Should().BeNull();
     }
 
     [Fact]
@@ -58,6 +57,6 @@ public class TemplatesWorkloadManifestReaderTests : IDisposable
         Directory.CreateDirectory(contentDir);
         File.WriteAllText(Path.Combine(contentDir, "templates-workload.json"), "{ not json");
 
-        Assert.Null(TemplatesWorkloadManifestReader.GetMinBundleVersion(_installDir));
+        TemplatesWorkloadManifestReader.GetMinBundleVersion(_installDir).Should().BeNull();
     }
 }

--- a/test/Func.Tests/Templates/V2/V2EngineProviderTests.cs
+++ b/test/Func.Tests/Templates/V2/V2EngineProviderTests.cs
@@ -4,7 +4,6 @@
 using Azure.Functions.Cli.Templates;
 using Azure.Functions.Cli.Templates.V2;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Templates.V2;
 
@@ -37,7 +36,7 @@ public class V2EngineProviderTests : IDisposable
             new TemplateListContext(new Cli.Common.WorkingDirectory(new DirectoryInfo(_workloadHome), false), "node", "javascript"),
             CancellationToken.None);
 
-        Assert.Empty(templates);
+        templates.Should().BeEmpty();
     }
 
     [Fact]
@@ -54,12 +53,12 @@ public class V2EngineProviderTests : IDisposable
             new TemplateListContext(new Cli.Common.WorkingDirectory(new DirectoryInfo(_workloadHome), false), "node", null),
             CancellationToken.None);
 
-        var http = Assert.Single(templates);
-        Assert.Equal("HttpTrigger-JavaScript", http.Id);
-        Assert.Equal(EngineIds.V2, http.EngineId);
-        Assert.Equal("node", http.Stack);
-        Assert.Equal("HTTP trigger", http.DisplayName);
-        Assert.Equal("HttpTrigger", http.DefaultFunctionName);
+        var http = templates.Should().ContainSingle().Subject;
+        http.Id.Should().Be("HttpTrigger-JavaScript");
+        http.EngineId.Should().Be(EngineIds.V2);
+        http.Stack.Should().Be("node");
+        http.DisplayName.Should().Be("HTTP trigger");
+        http.DefaultFunctionName.Should().Be("HttpTrigger");
     }
 
     [Fact]
@@ -77,7 +76,7 @@ public class V2EngineProviderTests : IDisposable
             CancellationToken.None);
 
         // The fixture template has language="javascript"; "typescript" filter drops it.
-        Assert.Empty(typescriptOnly);
+        typescriptOnly.Should().BeEmpty();
     }
 
     [Fact]
@@ -96,8 +95,8 @@ public class V2EngineProviderTests : IDisposable
 
         // BlobTrigger-TypeScript and DurableFunctionsOrchestrator-JavaScript
         // are on the hidden list; only the HTTP trigger should remain.
-        Assert.Single(templates);
-        Assert.Equal("HttpTrigger-JavaScript", templates[0].Id);
+        templates.Should().ContainSingle();
+        templates[0].Id.Should().Be("HttpTrigger-JavaScript");
     }
 
     private static void WriteFixturePayload(string installDir)

--- a/test/Func.Tests/Templates/V2/V2TemplateEngineTests.cs
+++ b/test/Func.Tests/Templates/V2/V2TemplateEngineTests.cs
@@ -94,8 +94,8 @@ public class V2TemplateEngineTests : IDisposable
             workingDirectory: new DirectoryInfo(_workingDir),
             force: false);
 
-        var existed = result.Should().BeOfType<TemplateApplicationResult.AlreadyExists>().Subject;
-        existed.ExistingFiles.Should().ContainSingle();
+        result.Should().BeOfType<TemplateApplicationResult.AlreadyExists>()
+            .Which.ExistingFiles.Should().ContainSingle();
         File.ReadAllText(target).Should().Be("preexisting");
     }
 
@@ -212,8 +212,8 @@ public class V2TemplateEngineTests : IDisposable
             force: false);
 
         var failed = result.Should().BeOfType<TemplateApplicationResult.Failed>().Subject;
-        var invalid = failed.Failure.Should().BeOfType<TemplateApplicationFailure.InvalidPrompt>().Subject;
-        invalid.PromptId.Should().Be("queueName");
+        failed.Failure.Should().BeOfType<TemplateApplicationFailure.InvalidPrompt>()
+            .Which.PromptId.Should().Be("queueName");
     }
 
     [Fact]
@@ -236,8 +236,8 @@ public class V2TemplateEngineTests : IDisposable
             workingDirectory: new DirectoryInfo(_workingDir),
             force: false);
 
-        var failed = result.Should().BeOfType<TemplateApplicationResult.Failed>().Subject;
-        failed.Failure.Should().BeOfType<TemplateApplicationFailure.ProviderError>();
+        result.Should().BeOfType<TemplateApplicationResult.Failed>()
+            .Which.Failure.Should().BeOfType<TemplateApplicationFailure.ProviderError>();
     }
 
     [Theory]
@@ -302,9 +302,8 @@ public class V2TemplateEngineTests : IDisposable
             workingDirectory: new DirectoryInfo(_workingDir),
             force: false);
 
-        var created = result.Should().BeOfType<TemplateApplicationResult.Created>().Subject;
         string expectedPath = Path.GetFullPath(Path.Combine(_workingDir, "src", "functions", $"{sanitized}.py"));
-        created.Files.Single().Should().Be(expectedPath);
+        result.Should().BeOfType<TemplateApplicationResult.Created>().Which.Files.Single().Should().Be(expectedPath);
 
         string content = File.ReadAllText(expectedPath);
         content.Should().Contain($"def {sanitized}(");
@@ -375,9 +374,8 @@ public class V2TemplateEngineTests : IDisposable
             workingDirectory: new DirectoryInfo(_workingDir),
             force: false);
 
-        var created = result.Should().BeOfType<TemplateApplicationResult.Created>().Subject;
         string expectedPath = Path.GetFullPath(Path.Combine(_workingDir, "src", "functions", "HttpTrigger_Python.ts"));
-        created.Files.Single().Should().Be(expectedPath);
+        result.Should().BeOfType<TemplateApplicationResult.Created>().Which.Files.Single().Should().Be(expectedPath);
 
         string content = File.ReadAllText(expectedPath);
         content.Should().Contain("export async function HttpTrigger_Python(");
@@ -398,9 +396,8 @@ public class V2TemplateEngineTests : IDisposable
             workingDirectory: new DirectoryInfo(_workingDir),
             force: false);
 
-        var created = result.Should().BeOfType<TemplateApplicationResult.Created>().Subject;
         string target = Path.GetFullPath(Path.Combine(_workingDir, "function_app.py"));
-        created.Files.Single().Should().Be(target);
+        result.Should().BeOfType<TemplateApplicationResult.Created>().Which.Files.Single().Should().Be(target);
 
         string content = File.ReadAllText(target);
         content.Should().StartWith("# fresh app skeleton");
@@ -423,8 +420,8 @@ public class V2TemplateEngineTests : IDisposable
             workingDirectory: new DirectoryInfo(_workingDir),
             force: false);
 
-        var created = result.Should().BeOfType<TemplateApplicationResult.Created>().Subject;
-        created.Files.Single().Should().Be(Path.GetFullPath(target));
+        result.Should().BeOfType<TemplateApplicationResult.Created>()
+            .Which.Files.Single().Should().Be(Path.GetFullPath(target));
 
         string content = File.ReadAllText(target);
         content.Should().StartWith("# preexisting");

--- a/test/Func.Tests/Templates/V2/V2TemplateEngineTests.cs
+++ b/test/Func.Tests/Templates/V2/V2TemplateEngineTests.cs
@@ -3,7 +3,6 @@
 
 using Azure.Functions.Cli.Templates;
 using Azure.Functions.Cli.Templates.V2;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Templates.V2;
 
@@ -58,13 +57,13 @@ public class V2TemplateEngineTests : IDisposable
             workingDirectory: new DirectoryInfo(_workingDir),
             force: false);
 
-        var created = Assert.IsType<TemplateApplicationResult.Created>(result);
+        var created = result.Should().BeOfType<TemplateApplicationResult.Created>().Subject;
         string expectedPath = Path.GetFullPath(Path.Combine(_workingDir, "src", "functions", "MyHttp.js"));
-        Assert.Single(created.Files);
-        Assert.Equal(expectedPath, created.Files[0]);
-        Assert.True(File.Exists(expectedPath));
+        created.Files.Should().ContainSingle();
+        created.Files[0].Should().Be(expectedPath);
+        File.Exists(expectedPath).Should().BeTrue();
         string content = File.ReadAllText(expectedPath);
-        Assert.Contains("hello MyHttp", content);
+        content.Should().Contain("hello MyHttp");
     }
 
     [Fact]
@@ -95,9 +94,9 @@ public class V2TemplateEngineTests : IDisposable
             workingDirectory: new DirectoryInfo(_workingDir),
             force: false);
 
-        var existed = Assert.IsType<TemplateApplicationResult.AlreadyExists>(result);
-        Assert.Single(existed.ExistingFiles);
-        Assert.Equal("preexisting", File.ReadAllText(target));
+        var existed = result.Should().BeOfType<TemplateApplicationResult.AlreadyExists>().Subject;
+        existed.ExistingFiles.Should().ContainSingle();
+        File.ReadAllText(target).Should().Be("preexisting");
     }
 
     [Fact]
@@ -128,8 +127,8 @@ public class V2TemplateEngineTests : IDisposable
             workingDirectory: new DirectoryInfo(_workingDir),
             force: true);
 
-        Assert.IsType<TemplateApplicationResult.Created>(result);
-        Assert.Equal("new content", File.ReadAllText(target));
+        result.Should().BeOfType<TemplateApplicationResult.Created>();
+        File.ReadAllText(target).Should().Be("new content");
     }
 
     [Fact]
@@ -176,8 +175,8 @@ public class V2TemplateEngineTests : IDisposable
             workingDirectory: new DirectoryInfo(_workingDir),
             force: false);
 
-        Assert.IsType<TemplateApplicationResult.Created>(result);
-        Assert.Equal("auth=anonymous", File.ReadAllText(Path.Combine(_workingDir, "config.txt")));
+        result.Should().BeOfType<TemplateApplicationResult.Created>();
+        File.ReadAllText(Path.Combine(_workingDir, "config.txt")).Should().Be("auth=anonymous");
     }
 
     [Fact]
@@ -212,9 +211,9 @@ public class V2TemplateEngineTests : IDisposable
             workingDirectory: new DirectoryInfo(_workingDir),
             force: false);
 
-        var failed = Assert.IsType<TemplateApplicationResult.Failed>(result);
-        var invalid = Assert.IsType<TemplateApplicationFailure.InvalidPrompt>(failed.Failure);
-        Assert.Equal("queueName", invalid.PromptId);
+        var failed = result.Should().BeOfType<TemplateApplicationResult.Failed>().Subject;
+        var invalid = failed.Failure.Should().BeOfType<TemplateApplicationFailure.InvalidPrompt>().Subject;
+        invalid.PromptId.Should().Be("queueName");
     }
 
     [Fact]
@@ -237,8 +236,8 @@ public class V2TemplateEngineTests : IDisposable
             workingDirectory: new DirectoryInfo(_workingDir),
             force: false);
 
-        var failed = Assert.IsType<TemplateApplicationResult.Failed>(result);
-        Assert.IsType<TemplateApplicationFailure.ProviderError>(failed.Failure);
+        var failed = result.Should().BeOfType<TemplateApplicationResult.Failed>().Subject;
+        failed.Failure.Should().BeOfType<TemplateApplicationFailure.ProviderError>();
     }
 
     [Theory]
@@ -251,7 +250,7 @@ public class V2TemplateEngineTests : IDisposable
     [InlineData("already_valid", "already_valid")]
     public void SanitizeFunctionIdentifier_ProducesValidIdentifier(string input, string expected)
     {
-        Assert.Equal(expected, V2TemplateEngine.SanitizeFunctionIdentifier(input));
+        V2TemplateEngine.SanitizeFunctionIdentifier(input).Should().Be(expected);
     }
 
     [Theory]
@@ -303,13 +302,13 @@ public class V2TemplateEngineTests : IDisposable
             workingDirectory: new DirectoryInfo(_workingDir),
             force: false);
 
-        var created = Assert.IsType<TemplateApplicationResult.Created>(result);
+        var created = result.Should().BeOfType<TemplateApplicationResult.Created>().Subject;
         string expectedPath = Path.GetFullPath(Path.Combine(_workingDir, "src", "functions", $"{sanitized}.py"));
-        Assert.Equal(expectedPath, created.Files.Single());
+        created.Files.Single().Should().Be(expectedPath);
 
         string content = File.ReadAllText(expectedPath);
-        Assert.Contains($"def {sanitized}(", content);
-        Assert.DoesNotContain($"def {functionName}(", content);
+        content.Should().Contain($"def {sanitized}(");
+        content.Should().NotContain($"def {functionName}(");
     }
 
     [Fact]
@@ -376,14 +375,14 @@ public class V2TemplateEngineTests : IDisposable
             workingDirectory: new DirectoryInfo(_workingDir),
             force: false);
 
-        var created = Assert.IsType<TemplateApplicationResult.Created>(result);
+        var created = result.Should().BeOfType<TemplateApplicationResult.Created>().Subject;
         string expectedPath = Path.GetFullPath(Path.Combine(_workingDir, "src", "functions", "HttpTrigger_Python.ts"));
-        Assert.Equal(expectedPath, created.Files.Single());
+        created.Files.Single().Should().Be(expectedPath);
 
         string content = File.ReadAllText(expectedPath);
-        Assert.Contains("export async function HttpTrigger_Python(", content);
-        Assert.Contains("handler: HttpTrigger_Python", content);
-        Assert.DoesNotContain("HttpTrigger-Python", content);
+        content.Should().Contain("export async function HttpTrigger_Python(");
+        content.Should().Contain("handler: HttpTrigger_Python");
+        content.Should().NotContain("HttpTrigger-Python");
     }
 
     [Fact]
@@ -399,13 +398,13 @@ public class V2TemplateEngineTests : IDisposable
             workingDirectory: new DirectoryInfo(_workingDir),
             force: false);
 
-        var created = Assert.IsType<TemplateApplicationResult.Created>(result);
+        var created = result.Should().BeOfType<TemplateApplicationResult.Created>().Subject;
         string target = Path.GetFullPath(Path.Combine(_workingDir, "function_app.py"));
-        Assert.Equal(target, created.Files.Single());
+        created.Files.Single().Should().Be(target);
 
         string content = File.ReadAllText(target);
-        Assert.StartsWith("# fresh app skeleton", content);
-        Assert.DoesNotContain("@app.route", content);
+        content.Should().StartWith("# fresh app skeleton");
+        content.Should().NotContain("@app.route");
     }
 
     [Fact]
@@ -424,12 +423,12 @@ public class V2TemplateEngineTests : IDisposable
             workingDirectory: new DirectoryInfo(_workingDir),
             force: false);
 
-        var created = Assert.IsType<TemplateApplicationResult.Created>(result);
-        Assert.Equal(Path.GetFullPath(target), created.Files.Single());
+        var created = result.Should().BeOfType<TemplateApplicationResult.Created>().Subject;
+        created.Files.Single().Should().Be(Path.GetFullPath(target));
 
         string content = File.ReadAllText(target);
-        Assert.StartsWith("# preexisting", content);
-        Assert.Contains("@app.route(MyFn)", content);
+        content.Should().StartWith("# preexisting");
+        content.Should().Contain("@app.route(MyFn)");
     }
 
     [Fact]
@@ -450,10 +449,10 @@ public class V2TemplateEngineTests : IDisposable
             workingDirectory: new DirectoryInfo(_workingDir),
             force: false);
 
-        Assert.IsType<TemplateApplicationResult.Created>(result);
+        result.Should().BeOfType<TemplateApplicationResult.Created>();
         string content = File.ReadAllText(target);
-        Assert.DoesNotContain("prior_no_newline@app.route", content);
-        Assert.Matches(@"prior_no_newline\r?\n@app\.route\(Next\)", content);
+        content.Should().NotContain("prior_no_newline@app.route");
+        content.Should().MatchRegex(@"prior_no_newline\r?\n@app\.route\(Next\)");
     }
 
     [Fact]
@@ -502,8 +501,8 @@ public class V2TemplateEngineTests : IDisposable
             workingDirectory: new DirectoryInfo(_workingDir),
             force: false);
 
-        Assert.IsType<TemplateApplicationResult.Created>(result);
-        Assert.Equal("blueprint body", File.ReadAllText(Path.Combine(_workingDir, "blueprint.py")));
+        result.Should().BeOfType<TemplateApplicationResult.Created>();
+        File.ReadAllText(Path.Combine(_workingDir, "blueprint.py")).Should().Be("blueprint body");
     }
 
     private static NewTemplate MakeCreateOrAppendTemplate() => new()

--- a/test/Func.Tests/Templates/V2/V2TemplateProjectionTests.cs
+++ b/test/Func.Tests/Templates/V2/V2TemplateProjectionTests.cs
@@ -3,7 +3,6 @@
 
 using Azure.Functions.Cli.Templates;
 using Azure.Functions.Cli.Templates.V2;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Templates.V2;
 
@@ -36,8 +35,8 @@ public class V2TemplateProjectionTests
 
         FunctionTemplateInfo? info = V2TemplateProjection.Project(template, EmptyPayload(), "node");
 
-        Assert.NotNull(info);
-        Assert.Equal("httpTrigger", info!.DefaultFunctionName);
+        info.Should().NotBeNull();
+        info!.DefaultFunctionName.Should().Be("httpTrigger");
     }
 
     [Fact]
@@ -69,8 +68,8 @@ public class V2TemplateProjectionTests
 
         FunctionTemplateInfo? info = V2TemplateProjection.Project(template, EmptyPayload(), "python");
 
-        Assert.NotNull(info);
-        Assert.Equal("http_trigger", info!.DefaultFunctionName);
+        info.Should().NotBeNull();
+        info!.DefaultFunctionName.Should().Be("http_trigger");
     }
 
     [Fact]
@@ -101,8 +100,8 @@ public class V2TemplateProjectionTests
 
         FunctionTemplateInfo? info = V2TemplateProjection.Project(template, EmptyPayload(), "node");
 
-        Assert.NotNull(info);
-        Assert.Null(info!.DefaultFunctionName);
+        info.Should().NotBeNull();
+        info!.DefaultFunctionName.Should().BeNull();
     }
 
     [Fact]
@@ -131,8 +130,8 @@ public class V2TemplateProjectionTests
 
         FunctionTemplateInfo? info = V2TemplateProjection.Project(template, EmptyPayload(), "node");
 
-        Assert.NotNull(info);
-        Assert.Null(info!.DefaultFunctionName);
+        info.Should().NotBeNull();
+        info!.DefaultFunctionName.Should().BeNull();
     }
 
     private static V2Payload EmptyPayload() =>

--- a/test/Func.Tests/TestParser.cs
+++ b/test/Func.Tests/TestParser.cs
@@ -7,7 +7,6 @@ using Azure.Functions.Cli.Commands.Start.Initialization;
 using Azure.Functions.Cli.Configuration;
 using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Hosting;
-using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Quickstart;
 using Azure.Functions.Cli.Templates;
 using Azure.Functions.Cli.Workloads;

--- a/test/Func.Tests/Update/CdnReleaseFeedTests.cs
+++ b/test/Func.Tests/Update/CdnReleaseFeedTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Net;
-using System.Net.Http;
 using System.Reflection;
 using Azure.Functions.Cli.Update;
 using Microsoft.Extensions.Logging.Abstractions;
 using Semver;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Update;
 
@@ -22,8 +20,8 @@ public sealed class CdnReleaseFeedTests
 
         Release latest = await feed.GetLatestAsync(includePrerelease: false, CancellationToken.None);
 
-        Assert.Equal("5.1.0", latest.Version.ToString());
-        Assert.False(latest.IsPrerelease);
+        latest.Version.ToString().Should().Be("5.1.0");
+        latest.IsPrerelease.Should().BeFalse();
     }
 
     [Fact]
@@ -35,8 +33,8 @@ public sealed class CdnReleaseFeedTests
 
         Release latest = await feed.GetLatestAsync(includePrerelease: true, CancellationToken.None);
 
-        Assert.Equal("5.2.0-preview.1", latest.Version.ToString());
-        Assert.True(latest.IsPrerelease);
+        latest.Version.ToString().Should().Be("5.2.0-preview.1");
+        latest.IsPrerelease.Should().BeTrue();
     }
 
     [Fact]
@@ -47,8 +45,8 @@ public sealed class CdnReleaseFeedTests
 
         Release latest = await feed.GetLatestAsync(includePrerelease: true, CancellationToken.None);
 
-        Assert.Equal("5.3.0", latest.Version.ToString());
-        Assert.False(latest.IsPrerelease);
+        latest.Version.ToString().Should().Be("5.3.0");
+        latest.IsPrerelease.Should().BeFalse();
     }
 
     [Fact]
@@ -58,7 +56,7 @@ public sealed class CdnReleaseFeedTests
 
         Release latest = await feed.GetLatestAsync(includePrerelease: true, CancellationToken.None);
 
-        Assert.Equal("5.1.0", latest.Version.ToString());
+        latest.Version.ToString().Should().Be("5.1.0");
     }
 
     [Fact]
@@ -66,10 +64,9 @@ public sealed class CdnReleaseFeedTests
     {
         CdnReleaseFeed feed = CreateFeed(RespondWithJson("""{"stable": null, "preview": "5.2.0-preview.1"}"""));
 
-        InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => feed.GetLatestAsync(includePrerelease: false, CancellationToken.None));
+        InvalidOperationException ex = (await FluentActions.Awaiting(() => feed.GetLatestAsync(includePrerelease: false, CancellationToken.None)).Should().ThrowAsync<InvalidOperationException>()).Which;
 
-        Assert.Contains("version is missing", ex.Message, StringComparison.Ordinal);
+        ex.Message.Should().Contain("version is missing");
     }
 
     [Fact]
@@ -77,10 +74,9 @@ public sealed class CdnReleaseFeedTests
     {
         CdnReleaseFeed feed = CreateFeed(RespondWithJson("""{"stable": "not-a-version", "preview": null}"""));
 
-        InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => feed.GetLatestAsync(includePrerelease: false, CancellationToken.None));
+        InvalidOperationException ex = (await FluentActions.Awaiting(() => feed.GetLatestAsync(includePrerelease: false, CancellationToken.None)).Should().ThrowAsync<InvalidOperationException>()).Which;
 
-        Assert.Contains("invalid version", ex.Message, StringComparison.Ordinal);
+        ex.Message.Should().Contain("invalid version");
     }
 
     [Fact]
@@ -90,9 +86,9 @@ public sealed class CdnReleaseFeedTests
 
         Release latest = await feed.GetLatestAsync(includePrerelease: false, CancellationToken.None);
 
-        Assert.Contains("5.1.0", latest.DownloadUrl.ToString(), StringComparison.Ordinal);
-        Assert.Contains("Azure.Functions.Cli.", latest.DownloadUrl.ToString(), StringComparison.Ordinal);
-        Assert.EndsWith(".zip", latest.DownloadUrl.ToString(), StringComparison.Ordinal);
+        latest.DownloadUrl.ToString().Should().Contain("5.1.0");
+        latest.DownloadUrl.ToString().Should().Contain("Azure.Functions.Cli.");
+        latest.DownloadUrl.ToString().Should().EndWith(".zip");
     }
 
     [Fact]
@@ -113,8 +109,8 @@ public sealed class CdnReleaseFeedTests
 
         Release result = await feed.GetVersionAsync(target, CancellationToken.None);
 
-        Assert.Equal("5.0.0-preview.1", result.Version.ToString());
-        Assert.True(result.IsPrerelease);
+        result.Version.ToString().Should().Be("5.0.0-preview.1");
+        result.IsPrerelease.Should().BeTrue();
     }
 
     [Fact]
@@ -133,10 +129,9 @@ public sealed class CdnReleaseFeedTests
         CdnReleaseFeed feed = CreateFeed(handler);
         var target = SemVersion.Parse("99.0.0", SemVersionStyles.Strict);
 
-        InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => feed.GetVersionAsync(target, CancellationToken.None));
+        InvalidOperationException ex = (await FluentActions.Awaiting(() => feed.GetVersionAsync(target, CancellationToken.None)).Should().ThrowAsync<InvalidOperationException>()).Which;
 
-        Assert.Contains("not found", ex.Message, StringComparison.OrdinalIgnoreCase);
+        ex.Message.Should().ContainEquivalentOf("not found");
     }
 
     [Fact]
@@ -155,10 +150,9 @@ public sealed class CdnReleaseFeedTests
         CdnReleaseFeed feed = CreateFeed(handler);
         var target = SemVersion.Parse("5.0.0", SemVersionStyles.Strict);
 
-        InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => feed.GetVersionAsync(target, CancellationToken.None));
+        InvalidOperationException ex = (await FluentActions.Awaiting(() => feed.GetVersionAsync(target, CancellationToken.None)).Should().ThrowAsync<InvalidOperationException>()).Which;
 
-        Assert.Contains("ServiceUnavailable", ex.Message, StringComparison.Ordinal);
+                ex.Message.Should().Contain("ServiceUnavailable");
     }
 
     [Fact]
@@ -169,10 +163,9 @@ public sealed class CdnReleaseFeedTests
 
         CdnReleaseFeed feed = CreateFeed(handler);
 
-        InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => feed.GetLatestAsync(includePrerelease: false, CancellationToken.None));
+        InvalidOperationException ex = (await FluentActions.Awaiting(() => feed.GetLatestAsync(includePrerelease: false, CancellationToken.None)).Should().ThrowAsync<InvalidOperationException>()).Which;
 
-        Assert.Contains("version.json", ex.Message, StringComparison.Ordinal);
+        ex.Message.Should().Contain("version.json");
     }
 
     [Fact]
@@ -183,10 +176,9 @@ public sealed class CdnReleaseFeedTests
 
         CdnReleaseFeed feed = CreateFeed(handler);
 
-        InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => feed.GetLatestAsync(includePrerelease: false, CancellationToken.None));
+        InvalidOperationException ex = (await FluentActions.Awaiting(() => feed.GetLatestAsync(includePrerelease: false, CancellationToken.None)).Should().ThrowAsync<InvalidOperationException>()).Which;
 
-        Assert.Contains("ServiceUnavailable", ex.Message, StringComparison.Ordinal);
+                ex.Message.Should().Contain("ServiceUnavailable");
     }
 
     [Fact]
@@ -198,8 +190,7 @@ public sealed class CdnReleaseFeedTests
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
-        await Assert.ThrowsAsync<TaskCanceledException>(
-            () => feed.GetLatestAsync(includePrerelease: false, cts.Token));
+        await FluentActions.Awaiting(() => feed.GetLatestAsync(includePrerelease: false, cts.Token)).Should().ThrowAsync<TaskCanceledException>();
     }
 
     private static Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> RespondWithManifest()

--- a/test/Func.Tests/Workers/DefaultFunctionsWorkerInstallerTests.cs
+++ b/test/Func.Tests/Workers/DefaultFunctionsWorkerInstallerTests.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.Options;
 using NSubstitute;
 using NuGet.Configuration;
 using NuGet.Versioning;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Workers;
 
@@ -65,12 +64,10 @@ public class DefaultFunctionsWorkerInstallerTests
 
         FunctionsWorkerInstallResult result = await installer.InstallAsync(workerId, workerRanges, CancellationToken.None);
 
-        Assert.Equal(WorkerRuntime, result.Worker.WorkerRuntime);
-        Assert.Equal("3.13.0", result.Worker.Version);
-        Assert.False(result.WorkloadInstallResult.AlreadyInstalled);
-        Assert.Equal(
-            Path.Combine(GetInstallDirectory("3.13.0"), "tools", "any", "worker.config.json"),
-            result.Worker.WorkerConfigPath);
+        result.Worker.WorkerRuntime.Should().Be(WorkerRuntime);
+        result.Worker.Version.Should().Be("3.13.0");
+        result.WorkloadInstallResult.AlreadyInstalled.Should().BeFalse();
+        result.Worker.WorkerConfigPath.Should().Be(Path.Combine(GetInstallDirectory("3.13.0"), "tools", "any", "worker.config.json"));
         await _workloadInstaller.Received(1).InstallFromCatalogAsync(
             WorkerPackageId,
             Arg.Is<NuGetVersion?>(version => version != null && version.ToNormalizedString() == "3.13.0"),
@@ -100,8 +97,8 @@ public class DefaultFunctionsWorkerInstallerTests
 
         FunctionsWorkerInstallResult result = await installer.InstallAsync(workerId, new Dictionary<string, VersionRange>(), CancellationToken.None);
 
-        Assert.True(result.WorkloadInstallResult.AlreadyInstalled);
-        Assert.Equal("3.14.0", result.Worker.Version);
+        result.WorkloadInstallResult.AlreadyInstalled.Should().BeTrue();
+        result.Worker.Version.Should().Be("3.14.0");
         await _workloadInstaller.Received(1).InstallFromCatalogAsync(
             WorkerPackageId,
             version: null,
@@ -131,11 +128,10 @@ public class DefaultFunctionsWorkerInstallerTests
             .Returns((ResolvedPackage?)null);
         DefaultFunctionsWorkerInstaller installer = CreateInstaller();
 
-        WorkloadPackageNotFoundException exception = await Assert.ThrowsAsync<WorkloadPackageNotFoundException>(
-            async () => await installer.InstallAsync(workerId, workerRanges, CancellationToken.None));
+        WorkloadPackageNotFoundException exception = (await FluentActions.Awaiting(async () => await installer.InstallAsync(workerId, workerRanges, CancellationToken.None)).Should().ThrowAsync<WorkloadPackageNotFoundException>()).Which;
 
-        Assert.Contains(WorkerPackageId, exception.Message);
-        Assert.Contains("[3.13.0]", exception.Message);
+        exception.Message.Should().Contain(WorkerPackageId);
+        exception.Message.Should().Contain("[3.13.0]");
     }
 
     [Fact]
@@ -155,10 +151,9 @@ public class DefaultFunctionsWorkerInstallerTests
             .Returns(new WorkloadInstallResult(entry, AlreadyInstalled: false));
         DefaultFunctionsWorkerInstaller installer = CreateInstaller();
 
-        InvalidWorkloadException exception = await Assert.ThrowsAsync<InvalidWorkloadException>(
-            async () => await installer.InstallAsync(workerId, new Dictionary<string, VersionRange>(), CancellationToken.None));
+        InvalidWorkloadException exception = (await FluentActions.Awaiting(async () => await installer.InstallAsync(workerId, new Dictionary<string, VersionRange>(), CancellationToken.None)).Should().ThrowAsync<InvalidWorkloadException>()).Which;
 
-        Assert.Contains("kind 'content'", exception.Message);
+        exception.Message.Should().Contain("kind 'content'");
     }
 
     [Fact]
@@ -166,8 +161,7 @@ public class DefaultFunctionsWorkerInstallerTests
     {
         DefaultFunctionsWorkerInstaller installer = CreateInstaller();
 
-        await Assert.ThrowsAsync<ArgumentNullException>(
-            async () => await installer.InstallAsync(null!, new Dictionary<string, VersionRange>(), CancellationToken.None));
+        await FluentActions.Awaiting(async () => await installer.InstallAsync(null!, new Dictionary<string, VersionRange>(), CancellationToken.None)).Should().ThrowAsync<ArgumentNullException>();
     }
 
     [Fact]
@@ -175,8 +169,7 @@ public class DefaultFunctionsWorkerInstallerTests
     {
         DefaultFunctionsWorkerInstaller installer = CreateInstaller();
 
-        await Assert.ThrowsAsync<ArgumentNullException>(
-            async () => await installer.InstallAsync(new FunctionsWorkerId(WorkerRuntime), null!, CancellationToken.None));
+        await FluentActions.Awaiting(async () => await installer.InstallAsync(new FunctionsWorkerId(WorkerRuntime), null!, CancellationToken.None)).Should().ThrowAsync<ArgumentNullException>();
     }
 
     [Fact]
@@ -184,10 +177,10 @@ public class DefaultFunctionsWorkerInstallerTests
     {
         var contentResolver = new DefaultFunctionsWorkerContentResolver(_fileSystem, Options.Create(new WorkloadCatalogOptions()));
 
-        Assert.Throws<ArgumentNullException>(() => new DefaultFunctionsWorkerInstaller(null!, _workloadInstaller, _workloadPaths, contentResolver));
-        Assert.Throws<ArgumentNullException>(() => new DefaultFunctionsWorkerInstaller(_workloadCatalog, null!, _workloadPaths, contentResolver));
-        Assert.Throws<ArgumentNullException>(() => new DefaultFunctionsWorkerInstaller(_workloadCatalog, _workloadInstaller, null!, contentResolver));
-        Assert.Throws<ArgumentNullException>(() => new DefaultFunctionsWorkerInstaller(_workloadCatalog, _workloadInstaller, _workloadPaths, null!));
+        FluentActions.Invoking(() => new DefaultFunctionsWorkerInstaller(null!, _workloadInstaller, _workloadPaths, contentResolver)).Should().ThrowExactly<ArgumentNullException>();
+        FluentActions.Invoking(() => new DefaultFunctionsWorkerInstaller(_workloadCatalog, null!, _workloadPaths, contentResolver)).Should().ThrowExactly<ArgumentNullException>();
+        FluentActions.Invoking(() => new DefaultFunctionsWorkerInstaller(_workloadCatalog, _workloadInstaller, null!, contentResolver)).Should().ThrowExactly<ArgumentNullException>();
+        FluentActions.Invoking(() => new DefaultFunctionsWorkerInstaller(_workloadCatalog, _workloadInstaller, _workloadPaths, null!)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     private DefaultFunctionsWorkerInstaller CreateInstaller()

--- a/test/Func.Tests/Workers/DefaultFunctionsWorkerResolverTests.cs
+++ b/test/Func.Tests/Workers/DefaultFunctionsWorkerResolverTests.cs
@@ -181,8 +181,7 @@ public class DefaultFunctionsWorkerResolverTests
             new FunctionsWorkerId("node"),
             CancellationToken.None);
 
-        FunctionsWorkerResolutionResult.Resolved resolved = result.Should().BeOfType<FunctionsWorkerResolutionResult.Resolved>().Subject;
-        resolved.Worker.Version.Should().Be("3.13.0");
+        result.Should().BeOfType<FunctionsWorkerResolutionResult.Resolved>().Which.Worker.Version.Should().Be("3.13.0");
     }
 
     [Fact]
@@ -289,8 +288,8 @@ public class DefaultFunctionsWorkerResolverTests
             new FunctionsWorkerId("node"),
             CancellationToken.None);
 
-        FunctionsWorkerResolutionResult.Resolved resolved = result.Should().BeOfType<FunctionsWorkerResolutionResult.Resolved>().Subject;
-        resolved.Worker.Version.Should().Be("3.13.0-preview.1");
+        result.Should().BeOfType<FunctionsWorkerResolutionResult.Resolved>()
+            .Which.Worker.Version.Should().Be("3.13.0-preview.1");
     }
 
     [Fact]

--- a/test/Func.Tests/Workers/DefaultFunctionsWorkerResolverTests.cs
+++ b/test/Func.Tests/Workers/DefaultFunctionsWorkerResolverTests.cs
@@ -7,7 +7,6 @@ using Azure.Functions.Cli.Workloads.Catalog;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using NuGet.Versioning;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Workers;
 
@@ -38,11 +37,11 @@ public class DefaultFunctionsWorkerResolverTests
             new FunctionsWorkerId("node"),
             CancellationToken.None);
 
-        FunctionsWorkerResolutionResult.Resolved resolved = Assert.IsType<FunctionsWorkerResolutionResult.Resolved>(result);
-        Assert.Equal("node", resolved.Worker.Id.Value);
-        Assert.Equal("node", resolved.Worker.WorkerRuntime);
-        Assert.Equal(Path.Combine(workload.ContentRoot, "worker.config.json"), resolved.Worker.WorkerConfigPath);
-        Assert.Equal("3.13.0", resolved.Worker.Version);
+        FunctionsWorkerResolutionResult.Resolved resolved = result.Should().BeOfType<FunctionsWorkerResolutionResult.Resolved>().Subject;
+        resolved.Worker.Id.Value.Should().Be("node");
+        resolved.Worker.WorkerRuntime.Should().Be("node");
+        resolved.Worker.WorkerConfigPath.Should().Be(Path.Combine(workload.ContentRoot, "worker.config.json"));
+        resolved.Worker.Version.Should().Be("3.13.0");
     }
 
     [Fact]
@@ -57,9 +56,9 @@ public class DefaultFunctionsWorkerResolverTests
             new FunctionsWorkerId("node"),
             CancellationToken.None);
 
-        FunctionsWorkerResolutionResult.Resolved resolved = Assert.IsType<FunctionsWorkerResolutionResult.Resolved>(result);
-        Assert.Equal("3.13.0", resolved.Worker.Version);
-        Assert.Equal(Path.Combine(newer.ContentRoot, "worker.config.json"), resolved.Worker.WorkerConfigPath);
+        FunctionsWorkerResolutionResult.Resolved resolved = result.Should().BeOfType<FunctionsWorkerResolutionResult.Resolved>().Subject;
+        resolved.Worker.Version.Should().Be("3.13.0");
+        resolved.Worker.WorkerConfigPath.Should().Be(Path.Combine(newer.ContentRoot, "worker.config.json"));
     }
 
     [Fact]
@@ -73,10 +72,10 @@ public class DefaultFunctionsWorkerResolverTests
             new FunctionsWorkerId("node"),
             CancellationToken.None);
 
-        FunctionsWorkerResolutionResult.Resolved resolved = Assert.IsType<FunctionsWorkerResolutionResult.Resolved>(result);
-        Assert.Equal("node", resolved.Worker.Id.Value);
-        Assert.Equal("3.13.0", resolved.Worker.Version);
-        Assert.Equal(Path.Combine(workload.ContentRoot, "worker.config.json"), resolved.Worker.WorkerConfigPath);
+        FunctionsWorkerResolutionResult.Resolved resolved = result.Should().BeOfType<FunctionsWorkerResolutionResult.Resolved>().Subject;
+        resolved.Worker.Id.Value.Should().Be("node");
+        resolved.Worker.Version.Should().Be("3.13.0");
+        resolved.Worker.WorkerConfigPath.Should().Be(Path.Combine(workload.ContentRoot, "worker.config.json"));
     }
 
     [Fact]
@@ -90,10 +89,10 @@ public class DefaultFunctionsWorkerResolverTests
             new FunctionsWorkerId("ruby"),
             CancellationToken.None);
 
-        FunctionsWorkerResolutionResult.Resolved resolved = Assert.IsType<FunctionsWorkerResolutionResult.Resolved>(result);
-        Assert.Equal("ruby", resolved.Worker.Id.Value);
-        Assert.Equal("ruby", resolved.Worker.WorkerRuntime);
-        Assert.Equal(Path.Combine(workload.ContentRoot, "worker.config.json"), resolved.Worker.WorkerConfigPath);
+        FunctionsWorkerResolutionResult.Resolved resolved = result.Should().BeOfType<FunctionsWorkerResolutionResult.Resolved>().Subject;
+        resolved.Worker.Id.Value.Should().Be("ruby");
+        resolved.Worker.WorkerRuntime.Should().Be("ruby");
+        resolved.Worker.WorkerConfigPath.Should().Be(Path.Combine(workload.ContentRoot, "worker.config.json"));
         _workloads.Received().GetContentWorkloadsByPackageId("Azure.Functions.Cli.Workloads.Workers.ruby");
     }
 
@@ -107,10 +106,10 @@ public class DefaultFunctionsWorkerResolverTests
             new FunctionsWorkerId("python"),
             CancellationToken.None);
 
-        FunctionsWorkerResolutionResult.NotResolved notResolved = Assert.IsType<FunctionsWorkerResolutionResult.NotResolved>(result);
+        FunctionsWorkerResolutionResult.NotResolved notResolved = result.Should().BeOfType<FunctionsWorkerResolutionResult.NotResolved>().Subject;
         FunctionsWorkerResolutionFailure.NotInstalled failure =
-            Assert.IsType<FunctionsWorkerResolutionFailure.NotInstalled>(notResolved.Failure);
-        Assert.Equal("python", failure.WorkerId.Value);
+            notResolved.Failure.Should().BeOfType<FunctionsWorkerResolutionFailure.NotInstalled>().Subject;
+        failure.WorkerId.Value.Should().Be("python");
     }
 
     [Fact]
@@ -123,11 +122,11 @@ public class DefaultFunctionsWorkerResolverTests
             new FunctionsWorkerId("ruby"),
             CancellationToken.None);
 
-        FunctionsWorkerResolutionResult.NotResolved notResolved = Assert.IsType<FunctionsWorkerResolutionResult.NotResolved>(result);
+        FunctionsWorkerResolutionResult.NotResolved notResolved = result.Should().BeOfType<FunctionsWorkerResolutionResult.NotResolved>().Subject;
         FunctionsWorkerResolutionFailure.NotInstalled failure =
-            Assert.IsType<FunctionsWorkerResolutionFailure.NotInstalled>(notResolved.Failure);
-        Assert.Equal("ruby", failure.WorkerId.Value);
-        Assert.Contains("func workload install Azure.Functions.Cli.Workloads.Workers.ruby --exact", failure.Message);
+            notResolved.Failure.Should().BeOfType<FunctionsWorkerResolutionFailure.NotInstalled>().Subject;
+        failure.WorkerId.Value.Should().Be("ruby");
+        failure.Message.Should().Contain("func workload install Azure.Functions.Cli.Workloads.Workers.ruby --exact");
     }
 
     [Fact]
@@ -140,12 +139,12 @@ public class DefaultFunctionsWorkerResolverTests
             new FunctionsWorkerId("node"),
             CancellationToken.None);
 
-        FunctionsWorkerResolutionResult.NotResolved notResolved = Assert.IsType<FunctionsWorkerResolutionResult.NotResolved>(result);
+        FunctionsWorkerResolutionResult.NotResolved notResolved = result.Should().BeOfType<FunctionsWorkerResolutionResult.NotResolved>().Subject;
         FunctionsWorkerResolutionFailure.MissingCompatibleVersion failure =
-            Assert.IsType<FunctionsWorkerResolutionFailure.MissingCompatibleVersion>(notResolved.Failure);
-        Assert.Equal("node", failure.WorkerId.Value);
-        Assert.Null(failure.VersionConstraint);
-        Assert.Contains("func workload install Azure.Functions.Cli.Workloads.Workers.node --exact --force", failure.Message);
+            notResolved.Failure.Should().BeOfType<FunctionsWorkerResolutionFailure.MissingCompatibleVersion>().Subject;
+        failure.WorkerId.Value.Should().Be("node");
+        failure.VersionConstraint.Should().BeNull();
+        failure.Message.Should().Contain("func workload install Azure.Functions.Cli.Workloads.Workers.node --exact --force");
         _fileSystem.DidNotReceive().FileExists(Arg.Any<string>());
     }
 
@@ -159,10 +158,10 @@ public class DefaultFunctionsWorkerResolverTests
             new FunctionsWorkerId("go"),
             CancellationToken.None);
 
-        FunctionsWorkerResolutionResult.Resolved resolved = Assert.IsType<FunctionsWorkerResolutionResult.Resolved>(result);
-        Assert.Equal("go", resolved.Worker.Id.Value);
-        Assert.Equal("go", resolved.Worker.WorkerRuntime);
-        Assert.Equal("0.1.0", resolved.Worker.Version);
+        FunctionsWorkerResolutionResult.Resolved resolved = result.Should().BeOfType<FunctionsWorkerResolutionResult.Resolved>().Subject;
+        resolved.Worker.Id.Value.Should().Be("go");
+        resolved.Worker.WorkerRuntime.Should().Be("go");
+        resolved.Worker.Version.Should().Be("0.1.0");
     }
 
     [Fact]
@@ -182,8 +181,8 @@ public class DefaultFunctionsWorkerResolverTests
             new FunctionsWorkerId("node"),
             CancellationToken.None);
 
-        FunctionsWorkerResolutionResult.Resolved resolved = Assert.IsType<FunctionsWorkerResolutionResult.Resolved>(result);
-        Assert.Equal("3.13.0", resolved.Worker.Version);
+        FunctionsWorkerResolutionResult.Resolved resolved = result.Should().BeOfType<FunctionsWorkerResolutionResult.Resolved>().Subject;
+        resolved.Worker.Version.Should().Be("3.13.0");
     }
 
     [Fact]
@@ -200,11 +199,11 @@ public class DefaultFunctionsWorkerResolverTests
             new FunctionsWorkerId("node"),
             CancellationToken.None);
 
-        FunctionsWorkerResolutionResult.NotResolved notResolved = Assert.IsType<FunctionsWorkerResolutionResult.NotResolved>(result);
+        FunctionsWorkerResolutionResult.NotResolved notResolved = result.Should().BeOfType<FunctionsWorkerResolutionResult.NotResolved>().Subject;
         FunctionsWorkerResolutionFailure.MissingCompatibleVersion failure =
-            Assert.IsType<FunctionsWorkerResolutionFailure.MissingCompatibleVersion>(notResolved.Failure);
-        Assert.Equal("[3.13.0]", failure.VersionConstraint);
-        Assert.Contains("func workload install Azure.Functions.Cli.Workloads.Workers.node --exact", failure.Message);
+            notResolved.Failure.Should().BeOfType<FunctionsWorkerResolutionFailure.MissingCompatibleVersion>().Subject;
+        failure.VersionConstraint.Should().Be("[3.13.0]");
+        failure.Message.Should().Contain("func workload install Azure.Functions.Cli.Workloads.Workers.node --exact");
     }
 
     [Fact]
@@ -220,14 +219,14 @@ public class DefaultFunctionsWorkerResolverTests
             new FunctionsWorkerId("python"),
             CancellationToken.None);
 
-        FunctionsWorkerResolutionResult.NotResolved notResolved = Assert.IsType<FunctionsWorkerResolutionResult.NotResolved>(result);
+        FunctionsWorkerResolutionResult.NotResolved notResolved = result.Should().BeOfType<FunctionsWorkerResolutionResult.NotResolved>().Subject;
         FunctionsWorkerResolutionFailure.InvalidInstallation failure =
-            Assert.IsType<FunctionsWorkerResolutionFailure.InvalidInstallation>(notResolved.Failure);
-        Assert.Equal("python", failure.WorkerId.Value);
-        Assert.Equal(PythonWorkerPackageId, failure.PackageId);
-        Assert.Equal("4.43.0", failure.PackageVersion);
-        Assert.Equal(workerConfigPath, failure.WorkerConfigPath);
-        Assert.Contains("func workload install Azure.Functions.Cli.Workloads.Workers.python --exact --force", failure.Message);
+            notResolved.Failure.Should().BeOfType<FunctionsWorkerResolutionFailure.InvalidInstallation>().Subject;
+        failure.WorkerId.Value.Should().Be("python");
+        failure.PackageId.Should().Be(PythonWorkerPackageId);
+        failure.PackageVersion.Should().Be("4.43.0");
+        failure.WorkerConfigPath.Should().Be(workerConfigPath);
+        failure.Message.Should().Contain("func workload install Azure.Functions.Cli.Workloads.Workers.python --exact --force");
     }
 
     [Fact]
@@ -237,8 +236,7 @@ public class DefaultFunctionsWorkerResolverTests
         source.Cancel();
         DefaultFunctionsWorkerResolver resolver = CreateResolver();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(
-            async () => await resolver.ResolveWorkerAsync(new FunctionsWorkerId("node"), source.Token));
+        await FluentActions.Awaiting(async () => await resolver.ResolveWorkerAsync(new FunctionsWorkerId("node"), source.Token)).Should().ThrowAsync<OperationCanceledException>();
         _workloads.DidNotReceive().GetContentWorkloadsByPackageId(Arg.Any<string>());
     }
 
@@ -247,33 +245,31 @@ public class DefaultFunctionsWorkerResolverTests
     {
         DefaultFunctionsWorkerResolver resolver = CreateResolver();
 
-        await Assert.ThrowsAsync<ArgumentNullException>(
-            async () => await resolver.ResolveWorkerAsync(null!, CancellationToken.None));
+        await FluentActions.Awaiting(async () => await resolver.ResolveWorkerAsync(null!, CancellationToken.None)).Should().ThrowAsync<ArgumentNullException>();
     }
 
     [Fact]
     public void Ctor_NullWorkloadProvider_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => new DefaultFunctionsWorkerResolver(null!, CreateContentResolver()));
+        FluentActions.Invoking(() => new DefaultFunctionsWorkerResolver(null!, CreateContentResolver())).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
     public void Ctor_NullContentResolver_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => new DefaultFunctionsWorkerResolver(_workloads, null!));
+        FluentActions.Invoking(() => new DefaultFunctionsWorkerResolver(_workloads, null!)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
     public void ContentResolverCtor_NullWorkerConfigFileSystem_Throws()
     {
-        Assert.Throws<ArgumentNullException>(
-            () => new DefaultFunctionsWorkerContentResolver(null!, Options.Create(new WorkloadCatalogOptions())));
+        FluentActions.Invoking(() => new DefaultFunctionsWorkerContentResolver(null!, Options.Create(new WorkloadCatalogOptions()))).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
     public void ContentResolverCtor_NullCatalogOptions_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => new DefaultFunctionsWorkerContentResolver(_fileSystem, null!));
+        FluentActions.Invoking(() => new DefaultFunctionsWorkerContentResolver(_fileSystem, null!)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
@@ -293,8 +289,8 @@ public class DefaultFunctionsWorkerResolverTests
             new FunctionsWorkerId("node"),
             CancellationToken.None);
 
-        FunctionsWorkerResolutionResult.Resolved resolved = Assert.IsType<FunctionsWorkerResolutionResult.Resolved>(result);
-        Assert.Equal("3.13.0-preview.1", resolved.Worker.Version);
+        FunctionsWorkerResolutionResult.Resolved resolved = result.Should().BeOfType<FunctionsWorkerResolutionResult.Resolved>().Subject;
+        resolved.Worker.Version.Should().Be("3.13.0-preview.1");
     }
 
     [Fact]
@@ -311,7 +307,7 @@ public class DefaultFunctionsWorkerResolverTests
             new FunctionsWorkerId("node"),
             CancellationToken.None);
 
-        Assert.IsType<FunctionsWorkerResolutionResult.NotResolved>(result);
+        result.Should().BeOfType<FunctionsWorkerResolutionResult.NotResolved>();
     }
 
     private void UseContentWorkloads(params ContentWorkloadInfo[] workloads)

--- a/test/Func.Tests/Workers/FunctionsWorkerReferenceTests.cs
+++ b/test/Func.Tests/Workers/FunctionsWorkerReferenceTests.cs
@@ -3,7 +3,6 @@
 
 using Azure.Functions.Cli.Workers;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Workers;
 
@@ -24,7 +23,7 @@ public class FunctionsWorkerReferenceTests
 
         FunctionsWorkerResolutionResult result = await reference.ResolveWorkerAsync(context, CancellationToken.None);
 
-        Assert.Same(expected, result);
+        result.Should().BeSameAs(expected);
     }
 
     [Fact]
@@ -42,11 +41,11 @@ public class FunctionsWorkerReferenceTests
 
         FunctionsWorkerResolutionResult result = await reference.ResolveWorkerAsync(context, CancellationToken.None);
 
-        FunctionsWorkerResolutionResult.Resolved resolved = Assert.IsType<FunctionsWorkerResolutionResult.Resolved>(result);
-        Assert.Equal("go", resolved.Worker.Id.Value);
-        Assert.Equal("native", resolved.Worker.WorkerRuntime);
-        Assert.Equal("/workloads/go/worker.config.json", resolved.Worker.WorkerConfigPath);
-        Assert.Equal("1.0.0", resolved.Worker.Version);
+        FunctionsWorkerResolutionResult.Resolved resolved = result.Should().BeOfType<FunctionsWorkerResolutionResult.Resolved>().Subject;
+        resolved.Worker.Id.Value.Should().Be("go");
+        resolved.Worker.WorkerRuntime.Should().Be("native");
+        resolved.Worker.WorkerConfigPath.Should().Be("/workloads/go/worker.config.json");
+        resolved.Worker.Version.Should().Be("1.0.0");
     }
 
     [Fact]
@@ -62,23 +61,23 @@ public class FunctionsWorkerReferenceTests
 
         FunctionsWorkerResolutionResult result = await reference.ResolveWorkerAsync(context, CancellationToken.None);
 
-        Assert.Same(expected, result);
+        result.Should().BeSameAs(expected);
     }
 
     [Fact]
     public void FromWorkload_WithRuntimeOverride_RejectsNullWorkerId()
     {
-        Assert.Throws<ArgumentNullException>(() => FunctionsWorkerReference.FromWorkload(
+        FluentActions.Invoking(() => FunctionsWorkerReference.FromWorkload(
             (FunctionsWorkerId)null!,
-            workerRuntime: "native"));
+            workerRuntime: "native")).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
     public void FromWorkload_WithRuntimeOverride_RejectsBlankRuntime()
     {
-        Assert.Throws<ArgumentException>(() => FunctionsWorkerReference.FromWorkload(
+        FluentActions.Invoking(() => FunctionsWorkerReference.FromWorkload(
             new FunctionsWorkerId("go"),
-            workerRuntime: "   "));
+            workerRuntime: "   ")).Should().ThrowExactly<ArgumentException>();
     }
 
     private static class FunctionsWorkerReferenceTestHelpers
@@ -108,54 +107,54 @@ public class FunctionsWorkerReferenceTests
 
         FunctionsWorkerResolutionResult result = await reference.ResolveWorkerAsync(context, CancellationToken.None);
 
-        FunctionsWorkerResolutionResult.Resolved resolved = Assert.IsType<FunctionsWorkerResolutionResult.Resolved>(result);
-        Assert.Equal("custom", resolved.Worker.Id.Value);
-        Assert.Equal("custom", resolved.Worker.WorkerRuntime);
-        Assert.Equal(WorkerConfigPath, resolved.Worker.WorkerConfigPath);
-        Assert.Equal("1.0.0", resolved.Worker.Version);
+        FunctionsWorkerResolutionResult.Resolved resolved = result.Should().BeOfType<FunctionsWorkerResolutionResult.Resolved>().Subject;
+        resolved.Worker.Id.Value.Should().Be("custom");
+        resolved.Worker.WorkerRuntime.Should().Be("custom");
+        resolved.Worker.WorkerConfigPath.Should().Be(WorkerConfigPath);
+        resolved.Worker.Version.Should().Be("1.0.0");
         _ = resolver.DidNotReceive().ResolveWorkerAsync(Arg.Any<FunctionsWorkerId>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public void FromWorkerInfo_NullWorkerId_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => FunctionsWorkerReference.FromWorkerInfo(
+        FluentActions.Invoking(() => FunctionsWorkerReference.FromWorkerInfo(
             (FunctionsWorkerId)null!,
             "custom",
-            "worker.config.json"));
+            "worker.config.json")).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
     public void FromWorkerInfo_EmptyWorkerRuntime_Throws()
     {
-        Assert.Throws<ArgumentException>(() => FunctionsWorkerReference.FromWorkerInfo(
+        FluentActions.Invoking(() => FunctionsWorkerReference.FromWorkerInfo(
             new FunctionsWorkerId("custom"),
             string.Empty,
-            "worker.config.json"));
+            "worker.config.json")).Should().ThrowExactly<ArgumentException>();
     }
 
     [Fact]
     public void FromWorkerInfo_EmptyWorkerConfigPath_Throws()
     {
-        Assert.Throws<ArgumentException>(() => FunctionsWorkerReference.FromWorkerInfo(
+        FluentActions.Invoking(() => FunctionsWorkerReference.FromWorkerInfo(
             new FunctionsWorkerId("custom"),
             "custom",
-            string.Empty));
+            string.Empty)).Should().ThrowExactly<ArgumentException>();
     }
 
     [Fact]
     public void FromWorkerInfo_NullVersion_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => FunctionsWorkerReference.FromWorkerInfo(
+        FluentActions.Invoking(() => FunctionsWorkerReference.FromWorkerInfo(
             new FunctionsWorkerId("custom"),
             "custom",
             "worker.config.json",
-            null!));
+            null!)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
     public void Ctor_NullResolver_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => new FunctionsWorkerResolutionContext(null!));
+        FluentActions.Invoking(() => new FunctionsWorkerResolutionContext(null!)).Should().ThrowExactly<ArgumentNullException>();
     }
 }

--- a/test/Func.Tests/Workloads/Catalog/NuGetProtocolSourceClientTests.cs
+++ b/test/Func.Tests/Workloads/Catalog/NuGetProtocolSourceClientTests.cs
@@ -7,7 +7,6 @@ using NSubstitute;
 using NuGet.Common;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
-using Xunit;
 using PackageSource = NuGet.Configuration.PackageSource;
 
 namespace Azure.Functions.Cli.Tests.Workloads.Catalog;
@@ -33,9 +32,9 @@ public sealed class NuGetProtocolSourceClientTests
             }
             """);
 
-        CatalogSearchResult only = Assert.Single(NuGetProtocolSourceClient.ParseV3Hits(response, _source));
-        Assert.Equal("workloads.python", only.PackageId);
-        Assert.Equal(["python"], only.Aliases);
+        CatalogSearchResult only = NuGetProtocolSourceClient.ParseV3Hits(response, _source).Should().ContainSingle().Subject;
+        only.PackageId.Should().Be("workloads.python");
+        only.Aliases.Should().Equal(["python"]);
     }
 
     [Fact]
@@ -53,8 +52,8 @@ public sealed class NuGetProtocolSourceClientTests
             }
             """);
 
-        CatalogSearchResult only = Assert.Single(NuGetProtocolSourceClient.ParseV3Hits(response, _source));
-        Assert.Equal(["node", "nodejs"], only.Aliases);
+        CatalogSearchResult only = NuGetProtocolSourceClient.ParseV3Hits(response, _source).Should().ContainSingle().Subject;
+        only.Aliases.Should().Equal(["node", "nodejs"]);
     }
 
     [Fact]
@@ -72,10 +71,10 @@ public sealed class NuGetProtocolSourceClientTests
 
         var results = NuGetProtocolSourceClient.ParseV3Hits(response, _source);
 
-        Assert.Equal(3, results.Count);
-        Assert.Equal("workload", results.Single(r => r.PackageId == "workloads.python").Kind);
-        Assert.Equal("content", results.Single(r => r.PackageId == "workloads.host").Kind);
-        Assert.Null(results.Single(r => r.PackageId == "workloads.nokind").Kind);
+        results.Count.Should().Be(3);
+        results.Single(r => r.PackageId == "workloads.python").Kind.Should().Be("workload");
+        results.Single(r => r.PackageId == "workloads.host").Kind.Should().Be("content");
+        results.Single(r => r.PackageId == "workloads.nokind").Kind.Should().BeNull();
     }
 
     [Fact]
@@ -91,7 +90,7 @@ public sealed class NuGetProtocolSourceClientTests
             }
             """);
 
-        Assert.Empty(NuGetProtocolSourceClient.ParseV3Hits(response, _source));
+        NuGetProtocolSourceClient.ParseV3Hits(response, _source).Should().BeEmpty();
     }
 
     [Fact]
@@ -99,7 +98,7 @@ public sealed class NuGetProtocolSourceClientTests
     {
         var response = JObject.Parse("""{ "totalHits": 0 }""");
 
-        Assert.Empty(NuGetProtocolSourceClient.ParseV3Hits(response, _source));
+        NuGetProtocolSourceClient.ParseV3Hits(response, _source).Should().BeEmpty();
     }
 
     [Fact]
@@ -132,10 +131,10 @@ public sealed class NuGetProtocolSourceClientTests
 
         var results = NuGetProtocolSourceClient.ParseV3Hits(response, _source);
 
-        Assert.Equal(2, results.Count);
-        Assert.Contains(results, r => r.PackageId == "workloads.python");
-        Assert.Contains(results, r => r.PackageId == "workloads.nopackagetypes");
-        Assert.DoesNotContain(results, r => r.PackageId == "azure.functions.cli.abstractions");
+        results.Count.Should().Be(2);
+        results.Should().Contain(r => r.PackageId == "workloads.python");
+        results.Should().Contain(r => r.PackageId == "workloads.nopackagetypes");
+        results.Should().NotContain(r => r.PackageId == "azure.functions.cli.abstractions");
     }
 
     [Fact]
@@ -153,7 +152,7 @@ public sealed class NuGetProtocolSourceClientTests
             }
             """);
 
-        Assert.Single(NuGetProtocolSourceClient.ParseV3Hits(response, _source));
+        NuGetProtocolSourceClient.ParseV3Hits(response, _source).Should().ContainSingle();
     }
 
 
@@ -176,9 +175,7 @@ public sealed class NuGetProtocolSourceClientTests
         NuGetProtocolSourceClient client = NewClient(findResource: find);
         IReadOnlyList<NuGetVersion> versions = await client.ListVersionsAsync("Workloads.Python", CancellationToken.None);
 
-        Assert.Equal(
-            [NuGetVersion.Parse("1.0.0"), NuGetVersion.Parse("2.0.0"), NuGetVersion.Parse("2.0.0-beta.1")],
-            versions);
+        versions.Should().Equal([NuGetVersion.Parse("1.0.0"), NuGetVersion.Parse("2.0.0"), NuGetVersion.Parse("2.0.0-beta.1")]);
     }
 
     [Fact]
@@ -189,7 +186,7 @@ public sealed class NuGetProtocolSourceClientTests
             .Returns(Task.FromResult<IEnumerable<NuGetVersion>>(null!));
 
         NuGetProtocolSourceClient client = NewClient(findResource: find);
-        Assert.Empty(await client.ListVersionsAsync("workload.absent", CancellationToken.None));
+        (await client.ListVersionsAsync("workload.absent", CancellationToken.None)).Should().BeEmpty();
     }
 
     [Fact]
@@ -217,10 +214,10 @@ public sealed class NuGetProtocolSourceClientTests
             NuGetVersion.Parse("1.2.3"),
             CancellationToken.None);
 
-        Assert.True(stream.CanSeek);
+        stream.CanSeek.Should().BeTrue();
         var copied = new MemoryStream();
         await stream.CopyToAsync(copied);
-        Assert.Equal(payload, copied.ToArray());
+        copied.ToArray().Should().Equal(payload);
     }
 
     [Fact]
@@ -238,8 +235,7 @@ public sealed class NuGetProtocolSourceClientTests
 
         NuGetProtocolSourceClient client = NewClient(findResource: find);
 
-        await Assert.ThrowsAsync<WorkloadPackageNotFoundException>(
-            () => client.OpenPackageAsync("workload.absent", NuGetVersion.Parse("1.0.0"), CancellationToken.None));
+        await FluentActions.Awaiting(() => client.OpenPackageAsync("workload.absent", NuGetVersion.Parse("1.0.0"), CancellationToken.None)).Should().ThrowAsync<WorkloadPackageNotFoundException>();
     }
 
     private static NuGetProtocolSourceClient NewClient(FindPackageByIdResource? findResource = null)

--- a/test/Func.Tests/Workloads/Catalog/NuGetProtocolSourceClientTests.cs
+++ b/test/Func.Tests/Workloads/Catalog/NuGetProtocolSourceClientTests.cs
@@ -52,8 +52,8 @@ public sealed class NuGetProtocolSourceClientTests
             }
             """);
 
-        CatalogSearchResult only = NuGetProtocolSourceClient.ParseV3Hits(response, _source).Should().ContainSingle().Subject;
-        only.Aliases.Should().Equal(["node", "nodejs"]);
+        NuGetProtocolSourceClient.ParseV3Hits(response, _source).Should().ContainSingle()
+            .Which.Aliases.Should().Equal(["node", "nodejs"]);
     }
 
     [Fact]

--- a/test/Func.Tests/Workloads/Catalog/PackageSourceProviderTests.cs
+++ b/test/Func.Tests/Workloads/Catalog/PackageSourceProviderTests.cs
@@ -3,7 +3,6 @@
 
 using Azure.Functions.Cli.Workloads.Catalog;
 using Microsoft.Extensions.Options;
-using Xunit;
 using PackageSource = NuGet.Configuration.PackageSource;
 
 namespace Azure.Functions.Cli.Tests.Workloads.Catalog;
@@ -17,8 +16,8 @@ public sealed class PackageSourceProviderTests
 
         PackageSource source = provider.GetSource("https://example.test/v3/index.json");
 
-        Assert.False(source.IsLocal);
-        Assert.Equal("https://example.test/v3/index.json", source.Source);
+        source.IsLocal.Should().BeFalse();
+        source.Source.Should().Be("https://example.test/v3/index.json");
     }
 
     [Fact]
@@ -28,7 +27,7 @@ public sealed class PackageSourceProviderTests
 
         PackageSource source = provider.GetSource("https://override.test/v3/index.json");
 
-        Assert.Equal("https://override.test/v3/index.json", source.Source);
+        source.Source.Should().Be("https://override.test/v3/index.json");
     }
 
     [Fact]
@@ -38,7 +37,7 @@ public sealed class PackageSourceProviderTests
 
         PackageSource source = provider.GetSource();
 
-        Assert.Equal("https://configured.test/v3/index.json", source.Source);
+        source.Source.Should().Be("https://configured.test/v3/index.json");
     }
 
     [Fact]
@@ -48,8 +47,8 @@ public sealed class PackageSourceProviderTests
 
         PackageSource source = provider.GetSource();
 
-        Assert.False(source.IsLocal);
-        Assert.Equal(PackageSourceProvider.DefaultSourceUrl, source.Source);
+        source.IsLocal.Should().BeFalse();
+        source.Source.Should().Be(PackageSourceProvider.DefaultSourceUrl);
     }
 
     [Theory]
@@ -61,8 +60,8 @@ public sealed class PackageSourceProviderTests
     {
         PackageSourceProvider provider = NewProvider();
 
-        ArgumentException ex = Assert.Throws<ArgumentException>(() => provider.GetSource(value));
-        Assert.Contains("not a supported NuGet feed", ex.Message, StringComparison.OrdinalIgnoreCase);
+        ArgumentException ex = FluentActions.Invoking(() => provider.GetSource(value)).Should().ThrowExactly<ArgumentException>().Which;
+        ex.Message.Should().ContainEquivalentOf("not a supported NuGet feed");
     }
 
     [Fact]
@@ -70,7 +69,7 @@ public sealed class PackageSourceProviderTests
     {
         PackageSourceProvider provider = NewProvider("ftp://unsupported.example/feed");
 
-        Assert.Throws<ArgumentException>(() => provider.GetSource());
+        FluentActions.Invoking(() => provider.GetSource()).Should().ThrowExactly<ArgumentException>();
     }
 
     private static PackageSourceProvider NewProvider(string? source = null)

--- a/test/Func.Tests/Workloads/Catalog/WorkloadCatalogTests.cs
+++ b/test/Func.Tests/Workloads/Catalog/WorkloadCatalogTests.cs
@@ -10,7 +10,6 @@ using NuGet.Common;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
-using Xunit;
 using PackageSource = NuGet.Configuration.PackageSource;
 
 namespace Azure.Functions.Cli.Tests.Workloads.Catalog;
@@ -28,9 +27,9 @@ public sealed class WorkloadCatalogTests
 
         IReadOnlyList<CatalogSearchResult> results = await catalog.SearchAsync(new CatalogSearchQuery());
 
-        CatalogSearchResult only = Assert.Single(results);
-        Assert.Equal("alpha", only.PackageId);
-        Assert.Equal(_defaultSource.Name, only.Source.Name);
+        CatalogSearchResult only = results.Should().ContainSingle().Subject;
+        only.PackageId.Should().Be("alpha");
+        only.Source.Name.Should().Be(_defaultSource.Name);
     }
 
     [Fact]
@@ -50,7 +49,7 @@ public sealed class WorkloadCatalogTests
 
         IReadOnlyList<CatalogSearchResult> results = await catalog.SearchAsync(new CatalogSearchQuery { Source = _altSource.Source });
 
-        Assert.Equal("override-pkg", Assert.Single(results).PackageId);
+        results.Should().ContainSingle().Subject.PackageId.Should().Be("override-pkg");
     }
 
     [Fact]
@@ -61,9 +60,9 @@ public sealed class WorkloadCatalogTests
 
         ResolvedPackage? resolved = await catalog.ResolveLatestVersionAsync("alpha", includePrerelease: false);
 
-        Assert.NotNull(resolved);
-        Assert.Equal(V("1.5.0"), resolved!.Version);
-        Assert.Equal(_defaultSource.Name, resolved.Source.Name);
+        resolved.Should().NotBeNull();
+        resolved!.Version.Should().Be(V("1.5.0"));
+        resolved.Source.Name.Should().Be(_defaultSource.Name);
     }
 
     [Fact]
@@ -74,7 +73,7 @@ public sealed class WorkloadCatalogTests
 
         ResolvedPackage? resolved = await catalog.ResolveLatestVersionAsync("alpha", includePrerelease: true);
 
-        Assert.Equal(V("2.0.0-beta.1"), resolved!.Version);
+        resolved!.Version.Should().Be(V("2.0.0-beta.1"));
     }
 
     [Fact]
@@ -86,7 +85,7 @@ public sealed class WorkloadCatalogTests
 
         ResolvedPackage? resolved = await catalog.ResolveLatestVersionAsync("alpha", includePrerelease: null);
 
-        Assert.Equal(V("2.0.0-beta.1"), resolved!.Version);
+        resolved!.Version.Should().Be(V("2.0.0-beta.1"));
     }
 
     [Fact]
@@ -97,9 +96,9 @@ public sealed class WorkloadCatalogTests
 
         await catalog.SearchAsync(new CatalogSearchQuery { IncludePrerelease = null });
 
-        var fakeClient = Assert.IsType<FakeClient>(client);
-        Assert.NotNull(fakeClient.LastSearchUri);
-        Assert.Contains("prerelease=true", fakeClient.LastSearchUri!.Query, StringComparison.OrdinalIgnoreCase);
+        var fakeClient = client.Should().BeOfType<FakeClient>().Subject;
+        fakeClient.LastSearchUri.Should().NotBeNull();
+        fakeClient.LastSearchUri!.Query.Should().ContainEquivalentOf("prerelease=true");
     }
 
     [Fact]
@@ -112,7 +111,7 @@ public sealed class WorkloadCatalogTests
 
         ResolvedPackage? resolved = await catalog.ResolveLatestVersionInRangeAsync("alpha", range, includePrerelease: null);
 
-        Assert.Equal(V("2.0.0-beta.1"), resolved!.Version);
+        resolved!.Version.Should().Be(V("2.0.0-beta.1"));
     }
 
     [Fact]
@@ -130,8 +129,8 @@ public sealed class WorkloadCatalogTests
 
         ResolvedPackage? resolved = await catalog.ResolveLatestVersionInRangeAsync("node", range, includePrerelease: null);
 
-        Assert.NotNull(resolved);
-        Assert.Equal(V("3.13.0-preview.1"), resolved!.Version);
+        resolved.Should().NotBeNull();
+        resolved!.Version.Should().Be(V("3.13.0-preview.1"));
     }
 
     [Fact]
@@ -144,7 +143,7 @@ public sealed class WorkloadCatalogTests
 
         ResolvedPackage? resolved = await catalog.ResolveLatestVersionInRangeAsync("node", range, includePrerelease: false);
 
-        Assert.Null(resolved);
+        resolved.Should().BeNull();
     }
 
     [Theory]
@@ -167,7 +166,7 @@ public sealed class WorkloadCatalogTests
 
         setup.Configure(options);
 
-        Assert.Equal(expected, options.IncludePrerelease);
+        options.IncludePrerelease.Should().Be(expected);
     }
 
     [Theory]
@@ -186,7 +185,7 @@ public sealed class WorkloadCatalogTests
 
         setup.Configure(options);
 
-        Assert.True(options.IncludePrerelease);
+        options.IncludePrerelease.Should().BeTrue();
     }
 
     [Fact]
@@ -201,7 +200,7 @@ public sealed class WorkloadCatalogTests
 
         setup.Configure(options);
 
-        Assert.False(options.IncludePrerelease);
+        options.IncludePrerelease.Should().BeFalse();
     }
 
     [Fact]
@@ -216,7 +215,7 @@ public sealed class WorkloadCatalogTests
 
         setup.Configure(options);
 
-        Assert.False(options.IncludePrerelease);
+        options.IncludePrerelease.Should().BeFalse();
     }
 
     [Fact]
@@ -230,7 +229,7 @@ public sealed class WorkloadCatalogTests
 
         setup.Configure(options);
 
-        Assert.Equal("https://source.test/v3/index.json", options.Source);
+        options.Source.Should().Be("https://source.test/v3/index.json");
     }
 
     [Fact]
@@ -242,7 +241,7 @@ public sealed class WorkloadCatalogTests
         ResolvedPackage? resolved = await catalog.ResolveLatestVersionAsync(
             "alpha", includePrerelease: false, currentVersion: V("1.0.0"), allowMajor: false);
 
-        Assert.Equal(V("1.5.0"), resolved!.Version);
+        resolved!.Version.Should().Be(V("1.5.0"));
     }
 
     [Fact]
@@ -253,7 +252,7 @@ public sealed class WorkloadCatalogTests
 
         ResolvedPackage? resolved = await catalog.ResolveLatestVersionAsync("alpha", includePrerelease: false);
 
-        Assert.Null(resolved);
+        resolved.Should().BeNull();
     }
 
     [Fact]
@@ -266,9 +265,9 @@ public sealed class WorkloadCatalogTests
 
         ResolvedPackage? resolved = await catalog.ResolveLatestVersionInRangeAsync("alpha", range, includePrerelease: false);
 
-        Assert.NotNull(resolved);
-        Assert.Equal(V("4.1048.199"), resolved!.Version);
-        Assert.Equal(_defaultSource.Name, resolved.Source.Name);
+        resolved.Should().NotBeNull();
+        resolved!.Version.Should().Be(V("4.1048.199"));
+        resolved.Source.Name.Should().Be(_defaultSource.Name);
     }
 
     [Fact]
@@ -279,8 +278,8 @@ public sealed class WorkloadCatalogTests
 
         ResolvedPackage? resolved = await catalog.ResolveLatestVersionOnChannelAsync("alpha", prereleaseLabel: null);
 
-        Assert.NotNull(resolved);
-        Assert.Equal(V("1.5.0"), resolved!.Version);
+        resolved.Should().NotBeNull();
+        resolved!.Version.Should().Be(V("1.5.0"));
     }
 
     [Fact]
@@ -292,8 +291,8 @@ public sealed class WorkloadCatalogTests
 
         ResolvedPackage? resolved = await catalog.ResolveLatestVersionOnChannelAsync("alpha", prereleaseLabel: "preview");
 
-        Assert.NotNull(resolved);
-        Assert.Equal(V("2.0.0-preview.3"), resolved!.Version);
+        resolved.Should().NotBeNull();
+        resolved!.Version.Should().Be(V("2.0.0-preview.3"));
     }
 
     [Fact]
@@ -305,8 +304,8 @@ public sealed class WorkloadCatalogTests
 
         ResolvedPackage? resolved = await catalog.ResolveLatestVersionOnChannelAsync("alpha", prereleaseLabel: "experimental");
 
-        Assert.NotNull(resolved);
-        Assert.Equal(V("2.5.0-experimental.2"), resolved!.Version);
+        resolved.Should().NotBeNull();
+        resolved!.Version.Should().Be(V("2.5.0-experimental.2"));
     }
 
     [Fact]
@@ -317,7 +316,7 @@ public sealed class WorkloadCatalogTests
 
         ResolvedPackage? resolved = await catalog.ResolveLatestVersionOnChannelAsync("alpha", prereleaseLabel: "preview");
 
-        Assert.Null(resolved);
+        resolved.Should().BeNull();
     }
 
     [Fact]
@@ -329,8 +328,8 @@ public sealed class WorkloadCatalogTests
 
         ResolvedPackage? resolved = await catalog.ResolveLatestVersionOnChannelAsync("alpha", prereleaseLabel: "preview", versionRange: range);
 
-        Assert.NotNull(resolved);
-        Assert.Equal(V("4.10.0-preview.1"), resolved!.Version);
+        resolved.Should().NotBeNull();
+        resolved!.Version.Should().Be(V("4.10.0-preview.1"));
     }
 
     [Fact]
@@ -341,9 +340,9 @@ public sealed class WorkloadCatalogTests
 
         ResolvedPackage? resolved = await catalog.ResolveVersionAsync("alpha", V("2.0.0"));
 
-        Assert.NotNull(resolved);
-        Assert.Equal(V("2.0.0"), resolved!.Version);
-        Assert.Equal(_defaultSource.Name, resolved.Source.Name);
+        resolved.Should().NotBeNull();
+        resolved!.Version.Should().Be(V("2.0.0"));
+        resolved.Source.Name.Should().Be(_defaultSource.Name);
     }
 
     [Fact]
@@ -354,7 +353,7 @@ public sealed class WorkloadCatalogTests
 
         ResolvedPackage? resolved = await catalog.ResolveVersionAsync("alpha", V("9.9.9"));
 
-        Assert.Null(resolved);
+        resolved.Should().BeNull();
     }
 
     [Fact]
@@ -365,7 +364,7 @@ public sealed class WorkloadCatalogTests
 
         ResolvedPackage? resolved = await catalog.ResolveVersionAsync("Alpha", V("1.0.0"));
 
-        Assert.Equal("alpha", resolved!.PackageId);
+        resolved!.PackageId.Should().Be("alpha");
     }
 
     [Fact]
@@ -390,7 +389,7 @@ public sealed class WorkloadCatalogTests
 
         var copied = new MemoryStream();
         await result.CopyToAsync(copied);
-        Assert.Equal(payload, copied.ToArray());
+        copied.ToArray().Should().Equal(payload);
     }
 
     [Fact]
@@ -405,8 +404,7 @@ public sealed class WorkloadCatalogTests
         WorkloadCatalog catalog = NewCatalog(
             (_defaultSource, new NuGetProtocolSourceClient(TestRepository.Build(_defaultSource, find))));
 
-        await Assert.ThrowsAsync<WorkloadPackageNotFoundException>(
-            () => catalog.DownloadAsync(new ResolvedPackage("alpha", V("1.0.0"), _defaultSource)));
+        await FluentActions.Awaiting(() => catalog.DownloadAsync(new ResolvedPackage("alpha", V("1.0.0"), _defaultSource))).Should().ThrowAsync<WorkloadPackageNotFoundException>();
     }
 
     private static NuGetVersion V(string v) => NuGetVersion.Parse(v);

--- a/test/Func.Tests/Workloads/Discovery/WorkloadMetadataReaderTests.cs
+++ b/test/Func.Tests/Workloads/Discovery/WorkloadMetadataReaderTests.cs
@@ -4,7 +4,6 @@
 using Azure.Functions.Cli.Workloads;
 using Azure.Functions.Cli.Workloads.Discovery;
 using Azure.Functions.Cli.Workloads.Storage;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Workloads.Discovery;
 
@@ -46,10 +45,10 @@ public class WorkloadMetadataReaderTests : IDisposable
 
         WorkloadMetadata metadata = _reader.Read(_tempDir);
 
-        Assert.Equal(SchemaUrl, metadata.Schema);
-        Assert.Equal(WorkloadKind.Workload, metadata.Kind);
-        Assert.Equal("Foo.dll", metadata.EntryPoint!.AssemblyPath);
-        Assert.Equal("Foo.MyWorkload", metadata.EntryPoint.Type);
+        metadata.Schema.Should().Be(SchemaUrl);
+        metadata.Kind.Should().Be(WorkloadKind.Workload);
+        metadata.EntryPoint!.AssemblyPath.Should().Be("Foo.dll");
+        metadata.EntryPoint.Type.Should().Be("Foo.MyWorkload");
     }
 
     [Fact]
@@ -70,7 +69,7 @@ public class WorkloadMetadataReaderTests : IDisposable
 
         WorkloadMetadata metadata = _reader.Read(_tempDir);
 
-        Assert.Equal(WorkloadKind.Workload, metadata.Kind);
+        metadata.Kind.Should().Be(WorkloadKind.Workload);
     }
 
     [Fact]
@@ -88,8 +87,8 @@ public class WorkloadMetadataReaderTests : IDisposable
 
         WorkloadMetadata metadata = _reader.Read(_tempDir);
 
-        Assert.Equal(WorkloadKind.Content, metadata.Kind);
-        Assert.Null(metadata.EntryPoint);
+        metadata.Kind.Should().Be(WorkloadKind.Content);
+        metadata.EntryPoint.Should().BeNull();
     }
 
     [Fact]
@@ -107,8 +106,8 @@ public class WorkloadMetadataReaderTests : IDisposable
 
         WorkloadMetadata metadata = _reader.Read(_tempDir);
 
-        Assert.Equal("Functions Host", metadata.DisplayName);
-        Assert.Equal("Azure Functions host payload.", metadata.Description);
+        metadata.DisplayName.Should().Be("Functions Host");
+        metadata.Description.Should().Be("Azure Functions host payload.");
     }
 
     [Fact]
@@ -124,8 +123,8 @@ public class WorkloadMetadataReaderTests : IDisposable
 
         WorkloadMetadata metadata = _reader.Read(_tempDir);
 
-        Assert.Equal(WorkloadKind.Meta, metadata.Kind);
-        Assert.Null(metadata.EntryPoint);
+        metadata.Kind.Should().Be(WorkloadKind.Meta);
+        metadata.EntryPoint.Should().BeNull();
     }
 
     [Theory]
@@ -147,11 +146,10 @@ public class WorkloadMetadataReaderTests : IDisposable
             }
             """);
 
-        InvalidWorkloadException ex = Assert.Throws<InvalidWorkloadException>(
-            () => _reader.Read(_tempDir));
+        InvalidWorkloadException ex = FluentActions.Invoking(() => _reader.Read(_tempDir)).Should().ThrowExactly<InvalidWorkloadException>().Which;
 
-        Assert.Contains(kind, ex.Message);
-        Assert.Contains("entryPoint", ex.Message);
+        ex.Message.Should().Contain(kind);
+        ex.Message.Should().Contain("entryPoint");
     }
 
     [Fact]
@@ -169,21 +167,19 @@ public class WorkloadMetadataReaderTests : IDisposable
             }
             """);
 
-        InvalidWorkloadException ex = Assert.Throws<InvalidWorkloadException>(
-            () => _reader.Read(_tempDir));
+        InvalidWorkloadException ex = FluentActions.Invoking(() => _reader.Read(_tempDir)).Should().ThrowExactly<InvalidWorkloadException>().Which;
 
-        Assert.Contains("schema", ex.Message);
-        Assert.Contains("v999", ex.Message);
+        ex.Message.Should().Contain("schema");
+        ex.Message.Should().Contain("v999");
     }
 
     [Fact]
     public void Read_Throws_WhenManifestMissing()
     {
-        InvalidWorkloadException ex = Assert.Throws<InvalidWorkloadException>(
-            () => _reader.Read(_tempDir));
+        InvalidWorkloadException ex = FluentActions.Invoking(() => _reader.Read(_tempDir)).Should().ThrowExactly<InvalidWorkloadException>().Which;
 
-        Assert.Contains(_tempDir, ex.Message);
-        Assert.Contains(WorkloadMetadataReader.MetadataFileName, ex.Message);
+        ex.Message.Should().Contain(_tempDir);
+        ex.Message.Should().Contain(WorkloadMetadataReader.MetadataFileName);
     }
 
     [Fact]
@@ -191,11 +187,10 @@ public class WorkloadMetadataReaderTests : IDisposable
     {
         WriteMetadata("{ not valid json");
 
-        InvalidWorkloadException ex = Assert.Throws<InvalidWorkloadException>(
-            () => _reader.Read(_tempDir));
+        InvalidWorkloadException ex = FluentActions.Invoking(() => _reader.Read(_tempDir)).Should().ThrowExactly<InvalidWorkloadException>().Which;
 
-        Assert.Contains(WorkloadMetadataReader.MetadataFileName, ex.Message);
-        Assert.IsType<System.Text.Json.JsonException>(ex.InnerException);
+        ex.Message.Should().Contain(WorkloadMetadataReader.MetadataFileName);
+        ex.InnerException.Should().BeOfType<System.Text.Json.JsonException>();
     }
 
     [Fact]
@@ -210,10 +205,9 @@ public class WorkloadMetadataReaderTests : IDisposable
             }
             """);
 
-        InvalidWorkloadException ex = Assert.Throws<InvalidWorkloadException>(
-            () => _reader.Read(_tempDir));
+        InvalidWorkloadException ex = FluentActions.Invoking(() => _reader.Read(_tempDir)).Should().ThrowExactly<InvalidWorkloadException>().Which;
 
-        Assert.Contains("entryPoint", ex.Message);
+        ex.Message.Should().Contain("entryPoint");
     }
 
     [Fact]
@@ -231,10 +225,9 @@ public class WorkloadMetadataReaderTests : IDisposable
             }
             """);
 
-        InvalidWorkloadException ex = Assert.Throws<InvalidWorkloadException>(
-            () => _reader.Read(_tempDir));
+        InvalidWorkloadException ex = FluentActions.Invoking(() => _reader.Read(_tempDir)).Should().ThrowExactly<InvalidWorkloadException>().Which;
 
-        Assert.Contains("assemblyPath", ex.Message);
+        ex.Message.Should().Contain("assemblyPath");
     }
 
     [Fact]
@@ -252,10 +245,9 @@ public class WorkloadMetadataReaderTests : IDisposable
             }
             """);
 
-        InvalidWorkloadException ex = Assert.Throws<InvalidWorkloadException>(
-            () => _reader.Read(_tempDir));
+        InvalidWorkloadException ex = FluentActions.Invoking(() => _reader.Read(_tempDir)).Should().ThrowExactly<InvalidWorkloadException>().Which;
 
-        Assert.Contains("type", ex.Message);
+        ex.Message.Should().Contain("type");
     }
 
     [Fact]
@@ -263,10 +255,9 @@ public class WorkloadMetadataReaderTests : IDisposable
     {
         string missing = Path.Combine(_tempDir, "does-not-exist");
 
-        DirectoryNotFoundException ex = Assert.Throws<DirectoryNotFoundException>(
-            () => _reader.Read(missing));
+        DirectoryNotFoundException ex = FluentActions.Invoking(() => _reader.Read(missing)).Should().ThrowExactly<DirectoryNotFoundException>().Which;
 
-        Assert.Contains(missing, ex.Message);
+        ex.Message.Should().Contain(missing);
     }
 
     [Theory]
@@ -286,11 +277,10 @@ public class WorkloadMetadataReaderTests : IDisposable
             }
             """);
 
-        InvalidWorkloadException ex = Assert.Throws<InvalidWorkloadException>(
-            () => _reader.Read(_tempDir));
+        InvalidWorkloadException ex = FluentActions.Invoking(() => _reader.Read(_tempDir)).Should().ThrowExactly<InvalidWorkloadException>().Which;
 
-        Assert.Contains("absolute", ex.Message);
-        Assert.Contains("assemblyPath", ex.Message);
+        ex.Message.Should().Contain("absolute");
+        ex.Message.Should().Contain("assemblyPath");
     }
 
     [Theory]
@@ -311,11 +301,10 @@ public class WorkloadMetadataReaderTests : IDisposable
             }
             """);
 
-        InvalidWorkloadException ex = Assert.Throws<InvalidWorkloadException>(
-            () => _reader.Read(_tempDir));
+        InvalidWorkloadException ex = FluentActions.Invoking(() => _reader.Read(_tempDir)).Should().ThrowExactly<InvalidWorkloadException>().Which;
 
-        Assert.Contains("..", ex.Message);
-        Assert.Contains("assemblyPath", ex.Message);
+        ex.Message.Should().Contain("..");
+        ex.Message.Should().Contain("assemblyPath");
     }
 
     [Fact]
@@ -328,13 +317,9 @@ public class WorkloadMetadataReaderTests : IDisposable
         // surfaces here.
         WorkloadMetadata metadata = _reader.Read(AppContext.BaseDirectory);
 
-        Assert.Equal(WorkloadKind.Workload, metadata.Kind);
-        Assert.Equal(
-            "Azure.Functions.Cli.Workloads.Tests.Fixtures.Default.dll",
-            metadata.EntryPoint!.AssemblyPath);
-        Assert.Equal(
-            "Azure.Functions.Cli.Workloads.Tests.Fixtures.Default.StubWorkload",
-            metadata.EntryPoint.Type);
+        metadata.Kind.Should().Be(WorkloadKind.Workload);
+        metadata.EntryPoint!.AssemblyPath.Should().Be("Azure.Functions.Cli.Workloads.Tests.Fixtures.Default.dll");
+        metadata.EntryPoint.Type.Should().Be("Azure.Functions.Cli.Workloads.Tests.Fixtures.Default.StubWorkload");
     }
 
     private void WriteMetadata(string json)

--- a/test/Func.Tests/Workloads/ExternalCommandTests.cs
+++ b/test/Func.Tests/Workloads/ExternalCommandTests.cs
@@ -74,8 +74,7 @@ public class ExternalCommandTests
 
         var middleSub = external.Subcommands.Should().ContainSingle().Subject;
         middleSub.Name.Should().Be("middle");
-        var leafSub = middleSub.Subcommands.Should().ContainSingle().Subject;
-        leafSub.Name.Should().Be("leaf");
+        middleSub.Subcommands.Should().ContainSingle().Which.Name.Should().Be("leaf");
     }
 
     [Fact]

--- a/test/Func.Tests/Workloads/ExternalCommandTests.cs
+++ b/test/Func.Tests/Workloads/ExternalCommandTests.cs
@@ -4,7 +4,6 @@
 using System.CommandLine;
 using Azure.Functions.Cli.Commands;
 using Azure.Functions.Cli.Workloads;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Workloads;
 
@@ -16,8 +15,8 @@ public class ExternalCommandTests
         var source = new TestWorkloads.StubFuncCommand("deploy", "Deploy the app.");
         var external = new ExternalCommand(TestWorkloads.CreateInfo(), source);
 
-        Assert.Equal("deploy", external.Name);
-        Assert.Equal("Deploy the app.", external.Description);
+        external.Name.Should().Be("deploy");
+        external.Description.Should().Be("Deploy the app.");
     }
 
     [Fact]
@@ -30,11 +29,11 @@ public class ExternalCommandTests
         var external = new ExternalCommand(TestWorkloads.CreateInfo(), source);
 
         var parserOptions = external.Options.Select(o => o.Name).ToList();
-        Assert.Contains("--stack", parserOptions);
-        Assert.Contains("--verbose", parserOptions);
+        parserOptions.Should().Contain("--stack");
+        parserOptions.Should().Contain("--verbose");
 
         var stackOption = external.Options.Single(o => o.Name == "--stack");
-        Assert.Contains("-s", stackOption.Aliases);
+        stackOption.Aliases.Should().Contain("-s");
     }
 
     [Fact]
@@ -46,7 +45,7 @@ public class ExternalCommandTests
 
         var typed = (Option<int>)external.Options.Single(o => o.Name == "--port");
         var parseResult = external.Parse(string.Empty);
-        Assert.Equal(7071, parseResult.GetValue(typed));
+        parseResult.GetValue(typed).Should().Be(7071);
     }
 
     [Fact]
@@ -60,8 +59,8 @@ public class ExternalCommandTests
 
         var pathArg = external.Arguments.Single(a => a.Name == "path");
         var nameArg = external.Arguments.Single(a => a.Name == "name");
-        Assert.Equal(ArgumentArity.ZeroOrOne, pathArg.Arity);
-        Assert.Equal(ArgumentArity.ExactlyOne, nameArg.Arity);
+        pathArg.Arity.Should().Be(ArgumentArity.ZeroOrOne);
+        nameArg.Arity.Should().Be(ArgumentArity.ExactlyOne);
     }
 
     [Fact]
@@ -73,10 +72,10 @@ public class ExternalCommandTests
 
         var external = new ExternalCommand(TestWorkloads.CreateInfo(), top);
 
-        var middleSub = Assert.Single(external.Subcommands);
-        Assert.Equal("middle", middleSub.Name);
-        var leafSub = Assert.Single(middleSub.Subcommands);
-        Assert.Equal("leaf", leafSub.Name);
+        var middleSub = external.Subcommands.Should().ContainSingle().Subject;
+        middleSub.Name.Should().Be("middle");
+        var leafSub = middleSub.Subcommands.Should().ContainSingle().Subject;
+        leafSub.Name.Should().Be("leaf");
     }
 
     [Fact]
@@ -86,10 +85,9 @@ public class ExternalCommandTests
         var b = new FuncCommandOption<string>("--name", null, "second");
         var source = new TestWorkloads.StubFuncCommand("deploy", options: [a, b]);
 
-        var ex = Assert.Throws<WorkloadOperationException>(
-            () => new ExternalCommand(TestWorkloads.CreateInfo("Workload.A"), source));
-        Assert.Contains("Workload.A", ex.Message);
-        Assert.Contains("--name", ex.Message);
+        var ex = FluentActions.Invoking(() => new ExternalCommand(TestWorkloads.CreateInfo("Workload.A"), source)).Should().ThrowExactly<WorkloadOperationException>().Which;
+        ex.Message.Should().Contain("Workload.A");
+        ex.Message.Should().Contain("--name");
     }
 
     [Fact]
@@ -99,9 +97,8 @@ public class ExternalCommandTests
         var b = new FuncCommandOption<string>("--second", "-x", "second");
         var source = new TestWorkloads.StubFuncCommand("deploy", options: [a, b]);
 
-        var ex = Assert.Throws<WorkloadOperationException>(
-            () => new ExternalCommand(TestWorkloads.CreateInfo(), source));
-        Assert.Contains("-x", ex.Message);
+        var ex = FluentActions.Invoking(() => new ExternalCommand(TestWorkloads.CreateInfo(), source)).Should().ThrowExactly<WorkloadOperationException>().Which;
+        ex.Message.Should().Contain("-x");
     }
 
     [Fact]
@@ -111,9 +108,8 @@ public class ExternalCommandTests
         var b = new FuncCommandArgument<string>("path", "second");
         var source = new TestWorkloads.StubFuncCommand("deploy", arguments: [a, b]);
 
-        var ex = Assert.Throws<WorkloadOperationException>(
-            () => new ExternalCommand(TestWorkloads.CreateInfo(), source));
-        Assert.Contains("path", ex.Message);
+        var ex = FluentActions.Invoking(() => new ExternalCommand(TestWorkloads.CreateInfo(), source)).Should().ThrowExactly<WorkloadOperationException>().Which;
+        ex.Message.Should().Contain("path");
     }
 
     [Fact]
@@ -123,9 +119,8 @@ public class ExternalCommandTests
         var b = new TestWorkloads.StubFuncCommand("dup");
         var source = new TestWorkloads.StubFuncCommand("parent", subcommands: [a, b]);
 
-        var ex = Assert.Throws<WorkloadOperationException>(
-            () => new ExternalCommand(TestWorkloads.CreateInfo(), source));
-        Assert.Contains("dup", ex.Message);
+        var ex = FluentActions.Invoking(() => new ExternalCommand(TestWorkloads.CreateInfo(), source)).Should().ThrowExactly<WorkloadOperationException>().Which;
+        ex.Message.Should().Contain("dup");
     }
 
     [Fact]
@@ -136,23 +131,21 @@ public class ExternalCommandTests
         var source = new TestWorkloads.StubFuncCommand("deploy", options: [a, b]);
         var workload = TestWorkloads.CreateInfo("Workload.B");
 
-        var ex = Assert.Throws<WorkloadOperationException>(
-            () => new ExternalCommand(workload, source));
-        Assert.Same(workload, ex.Workload);
+        var ex = FluentActions.Invoking(() => new ExternalCommand(workload, source)).Should().ThrowExactly<WorkloadOperationException>().Which;
+        ex.Workload.Should().BeSameAs(workload);
     }
 
     [Fact]
     public void Ctor_NullSourceCommand_Throws()
     {
-        Assert.Throws<ArgumentNullException>(
-            () => new ExternalCommand(TestWorkloads.CreateInfo(), null!));
+        FluentActions.Invoking(() => new ExternalCommand(TestWorkloads.CreateInfo(), null!)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
     public void Ctor_NullWorkload_Throws()
     {
         var source = new TestWorkloads.StubFuncCommand("ok");
-        Assert.Throws<ArgumentNullException>(() => new ExternalCommand(null!, source));
+        FluentActions.Invoking(() => new ExternalCommand(null!, source)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
@@ -173,8 +166,8 @@ public class ExternalCommandTests
         var parseResult = external.Parse("--stack dotnet");
         var exit = await parseResult.InvokeAsync();
 
-        Assert.Equal(0, exit);
-        Assert.Equal("dotnet", captured);
+        exit.Should().Be(0);
+        captured.Should().Be("dotnet");
     }
 
     [Fact]
@@ -194,7 +187,7 @@ public class ExternalCommandTests
 
         await external.Parse("my-app").InvokeAsync();
 
-        Assert.Equal("my-app", captured);
+        captured.Should().Be("my-app");
     }
 
     [Fact]
@@ -214,7 +207,7 @@ public class ExternalCommandTests
 
         await external.Parse(string.Empty).InvokeAsync();
 
-        Assert.Equal(7071, captured);
+        captured.Should().Be(7071);
     }
 
     [Fact]
@@ -243,8 +236,8 @@ public class ExternalCommandTests
 
         await external.Parse("--name foo").InvokeAsync();
 
-        Assert.IsType<ArgumentException>(captured);
-        Assert.Contains("--name", captured!.Message);
+        captured.Should().BeOfType<ArgumentException>();
+        captured!.Message.Should().Contain("--name");
     }
 
     [Fact]
@@ -269,6 +262,6 @@ public class ExternalCommandTests
 
         await external.Parse(string.Empty).InvokeAsync();
 
-        Assert.IsType<ArgumentNullException>(captured);
+        captured.Should().BeOfType<ArgumentNullException>();
     }
 }

--- a/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
+++ b/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
@@ -13,7 +13,6 @@ using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
-using Xunit;
 using PackageSource = NuGet.Configuration.PackageSource;
 
 namespace Azure.Functions.Cli.Tests.Workloads.Install;
@@ -47,18 +46,18 @@ public sealed class WorkloadInstallerTests : IDisposable
         WorkloadInstaller installer = NewInstaller();
         WorkloadInstallResult result = await installer.InstallFromPackageAsync(nupkg);
 
-        Assert.False(result.AlreadyInstalled);
-        Assert.Equal("test.workload", result.Entry.PackageId);
-        Assert.Equal("1.0.0", result.Entry.PackageVersion);
-        Assert.Equal(["test", "stub"], result.Entry.Aliases);
-        Assert.Equal("Test.dll", result.Entry.EntryPoint!.AssemblyPath);
-        Assert.Equal(Path.GetFullPath(nupkg), result.Entry.Source);
-        Assert.Equal(1, result.Entry.InstallRefCount);
+        result.AlreadyInstalled.Should().BeFalse();
+        result.Entry.PackageId.Should().Be("test.workload");
+        result.Entry.PackageVersion.Should().Be("1.0.0");
+        result.Entry.Aliases.Should().Equal(["test", "stub"]);
+        result.Entry.EntryPoint!.AssemblyPath.Should().Be("Test.dll");
+        result.Entry.Source.Should().Be(Path.GetFullPath(nupkg));
+        result.Entry.InstallRefCount.Should().Be(1);
 
         string installDir = _paths.GetInstallDirectory("test.workload", "1.0.0");
-        Assert.True(Directory.Exists(installDir));
-        Assert.True(File.Exists(Path.Combine(installDir, "tools", "any", "Test.dll")));
-        Assert.True(File.Exists(nupkg), "Source .nupkg must be left in place.");
+        Directory.Exists(installDir).Should().BeTrue();
+        File.Exists(Path.Combine(installDir, "tools", "any", "Test.dll")).Should().BeTrue();
+        File.Exists(nupkg).Should().BeTrue("Source .nupkg must be left in place.");
 
         await _store.Received(1).SaveWorkloadAsync(
             Arg.Is<WorkloadEntry>(e =>
@@ -81,7 +80,7 @@ public sealed class WorkloadInstallerTests : IDisposable
         WorkloadInstaller installer = NewInstaller();
         WorkloadInstallResult result = await installer.InstallFromPackageAsync(nupkg);
 
-        Assert.Empty(result.Entry.Aliases);
+        result.Entry.Aliases.Should().BeEmpty();
     }
 
     [Fact]
@@ -106,9 +105,7 @@ public sealed class WorkloadInstallerTests : IDisposable
             .Select(p => Path.GetRelativePath(installDir, p).Replace(Path.DirectorySeparatorChar, '/'))
             .OrderBy(p => p, StringComparer.Ordinal)];
 
-        Assert.Equal(
-            new[] { "tools", "tools/any", "tools/any/Test.dll", "workload.json" },
-            entries);
+        entries.Should().Equal(["tools", "tools/any", "tools/any/Test.dll", "workload.json"]);
     }
 
     [Fact]
@@ -119,11 +116,10 @@ public sealed class WorkloadInstallerTests : IDisposable
             .Returns(_ => throw new InvalidWorkloadException("missing workload.json"));
 
         WorkloadInstaller installer = NewInstaller();
-        InvalidWorkloadException ex = await Assert.ThrowsAsync<InvalidWorkloadException>(
-            () => installer.InstallFromPackageAsync(nupkg));
+        InvalidWorkloadException ex = (await FluentActions.Awaiting(() => installer.InstallFromPackageAsync(nupkg)).Should().ThrowAsync<InvalidWorkloadException>()).Which;
 
-        Assert.Contains("missing workload.json", ex.Message);
-        Assert.False(Directory.Exists(_paths.GetInstallDirectory("test.workload", "1.0.0")));
+        ex.Message.Should().Contain("missing workload.json");
+        Directory.Exists(_paths.GetInstallDirectory("test.workload", "1.0.0")).Should().BeFalse();
         await _store.DidNotReceive().SaveWorkloadAsync(Arg.Any<WorkloadEntry>(), Arg.Any<CancellationToken>());
     }
 
@@ -133,11 +129,10 @@ public sealed class WorkloadInstallerTests : IDisposable
         string nupkg = BuildNupkg(includeFuncCliWorkloadType: false);
 
         WorkloadInstaller installer = NewInstaller();
-        InvalidWorkloadException ex = await Assert.ThrowsAsync<InvalidWorkloadException>(
-            () => installer.InstallFromPackageAsync(nupkg));
+        InvalidWorkloadException ex = (await FluentActions.Awaiting(() => installer.InstallFromPackageAsync(nupkg)).Should().ThrowAsync<InvalidWorkloadException>()).Which;
 
-        Assert.Contains("FuncCliWorkload", ex.Message);
-        Assert.False(Directory.Exists(_paths.GetInstallDirectory("test.workload", "1.0.0")));
+        ex.Message.Should().Contain("FuncCliWorkload");
+        Directory.Exists(_paths.GetInstallDirectory("test.workload", "1.0.0")).Should().BeFalse();
         await _store.DidNotReceive().SaveWorkloadAsync(Arg.Any<WorkloadEntry>(), Arg.Any<CancellationToken>());
     }
 
@@ -145,9 +140,8 @@ public sealed class WorkloadInstallerTests : IDisposable
     public async Task InstallFromPackage_MissingFile_Throws()
     {
         WorkloadInstaller installer = NewInstaller();
-        FileNotFoundException ex = await Assert.ThrowsAsync<FileNotFoundException>(
-            () => installer.InstallFromPackageAsync(Path.Combine(_root, "missing.nupkg")));
-        Assert.Contains("does not exist", ex.Message);
+        FileNotFoundException ex = (await FluentActions.Awaiting(() => installer.InstallFromPackageAsync(Path.Combine(_root, "missing.nupkg"))).Should().ThrowAsync<FileNotFoundException>()).Which;
+        ex.Message.Should().Contain("does not exist");
     }
 
     [Fact]
@@ -174,8 +168,8 @@ public sealed class WorkloadInstallerTests : IDisposable
         WorkloadInstaller installer = NewInstaller();
         WorkloadInstallResult result = await installer.InstallFromPackageAsync(nupkg);
 
-        Assert.True(result.AlreadyInstalled);
-        Assert.Same(priorEntry, result.Entry);
+        result.AlreadyInstalled.Should().BeTrue();
+        result.Entry.Should().BeSameAs(priorEntry);
         await _store.DidNotReceive().SaveWorkloadAsync(Arg.Any<WorkloadEntry>(), Arg.Any<CancellationToken>());
         await _store.DidNotReceive().RemoveWorkloadAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
@@ -198,8 +192,8 @@ public sealed class WorkloadInstallerTests : IDisposable
         WorkloadInstaller installer = NewInstaller();
         WorkloadInstallResult result = await installer.InstallFromPackageAsync(nupkg);
 
-        Assert.False(result.AlreadyInstalled);
-        Assert.False(File.Exists(stalePath));
+        result.AlreadyInstalled.Should().BeFalse();
+        File.Exists(stalePath).Should().BeFalse();
         await _store.Received(1).SaveWorkloadAsync(
             Arg.Is<WorkloadEntry>(e => e.PackageId == "test.workload" && e.PackageVersion == "1.0.0"),
             Arg.Any<CancellationToken>());
@@ -220,10 +214,10 @@ public sealed class WorkloadInstallerTests : IDisposable
         WorkloadInstaller installer = NewInstaller();
         WorkloadInstallResult result = await installer.InstallFromPackageAsync(nupkg, force: true);
 
-        Assert.False(result.AlreadyInstalled);
-        Assert.Equal("test.workload", result.Entry.PackageId);
-        Assert.False(File.Exists(stalePath), "Stale files from the prior install must be gone after a forced reinstall.");
-        Assert.True(File.Exists(Path.Combine(installDir, "tools", "any", "Test.dll")));
+        result.AlreadyInstalled.Should().BeFalse();
+        result.Entry.PackageId.Should().Be("test.workload");
+        File.Exists(stalePath).Should().BeFalse("Stale files from the prior install must be gone after a forced reinstall.");
+        File.Exists(Path.Combine(installDir, "tools", "any", "Test.dll")).Should().BeTrue();
         await _store.Received(1).RemoveWorkloadAsync("test.workload", "1.0.0", Arg.Any<CancellationToken>());
         await _store.Received(1).SaveWorkloadAsync(Arg.Any<WorkloadEntry>(), Arg.Any<CancellationToken>());
     }
@@ -236,10 +230,9 @@ public sealed class WorkloadInstallerTests : IDisposable
             .Returns<Task>(_ => throw new InvalidOperationException("disk full"));
 
         WorkloadInstaller installer = NewInstaller();
-        await Assert.ThrowsAsync<InvalidOperationException>(
-            () => installer.InstallFromPackageAsync(nupkg));
+        await FluentActions.Awaiting(() => installer.InstallFromPackageAsync(nupkg)).Should().ThrowAsync<InvalidOperationException>();
 
-        Assert.False(Directory.Exists(_paths.GetInstallDirectory("test.workload", "1.0.0")));
+        Directory.Exists(_paths.GetInstallDirectory("test.workload", "1.0.0")).Should().BeFalse();
     }
 
     [Fact]
@@ -254,8 +247,8 @@ public sealed class WorkloadInstallerTests : IDisposable
         WorkloadInstaller installer = NewInstaller();
         bool removed = await installer.UninstallAsync("test.workload", "1.0.0");
 
-        Assert.True(removed);
-        Assert.False(Directory.Exists(installDir));
+        removed.Should().BeTrue();
+        Directory.Exists(installDir).Should().BeFalse();
     }
 
     [Fact]
@@ -269,8 +262,8 @@ public sealed class WorkloadInstallerTests : IDisposable
         WorkloadInstaller installer = NewInstaller();
         bool removed = await installer.UninstallAsync("test.workload", "1.0.0");
 
-        Assert.False(removed);
-        Assert.True(Directory.Exists(installDir));
+        removed.Should().BeFalse();
+        Directory.Exists(installDir).Should().BeTrue();
     }
 
     [Fact]
@@ -283,10 +276,10 @@ public sealed class WorkloadInstallerTests : IDisposable
         WorkloadInstaller installer = NewInstaller();
         WorkloadInstallResult result = await installer.InstallFromPackageAsync(nupkg);
 
-        Assert.Equal(WorkloadKind.Content, result.Entry.Kind);
-        Assert.Null(result.Entry.EntryPoint);
-        Assert.Equal("test.workload", result.Entry.DisplayName);
-        Assert.Equal("For tests.", result.Entry.Description);
+        result.Entry.Kind.Should().Be(WorkloadKind.Content);
+        result.Entry.EntryPoint.Should().BeNull();
+        result.Entry.DisplayName.Should().Be("test.workload");
+        result.Entry.Description.Should().Be("For tests.");
 
         await _store.Received(1).SaveWorkloadAsync(
             Arg.Is<WorkloadEntry>(e =>
@@ -313,10 +306,10 @@ public sealed class WorkloadInstallerTests : IDisposable
             "test.workload", version: null, source: null,
             includePrerelease: false, exact: true, force: false);
 
-        Assert.False(result.AlreadyInstalled);
-        Assert.Equal("test.workload", result.Entry.PackageId);
-        Assert.Equal("1.0.0", result.Entry.PackageVersion);
-        Assert.True(Directory.Exists(_paths.GetInstallDirectory("test.workload", "1.0.0")));
+        result.AlreadyInstalled.Should().BeFalse();
+        result.Entry.PackageId.Should().Be("test.workload");
+        result.Entry.PackageVersion.Should().Be("1.0.0");
+        Directory.Exists(_paths.GetInstallDirectory("test.workload", "1.0.0")).Should().BeTrue();
         await _store.Received(1).SaveWorkloadAsync(Arg.Any<WorkloadEntry>(), Arg.Any<CancellationToken>());
     }
 
@@ -328,13 +321,12 @@ public sealed class WorkloadInstallerTests : IDisposable
             .Returns((ResolvedPackage?)null);
 
         WorkloadInstaller installer = NewInstaller();
-        WorkloadPackageNotFoundException ex = await Assert.ThrowsAsync<WorkloadPackageNotFoundException>(
-            () => installer.InstallFromCatalogAsync(
+        WorkloadPackageNotFoundException ex = (await FluentActions.Awaiting(() => installer.InstallFromCatalogAsync(
                 "test.workload", version: null, source: null,
-                includePrerelease: false, exact: true, force: false));
+                includePrerelease: false, exact: true, force: false)).Should().ThrowAsync<WorkloadPackageNotFoundException>()).Which;
 
-        Assert.Contains("test.workload", ex.Message);
-        Assert.Contains("--prerelease", ex.Message);
+        ex.Message.Should().Contain("test.workload");
+        ex.Message.Should().Contain("--prerelease");
         await _catalog.DidNotReceive().DownloadAsync(Arg.Any<ResolvedPackage>(), Arg.Any<CancellationToken>());
     }
 
@@ -346,13 +338,12 @@ public sealed class WorkloadInstallerTests : IDisposable
             .Returns((ResolvedPackage?)null);
 
         WorkloadInstaller installer = NewInstaller(includePrerelease: true);
-        WorkloadPackageNotFoundException ex = await Assert.ThrowsAsync<WorkloadPackageNotFoundException>(
-            () => installer.InstallFromCatalogAsync(
+        WorkloadPackageNotFoundException ex = (await FluentActions.Awaiting(() => installer.InstallFromCatalogAsync(
                 "test.workload", version: null, source: null,
-                includePrerelease: null, exact: true, force: false));
+                includePrerelease: null, exact: true, force: false)).Should().ThrowAsync<WorkloadPackageNotFoundException>()).Which;
 
-        Assert.Contains("test.workload", ex.Message);
-        Assert.DoesNotContain("--prerelease", ex.Message);
+        ex.Message.Should().Contain("test.workload");
+        ex.Message.Should().NotContain("--prerelease");
         await _catalog.Received(1).ResolveLatestVersionAsync(
             "test.workload", true, null, true, null, Arg.Any<CancellationToken>());
         await _catalog.DidNotReceive().DownloadAsync(Arg.Any<ResolvedPackage>(), Arg.Any<CancellationToken>());
@@ -377,7 +368,7 @@ public sealed class WorkloadInstallerTests : IDisposable
             "test.workload", requested, source: null,
             includePrerelease: false, exact: true, force: false);
 
-        Assert.Equal("1.0.0", result.Entry.PackageVersion);
+        result.Entry.PackageVersion.Should().Be("1.0.0");
     }
 
     [Fact]
@@ -386,11 +377,10 @@ public sealed class WorkloadInstallerTests : IDisposable
         _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns([]);
 
         WorkloadInstaller installer = NewInstaller();
-        InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => installer.UpdateAsync(
-                "test.workload", null, null, false, allowMajor: false));
+        InvalidOperationException ex = (await FluentActions.Awaiting(() => installer.UpdateAsync(
+                "test.workload", null, null, false, allowMajor: false)).Should().ThrowAsync<InvalidOperationException>()).Which;
 
-        Assert.Contains("not installed", ex.Message);
+        ex.Message.Should().Contain("not installed");
         await _catalog.DidNotReceive().ResolveLatestVersionAsync(
             Arg.Any<string>(), Arg.Any<bool?>(), Arg.Any<NuGetVersion?>(),
             Arg.Any<bool>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
@@ -408,10 +398,10 @@ public sealed class WorkloadInstallerTests : IDisposable
         WorkloadInstaller installer = NewInstaller();
         WorkloadUpdateResult result = await installer.UpdateAsync("test.workload", null, null, false, allowMajor: false);
 
-        Assert.True(result.NoUpdateAvailable);
-        Assert.True(result.NoCandidateOnSource);
-        Assert.Equal("1.0.0", result.PreviousVersion);
-        Assert.Same(current, result.Entry);
+        result.NoUpdateAvailable.Should().BeTrue();
+        result.NoCandidateOnSource.Should().BeTrue();
+        result.PreviousVersion.Should().Be("1.0.0");
+        result.Entry.Should().BeSameAs(current);
         await _store.DidNotReceive().SaveWorkloadAsync(Arg.Any<WorkloadEntry>(), Arg.Any<CancellationToken>());
         await _store.DidNotReceive().RemoveWorkloadAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
@@ -429,8 +419,8 @@ public sealed class WorkloadInstallerTests : IDisposable
         WorkloadInstaller installer = NewInstaller();
         WorkloadUpdateResult result = await installer.UpdateAsync("test.workload", null, null, false, allowMajor: false);
 
-        Assert.True(result.NoUpdateAvailable);
-        Assert.False(result.NoCandidateOnSource);
+        result.NoUpdateAvailable.Should().BeTrue();
+        result.NoCandidateOnSource.Should().BeFalse();
     }
 
     [Fact]
@@ -454,13 +444,13 @@ public sealed class WorkloadInstallerTests : IDisposable
         WorkloadInstaller installer = NewInstaller();
         WorkloadUpdateResult result = await installer.UpdateAsync("test.workload", null, null, false, allowMajor: false);
 
-        Assert.False(result.NoUpdateAvailable);
-        Assert.Equal("1.0.0", result.PreviousVersion);
-        Assert.Equal("1.1.0", result.Entry.PackageVersion);
+        result.NoUpdateAvailable.Should().BeFalse();
+        result.PreviousVersion.Should().Be("1.0.0");
+        result.Entry.PackageVersion.Should().Be("1.1.0");
 
         string newDir = _paths.GetInstallDirectory("test.workload", "1.1.0");
-        Assert.True(Directory.Exists(newDir));
-        Assert.False(Directory.Exists(oldDir), "old install dir must be deleted after swap");
+        Directory.Exists(newDir).Should().BeTrue();
+        Directory.Exists(oldDir).Should().BeFalse("old install dir must be deleted after swap");
 
         Received.InOrder(() =>
         {
@@ -490,11 +480,11 @@ public sealed class WorkloadInstallerTests : IDisposable
             .ThrowsAsync(new IOException("network glitch"));
 
         WorkloadInstaller installer = NewInstaller();
-        await Assert.ThrowsAsync<IOException>(() => installer.UpdateAsync(
-            "test.workload", null, null, false, allowMajor: false));
+        await FluentActions.Awaiting(() => installer.UpdateAsync(
+            "test.workload", null, null, false, allowMajor: false)).Should().ThrowAsync<IOException>();
 
-        Assert.True(Directory.Exists(oldDir), "existing install must remain after staging failure");
-        Assert.True(File.Exists(Path.Combine(oldDir, "marker.txt")));
+        Directory.Exists(oldDir).Should().BeTrue("existing install must remain after staging failure");
+        File.Exists(Path.Combine(oldDir, "marker.txt")).Should().BeTrue();
         await _store.DidNotReceive().ReplaceWorkloadAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<WorkloadEntry>(), Arg.Any<CancellationToken>());
     }
@@ -506,12 +496,11 @@ public sealed class WorkloadInstallerTests : IDisposable
         _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns([current]);
 
         WorkloadInstaller installer = NewInstaller();
-        InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => installer.UpdateAsync(
-                "test.workload", NuGetVersion.Parse("0.9.0"), null, false, allowMajor: false));
+        InvalidOperationException ex = (await FluentActions.Awaiting(() => installer.UpdateAsync(
+                "test.workload", NuGetVersion.Parse("0.9.0"), null, false, allowMajor: false)).Should().ThrowAsync<InvalidOperationException>()).Which;
 
-        Assert.Contains("0.9.0", ex.Message);
-        Assert.Contains("not installed", ex.Message);
+        ex.Message.Should().Contain("0.9.0");
+        ex.Message.Should().Contain("not installed");
     }
 
     [Fact]
@@ -548,7 +537,7 @@ public sealed class WorkloadInstallerTests : IDisposable
             "node-worker", version: null, source: null,
             includePrerelease: true, exact: false, force: false);
 
-        Assert.Equal("test.workload", result.Entry.PackageId);
+        result.Entry.PackageId.Should().Be("test.workload");
         await _catalog.Received(1).SearchAsync(
             Arg.Is<CatalogSearchQuery>(q => q.Filter == null),
             Arg.Any<CancellationToken>());
@@ -596,12 +585,9 @@ public sealed class WorkloadInstallerTests : IDisposable
         WorkloadInstaller installer = NewInstaller();
         await installer.InstallFromPackageAsync(nupkg, force: false, progress);
 
-        Assert.Collection(
-            reports,
-            r => Assert.Equal(WorkloadInstallPhase.Extracting, r.Phase),
-            r => Assert.Equal(WorkloadInstallPhase.Registering, r.Phase));
-        Assert.Contains("test.workload", reports[0].Description);
-        Assert.Contains("test.workload", reports[1].Description);
+        reports.Should().SatisfyRespectively(r => r.Phase.Should().Be(WorkloadInstallPhase.Extracting), r => r.Phase.Should().Be(WorkloadInstallPhase.Registering));
+        reports[0].Description.Should().Contain("test.workload");
+        reports[1].Description.Should().Contain("test.workload");
     }
 
     [Fact]
@@ -612,8 +598,8 @@ public sealed class WorkloadInstallerTests : IDisposable
         WorkloadInstaller installer = NewInstaller();
         WorkloadInstallResult result = await installer.InstallFromPackageAsync(nupkg);
 
-        Assert.Equal("Functions Host", result.Entry.DisplayName);
-        Assert.Equal("Azure Functions host workload.", result.Entry.Description);
+        result.Entry.DisplayName.Should().Be("Functions Host");
+        result.Entry.Description.Should().Be("Azure Functions host workload.");
 
         await _store.Received(1).SaveWorkloadAsync(
             Arg.Is<WorkloadEntry>(e =>
@@ -638,8 +624,8 @@ public sealed class WorkloadInstallerTests : IDisposable
         WorkloadInstaller installer = NewInstaller();
         WorkloadInstallResult result = await installer.InstallFromPackageAsync(nupkg);
 
-        Assert.Equal("Manifest Name", result.Entry.DisplayName);
-        Assert.Equal("Manifest description.", result.Entry.Description);
+        result.Entry.DisplayName.Should().Be("Manifest Name");
+        result.Entry.Description.Should().Be("Manifest description.");
     }
 
     private sealed class RecordingProgress(List<WorkloadInstallProgress> sink) : IProgress<WorkloadInstallProgress>
@@ -682,7 +668,7 @@ public sealed class WorkloadInstallerTests : IDisposable
             "python-worker", version: null, source: null,
             includePrerelease: true, exact: false, force: false);
 
-        Assert.NotNull(result);
+        result.Should().NotBeNull();
         await _catalog.Received(1).ResolveLatestVersionAsync(
             targetId.ToLowerInvariant(), true, null, true, null, Arg.Any<CancellationToken>());
     }
@@ -714,14 +700,13 @@ public sealed class WorkloadInstallerTests : IDisposable
             });
 
         WorkloadInstaller installer = NewInstaller();
-        WorkloadPackageNotFoundException ex = await Assert.ThrowsAsync<WorkloadPackageNotFoundException>(
-            () => installer.InstallFromCatalogAsync(
+        WorkloadPackageNotFoundException ex = (await FluentActions.Awaiting(() => installer.InstallFromCatalogAsync(
                 "python-worker", version: null, source: null,
-                includePrerelease: true, exact: false, force: false));
+                includePrerelease: true, exact: false, force: false)).Should().ThrowAsync<WorkloadPackageNotFoundException>()).Which;
 
-        Assert.Contains("python-worker", ex.Message);
-        Assert.Contains(ridA, ex.Message);
-        Assert.Contains(ridB, ex.Message);
+        ex.Message.Should().Contain("python-worker");
+        ex.Message.Should().Contain(ridA);
+        ex.Message.Should().Contain(ridB);
     }
 
     [Fact]
@@ -744,10 +729,9 @@ public sealed class WorkloadInstallerTests : IDisposable
             });
 
         WorkloadInstaller installer = NewInstaller();
-        await Assert.ThrowsAsync<AmbiguousPackageMatchException>(
-            () => installer.InstallFromCatalogAsync(
+        await FluentActions.Awaiting(() => installer.InstallFromCatalogAsync(
                 "shared-alias", version: null, source: null,
-                includePrerelease: true, exact: false, force: false));
+                includePrerelease: true, exact: false, force: false)).Should().ThrowAsync<AmbiguousPackageMatchException>();
     }
 
     [Fact]
@@ -774,7 +758,7 @@ public sealed class WorkloadInstallerTests : IDisposable
             explicitId, version: null, source: null,
             includePrerelease: true, exact: true, force: false);
 
-        Assert.NotNull(result);
+        result.Should().NotBeNull();
         await _catalog.Received(1).ResolveLatestVersionAsync(
             explicitId, true, null, true, null, Arg.Any<CancellationToken>());
     }
@@ -816,11 +800,11 @@ public sealed class WorkloadInstallerTests : IDisposable
             _paths.GetInstallDirectory(result.Entry.PackageId, result.Entry.PackageVersion),
             "tools", "any", "Azure.Functions.Cli.Workloads.Host");
 
-        Assert.True(File.Exists(hostBinary));
+        File.Exists(hostBinary).Should().BeTrue();
         UnixFileMode mode = File.GetUnixFileMode(hostBinary);
-        Assert.True(mode.HasFlag(UnixFileMode.UserExecute));
-        Assert.True(mode.HasFlag(UnixFileMode.GroupExecute));
-        Assert.True(mode.HasFlag(UnixFileMode.OtherExecute));
+        mode.HasFlag(UnixFileMode.UserExecute).Should().BeTrue();
+        mode.HasFlag(UnixFileMode.GroupExecute).Should().BeTrue();
+        mode.HasFlag(UnixFileMode.OtherExecute).Should().BeTrue();
     }
 
     [Fact]
@@ -844,9 +828,9 @@ public sealed class WorkloadInstallerTests : IDisposable
             _paths.GetInstallDirectory(result.Entry.PackageId, result.Entry.PackageVersion),
             "tools", "any", "Azure.Functions.Cli.Workloads.Host");
 
-        Assert.True(File.Exists(payload));
+        File.Exists(payload).Should().BeTrue();
         UnixFileMode mode = File.GetUnixFileMode(payload);
-        Assert.False(mode.HasFlag(UnixFileMode.UserExecute));
+        mode.HasFlag(UnixFileMode.UserExecute).Should().BeFalse();
     }
 
     private string BuildNupkg(

--- a/test/Func.Tests/Workloads/Invocation/WorkloadInvokerTests.cs
+++ b/test/Func.Tests/Workloads/Invocation/WorkloadInvokerTests.cs
@@ -4,7 +4,6 @@
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Workloads;
 using Azure.Functions.Cli.Workloads.Invocation;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Workloads.Invocation;
 
@@ -24,7 +23,7 @@ public sealed class WorkloadInvokerTests
             return Task.CompletedTask;
         }, CancellationToken.None);
 
-        Assert.Equal(1, calls);
+        calls.Should().Be(1);
     }
 
     [Fact]
@@ -32,7 +31,7 @@ public sealed class WorkloadInvokerTests
     {
         int result = await _invoker.InvokeAsync(_workload, _ => Task.FromResult(42), CancellationToken.None);
 
-        Assert.Equal(42, result);
+        result.Should().Be(42);
     }
 
     [Fact]
@@ -40,14 +39,14 @@ public sealed class WorkloadInvokerTests
     {
         GracefulException original = new("boom", isUserError: true, verboseMessage: "v");
 
-        GracefulException thrown = await Assert.ThrowsAsync<GracefulException>(() =>
-            _invoker.InvokeAsync(_workload, _ => throw original, CancellationToken.None));
+        GracefulException thrown = (await FluentActions.Awaiting(() =>
+            _invoker.InvokeAsync(_workload, _ => throw original, CancellationToken.None)).Should().ThrowAsync<GracefulException>()).Which;
 
         // Must remain a plain GracefulException (not the protocol subclass).
-        Assert.IsType<GracefulException>(thrown);
-        Assert.Equal("[Pkg.Acme] boom", thrown.Message);
-        Assert.True(thrown.IsUserError);
-        Assert.Equal("v", thrown.VerboseMessage);
+        thrown.Should().BeOfType<GracefulException>();
+        thrown.Message.Should().Be("[Pkg.Acme] boom");
+        thrown.IsUserError.Should().BeTrue();
+        thrown.VerboseMessage.Should().Be("v");
     }
 
     [Fact]
@@ -55,14 +54,14 @@ public sealed class WorkloadInvokerTests
     {
         InvalidOperationException original = new("oops");
 
-        WorkloadProtocolException thrown = await Assert.ThrowsAsync<WorkloadProtocolException>(() =>
-            _invoker.InvokeAsync(_workload, _ => throw original, CancellationToken.None));
+        WorkloadProtocolException thrown = (await FluentActions.Awaiting(() =>
+            _invoker.InvokeAsync(_workload, _ => throw original, CancellationToken.None)).Should().ThrowAsync<WorkloadProtocolException>()).Which;
 
-        Assert.Contains("[Pkg.Acme] error: oops", thrown.Message);
-        Assert.Contains("Please file an issue against the workload.", thrown.Message);
-        Assert.Same(original, thrown.OriginalException);
-        Assert.Same(_workload, thrown.Workload);
-        Assert.False(thrown.IsUserError);
+        thrown.Message.Should().Contain("[Pkg.Acme] error: oops");
+        thrown.Message.Should().Contain("Please file an issue against the workload.");
+        thrown.OriginalException.Should().BeSameAs(original);
+        thrown.Workload.Should().BeSameAs(_workload);
+        thrown.IsUserError.Should().BeFalse();
     }
 
     [Fact]
@@ -71,14 +70,14 @@ public sealed class WorkloadInvokerTests
         using CancellationTokenSource cts = new();
         cts.Cancel();
 
-        OperationCanceledException thrown = await Assert.ThrowsAsync<OperationCanceledException>(() =>
+        OperationCanceledException thrown = (await FluentActions.Awaiting(() =>
             _invoker.InvokeAsync(_workload, ct =>
             {
                 ct.ThrowIfCancellationRequested();
                 return Task.CompletedTask;
-            }, cts.Token));
+            }, cts.Token)).Should().ThrowAsync<OperationCanceledException>()).Which;
 
-        Assert.IsAssignableFrom<OperationCanceledException>(thrown);
+        thrown.Should().BeAssignableTo<OperationCanceledException>();
         // Cancellation is not a workload error: not wrapped, not graceful.
     }
 
@@ -87,10 +86,10 @@ public sealed class WorkloadInvokerTests
     {
         GracefulException original = new("nope");
 
-        GracefulException thrown = await Assert.ThrowsAsync<GracefulException>(() =>
-            _invoker.InvokeAsync<int>(_workload, _ => throw original, CancellationToken.None));
+        GracefulException thrown = (await FluentActions.Awaiting(() =>
+            _invoker.InvokeAsync<int>(_workload, _ => throw original, CancellationToken.None)).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.Equal("[Pkg.Acme] nope", thrown.Message);
+        thrown.Message.Should().Be("[Pkg.Acme] nope");
     }
 
     [Fact]
@@ -98,24 +97,24 @@ public sealed class WorkloadInvokerTests
     {
         InvalidOperationException original = new("kaboom");
 
-        WorkloadProtocolException thrown = await Assert.ThrowsAsync<WorkloadProtocolException>(() =>
-            _invoker.InvokeAsync<int>(_workload, _ => throw original, CancellationToken.None));
+        WorkloadProtocolException thrown = (await FluentActions.Awaiting(() =>
+            _invoker.InvokeAsync<int>(_workload, _ => throw original, CancellationToken.None)).Should().ThrowAsync<WorkloadProtocolException>()).Which;
 
-        Assert.Contains("[Pkg.Acme] error: kaboom", thrown.Message);
-        Assert.Same(original, thrown.OriginalException);
+        thrown.Message.Should().Contain("[Pkg.Acme] error: kaboom");
+        thrown.OriginalException.Should().BeSameAs(original);
     }
 
     [Fact]
     public async Task InvokeAsync_NullWorkload_Throws()
     {
-        await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            _invoker.InvokeAsync(null!, _ => Task.CompletedTask, CancellationToken.None));
+        await FluentActions.Awaiting(() =>
+            _invoker.InvokeAsync(null!, _ => Task.CompletedTask, CancellationToken.None)).Should().ThrowAsync<ArgumentNullException>();
     }
 
     [Fact]
     public async Task InvokeAsync_NullOperation_Throws()
     {
-        await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            _invoker.InvokeAsync(_workload, null!, CancellationToken.None));
+        await FluentActions.Awaiting(() =>
+            _invoker.InvokeAsync(_workload, null!, CancellationToken.None)).Should().ThrowAsync<ArgumentNullException>();
     }
 }

--- a/test/Func.Tests/Workloads/Loading/WorkloadLoaderTests.cs
+++ b/test/Func.Tests/Workloads/Loading/WorkloadLoaderTests.cs
@@ -7,7 +7,6 @@ using Azure.Functions.Cli.Workloads.Discovery;
 using Azure.Functions.Cli.Workloads.Loading;
 using Azure.Functions.Cli.Workloads.Storage;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Workloads.Loading;
 
@@ -28,7 +27,7 @@ public class WorkloadLoaderTests
 
         var loaded = loader.Load([]);
 
-        Assert.Empty(loaded);
+        loaded.Should().BeEmpty();
     }
 
     [Fact]
@@ -38,9 +37,9 @@ public class WorkloadLoaderTests
 
         var loaded = loader.Load([FixtureEntry(FixturePackageId)]);
 
-        var item = Assert.Single(loaded);
-        Assert.Equal(FixtureTypeName, item.Instance.GetType().FullName);
-        Assert.Equal(FixturePackageId, item.PackageId);
+        var item = loaded.Should().ContainSingle().Subject;
+        item.Instance.GetType().FullName.Should().Be(FixtureTypeName);
+        item.PackageId.Should().Be(FixturePackageId);
     }
 
     [Fact]
@@ -49,11 +48,11 @@ public class WorkloadLoaderTests
         var loader = new WorkloadLoader(StubPaths());
         var entry = FixtureEntry(FixturePackageId, assemblyFileOverride: "DoesNotExist.dll");
 
-        var ex = Assert.Throws<InvalidWorkloadException>(() => loader.Load([entry]));
+        var ex = FluentActions.Invoking(() => loader.Load([entry])).Should().ThrowExactly<InvalidWorkloadException>().Which;
 
-        Assert.StartsWith($"[{FixturePackageId}]", ex.Message);
-        Assert.Contains("DoesNotExist.dll", ex.Message);
-        Assert.Contains(AppContext.BaseDirectory, ex.Message);
+        ex.Message.Should().StartWith($"[{FixturePackageId}]");
+        ex.Message.Should().Contain("DoesNotExist.dll");
+        ex.Message.Should().Contain(AppContext.BaseDirectory);
     }
 
     [Fact]
@@ -62,11 +61,11 @@ public class WorkloadLoaderTests
         var loader = new WorkloadLoader(StubPaths());
         var entry = FixtureEntry(FixturePackageId, typeNameOverride: "Some.Missing.Type");
 
-        var ex = Assert.Throws<InvalidWorkloadException>(() => loader.Load([entry]));
+        var ex = FluentActions.Invoking(() => loader.Load([entry])).Should().ThrowExactly<InvalidWorkloadException>().Which;
 
-        Assert.StartsWith($"[{FixturePackageId}]", ex.Message);
-        Assert.Contains("Some.Missing.Type", ex.Message);
-        Assert.Contains(AppContext.BaseDirectory, ex.Message);
+        ex.Message.Should().StartWith($"[{FixturePackageId}]");
+        ex.Message.Should().Contain("Some.Missing.Type");
+        ex.Message.Should().Contain(AppContext.BaseDirectory);
     }
 
     [Fact]
@@ -77,12 +76,12 @@ public class WorkloadLoaderTests
             FixturePackageId,
             typeNameOverride: "Azure.Functions.Cli.Workloads.Tests.Fixtures.Default.NotAWorkload");
 
-        var ex = Assert.Throws<InvalidWorkloadException>(() => loader.Load([entry]));
+        var ex = FluentActions.Invoking(() => loader.Load([entry])).Should().ThrowExactly<InvalidWorkloadException>().Which;
 
-        Assert.StartsWith($"[{FixturePackageId}]", ex.Message);
-        Assert.Contains("NotAWorkload", ex.Message);
-        Assert.Contains(nameof(Workload), ex.Message);
-        Assert.Contains(AppContext.BaseDirectory, ex.Message);
+        ex.Message.Should().StartWith($"[{FixturePackageId}]");
+        ex.Message.Should().Contain("NotAWorkload");
+        ex.Message.Should().Contain(nameof(Workload));
+        ex.Message.Should().Contain(AppContext.BaseDirectory);
     }
 
     [Fact]
@@ -97,13 +96,13 @@ public class WorkloadLoaderTests
 
         var loaded = loader.Load(entries);
 
-        Assert.Equal(2, loaded.Count);
+        loaded.Count.Should().Be(2);
         var ctxA = AssemblyLoadContext.GetLoadContext(loaded[0].Instance.GetType().Assembly);
         var ctxB = AssemblyLoadContext.GetLoadContext(loaded[1].Instance.GetType().Assembly);
-        Assert.NotNull(ctxA);
-        Assert.NotNull(ctxB);
-        Assert.NotSame(ctxA, ctxB);
-        Assert.NotSame(AssemblyLoadContext.Default, ctxA);
+        ctxA.Should().NotBeNull();
+        ctxB.Should().NotBeNull();
+        ctxB.Should().NotBeSameAs(ctxA);
+        ctxA.Should().NotBeSameAs(AssemblyLoadContext.Default);
     }
 
     [Fact]
@@ -114,10 +113,8 @@ public class WorkloadLoaderTests
         var loaded = loader.Load([FixtureEntry("collectible-fixture")]);
 
         var ctx = AssemblyLoadContext.GetLoadContext(loaded[0].Instance.GetType().Assembly);
-        Assert.NotNull(ctx);
-        Assert.True(
-            ctx!.IsCollectible,
-            "WorkloadLoadContext must be collectible so a single CLI invocation can release the workload's DLL handle.");
+        ctx.Should().NotBeNull();
+        ctx!.IsCollectible.Should().BeTrue("WorkloadLoadContext must be collectible so a single CLI invocation can release the workload's DLL handle.");
     }
 
     [Fact]
@@ -133,9 +130,9 @@ public class WorkloadLoaderTests
         // have failed; this test pins that contract.
         var hostWorkload = typeof(Workload);
         var workloadBase = loaded[0].Instance.GetType().BaseType;
-        Assert.NotNull(workloadBase);
-        Assert.Same(hostWorkload, workloadBase);
-        Assert.Same(hostWorkload.Assembly, workloadBase!.Assembly);
+        workloadBase.Should().NotBeNull();
+        workloadBase.Should().BeSameAs(hostWorkload);
+        workloadBase!.Assembly.Should().BeSameAs(hostWorkload.Assembly);
     }
 
     [Fact]
@@ -154,14 +151,14 @@ public class WorkloadLoaderTests
 
         var loaded = loader.Load([SdkFixtureEntry(SdkFixturePackageId)]);
 
-        var item = Assert.Single(loaded);
-        Assert.Equal(SdkFixtureTypeName, item.Instance.GetType().FullName);
+        var item = loaded.Should().ContainSingle().Subject;
+        item.Instance.GetType().FullName.Should().Be(SdkFixtureTypeName);
 
         var hostWorkload = typeof(Workload);
         var workloadBase = item.Instance.GetType().BaseType;
-        Assert.NotNull(workloadBase);
-        Assert.Same(hostWorkload, workloadBase);
-        Assert.Same(hostWorkload.Assembly, workloadBase!.Assembly);
+        workloadBase.Should().NotBeNull();
+        workloadBase.Should().BeSameAs(hostWorkload);
+        workloadBase!.Assembly.Should().BeSameAs(hostWorkload.Assembly);
     }
 
     [Fact]
@@ -182,13 +179,13 @@ public class WorkloadLoaderTests
         var resolved = resolver.ResolveAssemblyToPath(
             new System.Reflection.AssemblyName("Azure.Functions.Cli.Abstractions"));
 
-        Assert.Null(resolved);
+        resolved.Should().BeNull();
     }
 
     [Fact]
     public void Ctor_NullPaths_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => new WorkloadLoader(null!));
+        FluentActions.Invoking(() => new WorkloadLoader(null!)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
@@ -211,9 +208,9 @@ public class WorkloadLoaderTests
 
             var loaded = loader.Load([entry]);
 
-            var item = Assert.Single(loaded);
-            Assert.Equal(FixtureTypeName, item.Instance.GetType().FullName);
-            Assert.Equal(tempDir, item.ContentRoot);
+            var item = loaded.Should().ContainSingle().Subject;
+            item.Instance.GetType().FullName.Should().Be(FixtureTypeName);
+            item.ContentRoot.Should().Be(tempDir);
             UnloadAndRelease(item.LoadContext);
         }
         finally
@@ -243,9 +240,9 @@ public class WorkloadLoaderTests
 
             var loaded = loader.Load([entry]);
 
-            var item = Assert.Single(loaded);
-            Assert.Equal(FixtureTypeName, item.Instance.GetType().FullName);
-            Assert.Equal(subDir, item.ContentRoot);
+            var item = loaded.Should().ContainSingle().Subject;
+            item.Instance.GetType().FullName.Should().Be(FixtureTypeName);
+            item.ContentRoot.Should().Be(subDir);
             UnloadAndRelease(item.LoadContext);
         }
         finally
@@ -276,10 +273,10 @@ public class WorkloadLoaderTests
 
             var loaded = loader.Load([entry]);
 
-            var item = Assert.Single(loaded);
-            Assert.Equal(FixtureTypeName, item.Instance.GetType().FullName);
+            var item = loaded.Should().ContainSingle().Subject;
+            item.Instance.GetType().FullName.Should().Be(FixtureTypeName);
             // ContentRoot is the directory of the resolved assembly — should be the install root.
-            Assert.Equal(tempDir, item.ContentRoot);
+            item.ContentRoot.Should().Be(tempDir);
             UnloadAndRelease(item.LoadContext);
         }
         finally
@@ -309,10 +306,10 @@ public class WorkloadLoaderTests
             var loader = new WorkloadLoader(paths);
             var entry = FixtureEntry(FixturePackageId, assemblyFileOverride: $"../{FixtureAssemblyFile}");
 
-            var ex = Assert.Throws<InvalidWorkloadException>(() => loader.Load([entry]));
+            var ex = FluentActions.Invoking(() => loader.Load([entry])).Should().ThrowExactly<InvalidWorkloadException>().Which;
 
-            Assert.StartsWith($"[{FixturePackageId}]", ex.Message);
-            Assert.Contains("outside the install directory", ex.Message);
+            ex.Message.Should().StartWith($"[{FixturePackageId}]");
+            ex.Message.Should().Contain("outside the install directory");
         }
         finally
         {

--- a/test/Func.Tests/Workloads/PythonWorkerWorkloadPackageTests.cs
+++ b/test/Func.Tests/Workloads/PythonWorkerWorkloadPackageTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Workloads;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Workloads;
 
@@ -14,7 +13,7 @@ public sealed class PythonWorkerWorkloadPackageTests
     [InlineData(" osx-arm64 ", "Azure.Functions.Cli.Workloads.Workers.Python.osx-arm64")]
     public void FromRuntimeIdentifier_AppendsLowercasedRid(string runtimeIdentifier, string expected)
     {
-        Assert.Equal(expected, PythonWorkerWorkloadPackage.FromRuntimeIdentifier(runtimeIdentifier));
+        PythonWorkerWorkloadPackage.FromRuntimeIdentifier(runtimeIdentifier).Should().Be(expected);
     }
 
     [Theory]
@@ -22,19 +21,19 @@ public sealed class PythonWorkerWorkloadPackageTests
     [InlineData("   ")]
     public void FromRuntimeIdentifier_RejectsBlankRid(string runtimeIdentifier)
     {
-        Assert.Throws<ArgumentException>(() => PythonWorkerWorkloadPackage.FromRuntimeIdentifier(runtimeIdentifier));
+        FluentActions.Invoking(() => PythonWorkerWorkloadPackage.FromRuntimeIdentifier(runtimeIdentifier)).Should().ThrowExactly<ArgumentException>();
     }
 
     [Fact]
     public void FromRuntimeIdentifier_RejectsNullRid()
     {
-        Assert.Throws<ArgumentNullException>(() => PythonWorkerWorkloadPackage.FromRuntimeIdentifier(null!));
+        FluentActions.Invoking(() => PythonWorkerWorkloadPackage.FromRuntimeIdentifier(null!)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
     public void CurrentPackageId_StartsWithPrefix()
     {
-        Assert.StartsWith(PythonWorkerWorkloadPackage.PackageIdPrefix, PythonWorkerWorkloadPackage.CurrentPackageId);
+        PythonWorkerWorkloadPackage.CurrentPackageId.Should().StartWith(PythonWorkerWorkloadPackage.PackageIdPrefix);
     }
 
     [Theory]
@@ -48,6 +47,6 @@ public sealed class PythonWorkerWorkloadPackageTests
     [InlineData("freebsd-x64", false)]
     public void IsSupported_MatchesPublishedRids(string runtimeIdentifier, bool expected)
     {
-        Assert.Equal(expected, PythonWorkerWorkloadPackage.IsSupported(runtimeIdentifier));
+        PythonWorkerWorkloadPackage.IsSupported(runtimeIdentifier).Should().Be(expected);
     }
 }

--- a/test/Func.Tests/Workloads/Storage/WorkloadHomeResolverTests.cs
+++ b/test/Func.Tests/Workloads/Storage/WorkloadHomeResolverTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Workloads.Storage;
-using Xunit;
 using AbstractionsConstants = Azure.Functions.Cli.Abstractions.Common.Constants;
 using FuncConstants = Azure.Functions.Cli.Common.Constants;
 
@@ -19,7 +18,7 @@ public class WorkloadHomeResolverTests
 
         string resolved = WithEnv(workloadsHome, funcHome, WorkloadHomeResolver.Resolve);
 
-        Assert.Equal(Path.GetFullPath(workloadsHome), resolved);
+        resolved.Should().Be(Path.GetFullPath(workloadsHome));
     }
 
     [Fact]
@@ -29,7 +28,7 @@ public class WorkloadHomeResolverTests
 
         string resolved = WithEnv(null, funcHome, WorkloadHomeResolver.Resolve);
 
-        Assert.Equal(Path.GetFullPath(funcHome), resolved);
+        resolved.Should().Be(Path.GetFullPath(funcHome));
     }
 
     [Fact]
@@ -41,7 +40,7 @@ public class WorkloadHomeResolverTests
 
         string resolved = WithEnv(null, null, WorkloadHomeResolver.Resolve);
 
-        Assert.Equal(expected, resolved);
+        resolved.Should().Be(expected);
     }
 
     private static string WithEnv(string? workloadsHome, string? funcHome, Func<string> action)

--- a/test/Func.Tests/Workloads/Storage/WorkloadManifestSchemaTests.cs
+++ b/test/Func.Tests/Workloads/Storage/WorkloadManifestSchemaTests.cs
@@ -4,7 +4,6 @@
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Workloads;
 using Azure.Functions.Cli.Workloads.Storage;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Workloads.Storage;
 
@@ -35,7 +34,7 @@ public class WorkloadManifestSchemaTests : IDisposable
     [Fact]
     public void CurrentSchema_IsV1Url()
     {
-        Assert.Equal(V1Schema, WorkloadManifestSchema.CurrentRegistrySchema);
+        WorkloadManifestSchema.CurrentRegistrySchema.Should().Be(V1Schema);
     }
 
     [Fact]
@@ -45,11 +44,11 @@ public class WorkloadManifestSchemaTests : IDisposable
 
         string json = await File.ReadAllTextAsync(_registryPath);
 
-        Assert.Contains($"\"$schema\":\"{V1Schema}\"", json);
+        json.Should().Contain($"\"$schema\":\"{V1Schema}\"");
         int schemaIdx = json.IndexOf("\"$schema\"", StringComparison.Ordinal);
         int workloadsIdx = json.IndexOf("\"workloads\"", StringComparison.Ordinal);
-        Assert.True(schemaIdx >= 0 && workloadsIdx >= 0);
-        Assert.True(schemaIdx < workloadsIdx, "$schema must appear before workloads.");
+        (schemaIdx >= 0 && workloadsIdx >= 0).Should().BeTrue();
+        (schemaIdx < workloadsIdx).Should().BeTrue("$schema must appear before workloads.");
     }
 
     [Fact]
@@ -66,7 +65,7 @@ public class WorkloadManifestSchemaTests : IDisposable
 
         IReadOnlyList<WorkloadEntry> workloads = await _store.GetWorkloadsAsync();
 
-        Assert.Single(workloads);
+        workloads.Should().ContainSingle();
     }
 
     [Fact]
@@ -84,7 +83,7 @@ public class WorkloadManifestSchemaTests : IDisposable
 
         IReadOnlyList<WorkloadEntry> workloads = await _store.GetWorkloadsAsync();
 
-        Assert.Single(workloads);
+        workloads.Should().ContainSingle();
     }
 
     [Fact]
@@ -97,15 +96,14 @@ public class WorkloadManifestSchemaTests : IDisposable
             }
             """);
 
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => _store.GetWorkloadsAsync());
+        GracefulException ex = (await FluentActions.Awaiting(() => _store.GetWorkloadsAsync()).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.True(ex.IsUserError);
-        Assert.Contains("v999", ex.Message);
-        Assert.Contains("not supported", ex.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("Supported schemas", ex.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains(WorkloadManifestSchema.RegistryV1Schema, ex.Message);
-        Assert.Contains("updating the CLI", ex.Message, StringComparison.OrdinalIgnoreCase);
+        ex.IsUserError.Should().BeTrue();
+        ex.Message.Should().Contain("v999");
+        ex.Message.Should().ContainEquivalentOf("not supported");
+        ex.Message.Should().ContainEquivalentOf("Supported schemas");
+        ex.Message.Should().Contain(WorkloadManifestSchema.RegistryV1Schema);
+        ex.Message.Should().ContainEquivalentOf("updating the CLI");
     }
 
     [Fact]
@@ -117,7 +115,7 @@ public class WorkloadManifestSchemaTests : IDisposable
 
         string json = await File.ReadAllTextAsync(_registryPath);
 
-        Assert.Contains($"\"$schema\":\"{V1Schema}\"", json);
+        json.Should().Contain($"\"$schema\":\"{V1Schema}\"");
     }
 
     private static WorkloadEntry NewEntry(string packageId, string version) => new()

--- a/test/Func.Tests/Workloads/Storage/WorkloadPathsOptionsTests.cs
+++ b/test/Func.Tests/Workloads/Storage/WorkloadPathsOptionsTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Workloads.Storage;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Workloads.Storage;
 
@@ -16,7 +15,7 @@ public class WorkloadPathsOptionsTests
         // path," so callers don't have to normalise themselves.
         var options = new WorkloadPathsOptions("relative/path");
 
-        Assert.Equal(Path.GetFullPath("relative/path"), options.Home);
+        options.Home.Should().Be(Path.GetFullPath("relative/path"));
     }
 
     [Theory]
@@ -25,7 +24,7 @@ public class WorkloadPathsOptionsTests
     [InlineData("   ")]
     public void Constructor_ThrowsForMissingHome(string? home)
     {
-        Assert.ThrowsAny<ArgumentException>(() => new WorkloadPathsOptions(home!));
+        FluentActions.Invoking(() => new WorkloadPathsOptions(home!)).Should().Throw<ArgumentException>();
     }
 
     [Fact]
@@ -33,7 +32,7 @@ public class WorkloadPathsOptionsTests
     {
         var options = new WorkloadPathsOptions(Path.Combine(Path.GetTempPath(), "funcs"));
 
-        Assert.Equal(Path.Combine(options.Home, "workloads"), options.WorkloadsRoot);
+        options.WorkloadsRoot.Should().Be(Path.Combine(options.Home, "workloads"));
     }
 
     [Fact]
@@ -41,9 +40,7 @@ public class WorkloadPathsOptionsTests
     {
         var options = new WorkloadPathsOptions(Path.Combine(Path.GetTempPath(), "funcs"));
 
-        Assert.Equal(
-            Path.Combine(options.Home, WorkloadPathsOptions.WorkloadRegistryFileName),
-            options.WorkloadRegistryPath);
+        options.WorkloadRegistryPath.Should().Be(Path.Combine(options.Home, WorkloadPathsOptions.WorkloadRegistryFileName));
     }
 
     [Fact]
@@ -51,8 +48,6 @@ public class WorkloadPathsOptionsTests
     {
         var options = new WorkloadPathsOptions(Path.Combine(Path.GetTempPath(), "funcs"));
 
-        Assert.Equal(
-            Path.Combine(options.Home, "workloads", "Azure.Functions.Cli.Workloads.Dotnet", "1.2.3"),
-            options.GetInstallDirectory("Azure.Functions.Cli.Workloads.Dotnet", "1.2.3"));
+        options.GetInstallDirectory("Azure.Functions.Cli.Workloads.Dotnet", "1.2.3").Should().Be(Path.Combine(options.Home, "workloads", "Azure.Functions.Cli.Workloads.Dotnet", "1.2.3"));
     }
 }

--- a/test/Func.Tests/Workloads/Storage/WorkloadStoreTests.cs
+++ b/test/Func.Tests/Workloads/Storage/WorkloadStoreTests.cs
@@ -5,7 +5,6 @@ using System.Text.Json;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Workloads;
 using Azure.Functions.Cli.Workloads.Storage;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Workloads.Storage;
 
@@ -35,7 +34,7 @@ public class WorkloadStoreTests : IDisposable
     {
         var workloads = await _store.GetWorkloadsAsync();
 
-        Assert.Empty(workloads);
+        workloads.Should().BeEmpty();
     }
 
     [Fact]
@@ -44,9 +43,9 @@ public class WorkloadStoreTests : IDisposable
         await _store.SaveWorkloadAsync(NewEntry("Azure.Functions.Cli.Workloads.Dotnet", "1.0.0"));
 
         var workloads = await _store.GetWorkloadsAsync();
-        var installed = Assert.Single(workloads);
-        Assert.Equal("Azure.Functions.Cli.Workloads.Dotnet", installed.PackageId);
-        Assert.Equal("1.0.0", installed.PackageVersion);
+        var installed = workloads.Should().ContainSingle().Subject;
+        installed.PackageId.Should().Be("Azure.Functions.Cli.Workloads.Dotnet");
+        installed.PackageVersion.Should().Be("1.0.0");
     }
 
     [Fact]
@@ -56,9 +55,7 @@ public class WorkloadStoreTests : IDisposable
         await _store.SaveWorkloadAsync(NewEntry("Azure.Functions.Cli.Workloads.Dotnet", "2.0.0"));
 
         var workloads = await _store.GetWorkloadsAsync();
-        Assert.Equal(
-            ["1.0.0", "2.0.0"],
-            workloads.Select(w => w.PackageVersion).OrderBy(v => v));
+        workloads.Select(w => w.PackageVersion).OrderBy(v => v).Should().Equal(["1.0.0", "2.0.0"]);
     }
 
     [Fact]
@@ -68,8 +65,8 @@ public class WorkloadStoreTests : IDisposable
         await _store.SaveWorkloadAsync(NewEntry("pkg", "1.0.0", entryAssembly: "second.dll"));
 
         var workloads = await _store.GetWorkloadsAsync();
-        var installed = Assert.Single(workloads);
-        Assert.Equal("second.dll", installed.EntryPoint!.AssemblyPath);
+        var installed = workloads.Should().ContainSingle().Subject;
+        installed.EntryPoint!.AssemblyPath.Should().Be("second.dll");
     }
 
     [Fact]
@@ -79,8 +76,8 @@ public class WorkloadStoreTests : IDisposable
         await _store.SaveWorkloadAsync(NewEntry("azure.functions.cli.workloads.dotnet", "1.0.0", entryAssembly: "lower.dll"));
 
         var workloads = await _store.GetWorkloadsAsync();
-        var installed = Assert.Single(workloads);
-        Assert.Equal("lower.dll", installed.EntryPoint!.AssemblyPath);
+        var installed = workloads.Should().ContainSingle().Subject;
+        installed.EntryPoint!.AssemblyPath.Should().Be("lower.dll");
     }
 
     [Fact]
@@ -88,7 +85,7 @@ public class WorkloadStoreTests : IDisposable
     {
         var removed = await _store.RemoveWorkloadAsync("does.not.exist", "1.0.0");
 
-        Assert.False(removed);
+        removed.Should().BeFalse();
     }
 
     [Fact]
@@ -99,10 +96,10 @@ public class WorkloadStoreTests : IDisposable
 
         var removed = await _store.RemoveWorkloadAsync("PKG", "1.0.0");
 
-        Assert.True(removed);
+        removed.Should().BeTrue();
         var workloads = await _store.GetWorkloadsAsync();
-        var installed = Assert.Single(workloads);
-        Assert.Equal("2.0.0", installed.PackageVersion);
+        var installed = workloads.Should().ContainSingle().Subject;
+        installed.PackageVersion.Should().Be("2.0.0");
     }
 
     [Fact]
@@ -123,11 +120,11 @@ public class WorkloadStoreTests : IDisposable
         await _store.SaveWorkloadAsync(entry);
         var actual = (await _store.GetWorkloadsAsync()).Single();
 
-        Assert.Equal(entry.PackageId, actual.PackageId);
-        Assert.Equal(entry.PackageVersion, actual.PackageVersion);
-        Assert.Equal(entry.Aliases, actual.Aliases);
-        Assert.Equal(entry.EntryPoint!.AssemblyPath, actual.EntryPoint!.AssemblyPath);
-        Assert.Equal(entry.EntryPoint.Type, actual.EntryPoint.Type);
+        actual.PackageId.Should().Be(entry.PackageId);
+        actual.PackageVersion.Should().Be(entry.PackageVersion);
+        actual.Aliases.Should().Equal(entry.Aliases);
+        actual.EntryPoint!.AssemblyPath.Should().Be(entry.EntryPoint!.AssemblyPath);
+        actual.EntryPoint.Type.Should().Be(entry.EntryPoint.Type);
     }
 
     [Fact]
@@ -140,15 +137,15 @@ public class WorkloadStoreTests : IDisposable
         using var doc = JsonDocument.Parse(await File.ReadAllTextAsync(_paths.WorkloadRegistryPath));
         var workloads = doc.RootElement.GetProperty("workloads");
 
-        Assert.Equal(JsonValueKind.Array, workloads.ValueKind);
-        Assert.Equal(3, workloads.GetArrayLength());
+        workloads.ValueKind.Should().Be(JsonValueKind.Array);
+        workloads.GetArrayLength().Should().Be(3);
 
         // Each entry carries its own packageId / packageVersion now that the
         // outer shape is a list rather than a nested dictionary.
         foreach (var element in workloads.EnumerateArray())
         {
-            Assert.True(element.TryGetProperty("packageId", out _));
-            Assert.True(element.TryGetProperty("packageVersion", out _));
+            element.TryGetProperty("packageId", out _).Should().BeTrue();
+            element.TryGetProperty("packageVersion", out _).Should().BeTrue();
         }
     }
 
@@ -158,10 +155,9 @@ public class WorkloadStoreTests : IDisposable
         Directory.CreateDirectory(_tempHome);
         File.WriteAllText(_paths.WorkloadRegistryPath, "{ not valid json");
 
-        var ex = await Assert.ThrowsAsync<GracefulException>(
-            () => _store.SaveWorkloadAsync(NewEntry("a", "1.0.0")));
-        Assert.True(ex.IsUserError);
-        Assert.Contains(_paths.WorkloadRegistryPath, ex.Message);
+        var ex = (await FluentActions.Awaiting(() => _store.SaveWorkloadAsync(NewEntry("a", "1.0.0"))).Should().ThrowAsync<GracefulException>()).Which;
+        ex.IsUserError.Should().BeTrue();
+        ex.Message.Should().Contain(_paths.WorkloadRegistryPath);
     }
 
     [Fact]
@@ -170,7 +166,7 @@ public class WorkloadStoreTests : IDisposable
         await _store.SaveWorkloadAsync(NewEntry("a", "1.0.0"));
 
         var stragglers = Directory.GetFiles(_tempHome, "*.json.tmp");
-        Assert.Empty(stragglers);
+        stragglers.Should().BeEmpty();
     }
 
     [Fact]
@@ -185,11 +181,10 @@ public class WorkloadStoreTests : IDisposable
         // test that actually proves the atomic-rename guarantee.
         var failingStore = new ThrowingSerializeStore(_paths);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
-            () => failingStore.SaveWorkloadAsync(NewEntry("would-be-second", "2.0.0")));
+        await FluentActions.Awaiting(() => failingStore.SaveWorkloadAsync(NewEntry("would-be-second", "2.0.0"))).Should().ThrowAsync<InvalidOperationException>();
 
-        Assert.Equal(baselineBytes, File.ReadAllBytes(_paths.WorkloadRegistryPath));
-        Assert.Empty(Directory.GetFiles(_tempHome, "*.json.tmp"));
+        File.ReadAllBytes(_paths.WorkloadRegistryPath).Should().Equal(baselineBytes);
+        Directory.GetFiles(_tempHome, "*.json.tmp").Should().BeEmpty();
     }
 
     private static WorkloadEntry NewEntry(string packageId, string version, string entryAssembly = "x.dll")

--- a/test/Func.Tests/Workloads/Storage/WorkloadStoreTests.cs
+++ b/test/Func.Tests/Workloads/Storage/WorkloadStoreTests.cs
@@ -65,8 +65,7 @@ public class WorkloadStoreTests : IDisposable
         await _store.SaveWorkloadAsync(NewEntry("pkg", "1.0.0", entryAssembly: "second.dll"));
 
         var workloads = await _store.GetWorkloadsAsync();
-        var installed = workloads.Should().ContainSingle().Subject;
-        installed.EntryPoint!.AssemblyPath.Should().Be("second.dll");
+        workloads.Should().ContainSingle().Which.EntryPoint!.AssemblyPath.Should().Be("second.dll");
     }
 
     [Fact]
@@ -76,8 +75,7 @@ public class WorkloadStoreTests : IDisposable
         await _store.SaveWorkloadAsync(NewEntry("azure.functions.cli.workloads.dotnet", "1.0.0", entryAssembly: "lower.dll"));
 
         var workloads = await _store.GetWorkloadsAsync();
-        var installed = workloads.Should().ContainSingle().Subject;
-        installed.EntryPoint!.AssemblyPath.Should().Be("lower.dll");
+        workloads.Should().ContainSingle().Which.EntryPoint!.AssemblyPath.Should().Be("lower.dll");
     }
 
     [Fact]
@@ -98,8 +96,7 @@ public class WorkloadStoreTests : IDisposable
 
         removed.Should().BeTrue();
         var workloads = await _store.GetWorkloadsAsync();
-        var installed = workloads.Should().ContainSingle().Subject;
-        installed.PackageVersion.Should().Be("2.0.0");
+        workloads.Should().ContainSingle().Which.PackageVersion.Should().Be("2.0.0");
     }
 
     [Fact]

--- a/test/Func.Tests/Workloads/WorkloadProviderTests.cs
+++ b/test/Func.Tests/Workloads/WorkloadProviderTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Workloads;
-using Xunit;
 
 namespace Azure.Functions.Cli.Tests.Workloads;
 
@@ -21,10 +20,10 @@ public class WorkloadProviderTests
 
         // Materialized once at construction, so repeated calls return the
         // same list instance and never re-enumerate the source.
-        Assert.Same(first, second);
-        Assert.Equal(2, first.Count);
-        Assert.Same(a, first[0]);
-        Assert.Same(b, first[1]);
+        second.Should().BeSameAs(first);
+        first.Count.Should().Be(2);
+        first[0].Should().BeSameAs(a);
+        first[1].Should().BeSameAs(b);
     }
 
     [Fact]
@@ -38,10 +37,10 @@ public class WorkloadProviderTests
         IReadOnlyList<RuntimeWorkloadInfo> runtimeWorkloads = provider.GetRuntimeWorkloads();
         IReadOnlyList<ContentWorkloadInfo> contentWorkloads = provider.GetContentWorkloads();
 
-        Assert.Same(runtimeWorkloads, provider.GetRuntimeWorkloads());
-        Assert.Same(contentWorkloads, provider.GetContentWorkloads());
-        Assert.Same(runtime, Assert.Single(runtimeWorkloads));
-        Assert.Same(content, Assert.Single(contentWorkloads));
+        provider.GetRuntimeWorkloads().Should().BeSameAs(runtimeWorkloads);
+        provider.GetContentWorkloads().Should().BeSameAs(contentWorkloads);
+        runtimeWorkloads.Should().ContainSingle().Subject.Should().BeSameAs(runtime);
+        contentWorkloads.Should().ContainSingle().Subject.Should().BeSameAs(content);
     }
 
     [Fact]
@@ -57,13 +56,10 @@ public class WorkloadProviderTests
         IReadOnlyList<RuntimeWorkloadInfo> runtimeWorkloads = provider.GetRuntimeWorkloadsByPackageId("pkg.shared");
         IReadOnlyList<ContentWorkloadInfo> contentWorkloads = provider.GetContentWorkloadsByPackageId("PKG.SHARED");
 
-        Assert.Same(runtimeWorkloads, provider.GetRuntimeWorkloadsByPackageId("Pkg.Shared"));
-        Assert.Same(contentWorkloads, provider.GetContentWorkloadsByPackageId("pkg.shared"));
-        Assert.Same(runtimeMatch, Assert.Single(runtimeWorkloads));
-        Assert.Collection(
-            contentWorkloads,
-            workload => Assert.Same(contentOld, workload),
-            workload => Assert.Same(contentNew, workload));
+        provider.GetRuntimeWorkloadsByPackageId("Pkg.Shared").Should().BeSameAs(runtimeWorkloads);
+        provider.GetContentWorkloadsByPackageId("pkg.shared").Should().BeSameAs(contentWorkloads);
+        runtimeWorkloads.Should().ContainSingle().Subject.Should().BeSameAs(runtimeMatch);
+        contentWorkloads.Should().SatisfyRespectively(workload => workload.Should().BeSameAs(contentOld), workload => workload.Should().BeSameAs(contentNew));
     }
 
     [Fact]
@@ -75,8 +71,8 @@ public class WorkloadProviderTests
                 TestWorkloads.CreateContentInfo("Pkg.Content"),
             ]);
 
-        Assert.Empty(provider.GetRuntimeWorkloadsByPackageId("Pkg.Missing"));
-        Assert.Empty(provider.GetContentWorkloadsByPackageId("Pkg.Missing"));
+        provider.GetRuntimeWorkloadsByPackageId("Pkg.Missing").Should().BeEmpty();
+        provider.GetContentWorkloadsByPackageId("Pkg.Missing").Should().BeEmpty();
     }
 
     [Theory]
@@ -87,7 +83,7 @@ public class WorkloadProviderTests
     {
         var provider = new WorkloadProvider([]);
 
-        Assert.ThrowsAny<ArgumentException>(() => provider.GetRuntimeWorkloadsByPackageId(packageId!));
+        FluentActions.Invoking(() => provider.GetRuntimeWorkloadsByPackageId(packageId!)).Should().Throw<ArgumentException>();
     }
 
     [Theory]
@@ -98,12 +94,12 @@ public class WorkloadProviderTests
     {
         var provider = new WorkloadProvider([]);
 
-        Assert.ThrowsAny<ArgumentException>(() => provider.GetContentWorkloadsByPackageId(packageId!));
+        FluentActions.Invoking(() => provider.GetContentWorkloadsByPackageId(packageId!)).Should().Throw<ArgumentException>();
     }
 
     [Fact]
     public void Ctor_NullWorkloads_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => new WorkloadProvider(null!));
+        FluentActions.Invoking(() => new WorkloadProvider(null!)).Should().ThrowExactly<ArgumentNullException>();
     }
 }

--- a/test/Workloads/Host.Tests/ChildProcessHandleSanitizerTests.cs
+++ b/test/Workloads/Host.Tests/ChildProcessHandleSanitizerTests.cs
@@ -4,7 +4,6 @@
 using Azure.Functions.Cli.Workloads.Host.Interop;
 using Azure.Functions.Cli.Workloads.Host.Startup;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.Host.Tests;
 
@@ -15,7 +14,7 @@ public sealed class ChildProcessHandleSanitizerTests
 
     [Fact]
     public void Constructor_NullNativeHandleApi_Throws()
-        => Assert.Throws<ArgumentNullException>(() => new ChildProcessHandleSanitizer(null!));
+        => FluentActions.Invoking(() => new ChildProcessHandleSanitizer(null!)).Should().ThrowExactly<ArgumentNullException>();
 
     [Fact]
     public void DisableInheritanceOnOpenHandles_ClearsInheritOnlyOnInheritableHandles()
@@ -31,7 +30,7 @@ public sealed class ChildProcessHandleSanitizerTests
 
         int disabledCount = sanitizer.DisableInheritanceOnOpenHandles();
 
-        Assert.Equal(2, disabledCount);
+        disabledCount.Should().Be(2);
         nativeHandleApi.Received(1).TryDisableInheritance((nint)0x10);
         nativeHandleApi.Received(1).TryDisableInheritance((nint)0x20);
         nativeHandleApi.DidNotReceive().TryDisableInheritance((nint)0x30);
@@ -51,7 +50,7 @@ public sealed class ChildProcessHandleSanitizerTests
 
         int disabledCount = sanitizer.DisableInheritanceOnOpenHandles();
 
-        Assert.Equal(1, disabledCount);
+        disabledCount.Should().Be(1);
         nativeHandleApi.Received(1).TryDisableInheritance((nint)0x20);
     }
 
@@ -64,7 +63,7 @@ public sealed class ChildProcessHandleSanitizerTests
 
         int disabledCount = sanitizer.DisableInheritanceOnOpenHandles();
 
-        Assert.Equal(0, disabledCount);
+        disabledCount.Should().Be(0);
         nativeHandleApi.DidNotReceive().TryDisableInheritance(Arg.Any<nint>());
     }
 

--- a/test/Workloads/Host.Tests/HostShellTests.cs
+++ b/test/Workloads/Host.Tests/HostShellTests.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Xunit;
-
 namespace Azure.Functions.Cli.Workloads.Host.Tests;
 
 public sealed class HostShellTests
@@ -17,9 +15,9 @@ public sealed class HostShellTests
             ["--urls", "http://0.0.0.0:7072", "--hostid", "abc"],
             CancellationToken.None);
 
-        Assert.Equal(0, exitCode);
-        Assert.Equal(["--urls", "http://0.0.0.0:7072", "--hostid", "abc"], hostRunner.Args);
-        Assert.False(hostRunner.EnableAuth);
+        exitCode.Should().Be(0);
+        hostRunner.Args.Should().Equal(["--urls", "http://0.0.0.0:7072", "--hostid", "abc"]);
+        hostRunner.EnableAuth.Should().BeFalse();
     }
 
     [Fact]
@@ -32,8 +30,8 @@ public sealed class HostShellTests
             ["--urls", "http://0.0.0.0:7072", "--enable-auth", "--hostid", "abc"],
             CancellationToken.None);
 
-        Assert.Equal(["--urls", "http://0.0.0.0:7072", "--hostid", "abc"], hostRunner.Args);
-        Assert.True(hostRunner.EnableAuth);
+        hostRunner.Args.Should().Equal(["--urls", "http://0.0.0.0:7072", "--hostid", "abc"]);
+        hostRunner.EnableAuth.Should().BeTrue();
     }
 
     [Fact]
@@ -45,7 +43,7 @@ public sealed class HostShellTests
 
         await shell.RunAsync([], cancellationTokenSource.Token);
 
-        Assert.Equal(cancellationTokenSource.Token, hostRunner.CancellationToken);
+        hostRunner.CancellationToken.Should().Be(cancellationTokenSource.Token);
     }
 
     private sealed class TestHostRunner : IFunctionsHostRunner

--- a/test/Workloads/Host.Tests/HostStructuredEventWriterTests.cs
+++ b/test/Workloads/Host.Tests/HostStructuredEventWriterTests.cs
@@ -6,7 +6,6 @@ using System.Text.Json;
 using Azure.Functions.Cli.Workloads.Host.Logging;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Extensions.Logging;
-using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.Host.Tests;
 
@@ -50,18 +49,18 @@ public sealed class HostStructuredEventWriterTests
 
         using var document = JsonDocument.Parse(writer.ToString());
         JsonElement root = document.RootElement;
-        Assert.Equal(HostStructuredEventWriter.Source, root.GetProperty("source").GetString());
-        Assert.Equal(1, root.GetProperty("schema_version").GetInt32());
-        Assert.Equal("log", root.GetProperty("record_type").GetString());
-        Assert.Equal("Host.General", root.GetProperty("category").GetString());
-        Assert.Equal("information", root.GetProperty("level").GetString());
-        Assert.Equal(529, root.GetProperty("event_id").GetProperty("id").GetInt32());
-        Assert.Equal("HostStateChanged", root.GetProperty("event_id").GetProperty("name").GetString());
-        Assert.Equal("Host state changed from Initialized to Running", root.GetProperty("message").GetString());
-        Assert.Equal("ready", root.GetProperty("attributes").GetProperty("host.state").GetString());
-        Assert.Equal(12.5, root.GetProperty("attributes").GetProperty("duration_ms").GetDouble());
-        Assert.Equal("Running", root.GetProperty("state").GetProperty("NewState").GetString());
-        Assert.Equal("trace-1", root.GetProperty("scopes")[0].GetProperty("values").GetProperty("TraceId").GetString());
+        root.GetProperty("source").GetString().Should().Be(HostStructuredEventWriter.Source);
+        root.GetProperty("schema_version").GetInt32().Should().Be(1);
+        root.GetProperty("record_type").GetString().Should().Be("log");
+        root.GetProperty("category").GetString().Should().Be("Host.General");
+        root.GetProperty("level").GetString().Should().Be("information");
+        root.GetProperty("event_id").GetProperty("id").GetInt32().Should().Be(529);
+        root.GetProperty("event_id").GetProperty("name").GetString().Should().Be("HostStateChanged");
+        root.GetProperty("message").GetString().Should().Be("Host state changed from Initialized to Running");
+        root.GetProperty("attributes").GetProperty("host.state").GetString().Should().Be("ready");
+        root.GetProperty("attributes").GetProperty("duration_ms").GetDouble().Should().Be(12.5);
+        root.GetProperty("state").GetProperty("NewState").GetString().Should().Be("Running");
+        root.GetProperty("scopes")[0].GetProperty("values").GetProperty("TraceId").GetString().Should().Be("trace-1");
     }
 
     [Theory]
@@ -74,7 +73,7 @@ public sealed class HostStructuredEventWriterTests
     [InlineData("Function.HttpTrigger1.User", "Function.HttpTrigger1.User")]
     public void NormalizeCategory_AppliesKnownPrefixRules(string category, string expected)
     {
-        Assert.Equal(expected, HostStructuredEventWriter.NormalizeCategory(category));
+        HostStructuredEventWriter.NormalizeCategory(category).Should().Be(expected);
     }
 
     [Fact]
@@ -91,7 +90,7 @@ public sealed class HostStructuredEventWriterTests
             writer: writer);
 
         using var document = JsonDocument.Parse(writer.ToString());
-        Assert.Equal("ScriptStartupTypeLocator", document.RootElement.GetProperty("category").GetString());
+        document.RootElement.GetProperty("category").GetString().Should().Be("ScriptStartupTypeLocator");
     }
 
     [Fact]
@@ -111,12 +110,12 @@ public sealed class HostStructuredEventWriterTests
 
         using var document = JsonDocument.Parse(writer.ToString());
         JsonElement exceptionJson = document.RootElement.GetProperty("exception");
-        Assert.Equal(typeof(InvalidOperationException).FullName, exceptionJson.GetProperty("type").GetString());
-        Assert.Equal("outer failure", exceptionJson.GetProperty("message").GetString());
+        exceptionJson.GetProperty("type").GetString().Should().Be(typeof(InvalidOperationException).FullName);
+        exceptionJson.GetProperty("message").GetString().Should().Be("outer failure");
 
         JsonElement innerExceptionJson = exceptionJson.GetProperty("inner_exception");
-        Assert.Equal(typeof(Exception).FullName, innerExceptionJson.GetProperty("type").GetString());
-        Assert.Equal("inner failure", innerExceptionJson.GetProperty("message").GetString());
+        innerExceptionJson.GetProperty("type").GetString().Should().Be(typeof(Exception).FullName);
+        innerExceptionJson.GetProperty("message").GetString().Should().Be("inner failure");
     }
 
     [Fact]
@@ -147,28 +146,28 @@ public sealed class HostStructuredEventWriterTests
 
         using var document = JsonDocument.Parse(writer.ToString());
         JsonElement attributes = document.RootElement.GetProperty("attributes");
-        Assert.Equal("function_discovered", attributes.GetProperty("cli.event_kind").GetString());
-        Assert.Equal("HttpTrigger1", attributes.GetProperty("function.name").GetString());
-        Assert.Equal(@"C:\functions\HttpTrigger1", attributes.GetProperty("function.id").GetString());
-        Assert.Equal("http", attributes.GetProperty("function.trigger_type").GetString());
-        Assert.Equal("/api/widgets/{id}", attributes.GetProperty("function.route").GetString());
-        Assert.Equal("dotnet-isolated", attributes.GetProperty("function.language").GetString());
-        Assert.Equal("run.csx", attributes.GetProperty("function.script_file").GetString());
-        Assert.Equal("Functions.HttpTrigger1.Run", attributes.GetProperty("function.entry_point").GetString());
+        attributes.GetProperty("cli.event_kind").GetString().Should().Be("function_discovered");
+        attributes.GetProperty("function.name").GetString().Should().Be("HttpTrigger1");
+        attributes.GetProperty("function.id").GetString().Should().Be(@"C:\functions\HttpTrigger1");
+        attributes.GetProperty("function.trigger_type").GetString().Should().Be("http");
+        attributes.GetProperty("function.route").GetString().Should().Be("/api/widgets/{id}");
+        attributes.GetProperty("function.language").GetString().Should().Be("dotnet-isolated");
+        attributes.GetProperty("function.script_file").GetString().Should().Be("run.csx");
+        attributes.GetProperty("function.entry_point").GetString().Should().Be("Functions.HttpTrigger1.Run");
 
         JsonElement methods = attributes.GetProperty("function.http_methods");
-        Assert.Equal("GET", methods[0].GetString());
-        Assert.Equal("POST", methods[1].GetString());
+        methods[0].GetString().Should().Be("GET");
+        methods[1].GetString().Should().Be("POST");
 
         JsonElement binding = attributes.GetProperty("function.bindings")[0];
-        Assert.Equal("req", binding.GetProperty("name").GetString());
-        Assert.Equal("httpTrigger", binding.GetProperty("type").GetString());
-        Assert.Equal("In", binding.GetProperty("direction").GetString());
-        Assert.True(binding.GetProperty("is_trigger").GetBoolean());
-        Assert.False(binding.TryGetProperty("connection", out _));
-        Assert.False(binding.TryGetProperty("route", out _));
-        Assert.False(binding.TryGetProperty("methods", out _));
-        Assert.False(binding.TryGetProperty("customSecret", out _));
+        binding.GetProperty("name").GetString().Should().Be("req");
+        binding.GetProperty("type").GetString().Should().Be("httpTrigger");
+        binding.GetProperty("direction").GetString().Should().Be("In");
+        binding.GetProperty("is_trigger").GetBoolean().Should().BeTrue();
+        binding.TryGetProperty("connection", out _).Should().BeFalse();
+        binding.TryGetProperty("route", out _).Should().BeFalse();
+        binding.TryGetProperty("methods", out _).Should().BeFalse();
+        binding.TryGetProperty("customSecret", out _).Should().BeFalse();
     }
 
     [Fact]
@@ -194,15 +193,15 @@ public sealed class HostStructuredEventWriterTests
 
         using var document = JsonDocument.Parse(stdout.ToString());
         JsonElement attributes = document.RootElement.GetProperty("attributes");
-        Assert.Equal("HttpTrigger1", attributes.GetProperty("function.name").GetString());
-        Assert.Equal("abc123", attributes.GetProperty("function.invocation_id").GetString());
-        Assert.Equal("invocation_completed", attributes.GetProperty("cli.event_kind").GetString());
-        Assert.Equal("failed", attributes.GetProperty("function.result").GetString());
-        Assert.Equal(7, attributes.GetProperty("duration_ms").GetDouble());
-        Assert.Equal("trace-1", attributes.GetProperty("trace_id").GetString());
-        Assert.Equal("span-1", attributes.GetProperty("span_id").GetString());
-        Assert.Equal("parent-1", attributes.GetProperty("parent_span_id").GetString());
-        Assert.Equal(string.Empty, stderr.ToString());
+        attributes.GetProperty("function.name").GetString().Should().Be("HttpTrigger1");
+        attributes.GetProperty("function.invocation_id").GetString().Should().Be("abc123");
+        attributes.GetProperty("cli.event_kind").GetString().Should().Be("invocation_completed");
+        attributes.GetProperty("function.result").GetString().Should().Be("failed");
+        attributes.GetProperty("duration_ms").GetDouble().Should().Be(7);
+        attributes.GetProperty("trace_id").GetString().Should().Be("trace-1");
+        attributes.GetProperty("span_id").GetString().Should().Be("span-1");
+        attributes.GetProperty("parent_span_id").GetString().Should().Be("parent-1");
+        stderr.ToString().Should().Be(string.Empty);
     }
 
     [Fact]
@@ -224,8 +223,8 @@ public sealed class HostStructuredEventWriterTests
 
         using var document = JsonDocument.Parse(stdout.ToString());
         JsonElement attributes = document.RootElement.GetProperty("attributes");
-        Assert.Equal("host_state_changed", attributes.GetProperty("cli.event_kind").GetString());
-        Assert.Equal("ready", attributes.GetProperty("host.state").GetString());
+        attributes.GetProperty("cli.event_kind").GetString().Should().Be("host_state_changed");
+        attributes.GetProperty("host.state").GetString().Should().Be("ready");
     }
 
     [Fact]
@@ -248,11 +247,11 @@ public sealed class HostStructuredEventWriterTests
             42.25);
 
         using var document = JsonDocument.Parse(stdout.ToString());
-        Assert.Equal("SystemTraceMiddleware", document.RootElement.GetProperty("category").GetString());
+        document.RootElement.GetProperty("category").GetString().Should().Be("SystemTraceMiddleware");
         JsonElement attributes = document.RootElement.GetProperty("attributes");
-        Assert.Equal("GET", attributes.GetProperty("http.method").GetString());
-        Assert.Equal("http://localhost/api/HttpTrigger1", attributes.GetProperty("http.target").GetString());
-        Assert.Equal(200, attributes.GetProperty("http.status_code").GetInt32());
-        Assert.Equal(42.25, attributes.GetProperty("duration_ms").GetDouble());
+        attributes.GetProperty("http.method").GetString().Should().Be("GET");
+        attributes.GetProperty("http.target").GetString().Should().Be("http://localhost/api/HttpTrigger1");
+        attributes.GetProperty("http.status_code").GetInt32().Should().Be(200);
+        attributes.GetProperty("duration_ms").GetDouble().Should().Be(42.25);
     }
 }

--- a/test/Workloads/Host.Tests/HostStructuredScriptLoggingBuilderTests.cs
+++ b/test/Workloads/Host.Tests/HostStructuredScriptLoggingBuilderTests.cs
@@ -6,7 +6,6 @@ using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.Host.Tests;
 
@@ -29,7 +28,7 @@ public sealed class HostStructuredScriptLoggingBuilderTests
 
         using ServiceProvider provider = services.BuildServiceProvider();
         IEnumerable<ILoggerProvider> loggerProviders = provider.GetRequiredService<IEnumerable<ILoggerProvider>>();
-        Assert.Contains(loggerProviders, static provider => provider is HostStructuredLoggerProvider);
+        loggerProviders.Should().Contain(static provider => provider is HostStructuredLoggerProvider);
     }
 
     [Theory]
@@ -94,7 +93,7 @@ public sealed class HostStructuredScriptLoggingBuilderTests
     }
 
     private static void AssertStructuredLogFilterResult(LoggerFilterOptions filterOptions, string category, LogLevel logLevel, bool expected)
-        => Assert.Contains(filterOptions.Rules, rule =>
+        => filterOptions.Rules.Any(rule =>
             string.Equals(rule.ProviderName, typeof(HostStructuredLoggerProvider).FullName, StringComparison.Ordinal)
-            && rule.Filter?.Invoke(rule.ProviderName, category, logLevel) == expected);
+            && rule.Filter?.Invoke(rule.ProviderName, category, logLevel) == expected).Should().BeTrue();
 }

--- a/test/Workloads/Host.Tests/ProgramTests.cs
+++ b/test/Workloads/Host.Tests/ProgramTests.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Xunit;
-
 namespace Azure.Functions.Cli.Workloads.Host.Tests;
 
 public sealed class ProgramTests
@@ -16,11 +14,11 @@ public sealed class ProgramTests
         Task monitorTask = Program.StartStandardInputClosedMonitorAsync(reader, shutdownTokenSource);
 
         await reader.WaitForReadAsync();
-        Assert.False(monitorTask.IsCompleted);
+        monitorTask.IsCompleted.Should().BeFalse();
 
         reader.Release();
         await monitorTask.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.True(shutdownTokenSource.IsCancellationRequested);
+        shutdownTokenSource.IsCancellationRequested.Should().BeTrue();
     }
 
     private sealed class BlockingTextReader : TextReader

--- a/test/Workloads/Host.Tests/RawHostLogCaptureProviderTests.cs
+++ b/test/Workloads/Host.Tests/RawHostLogCaptureProviderTests.cs
@@ -54,8 +54,8 @@ public sealed class RawHostLogCaptureProviderTests
         exception.GetProperty("type").GetString().Should().Be(typeof(InvalidOperationException).FullName);
         exception.GetProperty("message").GetString().Should().Be("Something failed");
 
-        JsonElement capturedScope = root.GetProperty("scopes").EnumerateArray().Should().ContainSingle().Subject;
-        capturedScope.GetProperty("values").GetProperty("ScopeKey").GetString().Should().Be("ScopeValue");
+        root.GetProperty("scopes").EnumerateArray().Should().ContainSingle()
+            .Which.GetProperty("values").GetProperty("ScopeKey").GetString().Should().Be("ScopeValue");
     }
 
     [Fact]
@@ -82,7 +82,7 @@ public sealed class RawHostLogCaptureProviderTests
 
         string line = File.ReadAllLines(capturePath).Should().ContainSingle().Subject;
         using var document = JsonDocument.Parse(line);
-        JsonElement capturedScope = document.RootElement.GetProperty("scopes").EnumerateArray().Should().ContainSingle().Subject;
-        capturedScope.GetProperty("values").GetProperty("InvocationId").GetString().Should().Be("abc123");
+        document.RootElement.GetProperty("scopes").EnumerateArray().Should().ContainSingle()
+            .Which.GetProperty("values").GetProperty("InvocationId").GetString().Should().Be("abc123");
     }
 }

--- a/test/Workloads/Host.Tests/RawHostLogCaptureProviderTests.cs
+++ b/test/Workloads/Host.Tests/RawHostLogCaptureProviderTests.cs
@@ -4,7 +4,6 @@
 using System.Text.Json;
 using Azure.Functions.Cli.Workloads.Host.Logging;
 using Microsoft.Extensions.Logging;
-using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.Host.Tests;
 
@@ -31,32 +30,32 @@ public sealed class RawHostLogCaptureProviderTests
                 123);
         }
 
-        string line = Assert.Single(File.ReadAllLines(capturePath));
+        string line = File.ReadAllLines(capturePath).Should().ContainSingle().Subject;
         using var document = JsonDocument.Parse(line);
         JsonElement root = document.RootElement;
 
-        Assert.Equal(1, root.GetProperty("schema_version").GetInt32());
-        Assert.Equal(Environment.ProcessId, root.GetProperty("process_id").GetInt32());
-        Assert.True(root.GetProperty("thread_id").GetInt32() > 0);
-        Assert.Equal("Function.HttpTrigger1", root.GetProperty("category").GetString());
-        Assert.Equal("warning", root.GetProperty("level").GetString());
-        Assert.Equal("Processing HttpTrigger1 took 123ms", root.GetProperty("message").GetString());
+        root.GetProperty("schema_version").GetInt32().Should().Be(1);
+        root.GetProperty("process_id").GetInt32().Should().Be(Environment.ProcessId);
+        (root.GetProperty("thread_id").GetInt32() > 0).Should().BeTrue();
+        root.GetProperty("category").GetString().Should().Be("Function.HttpTrigger1");
+        root.GetProperty("level").GetString().Should().Be("warning");
+        root.GetProperty("message").GetString().Should().Be("Processing HttpTrigger1 took 123ms");
 
         JsonElement eventId = root.GetProperty("event_id");
-        Assert.Equal(42, eventId.GetProperty("id").GetInt32());
-        Assert.Equal("FunctionWarning", eventId.GetProperty("name").GetString());
+        eventId.GetProperty("id").GetInt32().Should().Be(42);
+        eventId.GetProperty("name").GetString().Should().Be("FunctionWarning");
 
         JsonElement state = root.GetProperty("state");
-        Assert.Equal("HttpTrigger1", state.GetProperty("Name").GetString());
-        Assert.Equal(123, state.GetProperty("ElapsedMs").GetInt32());
-        Assert.Equal("Processing {Name} took {ElapsedMs}ms", state.GetProperty("{OriginalFormat}").GetString());
+        state.GetProperty("Name").GetString().Should().Be("HttpTrigger1");
+        state.GetProperty("ElapsedMs").GetInt32().Should().Be(123);
+        state.GetProperty("{OriginalFormat}").GetString().Should().Be("Processing {Name} took {ElapsedMs}ms");
 
         JsonElement exception = root.GetProperty("exception");
-        Assert.Equal(typeof(InvalidOperationException).FullName, exception.GetProperty("type").GetString());
-        Assert.Equal("Something failed", exception.GetProperty("message").GetString());
+        exception.GetProperty("type").GetString().Should().Be(typeof(InvalidOperationException).FullName);
+        exception.GetProperty("message").GetString().Should().Be("Something failed");
 
-        JsonElement capturedScope = Assert.Single(root.GetProperty("scopes").EnumerateArray());
-        Assert.Equal("ScopeValue", capturedScope.GetProperty("values").GetProperty("ScopeKey").GetString());
+        JsonElement capturedScope = root.GetProperty("scopes").EnumerateArray().Should().ContainSingle().Subject;
+        capturedScope.GetProperty("values").GetProperty("ScopeKey").GetString().Should().Be("ScopeValue");
     }
 
     [Fact]
@@ -81,9 +80,9 @@ public sealed class RawHostLogCaptureProviderTests
             logger.LogInformation(new EventId(7, "HostStarted"), "Host started");
         }
 
-        string line = Assert.Single(File.ReadAllLines(capturePath));
+        string line = File.ReadAllLines(capturePath).Should().ContainSingle().Subject;
         using var document = JsonDocument.Parse(line);
-        JsonElement capturedScope = Assert.Single(document.RootElement.GetProperty("scopes").EnumerateArray());
-        Assert.Equal("abc123", capturedScope.GetProperty("values").GetProperty("InvocationId").GetString());
+        JsonElement capturedScope = document.RootElement.GetProperty("scopes").EnumerateArray().Should().ContainSingle().Subject;
+        capturedScope.GetProperty("values").GetProperty("InvocationId").GetString().Should().Be("abc123");
     }
 }

--- a/test/Workloads/Sdk.Tests/HelpersTests.cs
+++ b/test/Workloads/Sdk.Tests/HelpersTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Reflection;
-using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.Sdk.Tests;
 
@@ -16,8 +15,8 @@ public class HelpersTests
         using var mlc = MetadataLoadContext.Create(assemblyPath);
         Assembly asm = mlc.LoadFromAssemblyPath(assemblyPath);
 
-        Assert.NotNull(asm);
-        Assert.Equal("Azure.Functions.Cli.Workloads.DotNet", asm.GetName().Name);
+        asm.Should().NotBeNull();
+        asm.GetName().Name.Should().Be("Azure.Functions.Cli.Workloads.DotNet");
     }
 
     [Fact]
@@ -31,7 +30,7 @@ public class HelpersTests
         // The workload assembly references Abstractions — resolving its custom
         // attributes requires the Abstractions assembly to be loadable.
         CustomAttributeData[] attributes = [.. asm.GetCustomAttributesData()];
-        Assert.NotEmpty(attributes);
+        attributes.Should().NotBeEmpty();
     }
 
     [Fact]
@@ -44,7 +43,7 @@ public class HelpersTests
 
         bool found = asm.GetCustomAttributesData().Any(a => a.IsCliWorkloadAttribute());
 
-        Assert.True(found);
+        found.Should().BeTrue();
     }
 
     [Fact]
@@ -59,7 +58,7 @@ public class HelpersTests
         IEnumerable<CustomAttributeData> nonWorkloadAttrs = asm.GetCustomAttributesData()
             .Where(a => !a.AttributeType.IsGenericType);
 
-        Assert.All(nonWorkloadAttrs, a => Assert.False(a.IsCliWorkloadAttribute()));
+        nonWorkloadAttrs.Should().AllSatisfy(a => a.IsCliWorkloadAttribute().Should().BeFalse());
     }
 
     [Fact]
@@ -73,6 +72,6 @@ public class HelpersTests
 
         bool found = asm.GetCustomAttributesData().Any(a => a.IsCliWorkloadAttribute());
 
-        Assert.False(found);
+        found.Should().BeFalse();
     }
 }

--- a/test/Workloads/Sdk.Tests/Tasks/ResolveWorkloadCopyLocalTests.cs
+++ b/test/Workloads/Sdk.Tests/Tasks/ResolveWorkloadCopyLocalTests.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Build.Framework;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.Sdk.Tasks.Tests;
 
@@ -22,8 +21,8 @@ public class ResolveWorkloadCopyLocalTests
 
         bool result = task.Execute();
 
-        Assert.True(result);
-        Assert.Equal(2, task.WorkloadCopyLocal.Length);
+        result.Should().BeTrue();
+        task.WorkloadCopyLocal.Length.Should().Be(2);
     }
 
     [Fact]
@@ -41,8 +40,8 @@ public class ResolveWorkloadCopyLocalTests
 
         task.Execute();
 
-        Assert.Single(task.WorkloadCopyLocal);
-        Assert.Contains(task.WorkloadCopyLocal, i => i.ItemSpec == "lib/Keep.dll");
+        task.WorkloadCopyLocal.Should().ContainSingle();
+        task.WorkloadCopyLocal.Should().Contain(i => i.ItemSpec == "lib/Keep.dll");
     }
 
     [Fact]
@@ -62,8 +61,8 @@ public class ResolveWorkloadCopyLocalTests
 
         task.Execute();
 
-        Assert.Single(task.WorkloadCopyLocal);
-        Assert.Contains(task.WorkloadCopyLocal, i => i.ItemSpec == "lib/Keep.dll");
+        task.WorkloadCopyLocal.Should().ContainSingle();
+        task.WorkloadCopyLocal.Should().Contain(i => i.ItemSpec == "lib/Keep.dll");
     }
 
     [Fact]
@@ -80,7 +79,7 @@ public class ResolveWorkloadCopyLocalTests
 
         task.Execute();
 
-        Assert.Empty(task.WorkloadCopyLocal);
+        task.WorkloadCopyLocal.Should().BeEmpty();
     }
 
     [Fact]
@@ -93,7 +92,7 @@ public class ResolveWorkloadCopyLocalTests
 
         task.Execute();
 
-        Assert.Single(task.WorkloadCopyLocal);
+        task.WorkloadCopyLocal.Should().ContainSingle();
         task.WorkloadCopyLocal[0].Received().SetMetadata("TargetPath", "runtimes/win/MyLib.dll");
     }
 
@@ -107,7 +106,7 @@ public class ResolveWorkloadCopyLocalTests
 
         task.Execute();
 
-        Assert.Single(task.WorkloadCopyLocal);
+        task.WorkloadCopyLocal.Should().ContainSingle();
         task.WorkloadCopyLocal[0].Received().SetMetadata("TargetPath", "MyLib.dll");
     }
 
@@ -118,8 +117,8 @@ public class ResolveWorkloadCopyLocalTests
 
         bool result = task.Execute();
 
-        Assert.True(result);
-        Assert.Empty(task.WorkloadCopyLocal);
+        result.Should().BeTrue();
+        task.WorkloadCopyLocal.Should().BeEmpty();
     }
 
     [Fact]
@@ -131,7 +130,7 @@ public class ResolveWorkloadCopyLocalTests
 
         task.Execute();
 
-        Assert.Single(task.WorkloadCopyLocal);
+        task.WorkloadCopyLocal.Should().ContainSingle();
     }
 
     [Fact]
@@ -154,8 +153,8 @@ public class ResolveWorkloadCopyLocalTests
 
         task.Execute();
 
-        Assert.Single(task.WorkloadCopyLocal);
-        Assert.Contains(task.WorkloadCopyLocal, i => i.ItemSpec == "lib/C.dll");
+        task.WorkloadCopyLocal.Should().ContainSingle();
+        task.WorkloadCopyLocal.Should().Contain(i => i.ItemSpec == "lib/C.dll");
     }
 
     private static ResolveWorkloadCopyLocal CreateTask(ITaskItem[] items, ITaskItem[] unifiedItems)

--- a/test/Workloads/Sdk.Tests/Tasks/ResolveWorkloadEntryTests.cs
+++ b/test/Workloads/Sdk.Tests/Tasks/ResolveWorkloadEntryTests.cs
@@ -1,7 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Xunit;
 using NSubstitute;
 using Microsoft.Build.Framework;
 using Azure.Functions.Cli.Workloads.Sdk.Tests;
@@ -22,7 +21,7 @@ public class ResolveWorkloadEntryTests
 
         resolveWorkloadEntry.Execute();
 
-        Assert.Equal("Azure.Functions.Cli.Workloads.DotNet.DotNetWorkload", resolveWorkloadEntry.WorkloadType);
+        resolveWorkloadEntry.WorkloadType.Should().Be("Azure.Functions.Cli.Workloads.DotNet.DotNetWorkload");
     }
 
 
@@ -38,6 +37,6 @@ public class ResolveWorkloadEntryTests
 
         resolveWorkloadEntry.Execute();
 
-        Assert.Empty(resolveWorkloadEntry.WorkloadType);
+        resolveWorkloadEntry.WorkloadType.Should().BeEmpty();
     }
 }

--- a/test/Workloads/Sdk.Tests/Tasks/WriteWorkloadJsonTests.cs
+++ b/test/Workloads/Sdk.Tests/Tasks/WriteWorkloadJsonTests.cs
@@ -4,7 +4,6 @@
 using System.Text.Json;
 using Microsoft.Build.Framework;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.Sdk.Tasks.Tests;
 
@@ -33,14 +32,14 @@ public sealed class WriteWorkloadJsonTests : IDisposable
 
         bool result = task.Execute();
 
-        Assert.True(result);
-        Assert.True(File.Exists(outputPath));
+        result.Should().BeTrue();
+        File.Exists(outputPath).Should().BeTrue();
 
         JsonDocument doc = ParseOutput(outputPath);
-        Assert.Equal("https://example.com/schema.json", doc.RootElement.GetProperty("$schema").GetString());
-        Assert.Equal("content", doc.RootElement.GetProperty("kind").GetString());
-        Assert.False(doc.RootElement.TryGetProperty("entryPoint", out _));
-        Assert.False(doc.RootElement.TryGetProperty("packages", out _));
+        doc.RootElement.GetProperty("$schema").GetString().Should().Be("https://example.com/schema.json");
+        doc.RootElement.GetProperty("kind").GetString().Should().Be("content");
+        doc.RootElement.TryGetProperty("entryPoint", out _).Should().BeFalse();
+        doc.RootElement.TryGetProperty("packages", out _).Should().BeFalse();
     }
 
     [Fact]
@@ -55,13 +54,13 @@ public sealed class WriteWorkloadJsonTests : IDisposable
 
         bool result = task.Execute();
 
-        Assert.True(result);
+        result.Should().BeTrue();
         JsonDocument doc = ParseOutput(outputPath);
-        Assert.Equal("workload", doc.RootElement.GetProperty("kind").GetString());
+        doc.RootElement.GetProperty("kind").GetString().Should().Be("workload");
 
         JsonElement entryPoint = doc.RootElement.GetProperty("entryPoint");
-        Assert.Equal("My.Workload.dll", entryPoint.GetProperty("assemblyPath").GetString());
-        Assert.Equal("My.Namespace.MyWorkload", entryPoint.GetProperty("type").GetString());
+        entryPoint.GetProperty("assemblyPath").GetString().Should().Be("My.Workload.dll");
+        entryPoint.GetProperty("type").GetString().Should().Be("My.Namespace.MyWorkload");
     }
 
     [Fact]
@@ -78,11 +77,11 @@ public sealed class WriteWorkloadJsonTests : IDisposable
 
         bool result = task.Execute();
 
-        Assert.True(result);
+        result.Should().BeTrue();
         JsonDocument doc = ParseOutput(outputPath);
         JsonElement packages = doc.RootElement.GetProperty("packages");
-        Assert.Equal("My.Package.win-x64", packages.GetProperty("win-x64").GetString());
-        Assert.Equal("My.Package.linux-x64", packages.GetProperty("linux-x64").GetString());
+        packages.GetProperty("win-x64").GetString().Should().Be("My.Package.win-x64");
+        packages.GetProperty("linux-x64").GetString().Should().Be("My.Package.linux-x64");
     }
 
     [Fact]
@@ -94,7 +93,7 @@ public sealed class WriteWorkloadJsonTests : IDisposable
         task.Execute();
 
         JsonDocument doc = ParseOutput(outputPath);
-        Assert.False(doc.RootElement.TryGetProperty("entryPoint", out _));
+        doc.RootElement.TryGetProperty("entryPoint", out _).Should().BeFalse();
     }
 
     [Fact]
@@ -107,7 +106,7 @@ public sealed class WriteWorkloadJsonTests : IDisposable
         task.Execute();
 
         JsonDocument doc = ParseOutput(outputPath);
-        Assert.False(doc.RootElement.TryGetProperty("entryPoint", out _));
+        doc.RootElement.TryGetProperty("entryPoint", out _).Should().BeFalse();
     }
 
     [Fact]
@@ -120,7 +119,7 @@ public sealed class WriteWorkloadJsonTests : IDisposable
         task.Execute();
 
         JsonDocument doc = ParseOutput(outputPath);
-        Assert.False(doc.RootElement.TryGetProperty("entryPoint", out _));
+        doc.RootElement.TryGetProperty("entryPoint", out _).Should().BeFalse();
     }
 
     [Fact]
@@ -133,7 +132,7 @@ public sealed class WriteWorkloadJsonTests : IDisposable
         task.Execute();
 
         JsonDocument doc = ParseOutput(outputPath);
-        Assert.False(doc.RootElement.TryGetProperty("packages", out _));
+        doc.RootElement.TryGetProperty("packages", out _).Should().BeFalse();
     }
 
     [Fact]
@@ -145,9 +144,9 @@ public sealed class WriteWorkloadJsonTests : IDisposable
 
         bool result = task.Execute();
 
-        Assert.True(result);
-        Assert.True(Directory.Exists(nestedDir));
-        Assert.True(File.Exists(outputPath));
+        result.Should().BeTrue();
+        Directory.Exists(nestedDir).Should().BeTrue();
+        File.Exists(outputPath).Should().BeTrue();
     }
 
     [Fact]
@@ -166,7 +165,7 @@ public sealed class WriteWorkloadJsonTests : IDisposable
         task2.Execute();
 
         DateTime secondWriteTime = File.GetLastWriteTimeUtc(outputPath);
-        Assert.Equal(firstWriteTime, secondWriteTime);
+        secondWriteTime.Should().Be(firstWriteTime);
     }
 
     [Fact]
@@ -183,7 +182,7 @@ public sealed class WriteWorkloadJsonTests : IDisposable
         task2.Execute();
 
         string contentAfter = File.ReadAllText(outputPath);
-        Assert.NotEqual(contentBefore, contentAfter);
+        contentAfter.Should().NotBe(contentBefore);
     }
 
     [Fact]

--- a/test/Workloads/Stacks/DotNet.Tests/DotNetProjectFactoryTests.cs
+++ b/test/Workloads/Stacks/DotNet.Tests/DotNetProjectFactoryTests.cs
@@ -36,8 +36,8 @@ public class DotNetProjectFactoryTests : IDisposable
     {
         ProjectCreationResult result = await new DotNetProjectFactory(_dotnetCli).TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.NotCreated notCreated = result.Should().BeOfType<ProjectCreationResult.NotCreated>().Subject;
-        notCreated.Reason.Should().Be("no .NET project file or build output found");
+        result.Should().BeOfType<ProjectCreationResult.NotCreated>()
+            .Which.Reason.Should().Be("no .NET project file or build output found");
     }
 
     [Theory]
@@ -67,8 +67,7 @@ public class DotNetProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new DotNetProjectFactory(_dotnetCli).TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
-        created.Reason.Should().Be($"found {fileName}");
+        result.Should().BeOfType<ProjectCreationResult.Created>().Which.Reason.Should().Be($"found {fileName}");
     }
 
     [Fact]
@@ -79,8 +78,8 @@ public class DotNetProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new DotNetProjectFactory(_dotnetCli).TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.NotCreated notCreated = result.Should().BeOfType<ProjectCreationResult.NotCreated>().Subject;
-        notCreated.Reason.Should().Be("multiple .NET project files found; cannot determine which to use");
+        result.Should().BeOfType<ProjectCreationResult.NotCreated>()
+            .Which.Reason.Should().Be("multiple .NET project files found; cannot determine which to use");
     }
 
     [Fact]
@@ -91,8 +90,8 @@ public class DotNetProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new DotNetProjectFactory(_dotnetCli).TryCreateProjectAsync(context, default);
 
-        ProjectCreationResult.NotCreated notCreated = result.Should().BeOfType<ProjectCreationResult.NotCreated>().Subject;
-        notCreated.Reason.Should().Be("directory does not exist");
+        result.Should().BeOfType<ProjectCreationResult.NotCreated>()
+            .Which.Reason.Should().Be("directory does not exist");
     }
 
     [Fact]
@@ -159,8 +158,8 @@ public class DotNetProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new DotNetProjectFactory(_dotnetCli).TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
-        created.Project.Should().BeOfType<DotNetSourceProject>();
+        result.Should().BeOfType<ProjectCreationResult.Created>()
+            .Which.Project.Should().BeOfType<DotNetSourceProject>();
     }
 
     private void WriteFile(string name, string contents)

--- a/test/Workloads/Stacks/DotNet.Tests/DotNetProjectFactoryTests.cs
+++ b/test/Workloads/Stacks/DotNet.Tests/DotNetProjectFactoryTests.cs
@@ -4,7 +4,6 @@
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Projects;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.DotNet.Tests;
 
@@ -37,8 +36,8 @@ public class DotNetProjectFactoryTests : IDisposable
     {
         ProjectCreationResult result = await new DotNetProjectFactory(_dotnetCli).TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.NotCreated notCreated = Assert.IsType<ProjectCreationResult.NotCreated>(result);
-        Assert.Equal("no .NET project file or build output found", notCreated.Reason);
+        ProjectCreationResult.NotCreated notCreated = result.Should().BeOfType<ProjectCreationResult.NotCreated>().Subject;
+        notCreated.Reason.Should().Be("no .NET project file or build output found");
     }
 
     [Theory]
@@ -50,13 +49,13 @@ public class DotNetProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new DotNetProjectFactory(_dotnetCli).TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
-        DotNetSourceProject sourceProject = Assert.IsType<DotNetSourceProject>(created.Project);
-        Assert.Equal($"found {fileName}", created.Reason);
-        Assert.Equal("dotnet", sourceProject.StackName);
-        Assert.Equal(".NET", sourceProject.StackDisplayName);
-        Assert.False(sourceProject.SupportsExtensionBundles);
-        Assert.Equal(Path.Combine(_projectDir.FullName, fileName), sourceProject.ProjectFilePath);
+        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
+        DotNetSourceProject sourceProject = created.Project.Should().BeOfType<DotNetSourceProject>().Subject;
+        created.Reason.Should().Be($"found {fileName}");
+        sourceProject.StackName.Should().Be("dotnet");
+        sourceProject.StackDisplayName.Should().Be(".NET");
+        sourceProject.SupportsExtensionBundles.Should().BeFalse();
+        sourceProject.ProjectFilePath.Should().Be(Path.Combine(_projectDir.FullName, fileName));
     }
 
     [Theory]
@@ -68,8 +67,8 @@ public class DotNetProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new DotNetProjectFactory(_dotnetCli).TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
-        Assert.Equal($"found {fileName}", created.Reason);
+        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
+        created.Reason.Should().Be($"found {fileName}");
     }
 
     [Fact]
@@ -80,8 +79,8 @@ public class DotNetProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new DotNetProjectFactory(_dotnetCli).TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.NotCreated notCreated = Assert.IsType<ProjectCreationResult.NotCreated>(result);
-        Assert.Equal("multiple .NET project files found; cannot determine which to use", notCreated.Reason);
+        ProjectCreationResult.NotCreated notCreated = result.Should().BeOfType<ProjectCreationResult.NotCreated>().Subject;
+        notCreated.Reason.Should().Be("multiple .NET project files found; cannot determine which to use");
     }
 
     [Fact]
@@ -92,15 +91,14 @@ public class DotNetProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new DotNetProjectFactory(_dotnetCli).TryCreateProjectAsync(context, default);
 
-        ProjectCreationResult.NotCreated notCreated = Assert.IsType<ProjectCreationResult.NotCreated>(result);
-        Assert.Equal("directory does not exist", notCreated.Reason);
+        ProjectCreationResult.NotCreated notCreated = result.Should().BeOfType<ProjectCreationResult.NotCreated>().Subject;
+        notCreated.Reason.Should().Be("directory does not exist");
     }
 
     [Fact]
     public async Task NullContext_throws()
     {
-        await Assert.ThrowsAsync<ArgumentNullException>(
-            () => new DotNetProjectFactory(_dotnetCli).TryCreateProjectAsync(null!, default));
+        await FluentActions.Awaiting(() => new DotNetProjectFactory(_dotnetCli).TryCreateProjectAsync(null!, default)).Should().ThrowAsync<ArgumentNullException>();
     }
 
     [Fact]
@@ -111,7 +109,7 @@ public class DotNetProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new DotNetProjectFactory(_dotnetCli).TryCreateProjectAsync(CreateContext(), default);
 
-        Assert.IsType<ProjectCreationResult.NotCreated>(result);
+        result.Should().BeOfType<ProjectCreationResult.NotCreated>();
     }
 
     [Fact]
@@ -123,9 +121,9 @@ public class DotNetProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new DotNetProjectFactory(_dotnetCli).TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
-        Assert.IsType<DotNetOutputProject>(created.Project);
-        Assert.Equal("found .NET build output (host.json, worker.config.json, .azurefunctions)", created.Reason);
+        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
+        created.Project.Should().BeOfType<DotNetOutputProject>();
+        created.Reason.Should().Be("found .NET build output (host.json, worker.config.json, .azurefunctions)");
     }
 
     [Fact]
@@ -136,7 +134,7 @@ public class DotNetProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new DotNetProjectFactory(_dotnetCli).TryCreateProjectAsync(CreateContext(), default);
 
-        Assert.IsType<ProjectCreationResult.NotCreated>(result);
+        result.Should().BeOfType<ProjectCreationResult.NotCreated>();
     }
 
     [Fact]
@@ -147,7 +145,7 @@ public class DotNetProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new DotNetProjectFactory(_dotnetCli).TryCreateProjectAsync(CreateContext(), default);
 
-        Assert.IsType<ProjectCreationResult.NotCreated>(result);
+        result.Should().BeOfType<ProjectCreationResult.NotCreated>();
     }
 
     [Fact]
@@ -161,8 +159,8 @@ public class DotNetProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new DotNetProjectFactory(_dotnetCli).TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
-        Assert.IsType<DotNetSourceProject>(created.Project);
+        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
+        created.Project.Should().BeOfType<DotNetSourceProject>();
     }
 
     private void WriteFile(string name, string contents)

--- a/test/Workloads/Stacks/DotNet.Tests/DotNetProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/DotNet.Tests/DotNetProjectInitializerTests.cs
@@ -4,7 +4,6 @@
 using System.CommandLine;
 using Azure.Functions.Cli.Projects;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.DotNet.Tests;
 
@@ -34,7 +33,7 @@ public class DotNetProjectInitializerTests : IDisposable
     [Fact]
     public void Stack_IsDotNet()
     {
-        Assert.Equal("dotnet", CreateInitializer().Stack);
+        CreateInitializer().Stack.Should().Be("dotnet");
     }
 
     [Fact]
@@ -44,26 +43,26 @@ public class DotNetProjectInitializerTests : IDisposable
         RootCommand root = [];
         IReadOnlyList<Option> options = initializer.GetInitOptions(new InitOptionRegistry(root));
 
-        Assert.Single(options);
-        Assert.Same(initializer.FrameworkOption, options[0]);
+        options.Should().ContainSingle();
+        options[0].Should().BeSameAs(initializer.FrameworkOption);
     }
 
     [Fact]
     public void SupportedLanguages_ReturnsExpectedLanguages()
     {
-        Assert.Equal(["C#", "F#"], CreateInitializer().SupportedLanguages);
+        CreateInitializer().SupportedLanguages.Should().Equal(["C#", "F#"]);
     }
 
     [Fact]
     public void TemplatesPackageName_IsCorrect()
     {
-        Assert.Equal("Microsoft.Azure.Functions.Worker.ProjectTemplates", DotNetProjectInitializer.TemplatesPackageName);
+        DotNetProjectInitializer.TemplatesPackageName.Should().Be("Microsoft.Azure.Functions.Worker.ProjectTemplates");
     }
 
     [Fact]
     public void DefaultFramework_IsNet10()
     {
-        Assert.Equal("net10.0", DotNetProjectInitializer.DefaultFramework);
+        DotNetProjectInitializer.DefaultFramework.Should().Be("net10.0");
     }
 
     [Theory]
@@ -79,19 +78,19 @@ public class DotNetProjectInitializerTests : IDisposable
     [InlineData("unknown", "unknown")]
     public void NormalizeLanguage_ReturnsExpectedResult(string? input, string expected)
     {
-        Assert.Equal(expected, CreateInitializer().NormalizeLanguage(input));
+        CreateInitializer().NormalizeLanguage(input).Should().Be(expected);
     }
 
     [Fact]
     public void Constructor_ThrowsOnNullRunner()
     {
-        Assert.Throws<ArgumentNullException>(() => new DotNetProjectInitializer(null!, _hivePathProvider));
+        FluentActions.Invoking(() => new DotNetProjectInitializer(null!, _hivePathProvider)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
     public void Constructor_ThrowsOnNullHivePathProvider()
     {
-        Assert.Throws<ArgumentNullException>(() => new DotNetProjectInitializer(_dotnetCli, null!));
+        FluentActions.Invoking(() => new DotNetProjectInitializer(_dotnetCli, null!)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]

--- a/test/Workloads/Stacks/DotNet.Tests/DotNetSourceProjectTests.cs
+++ b/test/Workloads/Stacks/DotNet.Tests/DotNetSourceProjectTests.cs
@@ -4,7 +4,6 @@
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Projects;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.DotNet.Tests;
 
@@ -50,7 +49,7 @@ public class DotNetSourceProjectTests : IDisposable
         await project.PrepareForHostRunAsync(context, default);
 
         string expectedDir = Path.GetDirectoryName(assemblyPath)!;
-        Assert.Equal(expectedDir, context.StartupDirectory.FullName.TrimEnd(Path.DirectorySeparatorChar));
+        context.StartupDirectory.FullName.TrimEnd(Path.DirectorySeparatorChar).Should().Be(expectedDir);
     }
 
     [Fact]
@@ -75,12 +74,8 @@ public class DotNetSourceProjectTests : IDisposable
 
         await project.PrepareForHostRunAsync(context, default);
 
-        Assert.Contains(
-            reporter.Logs,
-            entry => entry.Severity == FunctionsProjectReportSeverity.Info && entry.Line == "Build succeeded.");
-        Assert.Contains(
-            reporter.Logs,
-            entry => entry.Severity == FunctionsProjectReportSeverity.Error && entry.Line == "warning XYZ: heads up");
+        reporter.Logs.Should().Contain(entry => entry.Severity == FunctionsProjectReportSeverity.Info && entry.Line == "Build succeeded.");
+        reporter.Logs.Should().Contain(entry => entry.Severity == FunctionsProjectReportSeverity.Error && entry.Line == "warning XYZ: heads up");
     }
 
     [Fact]
@@ -112,7 +107,7 @@ public class DotNetSourceProjectTests : IDisposable
             Arg.Any<CancellationToken>());
 
         string expectedDir = Path.GetDirectoryName(assemblyPath)!;
-        Assert.Equal(expectedDir, context.StartupDirectory.FullName.TrimEnd(Path.DirectorySeparatorChar));
+        context.StartupDirectory.FullName.TrimEnd(Path.DirectorySeparatorChar).Should().Be(expectedDir);
     }
 
     [Fact]
@@ -130,12 +125,11 @@ public class DotNetSourceProjectTests : IDisposable
         DotNetSourceProject project = CreateProject(projectFile);
         FunctionsProjectHostRunContext context = CreateHostRunContext(skipBuild: true);
 
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => project.PrepareForHostRunAsync(context, default));
+        GracefulException ex = (await FluentActions.Awaiting(() => project.PrepareForHostRunAsync(context, default)).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.Contains("--no-build", ex.Message);
-        Assert.Contains("MyApp", ex.Message);
-        Assert.True(ex.IsUserError);
+        ex.Message.Should().Contain("--no-build");
+        ex.Message.Should().Contain("MyApp");
+        ex.IsUserError.Should().BeTrue();
     }
 
     [Fact]
@@ -151,12 +145,11 @@ public class DotNetSourceProjectTests : IDisposable
         DotNetSourceProject project = CreateProject(projectFile);
         FunctionsProjectHostRunContext context = CreateHostRunContext(skipBuild: true);
 
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => project.PrepareForHostRunAsync(context, default));
+        GracefulException ex = (await FluentActions.Awaiting(() => project.PrepareForHostRunAsync(context, default)).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.Contains("dotnet build", ex.Message);
-        Assert.Contains("exit 1", ex.Message);
-        Assert.True(ex.IsUserError);
+        ex.Message.Should().Contain("dotnet build");
+        ex.Message.Should().Contain("exit 1");
+        ex.IsUserError.Should().BeTrue();
     }
 
     [Fact]
@@ -170,11 +163,10 @@ public class DotNetSourceProjectTests : IDisposable
         DotNetSourceProject project = CreateProject(projectFile);
         FunctionsProjectHostRunContext context = CreateHostRunContext();
 
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => project.PrepareForHostRunAsync(context, default));
+        GracefulException ex = (await FluentActions.Awaiting(() => project.PrepareForHostRunAsync(context, default)).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.Contains("output directory", ex.Message);
-        Assert.True(ex.IsUserError);
+        ex.Message.Should().Contain("output directory");
+        ex.IsUserError.Should().BeTrue();
     }
 
     [Fact]
@@ -190,12 +182,11 @@ public class DotNetSourceProjectTests : IDisposable
         DotNetSourceProject project = CreateProject(projectFile);
         FunctionsProjectHostRunContext context = CreateHostRunContext();
 
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => project.PrepareForHostRunAsync(context, default));
+        GracefulException ex = (await FluentActions.Awaiting(() => project.PrepareForHostRunAsync(context, default)).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.Contains("dotnet build", ex.Message);
-        Assert.Contains("exit 1", ex.Message);
-        Assert.True(ex.IsUserError);
+        ex.Message.Should().Contain("dotnet build");
+        ex.Message.Should().Contain("exit 1");
+        ex.IsUserError.Should().BeTrue();
     }
 
     [Fact]
@@ -206,8 +197,7 @@ public class DotNetSourceProjectTests : IDisposable
 
         DotNetSourceProject project = CreateProject(projectFile);
 
-        await Assert.ThrowsAsync<ArgumentNullException>(
-            () => project.PrepareForHostRunAsync(null!, default));
+        await FluentActions.Awaiting(() => project.PrepareForHostRunAsync(null!, default)).Should().ThrowAsync<ArgumentNullException>();
     }
 
     [Fact]
@@ -221,8 +211,7 @@ public class DotNetSourceProjectTests : IDisposable
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(
-            () => project.PrepareForHostRunAsync(context, cts.Token));
+        await FluentActions.Awaiting(() => project.PrepareForHostRunAsync(context, cts.Token)).Should().ThrowAsync<OperationCanceledException>();
     }
 
     [Fact]
@@ -233,12 +222,11 @@ public class DotNetSourceProjectTests : IDisposable
 
         DotNetSourceProject project = CreateProject(projectFile);
 
-        GracefulException ex = Assert.Throws<GracefulException>(
-            () => project.ParseTargetResult("not json at all", "Build"));
+        GracefulException ex = FluentActions.Invoking(() => project.ParseTargetResult("not json at all", "Build")).Should().ThrowExactly<GracefulException>().Which;
 
-        Assert.Contains("not valid JSON", ex.Message);
-        Assert.IsAssignableFrom<System.Text.Json.JsonException>(ex.InnerException);
-        Assert.True(ex.IsUserError);
+        ex.Message.Should().Contain("not valid JSON");
+        ex.InnerException.Should().BeAssignableTo<System.Text.Json.JsonException>();
+        ex.IsUserError.Should().BeTrue();
     }
 
     [Fact]
@@ -259,11 +247,10 @@ public class DotNetSourceProjectTests : IDisposable
             }
             """;
 
-        GracefulException ex = Assert.Throws<GracefulException>(
-            () => project.ParseTargetResult(json, "Build"));
+        GracefulException ex = FluentActions.Invoking(() => project.ParseTargetResult(json, "Build")).Should().ThrowExactly<GracefulException>().Which;
 
-        Assert.Contains("output directory", ex.Message);
-        Assert.True(ex.IsUserError);
+        ex.Message.Should().Contain("output directory");
+        ex.IsUserError.Should().BeTrue();
     }
 
     [Theory]
@@ -275,7 +262,7 @@ public class DotNetSourceProjectTests : IDisposable
         string projectFile = Path.Combine(_projectDir.FullName, projectFileName);
         DotNetSourceProject project = CreateProject(projectFile);
 
-        Assert.Equal(expectedLanguage, project.Language);
+        project.Language.Should().Be(expectedLanguage);
     }
 
     private DotNetSourceProject CreateProject(string projectFile)

--- a/test/Workloads/Stacks/DotNet.Tests/DotNetWorkloadTests.cs
+++ b/test/Workloads/Stacks/DotNet.Tests/DotNetWorkloadTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Projects;
-using Azure.Functions.Cli.Workloads;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.DotNet.Tests;
 
@@ -18,7 +16,7 @@ public class DotNetWorkloadTests
         var workload = new DotNetWorkload();
 
         // Act & Assert
-        Assert.Equal(".NET Stack", workload.DisplayName);
+        workload.DisplayName.Should().Be(".NET Stack");
     }
 
     [Fact]
@@ -28,7 +26,7 @@ public class DotNetWorkloadTests
         var workload = new DotNetWorkload();
 
         // Act & Assert
-        Assert.Equal("Azure Functions CLI tooling for .NET (C#) projects.", workload.Description);
+        workload.Description.Should().Be("Azure Functions CLI tooling for .NET (C#) projects.");
     }
 
     [Fact]
@@ -42,15 +40,15 @@ public class DotNetWorkloadTests
 
         ServiceProvider provider = services.BuildServiceProvider();
         IProjectInitializer initializer = provider.GetRequiredService<IProjectInitializer>();
-        Assert.IsType<DotNetProjectInitializer>(initializer);
-        Assert.Equal("dotnet", initializer.Stack);
-        Assert.Equal(["C#", "F#"], initializer.SupportedLanguages);
+        initializer.Should().BeOfType<DotNetProjectInitializer>();
+        initializer.Stack.Should().Be("dotnet");
+        initializer.SupportedLanguages.Should().Equal(["C#", "F#"]);
     }
 
     [Fact]
     public void Configure_NullBuilder_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => new DotNetWorkload().Configure(null!));
+        FluentActions.Invoking(() => new DotNetWorkload().Configure(null!)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]

--- a/test/Workloads/Stacks/Go.Tests/GoFunctionsProjectTests.cs
+++ b/test/Workloads/Stacks/Go.Tests/GoFunctionsProjectTests.cs
@@ -3,7 +3,6 @@
 
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Projects;
-using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.Go.Tests;
 
@@ -48,11 +47,11 @@ public class GoFunctionsProjectTests : IDisposable
         await project.PrepareForHostRunAsync(context, default);
 
         string expectedName = OperatingSystem.IsWindows() ? "app.exe" : "app";
-        Assert.Equal(_projectDir.FullName, observedRoot);
-        Assert.Equal(Path.Combine(_projectDir.FullName, "bin", expectedName), observedOutput);
+        observedRoot.Should().Be(_projectDir.FullName);
+        observedOutput.Should().Be(Path.Combine(_projectDir.FullName, "bin", expectedName));
         // StartupDirectory must remain the project root so the host finds host.json
         // and the worker's `defaultExecutablePath = bin/app` resolves correctly.
-        Assert.Equal(_projectDir.FullName, context.StartupDirectory.FullName);
+        context.StartupDirectory.FullName.Should().Be(_projectDir.FullName);
     }
 
     [Fact]
@@ -72,8 +71,8 @@ public class GoFunctionsProjectTests : IDisposable
 
         await project.PrepareForHostRunAsync(context, default);
 
-        Assert.Contains(reporter.Logs, e => e.Severity == FunctionsProjectReportSeverity.Info && e.Line == "compiling example.com/myapp");
-        Assert.Contains(reporter.Logs, e => e.Severity == FunctionsProjectReportSeverity.Error && e.Line == "go: warning");
+        reporter.Logs.Should().Contain(e => e.Severity == FunctionsProjectReportSeverity.Info && e.Line == "compiling example.com/myapp");
+        reporter.Logs.Should().Contain(e => e.Severity == FunctionsProjectReportSeverity.Error && e.Line == "go: warning");
     }
 
     [Fact]
@@ -88,13 +87,12 @@ public class GoFunctionsProjectTests : IDisposable
         FunctionsProjectHostRunContext context = CreateContext();
         context.Reporter = reporter;
 
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => project.PrepareForHostRunAsync(context, default));
+        GracefulException ex = (await FluentActions.Awaiting(() => project.PrepareForHostRunAsync(context, default)).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.True(ex.IsUserError);
-        Assert.Contains("go build", ex.Message);
-        Assert.Contains("exit 1", ex.Message);
-        Assert.Contains(reporter.Logs, e => e.Severity == FunctionsProjectReportSeverity.Error && e.Line == "compile error");
+        ex.IsUserError.Should().BeTrue();
+        ex.Message.Should().Contain("go build");
+        ex.Message.Should().Contain("exit 1");
+        reporter.Logs.Should().Contain(e => e.Severity == FunctionsProjectReportSeverity.Error && e.Line == "compile error");
     }
 
     [Fact]
@@ -110,8 +108,8 @@ public class GoFunctionsProjectTests : IDisposable
         FunctionsProjectHostRunContext context = CreateContext(skipBuild: true);
         await project.PrepareForHostRunAsync(context, default);
 
-        Assert.False(invoked);
-        Assert.Equal(_projectDir.FullName, context.StartupDirectory.FullName);
+        invoked.Should().BeFalse();
+        context.StartupDirectory.FullName.Should().Be(_projectDir.FullName);
     }
 
     [Fact]
@@ -120,11 +118,10 @@ public class GoFunctionsProjectTests : IDisposable
         GoFunctionsProject project = CreateProject((_, _, _, _, _) => Task.FromResult(0));
         project.ReadGoVersion = _ => Task.FromResult<(int, int)?>(null);
 
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => project.PrepareForHostRunAsync(CreateContext(), default));
+        GracefulException ex = (await FluentActions.Awaiting(() => project.PrepareForHostRunAsync(CreateContext(), default)).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.True(ex.IsUserError);
-        Assert.Contains("Could not find a Go installation", ex.Message);
+        ex.IsUserError.Should().BeTrue();
+        ex.Message.Should().Contain("Could not find a Go installation");
     }
 
     [Fact]
@@ -133,11 +130,10 @@ public class GoFunctionsProjectTests : IDisposable
         GoFunctionsProject project = CreateProject((_, _, _, _, _) => Task.FromResult(0));
         project.ReadGoVersion = _ => Task.FromResult<(int, int)?>((1, 21));
 
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => project.PrepareForHostRunAsync(CreateContext(), default));
+        GracefulException ex = (await FluentActions.Awaiting(() => project.PrepareForHostRunAsync(CreateContext(), default)).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.True(ex.IsUserError);
-        Assert.Contains("Go 1.21 is not supported", ex.Message);
+        ex.IsUserError.Should().BeTrue();
+        ex.Message.Should().Contain("Go 1.21 is not supported");
     }
 
     [Fact]
@@ -159,9 +155,9 @@ public class GoFunctionsProjectTests : IDisposable
 
         await project.PrepareForHostRunAsync(CreateContext(), default);
 
-        Assert.Equal(2, calls.Count);
-        Assert.Equal($"tidy:{_projectDir.FullName}", calls[0]);
-        Assert.Equal("build", calls[1]);
+        calls.Count.Should().Be(2);
+        calls[0].Should().Be($"tidy:{_projectDir.FullName}");
+        calls[1].Should().Be("build");
     }
 
     [Fact]
@@ -177,13 +173,12 @@ public class GoFunctionsProjectTests : IDisposable
         FunctionsProjectHostRunContext context = CreateContext();
         context.Reporter = reporter;
 
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => project.PrepareForHostRunAsync(context, default));
+        GracefulException ex = (await FluentActions.Awaiting(() => project.PrepareForHostRunAsync(context, default)).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.True(ex.IsUserError);
-        Assert.Contains("go mod tidy", ex.Message);
-        Assert.Contains("exit 1", ex.Message);
-        Assert.Contains(reporter.Logs, e => e.Severity == FunctionsProjectReportSeverity.Error && e.Line == "module not found");
+        ex.IsUserError.Should().BeTrue();
+        ex.Message.Should().Contain("go mod tidy");
+        ex.Message.Should().Contain("exit 1");
+        reporter.Logs.Should().Contain(e => e.Severity == FunctionsProjectReportSeverity.Error && e.Line == "module not found");
     }
 
     [Fact]
@@ -199,7 +194,7 @@ public class GoFunctionsProjectTests : IDisposable
 
         await project.PrepareForHostRunAsync(CreateContext(skipBuild: true), default);
 
-        Assert.False(tidyInvoked);
+        tidyInvoked.Should().BeFalse();
     }
 
     private GoFunctionsProject CreateProject(Func<string, string, Action<string>, Action<string>, CancellationToken, Task<int>> runner)

--- a/test/Workloads/Stacks/Go.Tests/GoProjectFactoryTests.cs
+++ b/test/Workloads/Stacks/Go.Tests/GoProjectFactoryTests.cs
@@ -5,7 +5,6 @@ using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Workers;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.Go.Tests;
 
@@ -40,8 +39,8 @@ public class GoProjectFactoryTests : IDisposable
     {
         ProjectCreationResult result = await new GoProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.NotCreated notCreated = Assert.IsType<ProjectCreationResult.NotCreated>(result);
-        Assert.Equal("no Go project fingerprint found", notCreated.Reason);
+        ProjectCreationResult.NotCreated notCreated = result.Should().BeOfType<ProjectCreationResult.NotCreated>().Subject;
+        notCreated.Reason.Should().Be("no Go project fingerprint found");
     }
 
     [Theory]
@@ -53,7 +52,7 @@ public class GoProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new GoProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        Assert.IsType<ProjectCreationResult.Created>(result);
+        result.Should().BeOfType<ProjectCreationResult.Created>();
     }
 
     [Fact]
@@ -64,7 +63,7 @@ public class GoProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new GoProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        Assert.IsType<ProjectCreationResult.NotCreated>(result);
+        result.Should().BeOfType<ProjectCreationResult.NotCreated>();
     }
 
     [Fact]
@@ -75,7 +74,7 @@ public class GoProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new GoProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        Assert.IsType<ProjectCreationResult.NotCreated>(result);
+        result.Should().BeOfType<ProjectCreationResult.NotCreated>();
     }
 
     [Theory]
@@ -88,12 +87,12 @@ public class GoProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new GoProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
-        Assert.Equal("go", created.Project.StackName);
-        Assert.Equal("Go", created.Project.StackDisplayName);
+        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
+        created.Project.StackName.Should().Be("go");
+        created.Project.StackDisplayName.Should().Be("Go");
         IFunctionsWorker worker = await ResolveWorkerAsync(created.Project);
-        Assert.Equal("native", worker.WorkerRuntime);
-        Assert.NotNull(created.Reason);
+        worker.WorkerRuntime.Should().Be("native");
+        created.Reason.Should().NotBeNull();
     }
 
     [Fact]
@@ -105,8 +104,8 @@ public class GoProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new GoProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
-        Assert.Equal("found go.mod", created.Reason);
+        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
+        created.Reason.Should().Be("found go.mod");
     }
 
     [Fact]
@@ -116,7 +115,7 @@ public class GoProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new GoProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        Assert.IsType<ProjectCreationResult.NotCreated>(result);
+        result.Should().BeOfType<ProjectCreationResult.NotCreated>();
     }
 
     [Fact]
@@ -131,19 +130,18 @@ public class GoProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new GoProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
+        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
         FunctionsWorkerResolutionResult workerResult = await created.Project.WorkerReference.ResolveWorkerAsync(
             new FunctionsWorkerResolutionContext(_workerResolver),
             default);
-        FunctionsWorkerResolutionResult.NotResolved notResolved = Assert.IsType<FunctionsWorkerResolutionResult.NotResolved>(workerResult);
-        Assert.Same(failure, notResolved.Failure);
+        FunctionsWorkerResolutionResult.NotResolved notResolved = workerResult.Should().BeOfType<FunctionsWorkerResolutionResult.NotResolved>().Subject;
+        notResolved.Failure.Should().BeSameAs(failure);
     }
 
     [Fact]
     public async Task NullContext_throws()
     {
-        await Assert.ThrowsAsync<ArgumentNullException>(
-            () => new GoProjectFactory().TryCreateProjectAsync(null!, default));
+        await FluentActions.Awaiting(() => new GoProjectFactory().TryCreateProjectAsync(null!, default)).Should().ThrowAsync<ArgumentNullException>();
     }
 
     private void WriteFile(string name, string contents)
@@ -157,7 +155,7 @@ public class GoProjectFactoryTests : IDisposable
         FunctionsWorkerResolutionResult result = await project.WorkerReference.ResolveWorkerAsync(
             new FunctionsWorkerResolutionContext(_workerResolver),
             default);
-        FunctionsWorkerResolutionResult.Resolved resolved = Assert.IsType<FunctionsWorkerResolutionResult.Resolved>(result);
+        FunctionsWorkerResolutionResult.Resolved resolved = result.Should().BeOfType<FunctionsWorkerResolutionResult.Resolved>().Subject;
         return resolved.Worker;
     }
 

--- a/test/Workloads/Stacks/Go.Tests/GoProjectFactoryTests.cs
+++ b/test/Workloads/Stacks/Go.Tests/GoProjectFactoryTests.cs
@@ -39,8 +39,8 @@ public class GoProjectFactoryTests : IDisposable
     {
         ProjectCreationResult result = await new GoProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.NotCreated notCreated = result.Should().BeOfType<ProjectCreationResult.NotCreated>().Subject;
-        notCreated.Reason.Should().Be("no Go project fingerprint found");
+        result.Should().BeOfType<ProjectCreationResult.NotCreated>()
+            .Which.Reason.Should().Be("no Go project fingerprint found");
     }
 
     [Theory]
@@ -104,8 +104,7 @@ public class GoProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new GoProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
-        created.Reason.Should().Be("found go.mod");
+        result.Should().BeOfType<ProjectCreationResult.Created>().Which.Reason.Should().Be("found go.mod");
     }
 
     [Fact]
@@ -134,8 +133,8 @@ public class GoProjectFactoryTests : IDisposable
         FunctionsWorkerResolutionResult workerResult = await created.Project.WorkerReference.ResolveWorkerAsync(
             new FunctionsWorkerResolutionContext(_workerResolver),
             default);
-        FunctionsWorkerResolutionResult.NotResolved notResolved = workerResult.Should().BeOfType<FunctionsWorkerResolutionResult.NotResolved>().Subject;
-        notResolved.Failure.Should().BeSameAs(failure);
+        workerResult.Should().BeOfType<FunctionsWorkerResolutionResult.NotResolved>()
+            .Which.Failure.Should().BeSameAs(failure);
     }
 
     [Fact]

--- a/test/Workloads/Stacks/Go.Tests/GoProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/Go.Tests/GoProjectInitializerTests.cs
@@ -7,7 +7,6 @@ using System.Text.Json.Nodes;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Commands;
 using Azure.Functions.Cli.Projects;
-using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.Go.Tests;
 
@@ -38,7 +37,7 @@ public class GoProjectInitializerTests : IDisposable
     [Fact]
     public void Stack_IsGo()
     {
-        Assert.Equal("go", new GoProjectInitializer().Stack);
+        new GoProjectInitializer().Stack.Should().Be("go");
     }
 
     [Fact]
@@ -48,9 +47,9 @@ public class GoProjectInitializerTests : IDisposable
         IReadOnlyList<Option> options = new GoProjectInitializer().GetInitOptions(new InitOptionRegistry(root));
         IReadOnlyList<string> names = [.. options.Select(o => o.Name)];
 
-        Assert.Contains("--skip-go-mod-tidy", names);
-        Assert.Contains("--no-bundles", names);
-        Assert.Contains("--bundles-channel", names);
+        names.Should().Contain("--skip-go-mod-tidy");
+        names.Should().Contain("--no-bundles");
+        names.Should().Contain("--bundles-channel");
     }
 
     [Fact]
@@ -59,20 +58,20 @@ public class GoProjectInitializerTests : IDisposable
         await RunAsync(projectName: "my-go-app", force: false);
 
         string goMod = File.ReadAllText(Path.Combine(_projectDir.FullName, "go.mod"));
-        Assert.Contains("module my-go-app", goMod);
-        Assert.Contains("go 1.24", goMod);
+        goMod.Should().Contain("module my-go-app");
+        goMod.Should().Contain("go 1.24");
         // go.mod intentionally omits a `require` line; `go mod tidy` resolves it from main.go imports.
-        Assert.DoesNotContain("require", goMod);
+        goMod.Should().NotContain("require");
 
         string mainGo = File.ReadAllText(Path.Combine(_projectDir.FullName, "main.go"));
-        Assert.Contains("github.com/azure/azure-functions-golang-worker/sdk", mainGo);
-        Assert.Contains("worker.Start", mainGo);
+        mainGo.Should().Contain("github.com/azure/azure-functions-golang-worker/sdk");
+        mainGo.Should().Contain("worker.Start");
 
-        Assert.True(File.Exists(Path.Combine(_projectDir.FullName, ".funcignore")));
-        Assert.True(File.Exists(Path.Combine(_projectDir.FullName, ".gitignore")));
+        File.Exists(Path.Combine(_projectDir.FullName, ".funcignore")).Should().BeTrue();
+        File.Exists(Path.Combine(_projectDir.FullName, ".gitignore")).Should().BeTrue();
 
         using var settings = JsonDocument.Parse(File.ReadAllText(Path.Combine(_projectDir.FullName, "local.settings.json")));
-        Assert.Equal("native", settings.RootElement.GetProperty("Values").GetProperty("FUNCTIONS_WORKER_RUNTIME").GetString());
+        settings.RootElement.GetProperty("Values").GetProperty("FUNCTIONS_WORKER_RUNTIME").GetString().Should().Be("native");
     }
 
     [Fact]
@@ -81,7 +80,7 @@ public class GoProjectInitializerTests : IDisposable
         await RunAsync(projectName: null, force: false);
 
         string goMod = File.ReadAllText(Path.Combine(_projectDir.FullName, "go.mod"));
-        Assert.Matches(@"^module \S+", goMod);
+        goMod.Should().MatchRegex(@"^module \S+");
     }
 
     [Fact]
@@ -92,12 +91,12 @@ public class GoProjectInitializerTests : IDisposable
         await RunAsync(projectName: "my-go-app", force: false);
 
         var root = JsonNode.Parse(File.ReadAllText(Path.Combine(_projectDir.FullName, "host.json")));
-        Assert.NotNull(root);
-        Assert.Equal("2.0", root!["version"]!.GetValue<string>());
+        root.Should().NotBeNull();
+        root!["version"]!.GetValue<string>().Should().Be("2.0");
         JsonNode? bundle = root["extensionBundle"];
-        Assert.NotNull(bundle);
-        Assert.Equal("Microsoft.Azure.Functions.ExtensionBundle", bundle!["id"]!.GetValue<string>());
-        Assert.Equal("[4.*, 5.0.0)", bundle["version"]!.GetValue<string>());
+        bundle.Should().NotBeNull();
+        bundle!["id"]!.GetValue<string>().Should().Be("Microsoft.Azure.Functions.ExtensionBundle");
+        bundle["version"]!.GetValue<string>().Should().Be("[4.*, 5.0.0)");
     }
 
     [Fact]
@@ -109,7 +108,7 @@ public class GoProjectInitializerTests : IDisposable
         await RunAsync(projectName: "my-go-app", force: false);
 
         JsonNode? bundle = JsonNode.Parse(File.ReadAllText(Path.Combine(_projectDir.FullName, "host.json")))!["extensionBundle"];
-        Assert.Equal("custom", bundle!["id"]!.GetValue<string>());
+        bundle!["id"]!.GetValue<string>().Should().Be("custom");
     }
 
     [Fact]
@@ -118,9 +117,7 @@ public class GoProjectInitializerTests : IDisposable
         await RunAsync(projectName: "my-go-app", force: false);
 
         var root = JsonNode.Parse(File.ReadAllText(Path.Combine(_projectDir.FullName, "host.json")));
-        Assert.Equal(
-            "Microsoft.Azure.Functions.ExtensionBundle",
-            root!["extensionBundle"]!["id"]!.GetValue<string>());
+        root!["extensionBundle"]!["id"]!.GetValue<string>().Should().Be("Microsoft.Azure.Functions.ExtensionBundle");
     }
 
     [Fact]
@@ -129,9 +126,7 @@ public class GoProjectInitializerTests : IDisposable
         await RunAsync(projectName: "my-go-app", force: false, args: ["--bundles-channel", "Preview"]);
 
         var root = JsonNode.Parse(File.ReadAllText(Path.Combine(_projectDir.FullName, "host.json")));
-        Assert.Equal(
-            "Microsoft.Azure.Functions.ExtensionBundle.Preview",
-            root!["extensionBundle"]!["id"]!.GetValue<string>());
+        root!["extensionBundle"]!["id"]!.GetValue<string>().Should().Be("Microsoft.Azure.Functions.ExtensionBundle.Preview");
     }
 
     [Fact]
@@ -140,9 +135,7 @@ public class GoProjectInitializerTests : IDisposable
         await RunAsync(projectName: "my-go-app", force: false, args: ["--bundles-channel", "Experimental"]);
 
         var root = JsonNode.Parse(File.ReadAllText(Path.Combine(_projectDir.FullName, "host.json")));
-        Assert.Equal(
-            "Microsoft.Azure.Functions.ExtensionBundle.Experimental",
-            root!["extensionBundle"]!["id"]!.GetValue<string>());
+        root!["extensionBundle"]!["id"]!.GetValue<string>().Should().Be("Microsoft.Azure.Functions.ExtensionBundle.Experimental");
     }
 
     [Fact]
@@ -151,10 +144,10 @@ public class GoProjectInitializerTests : IDisposable
         await RunAsync(projectName: "my-go-app", force: false, args: ["--no-bundles"]);
 
         string hostJsonPath = Path.Combine(_projectDir.FullName, "host.json");
-        Assert.True(File.Exists(hostJsonPath), "host.json should be created even with --no-bundles");
+        File.Exists(hostJsonPath).Should().BeTrue("host.json should be created even with --no-bundles");
         string content = File.ReadAllText(hostJsonPath);
-        Assert.Contains("\"version\"", content);
-        Assert.DoesNotContain("extensionBundle", content);
+        content.Should().Contain("\"version\"");
+        content.Should().NotContain("extensionBundle");
     }
 
     [Fact]
@@ -166,7 +159,7 @@ public class GoProjectInitializerTests : IDisposable
 
         await RunAsync(projectName: "my-go-app", force: false);
 
-        Assert.Equal(userEdit, File.ReadAllText(Path.Combine(_projectDir.FullName, "main.go")));
+        File.ReadAllText(Path.Combine(_projectDir.FullName, "main.go")).Should().Be(userEdit);
     }
 
     [Fact]
@@ -177,7 +170,7 @@ public class GoProjectInitializerTests : IDisposable
 
         await RunAsync(projectName: "my-go-app", force: true);
 
-        Assert.Contains("worker.Start", File.ReadAllText(Path.Combine(_projectDir.FullName, "main.go")));
+        File.ReadAllText(Path.Combine(_projectDir.FullName, "main.go")).Should().Contain("worker.Start");
     }
 
     [Fact]
@@ -196,7 +189,7 @@ public class GoProjectInitializerTests : IDisposable
         initializer.GetInitOptions(new InitOptionRegistry(root));
 
         await initializer.InitializeAsync(context, root.Parse("--skip-go-mod-tidy"));
-        Assert.Equal(0, calls);
+        calls.Should().Be(0);
     }
 
     [Fact]
@@ -215,7 +208,7 @@ public class GoProjectInitializerTests : IDisposable
         initializer.GetInitOptions(new InitOptionRegistry(root));
 
         await initializer.InitializeAsync(context, root.Parse(string.Empty));
-        Assert.Equal(1, calls);
+        calls.Should().Be(1);
     }
 
     private Task RunAsync(string? projectName, bool force, string[]? args = null)

--- a/test/Workloads/Stacks/Go.Tests/GoWorkloadTests.cs
+++ b/test/Workloads/Stacks/Go.Tests/GoWorkloadTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Projects;
-using Azure.Functions.Cli.Workloads;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.Go.Tests;
 
@@ -22,15 +20,15 @@ public class GoWorkloadTests
 
         ServiceProvider provider = services.BuildServiceProvider();
         IProjectInitializer initializer = provider.GetRequiredService<IProjectInitializer>();
-        Assert.IsType<GoProjectInitializer>(initializer);
-        Assert.Equal("go", initializer.Stack);
-        Assert.Equal("Go", Assert.Single(initializer.SupportedLanguages));
+        initializer.Should().BeOfType<GoProjectInitializer>();
+        initializer.Stack.Should().Be("go");
+        initializer.SupportedLanguages.Should().ContainSingle().Subject.Should().Be("Go");
     }
 
     [Fact]
     public void Configure_NullBuilder_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => new GoWorkload().Configure(null!));
+        FluentActions.Invoking(() => new GoWorkload().Configure(null!)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]

--- a/test/Workloads/Stacks/Node.Tests/NodeFunctionsProjectTests.cs
+++ b/test/Workloads/Stacks/Node.Tests/NodeFunctionsProjectTests.cs
@@ -3,7 +3,6 @@
 
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Projects;
-using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.Node.Tests;
 
@@ -42,7 +41,7 @@ public class NodeFunctionsProjectTests : IDisposable
 
         await project.PrepareForHostRunAsync(CreateContext(), default);
 
-        Assert.False(invoked);
+        invoked.Should().BeFalse();
     }
 
     [Fact]
@@ -58,8 +57,8 @@ public class NodeFunctionsProjectTests : IDisposable
 
         await project.PrepareForHostRunAsync(CreateContext(), default);
 
-        Assert.Single(commands);
-        Assert.Equal(new[] { "install" }, commands[0]);
+        commands.Should().ContainSingle();
+        commands[0].Should().Equal(["install"]);
     }
 
     [Fact]
@@ -76,7 +75,7 @@ public class NodeFunctionsProjectTests : IDisposable
 
         await project.PrepareForHostRunAsync(CreateContext(), default);
 
-        Assert.Empty(commands);
+        commands.Should().BeEmpty();
     }
 
     [Fact]
@@ -93,8 +92,8 @@ public class NodeFunctionsProjectTests : IDisposable
 
         await project.PrepareForHostRunAsync(CreateContext(), default);
 
-        Assert.Single(commands);
-        Assert.Equal(new[] { "run", "build" }, commands[0]);
+        commands.Should().ContainSingle();
+        commands[0].Should().Equal(["run", "build"]);
     }
 
     [Fact]
@@ -113,8 +112,8 @@ public class NodeFunctionsProjectTests : IDisposable
 
         await project.PrepareForHostRunAsync(context, default);
 
-        Assert.Contains(reporter.Logs, e => e.Severity == FunctionsProjectReportSeverity.Info && e.Line == "added 42 packages");
-        Assert.Contains(reporter.Logs, e => e.Severity == FunctionsProjectReportSeverity.Error && e.Line == "npm warn deprecated");
+        reporter.Logs.Should().Contain(e => e.Severity == FunctionsProjectReportSeverity.Info && e.Line == "added 42 packages");
+        reporter.Logs.Should().Contain(e => e.Severity == FunctionsProjectReportSeverity.Error && e.Line == "npm warn deprecated");
     }
 
     [Fact]
@@ -130,13 +129,12 @@ public class NodeFunctionsProjectTests : IDisposable
         FunctionsProjectHostRunContext context = CreateContext();
         context.Reporter = reporter;
 
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => project.PrepareForHostRunAsync(context, default));
+        GracefulException ex = (await FluentActions.Awaiting(() => project.PrepareForHostRunAsync(context, default)).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.True(ex.IsUserError);
-        Assert.Contains("install", ex.Message);
-        Assert.Contains("exit 1", ex.Message);
-        Assert.Contains(reporter.Logs, e => e.Severity == FunctionsProjectReportSeverity.Error && e.Line == "ENOENT");
+        ex.IsUserError.Should().BeTrue();
+        ex.Message.Should().Contain("install");
+        ex.Message.Should().Contain("exit 1");
+        reporter.Logs.Should().Contain(e => e.Severity == FunctionsProjectReportSeverity.Error && e.Line == "ENOENT");
     }
 
     [Fact]
@@ -153,7 +151,7 @@ public class NodeFunctionsProjectTests : IDisposable
 
         await project.PrepareForHostRunAsync(CreateContext(skipBuild: true), default);
 
-        Assert.Empty(commands);
+        commands.Should().BeEmpty();
     }
 
     [Fact]
@@ -169,8 +167,8 @@ public class NodeFunctionsProjectTests : IDisposable
 
         await project.PrepareForHostRunAsync(CreateContext(skipBuild: true), default);
 
-        Assert.Single(commands);
-        Assert.Equal(new[] { "install" }, commands[0]);
+        commands.Should().ContainSingle();
+        commands[0].Should().Equal(["install"]);
     }
 
     [Fact]
@@ -179,8 +177,8 @@ public class NodeFunctionsProjectTests : IDisposable
         var ts = new NodeFunctionsProject(WorkingDirectory.FromExplicit(_projectDir.FullName), "TypeScript");
         var js = new NodeFunctionsProject(WorkingDirectory.FromExplicit(_projectDir.FullName), "JavaScript");
 
-        Assert.Equal("TypeScript", ts.Language);
-        Assert.Equal("JavaScript", js.Language);
+        ts.Language.Should().Be("TypeScript");
+        js.Language.Should().Be("JavaScript");
     }
 
     private NodeFunctionsProject CreateProject(Func<string, IReadOnlyList<string>, Action<string>, Action<string>, CancellationToken, Task<int>> runner)

--- a/test/Workloads/Stacks/Node.Tests/NodeProjectFactoryTests.cs
+++ b/test/Workloads/Stacks/Node.Tests/NodeProjectFactoryTests.cs
@@ -5,7 +5,6 @@ using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Workers;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.Node.Tests;
 
@@ -40,8 +39,8 @@ public class NodeProjectFactoryTests : IDisposable
     {
         ProjectCreationResult result = await new NodeProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.NotCreated notCreated = Assert.IsType<ProjectCreationResult.NotCreated>(result);
-        Assert.Equal("no Node project fingerprint found", notCreated.Reason);
+        ProjectCreationResult.NotCreated notCreated = result.Should().BeOfType<ProjectCreationResult.NotCreated>().Subject;
+        notCreated.Reason.Should().Be("no Node project fingerprint found");
     }
 
     [Theory]
@@ -55,7 +54,7 @@ public class NodeProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new NodeProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        Assert.IsType<ProjectCreationResult.Created>(result);
+        result.Should().BeOfType<ProjectCreationResult.Created>();
     }
 
     [Fact]
@@ -66,7 +65,7 @@ public class NodeProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new NodeProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        Assert.IsType<ProjectCreationResult.NotCreated>(result);
+        result.Should().BeOfType<ProjectCreationResult.NotCreated>();
     }
 
     [Fact]
@@ -77,7 +76,7 @@ public class NodeProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new NodeProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        Assert.IsType<ProjectCreationResult.NotCreated>(result);
+        result.Should().BeOfType<ProjectCreationResult.NotCreated>();
     }
 
     [Theory]
@@ -94,12 +93,12 @@ public class NodeProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new NodeProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
-        Assert.Equal("node", created.Project.StackName);
-        Assert.Equal("Node.js", created.Project.StackDisplayName);
+        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
+        created.Project.StackName.Should().Be("node");
+        created.Project.StackDisplayName.Should().Be("Node.js");
         IFunctionsWorker worker = await ResolveWorkerAsync(created.Project);
-        Assert.Equal("node", worker.WorkerRuntime);
-        Assert.NotNull(created.Reason);
+        worker.WorkerRuntime.Should().Be("node");
+        created.Reason.Should().NotBeNull();
     }
 
     [Theory]
@@ -116,8 +115,8 @@ public class NodeProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new NodeProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
-        Assert.Equal(expectedLanguage, created.Project.Language);
+        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
+        created.Project.Language.Should().Be(expectedLanguage);
     }
 
     [Fact]
@@ -129,8 +128,8 @@ public class NodeProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new NodeProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
-        Assert.Equal("TypeScript", created.Project.Language);
+        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
+        created.Project.Language.Should().Be("TypeScript");
     }
 
     [Fact]
@@ -141,8 +140,8 @@ public class NodeProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new NodeProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
-        Assert.Equal("package.json declares @azure/functions", created.Reason);
+        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
+        created.Reason.Should().Be("package.json declares @azure/functions");
     }
 
     [Fact]
@@ -153,8 +152,8 @@ public class NodeProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new NodeProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
-        Assert.Equal("package.json declares @azure/functions", created.Reason);
+        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
+        created.Reason.Should().Be("package.json declares @azure/functions");
     }
 
     [Fact]
@@ -165,8 +164,8 @@ public class NodeProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new NodeProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
-        Assert.Equal("found package.json", created.Reason);
+        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
+        created.Reason.Should().Be("found package.json");
     }
 
     [Fact]
@@ -177,8 +176,8 @@ public class NodeProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new NodeProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
-        Assert.Equal("found package.json", created.Reason);
+        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
+        created.Reason.Should().Be("found package.json");
     }
 
     [Fact]
@@ -188,7 +187,7 @@ public class NodeProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new NodeProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        Assert.IsType<ProjectCreationResult.NotCreated>(result);
+        result.Should().BeOfType<ProjectCreationResult.NotCreated>();
     }
 
     [Fact]
@@ -203,19 +202,18 @@ public class NodeProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new NodeProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
+        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
         FunctionsWorkerResolutionResult workerResult = await created.Project.WorkerReference.ResolveWorkerAsync(
             new FunctionsWorkerResolutionContext(_workerResolver),
             default);
-        FunctionsWorkerResolutionResult.NotResolved notResolved = Assert.IsType<FunctionsWorkerResolutionResult.NotResolved>(workerResult);
-        Assert.Same(failure, notResolved.Failure);
+        FunctionsWorkerResolutionResult.NotResolved notResolved = workerResult.Should().BeOfType<FunctionsWorkerResolutionResult.NotResolved>().Subject;
+        notResolved.Failure.Should().BeSameAs(failure);
     }
 
     [Fact]
     public async Task NullContext_throws()
     {
-        await Assert.ThrowsAsync<ArgumentNullException>(
-            () => new NodeProjectFactory().TryCreateProjectAsync(null!, default));
+        await FluentActions.Awaiting(() => new NodeProjectFactory().TryCreateProjectAsync(null!, default)).Should().ThrowAsync<ArgumentNullException>();
     }
 
     private void WriteFile(string name, string contents)
@@ -229,7 +227,7 @@ public class NodeProjectFactoryTests : IDisposable
         FunctionsWorkerResolutionResult result = await project.WorkerReference.ResolveWorkerAsync(
             new FunctionsWorkerResolutionContext(_workerResolver),
             default);
-        FunctionsWorkerResolutionResult.Resolved resolved = Assert.IsType<FunctionsWorkerResolutionResult.Resolved>(result);
+        FunctionsWorkerResolutionResult.Resolved resolved = result.Should().BeOfType<FunctionsWorkerResolutionResult.Resolved>().Subject;
         return resolved.Worker;
     }
 

--- a/test/Workloads/Stacks/Node.Tests/NodeProjectFactoryTests.cs
+++ b/test/Workloads/Stacks/Node.Tests/NodeProjectFactoryTests.cs
@@ -39,8 +39,8 @@ public class NodeProjectFactoryTests : IDisposable
     {
         ProjectCreationResult result = await new NodeProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.NotCreated notCreated = result.Should().BeOfType<ProjectCreationResult.NotCreated>().Subject;
-        notCreated.Reason.Should().Be("no Node project fingerprint found");
+        result.Should().BeOfType<ProjectCreationResult.NotCreated>()
+            .Which.Reason.Should().Be("no Node project fingerprint found");
     }
 
     [Theory]
@@ -115,8 +115,7 @@ public class NodeProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new NodeProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
-        created.Project.Language.Should().Be(expectedLanguage);
+        result.Should().BeOfType<ProjectCreationResult.Created>().Which.Project.Language.Should().Be(expectedLanguage);
     }
 
     [Fact]
@@ -128,8 +127,7 @@ public class NodeProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new NodeProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
-        created.Project.Language.Should().Be("TypeScript");
+        result.Should().BeOfType<ProjectCreationResult.Created>().Which.Project.Language.Should().Be("TypeScript");
     }
 
     [Fact]
@@ -140,8 +138,8 @@ public class NodeProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new NodeProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
-        created.Reason.Should().Be("package.json declares @azure/functions");
+        result.Should().BeOfType<ProjectCreationResult.Created>()
+            .Which.Reason.Should().Be("package.json declares @azure/functions");
     }
 
     [Fact]
@@ -152,8 +150,8 @@ public class NodeProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new NodeProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
-        created.Reason.Should().Be("package.json declares @azure/functions");
+        result.Should().BeOfType<ProjectCreationResult.Created>()
+            .Which.Reason.Should().Be("package.json declares @azure/functions");
     }
 
     [Fact]
@@ -164,8 +162,7 @@ public class NodeProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new NodeProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
-        created.Reason.Should().Be("found package.json");
+        result.Should().BeOfType<ProjectCreationResult.Created>().Which.Reason.Should().Be("found package.json");
     }
 
     [Fact]
@@ -176,8 +173,7 @@ public class NodeProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new NodeProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
-        created.Reason.Should().Be("found package.json");
+        result.Should().BeOfType<ProjectCreationResult.Created>().Which.Reason.Should().Be("found package.json");
     }
 
     [Fact]
@@ -206,8 +202,8 @@ public class NodeProjectFactoryTests : IDisposable
         FunctionsWorkerResolutionResult workerResult = await created.Project.WorkerReference.ResolveWorkerAsync(
             new FunctionsWorkerResolutionContext(_workerResolver),
             default);
-        FunctionsWorkerResolutionResult.NotResolved notResolved = workerResult.Should().BeOfType<FunctionsWorkerResolutionResult.NotResolved>().Subject;
-        notResolved.Failure.Should().BeSameAs(failure);
+        workerResult.Should().BeOfType<FunctionsWorkerResolutionResult.NotResolved>()
+            .Which.Failure.Should().BeSameAs(failure);
     }
 
     [Fact]

--- a/test/Workloads/Stacks/Node.Tests/NodeProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/Node.Tests/NodeProjectInitializerTests.cs
@@ -7,7 +7,6 @@ using System.Text.Json.Nodes;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Commands;
 using Azure.Functions.Cli.Projects;
-using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.Node.Tests;
 
@@ -38,7 +37,7 @@ public class NodeProjectInitializerTests : IDisposable
     [Fact]
     public void Stack_IsNode()
     {
-        Assert.Equal("node", new NodeProjectInitializer().Stack);
+        new NodeProjectInitializer().Stack.Should().Be("node");
     }
 
     [Theory]
@@ -53,16 +52,15 @@ public class NodeProjectInitializerTests : IDisposable
     [InlineData("unknown", "unknown")]
     public void NormalizeLanguage_ReturnsExpectedResult(string? input, string expected)
     {
-        Assert.Equal(expected, new NodeProjectInitializer().NormalizeLanguage(input));
+        new NodeProjectInitializer().NormalizeLanguage(input).Should().Be(expected);
     }
 
     [Fact]
     public async Task InitializeAsync_UnsupportedLanguage_Throws()
     {
-        ArgumentException ex = await Assert.ThrowsAsync<ArgumentException>(
-            () => RunAsync(language: "ruby", force: false));
+        ArgumentException ex = (await FluentActions.Awaiting(() => RunAsync(language: "ruby", force: false)).Should().ThrowAsync<ArgumentException>()).Which;
 
-        Assert.Contains("ruby", ex.Message);
+        ex.Message.Should().Contain("ruby");
     }
 
     [Fact]
@@ -70,7 +68,7 @@ public class NodeProjectInitializerTests : IDisposable
     {
         await RunAsync(language: "ts", force: false);
 
-        Assert.True(File.Exists(Path.Combine(_projectDir.FullName, "tsconfig.json")));
+        File.Exists(Path.Combine(_projectDir.FullName, "tsconfig.json")).Should().BeTrue();
     }
 
     [Fact]
@@ -78,8 +76,8 @@ public class NodeProjectInitializerTests : IDisposable
     {
         await RunAsync(language: "js", force: false);
 
-        Assert.True(File.Exists(Path.Combine(_projectDir.FullName, "package.json")));
-        Assert.False(File.Exists(Path.Combine(_projectDir.FullName, "tsconfig.json")));
+        File.Exists(Path.Combine(_projectDir.FullName, "package.json")).Should().BeTrue();
+        File.Exists(Path.Combine(_projectDir.FullName, "tsconfig.json")).Should().BeFalse();
     }
 
     [Fact]
@@ -89,9 +87,9 @@ public class NodeProjectInitializerTests : IDisposable
         IReadOnlyList<Option> options = new NodeProjectInitializer().GetInitOptions(new InitOptionRegistry(root));
         IReadOnlyList<string> names = [.. options.Select(o => o.Name)];
 
-        Assert.Contains("--no-bundles", names);
-        Assert.Contains("--bundles-channel", names);
-        Assert.Contains("--skip-npm-install", names);
+        names.Should().Contain("--no-bundles");
+        names.Should().Contain("--bundles-channel");
+        names.Should().Contain("--skip-npm-install");
     }
 
     [Fact]
@@ -99,11 +97,11 @@ public class NodeProjectInitializerTests : IDisposable
     {
         await RunAsync(language: null, force: false);
 
-        Assert.True(File.Exists(Path.Combine(_projectDir.FullName, "package.json")));
-        Assert.False(File.Exists(Path.Combine(_projectDir.FullName, "tsconfig.json")));
+        File.Exists(Path.Combine(_projectDir.FullName, "package.json")).Should().BeTrue();
+        File.Exists(Path.Combine(_projectDir.FullName, "tsconfig.json")).Should().BeFalse();
 
         using var pkg = JsonDocument.Parse(File.ReadAllText(Path.Combine(_projectDir.FullName, "package.json")));
-        Assert.Equal("src/functions/*.js", pkg.RootElement.GetProperty("main").GetString());
+        pkg.RootElement.GetProperty("main").GetString().Should().Be("src/functions/*.js");
     }
 
     [Fact]
@@ -111,9 +109,9 @@ public class NodeProjectInitializerTests : IDisposable
     {
         await RunAsync(language: "typescript", force: false);
 
-        Assert.True(File.Exists(Path.Combine(_projectDir.FullName, "tsconfig.json")));
+        File.Exists(Path.Combine(_projectDir.FullName, "tsconfig.json")).Should().BeTrue();
         using var pkg = JsonDocument.Parse(File.ReadAllText(Path.Combine(_projectDir.FullName, "package.json")));
-        Assert.Contains("tsc", pkg.RootElement.GetProperty("scripts").GetProperty("build").GetString());
+        pkg.RootElement.GetProperty("scripts").GetProperty("build").GetString().Should().Contain("tsc");
     }
 
     [Fact]
@@ -122,7 +120,7 @@ public class NodeProjectInitializerTests : IDisposable
         await RunAsync(language: null, force: false, projectName: "My Cool App");
 
         using var pkg = JsonDocument.Parse(File.ReadAllText(Path.Combine(_projectDir.FullName, "package.json")));
-        Assert.Equal("my-cool-app", pkg.RootElement.GetProperty("name").GetString());
+        pkg.RootElement.GetProperty("name").GetString().Should().Be("my-cool-app");
     }
 
     [Fact]
@@ -130,12 +128,12 @@ public class NodeProjectInitializerTests : IDisposable
     {
         await RunAsync(language: null, force: false);
 
-        Assert.True(File.Exists(Path.Combine(_projectDir.FullName, ".funcignore")));
-        Assert.True(File.Exists(Path.Combine(_projectDir.FullName, ".gitignore")));
-        Assert.True(Directory.Exists(Path.Combine(_projectDir.FullName, "src", "functions")));
+        File.Exists(Path.Combine(_projectDir.FullName, ".funcignore")).Should().BeTrue();
+        File.Exists(Path.Combine(_projectDir.FullName, ".gitignore")).Should().BeTrue();
+        Directory.Exists(Path.Combine(_projectDir.FullName, "src", "functions")).Should().BeTrue();
 
         using var settings = JsonDocument.Parse(File.ReadAllText(Path.Combine(_projectDir.FullName, "local.settings.json")));
-        Assert.Equal("node", settings.RootElement.GetProperty("Values").GetProperty("FUNCTIONS_WORKER_RUNTIME").GetString());
+        settings.RootElement.GetProperty("Values").GetProperty("FUNCTIONS_WORKER_RUNTIME").GetString().Should().Be("node");
     }
 
     [Fact]
@@ -146,8 +144,8 @@ public class NodeProjectInitializerTests : IDisposable
         await RunAsync(language: null, force: false);
 
         JsonNode? bundle = JsonNode.Parse(File.ReadAllText(Path.Combine(_projectDir.FullName, "host.json")))!["extensionBundle"];
-        Assert.NotNull(bundle);
-        Assert.Equal("Microsoft.Azure.Functions.ExtensionBundle", bundle!["id"]!.GetValue<string>());
+        bundle.Should().NotBeNull();
+        bundle!["id"]!.GetValue<string>().Should().Be("Microsoft.Azure.Functions.ExtensionBundle");
     }
 
     [Fact]
@@ -159,7 +157,7 @@ public class NodeProjectInitializerTests : IDisposable
 
         await RunAsync(language: null, force: false);
 
-        Assert.Equal(userEdit, File.ReadAllText(Path.Combine(_projectDir.FullName, "package.json")));
+        File.ReadAllText(Path.Combine(_projectDir.FullName, "package.json")).Should().Be(userEdit);
     }
 
     [Fact]
@@ -170,7 +168,7 @@ public class NodeProjectInitializerTests : IDisposable
 
         await RunAsync(language: null, force: true);
 
-        Assert.Contains("@azure/functions", File.ReadAllText(Path.Combine(_projectDir.FullName, "package.json")));
+        File.ReadAllText(Path.Combine(_projectDir.FullName, "package.json")).Should().Contain("@azure/functions");
     }
 
     [Fact]
@@ -179,10 +177,10 @@ public class NodeProjectInitializerTests : IDisposable
         await RunAsync(language: null, force: false, args: ["--no-bundles"]);
 
         string hostJsonPath = Path.Combine(_projectDir.FullName, "host.json");
-        Assert.True(File.Exists(hostJsonPath), "host.json should be created even with --no-bundles");
+        File.Exists(hostJsonPath).Should().BeTrue("host.json should be created even with --no-bundles");
         string content = File.ReadAllText(hostJsonPath);
-        Assert.Contains("\"version\"", content);
-        Assert.DoesNotContain("extensionBundle", content);
+        content.Should().Contain("\"version\"");
+        content.Should().NotContain("extensionBundle");
     }
 
     [Fact]
@@ -191,7 +189,7 @@ public class NodeProjectInitializerTests : IDisposable
         await RunAsync(language: null, force: false, args: ["--bundles-channel", "Preview"]);
 
         JsonNode? bundle = JsonNode.Parse(File.ReadAllText(Path.Combine(_projectDir.FullName, "host.json")))!["extensionBundle"];
-        Assert.Equal("Microsoft.Azure.Functions.ExtensionBundle.Preview", bundle!["id"]!.GetValue<string>());
+        bundle!["id"]!.GetValue<string>().Should().Be("Microsoft.Azure.Functions.ExtensionBundle.Preview");
     }
 
     [Fact]
@@ -207,7 +205,7 @@ public class NodeProjectInitializerTests : IDisposable
             };
         });
 
-        Assert.Equal(1, npmCalls);
+        npmCalls.Should().Be(1);
     }
 
     [Fact]
@@ -223,7 +221,7 @@ public class NodeProjectInitializerTests : IDisposable
             };
         });
 
-        Assert.Equal(0, npmCalls);
+        npmCalls.Should().Be(0);
     }
 
     [Fact]
@@ -234,7 +232,7 @@ public class NodeProjectInitializerTests : IDisposable
             init.RunNpmInstall = (_, _) => Task.FromResult((1, "npm: command not found"));
         });
 
-        Assert.True(File.Exists(Path.Combine(_projectDir.FullName, "package.json")));
+        File.Exists(Path.Combine(_projectDir.FullName, "package.json")).Should().BeTrue();
     }
 
     private Task RunAsync(

--- a/test/Workloads/Stacks/Node.Tests/NodeWorkloadTests.cs
+++ b/test/Workloads/Stacks/Node.Tests/NodeWorkloadTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Projects;
-using Azure.Functions.Cli.Workloads;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.Node.Tests;
 
@@ -22,15 +20,15 @@ public class NodeWorkloadTests
 
         ServiceProvider provider = services.BuildServiceProvider();
         IProjectInitializer initializer = provider.GetRequiredService<IProjectInitializer>();
-        Assert.IsType<NodeProjectInitializer>(initializer);
-        Assert.Equal("node", initializer.Stack);
-        Assert.Equal(["JavaScript", "TypeScript"], initializer.SupportedLanguages);
+        initializer.Should().BeOfType<NodeProjectInitializer>();
+        initializer.Stack.Should().Be("node");
+        initializer.SupportedLanguages.Should().Equal(["JavaScript", "TypeScript"]);
     }
 
     [Fact]
     public void Configure_NullBuilder_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => new NodeWorkload().Configure(null!));
+        FluentActions.Invoking(() => new NodeWorkload().Configure(null!)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]

--- a/test/Workloads/Stacks/PowerShell.Tests/PowerShellProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/PowerShell.Tests/PowerShellProjectInitializerTests.cs
@@ -6,7 +6,6 @@ using System.Text.Json.Nodes;
 using Azure.Functions.Cli.Commands;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Projects;
-using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.PowerShell.Tests;
 
@@ -15,13 +14,13 @@ public class PowerShellProjectInitializerTests
     [Fact]
     public void Stack_IsPowerShell()
     {
-        Assert.Equal("powershell", new PowerShellProjectInitializer().Stack);
+        new PowerShellProjectInitializer().Stack.Should().Be("powershell");
     }
 
     [Fact]
     public void SupportedLanguages_ContainsPowerShell()
     {
-        Assert.Equal("PowerShell", Assert.Single(new PowerShellProjectInitializer().SupportedLanguages));
+        new PowerShellProjectInitializer().SupportedLanguages.Should().ContainSingle().Subject.Should().Be("PowerShell");
     }
 
     [Fact]
@@ -30,13 +29,13 @@ public class PowerShellProjectInitializerTests
         RootCommand root = [];
         IReadOnlyList<Option> options = new PowerShellProjectInitializer().GetInitOptions(new InitOptionRegistry(root));
 
-        Assert.Equal(4, options.Count);
+        options.Count.Should().Be(4);
     }
 
     [Fact]
     public void GetInitOptions_NullRegistry_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => new PowerShellProjectInitializer().GetInitOptions(null!));
+        FluentActions.Invoking(() => new PowerShellProjectInitializer().GetInitOptions(null!)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
@@ -62,15 +61,15 @@ public class PowerShellProjectInitializerTests
 
             await initializer.InitializeAsync(context, root.Parse([]));
 
-            Assert.True(File.Exists(Path.Combine(tempDir, "host.json")));
-            Assert.True(File.Exists(Path.Combine(tempDir, "local.settings.json")));
-            Assert.True(File.Exists(Path.Combine(tempDir, "profile.ps1")));
-            Assert.True(File.Exists(Path.Combine(tempDir, ".gitignore")));
-            Assert.False(File.Exists(Path.Combine(tempDir, "requirements.psd1")));
+            File.Exists(Path.Combine(tempDir, "host.json")).Should().BeTrue();
+            File.Exists(Path.Combine(tempDir, "local.settings.json")).Should().BeTrue();
+            File.Exists(Path.Combine(tempDir, "profile.ps1")).Should().BeTrue();
+            File.Exists(Path.Combine(tempDir, ".gitignore")).Should().BeTrue();
+            File.Exists(Path.Combine(tempDir, "requirements.psd1")).Should().BeFalse();
 
             string localSettings = File.ReadAllText(Path.Combine(tempDir, "local.settings.json"));
-            Assert.Contains("powershell", localSettings);
-            Assert.Contains("7.4", localSettings);
+            localSettings.Should().Contain("powershell");
+            localSettings.Should().Contain("7.4");
         }
         finally
         {
@@ -100,15 +99,15 @@ public class PowerShellProjectInitializerTests
 
             await initializer.InitializeAsync(context, root.Parse(["--managed-dependencies"]));
 
-            Assert.True(File.Exists(Path.Combine(tempDir, "requirements.psd1")));
+            File.Exists(Path.Combine(tempDir, "requirements.psd1")).Should().BeTrue();
             string requirements = File.ReadAllText(Path.Combine(tempDir, "requirements.psd1"));
-            Assert.Contains("12", requirements);
-            Assert.DoesNotContain("MAJOR_VERSION", requirements);
+            requirements.Should().Contain("12");
+            requirements.Should().NotContain("MAJOR_VERSION");
 
             // host.json should contain managedDependency
             string hostJson = File.ReadAllText(Path.Combine(tempDir, "host.json"));
             JsonObject host = JsonNode.Parse(hostJson)!.AsObject();
-            Assert.True(host.ContainsKey("managedDependency"));
+            host.ContainsKey("managedDependency").Should().BeTrue();
         }
         finally
         {
@@ -140,7 +139,7 @@ public class PowerShellProjectInitializerTests
 
             string hostJson = File.ReadAllText(Path.Combine(tempDir, "host.json"));
             JsonObject host = JsonNode.Parse(hostJson)!.AsObject();
-            Assert.False(host.ContainsKey("extensionBundle"));
+            host.ContainsKey("extensionBundle").Should().BeFalse();
         }
         finally
         {
@@ -155,8 +154,7 @@ public class PowerShellProjectInitializerTests
         RootCommand root = [];
         initializer.GetInitOptions(new InitOptionRegistry(root));
 
-        await Assert.ThrowsAsync<ArgumentNullException>(
-            () => initializer.InitializeAsync(null!, root.Parse([])));
+        await FluentActions.Awaiting(() => initializer.InitializeAsync(null!, root.Parse([]))).Should().ThrowAsync<ArgumentNullException>();
     }
 
     [Fact]
@@ -182,8 +180,8 @@ public class PowerShellProjectInitializerTests
             await initializer.InitializeAsync(context, root.Parse(["--runtime-version", "7.6"]));
 
             string localSettings = File.ReadAllText(Path.Combine(tempDir, "local.settings.json"));
-            Assert.Contains("\"7.6\"", localSettings);
-            Assert.DoesNotContain("7.4", localSettings);
+            localSettings.Should().Contain("\"7.6\"");
+            localSettings.Should().NotContain("7.4");
         }
         finally
         {
@@ -211,8 +209,7 @@ public class PowerShellProjectInitializerTests
                 Language: null,
                 Force: false);
 
-            await Assert.ThrowsAsync<ArgumentException>(
-                () => initializer.InitializeAsync(context, root.Parse(["--runtime-version", "6.0"])));
+            await FluentActions.Awaiting(() => initializer.InitializeAsync(context, root.Parse(["--runtime-version", "6.0"]))).Should().ThrowAsync<ArgumentException>();
         }
         finally
         {
@@ -233,8 +230,7 @@ public class PowerShellProjectInitializerTests
             Language: null,
             Force: false);
 
-        await Assert.ThrowsAsync<ArgumentNullException>(
-            () => initializer.InitializeAsync(context, null!));
+        await FluentActions.Awaiting(() => initializer.InitializeAsync(context, null!)).Should().ThrowAsync<ArgumentNullException>();
     }
 }
 

--- a/test/Workloads/Stacks/PowerShell.Tests/PowerShellWorkloadTests.cs
+++ b/test/Workloads/Stacks/PowerShell.Tests/PowerShellWorkloadTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Projects;
-using Azure.Functions.Cli.Workloads;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.PowerShell.Tests;
 
@@ -22,15 +20,15 @@ public class PowerShellWorkloadTests
 
         ServiceProvider provider = services.BuildServiceProvider();
         IProjectInitializer initializer = provider.GetRequiredService<IProjectInitializer>();
-        Assert.IsType<PowerShellProjectInitializer>(initializer);
-        Assert.Equal("powershell", initializer.Stack);
-        Assert.Equal("PowerShell", Assert.Single(initializer.SupportedLanguages));
+        initializer.Should().BeOfType<PowerShellProjectInitializer>();
+        initializer.Stack.Should().Be("powershell");
+        initializer.SupportedLanguages.Should().ContainSingle().Subject.Should().Be("PowerShell");
     }
 
     [Fact]
     public void Configure_NullBuilder_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => new PowerShellWorkload().Configure(null!));
+        FluentActions.Invoking(() => new PowerShellWorkload().Configure(null!)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
@@ -38,7 +36,7 @@ public class PowerShellWorkloadTests
     {
         PowerShellWorkload workload = new();
 
-        Assert.Equal("PowerShell Stack", workload.DisplayName);
-        Assert.Equal("Azure Functions CLI tooling for PowerShell projects.", workload.Description);
+        workload.DisplayName.Should().Be("PowerShell Stack");
+        workload.Description.Should().Be("Azure Functions CLI tooling for PowerShell projects.");
     }
 }

--- a/test/Workloads/Stacks/Python.Tests/PythonFunctionsProjectTests.cs
+++ b/test/Workloads/Stacks/Python.Tests/PythonFunctionsProjectTests.cs
@@ -3,7 +3,6 @@
 
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Projects;
-using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.Python.Tests;
 
@@ -59,11 +58,11 @@ public class PythonFunctionsProjectTests : IDisposable
 
         await project.PrepareForHostRunAsync(context, default);
 
-        Assert.Equal(Path.Combine(_projectDir.FullName, PythonFunctionsProject.DefaultVenvFolderName), venvCreatedAt);
-        Assert.NotNull(pipUsed);
-        Assert.Contains(PythonFunctionsProject.DefaultVenvFolderName, pipUsed!);
-        Assert.Equal(Path.Combine(_projectDir.FullName, "requirements.txt"), requirementsUsed);
-        Assert.Equal("1", context.EnvironmentVariables[PythonFunctionsProject.IsolateWorkerDepsEnvVar]);
+        venvCreatedAt.Should().Be(Path.Combine(_projectDir.FullName, PythonFunctionsProject.DefaultVenvFolderName));
+        pipUsed.Should().NotBeNull();
+        pipUsed!.Should().Contain(PythonFunctionsProject.DefaultVenvFolderName);
+        requirementsUsed.Should().Be(Path.Combine(_projectDir.FullName, "requirements.txt"));
+        context.EnvironmentVariables[PythonFunctionsProject.IsolateWorkerDepsEnvVar].Should().Be("1");
     }
 
     [Fact]
@@ -85,7 +84,7 @@ public class PythonFunctionsProjectTests : IDisposable
 
         await project.PrepareForHostRunAsync(CreateContext(), default);
 
-        Assert.False(venvCreated);
+        venvCreated.Should().BeFalse();
     }
 
     [Fact]
@@ -110,7 +109,7 @@ public class PythonFunctionsProjectTests : IDisposable
 
         await project.PrepareForHostRunAsync(CreateContext(), default);
 
-        Assert.False(pipRan);
+        pipRan.Should().BeFalse();
     }
 
     [Fact]
@@ -135,8 +134,8 @@ public class PythonFunctionsProjectTests : IDisposable
 
         await project.PrepareForHostRunAsync(context, default);
 
-        Assert.Contains(reporter.Logs, e => e.Severity == FunctionsProjectReportSeverity.Info && e.Line == "created virtual environment");
-        Assert.Contains(reporter.Logs, e => e.Severity == FunctionsProjectReportSeverity.Error && e.Line == "venv warning");
+        reporter.Logs.Should().Contain(e => e.Severity == FunctionsProjectReportSeverity.Info && e.Line == "created virtual environment");
+        reporter.Logs.Should().Contain(e => e.Severity == FunctionsProjectReportSeverity.Error && e.Line == "venv warning");
     }
 
     [Fact]
@@ -156,13 +155,12 @@ public class PythonFunctionsProjectTests : IDisposable
         FunctionsProjectHostRunContext context = CreateContext();
         context.Reporter = reporter;
 
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => project.PrepareForHostRunAsync(context, default));
+        GracefulException ex = (await FluentActions.Awaiting(() => project.PrepareForHostRunAsync(context, default)).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.True(ex.IsUserError);
-        Assert.Contains("venv", ex.Message);
-        Assert.Contains("exit 1", ex.Message);
-        Assert.Contains(reporter.Logs, e => e.Severity == FunctionsProjectReportSeverity.Error && e.Line == "python not found");
+        ex.IsUserError.Should().BeTrue();
+        ex.Message.Should().Contain("venv");
+        ex.Message.Should().Contain("exit 1");
+        reporter.Logs.Should().Contain(e => e.Severity == FunctionsProjectReportSeverity.Error && e.Line == "python not found");
     }
 
     [Fact]
@@ -187,13 +185,12 @@ public class PythonFunctionsProjectTests : IDisposable
         FunctionsProjectHostRunContext context = CreateContext();
         context.Reporter = reporter;
 
-        GracefulException ex = await Assert.ThrowsAsync<GracefulException>(
-            () => project.PrepareForHostRunAsync(context, default));
+        GracefulException ex = (await FluentActions.Awaiting(() => project.PrepareForHostRunAsync(context, default)).Should().ThrowAsync<GracefulException>()).Which;
 
-        Assert.True(ex.IsUserError);
-        Assert.Contains("pip install", ex.Message);
-        Assert.Contains("exit 2", ex.Message);
-        Assert.Contains(reporter.Logs, e => e.Severity == FunctionsProjectReportSeverity.Error && e.Line == "invalid spec");
+        ex.IsUserError.Should().BeTrue();
+        ex.Message.Should().Contain("pip install");
+        ex.Message.Should().Contain("exit 2");
+        reporter.Logs.Should().Contain(e => e.Severity == FunctionsProjectReportSeverity.Error && e.Line == "invalid spec");
     }
 
     [Fact]
@@ -219,8 +216,8 @@ public class PythonFunctionsProjectTests : IDisposable
             Path.Combine(_projectDir.FullName, PythonFunctionsProject.DefaultVenvFolderName),
             "python");
 
-        Assert.Equal(expectedExe, context.EnvironmentVariables[PythonFunctionsProject.WorkerExecutablePathEnvVar]);
-        Assert.Equal("3.12", context.EnvironmentVariables[PythonFunctionsProject.WorkerRuntimeVersionEnvVar]);
+        context.EnvironmentVariables[PythonFunctionsProject.WorkerExecutablePathEnvVar].Should().Be(expectedExe);
+        context.EnvironmentVariables[PythonFunctionsProject.WorkerRuntimeVersionEnvVar].Should().Be("3.12");
     }
 
     [Fact]
@@ -241,8 +238,8 @@ public class PythonFunctionsProjectTests : IDisposable
 
         await project.PrepareForHostRunAsync(context, default);
 
-        Assert.False(context.EnvironmentVariables.ContainsKey(PythonFunctionsProject.WorkerRuntimeVersionEnvVar));
-        Assert.True(context.EnvironmentVariables.ContainsKey(PythonFunctionsProject.WorkerExecutablePathEnvVar));
+        context.EnvironmentVariables.ContainsKey(PythonFunctionsProject.WorkerRuntimeVersionEnvVar).Should().BeFalse();
+        context.EnvironmentVariables.ContainsKey(PythonFunctionsProject.WorkerExecutablePathEnvVar).Should().BeTrue();
     }
 
     [Fact]
@@ -273,10 +270,10 @@ public class PythonFunctionsProjectTests : IDisposable
 
         await project.PrepareForHostRunAsync(context, default);
 
-        Assert.False(venvCreated);
-        Assert.NotNull(pipUsed);
-        Assert.Contains("my-shared-env", pipUsed!);
-        Assert.Contains("my-shared-env", context.EnvironmentVariables[PythonFunctionsProject.WorkerExecutablePathEnvVar]);
+        venvCreated.Should().BeFalse();
+        pipUsed.Should().NotBeNull();
+        pipUsed!.Should().Contain("my-shared-env");
+        context.EnvironmentVariables[PythonFunctionsProject.WorkerExecutablePathEnvVar].Should().Contain("my-shared-env");
     }
 
     [Theory]
@@ -308,9 +305,9 @@ public class PythonFunctionsProjectTests : IDisposable
 
         await project.PrepareForHostRunAsync(CreateContext(), default);
 
-        Assert.False(venvCreated);
-        Assert.NotNull(pipUsed);
-        Assert.Contains(folderName, pipUsed!);
+        venvCreated.Should().BeFalse();
+        pipUsed.Should().NotBeNull();
+        pipUsed!.Should().Contain(folderName);
     }
 
     private FunctionsProjectHostRunContext CreateContext()

--- a/test/Workloads/Stacks/Python.Tests/PythonProjectFactoryTests.cs
+++ b/test/Workloads/Stacks/Python.Tests/PythonProjectFactoryTests.cs
@@ -5,7 +5,6 @@ using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Projects;
 using Azure.Functions.Cli.Workers;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.Python.Tests;
 
@@ -41,8 +40,8 @@ public class PythonProjectFactoryTests : IDisposable
     {
         ProjectCreationResult result = await new PythonProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.NotCreated notCreated = Assert.IsType<ProjectCreationResult.NotCreated>(result);
-        Assert.Equal("no Python project fingerprint found", notCreated.Reason);
+        ProjectCreationResult.NotCreated notCreated = result.Should().BeOfType<ProjectCreationResult.NotCreated>().Subject;
+        notCreated.Reason.Should().Be("no Python project fingerprint found");
     }
 
     [Fact]
@@ -52,7 +51,7 @@ public class PythonProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new PythonProjectFactory().TryCreateProjectAsync(CreateContext(missing), default);
 
-        Assert.IsType<ProjectCreationResult.NotCreated>(result);
+        result.Should().BeOfType<ProjectCreationResult.NotCreated>();
     }
 
     [Theory]
@@ -67,7 +66,7 @@ public class PythonProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new PythonProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        Assert.IsType<ProjectCreationResult.Created>(result);
+        result.Should().BeOfType<ProjectCreationResult.Created>();
     }
 
     [Fact]
@@ -79,7 +78,7 @@ public class PythonProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new PythonProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        Assert.IsType<ProjectCreationResult.NotCreated>(result);
+        result.Should().BeOfType<ProjectCreationResult.NotCreated>();
     }
 
     [Fact]
@@ -90,7 +89,7 @@ public class PythonProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new PythonProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        Assert.IsType<ProjectCreationResult.NotCreated>(result);
+        result.Should().BeOfType<ProjectCreationResult.NotCreated>();
     }
 
     [Theory]
@@ -106,12 +105,12 @@ public class PythonProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new PythonProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
-        Assert.Equal("python", created.Project.StackName);
-        Assert.Equal("Python", created.Project.StackDisplayName);
+        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
+        created.Project.StackName.Should().Be("python");
+        created.Project.StackDisplayName.Should().Be("Python");
         IFunctionsWorker worker = await ResolveWorkerAsync(created.Project);
-        Assert.Equal("python", worker.WorkerRuntime);
-        Assert.NotNull(created.Reason);
+        worker.WorkerRuntime.Should().Be("python");
+        created.Reason.Should().NotBeNull();
     }
 
     [Fact]
@@ -125,8 +124,8 @@ public class PythonProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new PythonProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
-        Assert.Equal("found pyproject.toml", created.Reason);
+        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
+        created.Reason.Should().Be("found pyproject.toml");
     }
 
     [Fact]
@@ -138,8 +137,8 @@ public class PythonProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new PythonProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
-        Assert.Equal("found pyproject.toml", created.Reason);
+        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
+        created.Reason.Should().Be("found pyproject.toml");
     }
 
     [Fact]
@@ -150,8 +149,8 @@ public class PythonProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new PythonProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
-        Assert.Contains("*.py", created.Reason);
+        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
+        created.Reason.Should().Contain("*.py");
     }
 
     [Fact]
@@ -161,7 +160,7 @@ public class PythonProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new PythonProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        Assert.IsType<ProjectCreationResult.NotCreated>(result);
+        result.Should().BeOfType<ProjectCreationResult.NotCreated>();
     }
 
     [Fact]
@@ -176,19 +175,18 @@ public class PythonProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new PythonProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = Assert.IsType<ProjectCreationResult.Created>(result);
+        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
         FunctionsWorkerResolutionResult workerResult = await created.Project.WorkerReference.ResolveWorkerAsync(
             new FunctionsWorkerResolutionContext(_workerResolver),
             default);
-        FunctionsWorkerResolutionResult.NotResolved notResolved = Assert.IsType<FunctionsWorkerResolutionResult.NotResolved>(workerResult);
-        Assert.Same(failure, notResolved.Failure);
+        FunctionsWorkerResolutionResult.NotResolved notResolved = workerResult.Should().BeOfType<FunctionsWorkerResolutionResult.NotResolved>().Subject;
+        notResolved.Failure.Should().BeSameAs(failure);
     }
 
     [Fact]
     public async Task NullContext_throws()
     {
-        await Assert.ThrowsAsync<ArgumentNullException>(
-            () => new PythonProjectFactory().TryCreateProjectAsync(null!, default));
+        await FluentActions.Awaiting(() => new PythonProjectFactory().TryCreateProjectAsync(null!, default)).Should().ThrowAsync<ArgumentNullException>();
     }
 
     private void WriteFile(string name, string contents)
@@ -202,7 +200,7 @@ public class PythonProjectFactoryTests : IDisposable
         FunctionsWorkerResolutionResult result = await project.WorkerReference.ResolveWorkerAsync(
             new FunctionsWorkerResolutionContext(_workerResolver),
             default);
-        FunctionsWorkerResolutionResult.Resolved resolved = Assert.IsType<FunctionsWorkerResolutionResult.Resolved>(result);
+        FunctionsWorkerResolutionResult.Resolved resolved = result.Should().BeOfType<FunctionsWorkerResolutionResult.Resolved>().Subject;
         return resolved.Worker;
     }
 

--- a/test/Workloads/Stacks/Python.Tests/PythonProjectFactoryTests.cs
+++ b/test/Workloads/Stacks/Python.Tests/PythonProjectFactoryTests.cs
@@ -40,8 +40,8 @@ public class PythonProjectFactoryTests : IDisposable
     {
         ProjectCreationResult result = await new PythonProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.NotCreated notCreated = result.Should().BeOfType<ProjectCreationResult.NotCreated>().Subject;
-        notCreated.Reason.Should().Be("no Python project fingerprint found");
+        result.Should().BeOfType<ProjectCreationResult.NotCreated>()
+            .Which.Reason.Should().Be("no Python project fingerprint found");
     }
 
     [Fact]
@@ -124,8 +124,7 @@ public class PythonProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new PythonProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
-        created.Reason.Should().Be("found pyproject.toml");
+        result.Should().BeOfType<ProjectCreationResult.Created>().Which.Reason.Should().Be("found pyproject.toml");
     }
 
     [Fact]
@@ -137,8 +136,7 @@ public class PythonProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new PythonProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
-        created.Reason.Should().Be("found pyproject.toml");
+        result.Should().BeOfType<ProjectCreationResult.Created>().Which.Reason.Should().Be("found pyproject.toml");
     }
 
     [Fact]
@@ -149,8 +147,7 @@ public class PythonProjectFactoryTests : IDisposable
 
         ProjectCreationResult result = await new PythonProjectFactory().TryCreateProjectAsync(CreateContext(), default);
 
-        ProjectCreationResult.Created created = result.Should().BeOfType<ProjectCreationResult.Created>().Subject;
-        created.Reason.Should().Contain("*.py");
+        result.Should().BeOfType<ProjectCreationResult.Created>().Which.Reason.Should().Contain("*.py");
     }
 
     [Fact]
@@ -179,8 +176,8 @@ public class PythonProjectFactoryTests : IDisposable
         FunctionsWorkerResolutionResult workerResult = await created.Project.WorkerReference.ResolveWorkerAsync(
             new FunctionsWorkerResolutionContext(_workerResolver),
             default);
-        FunctionsWorkerResolutionResult.NotResolved notResolved = workerResult.Should().BeOfType<FunctionsWorkerResolutionResult.NotResolved>().Subject;
-        notResolved.Failure.Should().BeSameAs(failure);
+        workerResult.Should().BeOfType<FunctionsWorkerResolutionResult.NotResolved>()
+            .Which.Failure.Should().BeSameAs(failure);
     }
 
     [Fact]

--- a/test/Workloads/Stacks/Python.Tests/PythonProjectInitializerTests.cs
+++ b/test/Workloads/Stacks/Python.Tests/PythonProjectInitializerTests.cs
@@ -7,7 +7,6 @@ using System.Text.Json.Nodes;
 using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Commands;
 using Azure.Functions.Cli.Projects;
-using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.Python.Tests;
 
@@ -38,7 +37,7 @@ public class PythonProjectInitializerTests : IDisposable
     [Fact]
     public void Stack_IsPython()
     {
-        Assert.Equal("python", new PythonProjectInitializer().Stack);
+        new PythonProjectInitializer().Stack.Should().Be("python");
     }
 
     [Theory]
@@ -51,16 +50,15 @@ public class PythonProjectInitializerTests : IDisposable
     [InlineData("unknown", "unknown")]
     public void NormalizeLanguage_ReturnsExpectedResult(string? input, string expected)
     {
-        Assert.Equal(expected, new PythonProjectInitializer().NormalizeLanguage(input));
+        new PythonProjectInitializer().NormalizeLanguage(input).Should().Be(expected);
     }
 
     [Fact]
     public async Task InitializeAsync_UnsupportedLanguage_Throws()
     {
-        ArgumentException ex = await Assert.ThrowsAsync<ArgumentException>(
-            () => RunAsync(force: false, language: "ruby"));
+        ArgumentException ex = (await FluentActions.Awaiting(() => RunAsync(force: false, language: "ruby")).Should().ThrowAsync<ArgumentException>()).Which;
 
-        Assert.Contains("ruby", ex.Message);
+        ex.Message.Should().Contain("ruby");
     }
 
     [Fact]
@@ -68,7 +66,7 @@ public class PythonProjectInitializerTests : IDisposable
     {
         await RunAsync(force: false, language: "py");
 
-        Assert.True(File.Exists(Path.Combine(_projectDir.FullName, "function_app.py")));
+        File.Exists(Path.Combine(_projectDir.FullName, "function_app.py")).Should().BeTrue();
     }
 
     [Fact]
@@ -78,8 +76,8 @@ public class PythonProjectInitializerTests : IDisposable
         IReadOnlyList<Option> options = new PythonProjectInitializer().GetInitOptions(new InitOptionRegistry(root));
         IReadOnlyList<string> names = [.. options.Select(o => o.Name)];
 
-        Assert.Contains("--no-bundles", names);
-        Assert.Contains("--bundles-channel", names);
+        names.Should().Contain("--no-bundles");
+        names.Should().Contain("--bundles-channel");
     }
 
     [Fact]
@@ -87,18 +85,18 @@ public class PythonProjectInitializerTests : IDisposable
     {
         await RunAsync(force: false);
 
-        Assert.True(File.Exists(Path.Combine(_projectDir.FullName, "function_app.py")));
-        Assert.Contains("FunctionApp", File.ReadAllText(Path.Combine(_projectDir.FullName, "function_app.py")));
+        File.Exists(Path.Combine(_projectDir.FullName, "function_app.py")).Should().BeTrue();
+        File.ReadAllText(Path.Combine(_projectDir.FullName, "function_app.py")).Should().Contain("FunctionApp");
 
-        Assert.True(File.Exists(Path.Combine(_projectDir.FullName, "requirements.txt")));
-        Assert.Contains("azure-functions", File.ReadAllText(Path.Combine(_projectDir.FullName, "requirements.txt")));
+        File.Exists(Path.Combine(_projectDir.FullName, "requirements.txt")).Should().BeTrue();
+        File.ReadAllText(Path.Combine(_projectDir.FullName, "requirements.txt")).Should().Contain("azure-functions");
 
-        Assert.True(File.Exists(Path.Combine(_projectDir.FullName, "getting_started.md")));
-        Assert.True(File.Exists(Path.Combine(_projectDir.FullName, ".gitignore")));
+        File.Exists(Path.Combine(_projectDir.FullName, "getting_started.md")).Should().BeTrue();
+        File.Exists(Path.Combine(_projectDir.FullName, ".gitignore")).Should().BeTrue();
 
-        Assert.True(File.Exists(Path.Combine(_projectDir.FullName, "local.settings.json")));
+        File.Exists(Path.Combine(_projectDir.FullName, "local.settings.json")).Should().BeTrue();
         var settings = JsonDocument.Parse(File.ReadAllText(Path.Combine(_projectDir.FullName, "local.settings.json")));
-        Assert.Equal("python", settings.RootElement.GetProperty("Values").GetProperty("FUNCTIONS_WORKER_RUNTIME").GetString());
+        settings.RootElement.GetProperty("Values").GetProperty("FUNCTIONS_WORKER_RUNTIME").GetString().Should().Be("python");
     }
 
     [Fact]
@@ -112,12 +110,12 @@ public class PythonProjectInitializerTests : IDisposable
         await RunAsync(force: false);
 
         var root = JsonNode.Parse(File.ReadAllText(Path.Combine(_projectDir.FullName, "host.json")));
-        Assert.NotNull(root);
-        Assert.Equal("2.0", root!["version"]!.GetValue<string>());
+        root.Should().NotBeNull();
+        root!["version"]!.GetValue<string>().Should().Be("2.0");
         JsonNode? bundle = root["extensionBundle"];
-        Assert.NotNull(bundle);
-        Assert.Equal("Microsoft.Azure.Functions.ExtensionBundle", bundle!["id"]!.GetValue<string>());
-        Assert.Equal("[4.*, 5.0.0)", bundle["version"]!.GetValue<string>());
+        bundle.Should().NotBeNull();
+        bundle!["id"]!.GetValue<string>().Should().Be("Microsoft.Azure.Functions.ExtensionBundle");
+        bundle["version"]!.GetValue<string>().Should().Be("[4.*, 5.0.0)");
     }
 
     [Fact]
@@ -129,7 +127,7 @@ public class PythonProjectInitializerTests : IDisposable
         await RunAsync(force: false);
 
         JsonNode? bundle = JsonNode.Parse(File.ReadAllText(Path.Combine(_projectDir.FullName, "host.json")))!["extensionBundle"];
-        Assert.Equal("custom", bundle!["id"]!.GetValue<string>());
+        bundle!["id"]!.GetValue<string>().Should().Be("custom");
     }
 
     [Fact]
@@ -142,7 +140,7 @@ public class PythonProjectInitializerTests : IDisposable
 
         await RunAsync(force: false);
 
-        Assert.Equal(userEdit, File.ReadAllText(Path.Combine(_projectDir.FullName, "function_app.py")));
+        File.ReadAllText(Path.Combine(_projectDir.FullName, "function_app.py")).Should().Be(userEdit);
     }
 
     [Fact]
@@ -153,7 +151,7 @@ public class PythonProjectInitializerTests : IDisposable
 
         await RunAsync(force: true);
 
-        Assert.Contains("FunctionApp", File.ReadAllText(Path.Combine(_projectDir.FullName, "function_app.py")));
+        File.ReadAllText(Path.Combine(_projectDir.FullName, "function_app.py")).Should().Contain("FunctionApp");
     }
 
     [Fact]
@@ -162,10 +160,10 @@ public class PythonProjectInitializerTests : IDisposable
         await RunAsync(force: false, args: ["--no-bundles"]);
 
         string hostJsonPath = Path.Combine(_projectDir.FullName, "host.json");
-        Assert.True(File.Exists(hostJsonPath), "host.json should be created even with --no-bundles");
+        File.Exists(hostJsonPath).Should().BeTrue("host.json should be created even with --no-bundles");
         string content = File.ReadAllText(hostJsonPath);
-        Assert.Contains("\"version\"", content);
-        Assert.DoesNotContain("extensionBundle", content);
+        content.Should().Contain("\"version\"");
+        content.Should().NotContain("extensionBundle");
     }
 
     [Fact]
@@ -175,9 +173,7 @@ public class PythonProjectInitializerTests : IDisposable
 
         string hostJsonPath = Path.Combine(_projectDir.FullName, "host.json");
         var root = JsonNode.Parse(File.ReadAllText(hostJsonPath));
-        Assert.Equal(
-            "Microsoft.Azure.Functions.ExtensionBundle.Preview",
-            root!["extensionBundle"]!["id"]!.GetValue<string>());
+        root!["extensionBundle"]!["id"]!.GetValue<string>().Should().Be("Microsoft.Azure.Functions.ExtensionBundle.Preview");
     }
 
     [Fact]
@@ -187,9 +183,7 @@ public class PythonProjectInitializerTests : IDisposable
 
         string hostJsonPath = Path.Combine(_projectDir.FullName, "host.json");
         var root = JsonNode.Parse(File.ReadAllText(hostJsonPath));
-        Assert.Equal(
-            "Microsoft.Azure.Functions.ExtensionBundle.Experimental",
-            root!["extensionBundle"]!["id"]!.GetValue<string>());
+        root!["extensionBundle"]!["id"]!.GetValue<string>().Should().Be("Microsoft.Azure.Functions.ExtensionBundle.Experimental");
     }
 
     private Task RunAsync(bool force, string[]? args = null, string? language = null)

--- a/test/Workloads/Stacks/Python.Tests/PythonWorkloadTests.cs
+++ b/test/Workloads/Stacks/Python.Tests/PythonWorkloadTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Projects;
-using Azure.Functions.Cli.Workloads;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
-using Xunit;
 
 namespace Azure.Functions.Cli.Workloads.Python.Tests;
 
@@ -22,15 +20,15 @@ public class PythonWorkloadTests
 
         ServiceProvider provider = services.BuildServiceProvider();
         IProjectInitializer initializer = provider.GetRequiredService<IProjectInitializer>();
-        Assert.IsType<PythonProjectInitializer>(initializer);
-        Assert.Equal("python", initializer.Stack);
-        Assert.Equal("Python", Assert.Single(initializer.SupportedLanguages));
+        initializer.Should().BeOfType<PythonProjectInitializer>();
+        initializer.Stack.Should().Be("python");
+        initializer.SupportedLanguages.Should().ContainSingle().Subject.Should().Be("Python");
     }
 
     [Fact]
     public void Configure_NullBuilder_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => new PythonWorkload().Configure(null!));
+        FluentActions.Invoking(() => new PythonWorkload().Configure(null!)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]


### PR DESCRIPTION
FluentAssertions moved to a paid license, so this migrates the test suite off the old xUnit `Assert.*` API onto **AwesomeAssertions** (the maintained MIT fork), matching the stack mandated in the repo conventions. Doing this now keeps every new test on a consistent, license-clean fluent API. Making the migration because we originally documented that tests are to use `AwesomeAssertions`, but we never made the switch to it. Doing that now.

### Approach

- **Assertion migration (`test: switch to AwesomeAssertions`).** Converted ~3000 `Assert.*` calls across the test projects to their AwesomeAssertions equivalents (`Assert.Equal` to `.Should().Be()`, `Assert.IsType<T>` to `.Should().BeOfType<T>()`, etc.). Added `AwesomeAssertions` 9.4.0 to `eng/build/Packages.props` (the version flows into test projects via the central `test/Directory.Build.props`).
- **Idiomatic chaining (`test: use assertion chaining`).** Collapsed the `T x = expr.Should().BeOfType<T>().Subject; x.Prop.Should().Be(v);` boilerplate into `expr.Should().BeOfType<T>().Which.Prop.Should().Be(v);` wherever a `.Subject` local was used exactly once by the immediately following assertion (60 sites). Multi-use intermediates and deep multi-level extraction chains were deliberately left as named locals for readability.

### Notes for reviewers

- The second commit also removes a handful of now-unused `using` directives in `src/` that the analyzers flagged during the clean rebuild (38 line deletions across 29 files, no logic changes). CI runs with `TreatWarningsAsErrors=true`, so these had to go.
- CRLF line endings were preserved throughout; new chained lines were kept at roughly 120 chars max.
- Validation: clean Release build (0 warnings / 0 errors) and full suite **1541 / 1541 passing**.

### Pull request checklist

* [x] My changes **do not** require documentation changes
* [x] My changes **do not** need to be backported to a previous version
* [x] My changes **should not** be added to the release notes for the next release
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

Test-only behavior change; no product runtime code paths were modified.