### PR TITLE
Consolidate duplicate process execution utilities across CLI and workloads

### DIFF
--- a/src/Abstractions/Common/IProcessRunner.cs
+++ b/src/Abstractions/Common/IProcessRunner.cs
@@ -1,21 +1,20 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Azure.Functions.Cli.Commands.Start.Azurite.Processes;
+namespace Azure.Functions.Cli.Common;
 
 /// <summary>
 /// Launches short-lived child processes for the CLI. Wraps
-/// <see cref="System.Diagnostics.Process"/> behind a substitutable seam so the
-/// rest of the Azurite discovery code can be unit-tested without spawning real
-/// processes.
+/// <see cref="System.Diagnostics.Process"/> behind a substitutable seam so
+/// callers can be unit-tested without spawning real processes.
 /// </summary>
-internal interface IProcessRunner
+public interface IProcessRunner
 {
     /// <summary>
     /// Runs the requested process to completion (or to the configured timeout).
     /// </summary>
     /// <param name="request">The process invocation to perform.</param>
-    /// <param name="cancellationToken">Caller cancellation token. When triggered, the process is killed and the returned outcome reports <see cref="ProcessOutcome.TimedOut"/> as <c>false</c>; cancellation surfaces as <see cref="OperationCanceledException"/>.</param>
+    /// <param name="cancellationToken">Caller cancellation token. When triggered, the process is killed and cancellation surfaces as <see cref="OperationCanceledException"/>.</param>
     /// <returns>The captured <see cref="ProcessOutcome"/>. Never <c>null</c>.</returns>
     public Task<ProcessOutcome> RunAsync(ProcessRunRequest request, CancellationToken cancellationToken);
 }

--- a/src/Abstractions/Common/ProcessExecutionException.cs
+++ b/src/Abstractions/Common/ProcessExecutionException.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Common;
+
+/// <summary>
+/// Base exception for child process failures. Carries the exit code, captured
+/// output streams, and the command string so callers can inspect any of them
+/// without down-casting to a tool-specific subclass.
+/// </summary>
+public class ProcessExecutionException(int exitCode, string standardError, string standardOutput, string command, Exception? innerException = null)
+    : Exception(BuildMessage(exitCode, standardError, command), innerException)
+{
+    /// <summary>
+    /// The process exit code.
+    /// </summary>
+    public int ExitCode { get; } = exitCode;
+
+    /// <summary>
+    /// Captured standard error output.
+    /// </summary>
+    public string StandardError { get; } = standardError;
+
+    /// <summary>
+    /// Captured standard output.
+    /// </summary>
+    public string StandardOutput { get; } = standardOutput;
+
+    /// <summary>
+    /// The command string that was executed.
+    /// </summary>
+    public string Command { get; } = command;
+
+    private static string BuildMessage(int exitCode, string stderr, string command)
+    {
+        return $"'{command}' failed with exit code {exitCode}.{Environment.NewLine}{stderr}".TrimEnd();
+    }
+}

--- a/src/Abstractions/Common/ProcessOutcome.cs
+++ b/src/Abstractions/Common/ProcessOutcome.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Azure.Functions.Cli.Commands.Start.Azurite.Processes;
+namespace Azure.Functions.Cli.Common;
 
 /// <summary>
 /// Captured outcome of a child process invocation.
@@ -11,4 +11,4 @@ namespace Azure.Functions.Cli.Commands.Start.Azurite.Processes;
 /// <param name="StandardError">Captured standard error, possibly empty.</param>
 /// <param name="TimedOut"><c>true</c> when the process was killed because the per-request timeout elapsed.</param>
 /// <param name="ExecutableNotFound"><c>true</c> when the executable could not be located on the host.</param>
-internal sealed record ProcessOutcome(int? ExitCode, string StandardOutput, string StandardError, bool TimedOut, bool ExecutableNotFound);
+public sealed record ProcessOutcome(int? ExitCode, string StandardOutput, string StandardError, bool TimedOut, bool ExecutableNotFound);

