### PR TITLE
Workloads: add rid-pointer manifest kind and runtime identifier

### DIFF
--- a/src/Func/Workloads/Discovery/WorkloadMetadataReader.cs
+++ b/src/Func/Workloads/Discovery/WorkloadMetadataReader.cs
@@ -95,19 +95,13 @@ internal sealed class WorkloadMetadataReader : IWorkloadMetadataReader
                 return metadata;
 
             case WorkloadKind.Content:
-                if (metadata.EntryPoint is not null)
-                {
-                    throw new InvalidWorkloadException(
-                        $"'{metadataPath}' declares kind 'content' " +
-                        "but also defines an entryPoint. Remove the entryPoint or change the kind to 'workload'.");
-                }
-
+                ValidateNoEntryPoint(metadata, metadataPath);
                 ValidateNoPackages(metadata, metadataPath);
                 ValidateRuntimeIdentifier(metadata, metadataPath);
                 return metadata;
 
             case WorkloadKind.Meta:
-                ValidateNoEntryPoint(metadata, metadataPath, "meta");
+                ValidateNoEntryPoint(metadata, metadataPath);
                 ValidateNoPackages(metadata, metadataPath);
                 if (metadata.RuntimeIdentifier is not null)
                 {
@@ -118,7 +112,7 @@ internal sealed class WorkloadMetadataReader : IWorkloadMetadataReader
                 return metadata;
 
             case WorkloadKind.RidPointer:
-                ValidateNoEntryPoint(metadata, metadataPath, "rid-pointer");
+                ValidateNoEntryPoint(metadata, metadataPath);
                 if (metadata.RuntimeIdentifier is not null)
                 {
                     throw new InvalidWorkloadException(
@@ -134,12 +128,13 @@ internal sealed class WorkloadMetadataReader : IWorkloadMetadataReader
         }
     }
 
-    private static void ValidateNoEntryPoint(WorkloadMetadata metadata, string metadataPath, string kind)
+    private static void ValidateNoEntryPoint(WorkloadMetadata metadata, string metadataPath)
     {
         if (metadata.EntryPoint is not null)
         {
             throw new InvalidWorkloadException(
-                $"'{metadataPath}' declares kind '{kind}' but also defines an entryPoint.");
+                $"'{metadataPath}' declares kind '{metadata.Kind.ToWireValue()}' " +
+                "but also defines an entryPoint. Remove the entryPoint or change the kind to 'workload'.");
         }
     }
 
@@ -148,7 +143,7 @@ internal sealed class WorkloadMetadataReader : IWorkloadMetadataReader
         if (metadata.Packages is not null)
         {
             throw new InvalidWorkloadException(
-                $"'{metadataPath}' declares kind '{GetWireKind(metadata.Kind)}' but also defines packages.");
+                $"'{metadataPath}' declares kind '{metadata.Kind.ToWireValue()}' but also defines packages.");
         }
     }
 
@@ -196,9 +191,6 @@ internal sealed class WorkloadMetadataReader : IWorkloadMetadataReader
         => !string.IsNullOrWhiteSpace(value)
             && string.Equals(value, value.Trim(), StringComparison.Ordinal)
             && string.Equals(value, value.ToLowerInvariant(), StringComparison.Ordinal);
