### PR TITLE
Redact Authorization header in CLI_DEBUG request logging

### DIFF
--- a/src/Cli/func/Arm/ArmClient.cs
+++ b/src/Cli/func/Arm/ArmClient.cs
@@ -176,10 +176,10 @@ namespace Azure.Functions.Cli.Arm
         /// </summary>
         internal static string GetRedactedRequestString(string requestString)
         {
-            return AuthorizationHeaderRegex().Replace(requestString, "[REDACTED]");
+            return AuthorizationHeaderRegex().Replace(requestString, "$1[REDACTED]");
         }
 
-        [GeneratedRegex(@"(?<=\bAuthorization:\s)[^\r\n]+", RegexOptions.IgnoreCase)]
+        [GeneratedRegex(@"(?m)^([ \t]*Authorization:[ \t]*)[^\r\n]+", RegexOptions.IgnoreCase)]
         private static partial Regex AuthorizationHeaderRegex();
     }
 }

--- a/src/Cli/func/Arm/ArmClient.cs
+++ b/src/Cli/func/Arm/ArmClient.cs
@@ -3,6 +3,7 @@
 
 using System.Net.Sockets;
 using System.Text;
+using System.Text.RegularExpressions;
 using Azure.Functions.Cli.Common;
 using Colors.Net;
 using Newtonsoft.Json;
@@ -137,7 +138,7 @@ namespace Azure.Functions.Cli.Arm
     }
 
     // https://stackoverflow.com/a/18925296
-    public class LoggingHandler : DelegatingHandler
+    public partial class LoggingHandler : DelegatingHandler
     {
         public LoggingHandler(HttpMessageHandler innerHandler)
             : base(innerHandler)
@@ -147,7 +148,7 @@ namespace Azure.Functions.Cli.Arm
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             ColoredConsole.WriteLine(DarkGray("Request:"));
-            ColoredConsole.WriteLine(DarkGray(request.ToString()));
+            ColoredConsole.WriteLine(DarkGray(GetRedactedRequestString(request.ToString())));
             if (request.Content != null)
             {
                 ColoredConsole.WriteLine(DarkGray(await request.Content.ReadAsStringAsync()));
@@ -168,5 +169,17 @@ namespace Azure.Functions.Cli.Arm
 
             return response;
         }
+
+        /// <summary>
+        /// Replaces the <c>Authorization</c> header value in a pre-serialized HTTP request string
+        /// with <c>[REDACTED]</c> to prevent Bearer tokens from appearing in debug output.
+        /// </summary>
+        internal static string GetRedactedRequestString(string requestString)
+        {
+            return AuthorizationHeaderRegex().Replace(requestString, "[REDACTED]");
+        }
+
+        [System.Text.RegularExpressions.GeneratedRegex(@"(?<=\bAuthorization:\s)[^\r\n]+", System.Text.RegularExpressions.RegexOptions.IgnoreCase)]
+        private static partial System.Text.RegularExpressions.Regex AuthorizationHeaderRegex();
     }
 }

--- a/src/Cli/func/Arm/ArmClient.cs
+++ b/src/Cli/func/Arm/ArmClient.cs
@@ -179,7 +179,7 @@ namespace Azure.Functions.Cli.Arm
             return AuthorizationHeaderRegex().Replace(requestString, "[REDACTED]");
         }
 
-        [System.Text.RegularExpressions.GeneratedRegex(@"(?<=\bAuthorization:\s)[^\r\n]+", System.Text.RegularExpressions.RegexOptions.IgnoreCase)]
-        private static partial System.Text.RegularExpressions.Regex AuthorizationHeaderRegex();
+        [GeneratedRegex(@"(?<=\bAuthorization:\s)[^\r\n]+", RegexOptions.IgnoreCase)]
+        private static partial Regex AuthorizationHeaderRegex();
     }
 }

--- a/test/Cli/Func.UnitTests/ArmTests/LoggingHandlerTests.cs
+++ b/test/Cli/Func.UnitTests/ArmTests/LoggingHandlerTests.cs
@@ -53,5 +53,15 @@ namespace Azure.Functions.Cli.UnitTests.ArmTests
             result.Should().Contain("[REDACTED]");
             result.Should().NotContain("my-secret-token");
         }
