### PR TITLE
Bump Node.js engines requirement from >=20 to >=22

### DIFF
--- a/eng/tools/publish-tools/npm/package.json
+++ b/eng/tools/publish-tools/npm/package.json
@@ -25,7 +25,7 @@
     "linux"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "dependencies": {
     "chalk": "^4.1.2",


### PR DESCRIPTION
## Summary

Updates the `engines.node` field in `eng/tools/publish-tools/npm/package.json` from `>=20` to `>=22`.

## Motivation

- **chalk 6.0.0** (being adopted in #5499) requires Node.js 22+. Without this change, users on Node 20 would pass the engines check but hit runtime failures from chalk.
- **Node 20 LTS reached EOL in April 2026** and is no longer receiving security updates.
- All other dependencies already support Node 22+:
  | Dependency | Node requirement |
  |---|---|
  | chalk ^6.0.0 | >=22 |
  | rimraf ^6.1.3 | 20 \|\| >=22 |
  | https-proxy-agent 9.1.0 | >=20 |
  | extract-zip ^2.0.1 | >=10 |

## Changes

- `eng/tools/publish-tools/npm/package.json`: `"node": ">=20"` → `"node": ">=22"`

## Related

- #5499 (chalk 4→6 bump)