-
-    private static string GetWireKind(WorkloadKind kind)
-        => kind == WorkloadKind.RidPointer ? "rid-pointer" : kind.ToString().ToLowerInvariant();
 
     private static void ValidateWorkloadEntryPoint(WorkloadMetadata metadata, string metadataPath)
     {

--- a/src/Func/Workloads/Discovery/WorkloadMetadataReader.cs
+++ b/src/Func/Workloads/Discovery/WorkloadMetadataReader.cs
@@ -90,19 +90,42 @@ internal sealed class WorkloadMetadataReader : IWorkloadMetadataReader
         {
             case WorkloadKind.Workload:
                 ValidateWorkloadEntryPoint(metadata, metadataPath);
+                ValidateNoPackages(metadata, metadataPath);
+                ValidateRuntimeIdentifier(metadata, metadataPath);
                 return metadata;
 
             case WorkloadKind.Content:
-            case WorkloadKind.Meta:
-                // entryPoint is meaningless for content/meta packages — reject
-                // it at author time instead of silently ignoring the field.
                 if (metadata.EntryPoint is not null)
                 {
                     throw new InvalidWorkloadException(
-                        $"'{metadataPath}' declares kind '{metadata.Kind.ToString().ToLowerInvariant()}' " +
+                        $"'{metadataPath}' declares kind 'content' " +
                         "but also defines an entryPoint. Remove the entryPoint or change the kind to 'workload'.");
                 }
 
+                ValidateNoPackages(metadata, metadataPath);
+                ValidateRuntimeIdentifier(metadata, metadataPath);
+                return metadata;
+
+            case WorkloadKind.Meta:
+                ValidateNoEntryPoint(metadata, metadataPath, "meta");
+                ValidateNoPackages(metadata, metadataPath);
+                if (metadata.RuntimeIdentifier is not null)
+                {
+                    throw new InvalidWorkloadException(
+                        $"'{metadataPath}' declares kind 'meta' but also defines runtimeIdentifier.");
+                }
+
+                return metadata;
+
+            case WorkloadKind.RidPointer:
+                ValidateNoEntryPoint(metadata, metadataPath, "rid-pointer");
+                if (metadata.RuntimeIdentifier is not null)
+                {
+                    throw new InvalidWorkloadException(
+                        $"'{metadataPath}' declares kind 'rid-pointer' but also defines runtimeIdentifier.");
+                }
+
+                ValidatePointerPackages(metadata, metadataPath);
                 return metadata;
 
             default:
@@ -110,6 +133,72 @@ internal sealed class WorkloadMetadataReader : IWorkloadMetadataReader
                     $"'{metadataPath}' has unrecognized kind '{metadata.Kind}'.");
         }
     }