--- a/src/Abstractions/Common/ProcessRunRequest.cs
+++ b/src/Abstractions/Common/ProcessRunRequest.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Common;
+
+/// <summary>
+/// Describes a child process invocation routed through <see cref="IProcessRunner"/>.
+/// </summary>
+/// <summary>
+/// Describes a child process invocation routed through <see cref="IProcessRunner"/>.
+/// </summary>
+/// <param name="FileName">The executable to run.</param>
+/// <param name="Arguments">Command-line arguments.</param>
+/// <param name="WorkingDirectory">Optional working directory for the process.</param>
+/// <param name="Timeout">Maximum time to wait for the process to exit.</param>
+/// <param name="EnvironmentVariables">Optional per-process environment variable overrides.</param>
+public sealed record ProcessRunRequest(string FileName, IReadOnlyList<string> Arguments, string? WorkingDirectory, TimeSpan Timeout, IReadOnlyDictionary<string, string>? EnvironmentVariables = null);

--- a/src/Abstractions/Common/ProcessRunner.cs
+++ b/src/Abstractions/Common/ProcessRunner.cs
@@ -5,7 +5,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Text;
 
-namespace Azure.Functions.Cli.Commands.Start.Azurite.Processes;
+namespace Azure.Functions.Cli.Common;
 
 /// <inheritdoc cref="IProcessRunner" />
 internal sealed class ProcessRunner : IProcessRunner
@@ -31,6 +31,14 @@ internal sealed class ProcessRunner : IProcessRunner
         foreach (string arg in request.Arguments)
         {
             startInfo.ArgumentList.Add(arg);
+        }
+
+        if (request.EnvironmentVariables is not null)
+        {
+            foreach (KeyValuePair<string, string> kvp in request.EnvironmentVariables)
+            {
+                startInfo.Environment[kvp.Key] = kvp.Value;
+            }
         }
 
         using Process process = new() { StartInfo = startInfo };

--- a/src/Func/Commands/Start/Azurite/AzuriteExecutableLocator.cs
+++ b/src/Func/Commands/Start/Azurite/AzuriteExecutableLocator.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Azure.Functions.Cli.Commands.Start.Azurite.Processes;
+using Azure.Functions.Cli.Common;
 
 namespace Azure.Functions.Cli.Commands.Start.Azurite;
 

--- a/src/Func/Commands/Start/Azurite/AzuriteServiceCollectionExtensions.cs
+++ b/src/Func/Commands/Start/Azurite/AzuriteServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 using Azure.Functions.Cli.Commands.Start.Azurite.Launching;
 using Azure.Functions.Cli.Commands.Start.Azurite.Orchestration;
 using Azure.Functions.Cli.Commands.Start.Azurite.Processes;
+using Azure.Functions.Cli.Common;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -70,7 +71,6 @@ internal static class AzuriteServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.TryAddSingleton<IAzuriteHostEnvironment, AzuriteHostEnvironment>();
-        services.TryAddSingleton<IProcessRunner, ProcessRunner>();
         services.TryAddSingleton<IAzuriteExecutableLocator, AzuriteExecutableLocator>();
         services.TryAddSingleton<IDockerAvailabilityProbe, DockerAvailabilityProbe>();
         services.TryAddSingleton<IPortOwnershipStrategy>(

--- a/src/Func/Commands/Start/Azurite/DockerAvailabilityProbe.cs
+++ b/src/Func/Commands/Start/Azurite/DockerAvailabilityProbe.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Azure.Functions.Cli.Commands.Start.Azurite.Processes;
+using Azure.Functions.Cli.Common;
 
 namespace Azure.Functions.Cli.Commands.Start.Azurite;
 

--- a/src/Func/Commands/Start/Azurite/Orchestration/ManagedAzuriteOrchestrator.cs
+++ b/src/Func/Commands/Start/Azurite/Orchestration/ManagedAzuriteOrchestrator.cs
@@ -4,6 +4,7 @@
 using System.Text;
 using Azure.Functions.Cli.Commands.Start.Azurite.Launching;
 using Azure.Functions.Cli.Commands.Start.Azurite.Processes;
+using Azure.Functions.Cli.Common;
 using Microsoft.Extensions.Logging;
 
 namespace Azure.Functions.Cli.Commands.Start.Azurite.Orchestration;

--- a/src/Func/Commands/Start/Azurite/Processes/ListeningProcessInspector.cs
+++ b/src/Func/Commands/Start/Azurite/Processes/ListeningProcessInspector.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Common;
 using Microsoft.Extensions.Logging;
 
 namespace Azure.Functions.Cli.Commands.Start.Azurite.Processes;

--- a/src/Func/Commands/Start/Azurite/Processes/ProcessRunRequest.cs
+++ b/src/Func/Commands/Start/Azurite/Processes/ProcessRunRequest.cs
@@ -1,9 +1,0 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
-
-namespace Azure.Functions.Cli.Commands.Start.Azurite.Processes;
-
-/// <summary>
-/// Describes a child process invocation routed through <see cref="IProcessRunner"/>.
-/// </summary>
-internal sealed record ProcessRunRequest(string FileName, IReadOnlyList<string> Arguments, string? WorkingDirectory, TimeSpan Timeout);

--- a/src/Func/Hosting/CliHostFactory.cs
+++ b/src/Func/Hosting/CliHostFactory.cs
@@ -92,6 +92,7 @@ internal static class CliHostFactory
         }
 
         builder.Services.AddSingleton<IProcessEnvironment, ProcessEnvironment>();
