### PR TITLE
Add RID pointer package support

### DIFF
--- a/docs/building-a-workload.md
+++ b/docs/building-a-workload.md
@@ -2,9 +2,7 @@
 
 This guide walks through building a workload for the Azure Functions Core Tools v5 CLI. A workload is a NuGet package that the CLI loads at runtime to extend its behavior, most commonly to provide `func init` / `func new` support for a specific language stack (e.g. Node.js, Python, Java), but a workload can also contribute brand-new subcommands.
 
-> **Status**: the abstractions, DI host, and `func workload install` / `uninstall` commands described below are in the tree as of this PR. Workloads are installed from a local `.nupkg` on disk; NuGet feed acquisition lands in a follow-up.
->
-> **Spec**: this guide is the authoring view. The on-disk and on-feed layout, the `workload.json` schema, the `kind` discriminator (`workload` / `content` / `meta`), and the install pipeline are specified in [`docs/proposed/workload-package-layout.md`](./proposed/workload-package-layout.md). Consult that doc for the contract; this guide stays focused on the happy-path authoring experience for `kind: workload`.
+> **Spec**: this guide is the authoring view. The on-disk and on-feed layout, the `workload.json` schema, the `kind` discriminator (`workload` / `content` / `meta` / `rid-pointer`), and the install pipeline are specified in [`docs/proposed/workload-package-layout.md`](./proposed/workload-package-layout.md). Consult that doc for the contract; this guide stays focused on the happy-path authoring experience for `kind: workload`.
 
 ## Architecture
 
@@ -123,7 +121,27 @@ What each piece does:
 - `SuppressDependenciesWhenPacking=true` plus `PrivateAssets=all` / `ExcludeAssets=runtime` on the `Abstractions` reference keep the workload self-contained: the CLI provides Abstractions (and the other host-shared contract assemblies, see §9.2 of the layout spec) at runtime. The same `PrivateAssets=all` rule applies to **every** `<PackageReference>` you add later, not just `Abstractions`.
 - `NU5128`/`NU5100` are suppressed because we deliberately ship without `lib/` and place files under `tools/any/`.
 
-> **Pack scope today.** The csproj above packs only the workload assembly itself. That works for stubs and for workloads whose runtime closure is just the host-shared contracts. As soon as a workload pulls in a transitive managed dependency (e.g., `Newtonsoft.Json`), the long-term shape from the package-layout spec applies: the package must contain the publish output (workload `.dll`, `.deps.json`, optional `.pdb`, every transitive managed dep, and any `runtimes/<rid>/` assets the deps ship). The upcoming `Workload.Sdk` package will provide the publish-into-`tools/any/` target; until then, workloads with transitive deps need to wire that step manually. See `docs/proposed/workload-package-layout.md` §5 and §9.
+### Runtime-specific workload packages
+
+Set `RuntimeIdentifiers` when a workload's payload differs by platform. The Workload SDK then produces one user-facing pointer package and one implementation package per RID:
+
+```xml
+<PropertyGroup>
+  <RuntimeIdentifiers>win-x64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
+  <PackAsWorkload>true</PackAsWorkload>
+  <WorkloadKind>content</WorkloadKind>
+  <WorkloadAlias>python-worker</WorkloadAlias>
+</PropertyGroup>
+```
+
+- The pointer keeps the project package ID, uses package type `FuncCliWorkload`, and contains a `kind: rid-pointer` manifest whose `packages` map selects the implementation for each RID.
+- Each implementation uses the package ID `<pointer-package-id>.<rid>`, package type `FuncCliWorkloadRidPackage`, and retains the authored `workload` or `content` kind.
+- The SDK writes `runtimeIdentifier` into every implementation manifest and adds the matching `rid:<rid>` package tag. Do not author either value independently.
+- Publish the pointer and every implementation at the same exact version and to the same feed. The CLI resolves only the mapped package ID at the pointer's exact version from the source that supplied the pointer.
+
+Users install, update, uninstall, and list the pointer identity. The CLI records the selected physical implementation and RID as ownership details; `func workload list --json` exposes both logical and physical package IDs.
+
+> **Pack scope.** The package must contain the publish output (workload `.dll`, `.deps.json`, optional `.pdb`, every transitive managed dependency, and any `runtimes/<rid>/` assets the dependencies ship). Use the Workload SDK's `PackAsWorkload` targets rather than manually copying only the primary assembly when a workload has a runtime dependency closure.
 
 Add a sibling `Directory.Version.props` for the workload version:
 

--- a/docs/building-a-workload.md
+++ b/docs/building-a-workload.md
@@ -137,6 +137,7 @@ Set `RuntimeIdentifiers` when a workload's payload differs by platform. The Work
 - The pointer keeps the project package ID, uses package type `FuncCliWorkload`, and contains a `kind: rid-pointer` manifest whose `packages` map selects the implementation for each RID.
 - Each implementation uses the package ID `<pointer-package-id>.<rid>`, package type `FuncCliWorkloadRidPackage`, and retains the authored `workload` or `content` kind.
 - The SDK writes `runtimeIdentifier` into every implementation manifest and adds the matching `rid:<rid>` package tag. Do not author either value independently.
+- Implementation payloads ship under `tools/<rid>/` rather than `tools/any/`; the CLI derives the content root from the manifest's `runtimeIdentifier`.
 - Publish the pointer and every implementation at the same exact version and to the same feed. The CLI resolves only the mapped package ID at the pointer's exact version from the source that supplied the pointer.
 
 Users install, update, uninstall, and list the pointer identity. The CLI records the selected physical implementation and RID as ownership details; `func workload list --json` exposes both logical and physical package IDs.

--- a/eng/build/Workloads/Workload.targets
+++ b/eng/build/Workloads/Workload.targets
@@ -47,6 +47,7 @@
       <_WorkloadRidPath Condition="'$(RuntimeIdentifier)' == ''">any</_WorkloadRidPath>
       <_WorkloadRidPath Condition="'$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier)</_WorkloadRidPath>
       <_WorkloadPackageContentRoot>tools/$(_WorkloadRidPath)/</_WorkloadPackageContentRoot>
+      <_WorkloadManifestRuntimeIdentifier Condition="'$(RuntimeIdentifier)' != '' AND $(CreateRidSpecificWorkloadPackages)">$(RuntimeIdentifier)</_WorkloadManifestRuntimeIdentifier>
     </PropertyGroup>
   </Target>
 
@@ -69,10 +70,11 @@
   We hash the inputs into workload.json to determine if it needs to be regenerated.
   Does not use FileWrites as this is a pack-time operation. FileWrites are for build-time operations.
   -->
-  <Target Name="_GenerateWorkloadJsonCache" DependsOnTargets="_ResolveWorkloadEntryPoint;_ResolveRidSpecificWorkload" Outputs="$(_WorkloadJsonCacheFile)">
+  <Target Name="_GenerateWorkloadJsonCache" DependsOnTargets="_SetWorkloadProperties;_ResolveWorkloadEntryPoint;_ResolveRidSpecificWorkload">
     <ItemGroup>
       <_WorkloadJsonInputCacheToHash Include="$(WorkloadKind)" />
       <_WorkloadJsonInputCacheToHash Include="$(_FuncWorkloadSchema)" />
+      <_WorkloadJsonInputCacheToHash Include="$(_WorkloadManifestRuntimeIdentifier)" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(WorkloadKind)' == 'workload'">
@@ -104,8 +106,10 @@
       OutputPath="$(_WorkloadJsonFile)"
       Schema="$(_FuncWorkloadSchema)"
       Kind="$(WorkloadKind)"
+      PackageId="$(PackageId)"
       DisplayName="$(Title)"
       Description="$(Description)"
+      RuntimeIdentifier="$(_WorkloadManifestRuntimeIdentifier)"
       EntryPointAssemblyPath="$(WorkloadEntryPointAssembly)"
       EntryPointType="$(WorkloadEntryPointType)"
       InnerPackages="@(_WorkloadRidSpecificPackage)"/>

--- a/src/Func/Commands/Setup/SetupRunner.cs
+++ b/src/Func/Commands/Setup/SetupRunner.cs
@@ -427,14 +427,6 @@ internal sealed class SetupRunner(
 
             if (runtimeFeature.InstallWorker)
             {
-                if (TryDetectUnsupportedWorkerRid(runtimeFeature.Name, out string unsupportedMessage))
-                {
-                    failures.Add(SetupDependencyResult.Failed(
-                        SetupDependency.Worker(runtimeFeature.Name, versionRange: null),
-                        unsupportedMessage));
-                    continue;
-                }
-
                 VersionRange? workerRange = null;
                 profileScope.Profile?.WorkerVersionRanges.TryGetValue(runtimeFeature.ProfileRuntime, out workerRange);
                 dependencies.Add(SetupDependency.Worker(runtimeFeature.Name, workerRange));
@@ -784,18 +776,18 @@ internal sealed class SetupRunner(
     private static bool MatchesDependency(WorkloadEntry entry, SetupDependency dependency)
     {
         if (dependency.ResolvedPackageId is { } resolvedPackageId
-            && string.Equals(entry.PackageId, resolvedPackageId, StringComparison.OrdinalIgnoreCase))
+            && MatchesPackageId(entry, resolvedPackageId))
         {
             return true;
         }
 
-        if (string.Equals(entry.PackageId, dependency.PackageId, StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-
-        return false;
+        return MatchesPackageId(entry, dependency.PackageId);
     }
+
+    private static bool MatchesPackageId(WorkloadEntry entry, string packageId)
+        => string.Equals(entry.PackageId, packageId, StringComparison.OrdinalIgnoreCase)
+            || (entry.LogicalPackage is { } logical
+                && string.Equals(logical.PackageId, packageId, StringComparison.OrdinalIgnoreCase));
 
     private static bool IsDeclaredProfile(ProjectProfileOptions projectOptions, string profile)
         => projectOptions.Profiles.Any(candidate => string.Equals(candidate, profile, StringComparison.OrdinalIgnoreCase));
@@ -838,26 +830,6 @@ internal sealed class SetupRunner(
         {
             runtimeFeatures.Add(new SetupRuntimeFeature(name, profileRuntime, installWorker));
         }
-    }
-
-    // Reject runtimes whose worker workload isn't published for the current RID
-    // before we hit the catalog, so users get a clear "no python worker for
-    // win-arm64" message instead of an opaque "package not found".
-    private static bool TryDetectUnsupportedWorkerRid(string runtimeName, out string message)
-    {
-        if (string.Equals(runtimeName, "python", StringComparison.OrdinalIgnoreCase)
-            && !PythonWorkerWorkloadPackage.IsCurrentRuntimeSupported())
-        {
-            string currentRid = WorkloadRuntimeIdentifier.Current;
-            string supported = string.Join(", ", PythonWorkerWorkloadPackage.SupportedRuntimeIdentifiers
-                .OrderBy(r => r, StringComparer.OrdinalIgnoreCase));
-            message = $"No python worker is published for runtime identifier '{currentRid}'. "
-                + $"Supported runtimes: {supported}.";
-            return true;
-        }
-
-        message = string.Empty;
-        return false;
     }
 
     private static string NormalizeFeature(string value)
@@ -945,7 +917,7 @@ internal sealed record SetupDependency(
             SetupDependencyKind.Host,
             "host",
             "host",
-            HostWorkloadPackage.CurrentPackageId,
+            HostWorkloadPackage.PackageId,
             versionRange,
             SetupRunnerRangeText(versionRange),
             ResolvedPackageId: null);
@@ -1033,7 +1005,7 @@ internal sealed record SetupDependency(
 
     private static string SetupRunnerWorkerPackageId(string runtime)
         => string.Equals(runtime, "python", StringComparison.OrdinalIgnoreCase)
-            ? PythonWorkerWorkloadPackage.CurrentPackageId
+            ? PythonWorkerWorkloadPackage.PackageId
             : WorkerPackagePrefix + runtime;
 
     private static string? SetupRunnerRangeText(VersionRange? range)

--- a/src/Func/Commands/Start/Initialization/HostWorkloads/DefaultHostWorkloadResolver.cs
+++ b/src/Func/Commands/Start/Initialization/HostWorkloads/DefaultHostWorkloadResolver.cs
@@ -89,7 +89,7 @@ internal sealed class DefaultHostWorkloadResolver(
         return new HostWorkloadResolution.InstallRequired(
             version,
             $"No installed host workload found for {version}",
-            HostWorkloadPackage.CurrentPackageId);
+            HostWorkloadPackage.PackageId);
     }
 
     private IReadOnlyList<InstalledHostCandidate> GetInstalledHostCandidates()
@@ -97,7 +97,7 @@ internal sealed class DefaultHostWorkloadResolver(
         List<InstalledHostCandidate> candidates = [];
         foreach (ContentWorkloadInfo workload in _workloadProvider.GetContentWorkloads())
         {
-            if (!string.Equals(workload.PackageId, HostWorkloadPackage.CurrentPackageId, StringComparison.OrdinalIgnoreCase)
+            if (!workload.PackageId.StartsWith(HostWorkloadPackage.PackageIdPrefix, StringComparison.OrdinalIgnoreCase)
                 || !NuGetVersion.TryParse(workload.PackageVersion, out NuGetVersion? version))
             {
                 continue;
@@ -116,7 +116,7 @@ internal sealed class DefaultHostWorkloadResolver(
 
     private async Task<ResolvedPackage> ResolveLatestInstallPackageAsync(VersionRange? range, CancellationToken cancellationToken)
     {
-        string packageId = HostWorkloadPackage.CurrentPackageId;
+        string packageId = HostWorkloadPackage.PackageId;
         ResolvedPackage? package = range is null
             ? await _workloadCatalog.ResolveLatestVersionAsync(
                 packageId, includePrerelease: null, currentVersion: null, allowMajor: true, source: null, cancellationToken)

--- a/src/Func/Commands/Start/Initialization/Steps/InstallHostWorkloadInitializationStep.cs
+++ b/src/Func/Commands/Start/Initialization/Steps/InstallHostWorkloadInitializationStep.cs
@@ -24,7 +24,7 @@ internal sealed class InstallHostWorkloadInitializationStep(
 
     private readonly IWorkloadInstaller _installer = installer ?? throw new ArgumentNullException(nameof(installer));
     private readonly IWorkloadPaths _workloadPaths = workloadPaths ?? throw new ArgumentNullException(nameof(workloadPaths));
-    private readonly string _packageId = string.IsNullOrWhiteSpace(packageId) ? HostWorkloadPackage.CurrentPackageId : packageId;
+    private readonly string _packageId = string.IsNullOrWhiteSpace(packageId) ? HostWorkloadPackage.PackageId : packageId;
 
     private readonly NuGetVersion _hostVersion = NuGetVersion.TryParse(hostVersion, out NuGetVersion? parsedHostVersion)
         ? parsedHostVersion
@@ -77,7 +77,7 @@ internal sealed class InstallHostWorkloadInitializationStep(
         }
         catch (InvalidOperationException ex)
         {
-            string message = $"{ex.Message} Run 'func workload install {HostWorkloadPackage.CurrentPackageId} --exact --force' to repair the install.";
+            string message = $"{ex.Message} Run 'func workload install {HostWorkloadPackage.PackageId} --exact --force' to repair the install.";
             throw new GracefulException(message, isUserError: true, verboseMessage: ex.ToString());
         }
 

--- a/src/Func/Commands/Start/Initialization/Steps/InstallHostWorkloadInitializationStep.cs
+++ b/src/Func/Commands/Start/Initialization/Steps/InstallHostWorkloadInitializationStep.cs
@@ -105,7 +105,7 @@ internal sealed class InstallHostWorkloadInitializationStep(
             entry.PackageVersion,
             entry.Aliases,
             installDirectory,
-            Path.GetFullPath(Path.Combine(installDirectory, "tools", "any")),
+            WorkloadPackageLayout.GetContentRoot(installDirectory, entry.RuntimeIdentifier),
             string.IsNullOrWhiteSpace(entry.DisplayName) ? entry.PackageId : entry.DisplayName,
             entry.Description ?? string.Empty);
     }

--- a/src/Func/Commands/Workload/WorkloadInstallCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadInstallCommand.cs
@@ -167,9 +167,7 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
         }
         catch (InvalidOperationException ex)
         {
-            throw new GracefulException(
-                $"{ex.Message} Pass --force to repair the install.",
-                isUserError: true);
+            throw new GracefulException(ex.Message, isUserError: true);
         }
     }
 

--- a/src/Func/Commands/Workload/WorkloadInstallCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadInstallCommand.cs
@@ -205,8 +205,15 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
         // by alias unless --exact. We don't need to enforce uniqueness
         // here; if any version matches we prompt.
         WorkloadEntry? match = installed.FirstOrDefault(e =>
-            string.Equals(e.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
-            || (!exact && (e.Aliases?.Any(a => string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)) ?? false)));
+            e.LogicalPackage is not null
+            && (string.Equals(e.LogicalPackage.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
+                || (!exact && e.LogicalPackage.Aliases.Any(a =>
+                    string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)))));
+        match ??= installed.FirstOrDefault(e =>
+            e.IsExplicitlyInstalled
+            && (string.Equals(e.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
+                || (!exact && e.Aliases.Any(a =>
+                    string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)))));
 
         if (match is null)
         {
@@ -215,14 +222,18 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
 
         // Prefer the first alias for user-facing messages; fall back to the
         // canonical package id when no alias is published.
-        string display = match.Aliases.Count > 0 ? match.Aliases[0] : match.PackageId;
-        string prompt = $"'{display}' is already installed at {match.PackageVersion}. Update instead?";
+        LogicalPackage? logical = match.LogicalPackage;
+        IReadOnlyList<string> aliases = logical?.Aliases ?? match.Aliases;
+        string display = aliases.Count > 0 ? aliases[0] : logical?.PackageId ?? match.PackageId;
+        string installedVersion = logical?.PackageVersion ?? match.PackageVersion;
+        string prompt = $"'{display}' is already installed at {installedVersion}. Update instead?";
 
         if (!_interaction.IsInteractive)
         {
+            string updateIdentifier = logical?.PackageId ?? display;
             _interaction.WriteHint(
-                $"'{display}' is already installed at {match.PackageVersion}. " +
-                $"Run 'func workload update {display}' to upgrade, or pass --force to install side-by-side.");
+                $"'{display}' is already installed at {installedVersion}. " +
+                $"Run 'func workload update {updateIdentifier}' to upgrade, or pass --force to install side-by-side.");
             return 1;
         }
 
@@ -234,7 +245,7 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
             return null;
         }
 
-        return await DispatchToUpdateAsync(match.PackageId, source, includePrerelease, cancellationToken);
+        return await DispatchToUpdateAsync(logical?.PackageId ?? match.PackageId, source, includePrerelease, cancellationToken);
     }
 
     // Delegate to the `func workload update` command (Parse + InvokeAsync) so
@@ -266,14 +277,18 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
     private static string BuildSuccessMessage(WorkloadInstallResult result)
     {
         WorkloadEntry entry = result.Entry;
+        LogicalPackage? logical = entry.LogicalPackage;
+        string packageId = logical?.PackageId ?? entry.PackageId;
+        string packageVersion = logical?.PackageVersion ?? entry.PackageVersion;
+        IReadOnlyList<string> aliases = logical?.Aliases ?? entry.Aliases;
         string verb = result.AlreadyInstalled
-            ? $"Workload '{entry.PackageId}' version '{entry.PackageVersion}' is already installed"
-            : $"Installed workload '{entry.PackageId}' version '{entry.PackageVersion}'";
+            ? $"Workload '{packageId}' version '{packageVersion}' is already installed"
+            : $"Installed workload '{packageId}' version '{packageVersion}'";
 
         return entry.Kind switch
         {
-            WorkloadKind.Workload when entry.Aliases.Count > 0
-                => $"{verb} (aliases: {string.Join(", ", entry.Aliases)}).",
+            WorkloadKind.Workload when aliases.Count > 0
+                => $"{verb} (aliases: {string.Join(", ", aliases)}).",
             WorkloadKind.Content
                 => $"{verb} (content at '{entry.Source}').",
             _ => $"{verb}.",

--- a/src/Func/Commands/Workload/WorkloadListCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadListCommand.cs
@@ -56,7 +56,7 @@ internal sealed class WorkloadListCommand : FuncCliCommand
 
         IReadOnlyList<ListRow> rows = allVersions
             ? await BuildAllVersionsRowsAsync(cancellationToken)
-            : BuildLoadedRows();
+            : await BuildLoadedRowsAsync(cancellationToken);
 
         if (json)
         {
@@ -117,6 +117,13 @@ internal sealed class WorkloadListCommand : FuncCliCommand
             card.WriteHeading(DisplayNameOrPackageId(row));
             card.WriteField("Version", row.PackageVersion);
             card.WriteField("Package ID", row.PackageId);
+            card.WriteField("Implementation", $"{row.PhysicalPackageId} {row.PhysicalPackageVersion}");
+            if (!string.IsNullOrWhiteSpace(row.RuntimeIdentifier))
+            {
+                card.WriteField("Runtime Identifier", row.RuntimeIdentifier);
+            }
+
+            card.WriteField("Ownership", row.Ownership);
             card.WriteAliases(row.Aliases);
             card.WriteDescription(row.Description);
         }
@@ -193,45 +200,106 @@ internal sealed class WorkloadListCommand : FuncCliCommand
         _interaction.WriteHint($"{rows.Count} {Plural(rows.Count, "workload")} installed.");
     }
 
-    private IReadOnlyList<ListRow> BuildLoadedRows()
+    private async Task<IReadOnlyList<ListRow>> BuildLoadedRowsAsync(CancellationToken cancellationToken)
     {
         IReadOnlyList<WorkloadInfo> workloads = _workloads.GetWorkloads();
-        return [.. workloads.Select(w => new ListRow(
-            w.PackageId,
-            w.PackageVersion,
-            w.Aliases,
-            w.DisplayName,
-            w.Description,
-            Loaded: null))];
+        IReadOnlyList<WorkloadEntry>? installed = await _store.GetWorkloadsAsync(cancellationToken);
+        if (installed is null || installed.Count == 0)
+        {
+            return [.. workloads.Select(CreateLegacyRow)];
+        }
+
+        HashSet<(string PackageId, string Version)> loadedKeys = new(
+            workloads.Select(w => (w.PackageId, w.PackageVersion)),
+            new PackageVersionKeyComparer());
+        Dictionary<(string PackageId, string Version), WorkloadInfo> loadedByKey = workloads.ToDictionary(
+            w => (w.PackageId, w.PackageVersion),
+            w => w,
+            new PackageVersionKeyComparer());
+        return [.. installed
+            .Where(e => loadedKeys.Contains((e.PackageId, e.PackageVersion)))
+            .Select(e => CreateRow(e, loaded: null, loadedByKey[(e.PackageId, e.PackageVersion)]))];
     }
 
     private async Task<IReadOnlyList<ListRow>> BuildAllVersionsRowsAsync(CancellationToken cancellationToken)
     {
-        IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
+        IReadOnlyList<WorkloadEntry>? installed = await _store.GetWorkloadsAsync(cancellationToken);
+        if (installed is null || installed.Count == 0)
+        {
+            return [.. _workloads.GetWorkloads().Select(CreateLegacyRow)];
+        }
 
-        // Cross-reference runtime info so loaded versions use presentation
-        // from their instances; older and content entries use registry data.
-        Dictionary<(string PackageId, string Version), RuntimeWorkloadInfo> loadedByKey = _workloads
-            .GetRuntimeWorkloads()
+        Dictionary<(string PackageId, string Version), WorkloadInfo> loadedByKey = _workloads
+            .GetWorkloads()
             .ToDictionary(
                 w => (w.PackageId, w.PackageVersion),
                 w => w,
                 new PackageVersionKeyComparer());
 
         return [.. installed
-            .OrderBy(e => e.PackageId, StringComparer.OrdinalIgnoreCase)
-            .ThenByDescending(e => ParseVersion(e.PackageVersion))
             .Select(e =>
             {
-                bool loaded = loadedByKey.TryGetValue((e.PackageId, e.PackageVersion), out RuntimeWorkloadInfo? info);
-                return new ListRow(
-                    e.PackageId,
-                    e.PackageVersion,
-                    e.Aliases ?? [],
-                    info?.DisplayName ?? GetDisplayName(e),
-                    info?.Description ?? e.Description ?? string.Empty,
-                    Loaded: loaded);
-            })];
+                bool loaded = loadedByKey.TryGetValue((e.PackageId, e.PackageVersion), out WorkloadInfo? info);
+                return CreateRow(e, loaded, info);
+            })
+            .OrderBy(e => e.PackageId, StringComparer.OrdinalIgnoreCase)
+            .ThenByDescending(e => ParseVersion(e.PackageVersion))];
+    }
+
+    private static ListRow CreateRow(WorkloadEntry entry, bool? loaded, WorkloadInfo? loadedInfo)
+    {
+        LogicalPackage? logical = entry.LogicalPackage;
+        return new ListRow(
+            logical?.PackageId ?? entry.PackageId,
+            logical?.PackageVersion ?? entry.PackageVersion,
+            logical?.Aliases ?? entry.Aliases,
+            logical?.DisplayName ?? loadedInfo?.DisplayName ?? GetDisplayName(entry),
+            logical?.Description ?? loadedInfo?.Description ?? entry.Description,
+            entry.PackageId,
+            entry.PackageVersion,
+            entry.RuntimeIdentifier,
+            entry.IsExplicitlyInstalled,
+            entry.InstallRefCount,
+            DescribeOwnership(entry),
+            loaded);
+    }
+
+    private static ListRow CreateLegacyRow(WorkloadInfo workload)
+        => new(
+            workload.PackageId,
+            workload.PackageVersion,
+            workload.Aliases,
+            workload.DisplayName,
+            workload.Description,
+            workload.PackageId,
+            workload.PackageVersion,
+            RuntimeIdentifier: null,
+            IsExplicitlyInstalled: true,
+            InstallRefCount: 1,
+            Ownership: "explicit",
+            Loaded: null);
+
+    private static string DescribeOwnership(WorkloadEntry entry)
+    {
+        List<string> owners = [];
+        if (entry.IsExplicitlyInstalled)
+        {
+            owners.Add("explicit");
+        }
+
+        if (entry.LogicalPackage is not null)
+        {
+            owners.Add($"logical:{entry.LogicalPackage.PackageId}");
+        }
+
+        int knownOwnerCount = (entry.IsExplicitlyInstalled ? 1 : 0) + (entry.LogicalPackage is null ? 0 : 1);
+        int metaOwnerCount = Math.Max(0, entry.InstallRefCount - knownOwnerCount);
+        if (metaOwnerCount > 0)
+        {
+            owners.Add($"meta:{metaOwnerCount}");
+        }
+
+        return string.Join(", ", owners);
     }
 
     private static string PrimaryAlias(ListRow row)
@@ -241,7 +309,7 @@ internal sealed class WorkloadListCommand : FuncCliCommand
         => string.IsNullOrWhiteSpace(row.DisplayName) ? row.PackageId : row.DisplayName;
 
     private static string GetDisplayName(WorkloadEntry entry)
-        => string.IsNullOrWhiteSpace(entry.DisplayName) ? entry.PackageId : entry.DisplayName;
+        => string.IsNullOrWhiteSpace(entry.DisplayName) ? entry.LogicalPackage?.PackageId ?? entry.PackageId : entry.DisplayName;
 
     private static string GroupDisplayName(IGrouping<string, ListRow> group)
     {
@@ -276,6 +344,12 @@ internal sealed class WorkloadListCommand : FuncCliCommand
         IReadOnlyList<string> Aliases,
         string DisplayName,
         string Description,
+        string PhysicalPackageId,
+        string PhysicalPackageVersion,
+        string? RuntimeIdentifier,
+        bool IsExplicitlyInstalled,
+        int InstallRefCount,
+        string Ownership,
         bool? Loaded);
 
     private sealed class PackageVersionKeyComparer : IEqualityComparer<(string PackageId, string Version)>

--- a/src/Func/Commands/Workload/WorkloadPruneCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadPruneCommand.cs
@@ -57,23 +57,20 @@ internal sealed class WorkloadPruneCommand : FuncCliCommand
             return 0;
         }
 
-        IReadOnlyList<WorkloadEntry> scoped = ScopeToTarget(installed, identifier, exact);
+        IReadOnlyList<PruneCandidate> scoped = ScopeToTarget(installed, identifier, exact);
         if (scoped.Count == 0)
         {
             _interaction.WriteWarning($"Workload '{identifier}' is not installed; nothing to prune.");
             return 0;
         }
 
-        // Group by canonical package id so an alias that maps to one
-        // package doesn't accidentally prune another. Within each group
-        // keep the highest installable semver and remove the rest.
-        IEnumerable<IGrouping<string, WorkloadEntry>> byPackageId = scoped
-            .GroupBy(e => e.PackageId, StringComparer.OrdinalIgnoreCase);
+        IEnumerable<IGrouping<string, PruneCandidate>> byPackageId = scoped
+            .GroupBy(e => $"{e.Ownership}:{e.PackageId}", StringComparer.OrdinalIgnoreCase);
 
         int removedCount = 0;
-        foreach (IGrouping<string, WorkloadEntry> group in byPackageId)
+        foreach (IGrouping<string, PruneCandidate> group in byPackageId)
         {
-            List<WorkloadEntry> ordered = [.. group.OrderByDescending(e => ParseVersion(e.PackageVersion))];
+            List<PruneCandidate> ordered = [.. group.OrderByDescending(e => ParseVersion(e.PackageVersion))];
             if (ordered.Count <= 1)
             {
                 continue;
@@ -82,9 +79,17 @@ internal sealed class WorkloadPruneCommand : FuncCliCommand
             // Skip ordered[0] (the highest version), uninstall the rest.
             for (int i = 1; i < ordered.Count; i++)
             {
-                WorkloadEntry candidate = ordered[i];
-                bool removed = await _installer.UninstallAsync(
-                    candidate.PackageId, candidate.PackageVersion, cancellationToken);
+                PruneCandidate candidate = ordered[i];
+                bool removed = candidate.Ownership == WorkloadOwnershipKind.Logical
+                    ? await _installer.UninstallAsync(
+                        candidate.PackageId,
+                        candidate.PackageVersion,
+                        WorkloadOwnershipKind.Logical,
+                        cancellationToken)
+                    : await _installer.UninstallAsync(
+                        candidate.PackageId,
+                        candidate.PackageVersion,
+                        cancellationToken);
                 if (removed)
                 {
                     removedCount++;
@@ -102,18 +107,52 @@ internal sealed class WorkloadPruneCommand : FuncCliCommand
         return 0;
     }
 
-    private static IReadOnlyList<WorkloadEntry> ScopeToTarget(IReadOnlyList<WorkloadEntry> installed, string? identifier, bool exact)
+    private static IReadOnlyList<PruneCandidate> ScopeToTarget(
+        IReadOnlyList<WorkloadEntry> installed,
+        string? identifier,
+        bool exact)
     {
+        IReadOnlyList<PruneCandidate> logical = [.. installed
+            .Where(e => e.LogicalPackage is not null)
+            .Select(e => new PruneCandidate(
+                e.LogicalPackage!.PackageId,
+                e.LogicalPackage.PackageVersion,
+                e.LogicalPackage.Aliases,
+                WorkloadOwnershipKind.Logical))];
+        IReadOnlyList<PruneCandidate> explicitPackages = [.. installed
+            .Where(e => e.IsExplicitlyInstalled)
+            .Select(e => new PruneCandidate(
+                e.PackageId,
+                e.PackageVersion,
+                e.Aliases,
+                WorkloadOwnershipKind.Explicit))];
+
         if (string.IsNullOrWhiteSpace(identifier))
         {
-            return installed;
+            return [.. logical, .. explicitPackages];
         }
 
-        return [.. installed.Where(e =>
+        IReadOnlyList<PruneCandidate> logicalMatches = [.. logical.Where(e =>
             string.Equals(e.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
-            || (!exact && (e.Aliases?.Any(a => string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)) ?? false)))];
+            || (!exact && e.Aliases.Any(a =>
+                string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase))))];
+        if (logicalMatches.Count > 0)
+        {
+            return logicalMatches;
+        }
+
+        return [.. explicitPackages.Where(e =>
+            string.Equals(e.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
+            || (!exact && e.Aliases.Any(a =>
+                string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase))))];
     }
 
     private static NuGetVersion ParseVersion(string raw) =>
         NuGetVersion.TryParse(raw, out NuGetVersion? v) ? v : new NuGetVersion(0, 0, 0);
+
+    private sealed record PruneCandidate(
+        string PackageId,
+        string PackageVersion,
+        IReadOnlyList<string> Aliases,
+        WorkloadOwnershipKind Ownership);
 }

--- a/src/Func/Commands/Workload/WorkloadUninstallCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadUninstallCommand.cs
@@ -76,9 +76,7 @@ internal sealed class WorkloadUninstallCommand : FuncCliCommand
         bool exact = parseResult.GetValue(ExactOption);
 
         IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
-        List<WorkloadEntry> matches = [.. installed
-            .Where(w => string.Equals(w.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
-                || (!exact && (w.Aliases?.Any(a => string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)) ?? false)))];
+        IReadOnlyList<UninstallCandidate> matches = ResolveCandidates(identifier, installed, exact);
 
         if (matches.Count == 0)
         {
@@ -87,7 +85,7 @@ internal sealed class WorkloadUninstallCommand : FuncCliCommand
         }
 
         string[] distinctPackageIds = [.. matches
-            .Select(m => m.PackageId)
+            .Select(m => m.OwnerPackageId)
             .Distinct(StringComparer.OrdinalIgnoreCase)];
 
         if (distinctPackageIds.Length > 1)
@@ -99,26 +97,65 @@ internal sealed class WorkloadUninstallCommand : FuncCliCommand
         }
 
         string packageId = distinctPackageIds[0];
-        IReadOnlyList<WorkloadEntry> toRemove = ResolveVersionsToRemove(packageId, version, all, matches);
+        IReadOnlyList<UninstallCandidate> toRemove = ResolveVersionsToRemove(packageId, version, all, matches);
 
-        foreach (WorkloadEntry candidate in toRemove)
+        foreach (UninstallCandidate candidate in toRemove)
         {
-            bool removed = await _installer.UninstallAsync(candidate.PackageId, candidate.PackageVersion, cancellationToken);
+            bool removed = candidate.Ownership == WorkloadOwnershipKind.Logical
+                ? await _installer.UninstallAsync(
+                    candidate.OwnerPackageId,
+                    candidate.OwnerPackageVersion,
+                    WorkloadOwnershipKind.Logical,
+                    cancellationToken: cancellationToken)
+                : await _installer.UninstallAsync(
+                    candidate.OwnerPackageId,
+                    candidate.OwnerPackageVersion,
+                    cancellationToken: cancellationToken);
             if (removed)
             {
                 _interaction.WriteSuccess(
-                    $"Uninstalled workload '{candidate.PackageId}' version '{candidate.PackageVersion}'.");
+                    $"Uninstalled workload '{candidate.OwnerPackageId}' version '{candidate.OwnerPackageVersion}'.");
             }
         }
 
         return 0;
     }
 
