### PR TITLE
Workload SDK: author RID pointer and implementation packages

### DIFF
--- a/docs/building-a-workload.md
+++ b/docs/building-a-workload.md
@@ -2,9 +2,7 @@
 
 This guide walks through building a workload for the Azure Functions Core Tools v5 CLI. A workload is a NuGet package that the CLI loads at runtime to extend its behavior, most commonly to provide `func init` / `func new` support for a specific language stack (e.g. Node.js, Python, Java), but a workload can also contribute brand-new subcommands.
 
-> **Status**: the abstractions, DI host, and `func workload install` / `uninstall` commands described below are in the tree as of this PR. Workloads are installed from a local `.nupkg` on disk; NuGet feed acquisition lands in a follow-up.
->
-> **Spec**: this guide is the authoring view. The on-disk and on-feed layout, the `workload.json` schema, the `kind` discriminator (`workload` / `content` / `meta`), and the install pipeline are specified in [`docs/proposed/workload-package-layout.md`](./proposed/workload-package-layout.md). Consult that doc for the contract; this guide stays focused on the happy-path authoring experience for `kind: workload`.
+> **Spec**: this guide is the authoring view. The on-disk and on-feed layout, the `workload.json` schema, the `kind` discriminator (`workload` / `content` / `meta` / `rid-pointer`), and the install pipeline are specified in [`docs/proposed/workload-package-layout.md`](./proposed/workload-package-layout.md). Consult that doc for the contract; this guide stays focused on the happy-path authoring experience for `kind: workload`.
 
 ## Architecture
 
@@ -123,7 +121,28 @@ What each piece does:
 - `SuppressDependenciesWhenPacking=true` plus `PrivateAssets=all` / `ExcludeAssets=runtime` on the `Abstractions` reference keep the workload self-contained: the CLI provides Abstractions (and the other host-shared contract assemblies, see §9.2 of the layout spec) at runtime. The same `PrivateAssets=all` rule applies to **every** `<PackageReference>` you add later, not just `Abstractions`.
 - `NU5128`/`NU5100` are suppressed because we deliberately ship without `lib/` and place files under `tools/any/`.
 
-> **Pack scope today.** The csproj above packs only the workload assembly itself. That works for stubs and for workloads whose runtime closure is just the host-shared contracts. As soon as a workload pulls in a transitive managed dependency (e.g., `Newtonsoft.Json`), the long-term shape from the package-layout spec applies: the package must contain the publish output (workload `.dll`, `.deps.json`, optional `.pdb`, every transitive managed dep, and any `runtimes/<rid>/` assets the deps ship). The upcoming `Workload.Sdk` package will provide the publish-into-`tools/any/` target; until then, workloads with transitive deps need to wire that step manually. See `docs/proposed/workload-package-layout.md` §5 and §9.
+### Runtime-specific workload packages
+
+Set `RuntimeIdentifiers` when a workload's payload differs by platform. The Workload SDK then produces one user-facing pointer package and one implementation package per RID:
+
+```xml
+<PropertyGroup>
+  <RuntimeIdentifiers>win-x64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
+  <PackAsWorkload>true</PackAsWorkload>
+  <WorkloadKind>content</WorkloadKind>
+  <WorkloadAlias>python-worker</WorkloadAlias>
+</PropertyGroup>
+```
+
+- The pointer keeps the project package ID, uses package type `FuncCliWorkload`, and contains a `kind: rid-pointer` manifest whose `packages` map selects the implementation for each RID.
+- Each implementation uses the package ID `<pointer-package-id>.<rid>`, package type `FuncCliWorkloadRidPackage`, and retains the authored `workload` or `content` kind.
+- The SDK writes `runtimeIdentifier` into every implementation manifest and adds the matching `rid:<rid>` package tag. Do not author either value independently.
+- Implementation payloads ship under `tools/<rid>/` rather than `tools/any/`; the CLI derives the content root from the manifest's `runtimeIdentifier`.
+- Publish the pointer and every implementation at the same exact version and to the same feed. The CLI resolves only the mapped package ID at the pointer's exact version from the source that supplied the pointer.
+
+Users install, update, uninstall, and list the pointer identity. The CLI records the selected physical implementation and RID as ownership details; `func workload list --json` exposes both logical and physical package IDs.
+
+> **Pack scope.** The package must contain the publish output (workload `.dll`, `.deps.json`, optional `.pdb`, every transitive managed dependency, and any `runtimes/<rid>/` assets the dependencies ship). Use the Workload SDK's `PackAsWorkload` targets rather than manually copying only the primary assembly when a workload has a runtime dependency closure.
 
 Add a sibling `Directory.Version.props` for the workload version:
 

