### PR TITLE
fix(azurite): detect and classify existing Azurite by data directory (#5264)

### DIFF
--- a/src/Func/Commands/Start/Azurite/AzuriteCommandLine.cs
+++ b/src/Func/Commands/Start/Azurite/AzuriteCommandLine.cs
@@ -1,0 +1,136 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Text;
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite;
+
+/// <summary>
+/// Pure helpers for recognizing an Azurite process from its command line and
+/// extracting the data directory it was launched against.
+/// </summary>
+internal static class AzuriteCommandLine
+{
+    /// <summary>
+    /// Returns <c>true</c> when the command line looks like an Azurite process.
+    /// </summary>
+    public static bool LooksLikeAzurite(string? commandLine)
+        => !string.IsNullOrWhiteSpace(commandLine)
+            && commandLine.Contains("azurite", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Extracts the data directory from an Azurite command line, i.e. the value
+    /// following the <c>-l</c> / <c>--location</c> switch.
+    /// </summary>
+    public static bool TryGetDataDirectory(string? commandLine, out string? dataDirectory)
+    {
+        dataDirectory = null;
+        if (string.IsNullOrWhiteSpace(commandLine))
+        {
+            return false;
+        }
+
+        IReadOnlyList<string> tokens = Tokenize(commandLine);
+        for (int i = 0; i < tokens.Count; i++)
+        {
+            string token = tokens[i];
+
+            // Equals form: -l=<dir> / --location=<dir>.
+            if (TryGetInlineValue(token, "-l", out string? inline)
+                || TryGetInlineValue(token, "--location", out inline))
+            {
+                if (!string.IsNullOrWhiteSpace(inline))
+                {
+                    dataDirectory = inline;
+                    return true;
+                }
+
+                continue;
+            }
+
+            // Space form: -l <dir> / --location <dir>.
+            if (token is "-l" or "--location" && i + 1 < tokens.Count)
+            {
+                string candidate = tokens[i + 1];
+                if (!string.IsNullOrWhiteSpace(candidate))
+                {
+                    dataDirectory = candidate;
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryGetInlineValue(string token, string flag, out string? value)
+    {
+        value = null;
+        string prefix = flag + "=";
+        if (token.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            value = token[prefix.Length..];
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Splits a command line into tokens, honoring single and double quotes so
+    /// paths containing spaces survive as one token. Quotes are stripped.
+    /// </summary>
+    private static List<string> Tokenize(string commandLine)
+    {
+        List<string> tokens = [];
+        StringBuilder current = new();
+        bool inToken = false;
+        char quote = '\0';
+
+        foreach (char c in commandLine)
+        {
+            if (quote != '\0')
+            {
+                if (c == quote)
+                {
+                    quote = '\0';
+                }
+                else
+                {
+                    current.Append(c);
+                }
+
+                continue;
+            }
+
+            if (c is '"' or '\'')
+            {
+                quote = c;
+                inToken = true;
+                continue;
+            }
+
+            if (char.IsWhiteSpace(c))
+            {
+                if (inToken)
+                {
+                    tokens.Add(current.ToString());
+                    current.Clear();
+                    inToken = false;
+                }
+
+                continue;
+            }
+
+            current.Append(c);
+            inToken = true;
+        }
+
+        if (inToken)
+        {
+            tokens.Add(current.ToString());
+        }
+
+        return tokens;
+    }
+}

--- a/src/Func/Commands/Start/Azurite/AzuritePath.cs
+++ b/src/Func/Commands/Start/Azurite/AzuritePath.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite;
+
+/// <summary>
+/// Pure helpers for comparing managed-Azurite directory paths using
+/// platform-appropriate normalization and case sensitivity.
+/// </summary>
+internal static class AzuritePath
+{
+    /// <summary>
+    /// Returns <c>true</c> when two paths refer to the same directory after
+    /// normalization. Comparison is case-insensitive on Windows and
+    /// case-sensitive elsewhere.
+    /// </summary>
+    public static bool AreSameDirectory(string first, string second)
+    {
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+
+        StringComparison comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        return string.Equals(Normalize(first), Normalize(second), comparison);
+    }
+
+    private static string Normalize(string path)
+    {
+        try
+        {
+            return Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException or System.Security.SecurityException)
+        {
+            // A malformed path from a detected command line cannot be fully
+            // normalized; still trim a trailing separator so comparison keeps
+            // its "ignore trailing separator" contract.
+            return Path.TrimEndingDirectorySeparator(path.Trim());
+        }
+    }
+}

--- a/src/Func/Commands/Start/Azurite/AzuriteServiceCollectionExtensions.cs
+++ b/src/Func/Commands/Start/Azurite/AzuriteServiceCollectionExtensions.cs
@@ -73,6 +73,9 @@ internal static class AzuriteServiceCollectionExtensions
         services.TryAddSingleton<IProcessRunner, ProcessRunner>();
         services.TryAddSingleton<IAzuriteExecutableLocator, AzuriteExecutableLocator>();
         services.TryAddSingleton<IDockerAvailabilityProbe, DockerAvailabilityProbe>();
+        services.TryAddSingleton<IPortOwnershipStrategy>(
+            static _ => OperatingSystem.IsWindows() ? new WindowsPortOwnershipStrategy() : new UnixPortOwnershipStrategy());
+        services.TryAddSingleton<IListeningProcessInspector, ListeningProcessInspector>();
 
         return services;
     }

--- a/src/Func/Commands/Start/Azurite/Orchestration/ManagedAzuriteOrchestrator.cs
+++ b/src/Func/Commands/Start/Azurite/Orchestration/ManagedAzuriteOrchestrator.cs
@@ -3,6 +3,7 @@
 
 using System.Text;
 using Azure.Functions.Cli.Commands.Start.Azurite.Launching;
+using Azure.Functions.Cli.Commands.Start.Azurite.Processes;
 using Microsoft.Extensions.Logging;
 
 namespace Azure.Functions.Cli.Commands.Start.Azurite.Orchestration;
@@ -19,6 +20,7 @@ internal sealed class ManagedAzuriteOrchestrator : IManagedAzuriteOrchestrator
     private readonly IDockerAvailabilityProbe _dockerProbe;
     private readonly IAzuriteLauncher _launcher;
     private readonly IAzuriteManagedPathsProvider _pathsProvider;
+    private readonly IListeningProcessInspector _inspector;
     private readonly ILogger<ManagedAzuriteOrchestrator> _logger;
 
     public ManagedAzuriteOrchestrator(
@@ -28,6 +30,7 @@ internal sealed class ManagedAzuriteOrchestrator : IManagedAzuriteOrchestrator
         IDockerAvailabilityProbe dockerProbe,
         IAzuriteLauncher launcher,
         IAzuriteManagedPathsProvider pathsProvider,
+        IListeningProcessInspector inspector,
         ILogger<ManagedAzuriteOrchestrator> logger)
     {
         _classifier = classifier ?? throw new ArgumentNullException(nameof(classifier));
@@ -36,6 +39,7 @@ internal sealed class ManagedAzuriteOrchestrator : IManagedAzuriteOrchestrator
         _dockerProbe = dockerProbe ?? throw new ArgumentNullException(nameof(dockerProbe));
         _launcher = launcher ?? throw new ArgumentNullException(nameof(launcher));
         _pathsProvider = pathsProvider ?? throw new ArgumentNullException(nameof(pathsProvider));
+        _inspector = inspector ?? throw new ArgumentNullException(nameof(inspector));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -108,20 +112,7 @@ internal sealed class ManagedAzuriteOrchestrator : IManagedAzuriteOrchestrator
         switch (probe.Status)
         {
             case AzuriteProbeStatus.Ready:
-                // §11 user-managed-reuse fallback: when MVP discovers something
-                // already on the ports, treat it as user-managed and skip
-                // launching our own.
-                _logger.LogInformation("Existing Azurite endpoint detected; reusing it without launching a managed instance.");
-
-                // This cannot render to the live display directly as it will introduce rendering issues.
-                // TODO: If this information needs to be surfaced beyond initialization, we can introduce a new mechanism to display this data.
-                //_interaction.WriteLine(l => l
-                //    .Muted("Using existing Azurite endpoint at ")
-                //    .Path(endpoints.BlobEndpoint.ToString())
-                //    .Muted("."));
-                //_interaction.WriteBlankLine();
-
-                return new ManagedAzuriteResult.UserManaged(endpoints, "Endpoints already responded with storage-shaped replies.");
+                return await AdoptExistingAsync(endpoints, cancellationToken);
 
             case AzuriteProbeStatus.PortConflict:
             case AzuriteProbeStatus.Partial:
@@ -164,6 +155,81 @@ internal sealed class ManagedAzuriteOrchestrator : IManagedAzuriteOrchestrator
             executablePath: null,
             progress,
             cancellationToken);
+    }
+
+    /// <summary>
+    /// Handles the case where something is already answering on the Azurite
+    /// ports. The connection string points here, so we always reuse it; when we
+    /// can identify the owning Azurite we surface its PID and data directory so
+    /// the reuse is visible and reset guidance targets the directory actually in
+    /// use. Never blocks startup.
+    /// </summary>
+    private async Task<ManagedAzuriteResult> AdoptExistingAsync(
+        AzuriteEndpointTuple endpoints,
+        CancellationToken cancellationToken)
+    {
+        AzuriteManagedPaths paths = _pathsProvider.GetPaths();
+        int blobPort = endpoints.BlobEndpoint.Port;
+
+        IReadOnlyList<ListeningProcessInfo> processes = await _inspector.GetListeningProcessesAsync(blobPort, cancellationToken);
+
+        // A dual-stack host can have more than one listener on the same port, so
+        // prefer the one that identifies as Azurite rather than the first PID.
+        ListeningProcessInfo? azurite = processes.FirstOrDefault(p => AzuriteCommandLine.LooksLikeAzurite(p.CommandLine));
+
+        // A relative -l resolves against azurite's working directory, not ours,
+        // so only compare when the detected directory is fully qualified.
+        if (azurite is { } identified
+            && AzuriteCommandLine.TryGetDataDirectory(identified.CommandLine, out string? detectedDirectory)
+            && detectedDirectory is not null
+            && Path.IsPathFullyQualified(detectedDirectory))
+        {
+            if (AzuritePath.AreSameDirectory(detectedDirectory, paths.DataDirectory))
+            {
+                _logger.LogInformation(
+                    "Reusing existing managed Azurite (PID {ProcessId}) already serving data directory {DataDirectory}.",
+                    identified.ProcessId,
+                    paths.DataDirectory);
+                return new ManagedAzuriteResult.UserManaged(
+                    endpoints,
+                    $"Reused existing Azurite (PID {identified.ProcessId}) serving {paths.DataDirectory}.");
+            }
+
+            // Reuse it (the app asked for this endpoint), but surface the actual
+            // directory so reset guidance points at the store in use rather than
+            // the managed default.
+            _logger.LogWarning(
+                "Reusing existing Azurite (PID {ProcessId}) serving data directory {DetectedDirectory}, which differs from the managed default {ExpectedDirectory}. Reset guidance should target the directory in use.",
+                identified.ProcessId,
+                detectedDirectory,
+                paths.DataDirectory);
+            return new ManagedAzuriteResult.UserManaged(
+                endpoints,
+                $"Reused existing Azurite (PID {identified.ProcessId}) serving {detectedDirectory} (differs from the managed default {paths.DataDirectory}).");
+        }
+
+        // Something is on the ports but we cannot read a managed data directory
+        // (Docker proxy, a user-launched tool, a relative -l, or an unreadable
+        // command line). Reuse it and log what we found for self-diagnosis.
+        if (processes.Count > 0)
+        {
+            ListeningProcessInfo representative = azurite ?? processes[0];
+            _logger.LogInformation(
+                "Reusing existing endpoint on port {BlobPort} owned by PID {ProcessId}. Detected command line: {CommandLine}",
+                blobPort,
+                representative.ProcessId,
+                string.IsNullOrEmpty(representative.CommandLine) ? "<unavailable>" : representative.CommandLine);
+            return new ManagedAzuriteResult.UserManaged(
+                endpoints,
+                $"Reused an existing endpoint on the local storage ports (PID {representative.ProcessId}).");
+        }
+
+        _logger.LogInformation(
+            "Reusing existing Azurite endpoint on port {BlobPort}. Could not identify the owning process.",
+            blobPort);
+        return new ManagedAzuriteResult.UserManaged(
+            endpoints,
+            "Reused an existing Azurite endpoint already listening on the local storage ports.");
     }
 
     private async Task<ManagedAzuriteResult> LaunchAsync(

--- a/src/Func/Commands/Start/Azurite/Processes/IListeningProcessInspector.cs
+++ b/src/Func/Commands/Start/Azurite/Processes/IListeningProcessInspector.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite.Processes;
+
+/// <summary>
+/// Best-effort resolver from a listening TCP port to the owning process and its
+/// command line. Used to tell whether an existing Azurite endpoint is a managed
+/// instance and which data directory it is serving.
+/// </summary>
+internal interface IListeningProcessInspector
+{
+    /// <summary>
+    /// Returns every process listening on the given TCP port (on any bind
+    /// address), empty when none can be determined (no listener, permission
+    /// denied, missing OS tooling, or an unsupported platform). More than one
+    /// can be returned on dual-stack hosts, so callers pick the relevant one.
+    /// </summary>
+    public Task<IReadOnlyList<ListeningProcessInfo>> GetListeningProcessesAsync(int port, CancellationToken cancellationToken);
+}

--- a/src/Func/Commands/Start/Azurite/Processes/IPortOwnershipStrategy.cs
+++ b/src/Func/Commands/Start/Azurite/Processes/IPortOwnershipStrategy.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite.Processes;
+
+/// <summary>
+/// Platform-specific commands and parsers for mapping a listening port to the
+/// owning process id and its command line. Build methods describe the child
+/// process to run; parse methods are pure and operate on its captured output.
+/// </summary>
+internal interface IPortOwnershipStrategy
+{
+    /// <summary>
+    /// Describes the command that lists the process listening on <paramref name="port"/>.
+    /// </summary>
+    public (string FileName, IReadOnlyList<string> Arguments) BuildListenerLookup(int port);
+
+    /// <summary>
+    /// Extracts the owning process ids from the listener command's output.
+    /// </summary>
+    public IReadOnlyList<int> ParseListenerPids(string standardOutput, int port);
+
+    /// <summary>
+    /// Describes the command that reads the command line of <paramref name="processId"/>.
+    /// </summary>
+    public (string FileName, IReadOnlyList<string> Arguments) BuildCommandLineLookup(int processId);
+
+    /// <summary>
+    /// Extracts the command line from the command-line lookup output, or
+    /// <c>null</c> when it is empty.
+    /// </summary>
+    public string? ParseCommandLine(string standardOutput);
+}

--- a/src/Func/Commands/Start/Azurite/Processes/ListeningProcessInfo.cs
+++ b/src/Func/Commands/Start/Azurite/Processes/ListeningProcessInfo.cs
@@ -1,0 +1,11 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite.Processes;
+
+/// <summary>
+/// A process discovered listening on a probed Azurite port.
+/// </summary>
+/// <param name="ProcessId">The owning process identifier.</param>
+/// <param name="CommandLine">The process command line, or empty when it could not be read.</param>
+internal sealed record ListeningProcessInfo(int ProcessId, string CommandLine);

--- a/src/Func/Commands/Start/Azurite/Processes/ListeningProcessInspector.cs
+++ b/src/Func/Commands/Start/Azurite/Processes/ListeningProcessInspector.cs
@@ -1,0 +1,75 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite.Processes;
+
+/// <inheritdoc cref="IListeningProcessInspector" />
+internal sealed class ListeningProcessInspector(
+    IProcessRunner runner,
+    IPortOwnershipStrategy strategy,
+    ILogger<ListeningProcessInspector> logger) : IListeningProcessInspector
+{
+    private static readonly TimeSpan _lookupTimeout = TimeSpan.FromSeconds(5);
+
+    private readonly IProcessRunner _runner = runner ?? throw new ArgumentNullException(nameof(runner));
+    private readonly IPortOwnershipStrategy _strategy = strategy ?? throw new ArgumentNullException(nameof(strategy));
+    private readonly ILogger<ListeningProcessInspector> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+    public async Task<IReadOnlyList<ListeningProcessInfo>> GetListeningProcessesAsync(int port, CancellationToken cancellationToken)
+    {
+        (string listenerFile, IReadOnlyList<string> listenerArgs) = _strategy.BuildListenerLookup(port);
+        ProcessOutcome? listener = await TryRunAsync(listenerFile, listenerArgs, cancellationToken);
+        if (listener is null || listener.ExecutableNotFound || listener.TimedOut)
+        {
+            return [];
+        }
+
+        IReadOnlyList<int> pids = _strategy.ParseListenerPids(listener.StandardOutput, port);
+        if (pids.Count == 0)
+        {
+            return [];
+        }
+
+        // Resolve command lines concurrently so total latency is bounded by the
+        // slowest lookup rather than the sum across listeners.
+        return await Task.WhenAll(pids.Select(pid => ResolveCommandLineAsync(pid, cancellationToken)));
+    }
+
+    private async Task<ListeningProcessInfo> ResolveCommandLineAsync(int processId, CancellationToken cancellationToken)
+    {
+        (string commandFile, IReadOnlyList<string> commandArgs) = _strategy.BuildCommandLineLookup(processId);
+        ProcessOutcome? outcome = await TryRunAsync(commandFile, commandArgs, cancellationToken);
+        string? commandLine = outcome is null || outcome.ExecutableNotFound || outcome.TimedOut
+            ? null
+            : _strategy.ParseCommandLine(outcome.StandardOutput);
+
+        return new ListeningProcessInfo(processId, commandLine ?? string.Empty);
+    }
+
+    private async Task<ProcessOutcome?> TryRunAsync(
+        string fileName,
+        IReadOnlyList<string> arguments,
+        CancellationToken cancellationToken)
+    {
+        ProcessRunRequest request = new(fileName, arguments, WorkingDirectory: null, Timeout: _lookupTimeout);
+        try
+        {
+            return await _runner.RunAsync(request, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Best-effort diagnostics: probing the OS for the owning process must
+            // never break `func start`. Any failure (missing tool, denied query,
+            // unexpected output) degrades to "could not identify", which the
+            // caller treats as adopt-and-log.
+            _logger.LogDebug(ex, "Process lookup '{FileName}' failed while inspecting the listening process.", fileName);
+            return null;
+        }
+    }
+}

--- a/src/Func/Commands/Start/Azurite/Processes/UnixPortOwnershipStrategy.cs
+++ b/src/Func/Commands/Start/Azurite/Processes/UnixPortOwnershipStrategy.cs
@@ -1,0 +1,64 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Globalization;
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite.Processes;
+
+/// <summary>
+/// Resolves port ownership on macOS and Linux using <c>lsof</c> for the PID and
+/// <c>ps</c> for the command line.
+/// </summary>
+internal sealed class UnixPortOwnershipStrategy : IPortOwnershipStrategy
+{
+    public (string FileName, IReadOnlyList<string> Arguments) BuildListenerLookup(int port)
+        => ("lsof",
+        [
+            "-nP",
+            $"-iTCP:{port.ToString(CultureInfo.InvariantCulture)}",
+            "-sTCP:LISTEN",
+            "-Fp",
+        ]);
+
+    public IReadOnlyList<int> ParseListenerPids(string standardOutput, int port)
+    {
+        List<int> pids = [];
+        if (string.IsNullOrEmpty(standardOutput))
+        {
+            return pids;
+        }
+
+        // lsof -Fp emits one "p<pid>" line per matching process; other field
+        // lines (f, n, ...) are ignored.
+        foreach (string rawLine in standardOutput.Split('\n'))
+        {
+            string line = rawLine.Trim();
+            if (line.Length < 2 || line[0] != 'p')
+            {
+                continue;
+            }
+
+            if (int.TryParse(line.AsSpan(1), NumberStyles.Integer, CultureInfo.InvariantCulture, out int pid)
+                && pid > 0
+                && !pids.Contains(pid))
+            {
+                pids.Add(pid);
+            }
+        }
+
+        return pids;
+    }
+
+    public (string FileName, IReadOnlyList<string> Arguments) BuildCommandLineLookup(int processId)
+        => ("ps",
+        [
+            "-ww",
+            "-o",
+            "command=",
+            "-p",
+            processId.ToString(CultureInfo.InvariantCulture),
+        ]);
+
+    public string? ParseCommandLine(string standardOutput)
+        => string.IsNullOrWhiteSpace(standardOutput) ? null : standardOutput.Trim();
+}

--- a/src/Func/Commands/Start/Azurite/Processes/WindowsPortOwnershipStrategy.cs
+++ b/src/Func/Commands/Start/Azurite/Processes/WindowsPortOwnershipStrategy.cs
@@ -1,0 +1,94 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Globalization;
+
+namespace Azure.Functions.Cli.Commands.Start.Azurite.Processes;
+
+/// <summary>
+/// Resolves port ownership on Windows using <c>netstat -ano</c> for the PID and
+/// a CIM query for the command line.
+/// </summary>
+internal sealed class WindowsPortOwnershipStrategy : IPortOwnershipStrategy
+{
+    public (string FileName, IReadOnlyList<string> Arguments) BuildListenerLookup(int port)
+        => ("netstat", ["-a", "-n", "-o", "-p", "TCP"]);
+
+    public IReadOnlyList<int> ParseListenerPids(string standardOutput, int port)
+    {
+        List<int> pids = [];
+        if (string.IsNullOrEmpty(standardOutput))
+        {
+            return pids;
+        }
+
+        foreach (string rawLine in standardOutput.Split('\n'))
+        {
+            string line = rawLine.Trim();
+            if (line.Length == 0)
+            {
+                continue;
+            }
+
+            string[] parts = line.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length < 5)
+            {
+                continue;
+            }
+
+            // The state column (parts[3]) is localized on non-English Windows,
+            // so key off the foreign address instead: a listening TCP socket
+            // always shows a wildcard remote (0.0.0.0:0 or [::]:0).
+            if (!parts[0].Equals("TCP", StringComparison.OrdinalIgnoreCase)
+                || !IsListeningForeignAddress(parts[2]))
+            {
+                continue;
+            }
+
+            if (!TryGetPort(parts[1], out int localPort) || localPort != port)
+            {
+                continue;
+            }
+
+            if (int.TryParse(parts[^1], NumberStyles.Integer, CultureInfo.InvariantCulture, out int pid)
+                && pid > 0
+                && !pids.Contains(pid))
+            {
+                pids.Add(pid);
+            }
+        }
+
+        return pids;
+    }
+
+    public (string FileName, IReadOnlyList<string> Arguments) BuildCommandLineLookup(int processId)
+        => ("powershell",
+        [
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            $"(Get-CimInstance Win32_Process -Filter 'ProcessId={processId.ToString(CultureInfo.InvariantCulture)}').CommandLine",
+        ]);
+
+    public string? ParseCommandLine(string standardOutput)
+        => string.IsNullOrWhiteSpace(standardOutput) ? null : standardOutput.Trim();
+
+    private static bool IsListeningForeignAddress(string foreignAddress)
+        => foreignAddress is "0.0.0.0:0" or "[::]:0";
+
+    private static bool TryGetPort(string localAddress, out int port)
+    {
+        port = 0;
+        int separator = localAddress.LastIndexOf(':');
+        if (separator < 0 || separator == localAddress.Length - 1)
+        {
+            return false;
+        }
+
+        return int.TryParse(
+            localAddress.AsSpan(separator + 1),
+            NumberStyles.Integer,
+            CultureInfo.InvariantCulture,
+            out port);
+    }
+}

--- a/test/Func.Tests/Commands/Start/Azurite/AzuriteCommandLineTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/AzuriteCommandLineTests.cs
@@ -1,0 +1,82 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Commands.Start.Azurite;
+
+namespace Azure.Functions.Cli.Tests.Commands.Start.Azurite;
+
+public class AzuriteCommandLineTests
+{
+    [Theory]
+    [InlineData("node /usr/lib/azurite/azurite.js -l /data --blobPort 10000")]
+    [InlineData("C:\\Program Files\\nodejs\\node.exe C:\\azurite\\azurite -l C:\\data")]
+    [InlineData("AZURITE -l /data")]
+    public void LooksLikeAzurite_TrueForAzuriteCommandLines(string commandLine)
+        => AzuriteCommandLine.LooksLikeAzurite(commandLine).Should().BeTrue();
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("com.docker.backend --proxy tcp 127.0.0.1:10000")]
+    [InlineData("node /usr/lib/something-else/server.js")]
+    public void LooksLikeAzurite_FalseOtherwise(string? commandLine)
+        => AzuriteCommandLine.LooksLikeAzurite(commandLine).Should().BeFalse();
+
+    [Fact]
+    public void TryGetDataDirectory_ExtractsShortFlag()
+    {
+        bool found = AzuriteCommandLine.TryGetDataDirectory(
+            "node azurite -l /home/me/.azure-functions/azurite/data --blobPort 10000",
+            out string? dataDirectory);
+
+        found.Should().BeTrue();
+        dataDirectory.Should().Be("/home/me/.azure-functions/azurite/data");
+    }
+
+    [Fact]
+    public void TryGetDataDirectory_ExtractsLongFlag()
+    {
+        bool found = AzuriteCommandLine.TryGetDataDirectory(
+            "azurite --location /var/azurite --silent",
+            out string? dataDirectory);
+
+        found.Should().BeTrue();
+        dataDirectory.Should().Be("/var/azurite");
+    }
+
+    [Fact]
+    public void TryGetDataDirectory_HandlesQuotedPathWithSpaces()
+    {
+        bool found = AzuriteCommandLine.TryGetDataDirectory(
+            "\"C:\\Program Files\\nodejs\\node.exe\" azurite -l \"C:\\Users\\John Doe\\.azure-functions\\azurite\\data\" --silent",
+            out string? dataDirectory);
+
+        found.Should().BeTrue();
+        dataDirectory.Should().Be("C:\\Users\\John Doe\\.azure-functions\\azurite\\data");
+    }
+
+    [Theory]
+    [InlineData("azurite --location=/var/azurite --silent", "/var/azurite")]
+    [InlineData("node azurite.js -l=/data --blobPort 10000", "/data")]
+    public void TryGetDataDirectory_ExtractsEqualsForm(string commandLine, string expected)
+    {
+        bool found = AzuriteCommandLine.TryGetDataDirectory(commandLine, out string? dataDirectory);
+
+        found.Should().BeTrue();
+        dataDirectory.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("azurite --silent --blobPort 10000")]
+    [InlineData("azurite -l")]
+    public void TryGetDataDirectory_FalseWhenNoDirectory(string? commandLine)
+    {
+        bool found = AzuriteCommandLine.TryGetDataDirectory(commandLine, out string? dataDirectory);
+
+        found.Should().BeFalse();
+        dataDirectory.Should().BeNull();
+    }
+}

--- a/test/Func.Tests/Commands/Start/Azurite/AzuritePathTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/AzuritePathTests.cs
@@ -1,0 +1,52 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Commands.Start.Azurite;
+
+namespace Azure.Functions.Cli.Tests.Commands.Start.Azurite;
+
+public class AzuritePathTests
+{
+    [Fact]
+    public void AreSameDirectory_TrueForIdenticalPaths()
+    {
+        string path = Path.Combine(Path.GetTempPath(), "azurite", "data");
+
+        AzuritePath.AreSameDirectory(path, path).Should().BeTrue();
+    }
+
+    [Fact]
+    public void AreSameDirectory_TrueIgnoringTrailingSeparator()
+    {
+        string path = Path.Combine(Path.GetTempPath(), "azurite", "data");
+
+        AzuritePath.AreSameDirectory(path, path + Path.DirectorySeparatorChar).Should().BeTrue();
+    }
+
+    [Fact]
+    public void AreSameDirectory_TrueForNonNormalizedPath()
+    {
+        string baseDirectory = Path.Combine(Path.GetTempPath(), "azurite", "data");
+        string indirect = Path.Combine(Path.GetTempPath(), "azurite", "sub", "..", "data");
+
+        AzuritePath.AreSameDirectory(baseDirectory, indirect).Should().BeTrue();
+    }
+
+    [Fact]
+    public void AreSameDirectory_FalseForDifferentPaths()
+    {
+        string first = Path.Combine(Path.GetTempPath(), "azurite", "data");
+        string second = Path.Combine(Path.GetTempPath(), "azurite", "other");
+
+        AzuritePath.AreSameDirectory(first, second).Should().BeFalse();
+    }
+
+    [Fact]
+    public void AreSameDirectory_UsesPlatformCaseSensitivity()
+    {
+        string original = Path.Combine(Path.GetTempPath(), "Azurite", "Data");
+        string uppercased = original.ToUpperInvariant();
+
+        AzuritePath.AreSameDirectory(original, uppercased).Should().Be(OperatingSystem.IsWindows());
+    }
+}

--- a/test/Func.Tests/Commands/Start/Azurite/Orchestration/ManagedAzuriteOrchestratorTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/Orchestration/ManagedAzuriteOrchestratorTests.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using Azure.Functions.Cli.Commands.Start.Azurite;
 using Azure.Functions.Cli.Commands.Start.Azurite.Launching;
 using Azure.Functions.Cli.Commands.Start.Azurite.Orchestration;
+using Azure.Functions.Cli.Commands.Start.Azurite.Processes;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 
@@ -22,18 +23,21 @@ public class ManagedAzuriteOrchestratorTests
     private readonly IDockerAvailabilityProbe _dockerProbe = Substitute.For<IDockerAvailabilityProbe>();
     private readonly IAzuriteLauncher _launcher = Substitute.For<IAzuriteLauncher>();
     private readonly IAzuriteManagedPathsProvider _paths = Substitute.For<IAzuriteManagedPathsProvider>();
+    private readonly IListeningProcessInspector _inspector = Substitute.For<IListeningProcessInspector>();
+    private readonly string _expectedDataDir = Path.Combine(Path.GetTempPath(), "azurite-data");
 
     public ManagedAzuriteOrchestratorTests()
     {
         AzuriteManagedPaths managed = new(
-            DataDirectory: Path.Combine(Path.GetTempPath(), "azurite-data"),
+            DataDirectory: _expectedDataDir,
             LogFilePath: Path.Combine(Path.GetTempPath(), "azurite", "azurite.log"));
         _paths.GetPaths().Returns(managed);
         _paths.EnsureCreatedAsync(Arg.Any<AzuriteManagedPaths>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+        _inspector.GetListeningProcessesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Listening());
     }
 
     private ManagedAzuriteOrchestrator CreateSut() => new(
-        _classifier, _probe, _locator, _dockerProbe, _launcher, _paths,
+        _classifier, _probe, _locator, _dockerProbe, _launcher, _paths, _inspector,
         NullLogger<ManagedAzuriteOrchestrator>.Instance);
 
     private static ManagedAzuriteRequest Request(bool disabled = false, TimeSpan? timeout = null) =>
@@ -65,6 +69,11 @@ public class ManagedAzuriteOrchestratorTests
         new AzuriteEndpointProbeOutcome(AzuriteService.Queue, new Uri("http://127.0.0.1:10001/devstoreaccount1"), AzuriteEndpointStatus.PortConflict),
         new AzuriteEndpointProbeOutcome(AzuriteService.Table, new Uri("http://127.0.0.1:10002/devstoreaccount1"), AzuriteEndpointStatus.PortConflict),
     });
+
+    private static string AzuriteCommandLineFor(string dataDirectory) =>
+        $"node /usr/lib/node_modules/azurite/dist/src/azurite.js -l \"{dataDirectory}\" --blobHost 127.0.0.1 --blobPort 10000 --queuePort 10001 --tablePort 10002 --silent";
+
+    private static IReadOnlyList<ListeningProcessInfo> Listening(params ListeningProcessInfo[] processes) => processes;
 
     [Fact]
     public async Task Disabled_ReturnsDisabled_WithoutTouchingOtherDependencies()
@@ -120,6 +129,110 @@ public class ManagedAzuriteOrchestratorTests
     {
         _classifier.Classify(Conn).Returns(Manageable());
         _probe.ProbeAsync(Arg.Any<AzuriteEndpointTuple>(), Arg.Any<CancellationToken>()).Returns(ProbeReady());
+
+        ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), progress: null, CancellationToken.None);
+
+        result.Should().BeOfType<ManagedAzuriteResult.UserManaged>();
+        await _launcher.DidNotReceive().StartAsync(Arg.Any<AzuriteLaunchRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Manageable_ProbeReady_ExistingAzuriteSameDataDir_ReturnsUserManaged()
+    {
+        _classifier.Classify(Conn).Returns(Manageable());
+        _probe.ProbeAsync(Arg.Any<AzuriteEndpointTuple>(), Arg.Any<CancellationToken>()).Returns(ProbeReady());
+        _inspector.GetListeningProcessesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Listening(new ListeningProcessInfo(4242, AzuriteCommandLineFor(_expectedDataDir))));
+
+        ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), progress: null, CancellationToken.None);
+
+        ManagedAzuriteResult.UserManaged userManaged = result.Should().BeOfType<ManagedAzuriteResult.UserManaged>().Subject;
+        userManaged.Reason.Should().Contain("4242");
+        userManaged.Reason.Should().Contain(_expectedDataDir);
+        await _launcher.DidNotReceive().StartAsync(Arg.Any<AzuriteLaunchRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Manageable_ProbeReady_MultipleListeners_PrefersAzuriteProcess()
+    {
+        _classifier.Classify(Conn).Returns(Manageable());
+        _probe.ProbeAsync(Arg.Any<AzuriteEndpointTuple>(), Arg.Any<CancellationToken>()).Returns(ProbeReady());
+
+        // A non-Azurite listener (e.g. bound on ::1) is returned first; the
+        // managed Azurite is second. Selection must not depend on order.
+        _inspector.GetListeningProcessesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Listening(
+                new ListeningProcessInfo(111, "com.docker.backend --proxy tcp [::1]:10000"),
+                new ListeningProcessInfo(222, AzuriteCommandLineFor(_expectedDataDir))));
+
+        ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), progress: null, CancellationToken.None);
+
+        ManagedAzuriteResult.UserManaged userManaged = result.Should().BeOfType<ManagedAzuriteResult.UserManaged>().Subject;
+        userManaged.Reason.Should().Contain("222");
+        userManaged.Reason.Should().NotContain("111");
+        userManaged.Reason.Should().Contain(_expectedDataDir);
+    }
+
+    [Fact]
+    public async Task Manageable_ProbeReady_ExistingAzuriteDifferentDataDir_ReusesAndSurfacesDirectory()
+    {
+        _classifier.Classify(Conn).Returns(Manageable());
+        _probe.ProbeAsync(Arg.Any<AzuriteEndpointTuple>(), Arg.Any<CancellationToken>()).Returns(ProbeReady());
+        string otherDirectory = Path.Combine(Path.GetTempPath(), "azurite-data-other");
+        _inspector.GetListeningProcessesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Listening(new ListeningProcessInfo(9999, AzuriteCommandLineFor(otherDirectory))));
+
+        ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), progress: null, CancellationToken.None);
+
+        // Sharing a storage endpoint is legitimate, so a different data directory
+        // is surfaced, not blocked.
+        ManagedAzuriteResult.UserManaged userManaged = result.Should().BeOfType<ManagedAzuriteResult.UserManaged>().Subject;
+        userManaged.Reason.Should().Contain("9999");
+        userManaged.Reason.Should().Contain(otherDirectory);
+        userManaged.Reason.Should().Contain(_expectedDataDir);
+        await _launcher.DidNotReceive().StartAsync(Arg.Any<AzuriteLaunchRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Manageable_ProbeReady_ExistingAzuriteRelativeDataDir_ReusesWithoutFailing()
+    {
+        _classifier.Classify(Conn).Returns(Manageable());
+        _probe.ProbeAsync(Arg.Any<AzuriteEndpointTuple>(), Arg.Any<CancellationToken>()).Returns(ProbeReady());
+
+        // A relative -l cannot be resolved against azurite's working directory,
+        // so it must never be treated as a mismatch.
+        _inspector.GetListeningProcessesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Listening(new ListeningProcessInfo(4321, "node azurite.js -l ./local-data --blobPort 10000")));
+
+        ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), progress: null, CancellationToken.None);
+
+        ManagedAzuriteResult.UserManaged userManaged = result.Should().BeOfType<ManagedAzuriteResult.UserManaged>().Subject;
+        userManaged.Reason.Should().Contain("4321");
+        await _launcher.DidNotReceive().StartAsync(Arg.Any<AzuriteLaunchRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Manageable_ProbeReady_ExistingNonAzuriteProcess_ReturnsUserManaged()
+    {
+        _classifier.Classify(Conn).Returns(Manageable());
+        _probe.ProbeAsync(Arg.Any<AzuriteEndpointTuple>(), Arg.Any<CancellationToken>()).Returns(ProbeReady());
+        _inspector.GetListeningProcessesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Listening(new ListeningProcessInfo(1357, "com.docker.backend --proxy tcp 127.0.0.1:10000")));
+
+        ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), progress: null, CancellationToken.None);
+
+        ManagedAzuriteResult.UserManaged userManaged = result.Should().BeOfType<ManagedAzuriteResult.UserManaged>().Subject;
+        userManaged.Reason.Should().Contain("1357");
+        await _launcher.DidNotReceive().StartAsync(Arg.Any<AzuriteLaunchRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Manageable_ProbeReady_UnidentifiedProcess_ReturnsUserManaged()
+    {
+        _classifier.Classify(Conn).Returns(Manageable());
+        _probe.ProbeAsync(Arg.Any<AzuriteEndpointTuple>(), Arg.Any<CancellationToken>()).Returns(ProbeReady());
+        _inspector.GetListeningProcessesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Listening());
 
         ManagedAzuriteResult result = await CreateSut().EnsureReadyAsync(Request(), progress: null, CancellationToken.None);
 

--- a/test/Func.Tests/Commands/Start/Azurite/Processes/ListeningProcessInspectorTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/Processes/ListeningProcessInspectorTests.cs
@@ -1,0 +1,109 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Commands.Start.Azurite.Processes;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Azure.Functions.Cli.Tests.Commands.Start.Azurite.Processes;
+
+public class ListeningProcessInspectorTests
+{
+    private readonly IProcessRunner _runner = Substitute.For<IProcessRunner>();
+    private readonly IPortOwnershipStrategy _strategy = Substitute.For<IPortOwnershipStrategy>();
+
+    private static ProcessOutcome Output(string standardOutput) =>
+        new(ExitCode: 0, standardOutput, StandardError: string.Empty, TimedOut: false, ExecutableNotFound: false);
+
+    private static (string FileName, IReadOnlyList<string> Arguments) Cmd(string fileName, params string[] arguments) =>
+        (fileName, arguments);
+
+    [Fact]
+    public async Task ResolvesSingleProcess_WhenOneListener()
+    {
+        _strategy.BuildListenerLookup(10000).Returns(Cmd("netstat", "-ano"));
+        _strategy.BuildCommandLineLookup(4242).Returns(Cmd("ps", "-p", "4242"));
+        _runner.RunAsync(Arg.Is<ProcessRunRequest>(r => r.FileName == "netstat"), Arg.Any<CancellationToken>())
+            .Returns(Output("listener"));
+        _runner.RunAsync(Arg.Is<ProcessRunRequest>(r => r.FileName == "ps"), Arg.Any<CancellationToken>())
+            .Returns(Output("azurite -l /data"));
+        _strategy.ParseListenerPids("listener", 10000).Returns([4242]);
+        _strategy.ParseCommandLine("azurite -l /data").Returns("azurite -l /data");
+
+        IReadOnlyList<ListeningProcessInfo> processes = await CreateSut().GetListeningProcessesAsync(10000, CancellationToken.None);
+
+        processes.Should().ContainSingle();
+        processes[0].ProcessId.Should().Be(4242);
+        processes[0].CommandLine.Should().Be("azurite -l /data");
+    }
+
+    [Fact]
+    public async Task ResolvesAllProcesses_WhenMultipleListeners()
+    {
+        _strategy.BuildListenerLookup(10000).Returns(Cmd("netstat", "-ano"));
+        _strategy.BuildCommandLineLookup(111).Returns(Cmd("cmd111"));
+        _strategy.BuildCommandLineLookup(222).Returns(Cmd("cmd222"));
+        _runner.RunAsync(Arg.Is<ProcessRunRequest>(r => r.FileName == "netstat"), Arg.Any<CancellationToken>())
+            .Returns(Output("listeners"));
+        _runner.RunAsync(Arg.Is<ProcessRunRequest>(r => r.FileName == "cmd111"), Arg.Any<CancellationToken>())
+            .Returns(Output("out111"));
+        _runner.RunAsync(Arg.Is<ProcessRunRequest>(r => r.FileName == "cmd222"), Arg.Any<CancellationToken>())
+            .Returns(Output("out222"));
+        _strategy.ParseListenerPids("listeners", 10000).Returns([111, 222]);
+        _strategy.ParseCommandLine("out111").Returns("first process");
+        _strategy.ParseCommandLine("out222").Returns("second process");
+
+        IReadOnlyList<ListeningProcessInfo> processes = await CreateSut().GetListeningProcessesAsync(10000, CancellationToken.None);
+
+        processes.Should().HaveCount(2);
+        processes[0].ProcessId.Should().Be(111);
+        processes[0].CommandLine.Should().Be("first process");
+        processes[1].ProcessId.Should().Be(222);
+        processes[1].CommandLine.Should().Be("second process");
+    }
+
+    [Fact]
+    public async Task ReturnsEmpty_WhenNoListenerPid()
+    {
+        _strategy.BuildListenerLookup(10000).Returns(Cmd("netstat", "-ano"));
+        _runner.RunAsync(Arg.Any<ProcessRunRequest>(), Arg.Any<CancellationToken>()).Returns(Output("nothing"));
+        _strategy.ParseListenerPids("nothing", 10000).Returns([]);
+
+        IReadOnlyList<ListeningProcessInfo> processes = await CreateSut().GetListeningProcessesAsync(10000, CancellationToken.None);
+
+        processes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ReturnsEmpty_WhenListenerToolMissing()
+    {
+        _strategy.BuildListenerLookup(10000).Returns(Cmd("lsof", "-Fp"));
+        _runner.RunAsync(Arg.Any<ProcessRunRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ProcessOutcome(ExitCode: null, StandardOutput: string.Empty, StandardError: string.Empty, TimedOut: false, ExecutableNotFound: true));
+
+        IReadOnlyList<ListeningProcessInfo> processes = await CreateSut().GetListeningProcessesAsync(10000, CancellationToken.None);
+
+        processes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ReturnsEmptyCommandLine_WhenCommandLineUnavailable()
+    {
+        _strategy.BuildListenerLookup(10000).Returns(Cmd("netstat", "-ano"));
+        _strategy.BuildCommandLineLookup(4242).Returns(Cmd("ps", "-p", "4242"));
+        _runner.RunAsync(Arg.Is<ProcessRunRequest>(r => r.FileName == "netstat"), Arg.Any<CancellationToken>())
+            .Returns(Output("listener"));
+        _runner.RunAsync(Arg.Is<ProcessRunRequest>(r => r.FileName == "ps"), Arg.Any<CancellationToken>())
+            .Returns(new ProcessOutcome(ExitCode: null, StandardOutput: string.Empty, StandardError: string.Empty, TimedOut: true, ExecutableNotFound: false));
+        _strategy.ParseListenerPids("listener", 10000).Returns([4242]);
+
+        IReadOnlyList<ListeningProcessInfo> processes = await CreateSut().GetListeningProcessesAsync(10000, CancellationToken.None);
+
+        processes.Should().ContainSingle();
+        processes[0].ProcessId.Should().Be(4242);
+        processes[0].CommandLine.Should().BeEmpty();
+    }
+
+    private ListeningProcessInspector CreateSut() =>
+        new(_runner, _strategy, NullLogger<ListeningProcessInspector>.Instance);
+}

--- a/test/Func.Tests/Commands/Start/Azurite/Processes/UnixPortOwnershipStrategyTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/Processes/UnixPortOwnershipStrategyTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Commands.Start.Azurite.Processes;
+
+namespace Azure.Functions.Cli.Tests.Commands.Start.Azurite.Processes;
+
+public class UnixPortOwnershipStrategyTests
+{
+    private readonly UnixPortOwnershipStrategy _strategy = new();
+
+    [Fact]
+    public void ParseListenerPids_ReadsPidFieldLines()
+    {
+        _strategy.ParseListenerPids("p12345\nf10\n", 10000)
+            .Should().ContainSingle().Which.Should().Be(12345);
+    }
+
+    [Fact]
+    public void ParseListenerPids_DeduplicatesPids()
+    {
+        _strategy.ParseListenerPids("p777\np777\n", 10000)
+            .Should().ContainSingle().Which.Should().Be(777);
+    }
+
+    [Fact]
+    public void ParseListenerPids_EmptyWhenNoProcessLines()
+    {
+        _strategy.ParseListenerPids("f10\nn127.0.0.1:10000\n", 10000).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseCommandLine_TrimsOutput()
+    {
+        _strategy.ParseCommandLine("node /usr/local/lib/azurite -l /data\n")
+            .Should().Be("node /usr/local/lib/azurite -l /data");
+    }
+
+    [Fact]
+    public void BuildListenerLookup_UsesLsofForPort()
+    {
+        (string fileName, IReadOnlyList<string> arguments) = _strategy.BuildListenerLookup(10000);
+
+        fileName.Should().Be("lsof");
+        arguments.Should().Contain("-iTCP:10000").And.Contain("-sTCP:LISTEN");
+    }
+
+    [Fact]
+    public void BuildCommandLineLookup_UsesPsForPid()
+    {
+        (string fileName, IReadOnlyList<string> arguments) = _strategy.BuildCommandLineLookup(555);
+
+        fileName.Should().Be("ps");
+        arguments.Should().Contain("555");
+    }
+}

--- a/test/Func.Tests/Commands/Start/Azurite/Processes/WindowsPortOwnershipStrategyTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/Processes/WindowsPortOwnershipStrategyTests.cs
@@ -1,0 +1,83 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Commands.Start.Azurite.Processes;
+
+namespace Azure.Functions.Cli.Tests.Commands.Start.Azurite.Processes;
+
+public class WindowsPortOwnershipStrategyTests
+{
+    private const string NetstatSample =
+        "Active Connections\n" +
+        "\n" +
+        "  Proto  Local Address          Foreign Address        State           PID\n" +
+        "  TCP    0.0.0.0:445            0.0.0.0:0              LISTENING       4\n" +
+        "  TCP    127.0.0.1:10000        0.0.0.0:0              LISTENING       21988\n" +
+        "  TCP    127.0.0.1:10001        0.0.0.0:0              LISTENING       21988\n" +
+        "  TCP    [::1]:10000            [::]:0                 LISTENING       21988\n" +
+        "  TCP    127.0.0.1:50123        127.0.0.1:443          ESTABLISHED     6120\n";
+
+    private readonly WindowsPortOwnershipStrategy _strategy = new();
+
+    [Fact]
+    public void ParseListenerPids_FindsPidForPort()
+    {
+        IReadOnlyList<int> pids = _strategy.ParseListenerPids(NetstatSample, 10000);
+
+        pids.Should().ContainSingle().Which.Should().Be(21988);
+    }
+
+    [Fact]
+    public void ParseListenerPids_IgnoresNonListeningEntries()
+    {
+        _strategy.ParseListenerPids(NetstatSample, 50123).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseListenerPids_EmptyForUnmatchedPort()
+    {
+        _strategy.ParseListenerPids(NetstatSample, 44444).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseListenerPids_IgnoresLocalizedStateColumn()
+    {
+        // The state column is localized on non-English Windows, so detection
+        // keys off the wildcard foreign address rather than the word "LISTENING".
+        const string localized = "  TCP    127.0.0.1:10000        0.0.0.0:0              ESCUCHANDO      7777\n";
+
+        _strategy.ParseListenerPids(localized, 10000).Should().ContainSingle().Which.Should().Be(7777);
+    }
+
+    [Fact]
+    public void ParseCommandLine_TrimsOutput()
+    {
+        string? commandLine = _strategy.ParseCommandLine("  \"C:\\Program Files\\nodejs\\node.exe\" azurite -l C:\\data \r\n");
+
+        commandLine.Should().Be("\"C:\\Program Files\\nodejs\\node.exe\" azurite -l C:\\data");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ParseCommandLine_NullWhenEmpty(string standardOutput)
+        => _strategy.ParseCommandLine(standardOutput).Should().BeNull();
+
+    [Fact]
+    public void BuildListenerLookup_UsesNetstat()
+    {
+        (string fileName, IReadOnlyList<string> arguments) = _strategy.BuildListenerLookup(10000);
+
+        fileName.Should().Be("netstat");
+        arguments.Should().Contain("-a").And.Contain("-n").And.Contain("-o");
+    }
+
+    [Fact]
+    public void BuildCommandLineLookup_QueriesCimForPid()
+    {
+        (string fileName, IReadOnlyList<string> arguments) = _strategy.BuildCommandLineLookup(4242);
+
+        fileName.Should().Be("powershell");
+        arguments.Should().Contain(argument => argument.Contains("Win32_Process") && argument.Contains("4242"));
+    }
+}


### PR DESCRIPTION
## What this does

This finishes #5264. When the CLI is asked to manage Azurite and something is already listening on the ports, the CLI no longer *silently* reuses whatever is there. It identifies the owning process and surfaces its PID and data directory, so the reuse is visible and the reset guidance from #5263 targets the directory actually in use. It always reuses the existing endpoint (the app's connection string points there) and never blocks startup.

## What is in it

When the probe finds the Azurite ports already answering, the orchestrator inspects the listening process (PID + command line) and reacts:

- **Serving the expected managed directory** → reuse and log the adoption.
- **Serving a different (fully-qualified) directory** → reuse it, but surface the detected PID and directory and note that it differs from the managed default, so reset guidance points at the store in use.
- **Not identifiable as managed Azurite** (Docker proxy, a user-launched tool, a relative `-l`, or an unreadable command line) → reuse and log the detected command line for self-diagnosis.

The detection is a best-effort `IListeningProcessInspector` routed through the existing `IProcessRunner`: `netstat -ano` + `Win32_Process` (CIM) on Windows, `lsof` + `ps` on macOS/Linux. It returns all listeners on the port (dual-stack hosts can have several) and the orchestrator prefers the one that identifies as Azurite. Any failure degrades to plain reuse-and-log, so it never breaks `func start`. The OS strategy is selected in the composition root; the parsers and the command-line / path classification are pure and unit-tested.

### Why reuse instead of fail

An earlier revision failed `func start` when the running Azurite served a different data directory. That's wrong: `AzureWebJobsStorage` (e.g. `UseDevelopmentStorage=true`) is the source of truth for *which* storage to use, and the data directory is an internal detail of whichever Azurite serves that endpoint. Sharing one storage endpoint across multiple `func start` sessions (or multiple apps) is a legitimate, common local workflow that mirrors production scale-out (many instances, one storage account). Blocking startup would second-guess the user's explicit configuration and regress that workflow, so the change surfaces the mismatch loudly but always reuses.

## How I tested it

Unit tests cover the netstat/lsof/ps parsers against captured sample output, the inspector's multi-listener resolution, the command-line and path helpers (short/long flag, quoted paths with spaces, relative paths, trailing separators, platform case sensitivity), and the orchestrator classifications (same dir, different dir, relative `-l`, non-Azurite, dual-stack preference, unidentified). The full suite passes.

I also validated end to end on Windows through the real CLI. I built a Java app, started a real azurite on the standard ports pointed at a throwaway directory (different from the default managed dir), and ran `func start`:

```
Ensure Azurite: Reused existing Azurite (PID 28680) serving ...\_e2e-5264\running-data (differs from the managed default C:\Users\...\.azure-functions\azurite\data).
Start host: Host process started
Host process started. Listening on http://localhost:7071/
HttpExample  HTTP  http://localhost:7071/api/HttpExample  ● Ready
```

So the real CLI detected the running azurite via netstat + CIM, surfaced its PID and actual data directory (noting the difference), reused it without blocking, and the host started and served the function. macOS/Linux use the same code path with lsof + ps, covered by the parser unit tests.

## Notes

This intentionally departs from the issue's step 4 ("stop it and restart, or fail loudly"). Two `func start` sessions on the same machine launch Azurite with identical command lines, so "ours vs another live session vs a user launch" is not reliably decidable from a running process — and, more importantly, sharing a storage endpoint is a legitimate use case, so blocking is the wrong default. The change keeps the issue's real intent (visibility instead of silently relying on it) while never breaking a working setup. Mismatch detection currently works for native Azurite; a Docker-launched Azurite holds the port via `docker-proxy`, so it lands in reuse-and-log.

## Definition of done

- [x] When something is already on the Azurite ports, the CLI identifies the process and surfaces its PID + data directory instead of silently reusing it
- [x] Sharing an existing Azurite (including on a different data directory) keeps working; startup is never blocked
- [x] Relative `-l` paths and non-Azurite listeners degrade to reuse-and-log
- [x] Unit tested, and the detection + adopt-and-surface path validated end to end through `func start`

Closes #5264