-    private static IReadOnlyList<WorkloadEntry> ResolveVersionsToRemove(
+    private static IReadOnlyList<UninstallCandidate> ResolveCandidates(
+        string identifier,
+        IReadOnlyList<WorkloadEntry> installed,
+        bool exact)
+    {
+        List<UninstallCandidate> logicalMatches = [.. installed
+            .Where(w => w.LogicalPackage is not null
+                && (string.Equals(w.LogicalPackage.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
+                    || (!exact && w.LogicalPackage.Aliases.Any(a =>
+                        string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)))))
+            .Select(w => new UninstallCandidate(
+                w.LogicalPackage!.PackageId,
+                w.LogicalPackage.PackageVersion,
+                WorkloadOwnershipKind.Logical))];
+        if (logicalMatches.Count > 0)
+        {
+            return logicalMatches;
+        }
+
+        return [.. installed
+            .Where(w => w.IsExplicitlyInstalled
+                && (string.Equals(w.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
+                    || (!exact && w.Aliases.Any(a =>
+                        string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)))))
+            .Select(w => new UninstallCandidate(
+                w.PackageId,
+                w.PackageVersion,
+                WorkloadOwnershipKind.Explicit))];
+    }
+
+    private static IReadOnlyList<UninstallCandidate> ResolveVersionsToRemove(
         string packageId,
         string? version,
         bool all,
-        IReadOnlyList<WorkloadEntry> matches)
+        IReadOnlyList<UninstallCandidate> matches)
     {
         if (all)
         {
@@ -127,12 +164,12 @@ internal sealed class WorkloadUninstallCommand : FuncCliCommand
 
         if (!string.IsNullOrEmpty(version))
         {
-            WorkloadEntry? match = matches.FirstOrDefault(
-                m => string.Equals(m.PackageVersion, version, StringComparison.Ordinal));
+            UninstallCandidate? match = matches.FirstOrDefault(
+                m => string.Equals(m.OwnerPackageVersion, version, StringComparison.Ordinal));
 
             if (match is null)
             {
-                string available = string.Join(", ", matches.Select(m => m.PackageVersion));
+                string available = string.Join(", ", matches.Select(m => m.OwnerPackageVersion));
                 throw new GracefulException(
                     $"Workload '{packageId}' version '{version}' is not installed. " +
                     $"Installed versions: {available}.",
@@ -144,7 +181,7 @@ internal sealed class WorkloadUninstallCommand : FuncCliCommand
 
         if (matches.Count > 1)
         {
-            string available = string.Join(", ", matches.Select(m => m.PackageVersion));
+            string available = string.Join(", ", matches.Select(m => m.OwnerPackageVersion));
             throw new GracefulException(
                 $"Multiple versions of '{packageId}' are installed ({available}). " +
                 "Pass --version <v> or --all-versions.",
@@ -153,4 +190,9 @@ internal sealed class WorkloadUninstallCommand : FuncCliCommand
 
         return matches;
     }
+
+    private sealed record UninstallCandidate(
+        string OwnerPackageId,
+        string OwnerPackageVersion,
+        WorkloadOwnershipKind Ownership);
 }

--- a/src/Func/Commands/Workload/WorkloadUpdateCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadUpdateCommand.cs
@@ -14,9 +14,9 @@ using NuGet.Versioning;
 namespace Azure.Functions.Cli.Commands.Workload;
 
 /// <summary>
-/// <c>func workload update [&lt;id&gt;]</c>. In-place atomic version
-/// swap per spec §6.4. Not side-by-side: use <c>install --force</c> for
-/// SxS. Pass <c>--all</c> to update every installed workload.
+/// <c>func workload update [&lt;id&gt;]</c>. Moves the selected explicit or
+/// logical ownership to the resolved package version. Pass <c>--all</c> to
+/// update every installed workload identity.
 /// </summary>
 internal sealed class WorkloadUpdateCommand : FuncCliCommand
 {
@@ -132,10 +132,10 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
             return await UpdateAllAsync(source, includePrerelease, allowMajor, cancellationToken);
         }
 
-        string packageId = await ResolveInstalledPackageIdAsync(identifier!, exact, cancellationToken);
+        UpdateTarget target = await ResolveInstalledTargetAsync(identifier!, exact, cancellationToken);
 
         return await UpdateOneAsync(
-            packageId,
+            target,
             string.IsNullOrEmpty(versionText) ? null : NuGetVersion.Parse(versionText),
             source,
             includePrerelease,
@@ -143,36 +143,47 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
             cancellationToken);
     }
 
-    private async Task<string> ResolveInstalledPackageIdAsync(string identifier, bool exact, CancellationToken cancellationToken)
+    private async Task<UpdateTarget> ResolveInstalledTargetAsync(string identifier, bool exact, CancellationToken cancellationToken)
     {
         IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
 
-        bool MatchesId(WorkloadEntry e) =>
-            string.Equals(e.PackageId, identifier, StringComparison.OrdinalIgnoreCase);
+        string[] logicalIds = [.. installed
+            .Where(e => e.LogicalPackage is not null
+                && (string.Equals(e.LogicalPackage.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
+                    || (!exact && e.LogicalPackage.Aliases.Any(a =>
+                        string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)))))
+            .Select(e => e.LogicalPackage!.PackageId)
+            .Distinct(StringComparer.OrdinalIgnoreCase)];
+        if (logicalIds.Length > 1)
+        {
+            throw CreateAmbiguousInstalledAlias(identifier, logicalIds);
+        }
 
-        bool MatchesAlias(WorkloadEntry e) =>
-            !exact && (e.Aliases?.Any(a => string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)) ?? false);
+        if (logicalIds.Length == 1)
+        {
+            return new UpdateTarget(logicalIds[0], WorkloadOwnershipKind.Logical);
+        }
 
         string[] matchedIds = [.. installed
-            .Where(e => MatchesId(e) || MatchesAlias(e))
+            .Where(e => e.IsExplicitlyInstalled
+                && (string.Equals(e.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
+                    || (!exact && e.Aliases.Any(a =>
+                        string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)))))
             .Select(e => e.PackageId)
             .Distinct(StringComparer.OrdinalIgnoreCase)];
 
         if (matchedIds.Length > 1)
         {
-            throw new GracefulException(
-                $"Alias '{identifier}' matches multiple installed workloads ({string.Join(", ", matchedIds)}). " +
-                "Pass the workload ID instead.",
-                isUserError: true);
+            throw CreateAmbiguousInstalledAlias(identifier, matchedIds);
         }
 
-        // Defer the "not installed" error to UpdateAsync so messaging stays
-        // consistent with the --version path that's also resolved there.
-        return matchedIds.Length == 1 ? matchedIds[0] : identifier;
+        return new UpdateTarget(
+            matchedIds.Length == 1 ? matchedIds[0] : identifier,
+            WorkloadOwnershipKind.Explicit);
     }
 
     private async Task<int> UpdateOneAsync(
-        string packageId,
+        UpdateTarget target,
         NuGetVersion? targetVersion,
         string? source,
         bool? includePrerelease,
@@ -181,10 +192,14 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
     {
         try
         {
-            WorkloadUpdateResult result = await _interaction.RunWithProgressAsync(
-                $"Updating workload '{packageId}'",
-                async (ctx, ct) => await _installer.UpdateAsync(
-                    packageId, targetVersion, source, includePrerelease, allowMajor,
+            WorkloadUpdateResult             result = await _interaction.RunWithProgressAsync(
+                $"Updating workload '{target.PackageId}'",
+                async (ctx, ct) => await UpdateTargetAsync(
+                    target,
+                    targetVersion,
+                    source,
+                    includePrerelease,
+                    allowMajor,
                     new WorkloadInstallProgressAdapter(ctx),
                     ct),
                 cancellationToken);
@@ -213,25 +228,23 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
     private async Task<int> UpdateAllAsync(string? source, bool? includePrerelease, bool allowMajor, CancellationToken cancellationToken)
     {
         IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
-        IReadOnlyList<string> packageIds = [.. installed
-            .Select(e => e.PackageId)
-            .Distinct(StringComparer.OrdinalIgnoreCase)];
+        IReadOnlyList<UpdateTarget> targets = BuildUpdateAllTargets(installed);
 
-        if (packageIds.Count == 0)
+        if (targets.Count == 0)
         {
             _interaction.WriteHint("No workloads installed.");
             return 0;
         }
 
         bool anyFailed = false;
-        foreach (string packageId in packageIds)
+        foreach (UpdateTarget target in targets)
         {
             try
             {
                 WorkloadUpdateResult result = await _interaction.RunWithProgressAsync(
-                    $"Updating workload '{packageId}'",
-                    async (ctx, ct) => await _installer.UpdateAsync(
-                        packageId,
+                    $"Updating workload '{target.PackageId}'",
+                    async (ctx, ct) => await UpdateTargetAsync(
+                        target,
                         targetInstalledVersion: null,
                         source,
                         includePrerelease,
@@ -251,7 +264,7 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
                 // the message and keep going; the final exit code reflects
                 // whether any failed.
                 anyFailed = true;
-                _interaction.WriteError($"Update failed for '{packageId}': {ex.Message}");
+                _interaction.WriteError($"Update failed for '{target.PackageId}': {ex.Message}");
             }
         }
 
@@ -263,7 +276,12 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
         // Prefer the published alias for user-facing messages so the output
         // matches the token the user typed; fall back to the package id when
         // no alias is published.
-        string display = result.Entry.Aliases.Count > 0 ? result.Entry.Aliases[0] : result.Entry.PackageId;
+        LogicalPackage? logical = result.Entry.LogicalPackage;
+        IReadOnlyList<string> aliases = logical?.Aliases ?? result.Entry.Aliases;
+        string display = aliases.Count > 0
+            ? aliases[0]
+            : logical?.PackageId ?? result.Entry.PackageId;
+        string version = logical?.PackageVersion ?? result.Entry.PackageVersion;
 
         if (result.NoCandidateOnSource)
         {
@@ -277,14 +295,73 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
         {
             _interaction.WriteWarning(
                 $"Workload '{display}' is already at the latest available version " +
-                $"({result.Entry.PackageVersion}).");
+                $"({version}).");
             return;
         }
 
         _interaction.WriteSuccess(
-            $"Updated workload '{display}' from {result.PreviousVersion} to {result.Entry.PackageVersion}.");
+            $"Updated workload '{display}' from {result.PreviousVersion} to {version}.");
     }
 
     private bool EffectivePrerelease(bool? userOverride) => userOverride ?? _catalogOptions.IncludePrerelease;
+
+    private Task<WorkloadUpdateResult> UpdateTargetAsync(
+        UpdateTarget target,
+        NuGetVersion? targetInstalledVersion,
+        string? source,
+        bool? includePrerelease,
+        bool allowMajor,
+        IProgress<WorkloadInstallProgress>? progress,
+        CancellationToken cancellationToken)
+        => target.Ownership == WorkloadOwnershipKind.Logical
+            ? _installer.UpdateAsync(
+                target.PackageId,
+                targetInstalledVersion,
+                source,
+                includePrerelease,
+                allowMajor,
+                WorkloadOwnershipKind.Logical,
+                progress,
+                cancellationToken)
+            : _installer.UpdateAsync(
+                target.PackageId,
+                targetInstalledVersion,
+                source,
+                includePrerelease,
+                allowMajor,
+                progress,
+                cancellationToken);
+
+    private static GracefulException CreateAmbiguousInstalledAlias(string identifier, IReadOnlyList<string> packageIds)
+        => new(
+            $"Alias '{identifier}' matches multiple installed workloads ({string.Join(", ", packageIds)}). " +
+            "Pass the workload ID instead.",
+            isUserError: true);
+
+    private static IReadOnlyList<UpdateTarget> BuildUpdateAllTargets(IReadOnlyList<WorkloadEntry> installed)
+    {
+        List<UpdateTarget> targets = [];
+        HashSet<string> logicalIds = new(StringComparer.OrdinalIgnoreCase);
+        foreach (WorkloadEntry entry in installed.Where(e => e.LogicalPackage is not null))
+        {
+            if (logicalIds.Add(entry.LogicalPackage!.PackageId))
+            {
+                targets.Add(new UpdateTarget(entry.LogicalPackage.PackageId, WorkloadOwnershipKind.Logical));
+            }
+        }
+
+        HashSet<string> explicitIds = new(StringComparer.OrdinalIgnoreCase);
+        foreach (WorkloadEntry entry in installed.Where(e => e.IsExplicitlyInstalled))
+        {
+            if (explicitIds.Add(entry.PackageId))
+            {
+                targets.Add(new UpdateTarget(entry.PackageId, WorkloadOwnershipKind.Explicit));
+            }
+        }
+
+        return targets;
+    }
+
+    private sealed record UpdateTarget(string PackageId, WorkloadOwnershipKind Ownership);
 
 }

--- a/src/Func/Commands/Workload/WorkloadUpdateCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadUpdateCommand.cs
@@ -299,6 +299,15 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
             return;
         }
 
+        // A RID pivot can land on the same version, where "from X to X" would read as a no-op.
+        if (string.Equals(result.PreviousVersion, version, StringComparison.Ordinal)
+            && !string.IsNullOrEmpty(result.Entry.RuntimeIdentifier))
+        {
+            _interaction.WriteSuccess(
+                $"Updated workload '{display}' to runtime identifier '{result.Entry.RuntimeIdentifier}' (version {version} unchanged).");
+            return;
+        }
+
         _interaction.WriteSuccess(
             $"Updated workload '{display}' from {result.PreviousVersion} to {version}.");
     }
@@ -350,8 +359,13 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
             }
         }
 
+        // A physical package owned by a pointer is updated through that pointer. Adding it again as an
+        // explicit target would re-resolve and replace the payload the logical update just staged.
+        HashSet<string> logicallyOwned = new(
+            installed.Where(e => e.LogicalPackage is not null).Select(e => e.PackageId),
+            StringComparer.OrdinalIgnoreCase);
         HashSet<string> explicitIds = new(StringComparer.OrdinalIgnoreCase);
-        foreach (WorkloadEntry entry in installed.Where(e => e.IsExplicitlyInstalled))
+        foreach (WorkloadEntry entry in installed.Where(e => e.IsExplicitlyInstalled && !logicallyOwned.Contains(e.PackageId)))
         {
             if (explicitIds.Add(entry.PackageId))
             {
@@ -363,5 +377,4 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
     }
 
     private sealed record UpdateTarget(string PackageId, WorkloadOwnershipKind Ownership);
-
 }

--- a/src/Func/Hosting/WorkloadRegistration.cs
+++ b/src/Func/Hosting/WorkloadRegistration.cs
@@ -81,11 +81,16 @@ internal static class WorkloadRegistration
         CancellationToken cancellationToken)
     {
         var store = new WorkloadStore(paths);
-        var loader = new WorkloadLoader(paths);
+        var runtimeIdentifierProvider = new WorkloadRuntimeIdentifierProvider();
+        var loader = new WorkloadLoader(paths, runtimeIdentifierProvider);
 
         IReadOnlyList<WorkloadEntry> allEntries = await store.GetWorkloadsAsync(cancellationToken);
-        IReadOnlyList<WorkloadEntry> liveEntries = SelectLiveRuntimeEntries(allEntries);
-        IReadOnlyList<ContentWorkloadInfo> contentWorkloads = CreateContentWorkloads(allEntries, paths);
+        IReadOnlyList<WorkloadEntry> compatibleEntries = SelectRuntimeCompatibleEntries(
+            allEntries,
+            runtimeIdentifierProvider.Current,
+            interaction);
+        IReadOnlyList<WorkloadEntry> liveEntries = SelectLiveRuntimeEntries(compatibleEntries);
+        IReadOnlyList<ContentWorkloadInfo> contentWorkloads = CreateContentWorkloads(compatibleEntries, paths);
 
         var runtimeWorkloads = new List<RuntimeWorkloadInfo>(liveEntries.Count);
         foreach (WorkloadEntry entry in liveEntries)
@@ -139,6 +144,31 @@ internal static class WorkloadRegistration
         }
 
         return runtimeWorkloads.Count;
+    }
+
+    private static IReadOnlyList<WorkloadEntry> SelectRuntimeCompatibleEntries(
+        IReadOnlyList<WorkloadEntry> entries,
+        string currentRuntimeIdentifier,
+        IInteractionService interaction)
+    {
+        List<WorkloadEntry> compatible = [];
+        foreach (WorkloadEntry entry in entries)
+        {
+            if (entry.RuntimeIdentifier is null
+                || string.Equals(entry.RuntimeIdentifier, currentRuntimeIdentifier, StringComparison.OrdinalIgnoreCase))
+            {
+                compatible.Add(entry);
+                continue;
+            }
+
+            string logicalPackageId = entry.LogicalPackage?.PackageId ?? entry.PackageId;
+            interaction.WriteWarning(
+                $"Workload '{logicalPackageId}@{entry.LogicalPackage?.PackageVersion ?? entry.PackageVersion}' targets runtime identifier " +
+                $"'{entry.RuntimeIdentifier}', but this machine uses '{currentRuntimeIdentifier}'. " +
+                $"Run 'func workload update {logicalPackageId}' to install the matching implementation.");
+        }
+
+        return compatible;
     }
 
     /// <summary>

--- a/src/Func/Hosting/WorkloadRegistration.cs
+++ b/src/Func/Hosting/WorkloadRegistration.cs
@@ -203,7 +203,7 @@ internal static class WorkloadRegistration
                     e.PackageVersion,
                     e.Aliases,
                     installDirectory,
-                    Path.GetFullPath(Path.Combine(installDirectory, "tools", "any")),
+                    WorkloadPackageLayout.GetContentRoot(installDirectory, e.RuntimeIdentifier),
                     GetDisplayName(e),
                     e.Description ?? string.Empty);
             })];

--- a/src/Func/Hosting/WorkloadStorageRegistration.cs
+++ b/src/Func/Hosting/WorkloadStorageRegistration.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Workloads;
 using Azure.Functions.Cli.Workloads.Discovery;
 using Azure.Functions.Cli.Workloads.Loading;
 using Azure.Functions.Cli.Workloads.Storage;

--- a/src/Func/Hosting/WorkloadStorageRegistration.cs
+++ b/src/Func/Hosting/WorkloadStorageRegistration.cs
@@ -32,6 +32,7 @@ internal static class WorkloadStorageRegistration
         services.AddSingleton<IWorkloadStore, WorkloadStore>();
         services.AddSingleton<IWorkloadLoader, WorkloadLoader>();
         services.AddSingleton<IWorkloadMetadataReader, WorkloadMetadataReader>();
+        services.AddSingleton<IWorkloadRuntimeIdentifierProvider, WorkloadRuntimeIdentifierProvider>();
 
         return services;
     }

