### PR TITLE
Onboard dependency restores to CFS

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,11 @@
 registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
 @azure:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@azure-rest:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@colors:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@dabh:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@js-joda:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@microsoft:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@opentelemetry:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@so-ric:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@types:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@typespec:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@azure:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,13 +2,15 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="Microsoft.Azure.Functions.PowerShellWorker" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/Microsoft.Azure.Functions.PowerShellWorker/nuget/v3/index.json" />
-    <add key="AzureFunctions" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctions/nuget/v3/index.json" />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
     <add key="AzureFunctionsRelease" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsRelease/nuget/v3/index.json" />
-    <add key="AzureFunctionsPreRelease" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsPreRelease/nuget/v3/index.json" />
-    <add key="AzureFunctionsTempStaging" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json" />
-    <add key="DotnetLibraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
-    <add key="Infra" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/infra/nuget/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="upstream-public">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="AzureFunctionsRelease">
+      <package pattern="Microsoft.Azure.WebJobs.Script*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -3,14 +3,44 @@
   <packageSources>
     <clear />
     <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
+    <add key="Microsoft.Azure.Functions.PowerShellWorker" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/Microsoft.Azure.Functions.PowerShellWorker/nuget/v3/index.json" />
+    <add key="AzureFunctions" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctions/nuget/v3/index.json" />
     <add key="AzureFunctionsRelease" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsRelease/nuget/v3/index.json" />
+    <add key="AzureFunctionsTempStaging" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json" />
+    <add key="Infra" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/infra/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="upstream-public">
       <package pattern="*" />
     </packageSource>
+    <packageSource key="Microsoft.Azure.Functions.PowerShellWorker">
+      <package pattern="Microsoft.Azure.Functions.PowerShellWorker.*" />
+    </packageSource>
+    <packageSource key="AzureFunctions">
+      <package pattern="Microsoft.Azure.AppService.Middleware" />
+      <package pattern="Microsoft.Azure.AppService.Middleware.Functions" />
+      <package pattern="Microsoft.Azure.AppService.Middleware.Modules" />
+      <package pattern="Microsoft.Azure.AppService.Middleware.NetCore" />
+    </packageSource>
     <packageSource key="AzureFunctionsRelease">
-      <package pattern="Microsoft.Azure.WebJobs.Script*" />
+      <package pattern="Microsoft.Azure.Functions.JavaWorker" />
+      <package pattern="Microsoft.Azure.Functions.NodeJsWorker" />
+      <package pattern="Microsoft.Azure.Functions.PythonWorker" />
+      <package pattern="Microsoft.Azure.WebJobs.Script" />
+      <package pattern="Microsoft.Azure.WebJobs.Script.Grpc" />
+      <package pattern="Microsoft.Azure.WebJobs.Script.WebHost" />
+    </packageSource>
+    <packageSource key="AzureFunctionsTempStaging">
+      <package pattern="Microsoft.Azure.AppService.Proxy.Client" />
+      <package pattern="Microsoft.Azure.AppService.Proxy.Common" />
+      <package pattern="Microsoft.Azure.AppService.Proxy.Runtime" />
+      <package pattern="Microsoft.Azure.DurableTask.AzureStorage.Internal" />
+      <package pattern="Microsoft.Azure.DurableTask.Core.Internal" />
+      <package pattern="Microsoft.Azure.Functions.Platform.Metrics.LinuxConsumption" />
+      <package pattern="Microsoft.Azure.WebSites.DataProtection" />
+    </packageSource>
+    <packageSource key="Infra">
+      <package pattern="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" />
     </packageSource>
   </packageSourceMapping>
 </configuration>

--- a/eng/ci/templates/jobs/test-e2e-linux.yml
+++ b/eng/ci/templates/jobs/test-e2e-linux.yml
@@ -46,6 +46,8 @@ jobs:
 
   - pwsh: ./eng/scripts/start-emulators.ps1
     displayName: 'Start emulators (NoWait)'
