### PR TITLE
Give a clear error when installing a missing .nupkg

### DIFF
--- a/src/Func/Commands/Workload/WorkloadInstallCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadInstallCommand.cs
@@ -174,14 +174,18 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
     }
 
     /// <summary>
-    /// Returns <c>true</c> when the positional argument looks like a path
-    /// to a <c>.nupkg</c> on disk (i.e. ends in <c>.nupkg</c> and points to
-    /// an existing file). Lets the user install a local package without
-    /// going through the catalog. NuGet package ids cannot legally end in
-    /// <c>.nupkg</c>, so this is unambiguous.
+    /// Returns <c>true</c> when the positional argument looks like a path to
+    /// a <c>.nupkg</c>, routing it to the local installer instead of the
+    /// catalog. NuGet package ids cannot legally end in <c>.nupkg</c>, so
+    /// this is unambiguous.
     /// </summary>
+    /// <remarks>
+    /// Existence is deliberately not checked here. A missing file then fails
+    /// with a clear "does not exist" error from the installer instead of an
+    /// obscure catalog-resolution error.
+    /// </remarks>
     private static bool LooksLikeLocalPackagePath(string value)
-        => value.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase) && File.Exists(value);
+        => value.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase);
 
     private async Task<int?> HandleAlreadyInstalledAsync(
         string identifier,

--- a/src/Func/Commands/Workload/WorkloadInstallCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadInstallCommand.cs
@@ -176,13 +176,15 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
     /// <summary>
     /// Returns <c>true</c> when the positional argument looks like a path to
     /// a <c>.nupkg</c>, routing it to the local installer instead of the
-    /// catalog. NuGet package ids cannot legally end in <c>.nupkg</c>, so
-    /// this is unambiguous.
+    /// catalog.
     /// </summary>
     /// <remarks>
-    /// Existence is deliberately not checked here. A missing file then fails
-    /// with a clear "does not exist" error from the installer instead of an
-    /// obscure catalog-resolution error.
+    /// Existence is deliberately not checked. A missing file then fails with
+    /// a clear "does not exist" error from the installer instead of an
+    /// obscure catalog-resolution error. The tradeoff is that the suffix now
+    /// always wins: a package id ending in <c>.nupkg</c> is legal per NuGet
+    /// but can no longer be resolved from the catalog. No published workload
+    /// is named that way.
     /// </remarks>
     private static bool LooksLikeLocalPackagePath(string value)
         => value.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase);

--- a/src/Func/Commands/Workload/WorkloadInstallCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadInstallCommand.cs
@@ -174,17 +174,16 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
     }
 
     /// <summary>
-    /// Returns <c>true</c> when the positional argument looks like a path to
-    /// a <c>.nupkg</c>, routing it to the local installer instead of the
-    /// catalog.
+    /// Returns <c>true</c> when the positional argument ends in <c>.nupkg</c>,
+    /// routing it to the local installer instead of the catalog. The suffix is
+    /// the only signal, so the value is not checked for existence or path shape.
     /// </summary>
     /// <remarks>
-    /// Existence is deliberately not checked. A missing file then fails with
-    /// a clear "does not exist" error from the installer instead of an
-    /// obscure catalog-resolution error. The tradeoff is that the suffix now
-    /// always wins: a package id ending in <c>.nupkg</c> is legal per NuGet
-    /// but can no longer be resolved from the catalog. No published workload
-    /// is named that way.
+    /// A missing file then fails with a clear "does not exist" error from the
+    /// installer instead of an obscure catalog-resolution error. The tradeoff
+    /// is that the suffix always wins. A package id ending in <c>.nupkg</c> is
+    /// legal per NuGet but can no longer be resolved from the catalog, and no
+    /// published workload is named that way.
     /// </remarks>
     private static bool LooksLikeLocalPackagePath(string value)
         => value.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase);

--- a/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
@@ -312,6 +312,28 @@ public class WorkloadInstallCommandTests
     }
 
     [Fact]
+    public async Task Install_MissingLocalNupkgPath_RoutesToLocalInstallerAndReportsMissingFile()
+    {
+        // A .nupkg path that does not exist must still route to the local
+        // installer so the user gets a clear "does not exist" error instead
+        // of an obscure catalog-resolution failure (#5479).
+        string missingPkg = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}-missing.nupkg");
+
+        _installer.InstallFromPackageAsync(missingPkg, Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>())
+            .Throws(new FileNotFoundException($"Package file '{missingPkg}' does not exist.", missingPkg));
+
+        var cmd = NewInstall();
+        GracefulException ex = (await FluentActions.Awaiting(() => InvokeAsync(cmd, missingPkg)).Should().ThrowAsync<GracefulException>()).Which;
+
+        ex.Message.Should().Contain("does not exist");
+        ex.IsUserError.Should().BeTrue();
+        await _installer.Received(1).InstallFromPackageAsync(
+            missingPkg, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
+        await _installer.DidNotReceiveWithAnyArgs().InstallFromCatalogAsync(
+            default!, default, default, default, default, default, default);
+    }
+
+    [Fact]
     public async Task Install_AlreadyInstalled_NonInteractive_ReturnsOneAndDoesNotInstall()
     {
         _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(new[]


### PR DESCRIPTION
Fixes #5479

`func workload install <path>.nupkg` printed a confusing catalog error when the file did not exist. It said "Could not resolve workload ... No matching version was found on any configured source", which points people at the wrong problem.

The cause was the local vs catalog check. It only treated the input as a local package when the file already existed, so a missing `.nupkg` fell through to catalog resolution and got treated as a package id.

I changed the check to match on the `.nupkg` suffix alone. A missing file now reaches the local installer, which already fails with a clear message.

**Before**
```
Error: Could not resolve workload 'C:/path/to/missing.nupkg'. No matching version was found on any configured source.
```

**After**
```
Error: Package file 'C:/path/to/missing.nupkg' does not exist.
```

The installer already validated existence and threw `FileNotFoundException`, and the command already turned that into a friendly user error, so the fix is just letting the missing path get there.

**Tradeoff worth calling out**

`func workload install foo.nupkg` is genuinely ambiguous. It could be a file path or a package id, and `foo.nupkg` is a legal NuGet id, I checked `PackageIdValidator.IsValidPackageId` and it returns true. Something has to break the tie.

The old rule was "it is a path only if the file exists", which is why a typo'd path got sent to the catalog and produced a nonsense error. The new rule is "the suffix makes it a path", which fixes the error but means anything ending in `.nupkg` is never resolved from the catalog. A workload whose published id ends in `.nupkg` would become uninstallable by id, and no flag works around it.

Nothing is published under a name like that and I do not expect anything ever will, so I think this is the right trade for a clear error message. Flagging it so the cost is visible rather than buried.

**Testing**
- Added a command test that a non-existent `.nupkg` routes to the local installer and surfaces the missing-file message as a user error. Confirmed it fails without the change and passes with it.
- Full `WorkloadInstallCommandTests` green, 24 tests.
- Release build clean with warnings as errors.

**End to end**
Ran the built `func.exe` against both paths.

Missing `.nupkg`, the fixed case.
```
> func workload install "C:/path/to/does-not-exist-9f3a2b.nupkg"
Error: Package file 'C:/path/to/does-not-exist-9f3a2b.nupkg' does not exist.
EXITCODE=1
```

Non `.nupkg` id, the catalog path stays the same.
```
> func workload install "some.nonexistent.workload"
Error: Could not resolve workload 'some.nonexistent.workload'. No matching version was found on any configured source.
EXITCODE=1
```
Both exit clean with code 1 and no stack trace. Neither run writes to disk since both fail before install.
