### PR TITLE
refactor: decompose NewCommandRunner

### DIFF
--- a/src/Func/Commands/NewCommand.cs
+++ b/src/Func/Commands/NewCommand.cs
@@ -12,9 +12,7 @@ namespace Azure.Functions.Cli.Commands;
 /// <c>func new</c> — scaffolds a new function from an installed templates
 /// content workload, or lists available templates when <c>--list</c> is
 /// supplied. Wires the command surface and delegates to
-/// <see cref="NewCommandRunner"/>, which currently terminates at
-/// the engine-dispatch step until <see cref="ITemplateEngineProvider"/>
-/// implementations exist.
+/// <see cref="INewCommandRunner"/> and the template option provider.
 /// </summary>
 internal sealed class NewCommand : FuncCliCommand, IBuiltInCommand, ITemplateAwareHelpProvider
 {
@@ -48,7 +46,8 @@ internal sealed class NewCommand : FuncCliCommand, IBuiltInCommand, ITemplateAwa
         Description = "Output mode (plain | json). Defaults to plain.",
     };
 
-    private readonly NewCommandRunner _runner;
+    private readonly INewCommandRunner _runner;
+    private readonly INewCommandTemplateOptionProvider _templateOptions;
     private readonly HashSet<string> _builtInOptionNames;
     private readonly Dictionary<string, string> _optionNameToPromptId = new(StringComparer.OrdinalIgnoreCase);
 
@@ -58,10 +57,11 @@ internal sealed class NewCommand : FuncCliCommand, IBuiltInCommand, ITemplateAwa
     // GetTemplateHelpInfo) to title the "Template Options (<id>)" section.
     private string? _attachedTemplateId;
 
-    public NewCommand(NewCommandRunner runner)
+    public NewCommand(INewCommandRunner runner, INewCommandTemplateOptionProvider templateOptions)
         : base("new", "Create a new function from a template.")
     {
         _runner = runner ?? throw new ArgumentNullException(nameof(runner));
+        _templateOptions = templateOptions ?? throw new ArgumentNullException(nameof(templateOptions));
 
         AddPathArgument();
         Options.Add(NameOption);
@@ -195,7 +195,7 @@ internal sealed class NewCommand : FuncCliCommand, IBuiltInCommand, ITemplateAwa
                 Force: false,
                 NonInteractive: true);
 
-            hydrated = _runner.HydrateOptionsForTemplateAsync(invocation, templateId, CancellationToken.None)
+            hydrated = _templateOptions.HydrateOptionsForTemplateAsync(invocation, templateId, CancellationToken.None)
                 .GetAwaiter().GetResult();
         }
         catch
@@ -283,7 +283,7 @@ internal sealed class NewCommand : FuncCliCommand, IBuiltInCommand, ITemplateAwa
         IReadOnlyList<HydratedTemplateOption>? hydrated;
         try
         {
-            hydrated = _runner.HydrateOptionsForTemplateWithIdsAsync(invocation, templateId, CancellationToken.None)
+            hydrated = _templateOptions.HydrateOptionsForTemplateWithIdsAsync(invocation, templateId, CancellationToken.None)
                 .GetAwaiter().GetResult();
         }
         catch
@@ -381,7 +381,7 @@ internal sealed class NewCommand : FuncCliCommand, IBuiltInCommand, ITemplateAwa
         IReadOnlyList<Option>? hydrated;
         try
         {
-            hydrated = _runner.HydrateOptionsForTemplateAsync(invocation, templateId, CancellationToken.None)
+            hydrated = _templateOptions.HydrateOptionsForTemplateAsync(invocation, templateId, CancellationToken.None)
                 .GetAwaiter().GetResult();
         }
         catch

--- a/src/Func/Templates/NewCommandBundleValidator.cs
+++ b/src/Func/Templates/NewCommandBundleValidator.cs
@@ -1,0 +1,120 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Bundles;
+using Azure.Functions.Cli.Console;
+
+namespace Azure.Functions.Cli.Templates;
+
+internal interface INewCommandBundleValidator
+{
+    public Task<int> ValidateAsync(NewCommandResolvedContext context, CancellationToken cancellationToken);
+}
+
+internal sealed class NewCommandBundleValidator(
+    IInteractionService interaction,
+    IHostJsonBundleSectionReader hostJsonReader,
+    IExtensionBundleResolver bundleResolver,
+    ITemplatesWorkloadManifestReader manifestReader) : INewCommandBundleValidator
+{
+    private readonly IInteractionService _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
+    private readonly IHostJsonBundleSectionReader _hostJsonReader = hostJsonReader ?? throw new ArgumentNullException(nameof(hostJsonReader));
+    private readonly IExtensionBundleResolver _bundleResolver = bundleResolver ?? throw new ArgumentNullException(nameof(bundleResolver));
+    private readonly ITemplatesWorkloadManifestReader _manifestReader = manifestReader ?? throw new ArgumentNullException(nameof(manifestReader));
+
+    public async Task<int> ValidateAsync(NewCommandResolvedContext context, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (string.Equals(context.Stack, "dotnet", StringComparison.OrdinalIgnoreCase)
+            || context.BundleId is null)
+        {
+            return 0;
+        }
+
+        HostJsonBundleSection? section = await _hostJsonReader.ReadAsync(context.WorkingDirectory.Info, cancellationToken);
+        if (section is null)
+        {
+            return 0;
+        }
+
+        var projectContext = new ExtensionBundleProjectContext(
+            BundleId: section.Id,
+            HostJsonVersionRange: section.Version,
+            WorkerRuntime: context.Stack,
+            ProfileName: null,
+            ProfileBundleVersionRange: null);
+
+        ExtensionBundleResolution resolution = await _bundleResolver.ResolveAsync(projectContext, cancellationToken);
+        switch (resolution)
+        {
+            case ExtensionBundleResolution.Resolved bundleResolved:
+                string? minRange = _manifestReader.GetMinBundleVersion(context.Workload.InstallDirectory);
+                if (!string.IsNullOrWhiteSpace(minRange)
+                    && !VersionRangeContains(minRange, bundleResolved.Version))
+                {
+                    _interaction.WriteError(
+                        $"Installed templates workload '{context.Workload.PackageVersion}' requires " +
+                        $"extension bundle in range '{minRange}', but the project resolves to '{bundleResolved.Version}'.");
+                    _interaction.WriteLine(line => line
+                        .Muted("Update the bundle range in ")
+                        .Code("host.json")
+                        .Muted(" or install an older templates workload pkg version."));
+                    return 1;
+                }
+
+                return 0;
+
+            case ExtensionBundleResolution.WorkloadMissing:
+            case ExtensionBundleResolution.EmptyIntersection:
+                _interaction.WriteError("The project requires an extension bundle but none is resolvable.");
+                _interaction.WriteLine(line => line
+                    .Muted("Install one with: ")
+                    .Code("func workload install Azure.Functions.Cli.Workloads.ExtensionBundles")
+                    .Muted(" or run ")
+                    .Code("func setup")
+                    .Muted("."));
+                return 1;
+
+            default:
+                return 0;
+        }
+    }
+
+    internal static bool VersionRangeContains(string range, string version)
+    {
+        if (string.IsNullOrWhiteSpace(range) || string.IsNullOrWhiteSpace(version))
+        {
+            return true;
+        }
+
+        string trimmed = range.Trim();
+        string lowerBound = trimmed;
+        if (trimmed.StartsWith('[') || trimmed.StartsWith('('))
+        {
+            int comma = trimmed.IndexOf(',');
+            lowerBound = comma > 1
+                ? trimmed[1..comma].Trim()
+                : trimmed.Trim('[', '(', ']', ')').Trim();
+        }
+
+        return CompareVersions(version, lowerBound) >= 0;
+    }
+
+    private static int CompareVersions(string first, string second)
+    {
+        if (Version.TryParse(StripPrerelease(first), out Version? firstVersion)
+            && Version.TryParse(StripPrerelease(second), out Version? secondVersion))
+        {
+            return firstVersion.CompareTo(secondVersion);
+        }
+
+        return string.Compare(first, second, StringComparison.Ordinal);
+    }
+
+    private static string StripPrerelease(string version)
+    {
+        int dash = version.IndexOf('-');
+        return dash < 0 ? version : version[..dash];
+    }
+}