--- a/docs/building-a-workload.md
+++ b/docs/building-a-workload.md
@@ -2,7 +2,7 @@
 
 This guide walks through building a workload for the Azure Functions Core Tools v5 CLI. A workload is a NuGet package that the CLI loads at runtime to extend its behavior, most commonly to provide `func init` / `func new` support for a specific language stack (e.g. Node.js, Python, Java), but a workload can also contribute brand-new subcommands.
 
-> **Spec**: this guide is the authoring view. The on-disk and on-feed layout, the `workload.json` schema, the `kind` discriminator (`workload` / `content` / `meta` / `rid-pointer`), and the install pipeline are specified in [`docs/proposed/workload-package-layout.md`](./proposed/workload-package-layout.md). Consult that doc for the contract; this guide stays focused on the happy-path authoring experience for `kind: workload`.
+> **Spec**: this guide is the authoring view. The on-disk and on-feed layout, the `workload.json` schema, the `kind` discriminator (`workload` / `content` / `meta` / `rid-pointer`), and the install pipeline are specified in [`./proposed/workload-package-layout.md`](./proposed/workload-package-layout.md). Consult that doc for the contract; this guide stays focused on the happy-path authoring experience for `kind: workload`.
 
 ## Architecture
 

--- a/eng/build/Workloads/Workload.targets
+++ b/eng/build/Workloads/Workload.targets
@@ -47,6 +47,7 @@
       <_WorkloadRidPath Condition="'$(RuntimeIdentifier)' == ''">any</_WorkloadRidPath>
       <_WorkloadRidPath Condition="'$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier)</_WorkloadRidPath>
       <_WorkloadPackageContentRoot>tools/$(_WorkloadRidPath)/</_WorkloadPackageContentRoot>
+      <_WorkloadManifestRuntimeIdentifier Condition="'$(RuntimeIdentifier)' != '' AND $(CreateRidSpecificWorkloadPackages)">$(RuntimeIdentifier)</_WorkloadManifestRuntimeIdentifier>
     </PropertyGroup>
   </Target>
 
@@ -69,10 +70,11 @@
   We hash the inputs into workload.json to determine if it needs to be regenerated.
   Does not use FileWrites as this is a pack-time operation. FileWrites are for build-time operations.
   -->
-  <Target Name="_GenerateWorkloadJsonCache" DependsOnTargets="_ResolveWorkloadEntryPoint;_ResolveRidSpecificWorkload" Outputs="$(_WorkloadJsonCacheFile)">
+  <Target Name="_GenerateWorkloadJsonCache" DependsOnTargets="_SetWorkloadProperties;_ResolveWorkloadEntryPoint;_ResolveRidSpecificWorkload">
     <ItemGroup>
       <_WorkloadJsonInputCacheToHash Include="$(WorkloadKind)" />
       <_WorkloadJsonInputCacheToHash Include="$(_FuncWorkloadSchema)" />
+      <_WorkloadJsonInputCacheToHash Include="$(_WorkloadManifestRuntimeIdentifier)" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(WorkloadKind)' == 'workload'">
@@ -104,8 +106,10 @@
       OutputPath="$(_WorkloadJsonFile)"
       Schema="$(_FuncWorkloadSchema)"
       Kind="$(WorkloadKind)"
+      PackageId="$(PackageId)"
       DisplayName="$(Title)"
       Description="$(Description)"
+      RuntimeIdentifier="$(_WorkloadManifestRuntimeIdentifier)"
       EntryPointAssemblyPath="$(WorkloadEntryPointAssembly)"
       EntryPointType="$(WorkloadEntryPointType)"
       InnerPackages="@(_WorkloadRidSpecificPackage)"/>

