### PR TITLE
Fix worker resolution failures by setting WEBSITE_SKU in host process environment

### DIFF
--- a/src/Func/Commands/Start/Host/HostProcessStartInfoFactory.cs
+++ b/src/Func/Commands/Start/Host/HostProcessStartInfoFactory.cs
@@ -14,6 +14,8 @@ internal sealed class HostProcessStartInfoFactory
     public const string ScriptRootEnvironmentVariable = "AzureWebJobsScriptRoot";
     public const string AzureFunctionsEnvironmentVariable = "AZURE_FUNCTIONS_ENVIRONMENT";
     public const string WebsiteHostnameEnvironmentVariable = "WEBSITE_HOSTNAME";
+    public const string WebsiteSkuEnvironmentVariable = "WEBSITE_SKU";
+    public const string DefaultLocalWebsiteSku = "Dynamic";
     public const string AspNetCoreSuppressStatusMessagesEnvironmentVariable = "ASPNETCORE_SUPPRESSSTATUSMESSAGES";
     public const string HostingLifetimeLogLevelEnvironmentVariable = "Logging__LogLevel__Microsoft.Hosting.Lifetime";
 
@@ -64,6 +66,13 @@ internal sealed class HostProcessStartInfoFactory
         startInfo.Environment[ScriptRootEnvironmentVariable] = context.HostRunContext.StartupDirectory.FullName;
         startInfo.Environment[AzureFunctionsEnvironmentVariable] = "Development";
         startInfo.Environment[WebsiteHostnameEnvironmentVariable] = new Uri(localBaseUriText).Authority;
+
+        // Set WEBSITE_SKU so that worker profile conditions referencing the SKU host property
+        // can evaluate correctly in the local development environment. Without this, profiles
+        // gated on SKU silently fail and the host falls back to a non-runnable base worker
+        // description, causing worker resolution to fail despite the worker being present.
+        startInfo.Environment.TryAdd(WebsiteSkuEnvironmentVariable, DefaultLocalWebsiteSku);
+
         startInfo.Environment.TryAdd(AspNetCoreSuppressStatusMessagesEnvironmentVariable, "true");
         startInfo.Environment[HostingLifetimeLogLevelEnvironmentVariable] = "None";
 

--- a/test/Func.Tests/Commands/HostProcessStartInfoFactoryTests.cs
+++ b/test/Func.Tests/Commands/HostProcessStartInfoFactoryTests.cs
@@ -61,6 +61,7 @@ public class HostProcessStartInfoFactoryTests : IDisposable
         launchInfo.StartInfo.Environment[HostProcessStartInfoFactory.ScriptRootEnvironmentVariable].Should().Be(_startupDirectory.FullName);
         launchInfo.StartInfo.Environment[HostProcessStartInfoFactory.AzureFunctionsEnvironmentVariable].Should().Be("Development");
         launchInfo.StartInfo.Environment[HostProcessStartInfoFactory.WebsiteHostnameEnvironmentVariable].Should().Be("localhost:7071");
+        launchInfo.StartInfo.Environment[HostProcessStartInfoFactory.WebsiteSkuEnvironmentVariable].Should().Be(HostProcessStartInfoFactory.DefaultLocalWebsiteSku);
         launchInfo.StartInfo.Environment[HostProcessStartInfoFactory.AspNetCoreSuppressStatusMessagesEnvironmentVariable].Should().Be("true");
         launchInfo.StartInfo.Environment[HostProcessStartInfoFactory.HostingLifetimeLogLevelEnvironmentVariable].Should().Be("None");
     }
@@ -81,6 +82,24 @@ public class HostProcessStartInfoFactoryTests : IDisposable
         launchInfo.ListenUri.Should().Be(new Uri("http://0.0.0.0:9090"));
         launchInfo.LocalBaseUri.Should().Be(new Uri("http://localhost:9090"));
         launchInfo.StartInfo.ArgumentList.Should().Equal(["--urls", "http://0.0.0.0:9090"]);
+    }
+
+    [Fact]
+    public void Create_WhenWebsiteSkuAlreadySet_PreservesUserValue()
+    {
+        var factory = new HostProcessStartInfoFactory();
+        HostProcessStartContext context = CreateContext(
+            port: null,
+            enableAuth: false,
+            environmentVariables: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [HostProcessStartInfoFactory.WebsiteSkuEnvironmentVariable] = "ElasticPremium",
+            });
+
+        HostProcessLaunchInfo launchInfo = factory.Create(context);
+
+        launchInfo.StartInfo.Environment[HostProcessStartInfoFactory.WebsiteSkuEnvironmentVariable]
+            .Should().Be("ElasticPremium");
     }
 
     [Theory]


### PR DESCRIPTION
## Summary

Fixes #5218

Sets `WEBSITE_SKU=Dynamic` in the host child process environment so that worker profile conditions referencing the SKU host property evaluate correctly during local development with `func run`.

## Root Cause

When `func run` launches the host as a child process, the host internally uses `WorkerProfileManager` to evaluate `worker.config.json` profiles. These profiles can include `HostPropertyCondition` entries (e.g., for `Sku`, `platform`) that resolve via `ScriptSettingsManager.GetSetting()` — which reads environment variables.

In the local dev environment, `WEBSITE_SKU` is unset, so:

1. `HostPropertyCondition.Evaluate()` returns `false` for any SKU-gated condition
2. Unresolvable conditions are replaced with `FalseCondition()` (Info-level log only)
3. No profiles match → host falls back to the base `description` (often a non-runnable placeholder)
4. `ThrowIfFileNotExists` throws in `BuildWorkerConfig`, caught by `catch when (!ex.IsFatal())`, logged generically as "Failed to initialize worker provider", returns `null`
5. Worker isn't added → "no worker for runtime"

The failure is **silent** because every swallow point only emits Info/Debug-level logs.

## Fix

Added `WEBSITE_SKU=Dynamic` via `TryAdd` in `HostProcessStartInfoFactory.Create()` — the single point where the host child process environment is built. `TryAdd` ensures user-provided values (e.g., from `local.settings.json`) take precedence.

### Why `Dynamic`?

`WEBSITE_SKU` maps to the Azure Functions hosting plan:

| Value | Plan |
|-------|------|
| `Dynamic` | Consumption (serverless, scale-to-zero) |
| `ElasticPremium` | Premium (pre-warmed, VNET) |
| `FlexConsumption` | Flex Consumption |
| *(unset)* | Dedicated / App Service |

`Dynamic` (Consumption) was chosen because:

1. **Most common local dev scenario** — the majority of Azure Functions projects target the Consumption plan, so local behavior should match that by default.
2. **Least restrictive profile evaluation** — Consumption is the baseline SKU that worker profiles are designed to support. Premium/Flex profiles add capabilities on top; Consumption profiles represent the minimal runnable configuration.
3. **Matches legacy Core Tools behavior** — the v4 `func start` experience implicitly operated under Consumption semantics locally.
4. **`TryAdd` preserves user intent** — if a developer sets `WEBSITE_SKU` in `local.settings.json` (e.g., to test Premium-specific behavior), that value is respected and not overwritten.

## Testing

- Added assertion in existing test to verify `WEBSITE_SKU` is set by default
- Added new test `Create_WhenWebsiteSkuAlreadySet_PreservesUserValue` to verify user-provided SKU is not overwritten
- All `HostProcessStartInfoFactory` tests pass