+        builder.Services.AddSingleton<IProcessRunner, ProcessRunner>();
         builder.Services.AddSingleton<FuncAliasNudge>();
         builder.Services.AddSingleton<IWorkerConfigFileSystem, WorkerConfigFileSystem>();
         builder.Services.AddSingleton<IFunctionsWorkerContentResolver, DefaultFunctionsWorkerContentResolver>();

--- a/src/Func/Quickstart/GitRunner.cs
+++ b/src/Func/Quickstart/GitRunner.cs
@@ -1,8 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.ComponentModel;
-using System.Diagnostics;
+using Azure.Functions.Cli.Common;
 
 namespace Azure.Functions.Cli.Quickstart;
 
@@ -10,9 +9,20 @@ namespace Azure.Functions.Cli.Quickstart;
 /// Executes <c>git</c> CLI commands in a child process with environment
 /// variables that suppress credential prompts and interactive behaviour.
 /// </summary>
-internal sealed class GitRunner : IGitRunner
+internal sealed class GitRunner(IProcessRunner processRunner) : IGitRunner
 {
     private static readonly TimeSpan _processTimeout = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan _versionProbeTimeout = TimeSpan.FromSeconds(5);
+
+    // Per-process env vars that suppress credential prompts and interactive behaviour.
+    private static readonly Dictionary<string, string> _gitEnvironment = new()
+    {
+        ["GIT_TERMINAL_PROMPT"] = "0",
+        ["GIT_ASKPASS"] = "echo",
+        ["GIT_SSH_COMMAND"] = "echo",
+    };
+
+    private readonly IProcessRunner _processRunner = processRunner ?? throw new ArgumentNullException(nameof(processRunner));
 
     public async Task RunAsync(IReadOnlyList<string> arguments, string? workingDirectory, CancellationToken cancellationToken)
     {
@@ -28,115 +38,52 @@ internal sealed class GitRunner : IGitRunner
     {
         ArgumentNullException.ThrowIfNull(arguments);
 
-        ProcessStartInfo psi = CreateStartInfo(workingDirectory);
-        foreach (string arg in arguments)
+        ProcessRunRequest request = new("git", arguments, workingDirectory, _processTimeout, _gitEnvironment);
+        ProcessOutcome outcome = await _processRunner.RunAsync(request, cancellationToken);
+
+        if (outcome.ExecutableNotFound)
         {
-            psi.ArgumentList.Add(arg);
+            throw new InvalidOperationException("Failed to start git process. Is git installed and on PATH?");
         }
 
-        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        timeoutCts.CancelAfter(_processTimeout);
-        CancellationToken linked = timeoutCts.Token;
-
-        using Process process = Process.Start(psi)
-            ?? throw new InvalidOperationException("Failed to start git process. Is git installed and on PATH?");
-
-        try
+        if (outcome.TimedOut)
         {
-            Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync(linked);
-            Task<string> stderrTask = process.StandardError.ReadToEndAsync(linked);
-
-            await Task.WhenAll(stdoutTask, stderrTask);
-            await process.WaitForExitAsync(linked);
-
-            if (process.ExitCode != 0)
-            {
-                throw new GitRunnerException(
-                    process.ExitCode,
-                    stderrTask.Result,
-                    stdoutTask.Result,
-                    string.Join(' ', arguments));
-            }
-
-            return stdoutTask.Result.Trim();
+            throw new GitRunnerException(
+                -1,
+                "Process timed out.",
+                outcome.StandardOutput,
+                string.Join(' ', arguments));
         }
-        finally
+
+        if (outcome.ExitCode != 0)
         {
-            KillProcess(process);
+            throw new GitRunnerException(
+                outcome.ExitCode!.Value,
+                outcome.StandardError,
+                outcome.StandardOutput,
+                string.Join(' ', arguments));
         }
+
+        return outcome.StandardOutput.Trim();
     }
-
-    private static readonly TimeSpan _versionProbeTimeout = TimeSpan.FromSeconds(5);
 
     public async Task<string?> TryGetVersionAsync(CancellationToken cancellationToken)
     {
         try
         {
-            ProcessStartInfo psi = CreateStartInfo(workingDirectory: null);
-            psi.ArgumentList.Add("--version");
+            ProcessRunRequest request = new("git", ["--version"], WorkingDirectory: null, _versionProbeTimeout, _gitEnvironment);
+            ProcessOutcome outcome = await _processRunner.RunAsync(request, cancellationToken);
 
-            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            timeoutCts.CancelAfter(_versionProbeTimeout);
-            CancellationToken linked = timeoutCts.Token;
-
-            using Process process = Process.Start(psi)
-                ?? throw new InvalidOperationException("Failed to start git process.");
-
-            try
+            if (outcome.ExecutableNotFound || outcome.TimedOut || outcome.ExitCode != 0)
             {
-                string output = await process.StandardOutput.ReadToEndAsync(linked);
-                await process.WaitForExitAsync(linked);
+                return null;
+            }
 
-                return process.ExitCode == 0 ? output.Trim() : null;
-            }
-            finally
-            {
-                KillProcess(process);
-            }
+            return outcome.StandardOutput.Trim();
         }
-        catch (Exception ex) when (ex is Win32Exception or InvalidOperationException or OperationCanceledException)
+        catch (OperationCanceledException)
         {
-            // git not installed, not on PATH, or timed out — fall back to HTTP
             return null;
-        }
-    }
-
-    private static ProcessStartInfo CreateStartInfo(string? workingDirectory)
-    {
-        var psi = new ProcessStartInfo
-        {
-            FileName = "git",
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true
-        };
-
-        if (workingDirectory is not null)
-        {
-            psi.WorkingDirectory = workingDirectory;
-        }
-
-        // Per-process env vars — do NOT affect the user's shell or global git config.
-        psi.Environment["GIT_TERMINAL_PROMPT"] = "0";
-        psi.Environment["GIT_ASKPASS"] = "echo";
-        psi.Environment["GIT_SSH_COMMAND"] = "echo";
-
-        return psi;
-    }
-
-    private static void KillProcess(Process process)
-    {
-        try
-        {
-            if (!process.HasExited)
-            {
-                process.Kill(entireProcessTree: true);
-            }
-        }
-        catch (Exception)
-        {
-            // Best effort — don't mask the original exception if the process already exited.
         }
     }
 }

