### PR TITLE
Make host.json optional across func publish, and pack

### DIFF
--- a/src/Cli/func/Actions/AzureActions/PublishFunctionAppAction.cs
+++ b/src/Cli/func/Actions/AzureActions/PublishFunctionAppAction.cs
@@ -210,7 +210,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
             }
 
             // Get the GitIgnoreParser from the functionApp root
-            var functionAppRoot = ScriptHostHelpers.GetFunctionAppRootDirectory(Environment.CurrentDirectory);
+            var functionAppRoot = ScriptHostHelpers.GetFunctionAppRootDirectory(Environment.CurrentDirectory, ScriptHostHelpers.GetProjectRootSearchFiles(workerRuntime));
             var ignoreParser = PublishHelper.GetIgnoreParser(functionAppRoot);
 
             // Get Stacks once for both .NET version determination and EOL checking
@@ -680,7 +680,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
         private async Task PublishFunctionApp(Site functionApp, GitIgnoreParser ignoreParser, IDictionary<string, string> additionalAppSettings, WorkerRuntime workerRuntime)
         {
             ColoredConsole.WriteLine("Getting site publishing info...");
-            var functionAppRoot = ScriptHostHelpers.GetFunctionAppRootDirectory(Environment.CurrentDirectory);
+            var functionAppRoot = ScriptHostHelpers.GetFunctionAppRootDirectory(Environment.CurrentDirectory, ScriptHostHelpers.GetProjectRootSearchFiles(workerRuntime));
 
             // For dedicated linux apps, we do not support run from package right now
             var isFunctionAppDedicatedLinux = functionApp.IsLinux && !functionApp.IsDynamic && !functionApp.IsElasticPremium && !functionApp.IsFlex;
@@ -1398,7 +1398,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 // even when 'func publish' is run from a subdirectory. The Go binary ('app') may
                 // not exist yet when --list-included-files is run before a build, so annotate it
                 // rather than printing a misleading path that doesn't exist on disk.
-                var functionAppRoot = ScriptHostHelpers.GetFunctionAppRootDirectory(Environment.CurrentDirectory);
+                var functionAppRoot = ScriptHostHelpers.GetFunctionAppRootDirectory(Environment.CurrentDirectory, ScriptHostHelpers.GetProjectRootSearchFiles(GlobalCoreToolsSettings.CurrentWorkerRuntime));
                 foreach (var file in GoHelpers.GetPackFiles(functionAppRoot))
                 {
                     if (FileSystemHelpers.FileExists(file))

--- a/src/Cli/func/Actions/HostActions/Startup.cs
+++ b/src/Cli/func/Actions/HostActions/Startup.cs
@@ -94,6 +94,14 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 o.LogPath = _hostOptions.LogPath;
                 o.IsSelfHost = _hostOptions.IsSelfHost;
                 o.SecretsPath = _hostOptions.SecretsPath;
+
+                // Only force read-only (never clear it), so a real read-only deployment
+                // detected by the host is preserved. This prevents the host from writing a
+                // default host.json to the project when the project doesn't have one.
+                if (_hostOptions.IsFileSystemReadOnly)
+                {
+                    o.IsFileSystemReadOnly = true;
+                }
             });
 
             services.AddSingleton<IConfigureBuilder<IConfigurationBuilder>>(_ => new ExtensionBundleConfigurationBuilder(_hostOptions));

--- a/src/Cli/func/Actions/HostActions/Startup.cs
+++ b/src/Cli/func/Actions/HostActions/Startup.cs
@@ -94,14 +94,6 @@ namespace Azure.Functions.Cli.Actions.HostActions
                 o.LogPath = _hostOptions.LogPath;
                 o.IsSelfHost = _hostOptions.IsSelfHost;
                 o.SecretsPath = _hostOptions.SecretsPath;
-
-                // Only force read-only (never clear it), so a real read-only deployment
-                // detected by the host is preserved. This prevents the host from writing a
-                // default host.json to the project when the project doesn't have one.
-                if (_hostOptions.IsFileSystemReadOnly)
-                {
-                    o.IsFileSystemReadOnly = true;
-                }
             });
 
             services.AddSingleton<IConfigureBuilder<IConfigurationBuilder>>(_ => new ExtensionBundleConfigurationBuilder(_hostOptions));

