### PR TITLE
Adding durable dependency if not present in package.json for node

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -19,3 +19,4 @@
 - Bumped https-proxy-agent dependency (#5335)
 - Updated target framework to .NET 10 (#4850)
 - Fix Flex Health Check to use `defaultHostName` instead of `enabledHostNames` (#5462)
+- Added `durable-functions` dependency to `package.json` when creating Node.js durable function templates (#5495)

--- a/src/Cli/func/Common/Constants.cs
+++ b/src/Cli/func/Common/Constants.cs
@@ -32,6 +32,12 @@ namespace Azure.Functions.Cli.Common
         public const string FunctionJsonFileName = "function.json";
         public const string HostJsonFileName = "host.json";
         public const string PackageJsonFileName = "package.json";
+        public const string DurableFunctionsNpmPackageName = "durable-functions";
+
+        // The Node.js v4 programming model requires the durable-functions v3.x npm package.
+        public const string DurableFunctionsNpmPackageVersion = "^3.x";
+        public const string OrchestrationTriggerType = "orchestrationTrigger";
+        public const string EntityTriggerType = "entityTrigger";
         public const string ProxiesJsonFileName = "proxies.json";
         public const string ArtifactsConfigFileName = "artifactsconfig.json";
         public const string MinifiedVersionConfigSectionName = "minifiedVersion";

--- a/src/Cli/func/Common/TemplatesManager.cs
+++ b/src/Cli/func/Common/TemplatesManager.cs
@@ -257,7 +257,11 @@ namespace Azure.Functions.Cli.Common
 
             try
             {
-                await NpmHelper.Install();
+                var exitCode = await NpmHelper.Install();
+                if (exitCode != 0)
+                {
+                    ColoredConsole.Error.WriteLine(WarningColor("Warning: 'npm install' did not complete successfully. You must run \"npm install\" manually."));
+                }
             }
             catch (Exception)
             {

--- a/src/Cli/func/Common/TemplatesManager.cs
+++ b/src/Cli/func/Common/TemplatesManager.cs
@@ -8,6 +8,7 @@ using Azure.Functions.Cli.Helpers;
 using Azure.Functions.Cli.Interfaces;
 using Colors.Net;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using static Azure.Functions.Cli.Common.OutputTheme;
 
 namespace Azure.Functions.Cli.Common
@@ -145,6 +146,7 @@ namespace Azure.Functions.Cli.Common
             if (template.Id.EndsWith("JavaScript-4.x", StringComparison.OrdinalIgnoreCase) || template.Id.EndsWith("TypeScript-4.x", StringComparison.OrdinalIgnoreCase))
             {
                 await DeployNewNodeProgrammingModel(name, fileName, template);
+                await EnsureDurableFunctionsNpmPackage(template);
             }
             else
             {
@@ -191,6 +193,75 @@ namespace Azure.Functions.Cli.Common
                 }
 
                 await FileSystemHelpers.WriteAllTextToFileAsync(filePath, fileList[filePath]);
+            }
+        }
+
+        private async Task EnsureDurableFunctionsNpmPackage(Template template)
+        {
+            var triggerType = template.Metadata?.TriggerType;
+            var isDurableTemplate =
+                string.Equals(triggerType, Constants.OrchestrationTriggerType, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(triggerType, Constants.EntityTriggerType, StringComparison.OrdinalIgnoreCase);
+
+            if (!isDurableTemplate)
+            {
+                return;
+            }
+
+            var packageJsonPath = Path.Combine(Environment.CurrentDirectory, Constants.PackageJsonFileName);
+            if (!FileSystemHelpers.FileExists(packageJsonPath))
+            {
+                return;
+            }
+
+            var dependencyAdded = false;
+            try
+            {
+                var packageJson = JObject.Parse(await FileSystemHelpers.ReadAllTextFromFileAsync(packageJsonPath));
+                if (packageJson["dependencies"] is not JObject dependencies)
+                {
+                    dependencies = new JObject();
+                    packageJson["dependencies"] = dependencies;
+                }
+
+                if (dependencies[Constants.DurableFunctionsNpmPackageName] == null)
+                {
+                    dependencies[Constants.DurableFunctionsNpmPackageName] = Constants.DurableFunctionsNpmPackageVersion;
+                    await FileSystemHelpers.WriteAllTextToFileAsync(packageJsonPath, JsonConvert.SerializeObject(packageJson, Formatting.Indented));
+                    dependencyAdded = true;
+                    ColoredConsole.WriteLine(AdditionalInfoColor($"Added '{Constants.DurableFunctionsNpmPackageName}' to {Constants.PackageJsonFileName}."));
+                }
+            }
+            catch (Exception ex)
+            {
+                ColoredConsole.Error.WriteLine(WarningColor($"Warning: Unable to add '{Constants.DurableFunctionsNpmPackageName}' to {Constants.PackageJsonFileName}. You must add it manually. {ex.Message}"));
+                return;
+            }
+
+            if (!dependencyAdded)
+            {
+                return;
+            }
+
+            if (GlobalCoreToolsSettings.IsOfflineMode)
+            {
+                ColoredConsole.WriteLine(WarningColor("Skipping \"npm install\" because the CLI is running in offline mode. You must run \"npm install\" manually when network is available."));
+                return;
+            }
+
+            if (!CommandChecker.CommandExists("npm"))
+            {
+                ColoredConsole.WriteLine(WarningColor("Skipping \"npm install\" because npm was not found. You must run \"npm install\" manually."));
+                return;
+            }
+
+            try
+            {
+                await NpmHelper.Install();
+            }
+            catch (Exception)
+            {
+                ColoredConsole.Error.WriteLine(WarningColor("Warning: You must run \"npm install\" manually"));
             }
         }
 

--- a/src/Cli/func/Helpers/NpmHelper.cs
+++ b/src/Cli/func/Helpers/NpmHelper.cs
@@ -10,12 +10,12 @@ namespace Azure.Functions.Cli.Helpers
 {
     public static class NpmHelper
     {
-        public static async Task Install()
+        public static async Task<int> Install()
         {
-            await RunNpmCommand("install", true);
+            return await RunNpmCommand("install", true);
         }
 
-        internal static async Task RunNpmCommand(string args, bool ignoreError = true, bool showProgress = true, string stdIn = null)
+        internal static async Task<int> RunNpmCommand(string args, bool ignoreError = true, bool showProgress = true, string stdIn = null)
         {
             if (showProgress || StaticSettings.IsDebug)
             {
@@ -24,11 +24,11 @@ namespace Azure.Functions.Cli.Helpers
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                await InternalRunCommand("cmd", $"/c npm {args}", ignoreError, stdIn: stdIn);
+                return (await InternalRunCommand("cmd", $"/c npm {args}", ignoreError, stdIn: stdIn)).ExitCode;
             }
             else
             {
-                await InternalRunCommand("npm", args, ignoreError, stdIn: stdIn);
+                return (await InternalRunCommand("npm", args, ignoreError, stdIn: stdIn)).ExitCode;
             }
         }
 

--- a/test/Cli/Func.E2ETests/Commands/FuncNew/NodeTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncNew/NodeTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using AwesomeAssertions;
@@ -156,6 +156,73 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncNew
 
             // Step 3: Assertions
             result.Should().HaveStdOutContaining("The function \"testfunc\" was created successfully from the \"httptrigger\" template.");
+        }
+
+        [Fact]
+        public async Task FuncNew_JavaScript_DurableOrchestrator_AddsDurableFunctionsDependency()
+        {
+            var testName = nameof(FuncNew_JavaScript_DurableOrchestrator_AddsDurableFunctionsDependency);
+
+            // Initialize a Node.js v4 (default) JavaScript function app
+            await FuncInitWithRetryAsync(testName, new[] { ".", "--worker-runtime", "node", "--language", "javascript" });
+
+            // Create a Durable Functions orchestrator. Run in offline mode so the assertion
+            // validates the package.json update without requiring a real 'npm install'.
+            var result = new FuncNewCommand(FuncPath, testName, Log)
+                .WithWorkingDirectory(WorkingDirectory)
+                .WithEnvironmentVariable("FUNCTIONS_CORE_TOOLS_OFFLINE", "true")
+                .Execute([".", "--template", "DurableFunctionsOrchestrator", "--name", "durableHello"]);
+
+            result.Should().ExitWith(0);
+            result.Should().HaveStdOutContaining("The function \"durableHello\" was created successfully");
+            result.Should().HaveStdOutContaining("Added 'durable-functions' to package.json.");
+
+            var packageJson = await File.ReadAllTextAsync(Path.Combine(WorkingDirectory, "package.json"));
+            packageJson.Should().Contain("durable-functions");
+        }
+
+        [Fact]
+        public async Task FuncNew_TypeScript_DurableEntity_AddsDurableFunctionsDependency()
+        {
+            var testName = nameof(FuncNew_TypeScript_DurableEntity_AddsDurableFunctionsDependency);
+
+            // Initialize a Node.js v4 (default) TypeScript function app
+            await FuncInitWithRetryAsync(testName, new[] { ".", "--worker-runtime", "node", "--language", "typescript" });
+
+            // Create a Durable Functions entity. Run in offline mode so the assertion
+            // validates the package.json update without requiring a real 'npm install'.
+            var result = new FuncNewCommand(FuncPath, testName, Log)
+                .WithWorkingDirectory(WorkingDirectory)
+                .WithEnvironmentVariable("FUNCTIONS_CORE_TOOLS_OFFLINE", "true")
+                .Execute([".", "--template", "DurableFunctionsEntity", "--name", "counter"]);
+
+            result.Should().ExitWith(0);
+            result.Should().HaveStdOutContaining("The function \"counter\" was created successfully");
+            result.Should().HaveStdOutContaining("Added 'durable-functions' to package.json.");
+
+            var packageJson = await File.ReadAllTextAsync(Path.Combine(WorkingDirectory, "package.json"));
+            packageJson.Should().Contain("durable-functions");
+        }
+
+        [Fact]
+        public async Task FuncNew_JavaScript_HttpTrigger_DoesNotAddDurableFunctionsDependency()
+        {
+            var testName = nameof(FuncNew_JavaScript_HttpTrigger_DoesNotAddDurableFunctionsDependency);
+
+            // Initialize a Node.js v4 (default) JavaScript function app
+            await FuncInitWithRetryAsync(testName, new[] { ".", "--worker-runtime", "node", "--language", "javascript" });
+
+            // A non-durable template must not pull in the durable-functions dependency
+            var result = new FuncNewCommand(FuncPath, testName, Log)
+                .WithWorkingDirectory(WorkingDirectory)
+                .WithEnvironmentVariable("FUNCTIONS_CORE_TOOLS_OFFLINE", "true")
+                .Execute([".", "--template", "HttpTrigger", "--name", "myHttp"]);
+
+            result.Should().ExitWith(0);
+            result.Should().NotHaveStdOutContaining("Added 'durable-functions' to package.json.");
+
+            var packageJson = await File.ReadAllTextAsync(Path.Combine(WorkingDirectory, "package.json"));
+            packageJson.Should().NotContain("durable-functions");
         }
     }
 }


### PR DESCRIPTION
This pull request adds support for automatically managing the `durable-functions` npm package dependency when creating Node.js v4 (JavaScript/TypeScript) Azure Functions using Durable Functions templates. Now, when a user creates an orchestrator or entity function, the CLI ensures that the correct dependency is added to `package.json` and attempts to install it, improving the developer experience and reducing manual setup steps. The changes also include comprehensive end-to-end tests to verify this behavior.

**Enhancements to Durable Functions dependency management:**

* Added a new method `EnsureDurableFunctionsNpmPackage` in `TemplatesManager.cs` that checks if the selected template is a Durable Functions orchestrator or entity, and if so, adds the `durable-functions` dependency (version `^3.x`) to `package.json` and runs `npm install` unless in offline mode or if npm is not available. [[1]](diffhunk://#diff-33cf586b4f099fa60f6eb180aeacfde7d016b9521f94aa51f1654d5f63c157b8R149) [[2]](diffhunk://#diff-33cf586b4f099fa60f6eb180aeacfde7d016b9521f94aa51f1654d5f63c157b8R199-R267)
* Introduced new constants in `Constants.cs` for the Durable Functions npm package name, version, and trigger types for orchestration and entity.

**Testing improvements:**

* Added three new end-to-end tests in `NodeTests.cs` to verify:
  - The `durable-functions` dependency is added for JavaScript orchestrator and TypeScript entity templates.
  - The dependency is not added for non-durable templates (e.g., HTTP trigger).

**Code quality:**

* Added `Newtonsoft.Json.Linq` import for working with JSON objects in `TemplatesManager.cs`.

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #5492

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