+
+    private static void ValidateNoEntryPoint(WorkloadMetadata metadata, string metadataPath, string kind)
+    {
+        if (metadata.EntryPoint is not null)
+        {
+            throw new InvalidWorkloadException(
+                $"'{metadataPath}' declares kind '{kind}' but also defines an entryPoint.");
+        }
+    }
+
+    private static void ValidateNoPackages(WorkloadMetadata metadata, string metadataPath)
+    {
+        if (metadata.Packages is not null)
+        {
+            throw new InvalidWorkloadException(
+                $"'{metadataPath}' declares kind '{GetWireKind(metadata.Kind)}' but also defines packages.");
+        }
+    }
+
+    private static void ValidateRuntimeIdentifier(WorkloadMetadata metadata, string metadataPath)
+    {
+        if (metadata.RuntimeIdentifier is not null && !IsNormalizedRuntimeIdentifier(metadata.RuntimeIdentifier))
+        {
+            throw new InvalidWorkloadException(
+                $"'{metadataPath}' has invalid runtimeIdentifier '{metadata.RuntimeIdentifier}'. Runtime identifiers must be lowercase.");
+        }
+    }
+
+    private static void ValidatePointerPackages(WorkloadMetadata metadata, string metadataPath)
+    {
+        if (metadata.Packages is null || metadata.Packages.Count == 0)
+        {
+            throw new InvalidWorkloadException(
+                $"'{metadataPath}' declares kind 'rid-pointer' but does not define a non-empty packages map.");
+        }
+
+        HashSet<string> runtimeIdentifiers = new(StringComparer.OrdinalIgnoreCase);
+        foreach ((string runtimeIdentifier, string packageId) in metadata.Packages)
+        {
+            if (!IsNormalizedRuntimeIdentifier(runtimeIdentifier))
+            {
+                throw new InvalidWorkloadException(
+                    $"'{metadataPath}' has invalid packages key '{runtimeIdentifier}'. Runtime identifiers must be lowercase.");
+            }
+
+            if (!runtimeIdentifiers.Add(runtimeIdentifier))
+            {
+                throw new InvalidWorkloadException(
+                    $"'{metadataPath}' defines runtime identifier '{runtimeIdentifier}' more than once.");
+            }
+
+            if (string.IsNullOrWhiteSpace(packageId))
+            {
+                throw new InvalidWorkloadException(
+                    $"'{metadataPath}' has an empty implementation package id for runtime identifier '{runtimeIdentifier}'.");
+            }
+        }
+    }
+
+    private static bool IsNormalizedRuntimeIdentifier(string value)
+        => !string.IsNullOrWhiteSpace(value)
+            && string.Equals(value, value.Trim(), StringComparison.Ordinal)
+            && string.Equals(value, value.ToLowerInvariant(), StringComparison.Ordinal);
+
+    private static string GetWireKind(WorkloadKind kind)
+        => kind == WorkloadKind.RidPointer ? "rid-pointer" : kind.ToString().ToLowerInvariant();
 
     private static void ValidateWorkloadEntryPoint(WorkloadMetadata metadata, string metadataPath)
     {

--- a/src/Func/Workloads/Storage/WorkloadJsonContext.cs
+++ b/src/Func/Workloads/Storage/WorkloadJsonContext.cs
@@ -25,9 +25,34 @@ namespace Azure.Functions.Cli.Workloads.Storage;
 internal sealed partial class WorkloadJsonContext : JsonSerializerContext;
 
 /// <summary>
-/// Serializes <see cref="WorkloadKind"/> as a lowercase string
-/// (<c>"workload"</c> / <c>"content"</c> / <c>"meta"</c>). The default
-/// <see cref="JsonStringEnumConverter{TEnum}"/> would emit PascalCase.
+/// Serializes <see cref="WorkloadKind"/> using the workload manifest's wire values.
 /// </summary>
-internal sealed class WorkloadKindJsonConverter() : JsonStringEnumConverter<WorkloadKind>(JsonNamingPolicy.CamelCase);
+internal sealed class WorkloadKindJsonConverter : JsonConverter<WorkloadKind>
+{
+    public override WorkloadKind Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        string? value = reader.GetString();
+        return value switch
+        {
+            "workload" => WorkloadKind.Workload,
+            "content" => WorkloadKind.Content,
+            "meta" => WorkloadKind.Meta,
+            "rid-pointer" => WorkloadKind.RidPointer,
+            _ => throw new JsonException($"Unknown workload kind '{value}'."),
+        };
+    }
 
+    public override void Write(Utf8JsonWriter writer, WorkloadKind value, JsonSerializerOptions options)
+    {
+        string wireValue = value switch
+        {
+            WorkloadKind.Workload => "workload",
+            WorkloadKind.Content => "content",
+            WorkloadKind.Meta => "meta",
+            WorkloadKind.RidPointer => "rid-pointer",
+            _ => throw new JsonException($"Unknown workload kind '{value}'."),
+        };
+
+        writer.WriteStringValue(wireValue);
+    }
+}

--- a/src/Func/Workloads/Storage/WorkloadJsonContext.cs
+++ b/src/Func/Workloads/Storage/WorkloadJsonContext.cs
@@ -30,27 +30,16 @@ internal sealed class WorkloadKindJsonConverter : JsonConverter<WorkloadKind>
     public override WorkloadKind Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         string? value = reader.GetString();
-        return value switch
+        if (!WorkloadKind.TryParseWireValue(value, out WorkloadKind kind))
         {
-            "workload" => WorkloadKind.Workload,
-            "content" => WorkloadKind.Content,
-            "meta" => WorkloadKind.Meta,
-            "rid-pointer" => WorkloadKind.RidPointer,
-            _ => throw new JsonException($"Unknown workload kind '{value}'."),
-        };
+            throw new JsonException($"Unknown workload kind '{value}'.");
+        }
+
+        return kind;
     }
 
     public override void Write(Utf8JsonWriter writer, WorkloadKind value, JsonSerializerOptions options)
     {
-        string wireValue = value switch
-        {
-            WorkloadKind.Workload => "workload",
-            WorkloadKind.Content => "content",
-            WorkloadKind.Meta => "meta",
-            WorkloadKind.RidPointer => "rid-pointer",
-            _ => throw new JsonException($"Unknown workload kind '{value}'."),
-        };
-
-        writer.WriteStringValue(wireValue);
+        writer.WriteStringValue(value.ToWireValue());
     }
 }