--- a/src/Cli/func/Actions/LocalActions/PackAction/CustomPackSubcommandAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/CustomPackSubcommandAction.cs
@@ -34,14 +34,25 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
             {
                 dir =>
                 {
+                    var validateCustomHandlerTitle = "Validate Custom Handler Configuration";
+                    var hostJsonPath = Path.Combine(dir, Constants.HostJsonFileName);
+
+                    // host.json is optional. Without it there is no custom handler configuration
+                    // to validate, so surface a non-blocking warning instead of failing the pack.
+                    if (!FileSystemHelpers.FileExists(hostJsonPath))
+                    {
+                        PackValidationHelper.DisplayValidationWarning(
+                            validateCustomHandlerTitle,
+                            $"No {Constants.HostJsonFileName} found. Skipping custom handler configuration validation.");
+                        return;
+                    }
+
                     // Validate custom handler configuration and executable
                     try
                     {
-                        var hostJsonPath = Path.Combine(dir, Constants.HostJsonFileName);
                         var hostJsonContent = FileSystemHelpers.ReadAllTextFromFileAsync(hostJsonPath).Result;
                         var hostConfig = JObject.Parse(hostJsonContent);
                         var customHandler = hostConfig["customHandler"];
-                        var validateCustomHandlerTitle = "Validate Custom Handler Configuration";
                         var configWarning = "No custom handler configuration found in host.json. Please visit https://aka.ms/custom-handler-host-json" +
                                             " to view examples on how to configure the app.";
 

--- a/src/Cli/func/Actions/LocalActions/PackAction/CustomPackSubcommandAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/CustomPackSubcommandAction.cs
@@ -45,14 +45,17 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
                     // another way. Point the user at the equivalent application setting override.
                     if (!FileSystemHelpers.FileExists(hostJsonPath))
                     {
-                        PackValidationHelper.DisplayValidationWarning(
-                            validateCustomHandlerTitle,
+                        var missingHostJsonWarning =
                             $"No {Constants.HostJsonFileName} found. Skipping custom handler configuration validation. " +
                             "Custom handler apps require the executable to be configured via the " +
                             "customHandler.description.defaultExecutablePath property in host.json. " +
                             "Without host.json, set the 'AzureFunctionsJobHost__customHandler__description__defaultExecutablePath' " +
                             "application setting on the function app after deployment so the custom handler can start. " +
-                            "See https://aka.ms/custom-handler-host-json for details.");
+                            "See https://aka.ms/custom-handler-host-json for details.";
+
+                        PackValidationHelper.DisplayValidationWarning(
+                            validateCustomHandlerTitle,
+                            missingHostJsonWarning);
                         return;
                     }
 

--- a/src/Cli/func/Actions/LocalActions/PackAction/CustomPackSubcommandAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/CustomPackSubcommandAction.cs
@@ -39,11 +39,20 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
 
                     // host.json is optional. Without it there is no custom handler configuration
                     // to validate, so surface a non-blocking warning instead of failing the pack.
+                    // Custom handler apps normally declare their executable via the
+                    // customHandler.description.defaultExecutablePath property in host.json, so when
+                    // host.json is absent the deployed app will not start unless that path is supplied
+                    // another way. Point the user at the equivalent application setting override.
                     if (!FileSystemHelpers.FileExists(hostJsonPath))
                     {
                         PackValidationHelper.DisplayValidationWarning(
                             validateCustomHandlerTitle,
-                            $"No {Constants.HostJsonFileName} found. Skipping custom handler configuration validation.");
+                            $"No {Constants.HostJsonFileName} found. Skipping custom handler configuration validation. " +
+                            "Custom handler apps require the executable to be configured via the " +
+                            "customHandler.description.defaultExecutablePath property in host.json. " +
+                            "Without host.json, set the 'AzureFunctionsJobHost__customHandler__description__defaultExecutablePath' " +
+                            "application setting on the function app after deployment so the custom handler can start. " +
+                            "See https://aka.ms/custom-handler-host-json for details.");
                         return;
                     }
 

--- a/src/Cli/func/Actions/LocalActions/PackAction/NodePackSubcommandAction.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/NodePackSubcommandAction.cs
@@ -50,7 +50,7 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
         {
             var validations = new List<Action<string>>
             {
-                dir => PackValidationHelper.RunRequiredFilesValidation(dir, new[] { "package.json", "host.json" }, "Validate Folder Structure")
+                dir => PackValidationHelper.RunRequiredFilesValidation(dir, new[] { "package.json" }, "Validate Folder Structure")
             };
             PackValidationHelper.RunValidations(functionAppRoot, validations);
         }

--- a/src/Cli/func/Actions/LocalActions/PackAction/PackHelpers.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/PackHelpers.cs
@@ -41,9 +41,11 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
 
         public static void ValidateFunctionAppRoot(string functionAppRoot)
         {
+            // host.json is optional and Core Tools no longer adds one, so its absence is not a
+            // hard error. The package is built from whatever the project contains.
             if (!FileSystemHelpers.FileExists(Path.Combine(functionAppRoot, ScriptConstants.HostMetadataFileName)))
             {
-                throw new CliException($"Can't find {Path.Combine(functionAppRoot, ScriptConstants.HostMetadataFileName)}");
+                ColoredConsole.WriteLine(WarningColor($"No {ScriptConstants.HostMetadataFileName} found in {functionAppRoot}. The package will be created without one."));
             }
         }
 

--- a/src/Cli/func/Actions/LocalActions/PackAction/PackHelpers.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/PackHelpers.cs
@@ -41,8 +41,8 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
 
         public static void ValidateFunctionAppRoot(string functionAppRoot)
         {
-            // host.json is optional and Core Tools no longer adds one, so its absence is not a
-            // hard error. The package is built from whatever the project contains.
+            // host.json is optional, so its absence is not a hard error.
+            // The package is built from whatever the project contains.
             if (!FileSystemHelpers.FileExists(Path.Combine(functionAppRoot, ScriptConstants.HostMetadataFileName)))
             {
                 ColoredConsole.WriteLine(WarningColor($"No {ScriptConstants.HostMetadataFileName} found in {functionAppRoot}. The package will be created without one."));

--- a/src/Cli/func/Actions/LocalActions/PackAction/PackValidationHelper.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/PackValidationHelper.cs
@@ -132,20 +132,22 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
         }
 
         /// <summary>
-        /// Runs a host.json existence validation and displays results.
-        /// Throws CliException if validation fails.
+        /// Runs a host.json existence check and displays the result.
+        /// host.json is optional: the runtime does not require it and Core Tools no longer adds
+        /// one, so its absence is surfaced as a non-blocking warning rather than a failure.
         /// </summary>
         public static void RunHostJsonValidation(string directory)
         {
             var hostJsonExists = FileSystemHelpers.FileExists(Path.Combine(directory, Constants.HostJsonFileName));
-            DisplayValidationResult(
-                $"Validate {Constants.HostJsonFileName}",
-                hostJsonExists,
-                hostJsonExists ? null : string.Empty);
-            if (!hostJsonExists)
+            if (hostJsonExists)
             {
-                DisplayValidationEnd();
-                throw new CliException($"Required file '{Constants.HostJsonFileName}' not found in directory: {directory}");
+                DisplayValidationResult($"Validate {Constants.HostJsonFileName}", passed: true);
+            }
+            else
+            {
+                DisplayValidationWarning(
+                    $"Validate {Constants.HostJsonFileName}",
+                    $"No {Constants.HostJsonFileName} found in {directory}. The package will be created without one.");
             }
         }
 

--- a/src/Cli/func/Actions/LocalActions/PackAction/PackValidationHelper.cs
+++ b/src/Cli/func/Actions/LocalActions/PackAction/PackValidationHelper.cs
@@ -133,8 +133,8 @@ namespace Azure.Functions.Cli.Actions.LocalActions.PackAction
 
         /// <summary>
         /// Runs a host.json existence check and displays the result.
-        /// host.json is optional: the runtime does not require it and Core Tools no longer adds
-        /// one, so its absence is surfaced as a non-blocking warning rather than a failure.
+        /// host.json is optional: the runtime does not require it, so its absence is surfaced
+        /// as a non-blocking warning rather than a failure.
         /// </summary>
         public static void RunHostJsonValidation(string directory)
         {

--- a/src/Cli/func/Common/SelfHostWebHostSettingsFactory.cs
+++ b/src/Cli/func/Common/SelfHostWebHostSettingsFactory.cs
@@ -14,7 +14,12 @@ namespace Azure.Functions.Cli.Common
                 IsSelfHost = true,
                 ScriptPath = scriptPath,
                 LogPath = Path.Combine(Path.GetTempPath(), "LogFiles", "Application", "Functions"),
-                SecretsPath = Path.Combine(Path.GetTempPath(), "secrets", "functions", "secrets")
+                SecretsPath = Path.Combine(Path.GetTempPath(), "secrets", "functions", "secrets"),
+
+                // host.json is optional. When the project has no host.json, run the host with a
+                // read-only file system so it does not synthesize and write a default host.json
+                // to the user's project directory (it uses an in-memory default config instead).
+                IsFileSystemReadOnly = !File.Exists(Path.Combine(scriptPath, ScriptConstants.HostMetadataFileName))
             };
         }
     }

--- a/src/Cli/func/Common/SelfHostWebHostSettingsFactory.cs
+++ b/src/Cli/func/Common/SelfHostWebHostSettingsFactory.cs
@@ -14,12 +14,7 @@ namespace Azure.Functions.Cli.Common
                 IsSelfHost = true,
                 ScriptPath = scriptPath,
                 LogPath = Path.Combine(Path.GetTempPath(), "LogFiles", "Application", "Functions"),
-                SecretsPath = Path.Combine(Path.GetTempPath(), "secrets", "functions", "secrets"),
-
-                // host.json is optional. When the project has no host.json, run the host with a
-                // read-only file system so it does not synthesize and write a default host.json
-                // to the user's project directory (it uses an in-memory default config instead).
-                IsFileSystemReadOnly = !File.Exists(Path.Combine(scriptPath, ScriptConstants.HostMetadataFileName))
+                SecretsPath = Path.Combine(Path.GetTempPath(), "secrets", "functions", "secrets")
             };
         }
     }