--- a/src/Func/Templates/NewCommandContextResolver.cs
+++ b/src/Func/Templates/NewCommandContextResolver.cs
@@ -143,6 +143,14 @@ internal sealed class NewCommandContextResolver(
             .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// Reads the configured language, falling back to the stack's single
+    /// canonical language on single-language stacks.
+    /// </summary>
+    /// <remarks>
+    /// Returns <c>null</c> for a multi-language stack with no configured
+    /// language. Callers treat that as a hard error pointing at <c>func init</c>.
+    /// </remarks>
     private string? ResolveLanguage(string stack, StackOptions stackOptions)
     {
         if (!string.IsNullOrWhiteSpace(stackOptions.Language))

--- a/src/Func/Templates/NewCommandContextResolver.cs
+++ b/src/Func/Templates/NewCommandContextResolver.cs
@@ -1,0 +1,204 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Bundles;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Configuration;
+using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Profiles;
+using Azure.Functions.Cli.Projects;
+using Microsoft.Extensions.Options;
+
+namespace Azure.Functions.Cli.Templates;
+
+internal interface INewCommandContextResolver
+{
+    public Task<NewCommandResolutionResult> ResolveAsync(NewInvocation invocation, CancellationToken cancellationToken);
+}
+
+internal sealed class NewCommandContextResolver(
+    IInteractionService interaction,
+    IFunctionsProjectResolver projectResolver,
+    IProfileResolver profileResolver,
+    IOptionsMonitor<StackOptions> stackOptions,
+    IEnumerable<IProjectInitializer> projectInitializers,
+    IInstalledTemplatesWorkloads installedTemplatesWorkloads,
+    IHostJsonBundleSectionReader hostJsonReader) : INewCommandContextResolver
+{
+    private readonly IInteractionService _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
+    private readonly IFunctionsProjectResolver _projectResolver = projectResolver ?? throw new ArgumentNullException(nameof(projectResolver));
+    private readonly IProfileResolver _profileResolver = profileResolver ?? throw new ArgumentNullException(nameof(profileResolver));
+    private readonly IOptionsMonitor<StackOptions> _stackOptions = stackOptions ?? throw new ArgumentNullException(nameof(stackOptions));
+    private readonly IReadOnlyDictionary<string, IProjectInitializer> _projectInitializersByStack = BuildProjectInitializersByStack(projectInitializers);
+    private readonly IInstalledTemplatesWorkloads _installedTemplatesWorkloads = installedTemplatesWorkloads ?? throw new ArgumentNullException(nameof(installedTemplatesWorkloads));
+    private readonly IHostJsonBundleSectionReader _hostJsonReader = hostJsonReader ?? throw new ArgumentNullException(nameof(hostJsonReader));
+
+    public async Task<NewCommandResolutionResult> ResolveAsync(NewInvocation invocation, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(invocation);
+
+        await _profileResolver.ResolveAsync(
+            new ProfileResolutionContext(
+                invocation.WorkingDirectory.Info,
+                RequestedProfileName: null,
+                CanPrompt: _interaction.IsInteractive),
+            cancellationToken);
+
+        ProjectResolutionResult projectResult = await _projectResolver.ResolveProjectAsync(
+            new ProjectResolutionContext(invocation.WorkingDirectory),
+            cancellationToken);
+
+        if (projectResult is not ProjectResolutionResult.Resolved resolved)
+        {
+            return NewCommandResolutionResult.Fail(new NewCommandResolutionFailure(NewCommandResolutionFailureKind.ProjectRequired));
+        }
+
+        string stack = resolved.Project.StackName;
+        InstalledTemplatesWorkload? workload;
+        string? bundleId = null;
+        BundleChannel channel = BundleChannel.Unknown;
+        bool usedStableFallback = false;
+
+        if (string.Equals(stack, "dotnet", StringComparison.OrdinalIgnoreCase))
+        {
+            IReadOnlyList<InstalledTemplatesWorkload> allRows =
+                await _installedTemplatesWorkloads.ListInstalledAsync(stack, cancellationToken);
+            workload = allRows
+                .OrderByDescending(row => row.PackageVersion, StringComparer.Ordinal)
+                .FirstOrDefault();
+        }
+        else
+        {
+            HostJsonBundleSection? section = await _hostJsonReader.ReadAsync(invocation.WorkingDirectory.Info, cancellationToken);
+            if (section is null || string.IsNullOrWhiteSpace(section.Id))
+            {
+                return NewCommandResolutionResult.Fail(
+                    new NewCommandResolutionFailure(NewCommandResolutionFailureKind.HostJsonBundleMissing));
+            }
+
+            bundleId = section.Id;
+            if (!BundleHelpers.TryGetBundleChannel(bundleId, out channel))
+            {
+                return NewCommandResolutionResult.Fail(new NewCommandResolutionFailure(
+                    NewCommandResolutionFailureKind.UnrecognisedBundleId,
+                    BundleId: bundleId));
+            }
+
+            IReadOnlyList<InstalledTemplatesWorkload> allRows =
+                await _installedTemplatesWorkloads.ListInstalledAsync(stack, cancellationToken);
+            workload = TemplatesChannelMapper.PickChannelMatched(allRows, channel);
+
+            if (workload is null && channel != BundleChannel.Stable)
+            {
+                workload = TemplatesChannelMapper.PickChannelMatched(allRows, BundleChannel.Stable);
+                usedStableFallback = workload is not null;
+            }
+        }
+
+        if (workload is null)
+        {
+            if (channel is BundleChannel.Unknown)
+            {
+                return NewCommandResolutionResult.Fail(new NewCommandResolutionFailure(
+                    NewCommandResolutionFailureKind.NoTemplatesWorkloadInstalled,
+                    Stack: stack));
+            }
+
+            return NewCommandResolutionResult.Fail(new NewCommandResolutionFailure(
+                NewCommandResolutionFailureKind.NoTemplatesWorkloadForChannel,
+                Stack: stack,
+                BundleId: bundleId,
+                Channel: channel));
+        }
+
+        string projectDirectory = Path.GetFullPath(invocation.WorkingDirectory.Info.FullName);
+        StackOptions stackOptionsBound = _stackOptions.Get(projectDirectory);
+        string? language = ResolveLanguage(stack, stackOptionsBound);
+        if (language is null)
+        {
+            return NewCommandResolutionResult.Fail(new NewCommandResolutionFailure(
+                NewCommandResolutionFailureKind.MissingLanguage,
+                Stack: stack,
+                ProjectPath: projectDirectory));
+        }
+
+        return NewCommandResolutionResult.Succeed(new NewCommandResolvedContext(
+            invocation.WorkingDirectory,
+            stack,
+            language,
+            workload,
+            bundleId,
+            channel,
+            usedStableFallback));
+    }
+
+    private static IReadOnlyDictionary<string, IProjectInitializer> BuildProjectInitializersByStack(
+        IEnumerable<IProjectInitializer> projectInitializers)
+    {
+        ArgumentNullException.ThrowIfNull(projectInitializers);
+
+        return projectInitializers
+            .Where(initializer => !string.IsNullOrWhiteSpace(initializer.Stack))
+            .GroupBy(initializer => initializer.Stack.Trim(), StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
+    }
+
+    private string? ResolveLanguage(string stack, StackOptions stackOptions)
+    {
+        if (!string.IsNullOrWhiteSpace(stackOptions.Language))
+        {
+            return stackOptions.Language.Trim();
+        }
+
+        if (_projectInitializersByStack.TryGetValue(stack, out IProjectInitializer? initializer)
+            && initializer.SupportedLanguages.Count == 1)
+        {
+            return initializer.SupportedLanguages[0];
+        }
+
+        return null;
+    }
+}
+
+internal sealed record NewCommandResolvedContext(
+    WorkingDirectory WorkingDirectory,
+    string Stack,
+    string Language,
+    InstalledTemplatesWorkload Workload,
+    string? BundleId,
+    BundleChannel Channel,
+    bool UsedStableFallback);
+
+internal enum NewCommandResolutionFailureKind
+{
+    ProjectRequired,
+    HostJsonBundleMissing,
+    UnrecognisedBundleId,
+    NoTemplatesWorkloadInstalled,
+    NoTemplatesWorkloadForChannel,
+    MissingLanguage,
+}
+
+internal sealed record NewCommandResolutionFailure(
+    NewCommandResolutionFailureKind Kind,
+    string? Stack = null,
+    string? ProjectPath = null,
+    string? BundleId = null,
+    BundleChannel Channel = BundleChannel.Unknown);
+
+internal readonly struct NewCommandResolutionResult
+{
+    private NewCommandResolutionResult(NewCommandResolvedContext? context, NewCommandResolutionFailure? failure)
+    {
+        Context = context;
+        Failure = failure;
+    }
+
+    public NewCommandResolvedContext? Context { get; }
+
+    public NewCommandResolutionFailure? Failure { get; }
+
+    public static NewCommandResolutionResult Succeed(NewCommandResolvedContext context) => new(context, null);
+
+    public static NewCommandResolutionResult Fail(NewCommandResolutionFailure failure) => new(null, failure);
+}

--- a/src/Func/Templates/NewCommandRenderer.cs
+++ b/src/Func/Templates/NewCommandRenderer.cs
@@ -19,20 +19,6 @@ internal sealed class NewCommandRenderer(IInteractionService interaction)
         interaction ?? throw new ArgumentNullException(nameof(interaction));
 
     /// <summary>
-    /// Renders the "no template providers registered" hint surfaced when no
-    /// engine project has been wired into DI yet. Terminal output of both
-    /// commands until engine-driven output paths replace it.
-    /// </summary>
-    public void RenderNoEnginesRegistered()
-    {
-        _interaction.WriteError("No templates available.");
-        _interaction.WriteLine(l => l
-            .Muted("Install a templates workload: ")
-            .Code("func workload install Azure.Functions.Cli.Workloads.Templates.<stack>")
-            .Muted("."));
-    }
-
-    /// <summary>
     /// Renders the warning surfaced when the project's bundle channel
     /// (preview / experimental) has no matching installed templates workload
     /// and the runner has fallen back to the stable workload (issue #5369).
@@ -108,9 +94,7 @@ internal sealed class NewCommandRenderer(IInteractionService interaction)
 
     /// <summary>
     /// Renders the plain-text catalogue for <c>func new --list</c>.
-    /// Surfaces an empty header for the resolved stack so the integration
-    /// path is exercised when no engines are registered; the populated
-    /// catalogue lands once engines exist.
+    /// Defensively renders an empty hint when called without templates.
     /// </summary>
     public void RenderCatalogue(string stack, string? language, IReadOnlyList<FunctionTemplateInfo> templates)
     {

--- a/src/Func/Templates/NewCommandResultRenderer.cs
+++ b/src/Func/Templates/NewCommandResultRenderer.cs
@@ -1,0 +1,162 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Diagnostics;
+using Azure.Functions.Cli.Bundles;
+using Azure.Functions.Cli.Console;
+
+namespace Azure.Functions.Cli.Templates;
+
+internal interface INewCommandResultRenderer
+{
+    public void RenderResolutionFailure(NewCommandResolutionFailure failure);
+
+    public int RenderApplyResult(FunctionTemplateInfo template, TemplateApplicationResult result);
+}
+
+internal sealed class NewCommandResultRenderer(
+    IInteractionService interaction,
+    NewCommandRenderer renderer) : INewCommandResultRenderer
+{
+    private readonly IInteractionService _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
+    private readonly NewCommandRenderer _renderer = renderer ?? throw new ArgumentNullException(nameof(renderer));
+
+    public void RenderResolutionFailure(NewCommandResolutionFailure failure)
+    {
+        ArgumentNullException.ThrowIfNull(failure);
+
+        switch (failure.Kind)
+        {
+            case NewCommandResolutionFailureKind.ProjectRequired:
+                _renderer.RenderProjectRequired();
+                break;
+
+            case NewCommandResolutionFailureKind.HostJsonBundleMissing:
+                _interaction.WriteError("Cannot resolve templates: host.json declares no extension bundle.");
+                _interaction.WriteLine(line => line
+                    .Muted("Configure ")
+                    .Code("extensionBundle.id")
+                    .Muted(" in host.json or run ")
+                    .Code("func init")
+                    .Muted(" with a stack that declares one."));
+                break;
+
+            case NewCommandResolutionFailureKind.UnrecognisedBundleId:
+                _interaction.WriteError($"Unrecognized extension bundle id '{failure.BundleId}'.");
+                _interaction.WriteLine(line => line
+                    .Muted("Use one of: ")
+                    .Code(BundleHelpers.StableBundleId)
+                    .Muted(", ")
+                    .Code(BundleHelpers.PreviewBundleId)
+                    .Muted(", or ")
+                    .Code(BundleHelpers.ExperimentalBundleId)
+                    .Muted("."));
+                break;
+
+            case NewCommandResolutionFailureKind.NoTemplatesWorkloadInstalled:
+                _renderer.RenderNoTemplatesWorkloadInstalled(failure.Stack!);
+                break;
+
+            case NewCommandResolutionFailureKind.NoTemplatesWorkloadForChannel:
+                RenderMissingTemplatesWorkloadChannel(failure);
+                break;
+
+            case NewCommandResolutionFailureKind.MissingLanguage:
+                _renderer.RenderMissingLanguage(failure.Stack!, failure.ProjectPath!);
+                break;
+
+            default:
+                throw new UnreachableException(
+                    $"Unhandled {nameof(NewCommandResolutionFailureKind)}: {failure.Kind}.");
+        }
+    }
+
+    public int RenderApplyResult(FunctionTemplateInfo template, TemplateApplicationResult result)
+    {
+        ArgumentNullException.ThrowIfNull(template);
+        ArgumentNullException.ThrowIfNull(result);
+
+        switch (result)
+        {
+            case TemplateApplicationResult.Created created:
+                _interaction.WriteSuccess($"Created function '{template.Id}'.");
+                foreach (string file in created.Files)
+                {
+                    _interaction.WriteLine(line => line.Muted("  ").Code(file));
+                }
+
+                return 0;
+
+            case TemplateApplicationResult.AlreadyExists existing:
+                _interaction.WriteError("Some files already exist:");
+                foreach (string file in existing.ExistingFiles)
+                {
+                    _interaction.WriteLine(line => line.Muted("  ").Code(file));
+                }
+
+                _interaction.WriteLine(line => line
+                    .Muted("Re-run with ")
+                    .Code("--force")
+                    .Muted(" to overwrite."));
+                return 1;
+
+            case TemplateApplicationResult.Failed failed:
+                RenderApplicationFailure(failed.Failure);
+                return 1;
+
+            default:
+                _interaction.WriteError("Unknown apply result.");
+                return 1;
+        }
+    }
+
+    private void RenderMissingTemplatesWorkloadChannel(NewCommandResolutionFailure failure)
+    {
+        string channelName = failure.Channel.ToDisplayString();
+        string suggestedPackage = TemplatesWorkloadConstants.GetPackageId(failure.Stack!);
+        string suggestedVersion = failure.Channel == Projects.BundleChannel.Stable
+            ? "<version>"
+            : $"<version>-{channelName}.1";
+        _interaction.WriteError(
+            $"No installed templates workload matches this project's bundle channel " +
+            $"({failure.BundleId} -> channel '{channelName}').");
+        _interaction.WriteLine(line => line
+            .Muted("Install one with: ")
+            .Code($"func workload install {suggestedPackage} --version {suggestedVersion}")
+            .Muted("."));
+    }
+
+    private void RenderApplicationFailure(TemplateApplicationFailure failure)
+    {
+        switch (failure)
+        {
+            case TemplateApplicationFailure.WriteFailed write:
+                _interaction.WriteError($"Failed to write '{write.Path}': {write.Message}");
+                break;
+            case TemplateApplicationFailure.InvalidPrompt prompt:
+                _interaction.WriteError($"Invalid prompt '{prompt.PromptId}': {prompt.Reason}");
+                break;
+            case TemplateApplicationFailure.ProviderError provider:
+                _interaction.WriteError(provider.Message);
+                break;
+            case TemplateApplicationFailure.MissingExtensionBundle bundle:
+                _interaction.WriteError($"Stack '{bundle.Stack}' requires extension bundle '{bundle.SuggestedBundleId}', which is not installed.");
+                break;
+            case TemplateApplicationFailure.MinBundleVersionTooOld min:
+                _interaction.WriteError(
+                    $"Installed bundle '{min.InstalledBundleVersion}' is outside required range '{min.RequiredRange}' for templates workload '{min.TemplatesWorkloadVersion}'.");
+                break;
+            case TemplateApplicationFailure.NoTemplatesWorkloadForChannel workload:
+                _interaction.WriteError(
+                    $"No templates workload installed for channel '{workload.Channel}' on stack '{workload.Stack}'.");
+                _interaction.WriteLine(line => line
+                    .Muted("Install one with: ")
+                    .Code($"func workload install {workload.SuggestedPackageId} --version {workload.SuggestedVersion}")
+                    .Muted("."));
+                break;
+            default:
+                _interaction.WriteError("Template application failed.");
+                break;
+        }
+    }
+}

--- a/src/Func/Templates/NewCommandResultRenderer.cs
+++ b/src/Func/Templates/NewCommandResultRenderer.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using Azure.Functions.Cli.Bundles;
 using Azure.Functions.Cli.Console;
+using Azure.Functions.Cli.Projects;
 
 namespace Azure.Functions.Cli.Templates;
 
@@ -114,7 +115,7 @@ internal sealed class NewCommandResultRenderer(
     {
         string channelName = failure.Channel.ToDisplayString();
         string suggestedPackage = TemplatesWorkloadConstants.GetPackageId(failure.Stack!);
-        string suggestedVersion = failure.Channel == Projects.BundleChannel.Stable
+        string suggestedVersion = failure.Channel == BundleChannel.Stable
             ? "<version>"
             : $"<version>-{channelName}.1";
         _interaction.WriteError(

--- a/src/Func/Templates/NewCommandRunner.cs
+++ b/src/Func/Templates/NewCommandRunner.cs
@@ -30,17 +30,33 @@ namespace Azure.Functions.Cli.Templates;
 internal sealed class NewCommandRunner
 {
     private readonly IInteractionService _interaction;
-    private readonly IFunctionsProjectResolver _projectResolver;
-    private readonly IProfileResolver _profileResolver;
-    private readonly IOptionsMonitor<StackOptions> _stackOptions;
-    private readonly IReadOnlyDictionary<string, IProjectInitializer> _projectInitializersByStack;
-    private readonly IInstalledTemplatesWorkloads _installedTemplatesWorkloads;
+    private readonly INewCommandContextResolver _contextResolver;
     private readonly ITemplateEngineProviderRegistry _engineProviders;
     private readonly TemplateOptionHydrator _optionHydrator;
     private readonly TemplatePicker _picker;
     private readonly NewCommandRenderer _renderer;
     private readonly IHostJsonBundleSectionReader _hostJsonReader;
     private readonly IExtensionBundleResolver _bundleResolver;
+
+    public NewCommandRunner(
+        IInteractionService interaction,
+        INewCommandContextResolver contextResolver,
+        ITemplateEngineProviderRegistry engineProviders,
+        TemplateOptionHydrator optionHydrator,
+        TemplatePicker picker,
+        NewCommandRenderer renderer,
+        IHostJsonBundleSectionReader hostJsonReader,
+        IExtensionBundleResolver bundleResolver)
+    {
+        _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
+        _contextResolver = contextResolver ?? throw new ArgumentNullException(nameof(contextResolver));
+        _engineProviders = engineProviders ?? throw new ArgumentNullException(nameof(engineProviders));
+        _optionHydrator = optionHydrator ?? throw new ArgumentNullException(nameof(optionHydrator));
+        _picker = picker ?? throw new ArgumentNullException(nameof(picker));
+        _renderer = renderer ?? throw new ArgumentNullException(nameof(renderer));
+        _hostJsonReader = hostJsonReader ?? throw new ArgumentNullException(nameof(hostJsonReader));
+        _bundleResolver = bundleResolver ?? throw new ArgumentNullException(nameof(bundleResolver));
+    }
 
     public NewCommandRunner(
         IInteractionService interaction,
@@ -55,38 +71,37 @@ internal sealed class NewCommandRunner
         NewCommandRenderer renderer,
         IHostJsonBundleSectionReader hostJsonReader,
         IExtensionBundleResolver bundleResolver)
+        : this(
+            interaction,
+            new NewCommandContextResolver(
+                interaction,
+                projectResolver,
+                profileResolver,
+                stackOptions,
+                projectInitializers,
+                installedTemplatesWorkloads,
+                hostJsonReader),
+            engineProviders,
+            optionHydrator,
+            picker,
+            renderer,
+            hostJsonReader,
+            bundleResolver)
     {
-        _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
-        _projectResolver = projectResolver ?? throw new ArgumentNullException(nameof(projectResolver));
-        _profileResolver = profileResolver ?? throw new ArgumentNullException(nameof(profileResolver));
-        _stackOptions = stackOptions ?? throw new ArgumentNullException(nameof(stackOptions));
-        ArgumentNullException.ThrowIfNull(projectInitializers);
-        _installedTemplatesWorkloads = installedTemplatesWorkloads ?? throw new ArgumentNullException(nameof(installedTemplatesWorkloads));
-        _engineProviders = engineProviders ?? throw new ArgumentNullException(nameof(engineProviders));
-        _optionHydrator = optionHydrator ?? throw new ArgumentNullException(nameof(optionHydrator));
-        _picker = picker ?? throw new ArgumentNullException(nameof(picker));
-        _renderer = renderer ?? throw new ArgumentNullException(nameof(renderer));
-        _hostJsonReader = hostJsonReader ?? throw new ArgumentNullException(nameof(hostJsonReader));
-        _bundleResolver = bundleResolver ?? throw new ArgumentNullException(nameof(bundleResolver));
-
-        _projectInitializersByStack = projectInitializers
-            .Where(p => !string.IsNullOrWhiteSpace(p.Stack))
-            .GroupBy(p => p.Stack.Trim(), StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
     }
 
     public async Task<int> ExecuteAsync(NewInvocation invocation, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(invocation);
 
-        ResolutionOutcome outcome = await ResolveContextAsync(invocation, cancellationToken);
+        NewCommandResolutionResult outcome = await _contextResolver.ResolveAsync(invocation, cancellationToken);
         if (outcome.Failure is { } executeFailure)
         {
             RenderResolutionFailure(executeFailure);
             return 1;
         }
 
-        ResolvedContext resolved = outcome.Context!;
+        NewCommandResolvedContext resolved = outcome.Context!;
 
         if (resolved.UsedStableFallback)
         {
@@ -170,14 +185,14 @@ internal sealed class NewCommandRunner
     {
         ArgumentNullException.ThrowIfNull(invocation);
 
-        ResolutionOutcome outcome = await ResolveContextAsync(invocation, cancellationToken);
+        NewCommandResolutionResult outcome = await _contextResolver.ResolveAsync(invocation, cancellationToken);
         if (outcome.Failure is { } listFailure)
         {
             RenderResolutionFailure(listFailure);
             return 1;
         }
 
-        ResolvedContext resolved = outcome.Context!;
+        NewCommandResolvedContext resolved = outcome.Context!;
 
         if (resolved.UsedStableFallback)
         {
@@ -244,7 +259,7 @@ internal sealed class NewCommandRunner
         ArgumentNullException.ThrowIfNull(invocation);
         ArgumentException.ThrowIfNullOrWhiteSpace(templateId);
 
-        ResolutionOutcome outcome = await ResolveContextAsync(invocation, cancellationToken);
+        NewCommandResolutionResult outcome = await _contextResolver.ResolveAsync(invocation, cancellationToken);
         if (outcome.Context is not { } resolved)
         {
             return null;
@@ -262,119 +277,6 @@ internal sealed class NewCommandRunner
         return _optionHydrator.HydrateWithIds(template);
     }
 
-    private async Task<ResolutionOutcome> ResolveContextAsync(
-        NewInvocation invocation,
-        CancellationToken cancellationToken)
-    {
-        // Step 1: resolve the active profile. Diagnostics are surfaced by
-        // the resolver itself; the stack-vs-profile gate is wired in a
-        // follow-up commit.
-        await _profileResolver.ResolveAsync(
-            new ProfileResolutionContext(
-                invocation.WorkingDirectory.Info,
-                RequestedProfileName: null,
-                CanPrompt: _interaction.IsInteractive),
-            cancellationToken);
-
-        // Step 2: resolve the project (hard exit if absent).
-        ProjectResolutionResult projectResult = await _projectResolver.ResolveProjectAsync(
-            new ProjectResolutionContext(invocation.WorkingDirectory),
-            cancellationToken);
-
-        if (projectResult is not ProjectResolutionResult.Resolved resolved)
-        {
-            return ResolutionOutcome.Fail(new ResolutionFailure(ResolutionFailureKind.ProjectRequired));
-        }
-
-        string stack = resolved.Project.StackName;
-
-        // Step 4 (Node/Python): channel match against host.json.
-        InstalledTemplatesWorkload? workload;
-        string? bundleId = null;
-        BundleChannel channel = BundleChannel.Unknown;
-        bool usedStableFallback = false;
-        if (string.Equals(stack, "dotnet", StringComparison.OrdinalIgnoreCase))
-        {
-            IReadOnlyList<InstalledTemplatesWorkload> allRows =
-                await _installedTemplatesWorkloads.ListInstalledAsync(stack, cancellationToken);
-            workload = allRows
-                .OrderByDescending(r => r.PackageVersion, StringComparer.Ordinal)
-                .FirstOrDefault();
-        }
-        else
-        {
-            HostJsonBundleSection? section = await _hostJsonReader.ReadAsync(
-                invocation.WorkingDirectory.Info, cancellationToken);
-            if (section is null || string.IsNullOrWhiteSpace(section.Id))
-            {
-                return ResolutionOutcome.Fail(new ResolutionFailure(ResolutionFailureKind.HostJsonBundleMissing));
-            }
-
-            bundleId = section.Id;
-            if (!BundleHelpers.TryGetBundleChannel(bundleId, out channel))
-            {
-                return ResolutionOutcome.Fail(new ResolutionFailure(
-                    ResolutionFailureKind.UnrecognisedBundleId,
-                    BundleId: bundleId));
-            }
-
-            IReadOnlyList<InstalledTemplatesWorkload> allRows =
-                await _installedTemplatesWorkloads.ListInstalledAsync(stack, cancellationToken);
-            workload = TemplatesChannelMapper.PickChannelMatched(allRows, channel);
-
-            // Issue #5369: when the project asks for a non-stable channel
-            // (preview / experimental) and no matching workload is installed,
-            // fall back to the stable templates workload if one exists rather
-            // than hard-failing. The warning is emitted by Execute / List so
-            // pre-parse hydration paths stay silent.
-            if (workload is null && channel != BundleChannel.Stable)
-            {
-                workload = TemplatesChannelMapper.PickChannelMatched(allRows, BundleChannel.Stable);
-                if (workload is not null)
-                {
-                    usedStableFallback = true;
-                }
-            }
-        }
-
-        if (workload is null)
-        {
-            if (channel is BundleChannel.Unknown)
-            {
-                return ResolutionOutcome.Fail(new ResolutionFailure(
-                    ResolutionFailureKind.NoTemplatesWorkloadInstalled,
-                    Stack: stack));
-            }
-
-            return ResolutionOutcome.Fail(new ResolutionFailure(
-                ResolutionFailureKind.NoTemplatesWorkloadForChannel,
-                Stack: stack,
-                BundleId: bundleId,
-                Channel: channel));
-        }
-
-        // Step 5: language resolution via IOptionsMonitor<StackOptions>.
-        string projectDirectory = Path.GetFullPath(invocation.WorkingDirectory.Info.FullName);
-        StackOptions stackOptionsBound = _stackOptions.Get(projectDirectory);
-        string? language = ResolveLanguage(stack, stackOptionsBound);
-        if (language is null)
-        {
-            return ResolutionOutcome.Fail(new ResolutionFailure(
-                ResolutionFailureKind.MissingLanguage,
-                Stack: stack,
-                ProjectPath: projectDirectory));
-        }
-
-        return ResolutionOutcome.Succeed(new ResolvedContext(
-            invocation.WorkingDirectory,
-            stack,
-            language,
-            workload,
-            bundleId,
-            channel,
-            usedStableFallback));
-    }
-
     /// <summary>
     /// Renders a single <see cref="ResolutionFailure"/>. Centralizing the
     /// render here keeps <see cref="ResolveContextAsync"/> side-effect free:
@@ -383,15 +285,15 @@ internal sealed class NewCommandRunner
     /// resolution passes a caller adds (pre-parse / hydration paths run the
     /// same resolver but consume the outcome silently).
     /// </summary>
-    private void RenderResolutionFailure(ResolutionFailure failure)
+    private void RenderResolutionFailure(NewCommandResolutionFailure failure)
     {
         switch (failure.Kind)
         {
-            case ResolutionFailureKind.ProjectRequired:
+            case NewCommandResolutionFailureKind.ProjectRequired:
                 _renderer.RenderProjectRequired();
                 break;
 
-            case ResolutionFailureKind.HostJsonBundleMissing:
+            case NewCommandResolutionFailureKind.HostJsonBundleMissing:
                 _interaction.WriteError(
                     "Cannot resolve templates: host.json declares no extension bundle.");
                 _interaction.WriteLine(l => l
@@ -402,7 +304,7 @@ internal sealed class NewCommandRunner
                     .Muted(" with a stack that declares one."));
                 break;
 
-            case ResolutionFailureKind.UnrecognisedBundleId:
+            case NewCommandResolutionFailureKind.UnrecognisedBundleId:
                 _interaction.WriteError($"Unrecognized extension bundle id '{failure.BundleId}'.");
                 _interaction.WriteLine(l => l
                     .Muted("Use one of: ")
@@ -414,11 +316,11 @@ internal sealed class NewCommandRunner
                     .Muted("."));
                 break;
 
-            case ResolutionFailureKind.NoTemplatesWorkloadInstalled:
+            case NewCommandResolutionFailureKind.NoTemplatesWorkloadInstalled:
                 _renderer.RenderNoTemplatesWorkloadInstalled(failure.Stack!);
                 break;
 
-            case ResolutionFailureKind.NoTemplatesWorkloadForChannel:
+            case NewCommandResolutionFailureKind.NoTemplatesWorkloadForChannel:
                 {
                     string channelName = failure.Channel.ToDisplayString();
                     string suggestedPkg = TemplatesWorkloadConstants.GetPackageId(failure.Stack!);
@@ -435,7 +337,7 @@ internal sealed class NewCommandRunner
                     break;
                 }
 
-            case ResolutionFailureKind.MissingLanguage:
+            case NewCommandResolutionFailureKind.MissingLanguage:
                 _renderer.RenderMissingLanguage(failure.Stack!, failure.ProjectPath!);
                 break;
 
@@ -445,12 +347,12 @@ internal sealed class NewCommandRunner
                 // with no user-visible error, reintroducing the class of bug this
                 // refactor exists to prevent.
                 throw new UnreachableException(
-                    $"Unhandled {nameof(ResolutionFailureKind)}: {failure.Kind}.");
+                    $"Unhandled {nameof(NewCommandResolutionFailureKind)}: {failure.Kind}.");
         }
     }
 
     private async Task<int> EnforceBundleGatesAsync(
-        ResolvedContext resolved,
+        NewCommandResolvedContext resolved,
         CancellationToken cancellationToken)
     {
         // DotNet skips both gates (no extension-bundle dependency).
@@ -517,7 +419,7 @@ internal sealed class NewCommandRunner
     }
 
     private async Task<IReadOnlyList<FunctionTemplateInfo>> ListTemplatesAsync(
-        ResolvedContext resolved,
+        NewCommandResolvedContext resolved,
         CancellationToken cancellationToken)
     {
         var listContext = new TemplateListContext(
@@ -666,29 +568,6 @@ internal sealed class NewCommandRunner
     }
 
     /// <summary>
-    /// Language resolution: read <c>StackOptions.Language</c>, fall back to
-    /// the stack's single canonical language for single-language stacks,
-    /// return <c>null</c> for multi-language stacks when the configured
-    /// language is missing (the runner treats <c>null</c> as a hard error
-    /// and points at <c>func init</c>).
-    /// </summary>
-    private string? ResolveLanguage(string stack, StackOptions stackOptions)
-    {
-        if (!string.IsNullOrWhiteSpace(stackOptions.Language))
-        {
-            return stackOptions.Language.Trim();
-        }
-
-        if (_projectInitializersByStack.TryGetValue(stack, out IProjectInitializer? initializer)
-            && initializer.SupportedLanguages.Count == 1)
-        {
-            return initializer.SupportedLanguages[0];
-        }
-
-        return null;
-    }
-
-    /// <summary>
     /// Minimal NuGet-style range containment check for v1 — accepts the
     /// open-ended forms <c>[X.Y.Z, )</c> and bare <c>X.Y.Z</c> (treated as
     /// "min X.Y.Z, no upper bound"). A follow-up can swap in NuGetVersion.
@@ -735,48 +614,6 @@ internal sealed class NewCommandRunner
         return dash < 0 ? version : version[..dash];
     }
 
-    private sealed record ResolvedContext(
-        WorkingDirectory WorkingDirectory,
-        string Stack,
-        string Language,
-        InstalledTemplatesWorkload Workload,
-        string? BundleId,
-        BundleChannel Channel,
-        bool UsedStableFallback);
-
-    private enum ResolutionFailureKind
-    {
-        ProjectRequired,
-        HostJsonBundleMissing,
-        UnrecognisedBundleId,
-        NoTemplatesWorkloadInstalled,
-        NoTemplatesWorkloadForChannel,
-        MissingLanguage,
-    }
-
-    private sealed record ResolutionFailure(
-        ResolutionFailureKind Kind,
-        string? Stack = null,
-        string? ProjectPath = null,
-        string? BundleId = null,
-        BundleChannel Channel = BundleChannel.Unknown);
-
-    private readonly struct ResolutionOutcome
-    {
-        private ResolutionOutcome(ResolvedContext? context, ResolutionFailure? failure)
-        {
-            Context = context;
-            Failure = failure;
-        }
-
-        public ResolvedContext? Context { get; }
-
-        public ResolutionFailure? Failure { get; }
-
-        public static ResolutionOutcome Succeed(ResolvedContext context) => new(context, null);
-
-        public static ResolutionOutcome Fail(ResolutionFailure failure) => new(null, failure);
-    }
 }
 
 /// <summary>

--- a/src/Func/Templates/NewCommandRunner.cs
+++ b/src/Func/Templates/NewCommandRunner.cs
@@ -1,93 +1,47 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.CommandLine;
-using System.Diagnostics;
-using Azure.Functions.Cli.Bundles;
 using Azure.Functions.Cli.Common;
-using Azure.Functions.Cli.Configuration;
-using Azure.Functions.Cli.Console;
-using Azure.Functions.Cli.Profiles;
-using Azure.Functions.Cli.Projects;
-using Microsoft.Extensions.Options;
 
 namespace Azure.Functions.Cli.Templates;
 
-/// <summary>
-/// Orchestrator for the <c>func new</c> pipeline. Lays out the resolution →
-/// selection → hydration → apply flow; the engine-dependent steps (channel
-/// match, min-bundle gate, engine dispatch) land once
-/// <see cref="ITemplateEngineProvider"/> implementations are registered.
-/// </summary>
-/// <remarks>
-/// This scaffold wires the always-available steps (profile / project / stack /
-/// language resolution) through real services so the failure modes that don't
-/// depend on an engine — no project, no <c>stack.runtime</c>, no
-/// <c>stack.language</c> on a multi-language stack, no installed templates
-/// workload — are already observable end-to-end. The engine-dispatch terminal
-/// returns a "no engines registered" hint until engines arrive.
-/// </remarks>
-internal sealed class NewCommandRunner
+internal interface INewCommandRunner
 {
-    private readonly IInteractionService _interaction;
+    public Task<int> ExecuteAsync(NewInvocation invocation, CancellationToken cancellationToken);
+
+    public Task<int> ListAsync(NewInvocation invocation, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Orchestrates the <c>func new</c> resolution, selection, validation, and
+/// application pipeline through focused template services.
+/// </summary>
+internal sealed class NewCommandRunner : INewCommandRunner
+{
     private readonly INewCommandContextResolver _contextResolver;
-    private readonly ITemplateEngineProviderRegistry _engineProviders;
-    private readonly TemplateOptionHydrator _optionHydrator;
-    private readonly TemplatePicker _picker;
+    private readonly INewCommandBundleValidator _bundleValidator;
+    private readonly INewCommandTemplateCatalog _templateCatalog;
+    private readonly INewCommandTemplateSelector _templateSelector;
+    private readonly INewCommandTemplateApplicator _templateApplicator;
     private readonly NewCommandRenderer _renderer;
-    private readonly IHostJsonBundleSectionReader _hostJsonReader;
-    private readonly IExtensionBundleResolver _bundleResolver;
+    private readonly INewCommandResultRenderer _resultRenderer;
 
     public NewCommandRunner(
-        IInteractionService interaction,
         INewCommandContextResolver contextResolver,
-        ITemplateEngineProviderRegistry engineProviders,
-        TemplateOptionHydrator optionHydrator,
-        TemplatePicker picker,
+        INewCommandBundleValidator bundleValidator,
+        INewCommandTemplateCatalog templateCatalog,
+        INewCommandTemplateSelector templateSelector,
+        INewCommandTemplateApplicator templateApplicator,
         NewCommandRenderer renderer,
-        IHostJsonBundleSectionReader hostJsonReader,
-        IExtensionBundleResolver bundleResolver)
+        INewCommandResultRenderer resultRenderer)
     {
-        _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
         _contextResolver = contextResolver ?? throw new ArgumentNullException(nameof(contextResolver));
-        _engineProviders = engineProviders ?? throw new ArgumentNullException(nameof(engineProviders));
-        _optionHydrator = optionHydrator ?? throw new ArgumentNullException(nameof(optionHydrator));
-        _picker = picker ?? throw new ArgumentNullException(nameof(picker));
+        _bundleValidator = bundleValidator ?? throw new ArgumentNullException(nameof(bundleValidator));
+        _templateCatalog = templateCatalog ?? throw new ArgumentNullException(nameof(templateCatalog));
+        _templateSelector = templateSelector ?? throw new ArgumentNullException(nameof(templateSelector));
+        _templateApplicator = templateApplicator ?? throw new ArgumentNullException(nameof(templateApplicator));
         _renderer = renderer ?? throw new ArgumentNullException(nameof(renderer));
-        _hostJsonReader = hostJsonReader ?? throw new ArgumentNullException(nameof(hostJsonReader));
-        _bundleResolver = bundleResolver ?? throw new ArgumentNullException(nameof(bundleResolver));
-    }
-
-    public NewCommandRunner(
-        IInteractionService interaction,
-        IFunctionsProjectResolver projectResolver,
-        IProfileResolver profileResolver,
-        IOptionsMonitor<StackOptions> stackOptions,
-        IEnumerable<IProjectInitializer> projectInitializers,
-        IInstalledTemplatesWorkloads installedTemplatesWorkloads,
-        ITemplateEngineProviderRegistry engineProviders,
-        TemplateOptionHydrator optionHydrator,
-        TemplatePicker picker,
-        NewCommandRenderer renderer,
-        IHostJsonBundleSectionReader hostJsonReader,
-        IExtensionBundleResolver bundleResolver)
-        : this(
-            interaction,
-            new NewCommandContextResolver(
-                interaction,
-                projectResolver,
-                profileResolver,
-                stackOptions,
-                projectInitializers,
-                installedTemplatesWorkloads,
-                hostJsonReader),
-            engineProviders,
-            optionHydrator,
-            picker,
-            renderer,
-            hostJsonReader,
-            bundleResolver)
-    {
+        _resultRenderer = resultRenderer ?? throw new ArgumentNullException(nameof(resultRenderer));
     }
 
     public async Task<int> ExecuteAsync(NewInvocation invocation, CancellationToken cancellationToken)
@@ -97,7 +51,7 @@ internal sealed class NewCommandRunner
         NewCommandResolutionResult outcome = await _contextResolver.ResolveAsync(invocation, cancellationToken);
         if (outcome.Failure is { } executeFailure)
         {
-            RenderResolutionFailure(executeFailure);
+            _resultRenderer.RenderResolutionFailure(executeFailure);
             return 1;
         }
 
@@ -111,7 +65,7 @@ internal sealed class NewCommandRunner
         // Steps 11a / 11b: extension-bundle presence + min-bundle gate.
         // DotNet doesn't ship a templates-workload.json, so the gate is a
         // no-op for it; Node and Python carry one.
-        int bundleGate = await EnforceBundleGatesAsync(resolved, cancellationToken);
+        int bundleGate = await _bundleValidator.ValidateAsync(resolved, cancellationToken);
         if (bundleGate != 0)
         {
             return bundleGate;
@@ -119,7 +73,7 @@ internal sealed class NewCommandRunner
 
         // Step 6: aggregate templates from every registered engine for the
         // active stack.
-        IReadOnlyList<FunctionTemplateInfo> templates = await ListTemplatesAsync(resolved, cancellationToken);
+        IReadOnlyList<FunctionTemplateInfo> templates = await _templateCatalog.ListAsync(resolved, cancellationToken);
         if (templates.Count == 0)
         {
             _renderer.RenderNoTemplatesWorkloadInstalled(resolved.Stack);
@@ -129,52 +83,20 @@ internal sealed class NewCommandRunner
         // Step 7: resolve --template, falling back to the picker in
         // interactive mode (errors when neither --template nor an
         // interactive shell is available).
-        FunctionTemplateInfo? template = await ResolveTemplateAsync(
+        FunctionTemplateInfo? template = await _templateSelector.SelectAsync(
             invocation, templates, cancellationToken);
         if (template is null)
         {
             return 1;
         }
 
-        // Step 8 / 9: stage-B hydration. Hands the engine the user's --name
-        // plus each prompt's declared default (no per-option CLI parsing
-        // yet); the engine reads from the supplied dictionary.
-        IReadOnlyDictionary<string, string?> optionValues = BuildPromptDefaults(template, invocation.UserOptionValues);
-
-        // Step 10: function name resolution.
-        string functionName = invocation.RequestedFunctionName
-            ?? template.DefaultFunctionName
-            ?? template.Id;
-
-        // Step 12: dispatch to the engine.
-        ITemplateEngineProvider? provider = _engineProviders.TryGet(template.EngineId);
-        if (provider is null)
-        {
-            _interaction.WriteError(
-                $"No engine registered for EngineId '{template.EngineId}'. This is a CLI bug.");
-            return 1;
-        }
-
-        // Hydrate options against the chosen template so the engine's
-        // ParseResult consumers see the right option set. Hydration runs but
-        // defers user-supplied per-prompt overrides — the engine resolves
-        // values primarily from `optionValues`.
-        IReadOnlyList<Option> hydrated = _optionHydrator.Hydrate(template);
-        _ = hydrated;
-
-        var context = new NewContext(
-            invocation.WorkingDirectory,
+        TemplateApplicationResult applyResult = await _templateApplicator.ApplyAsync(
+            invocation,
+            resolved,
             template,
-            functionName,
-            resolved.Language,
-            invocation.Force,
-            resolved.Workload.InstallDirectory,
-            invocation.UserOptionValues);
+            cancellationToken);
 
-        ParseResult emptyParseResult = new RootCommand().Parse(string.Empty);
-        TemplateApplicationResult applyResult = await provider.ApplyAsync(context, emptyParseResult, cancellationToken);
-
-        return RenderApplyResult(template, applyResult, optionValues);
+        return _resultRenderer.RenderApplyResult(template, applyResult);
     }
 
     /// <summary>
@@ -188,7 +110,7 @@ internal sealed class NewCommandRunner
         NewCommandResolutionResult outcome = await _contextResolver.ResolveAsync(invocation, cancellationToken);
         if (outcome.Failure is { } listFailure)
         {
-            RenderResolutionFailure(listFailure);
+            _resultRenderer.RenderResolutionFailure(listFailure);
             return 1;
         }
 
@@ -199,7 +121,7 @@ internal sealed class NewCommandRunner
             _renderer.RenderTemplatesChannelFallback(resolved.Stack, resolved.BundleId!, resolved.Channel);
         }
 
-        IReadOnlyList<FunctionTemplateInfo> templates = await ListTemplatesAsync(resolved, cancellationToken);
+        IReadOnlyList<FunctionTemplateInfo> templates = await _templateCatalog.ListAsync(resolved, cancellationToken);
         if (templates.Count == 0)
         {
             _renderer.RenderNoTemplatesWorkloadInstalled(resolved.Stack);
@@ -216,402 +138,6 @@ internal sealed class NewCommandRunner
         }
 
         return 0;
-    }
-
-    /// <summary>
-    /// Resolves the single template identified by <paramref name="templateId"/>
-    /// for the project at <paramref name="invocation"/>, then hands back the
-    /// hydrated <see cref="Option"/> list the stage-B help renderer needs.
-    /// Returns <c>null</c> when the project can't be resolved, the templates
-    /// workload isn't installed, or <paramref name="templateId"/> doesn't
-    /// match any catalogued template — the caller decides whether to fall
-    /// back to a built-ins-only help render or surface the failure.
-    /// </summary>
-    public async Task<IReadOnlyList<Option>?> HydrateOptionsForTemplateAsync(
-        NewInvocation invocation,
-        string templateId,
-        CancellationToken cancellationToken)
-    {
-        IReadOnlyList<HydratedTemplateOption>? paired =
-            await HydrateOptionsForTemplateWithIdsAsync(invocation, templateId, cancellationToken);
-
-        return paired?.Select(p => p.Option).ToList();
-    }
-
-    /// <summary>
-    /// Same as <see cref="HydrateOptionsForTemplateAsync"/> but also returns
-    /// the prompt id each option projects from. <c>NewCommand</c> uses this
-    /// overload on the execute path to map user-supplied values back to
-    /// the v2 paramId the engine resolves against.
-    /// </summary>
-    /// <remarks>
-    /// Pre-parse / hydration callers are best-effort: when resolution fails
-    /// they return <c>null</c> silently. Rendering the failure is the job of
-    /// the execute / list entry-points, which call <see cref="ResolveContextAsync"/>
-    /// themselves; rendering here too would surface the same error twice
-    /// (or three times, once #5304's third call site lands) for one invocation.
-    /// </remarks>
-    public async Task<IReadOnlyList<HydratedTemplateOption>?> HydrateOptionsForTemplateWithIdsAsync(
-        NewInvocation invocation,
-        string templateId,
-        CancellationToken cancellationToken)
-    {
-        ArgumentNullException.ThrowIfNull(invocation);
-        ArgumentException.ThrowIfNullOrWhiteSpace(templateId);
-
-        NewCommandResolutionResult outcome = await _contextResolver.ResolveAsync(invocation, cancellationToken);
-        if (outcome.Context is not { } resolved)
-        {
-            return null;
-        }
-
-        IReadOnlyList<FunctionTemplateInfo> templates = await ListTemplatesAsync(resolved, cancellationToken);
-        FunctionTemplateInfo? template = templates.FirstOrDefault(t =>
-            string.Equals(t.Id, templateId, StringComparison.OrdinalIgnoreCase));
-
-        if (template is null)
-        {
-            return null;
-        }
-
-        return _optionHydrator.HydrateWithIds(template);
-    }
-
-    /// <summary>
-    /// Renders a single <see cref="ResolutionFailure"/>. Centralizing the
-    /// render here keeps <see cref="ResolveContextAsync"/> side-effect free:
-    /// each <see cref="ExecuteAsync"/> / <see cref="ListAsync"/> entry-point
-    /// renders the failure at most once, regardless of how many internal
-    /// resolution passes a caller adds (pre-parse / hydration paths run the
-    /// same resolver but consume the outcome silently).
-    /// </summary>
-    private void RenderResolutionFailure(NewCommandResolutionFailure failure)
-    {
-        switch (failure.Kind)
-        {
-            case NewCommandResolutionFailureKind.ProjectRequired:
-                _renderer.RenderProjectRequired();
-                break;
-
-            case NewCommandResolutionFailureKind.HostJsonBundleMissing:
-                _interaction.WriteError(
-                    "Cannot resolve templates: host.json declares no extension bundle.");
-                _interaction.WriteLine(l => l
-                    .Muted("Configure ")
-                    .Code("extensionBundle.id")
-                    .Muted(" in host.json or run ")
-                    .Code("func init")
-                    .Muted(" with a stack that declares one."));
-                break;
-
-            case NewCommandResolutionFailureKind.UnrecognisedBundleId:
-                _interaction.WriteError($"Unrecognized extension bundle id '{failure.BundleId}'.");
-                _interaction.WriteLine(l => l
-                    .Muted("Use one of: ")
-                    .Code(BundleHelpers.StableBundleId)
-                    .Muted(", ")
-                    .Code(BundleHelpers.PreviewBundleId)
-                    .Muted(", or ")
-                    .Code(BundleHelpers.ExperimentalBundleId)
-                    .Muted("."));
-                break;
-
-            case NewCommandResolutionFailureKind.NoTemplatesWorkloadInstalled:
-                _renderer.RenderNoTemplatesWorkloadInstalled(failure.Stack!);
-                break;
-
-            case NewCommandResolutionFailureKind.NoTemplatesWorkloadForChannel:
-                {
-                    string channelName = failure.Channel.ToDisplayString();
-                    string suggestedPkg = TemplatesWorkloadConstants.GetPackageId(failure.Stack!);
-                    string suggestedVer = failure.Channel == BundleChannel.Stable
-                        ? "<version>"
-                        : $"<version>-{channelName}.1";
-                    _interaction.WriteError(
-                        $"No installed templates workload matches this project's bundle channel " +
-                        $"({failure.BundleId} -> channel '{channelName}').");
-                    _interaction.WriteLine(l => l
-                        .Muted("Install one with: ")
-                        .Code($"func workload install {suggestedPkg} --version {suggestedVer}")
-                        .Muted("."));
-                    break;
-                }
-
-            case NewCommandResolutionFailureKind.MissingLanguage:
-                _renderer.RenderMissingLanguage(failure.Stack!, failure.ProjectPath!);
-                break;
-
-            default:
-                // Guard against silently swallowing a future ResolutionFailureKind.
-                // Without this, a new enum value would return null from the caller
-                // with no user-visible error, reintroducing the class of bug this
-                // refactor exists to prevent.
-                throw new UnreachableException(
-                    $"Unhandled {nameof(NewCommandResolutionFailureKind)}: {failure.Kind}.");
-        }
-    }
-
-    private async Task<int> EnforceBundleGatesAsync(
-        NewCommandResolvedContext resolved,
-        CancellationToken cancellationToken)
-    {
-        // DotNet skips both gates (no extension-bundle dependency).
-        if (string.Equals(resolved.Stack, "dotnet", StringComparison.OrdinalIgnoreCase))
-        {
-            return 0;
-        }
-
-        if (resolved.BundleId is null)
-        {
-            return 0;
-        }
-
-        // Step 11a: bundle presence via IExtensionBundleResolver.
-        HostJsonBundleSection? section = await _hostJsonReader.ReadAsync(
-            resolved.WorkingDirectory.Info, cancellationToken);
-        if (section is null)
-        {
-            return 0;
-        }
-
-        var context = new ExtensionBundleProjectContext(
-            BundleId: section.Id,
-            HostJsonVersionRange: section.Version,
-            WorkerRuntime: resolved.Stack,
-            ProfileName: null,
-            ProfileBundleVersionRange: null);
-
-        ExtensionBundleResolution resolution = await _bundleResolver.ResolveAsync(context, cancellationToken);
-        switch (resolution)
-        {
-            case ExtensionBundleResolution.Resolved bundleResolved:
-                // Step 11b: min-bundle range from the templates
-                // workload's sibling manifest.
-                string? minRange = TemplatesWorkloadManifestReader.GetMinBundleVersion(resolved.Workload.InstallDirectory);
-                if (!string.IsNullOrWhiteSpace(minRange)
-                    && !VersionRangeContains(minRange, bundleResolved.Version))
-                {
-                    _interaction.WriteError(
-                        $"Installed templates workload '{resolved.Workload.PackageVersion}' requires " +
-                        $"extension bundle in range '{minRange}', but the project resolves to '{bundleResolved.Version}'.");
-                    _interaction.WriteLine(l => l
-                        .Muted("Update the bundle range in ")
-                        .Code("host.json")
-                        .Muted(" or install an older templates workload pkg version."));
-                    return 1;
-                }
-                return 0;
-
-            case ExtensionBundleResolution.WorkloadMissing:
-            case ExtensionBundleResolution.EmptyIntersection:
-                _interaction.WriteError("The project requires an extension bundle but none is resolvable.");
-                _interaction.WriteLine(l => l
-                    .Muted("Install one with: ")
-                    .Code("func workload install Azure.Functions.Cli.Workloads.ExtensionBundles")
-                    .Muted(" or run ")
-                    .Code("func setup")
-                    .Muted("."));
-                return 1;
-
-            default:
-                return 0;
-        }
-    }
-
-    private async Task<IReadOnlyList<FunctionTemplateInfo>> ListTemplatesAsync(
-        NewCommandResolvedContext resolved,
-        CancellationToken cancellationToken)
-    {
-        var listContext = new TemplateListContext(
-            resolved.WorkingDirectory,
-            resolved.Stack,
-            resolved.Language,
-            resolved.Workload.InstallDirectory);
-        List<FunctionTemplateInfo> templates = [];
-        foreach (ITemplateEngineProvider provider in _engineProviders.Providers)
-        {
-            IReadOnlyList<FunctionTemplateInfo> contributed = await provider.ListTemplatesAsync(listContext, cancellationToken);
-            templates.AddRange(contributed);
-        }
-
-        return templates;
-    }
-
-    private async Task<FunctionTemplateInfo?> ResolveTemplateAsync(
-        NewInvocation invocation,
-        IReadOnlyList<FunctionTemplateInfo> templates,
-        CancellationToken cancellationToken)
-    {
-        if (!string.IsNullOrWhiteSpace(invocation.RequestedTemplate))
-        {
-            FunctionTemplateInfo? matched = templates.FirstOrDefault(t =>
-                string.Equals(t.Id, invocation.RequestedTemplate, StringComparison.OrdinalIgnoreCase));
-            if (matched is null)
-            {
-                _interaction.WriteError(
-                    $"Template '{invocation.RequestedTemplate}' was not found for this project's stack.");
-                _interaction.WriteLine(l => l
-                    .Muted("Run ")
-                    .Code("func new --list")
-                    .Muted(" to see available templates."));
-                return null;
-            }
-
-            return matched;
-        }
-
-        if (invocation.NonInteractive || !_interaction.IsInteractive)
-        {
-            _interaction.WriteError("Missing required option: --template.");
-            _interaction.WriteLine(l => l
-                .Muted("Pass ")
-                .Code("--template <id>")
-                .Muted(" or run interactively to pick one. ")
-                .Code("func new --list")
-                .Muted(" shows available templates."));
-            return null;
-        }
-
-        return await _picker.PickAsync(templates, cancellationToken);
-    }
-
-    private static IReadOnlyDictionary<string, string?> BuildPromptDefaults(
-        FunctionTemplateInfo template,
-        IReadOnlyDictionary<string, string?>? userOverrides = null)
-    {
-        var dict = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
-        foreach (TemplateUserPrompt prompt in template.Metadata.UserPrompts)
-        {
-            dict[prompt.Id] = prompt.DefaultValue;
-        }
-
-        if (userOverrides is not null)
-        {
-            foreach (KeyValuePair<string, string?> pair in userOverrides)
-            {
-                dict[pair.Key] = pair.Value;
-            }
-        }
-
-        return dict;
-    }
-
-    private int RenderApplyResult(
-        FunctionTemplateInfo template,
-        TemplateApplicationResult result,
-        IReadOnlyDictionary<string, string?> _)
-    {
-        switch (result)
-        {
-            case TemplateApplicationResult.Created created:
-                _interaction.WriteSuccess($"Created function '{template.Id}'.");
-                foreach (string file in created.Files)
-                {
-                    _interaction.WriteLine(l => l.Muted("  ").Code(file));
-                }
-                return 0;
-
-            case TemplateApplicationResult.AlreadyExists existing:
-                _interaction.WriteError("Some files already exist:");
-                foreach (string file in existing.ExistingFiles)
-                {
-                    _interaction.WriteLine(l => l.Muted("  ").Code(file));
-                }
-                _interaction.WriteLine(l => l
-                    .Muted("Re-run with ")
-                    .Code("--force")
-                    .Muted(" to overwrite."));
-                return 1;
-
-            case TemplateApplicationResult.Failed failed:
-                RenderFailure(failed.Failure);
-                return 1;
-
-            default:
-                _interaction.WriteError("Unknown apply result.");
-                return 1;
-        }
-    }
-
-    private void RenderFailure(TemplateApplicationFailure failure)
-    {
-        switch (failure)
-        {
-            case TemplateApplicationFailure.WriteFailed write:
-                _interaction.WriteError($"Failed to write '{write.Path}': {write.Message}");
-                break;
-            case TemplateApplicationFailure.InvalidPrompt prompt:
-                _interaction.WriteError($"Invalid prompt '{prompt.PromptId}': {prompt.Reason}");
-                break;
-            case TemplateApplicationFailure.ProviderError provider:
-                _interaction.WriteError(provider.Message);
-                break;
-            case TemplateApplicationFailure.MissingExtensionBundle bundle:
-                _interaction.WriteError($"Stack '{bundle.Stack}' requires extension bundle '{bundle.SuggestedBundleId}', which is not installed.");
-                break;
-            case TemplateApplicationFailure.MinBundleVersionTooOld min:
-                _interaction.WriteError(
-                    $"Installed bundle '{min.InstalledBundleVersion}' is outside required range '{min.RequiredRange}' for templates workload '{min.TemplatesWorkloadVersion}'.");
-                break;
-            case TemplateApplicationFailure.NoTemplatesWorkloadForChannel ntw:
-                _interaction.WriteError(
-                    $"No templates workload installed for channel '{ntw.Channel}' on stack '{ntw.Stack}'.");
-                _interaction.WriteLine(l => l
-                    .Muted("Install one with: ")
-                    .Code($"func workload install {ntw.SuggestedPackageId} --version {ntw.SuggestedVersion}")
-                    .Muted("."));
-                break;
-            default:
-                _interaction.WriteError("Template application failed.");
-                break;
-        }
-    }
-
-    /// <summary>
-    /// Minimal NuGet-style range containment check for v1 — accepts the
-    /// open-ended forms <c>[X.Y.Z, )</c> and bare <c>X.Y.Z</c> (treated as
-    /// "min X.Y.Z, no upper bound"). A follow-up can swap in NuGetVersion.
-    /// </summary>
-    internal static bool VersionRangeContains(string range, string version)
-    {
-        if (string.IsNullOrWhiteSpace(range) || string.IsNullOrWhiteSpace(version))
-        {
-            return true;
-        }
-
-        string trimmed = range.Trim();
-        string lowerBound = trimmed;
-        if (trimmed.StartsWith('[') || trimmed.StartsWith('('))
-        {
-            int comma = trimmed.IndexOf(',');
-            if (comma > 1)
-            {
-                lowerBound = trimmed[1..comma].Trim();
-            }
-            else
-            {
-                lowerBound = trimmed.Trim('[', '(', ']', ')').Trim();
-            }
-        }
-
-        return CompareVersions(version, lowerBound) >= 0;
-    }
-
-    private static int CompareVersions(string a, string b)
-    {
-        if (Version.TryParse(StripPrerelease(a), out Version? va)
-            && Version.TryParse(StripPrerelease(b), out Version? vb))
-        {
-            return va.CompareTo(vb);
-        }
-
-        return string.Compare(a, b, StringComparison.Ordinal);
-    }
-
-    private static string StripPrerelease(string version)
-    {
-        int dash = version.IndexOf('-');
-        return dash < 0 ? version : version[..dash];
     }
 
 }

--- a/src/Func/Templates/NewCommandRunner.cs
+++ b/src/Func/Templates/NewCommandRunner.cs
@@ -16,33 +16,22 @@ internal interface INewCommandRunner
 /// Orchestrates the <c>func new</c> resolution, selection, validation, and
 /// application pipeline through focused template services.
 /// </summary>
-internal sealed class NewCommandRunner : INewCommandRunner
+internal sealed class NewCommandRunner(
+    INewCommandContextResolver contextResolver,
+    INewCommandBundleValidator bundleValidator,
+    INewCommandTemplateCatalog templateCatalog,
+    INewCommandTemplateSelector templateSelector,
+    INewCommandTemplateApplicator templateApplicator,
+    NewCommandRenderer renderer,
+    INewCommandResultRenderer resultRenderer) : INewCommandRunner
 {
-    private readonly INewCommandContextResolver _contextResolver;
-    private readonly INewCommandBundleValidator _bundleValidator;
-    private readonly INewCommandTemplateCatalog _templateCatalog;
-    private readonly INewCommandTemplateSelector _templateSelector;
-    private readonly INewCommandTemplateApplicator _templateApplicator;
-    private readonly NewCommandRenderer _renderer;
-    private readonly INewCommandResultRenderer _resultRenderer;
-
-    public NewCommandRunner(
-        INewCommandContextResolver contextResolver,
-        INewCommandBundleValidator bundleValidator,
-        INewCommandTemplateCatalog templateCatalog,
-        INewCommandTemplateSelector templateSelector,
-        INewCommandTemplateApplicator templateApplicator,
-        NewCommandRenderer renderer,
-        INewCommandResultRenderer resultRenderer)
-    {
-        _contextResolver = contextResolver ?? throw new ArgumentNullException(nameof(contextResolver));
-        _bundleValidator = bundleValidator ?? throw new ArgumentNullException(nameof(bundleValidator));
-        _templateCatalog = templateCatalog ?? throw new ArgumentNullException(nameof(templateCatalog));
-        _templateSelector = templateSelector ?? throw new ArgumentNullException(nameof(templateSelector));
-        _templateApplicator = templateApplicator ?? throw new ArgumentNullException(nameof(templateApplicator));
-        _renderer = renderer ?? throw new ArgumentNullException(nameof(renderer));
-        _resultRenderer = resultRenderer ?? throw new ArgumentNullException(nameof(resultRenderer));
-    }
+    private readonly INewCommandContextResolver _contextResolver = contextResolver ?? throw new ArgumentNullException(nameof(contextResolver));
+    private readonly INewCommandBundleValidator _bundleValidator = bundleValidator ?? throw new ArgumentNullException(nameof(bundleValidator));
+    private readonly INewCommandTemplateCatalog _templateCatalog = templateCatalog ?? throw new ArgumentNullException(nameof(templateCatalog));
+    private readonly INewCommandTemplateSelector _templateSelector = templateSelector ?? throw new ArgumentNullException(nameof(templateSelector));
+    private readonly INewCommandTemplateApplicator _templateApplicator = templateApplicator ?? throw new ArgumentNullException(nameof(templateApplicator));
+    private readonly NewCommandRenderer _renderer = renderer ?? throw new ArgumentNullException(nameof(renderer));
+    private readonly INewCommandResultRenderer _resultRenderer = resultRenderer ?? throw new ArgumentNullException(nameof(resultRenderer));
 
     public async Task<int> ExecuteAsync(NewInvocation invocation, CancellationToken cancellationToken)
     {

--- a/src/Func/Templates/NewCommandTemplateApplicator.cs
+++ b/src/Func/Templates/NewCommandTemplateApplicator.cs
@@ -1,0 +1,62 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+
+namespace Azure.Functions.Cli.Templates;
+
+internal interface INewCommandTemplateApplicator
+{
+    public Task<TemplateApplicationResult> ApplyAsync(
+        NewInvocation invocation,
+        NewCommandResolvedContext context,
+        FunctionTemplateInfo template,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class NewCommandTemplateApplicator(
+    ITemplateEngineProviderRegistry engineProviders,
+    TemplateOptionHydrator optionHydrator) : INewCommandTemplateApplicator
+{
+    private readonly ITemplateEngineProviderRegistry _engineProviders =
+        engineProviders ?? throw new ArgumentNullException(nameof(engineProviders));
+    private readonly TemplateOptionHydrator _optionHydrator =
+        optionHydrator ?? throw new ArgumentNullException(nameof(optionHydrator));
+
+    public async Task<TemplateApplicationResult> ApplyAsync(
+        NewInvocation invocation,
+        NewCommandResolvedContext context,
+        FunctionTemplateInfo template,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(invocation);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(template);
+
+        ITemplateEngineProvider? provider = _engineProviders.TryGet(template.EngineId);
+        if (provider is null)
+        {
+            return new TemplateApplicationResult.Failed(
+                new TemplateApplicationFailure.ProviderError(
+                    $"No engine registered for EngineId '{template.EngineId}'. This is a CLI bug.",
+                    InnerException: null));
+        }
+
+        _ = _optionHydrator.Hydrate(template);
+
+        string functionName = invocation.RequestedFunctionName
+            ?? template.DefaultFunctionName
+            ?? template.Id;
+        var newContext = new NewContext(
+            invocation.WorkingDirectory,
+            template,
+            functionName,
+            context.Language,
+            invocation.Force,
+            context.Workload.InstallDirectory,
+            invocation.UserOptionValues);
+
+        ParseResult emptyParseResult = new RootCommand().Parse(string.Empty);
+        return await provider.ApplyAsync(newContext, emptyParseResult, cancellationToken);
+    }
+}

--- a/src/Func/Templates/NewCommandTemplateCatalog.cs
+++ b/src/Func/Templates/NewCommandTemplateCatalog.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Templates;
+
+internal interface INewCommandTemplateCatalog
+{
+    public Task<IReadOnlyList<FunctionTemplateInfo>> ListAsync(
+        NewCommandResolvedContext context,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class NewCommandTemplateCatalog(ITemplateEngineProviderRegistry engineProviders) : INewCommandTemplateCatalog
+{
+    private readonly ITemplateEngineProviderRegistry _engineProviders =
+        engineProviders ?? throw new ArgumentNullException(nameof(engineProviders));
+
+    public async Task<IReadOnlyList<FunctionTemplateInfo>> ListAsync(
+        NewCommandResolvedContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var listContext = new TemplateListContext(
+            context.WorkingDirectory,
+            context.Stack,
+            context.Language,
+            context.Workload.InstallDirectory);
+        List<FunctionTemplateInfo> templates = [];
+        foreach (ITemplateEngineProvider provider in _engineProviders.Providers)
+        {
+            IReadOnlyList<FunctionTemplateInfo> contributed = await provider.ListTemplatesAsync(listContext, cancellationToken);
+            templates.AddRange(contributed);
+        }
+
+        return templates;
+    }
+}

--- a/src/Func/Templates/NewCommandTemplateOptionProvider.cs
+++ b/src/Func/Templates/NewCommandTemplateOptionProvider.cs
@@ -1,0 +1,64 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+
+namespace Azure.Functions.Cli.Templates;
+
+internal interface INewCommandTemplateOptionProvider
+{
+    public Task<IReadOnlyList<Option>?> HydrateOptionsForTemplateAsync(
+        NewInvocation invocation,
+        string templateId,
+        CancellationToken cancellationToken);
+
+    public Task<IReadOnlyList<HydratedTemplateOption>?> HydrateOptionsForTemplateWithIdsAsync(
+        NewInvocation invocation,
+        string templateId,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class NewCommandTemplateOptionProvider(
+    INewCommandContextResolver contextResolver,
+    INewCommandTemplateCatalog templateCatalog,
+    TemplateOptionHydrator optionHydrator) : INewCommandTemplateOptionProvider
+{
+    private readonly INewCommandContextResolver _contextResolver =
+        contextResolver ?? throw new ArgumentNullException(nameof(contextResolver));
+    private readonly INewCommandTemplateCatalog _templateCatalog =
+        templateCatalog ?? throw new ArgumentNullException(nameof(templateCatalog));
+    private readonly TemplateOptionHydrator _optionHydrator =
+        optionHydrator ?? throw new ArgumentNullException(nameof(optionHydrator));
+
+    public async Task<IReadOnlyList<Option>?> HydrateOptionsForTemplateAsync(
+        NewInvocation invocation,
+        string templateId,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<HydratedTemplateOption>? paired =
+            await HydrateOptionsForTemplateWithIdsAsync(invocation, templateId, cancellationToken);
+
+        return paired?.Select(pair => pair.Option).ToList();
+    }
+
+    public async Task<IReadOnlyList<HydratedTemplateOption>?> HydrateOptionsForTemplateWithIdsAsync(
+        NewInvocation invocation,
+        string templateId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(invocation);
+        ArgumentException.ThrowIfNullOrWhiteSpace(templateId);
+
+        NewCommandResolutionResult outcome = await _contextResolver.ResolveAsync(invocation, cancellationToken);
+        if (outcome.Context is not { } resolved)
+        {
+            return null;
+        }
+
+        IReadOnlyList<FunctionTemplateInfo> templates = await _templateCatalog.ListAsync(resolved, cancellationToken);
+        FunctionTemplateInfo? template = templates.FirstOrDefault(candidate =>
+            string.Equals(candidate.Id, templateId, StringComparison.OrdinalIgnoreCase));
+
+        return template is null ? null : _optionHydrator.HydrateWithIds(template);
+    }
+}

--- a/src/Func/Templates/NewCommandTemplateOptionProvider.cs
+++ b/src/Func/Templates/NewCommandTemplateOptionProvider.cs
@@ -5,6 +5,16 @@ using System.CommandLine;
 
 namespace Azure.Functions.Cli.Templates;
 
+/// <summary>
+/// Hydrates a single template's options for the help and pre-parse passes in
+/// <c>NewCommand</c>.
+/// </summary>
+/// <remarks>
+/// These callers are best-effort and return <c>null</c> silently when
+/// resolution fails. The execute and list entry-points resolve and render
+/// failures themselves, so rendering here too would surface the same error
+/// twice for a single invocation (issue #5304).
+/// </remarks>
 internal interface INewCommandTemplateOptionProvider
 {
     public Task<IReadOnlyList<Option>?> HydrateOptionsForTemplateAsync(

--- a/src/Func/Templates/NewCommandTemplateSelector.cs
+++ b/src/Func/Templates/NewCommandTemplateSelector.cs
@@ -1,0 +1,62 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Console;
+
+namespace Azure.Functions.Cli.Templates;
+
+internal interface INewCommandTemplateSelector
+{
+    public Task<FunctionTemplateInfo?> SelectAsync(
+        NewInvocation invocation,
+        IReadOnlyList<FunctionTemplateInfo> templates,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class NewCommandTemplateSelector(
+    IInteractionService interaction,
+    TemplatePicker picker) : INewCommandTemplateSelector
+{
+    private readonly IInteractionService _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
+    private readonly TemplatePicker _picker = picker ?? throw new ArgumentNullException(nameof(picker));
+
+    public async Task<FunctionTemplateInfo?> SelectAsync(
+        NewInvocation invocation,
+        IReadOnlyList<FunctionTemplateInfo> templates,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(invocation);
+        ArgumentNullException.ThrowIfNull(templates);
+
+        if (!string.IsNullOrWhiteSpace(invocation.RequestedTemplate))
+        {
+            FunctionTemplateInfo? matched = templates.FirstOrDefault(template =>
+                string.Equals(template.Id, invocation.RequestedTemplate, StringComparison.OrdinalIgnoreCase));
+            if (matched is null)
+            {
+                _interaction.WriteError(
+                    $"Template '{invocation.RequestedTemplate}' was not found for this project's stack.");
+                _interaction.WriteLine(line => line
+                    .Muted("Run ")
+                    .Code("func new --list")
+                    .Muted(" to see available templates."));
+            }
+
+            return matched;
+        }
+
+        if (invocation.NonInteractive || !_interaction.IsInteractive)
+        {
+            _interaction.WriteError("Missing required option: --template.");
+            _interaction.WriteLine(line => line
+                .Muted("Pass ")
+                .Code("--template <id>")
+                .Muted(" or run interactively to pick one. ")
+                .Code("func new --list")
+                .Muted(" shows available templates."));
+            return null;
+        }
+
+        return await _picker.PickAsync(templates, cancellationToken);
+    }
+}

--- a/src/Func/Templates/TemplatesServiceCollectionExtensions.cs
+++ b/src/Func/Templates/TemplatesServiceCollectionExtensions.cs
@@ -24,10 +24,17 @@ internal static class TemplatesServiceCollectionExtensions
         services.AddSingleton<IInstalledTemplatesWorkloads, InstalledTemplatesWorkloads>();
         services.AddSingleton<ITemplateEngineProviderRegistry, TemplateEngineProviderRegistry>();
         services.AddSingleton<INewCommandContextResolver, NewCommandContextResolver>();
+        services.AddSingleton<ITemplatesWorkloadManifestReader, TemplatesWorkloadManifestReader>();
+        services.AddSingleton<INewCommandBundleValidator, NewCommandBundleValidator>();
         services.AddSingleton<TemplateOptionHydrator>();
+        services.AddSingleton<INewCommandTemplateCatalog, NewCommandTemplateCatalog>();
+        services.AddSingleton<INewCommandTemplateApplicator, NewCommandTemplateApplicator>();
+        services.AddSingleton<INewCommandTemplateOptionProvider, NewCommandTemplateOptionProvider>();
         services.AddSingleton<TemplatePicker>();
+        services.AddSingleton<INewCommandTemplateSelector, NewCommandTemplateSelector>();
         services.AddSingleton<NewCommandRenderer>();
-        services.AddSingleton<NewCommandRunner>();
+        services.AddSingleton<INewCommandResultRenderer, NewCommandResultRenderer>();
+        services.AddSingleton<INewCommandRunner, NewCommandRunner>();
 
         return services;
     }

--- a/src/Func/Templates/TemplatesServiceCollectionExtensions.cs
+++ b/src/Func/Templates/TemplatesServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ internal static class TemplatesServiceCollectionExtensions
 
         services.AddSingleton<IInstalledTemplatesWorkloads, InstalledTemplatesWorkloads>();
         services.AddSingleton<ITemplateEngineProviderRegistry, TemplateEngineProviderRegistry>();
+        services.AddSingleton<INewCommandContextResolver, NewCommandContextResolver>();
         services.AddSingleton<TemplateOptionHydrator>();
         services.AddSingleton<TemplatePicker>();
         services.AddSingleton<NewCommandRenderer>();

--- a/src/Func/Templates/TemplatesWorkloadManifestReader.cs
+++ b/src/Func/Templates/TemplatesWorkloadManifestReader.cs
@@ -10,7 +10,12 @@ namespace Azure.Functions.Cli.Templates;
 /// <c>content/templates-workload.json</c> shipped by Node and Python
 /// templates content workloads (templates-workload-spec.md §4.4.4, §5.2).
 /// </summary>
-internal static class TemplatesWorkloadManifestReader
+internal interface ITemplatesWorkloadManifestReader
+{
+    public string? GetMinBundleVersion(string installDirectory);
+}
+
+internal sealed class TemplatesWorkloadManifestReader : ITemplatesWorkloadManifestReader
 {
     private static readonly JsonSerializerOptions _jsonOptions = new()
     {
@@ -25,7 +30,7 @@ internal static class TemplatesWorkloadManifestReader
     /// key isn't present. Missing manifest is treated as "no min-bundle
     /// constraint" — the §4.8.2 gate is a no-op in that case.
     /// </summary>
-    public static string? GetMinBundleVersion(string installDirectory)
+    public string? GetMinBundleVersion(string installDirectory)
     {
         if (string.IsNullOrWhiteSpace(installDirectory))
         {

--- a/test/Func.Tests/Commands/NewCommandTests.cs
+++ b/test/Func.Tests/Commands/NewCommandTests.cs
@@ -11,30 +11,20 @@ namespace Azure.Functions.Cli.Tests.Commands;
 public class NewCommandTests
 {
     private readonly TestInteractionService _interaction;
-    private readonly NewCommandRunner _runner;
+    private readonly INewCommandRunner _runner;
+    private readonly INewCommandTemplateOptionProvider _templateOptions;
 
     public NewCommandTests()
     {
         _interaction = new TestInteractionService();
-        _runner = new NewCommandRunner(
-            _interaction,
-            Substitute.For<Cli.Projects.IFunctionsProjectResolver>(),
-            Substitute.For<Cli.Profiles.IProfileResolver>(),
-            Substitute.For<Microsoft.Extensions.Options.IOptionsMonitor<Cli.Configuration.StackOptions>>(),
-            System.Array.Empty<Cli.Projects.IProjectInitializer>(),
-            Substitute.For<IInstalledTemplatesWorkloads>(),
-            new TemplateEngineProviderRegistry([]),
-            new TemplateOptionHydrator(System.Array.Empty<Cli.Projects.IProjectInitializer>()),
-            new TemplatePicker(_interaction),
-            new NewCommandRenderer(_interaction),
-            Substitute.For<Cli.Bundles.IHostJsonBundleSectionReader>(),
-            Substitute.For<Cli.Bundles.IExtensionBundleResolver>());
+        _runner = Substitute.For<INewCommandRunner>();
+        _templateOptions = Substitute.For<INewCommandTemplateOptionProvider>();
     }
 
     [Fact]
     public void NewCommand_HasExpectedOptions()
     {
-        var cmd = new NewCommand(_runner);
+        var cmd = new NewCommand(_runner, _templateOptions);
         var optionNames = cmd.Options.Select(o => o.Name).ToList();
 
         optionNames.Should().Contain("--name");
@@ -56,7 +46,7 @@ public class NewCommandTests
     [Fact]
     public void NewCommand_HasPathArgument()
     {
-        var cmd = new NewCommand(_runner);
+        var cmd = new NewCommand(_runner, _templateOptions);
         cmd.Arguments.Should().ContainSingle();
         cmd.Arguments[0].Name.Should().Be("path");
     }

--- a/test/Func.Tests/Templates/NewCommandBundleValidatorTests.cs
+++ b/test/Func.Tests/Templates/NewCommandBundleValidatorTests.cs
@@ -1,0 +1,112 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Bundles;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Templates;
+using NSubstitute;
+
+namespace Azure.Functions.Cli.Tests.Templates;
+
+public class NewCommandBundleValidatorTests
+{
+    private readonly TestInteractionService _interaction = new();
+    private readonly IHostJsonBundleSectionReader _hostJsonReader = Substitute.For<IHostJsonBundleSectionReader>();
+    private readonly IExtensionBundleResolver _bundleResolver = Substitute.For<IExtensionBundleResolver>();
+    private readonly ITemplatesWorkloadManifestReader _manifestReader = Substitute.For<ITemplatesWorkloadManifestReader>();
+
+    [Fact]
+    public async Task ValidateAsync_DotNetStack_SkipsBundleValidation()
+    {
+        NewCommandBundleValidator validator = CreateValidator();
+        NewCommandResolvedContext context = CreateContext("dotnet", bundleId: null);
+
+        int result = await validator.ValidateAsync(context, CancellationToken.None);
+
+        result.Should().Be(0);
+        await _hostJsonReader.DidNotReceiveWithAnyArgs().ReadAsync(default!, default);
+        await _bundleResolver.DidNotReceiveWithAnyArgs().ResolveAsync(default!, default);
+        _manifestReader.DidNotReceiveWithAnyArgs().GetMinBundleVersion(default!);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_MissingBundleWorkload_RendersInstallHint()
+    {
+        NewCommandBundleValidator validator = CreateValidator();
+        NewCommandResolvedContext context = CreateContext("node", BundleHelpers.StableBundleId);
+        _hostJsonReader.ReadAsync(context.WorkingDirectory.Info, Arg.Any<CancellationToken>())
+            .Returns(new HostJsonBundleSection(BundleHelpers.StableBundleId, "[4.0.0, 5.0.0)"));
+        _bundleResolver.ResolveAsync(Arg.Any<ExtensionBundleProjectContext>(), Arg.Any<CancellationToken>())
+            .Returns(new ExtensionBundleResolution.WorkloadMissing("missing"));
+
+        int result = await validator.ValidateAsync(context, CancellationToken.None);
+
+        result.Should().Be(1);
+        _interaction.Lines.Should().Contain(line => line.Contains("none is resolvable", StringComparison.Ordinal));
+        _interaction.Lines.Should().Contain(line => line.Contains("func setup", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ResolvedBundleBelowMinimum_RendersVersionError()
+    {
+        NewCommandBundleValidator validator = CreateValidator();
+        NewCommandResolvedContext context = CreateContext("python", BundleHelpers.StableBundleId);
+        _hostJsonReader.ReadAsync(context.WorkingDirectory.Info, Arg.Any<CancellationToken>())
+            .Returns(new HostJsonBundleSection(BundleHelpers.StableBundleId, "[3.0.0, 5.0.0)"));
+        _bundleResolver.ResolveAsync(Arg.Any<ExtensionBundleProjectContext>(), Arg.Any<CancellationToken>())
+            .Returns(new ExtensionBundleResolution.Resolved(BundleHelpers.StableBundleId, "3.9.0", "bundle", null));
+        _manifestReader.GetMinBundleVersion(context.Workload.InstallDirectory).Returns("[4.0.0, )");
+
+        int result = await validator.ValidateAsync(context, CancellationToken.None);
+
+        result.Should().Be(1);
+        _interaction.Lines.Should().Contain(line =>
+            line.Contains("requires extension bundle in range '[4.0.0, )'", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ResolvedBundleInRange_Succeeds()
+    {
+        NewCommandBundleValidator validator = CreateValidator();
+        NewCommandResolvedContext context = CreateContext("python", BundleHelpers.StableBundleId);
+        _hostJsonReader.ReadAsync(context.WorkingDirectory.Info, Arg.Any<CancellationToken>())
+            .Returns(new HostJsonBundleSection(BundleHelpers.StableBundleId, "[4.0.0, 5.0.0)"));
+        _bundleResolver.ResolveAsync(Arg.Any<ExtensionBundleProjectContext>(), Arg.Any<CancellationToken>())
+            .Returns(new ExtensionBundleResolution.Resolved(BundleHelpers.StableBundleId, "4.1.0", "bundle", null));
+        _manifestReader.GetMinBundleVersion(context.Workload.InstallDirectory).Returns("[4.0.0, )");
+
+        int result = await validator.ValidateAsync(context, CancellationToken.None);
+
+        result.Should().Be(0);
+        _interaction.Lines.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("[4.0.0, )", "4.0.0", true)]
+    [InlineData("[4.0.0, )", "3.9.0", false)]
+    [InlineData("4.0.0", "4.1.0-preview.1", true)]
+    public void VersionRangeContains_ReturnsExpectedResult(string range, string version, bool expected)
+    {
+        NewCommandBundleValidator.VersionRangeContains(range, version).Should().Be(expected);
+    }
+
+    private NewCommandBundleValidator CreateValidator()
+    {
+        return new NewCommandBundleValidator(_interaction, _hostJsonReader, _bundleResolver, _manifestReader);
+    }
+
+    private static NewCommandResolvedContext CreateContext(string stack, string? bundleId)
+    {
+        WorkingDirectory workingDirectory = new(new DirectoryInfo(Path.GetTempPath()), WasExplicit: false);
+        InstalledTemplatesWorkload workload = new(stack, "1.0.0", "install");
+        return new NewCommandResolvedContext(
+            workingDirectory,
+            stack,
+            "language",
+            workload,
+            bundleId,
+            BundleChannel.Stable,
+            UsedStableFallback: false);
+    }
+}

--- a/test/Func.Tests/Templates/NewCommandContextResolverTests.cs
+++ b/test/Func.Tests/Templates/NewCommandContextResolverTests.cs
@@ -1,0 +1,178 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Bundles;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Configuration;
+using Azure.Functions.Cli.Profiles;
+using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Templates;
+using Azure.Functions.Cli.Workers;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Azure.Functions.Cli.Tests.Templates;
+
+public class NewCommandContextResolverTests
+{
+    [Fact]
+    public async Task ResolveAsync_NullInvocation_ThrowsArgumentNullException()
+    {
+        ResolverFixture fixture = new();
+        NewCommandContextResolver resolver = fixture.CreateResolver();
+
+        await FluentActions.Awaiting(() => resolver.ResolveAsync(null!, CancellationToken.None))
+            .Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task ResolveAsync_MissingLanguage_ReturnsFailureWithoutRendering()
+    {
+        ResolverFixture fixture = new();
+        fixture.ResolveProject("dotnet", supportsExtensionBundles: false);
+        fixture.StackOptions.Get(Arg.Any<string>()).Returns(new StackOptions { Runtime = "dotnet", Language = null });
+        fixture.InstalledTemplates.ListInstalledAsync("dotnet", Arg.Any<CancellationToken>())
+            .Returns([new InstalledTemplatesWorkload("dotnet", "1.0.0", "install")]);
+        NewCommandContextResolver resolver = fixture.CreateResolver();
+
+        NewCommandResolutionResult result = await resolver.ResolveAsync(fixture.Invocation, CancellationToken.None);
+
+        result.Context.Should().BeNull();
+        result.Failure.Should().NotBeNull();
+        result.Failure!.Kind.Should().Be(NewCommandResolutionFailureKind.MissingLanguage);
+        fixture.Interaction.Lines.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ResolveAsync_MissingConfiguredLanguageOnSingleLanguageStack_UsesInitializerLanguage()
+    {
+        ResolverFixture fixture = new();
+        fixture.ResolveProject("dotnet", supportsExtensionBundles: false);
+        fixture.StackOptions.Get(Arg.Any<string>()).Returns(new StackOptions { Runtime = "dotnet", Language = null });
+        fixture.InstalledTemplates.ListInstalledAsync("dotnet", Arg.Any<CancellationToken>())
+            .Returns([new InstalledTemplatesWorkload("dotnet", "1.0.0", "install")]);
+        IProjectInitializer initializer = Substitute.For<IProjectInitializer>();
+        initializer.Stack.Returns("dotnet");
+        initializer.SupportedLanguages.Returns(["csharp"]);
+        NewCommandContextResolver resolver = fixture.CreateResolver([initializer]);
+
+        NewCommandResolutionResult result = await resolver.ResolveAsync(fixture.Invocation, CancellationToken.None);
+
+        result.Failure.Should().BeNull();
+        result.Context.Should().NotBeNull();
+        result.Context!.Language.Should().Be("csharp");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_PreviewChannelWithoutPreviewWorkload_UsesStableFallback()
+    {
+        ResolverFixture fixture = new();
+        fixture.ResolveProject("node", supportsExtensionBundles: true);
+        fixture.StackOptions.Get(Arg.Any<string>()).Returns(new StackOptions { Runtime = "node", Language = "javascript" });
+        fixture.HostJsonReader.ReadAsync(fixture.WorkingDirectory.Info, Arg.Any<CancellationToken>())
+            .Returns(new HostJsonBundleSection(BundleHelpers.PreviewBundleId, "[4.0.0, 5.0.0)"));
+        InstalledTemplatesWorkload stableWorkload = new("node", "1.0.0", "stable-install");
+        fixture.InstalledTemplates.ListInstalledAsync("node", Arg.Any<CancellationToken>())
+            .Returns([stableWorkload]);
+        NewCommandContextResolver resolver = fixture.CreateResolver();
+
+        NewCommandResolutionResult result = await resolver.ResolveAsync(fixture.Invocation, CancellationToken.None);
+
+        result.Failure.Should().BeNull();
+        result.Context.Should().NotBeNull();
+        result.Context!.Workload.Should().Be(stableWorkload);
+        result.Context.BundleId.Should().Be(BundleHelpers.PreviewBundleId);
+        result.Context.Channel.Should().Be(BundleChannel.Preview);
+        result.Context.UsedStableFallback.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ResolveAsync_PreviewChannelWithoutPreviewOrStableWorkload_ReturnsChannelFailure()
+    {
+        ResolverFixture fixture = new();
+        fixture.ResolveProject("node", supportsExtensionBundles: true);
+        fixture.StackOptions.Get(Arg.Any<string>()).Returns(new StackOptions { Runtime = "node", Language = "javascript" });
+        fixture.HostJsonReader.ReadAsync(fixture.WorkingDirectory.Info, Arg.Any<CancellationToken>())
+            .Returns(new HostJsonBundleSection(BundleHelpers.PreviewBundleId, "[4.0.0, 5.0.0)"));
+        fixture.InstalledTemplates.ListInstalledAsync("node", Arg.Any<CancellationToken>())
+            .Returns([new InstalledTemplatesWorkload("node", "1.0.0-experimental.1", "experimental-install")]);
+        NewCommandContextResolver resolver = fixture.CreateResolver();
+
+        NewCommandResolutionResult result = await resolver.ResolveAsync(fixture.Invocation, CancellationToken.None);
+
+        result.Context.Should().BeNull();
+        result.Failure.Should().NotBeNull();
+        result.Failure!.Kind.Should().Be(NewCommandResolutionFailureKind.NoTemplatesWorkloadForChannel);
+        result.Failure.Channel.Should().Be(BundleChannel.Preview);
+        result.Failure.BundleId.Should().Be(BundleHelpers.PreviewBundleId);
+    }
+
+    private sealed class ResolverFixture
+    {
+        public ResolverFixture()
+        {
+            WorkingDirectory = new WorkingDirectory(new DirectoryInfo(Path.GetTempPath()), WasExplicit: false);
+            Invocation = new NewInvocation(
+                WorkingDirectory,
+                RequestedTemplate: null,
+                RequestedFunctionName: null,
+                Force: false,
+                NonInteractive: true);
+        }
+
+        public TestInteractionService Interaction { get; } = new();
+
+        public IFunctionsProjectResolver ProjectResolver { get; } = Substitute.For<IFunctionsProjectResolver>();
+
+        public IProfileResolver ProfileResolver { get; } = Substitute.For<IProfileResolver>();
+
+        public IOptionsMonitor<StackOptions> StackOptions { get; } = Substitute.For<IOptionsMonitor<StackOptions>>();
+
+        public IInstalledTemplatesWorkloads InstalledTemplates { get; } = Substitute.For<IInstalledTemplatesWorkloads>();
+
+        public IHostJsonBundleSectionReader HostJsonReader { get; } = Substitute.For<IHostJsonBundleSectionReader>();
+
+        public WorkingDirectory WorkingDirectory { get; }
+
+        public NewInvocation Invocation { get; }
+
+        public NewCommandContextResolver CreateResolver(IEnumerable<IProjectInitializer>? projectInitializers = null)
+        {
+            return new NewCommandContextResolver(
+                Interaction,
+                ProjectResolver,
+                ProfileResolver,
+                StackOptions,
+                projectInitializers ?? [],
+                InstalledTemplates,
+                HostJsonReader);
+        }
+
+        public void ResolveProject(string stack, bool supportsExtensionBundles)
+        {
+            ProjectResolver.ResolveProjectAsync(Arg.Any<ProjectResolutionContext>(), Arg.Any<CancellationToken>())
+                .Returns(ProjectResolutionResults.Resolved(
+                    new FakeProject(WorkingDirectory, stack, supportsExtensionBundles),
+                    "fake"));
+        }
+    }
+
+    private sealed class FakeProject(
+        WorkingDirectory workingDirectory,
+        string stack,
+        bool supportsExtensionBundles) : FunctionsProject
+    {
+        private readonly FunctionsWorkerReference _workerReference =
+            FunctionsWorkerReference.FromWorkerInfo(stack, stack, "/tmp/worker.config.json", "1.0.0");
+
+        public override WorkingDirectory WorkingDirectory { get; } = workingDirectory;
+
+        public override string StackName { get; } = stack;
+
+        public override string StackDisplayName { get; } = stack;
+
+        public override bool SupportsExtensionBundles { get; } = supportsExtensionBundles;
+
+        public override FunctionsWorkerReference WorkerReference => _workerReference;
+    }
+}

--- a/test/Func.Tests/Templates/NewCommandResultRendererTests.cs
+++ b/test/Func.Tests/Templates/NewCommandResultRendererTests.cs
@@ -1,0 +1,87 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Templates;
+
+namespace Azure.Functions.Cli.Tests.Templates;
+
+public class NewCommandResultRendererTests
+{
+    private readonly TestInteractionService _interaction = new();
+
+    [Fact]
+    public void RenderResolutionFailure_MissingLanguage_RendersSetupHint()
+    {
+        NewCommandResultRenderer renderer = CreateRenderer();
+        NewCommandResolutionFailure failure = new(
+            NewCommandResolutionFailureKind.MissingLanguage,
+            Stack: "dotnet",
+            ProjectPath: "project");
+
+        renderer.RenderResolutionFailure(failure);
+
+        _interaction.Lines.Should().Contain(line =>
+            line.Contains("Cannot determine language for stack 'dotnet'", StringComparison.Ordinal));
+        _interaction.Lines.Should().Contain(line => line.Contains("func init", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void RenderApplyResult_Created_RendersFilesAndReturnsSuccess()
+    {
+        NewCommandResultRenderer renderer = CreateRenderer();
+        FunctionTemplateInfo template = CreateTemplate();
+
+        int result = renderer.RenderApplyResult(
+            template,
+            new TemplateApplicationResult.Created(["Function.cs", "function.json"]));
+
+        result.Should().Be(0);
+        _interaction.Lines.Should().Contain(line => line.Contains("Created function 'HttpTrigger'", StringComparison.Ordinal));
+        _interaction.Lines.Should().Contain(line => line.Contains("Function.cs", StringComparison.Ordinal));
+        _interaction.Lines.Should().Contain(line => line.Contains("function.json", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void RenderApplyResult_AlreadyExists_RendersForceHintAndReturnsFailure()
+    {
+        NewCommandResultRenderer renderer = CreateRenderer();
+
+        int result = renderer.RenderApplyResult(
+            CreateTemplate(),
+            new TemplateApplicationResult.AlreadyExists(["Function.cs"]));
+
+        result.Should().Be(1);
+        _interaction.Lines.Should().Contain(line => line.Contains("Function.cs", StringComparison.Ordinal));
+        _interaction.Lines.Should().Contain(line => line.Contains("--force", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void RenderApplyResult_ProviderFailure_RendersMessageAndReturnsFailure()
+    {
+        NewCommandResultRenderer renderer = CreateRenderer();
+        TemplateApplicationFailure failure = new TemplateApplicationFailure.ProviderError("engine failed", null);
+
+        int result = renderer.RenderApplyResult(CreateTemplate(), new TemplateApplicationResult.Failed(failure));
+
+        result.Should().Be(1);
+        _interaction.Lines.Should().Contain(line => line.Contains("engine failed", StringComparison.Ordinal));
+    }
+
+    private NewCommandResultRenderer CreateRenderer()
+    {
+        return new NewCommandResultRenderer(_interaction, new NewCommandRenderer(_interaction));
+    }
+
+    private static FunctionTemplateInfo CreateTemplate()
+    {
+        return new FunctionTemplateInfo(
+            "HttpTrigger",
+            "dotnet",
+            "dotnet",
+            "HTTP trigger",
+            Description: null,
+            DefaultFunctionName: null,
+            Languages: ["csharp"],
+            new TemplateMetadata([], RequiresExtensionBundle: false, MinBundleVersion: null));
+    }
+}

--- a/test/Func.Tests/Templates/NewCommandRunnerTests.cs
+++ b/test/Func.Tests/Templates/NewCommandRunnerTests.cs
@@ -16,6 +16,88 @@ namespace Azure.Functions.Cli.Tests.Templates;
 public class NewCommandRunnerTests
 {
     [Fact]
+    public async Task ExecuteAsync_Success_InvokesPipelineInOrderAndForwardsCancellationToken()
+    {
+        List<string> calls = [];
+        using CancellationTokenSource cancellation = new();
+        WorkingDirectory workingDirectory = new(new DirectoryInfo(Path.GetTempPath()), WasExplicit: false);
+        NewInvocation invocation = new(
+            workingDirectory,
+            RequestedTemplate: "HttpTrigger",
+            RequestedFunctionName: "MyFunction",
+            Force: false,
+            NonInteractive: true);
+        NewCommandResolvedContext context = new(
+            workingDirectory,
+            "node",
+            "javascript",
+            new InstalledTemplatesWorkload("node", "1.0.0", "install"),
+            BundleId: null,
+            BundleChannel.Unknown,
+            UsedStableFallback: false);
+        FunctionTemplateInfo template = new(
+            "HttpTrigger",
+            "node",
+            EngineIds.V2,
+            "HTTP trigger",
+            Description: null,
+            DefaultFunctionName: "HttpTrigger",
+            Languages: ["javascript"],
+            new TemplateMetadata([], RequiresExtensionBundle: false, MinBundleVersion: null));
+        TemplateApplicationResult applyResult = new TemplateApplicationResult.Created(["Function.js"]);
+
+        INewCommandContextResolver contextResolver = Substitute.For<INewCommandContextResolver>();
+        contextResolver.ResolveAsync(invocation, cancellation.Token).Returns(_ =>
+        {
+            calls.Add("resolve");
+            return Task.FromResult(NewCommandResolutionResult.Succeed(context));
+        });
+        INewCommandBundleValidator bundleValidator = Substitute.For<INewCommandBundleValidator>();
+        bundleValidator.ValidateAsync(context, cancellation.Token).Returns(_ =>
+        {
+            calls.Add("validate");
+            return Task.FromResult(0);
+        });
+        INewCommandTemplateCatalog templateCatalog = Substitute.For<INewCommandTemplateCatalog>();
+        templateCatalog.ListAsync(context, cancellation.Token).Returns(_ =>
+        {
+            calls.Add("catalog");
+            return Task.FromResult<IReadOnlyList<FunctionTemplateInfo>>([template]);
+        });
+        INewCommandTemplateSelector templateSelector = Substitute.For<INewCommandTemplateSelector>();
+        templateSelector.SelectAsync(invocation, Arg.Any<IReadOnlyList<FunctionTemplateInfo>>(), cancellation.Token).Returns(_ =>
+        {
+            calls.Add("select");
+            return Task.FromResult<FunctionTemplateInfo?>(template);
+        });
+        INewCommandTemplateApplicator templateApplicator = Substitute.For<INewCommandTemplateApplicator>();
+        templateApplicator.ApplyAsync(invocation, context, template, cancellation.Token).Returns(_ =>
+        {
+            calls.Add("apply");
+            return Task.FromResult(applyResult);
+        });
+        INewCommandResultRenderer resultRenderer = Substitute.For<INewCommandResultRenderer>();
+        resultRenderer.RenderApplyResult(template, applyResult).Returns(_ =>
+        {
+            calls.Add("render");
+            return 0;
+        });
+        TestInteractionService interaction = new();
+        NewCommandRunner runner = new(
+            contextResolver,
+            bundleValidator,
+            templateCatalog,
+            templateSelector,
+            templateApplicator,
+            new NewCommandRenderer(interaction),
+            resultRenderer);
+
+        int exitCode = await runner.ExecuteAsync(invocation, cancellation.Token);
+
+        exitCode.Should().Be(0);
+        calls.Should().Equal("resolve", "validate", "catalog", "select", "apply", "render");
+    }
+    [Fact]
     public async Task ExecuteAsync_MissingLanguageOnMultiLanguageStack_RendersErrorExactlyOnce()
     {
         // Repro of https://github.com/Azure/azure-functions-core-tools/issues/5304:
@@ -149,19 +231,24 @@ public class NewCommandRunnerTests
         // (initializer has > 1 SupportedLanguages or no entry), so the
         // single-language fallback in ResolveLanguage cannot fire and the
         // missing-language branch is taken.
+        ITemplateEngineProviderRegistry engineProviders = new TemplateEngineProviderRegistry([]);
+        TemplateOptionHydrator optionHydrator = new([]);
+        NewCommandRenderer renderer = new(interaction);
         return new NewCommandRunner(
-            interaction,
-            projectResolver,
-            profileResolver,
-            stackOptions,
-            projectInitializers: Array.Empty<IProjectInitializer>(),
-            installedTemplates,
-            new TemplateEngineProviderRegistry([]),
-            new TemplateOptionHydrator(Array.Empty<IProjectInitializer>()),
-            new TemplatePicker(interaction),
-            new NewCommandRenderer(interaction),
-            Substitute.For<IHostJsonBundleSectionReader>(),
-            Substitute.For<IExtensionBundleResolver>());
+            new NewCommandContextResolver(
+                interaction,
+                projectResolver,
+                profileResolver,
+                stackOptions,
+                projectInitializers: [],
+                installedTemplates,
+                Substitute.For<IHostJsonBundleSectionReader>()),
+            Substitute.For<INewCommandBundleValidator>(),
+            new NewCommandTemplateCatalog(engineProviders),
+            new NewCommandTemplateSelector(interaction, new TemplatePicker(interaction)),
+            new NewCommandTemplateApplicator(engineProviders, optionHydrator),
+            renderer,
+            new NewCommandResultRenderer(interaction, renderer));
     }
 
     private static NewCommandRunner BuildRunnerForChannelFallback(
@@ -190,19 +277,24 @@ public class NewCommandRunnerTests
             .ReadAsync(Arg.Any<DirectoryInfo>(), Arg.Any<CancellationToken>())
             .Returns(new HostJsonBundleSection(bundleId, "[4.*, 5.0.0)"));
 
+        ITemplateEngineProviderRegistry engineProviders = new TemplateEngineProviderRegistry([]);
+        TemplateOptionHydrator optionHydrator = new([]);
+        NewCommandRenderer renderer = new(interaction);
         return new NewCommandRunner(
-            interaction,
-            projectResolver,
-            profileResolver,
-            stackOptions,
-            projectInitializers: Array.Empty<IProjectInitializer>(),
-            installedTemplates,
-            new TemplateEngineProviderRegistry([]),
-            new TemplateOptionHydrator(Array.Empty<IProjectInitializer>()),
-            new TemplatePicker(interaction),
-            new NewCommandRenderer(interaction),
-            hostJsonReader,
-            Substitute.For<IExtensionBundleResolver>());
+            new NewCommandContextResolver(
+                interaction,
+                projectResolver,
+                profileResolver,
+                stackOptions,
+                projectInitializers: [],
+                installedTemplates,
+                hostJsonReader),
+            Substitute.For<INewCommandBundleValidator>(),
+            new NewCommandTemplateCatalog(engineProviders),
+            new NewCommandTemplateSelector(interaction, new TemplatePicker(interaction)),
+            new NewCommandTemplateApplicator(engineProviders, optionHydrator),
+            renderer,
+            new NewCommandResultRenderer(interaction, renderer));
     }
 
     private sealed class FakeDotNetProject(WorkingDirectory workingDirectory) : FunctionsProject

--- a/test/Func.Tests/Templates/NewCommandTemplateApplicatorTests.cs
+++ b/test/Func.Tests/Templates/NewCommandTemplateApplicatorTests.cs
@@ -1,0 +1,113 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Templates;
+using NSubstitute;
+
+namespace Azure.Functions.Cli.Tests.Templates;
+
+public class NewCommandTemplateApplicatorTests
+{
+    private readonly ITemplateEngineProviderRegistry _registry = Substitute.For<ITemplateEngineProviderRegistry>();
+    private readonly TemplateOptionHydrator _optionHydrator = new([]);
+
+    [Fact]
+    public async Task ApplyAsync_MissingEngine_ReturnsProviderFailure()
+    {
+        NewCommandTemplateApplicator applicator = new(_registry, _optionHydrator);
+        FunctionTemplateInfo template = CreateTemplate();
+        _registry.TryGet(template.EngineId).Returns((ITemplateEngineProvider?)null);
+
+        TemplateApplicationResult result = await applicator.ApplyAsync(
+            CreateInvocation(),
+            CreateContext(),
+            template,
+            CancellationToken.None);
+
+        TemplateApplicationResult.Failed failed = result.Should().BeOfType<TemplateApplicationResult.Failed>().Subject;
+        failed.Failure.Should().BeOfType<TemplateApplicationFailure.ProviderError>()
+            .Which.Message.Should().Contain("No engine registered for EngineId 'v2'");
+    }
+
+    [Fact]
+    public async Task ApplyAsync_RegisteredEngine_PassesResolvedContextAndReturnsProviderResult()
+    {
+        NewCommandTemplateApplicator applicator = new(_registry, _optionHydrator);
+        FunctionTemplateInfo template = CreateTemplate();
+        NewInvocation invocation = CreateInvocation();
+        NewCommandResolvedContext context = CreateContext();
+        ITemplateEngineProvider provider = Substitute.For<ITemplateEngineProvider>();
+        _registry.TryGet(template.EngineId).Returns(provider);
+        TemplateApplicationResult expected = new TemplateApplicationResult.Created(["Function.js"]);
+        NewContext? receivedContext = null;
+        provider.ApplyAsync(
+                Arg.Do<NewContext>(value => receivedContext = value),
+                Arg.Any<ParseResult>(),
+                Arg.Any<CancellationToken>())
+            .Returns(expected);
+
+        TemplateApplicationResult result = await applicator.ApplyAsync(
+            invocation,
+            context,
+            template,
+            CancellationToken.None);
+
+        result.Should().BeSameAs(expected);
+        receivedContext.Should().NotBeNull();
+        receivedContext!.WorkingDirectory.Should().Be(invocation.WorkingDirectory);
+        receivedContext.FunctionName.Should().Be(invocation.RequestedFunctionName);
+        receivedContext.Language.Should().Be(context.Language);
+        receivedContext.Force.Should().BeTrue();
+        receivedContext.InstallDirectory.Should().Be(context.Workload.InstallDirectory);
+        receivedContext.UserOptionValues.Should().BeSameAs(invocation.UserOptionValues);
+        await provider.Received(1).ApplyAsync(
+            Arg.Any<NewContext>(),
+            Arg.Any<ParseResult>(),
+            CancellationToken.None);
+    }
+
+    private static NewInvocation CreateInvocation()
+    {
+        WorkingDirectory workingDirectory = new(new DirectoryInfo(Path.GetTempPath()), WasExplicit: false);
+        Dictionary<string, string?> optionValues = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["authLevel"] = "anonymous",
+        };
+        return new NewInvocation(
+            workingDirectory,
+            RequestedTemplate: "HttpTrigger",
+            RequestedFunctionName: "MyFunction",
+            Force: true,
+            NonInteractive: true,
+            UserOptionValues: optionValues);
+    }
+
+    private static NewCommandResolvedContext CreateContext()
+    {
+        WorkingDirectory workingDirectory = new(new DirectoryInfo(Path.GetTempPath()), WasExplicit: false);
+        return new NewCommandResolvedContext(
+            workingDirectory,
+            "node",
+            "javascript",
+            new InstalledTemplatesWorkload("node", "1.0.0", "install"),
+            BundleId: null,
+            BundleChannel.Unknown,
+            UsedStableFallback: false);
+    }
+
+    private static FunctionTemplateInfo CreateTemplate()
+    {
+        return new FunctionTemplateInfo(
+            "HttpTrigger",
+            "node",
+            EngineIds.V2,
+            "HTTP trigger",
+            Description: null,
+            DefaultFunctionName: "HttpTrigger",
+            Languages: ["javascript"],
+            new TemplateMetadata([], RequiresExtensionBundle: false, MinBundleVersion: null));
+    }
+}

--- a/test/Func.Tests/Templates/NewCommandTemplateCatalogTests.cs
+++ b/test/Func.Tests/Templates/NewCommandTemplateCatalogTests.cs
@@ -1,0 +1,66 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Templates;
+using NSubstitute;
+
+namespace Azure.Functions.Cli.Tests.Templates;
+
+public class NewCommandTemplateCatalogTests
+{
+    [Fact]
+    public async Task ListAsync_MultipleProviders_AggregatesTemplatesInRegistrationOrder()
+    {
+        NewCommandResolvedContext context = CreateContext();
+        FunctionTemplateInfo firstTemplate = CreateTemplate("First", EngineIds.V2);
+        FunctionTemplateInfo secondTemplate = CreateTemplate("Second", EngineIds.DotNet);
+        ITemplateEngineProvider firstProvider = Substitute.For<ITemplateEngineProvider>();
+        ITemplateEngineProvider secondProvider = Substitute.For<ITemplateEngineProvider>();
+        firstProvider.ListTemplatesAsync(Arg.Any<TemplateListContext>(), Arg.Any<CancellationToken>())
+            .Returns([firstTemplate]);
+        secondProvider.ListTemplatesAsync(Arg.Any<TemplateListContext>(), Arg.Any<CancellationToken>())
+            .Returns([secondTemplate]);
+        ITemplateEngineProviderRegistry registry = Substitute.For<ITemplateEngineProviderRegistry>();
+        registry.Providers.Returns([firstProvider, secondProvider]);
+        NewCommandTemplateCatalog catalog = new(registry);
+
+        IReadOnlyList<FunctionTemplateInfo> result = await catalog.ListAsync(context, CancellationToken.None);
+
+        result.Should().ContainInOrder(firstTemplate, secondTemplate);
+        await firstProvider.Received(1).ListTemplatesAsync(
+            Arg.Is<TemplateListContext>(listContext =>
+                listContext.WorkingDirectory == context.WorkingDirectory
+                && listContext.Stack == context.Stack
+                && listContext.Language == context.Language
+                && listContext.InstallDirectory == context.Workload.InstallDirectory),
+            CancellationToken.None);
+    }
+
+    private static NewCommandResolvedContext CreateContext()
+    {
+        WorkingDirectory workingDirectory = new(new DirectoryInfo(Path.GetTempPath()), WasExplicit: false);
+        return new NewCommandResolvedContext(
+            workingDirectory,
+            "node",
+            "javascript",
+            new InstalledTemplatesWorkload("node", "1.0.0", "install"),
+            BundleId: null,
+            BundleChannel.Unknown,
+            UsedStableFallback: false);
+    }
+
+    private static FunctionTemplateInfo CreateTemplate(string id, string engineId)
+    {
+        return new FunctionTemplateInfo(
+            id,
+            "node",
+            engineId,
+            id,
+            Description: null,
+            DefaultFunctionName: null,
+            Languages: ["javascript"],
+            new TemplateMetadata([], RequiresExtensionBundle: false, MinBundleVersion: null));
+    }
+}

--- a/test/Func.Tests/Templates/NewCommandTemplateOptionProviderTests.cs
+++ b/test/Func.Tests/Templates/NewCommandTemplateOptionProviderTests.cs
@@ -1,0 +1,127 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.CommandLine;
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Projects;
+using Azure.Functions.Cli.Templates;
+using NSubstitute;
+
+namespace Azure.Functions.Cli.Tests.Templates;
+
+public class NewCommandTemplateOptionProviderTests
+{
+    private readonly INewCommandContextResolver _contextResolver = Substitute.For<INewCommandContextResolver>();
+    private readonly INewCommandTemplateCatalog _templateCatalog = Substitute.For<INewCommandTemplateCatalog>();
+    private readonly TemplateOptionHydrator _optionHydrator = new([]);
+
+    [Fact]
+    public async Task HydrateOptionsForTemplateWithIdsAsync_ResolutionFailure_ReturnsNullWithoutListingTemplates()
+    {
+        NewCommandTemplateOptionProvider provider = CreateProvider();
+        NewInvocation invocation = CreateInvocation();
+        _contextResolver.ResolveAsync(invocation, Arg.Any<CancellationToken>())
+            .Returns(NewCommandResolutionResult.Fail(
+                new NewCommandResolutionFailure(NewCommandResolutionFailureKind.ProjectRequired)));
+
+        IReadOnlyList<HydratedTemplateOption>? result = await provider.HydrateOptionsForTemplateWithIdsAsync(
+            invocation,
+            "HttpTrigger",
+            CancellationToken.None);
+
+        result.Should().BeNull();
+        await _templateCatalog.DidNotReceiveWithAnyArgs().ListAsync(default!, default);
+    }
+
+    [Fact]
+    public async Task HydrateOptionsForTemplateWithIdsAsync_MatchingTemplate_ReturnsPromptIdsAndOptions()
+    {
+        NewCommandTemplateOptionProvider provider = CreateProvider();
+        NewInvocation invocation = CreateInvocation();
+        NewCommandResolvedContext context = CreateContext();
+        FunctionTemplateInfo template = CreateTemplate();
+        _contextResolver.ResolveAsync(invocation, Arg.Any<CancellationToken>())
+            .Returns(NewCommandResolutionResult.Succeed(context));
+        _templateCatalog.ListAsync(context, Arg.Any<CancellationToken>()).Returns([template]);
+
+        IReadOnlyList<HydratedTemplateOption>? result = await provider.HydrateOptionsForTemplateWithIdsAsync(
+            invocation,
+            "httptrigger",
+            CancellationToken.None);
+
+        result.Should().ContainSingle();
+        result![0].PromptId.Should().Be("authLevel");
+        result[0].Option.Name.Should().Be("--auth-level");
+    }
+
+    [Fact]
+    public async Task HydrateOptionsForTemplateAsync_MatchingTemplate_ReturnsOptionsOnly()
+    {
+        NewCommandTemplateOptionProvider provider = CreateProvider();
+        NewInvocation invocation = CreateInvocation();
+        NewCommandResolvedContext context = CreateContext();
+        FunctionTemplateInfo template = CreateTemplate();
+        _contextResolver.ResolveAsync(invocation, Arg.Any<CancellationToken>())
+            .Returns(NewCommandResolutionResult.Succeed(context));
+        _templateCatalog.ListAsync(context, Arg.Any<CancellationToken>()).Returns([template]);
+
+        IReadOnlyList<Option>? result = await provider.HydrateOptionsForTemplateAsync(
+            invocation,
+            template.Id,
+            CancellationToken.None);
+
+        result.Should().ContainSingle().Which.Name.Should().Be("--auth-level");
+    }
+
+    private NewCommandTemplateOptionProvider CreateProvider()
+    {
+        return new NewCommandTemplateOptionProvider(_contextResolver, _templateCatalog, _optionHydrator);
+    }
+
+    private static NewInvocation CreateInvocation()
+    {
+        WorkingDirectory workingDirectory = new(new DirectoryInfo(Path.GetTempPath()), WasExplicit: false);
+        return new NewInvocation(
+            workingDirectory,
+            RequestedTemplate: "HttpTrigger",
+            RequestedFunctionName: null,
+            Force: false,
+            NonInteractive: true);
+    }
+
+    private static NewCommandResolvedContext CreateContext()
+    {
+        WorkingDirectory workingDirectory = new(new DirectoryInfo(Path.GetTempPath()), WasExplicit: false);
+        return new NewCommandResolvedContext(
+            workingDirectory,
+            "node",
+            "javascript",
+            new InstalledTemplatesWorkload("node", "1.0.0", "install"),
+            BundleId: null,
+            BundleChannel.Unknown,
+            UsedStableFallback: false);
+    }
+
+    private static FunctionTemplateInfo CreateTemplate()
+    {
+        TemplateUserPrompt prompt = new(
+            "authLevel",
+            "Authorization level",
+            "string",
+            DefaultValue: "function",
+            Choices: ["anonymous", "function", "admin"],
+            IsRequired: false,
+            ValidatorRegex: null,
+            ShortAlias: null,
+            LongAlias: null);
+        return new FunctionTemplateInfo(
+            "HttpTrigger",
+            "node",
+            EngineIds.V2,
+            "HTTP trigger",
+            Description: null,
+            DefaultFunctionName: null,
+            Languages: ["javascript"],
+            new TemplateMetadata([prompt], RequiresExtensionBundle: false, MinBundleVersion: null));
+    }
+}

--- a/test/Func.Tests/Templates/NewCommandTemplateSelectorTests.cs
+++ b/test/Func.Tests/Templates/NewCommandTemplateSelectorTests.cs
@@ -1,0 +1,105 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Templates;
+
+namespace Azure.Functions.Cli.Tests.Templates;
+
+public class NewCommandTemplateSelectorTests
+{
+    [Fact]
+    public async Task SelectAsync_RequestedTemplate_MatchesCaseInsensitively()
+    {
+        TestInteractionService interaction = new();
+        NewCommandTemplateSelector selector = CreateSelector(interaction);
+        FunctionTemplateInfo template = CreateTemplate("HttpTrigger");
+        NewInvocation invocation = CreateInvocation(requestedTemplate: "httptrigger", nonInteractive: true);
+
+        FunctionTemplateInfo? result = await selector.SelectAsync(invocation, [template], CancellationToken.None);
+
+        result.Should().BeSameAs(template);
+        interaction.Lines.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SelectAsync_UnknownRequestedTemplate_RendersListHint()
+    {
+        TestInteractionService interaction = new();
+        NewCommandTemplateSelector selector = CreateSelector(interaction);
+        NewInvocation invocation = CreateInvocation(requestedTemplate: "Missing", nonInteractive: true);
+
+        FunctionTemplateInfo? result = await selector.SelectAsync(
+            invocation,
+            [CreateTemplate("HttpTrigger")],
+            CancellationToken.None);
+
+        result.Should().BeNull();
+        interaction.Lines.Should().Contain(line => line.Contains("Template 'Missing' was not found", StringComparison.Ordinal));
+        interaction.Lines.Should().Contain(line => line.Contains("func new --list", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task SelectAsync_MissingTemplateInNonInteractiveMode_RendersRequiredOptionHint()
+    {
+        TestInteractionService interaction = new();
+        NewCommandTemplateSelector selector = CreateSelector(interaction);
+        NewInvocation invocation = CreateInvocation(requestedTemplate: null, nonInteractive: true);
+
+        FunctionTemplateInfo? result = await selector.SelectAsync(
+            invocation,
+            [CreateTemplate("HttpTrigger")],
+            CancellationToken.None);
+
+        result.Should().BeNull();
+        interaction.Lines.Should().Contain(line => line.Contains("Missing required option: --template", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task SelectAsync_MissingTemplateInInteractiveMode_UsesPicker()
+    {
+        InteractiveTestInteractionService interaction = new();
+        NewCommandTemplateSelector selector = CreateSelector(interaction);
+        FunctionTemplateInfo template = CreateTemplate("HttpTrigger");
+        NewInvocation invocation = CreateInvocation(requestedTemplate: null, nonInteractive: false);
+
+        FunctionTemplateInfo? result = await selector.SelectAsync(invocation, [template], CancellationToken.None);
+
+        result.Should().BeSameAs(template);
+        interaction.Lines.Should().Contain(line => line.StartsWith("SELECT: Select a template:", StringComparison.Ordinal));
+    }
+
+    private static NewCommandTemplateSelector CreateSelector(TestInteractionService interaction)
+    {
+        return new NewCommandTemplateSelector(interaction, new TemplatePicker(interaction));
+    }
+
+    private static NewInvocation CreateInvocation(string? requestedTemplate, bool nonInteractive)
+    {
+        WorkingDirectory workingDirectory = new(new DirectoryInfo(Path.GetTempPath()), WasExplicit: false);
+        return new NewInvocation(
+            workingDirectory,
+            requestedTemplate,
+            RequestedFunctionName: null,
+            Force: false,
+            nonInteractive);
+    }
+
+    private static FunctionTemplateInfo CreateTemplate(string id)
+    {
+        return new FunctionTemplateInfo(
+            id,
+            "node",
+            EngineIds.V2,
+            "HTTP trigger",
+            Description: null,
+            DefaultFunctionName: null,
+            Languages: ["javascript"],
+            new TemplateMetadata([], RequiresExtensionBundle: false, MinBundleVersion: null));
+    }
+
+    private sealed class InteractiveTestInteractionService : TestInteractionService
+    {
+        public override bool IsInteractive => true;
+    }
+}

--- a/test/Func.Tests/Templates/TemplatesWorkloadManifestReaderTests.cs
+++ b/test/Func.Tests/Templates/TemplatesWorkloadManifestReaderTests.cs
@@ -8,6 +8,7 @@ namespace Azure.Functions.Cli.Tests.Templates;
 public class TemplatesWorkloadManifestReaderTests : IDisposable
 {
     private readonly string _installDir;
+    private readonly TemplatesWorkloadManifestReader _reader = new();
 
     public TemplatesWorkloadManifestReaderTests()
     {
@@ -23,7 +24,7 @@ public class TemplatesWorkloadManifestReaderTests : IDisposable
     [Fact]
     public void Missing_File_Returns_Null()
     {
-        TemplatesWorkloadManifestReader.GetMinBundleVersion(_installDir).Should().BeNull();
+        _reader.GetMinBundleVersion(_installDir).Should().BeNull();
     }
 
     [Fact]
@@ -35,7 +36,7 @@ public class TemplatesWorkloadManifestReaderTests : IDisposable
             Path.Combine(contentDir, "templates-workload.json"),
             """{ "minBundleVersion": "[4.0.0, )" }""");
 
-        TemplatesWorkloadManifestReader.GetMinBundleVersion(_installDir).Should().Be("[4.0.0, )");
+        _reader.GetMinBundleVersion(_installDir).Should().Be("[4.0.0, )");
     }
 
     [Fact]
@@ -47,7 +48,7 @@ public class TemplatesWorkloadManifestReaderTests : IDisposable
             Path.Combine(contentDir, "templates-workload.json"),
             """{ "somethingElse": "ignored" }""");
 
-        TemplatesWorkloadManifestReader.GetMinBundleVersion(_installDir).Should().BeNull();
+        _reader.GetMinBundleVersion(_installDir).Should().BeNull();
     }
 
     [Fact]
@@ -57,6 +58,6 @@ public class TemplatesWorkloadManifestReaderTests : IDisposable
         Directory.CreateDirectory(contentDir);
         File.WriteAllText(Path.Combine(contentDir, "templates-workload.json"), "{ not json");
 
-        TemplatesWorkloadManifestReader.GetMinBundleVersion(_installDir).Should().BeNull();
+        _reader.GetMinBundleVersion(_installDir).Should().BeNull();
     }
 }


### PR DESCRIPTION
### Issue describing the changes in this PR

resolves #5448

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)
  * This repo has no E2E test project, so this is unit tests plus the manual CLI run below.

### Additional information

Decomposes `NewCommandRunner` from 794 lines to 157 lines. The runner now coordinates focused services for context resolution, extension bundle validation, template catalog loading, template selection, application, option hydration, and result rendering.

This is a pure restructure. Every method from the original was either moved unchanged or is dead code that nothing referenced (`BuildPromptDefaults`, whose result was passed to a discarded parameter, and `RenderNoEnginesRegistered`, which had no callers).

Each extracted service has its own unit tests. The runner also has a success-path test covering pipeline ordering and cancellation token forwarding.

#### Validation

Automated:

* Full suite: `dotnet test Azure.Functions.Cli.slnx` (1348 tests in `Func.Tests` plus all workload projects, 0 failures)
* `CI=true dotnet build Azure.Functions.Cli.slnx --configuration Release` (0 warnings, 0 errors)

Manual CLI run against a real Node project, using a locally published `func` and the local workloads feed:

| Scenario | Result |
| --- | --- |
| `func new --list` | catalog renders, exit 0 |
| `func new --list --output json` | JSON renders, exit 0 |
| `func new -t HttpTrigger-JavaScript -n MyHttp` | creates `src/functions/MyHttp.js`, exit 0 |
| same name again | "Some files already exist" plus `--force` hint, exit 1 |
| same name with `--force` | overwrites, exit 0 |
| `func new -t TimerTrigger-JavaScript -n MyTimer` | creates second function, exit 0 |
| unknown template id | "was not found for this project's stack", exit 1 |
| `func new --non-interactive` with no `--template` | "Missing required option: --template", exit 1 |
| `func new` outside a project | "needs a Functions project", exit 1 |
| `func new -t HttpTrigger-JavaScript --help` | template options hydrate, exit 0 |

Each error path rendered exactly once, which is the behaviour #5304 guards against.