+    env:
+      NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
 
   - template: /eng/ci/templates/steps/restore-nuget.yml@self
 

--- a/eng/ci/templates/jobs/test-e2e-linux.yml
+++ b/eng/ci/templates/jobs/test-e2e-linux.yml
@@ -32,6 +32,8 @@ jobs:
   steps:
   - template: /eng/ci/templates/steps/install-tools.yml@self
 
+  - template: /eng/ci/templates/steps/authenticate-e2e-dependencies.yml@self
+
   # The 1es-ubuntu-24.04-min image doesn't ship npm. NodeTool@0 in install-tools.yml
   # installs Node into the agent user's tool cache, but start-emulators.ps1 runs
   # `sudo npm install -g azurite` and sudo's PATH doesn't include the tool cache.
@@ -44,6 +46,8 @@ jobs:
 
   - pwsh: ./eng/scripts/start-emulators.ps1
     displayName: 'Start emulators (NoWait)'
+
+  - template: /eng/ci/templates/steps/restore-nuget.yml@self
 
   - pwsh: |
       dotnet publish src/Cli/func/Azure.Functions.Cli.csproj `

--- a/eng/ci/templates/jobs/test-e2e-osx.yml
+++ b/eng/ci/templates/jobs/test-e2e-osx.yml
@@ -30,12 +30,14 @@ jobs:
         runtime: 'osx-x64'
 
   steps:
+  - template: /eng/ci/templates/steps/authenticate-e2e-dependencies.yml@self
+
   - pwsh: ./eng/scripts/start-emulators.ps1
     displayName: 'Start emulators (NoWait)'
 
   - script: |
       sudo chown -R $(id -u):$(id -g) ~/.npm
-      npm install -g @azure/functions
+      npm install -g @azure/functions --userconfig "$(Build.SourcesDirectory)/.npmrc"
     displayName: 'Install @azure/functions'
 
   - template: /eng/ci/templates/steps/install-tools.yml@self

--- a/eng/ci/templates/jobs/test-e2e-osx.yml
+++ b/eng/ci/templates/jobs/test-e2e-osx.yml
@@ -34,11 +34,15 @@ jobs:
 
   - pwsh: ./eng/scripts/start-emulators.ps1
     displayName: 'Start emulators (NoWait)'
+    env:
+      NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
 
   - script: |
       sudo chown -R $(id -u):$(id -g) ~/.npm
       npm install -g @azure/functions --userconfig "$(Build.SourcesDirectory)/.npmrc"
     displayName: 'Install @azure/functions'
+    env:
+      NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
 
   - template: /eng/ci/templates/steps/install-tools.yml@self
 

--- a/eng/ci/templates/jobs/test-e2e-windows.yml
+++ b/eng/ci/templates/jobs/test-e2e-windows.yml
@@ -34,6 +34,8 @@ jobs:
 
   - pwsh: ./eng/scripts/start-emulators.ps1 -NoWait
     displayName: 'Start emulators (NoWait)'
+    env:
+      NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
 
   - template: /eng/ci/templates/steps/install-tools.yml@self
 

--- a/eng/ci/templates/jobs/test-e2e-windows.yml
+++ b/eng/ci/templates/jobs/test-e2e-windows.yml
@@ -30,6 +30,8 @@ jobs:
         runtime: 'win-x64'
 
   steps:
+  - template: /eng/ci/templates/steps/authenticate-e2e-dependencies.yml@self
+
   - pwsh: ./eng/scripts/start-emulators.ps1 -NoWait
     displayName: 'Start emulators (NoWait)'
 

--- a/eng/ci/templates/official/jobs/consolidate-cli-artifacts.yml
+++ b/eng/ci/templates/official/jobs/consolidate-cli-artifacts.yml
@@ -49,6 +49,9 @@ jobs:
 
   - template: /eng/ci/templates/steps/install-tools.yml@self
 
+  - task: NuGetAuthenticate@1
+    displayName: 'Authenticate NuGet'
+
   - task: DotNetCoreCLI@2
     displayName: "Run ArtifactAssembler"
     inputs:

--- a/eng/ci/templates/official/jobs/host-build-pack.yml
+++ b/eng/ci/templates/official/jobs/host-build-pack.yml
@@ -9,6 +9,9 @@ jobs:
   steps:
   - template: /eng/ci/templates/steps/install-tools.yml@self
 
+  - task: NuGetAuthenticate@1
+    displayName: 'Authenticate NuGet'
+
   # Building the solution gets us the latest version of the CLI and sets the Build.BuildNumber
   - task: DotnetCoreCLI@2
     displayName: Build sln
@@ -136,6 +139,9 @@ jobs:
       includePreviewVersions: true
     displayName: Install .NET 10
 
+  - task: NuGetAuthenticate@1
+    displayName: 'Authenticate NuGet'
+
   - task: DotnetCoreCLI@2
     displayName: Dotnet Publish (linux-x64)
     inputs:
@@ -181,6 +187,12 @@ jobs:
       artifact: func-host-linux
       path: $(Build.SourcesDirectory)/func-host-linux
 
+  - task: PipAuthenticate@1
+    displayName: 'Authenticate pip'
+    inputs:
+      artifactFeeds: 'public/upstream-public'
+      onlyAddExtraIndex: false
+
   - task: Bash@3
     inputs:
       targetType: 'inline'  # Specify 'filePath' if you want to use an external script file.
@@ -188,7 +200,7 @@ jobs:
         cd publish-scripts
         python3 -m venv publish-env
         source publish-env/bin/activate
-        sudo pip install -r requirements.txt
+        pip install -r requirements.txt
         sudo apt-get install fakeroot
         export PATH="$PATH:/mnt/vss/_work/_tasks/EsrpCodeSigning_7e3c371a-7f9c-4791-b1ce-742f18ad3a9b/5.1.4/net462"
       bashEnvValue: '~/.profile'  # Set value for BASH_ENV environment variable

--- a/eng/ci/templates/official/jobs/linux-deb-build-pack.yml
+++ b/eng/ci/templates/official/jobs/linux-deb-build-pack.yml
@@ -58,6 +58,12 @@ jobs:
         # Set version as the build number
         Write-Host "##vso[build.updatebuildnumber]$($metadata.defaultArtifactVersion)"
 
+  - task: PipAuthenticate@1
+    displayName: 'Authenticate pip'
+    inputs:
+      artifactFeeds: 'public/upstream-public'
+      onlyAddExtraIndex: false
+
   - task: Bash@3
     displayName: 'Build DEB package'
     inputs:

--- a/eng/ci/templates/official/jobs/test-consolidated-cli-artifacts.yml
+++ b/eng/ci/templates/official/jobs/test-consolidated-cli-artifacts.yml
@@ -31,6 +31,9 @@ jobs:
 
   - template: /eng/ci/templates/steps/install-tools.yml@self
 
+  - task: NuGetAuthenticate@1
+    displayName: 'Authenticate NuGet'
+
   # For win-x86, we need to install x86 .NET 10 runtime. The install-tools.yml installs x64 versions.
   # The x86 func CLI spawns x86 worker processes that look for .NET in 'C:\Program Files (x86)\dotnet\'.
   # We install 'aspnetcore' runtime which includes both Microsoft.NETCore.App and Microsoft.AspNetCore.App.

--- a/eng/ci/templates/steps/authenticate-e2e-dependencies.yml
+++ b/eng/ci/templates/steps/authenticate-e2e-dependencies.yml
@@ -1,0 +1,27 @@
+steps:
+- task: npmAuthenticate@0
+  displayName: 'Authenticate npm for repository tools'
+  inputs:
+    workingFile: '$(Build.SourcesDirectory)/.npmrc'
+
+- task: npmAuthenticate@0
+  displayName: 'Authenticate npm for Node test project'
+  inputs:
+    workingFile: '$(Build.SourcesDirectory)/test/TestFunctionApps/TestNodeProject/.npmrc'
+
+- task: PipAuthenticate@1
+  displayName: 'Authenticate pip'
+  inputs:
+    artifactFeeds: 'public/upstream-public'
+    onlyAddExtraIndex: false
+
+- pwsh: |
+    if ($IsWindows) {
+      $userConfigDirectory = Join-Path $env:APPDATA 'NuGet'
+    } else {
+      $userConfigDirectory = Join-Path $HOME '.nuget/NuGet'
+    }
+
+    New-Item -ItemType Directory -Force -Path $userConfigDirectory | Out-Null
+    Copy-Item '$(Build.SourcesDirectory)/NuGet.Config' (Join-Path $userConfigDirectory 'NuGet.Config') -Force
+  displayName: 'Configure NuGet for temporary E2E projects'

--- a/eng/ci/templates/steps/authenticate-e2e-dependencies.yml
+++ b/eng/ci/templates/steps/authenticate-e2e-dependencies.yml
@@ -23,5 +23,24 @@ steps:
     }
 
     New-Item -ItemType Directory -Force -Path $userConfigDirectory | Out-Null
-    Copy-Item '$(Build.SourcesDirectory)/NuGet.Config' (Join-Path $userConfigDirectory 'NuGet.Config') -Force
+    $userConfigPath = Join-Path $userConfigDirectory 'NuGet.Config'
+    [xml]$nugetConfig = Get-Content '$(Build.SourcesDirectory)/NuGet.Config' -Raw
+
+    # Source mapping is repository-specific. Applying it at user scope blocks
+    # auto-injected pipeline tools from restoring packages from their own feeds.
+    $packageSourceMapping = $nugetConfig.configuration.packageSourceMapping
+    if ($null -ne $packageSourceMapping) {
+      $nugetConfig.configuration.RemoveChild($packageSourceMapping) | Out-Null
+    }
+
+    if (Test-Path $userConfigPath) {
+      [xml]$existingConfig = Get-Content $userConfigPath -Raw
+      $packageSourceCredentials = $existingConfig.configuration.packageSourceCredentials
+      if ($null -ne $packageSourceCredentials) {
+        $importedCredentials = $nugetConfig.ImportNode($packageSourceCredentials, $true)
+        $nugetConfig.configuration.AppendChild($importedCredentials) | Out-Null
+      }
+    }
+
+    $nugetConfig.Save($userConfigPath)
   displayName: 'Configure NuGet for temporary E2E projects'

--- a/eng/ci/templates/steps/restore-nuget.yml
+++ b/eng/ci/templates/steps/restore-nuget.yml
@@ -1,4 +1,7 @@
 steps:
+- task: NuGetAuthenticate@1
+  displayName: 'Authenticate NuGet'
+
 - task: DotNetCoreCLI@2
   displayName: 'Restore NuGet packages'
   inputs:

--- a/eng/ci/templates/steps/run-e2e-tests.yml
+++ b/eng/ci/templates/steps/run-e2e-tests.yml
@@ -64,6 +64,7 @@ steps:
     FUNC_PATH: $(FUNC_PATH)
     DURABLE_STORAGE_CONNECTION: $(DURABLE_STORAGE_CONNECTION)
     DURABLE_FUNCTION_PATH: $(DURABLE_FUNCTION_PATH)
+    NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
 
 - task: 1ES.PublishPipelineArtifact@1
   condition: succeededOrFailed()

--- a/eng/scripts/download-templates.ps1
+++ b/eng/scripts/download-templates.ps1
@@ -1,10 +1,7 @@
 # Run: ./download-templates.ps1 || From root of the repo: ./eng/scripts/download-templates.ps1
 # Optional parameters: -OutputPath "./desired/output/path" -TemplatesVersion "4.0.5337" -TemplateJsonVersion "3.1.1648"
 
-# You can check NuGet for the latest template versions:
-# https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.ItemTemplates/
-# https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.ProjectTemplates/
-# https://www.nuget.org/packages/Microsoft.Azure.WebJobs.ItemTemplates/
+# Template packages are restored from the repository's configured NuGet feed.
 
 # For the json templates version, you can check the latest entry of the tooling feed i.e.
 # https://github.com/Azure/azure-functions-tooling-feed/blob/eeb299f0f24e4f778a6e2ec3c92e3f76a7fd03e8/cli-feed-v4.json#L36596
@@ -27,10 +24,6 @@ $templatesV2Path = Join-Path $OUTPUT_DIR "templates-v2"
 $isolatedTemplatesPath = Join-Path $templatesPath "net-isolated"
 
 # URLs
-$DOTNET_ISOLATED_ITEM_TEMPLATES_URL = "https://www.nuget.org/api/v2/package/Microsoft.Azure.Functions.Worker.ItemTemplates/$TEMPLATES_VERSION"
-$DOTNET_ISOLATED_PROJECT_TEMPLATES_URL = "https://www.nuget.org/api/v2/package/Microsoft.Azure.Functions.Worker.ProjectTemplates/$TEMPLATES_VERSION"
-$DOTNET_ITEM_TEMPLATES_URL = "https://www.nuget.org/api/v2/package/Microsoft.Azure.WebJobs.ItemTemplates/$TEMPLATES_VERSION"
-$DOTNET_PROJECT_TEMPLATES_URL = "https://www.nuget.org/api/v2/package/Microsoft.Azure.WebJobs.ProjectTemplates/$TEMPLATES_VERSION"
 $TEMPLATES_JSON_ZIP_URL = "https://cdn.functions.azure.com/public/TemplatesApi/$TEMPLATE_JSON_VERSION.zip"
 
 Write-Verbose "Setting up directories for templates and isolated templates"
@@ -41,16 +34,50 @@ New-Item -ItemType Directory -Path $isolatedTemplatesPath -Force | Out-Null
 
 Write-Host "Downloading templates to $templatesPath and $isolatedTemplatesPath"
 
-# Download files
-Invoke-WebRequest -Uri $DOTNET_ISOLATED_ITEM_TEMPLATES_URL -OutFile (Join-Path $isolatedTemplatesPath "itemTemplates.$TEMPLATES_VERSION.nupkg")
-Invoke-WebRequest -Uri $DOTNET_ISOLATED_PROJECT_TEMPLATES_URL -OutFile (Join-Path $isolatedTemplatesPath "projectTemplates.$TEMPLATES_VERSION.nupkg")
-Invoke-WebRequest -Uri $DOTNET_ITEM_TEMPLATES_URL -OutFile (Join-Path $templatesPath "itemTemplates.$TEMPLATES_VERSION.nupkg")
-Invoke-WebRequest -Uri $DOTNET_PROJECT_TEMPLATES_URL -OutFile (Join-Path $templatesPath "projectTemplates.$TEMPLATES_VERSION.nupkg")
-
-# Setup template.json
 $tempDirectoryPath = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString())
 New-Item -ItemType Directory -Path $tempDirectoryPath | Out-Null
 
+# Restore template packages through NuGet so the Azure Artifacts credential provider can authenticate.
+$packagesConfigPath = Join-Path $tempDirectoryPath "packages.config"
+$packagesPath = Join-Path $tempDirectoryPath "packages"
+$nugetConfigPath = Join-Path $PSScriptRoot "..\..\NuGet.Config"
+if (-not (Get-Command nuget -ErrorAction SilentlyContinue)) {
+  throw "The NuGet CLI is required to download template packages."
+}
+
+@"
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Azure.Functions.Worker.ItemTemplates" version="$TEMPLATES_VERSION" />
+  <package id="Microsoft.Azure.Functions.Worker.ProjectTemplates" version="$TEMPLATES_VERSION" />
+  <package id="Microsoft.Azure.WebJobs.ItemTemplates" version="$TEMPLATES_VERSION" />
+  <package id="Microsoft.Azure.WebJobs.ProjectTemplates" version="$TEMPLATES_VERSION" />
+</packages>
+"@ | Set-Content -Path $packagesConfigPath -Encoding utf8
+
+& nuget restore $packagesConfigPath `
+  -PackagesDirectory $packagesPath `
+  -ConfigFile $nugetConfigPath `
+  -PackageSaveMode nupkg `
+  -DirectDownload `
+  -NonInteractive
+if ($LASTEXITCODE -ne 0) {
+  throw "Failed to restore template packages from the configured NuGet feed."
+}
+
+$templatePackages = @(
+  @{ Id = "Microsoft.Azure.Functions.Worker.ItemTemplates"; OutputPath = Join-Path $isolatedTemplatesPath "itemTemplates.$TEMPLATES_VERSION.nupkg" },
+  @{ Id = "Microsoft.Azure.Functions.Worker.ProjectTemplates"; OutputPath = Join-Path $isolatedTemplatesPath "projectTemplates.$TEMPLATES_VERSION.nupkg" },
+  @{ Id = "Microsoft.Azure.WebJobs.ItemTemplates"; OutputPath = Join-Path $templatesPath "itemTemplates.$TEMPLATES_VERSION.nupkg" },
+  @{ Id = "Microsoft.Azure.WebJobs.ProjectTemplates"; OutputPath = Join-Path $templatesPath "projectTemplates.$TEMPLATES_VERSION.nupkg" }
+)
+foreach ($package in $templatePackages) {
+  $packageDirectory = Join-Path $packagesPath "$($package.Id).$TEMPLATES_VERSION"
+  $packagePath = Join-Path $packageDirectory "$($package.Id).$TEMPLATES_VERSION.nupkg"
+  Copy-Item -Path $packagePath -Destination $package.OutputPath
+}
+
+# Setup template.json
 $zipFilePath = Join-Path $tempDirectoryPath "templates.zip"
 Invoke-WebRequest -Uri $TEMPLATES_JSON_ZIP_URL -OutFile $zipFilePath
 