--- a/src/Cli/func/Helpers/GoHelpers.cs
+++ b/src/Cli/func/Helpers/GoHelpers.cs
@@ -295,11 +295,15 @@ namespace Azure.Functions.Cli.Helpers
         internal static IEnumerable<string> GetPackFiles(string functionAppRoot)
         {
             functionAppRoot ??= Environment.CurrentDirectory;
-            return new[]
+
+            // host.json is optional; only include it in the allowlist when it exists.
+            var hostJsonPath = Path.Combine(functionAppRoot, Constants.HostJsonFileName);
+            if (FileSystemHelpers.FileExists(hostJsonPath))
             {
-                Path.Combine(functionAppRoot, Constants.HostJsonFileName),
-                Path.Combine(functionAppRoot, GoBinDir, GoBinaryName),
-            };
+                yield return hostJsonPath;
+            }
+
+            yield return Path.Combine(functionAppRoot, GoBinDir, GoBinaryName);
         }
 
         /// <summary>

--- a/src/Cli/func/Helpers/GoHelpers.cs
+++ b/src/Cli/func/Helpers/GoHelpers.cs
@@ -307,9 +307,10 @@ namespace Azure.Functions.Cli.Helpers
         }
 
         /// <summary>
-        /// Verifies the function app root has the files required to build/publish a Go app
-        /// (<c>host.json</c> and <c>go.mod</c>) by routing through <see cref="PackValidationHelper"/>
-        /// so <c>func pack</c> and <c>func publish</c> share the same validation flow and messages.
+        /// Verifies the function app root has the files required to build/publish a Go app.
+        /// <c>go.mod</c> is required; <c>host.json</c> is optional (a warning is emitted when it
+        /// is absent). Routes through <see cref="PackValidationHelper"/> so <c>func pack</c> and
+        /// <c>func publish</c> share the same validation flow and messages.
         /// Throws <see cref="CliException"/> on failure.
         /// </summary>
         internal static void AssertGoFunctionAppLayout(string functionAppRoot)