--- a/src/Func/Workers/DefaultFunctionsWorkerInstaller.cs
+++ b/src/Func/Workers/DefaultFunctionsWorkerInstaller.cs
@@ -108,7 +108,7 @@ internal sealed class DefaultFunctionsWorkerInstaller(
     private ContentWorkloadInfo CreateContentWorkloadInfo(WorkloadEntry entry)
     {
         string installDirectory = _workloadPaths.GetInstallDirectory(entry.PackageId, entry.PackageVersion);
-        string contentRoot = Path.GetFullPath(Path.Combine(installDirectory, "tools", "any"));
+        string contentRoot = WorkloadPackageLayout.GetContentRoot(installDirectory, entry.RuntimeIdentifier);
 
         return new ContentWorkloadInfo(
             entry.PackageId,

--- a/src/Func/Workers/DefaultFunctionsWorkerInstaller.cs
+++ b/src/Func/Workers/DefaultFunctionsWorkerInstaller.cs
@@ -80,7 +80,8 @@ internal sealed class DefaultFunctionsWorkerInstaller(
         CancellationToken cancellationToken)
     {
         WorkloadEntry entry = result.Entry;
-        if (!string.Equals(entry.PackageId, expectedPackageId, StringComparison.OrdinalIgnoreCase))
+        string installedPackageId = entry.LogicalPackage?.PackageId ?? entry.PackageId;
+        if (!string.Equals(installedPackageId, expectedPackageId, StringComparison.OrdinalIgnoreCase))
         {
             throw new InvalidWorkloadException(
                 $"Expected worker workload package '{expectedPackageId}' but installed package '{entry.PackageId}'.");

--- a/src/Func/Workloads/Discovery/WorkloadMetadataReader.cs
+++ b/src/Func/Workloads/Discovery/WorkloadMetadataReader.cs
@@ -172,16 +172,16 @@ internal sealed class WorkloadMetadataReader : IWorkloadMetadataReader
         HashSet<string> runtimeIdentifiers = new(StringComparer.OrdinalIgnoreCase);
         foreach ((string runtimeIdentifier, string packageId) in metadata.Packages)
         {
-            if (!runtimeIdentifiers.Add(runtimeIdentifier))
-            {
-                throw new InvalidWorkloadException(
-                    $"'{metadataPath}' defines runtime identifier '{runtimeIdentifier}' more than once.");
-            }
-
             if (!IsNormalizedRuntimeIdentifier(runtimeIdentifier))
             {
                 throw new InvalidWorkloadException(
                     $"'{metadataPath}' has invalid packages key '{runtimeIdentifier}'. Runtime identifiers must be lowercase.");
+            }
+
+            if (!runtimeIdentifiers.Add(runtimeIdentifier))
+            {
+                throw new InvalidWorkloadException(
+                    $"'{metadataPath}' defines runtime identifier '{runtimeIdentifier}' more than once.");
             }
 
             if (string.IsNullOrWhiteSpace(packageId))

--- a/src/Func/Workloads/Discovery/WorkloadMetadataReader.cs
+++ b/src/Func/Workloads/Discovery/WorkloadMetadataReader.cs
@@ -90,19 +90,42 @@ internal sealed class WorkloadMetadataReader : IWorkloadMetadataReader
         {
             case WorkloadKind.Workload:
                 ValidateWorkloadEntryPoint(metadata, metadataPath);
+                ValidateNoPackages(metadata, metadataPath);
+                ValidateRuntimeIdentifier(metadata, metadataPath);
                 return metadata;
 
             case WorkloadKind.Content:
-            case WorkloadKind.Meta:
-                // entryPoint is meaningless for content/meta packages — reject
-                // it at author time instead of silently ignoring the field.
                 if (metadata.EntryPoint is not null)
                 {
                     throw new InvalidWorkloadException(
-                        $"'{metadataPath}' declares kind '{metadata.Kind.ToString().ToLowerInvariant()}' " +
+                        $"'{metadataPath}' declares kind 'content' " +
                         "but also defines an entryPoint. Remove the entryPoint or change the kind to 'workload'.");
                 }
 
+                ValidateNoPackages(metadata, metadataPath);
+                ValidateRuntimeIdentifier(metadata, metadataPath);
+                return metadata;
+
+            case WorkloadKind.Meta:
+                ValidateNoEntryPoint(metadata, metadataPath, "meta");
+                ValidateNoPackages(metadata, metadataPath);
+                if (metadata.RuntimeIdentifier is not null)
+                {
+                    throw new InvalidWorkloadException(
+                        $"'{metadataPath}' declares kind 'meta' but also defines runtimeIdentifier.");
+                }
+
+                return metadata;
+
+            case WorkloadKind.RidPointer:
+                ValidateNoEntryPoint(metadata, metadataPath, "rid-pointer");
+                if (metadata.RuntimeIdentifier is not null)
+                {
+                    throw new InvalidWorkloadException(
+                        $"'{metadataPath}' declares kind 'rid-pointer' but also defines runtimeIdentifier.");
+                }
+
+                ValidatePointerPackages(metadata, metadataPath);
                 return metadata;
 
             default:
@@ -110,6 +133,72 @@ internal sealed class WorkloadMetadataReader : IWorkloadMetadataReader
                     $"'{metadataPath}' has unrecognized kind '{metadata.Kind}'.");
         }
     }
+
+    private static void ValidateNoEntryPoint(WorkloadMetadata metadata, string metadataPath, string kind)
+    {
+        if (metadata.EntryPoint is not null)
+        {
+            throw new InvalidWorkloadException(
+                $"'{metadataPath}' declares kind '{kind}' but also defines an entryPoint.");
+        }
+    }
+
+    private static void ValidateNoPackages(WorkloadMetadata metadata, string metadataPath)
+    {
+        if (metadata.Packages is not null)
+        {
+            throw new InvalidWorkloadException(
+                $"'{metadataPath}' declares kind '{GetWireKind(metadata.Kind)}' but also defines packages.");
+        }
+    }
+
+    private static void ValidateRuntimeIdentifier(WorkloadMetadata metadata, string metadataPath)
+    {
+        if (metadata.RuntimeIdentifier is not null && !IsNormalizedRuntimeIdentifier(metadata.RuntimeIdentifier))
+        {
+            throw new InvalidWorkloadException(
+                $"'{metadataPath}' has invalid runtimeIdentifier '{metadata.RuntimeIdentifier}'. Runtime identifiers must be lowercase.");
+        }
+    }
+
+    private static void ValidatePointerPackages(WorkloadMetadata metadata, string metadataPath)
+    {
+        if (metadata.Packages is null || metadata.Packages.Count == 0)
+        {
+            throw new InvalidWorkloadException(
+                $"'{metadataPath}' declares kind 'rid-pointer' but does not define a non-empty packages map.");
+        }
+
+        HashSet<string> runtimeIdentifiers = new(StringComparer.OrdinalIgnoreCase);
+        foreach ((string runtimeIdentifier, string packageId) in metadata.Packages)
+        {
+            if (!runtimeIdentifiers.Add(runtimeIdentifier))
+            {
+                throw new InvalidWorkloadException(
+                    $"'{metadataPath}' defines runtime identifier '{runtimeIdentifier}' more than once.");
+            }
+
+            if (!IsNormalizedRuntimeIdentifier(runtimeIdentifier))
+            {
+                throw new InvalidWorkloadException(
+                    $"'{metadataPath}' has invalid packages key '{runtimeIdentifier}'. Runtime identifiers must be lowercase.");
+            }
+
+            if (string.IsNullOrWhiteSpace(packageId))
+            {
+                throw new InvalidWorkloadException(
+                    $"'{metadataPath}' has an empty implementation package id for runtime identifier '{runtimeIdentifier}'.");
+            }
+        }
+    }
+
+    private static bool IsNormalizedRuntimeIdentifier(string value)
+        => !string.IsNullOrWhiteSpace(value)
+            && string.Equals(value, value.Trim(), StringComparison.Ordinal)
+            && string.Equals(value, value.ToLowerInvariant(), StringComparison.Ordinal);
+
+    private static string GetWireKind(WorkloadKind kind)
+        => kind == WorkloadKind.RidPointer ? "rid-pointer" : kind.ToString().ToLowerInvariant();
 
     private static void ValidateWorkloadEntryPoint(WorkloadMetadata metadata, string metadataPath)
     {

--- a/src/Func/Workloads/HostWorkloadPackage.cs
+++ b/src/Func/Workloads/HostWorkloadPackage.cs
@@ -5,6 +5,7 @@ namespace Azure.Functions.Cli.Workloads;
 
 internal static class HostWorkloadPackage
 {
+    internal const string PackageId = "Azure.Functions.Cli.Workloads.Host";
     internal const string PackageIdPrefix = "Azure.Functions.Cli.Workloads.Host.";
 
     public static string CurrentPackageId => FromRuntimeIdentifier(CurrentRuntimeIdentifier);

--- a/src/Func/Workloads/IWorkloadRuntimeIdentifierProvider.cs
+++ b/src/Func/Workloads/IWorkloadRuntimeIdentifierProvider.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workloads;
+
+internal interface IWorkloadRuntimeIdentifierProvider
+{
+    public string Current { get; }
+}
+
+internal sealed class WorkloadRuntimeIdentifierProvider : IWorkloadRuntimeIdentifierProvider
+{
+    public string Current => WorkloadRuntimeIdentifier.Current;
+}

--- a/src/Func/Workloads/Install/IWorkloadInstaller.cs
+++ b/src/Func/Workloads/Install/IWorkloadInstaller.cs
@@ -122,10 +122,29 @@ internal interface IWorkloadInstaller
         IProgress<WorkloadInstallProgress>? progress = null,
         CancellationToken cancellationToken = default);
 
+    public Task<WorkloadUpdateResult> UpdateAsync(
+        string packageId,
+        NuGetVersion? targetInstalledVersion,
+        string? source,
+        bool? includePrerelease,
+        bool allowMajor,
+        WorkloadOwnershipKind ownership,
+        IProgress<WorkloadInstallProgress>? progress = null,
+        CancellationToken cancellationToken = default);
+
     /// <summary>
     /// Removes the install directory and registry entry for
     /// (<paramref name="packageId"/>, <paramref name="version"/>). Returns
     /// <c>true</c> when an entry was removed, <c>false</c> when none existed.
     /// </summary>
-    public Task<bool> UninstallAsync(string packageId, string version, CancellationToken cancellationToken = default);
+    public Task<bool> UninstallAsync(
+        string packageId,
+        string version,
+        CancellationToken cancellationToken = default);
+
+    public Task<bool> UninstallAsync(
+        string packageId,
+        string version,
+        WorkloadOwnershipKind ownership,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Func/Workloads/Install/WorkloadInstaller.cs
+++ b/src/Func/Workloads/Install/WorkloadInstaller.cs
@@ -12,58 +12,38 @@ using NuGet.Versioning;
 
 namespace Azure.Functions.Cli.Workloads.Install;
 
-/// <summary>
-/// Default <see cref="IWorkloadInstaller"/>. Extracts a <c>.nupkg</c> into
-/// the install directory, validates its <c>workload.json</c>, then writes
-/// the registry entry. On any failure after the install directory is
-/// created, the directory is rolled back so disk and registry stay in sync.
-/// </summary>
 internal sealed class WorkloadInstaller(
     IWorkloadPaths paths,
     IWorkloadStore store,
     IWorkloadMetadataReader metadataReader,
     IWorkloadCatalog catalog,
+    IWorkloadRuntimeIdentifierProvider runtimeIdentifierProvider,
     IOptions<WorkloadCatalogOptions> catalogOptions) : IWorkloadInstaller
 {
-    /// <summary>
-    /// Prefix on nuspec tags that marks the tag as a CLI-facing alias, so
-    /// workloads can keep using other tags for search/categories without
-    /// leaking them into alias resolution.
-    /// </summary>
     public const string AliasTagPrefix = "alias:";
-
-    /// <summary>
-    /// NuGet-tag prefix that flags a workload's package shape. Mirrors the
-    /// <c>kind</c> field in <c>workload.json</c>: <c>kind:workload</c> for a
-    /// stack, <c>kind:content</c> for a payload-only package, <c>kind:meta</c>
-    /// for a meta package. Surfaced in catalog responses so the CLI can filter
-    /// search results (e.g. <c>func workload search --stack</c>) without
-    /// downloading the package.
-    /// </summary>
     public const string KindTagPrefix = "kind:";
-
-    /// <summary>
-    /// NuGet-tag prefix that pins a per-RID workload package to the runtime
-    /// identifier it targets (e.g. <c>rid:win-x64</c>). Lets alias resolution
-    /// pick the variant matching the current platform when an alias spans
-    /// multiple per-RID packs (host, python worker).
-    /// </summary>
     public const string RidTagPrefix = "rid:";
-
-    /// <summary>
-    /// Package-type name a workload package must declare in its .nuspec so
-    /// the installer can refuse arbitrary .nupkgs. Mirrors dotnet's
-    /// <c>DotnetTool</c> convention.
-    /// </summary>
     public const string FuncCliWorkloadPackageType = "FuncCliWorkload";
+    public const string FuncCliWorkloadRidPackageType = "FuncCliWorkloadRidPackage";
 
     private readonly IWorkloadPaths _paths = paths ?? throw new ArgumentNullException(nameof(paths));
     private readonly IWorkloadStore _store = store ?? throw new ArgumentNullException(nameof(store));
     private readonly IWorkloadMetadataReader _metadataReader = metadataReader ?? throw new ArgumentNullException(nameof(metadataReader));
     private readonly IWorkloadCatalog _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
+    private readonly IWorkloadRuntimeIdentifierProvider _runtimeIdentifierProvider =
+        runtimeIdentifierProvider ?? throw new ArgumentNullException(nameof(runtimeIdentifierProvider));
     private readonly WorkloadCatalogOptions _catalogOptions = catalogOptions?.Value ?? throw new ArgumentNullException(nameof(catalogOptions));
 
-    /// <inheritdoc />
+    internal WorkloadInstaller(
+        IWorkloadPaths paths,
+        IWorkloadStore store,
+        IWorkloadMetadataReader metadataReader,
+        IWorkloadCatalog catalog,
+        IOptions<WorkloadCatalogOptions> catalogOptions)
+        : this(paths, store, metadataReader, catalog, new WorkloadRuntimeIdentifierProvider(), catalogOptions)
+    {
+    }
+
     public async Task<WorkloadInstallResult> InstallFromPackageAsync(
         string nupkgPath,
         bool force = false,
@@ -71,105 +51,45 @@ internal sealed class WorkloadInstaller(
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(nupkgPath);
-
         if (!File.Exists(nupkgPath))
         {
-            throw new FileNotFoundException(
-                $"Package file '{nupkgPath}' does not exist.",
-                nupkgPath);
+            throw new FileNotFoundException($"Package file '{nupkgPath}' does not exist.", nupkgPath);
         }
 
-        using PackageArchiveReader reader = OpenPackage(nupkgPath);
-        NuspecReader nuspec = reader.NuspecReader;
-
-        // NuGet package ids are case-insensitive; lowercase so the install
-        // path, registry key, and later lookups all agree.
-        string packageId = nuspec.GetId().ToLowerInvariant();
-        string version = nuspec.GetVersion().ToNormalizedString();
-        IReadOnlyList<string> aliases = ParseAliases(nuspec.GetTags());
-        string nuspecTitle = nuspec.GetTitle();
-        string nuspecDescription = nuspec.GetDescription();
-
-        if (!nuspec.GetPackageTypes().Any(t => string.Equals(t.Name, FuncCliWorkloadPackageType, StringComparison.OrdinalIgnoreCase)))
+        string fullPath = Path.GetFullPath(nupkgPath);
+        InspectedPackage package = await InspectPackageAsync(fullPath, cancellationToken);
+        if (package.Role != PackageRole.Pointer)
         {
-            throw new InvalidWorkloadException(
-                $"Package '{packageId}' is not a func CLI workload " +
-                $"(missing package type '{FuncCliWorkloadPackageType}' in its .nuspec).");
+            return await InstallPayloadAsync(
+                package,
+                fullPath,
+                WorkloadOwnershipKind.Explicit,
+                logicalPackage: null,
+                force,
+                progress,
+                cancellationToken);
         }
 
-        string installPath = _paths.GetInstallDirectory(packageId, version);
+        PointerSelection selection = SelectPointerImplementation(package);
+        LogicalPackage logicalPackage = CreateLogicalPackage(package, fullPath);
+        string implementationPath = FindLocalImplementation(
+            fullPath,
+            selection.PackageId,
+            package.Identity.Version,
+            selection.RuntimeIdentifier);
+        InspectedPackage implementation = await InspectPackageAsync(implementationPath, cancellationToken);
+        ValidatePointerImplementation(package, selection, implementation);
 
-        // Idempotent re-install: same (id, version) already on disk and in
-        // the registry returns success without re-extracting. Force still
-        // re-extracts so users can repair a broken install.
-        if (!force)
-        {
-            IReadOnlyList<WorkloadEntry> existing = await _store.GetWorkloadsAsync(cancellationToken);
-            WorkloadEntry? prior = existing.FirstOrDefault(e =>
-                string.Equals(e.PackageId, packageId, StringComparison.OrdinalIgnoreCase) &&
-                string.Equals(e.PackageVersion, version, StringComparison.Ordinal));
-
-            if (prior is not null && Directory.Exists(installPath))
-            {
-                return new WorkloadInstallResult(prior, AlreadyInstalled: true);
-            }
-        }
-
-        if (Directory.Exists(installPath))
-        {
-            // The registry is the source of truth. If the directory exists
-            // but no registry entry does, it's an orphan from a prior
-            // uninstall whose directory delete was blocked (AV, indexer,
-            // briefly-held handle). Self-heal by wiping it and re-extracting
-            // instead of leaving the user stuck behind a manual cleanup.
-            await _store.RemoveWorkloadAsync(packageId, version, cancellationToken);
-            Directory.Delete(installPath, recursive: true);
-        }
-
-        Directory.CreateDirectory(Path.GetDirectoryName(installPath)!);
-        Directory.CreateDirectory(installPath);
-
-        WorkloadEntry entry;
-        try
-        {
-            progress?.Report(new WorkloadInstallProgress(
-                WorkloadInstallPhase.Extracting,
-                $"Extracting workload '{packageId}' {version}"));
-
-            await ExtractPackageAsync(reader, installPath, cancellationToken);
-            EnsureHostExecutableBit(installPath, packageId);
-
-            WorkloadMetadata metadata = _metadataReader.Read(installPath);
-
-            entry = new WorkloadEntry
-            {
-                PackageId = packageId,
-                PackageVersion = version,
-                Aliases = aliases,
-                DisplayName = GetDisplayName(metadata, nuspecTitle, packageId),
-                Description = GetDescription(metadata, nuspecDescription),
-                EntryPoint = metadata.EntryPoint,
-                Kind = metadata.Kind,
-                Source = Path.GetFullPath(nupkgPath),
-                InstallRefCount = 1,
-            };
-
-            progress?.Report(new WorkloadInstallProgress(
-                WorkloadInstallPhase.Registering,
-                $"Registering workload '{packageId}' {version}"));
-
-            await _store.SaveWorkloadAsync(entry, cancellationToken);
-        }
-        catch
-        {
-            TryDeleteDirectory(installPath);
-            throw;
-        }
-
-        return new WorkloadInstallResult(entry, AlreadyInstalled: false);
+        return await InstallPayloadAsync(
+            implementation,
+            implementationPath,
+            WorkloadOwnershipKind.Logical,
+            logicalPackage,
+            force,
+            progress,
+            cancellationToken);
     }
 
-    /// <inheritdoc />
     public async Task<WorkloadInstallResult> InstallFromCatalogAsync(
         string packageId,
         NuGetVersion? version,
@@ -182,52 +102,89 @@ internal sealed class WorkloadInstaller(
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
         bool effectiveIncludePrerelease = IncludePrerelease(includePrerelease);
-
         progress?.Report(new WorkloadInstallProgress(WorkloadInstallPhase.Resolving, $"Resolving workload '{packageId}'"));
 
         string resolvedId = exact
             ? packageId
             : await ResolveAliasOrIdAsync(packageId, source, effectiveIncludePrerelease, cancellationToken);
+        ResolvedPackage resolved = await ResolveCatalogPackageAsync(
+            resolvedId,
+            version,
+            source,
+            effectiveIncludePrerelease,
+            cancellationToken);
 
-        ResolvedPackage resolved = await ResolveCatalogPackageAsync(resolvedId, version, source, effectiveIncludePrerelease, cancellationToken);
+        WorkloadInstallResult? reused = await TryReuseResolvedPackageAsync(resolved, force, cancellationToken);
+        if (reused is not null)
+        {
+            return reused;
+        }
 
-        string tempPath = Path.Combine(
-            Path.GetTempPath(),
-            $"func-workload-{Guid.NewGuid():N}.nupkg");
-
+        string packagePath = await DownloadToTempAsync(resolved, progress, cancellationToken);
         try
         {
-            progress?.Report(new WorkloadInstallProgress(
-                WorkloadInstallPhase.Downloading,
-                $"Downloading '{resolved.PackageId}' {resolved.Version.ToNormalizedString()}"));
-
-            await using (Stream packageStream = await _catalog.DownloadAsync(resolved, cancellationToken))
-            await using (FileStream tempStream = File.Create(tempPath))
+            InspectedPackage package = await InspectPackageAsync(packagePath, cancellationToken);
+            ValidateResolvedIdentity(resolved, package.Identity);
+            if (package.Role != PackageRole.Pointer)
             {
-                await packageStream.CopyToAsync(tempStream, cancellationToken);
+                return await InstallPayloadAsync(
+                    package,
+                    resolved.Source.Source,
+                    WorkloadOwnershipKind.Explicit,
+                    logicalPackage: null,
+                    force,
+                    progress,
+                    cancellationToken);
             }
 
-            return await InstallFromPackageAsync(tempPath, force, progress, cancellationToken);
+            PointerSelection selection = SelectPointerImplementation(package);
+            LogicalPackage logicalPackage = CreateLogicalPackage(package, resolved.Source.Source);
+            WorkloadInstallResult? existingImplementation = !force
+                ? await TryReuseInstalledImplementationAsync(
+                    selection.PackageId,
+                    package.Identity.Version,
+                    selection.RuntimeIdentifier,
+                    resolved.Source.Source,
+                    WorkloadOwnershipKind.Logical,
+                    logicalPackage,
+                    cancellationToken)
+                : null;
+            if (existingImplementation is not null)
+            {
+                return existingImplementation;
+            }
+
+            ResolvedPackage implementationResolved = await ResolvePointerImplementationAsync(
+                package,
+                selection,
+                resolved.Source.Source,
+                cancellationToken);
+            string implementationPath = await DownloadToTempAsync(implementationResolved, progress, cancellationToken);
+            try
+            {
+                InspectedPackage implementation = await InspectPackageAsync(implementationPath, cancellationToken);
+                ValidateResolvedIdentity(implementationResolved, implementation.Identity);
+                ValidatePointerImplementation(package, selection, implementation);
+                return await InstallPayloadAsync(
+                    implementation,
+                    implementationResolved.Source.Source,
+                    WorkloadOwnershipKind.Logical,
+                    logicalPackage,
+                    force,
+                    progress,
+                    cancellationToken);
+            }
+            finally
+            {
+                TryDeleteFile(implementationPath);
+            }
         }
         finally
         {
-            try
-            {
-                if (File.Exists(tempPath))
-                {
-                    File.Delete(tempPath);
-                }
-            }
-            catch
-            {
-                // Best-effort cleanup of the temp .nupkg; the OS reaps the
-                // temp dir periodically and the registry / install dir are
-                // already consistent at this point.
-            }
+            TryDeleteFile(packagePath);
         }
     }
 
-    /// <inheritdoc />
     public async Task<WorkloadUpdateResult> UpdateAsync(
         string packageId,
         NuGetVersion? targetInstalledVersion,
@@ -236,27 +193,128 @@ internal sealed class WorkloadInstaller(
         bool allowMajor,
         IProgress<WorkloadInstallProgress>? progress = null,
         CancellationToken cancellationToken = default)
+        => await UpdateAsync(
+            packageId,
+            targetInstalledVersion,
+            source,
+            includePrerelease,
+            allowMajor,
+            WorkloadOwnershipKind.Explicit,
+            progress,
+            cancellationToken);
+
+    public async Task<WorkloadUpdateResult> UpdateAsync(
+        string packageId,
+        NuGetVersion? targetInstalledVersion,
+        string? source,
+        bool? includePrerelease,
+        bool allowMajor,
+        WorkloadOwnershipKind ownership,
+        IProgress<WorkloadInstallProgress>? progress = null,
+        CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+        return ownership == WorkloadOwnershipKind.Logical
+            ? await UpdateLogicalAsync(
+                packageId,
+                targetInstalledVersion,
+                source,
+                includePrerelease,
+                allowMajor,
+                progress,
+                cancellationToken)
+            : await UpdateExplicitAsync(
+                packageId,
+                targetInstalledVersion,
+                source,
+                includePrerelease,
+                allowMajor,
+                progress,
+                cancellationToken);
+    }
+
+    public async Task<bool> UninstallAsync(
+        string packageId,
+        string version,
+        CancellationToken cancellationToken = default)
+        => await UninstallAsync(
+            packageId,
+            version,
+            WorkloadOwnershipKind.Explicit,
+            cancellationToken);
+
+    public async Task<bool> UninstallAsync(
+        string packageId,
+        string version,
+        WorkloadOwnershipKind ownership,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(version);
+
+        string physicalPackageId = packageId;
+        string physicalVersion = version;
+        if (ownership == WorkloadOwnershipKind.Logical)
+        {
+            IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
+            WorkloadEntry[] logicalMatches = [.. installed.Where(e =>
+                e.LogicalPackage is not null
+                && string.Equals(e.LogicalPackage.PackageId, packageId, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(e.LogicalPackage.PackageVersion, version, StringComparison.Ordinal))];
+            if (logicalMatches.Length == 0)
+            {
+                return false;
+            }
+
+            if (logicalMatches.Length > 1)
+            {
+                throw new InvalidOperationException(
+                    $"Logical workload '{packageId}' version '{version}' is attached to multiple physical packages.");
+            }
+
+            physicalPackageId = logicalMatches[0].PackageId;
+            physicalVersion = logicalMatches[0].PackageVersion;
+        }
+
+        WorkloadOwnershipRemovalResult result = await _store.RemoveOwnershipAsync(
+            physicalPackageId,
+            physicalVersion,
+            ownership,
+            cancellationToken);
+        if (!result.OwnershipRemoved)
+        {
+            return false;
+        }
+
+        if (result.EntryRemoved)
+        {
+            TryDeleteDirectory(_paths.GetInstallDirectory(physicalPackageId, physicalVersion));
+        }
+
+        return true;
+    }
+
+    private async Task<WorkloadUpdateResult> UpdateExplicitAsync(
+        string packageId,
+        NuGetVersion? targetInstalledVersion,
+        string? source,
+        bool? includePrerelease,
+        bool allowMajor,
+        IProgress<WorkloadInstallProgress>? progress,
+        CancellationToken cancellationToken)
+    {
         bool effectiveIncludePrerelease = IncludePrerelease(includePrerelease);
-
-        progress?.Report(new WorkloadInstallProgress(
-            WorkloadInstallPhase.Resolving,
-            $"Resolving update for '{packageId}'"));
-
         IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
-        List<WorkloadEntry> matches = [.. installed
-            .Where(e => string.Equals(e.PackageId, packageId, StringComparison.OrdinalIgnoreCase))];
-
+        List<WorkloadEntry> matches = [.. installed.Where(e =>
+            e.IsExplicitlyInstalled
+            && string.Equals(e.PackageId, packageId, StringComparison.OrdinalIgnoreCase))];
         if (matches.Count == 0)
         {
-            throw new InvalidOperationException(
-                $"Workload '{packageId}' is not installed.");
+            throw new InvalidOperationException($"Explicit ownership for workload '{packageId}' is not installed.");
         }
 
         WorkloadEntry currentEntry = ResolveUpdateTarget(packageId, targetInstalledVersion, matches);
         var currentVersion = NuGetVersion.Parse(currentEntry.PackageVersion);
-
         ResolvedPackage? resolved = await _catalog.ResolveLatestVersionAsync(
             currentEntry.PackageId,
             effectiveIncludePrerelease,
@@ -264,41 +322,700 @@ internal sealed class WorkloadInstaller(
             allowMajor,
             source,
             cancellationToken);
-
         if (resolved is null)
         {
-            return new WorkloadUpdateResult(
-                currentEntry,
-                currentEntry.PackageVersion,
-                NoUpdateAvailable: true,
-                NoCandidateOnSource: true);
+            return new WorkloadUpdateResult(currentEntry, currentEntry.PackageVersion, true, true);
         }
 
         if (resolved.Version <= currentVersion)
         {
-            return new WorkloadUpdateResult(currentEntry, currentEntry.PackageVersion, NoUpdateAvailable: true);
+            return new WorkloadUpdateResult(currentEntry, currentEntry.PackageVersion, true);
         }
 
-        WorkloadEntry newEntry = await StageAndSwapAsync(currentEntry, resolved, progress, cancellationToken);
-
-        return new WorkloadUpdateResult(newEntry, currentEntry.PackageVersion, NoUpdateAvailable: false);
+        WorkloadEntry newEntry = await StagePhysicalUpdateAsync(
+            currentEntry,
+            resolved,
+            WorkloadOwnershipKind.Explicit,
+            logicalPackage: null,
+            progress,
+            cancellationToken);
+        return new WorkloadUpdateResult(newEntry, currentEntry.PackageVersion, false);
     }
 
-    /// <inheritdoc />
-    public async Task<bool> UninstallAsync(string packageId, string version, CancellationToken cancellationToken = default)
+    private async Task<WorkloadUpdateResult> UpdateLogicalAsync(
+        string packageId,
+        NuGetVersion? targetInstalledVersion,
+        string? source,
+        bool? includePrerelease,
+        bool allowMajor,
+        IProgress<WorkloadInstallProgress>? progress,
+        CancellationToken cancellationToken)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
-        ArgumentException.ThrowIfNullOrWhiteSpace(version);
-
-        bool removed = await _store.RemoveWorkloadAsync(packageId, version, cancellationToken);
-        if (!removed)
+        bool effectiveIncludePrerelease = IncludePrerelease(includePrerelease);
+        IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
+        List<WorkloadEntry> matches = [.. installed.Where(e =>
+            e.LogicalPackage is not null
+            && string.Equals(e.LogicalPackage.PackageId, packageId, StringComparison.OrdinalIgnoreCase))];
+        if (matches.Count == 0)
         {
-            return false;
+            throw new InvalidOperationException($"Logical workload '{packageId}' is not installed.");
         }
 
+        WorkloadEntry currentEntry = ResolveLogicalUpdateTarget(packageId, targetInstalledVersion, matches);
+        LogicalPackage currentLogical = currentEntry.LogicalPackage!;
+        if (source is null && IsLocalPackageSource(currentLogical.Source))
+        {
+            throw new InvalidOperationException(
+                $"Logical workload '{currentLogical.PackageId}' was installed from a local package and has no automatic update source. " +
+                "Install a newer local pointer package explicitly or pass --source.");
+        }
+
+        var currentVersion = NuGetVersion.Parse(currentLogical.PackageVersion);
+        string? effectiveSource = source ?? (string.IsNullOrWhiteSpace(currentLogical.Source) ? null : currentLogical.Source);
+        ResolvedPackage? pointerResolved = await _catalog.ResolveLatestVersionAsync(
+            currentLogical.PackageId,
+            effectiveIncludePrerelease,
+            currentVersion,
+            allowMajor,
+            effectiveSource,
+            cancellationToken);
+        if (pointerResolved is null)
+        {
+            return new WorkloadUpdateResult(currentEntry, currentLogical.PackageVersion, true, true);
+        }
+
+        if (pointerResolved.Version < currentVersion)
+        {
+            return new WorkloadUpdateResult(currentEntry, currentLogical.PackageVersion, true);
+        }
+
+        string pointerPath = await DownloadToTempAsync(pointerResolved, progress, cancellationToken);
+        try
+        {
+            InspectedPackage pointer = await InspectPackageAsync(pointerPath, cancellationToken);
+            ValidateResolvedIdentity(pointerResolved, pointer.Identity);
+            if (pointer.Role != PackageRole.Pointer)
+            {
+                throw new InvalidWorkloadException(
+                    $"Package '{pointer.Identity.PackageId}' {pointer.Identity.Version} is not a rid-pointer workload.");
+            }
+
+            PointerSelection selection = SelectPointerImplementation(pointer);
+            bool ridPivot = !string.Equals(
+                currentEntry.RuntimeIdentifier,
+                selection.RuntimeIdentifier,
+                StringComparison.Ordinal);
+            if (pointerResolved.Version == currentVersion && !ridPivot)
+            {
+                return new WorkloadUpdateResult(currentEntry, currentLogical.PackageVersion, true);
+            }
+
+            LogicalPackage newLogical = CreateLogicalPackage(pointer, pointerResolved.Source.Source);
+            WorkloadEntry? reusable = await FindReusableImplementationAsync(
+                selection.PackageId,
+                pointer.Identity.Version,
+                selection.RuntimeIdentifier,
+                pointerResolved.Source.Source,
+                cancellationToken);
+            if (reusable is not null)
+            {
+                WorkloadEntry incoming = CopyForOwnership(reusable, WorkloadOwnershipKind.Logical, newLogical);
+                WorkloadOwnershipMoveResult moved = await _store.MoveLogicalOwnershipAsync(
+                    currentEntry.PackageId,
+                    currentEntry.PackageVersion,
+                    incoming,
+                    cancellationToken);
+                if (moved.PreviousEntryRemoved)
+                {
+                    TryDeleteDirectory(_paths.GetInstallDirectory(currentEntry.PackageId, currentEntry.PackageVersion));
+                }
+
+                return new WorkloadUpdateResult(moved.Entry, currentLogical.PackageVersion, false);
+            }
+
+            ResolvedPackage implementationResolved = await ResolvePointerImplementationAsync(
+                pointer,
+                selection,
+                pointerResolved.Source.Source,
+                cancellationToken);
+            string implementationPath = await DownloadToTempAsync(implementationResolved, progress, cancellationToken);
+            try
+            {
+                InspectedPackage implementation = await InspectPackageAsync(implementationPath, cancellationToken);
+                ValidateResolvedIdentity(implementationResolved, implementation.Identity);
+                ValidatePointerImplementation(pointer, selection, implementation);
+                WorkloadEntry newEntry = await StagePhysicalUpdateAsync(
+                    currentEntry,
+                    implementationResolved,
+                    WorkloadOwnershipKind.Logical,
+                    newLogical,
+                    progress,
+                    cancellationToken,
+                    implementationPath,
+                    implementation);
+                return new WorkloadUpdateResult(newEntry, currentLogical.PackageVersion, false);
+            }
+            finally
+            {
+                TryDeleteFile(implementationPath);
+            }
+        }
+        finally
+        {
+            TryDeleteFile(pointerPath);
+        }
+    }
+
+    private async Task<WorkloadEntry> StagePhysicalUpdateAsync(
+        WorkloadEntry currentEntry,
+        ResolvedPackage resolved,
+        WorkloadOwnershipKind ownership,
+        LogicalPackage? logicalPackage,
+        IProgress<WorkloadInstallProgress>? progress,
+        CancellationToken cancellationToken,
+        string? downloadedPath = null,
+        InspectedPackage? inspectedPackage = null)
+    {
+        string version = resolved.Version.ToNormalizedString();
+        IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
+        WorkloadEntry? destination = installed.FirstOrDefault(entry =>
+            string.Equals(entry.PackageId, resolved.PackageId, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(entry.PackageVersion, version, StringComparison.Ordinal));
+        if (destination is not null && !SourcesMatch(destination.Source, resolved.Source.Source))
+        {
+            throw new InvalidOperationException(
+                $"Package '{resolved.PackageId}' version '{version}' is already installed from source '{destination.Source}' and cannot be " +
+                $"replaced from source '{resolved.Source.Source}'. Remove the existing package ownership before updating from a different source.");
+        }
+
+        bool ownsDownload = downloadedPath is null;
+        string packagePath = downloadedPath ?? await DownloadToTempAsync(resolved, progress, cancellationToken);
+        string finalPath = _paths.GetInstallDirectory(resolved.PackageId, version);
+        string stagingPath = finalPath + ".staging-" + Guid.NewGuid().ToString("N");
+
+        try
+        {
+            InspectedPackage package = inspectedPackage ?? await InspectPackageAsync(packagePath, cancellationToken);
+            ValidateResolvedIdentity(resolved, package.Identity);
+            if (package.Role == PackageRole.Pointer)
+            {
+                throw new InvalidWorkloadException(
+                    $"Pointer package '{package.Identity.PackageId}' cannot be installed as a physical workload.");
+            }
+
+            Directory.CreateDirectory(stagingPath);
+            using (PackageArchiveReader reader = OpenPackage(packagePath))
+            {
+                await ExtractPackageAsync(reader, stagingPath, cancellationToken);
+            }
+
+            WorkloadMetadata metadata = _metadataReader.Read(stagingPath);
+            EnsureMetadataMatchesInspection(package.Metadata, metadata, package.Identity.PackageId);
+            EnsureHostExecutableBit(stagingPath, package.Identity.PackageId);
+            WorkloadEntry incoming = CreateEntry(package, resolved.Source.Source, ownership, logicalPackage);
+
+            if (Directory.Exists(finalPath))
+            {
+                TryDeleteDirectory(finalPath);
+            }
+
+            MoveDirectory(stagingPath, finalPath);
+            WorkloadOwnershipMoveResult moved = ownership == WorkloadOwnershipKind.Logical
+                ? await _store.MoveLogicalOwnershipAsync(
+                    currentEntry.PackageId,
+                    currentEntry.PackageVersion,
+                    incoming,
+                    cancellationToken)
+                : await _store.MoveExplicitOwnershipAsync(
+                    currentEntry.PackageId,
+                    currentEntry.PackageVersion,
+                    incoming,
+                    cancellationToken);
+
+            if (moved.PreviousEntryRemoved)
+            {
+                string oldPath = _paths.GetInstallDirectory(currentEntry.PackageId, currentEntry.PackageVersion);
+                if (!string.Equals(oldPath, finalPath, StringComparison.Ordinal))
+                {
+                    TryDeleteDirectory(oldPath);
+                }
+            }
+
+            return moved.Entry;
+        }
+        catch
+        {
+            TryDeleteDirectory(stagingPath);
+            throw;
+        }
+        finally
+        {
+            if (ownsDownload)
+            {
+                TryDeleteFile(packagePath);
+            }
+        }
+    }
+
+    private async Task<WorkloadInstallResult> InstallPayloadAsync(
+        InspectedPackage package,
+        string source,
+        WorkloadOwnershipKind ownership,
+        LogicalPackage? logicalPackage,
+        bool force,
+        IProgress<WorkloadInstallProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        string packageId = package.Identity.PackageId;
+        string version = package.Identity.Version;
         string installPath = _paths.GetInstallDirectory(packageId, version);
-        TryDeleteDirectory(installPath);
-        return true;
+        IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
+        WorkloadEntry? existing = installed.FirstOrDefault(e =>
+            string.Equals(e.PackageId, packageId, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(e.PackageVersion, version, StringComparison.Ordinal));
+        WorkloadEntry? currentLogicalOwner = null;
+        if (ownership == WorkloadOwnershipKind.Logical && logicalPackage is not null)
+        {
+            WorkloadEntry[] logicalOwners = [.. installed.Where(e =>
+                e.LogicalPackage is not null
+                && string.Equals(e.LogicalPackage.PackageId, logicalPackage.PackageId, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(e.LogicalPackage.PackageVersion, logicalPackage.PackageVersion, StringComparison.Ordinal))];
+            if (logicalOwners.Length > 1)
+            {
+                throw new InvalidOperationException(
+                    $"Logical workload '{logicalPackage.PackageId}' version '{logicalPackage.PackageVersion}' is attached to multiple physical packages.");
+            }
+
+            currentLogicalOwner = logicalOwners.FirstOrDefault();
+        }
+
+        bool logicalOwnerMoves = currentLogicalOwner is not null
+            && (!string.Equals(currentLogicalOwner.PackageId, packageId, StringComparison.OrdinalIgnoreCase)
+                || !string.Equals(currentLogicalOwner.PackageVersion, version, StringComparison.Ordinal));
+
+        if (ownership == WorkloadOwnershipKind.Logical
+            && existing is not null
+            && !SourcesMatch(existing.Source, source))
+        {
+            throw new InvalidOperationException(
+                $"Package '{packageId}' version '{version}' is already installed from source '{existing.Source}' and cannot be used by " +
+                $"pointer source '{source}'. Remove the existing package ownership before installing from a different source.");
+        }
+
+        if (!force
+            && existing is not null
+            && (ownership == WorkloadOwnershipKind.Explicit || SourcesMatch(existing.Source, source))
+            && IsExistingInstallationValid(existing, package.Metadata))
+        {
+            if (logicalOwnerMoves)
+            {
+                WorkloadEntry incoming = CopyForOwnership(existing, WorkloadOwnershipKind.Logical, logicalPackage);
+                WorkloadOwnershipMoveResult moved = await _store.MoveLogicalOwnershipAsync(
+                    currentLogicalOwner!.PackageId,
+                    currentLogicalOwner.PackageVersion,
+                    incoming,
+                    cancellationToken);
+                if (moved.PreviousEntryRemoved)
+                {
+                    TryDeleteDirectory(_paths.GetInstallDirectory(
+                        currentLogicalOwner.PackageId,
+                        currentLogicalOwner.PackageVersion));
+                }
+
+                return new WorkloadInstallResult(moved.Entry, false);
+            }
+
+            bool alreadyOwned = HasOwnership(existing, ownership);
+            if (alreadyOwned)
+            {
+                return new WorkloadInstallResult(existing, true);
+            }
+
+            WorkloadEntry attached = await _store.AddOwnershipAsync(
+                CopyForOwnership(existing, ownership, logicalPackage),
+                ownership,
+                cancellationToken);
+            return new WorkloadInstallResult(attached, false);
+        }
+
+        string stagingPath = installPath + ".staging-" + Guid.NewGuid().ToString("N");
+        bool movedToFinal = false;
+        try
+        {
+            progress?.Report(new WorkloadInstallProgress(
+                WorkloadInstallPhase.Extracting,
+                $"Extracting workload '{packageId}' {version}"));
+            Directory.CreateDirectory(stagingPath);
+            using (PackageArchiveReader reader = OpenPackage(package.Path))
+            {
+                await ExtractPackageAsync(reader, stagingPath, cancellationToken);
+            }
+
+            WorkloadMetadata metadata = _metadataReader.Read(stagingPath);
+            EnsureMetadataMatchesInspection(package.Metadata, metadata, packageId);
+            EnsureHostExecutableBit(stagingPath, packageId);
+            WorkloadEntry incoming = CreateEntry(package, source, ownership, logicalPackage);
+            WorkloadEntry entry = existing is null
+                ? incoming
+                : MergeForReinstall(existing, incoming, ownership);
+
+            if (Directory.Exists(installPath))
+            {
+                TryDeleteDirectory(installPath);
+            }
+
+            MoveDirectory(stagingPath, installPath);
+            movedToFinal = true;
+            progress?.Report(new WorkloadInstallProgress(
+                WorkloadInstallPhase.Registering,
+                $"Registering workload '{packageId}' {version}"));
+            if (logicalOwnerMoves)
+            {
+                WorkloadOwnershipMoveResult moved = await _store.MoveLogicalOwnershipAsync(
+                    currentLogicalOwner!.PackageId,
+                    currentLogicalOwner.PackageVersion,
+                    entry,
+                    cancellationToken);
+                if (moved.PreviousEntryRemoved)
+                {
+                    TryDeleteDirectory(_paths.GetInstallDirectory(
+                        currentLogicalOwner.PackageId,
+                        currentLogicalOwner.PackageVersion));
+                }
+
+                return new WorkloadInstallResult(moved.Entry, false);
+            }
+
+            await _store.SaveWorkloadAsync(entry, cancellationToken);
+            return new WorkloadInstallResult(entry, false);
+        }
+        catch
+        {
+            TryDeleteDirectory(stagingPath);
+            if (movedToFinal && existing is null)
+            {
+                TryDeleteDirectory(installPath);
+            }
+
+            throw;
+        }
+    }
+
+    private async Task<WorkloadInstallResult?> TryReuseResolvedPackageAsync(
+        ResolvedPackage resolved,
+        bool force,
+        CancellationToken cancellationToken)
+    {
+        if (force)
+        {
+            return null;
+        }
+
+        IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
+        WorkloadEntry? existing = installed.FirstOrDefault(e =>
+            string.Equals(e.PackageId, resolved.PackageId, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(e.PackageVersion, resolved.Version.ToNormalizedString(), StringComparison.Ordinal));
+        if (existing is null || !existing.IsExplicitlyInstalled || !Directory.Exists(
+            _paths.GetInstallDirectory(existing.PackageId, existing.PackageVersion)))
+        {
+            return null;
+        }
+
+        return new WorkloadInstallResult(existing, true);
+    }
+
+    private async Task<WorkloadInstallResult?> TryReuseInstalledImplementationAsync(
+        string packageId,
+        string version,
+        string runtimeIdentifier,
+        string source,
+        WorkloadOwnershipKind ownership,
+        LogicalPackage logicalPackage,
+        CancellationToken cancellationToken)
+    {
+        WorkloadEntry? existing = await FindReusableImplementationAsync(
+            packageId,
+            version,
+            runtimeIdentifier,
+            source,
+            cancellationToken);
+        if (existing is null)
+        {
+            return null;
+        }
+
+        bool alreadyOwned = HasOwnership(existing, ownership);
+        if (alreadyOwned)
+        {
+            return new WorkloadInstallResult(existing, true);
+        }
+
+        WorkloadEntry attached = await _store.AddOwnershipAsync(
+            CopyForOwnership(existing, ownership, logicalPackage),
+            ownership,
+            cancellationToken);
+        return new WorkloadInstallResult(attached, false);
+    }
+
+    private async Task<WorkloadEntry?> FindReusableImplementationAsync(
+        string packageId,
+        string version,
+        string runtimeIdentifier,
+        string source,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
+        WorkloadEntry? existing = installed.FirstOrDefault(e =>
+            string.Equals(e.PackageId, packageId, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(e.PackageVersion, version, StringComparison.Ordinal)
+            && string.Equals(e.RuntimeIdentifier, runtimeIdentifier, StringComparison.Ordinal)
+            && SourcesMatch(e.Source, source));
+        if (existing is null)
+        {
+            return null;
+        }
+
+        string installPath = _paths.GetInstallDirectory(existing.PackageId, existing.PackageVersion);
+        if (!Directory.Exists(installPath))
+        {
+            return null;
+        }
+
+        try
+        {
+            WorkloadMetadata metadata = _metadataReader.Read(installPath);
+            return metadata.Kind is WorkloadKind.Workload or WorkloadKind.Content
+                && string.Equals(metadata.RuntimeIdentifier, runtimeIdentifier, StringComparison.Ordinal)
+                ? existing
+                : null;
+        }
+        catch (InvalidWorkloadException)
+        {
+            return null;
+        }
+    }
+
+    private async Task<InspectedPackage> InspectPackageAsync(string path, CancellationToken cancellationToken)
+    {
+        using PackageArchiveReader reader = OpenPackage(path);
+        NuspecReader nuspec = reader.NuspecReader;
+        PackageIdentity identity = new(
+            nuspec.GetId().ToLowerInvariant(),
+            nuspec.GetVersion().ToNormalizedString(),
+            [.. nuspec.GetPackageTypes().Select(t => t.Name)],
+            ParseAliases(nuspec.GetTags()),
+            ParseTagValues(nuspec.GetTags(), RidTagPrefix),
+            nuspec.GetTitle(),
+            nuspec.GetDescription());
+
+        string inspectionDirectory = Path.Combine(Path.GetTempPath(), $"func-workload-inspect-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(inspectionDirectory);
+            await ExtractPackageAsync(reader, inspectionDirectory, cancellationToken);
+            WorkloadMetadata metadata = _metadataReader.Read(inspectionDirectory);
+            IReadOnlyList<string> files = [.. await reader.GetFilesAsync(cancellationToken)];
+            PackageRole role = ValidatePackage(identity, metadata, files);
+            return new InspectedPackage(path, identity, metadata, role);
+        }
+        finally
+        {
+            TryDeleteDirectory(inspectionDirectory);
+        }
+    }
+
+    private PackageRole ValidatePackage(
+        PackageIdentity identity,
+        WorkloadMetadata metadata,
+        IReadOnlyList<string> files)
+    {
+        bool standardType = identity.PackageTypes.Any(t =>
+            string.Equals(t, FuncCliWorkloadPackageType, StringComparison.OrdinalIgnoreCase));
+        bool ridType = identity.PackageTypes.Any(t =>
+            string.Equals(t, FuncCliWorkloadRidPackageType, StringComparison.OrdinalIgnoreCase));
+        if (standardType && ridType)
+        {
+            throw new InvalidWorkloadException(
+                $"Package '{identity.PackageId}' declares both '{FuncCliWorkloadPackageType}' and '{FuncCliWorkloadRidPackageType}' package types.");
+        }
+
+        if (metadata.Kind == WorkloadKind.RidPointer)
+        {
+            RequirePackageType(identity, standardType, FuncCliWorkloadPackageType);
+            if (identity.RidTags.Count > 0)
+            {
+                throw new InvalidWorkloadException(
+                    $"RID pointer package '{identity.PackageId}' cannot declare a rid: tag.");
+            }
+
+            if (files.Any(IsPayloadFile))
+            {
+                throw new InvalidWorkloadException(
+                    $"RID pointer package '{identity.PackageId}' cannot contain a tools/ payload.");
+            }
+
+            ValidatePointerMap(identity, metadata);
+            return PackageRole.Pointer;
+        }
+
+        if (ridType)
+        {
+            if (metadata.Kind is not (WorkloadKind.Workload or WorkloadKind.Content))
+            {
+                throw new InvalidWorkloadException(
+                    $"RID implementation package '{identity.PackageId}' must declare kind 'workload' or 'content'.");
+            }
+
+            if (string.IsNullOrWhiteSpace(metadata.RuntimeIdentifier))
+            {
+                throw new InvalidWorkloadException(
+                    $"RID implementation package '{identity.PackageId}' is missing runtimeIdentifier.");
+            }
+
+            ValidateImplementationRid(identity, metadata.RuntimeIdentifier);
+            return PackageRole.RidImplementation;
+        }
+
+        RequirePackageType(identity, standardType, FuncCliWorkloadPackageType);
+        if (metadata.RuntimeIdentifier is not null || identity.RidTags.Count > 0)
+        {
+            throw new InvalidWorkloadException(
+                $"Package '{identity.PackageId}' uses RID implementation metadata but does not declare package type '{FuncCliWorkloadRidPackageType}'.");
+        }
+
+        return PackageRole.Ordinary;
+    }
+
+    private void ValidateImplementationRid(PackageIdentity identity, string manifestRuntimeIdentifier)
+    {
+        string currentRuntimeIdentifier = CurrentRuntimeIdentifier;
+        if (identity.RidTags.Count != 1)
+        {
+            throw new InvalidWorkloadException(
+                $"RID implementation package '{identity.PackageId}' must declare exactly one rid:<rid> tag.");
+        }
+
+        string tagRuntimeIdentifier = identity.RidTags[0];
+        string expectedSuffix = "." + manifestRuntimeIdentifier;
+        if (!string.Equals(tagRuntimeIdentifier, manifestRuntimeIdentifier, StringComparison.Ordinal)
+            || !identity.PackageId.EndsWith(expectedSuffix, StringComparison.OrdinalIgnoreCase)
+            || !string.Equals(manifestRuntimeIdentifier, currentRuntimeIdentifier, StringComparison.Ordinal))
+        {
+            throw new InvalidWorkloadException(
+                $"RID metadata mismatch for package '{identity.PackageId}': manifest runtimeIdentifier='{manifestRuntimeIdentifier}', " +
+                $"nuspec rid tag='{tagRuntimeIdentifier}', package-id suffix='{expectedSuffix}', current RID='{currentRuntimeIdentifier}'.");
+        }
+    }
+
+    private static void ValidatePointerMap(PackageIdentity identity, WorkloadMetadata metadata)
+    {
+        foreach ((string runtimeIdentifier, string implementationId) in metadata.Packages!)
+        {
+            string expected = $"{identity.PackageId}.{runtimeIdentifier}";
+            if (!string.Equals(implementationId, expected, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidWorkloadException(
+                    $"RID pointer package '{identity.PackageId}' maps runtime identifier '{runtimeIdentifier}' to '{implementationId}', " +
+                    $"but the required implementation id is '{expected}'.");
+            }
+        }
+    }
+
+    private PointerSelection SelectPointerImplementation(InspectedPackage pointer)
+    {
+        string currentRuntimeIdentifier = CurrentRuntimeIdentifier;
+        if (!pointer.Metadata.Packages!.TryGetValue(currentRuntimeIdentifier, out string? implementationId))
+        {
+            string supported = string.Join(
+                ", ",
+                pointer.Metadata.Packages.Keys.OrderBy(r => r, StringComparer.Ordinal));
+            throw new WorkloadPackageNotFoundException(
+                $"Workload '{pointer.Identity.PackageId}' {pointer.Identity.Version} does not support runtime identifier " +
+                $"'{currentRuntimeIdentifier}'. Supported runtime identifiers: {supported}.");
+        }
+
+        return new PointerSelection(currentRuntimeIdentifier, implementationId.ToLowerInvariant());
+    }
+
+    private static void ValidatePointerImplementation(
+        InspectedPackage pointer,
+        PointerSelection selection,
+        InspectedPackage implementation)
+    {
+        if (implementation.Role != PackageRole.RidImplementation)
+        {
+            throw new InvalidWorkloadException(
+                $"Pointer '{pointer.Identity.PackageId}' selected '{implementation.Identity.PackageId}', " +
+                $"but it is not a '{FuncCliWorkloadRidPackageType}' implementation package.");
+        }
+
+        if (!string.Equals(implementation.Identity.PackageId, selection.PackageId, StringComparison.OrdinalIgnoreCase)
+            || !string.Equals(implementation.Identity.Version, pointer.Identity.Version, StringComparison.Ordinal)
+            || !string.Equals(implementation.Metadata.RuntimeIdentifier, selection.RuntimeIdentifier, StringComparison.Ordinal))
+        {
+            throw new InvalidWorkloadException(
+                $"Pointer implementation mismatch: pointer='{pointer.Identity.PackageId}' {pointer.Identity.Version}, " +
+                $"map RID='{selection.RuntimeIdentifier}', mapped package='{selection.PackageId}', returned package=" +
+                $"'{implementation.Identity.PackageId}' {implementation.Identity.Version}, manifest runtimeIdentifier=" +
+                $"'{implementation.Metadata.RuntimeIdentifier}'.");
+        }
+    }
+
+    private async Task<ResolvedPackage> ResolvePointerImplementationAsync(
+        InspectedPackage pointer,
+        PointerSelection selection,
+        string source,
+        CancellationToken cancellationToken)
+    {
+        var version = NuGetVersion.Parse(pointer.Identity.Version);
+        ResolvedPackage? resolved = await _catalog.ResolveVersionAsync(
+            selection.PackageId,
+            version,
+            source,
+            cancellationToken);
+        if (resolved is null)
+        {
+            throw CreatePartialPublishException(pointer, selection, source);
+        }
+
+        return resolved;
+    }
+
+    private static WorkloadPackageNotFoundException CreatePartialPublishException(
+        InspectedPackage pointer,
+        PointerSelection selection,
+        string source)
+        => new(
+            $"RID pointer '{pointer.Identity.PackageId}' {pointer.Identity.Version} selected runtime identifier " +
+            $"'{selection.RuntimeIdentifier}', but implementation '{selection.PackageId}' {pointer.Identity.Version} " +
+            $"was not found on source '{source}'. This may be a partial publish or feed indexing delay.");
+
+    private string FindLocalImplementation(
+        string pointerPath,
+        string packageId,
+        string version,
+        string runtimeIdentifier)
+    {
+        string directory = Path.GetDirectoryName(pointerPath)!;
+        foreach (string candidate in Directory.EnumerateFiles(directory, "*.nupkg", SearchOption.TopDirectoryOnly))
+        {
+            if (string.Equals(candidate, pointerPath, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            using PackageArchiveReader reader = OpenPackage(candidate);
+            NuspecReader nuspec = reader.NuspecReader;
+            if (string.Equals(nuspec.GetId(), packageId, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(nuspec.GetVersion().ToNormalizedString(), version, StringComparison.Ordinal))
+            {
+                return candidate;
+            }
+        }
+
+        throw new FileNotFoundException(
+            $"Local RID pointer '{Path.GetFileName(pointerPath)}' requires implementation '{packageId}' {version} for RID " +
+            $"'{runtimeIdentifier}' in directory '{directory}'. No configured feed was searched.");
     }
 
     private async Task<string> ResolveAliasOrIdAsync(
@@ -307,16 +1024,8 @@ internal sealed class WorkloadInstaller(
         bool includePrerelease,
         CancellationToken cancellationToken)
     {
-        // Spec §6.1 step 2 (default flow): query the catalog for packages
-        // declaring `alias:<aliasOrId>` and pick the unique match. Zero
-        // matches falls back to treating the input as a literal package id.
-        // When an alias spans multiple per-RID packs (host, python worker),
-        // disambiguate by the `rid:` tag using the current runtime identifier.
-        // Multiple distinct package ids that don't disambiguate is an error;
-        // the user must re-run with --exact <packageId>.
         const int aliasSearchTake = 50;
-
-        var query = new CatalogSearchQuery
+        CatalogSearchQuery query = new()
         {
             Filter = aliasOrId,
             IncludePrerelease = includePrerelease,
@@ -326,12 +1035,6 @@ internal sealed class WorkloadInstaller(
 
         IReadOnlyList<CatalogSearchResult> hits = await _catalog.SearchAsync(query, cancellationToken);
         IReadOnlyList<CatalogSearchResult> aliasMatches = FilterByAlias(hits, aliasOrId);
-
-        // Some feeds (BaGet, older NuGet implementations) tokenize the `q=`
-        // term in ways that drop hyphenated aliases like `node-worker`. When
-        // the targeted query returns nothing, retry with an empty filter:
-        // the `packageType=FuncCliWorkload` constraint keeps the result set
-        // bounded to workload packages, which we then filter client-side.
         if (aliasMatches.Count == 0 && hits.Count == 0)
         {
             IReadOnlyList<CatalogSearchResult> all = await _catalog.SearchAsync(
@@ -340,50 +1043,26 @@ internal sealed class WorkloadInstaller(
             aliasMatches = FilterByAlias(all, aliasOrId);
         }
 
-        IReadOnlyList<string> matchedIds = DistinctPackageIds(aliasMatches);
+        IReadOnlyList<string> pointerIds = DistinctPackageIds(aliasMatches.Where(m =>
+            string.Equals(m.Kind, "rid-pointer", StringComparison.OrdinalIgnoreCase)));
+        if (pointerIds.Count == 1)
+        {
+            return pointerIds[0];
+        }
 
+        if (pointerIds.Count > 1)
+        {
+            throw new AmbiguousPackageMatchException(aliasOrId, pointerIds);
+        }
+
+        IReadOnlyList<string> matchedIds = DistinctPackageIds(aliasMatches);
         if (matchedIds.Count > 1)
         {
-            // Per-RID disambiguation: if every match carries a `rid:` tag,
-            // pick the one matching the current runtime identifier. This is
-            // what makes `func workload install host` and
-            // `func workload install python-worker` resolve to the user's
-            // platform without forcing them to spell out the full RID.
-            if (aliasMatches.All(m => m.Rid is not null))
-            {
-                string currentRid = WorkloadRuntimeIdentifier.Current.ToLowerInvariant();
-                IReadOnlyList<string> ridMatches = DistinctPackageIds(
-                    aliasMatches.Where(m => string.Equals(m.Rid, currentRid, StringComparison.OrdinalIgnoreCase)));
-
-                if (ridMatches.Count == 1)
-                {
-                    return ridMatches[0];
-                }
-
-                if (ridMatches.Count == 0)
-                {
-                    IReadOnlyList<string> supported = aliasMatches
-                        .Select(m => m.Rid!)
-                        .Distinct(StringComparer.OrdinalIgnoreCase)
-                        .OrderBy(r => r, StringComparer.OrdinalIgnoreCase)
-                        .ToArray();
-                    throw new WorkloadPackageNotFoundException(
-                        $"No '{aliasOrId}' workload is published for runtime identifier '{currentRid}'. "
-                        + $"Published runtimes: {string.Join(", ", supported)}.");
-                }
-            }
-
             throw new AmbiguousPackageMatchException(aliasOrId, matchedIds);
         }
 
         return matchedIds.Count == 1 ? matchedIds[0] : aliasOrId;
     }
-
-    private static IReadOnlyList<CatalogSearchResult> FilterByAlias(IReadOnlyList<CatalogSearchResult> hits, string alias) =>
-        [.. hits.Where(r => r.Aliases.Any(a => string.Equals(a, alias, StringComparison.OrdinalIgnoreCase)))];
-
-    private static IReadOnlyList<string> DistinctPackageIds(IEnumerable<CatalogSearchResult> hits) =>
-        [.. hits.Select(r => r.PackageId).Distinct(StringComparer.OrdinalIgnoreCase)];
 
     private async Task<ResolvedPackage> ResolveCatalogPackageAsync(
         string packageId,
@@ -394,27 +1073,149 @@ internal sealed class WorkloadInstaller(
     {
         ResolvedPackage? resolved = version is null
             ? await _catalog.ResolveLatestVersionAsync(
-                packageId, includePrerelease, currentVersion: null, allowMajor: true, source: source, cancellationToken)
+                packageId,
+                includePrerelease,
+                currentVersion: null,
+                allowMajor: true,
+                source,
+                cancellationToken)
             : await _catalog.ResolveVersionAsync(packageId, version, source, cancellationToken);
-
         if (resolved is null)
         {
             string detail = version is null
                 ? "No matching version was found on any configured source."
                 : $"Version '{version.ToNormalizedString()}' was not found on any configured source.";
-
-            string hint = includePrerelease
-                ? string.Empty
-                : " Pass --prerelease if it is a prerelease.";
-
-            throw new Catalog.WorkloadPackageNotFoundException(
+            string hint = includePrerelease ? string.Empty : " Pass --prerelease if it is a prerelease.";
+            throw new WorkloadPackageNotFoundException(
                 $"Could not resolve workload '{packageId}'. {detail}{hint}");
         }
 
         return resolved;
     }
 
-    private bool IncludePrerelease(bool? includePrerelease) => includePrerelease ?? _catalogOptions.IncludePrerelease;
+    private async Task<string> DownloadToTempAsync(
+        ResolvedPackage resolved,
+        IProgress<WorkloadInstallProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        progress?.Report(new WorkloadInstallProgress(
+            WorkloadInstallPhase.Downloading,
+            $"Downloading '{resolved.PackageId}' {resolved.Version.ToNormalizedString()}"));
+        string path = Path.Combine(Path.GetTempPath(), $"func-workload-{Guid.NewGuid():N}.nupkg");
+        try
+        {
+            await using Stream packageStream = await _catalog.DownloadAsync(resolved, cancellationToken);
+            await using FileStream tempStream = File.Create(path);
+            await packageStream.CopyToAsync(tempStream, cancellationToken);
+            return path;
+        }
+        catch
+        {
+            TryDeleteFile(path);
+            throw;
+        }
+    }
+
+    private static WorkloadEntry CreateEntry(
+        InspectedPackage package,
+        string source,
+        WorkloadOwnershipKind ownership,
+        LogicalPackage? logicalPackage)
+        => new()
+        {
+            PackageId = package.Identity.PackageId,
+            PackageVersion = package.Identity.Version,
+            Aliases = package.Identity.Aliases,
+            DisplayName = GetDisplayName(package.Metadata, package.Identity.Title, package.Identity.PackageId),
+            Description = GetDescription(package.Metadata, package.Identity.Description),
+            EntryPoint = package.Metadata.EntryPoint,
+            Kind = package.Metadata.Kind,
+            Source = source,
+            RuntimeIdentifier = package.Metadata.RuntimeIdentifier,
+            IsExplicitlyInstalled = ownership == WorkloadOwnershipKind.Explicit,
+            LogicalPackage = logicalPackage,
+            InstallRefCount = 1,
+        };
+
+    private static LogicalPackage CreateLogicalPackage(InspectedPackage pointer, string source)
+        => new()
+        {
+            PackageId = pointer.Identity.PackageId,
+            PackageVersion = pointer.Identity.Version,
+            Aliases = pointer.Identity.Aliases,
+            DisplayName = GetDisplayName(pointer.Metadata, pointer.Identity.Title, pointer.Identity.PackageId),
+            Description = GetDescription(pointer.Metadata, pointer.Identity.Description),
+            Source = source,
+        };
+
+    private static WorkloadEntry CopyForOwnership(
+        WorkloadEntry entry,
+        WorkloadOwnershipKind ownership,
+        LogicalPackage? logicalPackage)
+        => new()
+        {
+            PackageId = entry.PackageId,
+            PackageVersion = entry.PackageVersion,
+            Aliases = entry.Aliases,
+            DisplayName = entry.DisplayName,
+            Description = entry.Description,
+            EntryPoint = entry.EntryPoint,
+            Kind = entry.Kind,
+            Source = entry.Source,
+            RuntimeIdentifier = entry.RuntimeIdentifier,
+            IsExplicitlyInstalled = ownership == WorkloadOwnershipKind.Explicit || entry.IsExplicitlyInstalled,
+            LogicalPackage = entry.LogicalPackage ?? logicalPackage,
+            InstallRefCount = entry.InstallRefCount,
+        };
+
+    private static WorkloadEntry MergeForReinstall(
+        WorkloadEntry existing,
+        WorkloadEntry incoming,
+        WorkloadOwnershipKind ownership)
+    {
+        bool addExplicit = ownership == WorkloadOwnershipKind.Explicit && !existing.IsExplicitlyInstalled;
+        bool addLogical = ownership == WorkloadOwnershipKind.Logical && existing.LogicalPackage is null;
+        return new WorkloadEntry
+        {
+            PackageId = incoming.PackageId,
+            PackageVersion = incoming.PackageVersion,
+            Aliases = incoming.Aliases,
+            DisplayName = incoming.DisplayName,
+            Description = incoming.Description,
+            EntryPoint = incoming.EntryPoint,
+            Kind = incoming.Kind,
+            Source = incoming.Source,
+            RuntimeIdentifier = incoming.RuntimeIdentifier,
+            IsExplicitlyInstalled = existing.IsExplicitlyInstalled || incoming.IsExplicitlyInstalled,
+            LogicalPackage = existing.LogicalPackage ?? incoming.LogicalPackage,
+            InstallRefCount = existing.InstallRefCount + (addExplicit ? 1 : 0) + (addLogical ? 1 : 0),
+        };
+    }
+
+    private bool IsExistingInstallationValid(WorkloadEntry entry, WorkloadMetadata expectedMetadata)
+    {
+        string installPath = _paths.GetInstallDirectory(entry.PackageId, entry.PackageVersion);
+        if (!Directory.Exists(installPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            WorkloadMetadata actual = _metadataReader.Read(installPath);
+            return actual.Kind == expectedMetadata.Kind
+                && string.Equals(actual.RuntimeIdentifier, expectedMetadata.RuntimeIdentifier, StringComparison.Ordinal);
+        }
+        catch (InvalidWorkloadException)
+        {
+            return false;
+        }
+    }
+
+    private static bool HasOwnership(WorkloadEntry entry, WorkloadOwnershipKind ownership)
+        => ownership == WorkloadOwnershipKind.Explicit
+            ? entry.IsExplicitlyInstalled
+            : entry.LogicalPackage is not null;
 
     private static WorkloadEntry ResolveUpdateTarget(
         string packageId,
@@ -423,147 +1224,123 @@ internal sealed class WorkloadInstaller(
     {
         if (targetInstalledVersion is null)
         {
-            return matches
-                .OrderByDescending(e => NuGetVersion.Parse(e.PackageVersion))
-                .First();
+            return matches.OrderByDescending(e => NuGetVersion.Parse(e.PackageVersion)).First();
         }
 
         string requested = targetInstalledVersion.ToNormalizedString();
         WorkloadEntry? exact = matches.FirstOrDefault(e =>
             string.Equals(e.PackageVersion, requested, StringComparison.Ordinal));
-
         if (exact is null)
         {
             string available = string.Join(", ", matches.Select(m => m.PackageVersion));
             throw new InvalidOperationException(
-                $"Workload '{packageId}' version '{requested}' is not installed. " +
-                $"Installed versions: {available}.");
+                $"Workload '{packageId}' version '{requested}' is not installed. Installed versions: {available}.");
         }
 
         return exact;
     }
 
-    private async Task<WorkloadEntry> StageAndSwapAsync(
-        WorkloadEntry currentEntry,
-        ResolvedPackage resolved,
-        IProgress<WorkloadInstallProgress>? progress,
-        CancellationToken cancellationToken)
+    private static WorkloadEntry ResolveLogicalUpdateTarget(
+        string packageId,
+        NuGetVersion? targetInstalledVersion,
+        IReadOnlyList<WorkloadEntry> matches)
     {
-        string tempNupkg = Path.Combine(
-            Path.GetTempPath(),
-            $"func-workload-{Guid.NewGuid():N}.nupkg");
-
-        string finalInstallPath = _paths.GetInstallDirectory(
-            resolved.PackageId, resolved.Version.ToNormalizedString());
-        string stagingPath = finalInstallPath + ".staging-" + Guid.NewGuid().ToString("N");
-
-        try
+        if (targetInstalledVersion is null)
         {
-            progress?.Report(new WorkloadInstallProgress(
-                WorkloadInstallPhase.Downloading,
-                $"Downloading '{resolved.PackageId}' {resolved.Version.ToNormalizedString()}"));
-
-            await using (Stream packageStream = await _catalog.DownloadAsync(resolved, cancellationToken))
-            await using (FileStream tempStream = File.Create(tempNupkg))
-            {
-                await packageStream.CopyToAsync(tempStream, cancellationToken);
-            }
-
-            using PackageArchiveReader reader = OpenPackage(tempNupkg);
-            NuspecReader nuspec = reader.NuspecReader;
-
-            string newPackageId = nuspec.GetId().ToLowerInvariant();
-            string newVersion = nuspec.GetVersion().ToNormalizedString();
-            IReadOnlyList<string> aliases = ParseAliases(nuspec.GetTags());
-            string nuspecTitle = nuspec.GetTitle();
-            string nuspecDescription = nuspec.GetDescription();
-
-            if (!nuspec.GetPackageTypes().Any(t => string.Equals(t.Name, FuncCliWorkloadPackageType, StringComparison.OrdinalIgnoreCase)))
-            {
-                throw new InvalidWorkloadException(
-                    $"Package '{newPackageId}' is not a func CLI workload " +
-                    $"(missing package type '{FuncCliWorkloadPackageType}' in its .nuspec).");
-            }
-
-            // Sanity check: the resolved id+version should match the package
-            // we actually downloaded. If not, the source returned a wrong
-            // bundle and we abort before touching the existing install.
-            if (!string.Equals(newPackageId, resolved.PackageId, StringComparison.OrdinalIgnoreCase) ||
-                !string.Equals(newVersion, resolved.Version.ToNormalizedString(), StringComparison.Ordinal))
-            {
-                throw new InvalidWorkloadException(
-                    $"Resolved package '{resolved.PackageId}' {resolved.Version.ToNormalizedString()} but the source returned " +
-                    $"'{newPackageId}' {newVersion}.");
-            }
-
-            Directory.CreateDirectory(Path.GetDirectoryName(stagingPath)!);
-            Directory.CreateDirectory(stagingPath);
-
-            progress?.Report(new WorkloadInstallProgress(
-                WorkloadInstallPhase.Extracting,
-                $"Extracting workload '{newPackageId}' {newVersion}"));
-
-            await ExtractPackageAsync(reader, stagingPath, cancellationToken);
-            EnsureHostExecutableBit(stagingPath, newPackageId);
-            WorkloadMetadata metadata = _metadataReader.Read(stagingPath);
-
-            WorkloadEntry newEntry = new()
-            {
-                PackageId = newPackageId,
-                PackageVersion = newVersion,
-                Aliases = aliases,
-                DisplayName = GetDisplayName(metadata, nuspecTitle, newPackageId),
-                Description = GetDescription(metadata, nuspecDescription),
-                EntryPoint = metadata.EntryPoint,
-                Kind = metadata.Kind,
-                Source = resolved.Source.Source,
-                InstallRefCount = currentEntry.InstallRefCount,
-            };
-
-            // Atomic swap (spec §6.4 step 4):
-            //   1. Move staged dir into final location.
-            //   2. Replace registry row in a single write (old removed,
-            //      new added). The orphaned-dir case in §6.4 step 5 is
-            //      recoverable via `func workload prune`.
-            //   3. Delete the previous install directory.
-            Directory.Move(stagingPath, finalInstallPath);
-
-            progress?.Report(new WorkloadInstallProgress(
-                WorkloadInstallPhase.Registering,
-                $"Registering workload '{newPackageId}' {newVersion}"));
-
-            await _store.ReplaceWorkloadAsync(currentEntry.PackageId, currentEntry.PackageVersion, newEntry, cancellationToken);
-
-            string oldInstallPath = _paths.GetInstallDirectory(currentEntry.PackageId, currentEntry.PackageVersion);
-            if (!string.Equals(oldInstallPath, finalInstallPath, StringComparison.Ordinal))
-            {
-                // Spec §6.4 step 5: a delete failure here leaves an orphan
-                // directory, which `func workload prune` cleans up later.
-                TryDeleteDirectory(oldInstallPath);
-            }
-
-            return newEntry;
+            return matches
+                .OrderByDescending(e => NuGetVersion.Parse(e.LogicalPackage!.PackageVersion))
+                .First();
         }
-        catch
+
+        string requested = targetInstalledVersion.ToNormalizedString();
+        WorkloadEntry? exact = matches.FirstOrDefault(e =>
+            string.Equals(e.LogicalPackage!.PackageVersion, requested, StringComparison.Ordinal));
+        if (exact is null)
         {
-            TryDeleteDirectory(stagingPath);
-            throw;
+            string available = string.Join(", ", matches.Select(e => e.LogicalPackage!.PackageVersion));
+            throw new InvalidOperationException(
+                $"Logical workload '{packageId}' version '{requested}' is not installed. Installed versions: {available}.");
         }
-        finally
+
+        return exact;
+    }
+
+    private static void ValidateResolvedIdentity(ResolvedPackage resolved, PackageIdentity identity)
+    {
+        if (!string.Equals(identity.PackageId, resolved.PackageId, StringComparison.OrdinalIgnoreCase)
+            || !string.Equals(identity.Version, resolved.Version.ToNormalizedString(), StringComparison.Ordinal))
         {
-            try
-            {
-                if (File.Exists(tempNupkg))
-                {
-                    File.Delete(tempNupkg);
-                }
-            }
-            catch
-            {
-                // Best-effort temp cleanup.
-            }
+            throw new InvalidWorkloadException(
+                $"Resolved package '{resolved.PackageId}' {resolved.Version.ToNormalizedString()} but the source returned " +
+                $"'{identity.PackageId}' {identity.Version}.");
         }
     }
+
+    private static void EnsureMetadataMatchesInspection(
+        WorkloadMetadata expected,
+        WorkloadMetadata actual,
+        string packageId)
+    {
+        if (expected.Kind != actual.Kind
+            || !string.Equals(expected.RuntimeIdentifier, actual.RuntimeIdentifier, StringComparison.Ordinal))
+        {
+            throw new InvalidWorkloadException(
+                $"Package '{packageId}' workload.json changed while the package was being installed.");
+        }
+    }
+
+    private static void RequirePackageType(PackageIdentity identity, bool hasType, string expectedType)
+    {
+        if (!hasType)
+        {
+            throw new InvalidWorkloadException(
+                $"Package '{identity.PackageId}' is missing required package type '{expectedType}' in its .nuspec.");
+        }
+    }
+
+    private string CurrentRuntimeIdentifier
+    {
+        get
+        {
+            string runtimeIdentifier = _runtimeIdentifierProvider.Current.Trim().ToLowerInvariant();
+            if (string.IsNullOrWhiteSpace(runtimeIdentifier))
+            {
+                throw new InvalidOperationException("Unable to determine the current runtime identifier.");
+            }
+
+            return runtimeIdentifier;
+        }
+    }
+
+    private bool IncludePrerelease(bool? includePrerelease)
+        => includePrerelease ?? _catalogOptions.IncludePrerelease;
+
+    private static bool IsLocalPackageSource(string source)
+    {
+        if (string.IsNullOrWhiteSpace(source))
+        {
+            return false;
+        }
+
+        if (Path.IsPathFullyQualified(source))
+        {
+            return true;
+        }
+
+        return Uri.TryCreate(source, UriKind.Absolute, out Uri? uri) && uri.IsFile;
+    }
+
+    private static bool SourcesMatch(string left, string right)
+        => string.Equals(left, right, StringComparison.OrdinalIgnoreCase);
+
+    private static IReadOnlyList<CatalogSearchResult> FilterByAlias(
+        IReadOnlyList<CatalogSearchResult> hits,
+        string alias)
+        => [.. hits.Where(r => r.Aliases.Any(a =>
+            string.Equals(a, alias, StringComparison.OrdinalIgnoreCase)))];
+
+    private static IReadOnlyList<string> DistinctPackageIds(IEnumerable<CatalogSearchResult> hits)
+        => [.. hits.Select(r => r.PackageId).Distinct(StringComparer.OrdinalIgnoreCase)];
 
     private static PackageArchiveReader OpenPackage(string nupkgPath)
     {
@@ -579,23 +1356,71 @@ internal sealed class WorkloadInstaller(
         }
     }
 
-    /// <summary>
-    /// Targeted workaround: NuGet's zip extraction does not preserve Unix
-    /// mode bits, so the host apphost lands without the execute bit and
-    /// the launcher fails with "Permission denied". We narrowly chmod the
-    /// single well-known host binary path, and only for the host workload
-    /// package family (<c>Azure.Functions.Cli.Workloads.Host.*</c>), so no
-    /// other package can use this code path to mark files executable.
-    /// A general per-package executables mechanism can replace this later.
-    /// </summary>
-    private static void EnsureHostExecutableBit(string installPath, string packageId)
+    private static async Task ExtractPackageAsync(
+        PackageArchiveReader reader,
+        string destination,
+        CancellationToken cancellationToken)
     {
-        if (OperatingSystem.IsWindows())
+        foreach (string packageFile in await reader.GetFilesAsync(cancellationToken))
         {
-            return;
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!IsInstallablePackageFile(packageFile))
+            {
+                continue;
+            }
+
+            string targetPath = Path.Combine(
+                destination,
+                packageFile.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
+            using Stream entryStream = await reader.GetStreamAsync(packageFile, cancellationToken);
+            using FileStream output = File.Create(targetPath);
+            await entryStream.CopyToAsync(output, cancellationToken);
+        }
+    }
+
+    private static bool IsInstallablePackageFile(string packageFile)
+        => string.Equals(
+            packageFile,
+            WorkloadMetadataReader.MetadataFileName,
+            StringComparison.OrdinalIgnoreCase)
+            || IsPayloadFile(packageFile);
+
+    private static bool IsPayloadFile(string packageFile)
+        => packageFile.StartsWith("tools/", StringComparison.OrdinalIgnoreCase);
+
+    private static IReadOnlyList<string> ParseAliases(string? tags)
+        => ParseTagValues(tags, AliasTagPrefix);
+
+    private static IReadOnlyList<string> ParseTagValues(string? tags, string prefix)
+    {
+        if (string.IsNullOrWhiteSpace(tags))
+        {
+            return [];
         }
 
-        if (!packageId.StartsWith(HostWorkloadPackage.PackageIdPrefix, StringComparison.OrdinalIgnoreCase))
+        List<string> values = [];
+        foreach (string tag in tags.Split(
+            [' ', ','],
+            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (tag.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                string value = tag[prefix.Length..].Trim();
+                if (value.Length > 0)
+                {
+                    values.Add(value.ToLowerInvariant());
+                }
+            }
+        }
+
+        return values;
+    }
+
+    private static void EnsureHostExecutableBit(string installPath, string packageId)
+    {
+        if (OperatingSystem.IsWindows()
+            || !packageId.StartsWith(HostWorkloadPackage.PackageIdPrefix, StringComparison.OrdinalIgnoreCase))
         {
             return;
         }
@@ -605,7 +1430,6 @@ internal sealed class WorkloadInstaller(
             "tools",
             "any",
             HostProcessStartInfoFactory.ExecutableBaseName);
-
         if (!File.Exists(hostBinary))
         {
             return;
@@ -617,74 +1441,20 @@ internal sealed class WorkloadInstaller(
             mode | UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute);
     }
 
-    private static async Task ExtractPackageAsync(PackageArchiveReader reader, string destination, CancellationToken cancellationToken)
-    {
-        // PackageArchiveReader already filters OPC metadata and rejects
-        // path-escape entries. We additionally restrict the on-disk layout
-        // to the workload contract: workload.json at the root and the
-        // tools/ payload. Other package-level files (the .nuspec, NuGet's
-        // package icon, etc.) are pack-time artifacts the host never reads
-        // and would just bloat the install directory.
-        foreach (string packageFile in await reader.GetFilesAsync(cancellationToken))
-        {
-            cancellationToken.ThrowIfCancellationRequested();
+    private static string GetDisplayName(
+        WorkloadMetadata metadata,
+        string? nuspecTitle,
+        string packageId)
+        => !string.IsNullOrWhiteSpace(metadata.DisplayName)
+            ? metadata.DisplayName
+            : string.IsNullOrWhiteSpace(nuspecTitle) ? packageId : nuspecTitle;
 
-            if (!IsInstallablePackageFile(packageFile))
-            {
-                continue;
-            }
-
-            string targetPath = Path.Combine(destination, packageFile.Replace('/', Path.DirectorySeparatorChar));
-            Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
-
-            using Stream entryStream = await reader.GetStreamAsync(packageFile, cancellationToken);
-            using FileStream output = File.Create(targetPath);
-            await entryStream.CopyToAsync(output, cancellationToken);
-        }
-    }
-
-    /// <summary>
-    /// Whether a file inside the .nupkg is part of the workload's on-disk
-    /// contract. Only <c>workload.json</c> at the package root and entries
-    /// under <c>tools/</c> are extracted; everything else (.nuspec, package
-    /// icon, etc.) is pack-time metadata and stays inside the .nupkg.
-    /// </summary>
-    private static bool IsInstallablePackageFile(string packageFile)
-    {
-        if (string.Equals(packageFile, WorkloadMetadataReader.MetadataFileName, StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-
-        return packageFile.StartsWith("tools/", StringComparison.OrdinalIgnoreCase);
-    }
-
-    /// <summary>
-    /// Extracts CLI aliases from nuspec tags. Only tags prefixed with
-    /// <see cref="AliasTagPrefix"/> are surfaced.
-    /// </summary>
-    private static IReadOnlyList<string> ParseAliases(string? tags)
-    {
-        if (string.IsNullOrWhiteSpace(tags))
-        {
-            return [];
-        }
-
-        List<string> aliases = [];
-        foreach (string tag in tags.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-        {
-            if (tag.StartsWith(AliasTagPrefix, StringComparison.OrdinalIgnoreCase))
-            {
-                string alias = tag[AliasTagPrefix.Length..].Trim();
-                if (alias.Length > 0)
-                {
-                    aliases.Add(alias);
-                }
-            }
-        }
-
-        return aliases;
-    }
+    private static string GetDescription(
+        WorkloadMetadata metadata,
+        string? nuspecDescription)
+        => !string.IsNullOrWhiteSpace(metadata.Description)
+            ? metadata.Description
+            : string.IsNullOrWhiteSpace(nuspecDescription) ? string.Empty : nuspecDescription;
 
     private static void TryDeleteDirectory(string path)
     {
@@ -697,33 +1467,71 @@ internal sealed class WorkloadInstaller(
         }
         catch
         {
-            // Best-effort: if the directory can't be removed (e.g. AV holds
-            // an assembly open), the registry is already consistent and the
-            // user can clean up manually.
+            // Best-effort cleanup leaves registry ownership intact.
         }
     }
 
-    // Display name priority: workload.json (forward-compat), then nuspec
-    // <title>, then the package id so the column is never blank.
-    private static string GetDisplayName(WorkloadMetadata metadata, string? nuspecTitle, string packageId)
+    private static void MoveDirectory(string source, string destination)
     {
-        if (!string.IsNullOrWhiteSpace(metadata.DisplayName))
+        try
         {
-            return metadata.DisplayName;
+            Directory.Move(source, destination);
         }
+        catch (IOException)
+        {
+            Directory.CreateDirectory(destination);
+            foreach (string directory in Directory.EnumerateDirectories(source, "*", SearchOption.AllDirectories))
+            {
+                Directory.CreateDirectory(Path.Combine(destination, Path.GetRelativePath(source, directory)));
+            }
 
-        return string.IsNullOrWhiteSpace(nuspecTitle) ? packageId : nuspecTitle!;
+            foreach (string file in Directory.EnumerateFiles(source, "*", SearchOption.AllDirectories))
+            {
+                string target = Path.Combine(destination, Path.GetRelativePath(source, file));
+                Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+                File.Move(file, target, overwrite: true);
+            }
+
+            Directory.Delete(source, recursive: true);
+        }
     }
 
-    // Description priority: workload.json (forward-compat), then the nuspec
-    // <description> NuGet already requires. Empty string when neither is set.
-    private static string GetDescription(WorkloadMetadata metadata, string? nuspecDescription)
+    private static void TryDeleteFile(string path)
     {
-        if (!string.IsNullOrWhiteSpace(metadata.Description))
+        try
         {
-            return metadata.Description;
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
         }
-
-        return string.IsNullOrWhiteSpace(nuspecDescription) ? string.Empty : nuspecDescription!;
+        catch
+        {
+            // Best-effort cleanup; temporary files are reaped by the OS.
+        }
     }
+
+    private enum PackageRole
+    {
+        Ordinary,
+        Pointer,
+        RidImplementation,
+    }
+
+    private sealed record PackageIdentity(
+        string PackageId,
+        string Version,
+        IReadOnlyList<string> PackageTypes,
+        IReadOnlyList<string> Aliases,
+        IReadOnlyList<string> RidTags,
+        string? Title,
+        string? Description);
+
+    private sealed record InspectedPackage(
+        string Path,
+        PackageIdentity Identity,
+        WorkloadMetadata Metadata,
+        PackageRole Role);
+
+    private sealed record PointerSelection(string RuntimeIdentifier, string PackageId);
 }

--- a/src/Func/Workloads/Install/WorkloadInstaller.cs
+++ b/src/Func/Workloads/Install/WorkloadInstaller.cs
@@ -144,7 +144,6 @@ internal sealed class WorkloadInstaller(
                     selection.PackageId,
                     package.Identity.Version,
                     selection.RuntimeIdentifier,
-                    resolved.Source.Source,
                     WorkloadOwnershipKind.Logical,
                     logicalPackage,
                     cancellationToken)
@@ -411,12 +410,11 @@ internal sealed class WorkloadInstaller(
             }
 
             LogicalPackage newLogical = CreateLogicalPackage(pointer, pointerResolved.Source.Source);
-            WorkloadEntry? reusable = await FindReusableImplementationAsync(
+            WorkloadEntry? reusable = FindReusableImplementation(
+                installed,
                 selection.PackageId,
                 pointer.Identity.Version,
-                selection.RuntimeIdentifier,
-                pointerResolved.Source.Source,
-                cancellationToken);
+                selection.RuntimeIdentifier);
             if (reusable is not null)
             {
                 WorkloadEntry incoming = CopyForOwnership(reusable, WorkloadOwnershipKind.Logical, newLogical);
@@ -477,17 +475,6 @@ internal sealed class WorkloadInstaller(
         InspectedPackage? inspectedPackage = null)
     {
         string version = resolved.Version.ToNormalizedString();
-        IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
-        WorkloadEntry? destination = installed.FirstOrDefault(entry =>
-            string.Equals(entry.PackageId, resolved.PackageId, StringComparison.OrdinalIgnoreCase)
-            && string.Equals(entry.PackageVersion, version, StringComparison.Ordinal));
-        if (destination is not null && !SourcesMatch(destination.Source, resolved.Source.Source))
-        {
-            throw new InvalidOperationException(
-                $"Package '{resolved.PackageId}' version '{version}' is already installed from source '{destination.Source}' and cannot be " +
-                $"replaced from source '{resolved.Source.Source}'. Remove the existing package ownership before updating from a different source.");
-        }
-
         bool ownsDownload = downloadedPath is null;
         string packagePath = downloadedPath ?? await DownloadToTempAsync(resolved, progress, cancellationToken);
         string finalPath = _paths.GetInstallDirectory(resolved.PackageId, version);
@@ -511,13 +498,10 @@ internal sealed class WorkloadInstaller(
 
             WorkloadMetadata metadata = _metadataReader.Read(stagingPath);
             EnsureMetadataMatchesInspection(package.Metadata, metadata, package.Identity.PackageId);
-            EnsureHostExecutableBit(stagingPath, package.Identity.PackageId);
+            EnsureHostExecutableBit(stagingPath, package.Identity.PackageId, metadata.RuntimeIdentifier);
             WorkloadEntry incoming = CreateEntry(package, resolved.Source.Source, ownership, logicalPackage);
 
-            if (Directory.Exists(finalPath))
-            {
-                TryDeleteDirectory(finalPath);
-            }
+            DeleteInstallDirectory(finalPath);
 
             MoveDirectory(stagingPath, finalPath);
             WorkloadOwnershipMoveResult moved = ownership == WorkloadOwnershipKind.Logical
@@ -573,69 +557,12 @@ internal sealed class WorkloadInstaller(
         WorkloadEntry? existing = installed.FirstOrDefault(e =>
             string.Equals(e.PackageId, packageId, StringComparison.OrdinalIgnoreCase)
             && string.Equals(e.PackageVersion, version, StringComparison.Ordinal));
-        WorkloadEntry? currentLogicalOwner = null;
-        if (ownership == WorkloadOwnershipKind.Logical && logicalPackage is not null)
+        WorkloadEntry? currentLogicalOwner = ResolveCurrentLogicalOwner(installed, ownership, logicalPackage);
+        bool logicalOwnerMoves = LogicalOwnerMoves(currentLogicalOwner, packageId, version);
+
+        if (!force && existing is not null && IsExistingInstallationValid(existing, package.Metadata))
         {
-            WorkloadEntry[] logicalOwners = [.. installed.Where(e =>
-                e.LogicalPackage is not null
-                && string.Equals(e.LogicalPackage.PackageId, logicalPackage.PackageId, StringComparison.OrdinalIgnoreCase)
-                && string.Equals(e.LogicalPackage.PackageVersion, logicalPackage.PackageVersion, StringComparison.Ordinal))];
-            if (logicalOwners.Length > 1)
-            {
-                throw new InvalidOperationException(
-                    $"Logical workload '{logicalPackage.PackageId}' version '{logicalPackage.PackageVersion}' is attached to multiple physical packages.");
-            }
-
-            currentLogicalOwner = logicalOwners.FirstOrDefault();
-        }
-
-        bool logicalOwnerMoves = currentLogicalOwner is not null
-            && (!string.Equals(currentLogicalOwner.PackageId, packageId, StringComparison.OrdinalIgnoreCase)
-                || !string.Equals(currentLogicalOwner.PackageVersion, version, StringComparison.Ordinal));
-
-        if (ownership == WorkloadOwnershipKind.Logical
-            && existing is not null
-            && !SourcesMatch(existing.Source, source))
-        {
-            throw new InvalidOperationException(
-                $"Package '{packageId}' version '{version}' is already installed from source '{existing.Source}' and cannot be used by " +
-                $"pointer source '{source}'. Remove the existing package ownership before installing from a different source.");
-        }
-
-        if (!force
-            && existing is not null
-            && (ownership == WorkloadOwnershipKind.Explicit || SourcesMatch(existing.Source, source))
-            && IsExistingInstallationValid(existing, package.Metadata))
-        {
-            if (logicalOwnerMoves)
-            {
-                WorkloadEntry incoming = CopyForOwnership(existing, WorkloadOwnershipKind.Logical, logicalPackage);
-                WorkloadOwnershipMoveResult moved = await _store.MoveLogicalOwnershipAsync(
-                    currentLogicalOwner!.PackageId,
-                    currentLogicalOwner.PackageVersion,
-                    incoming,
-                    cancellationToken);
-                if (moved.PreviousEntryRemoved)
-                {
-                    TryDeleteDirectory(_paths.GetInstallDirectory(
-                        currentLogicalOwner.PackageId,
-                        currentLogicalOwner.PackageVersion));
-                }
-
-                return new WorkloadInstallResult(moved.Entry, false);
-            }
-
-            bool alreadyOwned = HasOwnership(existing, ownership);
-            if (alreadyOwned)
-            {
-                return new WorkloadInstallResult(existing, true);
-            }
-
-            WorkloadEntry attached = await _store.AddOwnershipAsync(
-                CopyForOwnership(existing, ownership, logicalPackage),
-                ownership,
-                cancellationToken);
-            return new WorkloadInstallResult(attached, false);
+            return await AttachOwnershipAsync(existing, ownership, logicalPackage, currentLogicalOwner, cancellationToken);
         }
 
         string stagingPath = installPath + ".staging-" + Guid.NewGuid().ToString("N");
@@ -653,16 +580,13 @@ internal sealed class WorkloadInstaller(
 
             WorkloadMetadata metadata = _metadataReader.Read(stagingPath);
             EnsureMetadataMatchesInspection(package.Metadata, metadata, packageId);
-            EnsureHostExecutableBit(stagingPath, packageId);
+            EnsureHostExecutableBit(stagingPath, packageId, metadata.RuntimeIdentifier);
             WorkloadEntry incoming = CreateEntry(package, source, ownership, logicalPackage);
             WorkloadEntry entry = existing is null
                 ? incoming
                 : MergeForReinstall(existing, incoming, ownership);
 
-            if (Directory.Exists(installPath))
-            {
-                TryDeleteDirectory(installPath);
-            }
+            DeleteInstallDirectory(installPath);
 
             MoveDirectory(stagingPath, installPath);
             movedToFinal = true;
@@ -728,24 +652,51 @@ internal sealed class WorkloadInstaller(
         string packageId,
         string version,
         string runtimeIdentifier,
-        string source,
         WorkloadOwnershipKind ownership,
         LogicalPackage logicalPackage,
         CancellationToken cancellationToken)
     {
-        WorkloadEntry? existing = await FindReusableImplementationAsync(
-            packageId,
-            version,
-            runtimeIdentifier,
-            source,
-            cancellationToken);
+        IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
+        WorkloadEntry? existing = FindReusableImplementation(installed, packageId, version, runtimeIdentifier);
         if (existing is null)
         {
             return null;
         }
 
-        bool alreadyOwned = HasOwnership(existing, ownership);
-        if (alreadyOwned)
+        WorkloadEntry? currentLogicalOwner = ResolveCurrentLogicalOwner(installed, ownership, logicalPackage);
+        return await AttachOwnershipAsync(existing, ownership, logicalPackage, currentLogicalOwner, cancellationToken);
+    }
+
+    /// <summary>
+    /// Attaches the requested ownership to an already-installed payload, moving an existing logical
+    /// owner off its previous physical package when the pointer now resolves elsewhere.
+    /// </summary>
+    private async Task<WorkloadInstallResult> AttachOwnershipAsync(
+        WorkloadEntry existing,
+        WorkloadOwnershipKind ownership,
+        LogicalPackage? logicalPackage,
+        WorkloadEntry? currentLogicalOwner,
+        CancellationToken cancellationToken)
+    {
+        if (LogicalOwnerMoves(currentLogicalOwner, existing.PackageId, existing.PackageVersion))
+        {
+            WorkloadEntry incoming = CopyForOwnership(existing, WorkloadOwnershipKind.Logical, logicalPackage);
+            WorkloadOwnershipMoveResult moved = await _store.MoveLogicalOwnershipAsync(
+                currentLogicalOwner!.PackageId,
+                currentLogicalOwner.PackageVersion,
+                incoming,
+                cancellationToken);
+            if (moved.PreviousEntryRemoved)
+            {
+                TryDeleteDirectory(_paths.GetInstallDirectory(
+                    currentLogicalOwner.PackageId,
+                    currentLogicalOwner.PackageVersion));
+            }
+
+            return new WorkloadInstallResult(moved.Entry, false);
+        }
+
+        if (HasOwnership(existing, ownership))
         {
             return new WorkloadInstallResult(existing, true);
         }
@@ -757,19 +708,47 @@ internal sealed class WorkloadInstaller(
         return new WorkloadInstallResult(attached, false);
     }
 
-    private async Task<WorkloadEntry?> FindReusableImplementationAsync(
+    /// <summary>
+    /// Finds the physical package that currently owns the given logical pointer, if any.
+    /// </summary>
+    private static WorkloadEntry? ResolveCurrentLogicalOwner(
+        IReadOnlyList<WorkloadEntry> installed,
+        WorkloadOwnershipKind ownership,
+        LogicalPackage? logicalPackage)
+    {
+        if (ownership != WorkloadOwnershipKind.Logical || logicalPackage is null)
+        {
+            return null;
+        }
+
+        WorkloadEntry[] logicalOwners = [.. installed.Where(e =>
+            e.LogicalPackage is not null
+            && string.Equals(e.LogicalPackage.PackageId, logicalPackage.PackageId, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(e.LogicalPackage.PackageVersion, logicalPackage.PackageVersion, StringComparison.Ordinal))];
+        if (logicalOwners.Length > 1)
+        {
+            throw new InvalidOperationException(
+                $"Logical workload '{logicalPackage.PackageId}' version '{logicalPackage.PackageVersion}' is attached to multiple physical packages.");
+        }
+
+        return logicalOwners.FirstOrDefault();
+    }
+
+    private static bool LogicalOwnerMoves(WorkloadEntry? currentLogicalOwner, string packageId, string version)
+        => currentLogicalOwner is not null
+            && (!string.Equals(currentLogicalOwner.PackageId, packageId, StringComparison.OrdinalIgnoreCase)
+                || !string.Equals(currentLogicalOwner.PackageVersion, version, StringComparison.Ordinal));
+
+    private WorkloadEntry? FindReusableImplementation(
+        IReadOnlyList<WorkloadEntry> installed,
         string packageId,
         string version,
-        string runtimeIdentifier,
-        string source,
-        CancellationToken cancellationToken)
+        string runtimeIdentifier)
     {
-        IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
         WorkloadEntry? existing = installed.FirstOrDefault(e =>
             string.Equals(e.PackageId, packageId, StringComparison.OrdinalIgnoreCase)
             && string.Equals(e.PackageVersion, version, StringComparison.Ordinal)
-            && string.Equals(e.RuntimeIdentifier, runtimeIdentifier, StringComparison.Ordinal)
-            && SourcesMatch(e.Source, source));
+            && string.Equals(e.RuntimeIdentifier, runtimeIdentifier, StringComparison.Ordinal));
         if (existing is null)
         {
             return null;
@@ -812,7 +791,7 @@ internal sealed class WorkloadInstaller(
         try
         {
             Directory.CreateDirectory(inspectionDirectory);
-            await ExtractPackageAsync(reader, inspectionDirectory, cancellationToken);
+            await ExtractMetadataOnlyAsync(reader, inspectionDirectory, cancellationToken);
             WorkloadMetadata metadata = _metadataReader.Read(inspectionDirectory);
             IReadOnlyList<string> files = [.. await reader.GetFilesAsync(cancellationToken)];
             PackageRole role = ValidatePackage(identity, metadata, files);
@@ -997,17 +976,21 @@ internal sealed class WorkloadInstaller(
         string runtimeIdentifier)
     {
         string directory = Path.GetDirectoryName(pointerPath)!;
-        foreach (string candidate in Directory.EnumerateFiles(directory, "*.nupkg", SearchOption.TopDirectoryOnly))
+        string expectedFileName = $"{packageId}.{version}.nupkg";
+
+        // Probe the conventional file name first so an unrelated or corrupt sibling neither slows the
+        // lookup down nor aborts the install.
+        IOrderedEnumerable<string> candidates = Directory
+            .EnumerateFiles(directory, "*.nupkg", SearchOption.TopDirectoryOnly)
+            .OrderByDescending(c => string.Equals(Path.GetFileName(c), expectedFileName, StringComparison.OrdinalIgnoreCase));
+        foreach (string candidate in candidates)
         {
             if (string.Equals(candidate, pointerPath, StringComparison.OrdinalIgnoreCase))
             {
                 continue;
             }
 
-            using PackageArchiveReader reader = OpenPackage(candidate);
-            NuspecReader nuspec = reader.NuspecReader;
-            if (string.Equals(nuspec.GetId(), packageId, StringComparison.OrdinalIgnoreCase)
-                && string.Equals(nuspec.GetVersion().ToNormalizedString(), version, StringComparison.Ordinal))
+            if (MatchesPackageIdentity(candidate, packageId, version))
             {
                 return candidate;
             }
@@ -1016,6 +999,22 @@ internal sealed class WorkloadInstaller(
         throw new FileNotFoundException(
             $"Local RID pointer '{Path.GetFileName(pointerPath)}' requires implementation '{packageId}' {version} for RID " +
             $"'{runtimeIdentifier}' in directory '{directory}'. No configured feed was searched.");
+    }
+
+    private static bool MatchesPackageIdentity(string packagePath, string packageId, string version)
+    {
+        try
+        {
+            using PackageArchiveReader reader = OpenPackage(packagePath);
+            NuspecReader nuspec = reader.NuspecReader;
+            return string.Equals(nuspec.GetId(), packageId, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(nuspec.GetVersion().ToNormalizedString(), version, StringComparison.Ordinal);
+        }
+        catch (Exception ex) when (ex is InvalidWorkloadException or IOException or UnauthorizedAccessException)
+        {
+            // An unreadable sibling cannot be the implementation we need; keep probing the directory.
+            return false;
+        }
     }
 
     private async Task<string> ResolveAliasOrIdAsync(
@@ -1330,9 +1329,6 @@ internal sealed class WorkloadInstaller(
         return Uri.TryCreate(source, UriKind.Absolute, out Uri? uri) && uri.IsFile;
     }
 
-    private static bool SourcesMatch(string left, string right)
-        => string.Equals(left, right, StringComparison.OrdinalIgnoreCase);
-
     private static IReadOnlyList<CatalogSearchResult> FilterByAlias(
         IReadOnlyList<CatalogSearchResult> hits,
         string alias)
@@ -1356,15 +1352,32 @@ internal sealed class WorkloadInstaller(
         }
     }
 
-    private static async Task ExtractPackageAsync(
+    private static Task ExtractPackageAsync(
         PackageArchiveReader reader,
         string destination,
+        CancellationToken cancellationToken)
+        => ExtractPackageFilesAsync(reader, destination, IsInstallablePackageFile, cancellationToken);
+
+    /// <summary>
+    /// Extracts only the workload manifest. Inspection happens before staging, so pulling the payload
+    /// out here would extract every package twice.
+    /// </summary>
+    private static Task ExtractMetadataOnlyAsync(
+        PackageArchiveReader reader,
+        string destination,
+        CancellationToken cancellationToken)
+        => ExtractPackageFilesAsync(reader, destination, IsMetadataFile, cancellationToken);
+
+    private static async Task ExtractPackageFilesAsync(
+        PackageArchiveReader reader,
+        string destination,
+        Func<string, bool> include,
         CancellationToken cancellationToken)
     {
         foreach (string packageFile in await reader.GetFilesAsync(cancellationToken))
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (!IsInstallablePackageFile(packageFile))
+            if (!include(packageFile))
             {
                 continue;
             }
@@ -1379,12 +1392,14 @@ internal sealed class WorkloadInstaller(
         }
     }
 
-    private static bool IsInstallablePackageFile(string packageFile)
+    private static bool IsMetadataFile(string packageFile)
         => string.Equals(
             packageFile,
             WorkloadMetadataReader.MetadataFileName,
-            StringComparison.OrdinalIgnoreCase)
-            || IsPayloadFile(packageFile);
+            StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsInstallablePackageFile(string packageFile)
+        => IsMetadataFile(packageFile) || IsPayloadFile(packageFile);
 
     private static bool IsPayloadFile(string packageFile)
         => packageFile.StartsWith("tools/", StringComparison.OrdinalIgnoreCase);
@@ -1417,7 +1432,7 @@ internal sealed class WorkloadInstaller(
         return values;
     }
 
-    private static void EnsureHostExecutableBit(string installPath, string packageId)
+    private static void EnsureHostExecutableBit(string installPath, string packageId, string? runtimeIdentifier)
     {
         if (OperatingSystem.IsWindows()
             || !packageId.StartsWith(HostWorkloadPackage.PackageIdPrefix, StringComparison.OrdinalIgnoreCase))
@@ -1426,9 +1441,7 @@ internal sealed class WorkloadInstaller(
         }
 
         string hostBinary = Path.Combine(
-            installPath,
-            "tools",
-            "any",
+            WorkloadPackageLayout.GetContentRoot(installPath, runtimeIdentifier),
             HostProcessStartInfoFactory.ExecutableBaseName);
         if (!File.Exists(hostBinary))
         {
@@ -1468,6 +1481,26 @@ internal sealed class WorkloadInstaller(
         catch
         {
             // Best-effort cleanup leaves registry ownership intact.
+        }
+    }
+
+    /// <summary>
+    /// Removes an install directory before a staged payload replaces it. Unlike best-effort cleanup this
+    /// must succeed: a partial delete would let the move merge the new payload into stale files.
+    /// </summary>
+    private static void DeleteInstallDirectory(string path)
+    {
+        if (!Directory.Exists(path))
+        {
+            return;
+        }
+
+        Directory.Delete(path, recursive: true);
+
+        // Windows can report a successful delete while the directory lingers until the last handle closes.
+        if (Directory.Exists(path))
+        {
+            throw new IOException($"Failed to remove the existing install directory '{path}'.");
         }
     }
 

--- a/src/Func/Workloads/Loading/WorkloadLoader.cs
+++ b/src/Func/Workloads/Loading/WorkloadLoader.cs
@@ -12,10 +12,19 @@ namespace Azure.Functions.Cli.Workloads.Loading;
 /// collectible <see cref="WorkloadLoadContext"/> so dependency versions
 /// don't collide across workloads.
 /// </summary>
-internal sealed class WorkloadLoader(IWorkloadPaths paths) : IWorkloadLoader
+internal sealed class WorkloadLoader(
+    IWorkloadPaths paths,
+    IWorkloadRuntimeIdentifierProvider runtimeIdentifierProvider) : IWorkloadLoader
 {
     private readonly IWorkloadPaths _paths = paths
         ?? throw new ArgumentNullException(nameof(paths));
+    private readonly IWorkloadRuntimeIdentifierProvider _runtimeIdentifierProvider = runtimeIdentifierProvider
+        ?? throw new ArgumentNullException(nameof(runtimeIdentifierProvider));
+
+    public WorkloadLoader(IWorkloadPaths paths)
+        : this(paths, new WorkloadRuntimeIdentifierProvider())
+    {
+    }
 
     /// <inheritdoc />
     public IReadOnlyList<RuntimeWorkloadInfo> Load(IReadOnlyList<WorkloadEntry> entries)
@@ -25,11 +34,30 @@ internal sealed class WorkloadLoader(IWorkloadPaths paths) : IWorkloadLoader
         var results = new List<RuntimeWorkloadInfo>(entries.Count);
         foreach (WorkloadEntry entry in entries)
         {
-            results.Add(LoadEntry(entry));
+            try
+            {
+                results.Add(LoadEntry(entry));
+            }
+            catch (InvalidWorkloadException ex) when (HasRuntimeIdentifierMismatch(entry))
+            {
+                string logicalPackageId = entry.LogicalPackage?.PackageId ?? entry.PackageId;
+                throw new InvalidWorkloadException(
+                    $"{ex.Message} The installed implementation targets runtime identifier '{entry.RuntimeIdentifier}', " +
+                    $"but this machine uses '{_runtimeIdentifierProvider.Current}'. " +
+                    $"Run 'func workload update {logicalPackageId}' to install the matching implementation.",
+                    ex);
+            }
         }
 
         return results;
     }
+
+    private bool HasRuntimeIdentifierMismatch(WorkloadEntry entry)
+        => entry.RuntimeIdentifier is not null
+            && !string.Equals(
+                entry.RuntimeIdentifier,
+                _runtimeIdentifierProvider.Current,
+                StringComparison.OrdinalIgnoreCase);
 
     private RuntimeWorkloadInfo LoadEntry(WorkloadEntry entry)
     {

--- a/src/Func/Workloads/PythonWorkerWorkloadPackage.cs
+++ b/src/Func/Workloads/PythonWorkerWorkloadPackage.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Collections.Frozen;
-
 namespace Azure.Functions.Cli.Workloads;
 
 /// <summary>
@@ -13,29 +11,11 @@ namespace Azure.Functions.Cli.Workloads;
 /// </summary>
 internal static class PythonWorkerWorkloadPackage
 {
+    internal const string PackageId = "Azure.Functions.Cli.Workloads.Workers.Python";
     internal const string PackageIdPrefix = "Azure.Functions.Cli.Workloads.Workers.Python.";
 
-    /// <summary>
-    /// RIDs we publish a python worker pack for. Must match the
-    /// <c>_CliRuntimeIdentifiers</c> set in
-    /// <c>src/Workloads/Workers/Python/Workloads.Workers.Python.csproj</c>.
-    /// The upstream PythonWorker package has no <c>win-arm64</c> assets.
-    /// </summary>
-    public static readonly FrozenSet<string> SupportedRuntimeIdentifiers =
-        new[] { "win-x64", "linux-x64", "linux-arm64", "osx-x64", "osx-arm64" }
-            .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
-
     public static string CurrentPackageId => FromRuntimeIdentifier(WorkloadRuntimeIdentifier.Current);
-
-    public static bool IsSupported(string runtimeIdentifier)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(runtimeIdentifier);
-        return SupportedRuntimeIdentifiers.Contains(runtimeIdentifier.Trim());
-    }
-
-    public static bool IsCurrentRuntimeSupported() => IsSupported(WorkloadRuntimeIdentifier.Current);
 
     public static string FromRuntimeIdentifier(string runtimeIdentifier)
         => WorkloadRuntimeIdentifier.Qualify(PackageIdPrefix, runtimeIdentifier);
 }
-

--- a/src/Func/Workloads/Storage/IWorkloadStore.cs
+++ b/src/Func/Workloads/Storage/IWorkloadStore.cs
@@ -51,4 +51,41 @@ internal interface IWorkloadStore
         string oldVersion,
         WorkloadEntry newEntry,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Atomically attaches explicit or logical ownership to an existing physical
+    /// row, or inserts <paramref name="entry"/> when it is not installed.
+    /// </summary>
+    public Task<WorkloadEntry> AddOwnershipAsync(
+        WorkloadEntry entry,
+        WorkloadOwnershipKind ownership,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Atomically removes only the requested ownership and deletes the physical
+    /// row when its final owner is removed.
+    /// </summary>
+    public Task<WorkloadOwnershipRemovalResult> RemoveOwnershipAsync(
+        string packageId,
+        string version,
+        WorkloadOwnershipKind ownership,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Atomically moves logical pointer ownership from one physical row to another.
+    /// </summary>
+    public Task<WorkloadOwnershipMoveResult> MoveLogicalOwnershipAsync(
+        string oldPackageId,
+        string oldVersion,
+        WorkloadEntry newEntry,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Atomically moves explicit ownership from one physical row to another.
+    /// </summary>
+    public Task<WorkloadOwnershipMoveResult> MoveExplicitOwnershipAsync(
+        string oldPackageId,
+        string oldVersion,
+        WorkloadEntry newEntry,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Func/Workloads/Storage/WorkloadJsonContext.cs
+++ b/src/Func/Workloads/Storage/WorkloadJsonContext.cs
@@ -25,9 +25,34 @@ namespace Azure.Functions.Cli.Workloads.Storage;
 internal sealed partial class WorkloadJsonContext : JsonSerializerContext;
 
 /// <summary>
-/// Serializes <see cref="WorkloadKind"/> as a lowercase string
-/// (<c>"workload"</c> / <c>"content"</c> / <c>"meta"</c>). The default
-/// <see cref="JsonStringEnumConverter{TEnum}"/> would emit PascalCase.
+/// Serializes <see cref="WorkloadKind"/> using the workload manifest's wire values.
 /// </summary>
-internal sealed class WorkloadKindJsonConverter() : JsonStringEnumConverter<WorkloadKind>(JsonNamingPolicy.CamelCase);
+internal sealed class WorkloadKindJsonConverter : JsonConverter<WorkloadKind>
+{
+    public override WorkloadKind Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        string? value = reader.GetString();
+        return value switch
+        {
+            "workload" => WorkloadKind.Workload,
+            "content" => WorkloadKind.Content,
+            "meta" => WorkloadKind.Meta,
+            "rid-pointer" => WorkloadKind.RidPointer,
+            _ => throw new JsonException($"Unknown workload kind '{value}'."),
+        };
+    }
 
+    public override void Write(Utf8JsonWriter writer, WorkloadKind value, JsonSerializerOptions options)
+    {
+        string wireValue = value switch
+        {
+            WorkloadKind.Workload => "workload",
+            WorkloadKind.Content => "content",
+            WorkloadKind.Meta => "meta",
+            WorkloadKind.RidPointer => "rid-pointer",
+            _ => throw new JsonException($"Unknown workload kind '{value}'."),
+        };
+
+        writer.WriteStringValue(wireValue);
+    }
+}

--- a/src/Func/Workloads/Storage/WorkloadManifestSchema.cs
+++ b/src/Func/Workloads/Storage/WorkloadManifestSchema.cs
@@ -8,9 +8,7 @@ namespace Azure.Functions.Cli.Workloads.Storage;
 /// </summary>
 /// <remarks>
 /// Each manifest carries its schema identity in the top-level <c>$schema</c>
-/// property. Breaking changes ship under a new versioned URL so older and
-/// newer CLIs can coexist on disk. The registry and per-package manifest
-/// version independently.
+/// property. The registry and per-package manifest version independently.
 /// </remarks>
 internal static class WorkloadManifestSchema
 {
@@ -59,4 +57,3 @@ internal static class WorkloadManifestSchema
         => !string.IsNullOrEmpty(schema)
            && SupportedPackageManifestSchemas.Contains(schema, StringComparer.Ordinal);
 }
-

--- a/src/Func/Workloads/Storage/WorkloadOwnership.cs
+++ b/src/Func/Workloads/Storage/WorkloadOwnership.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workloads.Storage;
+
+internal enum WorkloadOwnershipKind
+{
+    Explicit,
+    Logical,
+}
+
+internal sealed record WorkloadOwnershipRemovalResult(bool OwnershipRemoved, bool EntryRemoved, WorkloadEntry? Entry);
+
+internal sealed record WorkloadOwnershipMoveResult(WorkloadEntry Entry, bool PreviousEntryRemoved);

--- a/src/Func/Workloads/Storage/WorkloadRegistry.cs
+++ b/src/Func/Workloads/Storage/WorkloadRegistry.cs
@@ -37,6 +37,8 @@ internal sealed class WorkloadRegistry
 /// </summary>
 internal sealed class WorkloadEntry
 {
+    private bool? _isExplicitlyInstalled;
+
     /// <summary>
     /// NuGet package id (e.g. <c>"Azure.Functions.Cli.Workloads.Dotnet"</c>).
     /// Matched case-insensitively.
@@ -78,11 +80,38 @@ internal sealed class WorkloadEntry
     public string Source { get; init; } = string.Empty;
 
     /// <summary>
-    /// Number of installs that brought this package in. An explicit
-    /// <c>func workload install &lt;id&gt;</c> bumps the count; each meta package
-    /// that lists this package as a member also bumps the count at meta install.
-    /// Explicit uninstall removes the entry regardless of the count; meta
-    /// uninstall decrements and removes only when the count hits zero.
+    /// Runtime identifier validated for a RID-specific implementation package.
+    /// Null for ordinary and legacy entries.
+    /// </summary>
+    public string? RuntimeIdentifier { get; init; }
+
+    /// <summary>
+    /// Whether this physical package has an explicit install owner. Defaults
+    /// to true so registry rows written by older CLIs retain their ownership.
+    /// </summary>
+    [JsonIgnore]
+    public bool IsExplicitlyInstalled
+    {
+        get => _isExplicitlyInstalled ?? true;
+        init => _isExplicitlyInstalled = value;
+    }
+
+    [JsonPropertyName("isExplicitlyInstalled")]
+    public bool? PersistedIsExplicitlyInstalled
+    {
+        get => _isExplicitlyInstalled;
+        init => _isExplicitlyInstalled = value;
+    }
+
+    /// <summary>
+    /// Logical pointer package that selected this implementation, or null when
+    /// no pointer owner is attached.
+    /// </summary>
+    public LogicalPackage? LogicalPackage { get; init; }
+
+    /// <summary>
+    /// Number of distinct owners: explicit ownership, logical pointer ownership,
+    /// and meta owners. Repeating an install by the same owner is idempotent.
     /// Defaults to 1 for legacy entries that pre-date this field.
     /// </summary>
     public int InstallRefCount { get; init; } = 1;
@@ -94,6 +123,24 @@ internal sealed class WorkloadEntry
     /// for <see cref="WorkloadKind.Content"/>.
     /// </summary>
     public EntryPointSpec? EntryPoint { get; init; }
+}
+
+/// <summary>
+/// User-facing pointer package metadata persisted with its selected physical implementation.
+/// </summary>
+internal sealed class LogicalPackage
+{
+    public required string PackageId { get; init; }
+
+    public required string PackageVersion { get; init; }
+
+    public IReadOnlyList<string> Aliases { get; init; } = [];
+
+    public string DisplayName { get; init; } = string.Empty;
+
+    public string Description { get; init; } = string.Empty;
+
+    public string Source { get; init; } = string.Empty;
 }
 
 /// <summary>

--- a/src/Func/Workloads/Storage/WorkloadStore.cs
+++ b/src/Func/Workloads/Storage/WorkloadStore.cs
@@ -273,9 +273,8 @@ internal class WorkloadStore(IWorkloadPaths paths) : IWorkloadStore
     private static WorkloadEntry NormalizeNewEntry(WorkloadEntry entry, WorkloadOwnershipKind ownership)
     {
         bool explicitOwner = ownership == WorkloadOwnershipKind.Explicit || entry.IsExplicitlyInstalled;
-        LogicalPackage? logicalPackage = ownership == WorkloadOwnershipKind.Logical ? entry.LogicalPackage : entry.LogicalPackage;
-        int ownerCount = (explicitOwner ? 1 : 0) + (logicalPackage is null ? 0 : 1);
-        return CopyWithOwnership(entry, explicitOwner, logicalPackage, Math.Max(ownerCount, entry.InstallRefCount));
+        int ownerCount = (explicitOwner ? 1 : 0) + (entry.LogicalPackage is null ? 0 : 1);
+        return CopyWithOwnership(entry, explicitOwner, entry.LogicalPackage, Math.Max(ownerCount, entry.InstallRefCount));
     }
 
     private static WorkloadEntry MergeOwnership(WorkloadEntry current, WorkloadEntry incoming, WorkloadOwnershipKind ownership)
@@ -291,8 +290,10 @@ internal class WorkloadStore(IWorkloadPaths paths) : IWorkloadStore
                 $"'{current.LogicalPackage.PackageId}' version '{current.LogicalPackage.PackageVersion}'.");
         }
 
+        // Payload metadata comes from the incoming entry: the caller may have just replaced the payload
+        // on disk, and a legacy row would otherwise keep stale values such as a missing runtime identifier.
         return CopyWithOwnership(
-            current,
+            incoming,
             current.IsExplicitlyInstalled || ownership == WorkloadOwnershipKind.Explicit,
             current.LogicalPackage ?? incoming.LogicalPackage,
             current.InstallRefCount + (attachExplicit ? 1 : 0) + (attachLogical ? 1 : 0));

--- a/src/Func/Workloads/Storage/WorkloadStore.cs
+++ b/src/Func/Workloads/Storage/WorkloadStore.cs
@@ -93,6 +93,153 @@ internal class WorkloadStore(IWorkloadPaths paths) : IWorkloadStore
         await WriteRegistryAsync(registry, cancellationToken);
     }
 
+    public async Task<WorkloadEntry> AddOwnershipAsync(
+        WorkloadEntry entry,
+        WorkloadOwnershipKind ownership,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateEntry(entry);
+        ValidateOwnership(entry, ownership);
+
+        WorkloadRegistry registry = await ReadRegistryAsync(cancellationToken);
+        int index = FindIndex(registry, entry.PackageId, entry.PackageVersion);
+        WorkloadEntry merged = index < 0
+            ? NormalizeNewEntry(entry, ownership)
+            : MergeOwnership(registry.Workloads[index], entry, ownership);
+
+        if (index < 0)
+        {
+            registry.Workloads.Add(merged);
+        }
+        else
+        {
+            registry.Workloads[index] = merged;
+        }
+
+        await WriteRegistryAsync(registry, cancellationToken);
+        return merged;
+    }
+
+    public async Task<WorkloadOwnershipRemovalResult> RemoveOwnershipAsync(
+        string packageId,
+        string version,
+        WorkloadOwnershipKind ownership,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(version);
+
+        WorkloadRegistry registry = await ReadRegistryAsync(cancellationToken);
+        int index = FindIndex(registry, packageId, version);
+        if (index < 0)
+        {
+            return new WorkloadOwnershipRemovalResult(false, false, null);
+        }
+
+        WorkloadEntry current = registry.Workloads[index];
+        bool hasOwnership = ownership switch
+        {
+            WorkloadOwnershipKind.Explicit => current.IsExplicitlyInstalled,
+            WorkloadOwnershipKind.Logical => current.LogicalPackage is not null,
+            _ => throw new ArgumentOutOfRangeException(nameof(ownership)),
+        };
+
+        if (!hasOwnership)
+        {
+            return new WorkloadOwnershipRemovalResult(false, false, current);
+        }
+
+        int remainingReferences = current.InstallRefCount - 1;
+        if (remainingReferences <= 0)
+        {
+            registry.Workloads.RemoveAt(index);
+            await WriteRegistryAsync(registry, cancellationToken);
+            return new WorkloadOwnershipRemovalResult(true, true, null);
+        }
+
+        WorkloadEntry updated = CopyWithOwnership(
+            current,
+            isExplicitlyInstalled: ownership == WorkloadOwnershipKind.Explicit ? false : current.IsExplicitlyInstalled,
+            logicalPackage: ownership == WorkloadOwnershipKind.Logical ? null : current.LogicalPackage,
+            installRefCount: remainingReferences);
+        registry.Workloads[index] = updated;
+        await WriteRegistryAsync(registry, cancellationToken);
+        return new WorkloadOwnershipRemovalResult(true, false, updated);
+    }
+
+    public async Task<WorkloadOwnershipMoveResult> MoveLogicalOwnershipAsync(
+        string oldPackageId,
+        string oldVersion,
+        WorkloadEntry newEntry,
+        CancellationToken cancellationToken = default)
+        => await MoveOwnershipAsync(oldPackageId, oldVersion, newEntry, WorkloadOwnershipKind.Logical, cancellationToken);
+
+    public async Task<WorkloadOwnershipMoveResult> MoveExplicitOwnershipAsync(
+        string oldPackageId,
+        string oldVersion,
+        WorkloadEntry newEntry,
+        CancellationToken cancellationToken = default)
+        => await MoveOwnershipAsync(oldPackageId, oldVersion, newEntry, WorkloadOwnershipKind.Explicit, cancellationToken);
+
+    private async Task<WorkloadOwnershipMoveResult> MoveOwnershipAsync(
+        string oldPackageId,
+        string oldVersion,
+        WorkloadEntry newEntry,
+        WorkloadOwnershipKind ownership,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(oldPackageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(oldVersion);
+        ValidateEntry(newEntry);
+        ValidateOwnership(newEntry, ownership);
+
+        WorkloadRegistry registry = await ReadRegistryAsync(cancellationToken);
+        int oldIndex = FindIndex(registry, oldPackageId, oldVersion);
+        bool ownershipExists = oldIndex >= 0 && ownership switch
+        {
+            WorkloadOwnershipKind.Explicit => registry.Workloads[oldIndex].IsExplicitlyInstalled,
+            WorkloadOwnershipKind.Logical => registry.Workloads[oldIndex].LogicalPackage is not null,
+            _ => throw new ArgumentOutOfRangeException(nameof(ownership)),
+        };
+        if (!ownershipExists)
+        {
+            throw new InvalidOperationException(
+                $"{ownership} ownership for workload '{oldPackageId}' version '{oldVersion}' is not installed.");
+        }
+
+        WorkloadEntry oldEntry = registry.Workloads[oldIndex];
+        int remainingReferences = oldEntry.InstallRefCount - 1;
+        bool previousEntryRemoved = remainingReferences <= 0;
+        if (previousEntryRemoved)
+        {
+            registry.Workloads.RemoveAt(oldIndex);
+        }
+        else
+        {
+            registry.Workloads[oldIndex] = CopyWithOwnership(
+                oldEntry,
+                ownership == WorkloadOwnershipKind.Explicit ? false : oldEntry.IsExplicitlyInstalled,
+                ownership == WorkloadOwnershipKind.Logical ? null : oldEntry.LogicalPackage,
+                remainingReferences);
+        }
+
+        int newIndex = FindIndex(registry, newEntry.PackageId, newEntry.PackageVersion);
+        WorkloadEntry merged = newIndex < 0
+            ? NormalizeNewEntry(newEntry, ownership)
+            : MergeOwnership(registry.Workloads[newIndex], newEntry, ownership);
+        if (newIndex < 0)
+        {
+            registry.Workloads.Add(merged);
+        }
+        else
+        {
+            registry.Workloads[newIndex] = merged;
+        }
+
+        await WriteRegistryAsync(registry, cancellationToken);
+        return new WorkloadOwnershipMoveResult(merged, previousEntryRemoved);
+    }
+
     private static int FindIndex(WorkloadRegistry registry, string packageId, string version)
     {
         for (int i = 0; i < registry.Workloads.Count; i++)
@@ -107,6 +254,74 @@ internal class WorkloadStore(IWorkloadPaths paths) : IWorkloadStore
 
         return -1;
     }
+
+    private static void ValidateEntry(WorkloadEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        ArgumentException.ThrowIfNullOrWhiteSpace(entry.PackageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(entry.PackageVersion);
+    }
+
+    private static void ValidateOwnership(WorkloadEntry entry, WorkloadOwnershipKind ownership)
+    {
+        if (ownership == WorkloadOwnershipKind.Logical && entry.LogicalPackage is null)
+        {
+            throw new ArgumentException("Logical ownership requires logical package metadata.", nameof(entry));
+        }
+    }
+
+    private static WorkloadEntry NormalizeNewEntry(WorkloadEntry entry, WorkloadOwnershipKind ownership)
+    {
+        bool explicitOwner = ownership == WorkloadOwnershipKind.Explicit || entry.IsExplicitlyInstalled;
+        LogicalPackage? logicalPackage = ownership == WorkloadOwnershipKind.Logical ? entry.LogicalPackage : entry.LogicalPackage;
+        int ownerCount = (explicitOwner ? 1 : 0) + (logicalPackage is null ? 0 : 1);
+        return CopyWithOwnership(entry, explicitOwner, logicalPackage, Math.Max(ownerCount, entry.InstallRefCount));
+    }
+
+    private static WorkloadEntry MergeOwnership(WorkloadEntry current, WorkloadEntry incoming, WorkloadOwnershipKind ownership)
+    {
+        bool attachExplicit = ownership == WorkloadOwnershipKind.Explicit && !current.IsExplicitlyInstalled;
+        bool attachLogical = ownership == WorkloadOwnershipKind.Logical && current.LogicalPackage is null;
+        if (ownership == WorkloadOwnershipKind.Logical
+            && current.LogicalPackage is not null
+            && !SameLogicalOwner(current.LogicalPackage, incoming.LogicalPackage!))
+        {
+            throw new InvalidOperationException(
+                $"Physical workload '{current.PackageId}' version '{current.PackageVersion}' is already owned by logical package " +
+                $"'{current.LogicalPackage.PackageId}' version '{current.LogicalPackage.PackageVersion}'.");
+        }
+
+        return CopyWithOwnership(
+            current,
+            current.IsExplicitlyInstalled || ownership == WorkloadOwnershipKind.Explicit,
+            current.LogicalPackage ?? incoming.LogicalPackage,
+            current.InstallRefCount + (attachExplicit ? 1 : 0) + (attachLogical ? 1 : 0));
+    }
+
+    private static bool SameLogicalOwner(LogicalPackage left, LogicalPackage right)
+        => string.Equals(left.PackageId, right.PackageId, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(left.PackageVersion, right.PackageVersion, StringComparison.Ordinal);
+
+    private static WorkloadEntry CopyWithOwnership(
+        WorkloadEntry entry,
+        bool isExplicitlyInstalled,
+        LogicalPackage? logicalPackage,
+        int installRefCount)
+        => new()
+        {
+            PackageId = entry.PackageId,
+            PackageVersion = entry.PackageVersion,
+            Kind = entry.Kind,
+            Aliases = entry.Aliases,
+            DisplayName = entry.DisplayName,
+            Description = entry.Description,
+            Source = entry.Source,
+            RuntimeIdentifier = entry.RuntimeIdentifier,
+            IsExplicitlyInstalled = isExplicitlyInstalled,
+            LogicalPackage = logicalPackage,
+            InstallRefCount = installRefCount,
+            EntryPoint = entry.EntryPoint,
+        };
 
     private async Task<WorkloadRegistry> ReadRegistryAsync(CancellationToken cancellationToken)
     {

--- a/src/Func/Workloads/WorkloadKind.cs
+++ b/src/Func/Workloads/WorkloadKind.cs
@@ -4,10 +4,8 @@
 namespace Azure.Functions.Cli.Workloads;
 
 /// <summary>
-/// Discriminator for the three shapes a workload package can take, declared
-/// in <c>workload.json</c>'s <c>kind</c> field
-/// (workload-package-layout §5.4). Determines whether the loader activates
-/// the package, skips it, or treats it as install-time-only.
+/// Discriminator for workload package shapes declared in
+/// <c>workload.json</c>'s <c>kind</c> field.
 /// </summary>
 internal enum WorkloadKind
 {
@@ -31,4 +29,10 @@ internal enum WorkloadKind
     /// loader never activates it.
     /// </summary>
     Meta = 2,
+
+    /// <summary>
+    /// Carries no payload. Maps supported runtime identifiers to exact
+    /// implementation package ids for install and update resolution.
+    /// </summary>
+    RidPointer = 3,
 }

--- a/src/Func/Workloads/WorkloadMetadata.cs
+++ b/src/Func/Workloads/WorkloadMetadata.cs
@@ -31,6 +31,17 @@ internal sealed class WorkloadMetadata
     public EntryPointSpec? EntryPoint { get; init; }
 
     /// <summary>
+    /// Maps normalized runtime identifiers to exact implementation package ids.
+    /// Required only for <see cref="WorkloadKind.RidPointer"/>.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? Packages { get; init; }
+
+    /// <summary>
+    /// Runtime identifier of a RID-specific workload or content implementation.
+    /// </summary>
+    public string? RuntimeIdentifier { get; init; }
+
+    /// <summary>
     /// Human-readable name for inventory and list output.
     /// </summary>
     public string DisplayName { get; init; } = string.Empty;

--- a/src/Func/Workloads/WorkloadPackageLayout.cs
+++ b/src/Func/Workloads/WorkloadPackageLayout.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workloads;
+
+/// <summary>
+/// Payload layout inside an installed workload package.
+/// </summary>
+/// <remarks>
+/// RID-specific packages pack under <c>tools/&lt;rid&gt;/</c> while RID-agnostic packages use
+/// <c>tools/any/</c>, mirroring the content root the workload SDK builds.
+/// </remarks>
+internal static class WorkloadPackageLayout
+{
+    /// <summary>
+    /// Payload directory used by packages that do not target a specific runtime identifier.
+    /// </summary>
+    public const string AnyRuntimeIdentifier = "any";
+
+    private const string ToolsDirectoryName = "tools";
+
+    /// <summary>
+    /// Returns the absolute payload root for an installed package.
+    /// </summary>
+    public static string GetContentRoot(string installDirectory, string? runtimeIdentifier)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(installDirectory);
+
+        string ridSegment = string.IsNullOrWhiteSpace(runtimeIdentifier)
+            ? AnyRuntimeIdentifier
+            : runtimeIdentifier;
+        return Path.GetFullPath(Path.Combine(installDirectory, ToolsDirectoryName, ridSegment));
+    }
+}

--- a/src/Workloads/Sdk/Tasks/WriteWorkloadJson.cs
+++ b/src/Workloads/Sdk/Tasks/WriteWorkloadJson.cs
@@ -18,9 +18,14 @@ public sealed class WriteWorkloadJson : Microsoft.Build.Utilities.Task
     [Required]
     public string Kind { get; set; } = string.Empty;
 
+    [Required]
+    public string PackageId { get; set; } = string.Empty;
+
     public string DisplayName { get; set; } = string.Empty;
 
     public string Description { get; set; } = string.Empty;
+
+    public string RuntimeIdentifier { get; set; } = string.Empty;
 
     public string EntryPointAssemblyPath { get; set; } = string.Empty;
 
@@ -31,6 +36,11 @@ public sealed class WriteWorkloadJson : Microsoft.Build.Utilities.Task
 
     public override bool Execute()
     {
+        if (!ValidateInputs())
+        {
+            return false;
+        }
+
         EntryPointModel? entryPoint = null;
         if (!string.IsNullOrEmpty(EntryPointAssemblyPath) && !string.IsNullOrEmpty(EntryPointType))
         {
@@ -42,9 +52,9 @@ public sealed class WriteWorkloadJson : Microsoft.Build.Utilities.Task
         }
 
         Dictionary<string, string>? packages = null;
-        if (InnerPackages is { Length: > 0 })
+        if (string.Equals(Kind, "rid-pointer", StringComparison.Ordinal))
         {
-            packages = new(StringComparer.OrdinalIgnoreCase);
+            packages = new(StringComparer.Ordinal);
             foreach (ITaskItem package in InnerPackages)
             {
                 packages[package.GetMetadata("RuntimeIdentifier")] = package.ItemSpec;
@@ -57,6 +67,7 @@ public sealed class WriteWorkloadJson : Microsoft.Build.Utilities.Task
             Kind = Kind,
             DisplayName = string.IsNullOrEmpty(DisplayName) ? null : DisplayName,
             Description = string.IsNullOrEmpty(Description) ? null : Description,
+            RuntimeIdentifier = string.IsNullOrEmpty(RuntimeIdentifier) ? null : RuntimeIdentifier,
             EntryPoint = entryPoint,
             Packages = packages,
         };
@@ -79,6 +90,96 @@ public sealed class WriteWorkloadJson : Microsoft.Build.Utilities.Task
         File.WriteAllBytes(OutputPath, content);
         return true;
     }
+
+    private bool ValidateInputs()
+    {
+        bool isPointer = string.Equals(Kind, "rid-pointer", StringComparison.Ordinal);
+        bool isRidImplementation = !string.IsNullOrEmpty(RuntimeIdentifier);
+        bool hasEntryPoint = !string.IsNullOrEmpty(EntryPointAssemblyPath) || !string.IsNullOrEmpty(EntryPointType);
+
+        if (isPointer)
+        {
+            if (hasEntryPoint)
+            {
+                Log.LogError("A rid-pointer workload cannot define an entry point.");
+            }
+
+            if (isRidImplementation)
+            {
+                Log.LogError("A rid-pointer workload cannot define a runtime identifier.");
+            }
+
+            if (InnerPackages.Length == 0)
+            {
+                Log.LogError("A rid-pointer workload must define at least one inner package.");
+            }
+        }
+        else if (InnerPackages.Length > 0)
+        {
+            Log.LogError($"Workload kind '{Kind}' cannot define inner packages.");
+        }
+
+        if (isRidImplementation
+            && !string.Equals(Kind, "workload", StringComparison.Ordinal)
+            && !string.Equals(Kind, "content", StringComparison.Ordinal))
+        {
+            Log.LogError($"Workload kind '{Kind}' cannot define a runtime identifier.");
+        }
+
+        if (isRidImplementation && !IsNormalizedRuntimeIdentifier(RuntimeIdentifier))
+        {
+            Log.LogError($"Runtime identifier '{RuntimeIdentifier}' must be non-empty and lowercase.");
+        }
+
+        if (string.Equals(Kind, "workload", StringComparison.Ordinal))
+        {
+            if (string.IsNullOrEmpty(EntryPointAssemblyPath) || string.IsNullOrEmpty(EntryPointType))
+            {
+                Log.LogError("A workload must define both entry-point assembly path and type.");
+            }
+        }
+        else if (hasEntryPoint)
+        {
+            Log.LogError($"Workload kind '{Kind}' cannot define an entry point.");
+        }
+
+        if (isPointer)
+        {
+            ValidateInnerPackages();
+        }
+
+        return !Log.HasLoggedErrors;
+    }
+
+    private void ValidateInnerPackages()
+    {
+        HashSet<string> runtimeIdentifiers = new(StringComparer.OrdinalIgnoreCase);
+        foreach (ITaskItem package in InnerPackages)
+        {
+            string runtimeIdentifier = package.GetMetadata("RuntimeIdentifier");
+            if (!IsNormalizedRuntimeIdentifier(runtimeIdentifier))
+            {
+                Log.LogError($"Inner package '{package.ItemSpec}' has invalid runtime identifier '{runtimeIdentifier}'. Runtime identifiers must be lowercase.");
+                continue;
+            }
+
+            if (!runtimeIdentifiers.Add(runtimeIdentifier))
+            {
+                Log.LogError($"Runtime identifier '{runtimeIdentifier}' is defined more than once.");
+            }
+
+            string expectedPackageId = $"{PackageId}.{runtimeIdentifier}";
+            if (!string.Equals(package.ItemSpec, expectedPackageId, StringComparison.OrdinalIgnoreCase))
+            {
+                Log.LogError($"Inner package for runtime identifier '{runtimeIdentifier}' must be named '{expectedPackageId}', but was '{package.ItemSpec}'.");
+            }
+        }
+    }
+
+    private static bool IsNormalizedRuntimeIdentifier(string value)
+        => !string.IsNullOrWhiteSpace(value)
+            && string.Equals(value, value.Trim(), StringComparison.Ordinal)
+            && string.Equals(value, value.ToLowerInvariant(), StringComparison.Ordinal);
 
     private static bool FileContentEquals(string path, byte[] expected)
     {
@@ -119,6 +220,9 @@ internal sealed class WorkloadJsonModel
 
     [JsonPropertyName("description")]
     public string? Description { get; set; }
+
+    [JsonPropertyName("runtimeIdentifier")]
+    public string? RuntimeIdentifier { get; set; }
 
     [JsonPropertyName("entryPoint")]
     public EntryPointModel? EntryPoint { get; set; }

--- a/test/Func.Tests/Commands/HostWorkloadResolverTests.cs
+++ b/test/Func.Tests/Commands/HostWorkloadResolverTests.cs
@@ -18,6 +18,7 @@ namespace Azure.Functions.Cli.Tests.Commands;
 public class HostWorkloadResolverTests
 {
     private static readonly string _hostPackageId = HostWorkloadPackage.CurrentPackageId;
+    private static readonly string _hostPointerPackageId = HostWorkloadPackage.PackageId;
 
     private readonly IWorkloadProvider _workloadProvider = Substitute.For<IWorkloadProvider>();
     private readonly IWorkloadCatalog _workloadCatalog = Substitute.For<IWorkloadCatalog>();
@@ -122,15 +123,15 @@ public class HostWorkloadResolverTests
 
         HostWorkloadResolution.InstallRequired installRequired = result.Should().BeOfType<HostWorkloadResolution.InstallRequired>().Subject;
         installRequired.HostVersion.Should().Be("4.1000.0");
-        installRequired.PackageId.Should().Be(_hostPackageId);
+        installRequired.PackageId.Should().Be(_hostPointerPackageId);
     }
 
     [Fact]
     public async Task ResolveAsync_NoInstalledHost_ReturnsInstallRequired()
     {
-        ResolvedPackage resolved = CreateResolvedPackage(_hostPackageId, "4.1048.199");
+        ResolvedPackage resolved = CreateResolvedPackage(_hostPointerPackageId, "4.1048.199");
         _workloadCatalog.ResolveLatestVersionInRangeAsync(
-                _hostPackageId,
+                _hostPointerPackageId,
                 Arg.Any<VersionRange>(),
                 (bool?)null,
                 null,
@@ -146,7 +147,7 @@ public class HostWorkloadResolverTests
 
         HostWorkloadResolution.InstallRequired installRequired = result.Should().BeOfType<HostWorkloadResolution.InstallRequired>().Subject;
         installRequired.HostVersion.Should().Be("4.1048.199");
-        installRequired.PackageId.Should().Be(_hostPackageId);
+        installRequired.PackageId.Should().Be(_hostPointerPackageId);
     }
 
     [Fact]
@@ -178,7 +179,7 @@ public class HostWorkloadResolverTests
         HostWorkloadResolution resolution = new HostWorkloadResolution.InstallRequired(
             "4.1000.0",
             "No compatible host installed",
-            _hostPackageId);
+            _hostPointerPackageId);
         resolver.ResolveAsync(Arg.Any<HostWorkloadResolutionContext>(), Arg.Any<CancellationToken>())
             .Returns(resolution);
         var step = new ValidateHostWorkloadInitializationStep(
@@ -201,7 +202,7 @@ public class HostWorkloadResolverTests
         HostWorkloadResolution resolution = new HostWorkloadResolution.InstallRequired(
             "4.1000.0",
             "No compatible host installed",
-            _hostPackageId);
+            _hostPointerPackageId);
         resolver.ResolveAsync(Arg.Any<HostWorkloadResolutionContext>(), Arg.Any<CancellationToken>())
             .Returns(resolution);
         var step = new ValidateHostWorkloadInitializationStep(

--- a/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
+++ b/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
@@ -23,7 +23,7 @@ namespace Azure.Functions.Cli.Tests.Commands.Setup;
 
 public sealed class SetupRunnerTests : IDisposable
 {
-    private static readonly string _hostPackageId = HostWorkloadPackage.CurrentPackageId;
+    private static readonly string _hostPackageId = HostWorkloadPackage.PackageId;
     private static readonly string _dotNetStackPackageId = "Azure.Functions.Cli.Workloads.DotNet";
 
     private readonly string _tempDir;
@@ -375,6 +375,47 @@ public sealed class SetupRunnerTests : IDisposable
     }
 
     [Fact]
+    public async Task RunAsync_IfNeeded_RecognizesInstalledRidPointerWorkload()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>())
+            .Returns([LogicalEntry(_hostPackageId, "4.0.0", "win-x64")]);
+        FakeCatalog catalog = Catalog();
+        SetupRunner runner = CreateRunner(catalog);
+
+        SetupRunResult result = await runner.RunAsync(
+            Options(features: ["host"], installPolicy: SetupInstallPolicy.IfNeeded),
+            CancellationToken.None);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(0, catalog.ResolveLatestCallCount);
+        await _installer.DidNotReceive().InstallFromCatalogAsync(
+            Arg.Any<string>(),
+            Arg.Any<NuGetVersion?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunAsync_Check_RecognizesExactRidPointerWorkloadVersion()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>())
+            .Returns([LogicalEntry(_hostPackageId, "4.0.0", "win-x64")]);
+        FakeCatalog catalog = Catalog().WithLatest(_hostPackageId, "4.0.0");
+        SetupRunner runner = CreateRunner(catalog);
+
+        SetupRunResult result = await runner.RunAsync(
+            Options(features: ["host"], check: true),
+            CancellationToken.None);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.DoesNotContain(_interaction.Lines, line => line.Contains("not installed", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task RunAsync_LatestCompatibleCheck_FailsWhenLatestCompatibleIsMissing()
     {
         _store.GetWorkloadsAsync(Arg.Any<CancellationToken>())
@@ -664,7 +705,7 @@ public sealed class SetupRunnerTests : IDisposable
         await _installer.DidNotReceive().InstallFromCatalogAsync(
             Arg.Is<string>(id => id.StartsWith("Azure.Functions.Cli.Workloads.", StringComparison.OrdinalIgnoreCase)
                 && !id.StartsWith("Azure.Functions.Cli.Workloads.Workers.", StringComparison.OrdinalIgnoreCase)
-                && !id.StartsWith("Azure.Functions.Cli.Workloads.Host.", StringComparison.OrdinalIgnoreCase)
+                && !id.StartsWith(HostWorkloadPackage.PackageId, StringComparison.OrdinalIgnoreCase)
                 && !id.StartsWith("Azure.Functions.Cli.Workloads.ExtensionBundles", StringComparison.OrdinalIgnoreCase)),
             Arg.Any<NuGetVersion?>(),
             Arg.Any<string?>(),
@@ -871,6 +912,21 @@ public sealed class SetupRunnerTests : IDisposable
             PackageVersion = version,
             Aliases = aliases ?? [],
             Kind = kind,
+        };
+
+    private static WorkloadEntry LogicalEntry(string pointerPackageId, string version, string runtimeIdentifier)
+        => new()
+        {
+            PackageId = $"{pointerPackageId}.{runtimeIdentifier}",
+            PackageVersion = version,
+            RuntimeIdentifier = runtimeIdentifier,
+            IsExplicitlyInstalled = false,
+            LogicalPackage = new LogicalPackage
+            {
+                PackageId = pointerPackageId,
+                PackageVersion = version,
+            },
+            Kind = WorkloadKind.Content,
         };
 
     private sealed class FakeCatalog : IWorkloadCatalog

--- a/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
@@ -252,7 +252,7 @@ public class WorkloadInstallCommandTests
     }
 
     [Fact]
-    public async Task Install_BrokenInstall_AppendsForceHint()
+    public async Task Install_BrokenInstall_SurfacesInstallerMessageAsUserError()
     {
         _installer.InstallFromCatalogAsync(
                 Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
@@ -263,7 +263,6 @@ public class WorkloadInstallCommandTests
         var cmd = NewInstall();
         GracefulException ex = (await FluentActions.Awaiting(() => InvokeAsync(cmd, "Test.Workload")).Should().ThrowAsync<GracefulException>()).Which;
         ex.Message.Should().Contain("missing from the registry");
-        ex.Message.Should().Contain("--force");
         ex.IsUserError.Should().BeTrue();
     }
 

--- a/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
@@ -379,6 +379,36 @@ public class WorkloadInstallCommandTests
     }
 
     [Fact]
+    public async Task Install_AlreadyInstalledLogicalAlias_HintsPointerIdentity()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            new WorkloadEntry
+            {
+                PackageId = "Test.Workload.win-x64",
+                PackageVersion = "1.2.3",
+                RuntimeIdentifier = "win-x64",
+                IsExplicitlyInstalled = false,
+                LogicalPackage = new LogicalPackage
+                {
+                    PackageId = "Test.Workload",
+                    PackageVersion = "1.2.3",
+                    Aliases = ["test"],
+                },
+            },
+        ]);
+
+        var cmd = NewInstall();
+        int exit = await InvokeAsync(cmd, "test");
+
+        Assert.Equal(1, exit);
+        Assert.Contains(_interaction.Lines, line =>
+            line.StartsWith("HINT:", StringComparison.Ordinal)
+            && line.Contains("func workload update Test.Workload", StringComparison.Ordinal)
+            && line.Contains("1.2.3", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task Install_AlreadyInstalled_AliasMatch_NonInteractive_HintsCanonicalIdWhenNoAlias()
     {
         _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(new[]
@@ -419,6 +449,41 @@ public class WorkloadInstallCommandTests
         exit.Should().Be(0);
         await _installer.Received(1).InstallFromCatalogAsync(
             "alias1", null, null, (bool?)null, true, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Install_PhysicalPackageWithOnlyLogicalOwnership_AddsExplicitOwnership()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            new WorkloadEntry
+            {
+                PackageId = "Test.Workload.win-x64",
+                PackageVersion = "1.0.0",
+                IsExplicitlyInstalled = false,
+                LogicalPackage = new LogicalPackage
+                {
+                    PackageId = "Test.Workload",
+                    PackageVersion = "1.0.0",
+                    Aliases = ["test"],
+                },
+            },
+        ]);
+        StubCatalogResult(packageId: "Test.Workload.win-x64");
+
+        var cmd = NewInstall();
+        int exit = await InvokeAsync(cmd, "Test.Workload.win-x64", "--exact");
+
+        Assert.Equal(0, exit);
+        await _installer.Received(1).InstallFromCatalogAsync(
+            "Test.Workload.win-x64",
+            null,
+            null,
+            (bool?)null,
+            true,
+            false,
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/test/Func.Tests/Commands/Workload/WorkloadListCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadListCommandTests.cs
@@ -290,6 +290,45 @@ public class WorkloadListCommandTests
     }
 
     [Fact]
+    public async Task List_Json_ProjectsLogicalAndPhysicalPointerDetails()
+    {
+        RuntimeWorkloadInfo loaded = NewInfo(
+            new FakeWorkload(displayName: "Physical implementation"),
+            "Pkg.Pointer.win-x64",
+            "2.0.0",
+            ["pointer"]);
+        var entry = new WorkloadEntry
+        {
+            PackageId = "Pkg.Pointer.win-x64",
+            PackageVersion = "2.0.0",
+            Aliases = ["pointer"],
+            RuntimeIdentifier = "win-x64",
+            IsExplicitlyInstalled = false,
+            LogicalPackage = new LogicalPackage
+            {
+                PackageId = "Pkg.Pointer",
+                PackageVersion = "2.0.0",
+                Aliases = ["pointer"],
+                DisplayName = "Pointer workload",
+                Description = "RID-selected workload",
+            },
+            InstallRefCount = 1,
+        };
+        var store = Substitute.For<IWorkloadStore>();
+        store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns([entry]);
+
+        var cmd = new WorkloadListCommand(_interaction, Provider(loaded), store);
+        await InvokeAsync(cmd, "--json");
+
+        string jsonLine = _interaction.Lines.Single(line => line.StartsWith("JSON:", StringComparison.Ordinal));
+        Assert.Contains("\"packageId\":\"Pkg.Pointer\"", jsonLine);
+        Assert.Contains("\"physicalPackageId\":\"Pkg.Pointer.win-x64\"", jsonLine);
+        Assert.Contains("\"runtimeIdentifier\":\"win-x64\"", jsonLine);
+        Assert.Contains("\"ownership\":\"logical:Pkg.Pointer\"", jsonLine);
+        Assert.Contains("\"isExplicitlyInstalled\":false", jsonLine);
+    }
+
+    [Fact]
     public async Task List_HasJsonAndAllVersionsOptions()
     {
         var cmd = new WorkloadListCommand(_interaction, Provider(), Substitute.For<IWorkloadStore>());

--- a/test/Func.Tests/Commands/Workload/WorkloadPruneCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadPruneCommandTests.cs
@@ -134,6 +134,50 @@ public class WorkloadPruneCommandTests
     }
 
     [Fact]
+    public async Task Prune_LogicalPointer_KeepsHighestPointerVersion()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            LogicalEntry("Pkg.Pointer.win-x64", "1.0.0"),
+            LogicalEntry("Pkg.Pointer.win-x64", "2.0.0"),
+        ]);
+        _installer.UninstallAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                WorkloadOwnershipKind.Logical,
+                Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var cmd = new WorkloadPruneCommand(_interaction, _installer, _store);
+        int exit = await InvokeAsync(cmd, "pointer");
+
+        Assert.Equal(0, exit);
+        await _installer.Received(1).UninstallAsync(
+            "Pkg.Pointer",
+            "1.0.0",
+            WorkloadOwnershipKind.Logical,
+            Arg.Any<CancellationToken>());
+        await _installer.DidNotReceive().UninstallAsync(
+            "Pkg.Pointer",
+            "2.0.0",
+            WorkloadOwnershipKind.Logical,
+            Arg.Any<CancellationToken>());
+
+        static WorkloadEntry LogicalEntry(string physicalPackageId, string version) => new()
+        {
+            PackageId = physicalPackageId,
+            PackageVersion = version,
+            IsExplicitlyInstalled = false,
+            LogicalPackage = new LogicalPackage
+            {
+                PackageId = "Pkg.Pointer",
+                PackageVersion = version,
+                Aliases = ["pointer"],
+            },
+        };
+    }
+
+    [Fact]
     public async Task Prune_WhitespaceArg_FailsValidation()
     {
         var cmd = new WorkloadPruneCommand(_interaction, _installer, _store);

--- a/test/Func.Tests/Commands/Workload/WorkloadUninstallCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadUninstallCommandTests.cs
@@ -244,6 +244,48 @@ public class WorkloadUninstallCommandTests
         await _installer.Received(1).UninstallAsync("First.Workload", "1.0.0", Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task Uninstall_LogicalPackageId_RemovesOnlyLogicalOwnership()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            new WorkloadEntry
+            {
+                PackageId = "Test.Workload.win-x64",
+                PackageVersion = "1.0.0",
+                RuntimeIdentifier = "win-x64",
+                IsExplicitlyInstalled = true,
+                LogicalPackage = new LogicalPackage
+                {
+                    PackageId = "Test.Workload",
+                    PackageVersion = "1.0.0",
+                    Aliases = ["test"],
+                },
+                InstallRefCount = 2,
+            },
+        ]);
+        _installer.UninstallAsync(
+                "Test.Workload",
+                "1.0.0",
+                WorkloadOwnershipKind.Logical,
+                Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var cmd = NewCommand();
+        int exit = await InvokeAsync(cmd, "Test.Workload", "--exact");
+
+        Assert.Equal(0, exit);
+        await _installer.Received(1).UninstallAsync(
+            "Test.Workload",
+            "1.0.0",
+            WorkloadOwnershipKind.Logical,
+            Arg.Any<CancellationToken>());
+        await _installer.DidNotReceive().UninstallAsync(
+            "Test.Workload.win-x64",
+            "1.0.0",
+            Arg.Any<CancellationToken>());
+    }
+
     private WorkloadUninstallCommand NewCommand() => new(_interaction, _installer, _store);
 
     private void StubInstalled(params (string PackageId, string Version)[] entries)

--- a/test/Func.Tests/Commands/Workload/WorkloadUpdateCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadUpdateCommandTests.cs
@@ -353,6 +353,66 @@ public class WorkloadUpdateCommandTests
     }
 
     [Fact]
+    public async Task Update_LogicalAlias_UpdatesPointerOwnership()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            new WorkloadEntry
+            {
+                PackageId = "test.workload.win-x64",
+                PackageVersion = "1.0.0",
+                RuntimeIdentifier = "win-x64",
+                IsExplicitlyInstalled = false,
+                LogicalPackage = new LogicalPackage
+                {
+                    PackageId = "test.workload",
+                    PackageVersion = "1.0.0",
+                    Aliases = ["demo"],
+                },
+            },
+        ]);
+        _installer.UpdateAsync(
+                "test.workload",
+                Arg.Any<NuGetVersion?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<bool>(),
+                WorkloadOwnershipKind.Logical,
+                Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new WorkloadUpdateResult(
+                new WorkloadEntry
+                {
+                    PackageId = "test.workload.win-x64",
+                    PackageVersion = "1.1.0",
+                    RuntimeIdentifier = "win-x64",
+                    IsExplicitlyInstalled = false,
+                    LogicalPackage = new LogicalPackage
+                    {
+                        PackageId = "test.workload",
+                        PackageVersion = "1.1.0",
+                        Aliases = ["demo"],
+                    },
+                },
+                "1.0.0",
+                NoUpdateAvailable: false));
+
+        var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store, _testCatalogOptions);
+        int exit = await InvokeAsync(cmd, "demo");
+
+        Assert.Equal(0, exit);
+        await _installer.Received(1).UpdateAsync(
+            "test.workload",
+            Arg.Any<NuGetVersion?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<bool>(),
+            WorkloadOwnershipKind.Logical,
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task Update_ExactSkipsAliasLookup_PassesArgumentThrough()
     {
         _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(new WorkloadEntry[]

--- a/test/Func.Tests/Hosting/CliHostFactoryTests.cs
+++ b/test/Func.Tests/Hosting/CliHostFactoryTests.cs
@@ -88,6 +88,28 @@ public sealed class CliHostFactoryTests : IDisposable
     }
 
     [Fact]
+    public async Task CreateHostAsync_IncompatibleRidWorkload_IsSkippedWithUpdateGuidance()
+    {
+        StageFixtureWorkload("withcommand.fixture.incompatible-rid", "1.0.0", CommandWorkloadType);
+        WriteRegistryWithRuntimeIdentifier(
+            "withcommand.fixture.incompatible-rid",
+            "1.0.0",
+            CommandWorkloadType,
+            "incompatible-rid");
+
+        var interaction = new TestInteractionService();
+
+        using IHost host = await StartHostAsync(interaction);
+        var rootCommand = Parser.CreateCommand(host.Services);
+
+        Assert.DoesNotContain(rootCommand.Subcommands, c => string.Equals(c.Name, "hello-from-workload", StringComparison.Ordinal));
+        Assert.Contains(
+            interaction.Lines,
+            line => line.StartsWith("WARNING:", StringComparison.Ordinal)
+                && line.Contains("func workload update", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task CreateHostAsync_WhenWorkloadConfigureThrows_WarnsAndContinues()
     {
         StageFixtureWorkload("throwing.fixture", "1.0.0", ThrowingWorkloadType);
@@ -253,6 +275,33 @@ public sealed class CliHostFactoryTests : IDisposable
                     Type = e.TypeName,
                 },
             })],
+        };
+
+        Directory.CreateDirectory(_home);
+        string json = JsonSerializer.Serialize(registry, WorkloadJsonContext.Default.WorkloadRegistry);
+        File.WriteAllText(Path.Combine(_home, WorkloadPathsOptions.WorkloadRegistryFileName), json);
+    }
+
+    private void WriteRegistryWithRuntimeIdentifier(string packageId, string version, string typeName, string runtimeIdentifier)
+    {
+        WorkloadRegistry registry = new()
+        {
+            Workloads =
+            [
+                new WorkloadEntry
+                {
+                    PackageId = packageId,
+                    PackageVersion = version,
+                    RuntimeIdentifier = runtimeIdentifier,
+                    Aliases = [],
+                    Kind = WorkloadKind.Workload,
+                    EntryPoint = new EntryPointSpec
+                    {
+                        AssemblyPath = FixtureAssembly,
+                        Type = typeName,
+                    },
+                },
+            ],
         };
 
         Directory.CreateDirectory(_home);

--- a/test/Func.Tests/Workers/DefaultFunctionsWorkerInstallerTests.cs
+++ b/test/Func.Tests/Workers/DefaultFunctionsWorkerInstallerTests.cs
@@ -111,6 +111,48 @@ public class DefaultFunctionsWorkerInstallerTests
     }
 
     [Fact]
+    public async Task InstallAsync_RidPointerImplementationReturnsWorker()
+    {
+        var workerId = new FunctionsWorkerId(WorkerRuntime);
+        WorkloadEntry entry = new()
+        {
+            PackageId = $"{WorkerPackageId}.win-x64",
+            PackageVersion = "3.14.0",
+            Kind = WorkloadKind.Content,
+            Aliases = ["node-worker"],
+            DisplayName = WorkerPackageId,
+            Description = string.Empty,
+            IsExplicitlyInstalled = false,
+            LogicalPackage = new LogicalPackage
+            {
+                PackageId = WorkerPackageId,
+                PackageVersion = "3.14.0",
+            },
+        };
+        _workloadInstaller.InstallFromCatalogAsync(
+                Arg.Any<string>(),
+                Arg.Any<NuGetVersion?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new WorkloadInstallResult(entry, AlreadyInstalled: false));
+        DefaultFunctionsWorkerInstaller installer = CreateInstaller();
+
+        FunctionsWorkerInstallResult result = await installer.InstallAsync(
+            workerId,
+            new Dictionary<string, VersionRange>(),
+            CancellationToken.None);
+
+        Assert.Equal(WorkerRuntime, result.Worker.WorkerRuntime);
+        Assert.Equal(
+            Path.Combine(GetInstallDirectory("3.14.0", entry.PackageId), "tools", "any", "worker.config.json"),
+            result.Worker.WorkerConfigPath);
+    }
+
+    [Fact]
     public async Task InstallAsync_NoPackageInProfileRange_ThrowsWorkloadPackageNotFound()
     {
         var workerId = new FunctionsWorkerId(WorkerRuntime);
@@ -189,10 +231,13 @@ public class DefaultFunctionsWorkerInstallerTests
         return new DefaultFunctionsWorkerInstaller(_workloadCatalog, _workloadInstaller, _workloadPaths, contentResolver);
     }
 
-    private static WorkloadEntry CreateWorkerEntry(string packageVersion, WorkloadKind kind = WorkloadKind.Content)
+    private static WorkloadEntry CreateWorkerEntry(
+        string packageVersion,
+        WorkloadKind kind = WorkloadKind.Content,
+        string packageId = WorkerPackageId)
         => new()
         {
-            PackageId = WorkerPackageId,
+            PackageId = packageId,
             PackageVersion = packageVersion,
             Kind = kind,
             Aliases = ["node-worker"],
@@ -200,5 +245,6 @@ public class DefaultFunctionsWorkerInstallerTests
             Description = string.Empty,
         };
 
-    private static string GetInstallDirectory(string packageVersion) => Path.Combine(Path.GetTempPath(), "workloads", WorkerPackageId, packageVersion);
+    private static string GetInstallDirectory(string packageVersion, string packageId = WorkerPackageId)
+        => Path.Combine(Path.GetTempPath(), "workloads", packageId, packageVersion);
 }

--- a/test/Func.Tests/Workloads/Discovery/WorkloadMetadataReaderTests.cs
+++ b/test/Func.Tests/Workloads/Discovery/WorkloadMetadataReaderTests.cs
@@ -221,7 +221,7 @@ public class WorkloadMetadataReaderTests : IDisposable
     }
 
     [Fact]
-    public void Read_Throws_WhenRidPointerHasCaseInsensitiveDuplicateRuntimeIdentifiers()
+    public void Read_Throws_WhenRidPointerHasNonLowercaseRuntimeIdentifier()
     {
         WriteMetadata(
             $$"""
@@ -237,7 +237,7 @@ public class WorkloadMetadataReaderTests : IDisposable
 
         InvalidWorkloadException ex = Assert.Throws<InvalidWorkloadException>(() => _reader.Read(_tempDir));
 
-        Assert.Contains("more than once", ex.Message);
+        Assert.Contains("must be lowercase", ex.Message);
     }
 
     [Fact]

--- a/test/Func.Tests/Workloads/Discovery/WorkloadMetadataReaderTests.cs
+++ b/test/Func.Tests/Workloads/Discovery/WorkloadMetadataReaderTests.cs
@@ -127,6 +127,166 @@ public class WorkloadMetadataReaderTests : IDisposable
         metadata.EntryPoint.Should().BeNull();
     }
 
+    [Fact]
+    public void Read_ReturnsRidPointerMetadata()
+    {
+        WriteMetadata(
+            $$"""
+            {
+              "$schema": "{{SchemaUrl}}",
+              "kind": "rid-pointer",
+              "packages": {
+                "linux-x64": "Example.Workload.linux-x64",
+                "win-x64": "Example.Workload.win-x64"
+              }
+            }
+            """);
+
+        WorkloadMetadata metadata = _reader.Read(_tempDir);
+
+        Assert.Equal(WorkloadKind.RidPointer, metadata.Kind);
+        Assert.Equal("Example.Workload.win-x64", metadata.Packages!["win-x64"]);
+        Assert.Null(metadata.RuntimeIdentifier);
+    }
+
+    [Fact]
+    public void Read_ReturnsRidImplementationMetadata()
+    {
+        WriteMetadata(
+            $$"""
+            {
+              "$schema": "{{SchemaUrl}}",
+              "kind": "content",
+              "runtimeIdentifier": "linux-arm64"
+            }
+            """);
+
+        WorkloadMetadata metadata = _reader.Read(_tempDir);
+
+        Assert.Equal("linux-arm64", metadata.RuntimeIdentifier);
+        Assert.Null(metadata.Packages);
+    }
+
+    [Fact]
+    public void Read_Throws_WhenRidPointerPackagesAreMissing()
+    {
+        WriteMetadata(
+            $$"""
+            {
+              "$schema": "{{SchemaUrl}}",
+              "kind": "rid-pointer"
+            }
+            """);
+
+        InvalidWorkloadException ex = Assert.Throws<InvalidWorkloadException>(() => _reader.Read(_tempDir));
+
+        Assert.Contains("non-empty packages", ex.Message);
+    }
+
+    [Fact]
+    public void Read_Throws_WhenRidPointerPackagesAreEmpty()
+    {
+        WriteMetadata(
+            $$"""
+            {
+              "$schema": "{{SchemaUrl}}",
+              "kind": "rid-pointer",
+              "packages": {}
+            }
+            """);
+
+        InvalidWorkloadException ex = Assert.Throws<InvalidWorkloadException>(() => _reader.Read(_tempDir));
+
+        Assert.Contains("non-empty packages", ex.Message);
+    }
+
+    [Fact]
+    public void Read_Throws_WhenRidPointerRuntimeIdentifierIsUppercase()
+    {
+        WriteMetadata(
+            $$"""
+            {
+              "$schema": "{{SchemaUrl}}",
+              "kind": "rid-pointer",
+              "packages": {
+                "WIN-X64": "Example.Workload.win-x64"
+              }
+            }
+            """);
+
+        InvalidWorkloadException ex = Assert.Throws<InvalidWorkloadException>(() => _reader.Read(_tempDir));
+
+        Assert.Contains("WIN-X64", ex.Message);
+        Assert.Contains("lowercase", ex.Message);
+    }
+
+    [Fact]
+    public void Read_Throws_WhenRidPointerHasCaseInsensitiveDuplicateRuntimeIdentifiers()
+    {
+        WriteMetadata(
+            $$"""
+            {
+              "$schema": "{{SchemaUrl}}",
+              "kind": "rid-pointer",
+              "packages": {
+                "win-x64": "Example.Workload.win-x64",
+                "WIN-X64": "Example.Workload.win-x64"
+              }
+            }
+            """);
+
+        InvalidWorkloadException ex = Assert.Throws<InvalidWorkloadException>(() => _reader.Read(_tempDir));
+
+        Assert.Contains("more than once", ex.Message);
+    }
+
+    [Fact]
+    public void Read_Throws_WhenOrdinaryWorkloadDefinesPackages()
+    {
+        WriteMetadata(
+            $$"""
+            {
+              "$schema": "{{SchemaUrl}}",
+              "kind": "workload",
+              "entryPoint": {
+                "assemblyPath": "Foo.dll",
+                "type": "Foo.MyWorkload"
+              },
+              "packages": {
+                "win-x64": "Example.Workload.win-x64"
+              }
+            }
+            """);
+
+        InvalidWorkloadException ex = Assert.Throws<InvalidWorkloadException>(() => _reader.Read(_tempDir));
+
+        Assert.Contains("packages", ex.Message);
+    }
+
+    [Fact]
+    public void Read_Throws_WhenRidPointerDefinesEntryPointOrRuntimeIdentifier()
+    {
+        WriteMetadata(
+            $$"""
+            {
+              "$schema": "{{SchemaUrl}}",
+              "kind": "rid-pointer",
+              "entryPoint": {
+                "assemblyPath": "Foo.dll",
+                "type": "Foo.MyWorkload"
+              },
+              "runtimeIdentifier": "win-x64",
+              "packages": {
+                "win-x64": "Example.Workload.win-x64"
+              }
+            }
+            """);
+
+        InvalidWorkloadException ex = Assert.Throws<InvalidWorkloadException>(() => _reader.Read(_tempDir));
+
+        Assert.Contains("entryPoint", ex.Message);
+    }
+
     [Theory]
     [InlineData("content")]
     [InlineData("meta")]

--- a/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
+++ b/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
@@ -702,10 +702,8 @@ public sealed class WorkloadInstallerTests : IDisposable
     [Fact]
     public async Task InstallFromCatalog_LegacyRidAliasesRemainAmbiguous()
     {
-        // When an alias spans multiple per-RID packs (host, python worker),
-        // the resolver should pick the variant tagged with the current
-        // runtime identifier instead of throwing ambiguity.
-        string currentRid = WorkloadRuntimeIdentifier.Current.ToLowerInvariant();
+        // Legacy per-RID packs carry no pointer package, so an alias spanning several
+        // of them stays ambiguous: the current runtime identifier no longer disambiguates.
         var source = new PackageSource("https://example/v3/index.json", "test");
 
         _catalog.SearchAsync(
@@ -728,17 +726,11 @@ public sealed class WorkloadInstallerTests : IDisposable
     [Fact]
     public async Task InstallFromCatalog_LegacyRidAliasesDoNotUseCurrentRidFallback()
     {
-        // If the alias only matches per-RID packs and none of them target the
-        // current runtime (e.g. python on win-arm64), surface a clear "no
-        // package for this RID" message listing what is published instead of
-        // a generic "package not found" or alias ambiguity error.
+        // Legacy per-RID packs are ambiguous regardless of the host runtime identifier:
+        // there is no current-RID fallback to silently pick a winner.
+        const string ridA = "fake-rid-a";
+        const string ridB = "fake-rid-b";
         var source = new PackageSource("https://example/v3/index.json", "test");
-
-        // Use two RIDs that definitely aren't the current host so we exercise
-        // the "no pack for current RID" branch on every test environment.
-        string currentRid = WorkloadRuntimeIdentifier.Current.ToLowerInvariant();
-        string ridA = currentRid == "fake-rid-a" ? "fake-rid-c" : "fake-rid-a";
-        string ridB = currentRid == "fake-rid-b" ? "fake-rid-d" : "fake-rid-b";
 
         _catalog.SearchAsync(
                 Arg.Is<CatalogSearchQuery>(q => q.Filter == "python-worker"),
@@ -764,8 +756,7 @@ public sealed class WorkloadInstallerTests : IDisposable
     public async Task InstallFromCatalog_AliasResolution_StillAmbiguous_WhenMatchesLackRidTag()
     {
         // Two unrelated packages declaring the same alias without any `rid:`
-        // tag must still throw ambiguity. RID disambiguation only kicks in
-        // when every match is RID-tagged.
+        // tag must throw ambiguity, the same as RID-tagged matches.
         var source = new PackageSource("https://example/v3/index.json", "test");
 
         _catalog.SearchAsync(
@@ -909,6 +900,141 @@ public sealed class WorkloadInstallerTests : IDisposable
     }
 
     [Fact]
+    public async Task InstallFromCatalog_PointerReusingInstalledImplementation_MovesLogicalOwnershipOffOtherRid()
+    {
+        const string pointerId = "example.workload";
+        const string implementationId = "example.workload.win-x64";
+        const string otherImplementationId = "example.workload.linux-x64";
+        const string version = "2.3.4";
+        string pointerPath = BuildPointerNupkg(
+            pointerId,
+            version,
+            """{ "win-x64": "example.workload.win-x64" }""");
+        var source = new PackageSource("https://example.test/v3/index.json", "pointer-source");
+        var pointerResolved = new ResolvedPackage(pointerId, NuGetVersion.Parse(version), source);
+
+        // The current-RID implementation is already on disk, so the installer takes the reuse fast
+        // path while the pointer is still attached to a different RID's payload.
+        InstallImplementationOnDisk(implementationId, version, "win-x64");
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            new WorkloadEntry
+            {
+                PackageId = implementationId,
+                PackageVersion = version,
+                RuntimeIdentifier = "win-x64",
+                Source = source.Source,
+                IsExplicitlyInstalled = true,
+            },
+            new WorkloadEntry
+            {
+                PackageId = otherImplementationId,
+                PackageVersion = version,
+                RuntimeIdentifier = "linux-x64",
+                Source = source.Source,
+                IsExplicitlyInstalled = false,
+                LogicalPackage = new LogicalPackage
+                {
+                    PackageId = pointerId,
+                    PackageVersion = version,
+                    Source = source.Source,
+                },
+            },
+        ]);
+        _catalog.ResolveLatestVersionAsync(
+                pointerId,
+                Arg.Any<bool>(),
+                Arg.Any<NuGetVersion?>(),
+                Arg.Any<bool>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(pointerResolved);
+        _catalog.DownloadAsync(pointerResolved, Arg.Any<CancellationToken>())
+            .Returns(_ => File.OpenRead(pointerPath));
+
+        WorkloadInstaller installer = NewInstaller(metadataReader: new WorkloadMetadataReader());
+        WorkloadInstallResult result = await installer.InstallFromCatalogAsync(
+            pointerId,
+            version: null,
+            source: null,
+            includePrerelease: false,
+            exact: true,
+            force: false);
+
+        result.Entry.PackageId.Should().Be(implementationId);
+        await _store.Received(1).MoveLogicalOwnershipAsync(
+            otherImplementationId,
+            version,
+            Arg.Is<WorkloadEntry>(entry =>
+                entry.PackageId == implementationId
+                && entry.LogicalPackage!.PackageId == pointerId),
+            Arg.Any<CancellationToken>());
+        await _store.DidNotReceive().AddOwnershipAsync(
+            Arg.Any<WorkloadEntry>(),
+            WorkloadOwnershipKind.Logical,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InstallFromCatalog_PointerReusesPayloadInstalledFromAnotherSource()
+    {
+        const string pointerId = "example.workload";
+        const string implementationId = "example.workload.win-x64";
+        const string version = "2.3.4";
+        string pointerPath = BuildPointerNupkg(
+            pointerId,
+            version,
+            """{ "win-x64": "example.workload.win-x64" }""");
+        var pointerSource = new PackageSource("https://pointer.test/v3/index.json", "pointer-source");
+        var pointerResolved = new ResolvedPackage(pointerId, NuGetVersion.Parse(version), pointerSource);
+
+        // Installed identity is id + version, as with the NuGet global packages folder, so a payload
+        // installed from a different feed is reused rather than rejected.
+        InstallImplementationOnDisk(implementationId, version, "win-x64");
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            new WorkloadEntry
+            {
+                PackageId = implementationId,
+                PackageVersion = version,
+                RuntimeIdentifier = "win-x64",
+                Source = "https://other.test/v3/index.json",
+                IsExplicitlyInstalled = true,
+            },
+        ]);
+        _catalog.ResolveLatestVersionAsync(
+                pointerId,
+                Arg.Any<bool>(),
+                Arg.Any<NuGetVersion?>(),
+                Arg.Any<bool>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(pointerResolved);
+        _catalog.DownloadAsync(pointerResolved, Arg.Any<CancellationToken>())
+            .Returns(_ => File.OpenRead(pointerPath));
+
+        WorkloadInstaller installer = NewInstaller(metadataReader: new WorkloadMetadataReader());
+        WorkloadInstallResult result = await installer.InstallFromCatalogAsync(
+            pointerId,
+            version: null,
+            source: null,
+            includePrerelease: false,
+            exact: true,
+            force: false);
+
+        result.Entry.PackageId.Should().Be(implementationId);
+        await _store.Received(1).AddOwnershipAsync(
+            Arg.Is<WorkloadEntry>(entry => entry.LogicalPackage!.PackageId == pointerId),
+            WorkloadOwnershipKind.Logical,
+            Arg.Any<CancellationToken>());
+        await _catalog.DidNotReceive().ResolveVersionAsync(
+            Arg.Any<string>(),
+            Arg.Any<NuGetVersion>(),
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task InstallFromCatalog_PointerWithoutCurrentRidListsSupportedRids()
     {
         string pointerPath = BuildPointerNupkg(
@@ -990,10 +1116,8 @@ public sealed class WorkloadInstallerTests : IDisposable
         Assert.Contains(resolved.Source.Source, ex.Message);
     }
 
-    [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public async Task InstallFromCatalog_ImplementationFromDifferentSourceOrForced_IsNotReused(bool force)
+    [Fact]
+    public async Task InstallFromCatalog_ForcedInstall_DoesNotReuseInstalledImplementation()
     {
         const string pointerId = "example.workload";
         const string implementationId = "example.workload.win-x64";
@@ -1023,7 +1147,7 @@ public sealed class WorkloadInstallerTests : IDisposable
                 PackageVersion = version,
                 Kind = WorkloadKind.Content,
                 RuntimeIdentifier = "win-x64",
-                Source = "https://different.test/v3/index.json",
+                Source = pointerSource.Source,
                 IsExplicitlyInstalled = true,
             },
         ]);
@@ -1052,7 +1176,7 @@ public sealed class WorkloadInstallerTests : IDisposable
                 source: null,
                 includePrerelease: false,
                 exact: true,
-                force));
+                force: true));
 
         await _catalog.Received(1).ResolveVersionAsync(
             implementationId,
@@ -1151,48 +1275,6 @@ public sealed class WorkloadInstallerTests : IDisposable
                 Source = source.Source,
             },
         };
-    }
-
-    [Fact]
-    public async Task UpdateAsync_DoesNotReplaceDestinationInstalledFromDifferentSource()
-    {
-        WorkloadEntry current = ExistingEntry("test.workload", "1.0.0");
-        WorkloadEntry destination = new()
-        {
-            PackageId = "test.workload",
-            PackageVersion = "2.0.0",
-            Source = "https://different.test/v3/index.json",
-            IsExplicitlyInstalled = false,
-            LogicalPackage = new LogicalPackage
-            {
-                PackageId = "test.pointer",
-                PackageVersion = "2.0.0",
-            },
-        };
-        ResolvedPackage resolved = NewResolved("test.workload", "2.0.0");
-        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns([current, destination]);
-        _catalog.ResolveLatestVersionAsync(
-                "test.workload",
-                false,
-                Arg.Any<NuGetVersion?>(),
-                false,
-                null,
-                Arg.Any<CancellationToken>())
-            .Returns(resolved);
-
-        WorkloadInstaller installer = NewInstaller();
-        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => installer.UpdateAsync("test.workload", null, null, false, allowMajor: false));
-
-        Assert.Contains("different source", exception.Message);
-        await _catalog.DidNotReceive().DownloadAsync(
-            Arg.Any<ResolvedPackage>(),
-            Arg.Any<CancellationToken>());
-        await _store.DidNotReceive().MoveExplicitOwnershipAsync(
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<WorkloadEntry>(),
-            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -1309,7 +1391,7 @@ public sealed class WorkloadInstallerTests : IDisposable
     }
 
     [Fact]
-    public async Task InstallFromPackage_LocalPointer_DoesNotReusePhysicalPackageFromDifferentSource()
+    public async Task InstallFromPackage_LocalPointer_ReusesPhysicalPackageFromDifferentSource()
     {
         const string pointerId = "example.workload";
         const string implementationId = "example.workload.win-x64";
@@ -1319,6 +1401,7 @@ public sealed class WorkloadInstallerTests : IDisposable
             version,
             """{ "win-x64": "example.workload.win-x64" }""");
         _ = BuildRidImplementationNupkg(implementationId, version, "win-x64");
+        InstallImplementationOnDisk(implementationId, version, "win-x64");
         _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(
         [
             new WorkloadEntry
@@ -1332,16 +1415,12 @@ public sealed class WorkloadInstallerTests : IDisposable
         ]);
 
         WorkloadInstaller installer = NewInstaller(metadataReader: new WorkloadMetadataReader());
-        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => installer.InstallFromPackageAsync(pointerPath));
+        WorkloadInstallResult result = await installer.InstallFromPackageAsync(pointerPath);
 
-        Assert.Contains("different source", exception.Message);
-        await _store.DidNotReceive().AddOwnershipAsync(
-            Arg.Any<WorkloadEntry>(),
-            Arg.Any<WorkloadOwnershipKind>(),
-            Arg.Any<CancellationToken>());
-        await _store.DidNotReceive().SaveWorkloadAsync(
-            Arg.Any<WorkloadEntry>(),
+        Assert.Equal(implementationId, result.Entry.PackageId);
+        await _store.Received(1).AddOwnershipAsync(
+            Arg.Is<WorkloadEntry>(entry => entry.LogicalPackage!.PackageId == pointerId),
+            WorkloadOwnershipKind.Logical,
             Arg.Any<CancellationToken>());
     }
 
@@ -1585,6 +1664,21 @@ public sealed class WorkloadInstallerTests : IDisposable
             tags: $"kind:content rid:{runtimeIdentifier}",
             packageType: packageType,
             extraFiles: [(WriteTempFile("workload.json", manifest), "workload.json")]);
+    }
+
+    private void InstallImplementationOnDisk(string packageId, string version, string runtimeIdentifier)
+    {
+        string installDirectory = _paths.GetInstallDirectory(packageId, version);
+        Directory.CreateDirectory(installDirectory);
+        File.WriteAllText(
+            Path.Combine(installDirectory, "workload.json"),
+            $$"""
+            {
+              "$schema": "{{WorkloadManifestSchema.PackageManifestV1Schema}}",
+              "kind": "content",
+              "runtimeIdentifier": "{{runtimeIdentifier}}"
+            }
+            """);
     }
 
     private string WriteTempFile(string name, string contents)

--- a/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
+++ b/test/Func.Tests/Workloads/Install/WorkloadInstallerTests.cs
@@ -23,6 +23,7 @@ public sealed class WorkloadInstallerTests : IDisposable
     private readonly IWorkloadStore _store = Substitute.For<IWorkloadStore>();
     private readonly IWorkloadMetadataReader _metadataReader = Substitute.For<IWorkloadMetadataReader>();
     private readonly IWorkloadCatalog _catalog = Substitute.For<IWorkloadCatalog>();
+    private readonly IWorkloadRuntimeIdentifierProvider _runtimeIdentifierProvider = Substitute.For<IWorkloadRuntimeIdentifierProvider>();
     private readonly IWorkloadPaths _paths;
 
     public WorkloadInstallerTests()
@@ -34,6 +35,31 @@ public sealed class WorkloadInstallerTests : IDisposable
                 Schema = "https://example/workload.schema.json",
                 EntryPoint = new EntryPointSpec { AssemblyPath = "Test.dll", Type = "Test.Type" },
             });
+        _runtimeIdentifierProvider.Current.Returns("win-x64");
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns([]);
+        _store.AddOwnershipAsync(
+                Arg.Any<WorkloadEntry>(),
+                Arg.Any<WorkloadOwnershipKind>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call => call.Arg<WorkloadEntry>());
+        _store.MoveExplicitOwnershipAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<WorkloadEntry>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call => new WorkloadOwnershipMoveResult(call.Arg<WorkloadEntry>(), PreviousEntryRemoved: true));
+        _store.MoveLogicalOwnershipAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<WorkloadEntry>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call => new WorkloadOwnershipMoveResult(call.Arg<WorkloadEntry>(), PreviousEntryRemoved: true));
+        _store.RemoveOwnershipAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<WorkloadOwnershipKind>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new WorkloadOwnershipRemovalResult(false, false, null));
     }
 
     public void Dispose() => Directory.Delete(_root, recursive: true);
@@ -208,8 +234,12 @@ public sealed class WorkloadInstallerTests : IDisposable
         File.WriteAllText(stalePath, "leftover from prior install");
 
         string nupkg = BuildNupkg();
-        _store.RemoveWorkloadAsync("test.workload", "1.0.0", Arg.Any<CancellationToken>())
-            .Returns(true);
+        _store.RemoveOwnershipAsync(
+                "test.workload",
+                "1.0.0",
+                WorkloadOwnershipKind.Explicit,
+                Arg.Any<CancellationToken>())
+            .Returns(new WorkloadOwnershipRemovalResult(true, true, null));
 
         WorkloadInstaller installer = NewInstaller();
         WorkloadInstallResult result = await installer.InstallFromPackageAsync(nupkg, force: true);
@@ -218,7 +248,6 @@ public sealed class WorkloadInstallerTests : IDisposable
         result.Entry.PackageId.Should().Be("test.workload");
         File.Exists(stalePath).Should().BeFalse("Stale files from the prior install must be gone after a forced reinstall.");
         File.Exists(Path.Combine(installDir, "tools", "any", "Test.dll")).Should().BeTrue();
-        await _store.Received(1).RemoveWorkloadAsync("test.workload", "1.0.0", Arg.Any<CancellationToken>());
         await _store.Received(1).SaveWorkloadAsync(Arg.Any<WorkloadEntry>(), Arg.Any<CancellationToken>());
     }
 
@@ -241,8 +270,12 @@ public sealed class WorkloadInstallerTests : IDisposable
         string installDir = _paths.GetInstallDirectory("test.workload", "1.0.0");
         Directory.CreateDirectory(installDir);
         File.WriteAllText(Path.Combine(installDir, "Test.dll"), "stub");
-        _store.RemoveWorkloadAsync("test.workload", "1.0.0", Arg.Any<CancellationToken>())
-            .Returns(true);
+        _store.RemoveOwnershipAsync(
+                "test.workload",
+                "1.0.0",
+                WorkloadOwnershipKind.Explicit,
+                Arg.Any<CancellationToken>())
+            .Returns(new WorkloadOwnershipRemovalResult(true, true, null));
 
         WorkloadInstaller installer = NewInstaller();
         bool removed = await installer.UninstallAsync("test.workload", "1.0.0");
@@ -256,14 +289,50 @@ public sealed class WorkloadInstallerTests : IDisposable
     {
         string installDir = _paths.GetInstallDirectory("test.workload", "1.0.0");
         Directory.CreateDirectory(installDir);
-        _store.RemoveWorkloadAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(false);
-
         WorkloadInstaller installer = NewInstaller();
         bool removed = await installer.UninstallAsync("test.workload", "1.0.0");
 
         removed.Should().BeFalse();
         Directory.Exists(installDir).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Uninstall_LogicalOwnership_ResolvesPhysicalRegistryRow()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            new WorkloadEntry
+            {
+                PackageId = "example.workload.win-x64",
+                PackageVersion = "1.0.0",
+                RuntimeIdentifier = "win-x64",
+                IsExplicitlyInstalled = false,
+                LogicalPackage = new LogicalPackage
+                {
+                    PackageId = "example.workload",
+                    PackageVersion = "1.0.0",
+                },
+            },
+        ]);
+        _store.RemoveOwnershipAsync(
+                "example.workload.win-x64",
+                "1.0.0",
+                WorkloadOwnershipKind.Logical,
+                Arg.Any<CancellationToken>())
+            .Returns(new WorkloadOwnershipRemovalResult(true, false, null));
+
+        WorkloadInstaller installer = NewInstaller();
+        bool removed = await installer.UninstallAsync(
+            "example.workload",
+            "1.0.0",
+            WorkloadOwnershipKind.Logical);
+
+        Assert.True(removed);
+        await _store.Received(1).RemoveOwnershipAsync(
+            "example.workload.win-x64",
+            "1.0.0",
+            WorkloadOwnershipKind.Logical,
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -452,14 +521,11 @@ public sealed class WorkloadInstallerTests : IDisposable
         Directory.Exists(newDir).Should().BeTrue();
         Directory.Exists(oldDir).Should().BeFalse("old install dir must be deleted after swap");
 
-        Received.InOrder(() =>
-        {
-            _store.ReplaceWorkloadAsync(
-                "test.workload",
-                "1.0.0",
-                Arg.Is<WorkloadEntry>(e => e.PackageId == "test.workload" && e.PackageVersion == "1.1.0"),
-                Arg.Any<CancellationToken>());
-        });
+        await _store.Received(1).MoveExplicitOwnershipAsync(
+            "test.workload",
+            "1.0.0",
+            Arg.Is<WorkloadEntry>(e => e.PackageId == "test.workload" && e.PackageVersion == "1.1.0"),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -485,7 +551,7 @@ public sealed class WorkloadInstallerTests : IDisposable
 
         Directory.Exists(oldDir).Should().BeTrue("existing install must remain after staging failure");
         File.Exists(Path.Combine(oldDir, "marker.txt")).Should().BeTrue();
-        await _store.DidNotReceive().ReplaceWorkloadAsync(
+        await _store.DidNotReceive().MoveExplicitOwnershipAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<WorkloadEntry>(), Arg.Any<CancellationToken>());
     }
 
@@ -510,7 +576,7 @@ public sealed class WorkloadInstallerTests : IDisposable
         // hyphenated aliases (e.g. `node-worker`). When the targeted alias
         // search returns nothing, the installer should retry with an empty
         // filter and match by alias client-side.
-        string nupkg = BuildNupkg();
+        string nupkg = BuildNupkg(id: "real.workload.id");
         var resolved = NewResolved("real.workload.id", "1.0.0");
         var source = new PackageSource("https://example/v3/index.json", "test");
 
@@ -537,7 +603,7 @@ public sealed class WorkloadInstallerTests : IDisposable
             "node-worker", version: null, source: null,
             includePrerelease: true, exact: false, force: false);
 
-        result.Entry.PackageId.Should().Be("test.workload");
+        result.Entry.PackageId.Should().Be("real.workload.id");
         await _catalog.Received(1).SearchAsync(
             Arg.Is<CatalogSearchQuery>(q => q.Filter == null),
             Arg.Any<CancellationToken>());
@@ -548,7 +614,7 @@ public sealed class WorkloadInstallerTests : IDisposable
     {
         // If the targeted search returns any results (even non-matching),
         // we trust the server filter and don't pay for a second broad query.
-        string nupkg = BuildNupkg();
+        string nupkg = BuildNupkg(id: "node.pkg");
         var resolved = NewResolved("node.pkg", "1.0.0");
         var source = new PackageSource("https://example/v3/index.json", "test");
 
@@ -634,16 +700,13 @@ public sealed class WorkloadInstallerTests : IDisposable
     }
 
     [Fact]
-    public async Task InstallFromCatalog_AliasResolution_DisambiguatesByCurrentRid_WhenAllMatchesAreRidTagged()
+    public async Task InstallFromCatalog_LegacyRidAliasesRemainAmbiguous()
     {
         // When an alias spans multiple per-RID packs (host, python worker),
         // the resolver should pick the variant tagged with the current
         // runtime identifier instead of throwing ambiguity.
-        string nupkg = BuildNupkg();
         string currentRid = WorkloadRuntimeIdentifier.Current.ToLowerInvariant();
-        string targetId = $"Azure.Functions.Cli.Workloads.Workers.Python.{currentRid}";
         var source = new PackageSource("https://example/v3/index.json", "test");
-        var resolved = NewResolved(targetId, "1.0.0");
 
         _catalog.SearchAsync(
                 Arg.Is<CatalogSearchQuery>(q => q.Filter == "python-worker"),
@@ -654,27 +717,16 @@ public sealed class WorkloadInstallerTests : IDisposable
                     Title: null, Description: null, Aliases: ["python-worker"], Source: source) { Rid = "win-x64" },
                 new("azure.functions.cli.workloads.workers.python.linux-x64", NuGetVersion.Parse("1.0.0"),
                     Title: null, Description: null, Aliases: ["python-worker"], Source: source) { Rid = "linux-x64" },
-                new(targetId.ToLowerInvariant(), NuGetVersion.Parse("1.0.0"),
-                    Title: null, Description: null, Aliases: ["python-worker"], Source: source) { Rid = currentRid },
             });
-        _catalog.ResolveLatestVersionAsync(
-                targetId.ToLowerInvariant(), true, null, true, null, Arg.Any<CancellationToken>())
-            .Returns(resolved);
-        _catalog.DownloadAsync(resolved, Arg.Any<CancellationToken>())
-            .Returns(_ => File.OpenRead(nupkg));
 
         WorkloadInstaller installer = NewInstaller();
-        WorkloadInstallResult result = await installer.InstallFromCatalogAsync(
+        await FluentActions.Awaiting(() => installer.InstallFromCatalogAsync(
             "python-worker", version: null, source: null,
-            includePrerelease: true, exact: false, force: false);
-
-        result.Should().NotBeNull();
-        await _catalog.Received(1).ResolveLatestVersionAsync(
-            targetId.ToLowerInvariant(), true, null, true, null, Arg.Any<CancellationToken>());
+            includePrerelease: true, exact: false, force: false)).Should().ThrowAsync<AmbiguousPackageMatchException>();
     }
 
     [Fact]
-    public async Task InstallFromCatalog_AliasResolution_ThrowsClearError_WhenNoPackageForCurrentRid()
+    public async Task InstallFromCatalog_LegacyRidAliasesDoNotUseCurrentRidFallback()
     {
         // If the alias only matches per-RID packs and none of them target the
         // current runtime (e.g. python on win-arm64), surface a clear "no
@@ -700,13 +752,12 @@ public sealed class WorkloadInstallerTests : IDisposable
             });
 
         WorkloadInstaller installer = NewInstaller();
-        WorkloadPackageNotFoundException ex = (await FluentActions.Awaiting(() => installer.InstallFromCatalogAsync(
+        AmbiguousPackageMatchException ex = (await FluentActions.Awaiting(() => installer.InstallFromCatalogAsync(
                 "python-worker", version: null, source: null,
-                includePrerelease: true, exact: false, force: false)).Should().ThrowAsync<WorkloadPackageNotFoundException>()).Which;
+                includePrerelease: true, exact: false, force: false)).Should().ThrowAsync<AmbiguousPackageMatchException>()).Which;
 
         ex.Message.Should().Contain("python-worker");
-        ex.Message.Should().Contain(ridA);
-        ex.Message.Should().Contain(ridB);
+        ex.Message.Should().Contain("matches multiple packages");
     }
 
     [Fact]
@@ -741,9 +792,19 @@ public sealed class WorkloadInstallerTests : IDisposable
         // alias resolution must not rewrite it. exact:true short-circuits the
         // alias search entirely, but we also cover exact:false: passing a real
         // package id (not an alias) should resolve to that id.
-        string nupkg = BuildNupkg();
         string explicitId = "Azure.Functions.Cli.Workloads.Workers.Python.win-x64";
+        string nupkg = BuildNupkg(
+            id: explicitId,
+            tags: "rid:win-x64",
+            packageType: WorkloadInstaller.FuncCliWorkloadRidPackageType);
         var resolved = NewResolved(explicitId, "1.0.0");
+        _metadataReader.Read(Arg.Any<string>())
+            .Returns(new WorkloadMetadata
+            {
+                Schema = "https://example/workload.schema.json",
+                Kind = WorkloadKind.Content,
+                RuntimeIdentifier = "win-x64",
+            });
 
         _catalog.SearchAsync(Arg.Any<CatalogSearchQuery>(), Arg.Any<CancellationToken>())
             .Returns([]);
@@ -763,6 +824,583 @@ public sealed class WorkloadInstallerTests : IDisposable
             explicitId, true, null, true, null, Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task InstallFromCatalog_PointerAliasWinsAndResolvesExactImplementationFromSameSource()
+    {
+        const string pointerId = "example.workload";
+        const string implementationId = "example.workload.win-x64";
+        const string version = "2.3.4";
+        string pointerPath = BuildPointerNupkg(
+            pointerId,
+            version,
+            """
+            {
+              "win-x64": "example.workload.win-x64"
+            }
+            """);
+        string implementationPath = BuildRidImplementationNupkg(implementationId, version, "win-x64");
+        var source = new PackageSource("https://example.test/v3/index.json", "pointer-source");
+        var pointerResolved = new ResolvedPackage(pointerId, NuGetVersion.Parse(version), source);
+        var implementationResolved = new ResolvedPackage(implementationId, NuGetVersion.Parse(version), source);
+
+        _catalog.SearchAsync(Arg.Any<CatalogSearchQuery>(), Arg.Any<CancellationToken>())
+            .Returns(
+            [
+                new CatalogSearchResult(
+                    pointerId,
+                    NuGetVersion.Parse(version),
+                    "Example",
+                    "Example pointer",
+                    ["example"],
+                    source)
+                {
+                    Kind = "rid-pointer",
+                },
+                new CatalogSearchResult(
+                    implementationId,
+                    NuGetVersion.Parse(version),
+                    null,
+                    null,
+                    ["example"],
+                    source)
+                {
+                    Kind = "content",
+                    Rid = "win-x64",
+                },
+            ]);
+        _catalog.ResolveLatestVersionAsync(
+                pointerId,
+                false,
+                null,
+                true,
+                null,
+                Arg.Any<CancellationToken>())
+            .Returns(pointerResolved);
+        _catalog.ResolveVersionAsync(
+                implementationId,
+                NuGetVersion.Parse(version),
+                source.Source,
+                Arg.Any<CancellationToken>())
+            .Returns(implementationResolved);
+        _catalog.DownloadAsync(pointerResolved, Arg.Any<CancellationToken>())
+            .Returns(_ => File.OpenRead(pointerPath));
+        _catalog.DownloadAsync(implementationResolved, Arg.Any<CancellationToken>())
+            .Returns(_ => File.OpenRead(implementationPath));
+
+        WorkloadInstaller installer = NewInstaller(metadataReader: new WorkloadMetadataReader());
+        WorkloadInstallResult result = await installer.InstallFromCatalogAsync(
+            "example",
+            version: null,
+            source: null,
+            includePrerelease: false,
+            exact: false,
+            force: false);
+
+        Assert.Equal(implementationId, result.Entry.PackageId);
+        Assert.Equal("win-x64", result.Entry.RuntimeIdentifier);
+        Assert.False(result.Entry.IsExplicitlyInstalled);
+        Assert.Equal(pointerId, result.Entry.LogicalPackage!.PackageId);
+        Assert.Equal(version, result.Entry.LogicalPackage.PackageVersion);
+        await _catalog.Received(1).ResolveVersionAsync(
+            implementationId,
+            NuGetVersion.Parse(version),
+            source.Source,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InstallFromCatalog_PointerWithoutCurrentRidListsSupportedRids()
+    {
+        string pointerPath = BuildPointerNupkg(
+            "example.workload",
+            "1.0.0",
+            """
+            {
+              "linux-x64": "example.workload.linux-x64",
+              "osx-arm64": "example.workload.osx-arm64"
+            }
+            """);
+        var resolved = NewResolved("example.workload", "1.0.0");
+        _catalog.ResolveLatestVersionAsync(
+                "example.workload",
+                false,
+                null,
+                true,
+                null,
+                Arg.Any<CancellationToken>())
+            .Returns(resolved);
+        _catalog.DownloadAsync(resolved, Arg.Any<CancellationToken>())
+            .Returns(_ => File.OpenRead(pointerPath));
+
+        WorkloadInstaller installer = NewInstaller(metadataReader: new WorkloadMetadataReader());
+        WorkloadPackageNotFoundException ex = await Assert.ThrowsAsync<WorkloadPackageNotFoundException>(
+            () => installer.InstallFromCatalogAsync(
+                "example.workload",
+                version: null,
+                source: null,
+                includePrerelease: false,
+                exact: true,
+                force: false));
+
+        Assert.Contains("win-x64", ex.Message);
+        Assert.Contains("linux-x64, osx-arm64", ex.Message);
+    }
+
+    [Fact]
+    public async Task InstallFromCatalog_MissingPointerImplementationReportsPartialPublish()
+    {
+        string pointerPath = BuildPointerNupkg(
+            "example.workload",
+            "1.0.0",
+            """
+            {
+              "win-x64": "example.workload.win-x64"
+            }
+            """);
+        var resolved = NewResolved("example.workload", "1.0.0");
+        _catalog.ResolveLatestVersionAsync(
+                "example.workload",
+                false,
+                null,
+                true,
+                null,
+                Arg.Any<CancellationToken>())
+            .Returns(resolved);
+        _catalog.DownloadAsync(resolved, Arg.Any<CancellationToken>())
+            .Returns(_ => File.OpenRead(pointerPath));
+        _catalog.ResolveVersionAsync(
+                "example.workload.win-x64",
+                NuGetVersion.Parse("1.0.0"),
+                resolved.Source.Source,
+                Arg.Any<CancellationToken>())
+            .Returns((ResolvedPackage?)null);
+
+        WorkloadInstaller installer = NewInstaller(metadataReader: new WorkloadMetadataReader());
+        WorkloadPackageNotFoundException ex = await Assert.ThrowsAsync<WorkloadPackageNotFoundException>(
+            () => installer.InstallFromCatalogAsync(
+                "example.workload",
+                version: null,
+                source: null,
+                includePrerelease: false,
+                exact: true,
+                force: false));
+
+        Assert.Contains("partial publish", ex.Message);
+        Assert.Contains("example.workload.win-x64", ex.Message);
+        Assert.Contains(resolved.Source.Source, ex.Message);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task InstallFromCatalog_ImplementationFromDifferentSourceOrForced_IsNotReused(bool force)
+    {
+        const string pointerId = "example.workload";
+        const string implementationId = "example.workload.win-x64";
+        const string version = "1.0.0";
+        string pointerPath = BuildPointerNupkg(
+            pointerId,
+            version,
+            """{ "win-x64": "example.workload.win-x64" }""");
+        var pointerSource = new PackageSource("https://pointer.test/v3/index.json", "pointer");
+        var pointerResolved = new ResolvedPackage(pointerId, NuGetVersion.Parse(version), pointerSource);
+        string installDirectory = _paths.GetInstallDirectory(implementationId, version);
+        Directory.CreateDirectory(installDirectory);
+        File.WriteAllText(
+            Path.Combine(installDirectory, "workload.json"),
+            """
+            {
+              "$schema": "https://aka.ms/func-workloads/package/v1/schema.json",
+              "kind": "content",
+              "runtimeIdentifier": "win-x64"
+            }
+            """);
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            new WorkloadEntry
+            {
+                PackageId = implementationId,
+                PackageVersion = version,
+                Kind = WorkloadKind.Content,
+                RuntimeIdentifier = "win-x64",
+                Source = "https://different.test/v3/index.json",
+                IsExplicitlyInstalled = true,
+            },
+        ]);
+        _catalog.ResolveLatestVersionAsync(
+                pointerId,
+                false,
+                null,
+                true,
+                null,
+                Arg.Any<CancellationToken>())
+            .Returns(pointerResolved);
+        _catalog.DownloadAsync(pointerResolved, Arg.Any<CancellationToken>())
+            .Returns(_ => File.OpenRead(pointerPath));
+        _catalog.ResolveVersionAsync(
+                implementationId,
+                NuGetVersion.Parse(version),
+                pointerSource.Source,
+                Arg.Any<CancellationToken>())
+            .Returns((ResolvedPackage?)null);
+
+        WorkloadInstaller installer = NewInstaller(metadataReader: new WorkloadMetadataReader());
+        _ = await Assert.ThrowsAsync<WorkloadPackageNotFoundException>(() =>
+            installer.InstallFromCatalogAsync(
+                pointerId,
+                version: null,
+                source: null,
+                includePrerelease: false,
+                exact: true,
+                force));
+
+        await _catalog.Received(1).ResolveVersionAsync(
+            implementationId,
+            NuGetVersion.Parse(version),
+            pointerSource.Source,
+            Arg.Any<CancellationToken>());
+        await _store.DidNotReceive().AddOwnershipAsync(
+            Arg.Any<WorkloadEntry>(),
+            WorkloadOwnershipKind.Logical,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateLogical_LocalPointerSourceMissing_RequiresExplicitSource()
+    {
+        const string pointerId = "example.workload";
+        string missingPointerPath = Path.Combine(_root, "deleted-pointer.nupkg");
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            new WorkloadEntry
+            {
+                PackageId = "example.workload.win-x64",
+                PackageVersion = "1.0.0",
+                RuntimeIdentifier = "win-x64",
+                IsExplicitlyInstalled = false,
+                LogicalPackage = new LogicalPackage
+                {
+                    PackageId = pointerId,
+                    PackageVersion = "1.0.0",
+                    Source = missingPointerPath,
+                },
+            },
+        ]);
+
+        WorkloadInstaller installer = NewInstaller(metadataReader: new WorkloadMetadataReader());
+        InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            installer.UpdateAsync(
+                pointerId,
+                targetInstalledVersion: null,
+                source: null,
+                includePrerelease: false,
+                allowMajor: false,
+                WorkloadOwnershipKind.Logical));
+
+        Assert.Contains("local package", ex.Message);
+        await _catalog.DidNotReceive().ResolveLatestVersionAsync(
+            Arg.Any<string>(),
+            Arg.Any<bool>(),
+            Arg.Any<NuGetVersion?>(),
+            Arg.Any<bool>(),
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateLogical_WithoutVersionTargetsHighestInstalledPointerVersion()
+    {
+        const string pointerId = "example.workload";
+        var source = new PackageSource("https://example.test/v3/index.json", "test");
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            LogicalEntry("1.0.0"),
+            LogicalEntry("2.0.0"),
+        ]);
+        _catalog.ResolveLatestVersionAsync(
+                pointerId,
+                false,
+                NuGetVersion.Parse("2.0.0"),
+                false,
+                source.Source,
+                Arg.Any<CancellationToken>())
+            .Returns((ResolvedPackage?)null);
+
+        WorkloadInstaller installer = NewInstaller();
+        WorkloadUpdateResult result = await installer.UpdateAsync(
+            pointerId,
+            targetInstalledVersion: null,
+            source: null,
+            includePrerelease: false,
+            allowMajor: false,
+            WorkloadOwnershipKind.Logical);
+
+        Assert.Equal("2.0.0", result.PreviousVersion);
+
+        WorkloadEntry LogicalEntry(string version) => new()
+        {
+            PackageId = $"example.workload.win-x64.{version}",
+            PackageVersion = version,
+            RuntimeIdentifier = "win-x64",
+            Source = source.Source,
+            IsExplicitlyInstalled = false,
+            LogicalPackage = new LogicalPackage
+            {
+                PackageId = pointerId,
+                PackageVersion = version,
+                Source = source.Source,
+            },
+        };
+    }
+
+    [Fact]
+    public async Task UpdateAsync_DoesNotReplaceDestinationInstalledFromDifferentSource()
+    {
+        WorkloadEntry current = ExistingEntry("test.workload", "1.0.0");
+        WorkloadEntry destination = new()
+        {
+            PackageId = "test.workload",
+            PackageVersion = "2.0.0",
+            Source = "https://different.test/v3/index.json",
+            IsExplicitlyInstalled = false,
+            LogicalPackage = new LogicalPackage
+            {
+                PackageId = "test.pointer",
+                PackageVersion = "2.0.0",
+            },
+        };
+        ResolvedPackage resolved = NewResolved("test.workload", "2.0.0");
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns([current, destination]);
+        _catalog.ResolveLatestVersionAsync(
+                "test.workload",
+                false,
+                Arg.Any<NuGetVersion?>(),
+                false,
+                null,
+                Arg.Any<CancellationToken>())
+            .Returns(resolved);
+
+        WorkloadInstaller installer = NewInstaller();
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => installer.UpdateAsync("test.workload", null, null, false, allowMajor: false));
+
+        Assert.Contains("different source", exception.Message);
+        await _catalog.DidNotReceive().DownloadAsync(
+            Arg.Any<ResolvedPackage>(),
+            Arg.Any<CancellationToken>());
+        await _store.DidNotReceive().MoveExplicitOwnershipAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<WorkloadEntry>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateLogical_OlderPointerVersionDoesNotDowngradeForRidChange()
+    {
+        const string pointerId = "example.workload";
+        WorkloadEntry current = new()
+        {
+            PackageId = "example.workload.incompatible-rid",
+            PackageVersion = "2.0.0",
+            RuntimeIdentifier = "incompatible-rid",
+            Source = "https://example.test/v3/index.json",
+            IsExplicitlyInstalled = false,
+            LogicalPackage = new LogicalPackage
+            {
+                PackageId = pointerId,
+                PackageVersion = "2.0.0",
+                Source = "https://example.test/v3/index.json",
+            },
+        };
+        ResolvedPackage olderPointer = NewResolved(pointerId, "1.0.0");
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns([current]);
+        _catalog.ResolveLatestVersionAsync(
+                pointerId,
+                false,
+                NuGetVersion.Parse("2.0.0"),
+                false,
+                current.Source,
+                Arg.Any<CancellationToken>())
+            .Returns(olderPointer);
+
+        WorkloadInstaller installer = NewInstaller();
+        WorkloadUpdateResult result = await installer.UpdateAsync(
+            pointerId,
+            targetInstalledVersion: null,
+            source: null,
+            includePrerelease: false,
+            allowMajor: false,
+            WorkloadOwnershipKind.Logical);
+
+        Assert.True(result.NoUpdateAvailable);
+        Assert.Equal("2.0.0", result.Entry.PackageVersion);
+        await _catalog.DidNotReceive().DownloadAsync(
+            Arg.Any<ResolvedPackage>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InstallFromPackage_LocalPointerUsesExactSibling()
+    {
+        string pointerPath = BuildPointerNupkg(
+            "example.workload",
+            "1.0.0",
+            """
+            {
+              "win-x64": "example.workload.win-x64"
+            }
+            """);
+        _ = BuildRidImplementationNupkg("example.workload.win-x64", "1.0.0", "win-x64");
+
+        WorkloadInstaller installer = NewInstaller(metadataReader: new WorkloadMetadataReader());
+        WorkloadInstallResult result = await installer.InstallFromPackageAsync(pointerPath);
+
+        Assert.Equal("example.workload.win-x64", result.Entry.PackageId);
+        Assert.Equal(Path.GetFullPath(pointerPath), result.Entry.LogicalPackage!.Source);
+        await _catalog.DidNotReceive().ResolveVersionAsync(
+            Arg.Any<string>(),
+            Arg.Any<NuGetVersion>(),
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InstallFromPackage_LocalPointerRidChange_MovesLogicalOwnership()
+    {
+        const string pointerId = "example.workload";
+        const string version = "1.0.0";
+        string pointerPath = BuildPointerNupkg(
+            pointerId,
+            version,
+            """{ "win-x64": "example.workload.win-x64" }""");
+        _ = BuildRidImplementationNupkg("example.workload.win-x64", version, "win-x64");
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            new WorkloadEntry
+            {
+                PackageId = "example.workload.linux-x64",
+                PackageVersion = version,
+                RuntimeIdentifier = "linux-x64",
+                IsExplicitlyInstalled = false,
+                LogicalPackage = new LogicalPackage
+                {
+                    PackageId = pointerId,
+                    PackageVersion = version,
+                    Source = pointerPath,
+                },
+            },
+        ]);
+
+        WorkloadInstaller installer = NewInstaller(metadataReader: new WorkloadMetadataReader());
+        WorkloadInstallResult result = await installer.InstallFromPackageAsync(pointerPath);
+
+        Assert.Equal("example.workload.win-x64", result.Entry.PackageId);
+        await _store.Received(1).MoveLogicalOwnershipAsync(
+            "example.workload.linux-x64",
+            version,
+            Arg.Is<WorkloadEntry>(entry =>
+                entry.PackageId == "example.workload.win-x64"
+                && entry.LogicalPackage!.PackageId == pointerId),
+            Arg.Any<CancellationToken>());
+        await _store.DidNotReceive().SaveWorkloadAsync(
+            Arg.Any<WorkloadEntry>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InstallFromPackage_LocalPointer_DoesNotReusePhysicalPackageFromDifferentSource()
+    {
+        const string pointerId = "example.workload";
+        const string implementationId = "example.workload.win-x64";
+        const string version = "1.0.0";
+        string pointerPath = BuildPointerNupkg(
+            pointerId,
+            version,
+            """{ "win-x64": "example.workload.win-x64" }""");
+        _ = BuildRidImplementationNupkg(implementationId, version, "win-x64");
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            new WorkloadEntry
+            {
+                PackageId = implementationId,
+                PackageVersion = version,
+                RuntimeIdentifier = "win-x64",
+                Source = "https://different.test/v3/index.json",
+                IsExplicitlyInstalled = true,
+            },
+        ]);
+
+        WorkloadInstaller installer = NewInstaller(metadataReader: new WorkloadMetadataReader());
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => installer.InstallFromPackageAsync(pointerPath));
+
+        Assert.Contains("different source", exception.Message);
+        await _store.DidNotReceive().AddOwnershipAsync(
+            Arg.Any<WorkloadEntry>(),
+            Arg.Any<WorkloadOwnershipKind>(),
+            Arg.Any<CancellationToken>());
+        await _store.DidNotReceive().SaveWorkloadAsync(
+            Arg.Any<WorkloadEntry>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InstallFromPackage_LocalPointerMissingSiblingDoesNotUseCatalog()
+    {
+        string pointerPath = BuildPointerNupkg(
+            "missing.workload",
+            "1.0.0",
+            """
+            {
+              "win-x64": "missing.workload.win-x64"
+            }
+            """);
+
+        WorkloadInstaller installer = NewInstaller(metadataReader: new WorkloadMetadataReader());
+        FileNotFoundException ex = await Assert.ThrowsAsync<FileNotFoundException>(
+            () => installer.InstallFromPackageAsync(pointerPath));
+
+        Assert.Contains("missing.workload.win-x64", ex.Message);
+        Assert.Contains(Path.GetDirectoryName(pointerPath)!, ex.Message);
+        Assert.Contains("No configured feed", ex.Message);
+        await _catalog.DidNotReceive().SearchAsync(
+            Arg.Any<CatalogSearchQuery>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InstallFromPackage_RidImplementationWithOrdinaryPackageTypeIsRejected()
+    {
+        string packagePath = BuildRidImplementationNupkg(
+            "example.workload.win-x64",
+            "1.0.0",
+            "win-x64",
+            WorkloadInstaller.FuncCliWorkloadPackageType);
+
+        WorkloadInstaller installer = NewInstaller(metadataReader: new WorkloadMetadataReader());
+        InvalidWorkloadException ex = await Assert.ThrowsAsync<InvalidWorkloadException>(
+            () => installer.InstallFromPackageAsync(packagePath));
+
+        Assert.Contains(WorkloadInstaller.FuncCliWorkloadRidPackageType, ex.Message);
+    }
+
+    [Fact]
+    public async Task InstallFromPackage_RidImplementationForDifferentRuntimeIsRejected()
+    {
+        string packagePath = BuildRidImplementationNupkg(
+            "example.workload.linux-x64",
+            "1.0.0",
+            "linux-x64");
+
+        WorkloadInstaller installer = NewInstaller(metadataReader: new WorkloadMetadataReader());
+        InvalidWorkloadException ex = await Assert.ThrowsAsync<InvalidWorkloadException>(
+            () => installer.InstallFromPackageAsync(packagePath));
+
+        Assert.Contains("current RID='win-x64'", ex.Message);
+        Assert.Contains("linux-x64", ex.Message);
+    }
+
     private static WorkloadEntry ExistingEntry(string id, string version) => new()
     {
         PackageId = id,
@@ -778,8 +1416,16 @@ public sealed class WorkloadInstallerTests : IDisposable
         NuGetVersion.Parse(version),
         new PackageSource("https://example/v3/index.json", "test"));
 
-    private WorkloadInstaller NewInstaller(bool includePrerelease = false)
-        => new(_paths, _store, _metadataReader, _catalog, Options.Create(new WorkloadCatalogOptions { IncludePrerelease = includePrerelease }));
+    private WorkloadInstaller NewInstaller(
+        bool includePrerelease = false,
+        IWorkloadMetadataReader? metadataReader = null)
+        => new(
+            _paths,
+            _store,
+            metadataReader ?? _metadataReader,
+            _catalog,
+            _runtimeIdentifierProvider,
+            Options.Create(new WorkloadCatalogOptions { IncludePrerelease = includePrerelease }));
 
     [Fact]
     public async Task InstallFromPackage_HostPackage_SetsExecutableBitOnHostBinary_OnUnix()
@@ -841,6 +1487,8 @@ public sealed class WorkloadInstallerTests : IDisposable
         string description = "For tests.",
         string id = "Test.Workload",
         string payloadFileName = "Test.dll",
+        string packageType = WorkloadInstaller.FuncCliWorkloadPackageType,
+        bool includePayload = true,
         IEnumerable<(string SourcePath, string TargetPath)>? extraFiles = null)
     {
         string stubAssembly = Path.Combine(_root, $"stub-{Guid.NewGuid():N}.dll");
@@ -867,14 +1515,17 @@ public sealed class WorkloadInstallerTests : IDisposable
 
         if (includeFuncCliWorkloadType)
         {
-            builder.PackageTypes.Add(new PackageType(WorkloadInstaller.FuncCliWorkloadPackageType, new Version(0, 0)));
+            builder.PackageTypes.Add(new PackageType(packageType, new Version(0, 0)));
         }
 
-        builder.Files.Add(new PhysicalPackageFile
+        if (includePayload)
         {
-            SourcePath = stubAssembly,
-            TargetPath = $"tools/{NuGetFramework.Parse("any").GetShortFolderName()}/{payloadFileName}",
-        });
+            builder.Files.Add(new PhysicalPackageFile
+            {
+                SourcePath = stubAssembly,
+                TargetPath = $"tools/{NuGetFramework.Parse("any").GetShortFolderName()}/{payloadFileName}",
+            });
+        }
 
         if (extraFiles is not null)
         {
@@ -891,6 +1542,49 @@ public sealed class WorkloadInstallerTests : IDisposable
         }
 
         return path;
+    }
+
+    private string BuildPointerNupkg(
+        string id,
+        string version,
+        string packagesJson)
+    {
+        string manifest = $$"""
+            {
+              "$schema": "{{WorkloadManifestSchema.PackageManifestV1Schema}}",
+              "kind": "rid-pointer",
+              "displayName": "Example workload",
+              "description": "Example pointer.",
+              "packages": {{packagesJson}}
+            }
+            """;
+        return BuildNupkg(
+            id: id,
+            version: version,
+            tags: "kind:rid-pointer alias:example",
+            includePayload: false,
+            extraFiles: [(WriteTempFile("workload.json", manifest), "workload.json")]);
+    }
+
+    private string BuildRidImplementationNupkg(
+        string id,
+        string version,
+        string runtimeIdentifier,
+        string packageType = WorkloadInstaller.FuncCliWorkloadRidPackageType)
+    {
+        string manifest = $$"""
+            {
+              "$schema": "{{WorkloadManifestSchema.PackageManifestV1Schema}}",
+              "kind": "content",
+              "runtimeIdentifier": "{{runtimeIdentifier}}"
+            }
+            """;
+        return BuildNupkg(
+            id: id,
+            version: version,
+            tags: $"kind:content rid:{runtimeIdentifier}",
+            packageType: packageType,
+            extraFiles: [(WriteTempFile("workload.json", manifest), "workload.json")]);
     }
 
     private string WriteTempFile(string name, string contents)

--- a/test/Func.Tests/Workloads/Loading/WorkloadLoaderTests.cs
+++ b/test/Func.Tests/Workloads/Loading/WorkloadLoaderTests.cs
@@ -56,6 +56,47 @@ public class WorkloadLoaderTests
     }
 
     [Fact]
+    public void Load_InvalidWorkloadForDifferentRid_IncludesUpdateGuidance()
+    {
+        var runtimeIdentifierProvider = Substitute.For<IWorkloadRuntimeIdentifierProvider>();
+        runtimeIdentifierProvider.Current.Returns("linux-x64");
+        var loader = new WorkloadLoader(StubPaths(), runtimeIdentifierProvider);
+        WorkloadEntry entry = FixtureEntry(
+            FixturePackageId,
+            assemblyFileOverride: "DoesNotExist.dll",
+            runtimeIdentifier: "win-x64",
+            logicalPackage: new LogicalPackage
+            {
+                PackageId = "Fixture.Pointer",
+                PackageVersion = "1.0.0",
+            });
+
+        InvalidWorkloadException ex = Assert.Throws<InvalidWorkloadException>(() => loader.Load([entry]));
+
+        Assert.Contains("targets runtime identifier 'win-x64'", ex.Message);
+        Assert.Contains("this machine uses 'linux-x64'", ex.Message);
+        Assert.Contains("func workload update Fixture.Pointer", ex.Message);
+        Assert.IsType<InvalidWorkloadException>(ex.InnerException);
+    }
+
+    [Fact]
+    public void Load_InvalidWorkloadForCurrentRid_DoesNotIncludeUpdateGuidance()
+    {
+        var runtimeIdentifierProvider = Substitute.For<IWorkloadRuntimeIdentifierProvider>();
+        runtimeIdentifierProvider.Current.Returns("win-x64");
+        var loader = new WorkloadLoader(StubPaths(), runtimeIdentifierProvider);
+        WorkloadEntry entry = FixtureEntry(
+            FixturePackageId,
+            assemblyFileOverride: "DoesNotExist.dll",
+            runtimeIdentifier: "win-x64");
+
+        InvalidWorkloadException ex = Assert.Throws<InvalidWorkloadException>(() => loader.Load([entry]));
+
+        Assert.DoesNotContain("func workload update", ex.Message);
+        Assert.Null(ex.InnerException);
+    }
+
+    [Fact]
     public void Load_Throws_WhenTypeNotFoundInAssembly()
     {
         var loader = new WorkloadLoader(StubPaths());
@@ -334,10 +375,14 @@ public class WorkloadLoaderTests
     private static WorkloadEntry FixtureEntry(
         string packageId,
         string? assemblyFileOverride = null,
-        string? typeNameOverride = null) => new()
+        string? typeNameOverride = null,
+        string? runtimeIdentifier = null,
+        LogicalPackage? logicalPackage = null) => new()
         {
             PackageId = packageId,
             PackageVersion = "1.0.0",
+            RuntimeIdentifier = runtimeIdentifier,
+            LogicalPackage = logicalPackage,
             EntryPoint = new EntryPointSpec
             {
                 AssemblyPath = assemblyFileOverride ?? FixtureAssemblyFile,

--- a/test/Func.Tests/Workloads/PythonWorkerWorkloadPackageTests.cs
+++ b/test/Func.Tests/Workloads/PythonWorkerWorkloadPackageTests.cs
@@ -36,17 +36,9 @@ public sealed class PythonWorkerWorkloadPackageTests
         PythonWorkerWorkloadPackage.CurrentPackageId.Should().StartWith(PythonWorkerWorkloadPackage.PackageIdPrefix);
     }
 
-    [Theory]
-    [InlineData("win-x64", true)]
-    [InlineData("linux-x64", true)]
-    [InlineData("linux-arm64", true)]
-    [InlineData("osx-x64", true)]
-    [InlineData("osx-arm64", true)]
-    [InlineData("WIN-X64", true)]
-    [InlineData("win-arm64", false)]
-    [InlineData("freebsd-x64", false)]
-    public void IsSupported_MatchesPublishedRids(string runtimeIdentifier, bool expected)
+    [Fact]
+    public void PackageId_IsRidPointerPackageId()
     {
-        PythonWorkerWorkloadPackage.IsSupported(runtimeIdentifier).Should().Be(expected);
+        PythonWorkerWorkloadPackage.PackageId.Should().Be("Azure.Functions.Cli.Workloads.Workers.Python");
     }
 }

--- a/test/Func.Tests/Workloads/Storage/WorkloadStoreTests.cs
+++ b/test/Func.Tests/Workloads/Storage/WorkloadStoreTests.cs
@@ -107,6 +107,17 @@ public class WorkloadStoreTests : IDisposable
             PackageId = "Azure.Functions.Cli.Workloads.Dotnet",
             PackageVersion = "1.0.0",
             Aliases = ["dotnet", "dotnet-isolated"],
+            RuntimeIdentifier = "linux-x64",
+            IsExplicitlyInstalled = false,
+            LogicalPackage = new LogicalPackage
+            {
+                PackageId = "Azure.Functions.Cli.Workloads.Dotnet",
+                PackageVersion = "1.0.0",
+                Aliases = ["dotnet"],
+                DisplayName = "Azure Functions .NET workload",
+                Description = "Logical package.",
+                Source = "https://example.test/v3/index.json",
+            },
             EntryPoint = new EntryPointSpec
             {
                 AssemblyPath = "lib/net10.0/Foo.dll",
@@ -120,6 +131,10 @@ public class WorkloadStoreTests : IDisposable
         actual.PackageId.Should().Be(entry.PackageId);
         actual.PackageVersion.Should().Be(entry.PackageVersion);
         actual.Aliases.Should().Equal(entry.Aliases);
+        actual.RuntimeIdentifier.Should().Be("linux-x64");
+        actual.IsExplicitlyInstalled.Should().BeFalse();
+        actual.LogicalPackage!.PackageId.Should().Be(entry.LogicalPackage.PackageId);
+        actual.LogicalPackage.Source.Should().Be(entry.LogicalPackage.Source);
         actual.EntryPoint!.AssemblyPath.Should().Be(entry.EntryPoint!.AssemblyPath);
         actual.EntryPoint.Type.Should().Be(entry.EntryPoint.Type);
     }
@@ -184,12 +199,147 @@ public class WorkloadStoreTests : IDisposable
         Directory.GetFiles(_tempHome, "*.json.tmp").Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task GetWorkloadsAsync_LegacyEntryDefaultsToExplicitOwnership()
+    {
+        Directory.CreateDirectory(_tempHome);
+        await File.WriteAllTextAsync(
+            _paths.WorkloadRegistryPath,
+            $$"""
+            {
+              "$schema": "{{WorkloadManifestSchema.RegistryV1Schema}}",
+              "workloads": [
+                {
+                  "packageId": "legacy.package",
+                  "packageVersion": "1.0.0",
+                  "installRefCount": 1
+                }
+              ],
+              "metas": []
+            }
+            """);
+
+        WorkloadEntry entry = Assert.Single(await _store.GetWorkloadsAsync());
+
+        Assert.True(entry.IsExplicitlyInstalled);
+        Assert.Null(entry.LogicalPackage);
+        Assert.Null(entry.RuntimeIdentifier);
+    }
+
+    [Fact]
+    public async Task AddOwnershipAsync_AttachesLogicalOwnershipIdempotently()
+    {
+        await _store.SaveWorkloadAsync(NewEntry("pkg.win-x64", "1.0.0"));
+        WorkloadEntry pointerEntry = NewPointerEntry("pkg.win-x64", "1.0.0");
+
+        WorkloadEntry first = await _store.AddOwnershipAsync(pointerEntry, WorkloadOwnershipKind.Logical);
+        WorkloadEntry second = await _store.AddOwnershipAsync(pointerEntry, WorkloadOwnershipKind.Logical);
+
+        Assert.True(first.IsExplicitlyInstalled);
+        Assert.NotNull(first.LogicalPackage);
+        Assert.Equal(2, first.InstallRefCount);
+        Assert.Equal(2, second.InstallRefCount);
+    }
+
+    [Fact]
+    public async Task RemoveOwnershipAsync_RemovesOnlyExplicitOwner()
+    {
+        WorkloadEntry pointerEntry = NewPointerEntry("pkg.win-x64", "1.0.0");
+        WorkloadEntry entry = new()
+        {
+            PackageId = pointerEntry.PackageId,
+            PackageVersion = pointerEntry.PackageVersion,
+            Kind = pointerEntry.Kind,
+            RuntimeIdentifier = pointerEntry.RuntimeIdentifier,
+            LogicalPackage = pointerEntry.LogicalPackage,
+            IsExplicitlyInstalled = true,
+            InstallRefCount = 2,
+        };
+        await _store.SaveWorkloadAsync(entry);
+
+        WorkloadOwnershipRemovalResult result = await _store.RemoveOwnershipAsync(
+            entry.PackageId,
+            entry.PackageVersion,
+            WorkloadOwnershipKind.Explicit);
+
+        Assert.True(result.OwnershipRemoved);
+        Assert.False(result.EntryRemoved);
+        Assert.False(result.Entry!.IsExplicitlyInstalled);
+        Assert.NotNull(result.Entry.LogicalPackage);
+        Assert.Equal(1, result.Entry.InstallRefCount);
+    }
+
+    [Fact]
+    public async Task MoveLogicalOwnershipAsync_RetainsExplicitOldRow()
+    {
+        WorkloadEntry oldEntry = new()
+        {
+            PackageId = "pkg.win-x64",
+            PackageVersion = "1.0.0",
+            RuntimeIdentifier = "win-x64",
+            IsExplicitlyInstalled = true,
+            LogicalPackage = NewPointerEntry("pkg.win-x64", "1.0.0").LogicalPackage,
+            InstallRefCount = 2,
+        };
+        await _store.SaveWorkloadAsync(oldEntry);
+
+        WorkloadOwnershipMoveResult result = await _store.MoveLogicalOwnershipAsync(
+            oldEntry.PackageId,
+            oldEntry.PackageVersion,
+            NewPointerEntry("pkg.win-x64", "2.0.0"));
+
+        Assert.False(result.PreviousEntryRemoved);
+        IReadOnlyList<WorkloadEntry> entries = await _store.GetWorkloadsAsync();
+        WorkloadEntry retained = Assert.Single(entries, e => e.PackageVersion == "1.0.0");
+        Assert.True(retained.IsExplicitlyInstalled);
+        Assert.Null(retained.LogicalPackage);
+        Assert.Equal(1, retained.InstallRefCount);
+        Assert.Single(entries, e => e.PackageVersion == "2.0.0");
+    }
+
+    [Fact]
+    public void WorkloadKindJsonConverter_RoundTripsRidPointerWireValue()
+    {
+        string json = JsonSerializer.Serialize(
+            new WorkloadMetadata
+            {
+                Schema = WorkloadManifestSchema.PackageManifestV1Schema,
+                Kind = WorkloadKind.RidPointer,
+                Packages = new Dictionary<string, string> { ["win-x64"] = "pkg.win-x64" },
+            },
+            WorkloadJsonContext.Default.WorkloadMetadata);
+
+        Assert.Contains("\"kind\":\"rid-pointer\"", json);
+        WorkloadMetadata actual = JsonSerializer.Deserialize(json, WorkloadJsonContext.Default.WorkloadMetadata)!;
+        Assert.Equal(WorkloadKind.RidPointer, actual.Kind);
+    }
+
     private static WorkloadEntry NewEntry(string packageId, string version, string entryAssembly = "x.dll")
         => new()
         {
             PackageId = packageId,
             PackageVersion = version,
             EntryPoint = new EntryPointSpec { AssemblyPath = entryAssembly, Type = "X" },
+        };
+
+    private static WorkloadEntry NewPointerEntry(string packageId, string version)
+        => new()
+        {
+            PackageId = packageId,
+            PackageVersion = version,
+            Kind = WorkloadKind.Content,
+            RuntimeIdentifier = "win-x64",
+            IsExplicitlyInstalled = false,
+            LogicalPackage = new LogicalPackage
+            {
+                PackageId = "pkg",
+                PackageVersion = version,
+                Aliases = ["pkg"],
+                DisplayName = "Package",
+                Description = "Logical package.",
+                Source = "https://example.test/v3/index.json",
+            },
+            InstallRefCount = 1,
         };
 
     private sealed class ThrowingSerializeStore(IWorkloadPaths paths) : WorkloadStore(paths)

--- a/test/Func.Tests/Workloads/Storage/WorkloadStoreTests.cs
+++ b/test/Func.Tests/Workloads/Storage/WorkloadStoreTests.cs
@@ -227,6 +227,57 @@ public class WorkloadStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task GetWorkloadsAsync_ExplicitFalseIsPreserved()
+    {
+        Directory.CreateDirectory(_tempHome);
+        await File.WriteAllTextAsync(
+            _paths.WorkloadRegistryPath,
+            $$"""
+            {
+              "$schema": "{{WorkloadManifestSchema.RegistryV1Schema}}",
+              "workloads": [
+                {
+                  "packageId": "pkg.win-x64",
+                  "packageVersion": "1.0.0",
+                  "runtimeIdentifier": "win-x64",
+                  "isExplicitlyInstalled": false,
+                  "logicalPackage": {
+                    "packageId": "pkg",
+                    "packageVersion": "1.0.0"
+                  },
+                  "installRefCount": 1
+                }
+              ],
+              "metas": []
+            }
+            """);
+
+        WorkloadEntry entry = Assert.Single(await _store.GetWorkloadsAsync());
+
+        Assert.False(entry.IsExplicitlyInstalled);
+        Assert.NotNull(entry.LogicalPackage);
+    }
+
+    [Fact]
+    public async Task AddOwnershipAsync_ThrowsWhenRowAlreadyHasDifferentLogicalOwner()
+    {
+        await _store.SaveWorkloadAsync(NewPointerEntry("pkg.win-x64", "1.0.0"));
+        WorkloadEntry conflicting = new()
+        {
+            PackageId = "pkg.win-x64",
+            PackageVersion = "1.0.0",
+            Kind = WorkloadKind.Content,
+            RuntimeIdentifier = "win-x64",
+            IsExplicitlyInstalled = false,
+            LogicalPackage = new LogicalPackage { PackageId = "other.pkg", PackageVersion = "1.0.0" },
+            InstallRefCount = 1,
+        };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _store.AddOwnershipAsync(conflicting, WorkloadOwnershipKind.Logical));
+    }
+
+    [Fact]
     public async Task AddOwnershipAsync_AttachesLogicalOwnershipIdempotently()
     {
         await _store.SaveWorkloadAsync(NewEntry("pkg.win-x64", "1.0.0"));

--- a/test/Workloads/Sdk.Tests/Tasks/WriteWorkloadJsonTests.cs
+++ b/test/Workloads/Sdk.Tests/Tasks/WriteWorkloadJsonTests.cs
@@ -207,8 +207,19 @@ public sealed class WriteWorkloadJsonTests : IDisposable
         task.InnerPackages =
         [
             CreateTaskItem("My.Package.win-x64", "win-x64"),
-            CreateTaskItem("My.Package.WIN-X64", "WIN-X64"),
+            CreateTaskItem("My.Package.win-x64", "win-x64"),
         ];
+
+        Assert.False(task.Execute());
+        Assert.False(File.Exists(outputPath));
+    }
+
+    [Fact]
+    public void Execute_PointerWithNonLowercaseRuntimeIdentifier_Fails()
+    {
+        string outputPath = Path.Combine(_tempDir, "workload.json");
+        WriteWorkloadJson task = CreateTask(outputPath, kind: "rid-pointer");
+        task.InnerPackages = [CreateTaskItem("My.Package.WIN-X64", "WIN-X64")];
 
         Assert.False(task.Execute());
         Assert.False(File.Exists(outputPath));

--- a/test/Workloads/Sdk.Tests/Tasks/WriteWorkloadJsonTests.cs
+++ b/test/Workloads/Sdk.Tests/Tasks/WriteWorkloadJsonTests.cs
@@ -40,6 +40,7 @@ public sealed class WriteWorkloadJsonTests : IDisposable
         doc.RootElement.GetProperty("kind").GetString().Should().Be("content");
         doc.RootElement.TryGetProperty("entryPoint", out _).Should().BeFalse();
         doc.RootElement.TryGetProperty("packages", out _).Should().BeFalse();
+        doc.RootElement.TryGetProperty("runtimeIdentifier", out _).Should().BeFalse();
     }
 
     [Fact]
@@ -67,8 +68,7 @@ public sealed class WriteWorkloadJsonTests : IDisposable
     public void Execute_WithInnerPackages_WritesPackagesMap()
     {
         string outputPath = Path.Combine(_tempDir, "workload.json");
-        WriteWorkloadJson task = CreateTask(outputPath, kind: "workload",
-            entryPointAssemblyPath: "W.dll", entryPointType: "W.Type");
+        WriteWorkloadJson task = CreateTask(outputPath, kind: "rid-pointer");
         task.InnerPackages =
         [
             CreateTaskItem("My.Package.win-x64", "win-x64"),
@@ -97,29 +97,25 @@ public sealed class WriteWorkloadJsonTests : IDisposable
     }
 
     [Fact]
-    public void Execute_EmptyEntryPointAssemblyPath_OmitsEntryPoint()
+    public void Execute_WorkloadWithEmptyEntryPointAssemblyPath_Fails()
     {
         string outputPath = Path.Combine(_tempDir, "workload.json");
         WriteWorkloadJson task = CreateTask(outputPath, kind: "workload",
             entryPointAssemblyPath: "", entryPointType: "Some.Type");
 
-        task.Execute();
-
-        JsonDocument doc = ParseOutput(outputPath);
-        doc.RootElement.TryGetProperty("entryPoint", out _).Should().BeFalse();
+        task.Execute().Should().BeFalse();
+        File.Exists(outputPath).Should().BeFalse();
     }
 
     [Fact]
-    public void Execute_EmptyEntryPointType_OmitsEntryPoint()
+    public void Execute_WorkloadWithEmptyEntryPointType_Fails()
     {
         string outputPath = Path.Combine(_tempDir, "workload.json");
         WriteWorkloadJson task = CreateTask(outputPath, kind: "workload",
             entryPointAssemblyPath: "Some.dll", entryPointType: "");
 
-        task.Execute();
-
-        JsonDocument doc = ParseOutput(outputPath);
-        doc.RootElement.TryGetProperty("entryPoint", out _).Should().BeFalse();
+        task.Execute().Should().BeFalse();
+        File.Exists(outputPath).Should().BeFalse();
     }
 
     [Fact]
@@ -133,6 +129,89 @@ public sealed class WriteWorkloadJsonTests : IDisposable
 
         JsonDocument doc = ParseOutput(outputPath);
         doc.RootElement.TryGetProperty("packages", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Execute_RidImplementation_WritesRuntimeIdentifier()
+    {
+        string outputPath = Path.Combine(_tempDir, "workload.json");
+        WriteWorkloadJson task = CreateTask(outputPath, kind: "content");
+        task.RuntimeIdentifier = "win-x64";
+
+        Assert.True(task.Execute());
+
+        JsonDocument doc = ParseOutput(outputPath);
+        Assert.Equal("win-x64", doc.RootElement.GetProperty("runtimeIdentifier").GetString());
+    }
+
+    [Fact]
+    public void Execute_RidPointerWithoutInnerPackages_Fails()
+    {
+        string outputPath = Path.Combine(_tempDir, "workload.json");
+        WriteWorkloadJson task = CreateTask(outputPath, kind: "rid-pointer");
+
+        Assert.False(task.Execute());
+        Assert.False(File.Exists(outputPath));
+    }
+
+    [Fact]
+    public void Execute_NonPointerWithInnerPackages_Fails()
+    {
+        string outputPath = Path.Combine(_tempDir, "workload.json");
+        WriteWorkloadJson task = CreateTask(outputPath, kind: "content");
+        task.InnerPackages = [CreateTaskItem("My.Package.win-x64", "win-x64")];
+
+        Assert.False(task.Execute());
+        Assert.False(File.Exists(outputPath));
+    }
+
+    [Fact]
+    public void Execute_PointerWithRuntimeIdentifier_Fails()
+    {
+        string outputPath = Path.Combine(_tempDir, "workload.json");
+        WriteWorkloadJson task = CreateTask(outputPath, kind: "rid-pointer");
+        task.RuntimeIdentifier = "win-x64";
+        task.InnerPackages = [CreateTaskItem("My.Package.win-x64", "win-x64")];
+
+        Assert.False(task.Execute());
+        Assert.False(File.Exists(outputPath));
+    }
+
+    [Fact]
+    public void Execute_UppercaseRuntimeIdentifier_Fails()
+    {
+        string outputPath = Path.Combine(_tempDir, "workload.json");
+        WriteWorkloadJson task = CreateTask(outputPath, kind: "content");
+        task.RuntimeIdentifier = "WIN-X64";
+
+        Assert.False(task.Execute());
+        Assert.False(File.Exists(outputPath));
+    }
+
+    [Fact]
+    public void Execute_PointerWithMismatchedImplementationId_Fails()
+    {
+        string outputPath = Path.Combine(_tempDir, "workload.json");
+        WriteWorkloadJson task = CreateTask(outputPath, kind: "rid-pointer");
+        task.InnerPackages = [CreateTaskItem("Other.Package.win-x64", "win-x64")];
+
+        Assert.False(task.Execute());
+        Assert.False(File.Exists(outputPath));
+    }
+
+    [Fact]
+    public void Execute_PointerWithDuplicateRuntimeIdentifiers_Fails()
+    {
+        string outputPath = Path.Combine(_tempDir, "workload.json");
+        WriteWorkloadJson task = CreateTask(outputPath, kind: "rid-pointer");
+        task.InnerPackages =
+        [
+            CreateTaskItem("My.Package.win-x64", "win-x64"),
+            CreateTaskItem("My.Package.WIN-X64", "WIN-X64"),
+        ];
+
+        Assert.False(task.Execute());
+        Assert.False(File.Exists(outputPath));
     }
 
     [Fact]
@@ -189,9 +268,9 @@ public sealed class WriteWorkloadJsonTests : IDisposable
     public void Execute_OutputIsValidJson()
     {
         string outputPath = Path.Combine(_tempDir, "workload.json");
-        WriteWorkloadJson task = CreateTask(outputPath, kind: "workload",
-            entryPointAssemblyPath: "Test.dll", entryPointType: "Test.Workload");
+        WriteWorkloadJson task = CreateTask(outputPath, kind: "rid-pointer");
         task.InnerPackages = [CreateTaskItem("Pkg.win-x64", "win-x64")];
+        task.PackageId = "Pkg";
 
         task.Execute();
 
@@ -213,6 +292,7 @@ public sealed class WriteWorkloadJsonTests : IDisposable
             OutputPath = outputPath,
             Schema = schema,
             Kind = kind,
+            PackageId = "My.Package",
             EntryPointAssemblyPath = entryPointAssemblyPath,
             EntryPointType = entryPointType,
             InnerPackages = [],


### PR DESCRIPTION
### Issue describing the changes in this PR

N/A

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [x] Otherwise: Documentation is updated in this PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

Adds RID-pointer workload packages while preserving schema v1 and legacy installed registry rows.

* Authors payload-free `FuncCliWorkload` pointer packages with exact RID-to-package maps.
* Authors `FuncCliWorkloadRidPackage` implementations with required `runtimeIdentifier` metadata.
* Resolves implementations by exact package ID and pointer version from the pointer source, including deterministic local sibling resolution.
* Tracks physical payload ownership across explicit installs, logical pointers, and meta workloads for safe install, update, uninstall, list, and prune behavior.
* Prevents incompatible-RID activation and integrates logical identities with host, setup, and Python worker flows.

User-visible behavior: installing a multi-RID workload by its logical package ID now selects the implementation for the current RID while lifecycle commands continue to present the logical identity.

Installed packages are keyed on package ID and version only, matching the NuGet global packages folder. A payload already installed from one feed is reused when a pointer resolved from another feed maps to the same ID and version, rather than failing. Source is still recorded and still pins pointer implementation resolution to the feed that supplied the pointer.

Also fixes a bug where the payload content root was hardcoded to `tools/any`, so RID-specific host packs never received the executable bit on Linux and macOS.

Validation:

* `dotnet restore`
* `CI=true dotnet build -c Release --no-restore` (0 warnings, 0 errors)
* Release test suite across Func and workload test projects
* Real Host workload pack inspection: one payload-free pointer plus six exact-version RID implementation packages
* Local NuGet v3 feed end-to-end install/list/update/uninstall validation