### PR TITLE
Add diagnostic logging to worker resolution pipeline

### DIFF
--- a/src/Func/Commands/Start/Dashboard/Demo/DemoStartInitializationRunner.cs
+++ b/src/Func/Commands/Start/Dashboard/Demo/DemoStartInitializationRunner.cs
@@ -128,7 +128,10 @@ internal sealed class DemoStartInitializationRunner(
             new ResolveConstraintsInitializationStep(),
             new ValidateHostWorkloadInitializationStep(_hostWorkloadResolver, _workloadInstaller, _workloadPaths, _processEnvironment),
             new ResolveFunctionsProjectInitializationStep(_projectResolver),
-            new ResolveFunctionsWorkerInitializationStep(_workerResolverFactory, _workerInstaller),
+            new ResolveFunctionsWorkerInitializationStep(
+                _workerResolverFactory,
+                _workerInstaller,
+                _loggerFactory.CreateLogger<ResolveFunctionsWorkerInitializationStep>()),
             new ValidateExtensionBundleInitializationStep(
                 _bundleResolver,
                 _bundleSectionReader,

--- a/src/Func/Commands/Start/Initialization/Steps/ResolveFunctionsWorkerInitializationStep.cs
+++ b/src/Func/Commands/Start/Initialization/Steps/ResolveFunctionsWorkerInitializationStep.cs
@@ -7,6 +7,7 @@ using Azure.Functions.Cli.Workers;
 using Azure.Functions.Cli.Workloads.Catalog;
 using Azure.Functions.Cli.Workloads.Discovery;
 using Azure.Functions.Cli.Workloads.Install;
+using Microsoft.Extensions.Logging;
 using NuGet.Versioning;
 
 namespace Azure.Functions.Cli.Commands.Start.Initialization;
@@ -16,7 +17,8 @@ namespace Azure.Functions.Cli.Commands.Start.Initialization;
 /// </summary>
 internal sealed class ResolveFunctionsWorkerInitializationStep(
     IFunctionsWorkerResolverFactory workerResolverFactory,
-    IFunctionsWorkerInstaller workerInstaller) : FuncStartInitializationStep
+    IFunctionsWorkerInstaller workerInstaller,
+    ILogger<ResolveFunctionsWorkerInitializationStep> logger) : FuncStartInitializationStep
 {
     public const string StepId = "resolve_worker";
 
@@ -24,6 +26,9 @@ internal sealed class ResolveFunctionsWorkerInitializationStep(
         ?? throw new ArgumentNullException(nameof(workerResolverFactory));
 
     private readonly IFunctionsWorkerInstaller _workerInstaller = workerInstaller ?? throw new ArgumentNullException(nameof(workerInstaller));
+
+    private readonly ILogger<ResolveFunctionsWorkerInitializationStep> _logger = logger
+        ?? throw new ArgumentNullException(nameof(logger));
 
     public override string Id => StepId;
 
@@ -46,12 +51,21 @@ internal sealed class ResolveFunctionsWorkerInitializationStep(
             && TryGetInstallableWorker(notResolved.Failure, out FunctionsWorkerId? workerId)
             && workerId is not null)
         {
+            _logger.LogDebug(
+                "[worker-resolve] Initial resolution failed ({FailureType}): {Message}. Attempting install for '{WorkerId}'.",
+                notResolved.Failure.GetType().Name, notResolved.Failure.Message, workerId.Value);
             result = await TryInstallAndResolveWorkerAsync(context, workerId, workerVersionRanges, notResolved.Failure, cancellationToken);
         }
 
         if (result is not FunctionsWorkerResolutionResult.Resolved resolved)
         {
             var failedResult = (FunctionsWorkerResolutionResult.NotResolved)result;
+            _logger.LogWarning(
+                "[worker-resolve] Worker resolution failed. Profile: '{ProfileName}', worker version ranges: [{Ranges}], failure ({FailureType}): {Message}",
+                context.State.ResolvedProfile?.Name ?? "(none)",
+                string.Join(", ", workerVersionRanges.Select(kvp => $"{kvp.Key}={kvp.Value}")),
+                failedResult.Failure.GetType().Name,
+                failedResult.Failure.Message);
             throw CreateWorkerResolutionException(failedResult.Failure, context);
         }
 

--- a/src/Func/Commands/Start/Initialization/Steps/ResolveFunctionsWorkerInitializationStep.cs
+++ b/src/Func/Commands/Start/Initialization/Steps/ResolveFunctionsWorkerInitializationStep.cs
@@ -27,8 +27,7 @@ internal sealed class ResolveFunctionsWorkerInitializationStep(
 
     private readonly IFunctionsWorkerInstaller _workerInstaller = workerInstaller ?? throw new ArgumentNullException(nameof(workerInstaller));
 
-    private readonly ILogger<ResolveFunctionsWorkerInitializationStep> _logger = logger
-        ?? throw new ArgumentNullException(nameof(logger));
+    private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
     public override string Id => StepId;
 
@@ -51,17 +50,15 @@ internal sealed class ResolveFunctionsWorkerInitializationStep(
             && TryGetInstallableWorker(notResolved.Failure, out FunctionsWorkerId? workerId)
             && workerId is not null)
         {
-            _logger.LogDebug(
-                "[worker-resolve] Initial resolution failed ({FailureType}): {Message}. Attempting install for '{WorkerId}'.",
-                notResolved.Failure.GetType().Name, notResolved.Failure.Message, workerId.Value);
+            Log.ResolutionFailedAttemptingInstall(_logger, notResolved.Failure.GetType().Name, notResolved.Failure.Message, workerId.Value);
             result = await TryInstallAndResolveWorkerAsync(context, workerId, workerVersionRanges, notResolved.Failure, cancellationToken);
         }
 
         if (result is not FunctionsWorkerResolutionResult.Resolved resolved)
         {
             var failedResult = (FunctionsWorkerResolutionResult.NotResolved)result;
-            _logger.LogWarning(
-                "[worker-resolve] Worker resolution failed. Profile: '{ProfileName}', worker version ranges: [{Ranges}], failure ({FailureType}): {Message}",
+            Log.WorkerResolutionFailed(
+                _logger,
                 context.State.ResolvedProfile?.Name ?? "(none)",
                 string.Join(", ", workerVersionRanges.Select(kvp => $"{kvp.Key}={kvp.Value}")),
                 failedResult.Failure.GetType().Name,

--- a/src/Func/Workers/DefaultFunctionsWorkerContentResolver.cs
+++ b/src/Func/Workers/DefaultFunctionsWorkerContentResolver.cs
@@ -3,6 +3,7 @@
 
 using Azure.Functions.Cli.Workloads;
 using Azure.Functions.Cli.Workloads.Catalog;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NuGet.Versioning;
 
@@ -13,7 +14,8 @@ namespace Azure.Functions.Cli.Workers;
 /// </summary>
 internal sealed class DefaultFunctionsWorkerContentResolver(
     IWorkerConfigFileSystem workerConfigFileSystem,
-    IOptions<WorkloadCatalogOptions> catalogOptions) : IFunctionsWorkerContentResolver
+    IOptions<WorkloadCatalogOptions> catalogOptions,
+    ILogger<DefaultFunctionsWorkerContentResolver> logger) : IFunctionsWorkerContentResolver
 {
     private const string WorkerConfigFileName = "worker.config.json";
 
@@ -22,6 +24,9 @@ internal sealed class DefaultFunctionsWorkerContentResolver(
 
     private readonly WorkloadCatalogOptions _catalogOptions = catalogOptions?.Value
         ?? throw new ArgumentNullException(nameof(catalogOptions));
+
+    private readonly ILogger<DefaultFunctionsWorkerContentResolver> _logger = logger
+        ?? throw new ArgumentNullException(nameof(logger));
 
     public FunctionsWorkerResolutionResult ResolveWorker(
         FunctionsWorkerId workerId,
@@ -35,6 +40,7 @@ internal sealed class DefaultFunctionsWorkerContentResolver(
 
         if (installedWorkers.Count == 0)
         {
+            _logger.LogDebug("[worker-resolve] No installed workloads found for worker '{WorkerId}'.", workerId.Value);
             return NotInstalled(workerId);
         }
 
@@ -43,9 +49,19 @@ internal sealed class DefaultFunctionsWorkerContentResolver(
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (!NuGetVersion.TryParse(workload.PackageVersion, out NuGetVersion? version)
-                || !SatisfiesConstraint(version, versionConstraint))
+            if (!NuGetVersion.TryParse(workload.PackageVersion, out NuGetVersion? version))
             {
+                _logger.LogDebug(
+                    "[worker-resolve] Skipping workload '{PackageId}': version '{PackageVersion}' is not a valid NuGet version.",
+                    workload.PackageId, workload.PackageVersion);
+                continue;
+            }
+
+            if (!SatisfiesConstraint(version, versionConstraint))
+            {
+                _logger.LogDebug(
+                    "[worker-resolve] Skipping workload '{PackageId}' version '{Version}': does not satisfy constraint '{Constraint}'.",
+                    workload.PackageId, workload.PackageVersion, versionConstraint?.ToString() ?? "(none)");
                 continue;
             }
 
@@ -54,6 +70,11 @@ internal sealed class DefaultFunctionsWorkerContentResolver(
 
         if (candidates.Count == 0)
         {
+            _logger.LogWarning(
+                "[worker-resolve] No installed workloads for '{WorkerId}' satisfy version constraint '{Constraint}'. Installed: [{Packages}]",
+                workerId.Value,
+                versionConstraint?.ToString() ?? "(none)",
+                string.Join(", ", installedWorkers.Select(w => $"{w.PackageId}@{w.PackageVersion}")));
             return MissingCompatibleVersion(workerId, versionConstraint);
         }
 
@@ -64,6 +85,9 @@ internal sealed class DefaultFunctionsWorkerContentResolver(
         string workerConfigPath = Path.Combine(selected.Workload.ContentRoot, WorkerConfigFileName);
         if (!_workerConfigFileSystem.FileExists(workerConfigPath))
         {
+            _logger.LogWarning(
+                "[worker-resolve] Selected workload '{PackageId}' version '{Version}' is missing worker config at '{ConfigPath}'.",
+                selected.Workload.PackageId, selected.Version.ToNormalizedString(), workerConfigPath);
             return InvalidInstallation(workerId, selected, workerConfigPath);
         }
 

--- a/src/Func/Workers/DefaultFunctionsWorkerContentResolver.cs
+++ b/src/Func/Workers/DefaultFunctionsWorkerContentResolver.cs
@@ -25,8 +25,7 @@ internal sealed class DefaultFunctionsWorkerContentResolver(
     private readonly WorkloadCatalogOptions _catalogOptions = catalogOptions?.Value
         ?? throw new ArgumentNullException(nameof(catalogOptions));
 
-    private readonly ILogger<DefaultFunctionsWorkerContentResolver> _logger = logger
-        ?? throw new ArgumentNullException(nameof(logger));
+    private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
     public FunctionsWorkerResolutionResult ResolveWorker(
         FunctionsWorkerId workerId,
@@ -40,10 +39,7 @@ internal sealed class DefaultFunctionsWorkerContentResolver(
 
         if (installedWorkers.Count == 0)
         {
-            _logger.LogWarning(
-                "[worker-resolve] No installed workloads matched for worker '{WorkerId}'. "
-                + "The worker may be present on disk but not registered with the workload provider.",
-                workerId.Value);
+            Log.NoInstalledWorkloadsMatched(_logger, workerId.Value);
             return NotInstalled(workerId);
         }
 
@@ -54,17 +50,13 @@ internal sealed class DefaultFunctionsWorkerContentResolver(
 
             if (!NuGetVersion.TryParse(workload.PackageVersion, out NuGetVersion? version))
             {
-                _logger.LogDebug(
-                    "[worker-resolve] Skipping workload '{PackageId}': version '{PackageVersion}' is not a valid NuGet version.",
-                    workload.PackageId, workload.PackageVersion);
+                Log.SkippingInvalidVersion(_logger, workload.PackageId, workload.PackageVersion);
                 continue;
             }
 
             if (!SatisfiesConstraint(version, versionConstraint))
             {
-                _logger.LogDebug(
-                    "[worker-resolve] Skipping workload '{PackageId}' version '{PackageVersion}': does not satisfy constraint '{Constraint}'.",
-                    workload.PackageId, version.ToNormalizedString(), versionConstraint?.ToString() ?? "(none)");
+                Log.SkippingConstraintMismatch(_logger, workload.PackageId, version.ToNormalizedString(), versionConstraint?.ToString() ?? "(none)");
                 continue;
             }
 
@@ -73,8 +65,8 @@ internal sealed class DefaultFunctionsWorkerContentResolver(
 
         if (candidates.Count == 0)
         {
-            _logger.LogWarning(
-                "[worker-resolve] No installed workloads for '{WorkerId}' satisfy version constraint '{Constraint}'. Installed: [{Packages}]",
+            Log.NoCompatibleVersion(
+                _logger,
                 workerId.Value,
                 versionConstraint?.ToString() ?? "(none)",
                 string.Join(", ", installedWorkers.Select(w => $"{w.PackageId}@{w.PackageVersion}")));
@@ -88,9 +80,7 @@ internal sealed class DefaultFunctionsWorkerContentResolver(
         string workerConfigPath = Path.Combine(selected.Workload.ContentRoot, WorkerConfigFileName);
         if (!_workerConfigFileSystem.FileExists(workerConfigPath))
         {
-            _logger.LogWarning(
-                "[worker-resolve] Selected workload '{PackageId}' version '{Version}' is missing worker config at '{ConfigPath}'.",
-                selected.Workload.PackageId, selected.Version.ToNormalizedString(), workerConfigPath);
+            Log.MissingWorkerConfig(_logger, selected.Workload.PackageId, selected.Version.ToNormalizedString(), workerConfigPath);
             return InvalidInstallation(workerId, selected, workerConfigPath);
         }
 

--- a/src/Func/Workers/DefaultFunctionsWorkerContentResolver.cs
+++ b/src/Func/Workers/DefaultFunctionsWorkerContentResolver.cs
@@ -40,7 +40,10 @@ internal sealed class DefaultFunctionsWorkerContentResolver(
 
         if (installedWorkers.Count == 0)
         {
-            _logger.LogDebug("[worker-resolve] No installed workloads found for worker '{WorkerId}'.", workerId.Value);
+            _logger.LogWarning(
+                "[worker-resolve] No installed workloads matched for worker '{WorkerId}'. "
+                + "The worker may be present on disk but not registered with the workload provider.",
+                workerId.Value);
             return NotInstalled(workerId);
         }
 
@@ -60,8 +63,8 @@ internal sealed class DefaultFunctionsWorkerContentResolver(
             if (!SatisfiesConstraint(version, versionConstraint))
             {
                 _logger.LogDebug(
-                    "[worker-resolve] Skipping workload '{PackageId}' version '{Version}': does not satisfy constraint '{Constraint}'.",
-                    workload.PackageId, workload.PackageVersion, versionConstraint?.ToString() ?? "(none)");
+                    "[worker-resolve] Skipping workload '{PackageId}' version '{PackageVersion}': does not satisfy constraint '{Constraint}'.",
+                    workload.PackageId, version.ToNormalizedString(), versionConstraint?.ToString() ?? "(none)");
                 continue;
             }
 

--- a/src/Func/Workers/DefaultFunctionsWorkerResolver.cs
+++ b/src/Func/Workers/DefaultFunctionsWorkerResolver.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Workloads;
+using Microsoft.Extensions.Logging;
 using NuGet.Versioning;
 
 namespace Azure.Functions.Cli.Workers;
@@ -12,11 +13,13 @@ namespace Azure.Functions.Cli.Workers;
 internal sealed class DefaultFunctionsWorkerResolver(
     IWorkloadProvider workloadProvider,
     IFunctionsWorkerContentResolver workerContentResolver,
+    ILogger<DefaultFunctionsWorkerResolver> logger,
     IReadOnlyDictionary<string, VersionRange>? activeWorkerConstraints = null) : IFunctionsWorkerResolver
 {
     private readonly IWorkloadProvider _workloadProvider = workloadProvider ?? throw new ArgumentNullException(nameof(workloadProvider));
     private readonly IFunctionsWorkerContentResolver _workerContentResolver = workerContentResolver
         ?? throw new ArgumentNullException(nameof(workerContentResolver));
+    private readonly ILogger<DefaultFunctionsWorkerResolver> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     private readonly IReadOnlyDictionary<string, VersionRange> _activeWorkerConstraints =
         activeWorkerConstraints is null
             ? new Dictionary<string, VersionRange>(StringComparer.OrdinalIgnoreCase)
@@ -28,8 +31,15 @@ internal sealed class DefaultFunctionsWorkerResolver(
         cancellationToken.ThrowIfCancellationRequested();
 
         _activeWorkerConstraints.TryGetValue(workerId.Value, out VersionRange? constraint);
+        _logger.LogDebug(
+            "[worker-resolve] Resolving worker '{WorkerId}' with constraint '{Constraint}'.",
+            workerId.Value, constraint?.ToString() ?? "(none)");
 
         IReadOnlyList<ContentWorkloadInfo> installedWorkers = GetWorkerWorkloads(workerId);
+        _logger.LogDebug(
+            "[worker-resolve] Workload search for '{WorkerId}' found {Count} candidate(s).",
+            workerId.Value, installedWorkers.Count);
+
         return Task.FromResult(_workerContentResolver.ResolveWorker(workerId, installedWorkers, constraint, cancellationToken));
     }
 

--- a/src/Func/Workers/DefaultFunctionsWorkerResolver.cs
+++ b/src/Func/Workers/DefaultFunctionsWorkerResolver.cs
@@ -13,13 +13,13 @@ namespace Azure.Functions.Cli.Workers;
 internal sealed class DefaultFunctionsWorkerResolver(
     IWorkloadProvider workloadProvider,
     IFunctionsWorkerContentResolver workerContentResolver,
-    ILogger<DefaultFunctionsWorkerResolver> logger,
+    ILogger logger,
     IReadOnlyDictionary<string, VersionRange>? activeWorkerConstraints = null) : IFunctionsWorkerResolver
 {
     private readonly IWorkloadProvider _workloadProvider = workloadProvider ?? throw new ArgumentNullException(nameof(workloadProvider));
     private readonly IFunctionsWorkerContentResolver _workerContentResolver = workerContentResolver
         ?? throw new ArgumentNullException(nameof(workerContentResolver));
-    private readonly ILogger<DefaultFunctionsWorkerResolver> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     private readonly IReadOnlyDictionary<string, VersionRange> _activeWorkerConstraints =
         activeWorkerConstraints is null
             ? new Dictionary<string, VersionRange>(StringComparer.OrdinalIgnoreCase)
@@ -39,9 +39,8 @@ internal sealed class DefaultFunctionsWorkerResolver(
         if (installedWorkers.Count == 0)
         {
             IReadOnlyList<ContentWorkloadInfo> allWorkloads = _workloadProvider.GetContentWorkloads();
-            _logger.LogWarning(
-                "[worker-resolve] No workloads found for worker '{WorkerId}'. Searched package ID '{PackageId}' and alias '{Alias}'. "
-                + "Provider has {TotalCount} content workload(s): [{AllWorkloads}]",
+            Log.WorkloadSearchEmpty(
+                _logger,
                 workerId.Value,
                 packageId,
                 alias,

--- a/src/Func/Workers/DefaultFunctionsWorkerResolver.cs
+++ b/src/Func/Workers/DefaultFunctionsWorkerResolver.cs
@@ -31,22 +31,29 @@ internal sealed class DefaultFunctionsWorkerResolver(
         cancellationToken.ThrowIfCancellationRequested();
 
         _activeWorkerConstraints.TryGetValue(workerId.Value, out VersionRange? constraint);
-        _logger.LogDebug(
-            "[worker-resolve] Resolving worker '{WorkerId}' with constraint '{Constraint}'.",
-            workerId.Value, constraint?.ToString() ?? "(none)");
 
-        IReadOnlyList<ContentWorkloadInfo> installedWorkers = GetWorkerWorkloads(workerId);
-        _logger.LogDebug(
-            "[worker-resolve] Workload search for '{WorkerId}' found {Count} candidate(s).",
-            workerId.Value, installedWorkers.Count);
+        string packageId = FunctionsWorkerWorkloadPackages.GetPackageId(workerId);
+        string alias = GetWorkerAlias(workerId);
+        IReadOnlyList<ContentWorkloadInfo> installedWorkers = GetWorkerWorkloads(workerId, packageId, alias);
+
+        if (installedWorkers.Count == 0)
+        {
+            IReadOnlyList<ContentWorkloadInfo> allWorkloads = _workloadProvider.GetContentWorkloads();
+            _logger.LogWarning(
+                "[worker-resolve] No workloads found for worker '{WorkerId}'. Searched package ID '{PackageId}' and alias '{Alias}'. "
+                + "Provider has {TotalCount} content workload(s): [{AllWorkloads}]",
+                workerId.Value,
+                packageId,
+                alias,
+                allWorkloads.Count,
+                string.Join(", ", allWorkloads.Select(w => $"{w.PackageId}@{w.PackageVersion} (aliases: {string.Join(";", w.Aliases)})")));
+        }
 
         return Task.FromResult(_workerContentResolver.ResolveWorker(workerId, installedWorkers, constraint, cancellationToken));
     }
 
-    private IReadOnlyList<ContentWorkloadInfo> GetWorkerWorkloads(FunctionsWorkerId workerId)
+    private IReadOnlyList<ContentWorkloadInfo> GetWorkerWorkloads(FunctionsWorkerId workerId, string packageId, string alias)
     {
-        string packageId = FunctionsWorkerWorkloadPackages.GetPackageId(workerId);
-        string alias = GetWorkerAlias(workerId);
         List<ContentWorkloadInfo> workloads = [];
         AddDistinct(workloads, _workloadProvider.GetContentWorkloadsByPackageId(packageId));
 

--- a/src/Func/Workers/DefaultFunctionsWorkerResolverFactory.cs
+++ b/src/Func/Workers/DefaultFunctionsWorkerResolverFactory.cs
@@ -18,7 +18,7 @@ internal sealed class DefaultFunctionsWorkerResolverFactory(
     private readonly IWorkloadProvider _workloadProvider = workloadProvider ?? throw new ArgumentNullException(nameof(workloadProvider));
     private readonly IFunctionsWorkerContentResolver _workerContentResolver = workerContentResolver
         ?? throw new ArgumentNullException(nameof(workerContentResolver));
-    private readonly ILogger<DefaultFunctionsWorkerResolver> _resolverLogger = resolverLogger
+    private readonly ILogger _resolverLogger = resolverLogger
         ?? throw new ArgumentNullException(nameof(resolverLogger));
 
     public IFunctionsWorkerResolver Create(IReadOnlyDictionary<string, VersionRange> workerVersionRanges)

--- a/src/Func/Workers/DefaultFunctionsWorkerResolverFactory.cs
+++ b/src/Func/Workers/DefaultFunctionsWorkerResolverFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Workloads;
+using Microsoft.Extensions.Logging;
 using NuGet.Versioning;
 
 namespace Azure.Functions.Cli.Workers;
@@ -11,11 +12,14 @@ namespace Azure.Functions.Cli.Workers;
 /// </summary>
 internal sealed class DefaultFunctionsWorkerResolverFactory(
     IWorkloadProvider workloadProvider,
-    IFunctionsWorkerContentResolver workerContentResolver) : IFunctionsWorkerResolverFactory
+    IFunctionsWorkerContentResolver workerContentResolver,
+    ILogger<DefaultFunctionsWorkerResolver> resolverLogger) : IFunctionsWorkerResolverFactory
 {
     private readonly IWorkloadProvider _workloadProvider = workloadProvider ?? throw new ArgumentNullException(nameof(workloadProvider));
     private readonly IFunctionsWorkerContentResolver _workerContentResolver = workerContentResolver
         ?? throw new ArgumentNullException(nameof(workerContentResolver));
+    private readonly ILogger<DefaultFunctionsWorkerResolver> _resolverLogger = resolverLogger
+        ?? throw new ArgumentNullException(nameof(resolverLogger));
 
     public IFunctionsWorkerResolver Create(IReadOnlyDictionary<string, VersionRange> workerVersionRanges)
     {
@@ -24,6 +28,7 @@ internal sealed class DefaultFunctionsWorkerResolverFactory(
         return new DefaultFunctionsWorkerResolver(
             _workloadProvider,
             _workerContentResolver,
+            _resolverLogger,
             workerVersionRanges);
     }
 }

--- a/src/Func/Workers/Log.cs
+++ b/src/Func/Workers/Log.cs
@@ -1,0 +1,47 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Functions.Cli.Workers;
+
+/// <summary>
+/// Source-generated log messages for worker resolution diagnostics.
+/// </summary>
+internal static partial class Log
+{
+    [LoggerMessage(Level = LogLevel.Warning, Message =
+        "[worker-resolve] No workloads found for worker '{WorkerId}'. Searched package ID '{PackageId}' and alias '{Alias}'. "
+        + "Provider has {TotalCount} content workload(s): [{AllWorkloads}]")]
+    public static partial void WorkloadSearchEmpty(
+        ILogger logger, string workerId, string packageId, string alias, int totalCount, string allWorkloads);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message =
+        "[worker-resolve] No installed workloads matched for worker '{WorkerId}'. "
+        + "The worker may be present on disk but not registered with the workload provider.")]
+    public static partial void NoInstalledWorkloadsMatched(ILogger logger, string workerId);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message =
+        "[worker-resolve] Skipping workload '{PackageId}': version '{PackageVersion}' is not a valid NuGet version.")]
+    public static partial void SkippingInvalidVersion(ILogger logger, string packageId, string packageVersion);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message =
+        "[worker-resolve] Skipping workload '{PackageId}' version '{PackageVersion}': does not satisfy constraint '{Constraint}'.")]
+    public static partial void SkippingConstraintMismatch(ILogger logger, string packageId, string packageVersion, string constraint);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message =
+        "[worker-resolve] No installed workloads for '{WorkerId}' satisfy version constraint '{Constraint}'. Installed: [{Packages}]")]
+    public static partial void NoCompatibleVersion(ILogger logger, string workerId, string constraint, string packages);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message =
+        "[worker-resolve] Selected workload '{PackageId}' version '{Version}' is missing worker config at '{ConfigPath}'.")]
+    public static partial void MissingWorkerConfig(ILogger logger, string packageId, string version, string configPath);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message =
+        "[worker-resolve] Initial resolution failed ({FailureType}): {Message}. Attempting install for '{WorkerId}'.")]
+    public static partial void ResolutionFailedAttemptingInstall(ILogger logger, string failureType, string message, string workerId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message =
+        "[worker-resolve] Worker resolution failed. Profile: '{ProfileName}', worker version ranges: [{Ranges}], failure ({FailureType}): {Message}")]
+    public static partial void WorkerResolutionFailed(ILogger logger, string profileName, string ranges, string failureType, string message);
+}

--- a/test/Func.Tests/Workers/DefaultFunctionsWorkerInstallerTests.cs
+++ b/test/Func.Tests/Workers/DefaultFunctionsWorkerInstallerTests.cs
@@ -7,6 +7,7 @@ using Azure.Functions.Cli.Workloads.Catalog;
 using Azure.Functions.Cli.Workloads.Discovery;
 using Azure.Functions.Cli.Workloads.Install;
 using Azure.Functions.Cli.Workloads.Storage;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using NuGet.Configuration;
@@ -175,7 +176,7 @@ public class DefaultFunctionsWorkerInstallerTests
     [Fact]
     public void Ctor_NullDependencies_Throw()
     {
-        var contentResolver = new DefaultFunctionsWorkerContentResolver(_fileSystem, Options.Create(new WorkloadCatalogOptions()));
+        var contentResolver = new DefaultFunctionsWorkerContentResolver(_fileSystem, Options.Create(new WorkloadCatalogOptions()), NullLogger<DefaultFunctionsWorkerContentResolver>.Instance);
 
         FluentActions.Invoking(() => new DefaultFunctionsWorkerInstaller(null!, _workloadInstaller, _workloadPaths, contentResolver)).Should().ThrowExactly<ArgumentNullException>();
         FluentActions.Invoking(() => new DefaultFunctionsWorkerInstaller(_workloadCatalog, null!, _workloadPaths, contentResolver)).Should().ThrowExactly<ArgumentNullException>();
@@ -185,7 +186,7 @@ public class DefaultFunctionsWorkerInstallerTests
 
     private DefaultFunctionsWorkerInstaller CreateInstaller()
     {
-        var contentResolver = new DefaultFunctionsWorkerContentResolver(_fileSystem, Options.Create(new WorkloadCatalogOptions()));
+        var contentResolver = new DefaultFunctionsWorkerContentResolver(_fileSystem, Options.Create(new WorkloadCatalogOptions()), NullLogger<DefaultFunctionsWorkerContentResolver>.Instance);
         return new DefaultFunctionsWorkerInstaller(_workloadCatalog, _workloadInstaller, _workloadPaths, contentResolver);
     }
 

--- a/test/Func.Tests/Workers/DefaultFunctionsWorkerResolverTests.cs
+++ b/test/Func.Tests/Workers/DefaultFunctionsWorkerResolverTests.cs
@@ -4,6 +4,8 @@
 using Azure.Functions.Cli.Workers;
 using Azure.Functions.Cli.Workloads;
 using Azure.Functions.Cli.Workloads.Catalog;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using NuGet.Versioning;
@@ -250,25 +252,25 @@ public class DefaultFunctionsWorkerResolverTests
     [Fact]
     public void Ctor_NullWorkloadProvider_Throws()
     {
-        FluentActions.Invoking(() => new DefaultFunctionsWorkerResolver(null!, CreateContentResolver())).Should().ThrowExactly<ArgumentNullException>();
+        FluentActions.Invoking(() => new DefaultFunctionsWorkerResolver(null!, CreateContentResolver(), NullLogger<DefaultFunctionsWorkerResolver>.Instance)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
     public void Ctor_NullContentResolver_Throws()
     {
-        FluentActions.Invoking(() => new DefaultFunctionsWorkerResolver(_workloads, null!)).Should().ThrowExactly<ArgumentNullException>();
+        FluentActions.Invoking(() => new DefaultFunctionsWorkerResolver(_workloads, null!, NullLogger<DefaultFunctionsWorkerResolver>.Instance)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
     public void ContentResolverCtor_NullWorkerConfigFileSystem_Throws()
     {
-        FluentActions.Invoking(() => new DefaultFunctionsWorkerContentResolver(null!, Options.Create(new WorkloadCatalogOptions()))).Should().ThrowExactly<ArgumentNullException>();
+        FluentActions.Invoking(() => new DefaultFunctionsWorkerContentResolver(null!, Options.Create(new WorkloadCatalogOptions()), NullLogger<DefaultFunctionsWorkerContentResolver>.Instance)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
     public void ContentResolverCtor_NullCatalogOptions_Throws()
     {
-        FluentActions.Invoking(() => new DefaultFunctionsWorkerContentResolver(_fileSystem, null!)).Should().ThrowExactly<ArgumentNullException>();
+        FluentActions.Invoking(() => new DefaultFunctionsWorkerContentResolver(_fileSystem, null!, NullLogger<DefaultFunctionsWorkerContentResolver>.Instance)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
@@ -325,10 +327,10 @@ public class DefaultFunctionsWorkerResolverTests
     private DefaultFunctionsWorkerResolver CreateResolver(
         IReadOnlyDictionary<string, VersionRange>? workerVersionRanges = null,
         bool includePrerelease = false)
-        => new(_workloads, CreateContentResolver(includePrerelease), workerVersionRanges);
+        => new(_workloads, CreateContentResolver(includePrerelease), NullLogger<DefaultFunctionsWorkerResolver>.Instance, workerVersionRanges);
 
     private DefaultFunctionsWorkerContentResolver CreateContentResolver(bool includePrerelease = false)
-        => new(_fileSystem, Options.Create(new WorkloadCatalogOptions { IncludePrerelease = includePrerelease }));
+        => new(_fileSystem, Options.Create(new WorkloadCatalogOptions { IncludePrerelease = includePrerelease }), NullLogger<DefaultFunctionsWorkerContentResolver>.Instance);
 
     private static ContentWorkloadInfo CreateContentWorkload(string packageId, string packageVersion, IReadOnlyList<string>? aliases = null)
     {

--- a/test/Func.Tests/Workers/DefaultFunctionsWorkerResolverTests.cs
+++ b/test/Func.Tests/Workers/DefaultFunctionsWorkerResolverTests.cs
@@ -4,7 +4,6 @@
 using Azure.Functions.Cli.Workers;
 using Azure.Functions.Cli.Workloads;
 using Azure.Functions.Cli.Workloads.Catalog;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;


### PR DESCRIPTION
## Summary

Adds structured `ILogger` diagnostics to the worker resolution path to help investigate [#5218](https://github.com/Azure/azure-functions-core-tools/issues/5218) — intermittent worker resolution failures where `func run` fails to find a worker that is present on disk.

**This PR adds diagnostics only.** The confidence on the root cause is low, and no behavioral fix is included. The logging will help capture the resolution state when the failure reproduces.

## Changes

Logging is added to three components in the worker resolution pipeline:

| Component | What's logged | Level |
|---|---|---|
| `DefaultFunctionsWorkerContentResolver` | Installed workloads found, per-candidate version constraint filtering (with skip reasons), selected candidate, missing `worker.config.json` | Debug / Warning |
| `DefaultFunctionsWorkerResolver` | Active constraint for the worker ID, workload search results (package ID + alias lookup) | Debug |
| `ResolveFunctionsWorkerInitializationStep` | Active profile name, worker version ranges, install-fallback attempts, final failure type and message | Debug / Warning |

All log calls use structured templates (`{WorkerId}`, `{PackageId}`, etc.). No user-facing behavior changes.

## Test validation

- All 26 `DefaultFunctionsWorker*` tests pass
- All 23 `StartInitialization` tests pass
- Zero build warnings