--- a/src/Func/Workloads/Storage/WorkloadJsonContext.cs
+++ b/src/Func/Workloads/Storage/WorkloadJsonContext.cs
@@ -11,11 +11,9 @@ namespace Azure.Functions.Cli.Workloads.Storage;
 /// shapes. Keeps the JSON path reflection-free (AOT/trim-friendly).
 /// </summary>
 /// <remarks>
-/// We use a custom <see cref="JsonStringEnumConverter{T}"/> instead of
-/// <c>UseStringEnumConverter = true</c> because the source generator's
-/// generated converter does not apply <see cref="JsonNamingPolicy.CamelCase"/>
-/// to enum value names; it would emit <c>"Workload"</c> rather than the
-/// schema-required <c>"workload"</c>.
+/// The manifest's <c>kind</c> wire values are not derivable from a naming policy
+/// (<c>rid-pointer</c> is hyphenated), so <see cref="WorkloadKindJsonConverter"/>
+/// maps them explicitly instead of using <c>UseStringEnumConverter</c>.
 /// </remarks>
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,

--- a/src/Func/Workloads/Storage/WorkloadManifestSchema.cs
+++ b/src/Func/Workloads/Storage/WorkloadManifestSchema.cs
@@ -8,9 +8,7 @@ namespace Azure.Functions.Cli.Workloads.Storage;
 /// </summary>
 /// <remarks>
 /// Each manifest carries its schema identity in the top-level <c>$schema</c>
-/// property. Breaking changes ship under a new versioned URL so older and
-/// newer CLIs can coexist on disk. The registry and per-package manifest
-/// version independently.
+/// property. The registry and per-package manifest version independently.
 /// </remarks>
 internal static class WorkloadManifestSchema
 {
@@ -59,4 +57,3 @@ internal static class WorkloadManifestSchema
         => !string.IsNullOrEmpty(schema)
            && SupportedPackageManifestSchemas.Contains(schema, StringComparer.Ordinal);
 }
-

--- a/src/Func/Workloads/WorkloadKind.cs
+++ b/src/Func/Workloads/WorkloadKind.cs
@@ -4,10 +4,8 @@
 namespace Azure.Functions.Cli.Workloads;
 
 /// <summary>
-/// Discriminator for the three shapes a workload package can take, declared
-/// in <c>workload.json</c>'s <c>kind</c> field
-/// (workload-package-layout §5.4). Determines whether the loader activates
-/// the package, skips it, or treats it as install-time-only.
+/// Discriminator for workload package shapes declared in
+/// <c>workload.json</c>'s <c>kind</c> field.
 /// </summary>
 internal enum WorkloadKind
 {
@@ -31,4 +29,10 @@ internal enum WorkloadKind
     /// loader never activates it.
     /// </summary>
     Meta = 2,
+
+    /// <summary>
+    /// Carries no payload. Maps supported runtime identifiers to exact
+    /// implementation package ids for install and update resolution.
+    /// </summary>
+    RidPointer = 3,
 }

--- a/src/Func/Workloads/WorkloadKindExtensions.cs
+++ b/src/Func/Workloads/WorkloadKindExtensions.cs
@@ -1,0 +1,71 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workloads;
+
+/// <summary>
+/// Extension members that translate <see cref="WorkloadKind"/> to and from the
+/// wire values used by <c>workload.json</c>'s <c>kind</c> field.
+/// </summary>
+internal static class WorkloadKindExtensions
+{
+    private const string WorkloadValue = "workload";
+    private const string ContentValue = "content";
+    private const string MetaValue = "meta";
+    private const string RidPointerValue = "rid-pointer";
+
+    extension(WorkloadKind kind)
+    {
+        /// <summary>
+        /// Returns the manifest wire value for this kind.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown when <paramref name="kind"/> is not a defined
+        /// <see cref="WorkloadKind"/>.
+        /// </exception>
+        public string ToWireValue()
+            => kind switch
+            {
+                WorkloadKind.Workload => WorkloadValue,
+                WorkloadKind.Content => ContentValue,
+                WorkloadKind.Meta => MetaValue,
+                WorkloadKind.RidPointer => RidPointerValue,
+                _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unrecognized workload kind."),
+            };
+    }
+
+    extension(WorkloadKind)
+    {
+        /// <summary>
+        /// Converts a manifest wire value to its <see cref="WorkloadKind"/>,
+        /// returning <see langword="false"/> when the value is unrecognized.
+        /// </summary>
+        /// <remarks>
+        /// Named <c>TryParseWireValue</c> rather than <c>TryParse</c> because the
+        /// inherited <see cref="Enum.TryParse{TEnum}(string, out TEnum)"/> would win
+        /// overload resolution and silently match enum member names instead of wire
+        /// values.
+        /// </remarks>
+        public static bool TryParseWireValue(string? value, out WorkloadKind kind)
+        {
+            switch (value)
+            {
+                case WorkloadValue:
+                    kind = WorkloadKind.Workload;
+                    return true;
+                case ContentValue:
+                    kind = WorkloadKind.Content;
+                    return true;
+                case MetaValue:
+                    kind = WorkloadKind.Meta;
+                    return true;
+                case RidPointerValue:
+                    kind = WorkloadKind.RidPointer;
+                    return true;
+                default:
+                    kind = default;
+                    return false;
+            }
+        }
+    }
+}