--- a/src/Cli/func/Helpers/HostHelpers.cs
+++ b/src/Cli/func/Helpers/HostHelpers.cs
@@ -14,7 +14,9 @@ namespace Azure.Functions.Cli.Helpers
             var file = !string.IsNullOrEmpty(path) ? Path.Combine(path, Constants.HostJsonFileName) : Constants.HostJsonFileName;
             if (!FileSystemHelpers.FileExists(file))
             {
-                throw new InvalidOperationException();
+                // host.json is optional. A project without one cannot declare a custom handler,
+                // so there is no executable to report.
+                return string.Empty;
             }
 
             var hostJson = JsonConvert.DeserializeObject<JToken>(await FileSystemHelpers.ReadAllTextFromFileAsync(file));

--- a/src/Cli/func/Helpers/ScriptHostHelpers.cs
+++ b/src/Cli/func/Helpers/ScriptHostHelpers.cs
@@ -17,7 +17,16 @@ namespace Azure.Functions.Cli.Helpers
                 return startingDirectory;
             }
 
-            searchFiles = searchFiles ?? new List<string> { ScriptConstants.HostMetadataFileName };
+            // host.json is no longer strictly required in a Functions project (the runtime
+            // synthesizes a default when it is missing). Detect the project root using any of
+            // the common Functions project markers so publishing/packing works without host.json.
+            searchFiles = searchFiles ?? new List<string>
+            {
+                ScriptConstants.HostMetadataFileName,
+                Constants.LocalSettingsJsonFileName,
+                Constants.FuncIgnoreFile,
+                Constants.PySteinFunctionAppPy,
+            };
 
             if (searchFiles.Any(file => FileSystemHelpers.FileExists(Path.Combine(startingDirectory, file))))
             {

--- a/src/Cli/func/Helpers/ScriptHostHelpers.cs
+++ b/src/Cli/func/Helpers/ScriptHostHelpers.cs
@@ -19,13 +19,16 @@ namespace Azure.Functions.Cli.Helpers
 
             // host.json is no longer strictly required in a Functions project (the runtime
             // synthesizes a default when it is missing). Detect the project root using any of
-            // the common Functions project markers so publishing/packing works without host.json.
+            // the common Functions project markers (across languages) so publishing/packing
+            // works without host.json.
             searchFiles = searchFiles ?? new List<string>
             {
                 ScriptConstants.HostMetadataFileName,
                 Constants.LocalSettingsJsonFileName,
                 Constants.FuncIgnoreFile,
                 Constants.PySteinFunctionAppPy,
+                Constants.PackageJsonFileName,
+                GoHelpers.GoModFileName,
             };
 
             if (searchFiles.Any(file => FileSystemHelpers.FileExists(Path.Combine(startingDirectory, file))))

--- a/src/Cli/func/Helpers/ScriptHostHelpers.cs
+++ b/src/Cli/func/Helpers/ScriptHostHelpers.cs
@@ -17,19 +17,7 @@ namespace Azure.Functions.Cli.Helpers
                 return startingDirectory;
             }
 