--- a/src/Func/Quickstart/GitRunnerException.cs
+++ b/src/Func/Quickstart/GitRunnerException.cs
@@ -1,24 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Common;
+
 namespace Azure.Functions.Cli.Quickstart;
 
 /// <summary>
 /// Thrown when a <c>git</c> child process exits with a non-zero exit code.
 /// </summary>
 internal sealed class GitRunnerException(int exitCode, string standardError, string standardOutput, string command, Exception? innerException = null)
-    : Exception(BuildMessage(exitCode, standardError, command), innerException)
+    : ProcessExecutionException(exitCode, standardError, standardOutput, $"git {command}", innerException)
 {
-    public int ExitCode { get; } = exitCode;
-
-    public string StandardError { get; } = standardError;
-
-    public string StandardOutput { get; } = standardOutput;
-
-    public string Command { get; } = command;
-
-    private static string BuildMessage(int exitCode, string stderr, string command)
-    {
-        return $"'git {command}' failed with exit code {exitCode}.{Environment.NewLine}{stderr}".TrimEnd();
-    }
 }

--- a/src/Func/Quickstart/QuickstartScaffolderRegistration.cs
+++ b/src/Func/Quickstart/QuickstartScaffolderRegistration.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Common;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Azure.Functions.Cli.Quickstart;