--- a/src/Func/Workloads/WorkloadMetadata.cs
+++ b/src/Func/Workloads/WorkloadMetadata.cs
@@ -31,6 +31,17 @@ internal sealed class WorkloadMetadata
     public EntryPointSpec? EntryPoint { get; init; }
 
     /// <summary>
+    /// Maps normalized runtime identifiers to exact implementation package ids.
+    /// Required only for <see cref="WorkloadKind.RidPointer"/>.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? Packages { get; init; }
+
+    /// <summary>
+    /// Runtime identifier of a RID-specific workload or content implementation.
+    /// </summary>
+    public string? RuntimeIdentifier { get; init; }
+
+    /// <summary>
     /// Human-readable name for inventory and list output.
     /// </summary>
     public string DisplayName { get; init; } = string.Empty;

--- a/test/Func.Tests/Workloads/Discovery/WorkloadMetadataReaderTests.cs
+++ b/test/Func.Tests/Workloads/Discovery/WorkloadMetadataReaderTests.cs
@@ -127,6 +127,166 @@ public class WorkloadMetadataReaderTests : IDisposable
         metadata.EntryPoint.Should().BeNull();
     }
 
+    [Fact]
+    public void Read_ReturnsRidPointerMetadata()
+    {
+        WriteMetadata(
+            $$"""
+            {
+              "$schema": "{{SchemaUrl}}",
+              "kind": "rid-pointer",
+              "packages": {
+                "linux-x64": "Example.Workload.linux-x64",
+                "win-x64": "Example.Workload.win-x64"
+              }
+            }
+            """);
+
+        WorkloadMetadata metadata = _reader.Read(_tempDir);
+
+        metadata.Kind.Should().Be(WorkloadKind.RidPointer);
+        metadata.Packages!["win-x64"].Should().Be("Example.Workload.win-x64");
+        metadata.RuntimeIdentifier.Should().BeNull();
+    }
+
+    [Fact]
+    public void Read_ReturnsRidImplementationMetadata()
+    {
+        WriteMetadata(
+            $$"""
+            {
+              "$schema": "{{SchemaUrl}}",
+              "kind": "content",
+              "runtimeIdentifier": "linux-arm64"
+            }
+            """);
+
+        WorkloadMetadata metadata = _reader.Read(_tempDir);
+
+        metadata.RuntimeIdentifier.Should().Be("linux-arm64");
+        metadata.Packages.Should().BeNull();
+    }
+
+    [Fact]
+    public void Read_Throws_WhenRidPointerPackagesAreMissing()
+    {
+        WriteMetadata(
+            $$"""
+            {
+              "$schema": "{{SchemaUrl}}",
+              "kind": "rid-pointer"
+            }
+            """);
+
+        InvalidWorkloadException ex = FluentActions.Invoking(() => _reader.Read(_tempDir)).Should().ThrowExactly<InvalidWorkloadException>().Which;
+
+        ex.Message.Should().Contain("non-empty packages");
+    }
+
+    [Fact]
+    public void Read_Throws_WhenRidPointerPackagesAreEmpty()
+    {
+        WriteMetadata(
+            $$"""
+            {
+              "$schema": "{{SchemaUrl}}",
+              "kind": "rid-pointer",
+              "packages": {}
+            }
+            """);
+
+        InvalidWorkloadException ex = FluentActions.Invoking(() => _reader.Read(_tempDir)).Should().ThrowExactly<InvalidWorkloadException>().Which;
+
+        ex.Message.Should().Contain("non-empty packages");
+    }
+
+    [Fact]
+    public void Read_Throws_WhenRidPointerRuntimeIdentifierIsUppercase()
+    {
+        WriteMetadata(
+            $$"""
+            {
+              "$schema": "{{SchemaUrl}}",
+              "kind": "rid-pointer",
+              "packages": {
+                "WIN-X64": "Example.Workload.win-x64"
+              }
+            }
+            """);
+
+        InvalidWorkloadException ex = FluentActions.Invoking(() => _reader.Read(_tempDir)).Should().ThrowExactly<InvalidWorkloadException>().Which;
+
+        ex.Message.Should().Contain("WIN-X64");
+        ex.Message.Should().Contain("lowercase");
+    }
+
+    [Fact]
+    public void Read_Throws_WhenRidPointerHasNonLowercaseRuntimeIdentifier()
+    {
+        WriteMetadata(
+            $$"""
+            {
+              "$schema": "{{SchemaUrl}}",
+              "kind": "rid-pointer",
+              "packages": {
+                "win-x64": "Example.Workload.win-x64",
+                "WIN-X64": "Example.Workload.win-x64"
+              }
+            }
+            """);
+
+        InvalidWorkloadException ex = FluentActions.Invoking(() => _reader.Read(_tempDir)).Should().ThrowExactly<InvalidWorkloadException>().Which;
+
+        ex.Message.Should().Contain("must be lowercase");
+    }
+
+    [Fact]
+    public void Read_Throws_WhenOrdinaryWorkloadDefinesPackages()
+    {
+        WriteMetadata(
+            $$"""
+            {
+              "$schema": "{{SchemaUrl}}",
+              "kind": "workload",
+              "entryPoint": {
+                "assemblyPath": "Foo.dll",
+                "type": "Foo.MyWorkload"
+              },
+              "packages": {
+                "win-x64": "Example.Workload.win-x64"
+              }
+            }
+            """);
+
+        InvalidWorkloadException ex = FluentActions.Invoking(() => _reader.Read(_tempDir)).Should().ThrowExactly<InvalidWorkloadException>().Which;
+
+        ex.Message.Should().Contain("packages");
+    }
+
+    [Fact]
+    public void Read_Throws_WhenRidPointerDefinesEntryPointOrRuntimeIdentifier()
+    {
+        WriteMetadata(
+            $$"""
+            {
+              "$schema": "{{SchemaUrl}}",
+              "kind": "rid-pointer",
+              "entryPoint": {
+                "assemblyPath": "Foo.dll",
+                "type": "Foo.MyWorkload"
+              },
+              "runtimeIdentifier": "win-x64",
+              "packages": {
+                "win-x64": "Example.Workload.win-x64"
+              }
+            }
+            """);
+
+        InvalidWorkloadException ex = FluentActions.Invoking(() => _reader.Read(_tempDir)).Should().ThrowExactly<InvalidWorkloadException>().Which;
+
+        ex.Message.Should().Contain("entryPoint");
+    }
+
     [Theory]
     [InlineData("content")]
     [InlineData("meta")]