-            // host.json is no longer strictly required in a Functions project (the runtime
-            // synthesizes a default when it is missing). Detect the project root using any of
-            // the common Functions project markers (across languages) so publishing/packing
-            // works without host.json.
-            searchFiles = searchFiles ?? new List<string>
-            {
-                ScriptConstants.HostMetadataFileName,
-                Constants.LocalSettingsJsonFileName,
-                Constants.FuncIgnoreFile,
-                Constants.PySteinFunctionAppPy,
-                Constants.PackageJsonFileName,
-                GoHelpers.GoModFileName,
-            };
+            searchFiles = searchFiles ?? new List<string> { ScriptConstants.HostMetadataFileName };
 
             if (searchFiles.Any(file => FileSystemHelpers.FileExists(Path.Combine(startingDirectory, file))))
             {
@@ -47,6 +35,37 @@ namespace Azure.Functions.Cli.Helpers
             {
                 return GetFunctionAppRootDirectory(parent, searchFiles);
             }
+        }
+
+        // host.json is no longer strictly required in a Functions project (the runtime synthesizes a
+        // default when it is missing), so publish/pack must be able to locate the project root without
+        // it. Callers that have already resolved the worker runtime use this to build a marker list that
+        // combines the common Functions project files with a runtime-specific project marker. This is
+        // intentionally scoped to publish/pack and is not applied to the default root detection used by
+        // other commands (e.g. func start, func init), whose behavior remains host.json based.
+        public static List<string> GetProjectRootSearchFiles(WorkerRuntime workerRuntime)
+        {
+            var searchFiles = new List<string>
+            {
+                ScriptConstants.HostMetadataFileName,
+                Constants.LocalSettingsJsonFileName,
+                Constants.FuncIgnoreFile,
+            };
+
+            switch (workerRuntime)
+            {
+                case WorkerRuntime.Python:
+                    searchFiles.Add(Constants.PySteinFunctionAppPy);
+                    break;
+                case WorkerRuntime.Node:
+                    searchFiles.Add(Constants.PackageJsonFileName);
+                    break;
+                case WorkerRuntime.Go:
+                    searchFiles.Add(GoHelpers.GoModFileName);
+                    break;
+            }
+
+            return searchFiles;
         }
     }
 }

--- a/src/Cli/func/Helpers/ZipHelper.cs
+++ b/src/Cli/func/Helpers/ZipHelper.cs
@@ -125,8 +125,12 @@ namespace Azure.Functions.Cli.Helpers
 
             using (var zip = new ZipArchive(memStream, ZipArchiveMode.Create, leaveOpen: true))
             {
-                var hostEntry = zip.CreateEntryFromFile(hostJsonPath, Constants.HostJsonFileName);
-                hostEntry.ExternalAttributes = unixReadWritePermissions;
+                // host.json is optional; only include it when the project actually has one.
+                if (FileSystemHelpers.FileExists(hostJsonPath))
+                {
+                    var hostEntry = zip.CreateEntryFromFile(hostJsonPath, Constants.HostJsonFileName);
+                    hostEntry.ExternalAttributes = unixReadWritePermissions;
+                }
 
                 // Place binary at root as 'app', not 'bin/app'
                 var appEntry = zip.CreateEntryFromFile(binaryPath, GoHelpers.GoBinaryName);

--- a/test/Cli/Func.UnitTests/ActionsTests/PackAction/CustomPackSubcommandActionTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/PackAction/CustomPackSubcommandActionTests.cs
@@ -68,12 +68,14 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests.PackAction
         }
 
         [Fact]
