### PR TITLE
Update brace-expansion in publish-tools shrinkwrap

### DIFF
--- a/eng/tools/publish-tools/npm/npm-shrinkwrap.json
+++ b/eng/tools/publish-tools/npm/npm-shrinkwrap.json
@@ -84,15 +84,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer-crc32": {


### PR DESCRIPTION
Fixes #5503.

Bumps \`brace-expansion\` 5.0.6 -> 5.0.9 in \`eng/tools/publish-tools/npm/npm-shrinkwrap.json\`. No \`package.json\` change — minimatch's existing range already allows this version, the shrinkwrap was just stale (same as #5018).

cc @azure/azure-functions-core — would appreciate a look/merge when you get a chance.