### PR TITLE
Merge design documents into vnext

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ This branch hosts design and proposal documents for Azure Functions Core Tools. 
 ## Layout
 
 - `proposed/` — In-progress proposals open for discussion. Drafts live here while a design is being shaped and reviewed.
-- `accepted/` — Designs that have been reviewed and accepted. Once a proposal is approved, move it from `proposed/` to `accepted/`.
+- `accepted/` — Designs that have been reviewed, accepted and implemented into the product. Once a proposal is approved, move it from `proposed/` to `accepted/`.
 
 ## Workflow
 
 1. Add a new design under `proposed/` (e.g. `proposed/my-feature.md`).
 2. Open a PR against the `docs` branch for review.
-3. After acceptance, move the file to `accepted/` in a follow-up PR.
+3. After the design is part of the product (implemented), move the file to `accepted/` in a follow-up PR.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Azure Functions Core Tools — Design Docs
+
+This branch hosts design and proposal documents for Azure Functions Core Tools. It is intentionally separate from `main` and has no shared history with the source code.
+
+## Layout
+
+- `proposed/` — In-progress proposals open for discussion. Drafts live here while a design is being shaped and reviewed.
+- `accepted/` — Designs that have been reviewed and accepted. Once a proposal is approved, move it from `proposed/` to `accepted/`.
+
+## Workflow
+
+1. Add a new design under `proposed/` (e.g. `proposed/my-feature.md`).
+2. Open a PR against the `docs` branch for review.
+3. After acceptance, move the file to `accepted/` in a follow-up PR.

--- a/proposed/bundles-workload-spec.md
+++ b/proposed/bundles-workload-spec.md
@@ -1,0 +1,601 @@
+# Bundles Workload Spec
+
+> **Status:** Draft. This spec defines how Azure Functions **extension
+> bundles** are delivered as a content workload in v5 (vnext) Core
+> Tools, and how the CLI core resolves the correct version per
+> project + active profile. It layers on top of the
+> [Workload Spec](workload-spec.md) and the
+> [Profile-Based Local Development design](cli-profiles.md). It does
+> **not** redefine the bundle on-disk format consumed by the
+> Functions runtime host; that contract is unchanged.
+
+## 1. Goals
+
+- Move all bundle acquisition and on-disk layout out of the `func`
+  CLI binary and into a `kind: content` workload, mirroring how the
+  host runtime ships today (Workload Spec §4.6).
+- Keep version selection (host.json ∩ profile intersection,
+  highest-installed-wins) inside the CLI core. The bundles workload
+  ships **only the bundle payload**; it contains no resolution code
+  and registers no DI services.
+- Make `func start` resolution **deterministic and fully offline**.
+  The CLI performs no network I/O for bundles. All bundle payloads
+  are obtained at workload **install** time (the payload ships
+  inside the workload `.nupkg`).
+- Eliminate Core Tools' bespoke bundle download path
+  (`ExtensionBundleHelper`, `DownloadBundleAction`, `func extensions
+  install`). The bundles workload is the only acquisition mechanism
+  in v5, and acquisition is `func workload install` + nothing else.
+- Require no changes in the Functions runtime host. CT keeps using
+  the existing `AzureFunctionsJobHost__extensionBundle__downloadPath`
+  env var to point the host at the resolved bundle and to suppress
+  its built-in probe.
+
+## 2. Non-goals (v1)
+
+- **Project-level bundle pin.** No `--bundle-version` flag, no
+  `bundle.version` field in `.func/config.json`. Pinning is done by
+  authoring a custom profile (cli-profiles §5.2) that sets
+  `extensionBundle.version` to an exact range.
+- **Auto-install of the bundles workload on `func start`.** Follows
+  the host-workload rule (Workload Spec §4.5): a missing or
+  unsatisfying installed workload set causes `func start` to print
+  an install hint and exit non-zero. CT never installs workloads
+  implicitly. Auto-install gated on profile opt-in is a separate
+  cross-cutting concern (will apply to host runtime, bundles, and
+  any other content workload) and is out of scope for this spec.
+- **Bundle CDN access from CT at runtime.** Neither the CLI nor the
+  bundles workload contacts the bundle CDN at run time. The bundle
+  payload is part of the workload `.nupkg`, fetched from the bundle
+  build pipeline's artifacts (or, interim, the CDN) exactly once at
+  workload-build time by the workload's own MSBuild process. See
+  §5.3 for the payload-source pivot.
+- **Custom bundles install root.** Bundle payloads live inside the
+  workload install directory under `<workload-home>`. There is no
+  second on-disk root, no bundles-specific override env var, and no
+  plan to add one. (`<workload-home>` itself is customizable via
+  `FUNC_CLI_WORKLOADS_HOME`, per Workload Spec §11; this naturally
+  relocates bundle installs along with everything else.)
+- **Contribution points for bundles.** The bundles workload is
+  `kind: content` (Workload Spec §3, §5.3); content workloads
+  register no services and contribute no commands. There is **no**
+  `IExtensionBundleProvider` interface, no bundles-workload
+  assembly load. Resolution is a CLI-core concern.
+- **CT → host transport beyond today's env vars.** If a future
+  CT-host workload introduces a different startup transport, that
+  is out of scope for this spec.
+
+## 3. Definitions
+
+| Term | Meaning |
+|------|---------|
+| **Bundle id** | The `host.json` `extensionBundle.id` value. Three ids exist in v5: `Microsoft.Azure.Functions.ExtensionBundle` (stable), `Microsoft.Azure.Functions.ExtensionBundle.Preview`, and `Microsoft.Azure.Functions.ExtensionBundle.Experimental`. Each id is its own channel; experimental is **not** a label on the Preview id. |
+| **Bundle payload version** | The 3-part SemVer version of the extension bundle payload zip (e.g. `4.35.0`). This is the version the Functions runtime knows about and the version the user sees in `func` logs. It carries **no** prerelease label, even for the preview / experimental channels. |
+| **Workload pkg version** | The version of the bundles workload `.nupkg`. Maps **1:1** to the bundle payload version: stable channel uses the bare 3-part version (e.g. `4.35.0`); preview / experimental channels use the bare 3-part version with a channel prerelease label (e.g. `4.35.0-preview`, `4.35.0-experimental`). See §4.1.1. |
+| **Bundles workload** | The single `kind: content` workload package id `Azure.Functions.Cli.Workloads.ExtensionBundles`. Each installed instance carries exactly **one** bundle payload, packaged at workload-build time. |
+| **Bundle workload install dir** | The directory the workload subsystem extracts an installed bundles workload into, per Workload Spec §6.1: `<workload-home>/workloads/azure.functions.cli.workloads.extensionbundles/<workload-pkg-version>/`. |
+| **Resolved bundle path** | The directory the CLI core returns to its bundle consumer (today: `func start`). It is a subdirectory of the bundle workload install dir whose contents match today's extension bundle zip layout exactly, so the Functions runtime host needs no changes to consume it. |
+
+## 4. Architecture
+
+### 4.1 Content workload, one bundle payload per install
+
+There is **one** workload package id:
+
+```
+Azure.Functions.Cli.Workloads.ExtensionBundles
+```
+
+It is `kind: content` (Workload Spec §3, §5.3): the package ships
+the bundle payload under `tools/any/<BundleVersion>/` (see §5.2 for
+the version-nest contract) with no `entryPoint`. The workload
+subsystem records its registry row but does not load it (Workload
+Spec §6.2 step 3, §5.1 "non-`workload` kinds"). The CLI core
+resolves the install directory by package id and workload pkg
+version, in the same way `func start` resolves the host-runtime
+workload today (Workload Spec §4.6).
+
+#### 4.1.1 Version scheme
+
+The workload pkg version maps **1:1** to the bundle payload
+version. Because the workload pkg is content-only (no workload
+code), there is no reason to version it independently of the
+payload it carries.
+
+Two MSBuild props in `Directory.Version.props` drive
+`<VersionPrefix>`:
+
+- `$(BundleVersion)` (e.g. `4.35.0`): the 3-part SemVer version of
+  the bundle payload. Drives the CDN URL (§5.3.2) and the
+  user-facing version in `func` logs.
+- `$(BundleChannel)` (`stable` | `preview` | `experimental`):
+  selects the CDN bundle id at pack time (§5.3.1) and, for
+  non-stable channels, the prerelease label appended to the
+  workload pkg version.
+
+The resulting workload pkg versions per channel:
+
+| Channel | host.json `extensionBundle.id` | Workload pkg version | Bundle payload version |
+|---|---|---|---|
+| stable | `Microsoft.Azure.Functions.ExtensionBundle` | `4.35.0` | `4.35.0` |
+| preview | `Microsoft.Azure.Functions.ExtensionBundle.Preview` | `4.35.0-preview` | `4.35.0` |
+| experimental | `Microsoft.Azure.Functions.ExtensionBundle.Experimental` | `4.35.0-experimental` | `4.35.0` |
+
+Each installed workload pkg version ships **exactly one** bundle
+payload version; the 1:1 contract holds at every level.
+
+Rationale:
+
+- Content-only pkg: no workload code to revision separately, so a
+  4th-segment iteration counter would be cognitive cost with no
+  payoff.
+- The prerelease label is NuGet's built-in "this is preview"
+  signal: `func workload install` won't pick up preview /
+  experimental rows without an explicit pin or `--prerelease`.
+- A workload-only republish (build pipeline change, packaging fix,
+  etc.) bumps the bundle payload's patch version. If that case
+  ever becomes common, we can introduce an iteration knob then.
+
+Multiple bundle versions coexist on disk by installing the workload
+multiple times with `func workload install --force` (Workload Spec
+§4.6 already specifies this side-by-side model for the host-runtime
+workload; bundles use the same mechanism). Each install is a
+distinct row in the workload registry, keyed by workload pkg
+version.
+
+Other rationale:
+
+- Side-by-side coexistence via `--force` is already part of the
+  workload subsystem; bundles don't need a separate cache layer.
+- Keeping the workload payload-only (no assembly, no
+  contribution points) keeps the per-version `.nupkg` small,
+  AOT-friendly for the host CLI, and free of code-signing /
+  loading concerns.
+- Eliminating a second on-disk root removes an entire class of
+  override / migration concerns.
+
+### 4.2 Three-channel id model and resolver filter
+
+`host.json` `extensionBundle.id` selects the **channel**. Each of
+the three v5 ids maps to the same workload package
+(`Azure.Functions.Cli.Workloads.ExtensionBundles`); the CLI core
+resolver picks installed rows by matching the workload pkg
+version's prerelease label against the requested id:
+
+| host.json `extensionBundle.id` | Matching workload pkg versions |
+|---|---|
+| `Microsoft.Azure.Functions.ExtensionBundle` | versions with **no** prerelease label (e.g. `4.35.0`) |
+| `Microsoft.Azure.Functions.ExtensionBundle.Preview` | versions whose prerelease label is **exactly `preview`** (e.g. `4.35.0-preview`) |
+| `Microsoft.Azure.Functions.ExtensionBundle.Experimental` | versions whose prerelease label is **exactly `experimental`** (e.g. `4.35.0-experimental`) |
+
+The match is exact: a workload version's prerelease label is the
+encoded channel. Preview does not match experimental versions and
+vice versa.
+
+The version-range intersection (§5.1) is then evaluated against
+the **bundle payload version** (3-part `$(BundleVersion)`, which
+for stable channel is the workload pkg version itself, and for
+non-stable channels is the workload pkg version with the
+prerelease label stripped) of each matching candidate.
+
+### 4.3 CLI core ownership
+
+Because the bundles workload is content-only, **all** of the
+following live in the `func` CLI core (concretely: in
+`Azure.Functions.Cli` against `Func.Cli.Abstractions`):
+
+- Reading the workload registry to enumerate installed bundle
+  versions (Workload Spec §10.1).
+- Computing the host.json ∩ profile intersection (§5.1).
+- Filtering candidates by host.json `extensionBundle.id` (§4.2).
+- Picking the highest compatible installed version.
+- Resolving the on-disk path (§5.2) and handing it to the host
+  via `AzureFunctionsJobHost__extensionBundle__downloadPath`.
+- Owning the user-facing log lines, install hints, and telemetry
+  events (§6, §5.4, §7).
+
+The bundles workload contains **only** the bundle payload and the
+build-time plumbing that fetched it from the bundle build pipeline
+(or, interim, the CDN: §5.3). It has no runtime code.
+
+#### 4.3.1 Component shape
+
+The CLI-side implementation is factored into three pieces, all
+living in CT (not in the workload):
+
+| Component | Layer | Responsibility |
+|-----------|-------|----------------|
+| `IInstalledBundleWorkloads` | `Func.Cli.Abstractions` | Enumerates installed rows of the bundles content workload from the workload registry. Returns `(version, installDir)` pairs. Implementation wraps the existing workload subsystem (`IWorkloadStore` + `IWorkloadPaths`). |
+| `IExtensionBundleResolver` | `Func.Cli.Abstractions` | Runs the algorithm in §5.1. Pure function over `(ProjectContext, IInstalledBundleWorkloads)`; returns an `ExtensionBundleResolution` discriminated union. |
+| `ValidateExtensionBundleInitializationStep` | `Azure.Functions.Cli` (`func start` pipeline) | Sole consumer in v1. Calls the resolver, sets the env vars on success, prints the hint and exits non-zero on failure. Also unconditionally sets `AzureFunctionsJobHost__extensionBundle__ensureLatest=false` (see §4.4 step 6). |
+
+`ExtensionBundleResolution` is a closed discriminated union with
+four cases matching the outcomes in §5.1: `Resolved`,
+`WorkloadMissing`, `EmptyIntersection`, `NoCompatibleInstall`. Each
+failure case carries enough structured data for the consumer to
+emit the hint copy in §5.4 without re-deriving anything.
+
+The package id constant used by both the CT resolver and the
+workload `.csproj` to agree on the bundles package name lives in
+`Func.Cli.Abstractions` (e.g. on `IInstalledBundleWorkloads`) so
+there is exactly one source of truth.
+
+#### 4.3.2 Why these abstractions live in `Func.Cli.Abstractions`
+
+Even though the bundles workload itself ships no runtime assembly
+(content-only), the **resolver** and the **installed-workloads
+enumerator** are written against `Func.Cli.Abstractions` rather
+than CT's internals. This keeps two doors open:
+
+- A future non-content bundles delivery model could provide its
+  own `IInstalledBundleWorkloads` implementation without touching
+  CT.
+- An alternative consumer (e.g. `func pack` validation) can reuse
+  `IExtensionBundleResolver` without depending on `func start`
+  pipeline internals.
+
+Neither door is exercised in v1; the abstractions cost is small
+and keeps the layering consistent with the rest of the workload
+ecosystem.
+
+#### 4.3.3 Folder isolation in CT
+
+All bundles-specific code in `Azure.Functions.Cli` lives under a
+single top-level folder (`Bundles/`), and the abstractions in
+`Func.Cli.Abstractions` live under a matching `Bundles/`
+sub-namespace. Concretely:
+
+```
+src/Cli/func/
+  Bundles/
+    ExtensionBundleResolver.cs
+    InstalledBundleWorkloads.cs       # IInstalledBundleWorkloads impl
+    ExtensionBundleResolution.cs      # result union
+    BundleHintBuilder.cs              # §5.4 copy
+    BundleTelemetry.cs                # §7 event shape
+    ValidateExtensionBundleInitializationStep.cs  # func start consumer
+src/Cli/Abstractions/
+  Bundles/
+    IInstalledBundleWorkloads.cs
+    IExtensionBundleResolver.cs
+```
+
+`ValidateExtensionBundleInitializationStep` is registered into the
+`func start` initialization pipeline from its usual composition
+root, but the type itself lives under `Bundles/` so the whole
+feature is colocated. No other CT subsystem references types under
+`Bundles/` directly.
+
+This isolation is a soft guarantee that the bundles resolver can
+be lifted into a separate assembly (e.g. an
+`Azure.Functions.Cli.Bundles` library, or back into a `kind:
+workload`-style package) later without touching the rest of CT.
+
+### 4.4 `func start` responsibilities
+
+`func start` is the only v1 consumer. Its responsibilities:
+
+1. Detect whether the project's `host.json` declares an
+   `extensionBundle` section. If not, **skip** bundle resolution
+   entirely (do not read the workload registry, do not set any env
+   var).
+2. Resolve the active profile (cli-profiles §6).
+3. Run the resolution algorithm (§5.1).
+   - On `WorkloadMissing` (no rows for the bundles package at any
+     version), print the install hint:
+     ```
+     This project requires an extension bundle but no bundles
+     workload is installed. Install a version with:
+       func workload install Azure.Functions.Cli.Workloads.ExtensionBundles@<workload-pkg-version>
+     ```
+     e.g. `...@4.35.0` for stable or `...@4.35.0-preview` for
+     preview. Exit non-zero.
+4. On `Resolved`: set
+   `AzureFunctionsJobHost__extensionBundle__downloadPath` to the
+   returned path and launch the host. Log at Information:
+   ```
+   Using extension bundle <id> <bundle-payload-version> from <path>
+   ```
+   where `<bundle-payload-version>` is the 3-part bundle version
+   (e.g. `4.35.0`), not the workload pkg version.
+5. On `EmptyIntersection` or `NoCompatibleInstall`: print the
+   structured install hint (§5.4) and exit non-zero. Do not start
+   the host.
+6. **Always** set
+   `AzureFunctionsJobHost__extensionBundle__ensureLatest=false`
+   when launching the host, whether or not a bundle was resolved.
+   In v5 the bundles workload owns the bundle on disk; the host
+   runtime must never reach out for a newer bundle behind CT's
+   back.
+
+## 5. Resolution and on-disk layout (CLI core)
+
+### 5.1 Resolution algorithm
+
+Given the project context (host.json `extensionBundle` block,
+worker runtime, active profile), the CLI core:
+
+1. Computes the **constraint range** as the NuGet-style intersection
+   of:
+   - the `host.json` `extensionBundle.version` range, and
+   - the active profile's `extensionBundle.version` range (if
+     declared; otherwise the constraint equals the host.json range).
+2. Enumerates **installed bundle workload rows** by reading the
+   workload registry (`workloads.json`, Workload Spec §10.1) for
+   rows whose `packageId` is
+   `azure.functions.cli.workloads.extensionbundles`. Each row's
+   identity is its workload pkg version (e.g. `4.35.0`,
+   `4.35.0-preview`).
+3. Filters those rows by host.json `extensionBundle.id` per the
+   §4.2 channel rule (stable id → no prerelease label; Preview id
+   → prerelease label exactly `preview`; Experimental id →
+   prerelease label exactly `experimental`).
+4. Projects each surviving row to its **bundle payload version**
+   (3-part `$(BundleVersion)`) and selects the **highest** that
+   satisfies the constraint range.
+5. Produces one of:
+   - **Resolved**: the absolute path inside that workload's install
+     dir whose layout matches the extension bundle zip (§5.2). The
+     resolution carries the **3-part bundle payload version** as
+     its user-facing version, not the workload pkg version (the
+     two differ only by the prerelease label on non-stable
+     channels).
+   - **WorkloadMissing**: no rows for the bundles package id exist
+     at any version.
+   - **EmptyIntersection**: the host.json range and the profile
+     range do not overlap. Carries the highest bundle payload
+     version that would satisfy host.json alone (for the install
+     hint).
+   - **NoCompatibleInstall**: the constraint range and a list of
+     filtered installed bundle workload rows are non-empty but
+     none match. Carries the install hint for a satisfying
+     version.
+6. If the active profile declares `supportedRuntimes` and the
+   project's worker runtime is not listed, the result includes a
+   non-fatal warning. `func start` logs it and proceeds; mismatch
+   is informational for bundles and **must not** block start.
+
+The CLI core performs **no** network I/O.
+
+### 5.2 On-disk layout
+
+The bundles workload `.nupkg` ships its payload under
+`tools/any/<BundleVersion>/`, which the workload subsystem extracts
+into:
+
+```
+<workload-home>/workloads/azure.functions.cli.workloads.extensionbundles/<workload-pkg-version>/
+  tools/any/
+    <bundle-version>/          ← extension bundle root (bin/, extensions.json, ...)
+  workload.json
+```
+
+The install dir is keyed by the workload pkg version (e.g. `4.35.0`,
+`4.35.0-preview`), so stable and preview installs of the same
+bundle payload coexist as distinct directories. Inside, the bundle
+content (the layout the Functions runtime host already knows how
+to read: `bin/`, `extensions.json`, etc.) lives one level deeper
+in a directory named after the 3-part bundle payload version.
+
+#### 5.2.1 Resolved path and host probe contract
+
+The CLI core's bundle resolver returns the **parent** of the bundle
+version directory: `<install>/tools/any/`. The `func start` step
+then sets:
+
+```
+AzureFunctionsJobHost__extensionBundle__downloadPath = <install>/tools/any
+AzureFunctionsJobHost__extensionBundle__ensureLatest = false
+```
+
+The Functions runtime host's `ExtensionBundleManager` probes
+`<downloadPath>/<bundle-version>/...` for the bundle root, which
+lands on the version directory we just shipped. The version segment
+in the layout is what makes the host happy without CT having to set
+custom env vars or patch the host probe path.
+
+A practical consequence: a bundles workload `.nupkg` could in
+principle ship more than one bundle version under `tools/any/`
+(e.g. `tools/any/4.35.0/` and `tools/any/4.36.0/`) and the host
+would still probe correctly. Today each workload pkg carries
+exactly one bundle version per the 1:1 rule in §4.1.1, but the
+layout leaves that door open.
+
+No copy or relocation step is performed at install time, and there
+is no second on-disk root.
+
+### 5.3 Packaging (workload build time)
+
+The bundles workload `.csproj` is a packaging-only project (no
+runtime assembly). At workload-build time, MSBuild fetches the
+bundle payload zip for the target version, unpacks the bundle into
+the workload output, and packs the result into the `.nupkg` under
+`tools/any/<BundleVersion>/` (see §5.2 for why the version nest is
+required).
+
+Other `kind: content` workloads can still pack flat at `tools/any/`
+if the consumer doesn't impose a version-probing contract; the
+nested layout is specific to bundles because the consumer is the
+host's `ExtensionBundleManager`.
+
+#### 5.3.1 Payload source: bundle pipeline build artifacts
+
+The canonical payload source is the **bundle build pipeline's
+artifacts feed** in Azure DevOps, not the public bundle CDN.
+
+- The bundles repo publishes a pipeline build per branch. The
+  three branches that matter for this spec are:
+  - `main` → stable bundle versions.
+  - `main-preview` → preview bundle versions.
+  - `main-experimental` → experimental bundle versions.
+- Each successful build publishes an artifact named `zip` that
+  contains, among other things, files of the shape:
+  `Microsoft.Azure.Functions.ExtensionBundle.<version>_any-any.zip`
+  (one per platform; bundles ship a platform-neutral `any-any`
+  variant which is the one this workload uses).
+- The bundles-workload build pipeline downloads exactly that file
+  for the target `<version>` from the build matching the SemVer
+  prerelease channel (stable / preview / experimental).
+
+This gives the bundles workload the same payload that has been
+signed and validated by the bundles release process, with no
+dependency on the public CDN at workload-build time and no
+dependency on the CDN at user-run time.
+
+#### 5.3.2 Interim: temporary CDN fetch
+
+For the first cut, while the workload still lives in
+`Azure/azure-functions-core-tools` and is decoupled from the
+bundles release schedule, MSBuild uses `DownloadFile` against the
+**public bundle CDN** as a quick-setup payload source. This is an
+implementation detail of the workload build and has no effect on
+the on-disk shape or on `func` runtime behavior.
+
+The pivot to build artifacts happens when:
+
+- The bundles workload moves into the bundles repo (or is wired
+  into the bundles release pipeline from this repo), so the
+  workload `.nupkg` and the bundle `.zip` are produced by the same
+  build and the artifact handle is naturally available; or
+- The bundle release process exposes a stable cross-pipeline
+  artifact download URL the workload build can target without
+  manual handling.
+
+Until then, refreshing the pinned bundle payload requires manually
+downloading the artifact zip from the bundle pipeline run and
+updating the `DownloadFile` URL + checksum in the workload csproj.
+Tracking this transition is open question §9.Q5.
+
+#### 5.3.3 Consequences (shared between both payload sources)
+
+- The payload source is contacted by the **build pipeline that
+  publishes the workload**, not by any user machine running
+  `func`.
+- A user's machine acquires the bundle through the normal
+  `func workload install` flow, which downloads the workload
+  `.nupkg` from its catalog feed (Workload Spec §6.1).
+- Reproducibility: an installed workload version always carries
+  the exact bundle payload that was packed at build time. There
+  is no drift between "what the workload version says" and "what's
+  on disk."
+- Preview / experimental versions are produced the same way; the
+  only difference is the SemVer prerelease tag on the workload
+  version and the corresponding bundle artifact branch
+  (`main-preview` / `main-experimental`) the build pulls from.
+
+### 5.4 Install hints
+
+The CLI core owns hint copy for the failure variants of §5.1.
+Suggested pin versions in hints use the **workload pkg version**
+(with channel prerelease label as applicable):
+
+- `EmptyIntersection`:
+  ```
+  Profile '<profile>' constrains extensionBundle.version to
+  '<profile-range>', which does not intersect host.json's
+  '<host-range>'. There is no bundle version that satisfies both.
+  Either widen host.json or pick a different profile.
+  ```
+- `NoCompatibleInstall`:
+  ```
+  No installed bundles workload satisfies <constraint-range>
+  (id=<bundle-id>).
+  Installed versions: <v1>, <v2>, ...
+  Install a satisfying version with:
+    func workload install Azure.Functions.Cli.Workloads.ExtensionBundles@<workload-pkg-version> --force
+  ```
+  e.g. `...@4.35.0` for stable, `...@4.35.0-preview` for
+  preview.
+- `WorkloadMissing` hint: see §4.4 step 3.
+
+## 6. Logging and verbosity
+
+- **Default verbosity**: on resolution success, a single
+  Information line: `Using extension bundle <id> <version> from
+  <path>`. On failure, the hint and a non-zero exit. Nothing else.
+- **`--verbose`**: in addition to the above, log the resolution
+  trace at Debug:
+  ```
+  [bundle-resolve] id=<id>
+  [bundle-resolve] host.json range = <host-range>
+  [bundle-resolve] profile '<profile>' range = <profile-range>
+  [bundle-resolve] constraint = <intersection>
+  [bundle-resolve] installed workload pkg versions (filtered) = <wpv1>, <wpv2>, ...
+  [bundle-resolve] installed bundle payload versions = <bpv1>, <bpv2>, ...
+  [bundle-resolve] selected bundle payload version = <bundle-payload-version>
+  [bundle-resolve] path = <resolved-path>
+  ```
+
+## 7. Telemetry
+
+On every `func start` that performs bundle resolution, CT emits a
+single `bundle-resolve` event:
+
+| Field | Value |
+|-------|-------|
+| `bundleId` | `host.json` `extensionBundle.id` |
+| `resolvedVersion` | Selected 3-part **bundle payload version** (e.g. `4.35.0`) on success, or `null` on failure. The workload pkg version (which adds only a channel prerelease label on non-stable channels) is CLI-internal and is not emitted. |
+| `profileName` | Active profile name, or `null` if no profile |
+| `succeeded` | `true` if the host was launched with a resolved bundle |
+| `reason` | `ok` \| `no-host-json-bundle` \| `workload-missing` \| `empty-intersection` \| `no-compatible-install` |
+
+Workload install / update / uninstall telemetry is covered by the
+generic workload subsystem (Workload Spec §11); this spec adds
+none there.
+
+## 8. Compatibility & migration
+
+- **v4 → v5 projects.** Existing projects whose `host.json`
+  declares `extensionBundle` work unchanged in v5, **provided** an
+  installed bundles workload version satisfies the project's
+  host.json range and the active profile.
+- **`func extensions install`.** Removed in v5. Added to the
+  v4→v5 migration map (Workload Spec §4.7):
+  ```
+  'extensions install' is no longer supported. Extension bundles
+  are delivered as a workload. Install a version with:
+    func workload install Azure.Functions.Cli.Workloads.ExtensionBundles@<version>
+  ```
+- **In-CLI bundle download code.** `ExtensionBundleHelper`,
+  `DownloadBundleAction`, `ExtensionBundleConfigurationBuilder`,
+  and the related code paths in `Startup` are removed from the
+  `func` binary in v5.
+- **Profiles.** Built-in profiles (cli-profiles §6.1) carry
+  `extensionBundle.version` ranges the bundles workload catalog is
+  guaranteed to satisfy at publication time.
+
+## 9. Open questions
+
+1. Should `bundle-resolve` telemetry include constraint range
+   strings (potentially high cardinality) or just the outcome
+   enum?
+2. **Catalog feed.** Do bundle workload `.nupkg`s ship to the same
+   workload catalog as host-runtime workloads, or a dedicated
+   bundles feed? Most likely the same feed; verify with the
+   Extension Bundle publishing pipeline owners.
+3. **Payload-source pivot (CDN → build artifacts).** The first
+   cut pulls the bundle payload from the public bundle CDN via
+   MSBuild `DownloadFile` (§5.3.2) because the bundles workload
+   lives in this repo and not in the bundles repo. The target
+   state is to consume the bundle build pipeline's `zip` artifact
+   per branch (`main` / `main-preview` / `main-experimental`,
+   §5.3.1) so the workload version always packs a payload that
+   was produced and signed by the same pipeline run. Decide:
+   does the bundles workload move into the bundles repo, or
+   stay here and consume the artifact cross-pipeline? Either
+   option resolves this question. Until it is resolved, refreshing
+   the pinned bundle payload is a manual artifact download.
+
+### Resolved
+
+- **Bundle id mapping rule** (previously Q1). Resolved by §4.2:
+  three host.json ids (stable / Preview / Experimental), each
+  mapping to workload pkg versions whose prerelease label exactly
+  matches the channel. Implemented in PR #5036.
+- **Payload subpath inside `tools/any/`** (previously Q2).
+  Resolved by §5.2: the bundle payload lives under
+  `tools/any/<bundle-version>/`, and the CLI core returns the
+  parent (`tools/any/`) so the host's `ExtensionBundleManager`
+  can append the version segment in its probe. Implemented in
+  PR #5055 (packaging) and PR #5036 (resolver
+  `BundlePayloadSubpath = "tools/any"`).

--- a/proposed/cli-profiles.md
+++ b/proposed/cli-profiles.md
@@ -1,0 +1,726 @@
+# Design Document: Profile-Based Local Development for Azure Functions CLI
+
+**Status:** Draft
+
+## 1. Problem Statement
+
+Azure Functions supports multiple deployment SKUs — Flex Consumption, Linux Premium, Windows Consumption, Windows Dedicated, and Linux Consumption. Each SKU runs its own version of the Functions runtime, and our desire is to support different deployment cadences.
+
+Today, Azure Functions Core Tools bundles a **single host version**. To prevent "works locally, breaks in cloud" failures when the developer's code depends on host behaviors, APIs, or extension bundle features not yet deployed to their target SKU, Core Tools follows a strict deployment sequence to ensure it never gets ahead of the host versions deployed to the cloud.
+
+### Impact
+
+- **Silent correctness failures**: Code passes local testing but fails in production on an older host version.
+- **Extension bundle drift**: Locally-resolved bundle versions may exceed what the target environment supports, causing runtime errors after deployment.
+- **Side-by-side comparison impossible**: Developers cannot run two environment configurations simultaneously to validate migration or compare behavior.
+
+---
+
+## 2. Key Concept: Profiles
+
+Rather than coupling directly to SKU names, this design introduces **profiles** as the primary abstraction. A profile is a **constraint set** that defines the local development environment: host version bounds, extension bundle bounds, and feature toggles.
+
+Built-in profiles are named after SKUs (e.g., `flex`, `windows-consumption`), but the SKU is metadata _within_ the profile, not its identity. This decoupling enables:
+
+- **Custom profiles**: Teams can define profiles that pin host versions, use preview channels, or enforce organizational constraints — without waiting for a registry update.
+- **Dynamic resolution**: Instead of a static SKU → exact-version lookup, the CLI resolves the best available host version within a profile's version range from installed workloads.
+- **Cross-flow reuse**: The same profile informs `func start` (which host to launch), `func pack` (validate compatibility), and potentially `func deploy` (warn on mismatches).
+- **Composability**: Custom profiles can extend built-in profiles, overriding only what differs.
+
+---
+
+## 3. Goals
+
+1. **Environment alignment**: `func start --profile <name>` launches a host version matching the constraints of the target environment, so local behavior matches cloud behavior at the host-version level.
+2. **Side-by-side execution**: Developers can run two different profiles simultaneously on different ports for comparison testing.
+3. **Extension bundle constraining**: The extension bundle version resolved locally is constrained by the intersection of the project's `host.json` range and the profile's bundle range.
+4. **Automatic resolution**: When a project declares its target profile(s), `func start` uses the correct host version without manual intervention.
+5. **Custom profiles**: Developers and teams can define custom profiles that extend built-in profiles to pin versions, test preview channels, or enforce organizational standards.
+6. **Integrate with Workloads**: Profile resolution builds on the Workloads model (§4.6 of the Workloads Spec) where the host runtime is a separately-versioned workload.
+7. **Offline-capable**: Profile resolution degrades gracefully when network is unavailable, using cached or bundled profile data.
+
+## 4. Non-Goals and Scope Boundary
+
+This design targets **profile-level host version alignment**, not full cloud parity.
+
+### In scope
+- Matching the host runtime version within a profile's constraints
+- Constraining extension bundle versions to what the profile supports
+- Side-by-side host version execution
+- Built-in profile registry distribution and caching
+- Custom profile definition at project and user levels
+- Feature toggles (boolean constraints on host behavior)
+- Cross-flow profile usage (start, pack)
+
+### Out of scope
+- **Region/stamp/ring-level parity**: Cloud rollouts are staged (UD 0 → UD N). Built-in profiles model a SKU as a single version target, not per-region state.
+- **OS-level behavior differences**: A developer on macOS using the `windows-consumption` profile will get the correct host version but not Windows-specific OS behaviors.
+- **SKU-specific scale/networking/billing**: Consumption cold-start behavior, VNET integration, instance limits, etc. are not emulated.
+
+> NOTE: Planned future iterations of CLI will support running on target environment containers, more closely aligning with the cloud environments.
+
+---
+
+## 5. Profile Schema
+
+### 5.1 Built-in Profile Registry
+
+The registry uses a `$schema` URI for self-description and versioning, following the pattern established by Azure Resource Manager templates:
+
+```json
+{
+  "$schema": "https://aka.ms/func-profiles/v1/schema.json",
+  "generatedAt": "2026-04-20T00:00:00Z",
+  "profiles": {
+    "flex": {
+      "sku": "flex-consumption",
+      "status": "stable",
+      "host": {
+        "version": "[4.1048.0, 4.1049.0)"
+      },
+      "extensionBundle": {
+        "version": "[4.0.0, 4.99.1)"
+      },
+      "features": {
+        "proxies": false
+      },
+      "supportedRuntimes": ["node", "python", "java", "powershell", "dotnet-isolated", "custom"],
+      "notes": "Newest host — Flex gets bits first"
+    }
+  }
+}
+```
+
+The `$schema` URI encodes the version (`v1`). When the schema evolves in a breaking way, a new URI is published (`v2`). The CLI checks the URI against its supported set — an unrecognized schema triggers: `"Profile registry requires a newer CLI. Run: func upgrade"`
+
+Unknown fields within a supported schema version are ignored (forward-compatible additive changes do not require a new schema version).
+
+### 5.2 Custom Profile (User or Project Defined)
+
+Custom profiles also use `$schema` for editor support and validation:
+
+```json
+{
+  "$schema": "https://aka.ms/func-custom-profiles/v1/schema.json",
+  "staging": {
+    "extends": "flex",
+    "host": {
+      "version": "[4.1046.100]"
+    }
+  },
+  "locked-prod": {
+    "extends": "windows-consumption",
+    "extensionBundle": {
+      "version": "[4.0.0, 4.22.1)"
+    }
+  }
+}
+```
+
+### 5.3 Field Reference
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `sku` | string | no | Azure SKU identifier. Metadata only — not used for resolution. |
+| `status` | string | no | `stable`, `preview`, `deprecated`. CLI warns on deprecated profiles. |
+| `deprecationUrl` | string | no | URL to deprecation documentation with migration guidance. Used when `status` is `deprecated`. |
+| `extends` | string | no | Name of a parent profile to inherit from. Single inheritance only. |
+| `host.version` | version range | yes (or inherited) | NuGet-style version range for the host runtime. |
+| `extensionBundle.version` | version range | no | Version range constraining extension bundles (applied on top of `host.json`). |
+| `features` | object | no | Boolean feature toggles. See §7. |
+| `supportedRuntimes` | string[] | no | Worker runtimes this profile supports. Enables early validation. |
+| `notes` | string | no | Human-readable description. |
+
+### 5.4 Version Range Expressions
+
+All version constraints use NuGet-style version range syntax:
+
+| Intent | Expression |
+|--------|-----------|
+| Latest within SKU bounds | `[4.1045.0, 4.1049.0)` |
+| Pinned to exact version | `[4.1046.100]` |
+| Any 4.x | `[4.0.0, 5.0.0)` |
+| Preview channel | `[4.1048.100-preview, 4.1049.0)` |
+
+A single field replaces what would otherwise be separate `maxVersion`, `pinnedVersion`, and `channel` properties. The resolution rule is: **highest installed (or available) workload version satisfying the range**.
+
+---
+
+## 6. Profile Sources and Layering
+
+Profiles are resolved from four sources, in precedence order:
+
+```
+1. CLI flag           --profile <name>              (highest priority)
+2. Project config     .func/config.json             (team-shared)
+3. User profiles      ~/.azure-functions/profiles.json
+4. Built-in profiles  Registry (remote → cache → bundled fallback)
+```
+
+### 6.1 Built-in Profiles (Registry)
+
+Built-in profiles are distributed via the **profile registry** — a lightweight JSON artifact published to a well-known CDN endpoint, separate from host workload packages.
+
+**Distribution:**
+
+```
+1. Remote fetch    → https://aka.ms/func-profiles (canonical URL)
+                     https://aka.ms/func-profiles-sha256 (detached checksum)
+2. Local cache     → ~/.azure-functions/profiles/registry.json (1-hour TTL)
+3. Bundled fallback → Shipped with the CLI package (updated each CLI release)
+```
+
+**Publishing:**
+
+The registry is maintained in the same CDN-backed storage that serves extension bundles today. Updates are made by the existing SKU deployment pipelines:
+
+1. SKU deployment pipeline deploys a new host version
+2. Same pipeline updates `registry.json` in CDN-backed storage
+3. CDN serves the updated registry at the well-known URL
+4. **Publish ordering is inherent**: the pipeline that publishes the host binary is the same pipeline that updates the registry, so the host package is always available before the registry references it.
+
+**Integrity:**
+
+A detached checksum file (`registry.json.sha256`) is published alongside the registry. The CLI fetches both, computes the SHA-256 of the downloaded registry, and compares. Mismatches cause the fetch to be discarded and the cache/bundled fallback to be used instead.
+
+**Staleness:**
+
+The registry includes a `generatedAt` timestamp. If the cached registry is older than 7 days and a fresh fetch fails, the CLI warns: `"Profiles are N days old. Host versions may not match current cloud deployments."`
+
+### 6.2 User-Level Profiles
+
+Defined in `~/.azure-functions/profiles.json`. These are personal profiles for experiments, channel testing, or developer-specific overrides.
+
+```json
+{
+  "my-preview": {
+    "extends": "flex",
+    "host": {
+      "version": "[4.1050.0-preview, 4.1051.0)"
+    }
+  }
+}
+```
+
+### 6.3 Project-Level Profiles
+
+Defined in `.func/profiles.json` and committed to source control. These are team-shared custom profiles.
+
+```json
+{
+  "staging": {
+    "extends": "flex",
+    "host": {
+      "version": "[4.1046.100]"
+    }
+  },
+  "locked-prod": {
+    "extends": "windows-consumption",
+    "extensionBundle": {
+      "version": "[4.0.0, 4.22.1)"
+    }
+  }
+}
+```
+
+### 6.4 Project Configuration
+
+The project declares which profiles it targets in `.func/config.json`:
+
+```json
+{
+  "$schema": "https://aka.ms/func-config/v1/schema.json",
+  "profiles": ["flex", "staging"],
+  "defaultProfile": "flex"
+}
+```
+
+This file is committed to source control. CLI behavior based on this file:
+
+| Scenario | Behavior |
+|----------|----------|
+| Single profile declared, no `--profile` flag | Auto-apply it silently |
+| Multiple profiles declared, no `--profile` flag | **Interactive**: present a selector. **Non-interactive/CI**: use `defaultProfile`, or error if not set |
+| `--profile` flag matches a declared profile | Use it |
+| `--profile` flag names an undeclared profile | Allow it, but warn: `"Profile 'X' is not declared in this project's config"` |
+| No `.func/config.json` exists | Fall back to `--profile` flag or latest installed (backward-compat) |
+
+### 6.5 Name Resolution
+
+When looking up a profile by name, the CLI searches in order:
+
+```
+1. Project-level (.func/profiles.json)
+2. User-level (~/.azure-functions/profiles.json)
+3. Built-in (registry)
+```
+
+First match wins. A project-level profile can shadow a built-in profile name — this is intentional, allowing a project to override the built-in `flex` with a pinned version.
+
+---
+
+## 7. Features
+
+Features are boolean flags that the CLI uses to **configure the host process at launch time**, disabling capabilities that are unavailable in the target environment. This ensures local behavior matches the cloud — unsupported features simply don't work locally, rather than generating warnings that developers may ignore.
+
+### 7.1 Semantics
+
+- **Absent** → feature is enabled (default, no constraint)
+- **`false`** → feature is actively disabled in the host process
+- **`true`** → feature is explicitly enabled (useful in custom profiles to re-enable something a parent disabled)
+
+The CLI enforces features by setting the appropriate environment variables or host configuration when launching the host process.
+
+### 7.2 Schema
+
+```json
+"features": {
+  "proxies": false,
+  "inProcess": false
+}
+```
+
+All values are booleans. Feature names are simple identifiers (not `proxiesEnabled` — just `proxies`).
+
+### 7.3 Example
+
+A developer targeting Flex defines proxies in their app. The `flex` profile sets `"proxies": false`, so the CLI disables proxies in the host. Proxies don't work locally — the developer discovers the incompatibility before deploying, not after.
+
+### 7.4 Built-in Feature Catalog
+
+The initial set covers features where SKU behavior diverges and the host can be configured to match:
+
+| Feature | What it disables | Profiles that disable it |
+|---------|-----------------|--------------------------|
+| `proxies` | Azure Functions Proxies | `flex` |
+
+The feature catalog is owned by the CLI team, since features map to host launch configuration that the CLI controls. New features are added to the registry as SKU-level differences are identified.
+
+> **Note on in-process .NET:** In-process support is not modeled as a profile feature. The v5 CLI does not support in-process .NET at all — this is a CLI-level constraint enforced before host launch, independent of profiles. The CLI detects in-process projects from project files and exits with a clear error.
+
+### 7.5 Feature Inheritance
+
+Features use **deep merge** during inheritance (unlike other sections which use replace). When extending a profile:
+
+- Present keys override the parent value
+- `null` removes an inherited feature (restores to default: enabled)
+- New keys are added
+
+```json
+// Parent (flex)
+"features": { "proxies": false }
+
+// Child
+"features": { "proxies": null, "customHandler": false }
+
+// Resolved
+"features": { "customHandler": false }
+// proxies removed — restored to default (enabled)
+// customHandler disabled by child
+```
+
+---
+
+## 8. Profile Inheritance
+
+### 8.1 Merge Rules
+
+| Section | Merge behavior |
+|---------|---------------|
+| `host` | **Replace** — if present in child, replaces parent's `host` entirely |
+| `extensionBundle` | **Replace** — if present in child, replaces parent's `extensionBundle` entirely |
+| `features` | **Deep merge** — child values overlay parent. `null` removes a key |
+| `sku`, `name`, `status`, `notes` | **Replace** — child value wins |
+| `supportedRuntimes` | **Replace** — if present in child, replaces parent's list |
+
+### 8.2 Chain Rules
+
+- **Single inheritance only**: `extends` names exactly one parent profile. No multiple inheritance.
+- **Max chain depth**: 5 levels. The CLI validates and errors if exceeded: `"Profile inheritance chain exceeds maximum depth of 5."`
+- **Cycle detection**: If a profile name appears twice in the resolution chain, the CLI errors: `"Circular profile inheritance detected: A → B → A."`
+- **Cross-source inheritance**: A project-level profile can extend a user-level or built-in profile. A user-level profile can extend a built-in profile. Built-in profiles do not extend other profiles.
+
+### 8.3 Example Chain
+
+```
+"staging" (project) → extends "flex" (built-in)
+
+Resolved "staging":
+  name:             "staging"          (own)
+  sku:              "flex-consumption" (inherited from flex)
+  host.version:     "[4.1046.100]"     (own — replaces flex's range)
+  extensionBundle:  "[4.0.0, 4.99.1)" (inherited from flex)
+  features:         { proxies: false }  (inherited from flex)
+```
+
+---
+
+## 9. Resolution: Host Version
+
+### 9.1 Resolution Flow
+
+```
+func start --profile flex
+    │
+    ├─ Resolve profile (§6.5 name resolution)
+    ├─ Resolve inheritance chain (§8)
+    ├─ Extract host.version range from resolved profile
+    │
+    ├─ Find installed host workloads matching the version range
+    │   ├─ Match found → use highest matching version
+    │   └─ No match ─┐
+    │                 ├─ Interactive: prompt to install best available from feed
+    │                 ├─ Non-interactive/CI: error with install command
+    │                 └─ Offline: error if not cached
+    │
+    └─ Launch host
+```
+
+### 9.2 Precedence with `--host-version`
+
+The `--host-version` flag (from Workloads spec §4.6) bypasses profile resolution entirely:
+
+```bash
+func start --host-version 4.1045.200
+```
+
+The CLI emits a diagnostic note:
+
+```
+Note: Using explicit host version 4.1045.200. Profile constraints
+(extension bundle, features, runtime compatibility) are not applied.
+```
+
+### 9.3 Conflict: `--profile` + `--host-version`
+
+If both are specified, the CLI **errors**:
+
+```
+Error: --profile and --host-version are mutually exclusive.
+  Use --profile to apply environment constraints automatically.
+  Use --host-version to pin to a specific version regardless of profile.
+```
+
+### 9.4 Default Behavior (No Profile Specified)
+
+When no profile is specified via flag or project config:
+
+- The CLI uses the latest installed host-runtime workload with no constraints. This matches today's Core Tools behavior.
+- A warning is emitted suggesting the developer configure a target profile:
+  ```
+  Warning: No profile configured. Using latest installed host (4.1048.100).
+  To match a specific Azure environment, configure a target profile with:
+    func profile set flex
+  ```
+- The warning is suppressed once `.func/config.json` exists — the project has made an explicit choice.
+
+---
+
+## 10. Resolution: Extension Bundles
+
+### 10.1 Intersection Model
+
+Extension bundles have two version dimensions:
+
+1. **`host.json` range** — defined by the developer, shipped with the app. This is part of the deployment payload.
+2. **Profile bundle range** — defines what the target environment supports. This is a local-development constraint and is _not_ deployed.
+
+The CLI resolves the **intersection** of these two ranges:
+
+```
+host.json says:            [4.19.*, 5.0.0)
+Profile says:              [4.0.0, 4.25.1)
+Intersection:              [4.19.0, 4.25.1)
+→ Resolved:                4.25.0 (highest available in intersection)
+```
+
+### 10.2 Empty Intersection
+
+If the intersection is empty, the CLI errors with an actionable message:
+
+```
+Error: No extension bundle version satisfies both:
+  host.json range:     [4.30.*, 5.0.0)
+  Profile constraint:  [4.0.0, 4.25.1)  (windows-consumption)
+
+The app requires bundle versions newer than this profile supports.
+Update host.json or target a different profile.
+```
+
+### 10.3 Cross-Flow Reuse
+
+`func pack` performs the same intersection check at packaging time. If the app's `host.json` bundle range is incompatible with the project's declared profile, `func pack` warns before the developer deploys.
+
+### 10.4 No Profile Active
+
+When no profile is active (backward-compat mode), no bundle constraint is applied — `host.json` range is used as-is, matching today's behavior.
+
+---
+
+## 11. Side-by-Side Execution
+
+### 11.1 Usage
+
+```bash
+# Terminal 1
+func start --profile flex --port 7071
+
+# Terminal 2
+func start --profile windows-consumption --port 7072
+```
+
+Each invocation independently resolves its profile, ensures the appropriate host workload is installed, and launches a separate host process.
+
+### 11.2 Requirements
+
+- Each host process has its own port and environment.
+- The CLI detects port conflicts before spawning the host and suggests an available port.
+- The startup banner includes the profile name and resolved versions for disambiguation.
+
+### 11.3 Startup Banner
+
+```
+Azure Functions CLI
+Profile:           windows-consumption (built-in)
+Host Version:      4.1045.200
+Extension Bundle:  v4.25.0 (constrained to [4.0.0, 4.25.1))
+Registry:          remote (updated 2026-04-20)
+
+Functions:
+    HttpTrigger: [GET,POST] http://localhost:7072/api/HttpTrigger
+```
+
+---
+
+## 12. Profile Listing
+
+### 12.1 Commands
+
+```bash
+func profile list                                # List all available profiles (built-in + user + project)
+func profile list --source built-in              # Filter to built-in profiles only
+func profile list --source user                  # Filter to user-level profiles only
+func profile list --source project               # Filter to project-level profiles only
+func profile list --source built-in,project      # Combine sources (comma-separated)
+func profile list --json                         # Machine-readable output
+func profile show flex                           # Detailed view of a specific profile (resolved)
+func profile show staging --raw                  # Show without inheritance resolution
+```
+
+### 12.2 Output
+
+```
+Available profiles:
+
+  Name                    Source     Host Version Range       Bundle Range          Status
+  ─────────────────────── ───────── ──────────────────────── ───────────────────── ──────────
+  flex                    built-in  [4.1048.0, 4.1049.0)     [4.0.0, 4.99.1)       stable
+  linux-premium           built-in  [4.1046.0, 4.1047.0)     [4.0.0, 4.30.1)       stable
+  windows-consumption     built-in  [4.1045.0, 4.1046.0)     [4.0.0, 4.25.1)       stable
+  windows-dedicated       built-in  [4.1045.0, 4.1046.0)     [4.0.0, 4.25.1)       stable
+  linux-consumption       built-in  [4.1044.0, 4.1045.0)     [4.0.0, 4.22.1)       deprecated
+  staging                 project   [4.1046.100]             (inherited: flex)      —
+  my-preview              user      [4.1050.0-pre, 4.1051.0) (inherited: flex)      —
+
+  Project targets: flex, staging (default: flex)
+
+Registry: remote | Cache age: 2 hours
+```
+
+---
+
+## 13. Integration with Workloads
+
+### 13.1 Host-Runtime Workload Resolution
+
+The resolved profile's `host.version` range maps to host-runtime workload versions:
+
+```
+Profile "flex" → host.version "[4.1048.0, 4.1049.0)"
+    ↓
+Scan installed workloads: Azure.Functions.Cli.Workload.Host
+    ↓
+Highest installed version in range → 4.1048.100
+```
+
+### 13.2 Auto-Install Behavior
+
+When no installed workload satisfies the profile's version range:
+
+- **Interactive**: `"No installed host matches profile 'flex' [4.1048.0, 4.1049.0). Install latest? [Y/n]"`
+- **Non-interactive/CI**: Error with install command: `"Run: func workload install host --version 4.1048.100"`
+- **Offline**: Error: `"No installed host matches profile 'flex'. Pre-install with: func workload install host --version 4.1048.100"`
+
+### 13.3 Precedence with Workloads Spec
+
+The Workloads spec (§4.6) resolves the host version via: `--host-version` → project pin → latest installed. Profiles insert into this chain:
+
+```
+--host-version flag  →  --profile flag  →  project config profile  →  latest installed
+```
+
+When a profile is active, "latest installed" is replaced by "highest installed within profile range." This prevents a newer host installed for one project from silently becoming the default for a profile-constrained project.
+
+---
+
+## 14. Offline and Cache Behavior
+
+### 14.1 Fetch Strategy
+
+```
+func start --profile flex
+    │
+    ├─ Fetch remote profile registry
+    │   ├─ Success → validate checksum, persist to cache
+    │   └─ Failure ─┐
+    │               ├─ Cache exists and < 7 days old → use with warning
+    │               ├─ Cache exists and ≥ 7 days old → use with stronger warning
+    │               └─ No cache → use bundled fallback with warning
+    │
+    └─ Resolve host version from profile
+        ├─ Host workload installed → launch
+        └─ Host workload not installed → auto-install or error (§13.2)
+```
+
+### 14.2 `--offline` Flag
+
+```bash
+func start --profile flex --offline
+```
+
+Skips all network attempts. Uses cached registry (or bundled fallback) and installed host workloads only. Errors if no installed workload satisfies the profile.
+
+### 14.3 Cache and File Layout
+
+```
+~/.azure-functions/
+  profiles/
+    registry.json              # Cached built-in profile registry
+    registry.json.sha256       # Detached checksum
+    registry.json.meta         # Fetch timestamp, ETag, source URL
+  profiles.json                # User-level custom profiles
+  workloads/
+    host/
+      4.1048.100/              # Installed host workload
+      4.1045.200/              # Another version (side-by-side)
+
+<project>/
+  .func/
+    config.json                # Project config (profiles, defaultProfile)
+    profiles.json              # Project-level custom profiles
+  host.json
+  local.settings.json
+```
+
+---
+
+## 15. Diagnostics and User Experience
+
+### 15.1 Startup Diagnostics
+
+Every `func start` with a profile prints:
+
+```
+Profile:           flex (built-in, from project config)
+Host Version:      4.1048.100
+Extension Bundle:  v4.25.0 (constrained to [4.0.0, 4.99.1))
+Registry:          remote (2026-04-20)
+```
+
+### 15.2 `--verbose` Diagnostics
+
+```
+[profile] Resolution:
+  --profile flag:    (not set)
+  Project config:    flex (default of [flex, staging])
+  Resolved source:   built-in registry
+[profile] Inheritance: flex (no parent)
+[profile] Host range: [4.1048.0, 4.1049.0) → resolved 4.1048.100 (installed)
+[profile] Bundle: host.json [4.22.*, 5.0.0) ∩ profile [4.0.0, 4.99.1) → [4.22.0, 4.99.1) → resolved 4.25.0
+[profile] Features: proxies=false
+```
+
+### 15.3 Deprecation Warnings
+
+```
+Warning: Profile "linux-consumption" is deprecated (retirement: 2028-09-30).
+See: https://aka.ms/func-linux-consumption-deprecation
+```
+
+---
+
+## 16. Failure Modes and Recovery
+
+| Scenario | Behavior |
+|----------|----------|
+| Unknown profile name | Error listing available profiles. Suggest `func profile list`. |
+| Profile fetch fails, no cache | Use bundled fallback. Warn that versions may be stale. |
+| No installed host satisfies profile range | Auto-install prompt (interactive) or error with install command (CI). |
+| Host workload download fails midway | Atomic install: incomplete downloads are cleaned up. No partial state. |
+| Concurrent `func start` for same profile | Cross-process locking on the workload install directory (per Workloads spec §4.1). |
+| Bundle range intersection is empty | Error explaining the conflict between `host.json` and profile constraint. |
+| `--profile` + `--host-version` both specified | Error: mutually exclusive flags. |
+| Deprecated profile | Warn on every startup; do not block. |
+| Corrupt cached registry (checksum mismatch) | Discard cache, re-fetch. If re-fetch also fails, use bundled fallback. |
+| Project targets unsupported runtime | Error: `"Profile 'X' does not support runtime 'Y'. Supported: [...]"` |
+| Inheritance chain exceeds depth 5 | Error: `"Profile inheritance chain exceeds maximum depth of 5."` |
+| Circular inheritance | Error: `"Circular profile inheritance detected: A → B → A."` |
+| `--profile` names undeclared profile | Warn but allow: `"Profile 'X' is not declared in this project's config."` |
+| Profile extends unknown parent | Error: `"Profile 'X' extends 'Y', which was not found."` |
+
+---
+
+## 17. Open Questions
+
+1. **~~Who publishes the built-in profile registry?~~**
+   - **Resolved**: The registry lives in the existing CDN-backed storage (same infrastructure as extension bundles). Updates are made by the existing SKU deployment pipelines as part of the host deployment flow.
+
+2. **~~Should the default behavior (no profile specified) change?~~**
+   - **Resolved**: No default profile. When no profile is specified (no `--profile` flag, no `.func/config.json`), the CLI uses the latest installed host with no constraints (backward-compatible) and emits a one-time warning suggesting the developer configure a target profile using the appropriate CLI command. The warning is suppressed once a `.func/config.json` exists (the project has made an explicit choice). This avoids locking in a default SKU that becomes a breaking change to update later.
+
+3. **~~One host workload ID or one per major version?~~**
+   - **Resolved**: One workload ID (`host`) with semver versions. The profile's version range constrains which versions are valid. Major version boundaries are handled naturally by version range expressions (e.g., `[4.0.0, 5.0.0)`).
+
+4. **~~Pre-caching for CI/offline:~~**
+   - **Resolved**: `func profile install <name>` resolves the profile and installs all required dependencies (host workload + extension bundle). `func profile install` (no argument) installs dependencies for all profiles declared in `.func/config.json`. This is the recommended CI step for ensuring offline readiness.
+
+5. **~~Registry schema versioning~~** *(resolved)*
+   - All JSON documents in this design use `$schema` URIs for self-description and versioning, following the pattern established by Azure Resource Manager templates (e.g., `"$schema": "https://aka.ms/func-profiles/v1/schema.json"`).
+   - The version is encoded in the URI path (`v1`, `v2`). Breaking changes produce a new URI.
+   - Unknown fields within a supported schema version are ignored (additive changes do not require a new schema version).
+   - Unrecognized `$schema` URI → error: `"Profile registry requires a newer CLI. Run: func upgrade"`
+   - Applies to: registry (`func-profiles`), custom profiles (`func-custom-profiles`), and project config (`func-config`).
+
+6. **~~Feature catalog~~** *(resolved)*
+   - Features are **host configuration directives**, not validation checks. The CLI disables features in the host process at launch time, so local behavior matches the target environment. Absent features default to enabled; `false` actively disables.
+   - v1 set: `proxies`, `inProcess`. New features added by the CLI team as SKU differences are identified.
+   - No warn/block mode — the host simply runs with the target environment's capabilities.
+
+7. **~~Project config file name and location~~** *(resolved)*
+   - `.func/` directory in the project root. Contains `config.json` (project configuration) and `profiles.json` (custom profile definitions). Groups all CLI config together, avoids overloading `host.json` (which is deployed) or `func.json` (which has legacy v1 meaning). Follows the pattern of `.cargo/`, `.nuget/`.
+
+---
+
+## Appendix: Comparison with SKU-Centric Design
+
+This design introduces features and improvements compared to the SKU-centric approach. The following table captures the key differences and improvements.
+
+| Aspect | Original (SKU-Centric) | Current (Profile-Based) | Improvement |
+|--------|----------------------|------------------------|-------------|
+| **Primary abstraction** | SKU name is the identity | Profile is a constraint set; SKU is metadata | Decouples from Azure infrastructure naming; enables custom environments |
+| **Version targeting** | Static lookup: SKU → exact host version | Version range expression (NuGet-style) | Supports pinning, floating, minimum version and preview channels with one field |
+| **Custom environments** | Not supported — only registry-defined SKUs | First-class custom profiles at user and project level | Teams can enforce organizational standards without registry changes |
+| **Inheritance** | None | Single inheritance with `extends`, max depth 5 | Custom profiles derive from built-in profiles, overriding only what differs |
+| **Features** | Not modeled | Boolean host configuration directives | CLI configures the host to match target environment capabilities |
+| **Bundle constraining** | `maxVersion` cap applied on top of `host.json` | Intersection of two version ranges (`host.json` ∩ profile) | Cleaner semantics; both constraints are expressed the same way |
+| **Project configuration** | `local.settings.json` `TargetSku` field (gitignored) | `.func/config.json` with declared profiles + default (git-tracked) | Team shares target config via source control; supports multi-target |
+| **Multi-target** | One SKU at a time | Project declares multiple profiles | `func pack` validates against all declared targets; `func profile install` pre-caches all in one step; team intent is captured in source control |
+| **Profile sources** | Single: built-in registry | Three layers: built-in → user-level → project-level | Flexible layering for different use cases |
+| **Schema versioning** | Integer `schemaVersion` field | `$schema` URI with version in path | Self-describing documents; editor IntelliSense; ARM template alignment |
+| **Integrity** | Inline `checksum` field (circular) | Detached `.sha256` file | Avoids validating a hash that's inside the payload it protects |
+| **Deprecation guidance** | Hardcoded alternative profiles in CLI output | `deprecationUrl` links to online documentation | Docs own migration guidance; CLI stays simple |
+| **Default behavior** | Implicit default to a specific SKU | No default; warn and suggest `func profile set` | Avoids locking in a default that becomes a breaking change |
+| **Pre-caching** | Not addressed | `func profile install [<name>]` | CI-friendly; installs host + bundle for all declared profiles |
+| **Cross-flow reuse** | `func start` only | Profiles inform `func start`, `func pack`, and potentially `func deploy` | Catch incompatibilities at packaging time, before deployment |
+| **CLI commands** | `func sku list`, `--sku` flag | `func profile list/show/install/set`, `--profile` flag | Richer management surface; profile is a first-class concept |
+| **In-process .NET** | Modeled as a profile feature | CLI-level pre-launch constraint, independent of profiles | Cleaner separation: v5 CLI doesn't support in-process at all |

--- a/proposed/cli-release-story.md
+++ b/proposed/cli-release-story.md
@@ -1,0 +1,251 @@
+# Core Tools & Functions CLI Release Design
+
+## Summary of Decisions
+
+| # | Decision | Outcome |
+| --- | --- | --- |
+| 1 | Distribution philosophy | CDN-first. Install scripts depend on CDN; GitHub Releases are also published. Release pipeline pushes artifacts to CDN. Package managers wrap the CLI binary only; everything else is workloads on NuGet. |
+| 2 | v4 + v5 cadence | Independent. v4 enters maintenance mode at v5 GA (EOL: ~1 year, TBD). CLI releases independently from host. Expect higher release frequency initially, tapering as features shift to workloads. |
+| 3 | Channel matrix at GA | GA-blocking: install scripts (Linux signing blocker), Homebrew (Mac), winget (Windows, MSI may be needed), npm (cross-plat). Post-GA: APT (Linux). All other channels removed. Single install location recommended to avoid version conflicts. |
+| 4 | npm | Both `azure-functions-cli` and `azure-functions-core-tools` publish v5. Use publisher profile (can also use ESRP release). |
+| 5 | Rollback | Roll-forward-first, never retag. Workloads are unlisted, never deleted. Remove unused distribution channels. |
+
+## 1. Summary
+
+v4 is a single, monolithic CLI. v5 is a thin, stable CLI whose functionality
+ships as independently versioned **workloads** acquired on demand from NuGet.
+The two will ship side by side for a transition window, then v5 becomes the
+default (`vnext` becomes `main`, today's `main` is renamed to a v4 branch).
+
+The design is **CDN-first**: the `install.sh` / `install.ps1` scripts
+depend on CDN for release artifacts. GitHub Releases are also used and
+artifacts are published there. Every package manager (npm, winget, Homebrew)
+is a thin wrapper that delivers only the CLI binary. All language and runtime
+content stays in workloads on NuGet.
+
+## 2. Goals
+
+- Define a v5 release process that works while v4 is still supported.
+- Align independently versioned workloads (across owner repos) with a single
+  CLI version users can reason about.
+- Decide, per channel, whether and how v5 is distributed.
+- Define a rollback (or roll-forward) response per channel.
+- Surface the implementation work as follow-up issues (§11).
+
+## 3. Non-goals
+
+- The GA cutover mechanics themselves: switching the default branch, renaming
+  the v4 branch, and cutting `v5.0.0`. Tracked in
+  [#5363](https://github.com/Azure/azure-functions-core-tools/issues/5363).
+- The workload ownership migration to per-language repos. Tracked in
+  [#5346](https://github.com/Azure/azure-functions-core-tools/issues/5346).
+  This design assumes that end state an is focused on the core CLI release itself.
+- Profiles CDN and profile update pipelines. Tracked in
+  [#5332](https://github.com/Azure/azure-functions-core-tools/issues/5332)
+  and [#5329](https://github.com/Azure/azure-functions-core-tools/issues/5329).
+- The detailed per-component tag and pipeline mechanics, already specified in
+  `vnext-release-process.md`. This doc references that as the workload layer.
+
+## 4. Background: how we release today
+
+### 4.1 v4 (`main`): monolithic, fully automated
+
+- One CLI, one version, one `release_notes.md`.
+- Bump version and notes, cut a tag from `main`. The official pipeline runs,
+  then the consolidated pipeline, then the release pipeline on that tag.
+- The release pipeline does everything: creates the GitHub release, uploads
+  artifacts, updates the internal tooling feed, and publishes to every
+  distribution channel (npm, Chocolatey, apt/deb, MSI, Homebrew) via the
+  `eng/tools/publish-tools` driver.
+
+### 4.2 v5 (`vnext`): component/workload model, preview
+
+- The CLI is thin and stable. Functionality ships as independently versioned
+  workloads: host, bundles, templates, workers, language stacks, abstractions.
+- Each workload is released by pushing a per-component tag from `vnext` and
+  queuing its release pipeline (`eng/ci/release/official-release.workload.*.yml`).
+  The pipeline packs the workload and publishes a `.nupkg` to a NuGet feed
+  (staging `public/pre-release`, with a partner drop). Users acquire workloads
+  with `func workload install`. See `vnext-release-process.md`.
+- The CLI binary is distributed by `install.sh` / `install.ps1`
+  (`https://aka.ms/func-cli/install.sh`), which resolves the latest `v5.*`
+  GitHub Release and downloads `func-{os}-{arch}.tar.gz`. The CLI release is
+  **not yet fully automated**: the GitHub release and artifact upload are done
+  by hand today.
+- v5 has no npm, Homebrew, Chocolatey, apt, MSI, winget, scoop, or rpm
+  presence yet.
+
+### 4.3 Where this is heading
+
+Workloads move out of core-tools into owner repos (python worker to the
+python repo, templates to the templates repo, and so
+on, per #5346). A v5 release therefore becomes a cross-repo problem:
+each owner repo publishes its workload to NuGet on its own cadence, and
+tne core-tools repo owns the CLI release (and SDK/Abstractions).
+
+## 5. Decision 1: CDN-first distribution
+
+**Decision.** Install scripts depend on **CDN** for release artifacts. GitHub
+Releases are also used — the release pipeline will output artifacts there as
+well. The release pipeline must be updated to push artifacts to CDN.
+
+Package managers are thin wrappers that fetch the CLI binary. They never
+bundle language or runtime content; that always comes from workloads on NuGet.
+
+**Why.**
+
+- The v5 CLI is a small native binary. CDN gives reliable, geo-distributed
+  delivery that the install scripts can depend on without GitHub rate limits.
+- GitHub Releases provide a secondary source and a visible release history.
+- Keeping package managers as thin wrappers makes adding a channel cheap and
+  keeps every channel consistent.
+- It cleanly separates the two distribution problems: the CLI binary (a
+  handful of platform archives) and workloads (NuGet packages, on demand).
+
+**Implications.**
+
+- The release pipeline must be updated to push signed artifacts to CDN.
+- Each package-manager channel only needs: the CDN asset URL, a checksum, and
+  an auto-bump step on release. No channel ever needs to understand workloads.
+- **Single install location:** Users should install from one source (e.g. only
+  brew or only npm, not both) to avoid ending up with different versions of
+  the CLI on their PATH.
+
+## 6. Decision 2: Parallel cadence and v4 posture
+
+**Decision.**
+
+- v4 and v5 release on **independent** cadences. No shared release-day, no
+  coupled version numbers. They live on separate branches, architectures, and
+  pipelines.
+- v4 enters **maintenance mode** when v5 GAs.
+  - EOL: ~1 year after v5 GA (exact date TBD).
+  - Scope of security releases in core-tools needs to be defined clearly for
+    external comms.
+- The CLI releases **independently from the host**. The host workload will
+  need to align with the host release cadence (separate design).
+- v5 will likely release more frequently early on as features are added.
+  Eventually the CLI will be mostly maintenance as the majority of changes
+  shift to workloads.
+
+**Why.** Coupling two differently shaped products to one schedule adds
+coordination cost with no user benefit, and v4 is winding down. A maintenance
+-only posture lets the team put its weight behind v5 while keeping v4 users
+safe.
+
+**Open items.**
+
+- Define exact v4 EOL date.
+- Define scope of "security release" for core-tools (what's in vs out).
+- Host workload release alignment is a separate design exercise.
+
+## 7. Decision 3: Distribution channel matrix
+
+**Decision.** The following channels are supported for v5. "Ships" is always
+just the CLI binary; workloads come from NuGet regardless of channel.
+
+**Important:** Users should install from a **single source** to avoid ending
+up with different versions of the CLI on their PATH (e.g. don't mix npm and
+Homebrew installs).
+
+### GA-blocking channels
+
+| Channel | Notes |
+| --- | --- |
+| install.sh / install.ps1 | Primary install scripts. **Linux signing is a blocker.** Validate all supported os/arch. |
+| Homebrew (Mac) | Auto-bump formula on release. |
+| winget (Windows) | Auto-submit manifest on release. MSI might be needed and is not trivial. |
+| npm (cross-platform) | `azure-functions-cli` = v5, `azure-functions-core-tools` = v5. Need to use publisher profile (can also use ESRP release). |
+
+### Post-GA channels
+
+| Channel | Notes |
+| --- | --- |
+| APT (Linux) | Thin CLI .deb in MS apt repo. Repackage binary only. |
+
+All other channels (Chocolatey, MSI, Scoop, RPM, internal tooling feed) are
+**removed** from the v5 distribution plan.
+
+## 8. Decision 4: Rollback story
+
+**Decision.** Roll-forward-first. We do not retag or mutate a shipped
+version; a bad release is fixed by shipping the next patch. Remove unused
+distribution channels from rollback planning.
+
+| Channel | Normal fix | Emergency hatch |
+| --- | --- | --- |
+| CDN / GitHub Releases | Ship next patch | Mark the bad release as pre-release so the installer skips it; never delete assets users may have pinned. |
+| install.sh / ps1 | Resolves next stable automatically | Pin guidance: `VERSION=<last-good>`; mark the bad release pre-release. |
+| npm | Publish next patch | `npm deprecate` the bad version and move `latest` back to the last good. Never unpublish (npm policy). |
+| Homebrew | Bump formula | Revert the formula to the previous revision. |
+| winget | New manifest | Submit a manifest revert to the previous version. |
+| apt | Publish next patch | Re-point the repo metadata to the previous package. |
+| Workloads (NuGet) | Publish next patch | **Unlist** (never delete) the bad version so new resolves skip it, while environments that already installed it can still restore. |
+
+**Why.** Roll-forward keeps release history immutable and reproducible.
+Unlist-not-delete on NuGet is the key rule: it protects any environment that
+already installed a now-bad workload version from a broken restore, while
+stopping new installs from resolving it.
+
+## 9. Testing & OGFs
+
+- Automated smoke tests for v5.
+- No need for Watchtower.
+- Tests run on all supported distributions.
+- **TODO:** Document the test matrix (what we validate, on which os/arch).
+- **TODO (Lilian):** Review OGFs for v4.
+
+## 10. Follow-up issues
+
+Implementation items this design surfaces.
+
+**Release pipeline**
+
+1. Update the release pipeline to push artifacts to CDN.
+2. Fully automate the v5 CLI release pipeline: auto-create the GitHub Release,
+   upload signed `func-{os}-{arch}` archives + checksums. (Extends
+   [#5331](https://github.com/Azure/azure-functions-core-tools/issues/5331).)
+3. CLI archive signing + macOS notarization in the release pipeline.
+4. Linux signing (GA blocker for install scripts).
+
+**Channels (GA-blocking)**
+
+5. npm v5 package: publish both `azure-functions-cli` and
+   `azure-functions-core-tools` at v5 using publisher profile / ESRP release.
+6. winget manifest for v5 with auto-submit on release. Investigate MSI
+   requirement.
+7. Homebrew formula/tap for v5 with auto-bump on release.
+8. Installer coverage validation matrix (all supported os/arch) as a GA gate.
+9. Update ADO pipeline task and GitHub Actions workflow (azure/functions-action)
+   to support v5 CLI installation.
+
+**Channels (post-GA)**
+
+9. APT/.deb packaging for the v5 thin CLI + Microsoft apt repo publishing.
+
+**Policy and comms**
+
+10. v4 maintenance-mode announcement at v5 GA. Define EOL date (~1 year).
+    (Maps to
+    [#5359](https://github.com/Azure/azure-functions-core-tools/issues/5359).)
+11. Define scope of security releases in core-tools for clear external comms.
+12. Per-channel rollback playbook + tooling (deprecate / unlist /
+    mark-prerelease / revert runbooks).
+
+**Separate design work**
+
+13. Workload coordination model and CLI/workload alignment (moved to separate
+    issue — not a release concern).
+
+## 11. Open questions
+
+- Exact v4 EOL date after v5 GA.
+- Scope of "security release" for core-tools — what's included vs excluded.
+- Confirm MSI can be dropped for v5 or if winget requires it (enterprise blocker).
+- Host workload release alignment with host cadence (separate design).
+
+## 12. References
+
+- Issue: [#5328 Design: v4 + v5 release story](https://github.com/Azure/azure-functions-core-tools/issues/5328)
+- `vnext-release-process.md` (per-component tag and pipeline mechanics)
+- `v5-ga-plan.md` (GA milestones and release-process notes)

--- a/proposed/func-new.spec.md
+++ b/proposed/func-new.spec.md
@@ -51,12 +51,12 @@ a real `func new` command that:
   on-disk/in-memory shape (`Template` vs `NewTemplate`, `Files` map,
   `UserPrompt`s, `dotnet new` opaque handle) come straight from the templates
   workload — `func new` just consumes them.
-- **No template discovery via `func new`.** `func new --list` is **not** part
-  of this surface (decided 2026-05-27). Template discovery lives entirely on
-  the `func templates list` command, designed in §5.5. `func new` is the
-  scaffold-one-function verb; `func templates` is the inspect-the-catalog
-  verb.
-- **No `func templates show <id>` subcommand.** Per-template detail —
+- **Template discovery via `func new --list`, not `func new --list`.**
+  Discovery and scaffold share one verb. `func new --list` (alias `-l`) is
+  the catalog surface; `func new --template <id>` is the scaffold surface.
+  There is no separate `func new ...` command tree (decided
+  2026-05-28 — reverses the earlier "separate command" decision in §8 Q1).
+- **No `func new show <id>` subcommand.** Per-template detail —
   options, prompts, defaults, supported languages — surfaces via
   `func new --template <id> --help` through metadata hydration (§4.5).
   One source of truth, no duplicate rendering path.
@@ -92,7 +92,7 @@ a real `func new` command that:
 | **Active stack** | The stack pinned in `.func/config.json` (`StackOptions.Runtime`) — read once at command entry by `IFunctionsProjectResolver` ([[wcdesign §3.10]]). |
 | **NewContext** | The typed input passed to an engine provider — template id (resolved against the catalog), function name, working dir, and the resolved language already settled. |
 | **Resolved language** | The canonical language id selected for this `func new` invocation, **read via DI from `IOptionsMonitor<StackOptions>.Get(workingDirectory.FullName)`** — never by re-reading `.func/config.json` directly. `StackOptionsSetup` (registered as `IConfigureNamedOptions<StackOptions>` in `CliHostFactory`) binds the project's `stack.language` (written by `func init`) into the snapshot at host startup. For single-language stacks (Python, PowerShell, Java, Custom, Go) `stack.language` is **omitted** in the file by `InitCommand` (PR #5125) and the CLI substitutes the stack's canonical single language. For multi-language stacks (DotNet C#/F#, Node JS/TS) a missing `stack.language` is a hard error pointing at `func init`. |
-| **Active profile** | The profile resolved by `IProfileResolver` ([[wcdesign §3.17]]) at command entry — from `.func/config.json` `defaultProfile`, user prefs, or the built-in default. `func new` and `func templates list` do not accept a `--profile` override (D11); profile is a project-level pin set by `func profile set`. |
+| **Active profile** | The profile resolved by `IProfileResolver` ([[wcdesign §3.17]]) at command entry — from `.func/config.json` `defaultProfile`, user prefs, or the built-in default. `func new` and `func new --list` do not accept a `--profile` override (D11); profile is a project-level pin set by `func profile set`. |
 | **Templates content workload** | A workload package whose payload is template content (file bodies + metadata) for a single stack. Distinct from a *stack workload*, which contributes a provider (code). One stack typically has both — code and content — installed independently. Detailed in `templates-workload-spec.md`. |
 | **Templates channel** | `stable` / `preview` / `experimental`, encoded as the templates workload pkg version's prerelease label (templates-workload-spec.md §4.4.2). At `func new` time the channel is derived from the project's `host.json` `extensionBundle.id` — `func new` does not accept an explicit channel flag. Applies to Node/Python only; DotNet has no channel axis. |
 | **`minBundleVersion`** | NuGet version range a Node/Python templates workload pkg declares (in `content/templates-workload.json`) as the lowest extension-bundle version it is compatible with (templates-workload-spec.md §4.4.4). `func new` enforces this against the project's resolved bundle version (§4.8.2); a miss is a hard error in v1, not a warning. |
@@ -189,7 +189,7 @@ public interface ITemplateEngineProvider
     /// snapshots the orchestrator has produced from installed templates
     /// content workloads. The provider only sees templates whose payload
     /// directory matches its EngineId. Used for the interactive picker and
-    /// by <c>func templates list</c>.
+    /// by <c>func new --list</c>.
     /// </summary>
     Task<IReadOnlyList<FunctionTemplateInfo>> ListTemplatesAsync(
         TemplateListContext context,
@@ -282,7 +282,7 @@ dispatched against by engine identity, never by stack:
 | Project | Engine zone (workload payload dir) | Engine mechanism | Used by templates from |
 |---|---|---|---|
 | `Templates.V2` | `content/v2/` (with `templates/templates.json` + `bindings/userPrompts.json` + `resources/Resources*.json`) | Job/action DSL runner (`NewTemplate.Jobs[].Actions[]`); `$(KEY)` substitution against a variables dict; per-template files materialised from the inline `files: { "<name>": "<contents>" }` map (templates-workload-spec.md §5.2); layout encoded entirely in `TemplateAction.FilePath` — engine is layout-agnostic | Node and Python templates content workloads (templates-workload-spec.md §5.2) |
-| `Templates.DotNet` | `content/dotnet-templates.json` at content root, with `content/source.json` sibling (NuGet pin); the dotnet template hive is provisioned at `func workload install` time from `source.json` into a CLI-managed location (templates-workload-spec.md §5.3, §6.3) — **not** packed into the workload payload | Fully-hydrated declarative catalog + per-template `parameters[]` read directly from `dotnet-templates.json` for `func templates list` and `func new --template <id> --help` (offline, deterministic — no `dotnet new` invocation, no NuGet I/O on read paths); **shell-out** via `IDotnetCliRunner` (`dotnet new <shortName> …`) against the provisioned hive only for the actual apply step (D9 / Q-Eng-D) | .NET in-proc + isolated templates content workloads |
+| `Templates.DotNet` | `content/dotnet-templates.json` at content root, with `content/source.json` sibling (NuGet pin); the dotnet template hive is provisioned at `func workload install` time from `source.json` into a CLI-managed location (templates-workload-spec.md §5.3, §6.3) — **not** packed into the workload payload | Fully-hydrated declarative catalog + per-template `parameters[]` read directly from `dotnet-templates.json` for `func new --list` and `func new --template <id> --help` (offline, deterministic — no `dotnet new` invocation, no NuGet I/O on read paths); **shell-out** via `IDotnetCliRunner` (`dotnet new <shortName> …`) against the provisioned hive only for the actual apply step (D9 / Q-Eng-D) | .NET in-proc + isolated templates content workloads |
 
 **Engine identity is implicit** (D9 / Q-Eng-A). The orchestrator picks an
 engine provider by inspecting the workload payload's directory layout:
@@ -297,13 +297,13 @@ behind a template is CLI-internal dispatch.
 
 **No more programming-model knob.** Per D9 / Q-Eng-B, vnext drops every
 `programmingModel` axis: no `--programming-model` flag, no
-`FunctionTemplateInfo.ProgrammingModel` field, no `func templates list`
+`FunctionTemplateInfo.ProgrammingModel` field, no `func new --list`
 grouping by model. Workload publishers curate to ship only
 current-generation templates; "latest" is a publisher responsibility, not a
 runtime concept. (Main's `IsNewPythonProgrammingModel()` and
 `IsNewNodeJsProgrammingModel()` sniffs are dropped.)
 
-**Read vs scaffold paths (DotNet).** `func templates list` and
+**Read vs scaffold paths (DotNet).** `func new --list` and
 `func new --template <id> --help` source catalog rows **and** prompt
 definitions directly from the installed templates content workload's
 `dotnet-templates.json`, which the workload pack target hydrated at build
@@ -768,6 +768,7 @@ Built-in (declared on `NewCommand`, visible in top-level `func new --help`):
 | `--template` | `-t` | `string?` | Template id. If omitted in TTY, interactive picker. |
 | `--force` | — | `bool` | Overwrite existing files. |
 | `--non-interactive` | — | `bool` | Refuse to prompt; exit 1 if any input is missing. |
+| `--list` | `-l` | `bool` | List available templates for this project instead of scaffolding (§5.5). |
 | `--output` | — | `enum {plain, json}` | Output mode (mirrors `func setup`). |
 
 Path positional argument (inherited via `AddPathArgument()`): the project
@@ -813,7 +814,7 @@ can I scaffold?" signal in plain `func new --help`, the help renderer
 injects a per-stack **Available templates** section after the built-in
 `Options:` block. This section renders catalog rows only — no option flags,
 no per-template detail — and shares its data source with
-`func templates list` (§5.5), so the two surfaces stay in lockstep.
+`func new --list` (§5.5), so the two surfaces stay in lockstep.
 
 ```
 $ func new --help
@@ -838,13 +839,13 @@ Available templates (stack: python):
   blob        Blob trigger             Function triggered by Azure Blob Storage events.
   …
   Run 'func new --template <name> --help' for template-specific options,
-  or 'func templates list' for the full catalogue.
+  or 'func new --list' for the full catalogue.
 ```
 
 Rendering rules:
 
 - **Three columns** (short name, display name, description), truncated to
-  terminal width with `…`. Same layout as `func templates list` plain
+  terminal width with `…`. Same layout as `func new --list` plain
   output (§5.5.2) so the two read identically.
 - **Stack header** mirrors §5.5.2. `func new` requires an init'd project
   (§4.4), so the stack is always resolved — there is no stackless rendering
@@ -870,7 +871,7 @@ Rendering rules:
 Legacy: `func new HttpTrigger help` printed trigger-specific help (JS/TS/Python
 only). We **drop** that syntax. Per-template options surface via
 `func new --template HttpTrigger --help` (built-in `--help` over the
-metadata-hydrated options, §4.5) and `func templates list` for the catalogue
+metadata-hydrated options, §4.5) and `func new --list` for the catalogue
 (§5.5).
 
 (Captured as a behavioural break vs main; surfaces in §7 Migration.)
@@ -909,7 +910,7 @@ func new [path]
 │                                                       stack.language missing")
 │
 ├─ ListTemplates(selectedWorkload, language)         → aggregate across all engine providers; each template carries its EngineId
-│    (no list-and-exit branch — discovery lives on `func templates list`)
+│    (no list-and-exit branch — discovery lives on `func new --list`)
 │
 ├─ ResolveTemplate                                    (stage-A parse)
 │    --template given → match by Id (case-insensitive)
@@ -948,30 +949,41 @@ func new [path]
 └─ (post-deploy hints removed — vnext drops the programming-model concept; see §7)
 ```
 
-### 5.5 Template discovery — `func templates list`
+### 5.5 Template discovery — `func new --list`
 
-Decided 2026-05-27: discovery is a **separate top-level command**, not a flag
-on `func new`. This matches main's existing surface
-(`ListTemplatesAction` registered under `Context.Templates` →
-`func templates list`) and keeps `func new` strictly a scaffold-one-function
-verb.
+Decided 2026-05-28 (reverses the 2026-05-27 "separate command" decision in §8 Q1):
+discovery is a **switch on `func new`**, not a separate top-level command.
+One verb, two modes:
 
-`func templates list` is its own built-in command (`TemplatesListCommand`,
-sibling to `NewCommand` in `src/Func/Commands/`). It enumerates templates
-through the same engine provider registry the orchestrator uses
+| Invocation | Mode |
+|---|---|
+| `func new [options]` | Scaffold one function |
+| `func new --list [path]` | List available templates for the project |
+
+`NewCommand` exposes a `--list` / `-l` bool option. When set, the command
+dispatches to the same `NewCommandRunner.ListAsync` path that previously
+backed `func new --list`; all other options (`--template`, `--name`,
+`--force`, `--non-interactive`) are ignored. The catalog is enumerated
+through the same engine provider registry the scaffold path uses
 (`ITemplateEngineProviderRegistry` — see §4.1 and §6 step 6), aggregating
-across every engine provider for the active stack so the catalogue
-surfaced to the user is always the catalogue `func new` would actually
-scaffold from.
+across every engine provider for the active stack so the catalog the user
+sees is always the catalog `func new` would actually scaffold from.
+
+> **Why folded into `func new`.** Reviewers pointed out that a standalone
+> `func new --list` doubles the verb surface for one rendering path, and
+> users discovering `func new` expect a built-in way to see "what can I
+> scaffold here?" — matching `dotnet new --list`'s shape. Keeping the
+> catalog under `func new --list` gives one help target (`func new --help`)
+> that lists every relevant option, including `--list`.
 
 #### 5.5.1 Surface
 
 ```
-func templates list [path]
+func new --list [path]
   --output {plain|json}    output mode (default: plain)
 ```
 
-No `--stack <id>` override (§5.5.5: `func templates list` requires an
+No `--stack <id>` override (§5.5.5: `func new --list` requires an
 init'd Functions project; the stack is read from `.func/config.json`
 `stack.runtime`). No `--template <id>` filter (one-template-at-a-time
 isn't a list query — if we add per-template detail later it's a
@@ -982,7 +994,7 @@ exactly like §4.7.
 #### 5.5.2 Default output (plain)
 
 ```
-$ func templates list
+$ func new --list
 Templates for stack: python  (language: Python)
 
   NAME                     TRIGGER       DESCRIPTION
@@ -1022,7 +1034,7 @@ Layout rules:
 - **Node catalog is pre-filtered per channel at workload pack time**
   (templates-workload-spec.md §6.1). Templates whose required bindings
   aren't satisfied by the channel's authoritative bundle are dropped at
-  pack time, so the rows surfaced by `func templates list` /
+  pack time, so the rows surfaced by `func new --list` /
   `func new --help` for a Node project reflect only templates that should
   scaffold cleanly against the project's resolved bundle. Renderer-side
   hiding is therefore not needed — the workload already shipped the right
@@ -1032,8 +1044,8 @@ Layout rules:
 
 | Condition | Output | Exit |
 |---|---|---|
-| No `.func/config.json` resolvable at `<path>` (uninitialized directory; §5.5.5) | "`func templates list` needs a Functions project. Run `func init` first to choose a stack and language." | 1 |
-| `StackOptions.Runtime` is null/empty (no `stack.runtime` in `.func/config.json`) | "`func templates list` needs a stack pinned in .func/config.json. Run `func init` first." | 1 |
+| No `.func/config.json` resolvable at `<path>` (uninitialized directory; §5.5.5) | "`func new --list` needs a Functions project. Run `func init` first to choose a stack and language." | 1 |
+| `StackOptions.Runtime` is null/empty (no `stack.runtime` in `.func/config.json`) | "`func new --list` needs a stack pinned in .func/config.json. Run `func init` first." | 1 |
 | No template providers registered | "No templates available. Install a templates workload: `func workload install Azure.Functions.Cli.Workloads.Templates.<stack>`." | 1 |
 | Provider registered but content workload missing | Per-stack hint pointing at the specific package id. | 1 |
 | No installed templates workload matches project's bundle channel (Node/Python, §4.8.1) | "No installed templates workload matches this project's bundle channel (`<bundle-id>` → channel `<channel>`). Install: `func workload install Azure.Functions.Cli.Workloads.Templates.<stack> --version <ver-with-channel-suffix>`. Or change `host.json` `extensionBundle.id` if the channel was set in error." | 1 |
@@ -1084,7 +1096,7 @@ per HttpTrigger collapses on this), `classifications`, and
 
 #### 5.5.5 Resolution gates
 
-`func templates list` **requires an init'd Functions project**
+`func new --list` **requires an init'd Functions project**
 (`.func/config.json` resolvable from `[path]`, with at minimum
 `stack.runtime` set). The stack is read from `StackOptions.Runtime` via
 the same `IOptionsMonitor<StackOptions>.Get(workingDirectory.FullName)`
@@ -1111,7 +1123,7 @@ project should use `func quickstart list` (a separate command that
 ships its own catalogue, has no per-project channel concept, and
 explicitly targets the "evaluating which stack to pick" UX).
 
-If `[path]` does not resolve to an init'd project, `func templates list`
+If `[path]` does not resolve to an init'd project, `func new --list`
 exits 1 with the standard hint pointing at `func init` (see §5.5.3
 "No `.func/config.json` resolvable…" row). This matches `func new`'s
 project-gate posture (§4.4) so the two commands fail in the same way for
@@ -1217,7 +1229,7 @@ interaction surface.
 | `--csx` forces legacy CSX path | Dropped (see §8 Q6). `.csx` script-mode functions are not scaffoldable on v5. | No isolated-worker `.csx` model; in-process .NET is out of scope per vnext-design Part IX item 9. |
 | `func new <trigger> help` (positional help) | Dropped — use `func new --template <id> --help` | Two-stage parse exposes every per-template option to native `--help`. |
 | `func new <template>` (positional template id as first non-flag token) | Dropped (see §8 Q7). Template id must be supplied via `--template <id>` / `-t <id>`; the positional slot is reserved for the path. | Avoids positional-vs-path ambiguity; keeps the two-stage parse simple; matches modern System.CommandLine conventions. |
-| `func templates list` runs in any directory (v4 `ListTemplatesAction`) | Requires an init'd Functions project — uninitialised directory exits 1 with a hint pointing at `func init` (§5.5.5 / §8 Q11). No `--stack` override. | v5's channel-resolution algorithm (§4.8.1) keys off `host.json` `extensionBundle.id`; a stackless catalogue has no defined channel selection. Users browsing stacks before initialising should use `func quickstart list` (separate command, no channels). |
+| `func templates list` runs in any directory (v4 `ListTemplatesAction`) | Replaced by `func new --list`; requires an init'd Functions project — uninitialised directory exits 1 with a hint pointing at `func init` (§5.5.5 / §8 Q11). No `--stack` override. | v5's channel-resolution algorithm (§4.8.1) keys off `host.json` `extensionBundle.id`; a stackless catalogue has no defined channel selection. Folding the catalog onto `func new` keeps the verb surface flat. Users browsing stacks before initialising should use `func quickstart list` (separate command, no channels). |
 | `func function new` / `func function create` aliases | Dropped (see §5.1). Single canonical verb is `func new`. | One verb, one source of truth; legacy aliases produce a standard unknown-command hint pointing at `func new`. |
 | Installs missing NuGet extensions via `Metadata.Extensions` | Dropped — relies on extension bundles | Bundle resolver covers this in vnext. |
 | `_templatesManager.Deploy(...)` writes files directly | `provider.ApplyAsync(NewContext, ParseResult)` returns a result | Errors are typed (sealed hierarchy); writes happen behind the provider. |
@@ -1227,7 +1239,7 @@ interaction surface.
 | Language inferred from the first `--language`-like flag on `func new`; language asked anew on every invocation in some paths | Flag dropped. Language is **read** via DI from `IOptionsMonitor<StackOptions>.Get(workingDirectory.FullName).Language` — the bound view of `.func/config.json` `stack.language` (`StackOptionsSetup` is the single file-read path; `func new` consumes the snapshot). `func init` writes the value from **its** `--language` flag (PR #5125 omits the key for single-language stacks; `func new` substitutes the stack's canonical language in that case). `func new` requires an init'd project; a missing key on a multi-language stack → exit 1 pointing at `func init`. | One deterministic source of truth via the existing options pipeline; eliminates a redundant flag, the alias-resolution code path, the prompt loop, **and** any per-invocation file I/O. Matches the precedent in `ProfileResolver` / `SetupRunner` for `IOptionsMonitor<ProjectProfileOptions>`. |
 | No concept of templates-channel; bundle and templates were the same package | Templates ship as their own per-channel content workload; `func new` auto-matches the project's bundle channel (§4.8.1) with no cross-channel fallback. Missing match → `NoTemplatesWorkloadForChannel` with install hint. | Per templates-workload-spec.md §4.4.2; lets templates revisions ship independently of bundle releases. |
 | No `minBundleVersion` check at scaffold time | `func new` enforces the templates workload's `minBundleVersion` against the project's resolved bundle version (§4.8.2); violation → `MinBundleVersionTooOld` and exit 1 (no warning fallback in v1). | Per templates-workload-spec.md §4.4.4; catches binding compatibility issues before any file is written. |
-| `--profile <name>` and `--offline` mirrored from `func run` on every command | Dropped from `func new` and `func templates list`. Active profile is resolved silently from `.func/config.json defaultProfile → user prefs → built-in default`; stack-vs-profile gate still fires (pipeline step 3). Mismatch error hints at `func profile set <other>` / `func profile list`. | Scaffolds are static files — there is no scaffold-under-profile-X-then-run-under-Y use case. Profile is a project-level pin, not a per-invocation override; `--offline` only refreshed profile sources that scaffold output doesn't depend on. |
+| `--profile <name>` and `--offline` mirrored from `func run` on every command | Dropped from `func new` and `func new --list`. Active profile is resolved silently from `.func/config.json defaultProfile → user prefs → built-in default`; stack-vs-profile gate still fires (pipeline step 3). Mismatch error hints at `func profile set <other>` / `func profile list`. | Scaffolds are static files — there is no scaffold-under-profile-X-then-run-under-Y use case. Profile is a project-level pin, not a per-invocation override; `--offline` only refreshed profile sources that scaffold output doesn't depend on. |
 
 Telemetry continuity: emit `cli.new.invoked` (stack, language, template id,
 engine id) plus `cli.new.duration` histogram and `cli.new.outcome`
@@ -1239,14 +1251,18 @@ adoption without surfacing engine identity to users (D9 / Q-Eng-A).
 
 Promote to §4 once answered.
 
-- ✅ **Q1. `func new --list` vs `func templates list`. — RESOLVED 2026-05-27.**
-  Discovery lives only on `func templates list` (catalog-only — NAME / TRIGGER
-  / DESCRIPTION, §5.5). `func new --list` is **not** added. No `--detailed`
-  flag on `func templates list` either: per-template options surface on
-  `func new --template <id> --help` via two-stage hydration (§4.5). No
-  `func templates show <id>` either — `func new --template <id> --help` is
-  the per-template detail surface. Single source of truth for "what does this
-  template need."
+- ✅ **Q1. `func new --list` vs a separate `func templates list` command. — RESOLVED 2026-05-28 (revises 2026-05-27).**
+  Discovery is a **switch on `func new`** (`--list` / `-l`), not a separate
+  top-level command tree. Catalog-only (NAME / TRIGGER / DESCRIPTION, §5.5).
+  No `--detailed` flag on `func new --list` either: per-template options
+  surface on `func new --template <id> --help` via two-stage hydration
+  (§4.5). No `func templates show <id>` either — `func new --template <id>
+  --help` is the per-template detail surface. Single source of truth for
+  "what does this template need." Earlier 2026-05-27 resolution (separate
+  `func templates list` verb) reversed on reviewer feedback: one command,
+  two modes matches `dotnet new --list` and keeps `func new --help` as
+  one help target users can scan to discover both scaffold and catalog
+  paths.
 - ✅ **Q2. Are template-declared NuGet extension installs needed at all? — RESOLVED 2026-05-28.**
   **Dropped entirely.** The legacy `Template.Metadata.Extensions` path
   (which appended `<PackageReference>` entries to a project-local
@@ -1413,7 +1429,7 @@ Promote to §4 once answered.
   needs to support both generations in the same release window, they can
   ship two separate templates content workloads (different package ids,
   different channels).
-- ✅ **Q11. `func templates list --output json` envelope shape. — RESOLVED 2026-05-28.**
+- ✅ **Q11. `func new --list --output json` envelope shape. — RESOLVED 2026-05-28.**
   Single envelope `{ stack, language, templates: [ … ] }` per §5.5.4 —
   every invocation. There is no multi-stack case because §5.5.5 now
   requires an init'd project (no stackless run, no `--stack` override):
@@ -1487,7 +1503,7 @@ Promote to §4 once answered.
   authoritative — `func new` scaffolds for whatever language `func init`
   recorded. If `.func/config.json` is missing the key on a multi-language
   stack, `func new` exits 1 pointing at `func init`.
-- ✅ **Q-Lang-3 / D10. `--language` flag on `func new` and `func templates list`. — RESOLVED 2026-05-29 (revised).**
+- ✅ **Q-Lang-3 / D10. `--language` flag on `func new` and `func new --list`. — RESOLVED 2026-05-29 (revised).**
   Dropped from both commands. Language is **read via DI** from
   `IOptionsMonitor<StackOptions>.Get(workingDirectory.FullName).Language`
   — the bound view of `.func/config.json` `stack.language` that
@@ -1497,10 +1513,10 @@ Promote to §4 once answered.
   is the single file-read path, and the options pipeline caches/refreshes
   the snapshot, so per-invocation file I/O at scaffold time is avoided. A
   `func new --language` flag would either contradict the init choice
-  (drift) or be a no-op when it agrees. `func templates list` requires an
+  (drift) or be a no-op when it agrees. `func new --list` requires an
   init'd project for the same channel-resolution reasons (§5.5.5 / Q11),
   so it has no `--language` flag either.
-- ✅ **Q-Profile-1 / D11. `--profile` and `--offline` flags on `func new` and `func templates list`. — RESOLVED 2026-05-27.**
+- ✅ **Q-Profile-1 / D11. `--profile` and `--offline` flags on `func new` and `func new --list`. — RESOLVED 2026-05-27.**
   Dropped from both commands. Profile selection is a project-level pin set
   by `func profile set` (or `.func/config.json defaultProfile`, user prefs,
   or the built-in default — resolved silently by `IProfileResolver`).
@@ -1529,7 +1545,7 @@ Promote to §4 once answered.
   Publisher concern. vnext has no `programmingModel` field on templates,
   no `FunctionTemplateInfo.ProgrammingModel`, no
   `TemplateListContext.ProgrammingModelHint`, no `--programming-model`
-  flag, no `func templates list` grouping by model, no post-deploy
+  flag, no `func new --list` grouping by model, no post-deploy
   upgrade messaging. Workload publishers ship only current-generation
   templates ("latest" is what the workload version ships, not a runtime
   axis). Main-branch sniffs (`IsNewPythonProgrammingModel()`,
@@ -1549,7 +1565,7 @@ Promote to §4 once answered.
   package, templates-workload-spec.md §5.3, §6.3). At
   `func workload install` time the CLI provisions the pinned NuGet pkg
   into a CLI-managed dotnet template hive. The CLI's `DotNetEngineProvider`
-  reads the JSON for `func templates list` and `func new --template <id>
+  reads the JSON for `func new --list` and `func new --template <id>
   --help` (offline-deterministic, no `dotnet new` invocation, no NuGet
   I/O) and shells out via `IDotnetCliRunner` (`dotnet new <shortName>
   --<param> <value> …`) only for the actual apply step. Workloads stay

--- a/proposed/func-new.spec.md
+++ b/proposed/func-new.spec.md
@@ -1,0 +1,1607 @@
+# `func new` spec
+
+> Sister spec to `templates-workload-spec.md` (templates **workload** — payload,
+> layout, packaging) and the working-context reference in
+> `working_context_templates_workload_design.md` (which has the §3B legacy
+> behaviour and §3 vnext platform reference).
+>
+> **Scope of this doc:** the CLI-side `func new` command — its surface, its
+> orchestration pipeline, the contribution point templates workloads plug into,
+> and how the V2 / DotNet templating engines are isolated inside the CLI.
+> **Out of scope:** template *payload* shape, workload packaging, NuGet tagging,
+> StaticContent layout, channel/version axes — those live in the templates
+> workload spec.
+
+---
+
+## 1. Goal
+
+Replace the placeholder `NewCommand` in `src/Func/Commands/NewCommand.cs` with
+a real `func new` command that:
+
+1. Scaffolds a single function (file(s) + binding metadata) inside an existing
+   Functions project by selecting and applying a **template** contributed by an
+   installed **templates content workload**.
+2. Covers the in-scope `func new` behavioural surface — two template engines
+   (.NET hive shellout / v2 `NewTemplate[]` job/action DSL for Node and Python)
+   folded behind one CLI command. The v5 templates workloads ship **v2 only**;
+   the legacy V1 `Files`-map engine is not part of the vnext CLI
+   (templates-workload-spec.md §5.2: "v1 (legacy) programming-model templates
+   are not shipped in v5 templates workloads").
+3. Drives the picker / option-collection / file-write pipeline from the **CLI
+   core**, not from each workload — workloads only contribute *template
+   payloads* and *metadata*, never commands.
+4. Keeps the v2 (Node/Python `NewTemplate[]` job/action DSL) and DotNet
+   (`dotnet-templates.json` + shell-out) templating engines in **separate
+   CLI-internal projects**, behind one provider abstraction, so future
+   templating engines can be added without touching `NewCommand`.
+5. Hydrates per-template options (e.g. `--auth-level` for HTTP triggers,
+   `--file` for Python v2 blueprint routing) from template metadata, so the
+   user sees only the options that apply to the chosen template.
+6. Honours the profile system ([[wcdesign §3.17]]) — refuses to scaffold for a
+   stack the active profile doesn't list under `SupportedRuntimes`.
+
+## 2. Non-goals
+
+- **No auto-`func init`.** Legacy `func new` ran `func init` first when the
+  directory wasn't initialised. Post-#5057 init is stricter, and we don't want
+  to silently create projects from inside `func new` — fail with a clear hint
+  instead (see §4.4).
+- **No template payload format design here.** Template files and their
+  on-disk/in-memory shape (`Template` vs `NewTemplate`, `Files` map,
+  `UserPrompt`s, `dotnet new` opaque handle) come straight from the templates
+  workload — `func new` just consumes them.
+- **No template discovery via `func new`.** `func new --list` is **not** part
+  of this surface (decided 2026-05-27). Template discovery lives entirely on
+  the `func templates list` command, designed in §5.5. `func new` is the
+  scaffold-one-function verb; `func templates` is the inspect-the-catalog
+  verb.
+- **No `func templates show <id>` subcommand.** Per-template detail —
+  options, prompts, defaults, supported languages — surfaces via
+  `func new --template <id> --help` through metadata hydration (§4.5).
+  One source of truth, no duplicate rendering path.
+- **No `.func/config.json` writes from `func new`.** The command is pure
+  scaffold; it never mutates project config. Language is **read** on every
+  run from `.func/config.json` `stack.language` (§4.7 / D10) — which
+  `func init` writes from its `--language` flag — but `func new` itself
+  never writes the file; project config has one author at a time, and that
+  author is `func init`.
+- **No Java support in v1.** Legacy `func new` hard-rejected Java
+  ("use Maven"). vnext gets this for free — Java just won't ship a provider.
+- **No worker auto-install.** If the resolved stack workload requires a worker
+  or extension bundle that isn't installed, `func new` errors with a pointer
+  at `func setup --profile <name>` ([[wcdesign §3.18]]). It does **not**
+  install on demand. Same posture for templates content workloads:
+  channel-mismatch (§4.8.1) and missing-pkg cases are surfaced as
+  `func workload install` hints, not silent installs.
+- **No NuGet `extensions.csproj` install for missing bindings** — extension
+  bundles cover this in vnext, so the legacy `Metadata.Extensions` install
+  path from `CreateFunctionAction` is dropped (see §8 Q2).
+
+## 3. Definitions
+
+| Term | Meaning |
+|---|---|
+| **Template** | One unit of `func new` output: a set of file payloads + optional binding metadata + an option/prompt schema. Comes from a templates workload's payload. |
+| **Template engine** | One of two CLI-internal mechanisms that materialise a template: **DotNet** (shellout `dotnet new <shortName>` against an installed template hive, with catalog + `--help` read from a fully-hydrated `dotnet-templates.json`), or **V2** (`NewTemplate` job/action runner with `UserPrompt[]` inputs and `$(KEY)` substitution; used by **both** Node and Python in v5). The CLI ships both; workloads ship only payloads. The legacy V1 `Files`-map engine is **not** part of vnext — v5 templates workloads ship v2 templates only (templates-workload-spec.md §5.2). |
+| **Engine identity** | Determined implicitly by the **directory layout** of the workload payload: `content/v2/` → V2 engine (Node, Python); `content/dotnet-templates.json` at content root → DotNet engine. Never user-visible — no flag, no schema field, no help text. |
+| **Template engine provider** | A CLI-internal implementation of `ITemplateEngineProvider` — one **per engine**, not per stack. Two exist: `DotNetEngineProvider` and `V2EngineProvider`. Each knows how to enumerate and apply templates that live under its engine's payload directory. Engine providers are stack-agnostic; they are dispatched against based on Engine identity, not on the project's `StackName`. |
+| **Template metadata** | The schema fields that drive option hydration: trigger id, default function name, supported languages, prompts (`UserPrompt[]` for V2; `parameters[]` for DotNet — projected at workload pack time from `template.json` + `dotnetcli.host.json`, templates-workload-spec.md §5.3.1). **No `programmingModel` field, no engine field** — workload publishers ship only current-generation templates (§8 Q-Eng-B). |
+| **Provider options** | Per-template `Option<T>` instances surfaced via a hydration helper that reads `FunctionTemplateInfo.UserPrompts` and emits options into an `IInitOptionRegistry`. Visible only under `func new --template <id> --help` (§4.5). |
+| **Two-stage parse** | The pattern `func new` uses to expose template-specific options through native `--help`: stage A parses built-ins to discover `--template`; stage B re-parses argv with the template-hydrated options attached. |
+| **Active stack** | The stack pinned in `.func/config.json` (`StackOptions.Runtime`) — read once at command entry by `IFunctionsProjectResolver` ([[wcdesign §3.10]]). |
+| **NewContext** | The typed input passed to an engine provider — template id (resolved against the catalog), function name, working dir, and the resolved language already settled. |
+| **Resolved language** | The canonical language id selected for this `func new` invocation, **read via DI from `IOptionsMonitor<StackOptions>.Get(workingDirectory.FullName)`** — never by re-reading `.func/config.json` directly. `StackOptionsSetup` (registered as `IConfigureNamedOptions<StackOptions>` in `CliHostFactory`) binds the project's `stack.language` (written by `func init`) into the snapshot at host startup. For single-language stacks (Python, PowerShell, Java, Custom, Go) `stack.language` is **omitted** in the file by `InitCommand` (PR #5125) and the CLI substitutes the stack's canonical single language. For multi-language stacks (DotNet C#/F#, Node JS/TS) a missing `stack.language` is a hard error pointing at `func init`. |
+| **Active profile** | The profile resolved by `IProfileResolver` ([[wcdesign §3.17]]) at command entry — from `.func/config.json` `defaultProfile`, user prefs, or the built-in default. `func new` and `func templates list` do not accept a `--profile` override (D11); profile is a project-level pin set by `func profile set`. |
+| **Templates content workload** | A workload package whose payload is template content (file bodies + metadata) for a single stack. Distinct from a *stack workload*, which contributes a provider (code). One stack typically has both — code and content — installed independently. Detailed in `templates-workload-spec.md`. |
+| **Templates channel** | `stable` / `preview` / `experimental`, encoded as the templates workload pkg version's prerelease label (templates-workload-spec.md §4.4.2). At `func new` time the channel is derived from the project's `host.json` `extensionBundle.id` — `func new` does not accept an explicit channel flag. Applies to Node/Python only; DotNet has no channel axis. |
+| **`minBundleVersion`** | NuGet version range a Node/Python templates workload pkg declares (in `content/templates-workload.json`) as the lowest extension-bundle version it is compatible with (templates-workload-spec.md §4.4.4). `func new` enforces this against the project's resolved bundle version (§4.8.2); a miss is a hard error in v1, not a warning. |
+
+## 4. Architecture
+
+### 4.1 Component map
+
+```
+Func                 src/Func/                                 CLI executable
+ ├── Commands/NewCommand.cs                                    built-in command
+ ├── Templates/                                                orchestrator
+ │     NewCommandRunner.cs           pipeline driver
+ │     ITemplateEngineProviderRegistry.cs                      engine lookup by EngineId
+ │     TemplateOptionHydrator.cs     UserPrompt[] / parameters[] → Option<T> (engine-agnostic)
+ │     TemplatePicker.cs             interactive picker over IInteractionService
+ │     NewCommandRenderer.cs         user-facing output
+ ├── Templates.V2/                   ──► separate csproj       v2 engine (Node + Python)
+ │     V2TemplateEngine.cs           job/action DSL runner with $(KEY) substitution
+ │     V2EngineProvider.cs           ITemplateEngineProvider impl (EngineId = "v2")
+ │     (engine zone: workload payload's content/v2/)
+ └── Templates.DotNet/               ──► separate csproj       dotnet engine
+       DotNetTemplateEngine.cs       dotnet-templates.json reader (catalog/help)
+                                     + IDotnetCliRunner shell-out (apply)
+       DotNetEngineProvider.cs       ITemplateEngineProvider impl (EngineId = "dotnet")
+       (engine zone: workload payload's content/dotnet-templates.json
+        at content root; hive is provisioned at workload install time
+        from content/source.json — templates-workload-spec.md §5.3, §6.3)
+
+Abstractions         src/Abstractions/                         NuGet contract
+ └── Templates/                                                new namespace
+       ITemplateEngineProvider.cs                              engine-shaped provider
+       FunctionTemplateInfo.cs                                 surfaces a template
+                                                               (carries Stack + Language + EngineId)
+       NewContext.cs                                           engine input
+       TemplateApplicationResult.cs                            sealed result hierarchy
+
+Workloads            src/Workloads/                            runtime-loaded
+ └── Templates/<stack>/                                        templates content workload
+       content/
+         v2/templates/templates.json    → V2 engine zone (NewTemplate jobs/actions; Node, Python)
+         v2/bindings/userPrompts.json   → shared prompt catalog (V2 ParamId references)
+         v2/resources/Resources*.json   → i18n strings
+         dotnet-templates.json          → DotNet engine zone (catalog + parameters[] index;
+                                          hydrated at workload pack time — templates-workload-spec.md §5.3.1)
+         source.json                    → DotNet NuGet pin (hive provisioned at workload install time)
+         templates-workload.json        → CLI-owned sibling manifest (minBundleVersion; Node/Python only)
+       workload.json                    (kind: content; no entry-point assembly)
+```
+
+**Rule:** the CLI references `Templates.V2` and `Templates.DotNet` (project
+references). Templates content workloads ship payload only — no code, no DLL
+plugin contract. Engine selection is based on the payload's directory layout
+(see §4.3, Q-Eng-A); the CLI never asks a workload "which engine are you?"
+
+**Decision:** `Templates.V2` and `Templates.DotNet` are CLI-internal projects,
+not NuGet packages — shipped *inside* the `func` binary. The split exists
+purely for testability and to keep each engine's quirks (V2's action-runner +
+`$(KEY)` substitution, DotNet's `dotnet new` shell-out + JSON catalog) from
+leaking into one another. Language resolution is **orthogonal** to engine
+choice and is read from `.func/config.json` `stack.language` — there is no
+language-detection seam (§4.7). (See §8 Q3 on whether the two engines are
+separate assemblies or a single internal assembly with namespaces; D9
+supersedes D7's earlier "no separate DotNet engine" stance.)
+
+### 4.2 Contribution points — `ITemplateEngineProvider`
+
+One seam. Engine providers know how to enumerate and apply templates for one
+**engine** (V2, DotNet) — they're stack-agnostic, CLI-internal, and
+registered by the engine projects themselves (`Templates.V2` /
+`Templates.DotNet`), not by workloads. Top-level `func new --help` is
+template-agnostic; hydrated options only appear under
+`func new --template <id> --help` (hydration is engine-agnostic, see §4.5).
+Language resolution is **not** a contribution point — `func new` reads
+`stack.language` from `.func/config.json` (`StackOptions.Language`) and
+substitutes the stack's canonical single language for single-language stacks
+(§4.7).
+
+```csharp
+namespace Azure.Functions.Cli.Templates;
+
+public interface ITemplateEngineProvider
+{
+    /// <summary>
+    /// Stable engine identifier ("v2", "dotnet"). The orchestrator
+    /// dispatches to a provider by matching this against the engine zone
+    /// derived from a template's payload directory (see §4.3, Q-Eng-A). Not
+    /// user-visible — never appears in flags, help text, or schema fields.
+    /// </summary>
+    string EngineId { get; }
+
+    /// <summary>
+    /// Enumerates every template this engine can scaffold from the catalog
+    /// snapshots the orchestrator has produced from installed templates
+    /// content workloads. The provider only sees templates whose payload
+    /// directory matches its EngineId. Used for the interactive picker and
+    /// by <c>func templates list</c>.
+    /// </summary>
+    Task<IReadOnlyList<FunctionTemplateInfo>> ListTemplatesAsync(
+        TemplateListContext context,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Renders + writes the chosen template into the working directory.
+    /// </summary>
+    Task<TemplateApplicationResult> ApplyAsync(
+        NewContext context,
+        ParseResult parseResult,
+        CancellationToken cancellationToken);
+}
+```
+
+Supporting records:
+
+```csharp
+public sealed record TemplateListContext(
+    WorkingDirectory WorkingDirectory,
+    string Stack,                         // active stack — narrows the catalog
+    string? Language);                    // resolved from .func/config.json stack.language (§4.7)
+
+public sealed record FunctionTemplateInfo(
+    string Id,                            // template id (e.g. "HttpTrigger")
+    string Stack,                         // owning stack (e.g. "node")
+    string EngineId,                      // "v2" | "dotnet" — dispatch key
+    string DisplayName,                   // "HTTP trigger"
+    string TriggerKind,                   // "http" | "timer" | "queue" | ...
+    string? DefaultFunctionName,
+    IReadOnlyList<string> Languages,      // which stack languages this template applies to
+    TemplateMetadata Metadata);           // schema-driven (see §4.5)
+
+public sealed record NewContext(
+    WorkingDirectory WorkingDirectory,
+    FunctionTemplateInfo Template,        // resolved by NewCommand before calling
+    string FunctionName,
+    string? Language,
+    bool Force);
+
+public abstract record TemplateApplicationResult
+{
+    private TemplateApplicationResult() { }
+    public sealed record Created(IReadOnlyList<string> Files) : TemplateApplicationResult;
+    public sealed record AlreadyExists(IReadOnlyList<string> ExistingFiles) : TemplateApplicationResult;
+    public sealed record Failed(TemplateApplicationFailure Failure) : TemplateApplicationResult;
+}
+```
+
+`TemplateApplicationFailure` follows the sealed-hierarchy idiom ([[wcdesign §3.14]]):
+`NoTemplatesWorkloadForChannel(stack, channel, suggestedPackageId, suggestedVersion)`,
+`MissingExtensionBundle(stack, suggestedBundleId)`,
+`MinBundleVersionTooOld(installedBundleVersion, requiredRange, templatesWorkloadVersion)`,
+`WriteFailed`, `InvalidPrompt`, `ProviderError(message, innerException)`.
+
+The first three failure types correspond to the templates-workload-spec's
+channel-matching (§4.4.2) and `minBundleVersion` (§4.4.4) enforcement — see
+§4.8 below for the resolution + enforcement algorithm, and §5.5.3 / §7 for
+the user-facing error UX. The legacy `InvalidProgrammingModel` failure is
+dropped — there is no programming-model concept on vnext templates (D9 /
+Q-Eng-B).
+
+**Note: `FunctionTemplateInfo.ProgrammingModel` is gone.** Per Q-Eng-B,
+workload publishers ship only current-generation templates; there's no
+runtime model field to expose on the record. `TemplateListContext` loses its
+`ProgrammingModelHint` for the same reason.
+
+**Note: option hydration is no longer on the provider.** The legacy
+`GetTemplateOptions(FunctionTemplateInfo, IInitOptionRegistry)` method is
+gone; per-template option hydration is engine-agnostic and lives in a shared
+`TemplateOptionHydrator` (in `src/Func/Templates/`) that reads
+`FunctionTemplateInfo.Metadata.UserPrompts` directly. The result is the same
+real `Option<T>` instances under `func new --template <id> --help` (D5);
+hydration just doesn't depend on the engine. See §4.5.
+
+**Registration.** Engine providers register from their own `Templates.V2` /
+`Templates.DotNet` projects, bare:
+`services.AddSingleton<ITemplateEngineProvider, V2EngineProvider>()` (and one
+for DotNet). The orchestrator asks `IEnumerable<ITemplateEngineProvider>`
+and routes by EngineId. Engine providers don't need tagging — they're
+CLI-internal.
+
+### 4.3 Templating engine isolation (v2 / dotnet projects)
+
+vnext has two distinct templating engines. They share **no code** with one
+another — that's by construction, not accident. Each lives in its own
+CLI-internal csproj, exposes exactly one `ITemplateEngineProvider`, and is
+dispatched against by engine identity, never by stack:
+
+| Project | Engine zone (workload payload dir) | Engine mechanism | Used by templates from |
+|---|---|---|---|
+| `Templates.V2` | `content/v2/` (with `templates/templates.json` + `bindings/userPrompts.json` + `resources/Resources*.json`) | Job/action DSL runner (`NewTemplate.Jobs[].Actions[]`); `$(KEY)` substitution against a variables dict; per-template files materialised from the inline `files: { "<name>": "<contents>" }` map (templates-workload-spec.md §5.2); layout encoded entirely in `TemplateAction.FilePath` — engine is layout-agnostic | Node and Python templates content workloads (templates-workload-spec.md §5.2) |
+| `Templates.DotNet` | `content/dotnet-templates.json` at content root, with `content/source.json` sibling (NuGet pin); the dotnet template hive is provisioned at `func workload install` time from `source.json` into a CLI-managed location (templates-workload-spec.md §5.3, §6.3) — **not** packed into the workload payload | Fully-hydrated declarative catalog + per-template `parameters[]` read directly from `dotnet-templates.json` for `func templates list` and `func new --template <id> --help` (offline, deterministic — no `dotnet new` invocation, no NuGet I/O on read paths); **shell-out** via `IDotnetCliRunner` (`dotnet new <shortName> …`) against the provisioned hive only for the actual apply step (D9 / Q-Eng-D) | .NET in-proc + isolated templates content workloads |
+
+**Engine identity is implicit** (D9 / Q-Eng-A). The orchestrator picks an
+engine provider by inspecting the workload payload's directory layout:
+presence of `content/v2/` → V2 engine; presence of `content/dotnet-templates.json`
+at the content root → DotNet engine. A given templates workload ships
+exactly one engine zone, so there is no tiebreak — Node/Python ship `v2/`
+only, DotNet ships `dotnet-templates.json` only.
+
+**Engine identity is never user-visible.** No flag, no schema field, no help
+text mentions "engine". Users see templates by stack + name; the engine
+behind a template is CLI-internal dispatch.
+
+**No more programming-model knob.** Per D9 / Q-Eng-B, vnext drops every
+`programmingModel` axis: no `--programming-model` flag, no
+`FunctionTemplateInfo.ProgrammingModel` field, no `func templates list`
+grouping by model. Workload publishers curate to ship only
+current-generation templates; "latest" is a publisher responsibility, not a
+runtime concept. (Main's `IsNewPythonProgrammingModel()` and
+`IsNewNodeJsProgrammingModel()` sniffs are dropped.)
+
+**Read vs scaffold paths (DotNet).** `func templates list` and
+`func new --template <id> --help` source catalog rows **and** prompt
+definitions directly from the installed templates content workload's
+`dotnet-templates.json`, which the workload pack target hydrated at build
+time from each upstream `template.json` (+ `dotnetcli.host.json`)
+(templates-workload-spec.md §5.3.1). No `IDotnetCliRunner` invocation, no
+template-hive read on these paths. Only `provider.ApplyAsync` (the actual
+scaffold step in §6) shells out via `IDotnetCliRunner` against the dotnet
+template hive that `func workload install` provisioned from `source.json`.
+The result: both discovery and help are offline-deterministic from the
+workload payload, with **no NuGet I/O at `func new` time**. Workloads stay
+content-only — no DLL plugin contract.
+
+```
+                NewCommand (Func/Commands/)
+                       │
+                       ▼
+            NewCommandRunner (Func/Templates/)
+              1. resolves stack (project / --runtime)
+              2. resolves language (read .func/config.json stack.language
+                 via StackOptions; fall back to stack's single language
+                 if omitted — §4.7)
+              3. enumerates templates from installed templates content
+                 workloads, grouped by EngineId derived from payload dir
+              4. user picks a template
+              5. dispatches to engine provider by template.EngineId
+                       │
+                ┌──────┴────────┐
+                ▼               ▼
+          V2EngineProvider  DotNetEngineProvider
+          (Templates.V2)    (Templates.DotNet)
+                │               │
+                ▼               ▼
+           runs Jobs[].     reads dotnet-
+           Actions[] with   templates.json
+           $(KEY) subst;    for catalog +
+           writes per       parameters[];
+           action.FilePath  shells out
+           from inline      `dotnet new <sn>
+           files map        --<param> <value>`
+                            against hive
+                            provisioned at
+                            workload install
+```
+
+### 4.4 Project resolution (gate)
+
+`NewCommand` calls `IFunctionsProjectResolver.ResolveProjectAsync`
+([[wcdesign §3.10]]) **before** anything else. Outcomes:
+
+| Resolver result | `func new` action |
+|---|---|
+| `Created(project)` | Continue. `project.StackName` selects the templates content workload(s); each template's engine zone selects the engine provider (§4.3). |
+| `NotCreated(NoWorkloadsInstalled)` | Render hint → exit 1. |
+| `NotCreated(NoMatchingFactory)` | "Not a Functions project. Run `func init` first." → exit 1. |
+| `Failed(InvalidProject)` | Surface the factory's failure message → exit 1. |
+
+This kills the legacy "auto-init if no `local.settings.json`" branch. Init is
+the user's explicit step now ([[wcdesign §3.13]] — post-#5057 init is stricter).
+
+### 4.5 Template metadata hydrates `func new --template <X>` options
+
+A template's metadata schema declares every input the user can provide. The
+orchestrator hydrates each one as a typed `Option<T>` and attaches it to a
+**per-template parse pass**, so:
+
+- `func new --help` shows only **built-in options** (§5.2). Top-level help is
+  template-agnostic.
+- `func new --template HttpTrigger --help` shows built-ins **plus** the
+  HttpTrigger-hydrated options (`--auth-level`, `--methods`, `--route`, …).
+- Every per-template input is a real `Option<T>` — visible in `--help`,
+  autocompletion-friendly, validated by the parser. There is no
+  prompt-vs-option distinction in the CLI surface: from the user's view a
+  prompt **is** an option.
+
+A shared, engine-agnostic helper supplies the hydrated set:
+
+```csharp
+namespace Azure.Functions.Cli.Templates;
+
+internal sealed class TemplateOptionHydrator(IInitOptionRegistry registry)
+{
+    public IReadOnlyList<Option> Hydrate(FunctionTemplateInfo template);
+}
+```
+
+The hydrator reads `FunctionTemplateInfo.Metadata.UserPrompts` directly —
+the engine that produced the template (V2 or DotNet) doesn't participate.
+By the time the orchestrator hands the template to the hydrator, every
+engine has already projected its prompts into the unified `UserPrompts`
+shape on the metadata (V2's `UserPromptAction.Inputs` and DotNet's
+`parameters[]` both reach the same schema; see §3 Definitions / Template
+metadata).
+
+Hydration rules:
+
+| Metadata field | Maps to |
+|---|---|
+| V2 prompt `id`, or DotNet `parameters[].name` | Option name, kebab-cased (`authLevel` → `--auth-level`) |
+| V2 prompt `label`, or DotNet `parameters[].description` (or `displayName`) | `Option.Description` |
+| `defaultValue` | `Option.DefaultValueFactory` |
+| V2 prompt `enum`, or DotNet `parameters[].choices[].value` | `Option.AcceptOnlyFromAmong(...)` |
+| V2 prompt `validator` regex | Custom parser / `Validators` |
+| Missing `defaultValue` + `isRequired` (DotNet) or no default (V2) | Required option (parser errors if not supplied and `--non-interactive`) |
+| DotNet `shortNameOverride` / `longNameOverride` (from `dotnetcli.host.json`) | Short / long alias on the same `Option<T>` |
+
+For DotNet templates, every field above is already projected at workload
+build time into `dotnet-templates.json` (templates-workload-spec.md §5.3.1) —
+so `TemplateOptionHydrator.Hydrate` is a pure in-memory transform over
+already-parsed records, with no NuGet I/O or template-hive read.
+
+**DotNet `groupIdentity` dedup across language variants.**
+A single Functions item-template (e.g. HttpTrigger) typically ships **two
+records** in the upstream NuGet pkg — one C# and one F# — each with the
+same `shortName` but distinct `language` and `identity`. The hydrator
+treats `dotnet-templates.json` `parameters[]` as per-language; the
+catalog-display path (§5.5.2) dedupes adjacent records sharing
+`groupIdentity` (templates-workload-spec.md §5.3.1) so the user sees one
+"HttpTrigger" row even when both records are installed. The resolved
+language from §4.7 then picks the right record at scaffold time. F# users
+on a stack that ships F#-capable templates see the F# record's
+`parameters[]`; C# users see the C# record's.
+
+**Localization (v1: en-US only).** Per templates-workload-spec.md §5.3.1,
+v1 of the DotNet hydration pipeline emits en-US `description` /
+`choices[].description` only. The Node/Python `v2/resources/Resources*.json`
+sibling files (templates-workload-spec.md §5.2) ship locale variants, but
+v1 of `func new --template <id> --help` reads only the en-US default. A
+future locale axis can be added without changing the hydration contract —
+the schema reserves a `localizations` key.
+
+**Example — HTTP trigger.**
+
+```text
+template.Metadata.userPrompts = [
+  { id: "authLevel", label: "...", enum: ["function","anonymous","admin"], default: "function" },
+  { id: "methods",   label: "...", default: "get,post" },
+  { id: "route",     label: "..." /* optional */ }
+]
+
+  ── hydrated to ──►
+
+new Option<AuthLevel>("--auth-level")
+  { Description = "...", DefaultValueFactory = _ => AuthLevel.Function }
+  .AcceptOnlyFromAmong("function", "anonymous", "admin")
+
+new Option<string>("--methods")
+  { Description = "...", DefaultValueFactory = _ => "get,post" }
+
+new Option<string?>("--route")
+  { Description = "..." }   // optional, no default
+```
+
+User invocation is then native System.CommandLine:
+
+```
+func new --template HttpTrigger --name MyFn --auth-level anonymous --route api/v1/foo
+```
+
+**Two-stage parse.** Because the option set depends on `--template`, the
+orchestrator parses in two phases (§6 steps 7–9):
+
+1. **Stage A — discover the template.** Parse with the built-in options only
+   (which include `--template`). Extract `--template` value.
+2. **Stage B — hydrate + re-parse.** Resolve the template against the
+   listed catalog (§6 step 7), call `TemplateOptionHydrator.Hydrate(template)`,
+   attach the hydrated options to a second parser, re-parse the original
+   argv. Stage-B `--help` shows the union.
+
+`dotnet new <name>` uses the same two-stage trick; the System.CommandLine
+pattern is well-trodden.
+
+**No `-p key=value`.** Earlier drafts proposed a single repeatable
+`--prop key=value` option as a fallback for un-hydrated prompts. Resolved
+(2026-05-27): every prompt hydrates as a real `Option<T>`. There is no
+catch-all key/value bag. If a template needs an input, it appears as a
+first-class option.
+
+### 4.6 Profile integration
+
+Before resolving a provider, `NewCommand` calls
+`IProfileResolver.ResolveAsync` ([[wcdesign §3.17]]). If the resolved profile
+has `SupportedRuntimes`, the chosen provider's `Stack` must appear in that
+list. Otherwise, render:
+
+```
+The active profile `<name>` doesn't support runtime `<stack>`.
+Supported runtimes: <comma-separated list>.
+Run `func profile set <other-profile>` or `func profile list` to choose another.
+```
+
+→ exit 1.
+
+`func new` does **not** accept a `--profile` override or `--offline` flag (D11).
+The active profile is resolved silently via the precedence chain above;
+profile selection is a project-level pin set by `func profile set`, not a
+per-scaffold decision. Profile-source refresh (the `--offline` axis on
+`func run`) is irrelevant at scaffold time — the resolved profile is already
+in hand, and no scaffold output depends on a fresh remote refresh.
+
+### 4.7 Language resolution
+
+A stack can support multiple languages (dotnet: C#/F#; node: JS/TS). `func new`
+derives the language by **consuming `IOptionsMonitor<StackOptions>` from DI**
+and calling `.Get(workingDirectory.FullName)`. That snapshot is populated by
+`StackOptionsSetup` (`IConfigureNamedOptions<StackOptions>`, registered in
+`CliHostFactory`) at the time the snapshot is first requested for that
+directory — `StackOptionsSetup` is the **only** code path that reads
+`.func/config.json` for the `stack` section, and it does so via `IConfiguration`
+binding. **`func new` never opens `.func/config.json` itself.** This mirrors
+the established pattern for project-scoped config consumers
+(`ProfileResolver`, `SetupRunner`, `ProfileListCommand` all inject
+`IOptionsMonitor<ProjectProfileOptions>` and read via `.Get(projectDirectory)`).
+
+There is **no `--language` flag on `func new`, no interactive prompt, no
+filesystem fingerprinting**: `func init` already settled the language and
+persisted it in `.func/config.json`; the options pipeline has already
+materialised it into `StackOptions.Language`; `func new` is a plain reader
+of that snapshot (D10).
+
+`InitCommand` writes the key conditionally
+(`src/Func/Commands/InitCommand.cs:266`):
+
+```csharp
+if (!string.IsNullOrWhiteSpace(language))
+{
+    stackConfig[CliConfigurationNames.StackLanguageKey] = language;
+}
+```
+
+and **omits** `stack.language` when the stack only supports one language
+(PR #5125 — see Constants `CliConfigurationNames.StackLanguageKey = "language"`).
+
+**Injection shape** (concrete, mirroring `ProfileResolver`):
+
+```csharp
+internal sealed class NewCommandRunner(
+    IInteractionService interaction,
+    IFunctionsProjectResolver projectResolver,
+    IProfileResolver profileResolver,
+    IOptionsMonitor<StackOptions> stackOptions,           // ← DI-bound; no file read here
+    ITemplateEngineProviderRegistry engineProviders,
+    /* … */)
+{
+    public async Task<int> ExecuteAsync(NewInvocation invocation, CancellationToken ct)
+    {
+        // … step 5 (Language resolution):
+        string projectDirectory = Path.GetFullPath(invocation.WorkingDirectory.FullName);
+        StackOptions stack = stackOptions.Get(projectDirectory);
+        string? resolvedLanguage = ResolveLanguage(stack, activeStackId, supportedLanguages);
+        // …
+    }
+}
+```
+
+**Resolution rules** (single read of the bound options snapshot, no fallback chain):
+
+1. Read `StackOptions.Language` via
+   `IOptionsMonitor<StackOptions>.Get(workingDirectory.FullName)` (DI-bound;
+   no file I/O at this step).
+2. If non-null/non-empty → use it.
+3. If null/empty **and** the active stack is single-language (per the
+   `IProjectInitializer.SupportedLanguages` list for the active stack) →
+   substitute that single language. This mirrors `InitCommand`'s
+   omit-on-single-language behaviour (PR #5125).
+4. If null/empty **and** the active stack is multi-language → hard error.
+   The project is multi-language but `stack.language` is missing. Exit 1:
+
+   ```
+   Cannot determine language for stack '<stack>' in '<path>'.
+   `stack.language` is missing from .func/config.json — run 'func init'
+   to scaffold the project (which writes the language) before adding
+   functions.
+   ```
+
+**Per-stack expected values** (canonical ids — match what `InitCommand` /
+`IProjectInitializer.SupportedLanguageAliases` accept):
+
+| Stack | Multi-language? | `stack.language` values written by `func init` |
+|---|---|---|
+| dotnet | yes | `csharp` / `fsharp` (omitted only if the workload genuinely supports one language at install time) |
+| node | yes | `javascript` / `typescript` |
+| python | no — single-language | omitted by `InitCommand`; CLI substitutes `python` |
+| powershell | no | omitted; CLI substitutes `powershell` |
+| java | no | omitted; CLI substitutes `java` |
+| custom | no | omitted; CLI substitutes `custom` |
+| go (future) | no | omitted; CLI substitutes `go` |
+
+**Why options-binding instead of file-read or init-artifact fingerprinting
+(revisits D10).**
+The init contract — `func init --language typescript` for a Node-TS
+project — already persists the user's chosen language in
+`.func/config.json` via `InitCommand.WriteCliConfigurationFile`. The CLI's
+existing `IConfiguration` pipeline + `StackOptionsSetup` already binds that
+value into `StackOptions.Language`. Consuming the bound snapshot via
+`IOptionsMonitor<StackOptions>.Get(...)`:
+
+- **Avoids opening a file we've already read.** The DI options pipeline
+  is the single read path; per-call file I/O would duplicate work and
+  bypass the options system's caching/diagnostics surface.
+- **Matches the codebase convention.** AGENTS.md mandates options binding
+  over direct `IConfiguration` reads (let alone direct `File.ReadAllText`);
+  `ProfileResolver` / `SetupRunner` / `ProfileListCommand` already inject
+  `IOptionsMonitor<ProjectProfileOptions>` to the same effect.
+- **Skips the file-existence checks** (`tsconfig.json`, `*.csproj` /
+  `*.fsproj`) and their edge cases (mixed-language repos, missing markers,
+  contradictory markers — see legacy Q-Lang-2).
+- **Skips the `IStackLanguageDetector` per-stack seam** and its
+  registration ceremony.
+- **Eliminates drift** between what `func init` chose and what `func new`
+  re-derives — there's only one read path.
+
+`StackOptions.Language` IS the in-memory view of the persistence layer.
+`func new` is a strict reader of that view; it never opens `.func/config.json`
+itself.
+
+**No persistence write from `func new`.** Unchanged from §2: `func new`
+never mutates `.func/config.json`. The single author of the file is
+`func init` (today) or a future `func config` verb. If a user deletes
+`.func/config.json` outright, the bound `StackOptions` is empty
+(`Runtime` and `Language` both `null`) — for multi-language stacks
+`func new` errors with the same hint pointing at `func init`.
+
+### 4.8 Templates workload selection and bundle compatibility
+
+Once the provider is picked (§4.3) and the language is resolved (§4.7),
+`func new` selects exactly one **installed templates content workload** to
+source the template payload from. Selection is split across two concerns
+owned by the templates-workload-spec:
+
+- **Channel match** — pick the templates workload pkg whose prerelease
+  label matches the project's bundle channel
+  (templates-workload-spec.md §4.4.2).
+- **Min-bundle compatibility** — within the channel-matched pkg, verify
+  the project's resolved bundle version satisfies the templates workload's
+  declared `minBundleVersion`
+  (templates-workload-spec.md §4.4.4).
+
+This spec owns *when* the checks fire (pipeline placement and ordering),
+*what* the user sees (failure variants and hint text), and *which*
+`IExtensionBundleResolver` / templates-registry seams the orchestrator
+calls. The data shapes (`workload.json`, sibling
+`content/templates-workload.json`, nuspec `minBundle:` tag) live in the
+templates-workload-spec.
+
+#### 4.8.1 Channel match (Node and Python)
+
+DotNet templates workloads have **no channel axis** (no extension-bundle
+dependency — templates-workload-spec.md §4.4.3); the DotNet path skips this
+sub-step. Node and Python perform the following:
+
+1. **Read the project's bundle id.** Parse `host.json`'s
+   `extensionBundle.id`. If `extensionBundle` is absent or `id` is
+   missing, `func new` errors with a hint pointing at extension-bundle
+   configuration (no implicit default).
+2. **Map id → templates channel** via the table in
+   templates-workload-spec.md §4.4.2:
+
+   | `host.json` `extensionBundle.id` | Templates channel (prerelease label) |
+   |---|---|
+   | `Microsoft.Azure.Functions.ExtensionBundle` | stable (no label) |
+   | `Microsoft.Azure.Functions.ExtensionBundle.Preview` | `-preview` |
+   | `Microsoft.Azure.Functions.ExtensionBundle.Experimental` | `-experimental` |
+
+3. **Enumerate installed templates workload pkgs** for the active stack
+   (`Azure.Functions.Cli.Workloads.Templates.<stack>`) from the workload
+   registry.
+4. **Filter to the channel-matched subset** — prerelease label of the pkg
+   version must equal the channel from step 2. **No cross-channel
+   fallback** (a stable templates pkg does not satisfy an experimental
+   project; templates-workload-spec.md §4.4.2).
+5. **Pick the highest** version from the channel-matched subset.
+
+If the channel-matched subset is empty, fail with
+`NoTemplatesWorkloadForChannel(stack, channel, suggestedPackageId, suggestedVersion)`.
+The hint text identifies the specific channel-suffixed pkg the user needs
+(see §5.5.3 row "no installed templates workload matches project's bundle
+channel"). The hint shape:
+
+```
+No installed templates workload matches this project's bundle channel
+(`<bundle-id>` → channel `<channel>`).
+Install one with:
+  func workload install Azure.Functions.Cli.Workloads.Templates.<stack> --version <ver-with-channel-suffix>
+Or change `host.json` `extensionBundle.id` if the channel was set in error.
+```
+
+> **Pack-time channel pre-filter (Node only).** Per
+> templates-workload-spec.md §4.3 / §6.1, the Node templates workload's
+> pack pipeline already filters its `templates.json` against the channel's
+> authoritative bundle binding set (via HTTP-Range extraction of
+> `bin/extensions.json` from the channel's latest listed bundle in
+> `index.json`). Templates whose required bindings aren't present in the
+> channel are dropped at **pack time**. The catalog the channel-matched
+> Node workload carries on disk is therefore already a per-channel
+> subset — `func new` does not re-run the binding-availability check at
+> invocation time. This is a workload-build guarantee; the
+> `minBundleVersion` check in §4.8.2 remains the authoritative runtime
+> compatibility gate (it catches the cross-axis case of a project whose
+> resolved bundle is older than the templates workload's compatibility
+> floor, regardless of binding coverage).
+
+#### 4.8.2 Min-bundle compatibility check (Node and Python)
+
+After channel match succeeds and a single templates workload is selected,
+the orchestrator reads its sibling manifest
+`content/templates-workload.json` (templates-workload-spec.md §5.2) and
+extracts `minBundleVersion` (a NuGet version range, e.g. `[4.18.0, )`).
+
+The orchestrator then asks `IExtensionBundleResolver` ([[wcdesign §3.9]])
+for the project's resolved bundle version and compares:
+
+| Comparison result | Behaviour |
+|---|---|
+| Resolved bundle version ∈ `minBundleVersion` range | Continue. |
+| Resolved bundle version ∉ range (too old) | Fail with `MinBundleVersionTooOld(installedBundle, requiredRange, templatesWorkloadVersion)`. Exit 1. |
+| `IExtensionBundleResolver` returns `WorkloadMissing` / `EmptyIntersection` (no bundle resolvable at all) | Fail with `MissingExtensionBundle(stack, suggestedBundleId)`. Exit 1. |
+
+The min-bundle check is fail-fast at the pipeline stage in §6, **before**
+template hydration and **before** scaffolding. Catching the mismatch
+before any I/O keeps the partial-write window small.
+
+> The original templates-workload-spec.md §4.4.4 hedges "warning or
+> error." This spec **resolves to error** for v1 — a min-bundle violation
+> is exactly the kind of silent-failure-later we want to surface
+> immediately. A future `--ignore-min-bundle` opt-out can soften to a
+> warning if real users hit false positives.
+
+#### 4.8.3 DotNet templates workload
+
+DotNet's selection path is degenerate:
+
+- **No channel.** Pick the highest installed
+  `Azure.Functions.Cli.Workloads.Templates.DotNet` version.
+- **No `minBundleVersion`.** DotNet templates have no extension-bundle
+  dependency; the check is skipped entirely.
+- **Hive provisioning.** §6 step 11b for DotNet reduces to "verify the
+  `source.json`-pinned NuGet template pkg is provisioned into the dotnet
+  template hive." Provisioning happens at `func workload install` time
+  (templates-workload-spec.md §6.3); if the hive is empty (e.g. install
+  failed silently), `func new` errors with a re-install hint.
+
+## 5. CLI surface
+
+### 5.1 Command registrations
+
+| Invocation | Notes |
+|---|---|
+| `func new` | Primary. Built-in command. The only registered verb for the scaffold-one-function flow. |
+
+The legacy `func function new` / `func function create` aliases from v4 are
+**not carried forward**. v5 has a single canonical verb; users who type the
+old aliases see the standard "unknown command" hint pointing at `func new`
+(see §7 Migration).
+
+### 5.2 Options
+
+Built-in (declared on `NewCommand`, visible in top-level `func new --help`):
+
+| Option | Alias | Type | Purpose |
+|---|---|---|---|
+| `--name` | `-n` | `string?` | Function name. Defaults to template's `DefaultFunctionName`. |
+| `--template` | `-t` | `string?` | Template id. If omitted in TTY, interactive picker. |
+| `--force` | — | `bool` | Overwrite existing files. |
+| `--non-interactive` | — | `bool` | Refuse to prompt; exit 1 if any input is missing. |
+| `--output` | — | `enum {plain, json}` | Output mode (mirrors `func setup`). |
+
+Path positional argument (inherited via `AddPathArgument()`): the project
+directory. Defaults to cwd. **Note:** `func new` does not "create" a project —
+this is just the working directory.
+
+**No legacy positional template shortcut.** v4's `func new HttpTrigger`
+(first non-flag token = template id) is not carried forward — see §8 Q7.
+The template id is supplied only via `--template <id>` / `-t <id>`. The
+positional slot is reserved for the path. Typing the v4 form yields a
+standard System.CommandLine parse error pointing the user at `--help`;
+the §7 Migration table records the break.
+
+**Template-hydrated options** (visible only under
+`func new --template <id> --help`). Produced by the engine-agnostic
+`TemplateOptionHydrator.Hydrate(template)` from each template's
+`Metadata.UserPrompts` (§4.5). Examples surfaced by the v2 bundle metadata
+(Node, Python) and `dotnet-templates.json` (DotNet):
+
+| Option | Provider / template | Source field |
+|---|---|---|
+| `--auth-level` | HTTP triggers (Node, Python) | `UserPrompt[id=authLevel]` |
+| `--methods` | HTTP triggers | `UserPrompt[id=methods]` |
+| `--route` | HTTP triggers | `UserPrompt[id=route]` |
+| `--schedule` | Timer triggers | `UserPrompt[id=schedule]` |
+| `--queue-name`, `--connection` | Queue / Service Bus triggers | `UserPrompt[id=queueName]`, `connection` |
+| `--file` | Python v2 templates | Per-template prompt on each v2 entry |
+| `--namespace`, `--access-rights` (`--auth-level` alias via `dotnetcli.host.json`) | DotNet HTTP triggers | `dotnet-templates.json` `parameters[name=namespace \| AccessRights]` (templates-workload-spec.md §5.3.1) |
+
+The legacy `--csx` flag is **not** carried forward as a top-level option,
+and `.csx` script-mode .NET functions are not scaffoldable from v5 at
+all — see §8 Q6 for the full rationale (no isolated-worker `.csx`
+programming model; in-process .NET is out of scope per vnext-design
+Part IX). Users on `.csx` stay on v4 tooling until the in-process /
+script-mode story is revisited.
+
+#### 5.2.1 Available templates section in top-level `--help`
+
+Top-level `func new --help` stays **template-agnostic** for option flags
+(§4.5 / §8 Q5) — per-template `Option<T>` instances only appear under
+`func new --template <id> --help`. To still give the user a useful "what
+can I scaffold?" signal in plain `func new --help`, the help renderer
+injects a per-stack **Available templates** section after the built-in
+`Options:` block. This section renders catalog rows only — no option flags,
+no per-template detail — and shares its data source with
+`func templates list` (§5.5), so the two surfaces stay in lockstep.
+
+```
+$ func new --help
+Description:
+  Scaffold a new Azure Function from an installed template.
+
+Usage:
+  func new [options] [<path>]
+
+Options:
+  -n, --name <name>            ...
+  -t, --template <template>    ...
+  --force                      ...
+  --non-interactive            ...
+  --output <plain|json>        ...
+  -?, -h, --help               Show help and usage information.
+
+Available templates (stack: python):
+  http        HTTP trigger             Function triggered by HTTP requests.
+  timer       Timer trigger            Function triggered on a schedule (NCRONTAB).
+  queue       Queue trigger            Function triggered by Azure Storage Queue messages.
+  blob        Blob trigger             Function triggered by Azure Blob Storage events.
+  …
+  Run 'func new --template <name> --help' for template-specific options,
+  or 'func templates list' for the full catalogue.
+```
+
+Rendering rules:
+
+- **Three columns** (short name, display name, description), truncated to
+  terminal width with `…`. Same layout as `func templates list` plain
+  output (§5.5.2) so the two read identically.
+- **Stack header** mirrors §5.5.2. `func new` requires an init'd project
+  (§4.4), so the stack is always resolved — there is no stackless rendering
+  path on this surface.
+- **Tab completion.** `func new --template <TAB>` reuses the same catalog
+  as the help section by wiring `Option<string>.CompletionSources` to the
+  engine provider registry (§4.1). Same data, same source of truth.
+- **Engine-agnostic.** The renderer reads `FunctionTemplateInfo` records
+  aggregated across every `ITemplateEngineProvider.ListTemplatesAsync`
+  for the active stack; for DotNet that data ultimately comes from
+  `dotnet-templates.json`, for Node/Python from the workload-shipped
+  `content/v2/templates/templates.json`. The renderer itself doesn't care
+  which engine emitted a row.
+- **Per-template options remain under `--template <id> --help`.** This
+  section is a discovery aid, not an option-flag dump. The reasons
+  per-template option hydration cannot work at the top level (option-name
+  collisions across templates, help-text explosion, stage-A parser can't
+  pick a hydration target before `--template` is bound) are unchanged
+  from §4.5 / §8 Q5.
+
+### 5.3 `<trigger> help` special syntax
+
+Legacy: `func new HttpTrigger help` printed trigger-specific help (JS/TS/Python
+only). We **drop** that syntax. Per-template options surface via
+`func new --template HttpTrigger --help` (built-in `--help` over the
+metadata-hydrated options, §4.5) and `func templates list` for the catalogue
+(§5.5).
+
+(Captured as a behavioural break vs main; surfaces in §7 Migration.)
+
+### 5.4 Decision tree
+
+```
+func new [path]
+│
+├─ ResolveProfileAsync (.func/config.json defaultProfile → user prefs → built-in)
+│
+├─ ResolveProjectAsync (IFunctionsProjectResolver)
+│    NotCreated      → render hint, exit 1
+│    Failed          → render failure, exit 1
+│    Created(project) → project.StackName is the active stack
+│
+├─ ValidateStackAgainstProfile (ResolvedProfile.SupportedRuntimes)
+│    mismatch → render hint, exit 1
+│
+├─ SelectTemplatesWorkload (§4.8)                  (formerly two stages — engine providers are CLI-internal, not stack-keyed)
+│    Node/Python:
+│      read host.json extensionBundle.id → channel
+│        missing → render extension-bundle-config hint, exit 1
+│      filter installed Templates.<stack> pkgs by prerelease label == channel
+│        empty → NoTemplatesWorkloadForChannel → render install hint, exit 1
+│      pick highest version from channel-matched subset
+│    DotNet:
+│      pick highest installed Templates.DotNet (no channel)
+│        none → render install hint, exit 1
+│
+├─ ResolveLanguage (§4.7)
+│    inject IOptionsMonitor<StackOptions>; read .Get(workingDirectory.FullName).Language
+│      non-null → use it
+│      null && active stack is single-language → substitute stack's only language
+│      null && active stack is multi-language → exit 1 ("run 'func init' first;
+│                                                       stack.language missing")
+│
+├─ ListTemplates(selectedWorkload, language)         → aggregate across all engine providers; each template carries its EngineId
+│    (no list-and-exit branch — discovery lives on `func templates list`)
+│
+├─ ResolveTemplate                                    (stage-A parse)
+│    --template given → match by Id (case-insensitive)
+│    not given        → interactive picker (TemplatePicker) or exit 1 if --non-interactive
+│
+├─ HydrateTemplateOptions + re-parse                  (stage-B parse, §4.5)
+│    TemplateOptionHydrator.Hydrate(template)         (engine-agnostic; reads template.Metadata.UserPrompts)
+│    re-parse argv with hydrated options attached
+│
+├─ ResolveFunctionName
+│    --name given → use it
+│    not given    → prompt (default = Template.DefaultFunctionName ?? Template.Id)
+│
+├─ CollectRemainingInputs (interactive fallback)
+│    every hydrated option is parsed in stage B;
+│    missing required values without defaults → prompt or exit 1 if --non-interactive
+│
+├─ ValidateBundlePresence (§4.8.2, Node/Python only)
+│    IExtensionBundleResolver returns WorkloadMissing/EmptyIntersection
+│      → MissingExtensionBundle → render `func setup` hint, exit 1
+│
+├─ ValidateMinBundleVersion (§4.8.2)
+│    Node/Python:
+│      read selectedWorkload's content/templates-workload.json
+│      resolvedBundleVersion ∉ minBundleVersion range
+│        → MinBundleVersionTooOld → render version-mismatch hint, exit 1
+│    DotNet:
+│      verify source.json-pinned pkg is provisioned into dotnet template hive
+│        missing → render re-install hint, exit 1
+│
+├─ engineProviders[template.EngineId].ApplyAsync(NewContext, ParseResult)
+│    Created       → render file list, exit 0
+│    AlreadyExists → render "use --force" hint, exit 1
+│    Failed        → render typed failure, exit 1
+│
+└─ (post-deploy hints removed — vnext drops the programming-model concept; see §7)
+```
+
+### 5.5 Template discovery — `func templates list`
+
+Decided 2026-05-27: discovery is a **separate top-level command**, not a flag
+on `func new`. This matches main's existing surface
+(`ListTemplatesAction` registered under `Context.Templates` →
+`func templates list`) and keeps `func new` strictly a scaffold-one-function
+verb.
+
+`func templates list` is its own built-in command (`TemplatesListCommand`,
+sibling to `NewCommand` in `src/Func/Commands/`). It enumerates templates
+through the same engine provider registry the orchestrator uses
+(`ITemplateEngineProviderRegistry` — see §4.1 and §6 step 6), aggregating
+across every engine provider for the active stack so the catalogue
+surfaced to the user is always the catalogue `func new` would actually
+scaffold from.
+
+#### 5.5.1 Surface
+
+```
+func templates list [path]
+  --output {plain|json}    output mode (default: plain)
+```
+
+No `--stack <id>` override (§5.5.5: `func templates list` requires an
+init'd Functions project; the stack is read from `.func/config.json`
+`stack.runtime`). No `--template <id>` filter (one-template-at-a-time
+isn't a list query — if we add per-template detail later it's a
+separate verb). The single positional `[path]` is the project directory
+(defaults to cwd), passed through to `IOptionsMonitor<StackOptions>.Get(...)`
+exactly like §4.7.
+
+#### 5.5.2 Default output (plain)
+
+```
+$ func templates list
+Templates for stack: python  (language: Python)
+
+  NAME                     TRIGGER       DESCRIPTION
+  HttpTrigger              http          Function triggered by HTTP requests.
+  TimerTrigger             timer         Function triggered on a schedule (NCRONTAB).
+  QueueTrigger             queue         Function triggered by Azure Storage Queue messages.
+  BlobTrigger              blob          Function triggered by Azure Blob Storage events.
+  EventHubTrigger          eventhub      Function triggered by Azure Event Hubs events.
+  CosmosDBTrigger          cosmosdb      Function triggered by changes in Azure Cosmos DB.
+  ServiceBusQueueTrigger   servicebus    Function triggered by Service Bus queue messages.
+  ServiceBusTopicTrigger   servicebus    Function triggered by Service Bus topic subscriptions.
+  KafkaTrigger             kafka         Function triggered by Kafka messages.
+
+Create one with:
+  func new --template <NAME> --name <function-name>
+```
+
+Layout rules:
+- Three columns: `NAME`, `TRIGGER`, `DESCRIPTION`. `LANGUAGE` lives in the
+  header, not per row — when one language is resolved the column is noise.
+  For DotNet projects the resolver picks a single language (C# or F#) from
+  `stack.language` (§4.7); the catalog renderer dedupes adjacent records
+  sharing `dotnet-templates.json` `groupIdentity` so each `HttpTrigger`
+  (etc.) shows once even when both C# and F# variant records are installed
+  (templates-workload-spec.md §5.3.1).
+- `NAME` is the provider-scoped template id (`HttpTrigger`,
+  `python.HttpTrigger` — depending on the §8 Q-namespace outcome). For
+  Node/Python this is the V2 `NewTemplate.id`; for DotNet it is the
+  `dotnet-templates.json` `id` (= `shortNames[0]`).
+- `DESCRIPTION` is the template metadata's existing `Description` field
+  (already in v2 `NewTemplate[]` — no new schema needed). For the DotNet
+  provider, `DESCRIPTION` is the `description` field on each
+  `dotnet-templates.json` entry (templates-workload-spec.md §5.3.1), which
+  was hydrated at workload build time from the upstream `template.json` —
+  same data, no run-time `dotnet new list` shell-out.
+  Truncated to terminal width with `…`; full text via `--output json`.
+- **Node catalog is pre-filtered per channel at workload pack time**
+  (templates-workload-spec.md §6.1). Templates whose required bindings
+  aren't satisfied by the channel's authoritative bundle are dropped at
+  pack time, so the rows surfaced by `func templates list` /
+  `func new --help` for a Node project reflect only templates that should
+  scaffold cleanly against the project's resolved bundle. Renderer-side
+  hiding is therefore not needed — the workload already shipped the right
+  subset.
+
+#### 5.5.3 Empty / error cases
+
+| Condition | Output | Exit |
+|---|---|---|
+| No `.func/config.json` resolvable at `<path>` (uninitialized directory; §5.5.5) | "`func templates list` needs a Functions project. Run `func init` first to choose a stack and language." | 1 |
+| `StackOptions.Runtime` is null/empty (no `stack.runtime` in `.func/config.json`) | "`func templates list` needs a stack pinned in .func/config.json. Run `func init` first." | 1 |
+| No template providers registered | "No templates available. Install a templates workload: `func workload install Azure.Functions.Cli.Workloads.Templates.<stack>`." | 1 |
+| Provider registered but content workload missing | Per-stack hint pointing at the specific package id. | 1 |
+| No installed templates workload matches project's bundle channel (Node/Python, §4.8.1) | "No installed templates workload matches this project's bundle channel (`<bundle-id>` → channel `<channel>`). Install: `func workload install Azure.Functions.Cli.Workloads.Templates.<stack> --version <ver-with-channel-suffix>`. Or change `host.json` `extensionBundle.id` if the channel was set in error." | 1 |
+| Selected templates workload's `minBundleVersion` newer than project's resolved bundle (Node/Python, §4.8.2) | "Installed templates workload `<pkg> <ver>` requires extension bundle in range `<range>`, but the project resolves to `<resolvedBundleVersion>`. Update the bundle range in `host.json` or install an older templates workload pkg version." | 1 |
+| `StackOptions.Language` is null/empty and the active stack is multi-language (`stack.language` missing from `.func/config.json`) | "Cannot determine language for stack `<stack>` in `<path>`. `stack.language` is missing from .func/config.json — run `func init` to scaffold the project before adding functions." | 1 |
+| Provider matches but returns 0 templates after filtering | Print the header + "(no templates match the current filters)" | 0 |
+
+#### 5.5.4 JSON output
+
+`--output json` emits a single envelope (not NDJSON), since `list` is a
+finite, ordered query:
+
+```jsonc
+{
+  "stack": "python",
+  "language": "Python",
+  "templates": [
+    {
+      "id": "HttpTrigger",
+      "displayName": "HTTP trigger",
+      "triggerKind": "http",
+      "languages": ["Python"],
+      "engineId": "v2",
+      "description": "Function triggered by HTTP requests.",
+      "defaultFunctionName": "HttpTrigger",
+      "requiresExtensionBundle": true,
+      "minBundleVersion": "4.0.0",
+      "options": [
+        { "name": "--auth-level", "type": "enum", "values": ["function","anonymous","admin"], "default": "function" }
+      ],
+      "prompts": [ /* metadata-derived, see §4.5 */ ]
+    }
+  ]
+}
+```
+
+Tooling (IDE plugins, autocompletion, `gh`-style `--format` consumers) reads
+JSON. The plain output stays catalog-only (no per-template detail block);
+template options live on `func new --template <id> --help` (§4.5).
+
+**DotNet entries** carry additional fields from `dotnet-templates.json`
+(templates-workload-spec.md §5.3.1) so tooling can dedupe and dispatch
+without re-parsing the workload payload: `identity` (stable id used by
+the upstream dotnet template engine), `groupIdentity` (shared across
+C#/F# variants of the same template — tooling that wants a single row
+per HttpTrigger collapses on this), `classifications`, and
+`shortNames[]`. Node/Python entries do not carry these fields.
+
+#### 5.5.5 Resolution gates
+
+`func templates list` **requires an init'd Functions project**
+(`.func/config.json` resolvable from `[path]`, with at minimum
+`stack.runtime` set). The stack is read from `StackOptions.Runtime` via
+the same `IOptionsMonitor<StackOptions>.Get(workingDirectory.FullName)`
+path §4.7 uses for language. Language follows the same rules as §4.7:
+read `StackOptions.Language`, substitute the stack's canonical
+single-language constant when the key is omitted (PR #5125), hard-error
+on multi-language stacks when missing. For Node/Python the templates
+workload is selected via the channel-match algorithm in §4.8.1 against
+`host.json` `extensionBundle.id`; for DotNet the highest installed
+`Workloads.Templates.DotNet` pkg is picked (§4.8.3). The catalogue
+surfaced to the user is therefore always the catalogue `func new` would
+actually scaffold from.
+
+**No stackless run, no `--stack` override.** Three reasons:
+(a) Channel resolution requires `host.json` `extensionBundle.id`
+(§4.8.1); without a project there is no bundle id and no defined
+channel-selection algorithm.
+(b) Min-bundle compatibility (§4.8.2) cannot be evaluated without a
+resolved bundle version.
+(c) `func new` itself requires a project (§4.4); a discovery surface
+that lists templates the user cannot then scaffold is misleading.
+Users browsing "what templates exist for stack X" before initialising a
+project should use `func quickstart list` (a separate command that
+ships its own catalogue, has no per-project channel concept, and
+explicitly targets the "evaluating which stack to pick" UX).
+
+If `[path]` does not resolve to an init'd project, `func templates list`
+exits 1 with the standard hint pointing at `func init` (see §5.5.3
+"No `.func/config.json` resolvable…" row). This matches `func new`'s
+project-gate posture (§4.4) so the two commands fail in the same way for
+the same reason.
+
+> This **revises** an earlier draft (and v4's `ListTemplatesAction`,
+> which ran in any directory). v4 had no channel concept; v5 does, and
+> "show a stackless catalogue" has no coherent algorithm without a
+> project bundle. The constraint is intentional; see §8 Q11 for the
+> rationale and §7 for the migration note.
+
+## 6. Orchestration pipeline (CLI-side)
+
+```
+NewCommandRunner.ExecuteAsync
+ │
+ ├── 1. ResolveProfile             (IProfileResolver)
+ ├── 2. ResolveProject             (IFunctionsProjectResolver)
+ ├── 3. ValidateStack              (against ResolvedProfile.SupportedRuntimes)
+ ├── 4. SelectTemplatesWorkload    (§4.8: channel match for Node/Python; degenerate for DotNet)
+ │        Fail: NoTemplatesWorkloadForChannel(stack, channel, …)
+ ├── 5. ResolveLanguage            (§4.7: inject IOptionsMonitor<StackOptions>; read .Get(workingDirectory.FullName).Language — DI-bound, no file I/O; for single-language stacks fall back to the stack's canonical language when omitted; for multi-language stacks a missing value → exit 1 with "run func init first")
+ ├── 6. ListTemplates              (aggregate across every ITemplateEngineProvider for the active stack, scoped to step-4 workload) — filtered by language
+ ├── 7. ResolveTemplate            (stage-A parse: --template or interactive picker)
+ ├── 8. HydrateTemplateOptions     (TemplateOptionHydrator.Hydrate(template) — engine-agnostic)
+ ├── 9. ReParseWithHydration       (stage-B parse: built-ins + hydrated options against original argv)
+ ├── 10. ResolveFunctionName       (stage-B --name, then prompt fallback)
+ ├── 11a. ValidateBundlePresence   (IExtensionBundleResolver: bundle resolvable?)
+ │         Fail: MissingExtensionBundle(stack, suggestedBundleId)
+ ├── 11b. ValidateMinBundleVersion (§4.8.2: resolved bundle version ∈ workload's minBundleVersion range?)
+ │         Fail: MinBundleVersionTooOld(installedBundle, requiredRange, templatesWorkloadVersion)
+ │         (DotNet: skipped — no minBundleVersion declared. DotNet substitutes a hive-provisioning check.)
+ ├── 12. ApplyAsync                (dispatch by template.EngineId → engineProviders[EngineId].ApplyAsync)
+ └── 13. Render result             (NewCommandRenderer; honours --output)
+```
+
+Steps 1–5 reuse existing CLI services. Step **4** is the
+templates-workload selection stage detailed in §4.8 — for Node/Python it
+maps `host.json` `extensionBundle.id` → templates channel and picks the
+highest installed templates pkg whose prerelease label matches, with no
+cross-channel fallback; for DotNet it picks the highest installed
+`Azure.Functions.Cli.Workloads.Templates.DotNet` (no channel axis). The
+selected workload is what step 6 lists templates from — so subsequent
+steps operate on a single, fixed templates payload. Step **5** runs the
+language-resolution rule documented in §4.7: inject
+`IOptionsMonitor<StackOptions>` from DI and call
+`.Get(workingDirectory.FullName).Language`. `StackOptionsSetup` is the
+single code path that opens `.func/config.json` for the `stack` section;
+`func new` consumes the bound snapshot and never re-reads the file. When
+the key is present, use it; when omitted on a single-language stack, the
+CLI substitutes the stack's canonical language (PR #5125 — `InitCommand`
+intentionally omits `stack.language` for single-language stacks). When
+omitted on a multi-language stack (dotnet, node) it is a hard error
+pointing at `func init`. No prompt, no `--language` flag, no filesystem
+fingerprinting: the options pipeline is the single source of truth (D10).
+
+Steps **7–9 are the new core**:
+two-stage parsing. Stage A parses the built-in option set only (which is
+enough to discover `--template`); stage B asks the engine-agnostic
+`TemplateOptionHydrator` to hydrate per-template options from
+`template.Metadata.UserPrompts` and re-parses the original argv with the
+union. `dotnet new <name>` uses the same pattern. Step **12** then
+dispatches by `template.EngineId` to the matching engine provider's
+`ApplyAsync` — V2 runs the job/action DSL writing per-action `FilePath`
+from the inline `files` map; DotNet shells out via `IDotnetCliRunner`
+against the hive provisioned at workload install time from `source.json`
+(templates-workload-spec.md §6.3).
+
+Step **11a** reuses `IExtensionBundleResolver` ([[wcdesign §3.9]]) when the
+template declares a binding that needs an extension bundle. If the resolver
+returns `WorkloadMissing` / `EmptyIntersection`, the new-command emits
+`MissingExtensionBundle` with a hint pointing at `func setup --profile <name>`.
+
+Step **11b** runs the **min-bundle enforcement** described in §4.8.2 against
+the templates workload selected in step 4b: read its sibling manifest
+`content/templates-workload.json`, extract `minBundleVersion`, and verify
+the project's resolved bundle version satisfies the range. A miss surfaces
+`MinBundleVersionTooOld` with the installed-version / required-range /
+templates-pkg-version triple so the user can choose between updating
+`host.json` or installing a different templates workload pkg version
+(§5.5.3). For DotNet, 11b is replaced by a hive-presence check: the
+`source.json`-pinned NuGet pkg must be provisioned in the dotnet template
+hive — failure points the user at re-running `func workload install`
+(templates-workload-spec.md §6.3).
+
+Both step-4 and step-11b run **before** any I/O against the user's
+project directory. Catching channel and min-bundle mismatches early keeps
+the partial-write window empty: if `func new` exits non-zero before step
+12 (engine dispatch / `ApplyAsync`), no files have been written or modified.
+
+**Interactive fallback.** A required hydrated option (no default, not supplied
+on argv) prompts via `IInteractionService` when `--non-interactive` is not set;
+otherwise the parser errors with `--<name> is required`. There's no separate
+"prompt loop" — every prompt is an `Option<T>`, and the parser is the only
+interaction surface.
+
+## 7. Compatibility / migration
+
+| Legacy (main) | vnext `func new` | Reason |
+|---|---|---|
+| Auto-runs `func init` if not initialised | Errors with hint to run `func init` first | #5057 made init stricter; auto-init hides state. |
+| Hard-rejects Java with "use Maven" | No provider registered → generic "no template provider" hint | Java provider can be added without changing the orchestrator. |
+| `--csx` forces legacy CSX path | Dropped (see §8 Q6). `.csx` script-mode functions are not scaffoldable on v5. | No isolated-worker `.csx` model; in-process .NET is out of scope per vnext-design Part IX item 9. |
+| `func new <trigger> help` (positional help) | Dropped — use `func new --template <id> --help` | Two-stage parse exposes every per-template option to native `--help`. |
+| `func new <template>` (positional template id as first non-flag token) | Dropped (see §8 Q7). Template id must be supplied via `--template <id>` / `-t <id>`; the positional slot is reserved for the path. | Avoids positional-vs-path ambiguity; keeps the two-stage parse simple; matches modern System.CommandLine conventions. |
+| `func templates list` runs in any directory (v4 `ListTemplatesAction`) | Requires an init'd Functions project — uninitialised directory exits 1 with a hint pointing at `func init` (§5.5.5 / §8 Q11). No `--stack` override. | v5's channel-resolution algorithm (§4.8.1) keys off `host.json` `extensionBundle.id`; a stackless catalogue has no defined channel selection. Users browsing stacks before initialising should use `func quickstart list` (separate command, no channels). |
+| `func function new` / `func function create` aliases | Dropped (see §5.1). Single canonical verb is `func new`. | One verb, one source of truth; legacy aliases produce a standard unknown-command hint pointing at `func new`. |
+| Installs missing NuGet extensions via `Metadata.Extensions` | Dropped — relies on extension bundles | Bundle resolver covers this in vnext. |
+| `_templatesManager.Deploy(...)` writes files directly | `provider.ApplyAsync(NewContext, ParseResult)` returns a result | Errors are typed (sealed hierarchy); writes happen behind the provider. |
+| Two prompt loops (`RunUserInputActions` for v2, ad-hoc for v1) | Single hydration: every prompt becomes a real `Option<T>` via the engine-agnostic `TemplateOptionHydrator.Hydrate(template)` (§4.5). The parser is the interaction surface. v5 templates workloads ship v2 only — the ad-hoc V1 loop is dropped along with the V1 engine. | One uniform CLI surface; same hydration for v2 (Node, Python) and DotNet. |
+| `IsNewPythonProgrammingModel()` / `IsNewNodeJsProgrammingModel()` heuristics select v2 vs v1 engine; `-4.x` template-id suffix routes Node v4 to a separate code path | Dropped. v5 templates workloads ship v2 templates only (templates-workload-spec.md §5.2); the legacy V1 `Files`-map engine is removed from vnext entirely. Engine is derived from the template payload's directory (`content/v2/` → V2, `content/dotnet-templates.json` at content root → DotNet; §4.3 / D9 Q-Eng-A). Workload publishers ship only current-generation templates (D9 Q-Eng-B). | One uniform routing rule; no runtime sniffs to maintain. |
+| `--programming-model` knob + post-deploy "Python v1 → v2" / "Node v3 → v4" upgrade messaging | Both dropped. No model flag, no migration nudge — workloads curate to "latest" and publish only current-generation templates (D9 Q-Eng-B). | Cleaner UX; legacy-model upgrade is a workload-version concern, not a per-`func new` axis. |
+| Language inferred from the first `--language`-like flag on `func new`; language asked anew on every invocation in some paths | Flag dropped. Language is **read** via DI from `IOptionsMonitor<StackOptions>.Get(workingDirectory.FullName).Language` — the bound view of `.func/config.json` `stack.language` (`StackOptionsSetup` is the single file-read path; `func new` consumes the snapshot). `func init` writes the value from **its** `--language` flag (PR #5125 omits the key for single-language stacks; `func new` substitutes the stack's canonical language in that case). `func new` requires an init'd project; a missing key on a multi-language stack → exit 1 pointing at `func init`. | One deterministic source of truth via the existing options pipeline; eliminates a redundant flag, the alias-resolution code path, the prompt loop, **and** any per-invocation file I/O. Matches the precedent in `ProfileResolver` / `SetupRunner` for `IOptionsMonitor<ProjectProfileOptions>`. |
+| No concept of templates-channel; bundle and templates were the same package | Templates ship as their own per-channel content workload; `func new` auto-matches the project's bundle channel (§4.8.1) with no cross-channel fallback. Missing match → `NoTemplatesWorkloadForChannel` with install hint. | Per templates-workload-spec.md §4.4.2; lets templates revisions ship independently of bundle releases. |
+| No `minBundleVersion` check at scaffold time | `func new` enforces the templates workload's `minBundleVersion` against the project's resolved bundle version (§4.8.2); violation → `MinBundleVersionTooOld` and exit 1 (no warning fallback in v1). | Per templates-workload-spec.md §4.4.4; catches binding compatibility issues before any file is written. |
+| `--profile <name>` and `--offline` mirrored from `func run` on every command | Dropped from `func new` and `func templates list`. Active profile is resolved silently from `.func/config.json defaultProfile → user prefs → built-in default`; stack-vs-profile gate still fires (pipeline step 3). Mismatch error hints at `func profile set <other>` / `func profile list`. | Scaffolds are static files — there is no scaffold-under-profile-X-then-run-under-Y use case. Profile is a project-level pin, not a per-invocation override; `--offline` only refreshed profile sources that scaffold output doesn't depend on. |
+
+Telemetry continuity: emit `cli.new.invoked` (stack, language, template id,
+engine id) plus `cli.new.duration` histogram and `cli.new.outcome`
+(created / already-exists / failed). Failure subtypes go on
+`cli.new.failure_kind`. The `engine id` axis lets us track v2 vs dotnet
+adoption without surfacing engine identity to users (D9 / Q-Eng-A).
+
+## 8. Open questions
+
+Promote to §4 once answered.
+
+- ✅ **Q1. `func new --list` vs `func templates list`. — RESOLVED 2026-05-27.**
+  Discovery lives only on `func templates list` (catalog-only — NAME / TRIGGER
+  / DESCRIPTION, §5.5). `func new --list` is **not** added. No `--detailed`
+  flag on `func templates list` either: per-template options surface on
+  `func new --template <id> --help` via two-stage hydration (§4.5). No
+  `func templates show <id>` either — `func new --template <id> --help` is
+  the per-template detail surface. Single source of truth for "what does this
+  template need."
+- ✅ **Q2. Are template-declared NuGet extension installs needed at all? — RESOLVED 2026-05-28.**
+  **Dropped entirely.** The legacy `Template.Metadata.Extensions` path
+  (which appended `<PackageReference>` entries to a project-local
+  `extensions.csproj`) serves zero v5 templates: Node and Python ship
+  v2-only templates whose bindings are delivered by the extension
+  **bundles workload** (`Workloads.ExtensionBundles`,
+  bundles-workload-spec.md); PowerShell stays on extension bundles in
+  v5; DotNet uses worker-SDK `<PackageReference>` entries that the
+  `dotnet new` template adds directly to the user's `.csproj`. There is
+  no `extensions.csproj` build step in a v5 project either — `func start`
+  resolves bindings entirely through the bundles workload at launch
+  time, not via a per-project NuGet restore. `func new` therefore does
+  **not** consult `Template.Metadata.Extensions` on vnext; if a workload
+  payload happens to carry the field, it is ignored. Workload publishers
+  should not author it in v5 templates.
+- ✅ **Q3. `Templates.V2` + `Templates.DotNet` — one assembly or two? — RESOLVED 2026-05-28.**
+  **Two separate CLI-internal csprojs**, project-referenced from
+  `Func.csproj`, named `Templates.V2` and `Templates.DotNet` per the
+  standard naming rule (avoiding the `Func.` prefix that's reserved for
+  the entry-point binary and its tests per AGENTS.md). Each project
+  hosts exactly one `ITemplateEngineProvider` plus its engine
+  implementation; each has its own paired test project
+  (`Templates.V2.Tests` / `Templates.DotNet.Tests`). Per-engine
+  isolation keeps each engine's quirks (V2's job/action DSL + `$(KEY)`
+  substitution, DotNet's `dotnet new` shellout + JSON catalog reader)
+  out of `Func.csproj`'s dependency graph and makes the engine boundary
+  explicit at the project-reference level. The legacy V1 engine project
+  (`Templates.V1`) is **not** part of vnext — v5 templates workloads
+  ship v2 only (templates-workload-spec.md §5.2).
+- ✅ **Q4. `IStackLanguageDetector` registration — bare or tagged? — RESOLVED 2026-05-28.**
+  Not applicable. `IStackLanguageDetector` is dropped from the vnext design
+  (D10 revised). Language resolution reads `.func/config.json`
+  `stack.language` directly via `StackOptions` (PR #5125's omit-on-single-
+  language behaviour drives the fallback); no per-stack detector seam is
+  needed. The remaining seams (`ITemplateEngineProvider`,
+  `IProjectInitializer`) are unaffected.
+- ✅ **Q5. `--prop key=value` vs hydrated `Option<T>` per prompt. — RESOLVED 2026-05-27.**
+  Every prompt hydrates as a real `Option<T>` via the engine-agnostic
+  `TemplateOptionHydrator.Hydrate(template)` (§4.5). No `-p`/`--prop`
+  catch-all. `--help` is self-documenting, autocompletion works, validation
+  runs through the parser. Pollution concern dissolved because hydrated
+  options only appear under `func new --template <id> --help` — top-level
+  `func new --help` stays template-agnostic (built-ins only).
+- ✅ **Q5b. Can `func new --help` (top-level) be hydrated? — RESOLVED 2026-05-27.**
+  **Partially, yes.** Top-level `func new --help` renders an **Available
+  templates** catalog section (§5.2.1) showing short name + display name +
+  description for each template the active stack's provider exposes. Tab
+  completion on `--template <TAB>` uses the same catalog. **Per-template
+  option flags do not appear at the top level** — option-name collisions
+  across templates (every template has `--namespace`), help-text explosion,
+  and the stage-A parser's inability to pick a hydration target before
+  `--template` is bound make that infeasible. Per-template options stay
+  under `func new --template <id> --help` (Q5 stands).
+- ✅ **Q6. CSX (`.csx` DotNet functions) — do we keep `--csx` in vnext? — RESOLVED 2026-05-28.**
+  **Dropped.** `.csx` script-mode functions are not scaffoldable on v5
+  and `--csx` is not carried forward. Three reinforcing reasons:
+  (a) the v5 `Workloads.Templates.DotNet` content workload sources its
+  catalog from `Microsoft.Azure.Functions.Worker.ItemTemplates` — the
+  **isolated-worker** item-templates package, which ships compiled
+  (`.cs`) item-templates only; no `.csx` script templates exist
+  upstream to hydrate into `dotnet-templates.json` (§5.3 /
+  templates-workload-spec.md §5.3.1, §6.3).
+  (b) `.csx` is fundamentally an in-process .NET runtime concept;
+  vnext-design Part IX item 9 establishes that the v5 CLI does **not**
+  support in-process .NET ("this is a CLI-level constraint enforced
+  before host launch, independent of profiles. The CLI detects
+  in-process projects from project files and exits with a clear
+  error").
+  (c) The legacy V1 engine that hosted CSX scaffolding is removed from
+  vnext (Q-Eng-C); reintroducing CSX would require both an in-process
+  runtime workload and a v5-shaped templates content workload that
+  ships `.csx` items — neither exists.
+  Users on `.csx` stay on v4 tooling. Migration row in §7 captures
+  this. If in-process .NET is ever reconsidered on v5, CSX rides along
+  as a new `Workloads.Templates.DotNet.Csx` content workload (or
+  similar) — not a built-in `--csx` CLI flag.
+- ✅ **Q7. Should `func new` also accept `func new <template>` as a positional shortcut? — RESOLVED 2026-05-28.**
+  **No — explicit `--template` / `-t` only.** Three reasons:
+  (a) `func new` already takes one positional argument — the project
+  path, inherited via `AddPathArgument()` (§5.2). A second positional
+  for the template id collides for the common single-arg case
+  (`func new HttpTrigger` is indistinguishable from
+  `func new <some-path>` without out-of-band knowledge); System.CommandLine
+  has no clean disambiguation.
+  (b) The two-stage parse (§4.5) needs `--template` to be a stable,
+  discoverable option in stage A. A positional shortcut adds a parallel
+  resolution path and makes stage-A failure modes harder to reason about.
+  (c) Modern .NET CLI convention favours explicit options; `dotnet new`
+  takes the template short-name positionally only because it has no
+  path-positional collision. v5 `func new` does.
+  Users who type the v4 form get a standard System.CommandLine parse
+  error pointing them at `--help`. The §7 Migration table captures the
+  break.
+- ✅ **Q8. Where does `ITemplateEngineProvider` live — new `Templates` namespace in Abstractions or reuse `Projects`? — RESOLVED 2026-05-28.**
+  **New `Azure.Functions.Cli.Templates` namespace** under
+  `src/Abstractions/Templates/`. Holds `ITemplateEngineProvider`,
+  `FunctionTemplateInfo`, `TemplateListContext`, `NewContext`,
+  `TemplateApplicationResult`, and `TemplateApplicationFailure`. Three
+  reasons:
+  (a) Matches the per-domain Abstractions convention (`Projects/`,
+  `Bundles/`, `Workers/`, `Quickstart/` each own one cohesive contract
+  surface).
+  (b) `Quickstart/` is the direct precedent — it could have lived under
+  `Projects/` (it also scaffolds) but got its own folder because it is
+  a distinct user-facing verb (`func quickstart`) with its own
+  contracts. `func new` mirrors that: distinct verb, distinct contracts,
+  distinct lifecycle (post-init, picks one template, hydrates options).
+  (c) Aligns with the CLI-internal engine project naming from Q3
+  (`Templates.V2`, `Templates.DotNet`).
+  `Projects/` continues to own the scaffold-the-whole-app contracts
+  (`IProjectInitializer`, `IFunctionsProjectFactory`, `InitContext`); the
+  two contract surfaces stay cleanly separated.
+- ✅ **Q9. `--name` validation rules. — RESOLVED 2026-05-28.**
+  **Option C: template metadata is authoritative, with a per-stack
+  default fallback.** Two layers, in this order:
+  1. **Template-metadata validator (authoritative).** If the template
+     declares a validator for its function-name prompt — V2
+     `UserPrompt.validator` (regex), DotNet
+     `dotnet-templates.json` `parameters[].constraints` (projected from
+     the upstream `template.json` at workload pack time,
+     templates-workload-spec.md §5.3.1) — `TemplateOptionHydrator`
+     (§4.5) projects it as the `Option<string>`'s validator / parser
+     callback. This is the source of truth; the CLI never overrides it.
+  2. **Per-stack default (fallback).** When the template's function-name
+     prompt declares no validator, `NewCommand` consults a stack-default
+     validator surfaced through the active stack's `IProjectInitializer`.
+     A new optional member on the existing init interface
+     (`Regex? DefaultFunctionNameValidator { get; } => null`, or
+     `bool TryValidateFunctionName(string name, string language,
+     out string? error)` — exact shape settled at implementation time;
+     non-breaking default for stacks that don't supply one) keeps the
+     regex alongside the stack code that already knows the language's
+     identifier and filesystem rules. No new top-level contribution
+     seam, no per-template duplication.
+  **Why both layers.** Template-first matches the D5 / Q5 "every prompt
+  is a real `Option<T>` driven by metadata" stance and lets a template
+  with unusual substitution rules (e.g. a DotNet template that allows
+  dotted namespaces in the function name) override without a CLI change.
+  Stack-default ensures untrusted-template-author and missing-validator
+  cases still produce a sensible error before any file is written.
+  **Examples.**
+  - DotNet HttpTrigger ships
+    `symbols.namespace.constraints` etc. on the upstream `template.json`
+    → projected into `parameters[]` → hydrator applies the regex. CLI
+    fallback unused.
+  - Node v2 `HttpTrigger-JavaScript` declares its function-name input
+    with `validator: "[A-Za-z_][A-Za-z0-9_]*"` (or no validator) →
+    template-first if present, Node-default fallback otherwise (JS
+    identifier + filesystem-safe).
+  - Python v2 same shape; default falls through to Python identifier
+    rules.
+  **Error UX.** Validation failure surfaces as a standard
+  `System.CommandLine` parse error (Stage B), printed via
+  `IInteractionService`, exit 1 — same channel as any other typed
+  option failure.
+- ✅ **Q10. How does `func new` learn the programming model? — RESOLVED 2026-05-28 (D9 / Q-Eng-B).**
+  Not relevant. vnext drops the programming-model concept entirely.
+  Workload publishers curate to ship only current-generation templates
+  (e.g. the Node templates content workload ships v4 templates only; the
+  Python templates content workload ships v2 templates only). No runtime
+  sniff (`IsNewPythonProgrammingModel`, `IsNewNodeJsProgrammingModel`,
+  `-4.x` suffix), no `--programming-model` flag, no
+  `TemplateListContext.ProgrammingModelHint`. If a workload publisher
+  needs to support both generations in the same release window, they can
+  ship two separate templates content workloads (different package ids,
+  different channels).
+- ✅ **Q11. `func templates list --output json` envelope shape. — RESOLVED 2026-05-28.**
+  Single envelope `{ stack, language, templates: [ … ] }` per §5.5.4 —
+  every invocation. There is no multi-stack case because §5.5.5 now
+  requires an init'd project (no stackless run, no `--stack` override):
+  every invocation resolves to exactly one stack + language. Tooling
+  parses one shape always; no NDJSON, no `{ stacks: [...] }` wrapping
+  array. The shape is identical for plain and JSON output paths — JSON
+  just promotes the rendered fields into structured form (§5.5.4) and
+  adds DotNet-only `identity` / `groupIdentity` / `classifications` /
+  `shortNames[]` when applicable (templates-workload-spec.md §5.3.1).
+- ✅ **Q12a. Failure UX when no installed templates workload matches the
+  project's bundle channel (Node/Python).** — RESOLVED 2026-05-27 (§4.8.1,
+  §5.5.3, §6 step 4b). Fail with
+  `NoTemplatesWorkloadForChannel(stack, channel, suggestedPackageId, suggestedVersion)`,
+  exit 1. Hint text identifies the specific channel-suffixed pkg id +
+  version the user needs to install. No cross-channel fallback (a stable
+  templates pkg does **not** satisfy an experimental project, per
+  templates-workload-spec.md §4.4.2).
+- ✅ **Q12b. Failure UX when the selected templates workload's
+  `minBundleVersion` is newer than the project's resolved bundle
+  (Node/Python).** — RESOLVED 2026-05-27 (§4.8.2, §5.5.3, §6 step 11b).
+  Fail with
+  `MinBundleVersionTooOld(installedBundleVersion, requiredRange, templatesWorkloadVersion)`,
+  exit 1. v1 picks **error** over warning so partial-write windows stay
+  empty; if real users hit false positives, a future
+  `--ignore-min-bundle` opt-out can soften to a warning. Decision is
+  stricter than templates-workload-spec.md §4.4.4's "warning or error"
+  hedge — this spec owns the enforcement timing & severity.
+- ✅ **Q12c. Should `func setup` install templates content workloads? — RESOLVED 2026-05-28 (out of scope).**
+  **Out of scope for this spec.** `func setup`'s install set is owned
+  by `docs/proposed/func-setup-design.md` (refreshed in PR #5098), which
+  currently excludes templates content workloads (working-context
+  §3.18). `func new` continues to surface a per-channel install hint
+  via the Q12a `NoTemplatesWorkloadForChannel` failure when no matching
+  templates workload is installed — that's the supported acquisition
+  path. Whether `func setup` should later grow templates support
+  (and how it would pick a channel without a project's `host.json`
+  signal — `func setup` runs before any project exists) is a decision
+  for the `func-setup-design.md` owners, not for this spec.
+- ✅ **Q-Lang-1. Persisting language in `.func/config.json`. — RESOLVED 2026-05-29 (D10 revised).**
+  **Yes, persisted — and consumed via DI options binding.** `func init`
+  writes `stack.language` to `.func/config.json` when its `--language`
+  flag is supplied (`src/Func/Commands/InitCommand.cs:266`,
+  `CliConfigurationNames.StackLanguageKey = "language"`). PR #5125
+  intentionally **omits** the key when the active stack is single-language
+  (Python, PowerShell, Java, Custom, Go); for those cases the CLI
+  substitutes the stack's canonical single language at read time.
+  `func new` reads back the configured value by injecting
+  `IOptionsMonitor<StackOptions>` from DI and calling
+  `.Get(workingDirectory.FullName).Language` — the standard project-scoped
+  options pattern used elsewhere in the codebase
+  (`Profiles/ProfileResolver.cs`, `Commands/Setup/SetupRunner.cs`,
+  `Commands/Profile/ProfileListCommand.cs` all inject
+  `IOptionsMonitor<ProjectProfileOptions>` the same way).
+  `StackOptionsSetup` (registered as
+  `IConfigureNamedOptions<StackOptions>` in
+  `Hosting/CliHostFactory.cs:109`) is the single file-read path; `func new`
+  never opens `.func/config.json` itself, satisfying AGENTS.md's
+  "Bind configuration via `IOptions<T>` / `IOptionsMonitor<T>`; do not
+  read `IConfiguration` from business logic" rule. No fingerprinting, no
+  per-stack detector seam, no schema change beyond what's already
+  shipping on `vnext`. Supersedes the earlier D10 stance ("init artifacts
+  ARE the persistence layer; no config field"): the code already had a
+  config field bound through DI; the spec now matches reality.
+- ✅ **Q-Lang-2. Mixed-language repos (`.csproj` and `.fsproj` both present). — RESOLVED 2026-05-29 (D10 revised).**
+  Not a concern at `func new` time. Mixed-language detection lives in the
+  project-resolver layer (e.g. `NodeProjectFactory` / `DotNetProjectFactory`);
+  `func new` reads `stack.language` from `.func/config.json`, which
+  `func init` pinned to a single canonical value. If a user manually edits
+  the project to add a competing language file post-`func init` without
+  re-running `func init`, the value in `.func/config.json` is still
+  authoritative — `func new` scaffolds for whatever language `func init`
+  recorded. If `.func/config.json` is missing the key on a multi-language
+  stack, `func new` exits 1 pointing at `func init`.
+- ✅ **Q-Lang-3 / D10. `--language` flag on `func new` and `func templates list`. — RESOLVED 2026-05-29 (revised).**
+  Dropped from both commands. Language is **read via DI** from
+  `IOptionsMonitor<StackOptions>.Get(workingDirectory.FullName).Language`
+  — the bound view of `.func/config.json` `stack.language` that
+  `func init` wrote from **its** `--language` flag. `func new` cannot run
+  before `func init`, so the source of truth is always present. The
+  command does not open `.func/config.json` itself — `StackOptionsSetup`
+  is the single file-read path, and the options pipeline caches/refreshes
+  the snapshot, so per-invocation file I/O at scaffold time is avoided. A
+  `func new --language` flag would either contradict the init choice
+  (drift) or be a no-op when it agrees. `func templates list` requires an
+  init'd project for the same channel-resolution reasons (§5.5.5 / Q11),
+  so it has no `--language` flag either.
+- ✅ **Q-Profile-1 / D11. `--profile` and `--offline` flags on `func new` and `func templates list`. — RESOLVED 2026-05-27.**
+  Dropped from both commands. Profile selection is a project-level pin set
+  by `func profile set` (or `.func/config.json defaultProfile`, user prefs,
+  or the built-in default — resolved silently by `IProfileResolver`).
+  Scaffolds and template discovery are static, deterministic operations;
+  there is no scaffold-under-profile-X-then-run-under-Y use case worth a
+  per-invocation override. The stack-vs-profile gate (§4.6, pipeline step 3)
+  still fires against the resolved active profile; mismatch errors hint at
+  `func profile set <other>` and `func profile list`. `--offline` (refresh
+  remote profile sources) is irrelevant at scaffold time — the resolved
+  profile is already in hand and no scaffold output depends on a fresh
+  remote refresh. Mirrors the D10 pattern: drop redundant flags when the
+  deeper config already encodes the answer. `func run` keeps both flags,
+  since execution under a non-pinned profile is a legitimate use case there.
+- ✅ **Q-Eng-A. How does the CLI know which engine to use for a given template? — RESOLVED 2026-05-28 (D9, revised 2026-05-29).**
+  Implicit by the template payload's **directory layout** inside its
+  workload (templates-workload-spec.md §5.2, §5.3):
+  presence of `content/v2/templates/templates.json` → V2 engine (Node and
+  Python); presence of `content/dotnet-templates.json` at the content root
+  → DotNet engine. A given templates workload ships exactly one engine
+  zone, so there is no tiebreak — Node/Python ship v2 only (the legacy V1
+  engine is removed from vnext), DotNet ships `dotnet-templates.json`
+  only. No engine field on the template, no `--engine` flag, no help text.
+  Engine identity is CLI-internal dispatch (§4.3); end users only see
+  templates by stack + name.
+- ✅ **Q-Eng-B. Programming-model axis — runtime knob or publisher concern? — RESOLVED 2026-05-28 (D9).**
+  Publisher concern. vnext has no `programmingModel` field on templates,
+  no `FunctionTemplateInfo.ProgrammingModel`, no
+  `TemplateListContext.ProgrammingModelHint`, no `--programming-model`
+  flag, no `func templates list` grouping by model, no post-deploy
+  upgrade messaging. Workload publishers ship only current-generation
+  templates ("latest" is what the workload version ships, not a runtime
+  axis). Main-branch sniffs (`IsNewPythonProgrammingModel()`,
+  `IsNewNodeJsProgrammingModel()`, `-4.x` suffix routing) are dropped.
+- ✅ **Q-Eng-C. V1 engine layout — per-template, mixed, or workload-level? — RESOLVED 2026-05-29 (V1 engine removed).**
+  Not applicable. v5 templates workloads ship v2 only
+  (templates-workload-spec.md §5.2: "v1 (legacy) programming-model
+  templates are not shipped in v5 templates workloads"). The CLI does
+  **not** include a V1 engine project. The legacy `layout`
+  (`function-folder` / `src-functions`) workload manifest field is moot —
+  v2 encodes write paths entirely in `TemplateAction.FilePath`.
+- ✅ **Q-Eng-D. DotNet engine — separate plugin contract or hybrid catalog + shellout? — RESOLVED 2026-05-28 (D9).**
+  Hybrid. The DotNet templates content workload ships
+  `content/dotnet-templates.json` (fully-hydrated catalog + per-template
+  `parameters[]` index, templates-workload-spec.md §5.3.1) and a sibling
+  `content/source.json` (NuGet pin for the upstream item-templates
+  package, templates-workload-spec.md §5.3, §6.3). At
+  `func workload install` time the CLI provisions the pinned NuGet pkg
+  into a CLI-managed dotnet template hive. The CLI's `DotNetEngineProvider`
+  reads the JSON for `func templates list` and `func new --template <id>
+  --help` (offline-deterministic, no `dotnet new` invocation, no NuGet
+  I/O) and shells out via `IDotnetCliRunner` (`dotnet new <shortName>
+  --<param> <value> …`) only for the actual apply step. Workloads stay
+  content-only — no DLL plugin contract. This partially supersedes D7's
+  "no separate DotNet engine project" stance: the catalog reader +
+  shellout coordinator now live in their own `Templates.DotNet` project to
+  match V2.
+
+## 9. References
+
+- `working_context_templates_workload_design.md`
+  - §3B legacy `func new` surface (main)
+  - §3.5 `IProjectInitializer` + `IInitOptionRegistry` (the precedent)
+  - §3.9 `IExtensionBundleResolver`
+  - §3.10 project model
+  - §3.13 filesystem conventions
+  - §3.14 result/failure record pattern
+  - §3.17 profile system
+  - §3.18 `func setup`
+  - §3B.4 legacy decision tree
+  - §3B.6 the three template engines
+  - §3B.7 mapping to vnext
+- `templates-workload-spec.md` — templates workload spec (payload, layout,
+  packaging; §5.2 Node/Python v2-only payload, §5.3 / §5.3.1 DotNet
+  `dotnet-templates.json` schema, §6.3 hive provisioning at install time)
+- `src/Func/Commands/NewCommand.cs` — current placeholder
+- `src/Func/Commands/InitCommand.cs` — the `func init` orchestrator (writes
+  `stack.language` to `.func/config.json` per §4.7 / D10 revised; template
+  to mirror for `func new`)
+- `src/Func/Configuration/StackOptions.cs` —
+  `Runtime` / `Language` DTO that backs `stack.runtime` / `stack.language`
+- `src/Func/Configuration/StackOptionsSetup.cs` —
+  `IConfigureNamedOptions<StackOptions>`; the **single code path** that
+  reads `.func/config.json` for the `stack` section and binds it into
+  `StackOptions`. Consumed via `IOptionsMonitor<StackOptions>.Get(projectDir)`.
+- `src/Func/Hosting/CliHostFactory.cs:109` — registers
+  `AddSingleton<IConfigureOptions<StackOptions>, StackOptionsSetup>()`.
+- `src/Func/Configuration/CliConfigurationNames.cs` —
+  `StackSectionName = "stack"` / `StackLanguageKey = "language"`
+- `src/Func/Profiles/ProfileResolver.cs` — precedent for project-scoped
+  options consumption: injects `IOptionsMonitor<ProjectProfileOptions>`,
+  reads via `.Get(projectDirectory)`. `func new` follows the same pattern
+  for `IOptionsMonitor<StackOptions>` (§4.7).
+- `src/Func/Commands/Setup/SetupRunner.cs` — same precedent
+  (`IOptionsMonitor<ProjectProfileOptions>`).
+- `src/Abstractions/Projects/IProjectInitializer.cs` — direct precedent for
+  the bare engine-provider contract (`ITemplateEngineProvider` is
+  CLI-internal)
+- `src/Abstractions/Projects/IInitOptionRegistry.cs` — option-dedup machinery
+- `src/Workloads/Stacks/DotNet/DotNetProjectInitializer.cs` — `dotnet new func`
+  + template hive precedent (closest analogue for the DotNet template provider)
+- `src/Abstractions/Commands/InitContext.cs` — direct precedent for
+  `NewContext`
+- Main-branch `src/Cli/func/Actions/LocalActions/CreateFunctionAction.cs` —
+  the 624-line legacy implementation `func new` replaces

--- a/proposed/func-setup-design.md
+++ b/proposed/func-setup-design.md
@@ -1,0 +1,188 @@
+# `func setup` Design (Draft)
+
+This document describes the proposed `func setup` command for the Azure Functions CLI (`func`). It is a working draft. Open questions are called out inline.
+
+## 1. Identity
+
+`func setup` is a **machine readiness orchestrator**. It coordinates several subsystems so that a freshly installed `func` is ready to develop or run Azure Functions, in one command, idempotently, in both interactive and CI environments.
+
+It is intentionally a small, thin command. Its interface is small ("ready this machine for func"), but behind that interface it sequences work across:
+
+- Workload installation (via `func workload install`).
+- Profile pre-install for runtime constraint sets (via `func profile install`, see [cli-profiles.md](./cli-profiles.md)).
+- Cache priming (extension bundle cache, profile registry cache).
+- First-run hints (telemetry consent is handled separately, see §6).
+
+### What it is *not*
+
+- **Not an alias for `func workload install`.** That command is a sharp tool ("install this specific workload"). `setup` is an orchestration verb ("ready this machine"). The distinction is by intent, not capability.
+- **Not a project bootstrapper.** That is `func init`. `setup` may *read* project files for inference, but it never writes to the project.
+- **Not the telemetry owner.** Telemetry consent is a global first-CLI-invocation concern, not a `setup` concern. See §6.
+- **Not a profile authoring tool.** Profile authoring lives with [cli-profiles.md](./cli-profiles.md) (`.func/profiles.json`, `~/.azure-functions/profiles.json`).
+- **Has no "profile" concept of its own.** The word *profile* is reserved for [cli-profiles.md](./cli-profiles.md).
+
+## 2. Goals
+
+- Give a new user a single command to go from "I installed `func`" to "I can run a function".
+- Give CI a single command to bring a fresh runner to a known-ready state.
+- Be idempotent: safe to re-run on every CI job, on a developer's machine after adding new languages, after partial failures.
+- Keep responsibilities narrow: orchestrate, do not own. Each underlying subsystem remains the source of truth for its own state.
+
+## 3. Command Surface
+
+```
+func setup [--workloads <list>] [--profiles <list>]
+           [--non-interactive] [--yes] [--check]
+```
+
+| Option              | Description                                                                                                         |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `--workloads <list>`| Comma-separated workload IDs to ensure are installed (e.g. `node,python,durable`).                                  |
+| `--profiles <list>` | Comma-separated profile names whose dependencies should be pre-installed (see [cli-profiles.md](./cli-profiles.md)).|
+| `--non-interactive` | Never prompt. Fail if a required answer is missing or a step would otherwise block.                                 |
+| `--yes`, `-y`       | Accept defaults for any prompt that would otherwise block. Implies non-interactive.                                 |
+| `--check`           | Report what would change. Make no mutations. Exits non-zero if anything is missing.                                 |
+
+### 3.1 Interactive flow (default)
+
+1. If running inside a project directory, infer suggested workloads via the shared **project detection** module (see §9.6). This is a read-only signal source reused from the workloads spec's "find missing workloads" flow ([workload-spec.md](./workload-spec.md)).
+2. Present a grouped picker (language stacks, feature workloads).
+3. Confirm and install the selected workloads via the workload subsystem.
+4. If `.func/config.json` declares profiles (see [cli-profiles.md](./cli-profiles.md)), pre-install their dependencies.
+5. Print "what's next" hints (`func init`, `func new`, `func start`).
+
+### 3.2 Non-interactive flow (CI)
+
+```
+func setup --workloads node,python --profiles flex --non-interactive --yes
+```
+
+- No prompts. Telemetry default is whatever the env/config dictates (see §6).
+- Installs the listed workloads. Pre-installs dependencies for the listed profiles.
+- Exits non-zero on any failure or ambiguity.
+
+### 3.3 Catalog and recommendations
+
+The picker draws from two sources, owned by different layers:
+
+| Zone                  | Source                                                       | Owned by                               |
+| --------------------- | ------------------------------------------------------------ | -------------------------------------- |
+| Featured / recommended | CLI-curated stack list (`node`, `python`, `dotnet-isolated`, `java`, `powershell`, `custom`) plus a per-stack **recommendation bundle** | Func CLI (hard-coded, small)           |
+| Browse all            | `func workload search` against the configured NuGet feed     | Workload subsystem ([workload-spec.md](./workload-spec.md) §4.1) |
+
+**Featured** is what gets *surfaced first* and what counts as "the Python recommendation" for §9.3 pre-selection. Members are the well-known Functions worker runtimes; the same list already exists in the workloads spec for the install-hint flow (workload-spec §4.2). `setup` reuses that list, it does not introduce a new one.
+
+**Browse all** is the full dynamic catalog. Third-party workloads, less-common stacks, and anything the user reaches via search live here. `setup` does not maintain this list; it is whatever `func workload search` returns.
+
+A recommendation bundle is initially the single canonical workload for that stack (e.g. Python recommendation = `python`). Bundles can grow over time (e.g. `python` + `azure-tools` + `durable`) without changing the picker UX.
+
+This split avoids two failure modes: all hard-coded means stale catalogs and no third-party visibility; all catalog means no opinion and a slow path for new users.
+
+### 3.4 `--check` mode
+
+Same resolution logic as a real run, no mutations. Reports what is missing (workloads, profile dependencies, caches). Useful for verifying a pre-baked CI image.
+
+## 4. Re-run Model: Idempotent Additive Reconciliation
+
+Each invocation ensures the requested set is *present*. It never removes.
+
+- Workloads already installed are skipped.
+- Workloads not yet installed are installed.
+- Profile dependencies already cached are skipped.
+- Profile dependencies not yet cached are fetched.
+
+`setup` does not maintain a manifest of "what setup installed." The workload subsystem and profile registry are the source of truth for installed state. Removing a workload is `func workload uninstall`'s job, not `setup`'s.
+
+The only state `setup` writes is a **first-run completed** marker (user-level), used to suppress first-run hints on subsequent invocations.
+
+## 5. Boundaries with `init` and `start`
+
+The three commands each own one verb (scaffold, ready, run). They do not call each other. They communicate through state on disk and installed workloads, not through invocation.
+
+| Scenario                                                            | Behavior                                                                                                       |
+| ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `func init` on a fresh machine (no workloads installed)             | `init` succeeds. It does not check or auto-run `setup`. Project scaffolding does not gate on machine state.    |
+| `func start` on a fresh machine (no host workload installed)        | Uses the auto-install pattern from [cli-profiles.md](./cli-profiles.md) §13.2: prompt interactive, error in CI.|
+| `func setup` inside an existing project                             | Reads project files (read-only) for inference. Reads `.func/config.json` for declared profiles. No project writes.|
+
+## 6. Telemetry
+
+Telemetry consent is **out of scope for `func setup`**. It is a global concern, prompted on first invocation of any `func` command, owned by the CLI bootstrap path. `setup` happens to be one such command but is not special in this regard. Env vars (`DOTNET_CLI_TELEMETRY_OPTOUT`-style) override the prompt as expected.
+
+This avoids the failure mode where a user runs `func init` first, never sees `setup`, and is silently never asked about telemetry.
+
+## 7. State and File Layout
+
+`func setup` mutates only user-level state:
+
+```
+~/.azure-functions/
+  .first-run                     # Marker: first-run hints already shown
+  workloads/                     # Owned by the workload subsystem
+  profiles/                      # Owned by the profiles subsystem
+```
+
+`setup` does not write to:
+
+- `.func/config.json` (owned by the profiles proposal).
+- `.func/profiles.json` (owned by the profiles proposal).
+- `host.json`, `local.settings.json` (owned by `func init`).
+
+## 8. Failure Semantics
+
+- Each underlying subsystem call is atomic per its own contract (e.g. workload install per the Workloads spec).
+- `setup` itself accepts partial completion: a re-run finishes the job. There is no rollback.
+- Errors clearly state what completed and what did not, with the exact command to retry the failed step.
+- Non-zero exit on any failure in `--non-interactive` or `--check` mode.
+
+## 9. Resolved Questions
+
+These are concrete, lower-level decisions. The foundational architecture (identity, scope, re-run model, boundaries) is in §1 through §8.
+
+### 9.1 Progress reporting
+
+How is long-running workload install progress surfaced in CI logs (where TTY tricks fail)?
+
+**Decision:** Spinner / progress bar when a TTY is detected. Plain-text periodic lines otherwise (the default for CI). Opt-in structured output via `--output json` for tooling that wants to parse progress events.
+
+### 9.2 Offline / air-gapped
+
+Should `setup` accept a `--offline` flag that skips network attempts and only validates that already-cached artifacts satisfy the request?
+
+**Decision:** Deferred. Offline / air-gapped support will be addressed in a separate proposal that covers the CLI as a whole, not bolted onto `setup` in isolation. `setup` does not ship an `--offline` flag in v1.
+
+### 9.3 Picker UX
+
+Categorized prompt vs flat list. Do we ship a recommended-defaults set per detected language?
+
+**Decision:** Categorized picker (Languages / Features / Tools). When project inference suggests a language, that language's recommended defaults are pre-selected. The user can deselect or add to the recommendation before confirming.
+
+### 9.4 Discoverability after install
+
+Where does the "next step is `func setup`" hint surface?
+
+**Decision:** Both. The package installer prints a post-install message pointing at `func setup`, and `func` with no arguments shows a getting-started hint that includes `func setup`.
+
+### 9.5 `--check` exit codes
+
+Single non-zero on any drift, or distinct codes per drift type?
+
+**Decision:** Single non-zero exit (`exit 1`) on any drift. Drift details (which workloads are missing, which profile caches are stale, etc.) are written to stdout/stderr in human-readable form. No distinct exit codes per drift type. Tooling that needs structured drift information can use `--output json` (see §9.1).
+
+### 9.6 Inferring workloads from a project
+
+What signals does `setup` read, and how is the inference surfaced?
+
+**Decision:** `setup` does not implement its own detection. It calls the shared **project detection** module owned by the workloads spec (see [workload-spec.md](./workload-spec.md), and PR #4923 thread r3190018800 for the original signal list). Signals include:
+
+- `--stack <name>` (explicit override, when provided).
+- `local.settings.json` `FUNCTIONS_WORKER_RUNTIME`.
+- `host.json` (presence and `workerRuntime`).
+- Project marker files: `*.csproj`, `requirements.txt`, `package.json`, `pom.xml`, etc.
+- `.func/config.json` (for declared profiles, per [cli-profiles.md](./cli-profiles.md)).
+
+The inference is **informational**: the picker surfaces what was detected ("detected: Python"). What gets *pre-selected* in the picker comes from §9.3's curated recommendations, not raw detection output. The user remains the decider.
+
+Reusing the same detection module as the workloads "missing workloads" flow ensures the two callers cannot drift apart.
+
+

--- a/proposed/func-setup-design.md
+++ b/proposed/func-setup-design.md
@@ -1,6 +1,6 @@
 # `func setup` Design (Draft)
 
-This document describes the proposed `func setup` command for the Azure Functions CLI (`func`). It is a working draft. Open questions are called out inline.
+This document describes the proposed `func setup` command for the Azure Functions CLI (`func`). It is a working draft.
 
 ## 1. Identity
 
@@ -8,181 +8,259 @@ This document describes the proposed `func setup` command for the Azure Function
 
 It is intentionally a small, thin command. Its interface is small ("ready this machine for func"), but behind that interface it sequences work across:
 
-- Workload installation (via `func workload install`).
-- Profile pre-install for runtime constraint sets (via `func profile install`, see [cli-profiles.md](./cli-profiles.md)).
-- Cache priming (extension bundle cache, profile registry cache).
-- First-run hints (telemetry consent is handled separately, see §6).
+- Host workload installation.
+- Setup feature expansion, where user-facing feature IDs such as `runtime`, `node`, or `dotnet-isolated` map to one or more lower-level workload installs.
+- Profile-constrained installation for runtime constraint sets.
+- Extension bundle cache priming when the selected feature/worker runtime uses extension bundles.
 
 ### What it is *not*
 
-- **Not an alias for `func workload install`.** That command is a sharp tool ("install this specific workload"). `setup` is an orchestration verb ("ready this machine"). The distinction is by intent, not capability.
-- **Not a project bootstrapper.** That is `func init`. `setup` may *read* project files for inference, but it never writes to the project.
-- **Not the telemetry owner.** Telemetry consent is a global first-CLI-invocation concern, not a `setup` concern. See §6.
-- **Not a profile authoring tool.** Profile authoring lives with [cli-profiles.md](./cli-profiles.md) (`.func/profiles.json`, `~/.azure-functions/profiles.json`).
-- **Has no "profile" concept of its own.** The word *profile* is reserved for [cli-profiles.md](./cli-profiles.md).
+- **Not an alias for `func workload install`.** `workload install` is a sharp tool ("install this specific workload package"). `setup` is an orchestration verb ("ready this machine"). `setup --features node` may expand to multiple workload installs and should not be treated as a literal workload package ID.
+- **Not a project bootstrapper.** That is `func init`. `setup` may read selected project configuration for setup inputs, but it never writes to the project.
+- **Not a project detector.** Stack/project detection remains a stack-specific implementation detail. `setup` does not infer stacks from files such as `package.json`, `requirements.txt`, `*.csproj`, `pom.xml`, or `local.settings.json`.
+- **Not the telemetry owner.** Telemetry consent is a global first-CLI-invocation concern, not a `setup` concern.
+- **Not a profile authoring tool.** Profile authoring remains with profile configuration files and profile-specific commands.
 
 ## 2. Goals
 
 - Give a new user a single command to go from "I installed `func`" to "I can run a function".
 - Give CI a single command to bring a fresh runner to a known-ready state.
-- Be idempotent: safe to re-run on every CI job, on a developer's machine after adding new languages, after partial failures.
+- Be idempotent: safe to re-run on every CI job, on a developer's machine after adding new features, and after partial failures.
 - Keep responsibilities narrow: orchestrate, do not own. Each underlying subsystem remains the source of truth for its own state.
+- Allow profile constraints to influence dependency selection, including installing the maximum available version inside a profile range when requested.
 
 ## 3. Command Surface
 
-```
-func setup [--workloads <list>] [--profiles <list>]
+```text
+func setup [--features <list>]
+           [--profile <name>]... [--profiles <list>]
+           [--install-policy <latest-compatible|if-needed>]
+           [--source <nuget-feed>]
+           [--prerelease]
            [--non-interactive] [--yes] [--check]
+           [--output <plain|json>]
 ```
 
-| Option              | Description                                                                                                         |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `--workloads <list>`| Comma-separated workload IDs to ensure are installed (e.g. `node,python,durable`).                                  |
-| `--profiles <list>` | Comma-separated profile names whose dependencies should be pre-installed (see [cli-profiles.md](./cli-profiles.md)).|
-| `--non-interactive` | Never prompt. Fail if a required answer is missing or a step would otherwise block.                                 |
-| `--yes`, `-y`       | Accept defaults for any prompt that would otherwise block. Implies non-interactive.                                 |
-| `--check`           | Report what would change. Make no mutations. Exits non-zero if anything is missing.                                 |
+| Option | Description |
+| --- | --- |
+| `--features <list>` | Comma-separated setup feature IDs to ensure are present. Features are CLI-curated capabilities, not raw workload package IDs. |
+| `--profile <name>` | Canonical repeatable option for profile names whose constraints should be applied. |
+| `--profiles <list>` | Comma-separated convenience alias for passing multiple profiles. |
+| `--install-policy <policy>` | Dependency reconciliation policy. Default: `latest-compatible`. |
+| `--source <nuget-feed>` | Override the NuGet package source used for workload catalog resolution and installation. Same semantics as workload commands. |
+| `--prerelease` | Allow prerelease package versions during catalog resolution. Prerelease versions are not considered unless this option is present. |
+| `--non-interactive` | Never prompt. Fail if a required answer is missing or a step would otherwise block. |
+| `--yes`, `-y` | Accept defaults for any prompt that would otherwise block. Implies non-interactive. |
+| `--check` | Report what would change. Make no mutations. Exits non-zero if anything is missing or drifted according to the selected install policy. |
+| `--output <plain|json>` | Output mode. `plain` is human-readable text. `json` emits newline-delimited JSON events. |
 
-### 3.1 Interactive flow (default)
+## 4. Setup Features
 
-1. If running inside a project directory, infer suggested workloads via the shared **project detection** module (see §9.6). This is a read-only signal source reused from the workloads spec's "find missing workloads" flow ([workload-spec.md](./workload-spec.md)).
-2. Present a grouped picker (language stacks, feature workloads).
-3. Confirm and install the selected workloads via the workload subsystem.
-4. If `.func/config.json` declares profiles (see [cli-profiles.md](./cli-profiles.md)), pre-install their dependencies.
-5. Print "what's next" hints (`func init`, `func new`, `func start`).
+`--features` accepts setup feature IDs. A feature is a user-facing capability that expands to one or more lower-level dependencies.
 
-### 3.2 Non-interactive flow (CI)
+The initial built-in feature catalog is:
 
+| Feature | Meaning |
+| --- | --- |
+| `host` | Install or verify only the Azure Functions host workload. No workers. No extension bundle. |
+| `runtime` | Install or verify the host and the default stable extension bundle. No stack worker. |
+| `node`, `python`, `java`, `powershell`, `custom`, `go` | Install or verify host, the selected worker workload, and the default stable extension bundle. |
+| `dotnet-isolated` | Install or verify host and the `dotnet-isolated` worker. Extension bundles are skipped because this stack does not use them. |
+| Future feature IDs, such as `durable` | Expand to one or more additional workloads or caches. |
+
+Raw workload package IDs remain the responsibility of `func workload install`. Unknown setup feature IDs fail with a message that distinguishes setup features from workload package IDs and points users to `func workload search` or `func workload install`.
+
+The supported .NET setup stack is `dotnet-isolated`. There is no separate in-process `dotnet` stack feature.
+
+## 5. Feature Defaults
+
+If `--features` is provided, it is the complete explicit feature request.
+
+If `--features` is not provided:
+
+1. If `.func/config.json` declares a worker runtime, setup treats that worker runtime as the stack feature to prepare.
+2. Otherwise, setup defaults to the `runtime` feature.
+
+Setup does not infer worker runtime from any other project file.
+
+## 6. Profile Selection
+
+Profiles provide version constraints. `setup` has no separate profile concept of its own; it consumes the existing profile catalog/resolution model.
+
+Profile selection order:
+
+1. Explicit profiles from repeatable `--profile` and comma-separated `--profiles`.
+2. If no explicit profiles are provided and the project `.func/config.json` declares profiles, setup runs once for each declared profile.
+3. If no project profiles are declared, setup uses the user default profile when one is configured.
+4. If no profile is selected, setup runs without profile constraints.
+
+Explicit profile names are de-duplicated case-insensitively while preserving the first occurrence.
+
+If a profile is explicitly requested inside a project that declares a profile allow-list, and the profile is not listed in `.func/config.json`, setup warns but continues if the profile can be resolved. This matches the current active-profile resolver behavior.
+
+Deprecated profiles warn and continue.
+
+## 7. Profile-Constrained Dependencies
+
+For each selected profile, setup runs a separate reconciliation loop. Profile constraints are not merged across profiles.
+
+The profile affects dependency selection as follows:
+
+| Dependency | Constraint behavior |
+| --- | --- |
+| Host workload | Constrained by the profile host version range. |
+| Selected worker workloads | Constrained by the matching profile worker version range when one exists. |
+| Extension bundle | Constrained by the profile extension bundle range, but only when the selected feature/worker runtime uses extension bundles. |
+
+Host workload catalog resolution and installation must use a literal RID-specific package ID, not alias/tag lookup. The package ID format is `Azure.Functions.Cli.Workloads.Host.<RID>`, where `<RID>` is the current CLI runtime identifier, such as `win-x64`, `linux-arm64`, or `osx-arm64`. This prevents a package from hijacking the host install through an alias and supports multiple RID-specific host packages sharing the same public alias.
+
+Worker constraints apply only to workers selected by `--features` or by `.func/config.json` worker runtime. Setup does not install every worker listed by a profile.
+
+If a selected worker runtime is not supported by a profile, setup fails for that profile. If the profile supports the runtime but does not specify an explicit worker version range for it, setup installs the worker according to the selected install policy without a profile range.
+
+## 8. Extension Bundle Policy
+
+Setup uses a two-value extension bundle policy:
+
+```text
+NotSupported
+DefaultStable
 ```
-func setup --workloads node,python --profiles flex --non-interactive --yes
-```
 
-- No prompts. Telemetry default is whatever the env/config dictates (see §6).
-- Installs the listed workloads. Pre-installs dependencies for the listed profiles.
-- Exits non-zero on any failure or ambiguity.
+Policy resolution:
 
-### 3.3 Catalog and recommendations
+| Worker runtime / feature | Policy |
+| --- | --- |
+| `dotnet-isolated` | `NotSupported` |
+| All other known stack features | `DefaultStable` |
+| Unknown worker runtimes | `DefaultStable` |
 
-The picker draws from two sources, owned by different layers:
+`NotSupported` means setup does not install or check extension bundles for that feature. A profile `extensionBundle` range does not force bundle installation for a stack that does not use bundles.
 
-| Zone                  | Source                                                       | Owned by                               |
-| --------------------- | ------------------------------------------------------------ | -------------------------------------- |
-| Featured / recommended | CLI-curated stack list (`node`, `python`, `dotnet-isolated`, `java`, `powershell`, `custom`) plus a per-stack **recommendation bundle** | Func CLI (hard-coded, small)           |
-| Browse all            | `func workload search` against the configured NuGet feed     | Workload subsystem ([workload-spec.md](./workload-spec.md) §4.1) |
+`DefaultStable` means setup ensures the stable default extension bundle workload is present when the selected feature includes bundle setup.
 
-**Featured** is what gets *surfaced first* and what counts as "the Python recommendation" for §9.3 pre-selection. Members are the well-known Functions worker runtimes; the same list already exists in the workloads spec for the install-hint flow (workload-spec §4.2). `setup` reuses that list, it does not introduce a new one.
+When a project `host.json` declares an extension bundle, setup intersects the `host.json` bundle version range with the selected profile range. When no project bundle declaration is available, setup uses the stable default bundle ID with the profile range, if any.
 
-**Browse all** is the full dynamic catalog. Third-party workloads, less-common stacks, and anything the user reaches via search live here. `setup` does not maintain this list; it is whatever `func workload search` returns.
+## 9. Install Policy
 
-A recommendation bundle is initially the single canonical workload for that stack (e.g. Python recommendation = `python`). Bundles can grow over time (e.g. `python` + `azure-tools` + `durable`) without changing the picker UX.
+`--install-policy` controls how aggressively setup reconciles installed state.
 
-This split avoids two failure modes: all hard-coded means stale catalogs and no third-party visibility; all catalog means no opinion and a slow path for new users.
+### `latest-compatible` (default)
 
-### 3.4 `--check` mode
+For each dependency, setup resolves the maximum available version that satisfies all active constraints and ensures that version is installed.
 
-Same resolution logic as a real run, no mutations. Reports what is missing (workloads, profile dependencies, caches). Useful for verifying a pre-baked CI image.
+- If a lower compatible version is installed and the catalog resolves a newer compatible version, setup installs the newer version.
+- If catalog resolution fails for any reason but an installed version satisfies the active constraints, setup warns and accepts the installed version as a fallback. JSON output reports this as a fallback result.
+- If no installed compatible version exists and catalog resolution fails, setup fails.
 
-## 4. Re-run Model: Idempotent Additive Reconciliation
+### `if-needed`
 
-Each invocation ensures the requested set is *present*. It never removes.
+For each dependency, setup first checks installed state.
 
-- Workloads already installed are skipped.
-- Workloads not yet installed are installed.
-- Profile dependencies already cached are skipped.
-- Profile dependencies not yet cached are fetched.
+- If any installed version satisfies the active constraints, setup skips installation.
+- If no installed compatible version exists, setup resolves and installs the maximum available compatible version.
+- If no installed compatible version exists and catalog resolution fails, setup fails.
 
-`setup` does not maintain a manifest of "what setup installed." The workload subsystem and profile registry are the source of truth for installed state. Removing a workload is `func workload uninstall`'s job, not `setup`'s.
+### `--prerelease`
 
-The only state `setup` writes is a **first-run completed** marker (user-level), used to suppress first-run hints on subsequent invocations.
+Prerelease versions are considered only when `--prerelease` is present. Otherwise, setup resolves stable packages only.
 
-## 5. Boundaries with `init` and `start`
+### `--source`
 
-The three commands each own one verb (scaffold, ready, run). They do not call each other. They communicate through state on disk and installed workloads, not through invocation.
+`--source` passes a NuGet source override to workload catalog resolution and workload installation. This lets CI and development workflows validate setup against private or staging workload feeds without changing global CLI configuration.
 
-| Scenario                                                            | Behavior                                                                                                       |
-| ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `func init` on a fresh machine (no workloads installed)             | `init` succeeds. It does not check or auto-run `setup`. Project scaffolding does not gate on machine state.    |
-| `func start` on a fresh machine (no host workload installed)        | Uses the auto-install pattern from [cli-profiles.md](./cli-profiles.md) §13.2: prompt interactive, error in CI.|
-| `func setup` inside an existing project                             | Reads project files (read-only) for inference. Reads `.func/config.json` for declared profiles. No project writes.|
+## 10. Check Mode
 
-## 6. Telemetry
+`--check` uses the same resolution logic as a real run but makes no mutations.
 
-Telemetry consent is **out of scope for `func setup`**. It is a global concern, prompted on first invocation of any `func` command, owned by the CLI bootstrap path. `setup` happens to be one such command but is not special in this regard. Env vars (`DOTNET_CLI_TELEMETRY_OPTOUT`-style) override the prompt as expected.
+`--check` follows the selected install policy:
 
-This avoids the failure mode where a user runs `func init` first, never sees `setup`, and is silently never asked about telemetry.
+- With `latest-compatible`, check reports drift when an installed compatible version is older than the maximum available compatible version.
+- With `if-needed`, check passes when any installed version satisfies the active constraints.
+- If catalog resolution fails and an installed compatible version exists, check reports the same fallback result as install mode.
 
-## 7. State and File Layout
+`--check` exits with code `1` on any drift, missing dependency, incompatible installed state, or failed dependency resolution. It exits with code `0` only when all selected profiles and dependencies are satisfied according to the selected install policy.
 
-`func setup` mutates only user-level state:
+When multiple profiles are selected, check mode evaluates all profile loops and summarizes all failures.
 
-```
+## 11. Interactive and Non-Interactive Behavior
+
+The default interactive flow may prompt before installing selected dependencies.
+
+`--non-interactive` never prompts. It fails if setup cannot decide what to install from explicit arguments and supported defaults.
+
+`--yes` implies non-interactive and accepts setup defaults. For example, with no `--features` and no `.func/config.json` worker runtime, `--yes` accepts the default `runtime` feature.
+
+Telemetry consent remains out of scope for `func setup`; it is handled by the global CLI bootstrap path.
+
+## 12. JSON Output
+
+`--output json` emits newline-delimited JSON (NDJSON). Each line is one event object. There is no separate final JSON document; the final state is represented by the `setup.completed` or `setup.failed` event.
+
+The v1 event set is:
+
+| Event | Description |
+| --- | --- |
+| `setup.started` | Emitted once when setup begins. Includes selected features, profiles, source override, install policy, check mode, and prerelease setting. |
+| `profile.started` | Emitted at the start of each profile loop. Includes profile name/source when one is active. |
+| `dependency.detected` | Emitted for every resolved dependency before it is checked or installed. Includes dependency type, ID, constraints, feature, and profile. |
+| `dependency.result` | Emitted after each dependency is checked or reconciled. Includes action/result, selected version, installed version, fallback state, and message. |
+| `profile.completed` | Emitted after a profile loop completes. Includes profile outcome and summary counts. |
+| `setup.completed` | Emitted when setup completes successfully or with check drift. Includes exit code and summary counts. |
+| `setup.failed` | Emitted for fatal failures that prevent normal completion. |
+
+Recommended dependency result states:
+
+- `installed`
+- `already-satisfied`
+- `satisfied-fallback`
+- `would-install`
+- `would-skip`
+- `skipped`
+- `failed`
+
+Human-readable output should present the same decisions in plain language.
+
+## 13. State and File Layout
+
+`func setup` mutates only dependency/cache state owned by the underlying subsystems:
+
+```text
 ~/.azure-functions/
-  .first-run                     # Marker: first-run hints already shown
-  workloads/                     # Owned by the workload subsystem
-  profiles/                      # Owned by the profiles subsystem
+  workloads/   # Owned by the workload subsystem
+  profiles/    # Owned by the profiles subsystem, if applicable
 ```
 
-`setup` does not write to:
+Setup does not write to:
 
-- `.func/config.json` (owned by the profiles proposal).
-- `.func/profiles.json` (owned by the profiles proposal).
-- `host.json`, `local.settings.json` (owned by `func init`).
+- `.func/config.json`
+- `.func/profiles.json`
+- `host.json`
+- `local.settings.json`
 
-## 8. Failure Semantics
+The first-run marker/hints originally proposed for setup are deferred from v1. First-run UX should be handled separately.
 
-- Each underlying subsystem call is atomic per its own contract (e.g. workload install per the Workloads spec).
-- `setup` itself accepts partial completion: a re-run finishes the job. There is no rollback.
-- Errors clearly state what completed and what did not, with the exact command to retry the failed step.
-- Non-zero exit on any failure in `--non-interactive` or `--check` mode.
+## 14. Failure Semantics
 
-## 9. Resolved Questions
+- Each underlying subsystem call is atomic per its own contract.
+- Setup accepts partial completion; a re-run finishes the job. There is no rollback.
+- Install mode stops at the first failed profile loop and exits non-zero.
+- Check mode continues through all selected profile loops and exits non-zero if any loop fails or drifts.
+- Errors clearly state what completed and what did not, with the exact command or option to retry when possible.
 
-These are concrete, lower-level decisions. The foundational architecture (identity, scope, re-run model, boundaries) is in §1 through §8.
+## 15. Boundaries with `init`, `start`, and `workload`
 
-### 9.1 Progress reporting
+The commands each own one verb:
 
-How is long-running workload install progress surfaced in CI logs (where TTY tricks fail)?
+| Command | Verb |
+| --- | --- |
+| `func init` | Scaffold a project. |
+| `func setup` | Ready a machine by ensuring selected features and profile-constrained dependencies are present. |
+| `func start` | Run a project. |
+| `func workload install` | Install a specific workload package ID or alias. |
 
-**Decision:** Spinner / progress bar when a TTY is detected. Plain-text periodic lines otherwise (the default for CI). Opt-in structured output via `--output json` for tooling that wants to parse progress events.
+`setup` does not call `init` or `start`.
 
-### 9.2 Offline / air-gapped
+`setup` may reuse the same lower-level resolvers as `start` for host, worker, profile, and extension bundle compatibility, but the setup reconciliation policy is different: setup can install or check the maximum compatible version according to `--install-policy`.
 
-Should `setup` accept a `--offline` flag that skips network attempts and only validates that already-cached artifacts satisfy the request?
-
-**Decision:** Deferred. Offline / air-gapped support will be addressed in a separate proposal that covers the CLI as a whole, not bolted onto `setup` in isolation. `setup` does not ship an `--offline` flag in v1.
-
-### 9.3 Picker UX
-
-Categorized prompt vs flat list. Do we ship a recommended-defaults set per detected language?
-
-**Decision:** Categorized picker (Languages / Features / Tools). When project inference suggests a language, that language's recommended defaults are pre-selected. The user can deselect or add to the recommendation before confirming.
-
-### 9.4 Discoverability after install
-
-Where does the "next step is `func setup`" hint surface?
-
-**Decision:** Both. The package installer prints a post-install message pointing at `func setup`, and `func` with no arguments shows a getting-started hint that includes `func setup`.
-
-### 9.5 `--check` exit codes
-
-Single non-zero on any drift, or distinct codes per drift type?
-
-**Decision:** Single non-zero exit (`exit 1`) on any drift. Drift details (which workloads are missing, which profile caches are stale, etc.) are written to stdout/stderr in human-readable form. No distinct exit codes per drift type. Tooling that needs structured drift information can use `--output json` (see §9.1).
-
-### 9.6 Inferring workloads from a project
-
-What signals does `setup` read, and how is the inference surfaced?
-
-**Decision:** `setup` does not implement its own detection. It calls the shared **project detection** module owned by the workloads spec (see [workload-spec.md](./workload-spec.md), and PR #4923 thread r3190018800 for the original signal list). Signals include:
-
-- `--stack <name>` (explicit override, when provided).
-- `local.settings.json` `FUNCTIONS_WORKER_RUNTIME`.
-- `host.json` (presence and `workerRuntime`).
-- Project marker files: `*.csproj`, `requirements.txt`, `package.json`, `pom.xml`, etc.
-- `.func/config.json` (for declared profiles, per [cli-profiles.md](./cli-profiles.md)).
-
-The inference is **informational**: the picker surfaces what was detected ("detected: Python"). What gets *pre-selected* in the picker comes from §9.3's curated recommendations, not raw detection output. The user remains the decider.
-
-Reusing the same detection module as the workloads "missing workloads" flow ensures the two callers cannot drift apart.
-
-
+`setup --features` should not accept arbitrary workload package IDs as if it were `func workload install`. That separation keeps the user-facing readiness command distinct from the lower-level workload package command.

--- a/proposed/func-update.spec.md
+++ b/proposed/func-update.spec.md
@@ -1,0 +1,269 @@
+# Spec: `func update` (in-place CLI update)
+
+## Goal
+
+Add a `func update` command that updates the installed `func` CLI in place,
+mirroring the relevant parts of `aspire update --self`. No `--self` flag, since
+the func CLI has no separate project-pinning concern: `func update` always means
+"update the CLI itself".
+
+## User experience
+
+```text
+func update                       # update to latest stable release
+func update --prerelease          # update to latest release including prereleases
+func update --version 5.1.0       # pin to a specific version
+func update -y / --yes            # skip confirmation prompts (required when non-interactive)
+```
+
+`--prerelease` matches the existing install scripts (`install.sh PRERELEASE=true`
+/ `install.ps1 -Prerelease`) so the same mental model carries over.
+
+Output is concise, themed via `IInteractionService` / `ITheme`:
+
+1. Resolve channel (stable, or prerelease when `--prerelease`).
+2. Show "Checking for updates…" spinner; print current + latest version.
+3. If up to date, exit 0 with a one-liner.
+4. If newer, prompt `Update func from X to Y? (Y/n)` (suppressed by `-y` / `--yes`).
+5. Spinner: download archive (with progress if practical), extract, swap, verify.
+6. Print new version on success, restore backup on any failure.
+
+Exit codes: `0` success / already current, non-zero on failure
+(`GracefulException` with a user-facing message for known failure modes).
+
+## Channel resolution
+
+Two release channels, matching the existing install-script behaviour:
+
+| Channel | Source | Selector |
+| --- | --- | --- |
+| stable | latest non-prerelease GitHub release | default |
+| prerelease | latest GitHub release including prereleases | `--prerelease` |
+
+Precedence:
+
+1. `--version X.Y.Z` (explicit, wins; `--prerelease` is still allowed for clarity).
+2. `--prerelease` flag → prerelease channel.
+3. Default → stable.
+
+No per-project channel config.
+
+### Version classification (SemVer)
+
+Release classification uses [SemVer 2.0](https://semver.org/) on the GitHub
+release tag, NOT the GitHub `prerelease` flag on the release object. The repo
+already publishes tags in SemVer form:
+
+| Tag           | SemVer parse                               | Channel    |
+| ------------- | ------------------------------------------ | ---------- |
+| `v5.0.0`      | `5.0.0` (no prerelease label)              | stable     |
+| `v5.1.2`      | `5.1.2` (no prerelease label)              | stable     |
+| `v5.0.0-preview.1` | `5.0.0-preview.1` (prerelease label)  | prerelease |
+| `v5.0.0-rc.1` | `5.0.0-rc.1` (prerelease label)            | prerelease |
+
+Rules:
+
+- A release is **stable** iff `SemVersion.Prerelease` is empty.
+- A release is **prerelease** iff `SemVersion.Prerelease` is non-empty
+  (any label: `preview.N`, `rc.N`, `beta.N`, etc.).
+- Tag → version: strip a leading `v`, then `SemVersion.Parse(value, SemVersionStyles.Strict)`.
+  Tags that don't parse strictly are skipped with a debug log.
+- "Latest" within a channel = the max `SemVersion` by SemVer precedence (NOT
+  GitHub's `published_at` ordering), filtered to the channel set defined above.
+- The GitHub release object's `prerelease` boolean is used only as a tiebreaker
+  when SemVer alone is ambiguous (which it shouldn't be for our tags). The
+  authoritative signal is the SemVer prerelease label.
+- The running CLI's own version (from `AssemblyCliVersionProvider`) is parsed
+  the same way, so "newer than current" comparisons use SemVer precedence.
+
+This keeps `func update` and the install scripts in lockstep: both already
+decide "is this a prerelease?" from the SemVer label, so a tag like
+`v5.0.0-preview.1` is treated as prerelease everywhere without any extra
+metadata.
+
+We pick up [Semver](https://www.nuget.org/packages/Semver) (the library Aspire
+uses) rather than `NuGet.Versioning`. It's a single small dependency that
+implements SemVer 2.0 cleanly and matches the upstream reference we're
+mirroring.
+
+### Release channels vs deployment channels (future)
+
+The `--prerelease` flag selects a **release channel** (which GitHub release to
+fetch). It is intentionally distinct from the **deployment channel**, i.e. the
+install method the user originally used (GitHub install script, npm, Homebrew,
+Chocolatey, winget, MSI).
+
+When we later support installing via npm / Homebrew / etc., `func update` MUST
+keep the user on their original deployment channel:
+
+- A user who installed via `npm i -g` should be told to run `npm i -g …` and
+  never have their npm-owned files overwritten by an in-process binary swap.
+- A Homebrew user should be told to run `brew upgrade`, and so on.
+- Only the install-script deployment channel (`~/.azure-functions/func`) ever
+  performs an in-process update.
+
+The install-method detector (see below) is the mechanism that enforces this.
+The `--prerelease` selector on `func update` still applies inside whichever
+deployment channel the user is on (e.g. `npm i -g @azure/functions-core-tools@next`
+for prerelease on npm), so the user-facing flag stays consistent across all
+install methods.
+
+## Install-method detection (must do, copy from Aspire)
+
+`func update` MUST detect package-manager installs and **defer** to them instead
+of overwriting their files:
+
+| Detected install | Behaviour |
+| --- | --- |
+| npm (`@azure/functions-core-tools` global) | Print `npm i -g @azure/functions-core-tools@<tag>` and exit 0 |
+| Homebrew (`brew list azure-functions-core-tools`) | Print `brew upgrade azure-functions-core-tools` and exit 0 |
+| Chocolatey (`choco`) | Print `choco upgrade azure-functions-core-tools` and exit 0 |
+| MSI / winget | Print `winget upgrade …` and exit 0 |
+| Install script (`~/.azure-functions/func`) | Perform in-place update (this spec) |
+
+Detection signals:
+
+- npm: env vars set by the npm launcher (Aspire pattern) and/or process path under `node_modules`.
+- brew: process path under `Cellar/`/`opt/`.
+- choco: process path under `chocolatey/lib/`.
+- winget: WindowsApps path or registry marker.
+- Fallback: in-place update if `Environment.ProcessPath` is under the install-script target dir (`~/.azure-functions` by default, configurable via env).
+
+If the binary is in an unrecognised location and not under `~/.azure-functions`,
+fail with a `GracefulException` pointing the user to re-run the install script.
+
+## In-place update flow (mirrors `ExtractAndUpdateAsync` in Aspire)
+
+1. Resolve `currentExePath = Environment.ProcessPath`; derive `installDir`.
+2. Resolve target asset from GitHub releases:
+
+Endpoint: `https://api.github.com/repos/Azure/azure-functions-core-tools/releases` (filter by `prerelease` flag).Match asset by RID (`win-x64`, `osx-arm64`, `linux-x64`, etc.), same logic the install scripts already use; share that table.
+
+3. Download the archive (`.zip` / `.tar.gz`) to a temp dir; validate SHA-256 against the release asset's published hash (the install scripts already do this; reuse).
+4. Extract to a temp dir.
+5. Locate the new `func` / `func.exe` in the extracted payload.
+6. Rename current binary to `func.old.<unixTimestamp>` (backup).
+7. Copy new binary into `installDir`; on Unix set executable bit.
+8. Probe `func --version` on the new binary; if it fails or returns garbage, roll back from backup.
+9. On success, sweep old `.old.*` siblings (Aspire's `FileDeleteHelper.TryCleanupOldItems`).
+10. If `installDir` is not on `PATH`, print the same "add to PATH" hint the install script prints.
+
+Important deltas from Aspire:
+
+- None substantive. `func` ships as a single self-contained binary
+  (`func` / `func.exe`), so the swap is the same single-file rename Aspire
+  performs: extract → backup current as `.old.<timestamp>` → copy new in place
+  → `chmod +x` on Unix → verify `func --version` → sweep old backups
+  (rollback on failure).
+- Sibling state (e.g. `~/.azure-functions/workloads`) MUST NOT be touched;
+  workloads are managed by `func workload install/update` and survive a CLI
+  update. The swap only ever writes the `func` binary itself.
+
+## Cancellation / errors
+
+- All async paths take a `CancellationToken`; Ctrl+C cancels cleanly.
+- HTTP, archive, and filesystem errors are caught at the command boundary and
+  wrapped in `GracefulException(message, isUserError: true)` with actionable
+  text (e.g. "Run with sudo" on `UnauthorizedAccessException`, "Re-run the
+  install script" if `installDir` is not writable).
+- Unrecognised exceptions surface as runtime bugs (stack trace), per repo
+  conventions.
+
+## Code layout (proposed)
+
+```text
+src/Func/Commands/Update/
+  UpdateCommand.cs          # FuncCliCommand + IBuiltInCommand, thin handler
+  UpdateCommandOptions.cs   # parsed options DTO
+  UpdateRunner.cs           # orchestrates check → download → swap → verify
+
+src/Func/Update/
+  IReleaseFeed.cs           # GitHub releases abstraction
+  GitHubReleaseFeed.cs      # IHttpClientFactory-backed impl
+  IInstallMethodDetector.cs # detects npm/brew/choco/winget/install-script
+  InstallMethodDetector.cs
+  ICliInstaller.cs          # extract + swap + verify + rollback
+  CliInstaller.cs
+  RidResolver.cs            # OS + arch → asset suffix (shared with install scripts spec)
+```
+
+All types `internal`, primary-constructor DI, no static helpers except pure
+utilities. Wire registrations in `Program.cs` / DI module. Add to
+`BuiltInCommands.cs` and `Parser.cs` per the `add-command` skill.
+
+## Tests (xUnit + NSubstitute + AwesomeAssertions)
+
+- `UpdateCommandTests` — option parsing, channel selection precedence, confirm prompt, `--yes` enforcement under non-interactive.
+- `InstallMethodDetectorTests` — npm/brew/choco/winget/script paths, env-var overrides, unknown location.
+- `CliInstallerTests` — fake filesystem + fake archive: happy path, version-probe failure → rollback, write-permission failure → rollback, partial extract failure → rollback, backup cleanup.
+- `GitHubReleaseFeedTests` — `HttpMessageHandler` stub returning fixture payloads; stable vs prerelease filtering, asset matching by RID, hash field plumbing.
+
+## Update notifier (in scope)
+
+Modeled on Aspire's `ICliUpdateNotifier`: a low-cost, non-blocking check that
+prints a single hint when a newer release is available, leaving the actual
+update as the user's explicit `func update` invocation.
+
+Behaviour:
+
+- On every `func` invocation, a background task asks `IReleaseFeed` for the
+  latest version on the current channel (stable by default; prerelease when
+  the running build is a prerelease, mirroring the install-script auto-detect).
+- The check is cached on disk under `~/.azure-functions/.update-check.json`
+  (`{ checkedAt, latestVersion, channel }`). TTL: 24 hours. Cache hit → no
+  network call.
+- The check never blocks the command: it runs in parallel with the invoked
+  command and is awaited briefly at shutdown. If it hasn't completed (or
+  errored, or is rate-limited) the CLI exits without printing anything.
+- When a newer version is detected, a single themed line is printed to stderr
+  after the command's normal output:
+
+  ```text
+  A new func release is available: 5.1.0 → 5.2.0
+  Run 'func update' to upgrade.
+  ```
+
+- Suppressed when:
+  - `--quiet` / non-TTY stderr.
+  - `FUNC_CLI_UPDATE_NOTIFIER=0` is set.
+  - The current invocation IS `func update` (avoid double-printing).
+  - The detected install method is a package manager (npm/brew/choco/winget):
+    the hint instead points at the appropriate `upgrade` command, same as
+    `func update` itself.
+- Failures (network, JSON parse, FS) are logged at `Debug` and swallowed.
+  The notifier MUST NOT change exit codes or surface stack traces.
+
+Out of the notifier's scope (separate follow-up):
+- Telemetry on hint-shown / hint-acted-on rates.
+- Per-channel opt-out (the env var is global on/off for v1).
+
+### Notifier code layout
+
+```text
+src/Func/Update/
+  ICliUpdateNotifier.cs
+  CliUpdateNotifier.cs        # background check + cache + render
+  UpdateCheckCache.cs         # JSON read/write on ~/.azure-functions/.update-check.json
+```
+
+Wired in `Program.cs` so the notifier is started before command execution and
+awaited (with a short timeout) during shutdown.
+
+### Notifier tests
+
+- `CliUpdateNotifierTests` — fresh check / cache hit / cache stale, env-var
+  off, package-manager install path (no hint), `func update` invocation
+  (suppressed), network failure (silent).
+- `UpdateCheckCacheTests` — JSON round-trip, corrupted-file recovery, TTL
+  boundary, concurrent-write race (best-effort, single writer wins).
+
+## Out of scope (for this spec)
+
+- Silent in-process auto-update on launch (download + swap without user action). Notifier only; the actual update remains an explicit `func update`.
+- Updating across major versions with breaking workload changes — same UX, but the install method detector must refuse `--version <older-major>` downgrades unless `--force` is passed.
+- Telemetry events (add once the telemetry surface stabilises).
+
+## Open questions
+
+1. Should `--version` accept a `5.x` floating spec? Aspire doesn't. Recommend: no, exact version only.
+2. Hash validation: the existing install scripts already compute and verify SHA-256 from the release notes. Confirm where the canonical hash list lives so the in-process updater reads the same source.

--- a/proposed/func-update.spec.md
+++ b/proposed/func-update.spec.md
@@ -16,12 +16,9 @@ func update --version 5.1.0       # pin to a specific version
 func update -y / --yes            # skip confirmation prompts (required when non-interactive)
 ```
 
-`--prerelease` matches the existing install scripts (`install.sh PRERELEASE=true`
-/ `install.ps1 -Prerelease`) so the same mental model carries over.
-
 Output is concise, themed via `IInteractionService` / `ITheme`:
 
-1. Resolve channel (stable, or prerelease when `--prerelease`).
+1. Determine release quality (stable only, or include prereleases).
 2. Show "Checking for updates…" spinner; print current + latest version.
 3. If up to date, exit 0 with a one-liner.
 4. If newer, prompt `Update func from X to Y? (Y/n)` (suppressed by `-y` / `--yes`).
@@ -31,87 +28,146 @@ Output is concise, themed via `IInteractionService` / `ITheme`:
 Exit codes: `0` success / already current, non-zero on failure
 (`GracefulException` with a user-facing message for known failure modes).
 
-## Channel resolution
+## Version discovery (CDN version manifest)
 
-Two release channels, matching the existing install-script behaviour:
+Version discovery uses a **version manifest** hosted on the Azure Functions CDN,
+replacing the previous GitHub Releases API approach. This avoids GitHub API rate
+limits and authentication requirements, making `func update` reliable in CI
+environments and for unauthenticated users.
 
-| Channel | Source | Selector |
+### Manifest URL
+
+```
+https://cdn.functions.azure.com/public/cli/v5/version.json
+```
+
+### Manifest format
+
+The manifest publishes the latest version at each release quality level:
+
+```json
+{
+  "stable": "5.3.0",
+  "preview": "5.4.0-preview.1"
+}
+```
+
+| Field | Description |
+| --- | --- |
+| `stable` | Latest stable release version (no prerelease label) |
+| `preview` | Latest prerelease version (any prerelease label: `preview.N`, `rc.N`, `beta.N`, etc.) |
+
+Both fields contain bare SemVer version strings (no `v` prefix).
+
+### Download URL pattern
+
+Artifacts are hosted on the same CDN at a predictable path:
+
+```
+https://cdn.functions.azure.com/public/cli/v5/{version}/Azure.Functions.Cli.{rid}.{version}.zip
+```
+
+Examples:
+
+- `https://cdn.functions.azure.com/public/cli/v5/5.1.2/Azure.Functions.Cli.win-x64.5.1.2.zip`
+- `https://cdn.functions.azure.com/public/cli/v5/5.2.0-preview.1/Azure.Functions.Cli.osx-arm64.5.2.0-preview.1.zip`
+
+### Advantages over GitHub Releases
+
+- **Better rate limits**: anonymous CDN access with far more generous limits
+  than GitHub API (60 req/hr unauthenticated).
+- **No authentication required**: works in CI, air-gapped proxies, and
+  environments where GitHub tokens aren't available.
+- **Predictable URLs**: download URLs are deterministic from version + RID,
+  no need to enumerate release assets.
+- **Faster discovery**: a single small JSON fetch vs paginated GitHub API calls.
+
+## Version selection
+
+The `--prerelease` flag controls which release quality levels are eligible when
+determining whether a newer version exists. This is about **release quality**,
+not channels — there is no channel subscription or pinning.
+
+| Quality | Manifest field | Selector |
 | --- | --- | --- |
-| stable | latest non-prerelease GitHub release | default |
-| prerelease | latest GitHub release including prereleases | `--prerelease` |
+| stable | `stable` | default (no flag) |
+| prerelease | `preview` | `--prerelease` |
 
-Precedence:
+Behaviour:
 
-1. `--version X.Y.Z` (explicit, wins; `--prerelease` is still allowed for clarity).
-2. `--prerelease` flag → prerelease channel.
-3. Default → stable.
+- **Default** (no flag): reads `stable` from manifest. Only stable releases are
+  considered.
+- **`--prerelease`**: reads both `stable` and `preview` from manifest, picks
+  whichever is higher by SemVer precedence. This means a prerelease is only
+  offered if it's actually newer than the current stable.
+- **`--version X.Y.Z`** (explicit pin): downloads directly from the CDN at the
+  specified version without consulting the manifest. `--prerelease` is still
+  allowed alongside for clarity but has no effect.
 
-No per-project channel config.
+No per-project version pinning or quality config.
 
 ### Version classification (SemVer)
 
-Release classification uses [SemVer 2.0](https://semver.org/) on the GitHub
-release tag, NOT the GitHub `prerelease` flag on the release object. The repo
-already publishes tags in SemVer form:
+Release classification uses [SemVer 2.0](https://semver.org/) on the version
+string:
 
-| Tag           | SemVer parse                               | Channel    |
-| ------------- | ------------------------------------------ | ---------- |
-| `v5.0.0`      | `5.0.0` (no prerelease label)              | stable     |
-| `v5.1.2`      | `5.1.2` (no prerelease label)              | stable     |
-| `v5.0.0-preview.1` | `5.0.0-preview.1` (prerelease label)  | prerelease |
-| `v5.0.0-rc.1` | `5.0.0-rc.1` (prerelease label)            | prerelease |
+| Version | SemVer parse | Quality |
+| --- | --- | --- |
+| `5.0.0` | no prerelease label | stable |
+| `5.1.2` | no prerelease label | stable |
+| `5.0.0-preview.1` | prerelease label | prerelease |
+| `5.0.0-rc.1` | prerelease label | prerelease |
 
 Rules:
 
-- A release is **stable** iff `SemVersion.Prerelease` is empty.
-- A release is **prerelease** iff `SemVersion.Prerelease` is non-empty
-  (any label: `preview.N`, `rc.N`, `beta.N`, etc.).
-- Tag → version: strip a leading `v`, then `SemVersion.Parse(value, SemVersionStyles.Strict)`.
-  Tags that don't parse strictly are skipped with a debug log.
-- "Latest" within a channel = the max `SemVersion` by SemVer precedence (NOT
-  GitHub's `published_at` ordering), filtered to the channel set defined above.
-- The GitHub release object's `prerelease` boolean is used only as a tiebreaker
-  when SemVer alone is ambiguous (which it shouldn't be for our tags). The
-  authoritative signal is the SemVer prerelease label.
+- A version is **stable** iff `SemVersion.Prerelease` is empty.
+- A version is **prerelease** iff `SemVersion.Prerelease` is non-empty.
 - The running CLI's own version (from `AssemblyCliVersionProvider`) is parsed
   the same way, so "newer than current" comparisons use SemVer precedence.
 
-This keeps `func update` and the install scripts in lockstep: both already
-decide "is this a prerelease?" from the SemVer label, so a tag like
-`v5.0.0-preview.1` is treated as prerelease everywhere without any extra
-metadata.
-
 We pick up [Semver](https://www.nuget.org/packages/Semver) (the library Aspire
 uses) rather than `NuGet.Versioning`. It's a single small dependency that
-implements SemVer 2.0 cleanly and matches the upstream reference we're
-mirroring.
+implements SemVer 2.0 cleanly.
 
-### Release channels vs deployment channels (future)
+### Release quality vs deployment method (future)
 
-The `--prerelease` flag selects a **release channel** (which GitHub release to
-fetch). It is intentionally distinct from the **deployment channel**, i.e. the
-install method the user originally used (GitHub install script, npm, Homebrew,
-Chocolatey, winget, MSI).
+The `--prerelease` flag controls which **release quality** is eligible (stable
+only, or include prereleases). It is intentionally distinct from the
+**deployment method** — i.e. how the user originally installed `func` (install
+script, npm, Homebrew, Chocolatey, winget, MSI).
 
 When we later support installing via npm / Homebrew / etc., `func update` MUST
-keep the user on their original deployment channel:
+keep the user on their original deployment method:
 
 - A user who installed via `npm i -g` should be told to run `npm i -g …` and
   never have their npm-owned files overwritten by an in-process binary swap.
 - A Homebrew user should be told to run `brew upgrade`, and so on.
-- Only the install-script deployment channel (`~/.azure-functions/func`) ever
+- Only the install-script deployment method (`~/.azure-functions/func`) ever
   performs an in-process update.
 
 The install-method detector (see below) is the mechanism that enforces this.
-The `--prerelease` selector on `func update` still applies inside whichever
-deployment channel the user is on (e.g. `npm i -g @azure/functions-core-tools@next`
-for prerelease on npm), so the user-facing flag stays consistent across all
-install methods.
+The `--prerelease` flag still applies regardless of deployment method (e.g.
+`npm i -g @azure/functions-core-tools@next` for prerelease on npm), so the
+user-facing flag stays consistent across all install methods.
+
+## Update flow
+
+```
+GET https://cdn.functions.azure.com/public/cli/v5/version.json
+  → parse manifest, select version based on release quality (stable or include prerelease)
+  → compare with current version (SemVer precedence)
+  → if newer: download zip from CDN at public/cli/v5/{version}/Azure.Functions.Cli.{rid}.{version}.zip
+  → extract, swap, verify
+```
 
 ## Install-method detection (must do, copy from Aspire)
 
 `func update` MUST detect package-manager installs and **defer** to them instead
-of overwriting their files:
+of overwriting their files.
+
+Installation source is baked into the global state directory at
+`~/.azure-functions/`. Only global installs are in scope; project-local installs
+are out of scope for v1.
 
 | Detected install | Behaviour |
 | --- | --- |
@@ -135,18 +191,16 @@ fail with a `GracefulException` pointing the user to re-run the install script.
 ## In-place update flow (mirrors `ExtractAndUpdateAsync` in Aspire)
 
 1. Resolve `currentExePath = Environment.ProcessPath`; derive `installDir`.
-2. Resolve target asset from GitHub releases:
-
-Endpoint: `https://api.github.com/repos/Azure/azure-functions-core-tools/releases` (filter by `prerelease` flag).Match asset by RID (`win-x64`, `osx-arm64`, `linux-x64`, etc.), same logic the install scripts already use; share that table.
-
-3. Download the archive (`.zip` / `.tar.gz`) to a temp dir; validate SHA-256 against the release asset's published hash (the install scripts already do this; reuse).
-4. Extract to a temp dir.
-5. Locate the new `func` / `func.exe` in the extracted payload.
-6. Rename current binary to `func.old.<unixTimestamp>` (backup).
-7. Copy new binary into `installDir`; on Unix set executable bit.
-8. Probe `func --version` on the new binary; if it fails or returns garbage, roll back from backup.
-9. On success, sweep old `.old.*` siblings (Aspire's `FileDeleteHelper.TryCleanupOldItems`).
-10. If `installDir` is not on `PATH`, print the same "add to PATH" hint the install script prints.
+2. Resolve target version from CDN manifest (or `--version` directly).
+3. Build download URL: `https://cdn.functions.azure.com/public/cli/v5/{version}/Azure.Functions.Cli.{rid}.{version}.zip`
+4. Download the archive to a temp dir.
+5. Extract to a temp dir.
+6. Locate the new `func` / `func.exe` in the extracted payload.
+7. Rename current binary to `func.old.<unixTimestamp>` (backup).
+8. Copy new binary into `installDir`; on Unix set executable bit.
+9. Probe `func --version` on the new binary; if it fails or returns garbage, roll back from backup.
+10. On success, sweep old `.old.*` siblings (Aspire's `FileDeleteHelper.TryCleanupOldItems`).
+11. If `installDir` is not on `PATH`, print the same "add to PATH" hint the install script prints.
 
 Important deltas from Aspire:
 
@@ -159,111 +213,124 @@ Important deltas from Aspire:
   workloads are managed by `func workload install/update` and survive a CLI
   update. The swap only ever writes the `func` binary itself.
 
+## Pipeline requirements (CDN publishing)
+
+The release pipeline must publish artifacts to the CDN and update the version
+manifest. The process uses a multi-phase approach for atomicity:
+
+### Phase 1: Upload versioned artifacts
+
+Upload the platform-specific zip archives to the CDN:
+
+```
+public/cli/v5/{version}/Azure.Functions.Cli.{rid}.{version}.zip
+```
+
+For all supported RIDs:
+
+- `win-x64`
+- `win-arm64`
+- `osx-x64`
+- `osx-arm64`
+- `linux-x64`
+- `linux-arm64`
+
+All artifacts for a version MUST be uploaded and verified before proceeding to
+Phase 2. This ensures that when a client reads a version from the manifest, the
+corresponding artifact is guaranteed to be available.
+
+### Phase 2: Upload install scripts
+
+The install scripts (`install.ps1`, `install.sh`) are hosted on the CDN at:
+
+```
+public/cli/v5/install.ps1
+public/cli/v5/install.sh
+```
+
+Install scripts MUST be **code-signed** before upload to CDN. The signing step
+is part of the release pipeline and must complete before the scripts are
+published.
+
+### Phase 3: Update version manifest
+
+After all artifacts are confirmed available, update:
+
+```
+public/cli/v5/version.json
+```
+
+Update rules:
+
+- If the published version has no prerelease label → update the `stable` field.
+- If the published version has a prerelease label → update the `preview` field.
+- Both fields are always present in the manifest (even if unchanged).
+
+### Atomicity guarantees
+
+- **Artifacts before manifest**: clients will never see a version in the manifest
+  that doesn't have downloadable artifacts. The manifest is updated last.
+- **Manifest update is a single blob write**: CDN blob overwrites are atomic from
+  the client's perspective (readers get either the old or new content, never a
+  partial write).
+- **Rollback**: to roll back a bad release, revert the manifest to the previous
+  version. The old artifacts remain on CDN and can be re-promoted by updating
+  the manifest again.
+
+### CDN caching considerations
+
+- The version manifest should have a short TTL (e.g. 5 minutes) so clients pick
+  up new versions quickly.
+- Versioned artifact blobs are immutable and can be cached aggressively
+  (long TTL / indefinite).
+- Cache drop strategy: purge all files under `public/cli/v5/` **except** for
+  `{version}/` folders (which are immutable). The manifest and install scripts
+  need cache invalidation on publish.
+- Investigate: CDN API to programmatically drop cache for specific files, to
+  integrate into release CI pipeline.
+
 ## Cancellation / errors
 
 - All async paths take a `CancellationToken`; Ctrl+C cancels cleanly.
-- HTTP, archive, and filesystem errors are caught at the command boundary and
-  wrapped in `GracefulException(message, isUserError: true)` with actionable
-  text (e.g. "Run with sudo" on `UnauthorizedAccessException`, "Re-run the
-  install script" if `installDir` is not writable).
+- HTTP errors (manifest fetch or artifact download) are caught at the command
+  boundary and wrapped in `GracefulException(message, isUserError: true)` with
+  actionable text (e.g. "Check network connectivity" on timeout, "Version not
+  found" on 404).
+- Filesystem errors are caught similarly (e.g. "Run with sudo" on
+  `UnauthorizedAccessException`, "Re-run the install script" if `installDir`
+  is not writable).
 - Unrecognised exceptions surface as runtime bugs (stack trace), per repo
   conventions.
 
-## Code layout (proposed)
+## Work items
 
-```text
-src/Func/Commands/Update/
-  UpdateCommand.cs          # FuncCliCommand + IBuiltInCommand, thin handler
-  UpdateCommandOptions.cs   # parsed options DTO
-  UpdateRunner.cs           # orchestrates check → download → swap → verify
+### Remaining (CLI implementation)
 
-src/Func/Update/
-  IReleaseFeed.cs           # GitHub releases abstraction
-  GitHubReleaseFeed.cs      # IHttpClientFactory-backed impl
-  IInstallMethodDetector.cs # detects npm/brew/choco/winget/install-script
-  InstallMethodDetector.cs
-  ICliInstaller.cs          # extract + swap + verify + rollback
-  CliInstaller.cs
-  RidResolver.cs            # OS + arch → asset suffix (shared with install scripts spec)
-```
+Proposed issue titles for remaining work under parent issue: https://github.com/Azure/azure-functions-core-tools/issues/5333
 
-All types `internal`, primary-constructor DI, no static helpers except pure
-utilities. Wire registrations in `Program.cs` / DI module. Add to
-`BuiltInCommands.cs` and `Parser.cs` per the `add-command` skill.
+- `wire UpdateCommand handler (version compare → download → swap → verify)`
+- `add IInstallMethodDetector to detect npm/brew/choco/winget installs`
+- `add confirmation prompt + --yes enforcement for non-interactive`
+- `add download progress reporting via IInteractionService`
+- `integration tests with fake HTTP server + binary swap verification`
 
-## Tests (xUnit + NSubstitute + AwesomeAssertions)
+### Remaining (pipeline / infrastructure)
 
-- `UpdateCommandTests` — option parsing, channel selection precedence, confirm prompt, `--yes` enforcement under non-interactive.
-- `InstallMethodDetectorTests` — npm/brew/choco/winget/script paths, env-var overrides, unknown location.
-- `CliInstallerTests` — fake filesystem + fake archive: happy path, version-probe failure → rollback, write-permission failure → rollback, partial extract failure → rollback, backup cleanup.
-- `GitHubReleaseFeedTests` — `HttpMessageHandler` stub returning fixture payloads; stable vs prerelease filtering, asset matching by RID, hash field plumbing.
+Existing issues:
 
-## Update notifier (in scope)
+- #5422 — Release pipeline: push v5 CLI artifacts to CDN
+- #5416 — Release pipeline: CLI archive signing + macOS notarization
+- #5423 — Per-channel rollback playbook and tooling
 
-Modeled on Aspire's `ICliUpdateNotifier`: a low-cost, non-blocking check that
-prints a single hint when a newer release is available, leaving the actual
-update as the user's explicit `func update` invocation.
+New work items (proposed):
 
-Behaviour:
+- `Update v5 install scripts (install.ps1 / install.sh) to fetch from CDN`
+- `Release pipeline: publish version.json manifest after artifact upload`
+- `Release pipeline: implement CDN cache invalidation for non-versioned files`
+- `Release pipeline: sign and upload v5 install scripts to CDN`
 
-- On every `func` invocation, a background task asks `IReleaseFeed` for the
-  latest version on the current channel (stable by default; prerelease when
-  the running build is a prerelease, mirroring the install-script auto-detect).
-- The check is cached on disk under `~/.azure-functions/.update-check.json`
-  (`{ checkedAt, latestVersion, channel }`). TTL: 24 hours. Cache hit → no
-  network call.
-- The check never blocks the command: it runs in parallel with the invoked
-  command and is awaited briefly at shutdown. If it hasn't completed (or
-  errored, or is rate-limited) the CLI exits without printing anything.
-- When a newer version is detected, a single themed line is printed to stderr
-  after the command's normal output:
+### Future (not blocking v1 of `func update`)
 
-  ```text
-  A new func release is available: 5.1.0 → 5.2.0
-  Run 'func update' to upgrade.
-  ```
-
-- Suppressed when:
-  - `--quiet` / non-TTY stderr.
-  - `FUNC_CLI_UPDATE_NOTIFIER=0` is set.
-  - The current invocation IS `func update` (avoid double-printing).
-  - The detected install method is a package manager (npm/brew/choco/winget):
-    the hint instead points at the appropriate `upgrade` command, same as
-    `func update` itself.
-- Failures (network, JSON parse, FS) are logged at `Debug` and swallowed.
-  The notifier MUST NOT change exit codes or surface stack traces.
-
-Out of the notifier's scope (separate follow-up):
-- Telemetry on hint-shown / hint-acted-on rates.
-- Per-channel opt-out (the env var is global on/off for v1).
-
-### Notifier code layout
-
-```text
-src/Func/Update/
-  ICliUpdateNotifier.cs
-  CliUpdateNotifier.cs        # background check + cache + render
-  UpdateCheckCache.cs         # JSON read/write on ~/.azure-functions/.update-check.json
-```
-
-Wired in `Program.cs` so the notifier is started before command execution and
-awaited (with a short timeout) during shutdown.
-
-### Notifier tests
-
-- `CliUpdateNotifierTests` — fresh check / cache hit / cache stale, env-var
-  off, package-manager install path (no hint), `func update` invocation
-  (suppressed), network failure (silent).
-- `UpdateCheckCacheTests` — JSON round-trip, corrupted-file recovery, TTL
-  boundary, concurrent-write race (best-effort, single writer wins).
-
-## Out of scope (for this spec)
-
-- Silent in-process auto-update on launch (download + swap without user action). Notifier only; the actual update remains an explicit `func update`.
-- Updating across major versions with breaking workload changes — same UX, but the install method detector must refuse `--version <older-major>` downgrades unless `--force` is passed.
-- Telemetry events (add once the telemetry surface stabilises).
-
-## Open questions
-
-1. Should `--version` accept a `5.x` floating spec? Aspire doesn't. Recommend: no, exact version only.
-2. Hash validation: the existing install scripts already compute and verify SHA-256 from the release notes. Confirm where the canonical hash list lives so the in-process updater reads the same source.
+- `func update: background update notifier on CLI startup`
+- `func update: deployment-method-aware upgrade hints for npm/brew/choco/winget`
+- `func update: SHA-256 verification of downloaded artifacts`

--- a/proposed/managed-azurite.md
+++ b/proposed/managed-azurite.md
@@ -1,0 +1,890 @@
+# Design Document: Managed Azurite for `func start`
+
+**Status:** Draft
+
+## 1. Problem Statement
+
+Many Azure Functions projects use local Azure Storage during development. The most common configuration is:
+
+```text
+AzureWebJobsStorage=UseDevelopmentStorage=true
+```
+
+This points the Functions host at the Azurite storage emulator, but Core Tools currently assumes the developer has already installed and started Azurite. When Azurite is missing or not running, `func start` eventually fails inside the host with storage-related errors that are not actionable for new users.
+
+The CLI can provide a better local-development experience by detecting when the host storage account is configured for Azurite, starting Azurite when needed, and failing early with clear guidance when the CLI cannot manage the emulator.
+
+### Impact
+
+- **Getting-started friction:** Developers often learn they need Azurite only after `func start` fails.
+- **Opaque failures:** Host storage failures do not clearly explain whether Azurite is missing, unavailable, or blocked by a port conflict.
+- **Inconsistent local setup:** Some users install Azurite globally, some use Docker, and some rely on IDE-integrated Azurite. The CLI should honor existing setups before falling back to managed startup.
+- **Manual coordination:** Developers must remember to start and stop Azurite separately from the Functions host.
+
+---
+
+## 2. Goals
+
+1. **Detect local host storage:** During `func start`, inspect the effective `AzureWebJobsStorage` value and determine whether it references local development storage.
+2. **Honor existing Azurite:** If the configured Azurite endpoints are already running, reuse them and do not start another emulator.
+3. **Prefer local Azurite installs:** If Azurite must be started and an Azurite executable is available locally, use it before Docker.
+4. **Docker fallback:** If no Azurite executable is available but Docker is installed and running, start a pinned Azurite container.
+5. **Actionable failure:** If neither Azurite nor Docker is available, fail before launching the host with clear installation guidance.
+6. **No Azure Storage SDK dependency:** Readiness checks must use `HttpClient` and storage-shaped HTTP responses rather than Azure Storage client libraries.
+7. **Safe ownership:** Stop only Azurite instances that Core Tools started, and never stop a user-managed Azurite process.
+8. **Predictable data and logs:** Use deterministic locations for managed Azurite data and logs.
+
+## 3. Non-goals and Scope Boundary
+
+### In scope
+
+- `func start` behavior only.
+- Detection based on `AzureWebJobsStorage` only.
+- Azurite startup using either:
+  - an existing Azurite executable, or
+  - a Docker container.
+- HTTP probing of Azurite blob, queue, and table endpoints.
+- Port conflict detection and clear error messages.
+- Cleanup of CLI-owned Azurite processes or containers.
+
+### Out of scope
+
+- Installing Azurite automatically via npm. Core Tools cannot assume that every project or development environment accepts an npm dependency, and `func start` should not impose one.
+- Installing Docker automatically.
+- Managing storage connection settings other than `AzureWebJobsStorage`.
+- Rewriting arbitrary user-defined storage connection strings.
+- Emulating Azure Storage with anything other than Azurite.
+- Supporting Azure Storage Emulator legacy binaries.
+- Guaranteeing cloud storage feature parity.
+- Adding a new long-running Azurite daemon service.
+
+> NOTE: Automatic npm installation can be considered later only if there is an explicit user opt-in and a well-defined install location. v1 should avoid modifying user projects, global npm state, or a CLI-managed npm cache because an npm dependency may be inappropriate for a given project, organization, or environment.
+
+---
+
+## 4. Key Concept: Host Storage Dependency
+
+This feature is scoped to the storage account used by the Functions host itself: `AzureWebJobsStorage`.
+
+`func start` resolves the effective value of `AzureWebJobsStorage` using the same configuration precedence that is used when launching the host. If that value references local development storage, the CLI ensures the referenced emulator is available before the host starts.
+
+The CLI does not scan every setting in `local.settings.json` in v1. Trigger-specific connection settings can independently reference Azurite, but they are not part of the host storage dependency contract for this feature.
+
+---
+
+## 5. User-facing Requirements
+
+### 5.1 Default `func start`
+
+```
+func start
+```
+
+When `AzureWebJobsStorage` references Azurite:
+
+1. Probe the configured endpoints.
+2. If Azurite is already running, reuse it.
+3. If not running, look for a local Azurite executable.
+4. If found, start Azurite as a child process.
+5. If not found, check Docker.
+6. If Docker is available, start a pinned Azurite container.
+7. If Docker is unavailable, fail with installation guidance.
+8. Once Azurite is ready, launch the Functions host.
+
+When `AzureWebJobsStorage` references Azure Storage or another non-local endpoint, `func start` does not attempt to manage Azurite.
+
+### 5.2 Opt out
+
+```
+func start --no-azurite
+```
+
+Disables all Azurite management for the current invocation.
+
+If `AzureWebJobsStorage` references local development storage and `--no-azurite` is specified, Core Tools launches the host without probing, starting, or validating Azurite. Any storage failures are left to the host.
+
+### 5.3 Verbose logging
+
+```
+func start --verbose
+```
+
+When Core Tools starts Azurite, normal output shows a short startup summary and the log file path. Verbose output may stream Azurite startup logs inline.
+
+Access logs should not be interleaved with normal Functions host output by default.
+
+### 5.4 Example output
+
+Azurite already running:
+
+```text
+AzureWebJobsStorage references local development storage.
+Using existing Azurite endpoint at http://127.0.0.1:10000.
+Starting Functions host...
+```
+
+Starting local Azurite executable:
+
+```text
+AzureWebJobsStorage references local development storage.
+Starting Azurite from C:\Users\me\AppData\Roaming\npm\azurite.cmd...
+Azurite data: C:\Users\me\.azure-functions\azurite\scopes\7f3a2c1b\data
+Azurite logs: C:\Users\me\.azure-functions\azurite\scopes\7f3a2c1b\logs\azurite.log
+Starting Functions host...
+```
+
+Starting Docker fallback:
+
+```text
+AzureWebJobsStorage references local development storage.
+Azurite executable was not found. Starting Azurite with Docker...
+Azurite image: mcr.microsoft.com/azure-storage/azurite:3.35.0
+Azurite data: C:\Users\me\.azure-functions\azurite\scopes\7f3a2c1b\data
+Starting Functions host...
+```
+
+No available runtime:
+
+```text
+AzureWebJobsStorage references local development storage, but Azurite is not running.
+
+Core Tools could not find an Azurite executable and Docker is not available.
+
+Install one of the following and run func start again:
+  - Azurite: npm install -g azurite
+  - Docker Desktop: https://docs.docker.com/desktop/
+
+Learn more about how to use Azurize with Azure Functions: https://aka.ms/azfunc-azururite
+```
+
+---
+
+## 6. Detecting Azurite References
+
+The CLI should parse the connection string into semicolon-delimited key/value pairs. Detection must be case-insensitive for keys and conservative for values.
+
+### 6.1 Positive local development storage formats
+
+#### Shortcut
+
+```text
+UseDevelopmentStorage=true
+```
+
+This is always a positive Azurite reference.
+
+#### Shortcut with proxy
+
+```text
+UseDevelopmentStorage=true;DevelopmentStorageProxyUri=http://127.0.0.1
+```
+
+This is a positive local development storage reference, but it is user-configured. The CLI may probe it, but should not attempt to start Azurite behind an arbitrary proxy in v1.
+
+#### Explicit default Azurite endpoints
+
+```text
+DefaultEndpointsProtocol=http;
+AccountName=devstoreaccount1;
+AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;
+BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;
+QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;
+TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;
+```
+
+This is a positive Azurite reference. If the endpoints use default ports and the default `devstoreaccount1` account, the CLI can manage Azurite.
+
+#### Explicit HTTPS Azurite endpoints
+
+```text
+DefaultEndpointsProtocol=https;
+AccountName=devstoreaccount1;
+AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;
+BlobEndpoint=https://localhost:10000/devstoreaccount1;
+QueueEndpoint=https://localhost:10001/devstoreaccount1;
+TableEndpoint=https://localhost:10002/devstoreaccount1;
+```
+
+This is a positive local emulator reference, but it requires certificate configuration. The CLI should probe and reuse it if already running, but should not auto-start HTTPS Azurite in v1 unless future configuration supplies certificate paths.
+
+#### Custom local endpoints
+
+```text
+DefaultEndpointsProtocol=http;
+AccountName=account1;
+AccountKey=<base64-key>;
+BlobEndpoint=http://127.0.0.1:10000/account1;
+QueueEndpoint=http://127.0.0.1:10001/account1;
+TableEndpoint=http://127.0.0.1:10002/account1;
+```
+
+This is a local emulator reference, but it may depend on `AZURITE_ACCOUNTS` or a user-managed Azurite configuration. The CLI should probe and reuse it if already running. It should not auto-start this configuration in v1 unless it can reproduce the required account settings.
+
+#### Production-style local endpoints
+
+```text
+DefaultEndpointsProtocol=http;
+AccountName=account1;
+AccountKey=<base64-key>;
+BlobEndpoint=http://account1.blob.localhost:10000;
+QueueEndpoint=http://account1.queue.localhost:10001;
+TableEndpoint=http://account1.table.localhost:10002;
+```
+
+This is a local emulator reference. The CLI should treat `*.localhost` endpoints as local. It should probe and reuse if running, but should not auto-start production-style custom account configurations in v1.
+
+### 6.2 Non-Azurite formats
+
+The CLI must not classify these as Azurite references:
+
+```text
+DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=<key>;EndpointSuffix=core.windows.net
+```
+
+```text
+BlobEndpoint=https://myaccount.blob.core.windows.net;SharedAccessSignature=<sas>
+```
+
+```text
+DefaultEndpointsProtocol=https;
+AccountName=myaccount;
+AccountKey=<key>;
+BlobEndpoint=https://myaccount.blob.core.windows.net;
+QueueEndpoint=https://myaccount.queue.core.windows.net;
+TableEndpoint=https://myaccount.table.core.windows.net;
+```
+
+### 6.3 Local host classification
+
+Endpoint hosts are considered local when they match one of:
+
+- `localhost`
+- `127.0.0.1`
+- `[::1]`
+- `::1`
+- any host ending in `.localhost`
+- `host.docker.internal`
+
+`host.docker.internal` should be considered local for detection and probing, but CLI-managed startup should still bind to loopback endpoints exposed to the host.
+
+### 6.4 Manageable vs user-configured references
+
+The CLI distinguishes between two positive classifications:
+
+| Classification | Meaning | CLI behavior |
+| --- | --- | --- |
+| `ManageableAzurite` | The CLI can reproduce the configuration exactly. | Probe; if not running, start local executable or Docker. |
+| `UserConfiguredAzurite` | The value points at local storage but requires user-specific configuration. | Probe; if not running, fail with guidance rather than guessing. |
+
+Initial `ManageableAzurite` cases:
+
+- `UseDevelopmentStorage=true` with no `DevelopmentStorageProxyUri`.
+- Explicit HTTP endpoints for `devstoreaccount1` on local hosts using blob, queue, and table endpoints.
+
+Initial `UserConfiguredAzurite` cases:
+
+- `UseDevelopmentStorage=true` with `DevelopmentStorageProxyUri`.
+- HTTPS endpoints.
+- Custom account names.
+- Production-style `*.localhost` account hosts.
+- Custom endpoint shapes that omit one or more required service endpoints.
+
+---
+
+## 7. Readiness and Endpoint Probing
+
+Azurite does not provide a dedicated `/health` endpoint. The CLI should probe storage service endpoints directly using `HttpClient`.
+
+### 7.1 Probe requirements
+
+- Do not use Azure Storage SDK packages.
+- Use short timeouts.
+- Avoid mutating storage state.
+- Treat expected storage errors as proof that a storage service is listening.
+- Distinguish "storage-shaped response" from "some other process is listening on this port."
+
+### 7.2 Blob probe
+
+For an account named `devstoreaccount1`:
+
+```http
+GET http://127.0.0.1:10000/devstoreaccount1?comp=list
+x-ms-version: 2021-12-02
+```
+
+The request does not need to be authenticated. A `400` or `403` response can still prove that Azurite or a storage-compatible service is listening.
+
+### 7.3 Queue probe
+
+```http
+GET http://127.0.0.1:10001/devstoreaccount1?comp=list
+x-ms-version: 2021-12-02
+```
+
+### 7.4 Table probe
+
+```http
+GET http://127.0.0.1:10002/devstoreaccount1/Tables
+x-ms-version: 2021-12-02
+```
+
+### 7.5 Storage-shaped response
+
+A response is storage-shaped when any of the following is true:
+
+- It includes `x-ms-request-id`.
+- It includes `x-ms-error-code`.
+- The response body is an Azure Storage-style error payload.
+- The `Server` header or equivalent response metadata identifies Azurite.
+
+The exact status code is not sufficient. A `200`, `400`, `403`, or `404` can all be valid signals depending on the request and emulator configuration.
+
+### 7.6 Probe result model
+
+| Result | Meaning | Behavior |
+| --- | --- | --- |
+| `Ready` | All required endpoints return storage-shaped responses. | Reuse or proceed. |
+| `NotListening` | No process accepts connections on one or more required endpoints. | Start Azurite if manageable. |
+| `PortConflict` | A process accepts connections but does not return storage-shaped responses. | Fail with port conflict guidance. |
+| `Partial` | Some required endpoints are ready and some are missing or conflicting. | Fail unless future configuration explicitly allows partial services. |
+
+---
+
+## 8. Startup Resolution
+
+### 8.1 Resolution flow
+
+```
+func start
+  |
+  +-- Resolve effective AzureWebJobsStorage
+  |
+  +-- If --no-azurite:
+  |     +-- Launch host without Azurite management
+  |
+  +-- Classify AzureWebJobsStorage
+        |
+        +-- Not local storage:
+        |     +-- Launch host
+        |
+        +-- UserConfiguredAzurite:
+        |     +-- Probe configured endpoints
+        |           +-- Ready: launch host
+        |           +-- Not ready: fail with user-managed Azurite guidance
+        |
+        +-- ManageableAzurite:
+              +-- Probe configured endpoints
+                    +-- Ready: launch host
+                    +-- PortConflict or Partial: fail with details
+                    +-- NotListening:
+                          +-- Find Azurite executable
+                                +-- Found: start native Azurite
+                                +-- Missing:
+                                      +-- Check Docker
+                                            +-- Available: start container
+                                            +-- Missing: fail with install guidance
+```
+
+### 8.2 Local executable discovery
+
+The CLI should look for an Azurite executable in this order:
+
+1. Project-local npm binary:
+   - Windows: `<projectRoot>\node_modules\.bin\azurite.cmd`
+   - Unix: `<projectRoot>/node_modules/.bin/azurite`
+2. PATH lookup:
+   - Windows: `azurite.cmd`, then `azurite.exe`, then `azurite`
+   - Unix: `azurite`
+
+The CLI should not require Node.js directly when an executable is present. It should execute Azurite through the discovered command path.
+
+### 8.3 Optional version check
+
+The CLI may run:
+
+```text
+azurite --version
+```
+
+If the command succeeds, Core Tools may warn when the version is below the minimum supported version. A version check failure should not block startup if the executable can still be launched and the readiness probe passes.
+
+### 8.4 Docker discovery
+
+Docker is considered available only when both checks succeed:
+
+```text
+docker --version
+docker info
+```
+
+`docker --version` alone is insufficient because Docker Desktop may be installed but not running.
+
+---
+
+## 9. Starting Azurite
+
+### 9.1 Native Azurite command
+
+For default HTTP development storage:
+
+```text
+azurite
+  -l <azuriteDataPath>
+  --blobHost 127.0.0.1
+  --queueHost 127.0.0.1
+  --tableHost 127.0.0.1
+  --blobPort 10000
+  --queuePort 10001
+  --tablePort 10002
+  --disableProductStyleUrl
+  --skipApiVersionCheck
+  --disableTelemetry
+  --silent
+  --debug <azuriteLogPath>
+```
+
+`--skipApiVersionCheck` is required to reduce local failures when the Functions host or storage libraries send a newer storage API version than the installed Azurite version recognizes.
+
+`--disableProductStyleUrl` ensures path-style URLs such as `http://127.0.0.1:10000/devstoreaccount1` are interpreted consistently.
+
+### 9.2 Docker image
+
+The Docker image must use a pinned tag, not `latest`.
+
+Initial image:
+
+```text
+mcr.microsoft.com/azure-storage/azurite:3.35.0
+```
+
+The pinned version should be owned by Core Tools and updated intentionally during CLI releases.
+
+### 9.3 Docker command
+
+```text
+docker run --rm
+  --name func-azurite-<storage-scope-id>
+  -p 127.0.0.1:10000:10000
+  -p 127.0.0.1:10001:10001
+  -p 127.0.0.1:10002:10002
+  -v <azuriteDataPath>:/data
+  -v <azuriteLogDirectory>:/logs
+  mcr.microsoft.com/azure-storage/azurite:3.35.0
+  azurite
+    -l /data
+    --blobHost 0.0.0.0
+    --queueHost 0.0.0.0
+    --tableHost 0.0.0.0
+    --blobPort 10000
+    --queuePort 10001
+    --tablePort 10002
+    --disableProductStyleUrl
+    --skipApiVersionCheck
+    --disableTelemetry
+    --silent
+    --debug /logs/azurite.log
+```
+
+Docker binds to `0.0.0.0` inside the container so mapped host ports can reach the services. Host port publishing should bind to `127.0.0.1` when supported.
+
+### 9.4 Startup timeout
+
+After starting Azurite, Core Tools polls the required endpoints until:
+
+- all required endpoints are ready,
+- the process exits,
+- the container exits,
+- a port conflict is detected, or
+- the startup timeout expires.
+
+The initial timeout should be long enough to cover Docker image startup but short enough to fail before the Functions host begins. A default of 30 seconds is recommended.
+
+---
+
+## 10. Data, Logs, and Cleanup
+
+### 10.1 Data location
+
+Managed Azurite data is scoped to the local Functions storage scope, but it is not stored under the project root by default. Core Tools should not assume `.azurite/` is ignored by source control, and `func start` should not silently create source-control-visible emulator state.
+
+Default managed data location:
+
+```text
+<funcHome>/azurite/scopes/<storage-scope-id>/data/
+```
+
+`<funcHome>` defaults to:
+
+```text
+~/.azure-functions
+```
+
+The storage scope ID must be stable for a given local host storage scope and must not contain raw project paths. It should be derived primarily from the effective Functions host ID and the endpoint tuple used by `AzureWebJobsStorage`. The normalized project root should be recorded as metadata and used as a fallback or disambiguator only when Core Tools cannot determine the effective host ID reliably.
+
+The Functions host ID is part of the storage coordination scope used by the host. Locally, the host derives a default host ID from the machine name and script path when no explicit host ID is configured, which already provides isolation between projects that use the default host ID. Core Tools should share that contract or call into the same host ID resolution logic where possible; if Core Tools cannot determine the effective host ID reliably, it should be conservative and avoid sharing a managed Azurite instance across ambiguous scopes.
+
+Reference: [`ScriptHostIdProvider`](https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script/Host/ScriptHostIdProvider.cs).
+
+Core Tools should not delete this directory automatically.
+
+Core Tools should not use a temporary directory for managed Azurite data. Local emulator data is useful development state, and temp cleanup would create unpredictable data loss.
+
+### 10.2 Project-local data opt in
+
+Project-local data may be supported as an explicit opt-in later, for example:
+
+```text
+<projectRoot>/.azurite/
+```
+
+When project-local data is explicitly configured, templates and documentation should recommend ignoring `.azurite/`. The CLI should not modify an existing `.gitignore` as part of `func start`.
+
+### 10.3 Log location
+
+Managed Azurite debug logs are written to:
+
+```text
+<funcHome>/azurite/scopes/<storage-scope-id>/logs/azurite.log
+```
+
+Normal `func start` output should include this path when Core Tools starts Azurite.
+
+### 10.4 Scope metadata
+
+Core Tools should maintain a metadata file for each managed storage scope:
+
+```text
+<funcHome>/azurite/scopes/<storage-scope-id>/scope.json
+```
+
+The metadata should include:
+
+- storage scope ID
+- effective host ID, when known
+- project root for display and cleanup decisions
+- endpoint tuple
+- data path
+- log path
+- created time
+- last-used time
+- last startup mechanism (`native` or `docker`)
+
+Each `func start` that uses a managed scope should update `lastUsedUtc`. The metadata enables future cleanup commands without scanning repository folders or inspecting Azurite data files.
+
+### 10.5 Cleanup policy
+
+Core Tools stops CLI-owned Azurite processes or containers when `func start` exits and no other active `func start` invocation has leased the same managed Azurite instance.
+
+Core Tools does not delete Azurite data or logs automatically.
+
+### 10.6 Future cleanup command
+
+Accumulation under `<funcHome>/azurite/scopes/` is expected over time. A future command should provide explicit cleanup rather than relying on temp-directory behavior or automatic deletion during `func start`.
+
+Possible command names:
+
+```text
+func azurite clean
+func storage clean
+```
+
+Cleanup should support:
+
+- listing managed scopes with project path, host ID, endpoint tuple, last-used time, and data size;
+- cleaning the current project's managed scope;
+- cleaning scopes older than a user-provided age;
+- cleaning all managed Azurite data with confirmation;
+- non-interactive mode only when the target scope is explicit.
+
+---
+
+## 11. Ownership and Multiple `func start` Instances
+
+The CLI must own only what it started.
+
+### 11.1 Ownership states
+
+| State | Description | Shutdown behavior |
+| --- | --- | --- |
+| User-managed | Azurite was already running before `func start`. | Never stop it. |
+| CLI-owned native | Core Tools started an Azurite executable. | Stop when the last lease exits. |
+| CLI-owned Docker | Core Tools started an Azurite container. | Stop the container when the last lease exits. |
+
+### 11.2 Lease file
+
+Core Tools should create a lease file for CLI-owned Azurite instances. The lease coordinates multiple `func start` processes for the same storage scope.
+
+Recommended location:
+
+```text
+<funcHome>/azurite/scopes/<storage-scope-id>/func-azurite.lock
+```
+
+The lock metadata should include:
+
+- project root
+- effective host ID, when known
+- storage scope ID
+- endpoint tuple
+- process id of the Azurite owner
+- process id of each active `func start` lease holder
+- startup mechanism (`native` or `docker`)
+- Docker container name, when applicable
+- data path
+- log path
+
+### 11.3 Same-scope sharing
+
+If a second `func start` detects a CLI-owned Azurite instance with matching storage scope ID, effective host ID, endpoint tuple, and data path:
+
+1. Add a lease.
+2. Reuse the existing emulator.
+3. Do not start a second emulator.
+4. Do not stop the emulator until all leases have exited.
+
+This is sharing, not isolation. Two Functions host instances that use the same host ID and the same storage account can coordinate through the same storage artifacts and may affect each other when run side-by-side. This is especially relevant for leases, singleton locks, timers, and other host-owned storage data. Users who need independent side-by-side runs should use distinct host IDs and distinct local storage endpoints.
+
+If Core Tools detects an existing CLI-owned Azurite instance with the same endpoints but a different effective host ID or data path, it should not silently share that instance. Because Azurite binds ports process-wide, independent scopes require different local endpoint ports in v1.
+
+### 11.4 Different-scope conflict
+
+If a `func start` detects a CLI-owned Azurite instance on the required ports for a different storage scope, Core Tools should not silently share the emulator because the data directory and host coordination scope belong to a different run context.
+
+The CLI should fail with a clear message:
+
+```text
+Azurite is already managed by another Functions storage scope on ports 10000, 10001, and 10002.
+
+Project: C:\repo\OtherFunctionApp
+Host ID: mymachine-123456789
+Data:    C:\Users\me\.azure-functions\azurite\scopes\9d4e620a\data
+
+Stop that func start session, start your own Azurite instance, or configure AzureWebJobsStorage with different local endpoints.
+```
+
+User-managed Azurite is different: if the user started Azurite outside Core Tools, Core Tools may reuse it because the user has already chosen to provide a shared emulator.
+
+### 11.5 Stale leases
+
+When reading a lease file, Core Tools should remove lease entries for processes that no longer exist. If the owner process no longer exists, Core Tools should treat the endpoints as normal:
+
+- if endpoints are ready, classify as user-managed and reuse;
+- if endpoints are not listening, start a new managed Azurite instance;
+- if endpoints conflict, fail.
+
+---
+
+## 12. Port Handling
+
+### 12.1 Defaults
+
+The default ports are:
+
+| Service | Port |
+| --- | --- |
+| Blob | `10000` |
+| Queue | `10001` |
+| Table | `10002` |
+
+### 12.2 Custom ports
+
+If `AzureWebJobsStorage` explicitly specifies local endpoints with custom ports, the CLI can classify the value as local storage. However, v1 should only auto-start when the configuration is manageable.
+
+For custom ports to be manageable, all of the following must be true:
+
+- blob, queue, and table endpoints are present;
+- all endpoints use HTTP;
+- all endpoint hosts are local;
+- account name is `devstoreaccount1`;
+- endpoint paths match the default account path format.
+
+If these conditions are met, Core Tools may start Azurite using the specified ports.
+
+### 12.3 No automatic port selection in v1
+
+The CLI should not automatically choose alternate ports when default ports are occupied.
+
+Automatically selecting ports requires rewriting `AzureWebJobsStorage` for the host process. That can be supported later, but v1 should prefer predictable behavior and explicit errors.
+
+### 12.4 Ports and data scopes
+
+Azurite uses one workspace per process. Independent storage scopes require separate Azurite workspaces, which means separate Azurite processes and separate endpoint ports when runs overlap.
+
+Because v1 does not automatically choose alternate ports, only one CLI-owned storage scope can use the default `10000`-`10002` ports at a time. A second `func start` may share the existing Azurite process only when it matches the same storage scope. Otherwise, the CLI should fail with guidance to stop the existing run or configure explicit local endpoints on different ports.
+
+### 12.5 Port conflict
+
+If a required port is occupied by a process that does not return a storage-shaped response, Core Tools should fail before starting the host.
+
+Example:
+
+```text
+AzureWebJobsStorage references local development storage, but port 10000 is already in use by a non-storage service.
+
+Stop the process using port 10000, or configure AzureWebJobsStorage with local Azurite endpoints that use different ports.
+```
+
+When practical, include process information. Failure to identify the process should not hide the port conflict.
+
+---
+
+## 13. Failure Behavior
+
+### 13.1 Azurite executable exits during startup
+
+If the native Azurite process exits before readiness:
+
+```text
+Azurite exited before it was ready.
+
+Log file: <azuriteLogPath>
+```
+
+Core Tools should not launch the Functions host.
+
+### 13.2 Docker container exits during startup
+
+If the Docker container exits before readiness, include:
+
+- container name,
+- image tag,
+- log file path if the volume was mounted,
+- a hint to run `docker logs <container>` when available.
+
+### 13.3 User-configured Azurite not running
+
+For local configurations that are not manageable:
+
+```text
+AzureWebJobsStorage points to a local storage emulator, but Core Tools cannot start this configuration automatically.
+
+Start Azurite with matching endpoints, then run func start again.
+```
+
+Include the endpoints that were expected.
+
+### 13.4 Docker unavailable
+
+Docker is unavailable when the executable is missing, Docker Desktop is not running, or the daemon cannot be reached.
+
+The error should distinguish:
+
+- Docker executable not found.
+- Docker installed but daemon unavailable.
+- Docker command failed.
+
+### 13.5 Startup timeout
+
+If the timeout expires:
+
+```text
+Azurite did not become ready within 30 seconds.
+
+Expected endpoints:
+  Blob:  http://127.0.0.1:10000/devstoreaccount1
+  Queue: http://127.0.0.1:10001/devstoreaccount1
+  Table: http://127.0.0.1:10002/devstoreaccount1
+
+Log file: <azuriteLogPath>
+```
+
+---
+
+## 14. Security and Privacy Considerations
+
+- Managed Azurite must bind to loopback by default.
+- Docker host port publishing should bind to `127.0.0.1` when supported.
+- Core Tools should not print account keys except for the known Azurite development key in examples or documentation.
+- Core Tools should not upload or transmit Azurite logs.
+- The managed data directory may contain user test data and should never be deleted automatically.
+- The default managed data directory should live under the Core Tools user data root, not the project repository, to reduce accidental source-control commits.
+- `--disableTelemetry` should be passed when Core Tools starts Azurite so the developer's `func start` does not implicitly opt into separate Azurite telemetry.
+
+---
+
+## 15. Configuration and Extensibility
+
+v1 should work without new project configuration. Future extensions may add:
+
+| Setting | Purpose |
+| --- | --- |
+| Azurite executable path | Start a specific Azurite binary. |
+| Azurite image tag | Override the pinned Docker image for testing. |
+| Azurite data path | Use a project-local, global, or custom workspace. |
+| Azurite startup timeout | Increase timeout for slow Docker startup. |
+| Azurite log mode | Stream, file-only, or silent. |
+| HTTPS certificate paths | Allow CLI-managed HTTPS Azurite. |
+
+Any persistent project-level configuration should be explicit and source-control friendly. Environment-variable overrides are preferable for machine-specific paths.
+
+---
+
+## 16. Testing Requirements
+
+### 16.1 Unit tests
+
+- Parses `UseDevelopmentStorage=true`.
+- Parses `UseDevelopmentStorage=true;DevelopmentStorageProxyUri=...`.
+- Classifies default Azurite explicit connection strings.
+- Classifies HTTPS local endpoints as user-configured.
+- Classifies custom local account endpoints as user-configured.
+- Does not classify Azure Storage account connection strings as Azurite.
+- Does not classify SAS connection strings targeting Azure as Azurite.
+- Handles connection string keys case-insensitively.
+- Handles extra semicolons and whitespace.
+- Produces expected endpoint tuples for default and explicit local formats.
+
+### 16.2 Probe tests
+
+Use a local HTTP test server, not Azurite, for most tests:
+
+- `x-ms-request-id` response is classified as storage-shaped.
+- `x-ms-error-code` response is classified as storage-shaped.
+- Non-storage response on the same port is classified as port conflict.
+- Connection refused is classified as not listening.
+- Partial endpoint readiness is classified as partial.
+
+### 16.3 Process management tests
+
+- Local Azurite executable discovery prefers project-local npm binary over PATH.
+- Docker is used only when native Azurite is not found.
+- Docker is not used when `docker info` fails.
+- CLI-owned native process is stopped when the last lease exits.
+- User-managed endpoint is not stopped.
+- Same-scope concurrent `func start` invocations share a CLI-owned emulator.
+- Same-project but different-host-ID scopes are not silently shared.
+- Different-scope CLI-owned emulator conflict is reported.
+- Managed scope metadata is created and `lastUsedUtc` is updated when a scope is used.
+- Stale leases are cleaned up.
+
+### 16.4 Integration tests
+
+- `func start` with `UseDevelopmentStorage=true` starts native Azurite when available.
+- `func start` with `UseDevelopmentStorage=true` starts Docker Azurite when native Azurite is unavailable and Docker is available.
+- `func start --no-azurite` does not probe or start Azurite.
+- Port conflict produces a pre-host-launch error.
+- The Functions host starts successfully after managed Azurite is ready.
+
+---
+
+## 17. Open Questions
+
+1. Should `--no-azurite` be the only public switch, or should v1 also include an explicit `--azurite` mode selector?
+2. Should Core Tools support a machine-level Azurite executable override in v1?
+3. Should Core Tools expose first-class flags for side-by-side isolated local storage scopes, including explicit host ID and local endpoint ports?
+4. Should custom HTTP ports be auto-startable in v1 when all endpoint details are explicit?
+5. Should the CLI surface Azurite process output in `--verbose`, or keep all Azurite output file-only?
+6. Should the future cleanup command be Azurite-specific (`func azurite clean`) or part of a broader local storage command group (`func storage clean`)?
+
+---
+
+## 18. Success Criteria
+
+- `func start` with `AzureWebJobsStorage=UseDevelopmentStorage=true` starts successfully when Azurite is already running.
+- `func start` starts a project-local or PATH Azurite executable when no emulator is running.
+- `func start` starts Docker Azurite when no executable is available and Docker is running.
+- `func start` fails before host launch with actionable guidance when neither Azurite nor Docker is available.
+- Core Tools does not take a dependency on Azure Storage SDK packages for readiness checks.
+- Core Tools never stops a user-managed Azurite instance.
+- CLI-owned Azurite data and logs are written under the Core Tools user data root by default, scoped primarily by effective host ID and endpoint tuple.
+- Port conflicts are detected before the Functions host starts.

--- a/proposed/templates-workload-spec.md
+++ b/proposed/templates-workload-spec.md
@@ -1,0 +1,606 @@
+# Templates Workload Spec
+
+## 1. Goals
+
+- Deliver function-scaffold templates as `kind: content` workloads,
+  with **one workload per language stack** (Node, Python, DotNet).
+  Each ships independently, side-by-side.
+- Preserve a single, **uniform `func new` UX across stacks** even
+  though the per-stack template formats and template sources differ.
+  A user types `func new` the same way regardless of which stack
+  workload supplied the template.
+- Make template metadata drive `func new` option hydration. Adding a
+  new template-specific input (e.g. `--auth-level`, `--queue-name`)
+  should require **no CLI release** — just a new template metadata
+  entry in the workload payload.
+- Keep the CLI binary and any *runtime* workload assemblies **free**
+  of templates. Templates ship only as installed content-workload
+  payloads. The CLI has no built-in templates.
+- Make `func new` resolution deterministic and fully offline at
+  invocation time. Every template the CLI considers comes from a
+  content workload already on disk. No CDN call from `func new` itself.
+- Decouple template revisions from CLI revisions: a templates workload
+  can be republished and reinstalled without a `func` upgrade.
+
+## 2. Non-Goals (v1)
+
+- **`func new` command implementation.** The orchestrator, prompt
+  flow, option hydration, template-engine wiring, and exit codes
+  all live in the CLI core. This spec only specifies what the
+  workload contributes to that flow.
+- **CDN access from `func new`.** Mirrors the bundles posture: the
+  CLI performs no network I/O for templates at invocation time. Template payloads are obtained at workload
+  **build time** (Node/Python) or via NuGet at `func new` time
+  through `dotnet new` (DotNet) — see §6.
+- **Auto-install of a templates workload on `func new`.** Missing or
+  unsatisfying installed templates causes `func new` to print an
+  install hint and exit non-zero (mirrors host/bundles workloads).
+- **Cross-stack templates.** Each templates workload owns exactly
+  one stack. A template that scaffolds artifacts spanning two
+  stacks (e.g. a Node trigger + Python helper) is out of scope.
+- **Contribution points / DI services.** A templates workload is
+  `kind: content`; it registers no services, contributes no commands
+  or interfaces, ships no entry-point assembly. All resolution is a
+  CLI-core concern.
+
+## 3. Definitions
+
+Listed alphabetically.
+
+| Term | Meaning |
+|------|---------|
+| **Channel** | One of `stable` / `preview` / `experimental`. Determines the templates workload pkg version's prerelease label. See §4.4.2. |
+| **`dotnet-templates.json`** | The DotNet templates workload's lean index file under `content/`. Lists template ids that the CLI core dispatches to `dotnet new` at scaffold time. Distinct from the bundle-derived `templates.json` schema used by Node and Python (§5.3). |
+| **Min bundle version** | The lowest extension-bundle version a Node/Python templates workload is known to be compatible with, expressed as a NuGet version range. |
+| **Source bundle** | The extension-bundle release (id + version) whose `StaticContent/v1` and `StaticContent/v2` sub-trees are the upstream source for a Node/Python templates workload's payload. Recorded as build-time provenance; the templates pkg version is independent of the source bundle version (§4.4.1, §4.4.2). |
+| **Stack** | The CLI's per-language axis: `node`, `python`, `dotnet`. |
+| **Template** | A single scaffoldable unit, identified by a stack-unique `id` and `name` (e.g. `HttpTrigger-JavaScript`). Produces one or more files. The exact production mechanism is engine-specific — see §4.4, §5.4. |
+| **Template metadata** | The per-template descriptor (id, language, trigger type, default function name, category, referenced user prompts, …) the CLI core reads to drive `func new`. |
+| **Template payload** | The set of file contents a template scaffolds. For Node/Python, **inlined** into the `files` map of each template entry inside `templates.json` — there are no separate per-template directories on disk. For DotNet, fetched at `func new` time via the upstream NuGet template pin (§6.3). |
+| **Templates workload** | A `kind: content` package whose payload is the function-scaffold templates for one language stack. One per stack: Node, Python, DotNet. |
+| **Templates workload install dir** | The directory the workload subsystem extracts an installed templates workload into: `<workload-home>/workloads/azure.functions.cli.workloads.templates.<stack>/<workload-pkg-version>/`. (Path is lowercased per NuGet install-path convention; the package id elsewhere uses PascalCase.) |
+| **Workload registry** | The CLI's on-disk record of installed workload packages at `<workload-home>/workloads.json`. The CLI core enumerates templates-workload rows here to find installed templates content. Read at `func new` time. |
+
+## 4. Architecture
+
+### 4.1 One content workload per stack
+
+There are three workload package ids in v1:
+
+```
+Azure.Functions.Cli.Workloads.Templates.Node
+Azure.Functions.Cli.Workloads.Templates.Python
+Azure.Functions.Cli.Workloads.Templates.DotNet
+```
+
+Each is `kind: content`:
+
+- No entry-point assembly; the workload subsystem records the
+  registry row but does not load any code.
+- The CLI core resolves the install dir by package id (mirrors
+  `Azure.Functions.Cli.Workloads.Host.<rid>` and
+  `Azure.Functions.Cli.Workloads.Workers.<stack>`).
+
+> Why per-stack packages instead of one mega-package: independent
+> ship cadence, smaller payloads, side-by-side install of multiple
+> stack versions, and natural alignment with the existing per-stack
+> packaging convention.
+
+### 4.2 CLI core ownership
+
+Templates workloads are content-only. **All** of the following live
+in the `func` CLI core:
+
+- Enumerating installed templates-workload rows from the registry.
+- Reading the templates index under each install dir.
+- Filtering by current stack or explicit `--stack`.
+- Selecting one template (by `--template` or interactive prompt).
+- Hydrating template-declared inputs into command-line options
+  before parse.
+- Invoking the right per-stack templating engine.
+- User-facing output and diagnostics.
+
+The templates workload contains **only** the template payload plus
+the build-time plumbing that fetched it. It has no runtime code.
+
+### 4.3 Per-stack divergence (details in §5–§6)
+
+| Concern | Node | Python | DotNet |
+|---|---|---|---|
+| Workload payload format | `v1/{bindings,resources,templates}/` | `v1/` + `v2/{bindings,resources,templates}/` | `dotnet-templates.json` + `source.json` (NuGet pin) |
+| Template source at workload build time | Extension-bundle CDN | Extension-bundle CDN | `Microsoft.Azure.Functions.Worker.ItemTemplates` NuGet pkg (pinned, not fetched at build) |
+| Template files inside `.nupkg`? | Yes (inline in `files` map) | Yes (inline in `files` map) | No (resolved at `func new` time via NuGet → `dotnet new` template hive) |
+| Channel axis (stable/preview/experimental)? | Yes (matches bundle channel id) | Yes (matches bundle channel id) | No (stable only; upstream NuGet preview signals propagate via `source.json`) |
+| Templating engine in CLI | Node schema engine | Python schema engine (v1 + v2) | `dotnet new <id>` shell-out |
+
+### 4.4 Versioning, channels, and bundle compatibility
+
+Templates workloads version independently of the CLI; each per-stack
+workload ships its own SemVer-tagged `.nupkg`. Node and Python
+workloads additionally track an extension-bundle channel; DotNet does
+not (no bundle dependency).
+
+#### 4.4.1 Pkg version
+
+Each templates workload has its own 3-part SemVer, decoupled from:
+
+- the CLI version (templates republish without `func` release),
+- the stack workload version (`Workloads.Stacks.<Stack>`),
+- the worker workload version (`Workloads.Workers.<Stack>`),
+- the Bundles workload version.
+
+**The templates pkg version is fully independent of any bundle
+version, regardless of stack.** The only version-axis relationship
+between a templates workload and the extension bundle is the
+min-bundle constraint (§4.4.4).
+
+Driven by two MSBuild props in `Directory.Version.props`:
+
+| Prop | Purpose |
+|---|---|
+| `$(TemplatesVersion)` | 3-part SemVer (e.g. `1.0.0`); drives `<VersionPrefix>` |
+| `$(TemplatesChannel)` | `stable` (default) / `preview` / `experimental`; selects prerelease label |
+
+| Channel | Workload pkg version (example) |
+|---|---|
+| stable | `1.0.0` |
+| preview | `1.0.0-preview` |
+| experimental | `1.0.0-experimental` |
+
+Side-by-side coexistence via `func workload install --force` matches
+the host/bundles model. Channel semantics differ by stack — see
+§4.4.2 (Node/Python) and §4.4.3 (DotNet).
+
+#### 4.4.2 Channel scheme and bundle compatibility — Node and Python
+
+A Node/Python templates workload is built from one extension-bundle
+channel's `v1/`+`v2/` content (§6.1, §6.2). The mapping is recorded
+on the workload pkg version via its prerelease label:
+
+| Templates channel (prerelease label) | Source bundle id |
+|---|---|
+| stable (no label) | `Microsoft.Azure.Functions.ExtensionBundle` |
+| preview (`-preview`) | `Microsoft.Azure.Functions.ExtensionBundle.Preview` |
+| experimental (`-experimental`) | `Microsoft.Azure.Functions.ExtensionBundle.Experimental` |
+
+**Channel is automatically derived from the project's bundle.** At
+`func new` time, the CLI reads the project's `host.json`
+`extensionBundle.id`, maps it to the corresponding templates channel
+via the table above, and picks the **highest installed templates
+pkg whose prerelease label matches** that channel. Selecting an
+experimental bundle in the project automatically resolves to the
+latest installed templates in the experimental channel. There is no
+explicit templates-channel selector — channel selection is fully
+implicit.
+
+If no installed templates workload matches the project's channel,
+the CLI surfaces a hint pointing the user at `func workload install`
+with the right channel's pkg version. There is no cross-channel
+fallback (e.g. stable templates do not satisfy an experimental
+project).
+
+**Install is independent of project state.** A user may install any
+channel's templates workload at any time, regardless of which (if
+any) bundle the current project references. Install is governed by
+explicit version (`func workload install <pkg> --version <ver>`); the
+channel is implicit in the pkg version's prerelease label.
+
+**Min-bundle compatibility check via hints.** Within the channel-
+matched set, the CLI also compares the selected templates workload's
+min-bundle (§4.4.4) against the project's resolved bundle version.
+If the bundle is too old, the CLI surfaces a warning or error.
+
+**Pkg version is independent of bundle version.** A Node/Python
+templates workload version does **not** encode the bundle version it
+was snapshot from. `$(TemplatesVersion)` follows its own SemVer
+cadence; the source-bundle version is recorded internally
+(workload-build provenance, not user-facing).
+
+#### 4.4.3 DotNet templates workload versioning
+
+The DotNet templates workload has no extension-bundle dependency
+(bindings come from NuGet references in the user's `.csproj`). It
+therefore has no channel mapping like Node/Python (§4.4.2):
+
+- `$(TemplatesChannel)` defaults to **stable** in v1. No preview /
+  experimental DotNet templates workload is planned for v1; future
+  channels can be added if a use case appears.
+- `$(TemplatesVersion)` follows its own SemVer cadence
+  (e.g. `1.0.0`, `1.1.0`), independent of the upstream
+  `Microsoft.Azure.Functions.Worker.ItemTemplates` NuGet version.
+- The pinned NuGet template-package version lives in
+  `content/source.json` (§5.3) — that's the version the CLI
+  provisions into the dotnet template hive at `func new` time.
+
+#### 4.4.4 Min-bundle version dependency
+
+A Node/Python templates workload declares a **minimum compatible
+bundle version** so the CLI can flag incompatibilities at `func new`
+time when the project's resolved bundle version is too old.
+
+- **Applies to:** Node and Python templates workloads. DotNet does
+  not declare min-bundle (no extension-bundle dependency).
+- **Granularity:** workload-wide for v1. Per-template granularity is
+  a possible future extension to the sibling manifest below.
+- **Format:** NuGet version range string (e.g. `[4.18.0, )`).
+- **Enforcement:** at `func new` time only. The CLI checks the
+  installed templates workload's min-bundle against the project's
+  resolved bundle version and surfaces mismatches as a warning or
+  error.
+
+**Storage** is duplicated across three locations, each serving a
+different consumer:
+
+- **`content/templates-workload.json` — sibling manifest** (CLI-owned
+  schema). Canonical source the CLI core reads at `func new` time.
+  Carries the structured `minBundleVersion` range and (in a future
+  extension) any per-template overrides. See §5.2 for placement.
+- **Nuspec `<tags>` field** — `minBundle:<range>` tag
+  (e.g. `minBundle:[4.18.0, )`). Workload-wide only. Lets
+  `func workload list` / `search` surface compatibility without
+  extracting the payload. Parsed at install time by the same
+  tag-prefix parser that already extracts `alias:*` tags (requires a
+  small installer extension; see §5.1).
+- **`workload.json` `description` field** — a human-readable sentence
+  in the manifest description, e.g. *"Python templates compatible
+  with `Microsoft.Azure.Functions.ExtensionBundle` (min version
+  4.0.0)."* Documentary only; surfaces in `func workload list` output.
+
+The sibling manifest is **authoritative** for CLI compatibility
+checks. The tag and description are derived and exist purely for
+discoverability — they MUST agree with the manifest at build time.
+
+## 5. Workload / Layout
+
+### 5.1 Package identity and metadata
+
+Each templates workload:
+
+- **Package id:** `Azure.Functions.Cli.Workloads.Templates.<Stack>`
+  (e.g. `Azure.Functions.Cli.Workloads.Templates.Node`).
+- **Package type:** `FuncCliWorkload`.
+- **Tags:** `kind:content alias:templates-<stack> alias:<stack>-templates func-workload`.
+  Node and Python workloads additionally carry a min-bundle tag,
+  e.g. `minBundle:[4.18.0, )` (§4.4.4).
+- **No `<dependencies>`** in the nuspec. Templates workloads are
+  self-contained; the min-bundle dependency is not expressed as a
+  NuGet dependency (§4.4.4).
+
+The `workload.json` at the package root carries the manifest plus a
+compatibility hint in the description (Node/Python):
+
+```json
+{
+  "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
+  "kind": "content",
+  "displayName": "Python templates",
+  "description": "Function-scaffold templates for Python Azure Functions projects. Compatible with Microsoft.Azure.Functions.ExtensionBundle (min version 4.0.0)."
+}
+```
+
+`displayName` and `description` surface in `func workload list`.
+The compatibility sentence in `description` is documentary; the
+authoritative min-bundle value lives in `content/templates-workload.json`
+(§4.4.4).
+
+### 5.2 On-disk layout — Node and Python
+
+Both stacks ship template content under `tools/any/content/` with
+`v1/` and `v2/` directories at the root, matching the programming-model
+split the Functions extension bundle uses internally. The CLI core
+reads from these directories directly.
+
+```
+Azure.Functions.Cli.Workloads.Templates.Node.<version>.nupkg
+├── workload.json                            (kind: content)
+├── README.md
+├── release_notes.md
+└── tools/
+    └── any/
+        └── content/
+            ├── templates-workload.json      ← CLI-owned sibling manifest:
+            │                                  { "minBundleVersion": "[4.0.0, )" }
+            │                                  (Node/Python only; §4.4.4)
+            ├── v1/                          ← legacy programming model
+            │   ├── bindings/
+            │   │   └── bindings.json
+            │   ├── resources/
+            │   │   ├── Resources.json        ← en-US default
+            │   │   ├── Resources.de-DE.json
+            │   │   ├── Resources.fr-FR.json
+            │   │   └── …                     ← i18n siblings
+            │   └── templates/
+            │       └── templates.json        ← Template[] (files inline)
+            └── v2/                          ← v2 programming model
+                ├── bindings/
+                │   └── userPrompts.json     ← UserPrompt[]
+                ├── resources/
+                │   └── Resources*.json
+                └── templates/
+                    └── templates.json        ← NewTemplate[] (jobs/actions)
+```
+
+**Per-stack content of these files:**
+
+- The **Node** workload ships `v1/templates/templates.json` populated
+  with Node-language `Template` entries (`language: "JavaScript"`,
+  `"TypeScript"`); `v1/bindings/` and `v1/resources/` are language-
+  agnostic and copied from the bundle source. `v2/` is absent
+  (Node has no v2 programming model).
+- The **Python** workload ships both `v1/` (legacy `Template` entries
+  with `language: "Python"`) and `v2/` (`NewTemplate` jobs/actions
+  for the v2 programming model).
+
+**Note on file representation.** Templates in both `v1/templates/templates.json`
+and `v2/templates/templates.json` carry their per-template files **inline**
+as a `files: { "<filename>": "<contents>" }` map within each template
+object. There is no separate on-disk file tree under `templates/`. The
+CLI core materialises individual files at `func new` time by reading
+these inline strings.
+
+**Mapping to the bundle source.** This layout is a filtered, repacked
+mirror of the bundle's `StaticContent/v1` and `StaticContent/v2`
+sub-trees. The bundle is the upstream source; the templates workload
+strips the bundle's `StaticContent/` wrapper since the workload
+package's `tools/any/content/` already plays that role. The bundle
+channel and the templates workload channel correspond 1:1 (§4.4.2).
+
+### 5.3 On-disk layout — DotNet
+
+Templates files are **not** in the workload payload, and the DotNet
+workload does **not** use the bundle StaticContent layout (DotNet has
+no extension-bundle dependency — §4.4.3). Instead the workload ships a
+small DotNet-specific index plus a pin on the upstream NuGet template
+package:
+
+```
+Azure.Functions.Cli.Workloads.Templates.DotNet.<version>.nupkg
+├── workload.json                            (kind: content)
+├── README.md
+├── release_notes.md
+└── tools/
+    └── any/
+        └── content/
+            ├── dotnet-templates.json        ← DotNet-only index (lean):
+            │                                  { "templates": [
+            │                                      { "id": "http", "language": "C#", ... },
+            │                                      { "id": "blob", "language": "C#", ... }
+            │                                    ] }
+            └── source.json                  ← NuGet pin (§6.3):
+                                               { "kind": "nuget",
+                                                 "packageId":
+                                                   "Microsoft.Azure.Functions.Worker.ItemTemplates",
+                                                 "version": "<pinned>" }
+```
+
+> Naming note: the DotNet workload's index file is named
+> `dotnet-templates.json` (not `templates.json`) to avoid clash with
+> the Node/Python bundle schema. The two are distinct file formats
+> with distinct readers in the CLI core.
+
+When `func new --stack dotnet` runs, the CLI core reads `source.json`,
+ensures the pinned NuGet template package is installed into the dotnet
+template hive maintained by the CLI core, and dispatches each
+`dotnet-templates.json` entry to `dotnet new <id>`.
+
+The full `dotnet-templates.json` schema (fields per entry, optional
+metadata) is open — see §8.
+
+### 5.4 Templates and binding schemas
+
+The templates workload uses a **CLI-owned schema** derived from the
+Functions extension bundle's `StaticContent/v1/` and `StaticContent/v2/`
+schemas. Minor modifications from the bundle baseline are expected
+(e.g. fields the bundle doesn't have, fields the CLI doesn't consume
+that may be omitted). Two top-level shapes apply, one per
+programming-model version.
+
+> Paths in the schema examples below are **bundle-source** paths.
+> Workload-side paths drop the `StaticContent/` prefix (§5.2).
+
+**v1 — `StaticContent/v1/templates/templates.json`** is a `Template[]`
+array. Each entry has the legacy fields the v4 CLI already understands:
+
+```jsonc
+{
+  "id": "HttpTrigger-JavaScript",
+  "files": {
+    "index.js": "module.exports = async function (context, req) { ... }",
+    "function.json": "{ \"bindings\": [ ... ] }",
+    "sample.dat": "..."
+  },
+  "function": { "bindings": [ { "type": "httpTrigger", ... } ] },
+  "metadata": {
+    "defaultFunctionName": "HttpTrigger",
+    "description": "$HttpTrigger_description",         // resource key
+    "name": "HTTP trigger",
+    "language": "JavaScript",
+    "category": [ "$temp_category_core", "$temp_category_api" ],
+    "categoryStyle": "http",
+    "enabledInTryMode": true,
+    "userPrompt": [ "connection", "httpTrigger-route", "httpTrigger-authLevel" ]
+  }
+}
+```
+
+> `userPrompt[]` references prompt ids defined in
+> `StaticContent/v2/bindings/userPrompts.json` — yes, v1 templates
+> reference v2 prompts. This is intentional in the upstream bundle:
+> the prompt catalog is unified across model versions.
+
+**v2 — `StaticContent/v2/templates/templates.json`** is a `NewTemplate[]`
+array used by the Python v2 programming model. Each entry carries the
+job/action DSL:
+
+```jsonc
+{
+  "name": "Blob trigger",
+  "description": "$BlobTrigger_description",
+  "programmingModel": "v2",
+  "language": "python",
+  "jobs": [
+    {
+      "name": "Create New Project with BlobTrigger function",
+      "type": "CreateNewApp",
+      "inputs": [
+        {
+          "assignTo": "$(APP_FILENAME)",
+          "paramId": "app-fileName",
+          "defaultValue": "function_app.py",
+          "required": true
+        }
+        // ... more input entries
+      ]
+    }
+  ]
+}
+```
+
+**Supporting files** (paths are bundle-source; workload-side drops the `StaticContent/` prefix):
+
+- `StaticContent/v1/bindings/bindings.json` — binding catalog (v1).
+- `StaticContent/v2/bindings/userPrompts.json` — `UserPrompt[]`, defines
+  validators / enums / labels referenced by `paramId` from templates and
+  `metadata.userPrompt`.
+- `StaticContent/<v1|v2>/resources/Resources.json` (+ `Resources.<locale>.json`)
+  — i18n strings the templates and prompts reference via `$key` syntax.
+
+**Schema authority.** The templates workload owns its schema. The
+bundle's schemas are the baseline; the workload-side schema may
+diverge as the CLI's needs evolve. The build pipeline (§6.1, §6.2)
+applies the divergences when extracting content from the bundle
+source.
+
+## 6. Template Source
+
+### 6.1 Node templates — bundle StaticContent
+
+The Node templates workload **does not reauthor templates**. It pulls
+its content at workload build time from the **Functions extension
+bundle CDN**, the same source the v4 CLI's `func new` resolves
+templates from today. Specifically: the templates workload package
+embeds a filtered snapshot of one bundle's `StaticContent/` directory
+tree (the layout shown in §5.2).
+
+**Source bundle.** Each templates workload package targets one of the
+three published bundle channels (channel ↔ bundle id mapping in §4.4.2).
+
+**Build pipeline.**
+
+1. The workload csproj declares two MSBuild properties:
+   - `$(SourceBundleId)` — one of the three bundle ids.
+   - `$(SourceBundleVersion)` — the bundle version to snapshot (e.g.
+     `4.30.0`). Recorded as workload-build provenance only; **not**
+     used to derive the templates pkg version (see §4.4.2).
+2. A `FetchBundleStaticContent.targets` target downloads
+   `<SourceBundleId>/<SourceBundleVersion>` from the bundle CDN and
+   extracts only the `StaticContent/` subdirectory of the bundle's
+   payload.
+3. A filter pass removes per-language template entries that don't
+   belong to this stack: keep `Template` entries with
+   `metadata.language ∈ {"JavaScript", "TypeScript"}` from
+   `v1/templates/templates.json`; drop everything else.
+   Bindings and resources are language-agnostic — copied.
+4. `Pack` places the filtered tree under `tools/any/content/` of the
+   templates workload nupkg, stripping the bundle's outer
+   `StaticContent/` wrapper so the layout in §5.2 is achieved.
+
+Build-time fetch keeps `func new` offline-at-invocation. The bundle
+CDN is contacted **once per workload republish**, not per user
+invocation.
+
+### 6.2 Python templates — bundle StaticContent
+
+Same mechanism as §6.1, filtered for Python.
+
+- **v1 templates:** keep `Template` entries with
+  `metadata.language == "Python"` from
+  `v1/templates/templates.json`.
+- **v2 templates:** keep `NewTemplate` entries with
+  `language == "python"` from `v2/templates/templates.json`
+  (the Python v2 programming model lives here).
+- Bindings and resources for both v1 and v2 are copied
+  (language-agnostic).
+
+The bundle's `v2/bindings/userPrompts.json` is included in the Python
+workload because Python v1 templates also reference v2 prompts via
+their `metadata.userPrompt[]` lists (see §5.4 note).
+
+### 6.3 DotNet templates — NuGet pin
+
+DotNet does not fetch templates at workload build time. Instead:
+
+1. The DotNet templates workload ships only `dotnet-templates.json` +
+   `source.json` (§5.3).
+2. `source.json` pins a specific version of
+   `Microsoft.Azure.Functions.Worker.ItemTemplates` (the upstream
+   `dotnet new` template package).
+
+At `func new` time, the CLI core consults `source.json`, provisions
+the pinned NuGet pkg into the dotnet template hive, and dispatches
+templates from `dotnet-templates.json` to `dotnet new <id>`. The
+CLI-side mechanics are out of scope; see the `func new` CLI spec.
+
+The DotNet templates workload is therefore much smaller (KB-scale:
+just the two JSON files). The pin gives the CLI a deterministic,
+reviewable template version.
+
+Open question (§8): when offline at `func new` time, can the CLI
+fall back to whatever templates are already in the hive even if
+they differ from `source.json`'s pin?
+
+## 7. Compatibility & Migration
+
+### 7.1 v4 → v5
+
+- `func extensions install` removal: already removed in the v5 CLI;
+  templates workload does not re-introduce it. Templates that
+  formerly relied on `Template.Metadata.Extensions` (a NuGet pkg
+  list) should be migrated to assume the extension bundle is the
+  source of truth.
+- The legacy `func new` command from v4 is replaced by the v5 CLI's
+  built-in `func new` consuming this workload model.
+
+### 7.2 Within v5 (templates workload revisions)
+
+Newer templates workload pkg versions install side-by-side with
+older ones. For v1, installs are explicit-version (§4.4.2); how the
+CLI picks which installed version to use at `func new` time is an
+open question (§8).
+
+## 8. Open Questions
+
+_None at this time._
+
+### Resolved
+
+- ✅ **`kind: content`, not `kind: workload`.** No DI / no
+  contribution points. Settled at this draft.
+- ✅ **One workload per stack, not a single mega-workload.**
+  §4.1.
+- ✅ **`func new` lives in CLI core, not in the workload.** §1.
+- ✅ **Templates pkg version is independent of bundle version**, for
+  every stack. The only version-axis relationship between a templates
+  workload and the extension bundle is `minBundleVersion`. §4.4.1,
+  §4.4.2.
+- ✅ **Templates packaged at workload build time** for Node/Python
+  (CDN fetch becomes a build dependency), **at `func new` time
+  via `dotnet new`** for DotNet (NuGet pin). §6.
+- ✅ **Schema is CLI-owned**, derived from but not identical to the
+  bundle baseline. Minor divergences expected over time. §5.4.
+- ✅ **Min-bundle storage:** sibling manifest `content/templates-workload.json`
+  (authoritative) + nuspec `minBundle:<range>` tag (discoverability) +
+  `workload.json` description sentence (human-readable). Workload-wide
+  granularity for v1. §4.4.4, §5.1, §5.2.
+- ✅ **`source.json` schema (DotNet only):** `{ kind: "nuget",
+  packageId, version }`. The `kind` discriminator leaves room for
+  future variants (e.g. embedded) without committing to one. §5.3.
+- ✅ **Partition by stack, not by language.** One workload per stack
+  (Node, Python, DotNet). Language is a per-template property
+  (`metadata.language`) within a stack's workload — Node ships both
+  JS and TS templates in one package, etc. §4.1.
+- ✅ **Templates channel auto-matches the project's bundle channel.**
+  At `func new`, the CLI picks the highest installed templates pkg
+  whose prerelease label matches the channel of the project's
+  `host.json` `extensionBundle.id`. No explicit `--templates-channel`
+  flag, no `.func/config.json` pin, no cross-channel fallback. §4.4.2.

--- a/proposed/templates-workload-spec.md
+++ b/proposed/templates-workload-spec.md
@@ -29,9 +29,13 @@
   all live in the CLI core. This spec only specifies what the
   workload contributes to that flow.
 - **CDN access from `func new`.** Mirrors the bundles posture: the
-  CLI performs no network I/O for templates at invocation time. Template payloads are obtained at workload
-  **build time** (Node/Python) or via NuGet at `func new` time
-  through `dotnet new` (DotNet) — see §6.
+  CLI performs no network I/O for templates at invocation time. Template
+  payloads are obtained at workload **build time**: Node/Python embed a
+  filtered bundle StaticContent snapshot; DotNet hydrates
+  `dotnet-templates.json` from the pinned NuGet template pkg and pins
+  the same pkg in `source.json`, which `func workload install`
+  provisions into the dotnet template hive (no NuGet I/O at `func new`
+  time) — see §6.
 - **Auto-install of a templates workload on `func new`.** Missing or
   unsatisfying installed templates causes `func new` to print an
   install hint and exit non-zero (mirrors host/bundles workloads).
@@ -50,9 +54,9 @@ Listed alphabetically.
 | Term | Meaning |
 |------|---------|
 | **Channel** | One of `stable` / `preview` / `experimental`. Determines the templates workload pkg version's prerelease label. See §4.4.2. |
-| **`dotnet-templates.json`** | The DotNet templates workload's lean index file under `content/`. Lists template ids that the CLI core dispatches to `dotnet new` at scaffold time. Distinct from the bundle-derived `templates.json` schema used by Node and Python (§5.3). |
+| **`dotnet-templates.json`** | The DotNet templates workload's fully-hydrated catalog + per-template option index under `content/`. Built at workload pack time from each upstream `template.json` (+ optional `dotnetcli.host.json`); drives `func templates list` and `func new --template <id> --help` fully offline from the workload payload. Distinct from the bundle-derived `templates.json` schema used by Node and Python (§5.3, §5.3.1). |
 | **Min bundle version** | The lowest extension-bundle version a Node/Python templates workload is known to be compatible with, expressed as a NuGet version range. |
-| **Source bundle** | The extension-bundle release (id + version) whose `StaticContent/v1` and `StaticContent/v2` sub-trees are the upstream source for a Node/Python templates workload's payload. Recorded as build-time provenance; the templates pkg version is independent of the source bundle version (§4.4.1, §4.4.2). |
+| **Source bundle** | The extension-bundle release (id + version) whose `StaticContent/v2` sub-tree is the upstream source for a Node/Python templates workload's payload. Recorded as build-time provenance; the templates pkg version is independent of the source bundle version (§4.4.1, §4.4.2). |
 | **Stack** | The CLI's per-language axis: `node`, `python`, `dotnet`. |
 | **Template** | A single scaffoldable unit, identified by a stack-unique `id` and `name` (e.g. `HttpTrigger-JavaScript`). Produces one or more files. The exact production mechanism is engine-specific — see §4.4, §5.4. |
 | **Template metadata** | The per-template descriptor (id, language, trigger type, default function name, category, referenced user prompts, …) the CLI core reads to drive `func new`. |
@@ -107,11 +111,12 @@ the build-time plumbing that fetched it. It has no runtime code.
 
 | Concern | Node | Python | DotNet |
 |---|---|---|---|
-| Workload payload format | `v1/{bindings,resources,templates}/` | `v1/` + `v2/{bindings,resources,templates}/` | `dotnet-templates.json` + `source.json` (NuGet pin) |
-| Template source at workload build time | Extension-bundle CDN | Extension-bundle CDN | `Microsoft.Azure.Functions.Worker.ItemTemplates` NuGet pkg (pinned, not fetched at build) |
-| Template files inside `.nupkg`? | Yes (inline in `files` map) | Yes (inline in `files` map) | No (resolved at `func new` time via NuGet → `dotnet new` template hive) |
-| Channel axis (stable/preview/experimental)? | Yes (matches bundle channel id) | Yes (matches bundle channel id) | No (stable only; upstream NuGet preview signals propagate via `source.json`) |
-| Templating engine in CLI | Node schema engine | Python schema engine (v1 + v2) | `dotnet new <id>` shell-out |
+| Workload payload format | `v2/{bindings,resources,templates}/` | `v2/{bindings,resources,templates}/` | `dotnet-templates.json` + `source.json` (NuGet pin) |
+| Template source at workload build time | **In-repo static content** (`src/Workloads/Templates/Node/content/v2/`), ported from the v4 Node templates in core-tools `main` via a converter script. The upstream extension bundle does not yet publish v2 Node entries. | Extension-bundle CDN | `Microsoft.Azure.Functions.Worker.ItemTemplates` NuGet pkg (fetched at build to hydrate `dotnet-templates.json`) |
+| Per-template source files in workload? | Yes (inline in `files` map) | Yes (inline in `files` map) | No — provisioned into the dotnet template hive from `source.json`'s NuGet pin (§6.3) |
+| Catalog + per-template option metadata in workload? | Inline in each `NewTemplate` entry | Inline in each `NewTemplate` entry | Yes — `dotnet-templates.json` is fully hydrated at workload build time from the pinned NuGet pkg's `template.json` files (§5.3, §6.3) |
+| Channel axis (stable/preview/experimental)? | **Yes**, with **per-channel template subsetting**: pack time fetches `bin/extensions.json` from the channel's latest listed bundle (`index.json` + HTTP-Range zip extraction) and drops templates whose required bindings aren't in the channel (§6.1). | Yes (matches bundle channel id) | No (stable only; upstream NuGet preview signals propagate via `source.json`) |
+| Templating engine in CLI | v2 schema engine (jobs / actions DSL) | v2 schema engine (jobs / actions DSL) | Catalog + `--help` from `dotnet-templates.json`; scaffold via `dotnet new <id>` shell-out (§5.3) |
 
 ### 4.4 Versioning, channels, and bundle compatibility
 
@@ -154,7 +159,7 @@ the host/bundles model. Channel semantics differ by stack — see
 #### 4.4.2 Channel scheme and bundle compatibility — Node and Python
 
 A Node/Python templates workload is built from one extension-bundle
-channel's `v1/`+`v2/` content (§6.1, §6.2). The mapping is recorded
+channel's `v2/` content (§6.1, §6.2). The mapping is recorded
 on the workload pkg version via its prerelease label:
 
 | Templates channel (prerelease label) | Source bundle id |
@@ -259,36 +264,35 @@ Each templates workload:
 - **Package id:** `Azure.Functions.Cli.Workloads.Templates.<Stack>`
   (e.g. `Azure.Functions.Cli.Workloads.Templates.Node`).
 - **Package type:** `FuncCliWorkload`.
-- **Tags:** `kind:content alias:templates-<stack> alias:<stack>-templates func-workload`.
+- **Tags:** `kind:content alias:<stack>-templates func-workload`.
   Node and Python workloads additionally carry a min-bundle tag,
   e.g. `minBundle:[4.18.0, )` (§4.4.4).
 - **No `<dependencies>`** in the nuspec. Templates workloads are
   self-contained; the min-bundle dependency is not expressed as a
   NuGet dependency (§4.4.4).
 
-The `workload.json` at the package root carries the manifest plus a
-compatibility hint in the description (Node/Python):
+The `workload.json` at the package root carries the manifest:
 
 ```json
 {
   "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
   "kind": "content",
-  "displayName": "Python templates",
-  "description": "Function-scaffold templates for Python Azure Functions projects. Compatible with Microsoft.Azure.Functions.ExtensionBundle (min version 4.0.0)."
+  "displayName": "Python function templates",
+  "description": "Function-scaffold templates for Python Azure Functions projects (v2 programming model)."
 }
 ```
 
-`displayName` and `description` surface in `func workload list`.
-The compatibility sentence in `description` is documentary; the
-authoritative min-bundle value lives in `content/templates-workload.json`
-(§4.4.4).
+`displayName` and `description` surface in `func workload list`. The
+`description` is kept short and bundle-agnostic; the authoritative
+min-bundle constraint lives in `content/templates-workload.json`
+(§4.4.4), not in the `workload.json` description.
 
 ### 5.2 On-disk layout — Node and Python
 
-Both stacks ship template content under `tools/any/content/` with
-`v1/` and `v2/` directories at the root, matching the programming-model
-split the Functions extension bundle uses internally. The CLI core
-reads from these directories directly.
+Both stacks ship template content under `tools/any/content/` with a
+single `v2/` directory at the root. v1 (legacy) programming-model
+templates are not shipped in v5 templates workloads. The CLI core
+reads from `v2/` directly.
 
 ```
 Azure.Functions.Cli.Workloads.Templates.Node.<version>.nupkg
@@ -301,57 +305,54 @@ Azure.Functions.Cli.Workloads.Templates.Node.<version>.nupkg
             ├── templates-workload.json      ← CLI-owned sibling manifest:
             │                                  { "minBundleVersion": "[4.0.0, )" }
             │                                  (Node/Python only; §4.4.4)
-            ├── v1/                          ← legacy programming model
-            │   ├── bindings/
-            │   │   └── bindings.json
-            │   ├── resources/
-            │   │   ├── Resources.json        ← en-US default
-            │   │   ├── Resources.de-DE.json
-            │   │   ├── Resources.fr-FR.json
-            │   │   └── …                     ← i18n siblings
-            │   └── templates/
-            │       └── templates.json        ← Template[] (files inline)
             └── v2/                          ← v2 programming model
                 ├── bindings/
                 │   └── userPrompts.json     ← UserPrompt[]
                 ├── resources/
-                │   └── Resources*.json
+                │   ├── Resources.json        ← en-US default
+                │   ├── Resources.de-DE.json
+                │   ├── Resources.fr-FR.json
+                │   └── …                     ← i18n siblings
                 └── templates/
                     └── templates.json        ← NewTemplate[] (jobs/actions)
 ```
 
 **Per-stack content of these files:**
 
-- The **Node** workload ships `v1/templates/templates.json` populated
-  with Node-language `Template` entries (`language: "JavaScript"`,
-  `"TypeScript"`); `v1/bindings/` and `v1/resources/` are language-
-  agnostic and copied from the bundle source. `v2/` is absent
-  (Node has no v2 programming model).
-- The **Python** workload ships both `v1/` (legacy `Template` entries
-  with `language: "Python"`) and `v2/` (`NewTemplate` jobs/actions
-  for the v2 programming model).
+- The **Node** workload ships `v2/templates/templates.json` populated
+  with Node-language `NewTemplate` entries (`language: "javascript"`,
+  `"typescript"`); `v2/bindings/` and `v2/resources/` are language-
+  agnostic and copied from the bundle source. **Status:** the
+  extension bundle does not yet publish v2 templates for Node, so the
+  Node v2 content pipeline is tracked as a follow-up (§6.1); the
+  shipped Node workload payload may be empty or transitional until
+  that work lands.
+- The **Python** workload ships `v2/` (`NewTemplate` jobs/actions for
+  the v2 programming model, `language: "python"`) filtered from the
+  bundle's `StaticContent/v2` sub-tree. v1 (legacy) Python templates
+  are not shipped.
 
-**Note on file representation.** Templates in both `v1/templates/templates.json`
-and `v2/templates/templates.json` carry their per-template files **inline**
-as a `files: { "<filename>": "<contents>" }` map within each template
-object. There is no separate on-disk file tree under `templates/`. The
-CLI core materialises individual files at `func new` time by reading
-these inline strings.
+**Note on file representation.** Templates in `v2/templates/templates.json`
+carry their per-template files **inline** as a `files: { "<filename>":
+"<contents>" }` map within each template object. There is no separate
+on-disk file tree under `templates/`. The CLI core materialises
+individual files at `func new` time by reading these inline strings.
 
 **Mapping to the bundle source.** This layout is a filtered, repacked
-mirror of the bundle's `StaticContent/v1` and `StaticContent/v2`
-sub-trees. The bundle is the upstream source; the templates workload
-strips the bundle's `StaticContent/` wrapper since the workload
-package's `tools/any/content/` already plays that role. The bundle
-channel and the templates workload channel correspond 1:1 (§4.4.2).
+mirror of the bundle's `StaticContent/v2` sub-tree. The bundle is the
+upstream source; the templates workload strips the bundle's
+`StaticContent/` wrapper since the workload package's
+`tools/any/content/` already plays that role. The bundle channel and
+the templates workload channel correspond 1:1 (§4.4.2).
 
 ### 5.3 On-disk layout — DotNet
 
-Templates files are **not** in the workload payload, and the DotNet
-workload does **not** use the bundle StaticContent layout (DotNet has
-no extension-bundle dependency — §4.4.3). Instead the workload ships a
-small DotNet-specific index plus a pin on the upstream NuGet template
-package:
+Template source files are **not** in the workload payload, and the DotNet
+workload does **not** use the bundle StaticContent layout (DotNet has no
+extension-bundle dependency — §4.4.3). The DotNet workload instead carries a
+**fully-hydrated catalog + option index** (`dotnet-templates.json`) generated at
+workload build time from the upstream NuGet template package, plus the NuGet
+pin that drives scaffold-time hive provisioning:
 
 ```
 Azure.Functions.Cli.Workloads.Templates.DotNet.<version>.nupkg
@@ -361,11 +362,12 @@ Azure.Functions.Cli.Workloads.Templates.DotNet.<version>.nupkg
 └── tools/
     └── any/
         └── content/
-            ├── dotnet-templates.json        ← DotNet-only index (lean):
-            │                                  { "templates": [
-            │                                      { "id": "http", "language": "C#", ... },
-            │                                      { "id": "blob", "language": "C#", ... }
-            │                                    ] }
+            ├── dotnet-templates.json        ← hydrated at workload build time
+            │                                  from each template's template.json
+            │                                  (+ dotnetcli.host.json). Drives
+            │                                  `func templates list` and
+            │                                  `func new --template <id> --help`
+            │                                  fully offline. Schema below.
             └── source.json                  ← NuGet pin (§6.3):
                                                { "kind": "nuget",
                                                  "packageId":
@@ -378,58 +380,129 @@ Azure.Functions.Cli.Workloads.Templates.DotNet.<version>.nupkg
 > the Node/Python bundle schema. The two are distinct file formats
 > with distinct readers in the CLI core.
 
-When `func new --stack dotnet` runs, the CLI core reads `source.json`,
-ensures the pinned NuGet template package is installed into the dotnet
-template hive maintained by the CLI core, and dispatches each
-`dotnet-templates.json` entry to `dotnet new <id>`.
+#### 5.3.1 `dotnet-templates.json` schema
 
-The full `dotnet-templates.json` schema (fields per entry, optional
-metadata) is open — see §8.
+`dotnet-templates.json` is the canonical CLI-side index for the DotNet stack.
+It is built once at workload pack time by projecting each
+`*/.template.config/template.json` (+ optional sibling `dotnetcli.host.json`)
+from the pinned NuGet template package into a CLI-friendly record. Every field
+needed to render catalog rows and to hydrate `func new --template <id> --help`
+options is present, so both commands serve **fully offline, deterministically,
+from the workload payload** — no NuGet I/O, no `dotnet new` shell-out on read
+paths. Only the actual scaffold (`func new <template>`) shells out to
+`dotnet new`, and even that is offline once the hive is provisioned at install
+time (see §6.3).
+
+```jsonc
+{
+  "$schema": "https://aka.ms/func-workloads/dotnet-templates/v1/schema.json",
+  "sourcePackage": {
+    "id":      "Microsoft.Azure.Functions.Worker.ItemTemplates.NetCore",
+    "version": "4.0.5569"
+  },
+  "templates": [
+    {
+      // ── Catalog row (powers `func templates list`) ───────────────────
+      "id":              "http",                                  // shortNameList[0]
+      "shortNames":      ["http"],                                // full alias list
+      "identity":        "Azure.Function.CSharp.HttpTrigger.2.x", // stable, used to dispatch dotnet new
+      "groupIdentity":   "Azure.Function.HttpTrigger",            // dedupes C#/F# variants
+      "name":            "HttpTrigger",
+      "description":     "Creates an HTTP-triggered function.",
+      "author":          "Microsoft",
+      "language":        "C#",                                    // tags.language
+      "type":            "item",                                  // tags.type
+      "classifications": ["Azure Function", "Trigger", "Http"],   // triggers the "TRIGGER" column
+      "defaultName":     "HttpTriggerCSharp",
+      "constraints":     [ /* mirrored from template.json `constraints` */ ],
+
+      // ── Option hydration (powers `func new --template http --help`) ──
+      "parameters": [
+        {
+          "name":         "namespace",
+          "description":  "namespace for the generated code",
+          "dataType":     "string",
+          "defaultValue": "Company.Function",
+          "isRequired":   false,
+          "isHidden":     false
+        },
+        {
+          "name":         "AccessRights",
+          "displayName":  "Authorization level",
+          "description":  "Authorization level controls whether the function requires an API key …",
+          "dataType":     "choice",
+          "defaultValue": "Function",
+          "choices": [
+            { "value": "Function",  "description": "Function"  },
+            { "value": "Anonymous", "description": "Anonymous" },
+            { "value": "Admin",     "description": "Admin"     }
+          ],
+          "allowMultipleValues": false,
+          "shortNameOverride":   null,    // from dotnetcli.host.json (if present)
+          "longNameOverride":    null
+        }
+        // `bind`, `derived`, `computed`, `generated`, and hidden symbols are
+        // not user-facing options and are excluded from `parameters[]`.
+      ]
+    }
+  ]
+}
+```
+
+**Field provenance.** Every field is derivable from the upstream NuGet
+template package without re-running the dotnet template engine at scaffold
+time, mirroring the surface exposed by `ITemplateInfo` / `ITemplateMetadata`
+and (for `parameters[]`) `CliTemplateParameter.GetOption(...)`:
+
+| Schema field | Source on the upstream template |
+|---|---|
+| `id`, `shortNames` | `template.json` `shortName` |
+| `identity` | `template.json` `identity` |
+| `groupIdentity` | `template.json` `groupIdentity` |
+| `name`, `description`, `author` | `template.json` `name` / `description` / `author` |
+| `language`, `type` | `template.json` `tags.language` / `tags.type` |
+| `classifications` | `template.json` `classifications` |
+| `defaultName` | `template.json` `defaultName` |
+| `constraints` | `template.json` `constraints` |
+| `parameters[].name` | `template.json` `symbols.<key>` |
+| `parameters[].dataType` | `symbols.<key>.datatype` |
+| `parameters[].defaultValue` | `symbols.<key>.defaultValue` |
+| `parameters[].choices[]` | `symbols.<key>.choices[]` |
+| `parameters[].isRequired` | derived from `symbols.<key>.isRequired` / precedence |
+| `parameters[].isHidden` | `dotnetcli.host.json` `hiddenParameterNames` ∪ implicit/disabled precedence |
+| `parameters[].displayName` | `symbols.<key>.displayName` |
+| `parameters[].shortNameOverride`, `parameters[].longNameOverride` | `dotnetcli.host.json` `symbolInfo[].shortName` / `longName` |
+
+**Symbol filter.** Only `type: parameter` symbols are projected into
+`parameters[]`. `bind` (host-supplied values like `HostIdentifier`), `derived`,
+`computed`, and `generated` symbols are excluded — they're engine- or
+host-resolved, not user-facing. Symbols whose precedence is `Implicit` or
+`Disabled` are also excluded.
+
+**Localization.** v1 hydrates **en-US only**. The schema reserves a future
+`localizations` key for per-locale `description` / `choices[].description`
+overrides without requiring a schema bump.
+
+**Scaffold path.** At `func new --template <id>` time, the CLI core dispatches
+`dotnet new <shortName> --<param> <value> …` against the dotnet template hive
+provisioned from the `source.json` pin (§6.3). The hydrated `parameters[]` is
+the canonical source for option names, aliases, and defaults; the engine
+only renders the template content.
 
 ### 5.4 Templates and binding schemas
 
 The templates workload uses a **CLI-owned schema** derived from the
-Functions extension bundle's `StaticContent/v1/` and `StaticContent/v2/`
-schemas. Minor modifications from the bundle baseline are expected
-(e.g. fields the bundle doesn't have, fields the CLI doesn't consume
-that may be omitted). Two top-level shapes apply, one per
-programming-model version.
+Functions extension bundle's `StaticContent/v2/` schema. Minor
+modifications from the bundle baseline are expected (e.g. fields the
+bundle doesn't have, fields the CLI doesn't consume that may be
+omitted). One top-level shape applies (v2 programming model). v1
+(legacy) templates are not shipped in v5 templates workloads.
 
 > Paths in the schema examples below are **bundle-source** paths.
 > Workload-side paths drop the `StaticContent/` prefix (§5.2).
 
-**v1 — `StaticContent/v1/templates/templates.json`** is a `Template[]`
-array. Each entry has the legacy fields the v4 CLI already understands:
-
-```jsonc
-{
-  "id": "HttpTrigger-JavaScript",
-  "files": {
-    "index.js": "module.exports = async function (context, req) { ... }",
-    "function.json": "{ \"bindings\": [ ... ] }",
-    "sample.dat": "..."
-  },
-  "function": { "bindings": [ { "type": "httpTrigger", ... } ] },
-  "metadata": {
-    "defaultFunctionName": "HttpTrigger",
-    "description": "$HttpTrigger_description",         // resource key
-    "name": "HTTP trigger",
-    "language": "JavaScript",
-    "category": [ "$temp_category_core", "$temp_category_api" ],
-    "categoryStyle": "http",
-    "enabledInTryMode": true,
-    "userPrompt": [ "connection", "httpTrigger-route", "httpTrigger-authLevel" ]
-  }
-}
-```
-
-> `userPrompt[]` references prompt ids defined in
-> `StaticContent/v2/bindings/userPrompts.json` — yes, v1 templates
-> reference v2 prompts. This is intentional in the upstream bundle:
-> the prompt catalog is unified across model versions.
-
 **v2 — `StaticContent/v2/templates/templates.json`** is a `NewTemplate[]`
-array used by the Python v2 programming model. Each entry carries the
+array used by the v2 programming model. Each entry carries the
 job/action DSL:
 
 ```jsonc
@@ -458,96 +531,190 @@ job/action DSL:
 
 **Supporting files** (paths are bundle-source; workload-side drops the `StaticContent/` prefix):
 
-- `StaticContent/v1/bindings/bindings.json` — binding catalog (v1).
 - `StaticContent/v2/bindings/userPrompts.json` — `UserPrompt[]`, defines
-  validators / enums / labels referenced by `paramId` from templates and
-  `metadata.userPrompt`.
-- `StaticContent/<v1|v2>/resources/Resources.json` (+ `Resources.<locale>.json`)
+  validators / enums / labels referenced by `paramId` from templates.
+- `StaticContent/v2/resources/Resources.json` (+ `Resources.<locale>.json`)
   — i18n strings the templates and prompts reference via `$key` syntax.
 
 **Schema authority.** The templates workload owns its schema. The
-bundle's schemas are the baseline; the workload-side schema may
+bundle's v2 schema is the baseline; the workload-side schema may
 diverge as the CLI's needs evolve. The build pipeline (§6.1, §6.2)
 applies the divergences when extracting content from the bundle
 source.
 
 ## 6. Template Source
 
-### 6.1 Node templates — bundle StaticContent
+### 6.1 Node templates — static in-repo content
 
-The Node templates workload **does not reauthor templates**. It pulls
-its content at workload build time from the **Functions extension
-bundle CDN**, the same source the v4 CLI's `func new` resolves
-templates from today. Specifically: the templates workload package
-embeds a filtered snapshot of one bundle's `StaticContent/` directory
-tree (the layout shown in §5.2).
+The Node templates workload **does not** snapshot template content from
+the extension-bundle CDN. The upstream bundle's
+`StaticContent/v2/templates/templates.json` does not yet publish Node
+entries (only Python). The Node v2 template content is therefore
+authored **statically in this repo** under
+`src/Workloads/Templates/Node/content/v2/`. The build pipeline packs
+these files directly into the nupkg at `tools/any/content/v2/`. No
+network access is required at pack time beyond the standard NuGet
+restore, so the workload builds cleanly under strict network-isolation
+CI policies.
 
-**Source bundle.** Each templates workload package targets one of the
-three published bundle channels (channel ↔ bundle id mapping in §4.4.2).
+**Authoring source.** The static `content/v2/templates/templates.json`
+is hand-curated against the v2 `NewTemplate` schema (see
+[v2 template engine schema](https://github.com/Azure/azure-functions-templates/tree/dev/Docs)).
+Each entry follows the same shape:
 
-**Build pipeline.**
+- `id`: stack-unique (e.g. `HttpTrigger-JavaScript`).
+- `language`: `"node"` for both JS and TS variants (the v2 schema
+  enumerates language as `dotnet`/`node`/`python`/`powershell`; the
+  JS/TS distinction is encoded in the `id`).
+- `programmingModel`: `"v2"` (refers to the **template-engine schema**,
+  not the Node runtime programming model — which is itself v4 /
+  decorators-based).
+- `jobs`: one `CreateNewApp` job per template carrying:
+  - an input for the function name (`paramId: trigger-functionName`)
+    with a stable default,
+  - one further input per binding-config field, with the paramId
+    resolved to a context-aware `<triggerContext>-<param>` form in the
+    workload's `content/v2/bindings/userPrompts.json`.
+- Top-level `actions`: a `GetTemplateFileContent` +
+  `WriteToFile` pair that materialises the function file at
+  `src/functions/$(FUNCTION_NAME_INPUT).<js|ts>`.
+- `files`: the function-body content, with `$(FUNCTION_NAME_INPUT)`
+  tokens for the function name. Per-binding literal values
+  (queue name, connection string, blob path, etc.) currently match
+  the v4 defaults; per-binding tokenisation is a follow-up (§8).
 
-1. The workload csproj declares two MSBuild properties:
-   - `$(SourceBundleId)` — one of the three bundle ids.
-   - `$(SourceBundleVersion)` — the bundle version to snapshot (e.g.
-     `4.30.0`). Recorded as workload-build provenance only; **not**
-     used to derive the templates pkg version (see §4.4.2).
-2. A `FetchBundleStaticContent.targets` target downloads
-   `<SourceBundleId>/<SourceBundleVersion>` from the bundle CDN and
-   extracts only the `StaticContent/` subdirectory of the bundle's
-   payload.
-3. A filter pass removes per-language template entries that don't
-   belong to this stack: keep `Template` entries with
-   `metadata.language ∈ {"JavaScript", "TypeScript"}` from
-   `v1/templates/templates.json`; drop everything else.
-   Bindings and resources are language-agnostic — copied.
-4. `Pack` places the filtered tree under `tools/any/content/` of the
-   templates workload nupkg, stripping the bundle's outer
-   `StaticContent/` wrapper so the layout in §5.2 is achieved.
+**Build pipeline (static mode).**
 
-Build-time fetch keeps `func new` offline-at-invocation. The bundle
-CDN is contacted **once per workload republish**, not per user
-invocation.
+```msbuild
+<TemplatesContentSource>static</TemplatesContentSource>
+<IncludeV1Templates>false</IncludeV1Templates>
+<IncludeV2Templates>true</IncludeV2Templates>
+<FilterTemplatesByBundleChannel>true</FilterTemplatesByBundleChannel>
+```
+
+is set in `Workloads.Templates.Node.csproj`. The shared
+`eng/build/Workloads.Templates.targets` recognises the `static` value
+of `$(TemplatesContentSource)` and:
+
+1. Skips every CDN `<DownloadFile>` and the language-filter scripts.
+2. Validates that `content/v2/templates/templates.json` exists under
+   the project directory.
+3. Adds every `content/v2/**/*.json` (and `content/v1/**/*.json` when
+   `$(IncludeV1Templates)` is true) as a `<None Pack="true"
+   PackagePath="tools/any/content/v2/" />` item — minus the build-time-
+   only manifest `content/v2/templates/_bindings.json` (excluded).
+4. Still generates the `templates-workload.json` sibling manifest from
+   `$(MinBundleVersionRange)`, identical to CDN-mode behaviour.
+
+**Per-channel subsetting** is **on** for the Node workload via
+`$(FilterTemplatesByBundleChannel)=true`. At pack time the build
+cross-references the master `content/v2/templates/templates.json`
+against the active `$(TemplatesChannel)`'s authoritative extension
+bundle:
+
+1. **Resolve the listed version.** `eng/scripts/fetch-bundle-extensions-json.ps1`
+   fetches `index.json` from CDN for the active channel
+   (`https://cdn.functions.azure.com/public/ExtensionBundles/<id>/index.json`,
+   id mapping per §4.4.2). It picks the **last `4.x` entry** — array
+   order in `index.json` is publication order, so the tail is the
+   newest listed bundle. Versions present on CDN but **not** listed in
+   `index.json` are unlisted and must not be consumed.
+2. **Extract `bin/extensions.json` via HTTP Range.** The script issues
+   two Range requests against `<id>/<version>/<id>.<version>.zip`: one
+   for the End-of-Central-Directory and central directory (last
+   ~64 KB), then one for the `bin/extensions.json` entry's local file
+   header + compressed payload. Total transfer is on the order of
+   10–20 KB instead of the full 150–250 MB bundle, so per-build cost
+   is negligible.
+3. **Filter against `_bindings.json`.** `eng/scripts/filter-node-templates-by-bundle.ps1`
+   reads:
+   - the master `templates.json` (NewTemplate[]),
+   - the committed `content/v2/templates/_bindings.json` (template
+     id → string[] of required binding names; empty array means the
+     template has no extension dependency and is always included),
+   - the channel's `bin/extensions.json`.
+
+   For each template entry, every required binding must appear (case-
+   insensitively) in some `extensions[].bindings[]` array of the
+   channel's `extensions.json`. Templates whose binding set isn't fully
+   satisfied are dropped. The filtered file is staged at
+   `$(IntermediateOutputPath)templates\v2\templates\templates.json`
+   and packed in place of the source file.
+
+If a new template is added to `templates.json` without a corresponding
+entry in `_bindings.json`, the filter script fails the build — so
+per-channel subsetting can't silently drop content.
+
+**Cross-reference snapshot at the time of this revision** (latest
+listed `4.x` per channel):
+
+| Channel | Listed bundle | Templates kept |
+|---|---|---|
+| stable | `Microsoft.Azure.Functions.ExtensionBundle` `4.32.0` | **31 of 33** — drops `McpPromptTrigger-{Javascript,Typescript}` (`mcpPromptTrigger` binding not yet in stable) |
+| preview | `Microsoft.Azure.Functions.ExtensionBundle.Preview` `4.42.0` | **33 of 33** — full set |
+| experimental | `Microsoft.Azure.Functions.ExtensionBundle.Experimental` `4.6.0` | **31 of 33** — same drop as stable |
 
 ### 6.2 Python templates — bundle StaticContent
 
-Same mechanism as §6.1, filtered for Python.
+Same mechanism as §6.1 (target), filtered for Python and shipping
+today.
 
-- **v1 templates:** keep `Template` entries with
-  `metadata.language == "Python"` from
-  `v1/templates/templates.json`.
 - **v2 templates:** keep `NewTemplate` entries with
-  `language == "python"` from `v2/templates/templates.json`
-  (the Python v2 programming model lives here).
-- Bindings and resources for both v1 and v2 are copied
-  (language-agnostic).
+  `language == "python"` (case-insensitive) from
+  `v2/templates/templates.json` (the Python v2 programming model
+  lives here).
+- **v1 templates:** **not shipped.** The Python templates workload
+  drops v1 (legacy programming model) content; users on v1 should
+  migrate to v2 (see §7.1).
+- Bindings (`v2/bindings/userPrompts.json`) and resources
+  (`v2/resources/Resources*.json`) are copied (language-agnostic).
 
 The bundle's `v2/bindings/userPrompts.json` is included in the Python
-workload because Python v1 templates also reference v2 prompts via
-their `metadata.userPrompt[]` lists (see §5.4 note).
+workload because v2 Python templates reference its prompt definitions
+via `paramId` references inside `jobs[].inputs[]`.
 
-### 6.3 DotNet templates — NuGet pin
+### 6.3 DotNet templates — hydrate-from-pinned-NuGet
 
-DotNet does not fetch templates at workload build time. Instead:
+DotNet does not author templates and does not ship the template *source
+files* in the workload payload. Instead, the workload build pipeline:
 
-1. The DotNet templates workload ships only `dotnet-templates.json` +
-   `source.json` (§5.3).
-2. `source.json` pins a specific version of
-   `Microsoft.Azure.Functions.Worker.ItemTemplates` (the upstream
-   `dotnet new` template package).
+1. **Pin the source.** The workload csproj declares two MSBuild properties:
+   - `$(SourceItemTemplatesPackageId)` — `Microsoft.Azure.Functions.Worker.ItemTemplates`
+     (or its `.NetCore` / `.NetFx` variant).
+   - `$(SourceItemTemplatesVersion)` — the upstream template-package version
+     to pin (e.g. `4.0.5569`).
+2. **Restore the pinned pkg at build time.** A `PackageDownload` (the same
+   pattern `eng/build/Templates.targets` uses today) drops the unpacked
+   contents into the workload's `obj/`.
+3. **Hydrate `dotnet-templates.json`.** A build target walks
+   `*/.template.config/template.json` (+ optional sibling
+   `dotnetcli.host.json`) inside the unpacked pkg and projects each Functions
+   template into a `dotnet-templates.json` entry (schema in §5.3.1). Selection
+   criteria:
+   - `classifications` contains `"Azure Function"` (or `groupIdentity`
+     starts with `"Azure.Function."`), **and**
+   - `tags.type == "item"`.
 
-At `func new` time, the CLI core consults `source.json`, provisions
-the pinned NuGet pkg into the dotnet template hive, and dispatches
-templates from `dotnet-templates.json` to `dotnet new <id>`. The
-CLI-side mechanics are out of scope; see the `func new` CLI spec.
+   The symbol filter described in §5.3.1 strips `bind` / `derived` /
+   `computed` / `generated` / hidden symbols before emitting `parameters[]`.
+4. **Emit `source.json`.** The pinned package id + version are written into
+   `content/source.json` so the CLI core knows which NuGet pkg to provision
+   into the dotnet template hive at install time (step 5).
+5. **Pack.** Both files land under `tools/any/content/` of the templates
+   workload nupkg (§5.3). No template *source* files are packed.
 
-The DotNet templates workload is therefore much smaller (KB-scale:
-just the two JSON files). The pin gives the CLI a deterministic,
-reviewable template version.
+At **`func workload install` time**, the CLI core reads `source.json` and
+provisions the pinned NuGet template pkg into the dotnet template hive it
+manages. After install, both read paths (`func templates list`,
+`func new --template <id> --help`) and the scaffold path
+(`func new --template <id>`) are offline-deterministic. The CLI-side
+mechanics of hive provisioning are out of scope for this spec; see the
+`func new` CLI spec.
 
-Open question (§8): when offline at `func new` time, can the CLI
-fall back to whatever templates are already in the hive even if
-they differ from `source.json`'s pin?
+The DotNet templates workload is therefore much smaller than Node/Python
+(KB-scale: just `dotnet-templates.json` and `source.json`), and reviewers
+can audit the hydrated catalog and parameter set directly from the workload
+package without unpacking the upstream NuGet pkg.
 
 ## 7. Compatibility & Migration
 
@@ -560,6 +727,12 @@ they differ from `source.json`'s pin?
   source of truth.
 - The legacy `func new` command from v4 is replaced by the v5 CLI's
   built-in `func new` consuming this workload model.
+- **v1 (legacy) programming-model templates are not shipped in v5
+  templates workloads.** Users still authoring against the v1
+  programming model should either migrate to v2 (the v5 baseline
+  shape — `NewTemplate[]` with jobs/actions) or stay on v4 tooling
+  until migration is complete. The CLI does not provide a
+  v5-side bridge for v1 template content.
 
 ### 7.2 Within v5 (templates workload revisions)
 
@@ -570,9 +743,46 @@ open question (§8).
 
 ## 8. Open Questions
 
-_None at this time._
+- **Per-binding tokenisation of Node template file contents.** The v4
+  Node templates rely on the v4 engine's userPrompt-name-matching
+  substitution: e.g. a `connection: ''` field in the JS source is
+  replaced based on the userPrompt named `connection`. The v2 schema
+  uses explicit `$(VAR)` tokens. The v4→v2 converter only handles the
+  function-name token mechanically (`%functionName%` →
+  `$(FUNCTION_NAME_INPUT)`); per-binding literals (queue name,
+  connection string, blob path, etc.) currently match v4 defaults.
+  Producing fully-tokenised v2 files requires per-template hand
+  tokenisation. Tracked as a follow-up against §6.1.
 
 ### Resolved
+
+- ✅ **Per-channel template subsetting for the Node workload.** At
+  pack time the build cross-references the master Node `templates.json`
+  against the active channel's authoritative extension bundle: the
+  latest **listed** version (per the channel's CDN `index.json`) has
+  its `bin/extensions.json` extracted via HTTP Range from
+  `<id>.<version>.zip`, and templates are filtered against a committed
+  `_bindings.json` map (template id → required binding names). The
+  filtered subset is what gets packed for the channel-tagged nupkg.
+  Versions present on CDN but not listed in `index.json` are unlisted
+  and not consumed. Cross-reference snapshot at this revision: stable
+  31 / 33, preview 33 / 33, experimental 31 / 33 (the two `McpPromptTrigger`
+  variants drop in stable + experimental because the
+  `mcpPromptTrigger` binding hasn't propagated to those channels yet)
+  — see §4.3 / §6.1.
+
+- ✅ **Node templates ship as in-repo static v2 content.** The
+  upstream extension bundle does not yet publish v2 Node templates,
+  so the Node templates workload owns its content under
+  `src/Workloads/Templates/Node/content/v2/`. The static `templates.json`
+  is hand-curated against the v2 `NewTemplate` schema. No CDN download
+  of templates at pack time (§4.3, §6.1).
+
+- ✅ **Node and Python templates workloads ship v2-only.** Both
+  stacks ship `NewTemplate[]` v2 programming-model content under
+  `tools/any/content/v2/`. v1 (legacy) programming-model templates
+  are not shipped. Users still on v1 migrate to v2 or stay on v4
+  tooling (§5.2, §5.4, §6.1, §6.2, §7.1).
 
 - ✅ **`kind: content`, not `kind: workload`.** No DI / no
   contribution points. Settled at this draft.
@@ -583,9 +793,29 @@ _None at this time._
   every stack. The only version-axis relationship between a templates
   workload and the extension bundle is `minBundleVersion`. §4.4.1,
   §4.4.2.
-- ✅ **Templates packaged at workload build time** for Node/Python
-  (CDN fetch becomes a build dependency), **at `func new` time
-  via `dotnet new`** for DotNet (NuGet pin). §6.
+- ✅ **Templates packaged at workload build time** for every stack.
+  Python embeds a filtered bundle StaticContent snapshot (§6.2);
+  Node packs in-repo static v2 content authored from the v4 Node
+  templates in core-tools `main` via a converter script (§6.1);
+  DotNet hydrates a catalog + parameter index (`dotnet-templates.json`)
+  from the pinned NuGet template pkg's `template.json` files (§6.3).
+  No CDN call from `func new` itself.
+- ✅ **`dotnet-templates.json` schema (DotNet only).** Fully-hydrated
+  catalog rows + `parameters[]` per template (§5.3.1). Drives
+  `func templates list` and `func new --template <id> --help` offline from
+  the workload payload — the upstream NuGet pkg is consulted only to
+  produce content during the workload's build. Field provenance traces
+  to the dotnet template engine's `ITemplateInfo` /
+  `ITemplateMetadata` / `CliTemplateParameter` surface.
+- ✅ **Offline at `func new` time for DotNet.** Catalog read and
+  `--template X --help` are always offline (served from
+  `dotnet-templates.json`). The scaffold path is also offline once the
+  pinned pkg from `source.json` has been provisioned into the dotnet
+  template hive — the CLI core does that provisioning **at
+  `func workload install` time**, not lazily at `func new` time. This
+  preserves the §1 "offline at invocation" goal across all paths and
+  removes the earlier open question about lazy fallback to whatever
+  templates are already in the hive.
 - ✅ **Schema is CLI-owned**, derived from but not identical to the
   bundle baseline. Minor divergences expected over time. §5.4.
 - ✅ **Min-bundle storage:** sibling manifest `content/templates-workload.json`

--- a/proposed/v5-ga-plan.md
+++ b/proposed/v5-ga-plan.md
@@ -1,0 +1,284 @@
+# Azure Functions CLI v5: Path to GA
+
+Everything we need to GA the v5 CLI, organized by milestone. Each bullet
+is one issue / one PR scope (unless explicitly informational).
+
+---
+
+## Milestone 1 (Now: August)
+
+GitHub milestone: [v5 Milestone 1](https://github.com/Azure/azure-functions-core-tools/milestone/104)
+
+Themes: release CI + profiles integration, tech debt cleanup, parity
+(Java + PowerShell), quickstart-as-workload, `func update`.
+
+- Implement Java worker workload (#5319)
+- Implement Java stack workload (#5320)
+- Implement PowerShell worker workload (#5321)
+- Implement PowerShell stack workload (#5322)
+- Implement PowerShell templates workload (#5323)
+- Extract `func quickstart` content from the core CLI into a workload (#5324)
+- Create quickstart workload release pipeline (#5325)
+- Drop `.{rid}` suffix from workload packages (host + python) (#5326)
+- Implement Go templates workload (#5327)
+- Design: v4 + v5 release story (parallel release, workload alignment,
+  distribution channels, rollback) (#5328)
+- Design: profile updates as part of release pipelines (#5329)
+- Refactor templates engine out of the core CLI (#5330)
+- Set up dedicated ADO pipelines for vnext (#5331)
+- Stand up profiles CDN (#5332)
+- Implement `func update` command (#5333)
+
+---
+
+## Milestone 2
+
+Themes: parity (durable + pack + custom handlers), CLI settings / config, tooling story.
+
+### Parity: Durable
+
+- Implement durable workload (#5340)
+- Setup durable workload CI/CD (#5341)
+
+### Parity: `func pack`
+
+- Design: new `func pack` experience & AZ CLI integration (#5342)
+
+### CLI settings / config
+
+- Design: figure out the settings story (local settings json / .env / app.settings etc.) (#5343)
+
+### Tooling: notify partner teams (#5344)
+
+Reach out to teams that ship tools embedding `func` so they have a head
+start migrating from v4 and can raise concerns before GA. We're not
+asking them to release anything; this is awareness + intake. Reference
+doc: https://aka.ms/func-cli.
+
+- Notify VS Code Azure Functions extension team + capture feedback
+- Notify Visual Studio Azure Functions tooling team + capture feedback
+- Notify Azure CLI (`az functionapp`) team + capture feedback
+- Notify Rider Azure Toolkit team + capture feedback
+- Notify IntelliJ Azure Toolkit team + capture feedback
+- Triage any concerns raised into follow-up issues before GA
+
+---
+
+## Milestone 3
+
+Themes: Kubernetes/KEDA decision, workload ownership migration, `func
+doctor`, schema store publishing.
+
+### Investigate Kubernetes / KEDA usage in v4 (#5345)
+
+- Pull telemetry on `func kubernetes` + `func keda` usage in v4
+- Decision: ship a v5 Kubernetes/KEDA workload, or drop?
+- If shipping: open implementation issues (kubernetes deploy/delete,
+  keda install/remove, scaler helpers, workload packaging + CI)
+
+### Workload ownership + migration to owner repos (#5346)
+
+- Document workload publisher onboarding (per-repo CI + feed publishing)
+- Move .NET templates workload to templates repo
+- Move Node templates workload to templates repo
+- Move Python templates workload to templates repo
+- Move Node worker workload to node-worker repo
+- Move Python worker workload to python-worker repo
+- Move Java worker workload to java-worker repo
+- Move PowerShell worker workload to pwsh-worker repo
+- Move Host workload to host repo
+
+### `func doctor` (#5347)
+
+Implement func doctor command.
+
+- Some troubleshoot area ideas:
+  - dotnet SDK check
+  - workload manifest health check
+  - Azurite availability check
+  - port conflict check
+  - workload package cache check
+- Integrate with [`azure-functions-skills`](https://github.com/Azure/azure-functions-skills):
+  the skills repo already ships a doctor command that runs LLM-driven
+  skills to validate config + code (~53% of incoming ICMs could be
+  prevented by keeping these skills current). Decide whether
+  `func doctor` shells out to the skills runtime, or whether the skills'
+  doctor calls into `func doctor` for the deterministic checks.
+
+### Schema store (#5348)
+
+Publish all defined schemas in the new CLI.
+
+- Publish `workload.json` schema
+- Publish `workloads.json` schema
+- Publish profile schema
+- Publish .func/config.json schema
+- Audit vnext for other authored configs and publish them
+- Add `$schema` references in samples and docs
+
+### Telemetry & diagnostics (#5349)
+
+- Telemetry vendor / pipeline decision
+- Telemetry opt-in/opt-out wiring
+- Honor `DO_NOT_TRACK`
+- Per-command timing + outcome instrumentation
+- PII scrubbing helpers
+- Crash reporting: unhandled exception capture
+- Crash reporting: stack scrubbing
+- `--verbose` audit across all commands
+- Consistent log scope IDs per command
+
+---
+
+## Future milestones / backlog
+
+Not yet assigned to a milestone. Grouped by area for easy sorting.
+
+### Docs (epic: #5350)
+
+#### External
+
+- learn.microsoft.com Functions Core Tools refresh for v5
+- Rebrand user-facing strings to "Azure Functions CLI"
+- Update Azure Functions docs sample snippets to v5
+
+#### In-Repo
+
+- README rewrite for v5
+- CONTRIBUTING refresh
+- repo-structure.md refresh
+- building-a-workload.md refresh
+- v4 -> v5 command map (in-repo)
+
+#### UX
+
+- `--help` audit: every command has a one-line description (#5351)
+- `--help` audit: every option has a one-line description (#5351)
+- Error messages include next-step hints (#5352)
+- `func completion bash`
+- `func completion zsh`
+- `func completion pwsh`
+- `func completion fish`
+
+### Quality
+
+E2E testing and performance.
+
+- E2E testing (#5353)
+- Performance budget: define cold-start target (#5354)
+- Performance budget: enforce in CI (#5354)
+
+### Parity Audit (epic: #5355)
+
+#### Languages (audit matrix)
+
+- Living parity matrix doc (per-language v4 vs v5)
+- .NET in-proc parity audit
+- .NET isolated parity audit
+- Node parity audit
+- Python parity audit
+- PowerShell parity audit
+- Java parity audit
+- Go parity audit
+
+#### Tools / extensions
+
+- Extension bundles parity audit
+- KEDA / Kubernetes tooling parity audit
+- Azure Container Apps tooling parity audit
+- Custom handlers parity audit
+- Worker indexing model parity (v4 -> v5)
+
+### Migration & v4 deprecation
+
+- v4 -> v5 migration guide content (#5356)
+- v4 -> v5 command map (companion to in-repo docs) (#5356)
+- v4 -> v5 behavior diffs catalog (#5356)
+- v4 -> v5 known gaps page (#5356)
+- `func --version` v4-detected migration pointer (#5357)
+- `local.settings.json` schema compatibility audit (#5358)
+- `host.json` schema compatibility audit (#5358)
+- Document any breaking schema changes (#5358)
+- v4 deprecation timeline (public announcement) (#5359)
+- v4 security-only support window decision (#5359)
+- v4 archive / sunset date decision (#5359)
+
+### Security (#5360)
+
+- Token handling review
+- Workload package signature verification
+- NuGet feed pinning
+- Supply-chain audit
+- Threat modeling
+
+### Localization (#5361)
+
+- Decision (in-scope for GA or defer)
+- Implementation (if in-scope)
+
+### Accessibility (#5362)
+
+- NO_COLOR audit
+- Non-TTY audit
+- Screen-reader friendliness via `IInteractionService`
+
+### Release process (GA cutover) (#5363)
+
+- Switch default branch (vnext -> main, or rename)
+- Cut `v5.0.0` tag
+- Comprehensive v5.0.0 release notes (full delta from v4 latest)
+- Issue templates refresh
+- Triage process documented
+- Post-GA 30-day SLA decision + comms
+
+---
+
+## Release Process Notes
+
+Everything related to shipping v5 to users. Most of these are
+informational (decisions, channel coverage, comms) rather than discrete
+issues. Pulled out into issues only when they need active work.
+
+### Distribution: installer (info)
+
+Installer scripts already exist (`install.sh`, `install.ps1`). Coverage
+to validate before GA: Windows x64, Windows arm64, macOS x64, macOS arm64,
+Linux x64, Linux arm64.
+
+### Distribution: package channels (info)
+
+Channels to make a per-channel decision on before GA:
+
+- Homebrew
+- npm (keep / deprecation-pointer / drop)
+- winget
+- Chocolatey
+- Scoop
+- apt
+- rpm
+
+### Distribution: signing (info)
+
+- Authenticode signing for Windows binaries in release pipeline
+- macOS notarization for the published archive
+- Documented signature verification for users
+
+#### Release story
+
+- v4 + v5 parallel cadence + branding split
+- Side-by-side install story across channels
+- Bug-fix backport policy v5 -> v4 during parallel window
+- Coordinated release notes across v4 and v5
+- Define rollback per distribution channel
+- Per-channel rollback playbook (npm, brew, winget, choco, scoop, apt,
+  rpm, installer scripts, CDN profiles)
+- Workload rollback story (unlist/yank without breaking older CLIs)
+- Profiles rollback (pinned previous-version URLs + CDN cache purge)
+- Incident comms template
+- Base CLI / workload version compatibility matrix
+- Coordinated release tagging across owner repos
+- Aggregate workload release notes into CLI release notes
+- Cross-repo release readiness checklist
+- Channel-by-channel release-day checklist
+- Cross-channel version-bump automation
+- Release-day per-channel status tracker

--- a/proposed/vnext-release-process.md
+++ b/proposed/vnext-release-process.md
@@ -1,0 +1,134 @@
+# vnext Release Process (Draft)
+
+## Overview
+
+The `vnext` branch ships the v5 CLI as a set of independently versioned
+components: the host, bundles, templates, workers, and language stacks. Each
+component is released by pushing a git tag from `vnext` and then queuing
+its release pipeline against that tag. The pipeline packs the matching
+workload(s) and publishes them to the appropriate feed.
+
+Versions follow SemVer. Preview releases use `-preview.N` suffixes.
+
+## Tag format
+
+Every tag's `<semver>` comes from the `VersionPrefix` (+ optional
+`VersionSuffix`) in that component's `Directory.Version.props`. The tag is
+the signal; the props file is the source of truth.
+
+- **CLI** has no prefix: `v<version>` (e.g. `v5.0.0`). Version lives in
+  `src/Directory.Version.props`.
+- **Workloads** are prefixed by their alias: `<component>/v<version>`.
+  Version lives in `src/Workloads/<area>/<Name>/Directory.Version.props`.
+
+| Component         | Tag prefix          | Example                              |
+| ----------------- | ------------------- | ------------------------------------ |
+| CLI (`func`)      | _(none)_            | `v5.0.0`                             |
+| Host              | `host/`             | `host/v4.1048.200-preview.1`         |
+| Bundles           | `bundles/`          | `bundles/v4.35.0`                    |
+| Node templates    | `node-templates/`   | `node-templates/v1.0.1`              |
+| Python templates  | `python-templates/` | `python-templates/v1.0.1`            |
+| .NET templates    | `dotnet-templates/` | `dotnet-templates/v1.0.1`            |
+| Node worker       | `node-worker/`      | `node-worker/v3.13.0-preview.1`      |
+| Python worker     | `python-worker/`    | `python-worker/v4.43.0-preview.1`    |
+| Go worker         | `go-worker/`        | `go-worker/v1.0.0-preview.1`         |
+| Node stack        | `node-stack/`       | `node-stack/v1.0.0-preview.1`        |
+| Python stack      | `python-stack/`     | `python-stack/v1.0.0-preview.1`      |
+| .NET stack        | `dotnet-stack/`     | `dotnet-stack/v1.0.0-preview.1`      |
+| Go stack          | `go-stack/`         | `go-stack/v1.0.0-preview.1`          |
+
+Rules:
+- Always prefix the version with `v`.
+- The version in the tag must match `Directory.Version.props` on the tagged
+  commit.
+- Use `-preview.N` for unstable releases, no suffix for GA.
+- One component per tag. Bumping multiple components means multiple tags.
+
+## SemVer guidance
+
+- **MAJOR** — breaking changes (host contract, worker protocol, template API).
+- **MINOR** — backward-compatible features.
+- **PATCH** — bug fixes and hotfixes.
+
+## Release steps
+
+1. **Pick the component(s)** to release and decide the new version per SemVer.
+2. **Open a release-prep PR against `vnext`** that:
+   - Bumps the component's version in its props file (e.g.
+     `src/Workloads/<area>/<Name>/Directory.Version.props`).
+   - Updates `release_notes.md` with the new version and a short changelog.
+3. **Merge the PR** into `vnext` once CI is green and reviews are in.
+4. **Tag the merge commit** on `vnext`:
+   ```bash
+   git checkout vnext && git pull
+   git tag <component>/v<semver>
+   git push origin <component>/v<semver>
+   ```
+5. **Trigger the release pipeline** for the component from the
+   [internal release pipelines folder][release-pipelines] (one pipeline per
+   component). Queue the run against the tag you just pushed.
+   - Check **Publish to NuGet** if the release is going out to customers.
+   - Leave it unchecked to publish only to the internal feed for testing.
+6. **Verify CI**: the pipeline packs the workload and publishes the
+   `.nupkg` to the selected feed.
+7. **Smoke test** the published package via `func workload install` against
+   the feed.
+
+[release-pipelines]: https://azfunc.visualstudio.com/internal/_build?definitionScope=%5Cazure%5Cazure-functions-core-tools%5Cvnext%5Crelease
+
+## Multi-component releases
+
+When several components ship together (e.g. a host bump that requires worker
+updates), push all tags from the same `vnext` commit. Call out the grouping
+in the PR description, and in `release_notes.md`, so consumers know which
+versions are compatible.
+
+## Releasing bundles (stable, preview, experimental)
+
+The extension bundles workload ships three channels: `stable`, `preview`,
+and `experimental`. Unlike other workloads, bundles is **content-only**:
+the channel is just a label and a CDN bundle id, not compiled output. So
+for bundles, **the tag is the version**, including the channel.
+
+`vnext` keeps `BundleChannel` at its default in
+`src/Workloads/Tools/ExtensionBundles/Directory.Version.props`. The release
+pipeline inspects the tag it was queued against and overrides the channel
+at pack time:
+
+| Channel        | Example tag                       | Resulting package version |
+| -------------- | --------------------------------- | ------------------------- |
+| `stable`       | `bundles/v4.35.0`                 | `4.35.0`                  |
+| `preview`      | `bundles/v4.35.0-preview.1`       | `4.35.0-preview.1`        |
+| `experimental` | `bundles/v4.35.0-experimental.1`  | `4.35.0-experimental.1`   |
+
+The `BundleVersion` (payload version) is shared across channels and
+defaults to `$(LatestExtensionBundleVersion)` so the bundle payload always
+matches the snapshot the templates workloads were built against.
+
+### Release steps (bundles)
+
+1. **Tag a commit on `vnext`** with the channel-suffixed tag, e.g.
+   `bundles/v4.35.0`, `bundles/v4.35.0-preview.1`, or
+   `bundles/v4.35.0-experimental.1`. No PR is required for a channel
+   change.
+2. **Trigger the bundles release pipeline** from the
+   [internal release pipelines folder][release-pipelines] against the tag.
+   - Check **Publish to NuGet** only when pushing to customers.
+   - Leave it unchecked for internal-feed testing.
+3. The pipeline parses the tag's prerelease suffix, sets
+   `-p:BundleChannel=preview` (or `experimental`) for the pack, and
+   publishes the workload with the matching version.
+4. **Smoke test** with `func workload install bundles --version <tag-version>`.
+
+> Increment prerelease tags per release (`-preview.1`, `-preview.2`, ...).
+> Do not reuse a prerelease tag.
+
+> Tracking work to support this: props-based channel conditions in
+> `Directory.Version.props` and the tag-parsing logic in the bundles
+> release pipeline.
+
+## Notes
+
+- Do not retag. If a release is broken, bump the patch (or `-preview.N+1`)
+  and tag again.
+- Tags are the source of truth for what shipped; release notes describe it.

--- a/proposed/workload-package-layout.md
+++ b/proposed/workload-package-layout.md
@@ -1,0 +1,1694 @@
+# Workload Package Layout
+
+> **Status:** Draft v0.9. Companion to [`workload-spec.md`](./workload-spec.md).
+> This document defines the on-disk and on-feed layout of the NuGet package
+> that ships a Func CLI workload. The spec defines *what* a workload is and
+> *how* the CLI loads it; this document defines *how the bytes are arranged*
+> inside the `.nupkg`.
+>>
+> **Spec coordination required.** The `kind` rename, the meta concept,
+> and the `installedExplicitly` flag affect `workload-spec.md` §5.3,
+> §6.1, §6.2, and §10.1. They are tracked here so the spec PR can
+> ride along with the layout iteration.
+
+## 1. Goals
+
+- Pick a single, opinionated package layout so workload authors don't have
+  to invent one and the install pipeline doesn't have to support multiple
+  shapes.
+- Re-use **existing NuGet folder conventions** wherever they already mean
+  the right thing, so that authors with NuGet background recognise the
+  layout and tooling (`dotnet pack`, NuGet feed UIs, `nuget verify`)
+  understands the package without custom configuration.
+- Keep the layout **portable** (RID-agnostic at the workload level).
+  Per-RID assets are an implementation detail of a workload's transitive
+  dependencies, not a fork in the package layout the CLI has to reason
+  about.
+- Make the package readable by tooling that doesn't know about Func
+  workloads (a developer cracking the `.nupkg` open in 7-zip, a feed UI,
+  a security scanner).
+
+## 2. Non-goals
+
+- Defining the *contents* of templates or other workload payload formats.
+  The layout reserves a folder for them; format is workload-internal.
+- Defining the install pipeline's on-disk layout under
+  `~/.azure-functions/workloads/<id>/<version>/`. Install can mirror the
+  package layout 1:1 or flatten it; that's a separate decision.
+- Per-RID workload variants. v1 ships portable workloads only (see §6 in
+  `workload-spec.md` and the user direction recorded in §4 below).
+- Compile-time consumption of workload assemblies by other projects.
+  Workloads are CLI extensions, never `<PackageReference>`-d by
+  another csproj.
+
+## 3. Pre-existing patterns considered
+
+NuGet has a handful of well-defined "this folder means X" conventions.
+We evaluated each against the workload use case — *a portable .NET
+assembly, plus its dependencies and static assets, that the Func CLI
+extracts and loads at runtime*.
+
+| Convention                           | What it means                                                      | Fits workloads? |
+|--------------------------------------|--------------------------------------------------------------------|-----------------|
+| `lib/<tfm>/`                         | Managed assemblies referenced at compile-time and runtime by the consuming project. | Partial. We don't want consumers to `<PackageReference>` workloads. Using `lib/` would create some confusion and potential invalid expectations, even if the package type does not allow consumption from other projects. |
+| `ref/<tfm>/`                         | Reference-only assemblies for compile-time.                        | No. Workloads aren't compiled against. |
+| `runtimes/<rid>/lib/<tfm>/`          | RID-specific managed assemblies, picked by NuGet at restore.       | No at the workload level (see §4). Yes for transitive deps that ship native bits. |
+| `runtimes/<rid>/native/`             | RID-specific native binaries, surfaced to the published app.       | Same as above — only for transitive deps. |
+| `content/`, `contentFiles/<lang>/<tfm>/` | Files copied into the consuming project's source tree.         | No. There is no consuming project. |
+| `build/<tfm>/<id>.{props,targets}`   | MSBuild logic auto-imported into the consuming project.            | No. |
+| `analyzers/dotnet/{cs,vb}/`          | Roslyn analyzers loaded by the C#/VB compiler.                     | No. |
+| `tools/<tfm>/<rid>/`                 | A self-contained .NET payload that an external runner extracts and invokes. The package declares `<PackageType>DotnetTool</PackageType>` and the runner (`dotnet tool`) reads `DotnetToolSettings.xml` to discover the entry point. | **Yes — this is the closest match.** The Func CLI plays the same role for `FuncCliWorkload` packages that `dotnet tool` plays for `DotnetTool` packages. |
+| `Sdk/Sdk.{props,targets}`            | An MSBuild project SDK loaded by MSBuild's SDK resolver.           | No. Different host. |
+
+The closest pre-existing pattern is **`DotnetTool`**, and the closest
+pre-existing **install pipeline** is `dotnet tool install` (with
+`dotnet new install` as a corroborating data point). Both .NET SDK
+features are NuGet-distributed CLI extensions, and both make the same
+shape of choices we make here:
+
+- The package contains a portable .NET payload.
+- The runner (`dotnet tool` / `dotnet new` / `func`) extracts the
+  package and loads the payload, rather than the .NET SDK linking it
+  into another project.
+- A package-type marker (`DotnetTool` / `Template` / `FuncCliWorkload`)
+  identifies the package as a runner-consumed unit, not a library.
+- A **per-package settings file** declares what the runner should
+  invoke: `DotnetToolSettings.xml` for `DotnetTool`, `template.json`
+  for `Template`, `workload.json` for `FuncCliWorkload` (see §5.4).
+  None of the three rely on a runtime scan of assemblies.
+- The install code references **only** `NuGet.Protocol` /
+  `NuGet.Versioning` / `NuGet.Packaging` / `NuGet.Configuration` /
+  `NuGet.Credentials` — *not* `NuGet.Resolver` or
+  `NuGet.PackageManagement` — and never calls `RestoreCommand` /
+  `RestoreRunner`
+  ([`dotnet/sdk:src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs`](https://github.com/dotnet/sdk/blob/main/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs),
+  [`dotnet/templating:src/Microsoft.TemplateEngine.Edge/Installers/NuGet/`](https://github.com/dotnet/templating/tree/main/src/Microsoft.TemplateEngine.Edge/Installers/NuGet)).
+- Bytes go to a private CLI-managed location
+  (`~/.dotnet/tools/.store/<id>/<version>/` for tools,
+  `~/.templateengine/.../packages/<id>.<version>.nupkg` for
+  templates), **not** the standard NuGet packages cache.
+- The package type is enforced as a hard gate at install time
+  (`ToolPackageDownloader` throws `ToolPackageNotATool` immediately
+  on a missing `<packageType name="DotnetTool"/>`).
+
+We adopt the `tools/` location and the `any` RID slot from
+`DotnetTool`, plus the per-package settings-file pattern, but **drop
+the `<tfm>/` segment** — the workload's TFM is recorded in its
+assembly metadata and `.deps.json`, and the compatibility boundary
+that actually matters is the host-shared contract-assembly versions
+(see §6), not the folder name. Spending a folder segment on something
+the package's own metadata already states buys nothing in v1 and
+would commit the install pipeline to TFM matching for a multi-TFM
+scenario we don't need.
+
+For two of the three package kinds (`workload` and `content`,
+§5.5), we **align** with that SDK precedent on dependency handling:
+their `.nuspec` `<dependencies>` is **empty** and they are fully
+self-contained, with library `<PackageReference>`s vendored into
+`tools/any/` by `dotnet publish` (§5.5, §9.3). The install pipeline
+does no transitive resolution and no closure tracking for these
+kinds.
+
+Where we **diverge** from the SDK precedent — and the divergence we
+have to justify carefully — is the third kind, **`meta` packages**
+(§5.5), that bundle multiple workloads under a single id. Both
+`dotnet tool install` and `dotnet new install` silently ignore
+`.nuspec <dependencies>` and have no transitive-install support at
+all. We take a more ambitious position because curated bundles of
+workloads (a "Worker Family" meta packaging Node + Python + Java
+together, a versioned bundle that bumps several workloads in
+lockstep) materially help users. The mechanism is detailed in §5.5
+and consciously stays close to the SDK shape: NuGet for transport
++ metadata, Func code for the meta-expansion + uninstall semantics
+on top. The resolution is one level deep (no meta-of-meta in v1),
+so the install pipeline never grows a transitive dep solver.
+
+## 4. User direction (recorded for context)
+
+From the design conversation:
+
+> *"No RID specific logic in the layout. The workload should always be
+> in portable format, with a RID that would be compatible with the host,
+> so the host wouldn't have to load the workload from different RID
+> folders. The workload itself could have RID specific assets, but that
+> would simply be for the runtime dependencies load behavior."*
+
+In layout terms:
+
+- The workload's own assembly is **always portable** and lives under a
+  single `tools/any/` folder — `any` is the only RID slot the package
+  layout uses. There is **no TFM segment**: the workload's TFM is
+  recorded in the assembly's `TargetFrameworkAttribute` and in the
+  adjacent `.deps.json`, and binary compatibility with the running
+  CLI is determined by the contract-assembly versions (§6), not by a
+  folder name. Spending a folder segment on something the package's
+  own metadata already states would be cargo-cult NuGet conventions
+  for no gain.
+- A workload **may** include `runtimes/<rid>/...` assets *inside*
+  `tools/any/runtimes/`, exactly as `dotnet publish` arranges them,
+  so the .NET runtime resolves RID-specific transitive dependencies
+  (managed or native) without the Func CLI having to know about
+  them.
+
+> *"Instead of scanning, we expect to have a workloads.json file that
+> defines the workload metadata. This would have a relative path to
+> the entrypoint assembly we'd ultimately load in the CLI (along with
+> the entry point type)."*
+
+In layout terms:
+
+- A required `workload.json` (singular, to disambiguate from the
+  global `workloads.json`) sits at the **package root**. It declares
+  `entryPoint.assemblyPath` (a path relative to `tools/any/`) and
+  `entryPoint.type` (the FQN to instantiate). See §5.4.
+- The install pipeline reads this file and **never** reflects on the
+  workload's assemblies. The marker attribute survives only as an
+  optional compile-time aid (§9.1).
+
+## 5. Recommended layout
+
+```
+<PackageId>.<Version>.nupkg
+│
+├── tools/
+│   └── any/                                            # Always 'any'. Workloads are portable.
+│       ├── <PackageId>.dll                             # The workload assembly. Implements
+│       │                                               # IWorkload. May (optionally) carry
+│       │                                               # [assembly: ExportCliWorkload<T>] as
+│       │                                               # a compile-time check.
+│       ├── <PackageId>.deps.json                       # Standard .NET runtime asset graph.
+│       │                                               # Lets the loader resolve managed deps
+│       │                                               # and runtimes/<rid>/native/* via the
+│       │                                               # AssemblyDependencyResolver. Records the
+│       │                                               # workload's TFM.
+│       ├── <PackageId>.pdb                             # Portable PDB (recommended; included
+│       │                                               # so workload errors surface usable
+│       │                                               # stack traces in the CLI).
+│       ├── <transitive managed dependencies>.dll       # As emitted by `dotnet publish`.
+│       └── runtimes/                                   # OPTIONAL. Present only if a transitive
+│           ├── win-x64/                                # dep ships native or RID-specific managed
+│           │   ├── lib/net10.0/...                     # bits. Workload-private; resolved by the
+│           │   └── native/...                          # .NET runtime, not the CLI.
+│           ├── linux-x64/...
+│           └── osx-arm64/...
+│
+│       # Authors may include other workload-internal asset directories
+│       # under tools/any/ (e.g., embedded resources). The CLI does not
+│       # enumerate them. Whether `func init`/`func new` templates ship
+│       # in-package or as a separate `Template`-typed package is open
+│       # (§11).
+│
+├── workload.json                                       # Func-defined per-package manifest.
+│                                                       # Declares the entry-point assembly path
+│                                                       # (relative to the package root) and the
+│                                                       # entry-point type FQN. Read by the install
+│                                                       # pipeline; the CLI does not load any
+│                                                       # workload assembly during install. See §5.4.
+│
+├── README.md                                           # Surfaced by NuGet feeds and `func workload list`'s
+│                                                       # verbose output. Set via <PackageReadmeFile>.
+│
+├── icon.png                                            # Set via <PackageIcon>.
+│
+└── <PackageId>.nuspec                                  # Auto-generated by `dotnet pack`.
+                                                        # Required NuGet metadata:
+                                                        #   <packageTypes>
+                                                        #     <packageType name="FuncCliWorkload" />
+                                                        #   </packageTypes>
+                                                        #   <tags>alias:<name></tags>      (and optionally func-workload)
+```
+
+Plus the standard NuGet envelope (`[Content_Types].xml`, `_rels/`,
+`package/`) which `dotnet pack` writes automatically.
+
+### 5.1 Why `tools/`, not `lib/<tfm>/` or `content[Files]/`
+
+`tools/` is a **Func-defined convention** that borrows the folder
+shape `DotnetTool` packages use. Generic NuGet tooling does not
+recognise `FuncCliWorkload` and will render these as plain packages
+in feed UIs; the goal of using `tools/` is not to opt in to special
+UI treatment, it's to keep the workload payload out of the asset
+paths that PackageReference consumers — or other NuGet-aware
+tooling — would pick up unexpectedly.
+
+§3's table lists every NuGet folder convention. This section is the
+"why not the obvious alternatives" deep dive for the three folders an
+author might reasonably reach for: `lib/`, `content/`, and
+`contentFiles/`.
+
+#### `lib/<tfm>/` — the canonical assembly location
+
+PackageReference restore surfaces `lib/<tfm>/<assembly>.dll` as a
+compile + runtime reference to any consuming project. A user who
+accidentally `<PackageReference>`s a workload package would get the
+workload assembly on their build path, which is wrong. The package
+type alone does not gate this — restore happens before the consumer
+project sees the package type and does not refuse to surface assets
+for unknown types. Keeping the workload payload out of `lib/` is a
+hard prerequisite, not a preference. `lib/` is also the canonical
+shape for `<PackageType>Dependency</PackageType>` packages, which is
+exactly the framing `FuncCliWorkload` is trying *not* to take.
+
+#### `content/` — the packages.config-era content path
+
+Files in `content/` were copied into the consuming project's source
+tree at install time. The path is **deprecated** under PackageReference;
+modern clients largely ignore it (which is why a workload accidentally
+placed there wouldn't break a consumer's build), but the deprecation
+cuts the other way too: using a deprecated NuGet path for a brand-new
+Func feature is a bad signal to authors, scanners, and future tool
+integrations. `content/` also has no semantic relationship to "a
+runtime payload an external runner extracts and invokes" — its whole
+point is "files copied into a consumer project".
+
+#### `contentFiles/<lang>/<tfm>/` — the PackageReference replacement
+
+The modern replacement for `content/`. Files are surfaced to consumers
+with `buildAction` / `copyToOutput` / `copyToPublishDirectory` metadata,
+wired up by `<contentFiles>` groups in the .nuspec and a `.targets`
+import that NuGet auto-imports. Default behaviour without that wiring
+*is* to ignore the files — but at that point we'd be using a folder
+whose *reason for existing* is to put files into consumer builds, and
+relying on the absence of metadata to say "actually, ignore them". A
+future PackageReference change to default-include unmarked
+`contentFiles/` would silently break the workload contract. `tools/`
+says the right thing without needing escape hatches or metadata
+gymnastics.
+
+#### Why "templates use `content/`" doesn't generalise
+
+`Template` packages (`<PackageType>Template</PackageType>`, consumed
+by `dotnet new install`) ship their template content under `content/`
+**by convention only** — the dotnet templating engine doesn't require
+it. `NuGetInstaller` recursively scans the entire package for
+`.template.config/template.json` markers regardless of folder
+([`dotnet/templating:src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NuGetInstaller.cs`](https://github.com/dotnet/templating/tree/main/src/Microsoft.TemplateEngine.Edge/Installers/NuGet)).
+Templates can sit in `content/` because nothing about a Template
+package contradicts a content folder, not because `content/` carries
+useful semantics for the install pipeline. For a workload — which is
+primarily a runtime .NET payload with workload-internal data — the
+right semantics is `tools/`: a folder defined as "runner-consumed
+bytes that PackageReference consumers must not see".
+
+#### Is `tools/` "modern"?
+
+`tools/` originally housed packages.config-era PowerShell hooks
+(`init.ps1`, `install.ps1`, `uninstall.ps1`). Those hooks are
+deprecated under PackageReference. **But `dotnet tool install`
+revived `tools/` for a different purpose** — the .NET tool payload
+under `tools/<tfm>/<rid>/` — and that revival is the convention we
+align with, not the old PowerShell-hook semantics. `tools/<tfm>/<rid>/`
+has shipped with every modern dotnet SDK since .NET Core 2.1 (2018)
+and is actively maintained. Choosing `tools/` for workloads picks the
+maintained, widely-understood "CLI-extension payload" slot, not the
+abandoned scripting one.
+
+#### Other dimensions (vs `lib/`)
+
+| Aspect                                    | `tools/` (chosen)                                   | `lib/` (rejected) |
+|-------------------------------------------|-----------------------------------------------------|--------------------|
+| Layout `dotnet publish` produces          | 1:1 — publish output drops straight in.             | Requires custom `<PackagePath>` plumbing for the runtime asset graph. |
+| Matches `<PackageType>` semantics         | Mirrors `DotnetTool`'s "runner-consumed payload" intent. | `lib/` packages are normally type=`Dependency`, which contradicts `FuncCliWorkload`. |
+| Discoverability for non-Func tooling      | Generic feeds render the package as "a NuGet" with no special UI. `func workload search` filters by the `FuncCliWorkload` package type; the `func-workload` tag is a recommended hint for feed UIs. | Same. |
+
+#### Note on custom package types and standard clients
+
+NuGet's docs note that arbitrary custom `<packageType>` values are
+not installable by some general-purpose clients (e.g. older
+`nuget.exe`, certain Visual Studio flows). This is acceptable here
+because workload packages are not meant to be installed by those
+clients — only by `func workload install`. We rely on
+`FuncCliWorkload` purely as a filter / classifier, not as an
+instruction to those clients.
+
+### 5.2 Install-time payload resolution
+
+The install pipeline reads `workload.json` (§5.4) at the package root
+to learn what to load — it does **not** scan the package's assemblies.
+
+1. Open the package and read `/workload.json`. Reject the package if
+   the file is missing, isn't valid JSON, or has a `$schema` URL the
+   CLI doesn't recognise (per spec §10.1, mirrored here for the
+   per-package manifest).
+2. **Branch on `kind`** (per `workload.json`, §5.4):
+   - `kind: workload` (or absent — defaults to workload): proceed to
+     step 3.
+   - `kind: content`: proceed to step 3 (identical extraction; the
+     loader will skip the entry at activation, but the install
+     pipeline treats it the same shape on disk).
+   - `kind: meta`: hand off to the **meta install flow** in §5.5.
+     Metas have no payload of their own; the rest of this section
+     describes the per-package payload-resolution path that
+     applies to `workload` and `content` kinds only.
+3. **Validate manifest shape** (§5.4). For `kind: workload`,
+   `entryPoint.assemblyPath` and `entryPoint.type` must both be
+   present, the path must not be absolute or contain `..` segments,
+   and the file it points to (resolved relative to `tools/any/`)
+   must exist inside the package. For `kind: content`, `entryPoint`
+   must be absent and the `tools/any/` payload contents are not
+   further inspected. Reject the package on any failure.
+4. Move the **entire `tools/any/` payload** into the install location
+   (`<workload-home>/workloads/<packageId>/<packageVersion>/tools/any/`)
+   preserving its internal structure. The workload assembly, its
+   `.deps.json`, the `runtimes/` subtree, and any workload-internal
+   asset directories must remain adjacent so
+   `AssemblyDependencyResolver` can resolve dependencies relative to
+   the workload assembly and so workload code can find its data
+   files at paths relative to `AppContext.BaseDirectory`. Copy
+   `workload.json` itself to the install-dir root next to `tools/`
+   so the loader can re-read it without going back to the package.
+5. Record the package in the global registry (spec §10.1) with
+   `packageId` (lowercased, NuGet-normalized), `packageVersion`,
+   `kind`, `aliases` (from `.nuspec` `alias:` tags), `source`, and
+   — for `kind: workload` — `entryPoint.assemblyPath` and
+   `entryPoint.type` copied verbatim from `workload.json`. New rows
+   carry `installedExplicitly: true` when the user invoked
+   `func workload install <id>` directly, or `installedExplicitly:
+   false` when this row is being created as a member of a meta
+   install (§5.5). The registry write is atomic (temp file +
+   rename) so a crashed install either leaves the row absent
+   (orphan dir, cleaned by `func workload prune`) or fully present.
+
+The full eight-step install pipeline (download, signature
+verification, extract, atomic move, registry update, post-install
+hooks) is owned by `workload-spec.md` §6.1; this section's contract
+is purely "how the bytes are arranged on disk after a successful
+install" for `kind: workload` and `kind: content` packages. The
+meta-package install flow (download, pre-flight resolve members,
+extract each member as if it were an explicit install but with
+`installedExplicitly: false`, write the meta's row last) is
+detailed in §5.5.
+
+This makes the layout the **install pipeline's contract**, not just
+an authoring convenience. The pipeline is allowed to drop everything
+outside `tools/any/` and `workload.json` (`README.md`, `icon.png`,
+etc.) but must not reorganise what's inside `tools/any/`.
+
+The pipeline does **not**:
+
+- Load any assembly (no `AssemblyLoadContext` spin-up at install).
+- Match TFMs at install time. The workload's TFM is recorded in its
+  assembly metadata and `.deps.json`; binary compatibility with the
+  running CLI is enforced via the contract-assembly versioning
+  described in §6, not via folder selection.
+- Trust the assembly's `[assembly: ExportCliWorkload<T>]` attribute
+  (if present) over `workload.json`. The manifest is the source of
+  truth; the attribute is a compile-time aid only (§9).
+
+### 5.3 Why `tools/any/` and not flat `tools/`
+
+The `tools/` segment alone would be enough to keep the payload out
+of PackageReference asset paths (§5.1). The trailing `any/` segment
+is kept for two specific reasons:
+
+1. **Future-proofing for RID-specific workloads.** The slot exists
+   in the established `DotnetTool` convention (`tools/<tfm>/<rid>/`)
+   for a reason: a tool may need separate bytes per RID. Workloads
+   in v1 are portable (§4) and always populate `tools/any/`. If a
+   future workload class needs RID-specific bits — e.g., a workload
+   that wraps a native CLI it ships alongside — `tools/win-x64/` can
+   sit next to `tools/any/` without a layout migration. With a flat
+   `tools/`, the same scenario forces either a sub-folder rename
+   (breaking change) or reading the payload's `.deps.json` to pick
+   one of several flat sets, both of which are incompatible with
+   the "extract the `tools/<rid>/` subtree as-is" install rule
+   (§5.2).
+2. **Reads as "explicitly portable", not "RID forgotten".** A
+   reviewer or scanner looking at the package sees `tools/any/` and
+   immediately knows the package author marked the payload as
+   cross-platform. A flat `tools/` is silent on the question, and
+   tools that already understand `tools/<tfm>/<rid>/` (signing
+   pipelines, content scanners, mirroring tools) may misinterpret
+   it.
+
+Why **`any`** and not the host's RID for v1: per §4, the workload
+assembly is portable. Picking `any` keeps a single folder authors
+fill from `dotnet publish`, and lets the install pipeline extract
+the same bytes regardless of the user's RID. Any RID-specific
+behaviour comes from transitive dependencies and is resolved by the
+.NET runtime via the workload's `.deps.json` — the same mechanism
+every other portable .NET app relies on.
+
+The cost of the extra segment is one three-letter folder name in
+the package layout, generated by the pack target; authors never
+type it manually. The benefit is preserving an established slot
+that's already understood by NuGet content scanners and pack tools
+that know about `tools/<tfm>/<rid>/`.
+
+### 5.4 Workload manifest (`workload.json`)
+
+A single JSON file at the **package root** declares the workload's
+entry point. Modeled on `DotnetToolSettings.xml` for `DotnetTool`
+packages, but in JSON because every other Func CLI manifest in this
+design is JSON.
+
+#### Schema (v1)
+
+The `kind` field discriminates between three package shapes. Default
+is `"workload"`; the field may be omitted in normal workload
+manifests.
+
+Normal workload (default; runs in the loader, contributes services):
+
+```json
+{
+  "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
+  "kind": "workload",
+  "entryPoint": {
+    "assemblyPath": "Azure.Functions.Cli.Workload.Node.dll",
+    "type": "Azure.Functions.Cli.Workload.Node.NodeWorkload"
+  }
+}
+```
+
+Content package (e.g. host runtime — ships files, no entry point,
+loader skips):
+
+```json
+{
+  "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
+  "kind": "content"
+}
+```
+
+Meta package (no payload — bundles other workloads via
+`.nuspec` `<dependencies>`):
+
+```json
+{
+  "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
+  "kind": "meta"
+}
+```
+
+| Field                       | Required                      | Meaning |
+|-----------------------------|-------------------------------|---------|
+| `$schema`                   | Required                      | Versioned JSON Schema URL. Same convention as the global registry (spec §10.1). The CLI rejects packages whose `$schema` URL it doesn't recognise; the manifest is **never** parsed partially (see "Forward compatibility" below). |
+| `kind`                      | Optional (default `"workload"`) | One of `"workload"`, `"content"`, or `"meta"`. **`workload`** packages carry a runtime payload and contribute services to the host via `Configure()`. **`content`** packages carry a payload but no entry point — the loader skips them; built-in commands resolve their install dirs by package id (e.g. the host runtime; spec §4.6). **`meta`** packages carry no payload — they bundle other workload-or-content packages via the `.nuspec`'s `<dependencies>` (§5.5 "Meta packages"). |
+| `entryPoint.assemblyPath`   | Required for `workload`; **forbidden** for `content` and `meta` | Path to the workload assembly **relative to `tools/any/`** (forward slashes; no leading `/`; no `..` segments; not absolute). Conventionally a bare filename. The loader resolves it as `<workload-home>/workloads/<packageId>/<packageVersion>/tools/any/<assemblyPath>`. |
+| `entryPoint.type`           | Required for `workload`; **forbidden** for `content` and `meta` | Fully-qualified name of the type extending the abstract `Workload` base class. The loader instantiates this type by name when the workload is activated. The pack target validates that this type exists in the assembly, derives from `Workload`, and has a public parameterless constructor (§9.1). |
+
+That's the entire v1 schema. The manifest is intentionally minimal:
+
+- **Display metadata** (title, description, aliases) lives in the
+  `.nuspec` and is captured by the install pipeline from there.
+  Display name and description for the running CLI come from the
+  loaded `Workload` instance's `DisplayName` / `Description`
+  properties (spec §5.3) — no duplication.
+- **Compatibility constraints** (CLI version, contract-assembly
+  versions) are deferred to §11.1.
+- **Transitive workload-on-workload dependencies are not supported
+  in v1** for `workload` or `content` packages. They are
+  self-contained: every library each one needs is vendored into its
+  `tools/any/` payload by `dotnet publish`. The only mechanism for
+  packaging multiple workloads under a single id is a `meta`
+  package whose `.nuspec` `<dependencies>` enumerates them (§5.5).
+- **Capability lists / contribution-point inventories** are
+  intentionally absent. Per spec §5.1 the contract is "what services
+  the workload registers in `Configure`", not a static manifest;
+  baking it into `workload.json` would just create a second source
+  of truth that has to stay in sync with the code.
+
+#### Forward compatibility
+
+The CLI rejects any `workload.json` whose `$schema` URL it doesn't
+recognise. A v1 CLI will not load a v2 manifest even if v2 only adds
+fields that could be ignored. This is a deliberate trade-off:
+**forward compatibility is sacrificed for safety**. Partially
+interpreting a future schema risks loading a workload whose contract
+the CLI doesn't fully understand (e.g., a v2 field marks the
+workload as requiring a CLI capability that's missing). Strict
+rejection forces an explicit opt-in (`func upgrade` or installing a
+newer CLI) before such workloads are honoured.
+
+#### Why a manifest instead of attribute scanning
+
+The spec's original v1 had the install pipeline scan the package's
+top-level assemblies for `[assembly: ExportCliWorkload<T>]`. We move
+to an explicit manifest because:
+
+1. **No code execution at install.** Reading JSON beats spinning up
+   an `AssemblyLoadContext` (even a metadata-only one) just to discover
+   an attribute.
+2. **Faster install + better diagnostics.** Malformed packages fail
+   with a clear "manifest missing/invalid" error before any reflection
+   path runs.
+3. **Inspectability.** Anyone can crack the `.nupkg` open in a zip
+   tool and see what would be loaded. No .NET reflection knowledge
+   required to audit a workload.
+4. **Future non-.NET workloads.** The marker attribute is a .NET-only
+   construct. A JSON manifest leaves the door open without committing
+   to it in v1.
+
+The marker attribute (`[assembly: ExportCliWorkload<T>]`) survives as
+an **optional compile-time check** (§9.1): when present, the pack
+target validates that `workload.json`'s `entryPoint.type` matches the
+attribute's `T`. Authors can choose to drop the attribute entirely if
+they prefer.
+
+### 5.5 The three kinds, side-by-side installs, and meta expansion
+
+Most of the install/uninstall/load lifecycle is owned by
+[`workload-spec.md`](./workload-spec.md) §6.1, §6.2, §6.4, §6.5,
+§6.7. This section captures the **layout-level** consequences of
+that lifecycle plus the **meta-package install/uninstall flow**,
+which the spec doc does not cover.
+
+#### The three kinds at a glance
+
+| Kind | `entryPoint`? | `tools/any/`? | `<dependencies>`? | Loader behaviour | Has install dir? |
+|---|---|---|---|---|---|
+| `workload` (default) | required | required | empty | Loaded into a collectible ALC; `Workload.Configure(builder)` called; contributes services | yes |
+| `content` | forbidden | required | empty | Skipped — no ALC, no `Configure` call | yes |
+| `meta` | forbidden | forbidden | non-empty | Skipped — never seen by the loader | **no** (registry row only) |
+
+`workload` and `content` packages are full installable units:
+extracted to their own per-version directory, recorded in the
+registry's `workloads[]` array. `meta` packages exist purely as a
+registry concept — installing one resolves and installs each member
+as a `workload` or `content`, then records the resolved member list
+in the registry's `metas[]` array; the meta itself never gets an
+install dir.
+
+#### Workload and content packages are self-contained
+
+Every `workload` or `content` package's `.nuspec` `<dependencies>`
+element is **empty**. Every library a `workload` needs at runtime is
+vendored into its `tools/any/` payload by `dotnet publish`; every
+file a `content` package ships is laid out under `tools/any/` by the
+package author. Pack-time enforcement (§9.3) hard-fails any
+`<PackageReference>` not marked `<PrivateAssets>all</PrivateAssets>`.
+
+This matches `dotnet tool install` and `dotnet new install`, which
+both ignore `<dependencies>` entirely (§3). It also keeps the
+single-package install pipeline trivial: download, validate,
+extract, record. No transitive resolution, no closure tracking, no
+provenance metadata, no version-range arithmetic.
+
+The only place `<dependencies>` is non-empty — and load-bearing for
+the install pipeline — is `kind: meta` (below).
+
+#### Side-by-side installs (SxS)
+
+Multiple versions of the same `workload` or `content` `packageId`
+may coexist on disk. Each install gets its own directory, keyed by
+lowercased `packageId` (NuGet's normalization) and ordinal-matched
+`packageVersion`:
+
+```
+<workload-home>/workloads/
+  <packageid>/
+    <version-A>/
+      workload.json
+      tools/any/
+        <Workload>.dll
+        ...
+    <version-B>/
+      workload.json
+      tools/any/
+        <Workload>.dll
+        ...
+```
+
+The global registry (spec §10.1) records each install as a separate
+`(packageId, packageVersion)` row in its `workloads[]` array. SxS is
+triggered by `func workload install --force` (or by the user
+answering "yes" to the SxS prompt) when a different version is
+already installed (spec §6.1 step 1).
+
+##### Activation policy: latest installed wins
+
+The loader (spec §6.2 step 2) picks **one** version per `packageId`
+per CLI invocation: the highest installed semver. Older installed
+versions sit on disk but are not loaded into the running process.
+They exist on disk so:
+
+- `func workload list --all-versions` can show them.
+- `func workload uninstall <id> <version>` can revert by removing
+  the newer install — the loader then picks the next-highest
+  remaining version on the next CLI invocation.
+- `func workload prune` (spec §6.7) can clean them up later.
+
+There is **no project-level pinning, no `activeVersions` pointer,
+no per-profile selection** in v1. "Latest installed wins" is the
+entire policy (spec §6.2 "Multiple-version policy").
+
+##### Metas are unique per id
+
+The `metas[]` array carries at most one row per meta `packageId`.
+There is no SxS for metas. Reasons:
+
+- Metas don't run anything — there's no "live version" to pick.
+- Their only purpose is to record "user asked for bundle X" so
+  uninstall can offer cascade. Two rows would make
+  `func workload uninstall <metaId>` ambiguous.
+- Member SxS is already first-class at the workload/content level;
+  the meta layer doesn't need its own SxS to enable that.
+
+Installing a different version of an already-installed meta is an
+**update** (re-resolve members from the new version's
+`<dependencies>`, install new members, replace the `metas[]` row in
+place). Members that the new meta no longer references are left on
+disk — they're independently useful workloads now and the user can
+remove them explicitly. See "Meta-package update" below.
+
+#### Meta packages
+
+A meta package bundles a curated set of workloads and/or content
+packages under a single id. Installing a meta installs each member
+as a normal `workload` or `content`. The meta itself contributes no
+runtime — it is purely an install-time artifact.
+
+##### Why the discriminator (`kind`) lives in `workload.json`
+
+The `.nuspec` `<packageType>` value is `FuncCliWorkload` for all
+three kinds. NuGet V3 `SearchQueryService` accepts only one
+`packageType` filter per query, so using one type keeps feed search
+to a single round-trip. The `kind`-vs-kind discrimination then
+happens by reading the in-package `workload.json` after download.
+
+Trade-off: `kind` is not visible in NuGet feed metadata, so a
+pack-time check that "all of this meta's members are
+`kind: workload` or `kind: content` (i.e., not other metas)"
+requires opening each member `.nupkg` to read its `workload.json`.
+The pack target (§9.3) opts to defer that check to **install time**
+in v1, where the error message is clear and the failure surfaces in
+the author's own dev loop (they install their own meta to test it).
+
+Mitigations the layout *does* take advantage of, both feed-visible
+and free:
+
+- **`kind:*` tags** in the `.nuspec`. Authors **should** set one of
+  `kind:workload` / `kind:content` / `kind:meta` in `<tags>`. Feed
+  UIs and `func workload search --kind <kind>` use this for cheap
+  filtering. The tag is convention only — `workload.json` remains
+  authoritative — but it covers the common search path without
+  per-package downloads.
+
+##### Meta install flow
+
+`func workload install <metaId>` runs spec §6.1's eight-step flow
+once for the meta itself, then expands its members:
+
+1. **Resolve and download the meta package.** Standard
+   `(packageId, packageVersion)` resolution against the configured
+   feeds. Validate the package type is `FuncCliWorkload`, open it,
+   read `workload.json`, and confirm `kind: meta`.
+2. **Read the `.nuspec` `<dependencies>`.** Reject if empty (an
+   empty meta is a packaging error caught at pack time, but
+   defended in depth at install time).
+3. **Pre-flight: resolve and download every member** before any
+   extraction. For each `<dependency>` entry: select the
+   highest-feed-version satisfying the declared range,
+   `FindPackageByIdResource`-download to a scratch staging
+   directory, and read each member's `workload.json` to assert
+   `kind ∈ {workload, content}` (rejecting nested metas). Pre-flight
+   surfaces resolution errors, range mismatches, and meta-of-meta
+   violations *before* any byte hits the install location, so the
+   common failure modes don't strand the user mid-bundle.
+4. **Extract each member.** For each pre-flighted member,
+   atomic-rename its staged `tools/any/` into
+   `<workload-home>/workloads/<packageId>/<packageVersion>/`. This
+   step is fast (rename only — bytes are already on disk in the
+   staging dir from pre-flight).
+5. **Record each member's registry row** in `workloads[]`. New rows
+   carry `installedExplicitly: false` (members brought in by the
+   meta, not by an explicit `func workload install <id>`). If a
+   row for the same `(packageId, packageVersion)` already exists,
+   skip; if it exists with `installedExplicitly: true`, the row's
+   `installedExplicitly` stays `true` (the user installed it
+   explicitly *and* it's now in a meta — see "uninstall flow"
+   below).
+6. **Record the meta itself last** in `metas[]`. The row carries
+   `(metaPackageId, metaPackageVersion)` and a frozen `members[]`
+   snapshot of the resolved `(packageId, packageVersion)` pairs.
+   Writing `metas[]` last means a crash mid-install never leaves a
+   half-finished meta row — the user runs `func workload list`
+   and sees the partially-installed members as standalone, with
+   no broken meta state to recover from.
+
+The `.nupkg` of the meta itself is **discarded** after step 6 (and
+after each member's extraction). v1 does not cache it. If a future
+`func workload repair` needs to re-resolve a meta's members, it
+re-downloads the `(metaPackageId, metaPackageVersion)` from the
+configured feeds.
+
+If `func workload install <metaId>` is run when the meta is already
+recorded in `metas[]`, the request becomes a **meta-package update**
+— see below.
+
+##### Meta-package update
+
+`func workload install <metaId> --force` (or accepting the
+"different version detected" prompt) on an installed meta:
+
+1. Resolve and download the new meta version; pre-flight all of its
+   members (same as step 3 of the install flow).
+2. For each pre-flighted member not already in `workloads[]`,
+   extract and record (`installedExplicitly: false`).
+3. For each member already in `workloads[]`, leave it alone —
+   idempotency. The `installedExplicitly` flag is unchanged.
+4. **Replace** the meta's `metas[]` row in place with the new
+   version + new `members[]` snapshot. The old version's frozen
+   `members[]` is gone.
+5. Members that the new meta version no longer references are
+   **left on disk and in `workloads[]`** unchanged. The user can
+   remove them explicitly with `func workload uninstall <id>` if
+   they want.
+
+Update is non-destructive of pre-existing members. The meta layer
+only ever adds rows or rewrites its own row.
+
+##### Meta uninstall flow
+
+`func workload uninstall <metaId>` runs:
+
+1. Look up the meta's `metas[]` row. Snapshot its `members[]` list.
+2. **Default (interactive):** print
+   ```
+   Uninstalling meta package WorkerFamily 1.0.0.
+   It was installed with the following members:
+     [x] Workload.Node     2.0.0  (also installed explicitly — keep checked to remove)
+     [x] Workload.Python   2.0.0
+     [ ] Workload.Java     2.0.0  (installed explicitly; default: keep)
+   Remove selected members?
+   ```
+   Pre-checking is driven by each member's `installedExplicitly`
+   flag: members where the flag is `false` are pre-checked for
+   removal; members where it is `true` are pre-checked **off**
+   (they were installed explicitly and the user probably wants to
+   keep them). The user adjusts the selection and confirms.
+3. `--meta-only`: skip the prompt; only remove the `metas[]` row.
+   Members are untouched.
+4. `--with-dependencies`: skip the prompt; remove every member in
+   the snapshot **whose `installedExplicitly` flag is `false`**.
+   Members with `installedExplicitly: true` are kept (the user
+   installed them independently of this meta; the meta uninstall
+   should not clobber them). To force-remove explicitly-installed
+   members too, pass `--with-dependencies --force`.
+5. `--with-dependencies --force`: remove every member listed in
+   the meta's `members[]` snapshot, regardless of
+   `installedExplicitly`. This is the "blow away the bundle's
+   footprint" escape hatch.
+6. Member uninstall uses **id-only lookup** (fuzzy): if the
+   snapshot's `(memberId, memberVersion)` no longer matches a row
+   in `workloads[]` (e.g., the user ran `func workload update
+   <memberId>` since the meta was installed and the version in the
+   snapshot is gone), the cascade still finds the current row by
+   id and removes it. This matches the `--with-dependencies`
+   intent ("the bundle's footprint"). Strict-version lookup is
+   recorded as an open question (§11) for future revisiting.
+7. Once all selected members are removed, remove the `metas[]`
+   row.
+
+A member listed in two metas (rare) is removed by the first
+`--with-dependencies` cascade that hits it; the second meta's
+`metas[]` row then references a missing member. `func workload
+list` surfaces this as a `[broken meta]` warning; remediation is
+deferred to a future `func workload repair` (§11).
+
+##### `installedExplicitly` lifecycle
+
+The flag is per-row in `workloads[]`. Transitions:
+
+- `func workload install <id>` → row created with
+  `installedExplicitly: true`.
+- Meta install brings in a new member → row created with
+  `installedExplicitly: false`.
+- `func workload install <id>` on a row that already exists with
+  `installedExplicitly: false` → flag flips to `true`. (The user
+  is now claiming it.)
+- The flag never flips back to `false`. Once explicit, always
+  explicit, until uninstalled.
+
+This is a deliberate simplification of v0.7's `installedBy`
+reason-list. We don't need to track *which* metas brought a member
+in — only "did the user ask for it directly at any point." The
+member's frozen `members[]` snapshot in each meta covers the rest.
+
+#### What we use NuGet for, what we own
+
+We use NuGet for:
+
+- Feed protocol (V2 + V3), package download — `NuGet.Protocol`.
+  `FindPackageByIdResource` for download (the same API
+  `dotnet tool install` uses); `PackageMetadataResource` for
+  per-package metadata (id, version, package types, tags,
+  `<dependencies>`).
+- Version range syntax (`[1.2.0,2.0.0)`) and comparison —
+  `NuGet.Versioning`. Used for meta-member range resolution and
+  installed-vs-requested SxS decisions.
+- `nuget.config` discovery, source ordering, package source
+  mapping, credential providers — `NuGet.Configuration`,
+  `NuGet.Credentials`.
+- `.nupkg` / `.nuspec` parsing — `NuGet.Packaging`.
+
+We **don't** use:
+
+- `NuGet.Resolver` / `NuGet.PackageManagement` —
+  `RestoreCommand` / `RestoreRunner`. Workload packages are not
+  projects; per-workload resolution at install would frame them as
+  references with asset selection rules that don't apply to
+  payload-vendored packages. See §10.5.
+- `NuGet.DependencyResolver.Core`. Meta resolution is one level
+  deep (no meta-of-meta in v1; member ranges resolve independently
+  against the feed); transitive graph walking would be unused
+  machinery.
+
+We own:
+
+- The install layout and per-version install dirs (see §5.1, §5.3).
+- `kind` enforcement — pack-time checks for `workload` /
+  `content`, install-time checks for `meta` member kinds.
+- Meta expansion — pre-flight + per-member extraction + member
+  recording + meta row write.
+- Activation under SxS — loader picks one version per id per
+  invocation.
+- Uninstall semantics — interactive prompt + `--meta-only` /
+  `--with-dependencies` / `--force` flags; `installedExplicitly`
+  bookkeeping.
+- Atomic registry writes — temp file + rename; concurrent-safe.
+- Recovery — broken-meta detection in `list` (§11).
+
+#### What the layout does not need to record
+
+The full registry shape (per-row fields, `$schema` URL versioning,
+the `aliases`/`source` columns, the `metas[].members[]` snapshot,
+the `installedExplicitly` flag) is owned by spec §10.1. This doc
+commits only to the on-disk install layout that makes that registry
+shape possible:
+
+- A per-version install directory under the workloads home keyed
+  by `(packageId, packageVersion)` for each `workload` or `content`
+  package.
+- `workload.json` at the install-dir root, copied verbatim from the
+  package, so the loader can re-read it without going back to the
+  package.
+- `tools/any/` next to it, containing whatever the package shipped.
+- **No install dir for `meta` packages.** The meta is recorded only
+  in the central registry's `metas[]` array.
+- No CLI-managed metadata files inside any install dir beyond what
+  the package itself shipped — install metadata
+  (timestamp, source feed, alias list, `installedExplicitly` flag,
+  `members[]` snapshot) lives in the central registry.
+
+#### Recovery cases at the layout level
+
+- **Orphan install dir** (move-into-place succeeded, registry
+  write failed): there's an extracted `(packageId, packageVersion)`
+  directory the CLI doesn't know about. `func workload prune`
+  (spec §6.7) cleans these up.
+- **Missing install dir** (registry has a row whose install dir is
+  missing): the loader surfaces this as a `[<packageId>]`-prefixed
+  warning and continues (spec §6.2 "Failure isolation"). A future
+  `func workload repair` re-extracts from a fresh download.
+- **Broken meta** (a `metas[].members[]` entry references a
+  `(packageId, packageVersion)` not present in `workloads[]`):
+  `func workload list` shows `[broken meta]` next to the meta's
+  row. Remediation deferred to `func workload repair` (§11).
+- **Crashed meta install** (some members extracted, no `metas[]`
+  row): the partially-installed members appear in `workloads[]`
+  with `installedExplicitly: false`. The user re-runs
+  `func workload install <metaId>`; idempotency skips already-
+  installed members, fills in any missing ones, and writes the
+  `metas[]` row. The previously-failed member rows are absorbed
+  into the meta's `members[]` snapshot — they were intended as
+  members all along. (Documented design point.)
+
+The atomic-rename used by the install pipeline plus the registry's
+atomic write keep these failure modes mutually exclusive at the
+bytes level.
+
+## 6. Host/workload compatibility
+
+A workload is binary-compatible with a CLI when **both** of these hold:
+
+1. **Host-shared contract assemblies:** the workload was built against
+   contract assemblies whose public surface the running CLI still
+   satisfies. The contract assemblies are the ones the loader
+   delegates back to the default load context — currently
+   `Azure.Functions.Cli.Abstractions`,
+   `Microsoft.Extensions.DependencyInjection.Abstractions`, and
+   `System.CommandLine`
+   ([`src/Func/Workloads/Loading/WorkloadLoadContext.cs:73-76`](../src/Func/Workloads/Loading/WorkloadLoadContext.cs)).
+   `System.CommandLine` is on the list today only as a transitional
+   measure; it is expected to be removed from the shared contract
+   before v1, leaving `Abstractions` and the DI abstractions as the
+   stable surface. The CLI ships exactly one version of each; the
+   workload's resolved reference must bind to that version. The
+   workload's TFM is recorded in its assembly's
+   `TargetFrameworkAttribute` and `.deps.json`; the .NET runtime's
+   standard load rules handle TFM compatibility (a `net10.0`
+   workload runs on a CLI on a `net10.0`-or-newer runtime without
+   further intervention).
+2. **Shared frameworks:** the workload may **not** depend on any
+   shared framework (`Microsoft.NETCore.App`, `Microsoft.AspNetCore.App`,
+   `Microsoft.WindowsDesktop.App`) the CLI does not itself carry.
+   Workloads do not ship their own `.runtimeconfig.json` — they run
+   inside the CLI's process and inherit its framework set. A workload
+   that needs ASP.NET shared framework primitives must vendor them or
+   target a CLI that already loads them.
+
+The package layout cannot fully express (1) on its own. Two
+candidate mechanisms for the workload to declare its compatibility
+window — neither is committed in v1, both are open questions:
+
+- **NuGet `<dependencies>`** on the contract packages
+  (`Azure.Functions.Cli.Abstractions`, etc.) with version ranges. The
+  install pipeline reads these and rejects packages whose ranges
+  exclude the running CLI. This is the closest match to existing
+  NuGet conventions but requires the install pipeline to evaluate
+  ranges.
+- **A first-class CLI-version field** in the package's metadata
+  (e.g. via a reserved tag like `func-cli-min:5.2`). Simpler to
+  evaluate; requires a Func-defined convention.
+
+See §11 for the open question.
+
+> **Authoring rule (consequence of (1)):** the contract assemblies
+> **must not** be packed inside the workload — see §9.2.
+
+## 7. Required NuGet metadata
+
+These already appear in `workload-spec.md` §5.3; restated here so the
+layout is self-contained. The in-package `workload.json` (§5.4) is
+**required** in addition to this metadata — it lives outside the
+`.nuspec` because it carries CLI-specific contract data the
+`.nuspec` schema can't express cleanly. The role of the `.nuspec`'s
+`<dependencies>` element **branches on `kind`** (§5.5):
+
+- `kind: workload` and `kind: content`: `<dependencies>` is
+  **empty**. Library `<PackageReference>`s in the package's
+  `.csproj` must carry `<PrivateAssets>all</PrivateAssets>` per
+  §9.2 and §9.3 so `dotnet publish` vendors their runtime into
+  `tools/any/` rather than declaring it as a NuGet dependency.
+- `kind: meta`: `<dependencies>` is **non-empty** and lists each
+  bundled `kind: workload` or `kind: content` member. The install
+  pipeline reads it to drive meta-expansion (§5.5). Each
+  `<dependency>` must resolve to a `FuncCliWorkload`-typed package
+  on the configured feeds; the deeper `kind` check on members
+  (must be `workload` or `content`, not another meta) happens at
+  install time.
+
+| Field          | Value                                                 |
+|----------------|-------------------------------------------------------|
+| `id`           | `Azure.Functions.Cli.Workload.<Name>` for first-party workloads. Third-party authors choose any NuGet-legal id. |
+| `version`      | SemVer 2.0.                                           |
+| `title`        | Display name shown in `func workload list`.           |
+| `description`  | One-line summary shown in `func workload list`.       |
+| `packageTypes` | **Must** include a `FuncCliWorkload` entry. Packages without this type are rejected by `func workload install`. |
+| `tags`         | **Should** include exactly one `kind:<workload\|content\|meta>` tag matching `workload.json`'s `kind` field (§5.5; convention only — `workload.json` remains authoritative). **Should** also include one or more `alias:<name>` tags so users can install by short name. The `func-workload` tag is **recommended** (improves discoverability in NuGet feed UIs and `nuget search`-style tooling that does not filter by package type) but **not required** — the `FuncCliWorkload` package type already self-identifies the package, and `func workload search` filters by that plus optionally by `kind:`. |
+| `dependencies` | **Branches on `workload.json`'s `kind` field** (§5.4): for `kind: workload` and `kind: content`, **must be empty** — every `<PackageReference>` must carry `<PrivateAssets>all</PrivateAssets>` so its runtime is vendored into `tools/any/`. For `kind: meta`, **must be non-empty** and list each bundled member as a `<dependency>` resolving to a `FuncCliWorkload`-typed package on the configured feeds (the pack target validates the package type cheaply via `PackageMetadataResource`; the deeper `kind ∈ {workload, content}` check on members is deferred to install time). See §5.5, §9.3. |
+| `readme`       | Path to `README.md` packed at the root.               |
+| `icon`         | Path to `icon.png` packed at the root.                |
+| `releaseNotes` | Recommended. Sourced from `release_notes.md` via the existing `Release.targets`. |
+
+## 8. Worked examples
+
+### 8.1 Normal workload: `Azure.Functions.Cli.Workload.Node`
+
+```
+Azure.Functions.Cli.Workload.Node.1.0.0.nupkg
+├── tools/
+│   └── any/
+│       ├── Azure.Functions.Cli.Workload.Node.dll
+│       ├── Azure.Functions.Cli.Workload.Node.deps.json
+│       ├── Azure.Functions.Cli.Workload.Node.pdb
+│       └── Newtonsoft.Json.dll                       # transitive managed dep
+├── workload.json
+├── README.md
+├── icon.png
+└── Azure.Functions.Cli.Workload.Node.nuspec
+```
+
+> Host-shared contract assemblies (`Azure.Functions.Cli.Abstractions.dll`,
+> `Microsoft.Extensions.DependencyInjection.Abstractions.dll`, and —
+> transitionally — `System.CommandLine.dll`) are **not** in the
+> package — see §6 (2) and §9.2.
+>
+> Templates for `func init` / `func new` are **not** in the worked
+> example: whether they ship inside the workload package or as a
+> separate `Template`-typed package is open (§11). Authors who do
+> ship templates in-package would place them under
+> `tools/any/<dir>/` alongside the workload assembly.
+
+`workload.json` (`kind` field omitted; `workload` is the default):
+
+```json
+{
+  "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
+  "entryPoint": {
+    "assemblyPath": "Azure.Functions.Cli.Workload.Node.dll",
+    "type": "Azure.Functions.Cli.Workload.Node.NodeWorkload"
+  }
+}
+```
+
+Note `assemblyPath` is a **bare filename** (relative to `tools/any/`),
+not a path including the `tools/any/` prefix; the loader prepends the
+content-root directory itself (§5.4).
+
+`.nuspec` excerpt:
+
+```xml
+<metadata>
+  <id>Azure.Functions.Cli.Workload.Node</id>
+  <version>1.0.0</version>
+  <title>Node.js</title>
+  <description>func init / func new support for Node.js and TypeScript.</description>
+  <authors>Microsoft</authors>
+  <packageTypes>
+    <packageType name="FuncCliWorkload" />
+  </packageTypes>
+  <tags>kind:workload alias:node alias:javascript alias:typescript</tags>
+  <readme>README.md</readme>
+  <icon>icon.png</icon>
+  <!-- No <dependencies>: workload packages are self-contained (§5.5, §9.3). -->
+</metadata>
+```
+
+### 8.2 Content package: Functions host runtime
+
+The Func host (`Microsoft.Azure.WebJobs.Script.WebHost`) ships as a
+`kind: content` package (§5.5; spec §4.6). The package contributes
+no `Workload` class and no DI services; `func start` resolves the
+install directory by package id and launches the host binaries
+directly.
+
+```
+Azure.Functions.Cli.Workload.Host.4.0.0.nupkg
+├── tools/
+│   └── any/
+│       ├── Microsoft.Azure.WebJobs.Script.WebHost.dll
+│       ├── Microsoft.Azure.WebJobs.Script.WebHost.deps.json
+│       ├── runtimes/
+│       │   ├── win-x64/...
+│       │   ├── linux-x64/...
+│       │   └── osx-x64/...
+│       └── ...                                       # rest of host's published output
+├── workload.json
+├── README.md
+└── Azure.Functions.Cli.Workload.Host.nuspec
+```
+
+`workload.json`:
+
+```json
+{
+  "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
+  "kind": "content"
+}
+```
+
+`.nuspec` excerpt:
+
+```xml
+<metadata>
+  <id>Azure.Functions.Cli.Workload.Host</id>
+  <version>4.0.0</version>
+  <title>Functions host runtime</title>
+  <description>The Microsoft.Azure.WebJobs.Script host process that func start launches.</description>
+  <authors>Microsoft</authors>
+  <packageTypes>
+    <packageType name="FuncCliWorkload" />
+  </packageTypes>
+  <tags>kind:content alias:host</tags>
+  <readme>README.md</readme>
+  <!-- No <dependencies>: content packages are self-contained (§5.5, §9.3). -->
+</metadata>
+```
+
+The loader (spec §6.2 step 3) skips this entry — no
+`AssemblyLoadContext` spin-up, no `Workload.Configure` call, no DI
+contribution. `func start` queries the workload-registry service
+for the `WorkloadEntry` instances it exposes, locates the host
+workload purely by its package id
+(`Azure.Functions.Cli.Workload.Host`), picks the right version
+— either the latest installed or the version that satisfies the
+active profile's requirement — and launches the host binary by
+path out of
+`<workload-home>/workloads/azure.functions.cli.workload.host/<resolved-version>/tools/any/`.
+This resolution is owned by `func start` and is fully isolated
+from the core CLI loading logic; the loader never sees this
+package, and `func start` never re-reads `workload.json` or the
+registry file directly — it goes through the service.
+
+### 8.3 Meta package: `Azure.Functions.Cli.Meta.WorkerFamily`
+
+A fictitious "Worker Family" meta bundles Node, Python, and Java
+under a single versioned id (§5.5 "Meta packages"); we don't plan
+to ship this package — it's used here purely to illustrate the
+shape:
+
+```
+Azure.Functions.Cli.Meta.WorkerFamily.1.0.0.nupkg
+├── workload.json                                     # kind: meta — no entryPoint
+├── README.md
+└── Azure.Functions.Cli.Meta.WorkerFamily.nuspec
+                                                     # No tools/any/ — metas have no payload.
+```
+
+`workload.json`:
+
+```json
+{
+  "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
+  "kind": "meta"
+}
+```
+
+`.nuspec` excerpt:
+
+```xml
+<metadata>
+  <id>Azure.Functions.Cli.Meta.WorkerFamily</id>
+  <version>1.0.0</version>
+  <title>Worker Family</title>
+  <description>Curated bundle of Func workloads for Worker-family languages.</description>
+  <packageTypes>
+    <packageType name="FuncCliWorkload" />
+  </packageTypes>
+  <tags>kind:meta</tags>
+  <readme>README.md</readme>
+  <dependencies>
+    <group>
+      <dependency id="Azure.Functions.Cli.Workload.Node"   version="[2.0.0,3.0.0)" />
+      <dependency id="Azure.Functions.Cli.Workload.Python" version="[2.0.0,3.0.0)" />
+      <dependency id="Azure.Functions.Cli.Workload.Java"   version="[2.0.0,3.0.0)" />
+    </group>
+  </dependencies>
+</metadata>
+```
+
+The meta's `.csproj` declares each member as a plain
+`<PackageReference>` — **no** `<PrivateAssets>` (which would hide the
+reference from `<dependencies>`):
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Azure.Functions.Cli.Workload.Node"   Version="[2.0.0,3.0.0)" />
+  <PackageReference Include="Azure.Functions.Cli.Workload.Python" Version="[2.0.0,3.0.0)" />
+  <PackageReference Include="Azure.Functions.Cli.Workload.Java"   Version="[2.0.0,3.0.0)" />
+</ItemGroup>
+```
+
+`func workload install Azure.Functions.Cli.Meta.WorkerFamily`
+pre-flights all three members, resolves each to a concrete
+`(packageId, packageVersion)`, downloads them into a staging area,
+extracts each into its own
+`<workload-home>/workloads/<packageId>/<packageVersion>/` directory
+(side-by-side with any pre-existing installs of the same id; SxS
+applies normally), records each member in `workloads[]` with
+`installedExplicitly: false`, and finally records the meta itself
+in `metas[]` with the resolved `members[]` snapshot. See §5.5
+"Meta install flow".
+
+## 9. Authoring impact (preview — full plumbing in a follow-up)
+
+Producing this layout from a workload csproj will be a small set of
+properties on top of `dotnet pack`'s defaults. The full
+`Workload.Common.targets` / `Workload.props` plumbing is out of scope
+for this design, but the salient knobs will be roughly:
+
+> **Workload authoring SDK.** We plan to ship a dedicated **Func
+> Workload SDK** that workload authors reference instead of the
+> standalone targets — at a minimum a `Azure.Functions.Cli.Workload.Sdk`
+> package (working name) that an author imports via
+> `<Project Sdk="Azure.Functions.Cli.Workload.Sdk/x.y.z">`
+> and that bundles the pack target, the `workload.json` generator,
+> the host-shared-assembly exclusions (§9.2), and the pack-time
+> rules (§9.3). The properties shown below are the knobs the SDK
+> will expose; everything else (publish-into-`tools/any/`, manifest
+> generation, contract-assembly stripping, package-type wiring)
+> the SDK takes care of. The SDK is out of scope for this layout
+> doc — it's tracked separately and will live alongside this
+> design — but it's worth flagging here so authors don't conclude
+> they'll need to hand-wire each property and target into every
+> workload `.csproj` forever.
+
+```xml
+<PropertyGroup>
+  <PackageType>FuncCliWorkload</PackageType>
+  <PackageTags>func-workload alias:node</PackageTags>
+  <IncludeBuildOutput>false</IncludeBuildOutput>  <!-- we use publish output, not build output -->
+  <IsPackable>true</IsPackable>
+</PropertyGroup>
+```
+
+Plus a target that runs `dotnet publish`, copies the publish output
+into `tools/any/`, and **generates `workload.json`**. We **cannot**
+reuse the SDK's `PackAsTool=true` machinery: that target (imported
+from `Microsoft.NET.PackTool.targets` only when `PackAsTool=true`) is
+hard-coded to set `<PackageType>DotnetTool</PackageType>` and emit a
+`DotnetToolSettings.xml`, both of which are wrong for a workload. The
+follow-up plumbing PR ships a parallel pack target (working name
+`Workload.Common.targets`) that re-implements the publish-into-tools
+step without the `DotnetTool` semantics.
+
+### 9.1 Generating `workload.json`
+
+The pack target produces `workload.json` automatically; authors
+should not hand-author it. The pack inputs are, in priority order:
+
+1. **MSBuild properties** the author sets on the project — e.g.
+   `<FuncWorkloadKind>workload|content|meta</FuncWorkloadKind>`
+   (default `workload`) and, for `kind: workload`,
+   `<FuncWorkloadEntryPointType>` for the entry-point FQN. When
+   `kind` is `content` or `meta`, no entry-point inputs are needed;
+   otherwise `assemblyPath` is inferred from the project's
+   published output filename (relative to `tools/any/`,
+   conventionally a bare filename).
+2. **The `[assembly: ExportCliWorkload<T>]` marker attribute** on the
+   workload assembly, when present (only applicable for
+   `kind: workload`). The pack target reads `T`'s FQN from the
+   published assembly's metadata (no execution required — this is
+   metadata-only inspection during pack, not at install).
+
+If both are present, the pack target validates they agree and fails
+the pack if they don't. If neither is present and `kind` is
+`workload`, the pack fails: the author must declare the entry point
+explicitly. For `kind: content` and `kind: meta` packages, no
+entry-point inputs are consulted.
+
+The marker attribute remains useful as a **compile-time** check of
+`T : Workload` — the constraint is enforced by the C# compiler the
+moment `[ExportCliWorkload<MyWorkload>]` is written. Authors who
+prefer a property-only flow can drop the attribute entirely.
+
+### 9.2 Excluding host-shared contract assemblies
+
+The CLI's load context delegates a fixed set of contract assemblies
+back to the default load context so types crossing the host/workload
+boundary keep a single `Type` identity
+([`WorkloadLoadContext.cs:73-76`](../src/Func/Workloads/Loading/WorkloadLoadContext.cs)).
+Today the set is:
+
+- `Azure.Functions.Cli.Abstractions`
+- `Microsoft.Extensions.DependencyInjection.Abstractions`
+- `System.CommandLine` *(transitional — slated to be removed from
+  the shared contract before v1; workloads will then take a direct
+  package reference to whichever version they need and the loader
+  will load it inside the workload's ALC like any other library)*
+
+If the workload package ships its own copy of any of these, three
+things go wrong: the package gets bigger for no reason, the workload
+carries a stale copy that drifts out of sync with the running CLI, and
+the loader's "default-context wins" rule has to deduplicate at every
+load. The fix is to keep these out of the workload's runtime closure
+in the first place. For each contract reference the workload csproj
+should set:
+
+```xml
+<PackageReference Include="Azure.Functions.Cli.Abstractions">
+  <PrivateAssets>all</PrivateAssets>
+  <ExcludeAssets>runtime</ExcludeAssets>
+</PackageReference>
+```
+
+The pack target should additionally **validate** that none of the
+host-shared contract assemblies appear inside `tools/any/` before
+producing the `.nupkg`. This is the same validation rule for all
+three assemblies, not an `Abstractions`-special-case.
+
+> The exact list of host-shared contract assemblies is owned by the
+> CLI, not the workload. The pack target should read it from a
+> well-known property the Abstractions package contributes (e.g.
+> `@(FuncCliHostSharedContractAssembly)`) so the list stays in lockstep
+> with `WorkloadLoadContext`.
+
+### 9.3 Pack-time enforcement of dependency declarations
+
+§5.5 makes the `.nuspec`'s `<dependencies>` element load-bearing for
+the install pipeline, with rules that **branch on the package's
+`kind`**. `Workload.Common.targets` enforces these rules at pack time.
+
+#### For `kind: workload` packages
+
+1. **Every `<PackageReference>` must carry
+   `<PrivateAssets>all</PrivateAssets>`.** This suppresses the
+   reference from the published `.nuspec` `<dependencies>` and lets
+   `dotnet publish` vendor the library's runtime into `tools/any/`.
+   Any `<PackageReference>` not so marked causes a hard pack failure
+   with a fixit message: workload packages are self-contained
+   (§5.5), so every reference is necessarily a private library
+   reference. The check catches the "library leaked into
+   `<dependencies>`" failure mode at pack time, before a malformed
+   package is published.
+
+2. **The published `.nuspec` `<dependencies>` element must be empty
+   or absent.** Defense-in-depth check, run after rule (1).
+
+3. **Manifest-shape validation** (`workload.json`):
+   - `kind` is `"workload"` or absent (defaults to workload).
+   - `entryPoint.assemblyPath` and `entryPoint.type` are present.
+   - `entryPoint.assemblyPath` is not absolute, not rooted, and
+     contains no `..` segments.
+
+4. **`tools/any/` must be non-empty** and contain the workload
+   assembly named in `entryPoint.assemblyPath`.
+
+5. **Entry-point validation:**
+   - `entryPoint.type` must exist inside that assembly's metadata
+     (no execution required —
+     Mono.Cecil / `System.Reflection.Metadata` scan).
+   - The type must derive from the abstract `Workload` base class.
+   - The type must have a public parameterless constructor.
+
+6. **The `kind:workload` tag should be present** in `<tags>`.
+   Recommendation, not a hard failure (the tag is convention only —
+   `workload.json` remains authoritative). Missing-tag emits a
+   warning fixit so the package shows up under `func workload
+   search --kind workload` without a package download.
+
+#### For `kind: content` packages
+
+1. Rules (1) and (2) from `kind: workload` apply unchanged: empty
+   `<dependencies>`, `<PrivateAssets>all</PrivateAssets>` on every
+   `<PackageReference>`. Content packages are self-contained too;
+   transitive resolution is the workload-pipeline path we don't run
+   for either kind.
+
+2. **Manifest-shape validation:**
+   - `kind` is `"content"` (must be explicit — not the default).
+   - `entryPoint` is **absent**. A `content` package with an
+     `entryPoint` is rejected at pack time even though the install
+     pipeline silently ignores it. Keeps `workload.json` a single
+     source of truth for the package's role.
+
+3. **`tools/any/` must be non-empty.** The pack target does not
+   validate its internal layout — that's between the package and
+   whatever built-in command consumes it (e.g., the host workload
+   ships a host runtime; `func start` knows that layout).
+
+4. **The `kind:content` tag should be present** in `<tags>`.
+   Same severity as for `workload`: warning fixit.
+
+#### For `kind: meta` packages
+
+1. **The `.nuspec` `<dependencies>` element must be non-empty.** A
+   meta with no members is a packaging error. Each `<dependency>`
+   must declare a version range; bare ids are rejected.
+
+2. **Every emitted `<dependency>` must resolve to a
+   `FuncCliWorkload`-typed package on the configured feeds.** The
+   pack target queries `PackageMetadataResource` for each member's
+   metadata and verifies the `<packageType>`. Catches authors
+   pointing a meta at non-workload packages.
+
+3. **The deeper kind check is deferred to install time.**
+   Pack-time only verifies the `FuncCliWorkload` package type on
+   members; it does **not** verify each member's in-package
+   `workload.json` `kind` field is `"workload"` or `"content"`.
+   That check would force per-member `.nupkg` downloads at pack
+   time. The trade-off is acceptable in v1 because:
+   - Authors typically install their own meta locally to test it,
+     hitting the install-time error in their own dev loop.
+   - The install-time error message is clear ("meta member X is
+     `kind: meta`; meta-of-meta is forbidden in v1, see §5.5").
+   - An MSBuild task that downloads + reads each member's
+     `workload.json` is recorded as a future enhancement (§11).
+
+4. **`tools/any/` must be empty or absent.** Metas have no
+   payload. A meta package with a non-empty `tools/any/` is
+   rejected at pack time.
+
+5. **Manifest-shape validation:**
+   - `kind` is `"meta"` (explicit).
+   - `entryPoint` is **absent**.
+
+6. **The `kind:meta` tag should be present** in `<tags>`. Same
+   severity as for `workload` / `content`: warning fixit.
+
+#### Cross-cutting
+
+The combination of rules (1)–(6) per kind, plus §9.2's contract-
+assembly exclusion, means that for a successfully packed first-
+party workload / content / meta, the install pipeline can trust
+both `<dependencies>` and `workload.json` to be well-formed.
+Failures move to CI where they're visible and actionable, instead
+of being delivered to end users at install time.
+
+## 10. Alternatives considered (and rejected)
+
+### 10.1 `lib/<tfm>/` for the workload assembly
+
+Already covered in §5.1. The decisive issue is that `lib/` packages are
+indistinguishable from referenceable libraries to NuGet feeds and to
+downstream tooling, which contradicts the `FuncCliWorkload` contract.
+
+### 10.2 Custom top-level folder (`workload/`, `extension/`, …)
+
+Tempting because it makes the package self-describing without any
+NuGet folder semantics. Rejected because:
+
+- It throws away every existing tool that already understands NuGet
+  conventions (publish layouts, security scanners, feed UIs).
+- It requires the install pipeline to know "the bytes live under
+  `<custom-folder>/`," adding a contract that needs to evolve.
+- The package-type + tag pair already self-describes the package; the
+  folder layout is an implementation detail the install pipeline
+  reads, not user-facing.
+
+### 10.3 Workload-internal asset directories at the package root, outside `tools/`
+
+Considered for any workload-internal data the workload reads at
+runtime (e.g. embedded JSON schemas, or — if templates ship in-package
+rather than as a separate `Template`-typed package, see §11 — the
+template files): ship them under `/<assets>/` at the package root
+rather than inside `tools/any/<assets>/`. Rejected because:
+
+- It splits a single workload's assets across two unrelated package
+  paths, which complicates the install pipeline (extract twice, track
+  two roots).
+- Putting assets next to the assembly mirrors `dotnet publish`
+  output, so authors don't need any custom MSBuild plumbing.
+- Workload code reads assets via paths relative to its assembly
+  (`AppContext.BaseDirectory`), which is the natural pattern.
+
+### 10.4 Scanning the package's assemblies for `[assembly: ExportCliWorkload<T>]`
+
+The spec's original v1 (§6.1 step 4) had the install pipeline scan
+the package's top-level assemblies for the marker attribute. Replaced
+by `workload.json` (§5.4) in this iteration. Reasons:
+
+- Requires loading (or at least metadata-only inspecting) assemblies
+  during `func workload install`, which is more code and more failure
+  modes than reading a JSON file.
+- Diagnostics are worse: "no assembly with the marker attribute" or
+  "multiple matches" surface only after the assemblies are inspected.
+- Inspectability is worse: a user can't audit what would be loaded
+  without .NET reflection knowledge.
+- .NET-only by construction; closes the door on a future non-.NET
+  workload mechanism.
+
+The marker attribute itself is retained as an optional compile-time
+check (§5.4, §9.1).
+
+### 10.5 Use NuGet's `RestoreCommand` / `RestoreRunner` to drive install end-to-end
+
+The most natural-looking alternative: model `func workload install`
+as a project-restore operation. Synthesise a project file that
+references the requested workload as a `<PackageReference>`, hand it
+to `NuGet.Commands.RestoreCommand` (or `RestoreRunner`), and let
+NuGet's full PackageReference-era pipeline — restore, conflict
+resolution, lock files, audit, source mapping enforcement, asset
+selection — produce a closed package graph that we then extract
+into the workload install location.
+
+Rejected because:
+
+- **The .NET SDK's two NuGet-distributed CLI extensions explicitly
+  don't do this.** `dotnet tool install` and `dotnet new install`
+  both build their install pipelines on top of `NuGet.Protocol` +
+  `NuGet.Versioning` + `NuGet.Packaging` + `NuGet.Configuration` /
+  `NuGet.Credentials`. Neither references `RestoreCommand` /
+  `RestoreRunner`; neither writes a `project.assets.json`. There
+  was a vestigial `ProjectRestorer` that shelled out to
+  `dotnet restore` ([`dotnet/sdk:src/Cli/dotnet/Commands/Tool/Install/ProjectRestorer.cs`](https://github.com/dotnet/sdk/blob/main/src/Cli/dotnet/Commands/Tool/Install/ProjectRestorer.cs)) — it is no longer
+  instantiated in modern code paths. The SDK actively walked away
+  from this approach.
+- **A workload isn't a project.** It has no compile-time references,
+  no asset selection per-TFM at install (the workload's runtime
+  closure was selected when `dotnet publish` ran during pack), and
+  no transitive runtime graph for the consumer to reconcile. Restore
+  exists to close a *project's* graph; we already have a closed
+  payload in `tools/any/`.
+- **Asset-selection semantics are wrong.** `RestoreCommand` would
+  try to pull `lib/<tfm>/` and `runtimes/<rid>/lib/<tfm>/` assets
+  into a graph that the workload has no use for. Suppressing this
+  means custom asset filters, which is more code than just walking
+  `<dependencies>` ourselves.
+- **No good fit for the install layout.** Restore writes its output
+  to a project's `obj/` and a global packages folder. We want a
+  per-workload, per-version subset extracted to a Func-managed
+  location. Mapping one onto the other is friction, not free
+  reuse.
+- **Lock files / audit are not free either.** They are restore-time
+  artifacts written into a project. Re-using them outside a project
+  context is non-obvious; we would still own how lock files are
+  surfaced in the CLI, where they live, and how they are validated
+  on subsequent installs. If we want lock-file semantics later, we
+  build them on top of our resolver pass — same as
+  `dotnet tool install` would have to.
+- **Confusing to authors.** A `FuncCliWorkload`-typed package
+  showing up in some downstream consumer's `<PackageReference>` (as
+  a side-effect of advertising restore semantics) would tempt
+  library-style consumption, which doesn't make sense — the
+  workload's runtime closure is already vendored and would pull
+  duplicate copies of every transitive dep.
+
+What this design *does* do: use `<dependencies>` as the declaration
+vector for **`kind: meta` packages** (§5.5; `kind: workload` and
+`kind: content` packages have empty `<dependencies>`), use
+`NuGet.Protocol`'s `PackageMetadataResource` to read each declared
+member's metadata from the feed, and use
+`NuGet.Protocol`'s `FindPackageByIdResource` to download the
+resolved set. Resolution is one level deep per install operation —
+metas don't depend on metas in v1 (§5.5), so there is no
+transitive graph to walk. That is *most* of what NuGet would have
+done as part of restore — minus the project framing, the asset
+selection, the project-output writing, and the transitive resolver
+— and is exactly the slice `dotnet tool install` uses today
+([`dotnet/sdk:src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs`](https://github.com/dotnet/sdk/blob/main/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs)).
+
+The remaining pieces — install layout, package-type and `kind`
+enforcement, meta-expansion with pre-flighted member resolution,
+side-by-side install dirs, "highest semver wins" activation,
+interactive uninstall with `--meta-only` / `--with-dependencies`
+flags and `installedExplicitly`-aware cascade, atomic registry
+writes, concurrency — have no NuGet equivalent in any framing and
+would have to be written either way. §5.5 and `workload-spec.md`
+§6 lay them out.
+
+## 11. Open questions (for the next iteration)
+
+1. **Compatibility-window declaration** (§6) — does the workload
+   declare its compatibility with the host via NuGet `<dependencies>`
+   on the contract packages, via a Func-defined metadata field
+   (e.g. a `func-cli-min:5.2` reserved tag), or as a new field in
+   `workload.json` (§5.4)? With `<dependencies>` empty by §9.3 for
+   `kind: workload` and `kind: content` packages, reusing it for
+   contract-package version constraints would re-introduce the
+   `<PackageReference>`-leak failure mode that rule exists to
+   prevent. A `workload.json` field is the cleanest fit (richer
+   constraint syntax, co-located with workload-specific metadata,
+   no conflict with §9.3); a reserved tag is the cheapest to
+   evaluate.
+
+2. **Pack-time validation diagnostics** (§9.2, §9.3) — the
+   per-`kind` rule sets in §9.3 (`<PackageReference>` suppression,
+   manifest-shape validation, entry-point validation, member
+   resolution for metas) need concrete diagnostic IDs, severities
+   (warning vs. error), and fixit messages.
+
+3. **Pack-time `kind: workload | content` member validation for
+   metas** (§5.5, §9.3) — pack-time only verifies the
+   `FuncCliWorkload` package type on a meta's members; the
+   `kind ∈ {workload, content}` check is deferred to install time.
+   A future MSBuild task could resolve each member to a cached
+   `.nupkg`, read its in-package `workload.json`, and assert the
+   member's `kind` at pack time. Trade-off: pack-time accuracy and
+   earlier failure surface vs. pack-time cost (one network round
+   trip per member if not cached) and added complexity in the pack
+   target.
+
+4. **Symbol packaging** — embed `.pdb` next to the `.dll`
+   (`<DebugType>portable</DebugType>` +
+   `<IncludeSymbols>false</IncludeSymbols>`) or ship a sidecar
+   `.snupkg`? Embedding gives readable stack traces out of the
+   box; sidecar shrinks the install footprint.
+
+5. **Package signing & trust** (deferred from `workload-spec.md`
+   §9 / §12 q2) — what does `func workload install` verify before
+   activating a package? Author-signed only, repository-signed
+   only, either, or neither for v1? Does `--source <local-path>`
+   bypass signature checks (typical dev-loop expectation), and if
+   so how is that surfaced in `func workload list`? Does the
+   package layout need to reserve a slot for signature metadata,
+   or is the standard NuGet `.signature.p7s` envelope sufficient?
+
+6. **License files** — `MIT` is fine via
+   `<PackageLicenseExpression>` for first-party workloads.
+   Third-party authors will pack a `LICENSE` file; do we want to
+   mandate either form?
+
+7. **`func workload prune` / `repair` commands** — operational
+   follow-on to §5.5's recovery cases. `prune` removes orphaned
+   install dirs not referenced in the global registry (and is
+   already speced as a real command in workload-spec §6.7);
+   `repair` re-extracts workloads whose install dirs are missing
+   or whose recorded hash mismatches what's on disk, **and**
+   surfaces / heals broken metas (a `metas[].members[]` entry
+   referencing a `(packageId, packageVersion)` not present in
+   `workloads[]`). Both commands also need a defined behavior for
+   metas: does `prune` remove a meta whose entire member set is
+   missing? Does `repair` re-resolve missing members against the
+   feed, given that the meta `.nupkg` itself was discarded after
+   install (§5.5)? Out of scope for this layout doc but must be
+   designed before v1.
+
+8. **Lock files / reproducibility** — should the global registry
+   be reproducible across machines via a `func workload restore`
+   verb that replays a recorded install set? With SxS first-class
+   (§5.5) and metas tracking their resolved `members[]`, the
+   registry already carries enough to reconstruct
+   `(packageId, packageVersion)` membership; the missing piece is
+   a serialized, committable artifact (e.g.,
+   `func.workloads.lock.json`) and the restore command itself.
+   `dotnet tool install` doesn't have this today.
+
+9. **NuGet audit / vulnerability scanning** — `NuGet.Protocol`
+   does not surface vulnerability metadata as a side-effect of
+   `PackageMetadataResource` queries. If `func workload install`
+   should warn on known-vulnerable packages, we own that
+   integration (likely against the GHSA-backed audit feed).
+   Defer to v1.x.
+
+10. **Templates: in-package or separate `Template`-typed package?**
+    — A workload that contributes `func init` / `func new`
+    templates can either embed them under `tools/any/<dir>/`
+    (single package, single install) or publish them as a separate
+    `<PackageType>Template</PackageType>` package consumed via the
+    dotnet templating engine (independent versioning, reusable
+    across workloads, but two installs and two-way version
+    coordination). The trade-off depends on how `func` integrates
+    with the templating engine — open until that integration is
+    designed. The package-layout doc accommodates both: in-package
+    templates sit under `tools/any/`; a separate package is just
+    another NuGet artifact and is out of scope for this layout.
+
+11. **Meta-of-meta relaxation** — v1 forbids a meta from depending
+    on another meta (§5.5). When (if ever) do we relax this?
+    Allowing meta-of-meta requires cycle detection on the meta
+    graph, decisions about how nested members are recorded in
+    `metas[].members[]` (snapshot the closure, or only direct
+    members?), and the resolver implications of bundling
+    transitive meta expansion. Worth deferring until a real
+    curation use case pushes for it.
+
+12. **Strict vs. fuzzy member-version lookup at meta uninstall**
+    (§5.5 "Meta uninstall flow") — when
+    `func workload uninstall <metaId> --with-dependencies` runs and
+    a member's installed version on disk no longer matches the
+    `members[]` snapshot (because the user updated the member
+    independently), the v1 design uses **id-only (fuzzy)** lookup
+    so the cascade still finds and removes the current row. The
+    alternative (**strict**) is to skip with a warning when the
+    snapshot's `(packageId, packageVersion)` is gone, preserving a
+    deliberately-upgraded member. Both are defensible; revisit
+    after v1 user feedback.
+
+13. **Generalized content-only consumption** (spec §12.8) — built-
+    in commands hard-code knowledge of the host workload's package
+    id (`func start` knows the host's id and resolves its install
+    directory). If a second `kind: content` workload appears, the
+    CLI needs a non-hard-coded contribution mechanism (e.g.
+    registering a content consumer with the loader) rather than
+    continuing to enumerate package ids inline. Out of scope for
+    this layout doc; the layout itself accommodates it.
+
+---
+
+*Once §11 is closed out, this doc will graduate from "proposed"
+to "accepted" and move into `docs/` alongside
+`building-a-workload.md`.*

--- a/proposed/workload-spec.md
+++ b/proposed/workload-spec.md
@@ -41,9 +41,9 @@
 | Term                  | Meaning                                                                 |
 |-----------------------|-------------------------------------------------------------------------|
 | **Func CLI**          | The `func` binary itself. Owns command parsing, UX, workload lifecycle. Distinct from the Functions host runtime, which is itself delivered as a workload (see §4.6). |
-| **Host runtime**      | `Microsoft.Azure.WebJobs.Script.WebHost`, the process that actually executes Functions. Acquired and versioned as a content-only workload (see below); `func start` knows how to launch it directly. |
+| **Host runtime**      | `Microsoft.Azure.WebJobs.Script.WebHost`, the process that actually executes Functions. Acquired and versioned as a `content` workload (see below); `func start` knows how to launch it directly. |
 | **Workload**          | An installable extension that contributes init/new/pack support and/or commands. Concretely: a NuGet package whose entry-point assembly contains a class deriving from the abstract `Workload` base in `Func.Cli.Abstractions` (see §5). |
-| **Content-only workload** | A workload that ships only files (no entry-point class, no `Configure` call, no contribution points). The CLI installs and tracks it like any other workload, but the loader skips it: it is consumed by built-in commands that know its package id and disk layout. The host-runtime workload is the canonical example. |
+| **Workload kind** | One of `workload`, `content`, or `meta`. **`workload`** packages carry an entry-point assembly and a `Workload`-derived class; the loader activates them and they contribute services. **`content`** packages ship files only (no entry point, no `Configure` call); the loader skips them and built-in commands consume them by package id (the host runtime is the canonical example). **`meta`** packages carry no payload; they bundle other workloads via the `.nuspec`'s `<dependencies>`, recorded in the registry's `metas[]` array. See `workload-package-layout.md` §5.4 for the full schema. |
 | **Workload package**  | The distributable unit. NuGet in v1; format may evolve.                 |
 | **Catalog**           | The package source `func workload search` / `install` queries to resolve workload packages. The configured default is the public NuGet feed; alternates can be passed via `--source`. |
 | **Alias**             | A short, NuGet-tag-safe handle (e.g. `python`) declared by a workload package via an `alias:<name>` tag. Users can pass aliases to `install` / `uninstall` / `update` / `prune` instead of the full package id (see §5.3, §6.1). |
@@ -63,8 +63,8 @@
 func workload list [--all-versions|-a] [--json]
 ```
 
-Lists installed workloads with id, version, type (normal or
-content-only), capabilities, and install path.
+Lists installed workloads with id, version, kind (`workload`,
+`content`, or `meta`), capabilities, and install path.
 
 ##### Options
 
@@ -144,7 +144,7 @@ exits non-zero with the same hint.
   - Skips the "already installed" prompt and proceeds with a
     side-by-side install. For normal workloads, the new version (if
     higher than the existing one) becomes the loaded version on the
-    next `func` invocation (see §6.2). For content-only workloads,
+    next `func` invocation (see §6.2). For `content` workloads,
     consumers (e.g. `func start` for the host workload) likewise pick
     the highest installed version.
 
@@ -315,7 +315,7 @@ have left old versions on disk.
 - The Functions host runtime is distributed as a first-class workload
   (e.g. `Azure.Functions.Cli.Workload.Host`). It is **not** bundled
   with the CLI binary.
-- The host-runtime workload is **content-only** (§3, §5.3): its
+- The host-runtime workload has **`kind: content`** (§3, §5.3): its
   package ships the host binaries under `tools/any/` with no
   `entryPoint`. The workload subsystem records its registry row but
   does not load it (§6.2 step 3). `func start` resolves the install
@@ -418,15 +418,20 @@ exists in `Func.Cli.Abstractions`. The other contribution points are
 designed but not yet implemented; they ship incrementally as the
 corresponding built-in commands move onto the workload model.
 
-**Content-only workloads** (`workload.json` with `contentOnly: true`,
-see §5.3) register no services. They do not implement `Workload`, are
-not loaded into an `AssemblyLoadContext`, and contribute no
-contribution points. Built-in CLI commands consume them directly by
-package id: today, `func start` knows the host workload's package id
+**Non-`workload` kinds** (`workload.json` with `kind: content` or
+`kind: meta`, see §5.3) register no services. They do not implement
+`Workload`, are not loaded into an `AssemblyLoadContext`, and
+contribute no contribution points. The CLI's responsibility for a
+`content` package ends at install / update / removal and
+guaranteeing a registry row (§6.1, §10.1); the **contract between
+the consumer and the content workload is owned by the consumer**,
+not by the CLI. `func start` knows the host workload's package id
 (`Azure.Functions.Cli.Workload.Host`) and resolves its on-disk
-location via `<workload-home>/workloads/<packageId>/<version>/`. How
-the CLI generalizes this for non-host content-only workloads is an
-open question (§12).
+location via `<workload-home>/workloads/<packageId>/<version>/`;
+any future consumer (built-in command or another workload)
+follows the same pattern. `meta` packages have no payload at all;
+they only exist as registry rows in `metas[]` (§10.1) so cascade
+uninstall can find their members.
 
 The exact interface names and shapes are documented in
 [`building-a-workload.md`](./building-a-workload.md). That document is
@@ -501,13 +506,22 @@ The metadata the CLI needs is split between two sources:
       (e.g. `?packageType=dotnettool` on the NuGet search API).
 2. **Per-workload manifest (`workload.json`)** — owned by the package
    author, shipped at the root of the workload's NuGet package.
-   Required: a package without this file is not a valid workload.
+   Required: a package without this file is not a valid workload. The
+   full schema lives in `workload-package-layout.md` §5.4; the
+   summary below covers what the install pipeline reads.
 
-   Normal workload:
+   Every `workload.json` carries a required `$schema` URL and a
+   `kind` discriminator (default `workload`). The CLI rejects any
+   `$schema` URL it doesn't recognise; the manifest is **never**
+   parsed partially.
+
+   `workload` package (default; runs in the loader, contributes
+   services):
 
    ```json
    {
-     "contentOnly": false,
+     "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
+     "kind": "workload",
      "entryPoint": {
        "assemblyPath": "Foo.dll",
        "type": "Foo.MyWorkload"
@@ -515,31 +529,42 @@ The metadata the CLI needs is split between two sources:
    }
    ```
 
-   Content-only workload:
+   `content` package (ships files only; loader skips):
 
    ```json
-   { "contentOnly": true }
+   {
+     "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
+     "kind": "content"
+   }
    ```
 
-   - `contentOnly` (optional, default `false`) → when `false`, this is
-     a normal workload: `entryPoint` is **required** and validated by
-     the install pipeline. When `true`, the package ships content only
-     (no entry-point class); `entryPoint` is **optional and ignored**
-     if present, and the loader (§6.2) skips this entry entirely.
-     Content-only workloads are consumed by built-in commands that know
-     the package id (see §5.1 and §12).
-   - `entryPoint.assemblyPath` → path to the assembly relative to the
-     package's content root (see "Package layout" below). Must not be
-     absolute or contain `..` segments; the install pipeline rejects
-     either. Required when `contentOnly` is `false`.
-   - `entryPoint.type` → fully-qualified type name extending the
-     abstract `Workload` base class. Required when `contentOnly` is
-     `false`.
+   `meta` package (no payload; bundles other packages via the
+   `.nuspec` `<dependencies>`):
 
-   The install pipeline reads `workload.json` once and stamps
-   `contentOnly` and `entryPoint` into the registry entry (§10.1) so
-   the loader can decide whether to activate without re-reading
-   `workload.json` for every package on every CLI invocation.
+   ```json
+   {
+     "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
+     "kind": "meta"
+   }
+   ```
+
+   - `kind` (optional, default `"workload"`) → one of `"workload"`,
+     `"content"`, or `"meta"`. Determines whether the loader
+     activates the package.
+   - `entryPoint.assemblyPath` → path to the assembly relative to
+     `tools/any/`. Must not be absolute or contain `..` segments;
+     the install pipeline rejects either. **Required** for
+     `kind: workload`; **forbidden** for `kind: content` and
+     `kind: meta` (the install pipeline rejects packages that
+     declare an `entryPoint` for a non-workload kind).
+   - `entryPoint.type` → fully-qualified type name extending the
+     abstract `Workload` base class. Same required/forbidden rules
+     as `assemblyPath`.
+
+   The install pipeline reads `workload.json` once and stamps `kind`
+   and `entryPoint` into the registry entry (§10.1) so the loader
+   can decide whether to activate without re-reading `workload.json`
+   for every package on every CLI invocation.
 
    **Package layout.** A workload `.nupkg` follows this convention:
 
@@ -559,12 +584,13 @@ The metadata the CLI needs is split between two sources:
    subdirectory because the CLI loads them in-process via
    `AssemblyLoadContext` rather than launching a separate runtime.
 
-   **Content-only workloads** follow the same package layout but have
-   no `entryPoint` constraint on `tools/any/`. The author lays out
-   whatever files the consuming command expects; the install pipeline
-   extracts them verbatim. The host workload, for example, ships its
-   runtime binaries under `tools/any/` and `func start` resolves them
-   by path convention.
+   `content` packages follow the same package layout but have no
+   `entryPoint` constraint on `tools/any/`. The author lays out
+   whatever files the consuming command expects; the install
+   pipeline extracts them verbatim. The host workload, for example,
+   ships its runtime binaries under `tools/any/` and `func start`
+   resolves them by path convention. `meta` packages typically have
+   no `tools/any/` payload at all.
 
 The CLI persists everything it needs for startup in a single
 **workload registry** at `~/.azure-functions/workloads.json` (see §6.1).
@@ -623,13 +649,17 @@ install` / `uninstall`.
    transitive NuGet dependencies. Anything the workload needs at
    runtime must be in the package.
 5. Read `workload.json` from the package root. The file is required;
-   reject if missing or malformed.
-   - If `contentOnly: true`, ignore any `entryPoint` field. No further
-     validation against `tools/any/` is performed.
-   - If `contentOnly` is `false` or absent, `entryPoint` is required.
-     Reject if `entryPoint.assemblyPath` is rooted, contains `..`
-     segments, or does not resolve to a file under the staged
-     `tools/any/` directory.
+   reject if missing or malformed. Validate the `$schema` URL: a URL
+   the CLI doesn't recognise causes the install to fail before any
+   field is read.
+   - If `kind: workload` (or `kind` is absent, defaulting to
+     `workload`), `entryPoint` is required. Reject if
+     `entryPoint.assemblyPath` is rooted, contains `..` segments, or
+     does not resolve to a file under the staged `tools/any/`
+     directory.
+   - If `kind: content` or `kind: meta`, `entryPoint` is **forbidden**.
+     Reject the package if it declares one. No further validation
+     against `tools/any/` is performed.
 6. Atomically move into
    `<workload-home>/workloads/<packageId>/<version>/`.
    `<packageId>` is stored lowercased (matching NuGet's normalization)
@@ -646,56 +676,67 @@ install` / `uninstall`.
    - `source` — the catalog feed URL or local path the package was
      installed from. Used to flag non-default-feed packages in
      `func workload list` (see §9).
-   - `contentOnly`: boolean stamped from `workload.json` (default
-     `false`). The loader (§6.2) uses this to decide whether to
-     activate the entry without re-reading `workload.json`.
-   - `entryPoint: { assemblyPath, type }`: copied from `workload.json`
-     when `contentOnly` is `false`. Omitted when `contentOnly` is
-     `true`.
+   - `kind` — `"workload"`, `"content"`, or `"meta"` stamped from
+     `workload.json` (default `"workload"`). The loader (§6.2) uses
+     this to decide whether to activate the entry without re-reading
+     `workload.json`.
+   - `installedExplicitly` — `true` when the user invoked
+     `func workload install <id>` directly; `false` when the row was
+     written as a member of a `meta` install (see
+     `workload-package-layout.md` §5.5). Drives cascade-uninstall
+     behaviour.
+   - `entryPoint: { assemblyPath, type }` — copied from `workload.json`
+     when `kind` is `workload`. Omitted for `content` and `meta`.
 
-   Side-by-side installs of the same package id at different versions
-   are separate entries. `displayName` and `description` are **not**
-   persisted in the registry; they are read from the loaded `Workload`
-   instance at runtime (and not applicable to content-only entries) so
-   an updated workload's metadata always reflects what's running.
-   Install paths are computed from the configured workload home plus
-   `(packageId, packageVersion)` and likewise not persisted.
+   For `meta` installs, the install pipeline also writes a row to the
+   registry's top-level `metas[]` array (§10.1) carrying the meta's
+   `(packageId, packageVersion)` and a frozen `members[]` snapshot.
+   Side-by-side installs of the same `(packageId, packageVersion)` in
+   `workloads[]` are separate entries; metas are unique per id (no
+   SxS for metas; see `workload-package-layout.md` §5.4 "Metas are
+   unique per id"). `displayName` and `description` are **not**
+   persisted in the registry; they are read from the loaded
+   `Workload` instance at runtime (and not applicable to `content` or
+   `meta` entries) so an updated workload's metadata always reflects
+   what's running. Install paths are computed from the configured
+   workload home plus `(packageId, packageVersion)` and likewise not
+   persisted.
 
    The write is atomic (temp file + rename) so a crash mid-install
    cannot corrupt the registry.
-8. Emit an "installed" message: for normal workloads, include the
-   resolved entry-point type; for content-only workloads, include the
-   install path so the consuming command (e.g. `func start` for the
-   host workload) can be discovered.
+8. Emit an "installed" message: for `kind: workload`, include the
+   resolved entry-point type; for `content`, include the install path
+   so the consuming command (e.g. `func start` for the host workload)
+   can be discovered; for `meta`, list the resolved members.
 
 ### 6.2 Discovery and activation
 
 On every Func CLI startup, the workload subsystem builds the in-process
 list of live workloads in a fixed sequence. The whole flow is one JSON
 read plus N assembly loads, where **N is the number of distinct
-package ids with at least one non-content-only installed version**, not
+package ids with at least one installed `kind: workload` version**, not
 the total entry count.
 
 1. **Read the registry.** Open
    `<workload-home>/workloads.json` once. Validate `$schema` (§10.1);
    reject unrecognized values via `GracefulException`. The registry
    carries a single `workloads[]` array of every installed
-   `(packageId, packageVersion)` row, each with its `contentOnly` flag
-   stamped at install time (§6.1 step 7).
+   `(packageId, packageVersion)` row, each with its `kind` stamped
+   at install time (§6.1 step 7).
 2. **Pick the live version per package id.** Group `workloads[]` by
    `packageId`. For each group, select the row with the highest
    semver. That row is the **live** version; every other row for the
    same package id is an inactive side-by-side install retained on
    disk for `func workload list --all-versions` and for rollback (the
    user removes the live one via `func workload uninstall` to revert).
-3. **Skip content-only entries.** If the live row has
-   `contentOnly: true`, the loader does **not** activate it: no
-   assembly load, no `Workload.Configure` call, no DI contribution.
-   The entry stays in the registry and is surfaced by
-   `func workload list` (with type `Content`); built-in commands that
-   know its `packageId` (e.g. `func start` for the host workload)
-   resolve its install directory directly. Steps 4-7 below run only
-   for entries with `contentOnly: false`.
+3. **Skip non-`workload` kinds.** If the live row has
+   `kind: content` or `kind: meta`, the loader does **not** activate
+   it: no assembly load, no `Workload.Configure` call, no DI
+   contribution. The entry stays in the registry and is surfaced by
+   `func workload list` (with its kind shown); built-in commands
+   that know its `packageId` (e.g. `func start` for the host
+   workload) resolve its install directory directly. Steps 4-7
+   below run only for entries with `kind: workload`.
 4. **Load the assembly.** Compute the assembly path under
    `<workload-home>/workloads/<packageId>/<packageVersion>/<entryPoint.assemblyPath>`
    and reject anything that resolves outside the workloads root
@@ -712,16 +753,18 @@ the total entry count.
    during discovery; the type's static constructor is the only workload
    code that runs, so workloads **must** keep static initialization
    side-effect-free.
-7. **Configure.** Once all live normal workloads are instantiated, the
-   CLI walks the resulting list and calls each
-   `Workload.Configure(builder)` exactly once, in registry order. This
-   is where contribution-point services (`IProjectInitializer`,
-   `IProjectDetector`, `ITemplateProvider`, `IPackProvider`,
-   `IExternalCommand`, see §5.1) are added to the CLI's DI container.
-8. **Cache for the process lifetime.** The list is cached in
-   `IWorkloadProvider` (singleton). Subsequent commands within the same
-   `func` invocation reuse it; they never re-read the registry or
-   re-instantiate workloads.
+7. **Configure.** Once all live `kind: workload` entries are
+   instantiated, the CLI walks the resulting list and calls each
+   `Workload.Configure(builder)` exactly once, in registry order.
+   This is where contribution-point services
+   (`IProjectInitializer`, `IProjectDetector`, `ITemplateProvider`,
+   `IPackProvider`, `IExternalCommand`, see §5.1) are added to the
+   CLI's DI container.
+8. **Cache for the process lifetime.** The list is materialized once
+   at host startup and exposed through `IWorkloadProvider`
+   (singleton). Subsequent commands within the same `func`
+   invocation inject `IWorkloadProvider` and reuse the cached list;
+   they never re-read the registry or re-instantiate workloads.
 
 #### Failure isolation
 
@@ -793,7 +836,7 @@ side install (use `install --force` for that, §6.1).
    harmless because no row references it and `func workload prune`
    (§6.7) cleans it up.
 
-For content-only workloads, the swap is the same shape: stage, swap
+For `content` workloads, the swap is the same shape: stage, swap
 the registry row, delete the old directory. There is no in-process
 cache to invalidate.
 
@@ -865,14 +908,14 @@ an older installed version, run `func workload uninstall <package>`
 
 - **CLI startup overhead** for workload discovery (no invocation) must
   remain under **100 ms** for up to 25 installed workloads on a warm cache.
-  Content-only workloads contribute zero activation cost (no assembly
-  load, no `Configure` call) and count against this budget only for
-  the registry row read.
+  `content` and `meta` entries contribute zero activation cost (no
+  assembly load, no `Configure` call) and count against this budget
+  only for the registry row read.
 - **First invocation** of a workload (cold) should complete the
   workload-side boot in under **300 ms** for AOT'd workloads and
-  **800 ms** for JIT. The host-runtime workload (§4.6) is content-only
-  and is not loaded by the workload subsystem at all; `func start`
-  launches its bundled binaries directly.
+  **800 ms** for JIT. The host-runtime workload (§4.6) has
+  `kind: content` and is not loaded by the workload subsystem at
+  all; `func start` launches its bundled binaries directly.
 - **Subsequent invocations** within the same `func` invocation should not
   re-pay boot cost when the Func CLI can reuse the workload connection (an
   optimization, not a v1 requirement).
@@ -915,13 +958,17 @@ The v1 registry shape is, at the top level:
 ```json
 {
   "$schema": "https://aka.ms/func/workloads/v1/schema.json",
-  "workloads": [ /* WorkloadEntry[] */ ]
+  "workloads": [ /* WorkloadEntry[] */ ],
+  "metas":     [ /* MetaEntry[]    */ ]
 }
 ```
 
 `workloads[]` is the flat list of every installed
 `(packageId, packageVersion)` row, including inactive side-by-side
-versions.
+versions and entries of every kind. `metas[]` is the parallel list
+of installed meta packages; it is empty until the user installs
+their first meta. The two arrays are independent: a meta's members
+live in `workloads[]` like any other install.
 
 A `WorkloadEntry` carries:
 
@@ -931,12 +978,31 @@ A `WorkloadEntry` carries:
   `alias:<name>` tags.
 - `source` (string): the catalog feed URL or local path the package
   was installed from.
-- `contentOnly` (bool, default `false`): stamped from the package's
-  `workload.json` at install time (§6.1 step 7). When `true`, the
-  loader skips activation (§6.2 step 3).
-- `entryPoint` (`{ assemblyPath, type }`): copied from `workload.json`.
-  Present when `contentOnly` is `false`; omitted when `contentOnly`
-  is `true`.
+- `kind` (string, default `"workload"`): one of `"workload"`,
+  `"content"`, or `"meta"`. Stamped from the package's `workload.json`
+  at install time (§6.1 step 7). The loader skips activation for
+  `"content"` and `"meta"` entries (§6.2 step 3).
+- `installedExplicitly` (bool, default `true`): `true` when the user
+  installed this row directly via `func workload install <id>`;
+  `false` when the row was written as a member of a meta install.
+  Drives cascade-uninstall behaviour
+  (`workload-package-layout.md` §5.5).
+- `entryPoint` (`{ assemblyPath, type }`): copied from
+  `workload.json`. Present when `kind` is `"workload"`; omitted (and
+  forbidden) for `"content"` and `"meta"` entries.
+
+A `MetaEntry` carries:
+
+- `packageId` (string): NuGet package id of the meta (lowercased).
+- `packageVersion` (string): installed meta version.
+- `members` (object[]): frozen snapshot of the
+  `(packageId, packageVersion)` pairs the meta resolved to at
+  install time. Used by `func workload uninstall <metaId>` to drive
+  cascade removal. Members are recorded here for traceability; their
+  loadable state lives in `workloads[]`.
+
+Metas are unique per `packageId` (no SxS for metas; see
+`workload-package-layout.md` §5.4 "Metas are unique per id").
 
 The loader's "live version per package id" resolution (§6.2 step 2)
 is computed from `workloads[]` alone: highest semver wins. There is
@@ -984,15 +1050,7 @@ no separate active-version pointer in the registry.
 7. **Host-runtime workload boundary** — does one workload ship all RIDs +
    all major host versions, or one workload per major (e.g. `...Workload.Host.v4`,
    `...Workload.Host.v5`)?
-8. **Non-host content-only consumption.** `func start` knows the host
-   workload's package id (`Azure.Functions.Cli.Workload.Host`) and
-   resolves its install directory directly. There is no general
-   contract today for other built-in commands to consume
-   content-only workloads. If a second content-only workload appears,
-   we'll need either a name-based registry lookup helper or a
-   content-only contribution mechanism (e.g. registering a content
-   directory under a stable key).
-9. **TTL-based prune.** `func workload prune` (§6.7) removes every
+8. **TTL-based prune.** `func workload prune` (§6.7) removes every
    non-live install unconditionally. A future variant
    (`--older-than 30d` or similar) would let a user keep recent
    versions for quick rollback while reclaiming disk for older ones.
@@ -1002,3 +1060,13 @@ no separate active-version pointer in the registry.
 prompts) is **CLI-rendered only in v1** (see §2 non-goals). A
 callback contract for richer UX may be introduced in a later
 abstractions release as a non-breaking additive change.
+
+**Resolved:** *Non-host `content` consumption* is **out of scope
+for the CLI**. The CLI's responsibility for a `content` workload
+ends at install / update / removal and guaranteeing a registry row
+(§6.1, §10.1). The contract between a consumer (a built-in command
+or another workload that depends on the content) and the content
+workload — package id, on-disk layout, expected files — is owned
+by the consumer, not by the CLI. `func start` consuming the host
+workload (§4.6) is one such consumer; future consumers follow the
+same pattern.

--- a/proposed/workload-spec.md
+++ b/proposed/workload-spec.md
@@ -1,0 +1,1004 @@
+# Workload Spec
+
+> **Status:** Draft. This spec defines the contract between the Func CLI
+> and workload packages. v1 uses an **in-process** model: workloads are
+> .NET assemblies loaded into the `func` process inside isolated
+> collectible `AssemblyLoadContext`s.
+
+## 1. Goals
+
+- Allow the v5 `func` CLI to be extended with language- and feature-
+  specific functionality without rebuilding or shipping a new CLI.
+- Keep the CLI binary small and stable; defer language-specific work to
+  workloads acquired on demand.
+- Provide a uniform UX across all languages: a user runs the same
+  `func init`, `func new`, `func pack` regardless of which workload backs
+  the project.
+- Allow the Functions team and external authors to ship workloads on their
+  own cadence, independent of the Func CLI's release schedule.
+- Make workload acquisition, update, and removal a first-class CLI
+  experience (`func workload ...`).
+
+## 2. Non-goals (v1)
+
+- **Sandboxing.** Workloads run with the same OS privileges as `func`. We
+  rely on package provenance (NuGet feed trust, signing where available)
+  for trust, not runtime containment. Whether v1 *requires* signed
+  packages or only warns is an open question (see §12).
+- **Cross-workload coordination.** Workloads do not call each other
+  directly. The Func CLI brokers the only legitimate cross-workload
+  interaction: invoking the host-runtime workload (§4.6) on behalf of a
+  language workload during `func start`.
+- **Authoring telemetry framework.** Workloads may emit logs/diagnostics;
+  shared telemetry primitives are out of scope for v1.
+- **GUI / IDE integration.** This spec covers the CLI only. IDE
+  integrations consume `func` as a black box.
+- **Workload-supplied UI prompts.** v1 keeps interactive prompts on the
+  CLI side; the workload returns data, the CLI renders.
+
+## 3. Definitions
+
+| Term                  | Meaning                                                                 |
+|-----------------------|-------------------------------------------------------------------------|
+| **Func CLI**          | The `func` binary itself. Owns command parsing, UX, workload lifecycle. Distinct from the Functions host runtime, which is itself delivered as a workload (see §4.6). |
+| **Host runtime**      | `Microsoft.Azure.WebJobs.Script.WebHost`, the process that actually executes Functions. Acquired and versioned as a content-only workload (see below); `func start` knows how to launch it directly. |
+| **Workload**          | An installable extension that contributes init/new/pack support and/or commands. Concretely: a NuGet package whose entry-point assembly contains a class deriving from the abstract `Workload` base in `Func.Cli.Abstractions` (see §5). |
+| **Content-only workload** | A workload that ships only files (no entry-point class, no `Configure` call, no contribution points). The CLI installs and tracks it like any other workload, but the loader skips it: it is consumed by built-in commands that know its package id and disk layout. The host-runtime workload is the canonical example. |
+| **Workload package**  | The distributable unit. NuGet in v1; format may evolve.                 |
+| **Catalog**           | The package source `func workload search` / `install` queries to resolve workload packages. The configured default is the public NuGet feed; alternates can be passed via `--source`. |
+| **Alias**             | A short, NuGet-tag-safe handle (e.g. `python`) declared by a workload package via an `alias:<name>` tag. Users can pass aliases to `install` / `uninstall` / `update` / `prune` instead of the full package id (see §5.3, §6.1). |
+| **Workload home**     | The on-disk root the CLI uses to install workloads and read the workload registry. Defaults to `~/.azure-functions`; configurable via the `FUNC_CLI_Workloads__Home` environment variable (see §11 for the env var prefix convention). |
+| **Workload registry**   | The single CLI-owned JSON file at `<workload-home>/workloads.json` recording which workload versions are installed and how to load them. |
+| **Worker runtime**    | The Functions runtime language identifier (`dotnet`, `node`, `python`, `java`, `powershell`, `custom`). |
+| **Contribution point** | An interface in `Func.Cli.Abstractions` (e.g. `IProjectInitializer`) that a workload registers to participate in a built-in command. |
+| **Project marker**    | A glob or file pattern (`*.csproj`, `package.json`, ...) that hints which workload owns a given directory. |
+
+## 4. User-facing requirements
+
+### 4.1 `func workload` — package management
+
+#### `func workload list`
+
+```
+func workload list [--all-versions|-a] [--json]
+```
+
+Lists installed workloads with id, version, type (normal or
+content-only), capabilities, and install path.
+
+##### Options
+
+- `--all-versions|-a`
+  - Lists every installed version of every workload. Default: only the
+    loaded version per workload is shown (the highest installed semver,
+    see §6.2).
+- `--json`
+  - Emits machine-readable JSON output instead of the default
+    human-readable table. Required for scripting.
+
+#### `func workload search`
+
+```
+func workload search [<query>] [--source <path>] [--include-prereleases] [--json]
+```
+
+Searches the configured workload catalog (NuGet feed by default) and
+returns id, latest version, and description for matching packages.
+
+##### Arguments
+
+- `<query>`
+  - Optional free-form search string. When omitted, returns all packages
+    in the catalog declaring the `FuncCliWorkload` package type.
+
+##### Options
+
+- `--source <path>`
+  - Queries an alternate feed (URL or local path) instead of the
+    configured default catalog.
+- `--include-prereleases`
+  - Includes pre-release versions in the results. Default: stable only.
+- `--json`
+  - Emits machine-readable JSON output.
+
+#### `func workload install`
+
+```
+func workload install <package> [--version|-v <v>] [--source <path>] [--exact|-e] [--include-prereleases] [--force|-f]
+```
+
+Acquires and installs a workload. See §6.1 for the full install pipeline.
+
+If any version of `<package>` is already installed, the CLI prompts:
+`<package> is already installed at <existing>. Run 'func workload
+update <package>' instead?` Pass `--force` to skip the prompt and add
+the new version side-by-side anyway. In non-interactive contexts (no
+TTY, `--json` upstream), the prompt is treated as decline and the CLI
+exits non-zero with the same hint.
+
+##### Arguments
+
+- `<package>`
+  - Required. Matched as an `alias:<name>` tag by default (see §5.3 and
+    §6.1 for the resolution flow). With `--exact`, must be the literal
+    package id.
+
+##### Options
+
+- `--version|-v`
+  - Installs the specified semver version. Default: the latest stable
+    version available in the catalog. Combine with
+    `--include-prereleases` to allow pre-release versions when resolving
+    "latest".
+- `--source <path>`
+  - Installs from a local path or alternate feed (e.g. for development
+    or internal mirrors) instead of the configured default catalog.
+- `--exact|-e`
+  - Disables alias matching. `<package>` must be the literal package id
+    (case-insensitive). Use when an alias collides across multiple
+    packages or when scripting against a known id.
+- `--include-prereleases`
+  - Allows pre-release versions to be selected when resolving "latest".
+    Default: stable only.
+- `--force|-f`
+  - Skips the "already installed" prompt and proceeds with a
+    side-by-side install. For normal workloads, the new version (if
+    higher than the existing one) becomes the loaded version on the
+    next `func` invocation (see §6.2). For content-only workloads,
+    consumers (e.g. `func start` for the host workload) likewise pick
+    the highest installed version.
+
+#### `func workload uninstall`
+
+```
+func workload uninstall <package> [--version|-v <v>] [--all-versions|-a] [--exact|-e]
+```
+
+Removes an installed workload. By default removes only the active version.
+
+##### Arguments
+
+- `<package>`
+  - Required. The workload to remove. Resolved using the same alias
+    rules as `install` (see §6.1).
+
+##### Options
+
+- `--version|-v`
+  - Removes a specific installed version. Useful for cleaning up old
+    side-by-side installs without affecting the active version.
+- `--all-versions|-a`
+  - Removes every installed version of the workload. Mutually exclusive
+    with `--version`.
+- `--exact|-e`
+  - Disables alias matching. `<package>` must be the literal package id
+    (case-insensitive). Use when an alias collides across multiple
+    installed packages or when scripting against a known id.
+
+#### `func workload update`
+
+```
+func workload update [<package>] [--version|-v <v>] [--all] [--major] [--source <path>] [--include-prereleases]
+```
+
+Updates a workload **in place**: removes one existing installed version
+and replaces it with the latest compatible version from the catalog.
+Default is "same major version only". See §6.4 for the full pipeline.
+
+##### Arguments
+
+- `<package>`
+  - Optional. Updates a single workload. Mutually exclusive with
+    `--all`. Omitting both `<package>` and `--all` is an error.
+
+##### Options
+
+- `--version|-v`
+  - Names the **existing installed version** to update. The CLI removes
+    `<v>` and installs the new version in its place. Errors if `<v>` is
+    not currently installed. Default: updates the latest installed
+    version of `<package>`.
+- `--all`
+  - Updates every installed workload (the latest installed version of
+    each). Mutually exclusive with `<package>`.
+- `--major`
+  - Allows crossing a major-version boundary. Default: same major
+    version only, to protect against breaking changes.
+- `--source <path>`
+  - Resolves updates from an alternate feed instead of the configured
+    default catalog.
+- `--include-prereleases`
+  - Allows pre-release versions to be selected when resolving "latest".
+    Default: stable only.
+
+#### `func workload prune`
+
+```
+func workload prune [<package>] [--exact|-e]
+```
+
+Removes inactive side-by-side installs. For each in-scope `packageId`,
+keeps the **latest installed version** and uninstalls every older
+version (directory + registry row). The latest version is never pruned
+(use `func workload uninstall --all-versions` for that).
+
+Pruning is local-only: no catalog round-trip. It is the cleanup
+counterpart to `install --force` and to repeated `update` runs that
+have left old versions on disk.
+
+##### Arguments
+
+- `<package>`
+  - Optional. Prunes only the named workload. Default: prunes every
+    installed workload.
+
+##### Options
+
+- `--exact|-e`
+  - Disables alias matching. `<package>` must be the literal package id
+    (case-insensitive).
+
+#### Required behaviors (all `func workload` commands)
+
+- All commands must be **non-interactive** when given complete arguments
+  and must exit with a non-zero code on failure.
+- `install`, `uninstall`, `update` must be **idempotent**: re-running
+  with the same effective state must succeed without error.
+- A failed install must leave no partial state on disk (atomic move
+  into the install root, or rollback).
+- Concurrent invocations must not corrupt the workload store
+  (cross-process locking on the install root).
+
+### 4.2 `func init` — scaffold a project
+
+- If no workload is installed for the requested runtime, the Func CLI **must**
+  print an actionable hint with the exact command to install one (e.g.
+  `func workload install python`) and exit with a clear error.
+- The CLI determines the suggested workload using, in order:
+  1. An explicit `--stack <name>` flag, if provided.
+  2. `FUNCTIONS_WORKER_RUNTIME` from `local.settings.json`, if present.
+  3. Lightweight project-marker detection (e.g. presence of `*.csproj`,
+     `requirements.txt`, `package.json`) to make a best-effort guess.
+- This fallback applies only when no workload is installed for the
+  requested runtime. When workloads *are* installed, §5.2 (Workload
+  resolution) describes the richer detector-based flow.
+- If detection is ambiguous or yields no signal, the hint **must** list the
+  canonical install command for each known stack rather than guessing.
+- If a workload is installed, the Func CLI delegates project scaffolding to it.
+
+### 4.3 `func new` — create a function from a template
+
+- Templates come **only** from installed workloads. The Func CLI has no
+  built-in templates.
+- `func new` (no args) lists templates from every installed workload that
+  matches the **current project's stack**. Stack resolution follows
+  §5.2 (Workload resolution).
+
+  If no stack can be resolved, `func new` lists templates from every
+  installed workload and prompts the user (or errors in non-interactive
+  mode) to disambiguate via `--stack`.
+- `func new --template <name> --name <fn>` materializes the template
+  identified by name. If multiple workloads expose the same template name,
+  the Func CLI disambiguates by `--stack` or via an error listing the
+  conflicts.
+
+### 4.4 `func pack` — build & package for deployment
+
+- The owning workload is selected via §5.2 (Workload resolution).
+  Exactly one workload must claim the directory. Zero is an error with an
+  install hint. More than one is an error listing the contenders,
+  suggesting `--stack` to disambiguate.
+- The owning workload performs the build and package via its
+  `IPackProvider` contribution (§5.1). Pack output paths and naming are
+  workload-defined; the Func CLI surfaces the resulting artifact path
+  back to the user.
+
+### 4.5 `func start` and other built-in commands
+
+- `func start` launches the Functions **host runtime**. The Func CLI **must
+  not** embed the host runtime in its own binary; the runtime is acquired
+  and updated as a workload (see §4.6) so it can ship and version
+  independently of the CLI.
+- In v1, `func start` resolves the host-runtime workload and delegates
+  process startup to it. If the workload is not installed, the Func CLI
+  **must** print the install hint
+  (`Run 'func workload install <package>' to install the host runtime.`)
+  and exit non-zero; it **must not** auto-install or prompt. Argument
+  forwarding, port selection, and log streaming remain CLI responsibilities.
+- Workloads **may** register additional command trees via
+  `IExternalCommand` (§5.1), e.g. `func durable ...`. The Func CLI must
+  surface these in `--help` output alongside built-in commands and label
+  the source workload in verbose help.
+
+### 4.6 Host runtime as a workload
+
+- The Functions host runtime is distributed as a first-class workload
+  (e.g. `Azure.Functions.Cli.Workload.Host`). It is **not** bundled
+  with the CLI binary.
+- The host-runtime workload is **content-only** (§3, §5.3): its
+  package ships the host binaries under `tools/any/` with no
+  `entryPoint`. The workload subsystem records its registry row but
+  does not load it (§6.2 step 3). `func start` resolves the install
+  directory by package id and launches the host binaries directly.
+- Multiple host-runtime versions **may** coexist on disk via
+  `func workload install --force` (§6.1). The CLI selects one per
+  invocation based on (in order): `--host-version` flag, project pin
+  (e.g. `host.json` / project file metadata), latest installed.
+- All other workload lifecycle steps (install, update, prune,
+  uninstall, telemetry) apply unchanged. There is no special-case
+  install path for the host runtime.
+- This separation lets host hotfixes ship without a CLI release and lets
+  the CLI itself be smaller and AOT-friendly.
+
+### 4.7 v4 → v5 migration hints
+
+Many subcommands that lived in the v4 monolith (`func azure ...`,
+`func kubernetes ...`, `func durable ...`, etc.) move into workloads in
+v5. Users with v4 muscle memory will still type the old commands, and
+without help they will see a generic "unknown command" error.
+
+- The Func CLI **must** maintain a curated map of known v4 subcommands
+  to the workload package id that now provides them.
+- When a user invokes one of these on v5 without the corresponding
+  workload installed, the CLI prints (and exits non-zero):
+  `'<cmd>' is now provided by a workload. Install it with 'func workload install <package>'.`
+- The map covers any v4 surface that has moved, not only `func init` /
+  `func new`; it applies to all unknown-subcommand paths.
+- The map is **CLI-internal**: workloads do not contribute to it. New
+  v4-migration entries ship in a CLI release; this is acceptable
+  because the v4 surface is closed.
+
+## 5. Workload contract — what a workload provides
+
+A workload is a NuGet package containing a .NET assembly with a class
+that extends the abstract `Workload` base from `Func.Cli.Abstractions`:
+
+```csharp
+public sealed class MyWorkload : Workload
+{
+    public override string Name => "Azure.Functions.Cli.Workload.MyStack";
+    public override string DisplayName => "My Stack";
+    public override string Description => "Functions support for My Stack.";
+
+    public override void Configure(FunctionsCliBuilder builder)
+    {
+        // register IProjectInitializer, ITemplateProvider, etc.
+    }
+}
+```
+
+`Version` defaults to the workload assembly's
+`AssemblyInformationalVersion` (falling back to `AssemblyFileVersion` /
+`AssemblyName.Version`), so most workloads can let the build supply
+the version. Override only when the running code should be the source
+of truth.
+
+`Name` is the identity the workload **claims for itself** in code. The
+CLI uses it as the prefix on diagnostic messages (`[<Name>] ...`) and as
+the `workload-id` field in telemetry (see §11). It is conventionally
+the assembly / package name (e.g.
+`"Azure.Functions.Cli.Workload.Dotnet"`) and normally matches the
+package id, but the two are distinct concepts:
+
+- **`Workload.Name`** — declared by the workload code. Stable across
+  republishes; what the workload calls itself in logs and telemetry.
+- **`packageId`** — the NuGet identity used by `func workload install` /
+  `uninstall` / `list` and recorded in the workload registry. What the
+  user types.
+
+They normally agree, but a workload republished under a new package id
+(e.g. an ownership transfer) can keep its `Name` stable so log filters,
+telemetry dashboards, and error-prefix grep patterns continue to work.
+
+The package also ships a `workload.json` at the package root pointing
+at the entry-point type; see §5.3 for the file shape and §6.1 for how
+the install pipeline consumes it.
+
+The `Workload` instance receives a `FunctionsCliBuilder` during host
+startup (`Configure`) and registers concrete services into DI. The CLI
+consumes those services via `IEnumerable<T>` collections and dispatches
+based on which workload contributed which service. There is **no static
+capability list**: what a workload can do is whatever it has registered.
+
+### 5.1 Contribution points (DI)
+
+A workload **may** register any subset of these services. Each service
+the workload registers means it participates in the corresponding command:
+
+| Service registered                | The workload can...                                          | Used by                          |
+|-----------------------------------|-----------------------------------------------------------|----------------------------------|
+| `IProjectInitializer`             | Scaffold a new project for a given worker runtime.        | `func init`                      |
+| `IProjectDetector`                | Decide whether a directory is "its" project.              | `func init`, `func new`, `func pack`, `func start` (workload resolution) |
+| `ITemplateProvider`               | Enumerate and materialize templates.                      | `func new`                       |
+| `IPackProvider`                   | Build & package the project.                              | `func pack`                      |
+| `IExternalCommand`                | Register additional CLI subcommands.                      | Any `func <subcommand>` contributed by a workload (e.g. `func durable ...`) |
+
+Implementation status: as of this spec revision, only `IProjectInitializer`
+exists in `Func.Cli.Abstractions`. The other contribution points are
+designed but not yet implemented; they ship incrementally as the
+corresponding built-in commands move onto the workload model.
+
+**Content-only workloads** (`workload.json` with `contentOnly: true`,
+see §5.3) register no services. They do not implement `Workload`, are
+not loaded into an `AssemblyLoadContext`, and contribute no
+contribution points. Built-in CLI commands consume them directly by
+package id: today, `func start` knows the host workload's package id
+(`Azure.Functions.Cli.Workload.Host`) and resolves its on-disk
+location via `<workload-home>/workloads/<packageId>/<version>/`. How
+the CLI generalizes this for non-host content-only workloads is an
+open question (§12).
+
+The exact interface names and shapes are documented in
+[`building-a-workload.md`](./building-a-workload.md). That document is
+currently stale and will be refreshed alongside the first contract
+revision; detailed interface signatures are deliberately out of scope
+for this spec. Adding a new contribution point is an additive change
+to `Func.Cli.Abstractions` (no manifest field to coordinate, no schema
+bump).
+
+### 5.2 Workload resolution
+
+For commands that act on an existing project (`new`, `pack`, `start`),
+the CLI must determine which installed workload owns the current
+directory. Resolution proceeds in this order:
+
+1. **Explicit selector.** A `--stack <name>` flag wins.
+2. **`FUNCTIONS_WORKER_RUNTIME`** in `local.settings.json`, mapped to
+   the workload that registered itself for that runtime. A workload
+   declares the runtime ids it claims via metadata on its
+   `IProjectDetector` registration (or, for workloads that ship no
+   detector, via a property on the `Workload` subclass).
+3. **`IProjectDetector`.** The CLI invokes every registered detector
+   against the working directory:
+   - **Pre-filter:** the CLI applies project-marker globs (declared by
+     the workload's `IProjectDetector` registration) before invoking
+     the detector. Workloads with no markers are always candidates.
+   - **Detection:** the workload's `IProjectDetector` returns a
+     confidence (`yes` / `no` / `maybe`) plus an optional reason string.
+   - **Tie-breaking:**
+     - Exactly one `yes` → that workload owns the command.
+     - Zero matches → the CLI prints an actionable error.
+     - Multiple `yes` results → the CLI errors with the list and asks
+       the user to disambiguate via `--stack`.
+
+`func init` is special: there is no project to detect against, so it
+uses only steps 1 and 2 (selector → runtime). Steps 3+ require an
+existing project.
+
+`IProjectDetector` is therefore **not** specific to `pack`; it is the
+shared mechanism for any command that needs to bind to a workload from
+a directory. The §5.1 table reflects this.
+
+### 5.3 Package metadata
+
+The metadata the CLI needs is split between two sources:
+
+1. **NuGet metadata (`.nuspec`)** — owned by the package author, captured
+   at install time:
+    - `id` → package id (NuGet rules apply, case-insensitive).
+    - `version` → semver, the workload version.
+    - `title` → display name shown in `func workload search` (catalog
+      browse). The runtime `Workload.DisplayName` is the source of
+      truth for `func workload list` once the package is installed.
+    - `description` → one-line summary shown in `func workload search`.
+      The runtime `Workload.Description` is the source of truth for
+      installed workloads.
+    - `tags` → NuGet tags. The CLI gives meaning to one reserved tag
+      convention; all other tags are treated as free-form metadata for
+      search ranking only:
+        - `alias:<name>` → declares a short alias (e.g. `alias:python`)
+          that the user can pass to `install` / `uninstall` / `update`
+          instead of the full package id. A workload may declare
+          multiple aliases. Aliases must be lowercase and
+          NuGet-tag-safe; uniqueness is by convention only (NuGet has
+          no central authority). Alias collisions across packages force
+          users into `--exact` resolution (see §6.1 install flow).
+    - `packageTypes` → **must** include a `FuncCliWorkload` entry. This
+      is how the CLI (and the catalog) distinguish workload packages
+      from arbitrary NuGets. Packages without this package type are
+      rejected at install time and excluded from `func workload search`
+      results. Modeled on the .NET CLI's `DotnetTool` package type
+      (e.g. `?packageType=dotnettool` on the NuGet search API).
+2. **Per-workload manifest (`workload.json`)** — owned by the package
+   author, shipped at the root of the workload's NuGet package.
+   Required: a package without this file is not a valid workload.
+
+   Normal workload:
+
+   ```json
+   {
+     "contentOnly": false,
+     "entryPoint": {
+       "assemblyPath": "Foo.dll",
+       "type": "Foo.MyWorkload"
+     }
+   }
+   ```
+
+   Content-only workload:
+
+   ```json
+   { "contentOnly": true }
+   ```
+
+   - `contentOnly` (optional, default `false`) → when `false`, this is
+     a normal workload: `entryPoint` is **required** and validated by
+     the install pipeline. When `true`, the package ships content only
+     (no entry-point class); `entryPoint` is **optional and ignored**
+     if present, and the loader (§6.2) skips this entry entirely.
+     Content-only workloads are consumed by built-in commands that know
+     the package id (see §5.1 and §12).
+   - `entryPoint.assemblyPath` → path to the assembly relative to the
+     package's content root (see "Package layout" below). Must not be
+     absolute or contain `..` segments; the install pipeline rejects
+     either. Required when `contentOnly` is `false`.
+   - `entryPoint.type` → fully-qualified type name extending the
+     abstract `Workload` base class. Required when `contentOnly` is
+     `false`.
+
+   The install pipeline reads `workload.json` once and stamps
+   `contentOnly` and `entryPoint` into the registry entry (§10.1) so
+   the loader can decide whether to activate without re-reading
+   `workload.json` for every package on every CLI invocation.
+
+   **Package layout.** A workload `.nupkg` follows this convention:
+
+   ```
+   <package-root>/
+     workload.json              ← required, at the package root
+     tools/any/
+       <Workload>.dll           ← entryPoint.assemblyPath is resolved
+       <dependencies>.dll          relative to tools/any/
+       ...
+   ```
+
+   `tools/any/` is the content directory the install pipeline extracts
+   and from which `entryPoint.assemblyPath` is resolved. The `tools/`
+   prefix mirrors the .NET CLI's `dotnet tool` package convention
+   (which uses `tools/<TFM>/any/`); workloads use a single `any`
+   subdirectory because the CLI loads them in-process via
+   `AssemblyLoadContext` rather than launching a separate runtime.
+
+   **Content-only workloads** follow the same package layout but have
+   no `entryPoint` constraint on `tools/any/`. The author lays out
+   whatever files the consuming command expects; the install pipeline
+   extracts them verbatim. The host workload, for example, ships its
+   runtime binaries under `tools/any/` and `func start` resolves them
+   by path convention.
+
+The CLI persists everything it needs for startup in a single
+**workload registry** at `~/.azure-functions/workloads.json` (see §6.1).
+Workload authors never touch this file; it is owned by `func workload
+install` / `uninstall`.
+
+### 5.4 Versioning
+
+- Workloads use **semver**. `func workload update` uses the same major
+  version by default; major bumps require an explicit opt-in.
+- The CLI declares a **minimum supported registry schema version**
+  (see §10) and rejects registries it cannot parse.
+
+## 6. Lifecycle
+
+### 6.1 Install
+
+0. **Idempotency.** If the same `(packageId, version)` is already
+   present in the workload registry and its install directory is
+   intact, exit success without re-fetching or re-extracting. This
+   makes `func workload install` safe to re-run with an explicit
+   `--version`.
+1. **Existence check.** If any other version of `packageId` is already
+   installed (registry contains at least one row for that `packageId`)
+   and `--force|-f` was not passed, prompt:
+   `'<packageId>' is already installed at <listed versions>. Install
+   <new version> side-by-side? [y/N]:` Default: no.
+   - **No** (or non-interactive context, e.g. no TTY) → exit non-zero
+     with the hint `Run 'func workload update <package>' to replace the
+     existing version, or pass --force to install side-by-side.`
+   - **Yes** or `--force` → continue.
+
+   This check runs **before** download to avoid wasted network round-
+   trips on a likely-cancelled install.
+2. Resolve `<package>` to a package via the catalog (NuGet by default),
+   filtered to packages declaring the `FuncCliWorkload` package type:
+   - **Alias path** (default): the resolver queries the catalog for
+     packages whose tags include `alias:<package>`.
+       - Exactly one match → install it.
+       - Zero matches → fall back to exact-match-by-id. If that also
+         finds nothing, fail with an actionable error listing close
+         matches.
+       - Multiple matches → fail and list the matched package ids;
+         the user must re-run with `--exact <packageId>`.
+   - **Exact path** (`--exact|-e`): the resolver targets exactly
+     `<package>` as a literal package id (case-insensitive). No alias
+     matching is performed. Fails if no such package exists in the
+     catalog.
+3. Download to a staging directory.
+4. Read NuGet metadata (`id`, `version`, `title`, `description`, `tags`,
+   `packageTypes`). Reject the package if `FuncCliWorkload` is not
+   among its declared package types.
+
+   Workloads ship **self-contained** under `tools/any/` (see §5.3
+   "Package layout"); the install pipeline does **not** restore
+   transitive NuGet dependencies. Anything the workload needs at
+   runtime must be in the package.
+5. Read `workload.json` from the package root. The file is required;
+   reject if missing or malformed.
+   - If `contentOnly: true`, ignore any `entryPoint` field. No further
+     validation against `tools/any/` is performed.
+   - If `contentOnly` is `false` or absent, `entryPoint` is required.
+     Reject if `entryPoint.assemblyPath` is rooted, contains `..`
+     segments, or does not resolve to a file under the staged
+     `tools/any/` directory.
+6. Atomically move into
+   `<workload-home>/workloads/<packageId>/<version>/`.
+   `<packageId>` is stored lowercased (matching NuGet's normalization)
+   so case differences in user input always resolve to the same
+   directory.
+7. Append an entry to the workload registry
+   `<workload-home>/workloads.json` under the top-level `workloads`
+   array. Each entry contains:
+   - `packageId` — NuGet package id (lowercased; case-insensitive match
+     on lookup).
+   - `packageVersion` — installed version (ordinal match).
+   - `aliases` — short aliases extracted from the package's
+     `alias:<name>` tags.
+   - `source` — the catalog feed URL or local path the package was
+     installed from. Used to flag non-default-feed packages in
+     `func workload list` (see §9).
+   - `contentOnly`: boolean stamped from `workload.json` (default
+     `false`). The loader (§6.2) uses this to decide whether to
+     activate the entry without re-reading `workload.json`.
+   - `entryPoint: { assemblyPath, type }`: copied from `workload.json`
+     when `contentOnly` is `false`. Omitted when `contentOnly` is
+     `true`.
+
+   Side-by-side installs of the same package id at different versions
+   are separate entries. `displayName` and `description` are **not**
+   persisted in the registry; they are read from the loaded `Workload`
+   instance at runtime (and not applicable to content-only entries) so
+   an updated workload's metadata always reflects what's running.
+   Install paths are computed from the configured workload home plus
+   `(packageId, packageVersion)` and likewise not persisted.
+
+   The write is atomic (temp file + rename) so a crash mid-install
+   cannot corrupt the registry.
+8. Emit an "installed" message: for normal workloads, include the
+   resolved entry-point type; for content-only workloads, include the
+   install path so the consuming command (e.g. `func start` for the
+   host workload) can be discovered.
+
+### 6.2 Discovery and activation
+
+On every Func CLI startup, the workload subsystem builds the in-process
+list of live workloads in a fixed sequence. The whole flow is one JSON
+read plus N assembly loads, where **N is the number of distinct
+package ids with at least one non-content-only installed version**, not
+the total entry count.
+
+1. **Read the registry.** Open
+   `<workload-home>/workloads.json` once. Validate `$schema` (§10.1);
+   reject unrecognized values via `GracefulException`. The registry
+   carries a single `workloads[]` array of every installed
+   `(packageId, packageVersion)` row, each with its `contentOnly` flag
+   stamped at install time (§6.1 step 7).
+2. **Pick the live version per package id.** Group `workloads[]` by
+   `packageId`. For each group, select the row with the highest
+   semver. That row is the **live** version; every other row for the
+   same package id is an inactive side-by-side install retained on
+   disk for `func workload list --all-versions` and for rollback (the
+   user removes the live one via `func workload uninstall` to revert).
+3. **Skip content-only entries.** If the live row has
+   `contentOnly: true`, the loader does **not** activate it: no
+   assembly load, no `Workload.Configure` call, no DI contribution.
+   The entry stays in the registry and is surfaced by
+   `func workload list` (with type `Content`); built-in commands that
+   know its `packageId` (e.g. `func start` for the host workload)
+   resolve its install directory directly. Steps 4-7 below run only
+   for entries with `contentOnly: false`.
+4. **Load the assembly.** Compute the assembly path under
+   `<workload-home>/workloads/<packageId>/<packageVersion>/<entryPoint.assemblyPath>`
+   and reject anything that resolves outside the workloads root
+   (defense in depth against a tampered registry). Open it in a fresh
+   collectible `AssemblyLoadContext`, one ALC per active workload, so
+   conflicting transitive dependencies between workloads cannot clash.
+5. **Resolve the entry-point type.** Look up `entryPoint.type` in the
+   loaded assembly. The type **must** derive from the abstract
+   `Workload` base class (§5); a non-`Workload` type fails this entry's
+   load with an `[<packageId>]` error and the install path, suggesting
+   `func workload uninstall && install`.
+6. **Instantiate.** Call `Activator.CreateInstance` to construct the
+   entry-point. The CLI **must not** invoke any other workload methods
+   during discovery; the type's static constructor is the only workload
+   code that runs, so workloads **must** keep static initialization
+   side-effect-free.
+7. **Configure.** Once all live normal workloads are instantiated, the
+   CLI walks the resulting list and calls each
+   `Workload.Configure(builder)` exactly once, in registry order. This
+   is where contribution-point services (`IProjectInitializer`,
+   `IProjectDetector`, `ITemplateProvider`, `IPackProvider`,
+   `IExternalCommand`, see §5.1) are added to the CLI's DI container.
+8. **Cache for the process lifetime.** The list is cached in
+   `IWorkloadProvider` (singleton). Subsequent commands within the same
+   `func` invocation reuse it; they never re-read the registry or
+   re-instantiate workloads.
+
+#### Failure isolation
+
+A load failure for one workload (missing assembly, type-not-found,
+malformed registry entry, etc.) **must not** abort discovery for the
+others. The CLI continues with the remaining live workloads and
+surfaces the failed one as a non-fatal `[<packageId>]`-prefixed warning
+on the next command that would have used it.
+
+#### Multiple-version policy
+
+Side-by-side installs are allowed (`func workload install --force`,
+§6.1 step 1). Loading is **not** side-by-side: only one version of a
+given `packageId` is live in the running process at any time, and that
+version is always the highest installed semver. Older installed
+versions sit on disk so the user can revert (uninstall the newer) or
+clean up later (`func workload prune`, §6.7).
+
+There is no pinning, no per-project profile, and no `activeVersions`
+pointer. The "latest installed wins" rule is the entire policy.
+
+### 6.3 Invocation
+
+- The Func CLI dispatches each request (init/new/pack/etc.) to whichever
+  workload(s) registered the corresponding contribution-point service
+  (see §5.1). When more than one workload registers the same service,
+  the dispatch rules of the consuming command apply (e.g. `--stack`
+  disambiguation, project detection routing).
+- Errors from a workload **must** surface to the user with the workload id
+  prefixed (e.g. `[python] error: ...`).
+- The Func CLI **must** distinguish between workload-protocol errors
+  (bug, ask user to file an issue) and user-facing errors (display
+  verbatim) by **exception type**: a `GracefulException` thrown from a
+  workload is a user-facing error and surfaced verbatim; any other
+  exception type is treated as a protocol error, prefixed with the
+  workload id, and accompanied by a "please file an issue against the
+  workload" hint.
+
+### 6.4 Update
+
+`func workload update <package>` is conceptually an in-place version
+swap: existing version out, new version in. It is **not** a side-by-
+side install (use `install --force` for that, §6.1).
+
+1. **Resolve the target installed version.** Without `--version|-v`,
+   target the highest installed semver for `<package>`. With
+   `--version|-v <existing>`, target that exact installed version;
+   error if `<existing>` is not present in the registry (no fallback,
+   no auto-install).
+2. **Resolve the new version** from the catalog, honoring
+   `--include-prereleases` and the same-major-by-default rule
+   (`--major` opts in to crossing a major boundary).
+3. **Fetch and validate** the new version through the same staging
+   pipeline as install (§6.1 steps 3-5). On any failure, the staging
+   directory is cleaned up and the registry is not modified; the
+   existing installed version remains live.
+4. **Atomic swap.** Once the new version is staged and validated:
+   - Move the new version into
+     `<workload-home>/workloads/<packageId>/<newVersion>/`.
+   - Remove the target installed version's row from `workloads[]` and
+     add the new row, in a single atomic registry write.
+   - Delete the target version's install directory.
+
+   The swap happens on disk; the running process keeps its cached
+   workloads (§6.2 step 8). The new version goes live on the next
+   `func` invocation.
+5. The error case where step 4 partially fails (registry rewritten but
+   directory delete fails) is recoverable: the orphaned directory is
+   harmless because no row references it and `func workload prune`
+   (§6.7) cleans it up.
+
+For content-only workloads, the swap is the same shape: stage, swap
+the registry row, delete the old directory. There is no in-process
+cache to invalidate.
+
+### 6.5 Removal
+
+- `func workload uninstall <package>` removes the live version: it
+  deletes the version's install directory and removes its row from
+  `workloads[]`. If other versions of the same package id remain
+  installed, the loader's "highest installed semver wins" rule (§6.2
+  step 2) promotes the next-highest on the next `func` invocation.
+  The user is informed (`Live version is now <package>@<promoted>.`).
+- `--version <v>` removes only the named version. The same promotion
+  rule applies if the removed version happened to be the live one.
+- `--all-versions` removes every installed version of the package and
+  removes every row.
+- Other installed workloads must be unaffected.
+- `uninstall` acquires the same registry lock as `install` (see §4.1
+  "Required behaviors"). Concurrent `func <command>` invocations either
+  complete with the prior version (if they discovered before the lock
+  was acquired) or fail to launch the workload after removal.
+
+### 6.6 Background staleness check
+
+- The Func CLI **may** periodically check the catalog for newer versions of
+  installed workloads and surface a one-line hint (`A new version of
+  python (1.2.3) is available. Run 'func workload update python' to
+  upgrade.`).
+- Frequency: at most once per 24h. Network failures must be silent.
+- Disabled by `FUNC_CLI_Workloads__DisableUpdateCheck=true` (follows
+  the configuration-binding env-var convention from §11).
+
+### 6.7 Prune
+
+`func workload prune` removes inactive side-by-side installs.
+
+1. **Determine scope.** Without `<package>`, prune every installed
+   package id. With `<package>`, prune only that one (alias-resolved
+   by default, exact-match with `--exact|-e`; same rules as
+   `install`).
+2. **Per package id, identify pruneable rows.** Group rows by
+   `packageId`. Within each group, the row with the highest semver is
+   **never** pruned (it's the live version per §6.2). Every other row
+   is pruneable.
+3. **Atomic removal per package id.** For each pruneable row, delete
+   the install directory and remove the registry row. Batch all
+   removals for a single package id into one registry write so a
+   crash mid-prune leaves the registry consistent.
+4. **Report.** Print one line per pruned `(packageId, version)` pair
+   and a total count. If nothing was pruneable, exit success with a
+   "Nothing to prune." message.
+
+Prune never removes the live version of any package id. To revert to
+an older installed version, run `func workload uninstall <package>`
+(or `--version <newer>`) first; the older version then becomes live.
+
+## 7. Error handling requirements
+
+| Scenario                                    | Required behavior                                                                                  |
+|---------------------------------------------|----------------------------------------------------------------------------------------------------|
+| No workload installed for runtime           | Print exact install command, exit non-zero.                                                       |
+| Workload registry unreadable / unknown schema | Throw a `GracefulException` with the registry path and the action to take (update CLI). Do not crash silently. |
+| Workload entry-point missing or unloadable  | Print the underlying error and the install path; suggest `func workload uninstall && install`.   |
+| Workload fails during request               | Surface the error with `[<workload-id>]` prefix; exit non-zero with the workload's exit code (or 1). |
+| Two workloads claim same project / template | Error listing all candidates, suggest `--stack` to disambiguate.                                  |
+| Catalog unreachable                         | `install`/`update` must error clearly; `list` and offline operations must still work.             |
+| Install failed mid-flight (download / extract / validation) | No partial state on disk; staging directory cleaned up; registry not updated; non-zero exit. |
+
+## 8. Performance requirements
+
+- **CLI startup overhead** for workload discovery (no invocation) must
+  remain under **100 ms** for up to 25 installed workloads on a warm cache.
+  Content-only workloads contribute zero activation cost (no assembly
+  load, no `Configure` call) and count against this budget only for
+  the registry row read.
+- **First invocation** of a workload (cold) should complete the
+  workload-side boot in under **300 ms** for AOT'd workloads and
+  **800 ms** for JIT. The host-runtime workload (§4.6) is content-only
+  and is not loaded by the workload subsystem at all; `func start`
+  launches its bundled binaries directly.
+- **Subsequent invocations** within the same `func` invocation should not
+  re-pay boot cost when the Func CLI can reuse the workload connection (an
+  optimization, not a v1 requirement).
+
+## 9. Security & trust
+
+- v1 trusts NuGet package provenance. Workloads acquired from non-default
+  feeds must be flagged in `func workload list` (`source: <feed>`).
+- The Func CLI **must not** execute any workload code during discovery. Any
+  code execution path must require explicit user action (install, init,
+  new, pack, custom command).
+- Workloads run with the user's privileges. We document this clearly in
+  `func workload install --help`.
+
+## 10. Compatibility & versioning
+
+### 10.1 Workload registry schema
+
+The workload registry at `~/.azure-functions/workloads.json` carries a
+top-level `$schema` field whose value is a versioned JSON Schema URL
+(e.g. `https://aka.ms/func/workloads/v1/schema.json`). The current
+schema is **v1**.
+
+This follows the same convention used by `tsconfig.json`,
+`azure-pipelines.yml`, and `dotnet/global.json`: editors and external
+validators can fetch the schema document directly, breaking changes
+ship under a new versioned URL (`/v2/`, `/v3/`, ...), and older + newer
+CLIs can coexist on disk without one silently corrupting the other.
+
+- The Func CLI **must** check `$schema` on every read.
+- A registry whose `$schema` URL the CLI does not recognize **must** be
+  rejected with a `GracefulException` instructing the user to update
+  the CLI. The CLI **must not** attempt a partial parse.
+- A registry with no `$schema` field (legacy, written before the field
+  existed) is treated as v1 and re-emitted with the current `$schema`
+  URL on the next write.
+
+The v1 registry shape is, at the top level:
+
+```json
+{
+  "$schema": "https://aka.ms/func/workloads/v1/schema.json",
+  "workloads": [ /* WorkloadEntry[] */ ]
+}
+```
+
+`workloads[]` is the flat list of every installed
+`(packageId, packageVersion)` row, including inactive side-by-side
+versions.
+
+A `WorkloadEntry` carries:
+
+- `packageId` (string): NuGet package id (lowercased).
+- `packageVersion` (string): installed version (ordinal match).
+- `aliases` (string[]): short aliases extracted from the package's
+  `alias:<name>` tags.
+- `source` (string): the catalog feed URL or local path the package
+  was installed from.
+- `contentOnly` (bool, default `false`): stamped from the package's
+  `workload.json` at install time (§6.1 step 7). When `true`, the
+  loader skips activation (§6.2 step 3).
+- `entryPoint` (`{ assemblyPath, type }`): copied from `workload.json`.
+  Present when `contentOnly` is `false`; omitted when `contentOnly`
+  is `true`.
+
+The loader's "live version per package id" resolution (§6.2 step 2)
+is computed from `workloads[]` alone: highest semver wins. There is
+no separate active-version pointer in the registry.
+
+### 10.2 Workload compatibility
+
+- Workloads use **semver**; `func workload install` and `update` honour
+  the standard NuGet resolution rules.
+- A workload built against an older abstractions package must continue
+  to work as long as the CLI can still satisfy the contract types it
+  resolves; otherwise the CLI rejects with "workload too old, please
+  run `func workload update`".
+
+## 11. Telemetry expectations
+
+- The Func CLI emits anonymous telemetry per command invocation including:
+  `command`, `workload-id` (when one was selected), `outcome`
+  (success / user-error / workload-error / cli-error), `duration`.
+- Workloads **may** emit their own telemetry but **must not** propagate
+  user-identifying data through the Func CLI.
+- Telemetry is opt-out via `FUNC_CLI_TELEMETRY_OPTOUT=1`. For
+  back-compat with v4, the legacy `FUNCTIONS_CORE_TOOLS_TELEMETRY_OPTOUT`
+  environment variable is also honored; if both are set, either being
+  truthy disables telemetry.
+
+## 12. Open questions
+
+1. **Catalog source** — single NuGet feed by default, or multi-feed with
+   precedence rules?
+2. **Workload signing** — do we require signed packages for v1, or only
+   warn?
+3. **Cross-RID workloads** — does `func workload install python` resolve
+   per-RID artifacts, or does the workload bundle all RIDs?
+4. **Self-contained / single-file `func`** — `WorkloadPaths` already
+   supports a configurable root, but a portable single-file `func`
+   loses portability the moment a workload is installed unless we
+   probe `<func-dir>/workloads` first. Decide before the install
+   command lands.
+5. **Built-in workload** — does the CLI ship with any workload pre-installed
+   (e.g. seed the host-runtime workload on first run), or is the post-install
+   state always "no workloads" and `func start` triggers an install prompt?
+6. **Host-runtime version pinning** — where does the per-project pin live
+   (`host.json`, `local.settings.json`, a new `func.json`, project file)?
+7. **Host-runtime workload boundary** — does one workload ship all RIDs +
+   all major host versions, or one workload per major (e.g. `...Workload.Host.v4`,
+   `...Workload.Host.v5`)?
+8. **Non-host content-only consumption.** `func start` knows the host
+   workload's package id (`Azure.Functions.Cli.Workload.Host`) and
+   resolves its install directory directly. There is no general
+   contract today for other built-in commands to consume
+   content-only workloads. If a second content-only workload appears,
+   we'll need either a name-based registry lookup helper or a
+   content-only contribution mechanism (e.g. registering a content
+   directory under a stable key).
+9. **TTL-based prune.** `func workload prune` (§6.7) removes every
+   non-live install unconditionally. A future variant
+   (`--older-than 30d` or similar) would let a user keep recent
+   versions for quick rollback while reclaiming disk for older ones.
+   Defer until we have telemetry on real prune usage.
+
+**Resolved:** *Bidirectional UX* (workload-driven logs, progress,
+prompts) is **CLI-rendered only in v1** (see §2 non-goals). A
+callback contract for richer UX may be introduced in a later
+abstractions release as a non-breaking additive change.


### PR DESCRIPTION
## Summary

- merge the unrelated `docs` branch history into `vnext`
- add all 12 design documents under `proposed/` without modifying their contents
- retain the newer `vnext` README and documentation, adding only a link and lifecycle note for proposals

## Merge details

The merge commit preserves the original documentation commits and their PR provenance. No files under `docs/` are changed or replaced.

## Validation

- confirmed both `origin/vnext` and `origin/docs` are ancestors of the result
- confirmed proposal files are byte-for-byte identical to the `docs` branch tip
- confirmed only `README.md` and the 12 proposal files differ from `vnext`
- confirmed no whitespace errors

Tests were not run because this is a documentation-only change.