--- a/src/Workloads/Stacks/DotNet/DotNetCli/DotnetCliException.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetCli/DotnetCliException.cs
@@ -1,32 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Azure.Functions.Cli.Common;
+
 namespace Azure.Functions.Cli.Workloads.DotNet;
 
 /// <summary>
 /// Thrown when a <c>dotnet</c> CLI child process exits with a non-zero exit code.
 /// </summary>
-internal sealed class DotnetCliException : Exception
+internal sealed class DotnetCliException(int exitCode, string standardError, string standardOutput, string command)
+    : ProcessExecutionException(exitCode, standardError, standardOutput, $"dotnet {command}")
 {
-    public int ExitCode { get; }
-
-    public string StandardError { get; }
-
-    public string StandardOutput { get; }
-
-    public string Command { get; }
-
-    public DotnetCliException(int exitCode, string standardError, string standardOutput, string command)
-        : base(BuildMessage(exitCode, standardError, standardOutput, command))
-    {
-        ExitCode = exitCode;
-        StandardError = standardError;
-        StandardOutput = standardOutput;
-        Command = command;
-    }
-
-    private static string BuildMessage(int exitCode, string stderr, string stdout, string command)
-    {
-        return $"'dotnet {command}' failed with exit code {exitCode}.{Environment.NewLine}{stderr}{stdout}";
-    }
 }

--- a/src/Workloads/Stacks/DotNet/DotNetCli/DotnetCliRunner.cs
+++ b/src/Workloads/Stacks/DotNet/DotNetCli/DotnetCliRunner.cs
@@ -1,158 +1,76 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Diagnostics;
-using System.Text;
+using Azure.Functions.Cli.Common;
 
 namespace Azure.Functions.Cli.Workloads.DotNet;
 
 /// <summary>
 /// Executes <c>dotnet</c> CLI commands in a child process.
 /// </summary>
