### PR TITLE
Fix Kubernetes deployment for hostname-only LoadBalancer ingress

### DIFF
--- a/src/Cli/func/Kubernetes/KubernetesHelper.cs
+++ b/src/Cli/func/Kubernetes/KubernetesHelper.cs
@@ -521,9 +521,13 @@ namespace Azure.Functions.Cli.Kubernetes
                 if (serviceExists)
                 {
                     service = TryParse<ServiceV1>(output);
-                    if (service?.Spec?.Type?.Equals("LoadBalancer", StringComparison.OrdinalIgnoreCase) == true && service?.Status?.LoadBalancer?.Ingress?.Any() == true)
+                    if (service?.Spec?.Type?.Equals("LoadBalancer", StringComparison.OrdinalIgnoreCase) == true)
                     {
-                        return service.Status.LoadBalancer.Ingress.First().Ip;
+                        var serviceAddress = GetServiceAddress(service);
+                        if (!string.IsNullOrWhiteSpace(serviceAddress))
+                        {
+                            return serviceAddress;
+                        }
                     }
                     else if (service?.Spec?.Type?.Equals("LoadBalancer", StringComparison.OrdinalIgnoreCase) == false && !string.IsNullOrEmpty(service?.Spec?.ClusterIp))
                     {
@@ -538,6 +542,12 @@ namespace Azure.Functions.Cli.Kubernetes
             return string.Empty;
         }
 
+        internal static string GetServiceAddress(ServiceV1 service)
+        {
+            var ingress = service?.Status?.LoadBalancer?.Ingress?.FirstOrDefault();
+            return !string.IsNullOrWhiteSpace(ingress?.Ip) ? ingress.Ip : ingress?.Hostname;
+        }
+
         private static IDictionary<string, string> GetFunctionKeys(IDictionary<string, string> currentImageFuncKeys, IDictionary<string, string> existingFuncKeys)
         {
             if ((currentImageFuncKeys == null || !currentImageFuncKeys.Any())
@@ -549,7 +559,7 @@ namespace Azure.Functions.Cli.Kubernetes
             // The function keys that doesn't exist in Kubernetes yet
             IDictionary<string, string> funcKeys = currentImageFuncKeys.Except(existingFuncKeys, new KeyBasedDictionaryComparer()).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
-             // Merge the new keys with the keys that already exist in kubernetes
+            // Merge the new keys with the keys that already exist in kubernetes
             foreach (var commonKey in existingFuncKeys.Intersect(currentImageFuncKeys, new KeyBasedDictionaryComparer()))
             {
                 funcKeys.Add(commonKey);

--- a/src/Cli/func/Kubernetes/Models/Kubernetes/ServiceV1.cs
+++ b/src/Cli/func/Kubernetes/Models/Kubernetes/ServiceV1.cs
@@ -57,5 +57,8 @@ namespace Azure.Functions.Cli.Kubernetes.Models.Kubernetes
     {
         [JsonProperty("ip")]
         public string Ip { get; set; }
+
+        [JsonProperty("hostname")]
+        public string Hostname { get; set; }
     }
 }

--- a/test/Cli/Func.UnitTests/HelperTests/KubernetesHelperTests.cs
+++ b/test/Cli/Func.UnitTests/HelperTests/KubernetesHelperTests.cs
@@ -5,6 +5,8 @@ using AwesomeAssertions;
 using Azure.Functions.Cli.Kubernetes;
 using Azure.Functions.Cli.Kubernetes.KEDA.Models;
 using Azure.Functions.Cli.Kubernetes.KEDA.V2.Models;
+using Azure.Functions.Cli.Kubernetes.Models.Kubernetes;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Azure.Functions.Cli.UnitTests.HelperTests
@@ -58,6 +60,18 @@ namespace Azure.Functions.Cli.UnitTests.HelperTests
             Kubernetes.Models.OutputSerializationOptions.Yaml);
 
             result.Should().Contain("\"1\"");
+        }
+
+        [Theory]
+        [InlineData(@"{""status"":{""loadBalancer"":{""ingress"":[{""ip"":""192.0.2.1""}]}}}", "192.0.2.1")]
+        [InlineData(@"{""status"":{""loadBalancer"":{""ingress"":[{""hostname"":""localhost""}]}}}", "localhost")]
+        [InlineData(@"{""status"":{""loadBalancer"":{""ingress"":[{""ip"":""192.0.2.1"",""hostname"":""example.test""}]}}}", "192.0.2.1")]
+        [InlineData(@"{""status"":{""loadBalancer"":{""ingress"":[]}}}", null)]
+        public void GetServiceAddressReturnsIpOrHostname(string json, string expected)
+        {
+            var service = JsonConvert.DeserializeObject<ServiceV1>(json);
+
+            KubernetesHelper.GetServiceAddress(service).Should().Be(expected);
         }
     }
 }


### PR DESCRIPTION
### Issue describing the changes in this PR

resolves #3215

### Pull request checklist

* [X] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [X] I have added all required tests (Unit tests, E2E tests)

### Additional information

Kubernetes LoadBalancer services may expose a hostname instead of an IP
address, for example when using Docker Desktop:

    ingress:
      - hostname: localhost

`GetServiceIp` previously returned only `ingress.ip`, causing the deployment
command to receive a null address.

This change:

- Adds hostname support to the Kubernetes service model.
- Prefers the ingress IP when both IP and hostname are present.
- Falls back to the hostname when no IP is available.
- Continues waiting when neither value is ready.
- Adds unit tests for IP-only, hostname-only, both-values and empty-ingress cases.

### Testing

- `dotnet build`
- `dotnet test test/Cli/Func.UnitTests/Azure.Functions.Cli.UnitTests.csproj`