### PR TITLE
Workloads: model physical and logical package ownership in the registry

### DIFF
--- a/src/Func/Hosting/WorkloadStorageRegistration.cs
+++ b/src/Func/Hosting/WorkloadStorageRegistration.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Azure.Functions.Cli.Common;
+using Azure.Functions.Cli.Workloads;
 using Azure.Functions.Cli.Workloads.Discovery;
 using Azure.Functions.Cli.Workloads.Loading;
 using Azure.Functions.Cli.Workloads.Storage;
@@ -32,6 +33,7 @@ internal static class WorkloadStorageRegistration
         services.AddSingleton<IWorkloadStore, WorkloadStore>();
         services.AddSingleton<IWorkloadLoader, WorkloadLoader>();
         services.AddSingleton<IWorkloadMetadataReader, WorkloadMetadataReader>();
+        services.AddSingleton<IWorkloadRuntimeIdentifierProvider, WorkloadRuntimeIdentifierProvider>();
 
         return services;
     }

--- a/src/Func/Workloads/IWorkloadRuntimeIdentifierProvider.cs
+++ b/src/Func/Workloads/IWorkloadRuntimeIdentifierProvider.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workloads;
+
+internal interface IWorkloadRuntimeIdentifierProvider
+{
+    public string Current { get; }
+}
+
+internal sealed class WorkloadRuntimeIdentifierProvider : IWorkloadRuntimeIdentifierProvider
+{
+    public string Current => WorkloadRuntimeIdentifier.Current;
+}

--- a/src/Func/Workloads/Storage/IWorkloadStore.cs
+++ b/src/Func/Workloads/Storage/IWorkloadStore.cs
@@ -46,46 +46,32 @@ internal interface IWorkloadStore
     /// (spec §6.4 step 4) to avoid leaving the registry in a half-swapped
     /// state if the process dies mid-write.
     /// </summary>