--- a/test/Func.Tests/Workloads/WorkloadKindExtensionsTests.cs
+++ b/test/Func.Tests/Workloads/WorkloadKindExtensionsTests.cs
@@ -1,0 +1,70 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Azure.Functions.Cli.Workloads;
+
+namespace Azure.Functions.Cli.Tests.Workloads;
+
+// WorkloadKind is internal, so it cannot appear in the signature of a public
+// test method (CS0051). Kinds are named inside the bodies rather than passed
+// as [InlineData] arguments.
+public class WorkloadKindExtensionsTests
+{
+    [Fact]
+    public void ToWireValue_ReturnsManifestValue()
+    {
+        WorkloadKind.Workload.ToWireValue().Should().Be("workload");
+        WorkloadKind.Content.ToWireValue().Should().Be("content");
+        WorkloadKind.Meta.ToWireValue().Should().Be("meta");
+        WorkloadKind.RidPointer.ToWireValue().Should().Be("rid-pointer");
+    }
+
+    [Fact]
+    public void ToWireValue_Throws_WhenKindIsUndefined()
+    {
+        var kind = (WorkloadKind)99;
+
+        FluentActions.Invoking(() => kind.ToWireValue()).Should().ThrowExactly<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void TryParseWireValue_ReturnsKind_ForManifestValue()
+    {
+        ShouldParseAs("workload", WorkloadKind.Workload);
+        ShouldParseAs("content", WorkloadKind.Content);
+        ShouldParseAs("meta", WorkloadKind.Meta);
+        ShouldParseAs("rid-pointer", WorkloadKind.RidPointer);
+    }
+
+    [Fact]
+    public void TryParseWireValue_RoundTrips_EveryKind()
+    {
+        foreach (WorkloadKind expected in Enum.GetValues<WorkloadKind>())
+        {
+            ShouldParseAs(expected.ToWireValue(), expected);
+        }
+    }
+
+    [Theory]
+    [InlineData("Workload")]
+    [InlineData("ridPointer")]
+    [InlineData("rid_pointer")]
+    [InlineData("unknown")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void TryParseWireValue_ReturnsFalse_ForUnrecognizedValue(string? value)
+    {
+        bool parsed = WorkloadKind.TryParseWireValue(value, out WorkloadKind kind);
+
+        parsed.Should().BeFalse();
+        kind.Should().Be(default(WorkloadKind));
+    }
+
+    private static void ShouldParseAs(string value, WorkloadKind expected)
+    {
+        bool parsed = WorkloadKind.TryParseWireValue(value, out WorkloadKind kind);
+
+        parsed.Should().BeTrue($"'{value}' is a known workload kind");
+        kind.Should().Be(expected);
+    }
+}


### PR DESCRIPTION
Layer 2 of 6 in a stack decomposing #5512 ("Add RID pointer package support") into small dependent PRs. Stacks on #5515 (layer 1) and targets `fabiocav/workload-sdk-rid-packages`.

## What this changes

This layer is the `workload.json` manifest contract that the CLI reads. It teaches the contract to describe RID pointer packages and their RID-specific implementations.

- **`WorkloadKind.RidPointer`** — a fourth kind whose JSON wire value is the hyphenated `rid-pointer`. Camel casing can't produce that, so `WorkloadKindJsonConverter` is rewritten from a `JsonStringEnumConverter<WorkloadKind>` into an explicit `JsonConverter<WorkloadKind>` with a declared read/write mapping that throws `JsonException` on unknown values.
- **`WorkloadMetadata.Packages`** — the RID-to-implementation package id map, required only for `rid-pointer`.
- **`WorkloadMetadata.RuntimeIdentifier`** — the RID an implementation package declares for itself.
- **`WorkloadMetadataReader` validation** for both shapes:
  - `rid-pointer` must declare a non-empty `packages` map, with lowercase and unique keys and non-empty package ids, and must not declare an `entryPoint` or a `runtimeIdentifier`.
  - `workload` and `content` must not declare `packages`, and any `runtimeIdentifier` they declare must be normalized (lowercase, untrimmed-free).
  - `meta` stays payload-free: no `entryPoint`, no `packages`, no `runtimeIdentifier`.

Validation ordering is preserved exactly as written in the source PR — it's load-bearing, since a test asserts which message wins when a manifest is invalid in more than one way.

## Testing

- `dotnet build -c Release` with `CI=true`: **0 warnings, 0 errors**. Adding the enum member produced no non-exhaustive `switch` fallout — every existing `switch` over `WorkloadKind` already had a default arm, so nothing outside the slice needed to change.
- `Func.Tests` filtered to `WorkloadMetadataReader`: 28 passed.
- Full `Func.Tests`: 1328 passed, 1 failed — `ProcessRunnerTests.RunAsync_Timeout_IsReported`, a pre-existing environment-dependent failure unrelated to this change.

No version or release-note changes: this is a decomposition of already-reviewed work, not a release.