-        public void ValidateCustomHandlerFunctionApp_MissingHostJson_Throws()
+        public void ValidateCustomHandlerFunctionApp_MissingHostJson_DoesNotThrow()
         {
+            // host.json is optional. When it is absent, pack should surface a non-blocking
+            // warning and skip custom handler validation rather than failing.
             var action = new CustomPackSubcommandAction();
             var options = new PackOptions();
-            var ex = Assert.Throws<CliException>(() => action.ValidateFunctionApp(_tempDirectory, options));
-            Assert.Contains("host.json", ex.Message);
+            var ex = Record.Exception(() => action.ValidateFunctionApp(_tempDirectory, options));
+            Assert.Null(ex);
         }
     }
 }

--- a/test/Cli/Func.UnitTests/ActionsTests/PackAction/GoPackSubcommandActionTests.cs
+++ b/test/Cli/Func.UnitTests/ActionsTests/PackAction/GoPackSubcommandActionTests.cs
@@ -39,15 +39,15 @@ namespace Azure.Functions.Cli.UnitTests.ActionsTests.PackAction
         }
 
         [Fact]
-        public void ValidateFunctionApp_MissingHostJson_ThrowsCliException()
+        public void ValidateFunctionApp_MissingHostJson_DoesNotThrow()
         {
+            // host.json is optional. Go pack should still validate on go.mod alone.
             File.WriteAllText(Path.Combine(_tempDirectory, "go.mod"), "module example.com/test\n\ngo 1.24\n");
 
             var action = new GoPackSubcommandAction();
             var validate = () => action.ValidateFunctionApp(_tempDirectory, new PackOptions());
 
-            validate.Should().Throw<CliException>()
-                .Which.Message.Should().Contain("host.json");
+            validate.Should().NotThrow();
         }
 
         [Fact]

--- a/test/Cli/Func.UnitTests/HelperTests/GoHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/GoHelperTests.cs
@@ -302,15 +302,36 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
         }
 
         [Fact]