+
+        [Fact]
+        public void GetRedactedRequestString_DoesNotRedactProxyAuthorizationHeader()
+        {
+            var input = "Method: GET, RequestUri: 'https://management.azure.com/subscriptions', Version: 1.1, Content: <null>, Headers:\r\n{\r\n  Proxy-Authorization: Bearer proxy-secret-token\r\n}";
+
+            var result = LoggingHandler.GetRedactedRequestString(input);
+
+            result.Should().Contain("Proxy-Authorization: Bearer proxy-secret-token");
+        }
     }
 }

--- a/test/Cli/Func.UnitTests/ArmTests/LoggingHandlerTests.cs
+++ b/test/Cli/Func.UnitTests/ArmTests/LoggingHandlerTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using AwesomeAssertions;
+using Azure.Functions.Cli.Arm;
+using Xunit;
+
+namespace Azure.Functions.Cli.UnitTests.ArmTests
+{
+    public class LoggingHandlerTests
+    {
+        [Fact]
+        public void GetRedactedRequestString_RedactsAuthorizationHeader()
+        {
+            var input = "Method: GET, RequestUri: 'https://management.azure.com/subscriptions', Version: 1.1, Content: <null>, Headers:\r\n{\r\n  Authorization: Bearer my-secret-token\r\n}";
+
+            var result = LoggingHandler.GetRedactedRequestString(input);
+
+            result.Should().Contain("Authorization: [REDACTED]");
+            result.Should().NotContain("my-secret-token");
+        }
+
+        [Fact]
+        public void GetRedactedRequestString_PreservesNonSensitiveHeaders()
+        {
+            var input = "Method: GET, RequestUri: 'https://management.azure.com/subscriptions', Version: 1.1, Content: <null>, Headers:\r\n{\r\n  Authorization: Bearer my-secret-token\r\n  Accept: application/json\r\n}";
+
+            var result = LoggingHandler.GetRedactedRequestString(input);
+
+            result.Should().Contain("Accept: application/json");
+        }
+
+        [Fact]
+        public void GetRedactedRequestString_WithNoAuthorizationHeader_ReturnsInputUnchanged()
+        {
+            var input = "Method: GET, RequestUri: 'https://management.azure.com/subscriptions', Version: 1.1, Content: <null>, Headers:\r\n{\r\n  Accept: application/json\r\n}";
+
+            var result = LoggingHandler.GetRedactedRequestString(input);
+
+            result.Should().Be(input);
+        }
+
+        [Theory]
+        [InlineData("authorization: Bearer my-secret-token")]
+        [InlineData("AUTHORIZATION: Bearer my-secret-token")]
+        [InlineData("Authorization: Bearer my-secret-token")]
+        public void GetRedactedRequestString_RedactsAuthorizationHeader_CaseInsensitive(string authHeaderLine)
+        {
+            var input = $"Method: GET, RequestUri: 'https://management.azure.com/subscriptions', Version: 1.1, Content: <null>, Headers:\r\n{{\r\n  {authHeaderLine}\r\n}}";
+
+            var result = LoggingHandler.GetRedactedRequestString(input);
+
+            result.Should().NotContain("my-secret-token");
+        }
+    }
+}

--- a/test/Cli/Func.UnitTests/ArmTests/LoggingHandlerTests.cs
+++ b/test/Cli/Func.UnitTests/ArmTests/LoggingHandlerTests.cs
@@ -50,6 +50,7 @@ namespace Azure.Functions.Cli.UnitTests.ArmTests
 
             var result = LoggingHandler.GetRedactedRequestString(input);
 
+            result.Should().Contain("[REDACTED]");
             result.Should().NotContain("my-secret-token");
         }
     }


### PR DESCRIPTION
Redact Authorization header value in CLI_DEBUG request logging.

#### Fix
Added GetRedactedRequestString(string) which uses a source-generated regex to replace the Authorization header value with [REDACTED] before writing to stdout. The output format is otherwise byte-for-byte identical to the original request.ToString().

#### Testing
Added unit tests in ArmTests/LoggingHandlerTests.cs covering:

1. Authorization header is redacted
2. Non-sensitive headers are preserved unchanged
3. No-op when Authorization header is absent
4. Case-insensitive matching (authorization, AUTHORIZATION, Authorization)

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)