-internal sealed class DotnetCliRunner(IDotnetPathResolver pathResolver) : IDotnetCliRunner
+internal sealed class DotnetCliRunner(IDotnetPathResolver pathResolver, IProcessRunner processRunner) : IDotnetCliRunner
 {
+    private static readonly TimeSpan _processTimeout = TimeSpan.FromMinutes(10);
+
     private readonly IDotnetPathResolver _pathResolver = pathResolver ?? throw new ArgumentNullException(nameof(pathResolver));
+    private readonly IProcessRunner _processRunner = processRunner ?? throw new ArgumentNullException(nameof(processRunner));
 
     public async Task RunAsync(IReadOnlyList<string> arguments, string? workingDirectory, CancellationToken cancellationToken)
     {
-        // Output is captured so it can be attached to the exception on failure, but is otherwise discarded.
-        StringBuilder stdout = new();
-        StringBuilder stderr = new();
+        ArgumentNullException.ThrowIfNull(arguments);
 
-        // Each callback is invoked only from its own stream's thread (serialized per stream), so the two
-        // builders are never touched concurrently and need no synchronization.
-        int exitCode = await ExecuteAsync(
-            arguments,
-            workingDirectory,
-            line => stdout.AppendLine(line),
-            line => stderr.AppendLine(line),
-            cancellationToken);
+        ProcessRunRequest request = new(_pathResolver.Resolve(), arguments, workingDirectory, _processTimeout);
+        ProcessOutcome outcome = await _processRunner.RunAsync(request, cancellationToken);
 
-        if (exitCode != 0)
+        if (outcome.ExecutableNotFound)
         {
-            throw new DotnetCliException(exitCode, stderr.ToString(), stdout.ToString(), string.Join(' ', arguments));
+            throw new InvalidOperationException("Failed to start dotnet process.");
+        }
+
+        if (outcome.ExitCode != 0)
+        {
+            throw new DotnetCliException(outcome.ExitCode!.Value, outcome.StandardError, outcome.StandardOutput, string.Join(' ', arguments));
         }
     }
 
     public async Task RunStreamingAsync(IReadOnlyList<string> arguments, string? workingDirectory, Action<string>? onOutputLine,
         Action<string>? onErrorLine, CancellationToken cancellationToken)
     {
-        int exitCode = await ExecuteAsync(arguments, workingDirectory, onOutputLine, onErrorLine, cancellationToken);
-
-        if (exitCode != 0)
-        {
-            // Output has already been surfaced live through the callbacks, so the exception only needs
-            // to carry the exit code and command.
-            throw new DotnetCliException(exitCode, string.Empty, string.Empty, string.Join(' ', arguments));
-        }
-    }
-
-    /// <summary>
-    /// Starts <c>dotnet</c>, streams each line of standard output and standard error to the supplied
-    /// callbacks as it is produced, waits for exit, and returns the process exit code.
-    /// </summary>
-    private async Task<int> ExecuteAsync(
-        IReadOnlyList<string> arguments,
-        string? workingDirectory,
-        Action<string>? onOutputLine,
-        Action<string>? onErrorLine,
-        CancellationToken cancellationToken)
-    {
         ArgumentNullException.ThrowIfNull(arguments);
 
-        using Process process = new() { StartInfo = CreateStartInfo(arguments, workingDirectory) };
+        ProcessRunRequest request = new(_pathResolver.Resolve(), arguments, workingDirectory, _processTimeout);
+        ProcessOutcome outcome = await _processRunner.RunAsync(request, cancellationToken);
 
-        // stdout and stderr are delivered on separate thread-pool threads, so each stream gets its own
-        // completion signal. The handlers share no mutable state, so the two threads never race each other;
-        // each line callback is invoked only from its own stream's thread (serialized per stream).
-        TaskCompletionSource stdoutComplete = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        TaskCompletionSource stderrComplete = new(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        process.OutputDataReceived += (_, e) =>
-        {
-            if (e.Data is null)
-            {
-                stdoutComplete.TrySetResult();
-            }
-            else
-            {
-                onOutputLine?.Invoke(e.Data);
-            }
-        };
-
-        process.ErrorDataReceived += (_, e) =>
-        {
-            if (e.Data is null)
-            {
-                stderrComplete.TrySetResult();
-            }
-            else
-            {
-                onErrorLine?.Invoke(e.Data);
-            }
-        };
-
-        if (!process.Start())
+        if (outcome.ExecutableNotFound)
         {
             throw new InvalidOperationException("Failed to start dotnet process.");
         }
 
-        try
+        // Deliver the captured output through the streaming callbacks so callers
+        // that registered callbacks still see the output lines.
+        DeliverCapturedOutput(outcome.StandardOutput, onOutputLine);
+        DeliverCapturedOutput(outcome.StandardError, onErrorLine);
+
+        if (outcome.ExitCode != 0)
         {
-            process.BeginOutputReadLine();
-            process.BeginErrorReadLine();
-
-            await process.WaitForExitAsync(cancellationToken);
-
-            // WaitForExitAsync does not guarantee the async stream readers have drained, so wait for the
-            // trailing (null Data) sentinel on both streams to ensure every line has been delivered.
-            await stdoutComplete.Task;
-            await stderrComplete.Task;
-
-            return process.ExitCode;
-        }
-        finally
-        {
-            KillProcess(process);
+            throw new DotnetCliException(outcome.ExitCode!.Value, outcome.StandardError, outcome.StandardOutput, string.Join(' ', arguments));
         }
     }
 
-    private ProcessStartInfo CreateStartInfo(IReadOnlyList<string> arguments, string? workingDirectory)
+    private static void DeliverCapturedOutput(string captured, Action<string>? callback)
     {
-        ProcessStartInfo psi = new()
+        if (callback is null || string.IsNullOrEmpty(captured))
         {
-            FileName = _pathResolver.Resolve(),
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true
-        };
-
-        if (workingDirectory is not null)
-        {
-            psi.WorkingDirectory = workingDirectory;
+            return;
         }
 
-        foreach (string arg in arguments)
+        foreach (string line in captured.Split('\n'))
         {
-            psi.ArgumentList.Add(arg);
-        }
-
-        return psi;
-    }
-
-    private static void KillProcess(Process process)
-    {
-        try
-        {
-            if (!process.HasExited)
+            string trimmed = line.TrimEnd('\r');
+            if (trimmed.Length > 0)
             {
-                process.Kill(entireProcessTree: true);
+                callback(trimmed);
             }
-        }
-        catch (Exception)
-        {
-            // This is best effort and we don't want to mask the original exception if the process has already exited.
         }
     }
 }

--- a/test/Func.Tests/Commands/Start/Azurite/AzuriteExecutableLocatorTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/AzuriteExecutableLocatorTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Commands.Start.Azurite;
-using Azure.Functions.Cli.Commands.Start.Azurite.Processes;
+using Azure.Functions.Cli.Common;
 using NSubstitute;
 
 namespace Azure.Functions.Cli.Tests.Commands.Start.Azurite;

--- a/test/Func.Tests/Commands/Start/Azurite/DockerAvailabilityProbeTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/DockerAvailabilityProbeTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Commands.Start.Azurite;
-using Azure.Functions.Cli.Commands.Start.Azurite.Processes;
+using Azure.Functions.Cli.Common;
 using NSubstitute;
 
 namespace Azure.Functions.Cli.Tests.Commands.Start.Azurite;

--- a/test/Func.Tests/Commands/Start/Azurite/Orchestration/ManagedAzuriteOrchestratorTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/Orchestration/ManagedAzuriteOrchestratorTests.cs
@@ -7,6 +7,7 @@ using Azure.Functions.Cli.Commands.Start.Azurite;
 using Azure.Functions.Cli.Commands.Start.Azurite.Launching;
 using Azure.Functions.Cli.Commands.Start.Azurite.Orchestration;
 using Azure.Functions.Cli.Commands.Start.Azurite.Processes;
+using Azure.Functions.Cli.Common;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 

--- a/test/Func.Tests/Commands/Start/Azurite/Processes/ListeningProcessInspectorTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/Processes/ListeningProcessInspectorTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Commands.Start.Azurite.Processes;
+using Azure.Functions.Cli.Common;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 

--- a/test/Func.Tests/Commands/Start/Azurite/Processes/ProcessRunnerTests.cs
+++ b/test/Func.Tests/Commands/Start/Azurite/Processes/ProcessRunnerTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Azure.Functions.Cli.Commands.Start.Azurite.Processes;
+using Azure.Functions.Cli.Common;
 
 namespace Azure.Functions.Cli.Tests.Commands.Start.Azurite.Processes;
 


### PR DESCRIPTION
## Summary

Consolidates 3 near-identical process runner implementations and 2 duplicate exception classes into shared abstractions, as described in #5450.

## Changes

### Shared `ProcessExecutionException` base class (`Abstractions/Common/`)
- New base exception with `ExitCode`, `StandardError`, `StandardOutput`, `Command` properties
- `GitRunnerException` and `DotnetCliException` now inherit from it, eliminating ~90% duplicate code

### Shared `IProcessRunner` / `ProcessRunner` in `Abstractions/Common/`
- Moved from `Func/Commands/Start/Azurite/Processes/` to `Abstractions/Common/` for cross-project reuse
- `ProcessRunRequest` now supports optional `EnvironmentVariables` for per-process env var overrides (used by GitRunner for `GIT_TERMINAL_PROMPT`, etc.)
- `IProcessRunner`, `ProcessRunRequest`, `ProcessOutcome` are `public` (shared contracts); `ProcessRunner` stays `internal`

### Refactored runners to delegate
- **GitRunner**: now takes `IProcessRunner` via DI instead of managing `Process` directly. All ProcessStartInfo creation, output capture, timeout, and kill logic removed.
- **DotnetCliRunner**: now takes `IProcessRunner` via DI instead of managing `Process` directly. Streaming output is delivered from captured output after process completion.

### DI registration
- `IProcessRunner` registered centrally in `CliHostFactory` (was previously only in Azurite discovery)

## Testing
- All 115 relevant tests pass (46 DotNet workload + 69 Func)
- Build succeeds with 0 warnings, 0 errors

## Net code reduction
`22 files changed, 160 insertions(+), 264 deletions(-)`

Fixes #5450