-    public Task ReplaceWorkloadAsync(
-        string oldPackageId,
-        string oldVersion,
-        WorkloadEntry newEntry,
+    public Task ReplaceWorkloadAsync(string oldPackageId, string oldVersion, WorkloadEntry newEntry,
         CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Atomically attaches explicit or logical ownership to an existing physical
     /// row, or inserts <paramref name="entry"/> when it is not installed.
     /// </summary>
-    public Task<WorkloadEntry> AddOwnershipAsync(
-        WorkloadEntry entry,
-        WorkloadOwnershipKind ownership,
+    public Task<WorkloadEntry> AddOwnershipAsync(WorkloadEntry entry, WorkloadOwnershipKind ownership,
         CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Atomically removes only the requested ownership and deletes the physical
     /// row when its final owner is removed.
     /// </summary>
-    public Task<WorkloadOwnershipRemovalResult> RemoveOwnershipAsync(
-        string packageId,
-        string version,
-        WorkloadOwnershipKind ownership,
-        CancellationToken cancellationToken = default);
+    public Task<WorkloadOwnershipRemovalResult> RemoveOwnershipAsync(string packageId, string version,
+        WorkloadOwnershipKind ownership, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Atomically moves logical pointer ownership from one physical row to another.
     /// </summary>
-    public Task<WorkloadOwnershipMoveResult> MoveLogicalOwnershipAsync(
-        string oldPackageId,
-        string oldVersion,
-        WorkloadEntry newEntry,
-        CancellationToken cancellationToken = default);
+    public Task<WorkloadOwnershipMoveResult> MoveLogicalOwnershipAsync(string oldPackageId, string oldVersion,
+        WorkloadEntry newEntry, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Atomically moves explicit ownership from one physical row to another.
     /// </summary>
-    public Task<WorkloadOwnershipMoveResult> MoveExplicitOwnershipAsync(
-        string oldPackageId,
-        string oldVersion,
-        WorkloadEntry newEntry,
-        CancellationToken cancellationToken = default);
+    public Task<WorkloadOwnershipMoveResult> MoveExplicitOwnershipAsync(string oldPackageId, string oldVersion,
+        WorkloadEntry newEntry, CancellationToken cancellationToken = default);
 }

--- a/src/Func/Workloads/Storage/IWorkloadStore.cs
+++ b/src/Func/Workloads/Storage/IWorkloadStore.cs
@@ -51,4 +51,41 @@ internal interface IWorkloadStore
         string oldVersion,
         WorkloadEntry newEntry,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Atomically attaches explicit or logical ownership to an existing physical
+    /// row, or inserts <paramref name="entry"/> when it is not installed.
+    /// </summary>
+    public Task<WorkloadEntry> AddOwnershipAsync(
+        WorkloadEntry entry,
+        WorkloadOwnershipKind ownership,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Atomically removes only the requested ownership and deletes the physical
+    /// row when its final owner is removed.
+    /// </summary>
+    public Task<WorkloadOwnershipRemovalResult> RemoveOwnershipAsync(
+        string packageId,
+        string version,
+        WorkloadOwnershipKind ownership,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Atomically moves logical pointer ownership from one physical row to another.
+    /// </summary>
+    public Task<WorkloadOwnershipMoveResult> MoveLogicalOwnershipAsync(
+        string oldPackageId,
+        string oldVersion,
+        WorkloadEntry newEntry,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Atomically moves explicit ownership from one physical row to another.
+    /// </summary>
+    public Task<WorkloadOwnershipMoveResult> MoveExplicitOwnershipAsync(
+        string oldPackageId,
+        string oldVersion,
+        WorkloadEntry newEntry,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Func/Workloads/Storage/WorkloadOwnership.cs
+++ b/src/Func/Workloads/Storage/WorkloadOwnership.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Azure.Functions.Cli.Workloads.Storage;
+
+internal enum WorkloadOwnershipKind
+{
+    Explicit,
+    Logical,
+}
+
+internal sealed record WorkloadOwnershipRemovalResult(bool OwnershipRemoved, bool EntryRemoved, WorkloadEntry? Entry);
+
+internal sealed record WorkloadOwnershipMoveResult(WorkloadEntry Entry, bool PreviousEntryRemoved);

--- a/src/Func/Workloads/Storage/WorkloadRegistry.cs
+++ b/src/Func/Workloads/Storage/WorkloadRegistry.cs
@@ -37,6 +37,8 @@ internal sealed class WorkloadRegistry
 /// </summary>
 internal sealed class WorkloadEntry
 {
+    private bool? _isExplicitlyInstalled;
+
     /// <summary>
     /// NuGet package id (e.g. <c>"Azure.Functions.Cli.Workloads.Dotnet"</c>).
     /// Matched case-insensitively.
@@ -78,11 +80,38 @@ internal sealed class WorkloadEntry
     public string Source { get; init; } = string.Empty;
 
     /// <summary>
-    /// Number of installs that brought this package in. An explicit
-    /// <c>func workload install &lt;id&gt;</c> bumps the count; each meta package
-    /// that lists this package as a member also bumps the count at meta install.
-    /// Explicit uninstall removes the entry regardless of the count; meta
-    /// uninstall decrements and removes only when the count hits zero.
+    /// Runtime identifier validated for a RID-specific implementation package.
+    /// Null for ordinary and legacy entries.
+    /// </summary>
+    public string? RuntimeIdentifier { get; init; }
+
+    /// <summary>
+    /// Whether this physical package has an explicit install owner. Defaults
+    /// to true so registry rows written by older CLIs retain their ownership.
+    /// </summary>
+    [JsonIgnore]
+    public bool IsExplicitlyInstalled
+    {
+        get => _isExplicitlyInstalled ?? true;
+        init => _isExplicitlyInstalled = value;
+    }
+
+    [JsonPropertyName("isExplicitlyInstalled")]
+    public bool? PersistedIsExplicitlyInstalled
+    {
+        get => _isExplicitlyInstalled;
+        init => _isExplicitlyInstalled = value;
+    }
+
+    /// <summary>
+    /// Logical pointer package that selected this implementation, or null when
+    /// no pointer owner is attached.
+    /// </summary>
+    public LogicalPackage? LogicalPackage { get; init; }
+
+    /// <summary>
+    /// Number of distinct owners: explicit ownership, logical pointer ownership,
+    /// and meta owners. Repeating an install by the same owner is idempotent.
     /// Defaults to 1 for legacy entries that pre-date this field.
     /// </summary>
     public int InstallRefCount { get; init; } = 1;
@@ -94,6 +123,24 @@ internal sealed class WorkloadEntry
     /// for <see cref="WorkloadKind.Content"/>.
     /// </summary>
     public EntryPointSpec? EntryPoint { get; init; }
+}
+
+/// <summary>
+/// User-facing pointer package metadata persisted with its selected physical implementation.
+/// </summary>
+internal sealed class LogicalPackage
+{
+    public required string PackageId { get; init; }
+
+    public required string PackageVersion { get; init; }
+
+    public IReadOnlyList<string> Aliases { get; init; } = [];
+
+    public string DisplayName { get; init; } = string.Empty;
+
+    public string Description { get; init; } = string.Empty;
+
+    public string Source { get; init; } = string.Empty;
 }
 
 /// <summary>

--- a/src/Func/Workloads/Storage/WorkloadRegistry.cs
+++ b/src/Func/Workloads/Storage/WorkloadRegistry.cs
@@ -37,8 +37,6 @@ internal sealed class WorkloadRegistry
 /// </summary>
 internal sealed class WorkloadEntry
 {
-    private bool? _isExplicitlyInstalled;
-
     /// <summary>
     /// NuGet package id (e.g. <c>"Azure.Functions.Cli.Workloads.Dotnet"</c>).
     /// Matched case-insensitively.
@@ -86,22 +84,11 @@ internal sealed class WorkloadEntry
     public string? RuntimeIdentifier { get; init; }
 
     /// <summary>
-    /// Whether this physical package has an explicit install owner. Defaults
-    /// to true so registry rows written by older CLIs retain their ownership.
+    /// Whether this physical package lacks an explicit install owner. Defaults
+    /// to false so registry rows written by older CLIs retain their ownership.
     /// </summary>
-    [JsonIgnore]
-    public bool IsExplicitlyInstalled
-    {
-        get => _isExplicitlyInstalled ?? true;
-        init => _isExplicitlyInstalled = value;
-    }
-
-    [JsonPropertyName("isExplicitlyInstalled")]
-    public bool? PersistedIsExplicitlyInstalled
-    {
-        get => _isExplicitlyInstalled;
-        init => _isExplicitlyInstalled = value;
-    }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public bool IsImplicitlyInstalled { get; init; }
 
     /// <summary>
     /// Logical pointer package that selected this implementation, or null when

--- a/src/Func/Workloads/Storage/WorkloadStore.cs
+++ b/src/Func/Workloads/Storage/WorkloadStore.cs
@@ -93,6 +93,153 @@ internal class WorkloadStore(IWorkloadPaths paths) : IWorkloadStore
         await WriteRegistryAsync(registry, cancellationToken);
     }
 
+    public async Task<WorkloadEntry> AddOwnershipAsync(
+        WorkloadEntry entry,
+        WorkloadOwnershipKind ownership,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateEntry(entry);
+        ValidateOwnership(entry, ownership);
+
+        WorkloadRegistry registry = await ReadRegistryAsync(cancellationToken);
+        int index = FindIndex(registry, entry.PackageId, entry.PackageVersion);
+        WorkloadEntry merged = index < 0
+            ? NormalizeNewEntry(entry, ownership)
+            : MergeOwnership(registry.Workloads[index], entry, ownership);
+
+        if (index < 0)
+        {
+            registry.Workloads.Add(merged);
+        }
+        else
+        {
+            registry.Workloads[index] = merged;
+        }
+
+        await WriteRegistryAsync(registry, cancellationToken);
+        return merged;
+    }
+
+    public async Task<WorkloadOwnershipRemovalResult> RemoveOwnershipAsync(
+        string packageId,
+        string version,
+        WorkloadOwnershipKind ownership,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(version);
+
+        WorkloadRegistry registry = await ReadRegistryAsync(cancellationToken);
+        int index = FindIndex(registry, packageId, version);
+        if (index < 0)
+        {
+            return new WorkloadOwnershipRemovalResult(false, false, null);
+        }
+
+        WorkloadEntry current = registry.Workloads[index];
+        bool hasOwnership = ownership switch
+        {
+            WorkloadOwnershipKind.Explicit => current.IsExplicitlyInstalled,
+            WorkloadOwnershipKind.Logical => current.LogicalPackage is not null,
+            _ => throw new ArgumentOutOfRangeException(nameof(ownership)),
+        };
+
+        if (!hasOwnership)
+        {
+            return new WorkloadOwnershipRemovalResult(false, false, current);
+        }
+
+        int remainingReferences = current.InstallRefCount - 1;
+        if (remainingReferences <= 0)
+        {
+            registry.Workloads.RemoveAt(index);
+            await WriteRegistryAsync(registry, cancellationToken);
+            return new WorkloadOwnershipRemovalResult(true, true, null);
+        }
+
+        WorkloadEntry updated = CopyWithOwnership(
+            current,
+            isExplicitlyInstalled: ownership == WorkloadOwnershipKind.Explicit ? false : current.IsExplicitlyInstalled,
+            logicalPackage: ownership == WorkloadOwnershipKind.Logical ? null : current.LogicalPackage,
+            installRefCount: remainingReferences);
+        registry.Workloads[index] = updated;
+        await WriteRegistryAsync(registry, cancellationToken);
+        return new WorkloadOwnershipRemovalResult(true, false, updated);
+    }
+
+    public async Task<WorkloadOwnershipMoveResult> MoveLogicalOwnershipAsync(
+        string oldPackageId,
+        string oldVersion,
+        WorkloadEntry newEntry,
+        CancellationToken cancellationToken = default)
+        => await MoveOwnershipAsync(oldPackageId, oldVersion, newEntry, WorkloadOwnershipKind.Logical, cancellationToken);
+
+    public async Task<WorkloadOwnershipMoveResult> MoveExplicitOwnershipAsync(
+        string oldPackageId,
+        string oldVersion,
+        WorkloadEntry newEntry,
+        CancellationToken cancellationToken = default)
+        => await MoveOwnershipAsync(oldPackageId, oldVersion, newEntry, WorkloadOwnershipKind.Explicit, cancellationToken);
+
+    private async Task<WorkloadOwnershipMoveResult> MoveOwnershipAsync(
+        string oldPackageId,
+        string oldVersion,
+        WorkloadEntry newEntry,
+        WorkloadOwnershipKind ownership,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(oldPackageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(oldVersion);
+        ValidateEntry(newEntry);
+        ValidateOwnership(newEntry, ownership);
+
+        WorkloadRegistry registry = await ReadRegistryAsync(cancellationToken);
+        int oldIndex = FindIndex(registry, oldPackageId, oldVersion);
+        bool ownershipExists = oldIndex >= 0 && ownership switch
+        {
+            WorkloadOwnershipKind.Explicit => registry.Workloads[oldIndex].IsExplicitlyInstalled,
+            WorkloadOwnershipKind.Logical => registry.Workloads[oldIndex].LogicalPackage is not null,
+            _ => throw new ArgumentOutOfRangeException(nameof(ownership)),
+        };
+        if (!ownershipExists)
+        {
+            throw new InvalidOperationException(
+                $"{ownership} ownership for workload '{oldPackageId}' version '{oldVersion}' is not installed.");
+        }
+
+        WorkloadEntry oldEntry = registry.Workloads[oldIndex];
+        int remainingReferences = oldEntry.InstallRefCount - 1;
+        bool previousEntryRemoved = remainingReferences <= 0;
+        if (previousEntryRemoved)
+        {
+            registry.Workloads.RemoveAt(oldIndex);
+        }
+        else
+        {
+            registry.Workloads[oldIndex] = CopyWithOwnership(
+                oldEntry,
+                ownership == WorkloadOwnershipKind.Explicit ? false : oldEntry.IsExplicitlyInstalled,
+                ownership == WorkloadOwnershipKind.Logical ? null : oldEntry.LogicalPackage,
+                remainingReferences);
+        }
+
+        int newIndex = FindIndex(registry, newEntry.PackageId, newEntry.PackageVersion);
+        WorkloadEntry merged = newIndex < 0
+            ? NormalizeNewEntry(newEntry, ownership)
+            : MergeOwnership(registry.Workloads[newIndex], newEntry, ownership);
+        if (newIndex < 0)
+        {
+            registry.Workloads.Add(merged);
+        }
+        else
+        {
+            registry.Workloads[newIndex] = merged;
+        }
+
+        await WriteRegistryAsync(registry, cancellationToken);
+        return new WorkloadOwnershipMoveResult(merged, previousEntryRemoved);
+    }
+
     private static int FindIndex(WorkloadRegistry registry, string packageId, string version)
     {
         for (int i = 0; i < registry.Workloads.Count; i++)
@@ -107,6 +254,75 @@ internal class WorkloadStore(IWorkloadPaths paths) : IWorkloadStore
 
         return -1;
     }
+
+    private static void ValidateEntry(WorkloadEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        ArgumentException.ThrowIfNullOrWhiteSpace(entry.PackageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(entry.PackageVersion);
+    }
+
+    private static void ValidateOwnership(WorkloadEntry entry, WorkloadOwnershipKind ownership)
+    {
+        if (ownership == WorkloadOwnershipKind.Logical && entry.LogicalPackage is null)
+        {
+            throw new ArgumentException("Logical ownership requires logical package metadata.", nameof(entry));
+        }
+    }
+
+    private static WorkloadEntry NormalizeNewEntry(WorkloadEntry entry, WorkloadOwnershipKind ownership)
+    {
+        bool explicitOwner = ownership == WorkloadOwnershipKind.Explicit || entry.IsExplicitlyInstalled;
+        int ownerCount = (explicitOwner ? 1 : 0) + (entry.LogicalPackage is null ? 0 : 1);
+        return CopyWithOwnership(entry, explicitOwner, entry.LogicalPackage, Math.Max(ownerCount, entry.InstallRefCount));
+    }
+
+    private static WorkloadEntry MergeOwnership(WorkloadEntry current, WorkloadEntry incoming, WorkloadOwnershipKind ownership)
+    {
+        bool attachExplicit = ownership == WorkloadOwnershipKind.Explicit && !current.IsExplicitlyInstalled;
+        bool attachLogical = ownership == WorkloadOwnershipKind.Logical && current.LogicalPackage is null;
+        if (ownership == WorkloadOwnershipKind.Logical
+            && current.LogicalPackage is not null
+            && !SameLogicalOwner(current.LogicalPackage, incoming.LogicalPackage!))
+        {
+            throw new InvalidOperationException(
+                $"Physical workload '{current.PackageId}' version '{current.PackageVersion}' is already owned by logical package " +
+                $"'{current.LogicalPackage.PackageId}' version '{current.LogicalPackage.PackageVersion}'.");
+        }
+
+        // Payload metadata comes from the incoming entry: the caller may have just replaced the payload
+        // on disk, and a legacy row would otherwise keep stale values such as a missing runtime identifier.
+        return CopyWithOwnership(
+            incoming,
+            current.IsExplicitlyInstalled || ownership == WorkloadOwnershipKind.Explicit,
+            current.LogicalPackage ?? incoming.LogicalPackage,
+            current.InstallRefCount + (attachExplicit ? 1 : 0) + (attachLogical ? 1 : 0));
+    }
+
+    private static bool SameLogicalOwner(LogicalPackage left, LogicalPackage right)
+        => string.Equals(left.PackageId, right.PackageId, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(left.PackageVersion, right.PackageVersion, StringComparison.Ordinal);
+
+    private static WorkloadEntry CopyWithOwnership(
+        WorkloadEntry entry,
+        bool isExplicitlyInstalled,
+        LogicalPackage? logicalPackage,
+        int installRefCount)
+        => new()
+        {
+            PackageId = entry.PackageId,
+            PackageVersion = entry.PackageVersion,
+            Kind = entry.Kind,
+            Aliases = entry.Aliases,
+            DisplayName = entry.DisplayName,
+            Description = entry.Description,
+            Source = entry.Source,
+            RuntimeIdentifier = entry.RuntimeIdentifier,
+            IsExplicitlyInstalled = isExplicitlyInstalled,
+            LogicalPackage = logicalPackage,
+            InstallRefCount = installRefCount,
+            EntryPoint = entry.EntryPoint,
+        };
 
     private async Task<WorkloadRegistry> ReadRegistryAsync(CancellationToken cancellationToken)
     {

--- a/src/Func/Workloads/Storage/WorkloadStore.cs
+++ b/src/Func/Workloads/Storage/WorkloadStore.cs
@@ -280,7 +280,7 @@ internal class WorkloadStore(IWorkloadPaths paths) : IWorkloadStore
     private static WorkloadEntry MergeOwnership(WorkloadEntry current, WorkloadEntry incoming, WorkloadOwnershipKind ownership)
     {
         bool attachExplicit = ownership == WorkloadOwnershipKind.Explicit && !current.IsExplicitlyInstalled;
-        bool attachLogical = ownership == WorkloadOwnershipKind.Logical && current.LogicalPackage is null;
+        bool attachLogical = current.LogicalPackage is null && incoming.LogicalPackage is not null;
         if (ownership == WorkloadOwnershipKind.Logical
             && current.LogicalPackage is not null
             && !SameLogicalOwner(current.LogicalPackage, incoming.LogicalPackage!))

--- a/src/Func/Workloads/Storage/WorkloadStore.cs
+++ b/src/Func/Workloads/Storage/WorkloadStore.cs
@@ -60,10 +60,7 @@ internal class WorkloadStore(IWorkloadPaths paths) : IWorkloadStore
         return true;
     }
 
-    public async Task ReplaceWorkloadAsync(
-        string oldPackageId,
-        string oldVersion,
-        WorkloadEntry newEntry,
+    public async Task ReplaceWorkloadAsync(string oldPackageId, string oldVersion, WorkloadEntry newEntry,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(oldPackageId);
@@ -93,15 +90,66 @@ internal class WorkloadStore(IWorkloadPaths paths) : IWorkloadStore
         await WriteRegistryAsync(registry, cancellationToken);
     }
 
-    public async Task<WorkloadEntry> AddOwnershipAsync(
-        WorkloadEntry entry,
-        WorkloadOwnershipKind ownership,
+    public async Task<WorkloadEntry> AddOwnershipAsync(WorkloadEntry entry, WorkloadOwnershipKind ownership,
         CancellationToken cancellationToken = default)
     {
         ValidateEntry(entry);
         ValidateOwnership(entry, ownership);
 
         WorkloadRegistry registry = await ReadRegistryAsync(cancellationToken);
+        WorkloadEntry merged = AddOwnershipCore(registry, entry, ownership);
+        await WriteRegistryAsync(registry, cancellationToken);
+        return merged;
+    }
+
+    public async Task<WorkloadOwnershipRemovalResult> RemoveOwnershipAsync(string packageId, string version,
+        WorkloadOwnershipKind ownership, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(version);
+
+        WorkloadRegistry registry = await ReadRegistryAsync(cancellationToken);
+        WorkloadOwnershipRemovalResult result = RemoveOwnershipCore(registry, packageId, version, ownership);
+        if (!result.OwnershipRemoved)
+        {
+            return result;
+        }
+
+        await WriteRegistryAsync(registry, cancellationToken);
+        return result;
+    }
+
+    public async Task<WorkloadOwnershipMoveResult> MoveLogicalOwnershipAsync(string oldPackageId, string oldVersion,
+        WorkloadEntry newEntry, CancellationToken cancellationToken = default)
+        => await MoveOwnershipAsync(oldPackageId, oldVersion, newEntry, WorkloadOwnershipKind.Logical, cancellationToken);
+
+    public async Task<WorkloadOwnershipMoveResult> MoveExplicitOwnershipAsync(string oldPackageId, string oldVersion,
+        WorkloadEntry newEntry, CancellationToken cancellationToken = default)
+        => await MoveOwnershipAsync(oldPackageId, oldVersion, newEntry, WorkloadOwnershipKind.Explicit, cancellationToken);
+
+    private async Task<WorkloadOwnershipMoveResult> MoveOwnershipAsync(string oldPackageId, string oldVersion,
+        WorkloadEntry newEntry, WorkloadOwnershipKind ownership, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(oldPackageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(oldVersion);
+        ValidateEntry(newEntry);
+        ValidateOwnership(newEntry, ownership);
+
+        WorkloadRegistry registry = await ReadRegistryAsync(cancellationToken);
+        WorkloadOwnershipRemovalResult removal = RemoveOwnershipCore(registry, oldPackageId, oldVersion, ownership);
+        if (!removal.OwnershipRemoved)
+        {
+            throw new InvalidOperationException(
+                $"{ownership} ownership for workload '{oldPackageId}' version '{oldVersion}' is not installed.");
+        }
+
+        WorkloadEntry merged = AddOwnershipCore(registry, newEntry, ownership);
+        await WriteRegistryAsync(registry, cancellationToken);
+        return new WorkloadOwnershipMoveResult(merged, removal.EntryRemoved);
+    }
+
+    private static WorkloadEntry AddOwnershipCore(WorkloadRegistry registry, WorkloadEntry entry, WorkloadOwnershipKind ownership)
+    {
         int index = FindIndex(registry, entry.PackageId, entry.PackageVersion);
         WorkloadEntry merged = index < 0
             ? NormalizeNewEntry(entry, ownership)
@@ -116,20 +164,12 @@ internal class WorkloadStore(IWorkloadPaths paths) : IWorkloadStore
             registry.Workloads[index] = merged;
         }
 
-        await WriteRegistryAsync(registry, cancellationToken);
         return merged;
     }
 
-    public async Task<WorkloadOwnershipRemovalResult> RemoveOwnershipAsync(
-        string packageId,
-        string version,
-        WorkloadOwnershipKind ownership,
-        CancellationToken cancellationToken = default)
+    private static WorkloadOwnershipRemovalResult RemoveOwnershipCore(
+        WorkloadRegistry registry, string packageId, string version, WorkloadOwnershipKind ownership)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
-        ArgumentException.ThrowIfNullOrWhiteSpace(version);
-
-        WorkloadRegistry registry = await ReadRegistryAsync(cancellationToken);
         int index = FindIndex(registry, packageId, version);
         if (index < 0)
         {
@@ -139,7 +179,7 @@ internal class WorkloadStore(IWorkloadPaths paths) : IWorkloadStore
         WorkloadEntry current = registry.Workloads[index];
         bool hasOwnership = ownership switch
         {
-            WorkloadOwnershipKind.Explicit => current.IsExplicitlyInstalled,
+            WorkloadOwnershipKind.Explicit => !current.IsImplicitlyInstalled,
             WorkloadOwnershipKind.Logical => current.LogicalPackage is not null,
             _ => throw new ArgumentOutOfRangeException(nameof(ownership)),
         };
@@ -153,91 +193,14 @@ internal class WorkloadStore(IWorkloadPaths paths) : IWorkloadStore
         if (remainingReferences <= 0)
         {
             registry.Workloads.RemoveAt(index);
-            await WriteRegistryAsync(registry, cancellationToken);
             return new WorkloadOwnershipRemovalResult(true, true, null);
         }
 
         WorkloadEntry updated = CopyWithOwnership(
-            current,
-            isExplicitlyInstalled: ownership == WorkloadOwnershipKind.Explicit ? false : current.IsExplicitlyInstalled,
-            logicalPackage: ownership == WorkloadOwnershipKind.Logical ? null : current.LogicalPackage,
-            installRefCount: remainingReferences);
+            current, isImplicitlyInstalled: ownership == WorkloadOwnershipKind.Explicit || current.IsImplicitlyInstalled,
+            logicalPackage: ownership == WorkloadOwnershipKind.Logical ? null : current.LogicalPackage, installRefCount: remainingReferences);
         registry.Workloads[index] = updated;
-        await WriteRegistryAsync(registry, cancellationToken);
         return new WorkloadOwnershipRemovalResult(true, false, updated);
-    }
-
-    public async Task<WorkloadOwnershipMoveResult> MoveLogicalOwnershipAsync(
-        string oldPackageId,
-        string oldVersion,
-        WorkloadEntry newEntry,
-        CancellationToken cancellationToken = default)
-        => await MoveOwnershipAsync(oldPackageId, oldVersion, newEntry, WorkloadOwnershipKind.Logical, cancellationToken);
-
-    public async Task<WorkloadOwnershipMoveResult> MoveExplicitOwnershipAsync(
-        string oldPackageId,
-        string oldVersion,
-        WorkloadEntry newEntry,
-        CancellationToken cancellationToken = default)
-        => await MoveOwnershipAsync(oldPackageId, oldVersion, newEntry, WorkloadOwnershipKind.Explicit, cancellationToken);
-
-    private async Task<WorkloadOwnershipMoveResult> MoveOwnershipAsync(
-        string oldPackageId,
-        string oldVersion,
-        WorkloadEntry newEntry,
-        WorkloadOwnershipKind ownership,
-        CancellationToken cancellationToken)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(oldPackageId);
-        ArgumentException.ThrowIfNullOrWhiteSpace(oldVersion);
-        ValidateEntry(newEntry);
-        ValidateOwnership(newEntry, ownership);
-
-        WorkloadRegistry registry = await ReadRegistryAsync(cancellationToken);
-        int oldIndex = FindIndex(registry, oldPackageId, oldVersion);
-        bool ownershipExists = oldIndex >= 0 && ownership switch
-        {
-            WorkloadOwnershipKind.Explicit => registry.Workloads[oldIndex].IsExplicitlyInstalled,
-            WorkloadOwnershipKind.Logical => registry.Workloads[oldIndex].LogicalPackage is not null,
-            _ => throw new ArgumentOutOfRangeException(nameof(ownership)),
-        };
-        if (!ownershipExists)
-        {
-            throw new InvalidOperationException(
-                $"{ownership} ownership for workload '{oldPackageId}' version '{oldVersion}' is not installed.");
-        }
-
-        WorkloadEntry oldEntry = registry.Workloads[oldIndex];
-        int remainingReferences = oldEntry.InstallRefCount - 1;
-        bool previousEntryRemoved = remainingReferences <= 0;
-        if (previousEntryRemoved)
-        {
-            registry.Workloads.RemoveAt(oldIndex);
-        }
-        else
-        {
-            registry.Workloads[oldIndex] = CopyWithOwnership(
-                oldEntry,
-                ownership == WorkloadOwnershipKind.Explicit ? false : oldEntry.IsExplicitlyInstalled,
-                ownership == WorkloadOwnershipKind.Logical ? null : oldEntry.LogicalPackage,
-                remainingReferences);
-        }
-
-        int newIndex = FindIndex(registry, newEntry.PackageId, newEntry.PackageVersion);
-        WorkloadEntry merged = newIndex < 0
-            ? NormalizeNewEntry(newEntry, ownership)
-            : MergeOwnership(registry.Workloads[newIndex], newEntry, ownership);
-        if (newIndex < 0)
-        {
-            registry.Workloads.Add(merged);
-        }
-        else
-        {
-            registry.Workloads[newIndex] = merged;
-        }
-
-        await WriteRegistryAsync(registry, cancellationToken);
-        return new WorkloadOwnershipMoveResult(merged, previousEntryRemoved);
     }
 
     private static int FindIndex(WorkloadRegistry registry, string packageId, string version)
@@ -272,14 +235,14 @@ internal class WorkloadStore(IWorkloadPaths paths) : IWorkloadStore
 
     private static WorkloadEntry NormalizeNewEntry(WorkloadEntry entry, WorkloadOwnershipKind ownership)
     {
-        bool explicitOwner = ownership == WorkloadOwnershipKind.Explicit || entry.IsExplicitlyInstalled;
+        bool explicitOwner = ownership == WorkloadOwnershipKind.Explicit || !entry.IsImplicitlyInstalled;
         int ownerCount = (explicitOwner ? 1 : 0) + (entry.LogicalPackage is null ? 0 : 1);
-        return CopyWithOwnership(entry, explicitOwner, entry.LogicalPackage, Math.Max(ownerCount, entry.InstallRefCount));
+        return CopyWithOwnership(entry, !explicitOwner, entry.LogicalPackage, Math.Max(ownerCount, entry.InstallRefCount));
     }
 
     private static WorkloadEntry MergeOwnership(WorkloadEntry current, WorkloadEntry incoming, WorkloadOwnershipKind ownership)
     {
-        bool attachExplicit = ownership == WorkloadOwnershipKind.Explicit && !current.IsExplicitlyInstalled;
+        bool attachExplicit = ownership == WorkloadOwnershipKind.Explicit && current.IsImplicitlyInstalled;
         bool attachLogical = current.LogicalPackage is null && incoming.LogicalPackage is not null;
         if (ownership == WorkloadOwnershipKind.Logical
             && current.LogicalPackage is not null
@@ -294,7 +257,7 @@ internal class WorkloadStore(IWorkloadPaths paths) : IWorkloadStore
         // on disk, and a legacy row would otherwise keep stale values such as a missing runtime identifier.
         return CopyWithOwnership(
             incoming,
-            current.IsExplicitlyInstalled || ownership == WorkloadOwnershipKind.Explicit,
+            current.IsImplicitlyInstalled && ownership != WorkloadOwnershipKind.Explicit,
             current.LogicalPackage ?? incoming.LogicalPackage,
             current.InstallRefCount + (attachExplicit ? 1 : 0) + (attachLogical ? 1 : 0));
     }
@@ -304,10 +267,7 @@ internal class WorkloadStore(IWorkloadPaths paths) : IWorkloadStore
             && string.Equals(left.PackageVersion, right.PackageVersion, StringComparison.Ordinal);
 
     private static WorkloadEntry CopyWithOwnership(
-        WorkloadEntry entry,
-        bool isExplicitlyInstalled,
-        LogicalPackage? logicalPackage,
-        int installRefCount)
+        WorkloadEntry entry, bool isImplicitlyInstalled, LogicalPackage? logicalPackage, int installRefCount)
         => new()
         {
             PackageId = entry.PackageId,
@@ -318,7 +278,7 @@ internal class WorkloadStore(IWorkloadPaths paths) : IWorkloadStore
             Description = entry.Description,
             Source = entry.Source,
             RuntimeIdentifier = entry.RuntimeIdentifier,
-            IsExplicitlyInstalled = isExplicitlyInstalled,
+            IsImplicitlyInstalled = isImplicitlyInstalled,
             LogicalPackage = logicalPackage,
             InstallRefCount = installRefCount,
             EntryPoint = entry.EntryPoint,

--- a/test/Func.Tests/Workloads/Storage/WorkloadStoreTests.cs
+++ b/test/Func.Tests/Workloads/Storage/WorkloadStoreTests.cs
@@ -107,6 +107,17 @@ public class WorkloadStoreTests : IDisposable
             PackageId = "Azure.Functions.Cli.Workloads.Dotnet",
             PackageVersion = "1.0.0",
             Aliases = ["dotnet", "dotnet-isolated"],
+            RuntimeIdentifier = "linux-x64",
+            IsExplicitlyInstalled = false,
+            LogicalPackage = new LogicalPackage
+            {
+                PackageId = "Azure.Functions.Cli.Workloads.Dotnet",
+                PackageVersion = "1.0.0",
+                Aliases = ["dotnet"],
+                DisplayName = "Azure Functions .NET workload",
+                Description = "Logical package.",
+                Source = "https://example.test/v3/index.json",
+            },
             EntryPoint = new EntryPointSpec
             {
                 AssemblyPath = "lib/net10.0/Foo.dll",
@@ -120,6 +131,10 @@ public class WorkloadStoreTests : IDisposable
         actual.PackageId.Should().Be(entry.PackageId);
         actual.PackageVersion.Should().Be(entry.PackageVersion);
         actual.Aliases.Should().Equal(entry.Aliases);
+        actual.RuntimeIdentifier.Should().Be("linux-x64");
+        actual.IsExplicitlyInstalled.Should().BeFalse();
+        actual.LogicalPackage!.PackageId.Should().Be(entry.LogicalPackage.PackageId);
+        actual.LogicalPackage.Source.Should().Be(entry.LogicalPackage.Source);
         actual.EntryPoint!.AssemblyPath.Should().Be(entry.EntryPoint!.AssemblyPath);
         actual.EntryPoint.Type.Should().Be(entry.EntryPoint.Type);
     }
@@ -184,12 +199,198 @@ public class WorkloadStoreTests : IDisposable
         Directory.GetFiles(_tempHome, "*.json.tmp").Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task GetWorkloadsAsync_LegacyEntryDefaultsToExplicitOwnership()
+    {
+        Directory.CreateDirectory(_tempHome);
+        await File.WriteAllTextAsync(
+            _paths.WorkloadRegistryPath,
+            $$"""
+            {
+              "$schema": "{{WorkloadManifestSchema.RegistryV1Schema}}",
+              "workloads": [
+                {
+                  "packageId": "legacy.package",
+                  "packageVersion": "1.0.0",
+                  "installRefCount": 1
+                }
+              ],
+              "metas": []
+            }
+            """);
+
+        WorkloadEntry entry = (await _store.GetWorkloadsAsync()).Should().ContainSingle().Subject;
+
+        entry.IsExplicitlyInstalled.Should().BeTrue();
+        entry.LogicalPackage.Should().BeNull();
+        entry.RuntimeIdentifier.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetWorkloadsAsync_ExplicitFalseIsPreserved()
+    {
+        Directory.CreateDirectory(_tempHome);
+        await File.WriteAllTextAsync(
+            _paths.WorkloadRegistryPath,
+            $$"""
+            {
+              "$schema": "{{WorkloadManifestSchema.RegistryV1Schema}}",
+              "workloads": [
+                {
+                  "packageId": "pkg.win-x64",
+                  "packageVersion": "1.0.0",
+                  "runtimeIdentifier": "win-x64",
+                  "isExplicitlyInstalled": false,
+                  "logicalPackage": {
+                    "packageId": "pkg",
+                    "packageVersion": "1.0.0"
+                  },
+                  "installRefCount": 1
+                }
+              ],
+              "metas": []
+            }
+            """);
+
+        WorkloadEntry entry = (await _store.GetWorkloadsAsync()).Should().ContainSingle().Subject;
+
+        entry.IsExplicitlyInstalled.Should().BeFalse();
+        entry.LogicalPackage.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task AddOwnershipAsync_ThrowsWhenRowAlreadyHasDifferentLogicalOwner()
+    {
+        await _store.SaveWorkloadAsync(NewPointerEntry("pkg.win-x64", "1.0.0"));
+        WorkloadEntry conflicting = new()
+        {
+            PackageId = "pkg.win-x64",
+            PackageVersion = "1.0.0",
+            Kind = WorkloadKind.Content,
+            RuntimeIdentifier = "win-x64",
+            IsExplicitlyInstalled = false,
+            LogicalPackage = new LogicalPackage { PackageId = "other.pkg", PackageVersion = "1.0.0" },
+            InstallRefCount = 1,
+        };
+
+        await FluentActions.Awaiting(() => _store.AddOwnershipAsync(conflicting, WorkloadOwnershipKind.Logical))
+            .Should().ThrowExactlyAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task AddOwnershipAsync_AttachesLogicalOwnershipIdempotently()
+    {
+        await _store.SaveWorkloadAsync(NewEntry("pkg.win-x64", "1.0.0"));
+        WorkloadEntry pointerEntry = NewPointerEntry("pkg.win-x64", "1.0.0");
+
+        WorkloadEntry first = await _store.AddOwnershipAsync(pointerEntry, WorkloadOwnershipKind.Logical);
+        WorkloadEntry second = await _store.AddOwnershipAsync(pointerEntry, WorkloadOwnershipKind.Logical);
+
+        first.IsExplicitlyInstalled.Should().BeTrue();
+        first.LogicalPackage.Should().NotBeNull();
+        first.InstallRefCount.Should().Be(2);
+        second.InstallRefCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task RemoveOwnershipAsync_RemovesOnlyExplicitOwner()
+    {
+        WorkloadEntry pointerEntry = NewPointerEntry("pkg.win-x64", "1.0.0");
+        WorkloadEntry entry = new()
+        {
+            PackageId = pointerEntry.PackageId,
+            PackageVersion = pointerEntry.PackageVersion,
+            Kind = pointerEntry.Kind,
+            RuntimeIdentifier = pointerEntry.RuntimeIdentifier,
+            LogicalPackage = pointerEntry.LogicalPackage,
+            IsExplicitlyInstalled = true,
+            InstallRefCount = 2,
+        };
+        await _store.SaveWorkloadAsync(entry);
+
+        WorkloadOwnershipRemovalResult result = await _store.RemoveOwnershipAsync(
+            entry.PackageId,
+            entry.PackageVersion,
+            WorkloadOwnershipKind.Explicit);
+
+        result.OwnershipRemoved.Should().BeTrue();
+        result.EntryRemoved.Should().BeFalse();
+        result.Entry!.IsExplicitlyInstalled.Should().BeFalse();
+        result.Entry.LogicalPackage.Should().NotBeNull();
+        result.Entry.InstallRefCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task MoveLogicalOwnershipAsync_RetainsExplicitOldRow()
+    {
+        WorkloadEntry oldEntry = new()
+        {
+            PackageId = "pkg.win-x64",
+            PackageVersion = "1.0.0",
+            RuntimeIdentifier = "win-x64",
+            IsExplicitlyInstalled = true,
+            LogicalPackage = NewPointerEntry("pkg.win-x64", "1.0.0").LogicalPackage,
+            InstallRefCount = 2,
+        };
+        await _store.SaveWorkloadAsync(oldEntry);
+
+        WorkloadOwnershipMoveResult result = await _store.MoveLogicalOwnershipAsync(
+            oldEntry.PackageId,
+            oldEntry.PackageVersion,
+            NewPointerEntry("pkg.win-x64", "2.0.0"));
+
+        result.PreviousEntryRemoved.Should().BeFalse();
+        IReadOnlyList<WorkloadEntry> entries = await _store.GetWorkloadsAsync();
+        WorkloadEntry retained = entries.Should().ContainSingle(e => e.PackageVersion == "1.0.0").Subject;
+        retained.IsExplicitlyInstalled.Should().BeTrue();
+        retained.LogicalPackage.Should().BeNull();
+        retained.InstallRefCount.Should().Be(1);
+        entries.Should().ContainSingle(e => e.PackageVersion == "2.0.0");
+    }
+
+    [Fact]
+    public void WorkloadKindJsonConverter_RoundTripsRidPointerWireValue()
+    {
+        string json = JsonSerializer.Serialize(
+            new WorkloadMetadata
+            {
+                Schema = WorkloadManifestSchema.PackageManifestV1Schema,
+                Kind = WorkloadKind.RidPointer,
+                Packages = new Dictionary<string, string> { ["win-x64"] = "pkg.win-x64" },
+            },
+            WorkloadJsonContext.Default.WorkloadMetadata);
+
+        json.Should().Contain("\"kind\":\"rid-pointer\"");
+        WorkloadMetadata actual = JsonSerializer.Deserialize(json, WorkloadJsonContext.Default.WorkloadMetadata)!;
+        actual.Kind.Should().Be(WorkloadKind.RidPointer);
+    }
+
     private static WorkloadEntry NewEntry(string packageId, string version, string entryAssembly = "x.dll")
         => new()
         {
             PackageId = packageId,
             PackageVersion = version,
             EntryPoint = new EntryPointSpec { AssemblyPath = entryAssembly, Type = "X" },
+        };
+
+    private static WorkloadEntry NewPointerEntry(string packageId, string version)
+        => new()
+        {
+            PackageId = packageId,
+            PackageVersion = version,
+            Kind = WorkloadKind.Content,
+            RuntimeIdentifier = "win-x64",
+            IsExplicitlyInstalled = false,
+            LogicalPackage = new LogicalPackage
+            {
+                PackageId = "pkg",
+                PackageVersion = version,
+                Aliases = ["pkg"],
+                DisplayName = "Package",
+                Description = "Logical package.",
+                Source = "https://example.test/v3/index.json",
+            },
+            InstallRefCount = 1,
         };
 
     private sealed class ThrowingSerializeStore(IWorkloadPaths paths) : WorkloadStore(paths)

--- a/test/Func.Tests/Workloads/Storage/WorkloadStoreTests.cs
+++ b/test/Func.Tests/Workloads/Storage/WorkloadStoreTests.cs
@@ -108,7 +108,7 @@ public class WorkloadStoreTests : IDisposable
             PackageVersion = "1.0.0",
             Aliases = ["dotnet", "dotnet-isolated"],
             RuntimeIdentifier = "linux-x64",
-            IsExplicitlyInstalled = false,
+            IsImplicitlyInstalled = true,
             LogicalPackage = new LogicalPackage
             {
                 PackageId = "Azure.Functions.Cli.Workloads.Dotnet",
@@ -132,7 +132,7 @@ public class WorkloadStoreTests : IDisposable
         actual.PackageVersion.Should().Be(entry.PackageVersion);
         actual.Aliases.Should().Equal(entry.Aliases);
         actual.RuntimeIdentifier.Should().Be("linux-x64");
-        actual.IsExplicitlyInstalled.Should().BeFalse();
+        actual.IsImplicitlyInstalled.Should().BeTrue();
         actual.LogicalPackage!.PackageId.Should().Be(entry.LogicalPackage.PackageId);
         actual.LogicalPackage.Source.Should().Be(entry.LogicalPackage.Source);
         actual.EntryPoint!.AssemblyPath.Should().Be(entry.EntryPoint!.AssemblyPath);
@@ -159,6 +159,21 @@ public class WorkloadStoreTests : IDisposable
             element.TryGetProperty("packageId", out _).Should().BeTrue();
             element.TryGetProperty("packageVersion", out _).Should().BeTrue();
         }
+    }
+
+    [Fact]
+    public async Task PersistedJson_WritesOnlyImplicitOwnership()
+    {
+        await _store.SaveWorkloadAsync(NewEntry("explicit.pkg", "1.0.0"));
+        await _store.SaveWorkloadAsync(NewPointerEntry("implicit.pkg", "1.0.0"));
+
+        using var doc = JsonDocument.Parse(await File.ReadAllTextAsync(_paths.WorkloadRegistryPath));
+        JsonElement workloads = doc.RootElement.GetProperty("workloads");
+        JsonElement explicitEntry = workloads.EnumerateArray().Single(e => e.GetProperty("packageId").GetString() == "explicit.pkg");
+        JsonElement implicitEntry = workloads.EnumerateArray().Single(e => e.GetProperty("packageId").GetString() == "implicit.pkg");
+
+        explicitEntry.TryGetProperty("isImplicitlyInstalled", out _).Should().BeFalse();
+        implicitEntry.GetProperty("isImplicitlyInstalled").GetBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -221,13 +236,13 @@ public class WorkloadStoreTests : IDisposable
 
         WorkloadEntry entry = (await _store.GetWorkloadsAsync()).Should().ContainSingle().Subject;
 
-        entry.IsExplicitlyInstalled.Should().BeTrue();
+        entry.IsImplicitlyInstalled.Should().BeFalse();
         entry.LogicalPackage.Should().BeNull();
         entry.RuntimeIdentifier.Should().BeNull();
     }
 
     [Fact]
-    public async Task GetWorkloadsAsync_ExplicitFalseIsPreserved()
+    public async Task GetWorkloadsAsync_ImplicitTrueIsPreserved()
     {
         Directory.CreateDirectory(_tempHome);
         await File.WriteAllTextAsync(
@@ -240,7 +255,7 @@ public class WorkloadStoreTests : IDisposable
                   "packageId": "pkg.win-x64",
                   "packageVersion": "1.0.0",
                   "runtimeIdentifier": "win-x64",
-                  "isExplicitlyInstalled": false,
+                  "isImplicitlyInstalled": true,
                   "logicalPackage": {
                     "packageId": "pkg",
                     "packageVersion": "1.0.0"
@@ -254,7 +269,7 @@ public class WorkloadStoreTests : IDisposable
 
         WorkloadEntry entry = (await _store.GetWorkloadsAsync()).Should().ContainSingle().Subject;
 
-        entry.IsExplicitlyInstalled.Should().BeFalse();
+        entry.IsImplicitlyInstalled.Should().BeTrue();
         entry.LogicalPackage.Should().NotBeNull();
     }
 
@@ -268,7 +283,7 @@ public class WorkloadStoreTests : IDisposable
             PackageVersion = "1.0.0",
             Kind = WorkloadKind.Content,
             RuntimeIdentifier = "win-x64",
-            IsExplicitlyInstalled = false,
+            IsImplicitlyInstalled = true,
             LogicalPackage = new LogicalPackage { PackageId = "other.pkg", PackageVersion = "1.0.0" },
             InstallRefCount = 1,
         };
@@ -286,7 +301,7 @@ public class WorkloadStoreTests : IDisposable
         WorkloadEntry first = await _store.AddOwnershipAsync(pointerEntry, WorkloadOwnershipKind.Logical);
         WorkloadEntry second = await _store.AddOwnershipAsync(pointerEntry, WorkloadOwnershipKind.Logical);
 
-        first.IsExplicitlyInstalled.Should().BeTrue();
+        first.IsImplicitlyInstalled.Should().BeFalse();
         first.LogicalPackage.Should().NotBeNull();
         first.InstallRefCount.Should().Be(2);
         second.InstallRefCount.Should().Be(2);
@@ -297,11 +312,9 @@ public class WorkloadStoreTests : IDisposable
     {
         await _store.SaveWorkloadAsync(NewEntry("pkg.win-x64", "1.0.0"));
 
-        WorkloadEntry merged = await _store.AddOwnershipAsync(
-            NewPointerEntry("pkg.win-x64", "1.0.0"),
-            WorkloadOwnershipKind.Explicit);
+        WorkloadEntry merged = await _store.AddOwnershipAsync(NewPointerEntry("pkg.win-x64", "1.0.0"), WorkloadOwnershipKind.Explicit);
 
-        merged.IsExplicitlyInstalled.Should().BeTrue();
+        merged.IsImplicitlyInstalled.Should().BeFalse();
         merged.LogicalPackage.Should().NotBeNull();
         merged.InstallRefCount.Should().Be(2);
     }
@@ -317,19 +330,16 @@ public class WorkloadStoreTests : IDisposable
             Kind = pointerEntry.Kind,
             RuntimeIdentifier = pointerEntry.RuntimeIdentifier,
             LogicalPackage = pointerEntry.LogicalPackage,
-            IsExplicitlyInstalled = true,
             InstallRefCount = 2,
         };
         await _store.SaveWorkloadAsync(entry);
 
         WorkloadOwnershipRemovalResult result = await _store.RemoveOwnershipAsync(
-            entry.PackageId,
-            entry.PackageVersion,
-            WorkloadOwnershipKind.Explicit);
+            entry.PackageId, entry.PackageVersion, WorkloadOwnershipKind.Explicit);
 
         result.OwnershipRemoved.Should().BeTrue();
         result.EntryRemoved.Should().BeFalse();
-        result.Entry!.IsExplicitlyInstalled.Should().BeFalse();
+        result.Entry!.IsImplicitlyInstalled.Should().BeTrue();
         result.Entry.LogicalPackage.Should().NotBeNull();
         result.Entry.InstallRefCount.Should().Be(1);
     }
@@ -342,24 +352,80 @@ public class WorkloadStoreTests : IDisposable
             PackageId = "pkg.win-x64",
             PackageVersion = "1.0.0",
             RuntimeIdentifier = "win-x64",
-            IsExplicitlyInstalled = true,
             LogicalPackage = NewPointerEntry("pkg.win-x64", "1.0.0").LogicalPackage,
             InstallRefCount = 2,
         };
         await _store.SaveWorkloadAsync(oldEntry);
 
         WorkloadOwnershipMoveResult result = await _store.MoveLogicalOwnershipAsync(
-            oldEntry.PackageId,
-            oldEntry.PackageVersion,
-            NewPointerEntry("pkg.win-x64", "2.0.0"));
+            oldEntry.PackageId, oldEntry.PackageVersion, NewPointerEntry("pkg.win-x64", "2.0.0"));
 
         result.PreviousEntryRemoved.Should().BeFalse();
         IReadOnlyList<WorkloadEntry> entries = await _store.GetWorkloadsAsync();
         WorkloadEntry retained = entries.Should().ContainSingle(e => e.PackageVersion == "1.0.0").Subject;
-        retained.IsExplicitlyInstalled.Should().BeTrue();
+        retained.IsImplicitlyInstalled.Should().BeFalse();
         retained.LogicalPackage.Should().BeNull();
         retained.InstallRefCount.Should().Be(1);
         entries.Should().ContainSingle(e => e.PackageVersion == "2.0.0");
+    }
+
+    [Fact]
+    public async Task MoveLogicalOwnershipAsync_RemovesOldRow_WhenLogicalOwnershipIsFinalOwner()
+    {
+        WorkloadEntry oldEntry = NewPointerEntry("pkg.win-x64", "1.0.0");
+        await _store.SaveWorkloadAsync(oldEntry);
+
+        WorkloadOwnershipMoveResult result = await _store.MoveLogicalOwnershipAsync(
+            oldEntry.PackageId, oldEntry.PackageVersion, NewPointerEntry("pkg.win-x64", "2.0.0"));
+
+        result.PreviousEntryRemoved.Should().BeTrue();
+        IReadOnlyList<WorkloadEntry> entries = await _store.GetWorkloadsAsync();
+        WorkloadEntry moved = entries.Should().ContainSingle().Subject;
+        moved.PackageVersion.Should().Be("2.0.0");
+        moved.IsImplicitlyInstalled.Should().BeTrue();
+        moved.LogicalPackage.Should().NotBeNull();
+        moved.InstallRefCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task MoveExplicitOwnershipAsync_RetainsLogicalOldRow()
+    {
+        WorkloadEntry oldEntry = new()
+        {
+            PackageId = "pkg.win-x64",
+            PackageVersion = "1.0.0",
+            RuntimeIdentifier = "win-x64",
+            LogicalPackage = NewPointerEntry("pkg.win-x64", "1.0.0").LogicalPackage,
+            InstallRefCount = 2,
+        };
+        await _store.SaveWorkloadAsync(oldEntry);
+
+        WorkloadOwnershipMoveResult result = await _store.MoveExplicitOwnershipAsync(
+            oldEntry.PackageId, oldEntry.PackageVersion, NewEntry("pkg.win-x64", "2.0.0"));
+
+        result.PreviousEntryRemoved.Should().BeFalse();
+        IReadOnlyList<WorkloadEntry> entries = await _store.GetWorkloadsAsync();
+        WorkloadEntry retained = entries.Should().ContainSingle(e => e.PackageVersion == "1.0.0").Subject;
+        retained.IsImplicitlyInstalled.Should().BeTrue();
+        retained.LogicalPackage.Should().NotBeNull();
+        retained.InstallRefCount.Should().Be(1);
+        WorkloadEntry moved = entries.Should().ContainSingle(e => e.PackageVersion == "2.0.0").Subject;
+        moved.IsImplicitlyInstalled.Should().BeFalse();
+        moved.InstallRefCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task MoveLogicalOwnershipAsync_WritesRegistryOnce()
+    {
+        var store = new CountingSerializeStore(_paths);
+        WorkloadEntry oldEntry = NewPointerEntry("pkg.win-x64", "1.0.0");
+        await store.SaveWorkloadAsync(oldEntry);
+        store.ResetSerializeCount();
+
+        await store.MoveLogicalOwnershipAsync(
+            oldEntry.PackageId, oldEntry.PackageVersion, NewPointerEntry("pkg.win-x64", "2.0.0"));
+
+        store.SerializeCount.Should().Be(1);
     }
 
     [Fact]
@@ -394,7 +460,7 @@ public class WorkloadStoreTests : IDisposable
             PackageVersion = version,
             Kind = WorkloadKind.Content,
             RuntimeIdentifier = "win-x64",
-            IsExplicitlyInstalled = false,
+            IsImplicitlyInstalled = true,
             LogicalPackage = new LogicalPackage
             {
                 PackageId = "pkg",
@@ -411,5 +477,19 @@ public class WorkloadStoreTests : IDisposable
     {
         internal override Task SerializeAsync(Stream stream, WorkloadRegistry registry, CancellationToken cancellationToken)
             => throw new InvalidOperationException("boom");
+    }
+
+    private sealed class CountingSerializeStore(IWorkloadPaths paths) : WorkloadStore(paths)
+    {
+        public int SerializeCount { get; private set; }
+
+        public void ResetSerializeCount()
+            => SerializeCount = 0;
+
+        internal override Task SerializeAsync(Stream stream, WorkloadRegistry registry, CancellationToken cancellationToken)
+        {
+            SerializeCount++;
+            return base.SerializeAsync(stream, registry, cancellationToken);
+        }
     }
 }

--- a/test/Func.Tests/Workloads/Storage/WorkloadStoreTests.cs
+++ b/test/Func.Tests/Workloads/Storage/WorkloadStoreTests.cs
@@ -293,6 +293,20 @@ public class WorkloadStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task AddOwnershipAsync_CountsLogicalOwnerAttachedWhileAddingExplicitOwnership()
+    {
+        await _store.SaveWorkloadAsync(NewEntry("pkg.win-x64", "1.0.0"));
+
+        WorkloadEntry merged = await _store.AddOwnershipAsync(
+            NewPointerEntry("pkg.win-x64", "1.0.0"),
+            WorkloadOwnershipKind.Explicit);
+
+        merged.IsExplicitlyInstalled.Should().BeTrue();
+        merged.LogicalPackage.Should().NotBeNull();
+        merged.InstallRefCount.Should().Be(2);
+    }
+
+    [Fact]
     public async Task RemoveOwnershipAsync_RemovesOnlyExplicitOwner()
     {
         WorkloadEntry pointerEntry = NewPointerEntry("pkg.win-x64", "1.0.0");


### PR DESCRIPTION
Layer 3 of 6 in a stack decomposing #5512 ("Add RID pointer package support") into small dependent PRs. Stacks on #5516 (layer 2) — this PR targets `fabiocav/stack-2-rid-pointer-manifest-schema`, not `vnext`.

## What this layer does

Teaches the on-disk workload registry the difference between the **physical** package installed on disk (a RID-specific implementation) and the **logical** package the user asked for (the RID pointer). This is the storage model everything above it in the stack depends on.

- `WorkloadEntry` gains `RuntimeIdentifier` (which RID the row was validated for) and `LogicalPackage` (which pointer selected it).
- `WorkloadEntry` gains `IsExplicitlyInstalled`, backed by a nullable persisted property. Rows written by older CLIs have no such field, and deserializing a missing `bool` as `false` would silently strip explicit ownership from every previously user-installed workload, making them eligible for `func workload prune`. The public property defaults a missing value to `true` instead. This is deliberate backward compatibility for the first release that ships this change.
- `IWorkloadStore` gains ownership APIs: `AddOwnershipAsync`, `RemoveOwnershipAsync`, `MoveLogicalOwnershipAsync`, `MoveExplicitOwnershipAsync`. A physical row can be owned explicitly by the user, logically by a pointer, or both. `InstallRefCount` now counts distinct owners, so repeating an install by the same owner is idempotent and removing one owner leaves the other intact. A row accepts at most one logical owner; attaching a different one throws.
- `IWorkloadRuntimeIdentifierProvider` makes the current RID substitutable in tests, registered in `AddWorkloadStorage`.

The persisted JSON stays a flat array; a test asserts that shape.

## Expected loose ends at this layer

`IWorkloadRuntimeIdentifierProvider` is referenced only by its DI registration here. Its consumers are `WorkloadInstaller` (layer 4) and `WorkloadLoader` (layer 6); it lives at this layer because it must sit below both. Likewise the new store ownership APIs are exercised only by tests here — the installer starts calling them in layer 4.

## Validation

- `CI=true dotnet build -c Release` — **0 warnings, 0 errors**.
- `dotnet test test/Func.Tests/Func.Tests.csproj -c Release --filter "FullyQualifiedName~WorkloadStore"` — 19/19 passed.
- `dotnet test test/Func.Tests/Func.Tests.csproj -c Release` — 1335 passed, 1 failed: `ProcessRunnerTests.RunAsync_Timeout_IsReported`, a pre-existing timing flake unrelated to this change.

No version or release-note changes in this layer.