-        public void GetPackFiles_ReturnsHostJsonAndAppBinary()
+        public void GetPackFiles_WhenHostJsonExists_ReturnsHostJsonAndAppBinary()
         {
+            var root = Path.Combine(Path.GetTempPath(), "func-go-files-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(root);
+            try
+            {
+                File.WriteAllText(Path.Combine(root, "host.json"), "{}");
+
+                var files = GoHelpers.GetPackFiles(root).ToArray();
+
+                files.Should().HaveCount(2);
+                files.Should().Contain(Path.Combine(root, "host.json"));
+                files.Should().Contain(Path.Combine(root, GoHelpers.GoBinDir, GoHelpers.GoBinaryName));
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void GetPackFiles_WhenHostJsonMissing_ReturnsOnlyAppBinary()
+        {
+            // host.json is optional; it is only included in the allowlist when present.
             var root = Path.Combine(Path.GetTempPath(), "func-go-files-" + Guid.NewGuid().ToString("N"));
 
             var files = GoHelpers.GetPackFiles(root).ToArray();
 
-            files.Should().HaveCount(2);
-            files.Should().Contain(Path.Combine(root, "host.json"));
-            files.Should().Contain(Path.Combine(root, GoHelpers.GoBinDir, GoHelpers.GoBinaryName));
+            files.Should().ContainSingle()
+                .Which.Should().Be(Path.Combine(root, GoHelpers.GoBinDir, GoHelpers.GoBinaryName));
         }
 
         // Builds a minimal 20-byte ELF identification region with EI_CLASS=64-bit, EI_DATA=little-endian

--- a/test/Cli/Func.UnitTests/HelperTests/HostHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/HostHelperTests.cs
@@ -14,16 +14,20 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
     public class HostHelperTests
     {
         [Fact]
-        public async Task GetCustomHandlerExecutable_Throws_When_HostJson_Missing()
+        public async Task GetCustomHandlerExecutable_Returns_Empty_When_HostJson_Missing()
         {
-            // Arrange
+            // host.json is optional. When it is absent there is no custom handler to resolve,
+            // so the helper returns empty rather than throwing.
             var fs = Substitute.For<IFileSystem>();
             fs.File.Exists(Arg.Any<string>()).Returns(false);
 
             using (FileSystemHelpers.Override(fs))
             {
-                // Act/Assert
-                await Assert.ThrowsAsync<InvalidOperationException>(() => HostHelpers.GetCustomHandlerExecutable());
+                // Act
+                var result = await HostHelpers.GetCustomHandlerExecutable();
+
+                // Assert
+                result.Should().BeEmpty();
             }
         }
 

--- a/test/Cli/Func.UnitTests/HelperTests/ScriptHostHelpersTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/ScriptHostHelpersTests.cs
@@ -13,13 +13,13 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
     public class ScriptHostHelpersTests
     {
         [Theory]
-        [InlineData("host.json")]
-        [InlineData("local.settings.json")]
-        [InlineData(".funcignore")]
-        [InlineData("function_app.py")]
-        [InlineData("package.json")]
-        [InlineData("go.mod")]
-        public void GetFunctionAppRootDirectory_DetectsRoot_ByAnyLanguageMarker_WithoutHostJson(string marker)
+        [InlineData(WorkerRuntime.Python, "host.json")]
+        [InlineData(WorkerRuntime.Python, "local.settings.json")]
+        [InlineData(WorkerRuntime.Python, ".funcignore")]
+        [InlineData(WorkerRuntime.Python, "function_app.py")]
+        [InlineData(WorkerRuntime.Node, "package.json")]
+        [InlineData(WorkerRuntime.Go, "go.mod")]
+        public void GetFunctionAppRootDirectory_DetectsRoot_ByRuntimeMarker_WithoutHostJson(WorkerRuntime workerRuntime, string marker)
         {
             // Arrange
             var projectRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
@@ -32,10 +32,51 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
             using (FileSystemHelpers.Override(fs))
             {
                 // Act
-                var result = ScriptHostHelpers.GetFunctionAppRootDirectory(projectRoot);
+                var result = ScriptHostHelpers.GetFunctionAppRootDirectory(projectRoot, ScriptHostHelpers.GetProjectRootSearchFiles(workerRuntime));
 
                 // Assert
                 result.Should().Be(projectRoot);
+            }
+        }
+
+        [Theory]
+        [InlineData(WorkerRuntime.Python, "function_app.py")]
+        [InlineData(WorkerRuntime.Node, "package.json")]
+        [InlineData(WorkerRuntime.Go, "go.mod")]
+        public void GetProjectRootSearchFiles_IncludesCommonMarkers_AndRuntimeMarker(WorkerRuntime workerRuntime, string runtimeMarker)
+        {
+            // Act
+            var searchFiles = ScriptHostHelpers.GetProjectRootSearchFiles(workerRuntime);
+
+            // Assert
+            searchFiles.Should().Contain("host.json");
+            searchFiles.Should().Contain("local.settings.json");
+            searchFiles.Should().Contain(".funcignore");
+            searchFiles.Should().Contain(runtimeMarker);
+        }
+
+        [Fact]
+        public void GetFunctionAppRootDirectory_DefaultSearchFiles_UsesHostJsonOnly()
+        {
+            // Arrange
+            var projectRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            var packageJsonPath = Path.Combine(projectRoot, "package.json");
+
+            // Only a non-host.json marker exists: the default (host.json-only) detection must not treat
+            // this directory as the project root, preserving pre-existing behavior for commands other
+            // than publish/pack.
+            var fs = Substitute.For<IFileSystem>();
+            fs.File.Exists(Arg.Any<string>())
+              .Returns(ci => string.Equals(ci.ArgAt<string>(0), packageJsonPath, StringComparison.OrdinalIgnoreCase));
+
+            using (FileSystemHelpers.Override(fs))
+            {
+                // Act
+                var act = () => ScriptHostHelpers.GetFunctionAppRootDirectory(projectRoot);
+
+                // Assert
+                act.Should().Throw<CliException>()
+                    .Which.Message.Should().Contain("Unable to find project root");
             }
         }
 

--- a/test/Cli/Func.UnitTests/HelperTests/ScriptHostHelpersTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/ScriptHostHelpersTests.cs
@@ -1,0 +1,62 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.IO.Abstractions;
+using AwesomeAssertions;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Helpers;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Functions.Cli.UnitTests.HelperTests
+{
+    public class ScriptHostHelpersTests
+    {
+        [Theory]
+        [InlineData("host.json")]
+        [InlineData("local.settings.json")]
+        [InlineData(".funcignore")]
+        [InlineData("function_app.py")]
+        [InlineData("package.json")]
+        [InlineData("go.mod")]
+        public void GetFunctionAppRootDirectory_DetectsRoot_ByAnyLanguageMarker_WithoutHostJson(string marker)
+        {
+            // Arrange
+            var projectRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            var markerPath = Path.Combine(projectRoot, marker);
+
+            var fs = Substitute.For<IFileSystem>();
+            fs.File.Exists(Arg.Any<string>())
+              .Returns(ci => string.Equals(ci.ArgAt<string>(0), markerPath, StringComparison.OrdinalIgnoreCase));
+
+            using (FileSystemHelpers.Override(fs))
+            {
+                // Act
+                var result = ScriptHostHelpers.GetFunctionAppRootDirectory(projectRoot);
+
+                // Assert
+                result.Should().Be(projectRoot);
+            }
+        }
+
+        [Fact]
+        public void GetFunctionAppRootDirectory_Throws_WhenNoMarkersFound()
+        {
+            // Arrange
+            var startingDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "sub", "dir");
+
+            var fs = Substitute.For<IFileSystem>();
+            fs.File.Exists(Arg.Any<string>()).Returns(false);
+
+            using (FileSystemHelpers.Override(fs))
+            {
+                // Act
+                var act = () => ScriptHostHelpers.GetFunctionAppRootDirectory(startingDirectory);
+
+                // Assert
+                act.Should().Throw<CliException>()
+                    .Which.Message.Should().Contain("Unable to find project root");
+            }
+        }
+    }
+}

--- a/test/Cli/Func.UnitTests/HelperTests/ZipHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/ZipHelperTests.cs
@@ -264,5 +264,65 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
                 Directory.Delete(dir, recursive: true);
             }
         }
+
+        [Fact]
+        public async Task GetAppZipFile_MissingHostJson_PackageDoesNotContainHostJsonAndSourceUntouched()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(dir);
+
+            try
+            {
+                // A Python v2 project with no host.json on disk.
+                File.WriteAllText(Path.Combine(dir, "function_app.py"), "import azure.functions as func\napp = func.FunctionApp()\n");
+
+                // noBuild:true keeps Python on the generic zip path (no pip/build required).
+                var stream = await ZipHelper.GetAppZipFile(dir, buildNativeDeps: false, BuildOption.Default, noBuild: true, WorkerRuntime.Python);
+
+                Assert.NotNull(stream);
+                using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
+
+                // host.json is optional and Core Tools does not add one: the package must not
+                // contain a host.json when the project does not have one...
+                Assert.DoesNotContain(archive.Entries, e => e.FullName == "host.json");
+                Assert.Contains(archive.Entries, e => e.FullName == "function_app.py");
+
+                // ...and the user's source tree is left untouched.
+                Assert.False(File.Exists(Path.Combine(dir, "host.json")), "host.json should not be written to the source directory.");
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public async Task GetAppZipFile_ExistingHostJson_IsIncludedUnchanged()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(dir);
+
+            try
+            {
+                const string marker = "\"MARKER_EXISTING\": true";
+                File.WriteAllText(Path.Combine(dir, "host.json"), "{ \"version\": \"2.0\", " + marker + " }");
+                File.WriteAllText(Path.Combine(dir, "function_app.py"), "import azure.functions as func\napp = func.FunctionApp()\n");
+
+                var stream = await ZipHelper.GetAppZipFile(dir, buildNativeDeps: false, BuildOption.Default, noBuild: true, WorkerRuntime.Python);
+
+                Assert.NotNull(stream);
+                using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
+                var hostEntries = archive.Entries.Where(e => e.FullName == "host.json").ToArray();
+
+                // Exactly one host.json, and it is the user's original content.
+                Assert.Single(hostEntries);
+                using var reader = new StreamReader(hostEntries[0].Open());
+                Assert.Contains(marker, reader.ReadToEnd());
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
     }
 }

--- a/test/Cli/Func.UnitTests/HelperTests/ZipHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/ZipHelperTests.cs
@@ -282,8 +282,8 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
                 Assert.NotNull(stream);
                 using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
 
-                // host.json is optional and Core Tools does not add one: the package must not
-                // contain a host.json when the project does not have one...
+                // host.json is optional and the pack path does not add one to the package:
+                // the package must not contain a host.json when the project does not have one...
                 Assert.DoesNotContain(archive.Entries, e => e.FullName == "host.json");
                 Assert.Contains(archive.Entries, e => e.FullName == "function_app.py");
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

## Summary

Aligns Core Tools with the fact that the Azure Functions runtime does not require a
`host.json` file. Previously `func azure functionapp publish` and `func pack` hard-failed
when a project had no `host.json` — root detection used `host.json` as the sole project
marker, so publish/pack aborted before packaging. This PR makes `host.json` optional for
`func pack` and `func azure functionapp publish` across all runtimes, while leaving
projects that *do* have a `host.json` completely unchanged.

Note: this PR does **not** change `func start`. The host runtime still synthesizes and
writes a default `host.json` during `func start` when one is missing; suppressing that
write requires a dedicated host-side option and will be handled separately (reusing the
host's `IsFileSystemReadOnly` flag was rejected because it also disables jobhost file
watching and the in-memory extension bundle).

Verified with a Python v2 (`function_app.py`) single HTTP-trigger project with no
`host.json`: `func pack` produces a deployable zip containing the app files and no
`host.json`.


resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