--- a/src/Workloads/Sdk/Tasks/WriteWorkloadJson.cs
+++ b/src/Workloads/Sdk/Tasks/WriteWorkloadJson.cs
@@ -18,9 +18,14 @@ public sealed class WriteWorkloadJson : Microsoft.Build.Utilities.Task
     [Required]
     public string Kind { get; set; } = string.Empty;
 
+    [Required]
+    public string PackageId { get; set; } = string.Empty;
+
     public string DisplayName { get; set; } = string.Empty;
 
     public string Description { get; set; } = string.Empty;
+
+    public string RuntimeIdentifier { get; set; } = string.Empty;
 
     public string EntryPointAssemblyPath { get; set; } = string.Empty;
 
@@ -31,6 +36,11 @@ public sealed class WriteWorkloadJson : Microsoft.Build.Utilities.Task
 
     public override bool Execute()
     {
+        if (!ValidateInputs())
+        {
+            return false;
+        }
+
         EntryPointModel? entryPoint = null;
         if (!string.IsNullOrEmpty(EntryPointAssemblyPath) && !string.IsNullOrEmpty(EntryPointType))
         {
@@ -42,9 +52,9 @@ public sealed class WriteWorkloadJson : Microsoft.Build.Utilities.Task
         }
 
         Dictionary<string, string>? packages = null;
-        if (InnerPackages is { Length: > 0 })
+        if (string.Equals(Kind, "rid-pointer", StringComparison.Ordinal))
         {
-            packages = new(StringComparer.OrdinalIgnoreCase);
+            packages = new(StringComparer.Ordinal);
             foreach (ITaskItem package in InnerPackages)
             {
                 packages[package.GetMetadata("RuntimeIdentifier")] = package.ItemSpec;
@@ -57,6 +67,7 @@ public sealed class WriteWorkloadJson : Microsoft.Build.Utilities.Task
             Kind = Kind,
             DisplayName = string.IsNullOrEmpty(DisplayName) ? null : DisplayName,
             Description = string.IsNullOrEmpty(Description) ? null : Description,
+            RuntimeIdentifier = string.IsNullOrEmpty(RuntimeIdentifier) ? null : RuntimeIdentifier,
             EntryPoint = entryPoint,
             Packages = packages,
         };
@@ -79,6 +90,96 @@ public sealed class WriteWorkloadJson : Microsoft.Build.Utilities.Task
         File.WriteAllBytes(OutputPath, content);
         return true;
     }
+
+    private bool ValidateInputs()
+    {
+        bool isPointer = string.Equals(Kind, "rid-pointer", StringComparison.Ordinal);
+        bool isRidImplementation = !string.IsNullOrEmpty(RuntimeIdentifier);
+        bool hasEntryPoint = !string.IsNullOrEmpty(EntryPointAssemblyPath) || !string.IsNullOrEmpty(EntryPointType);
+
+        if (isPointer)
+        {
+            if (hasEntryPoint)
+            {
+                Log.LogError("A rid-pointer workload cannot define an entry point.");
+            }
+
+            if (isRidImplementation)
+            {
+                Log.LogError("A rid-pointer workload cannot define a runtime identifier.");
+            }
+
+            if (InnerPackages.Length == 0)
+            {
+                Log.LogError("A rid-pointer workload must define at least one inner package.");
+            }
+        }
+        else if (InnerPackages.Length > 0)
+        {
+            Log.LogError($"Workload kind '{Kind}' cannot define inner packages.");
+        }
+
+        if (isRidImplementation
+            && !string.Equals(Kind, "workload", StringComparison.Ordinal)
+            && !string.Equals(Kind, "content", StringComparison.Ordinal))
+        {
+            Log.LogError($"Workload kind '{Kind}' cannot define a runtime identifier.");
+        }
+
+        if (isRidImplementation && !IsNormalizedRuntimeIdentifier(RuntimeIdentifier))
+        {
+            Log.LogError($"Runtime identifier '{RuntimeIdentifier}' must be non-empty and lowercase.");
+        }
+
+        if (string.Equals(Kind, "workload", StringComparison.Ordinal))
+        {
+            if (string.IsNullOrEmpty(EntryPointAssemblyPath) || string.IsNullOrEmpty(EntryPointType))
+            {
+                Log.LogError("A workload must define both entry-point assembly path and type.");
+            }
+        }
+        else if (hasEntryPoint)
+        {
+            Log.LogError($"Workload kind '{Kind}' cannot define an entry point.");
+        }
+
+        if (isPointer)
+        {
+            ValidateInnerPackages();
+        }
+
+        return !Log.HasLoggedErrors;
+    }
+
+    private void ValidateInnerPackages()
+    {
+        HashSet<string> runtimeIdentifiers = new(StringComparer.OrdinalIgnoreCase);
+        foreach (ITaskItem package in InnerPackages)
+        {
+            string runtimeIdentifier = package.GetMetadata("RuntimeIdentifier");
+            if (!IsNormalizedRuntimeIdentifier(runtimeIdentifier))
+            {
+                Log.LogError($"Inner package '{package.ItemSpec}' has invalid runtime identifier '{runtimeIdentifier}'. Runtime identifiers must be lowercase.");
+                continue;
+            }
+
+            if (!runtimeIdentifiers.Add(runtimeIdentifier))
+            {
+                Log.LogError($"Runtime identifier '{runtimeIdentifier}' is defined more than once.");
+            }
+
+            string expectedPackageId = $"{PackageId}.{runtimeIdentifier}";
+            if (!string.Equals(package.ItemSpec, expectedPackageId, StringComparison.OrdinalIgnoreCase))
+            {
+                Log.LogError($"Inner package for runtime identifier '{runtimeIdentifier}' must be named '{expectedPackageId}', but was '{package.ItemSpec}'.");
+            }
+        }
+    }
+
+    private static bool IsNormalizedRuntimeIdentifier(string value)
+        => !string.IsNullOrWhiteSpace(value)
+            && string.Equals(value, value.Trim(), StringComparison.Ordinal)
+            && string.Equals(value, value.ToLowerInvariant(), StringComparison.Ordinal);
 
     private static bool FileContentEquals(string path, byte[] expected)
     {
@@ -119,6 +220,9 @@ internal sealed class WorkloadJsonModel
 
     [JsonPropertyName("description")]
     public string? Description { get; set; }
+
+    [JsonPropertyName("runtimeIdentifier")]
+    public string? RuntimeIdentifier { get; set; }
 
     [JsonPropertyName("entryPoint")]
     public EntryPointModel? EntryPoint { get; set; }

--- a/test/Workloads/Sdk.Tests/Tasks/WriteWorkloadJsonTests.cs
+++ b/test/Workloads/Sdk.Tests/Tasks/WriteWorkloadJsonTests.cs
@@ -40,6 +40,7 @@ public sealed class WriteWorkloadJsonTests : IDisposable
         doc.RootElement.GetProperty("kind").GetString().Should().Be("content");
         doc.RootElement.TryGetProperty("entryPoint", out _).Should().BeFalse();
         doc.RootElement.TryGetProperty("packages", out _).Should().BeFalse();
+        doc.RootElement.TryGetProperty("runtimeIdentifier", out _).Should().BeFalse();
     }
 
     [Fact]
@@ -67,8 +68,7 @@ public sealed class WriteWorkloadJsonTests : IDisposable
     public void Execute_WithInnerPackages_WritesPackagesMap()
     {
         string outputPath = Path.Combine(_tempDir, "workload.json");
-        WriteWorkloadJson task = CreateTask(outputPath, kind: "workload",
-            entryPointAssemblyPath: "W.dll", entryPointType: "W.Type");
+        WriteWorkloadJson task = CreateTask(outputPath, kind: "rid-pointer");
         task.InnerPackages =
         [
             CreateTaskItem("My.Package.win-x64", "win-x64"),
@@ -97,29 +97,25 @@ public sealed class WriteWorkloadJsonTests : IDisposable
     }
 
     [Fact]
-    public void Execute_EmptyEntryPointAssemblyPath_OmitsEntryPoint()
+    public void Execute_WorkloadWithEmptyEntryPointAssemblyPath_Fails()
     {
         string outputPath = Path.Combine(_tempDir, "workload.json");
         WriteWorkloadJson task = CreateTask(outputPath, kind: "workload",
             entryPointAssemblyPath: "", entryPointType: "Some.Type");
 
-        task.Execute();
-
-        JsonDocument doc = ParseOutput(outputPath);
-        doc.RootElement.TryGetProperty("entryPoint", out _).Should().BeFalse();
+        task.Execute().Should().BeFalse();
+        File.Exists(outputPath).Should().BeFalse();
     }
 
     [Fact]
-    public void Execute_EmptyEntryPointType_OmitsEntryPoint()
+    public void Execute_WorkloadWithEmptyEntryPointType_Fails()
     {
         string outputPath = Path.Combine(_tempDir, "workload.json");
         WriteWorkloadJson task = CreateTask(outputPath, kind: "workload",
             entryPointAssemblyPath: "Some.dll", entryPointType: "");
 
-        task.Execute();
-
-        JsonDocument doc = ParseOutput(outputPath);
-        doc.RootElement.TryGetProperty("entryPoint", out _).Should().BeFalse();
+        task.Execute().Should().BeFalse();
+        File.Exists(outputPath).Should().BeFalse();
     }
 
     [Fact]
@@ -133,6 +129,100 @@ public sealed class WriteWorkloadJsonTests : IDisposable
 
         JsonDocument doc = ParseOutput(outputPath);
         doc.RootElement.TryGetProperty("packages", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Execute_RidImplementation_WritesRuntimeIdentifier()
+    {
+        string outputPath = Path.Combine(_tempDir, "workload.json");
+        WriteWorkloadJson task = CreateTask(outputPath, kind: "content");
+        task.RuntimeIdentifier = "win-x64";
+
+        task.Execute().Should().BeTrue();
+
+        JsonDocument doc = ParseOutput(outputPath);
+        doc.RootElement.GetProperty("runtimeIdentifier").GetString().Should().Be("win-x64");
+    }
+
+    [Fact]
+    public void Execute_RidPointerWithoutInnerPackages_Fails()
+    {
+        string outputPath = Path.Combine(_tempDir, "workload.json");
+        WriteWorkloadJson task = CreateTask(outputPath, kind: "rid-pointer");
+
+        task.Execute().Should().BeFalse();
+        File.Exists(outputPath).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Execute_NonPointerWithInnerPackages_Fails()
+    {
+        string outputPath = Path.Combine(_tempDir, "workload.json");
+        WriteWorkloadJson task = CreateTask(outputPath, kind: "content");
+        task.InnerPackages = [CreateTaskItem("My.Package.win-x64", "win-x64")];
+
+        task.Execute().Should().BeFalse();
+        File.Exists(outputPath).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Execute_PointerWithRuntimeIdentifier_Fails()
+    {
+        string outputPath = Path.Combine(_tempDir, "workload.json");
+        WriteWorkloadJson task = CreateTask(outputPath, kind: "rid-pointer");
+        task.RuntimeIdentifier = "win-x64";
+        task.InnerPackages = [CreateTaskItem("My.Package.win-x64", "win-x64")];
+
+        task.Execute().Should().BeFalse();
+        File.Exists(outputPath).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Execute_UppercaseRuntimeIdentifier_Fails()
+    {
+        string outputPath = Path.Combine(_tempDir, "workload.json");
+        WriteWorkloadJson task = CreateTask(outputPath, kind: "content");
+        task.RuntimeIdentifier = "WIN-X64";
+
+        task.Execute().Should().BeFalse();
+        File.Exists(outputPath).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Execute_PointerWithMismatchedImplementationId_Fails()
+    {
+        string outputPath = Path.Combine(_tempDir, "workload.json");
+        WriteWorkloadJson task = CreateTask(outputPath, kind: "rid-pointer");
+        task.InnerPackages = [CreateTaskItem("Other.Package.win-x64", "win-x64")];
+
+        task.Execute().Should().BeFalse();
+        File.Exists(outputPath).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Execute_PointerWithDuplicateRuntimeIdentifiers_Fails()
+    {
+        string outputPath = Path.Combine(_tempDir, "workload.json");
+        WriteWorkloadJson task = CreateTask(outputPath, kind: "rid-pointer");
+        task.InnerPackages =
+        [
+            CreateTaskItem("My.Package.win-x64", "win-x64"),
+            CreateTaskItem("My.Package.win-x64", "win-x64"),
+        ];
+
+        task.Execute().Should().BeFalse();
+        File.Exists(outputPath).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Execute_PointerWithNonLowercaseRuntimeIdentifier_Fails()
+    {
+        string outputPath = Path.Combine(_tempDir, "workload.json");
+        WriteWorkloadJson task = CreateTask(outputPath, kind: "rid-pointer");
+        task.InnerPackages = [CreateTaskItem("My.Package.WIN-X64", "WIN-X64")];
+
+        task.Execute().Should().BeFalse();
+        File.Exists(outputPath).Should().BeFalse();
     }
 
     [Fact]
@@ -189,9 +279,9 @@ public sealed class WriteWorkloadJsonTests : IDisposable
     public void Execute_OutputIsValidJson()
     {
         string outputPath = Path.Combine(_tempDir, "workload.json");
-        WriteWorkloadJson task = CreateTask(outputPath, kind: "workload",
-            entryPointAssemblyPath: "Test.dll", entryPointType: "Test.Workload");
+        WriteWorkloadJson task = CreateTask(outputPath, kind: "rid-pointer");
         task.InnerPackages = [CreateTaskItem("Pkg.win-x64", "win-x64")];
+        task.PackageId = "Pkg";
 
         task.Execute();
 
@@ -213,6 +303,7 @@ public sealed class WriteWorkloadJsonTests : IDisposable
             OutputPath = outputPath,
             Schema = schema,
             Kind = kind,
+            PackageId = "My.Package",
             EntryPointAssemblyPath = entryPointAssemblyPath,
             EntryPointType = entryPointType,
             InnerPackages = [],


### PR DESCRIPTION
This is **layer 1 of 6** in a stack decomposing #5512 ("Add RID pointer package support") into small dependent PRs. It targets `vnext` and is the bottom of the stack.

This layer is the MSBuild/SDK authoring half of the feature. It has no dependency on the `func` CLI code — `WriteWorkloadJson` only references `System.Text.Json` and `Microsoft.Build.Framework` — so it builds and tests standalone on `vnext`.

## What the SDK now emits

When a workload sets `RuntimeIdentifiers`, the Workload SDK produces two package shapes:

- **Outer pointer package** — `kind: rid-pointer`, with a generated non-empty RID-to-package map in `packages`. It carries no payload and no entry point.
- **Inner RID implementation packages** — keep their authored `workload` or `content` kind and emit a required, lowercase `runtimeIdentifier`.

`WriteWorkloadJson` gained a validation pass that fails the task (rather than writing a bad manifest) when:

- a `rid-pointer` declares an entry point, a `runtimeIdentifier`, or no inner packages;
- a non-pointer kind declares inner packages;
- a `runtimeIdentifier` is empty, padded, or not lowercase;
- inner package runtime identifiers are duplicated, or an inner package is not named `<pointer-package-id>.<rid>`;
- a `workload` kind is missing either the entry-point assembly path or type.

`Workload.targets` flows `PackageId` and the resolved per-RID identifier into the task, and includes the identifier in the incremental hash so the manifest regenerates when the RID changes.

`docs/building-a-workload.md` documents the same authoring contract, including that implementation payloads ship under `tools/<rid>/`.

## Validation

- `CI=true dotnet build -c Release` — **0 warnings, 0 errors**.
- `dotnet test test/Workloads/Sdk.Tests/Workloads.Sdk.Tests.csproj` — **35/35 passed**.
- End-to-end pack check on the multi-RID Python worker workload: the pointer package emits `kind: rid-pointer` with all five RIDs mapped and no `tools/` payload; each implementation package emits `kind: content` with its `runtimeIdentifier`.

## Notes

- No `src/Func/` code, version props, or release notes are touched — this is a decomposition of already-reviewed work, not a release.
- The eight new tests are written with AwesomeAssertions to match the rest of the file and `.github/instructions/tests.instructions.md`; behavior is identical to the source diff.