--- a/eng/scripts/start-emulators.ps1
+++ b/eng/scripts/start-emulators.ps1
@@ -8,6 +8,7 @@ param(
 )
 
 $DebugPreference = 'Continue'
+$npmConfigPath = Join-Path $PSScriptRoot '..\..\.npmrc'
 
 Write-Host "Skip Storage Emulator: $SkipStorageEmulator"
 
@@ -51,12 +52,12 @@ if (!$SkipStorageEmulator)
     {
         if ($IsWindows -or $assumeWindows)
         {
-            npm install -g azurite
+            npm install -g azurite --userconfig $npmConfigPath
             Start-Process azurite.cmd -ArgumentList "--silent --skipApiVersionCheck"
         }
         else
         {
-            sudo npm install -g azurite
+            sudo npm install -g azurite --userconfig $npmConfigPath
             sudo mkdir azurite
             sudo azurite --silent --skipApiVersionCheck --location azurite --debug azurite\debug.log &
         }

--- a/eng/tools/publish-tools/npm/.npmrc
+++ b/eng/tools/publish-tools/npm/.npmrc
@@ -1,0 +1,2 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@types:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/

--- a/test/Cli/Func.E2ETests/Commands/FuncNew/NodeTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncNew/NodeTests.cs
@@ -13,8 +13,6 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncNew
     [Trait(WorkerRuntimeTraits.WorkerRuntime, WorkerRuntimeTraits.Node)]
     public class NodeTests(ITestOutputHelper log) : BaseE2ETests(log)
     {
-        private static string BundleCacheHome { get; } = Path.Combine(Path.GetTempPath(), $"func-e2e-bundle-cache-{Environment.ProcessId}");
-
         [Fact]
         public void FuncNew_HttpTrigger_WithAuthLevelFunction_NodeV3_CreatesSuccessfully()
         {
@@ -167,14 +165,11 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncNew
 
             // Initialize a Node.js v4 (default) JavaScript function app
             await FuncInitWithRetryAsync(testName, new[] { ".", "--worker-runtime", "node", "--language", "javascript" });
-            CacheExtensionBundle(testName);
 
             // Create a Durable Functions orchestrator. Run in offline mode so the assertion
             // validates the package.json update without requiring a real 'npm install'.
             var result = new FuncNewCommand(FuncPath, testName, Log)
                 .WithWorkingDirectory(WorkingDirectory)
-                .WithEnvironmentVariable("HOME", BundleCacheHome)
-                .WithEnvironmentVariable("USERPROFILE", BundleCacheHome)
                 .WithEnvironmentVariable("FUNCTIONS_CORE_TOOLS_OFFLINE", "true")
                 .Execute([".", "--template", "DurableFunctionsOrchestrator", "--name", "durableHello"]);
 
@@ -193,14 +188,11 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncNew
 
             // Initialize a Node.js v4 (default) TypeScript function app
             await FuncInitWithRetryAsync(testName, new[] { ".", "--worker-runtime", "node", "--language", "typescript" });
-            CacheExtensionBundle(testName);
 
             // Create a Durable Functions entity. Run in offline mode so the assertion
             // validates the package.json update without requiring a real 'npm install'.
             var result = new FuncNewCommand(FuncPath, testName, Log)
                 .WithWorkingDirectory(WorkingDirectory)
-                .WithEnvironmentVariable("HOME", BundleCacheHome)
-                .WithEnvironmentVariable("USERPROFILE", BundleCacheHome)
                 .WithEnvironmentVariable("FUNCTIONS_CORE_TOOLS_OFFLINE", "true")
                 .Execute([".", "--template", "DurableFunctionsEntity", "--name", "counter"]);
 
@@ -231,17 +223,6 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncNew
 
             var packageJson = await File.ReadAllTextAsync(Path.Combine(WorkingDirectory, "package.json"));
             packageJson.Should().NotContain("durable-functions");
-        }
-
-        private void CacheExtensionBundle(string testName)
-        {
-            var result = new FuncRootCommand(FuncPath, testName, Log)
-                .WithWorkingDirectory(WorkingDirectory)
-                .WithEnvironmentVariable("HOME", BundleCacheHome)
-                .WithEnvironmentVariable("USERPROFILE", BundleCacheHome)
-                .Execute(["GetExtensionBundlePath"]);
-
-            result.Should().ExitWith(0);
         }
     }
 }

--- a/test/Cli/Func.E2ETests/Commands/FuncNew/NodeTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncNew/NodeTests.cs
@@ -13,6 +13,8 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncNew
     [Trait(WorkerRuntimeTraits.WorkerRuntime, WorkerRuntimeTraits.Node)]
     public class NodeTests(ITestOutputHelper log) : BaseE2ETests(log)
     {
+        private static string BundleCacheHome { get; } = Path.Combine(Path.GetTempPath(), $"func-e2e-bundle-cache-{Environment.ProcessId}");
+
         [Fact]
         public void FuncNew_HttpTrigger_WithAuthLevelFunction_NodeV3_CreatesSuccessfully()
         {
@@ -165,11 +167,14 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncNew
 
             // Initialize a Node.js v4 (default) JavaScript function app
             await FuncInitWithRetryAsync(testName, new[] { ".", "--worker-runtime", "node", "--language", "javascript" });
+            CacheExtensionBundle(testName);
 
             // Create a Durable Functions orchestrator. Run in offline mode so the assertion
             // validates the package.json update without requiring a real 'npm install'.
             var result = new FuncNewCommand(FuncPath, testName, Log)
                 .WithWorkingDirectory(WorkingDirectory)
+                .WithEnvironmentVariable("HOME", BundleCacheHome)
+                .WithEnvironmentVariable("USERPROFILE", BundleCacheHome)
                 .WithEnvironmentVariable("FUNCTIONS_CORE_TOOLS_OFFLINE", "true")
                 .Execute([".", "--template", "DurableFunctionsOrchestrator", "--name", "durableHello"]);
 
@@ -188,11 +193,14 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncNew
 
             // Initialize a Node.js v4 (default) TypeScript function app
             await FuncInitWithRetryAsync(testName, new[] { ".", "--worker-runtime", "node", "--language", "typescript" });
+            CacheExtensionBundle(testName);
 
             // Create a Durable Functions entity. Run in offline mode so the assertion
             // validates the package.json update without requiring a real 'npm install'.
             var result = new FuncNewCommand(FuncPath, testName, Log)
                 .WithWorkingDirectory(WorkingDirectory)
+                .WithEnvironmentVariable("HOME", BundleCacheHome)
+                .WithEnvironmentVariable("USERPROFILE", BundleCacheHome)
                 .WithEnvironmentVariable("FUNCTIONS_CORE_TOOLS_OFFLINE", "true")
                 .Execute([".", "--template", "DurableFunctionsEntity", "--name", "counter"]);
 
@@ -223,6 +231,17 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncNew
 
             var packageJson = await File.ReadAllTextAsync(Path.Combine(WorkingDirectory, "package.json"));
             packageJson.Should().NotContain("durable-functions");
+        }
+
+        private void CacheExtensionBundle(string testName)
+        {
+            var result = new FuncRootCommand(FuncPath, testName, Log)
+                .WithWorkingDirectory(WorkingDirectory)
+                .WithEnvironmentVariable("HOME", BundleCacheHome)
+                .WithEnvironmentVariable("USERPROFILE", BundleCacheHome)
+                .Execute(["GetExtensionBundlePath"]);
+
+            result.Should().ExitWith(0);
         }
     }
 }

--- a/test/TestFunctionApps/TestNodeProject/.npmrc
+++ b/test/TestFunctionApps/TestNodeProject/.npmrc
@@ -1,0 +1,3 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@azure:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@types:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/


### PR DESCRIPTION
## Summary
- route public NuGet and npm dependencies through `azfunc/public/upstream-public`
- retain only the necessary Azure Artifacts feeds for Functions-owned host, worker, and private transitive packages, isolated with exact package source mappings
- authenticate NuGet, npm, and pip before every affected Azure Pipelines restore/install path, including temporary E2E projects
- bind `NPM_CONFIG_USERCONFIG` to every global npm install step and map all scopes in the resolved `azurite` and `@azure/functions` production dependency graph
- restore template packages through configured NuGet feeds instead of downloading from nuget.org
- make durable Node E2E tests populate an isolated extension-bundle cache before testing offline behavior
- leave customer-facing scaffolding/Dockerfiles and existing npm lockfile URLs unchanged

## Validation
- cold-cache `dotnet restore --no-cache --configfile NuGet.Config --verbosity minimal` with an isolated `NUGET_PACKAGES` directory
- `dotnet build Azure.Functions.Cli.sln --no-restore --verbosity minimal` against the isolated restore
- durable JavaScript orchestrator and TypeScript entity E2E tests with a process-isolated extension-bundle cache
- authenticated `npm ci --ignore-scripts` for both repository npm projects, with HTTP routing asserted to CFS and no npmjs.org contact
- authenticated global installs of `azurite` and `@azure/functions` using only `NPM_CONFIG_USERCONFIG`, with HTTP routing asserted to CFS and no npmjs.org contact
- resolved the global packages' production graph and verified explicit mappings for every consumed npm scope
- authenticated pip dry-run for the publish-tool requirements through CFS
- `eng\scripts\download-templates.ps1` restored all four packages through CFS
- parsed all changed Azure Pipelines YAML and PowerShell scripts