### PR TITLE
Workloads: use RID-aware installer APIs in workload commands

### DIFF
--- a/src/Func/Commands/Workload/WorkloadInstallCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadInstallCommand.cs
@@ -199,19 +199,38 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
             return null;
         }
 
-        // Same matching rules as uninstall/update: by package id always,
-        // by alias unless --exact. We don't need to enforce uniqueness
-        // here; if any version matches we prompt.
-        WorkloadEntry? match = installed.FirstOrDefault(e =>
+        IReadOnlyList<WorkloadEntry> logicalMatches = [.. installed.Where(e =>
             e.LogicalPackage is not null
             && (string.Equals(e.LogicalPackage.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
                 || (!exact && e.LogicalPackage.Aliases.Any(a =>
-                    string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)))));
-        match ??= installed.FirstOrDefault(e =>
-            e.IsExplicitlyInstalled
-            && (string.Equals(e.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
-                || (!exact && e.Aliases.Any(a =>
-                    string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)))));
+                    string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)))))];
+        string[] logicalIds = [.. logicalMatches
+            .Select(e => e.LogicalPackage!.PackageId)
+            .Distinct(StringComparer.OrdinalIgnoreCase)];
+        if (logicalIds.Length > 1)
+        {
+            throw CreateAmbiguousInstalledAlias(identifier, logicalIds);
+        }
+
+        WorkloadEntry? match = logicalMatches.FirstOrDefault();
+        LogicalPackage? logical = match?.LogicalPackage;
+        if (match is null)
+        {
+            IReadOnlyList<WorkloadEntry> explicitMatches = [.. installed.Where(e =>
+                !e.IsImplicitlyInstalled
+                && (string.Equals(e.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
+                    || (!exact && e.Aliases.Any(a =>
+                        string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)))))];
+            string[] explicitIds = [.. explicitMatches
+                .Select(e => e.PackageId)
+                .Distinct(StringComparer.OrdinalIgnoreCase)];
+            if (explicitIds.Length > 1)
+            {
+                throw CreateAmbiguousInstalledAlias(identifier, explicitIds);
+            }
+
+            match = explicitMatches.FirstOrDefault();
+        }
 
         if (match is null)
         {
@@ -220,15 +239,14 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
 
         // Prefer the first alias for user-facing messages; fall back to the
         // canonical package id when no alias is published.
-        LogicalPackage? logical = match.LogicalPackage;
         IReadOnlyList<string> aliases = logical?.Aliases ?? match.Aliases;
         string display = aliases.Count > 0 ? aliases[0] : logical?.PackageId ?? match.PackageId;
         string installedVersion = logical?.PackageVersion ?? match.PackageVersion;
+        string updateIdentifier = logical?.PackageId ?? match.PackageId;
         string prompt = $"'{display}' is already installed at {installedVersion}. Update instead?";
 
         if (!_interaction.IsInteractive)
         {
-            string updateIdentifier = logical?.PackageId ?? display;
             _interaction.WriteHint(
                 $"'{display}' is already installed at {installedVersion}. " +
                 $"Run 'func workload update {updateIdentifier}' to upgrade, or pass --force to install side-by-side.");
@@ -243,8 +261,14 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
             return null;
         }
 
-        return await DispatchToUpdateAsync(logical?.PackageId ?? match.PackageId, source, includePrerelease, cancellationToken);
+        return await DispatchToUpdateAsync(updateIdentifier, source, includePrerelease, cancellationToken);
     }
+
+    private static GracefulException CreateAmbiguousInstalledAlias(string identifier, IReadOnlyList<string> packageIds)
+        => new(
+            $"Alias '{identifier}' matches multiple installed workloads ({string.Join(", ", packageIds)}). " +
+            "Pass the workload ID instead.",
+            isUserError: true);
 
     // Delegate to the `func workload update` command (Parse + InvokeAsync) so
     // confirm-yes goes through exactly the same flow the user would hit if they

--- a/src/Func/Commands/Workload/WorkloadInstallCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadInstallCommand.cs
@@ -167,9 +167,7 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
         }
         catch (InvalidOperationException ex)
         {
-            throw new GracefulException(
-                $"{ex.Message} Pass --force to repair the install.",
-                isUserError: true);
+            throw new GracefulException(ex.Message, isUserError: true);
         }
     }
 
@@ -205,8 +203,15 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
         // by alias unless --exact. We don't need to enforce uniqueness
         // here; if any version matches we prompt.
         WorkloadEntry? match = installed.FirstOrDefault(e =>
-            string.Equals(e.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
-            || (!exact && (e.Aliases?.Any(a => string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)) ?? false)));
+            e.LogicalPackage is not null
+            && (string.Equals(e.LogicalPackage.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
+                || (!exact && e.LogicalPackage.Aliases.Any(a =>
+                    string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)))));
+        match ??= installed.FirstOrDefault(e =>
+            e.IsExplicitlyInstalled
+            && (string.Equals(e.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
+                || (!exact && e.Aliases.Any(a =>
+                    string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)))));
 
         if (match is null)
         {
@@ -215,14 +220,18 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
 
         // Prefer the first alias for user-facing messages; fall back to the
         // canonical package id when no alias is published.
-        string display = match.Aliases.Count > 0 ? match.Aliases[0] : match.PackageId;
-        string prompt = $"'{display}' is already installed at {match.PackageVersion}. Update instead?";
+        LogicalPackage? logical = match.LogicalPackage;
+        IReadOnlyList<string> aliases = logical?.Aliases ?? match.Aliases;
+        string display = aliases.Count > 0 ? aliases[0] : logical?.PackageId ?? match.PackageId;
+        string installedVersion = logical?.PackageVersion ?? match.PackageVersion;
+        string prompt = $"'{display}' is already installed at {installedVersion}. Update instead?";
 
         if (!_interaction.IsInteractive)
         {
+            string updateIdentifier = logical?.PackageId ?? display;
             _interaction.WriteHint(
-                $"'{display}' is already installed at {match.PackageVersion}. " +
-                $"Run 'func workload update {display}' to upgrade, or pass --force to install side-by-side.");
+                $"'{display}' is already installed at {installedVersion}. " +
+                $"Run 'func workload update {updateIdentifier}' to upgrade, or pass --force to install side-by-side.");
             return 1;
         }
 
@@ -234,7 +243,7 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
             return null;
         }
 
-        return await DispatchToUpdateAsync(match.PackageId, source, includePrerelease, cancellationToken);
+        return await DispatchToUpdateAsync(logical?.PackageId ?? match.PackageId, source, includePrerelease, cancellationToken);
     }
 
     // Delegate to the `func workload update` command (Parse + InvokeAsync) so
@@ -266,14 +275,18 @@ internal sealed class WorkloadInstallCommand : FuncCliCommand
     private static string BuildSuccessMessage(WorkloadInstallResult result)
     {
         WorkloadEntry entry = result.Entry;
+        LogicalPackage? logical = entry.LogicalPackage;
+        string packageId = logical?.PackageId ?? entry.PackageId;
+        string packageVersion = logical?.PackageVersion ?? entry.PackageVersion;
+        IReadOnlyList<string> aliases = logical?.Aliases ?? entry.Aliases;
         string verb = result.AlreadyInstalled
-            ? $"Workload '{entry.PackageId}' version '{entry.PackageVersion}' is already installed"
-            : $"Installed workload '{entry.PackageId}' version '{entry.PackageVersion}'";
+            ? $"Workload '{packageId}' version '{packageVersion}' is already installed"
+            : $"Installed workload '{packageId}' version '{packageVersion}'";
 
         return entry.Kind switch
         {
-            WorkloadKind.Workload when entry.Aliases.Count > 0
-                => $"{verb} (aliases: {string.Join(", ", entry.Aliases)}).",
+            WorkloadKind.Workload when aliases.Count > 0
+                => $"{verb} (aliases: {string.Join(", ", aliases)}).",
             WorkloadKind.Content
                 => $"{verb} (content at '{entry.Source}').",
             _ => $"{verb}.",

--- a/src/Func/Commands/Workload/WorkloadListCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadListCommand.cs
@@ -56,7 +56,7 @@ internal sealed class WorkloadListCommand : FuncCliCommand
 
         IReadOnlyList<ListRow> rows = allVersions
             ? await BuildAllVersionsRowsAsync(cancellationToken)
-            : BuildLoadedRows();
+            : await BuildLoadedRowsAsync(cancellationToken);
 
         if (json)
         {
@@ -117,6 +117,13 @@ internal sealed class WorkloadListCommand : FuncCliCommand
             card.WriteHeading(DisplayNameOrPackageId(row));
             card.WriteField("Version", row.PackageVersion);
             card.WriteField("Package ID", row.PackageId);
+            card.WriteField("Implementation", $"{row.PhysicalPackageId} {row.PhysicalPackageVersion}");
+            if (!string.IsNullOrWhiteSpace(row.RuntimeIdentifier))
+            {
+                card.WriteField("Runtime Identifier", row.RuntimeIdentifier);
+            }
+
+            card.WriteField("Ownership", row.Ownership);
             card.WriteAliases(row.Aliases);
             card.WriteDescription(row.Description);
         }
@@ -193,45 +200,106 @@ internal sealed class WorkloadListCommand : FuncCliCommand
         _interaction.WriteHint($"{rows.Count} {Plural(rows.Count, "workload")} installed.");
     }
 
-    private IReadOnlyList<ListRow> BuildLoadedRows()
+    private async Task<IReadOnlyList<ListRow>> BuildLoadedRowsAsync(CancellationToken cancellationToken)
     {
         IReadOnlyList<WorkloadInfo> workloads = _workloads.GetWorkloads();
-        return [.. workloads.Select(w => new ListRow(
-            w.PackageId,
-            w.PackageVersion,
-            w.Aliases,
-            w.DisplayName,
-            w.Description,
-            Loaded: null))];
+        IReadOnlyList<WorkloadEntry>? installed = await _store.GetWorkloadsAsync(cancellationToken);
+        if (installed is null || installed.Count == 0)
+        {
+            return [.. workloads.Select(CreateLegacyRow)];
+        }
+
+        HashSet<(string PackageId, string Version)> loadedKeys = new(
+            workloads.Select(w => (w.PackageId, w.PackageVersion)),
+            new PackageVersionKeyComparer());
+        Dictionary<(string PackageId, string Version), WorkloadInfo> loadedByKey = workloads.ToDictionary(
+            w => (w.PackageId, w.PackageVersion),
+            w => w,
+            new PackageVersionKeyComparer());
+        return [.. installed
+            .Where(e => loadedKeys.Contains((e.PackageId, e.PackageVersion)))
+            .Select(e => CreateRow(e, loaded: null, loadedByKey[(e.PackageId, e.PackageVersion)]))];
     }
 
     private async Task<IReadOnlyList<ListRow>> BuildAllVersionsRowsAsync(CancellationToken cancellationToken)
     {
-        IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
+        IReadOnlyList<WorkloadEntry>? installed = await _store.GetWorkloadsAsync(cancellationToken);
+        if (installed is null || installed.Count == 0)
+        {
+            return [.. _workloads.GetWorkloads().Select(CreateLegacyRow)];
+        }
 
-        // Cross-reference runtime info so loaded versions use presentation
-        // from their instances; older and content entries use registry data.
-        Dictionary<(string PackageId, string Version), RuntimeWorkloadInfo> loadedByKey = _workloads
-            .GetRuntimeWorkloads()
+        Dictionary<(string PackageId, string Version), WorkloadInfo> loadedByKey = _workloads
+            .GetWorkloads()
             .ToDictionary(
                 w => (w.PackageId, w.PackageVersion),
                 w => w,
                 new PackageVersionKeyComparer());
 
         return [.. installed
-            .OrderBy(e => e.PackageId, StringComparer.OrdinalIgnoreCase)
-            .ThenByDescending(e => ParseVersion(e.PackageVersion))
             .Select(e =>
             {
-                bool loaded = loadedByKey.TryGetValue((e.PackageId, e.PackageVersion), out RuntimeWorkloadInfo? info);
-                return new ListRow(
-                    e.PackageId,
-                    e.PackageVersion,
-                    e.Aliases ?? [],
-                    info?.DisplayName ?? GetDisplayName(e),
-                    info?.Description ?? e.Description ?? string.Empty,
-                    Loaded: loaded);
-            })];
+                bool loaded = loadedByKey.TryGetValue((e.PackageId, e.PackageVersion), out WorkloadInfo? info);
+                return CreateRow(e, loaded, info);
+            })
+            .OrderBy(e => e.PackageId, StringComparer.OrdinalIgnoreCase)
+            .ThenByDescending(e => ParseVersion(e.PackageVersion))];
+    }
+
+    private static ListRow CreateRow(WorkloadEntry entry, bool? loaded, WorkloadInfo? loadedInfo)
+    {
+        LogicalPackage? logical = entry.LogicalPackage;
+        return new ListRow(
+            logical?.PackageId ?? entry.PackageId,
+            logical?.PackageVersion ?? entry.PackageVersion,
+            logical?.Aliases ?? entry.Aliases,
+            logical?.DisplayName ?? loadedInfo?.DisplayName ?? GetDisplayName(entry),
+            logical?.Description ?? loadedInfo?.Description ?? entry.Description,
+            entry.PackageId,
+            entry.PackageVersion,
+            entry.RuntimeIdentifier,
+            entry.IsExplicitlyInstalled,
+            entry.InstallRefCount,
+            DescribeOwnership(entry),
+            loaded);
+    }
+
+    private static ListRow CreateLegacyRow(WorkloadInfo workload)
+        => new(
+            workload.PackageId,
+            workload.PackageVersion,
+            workload.Aliases,
+            workload.DisplayName,
+            workload.Description,
+            workload.PackageId,
+            workload.PackageVersion,
+            RuntimeIdentifier: null,
+            IsExplicitlyInstalled: true,
+            InstallRefCount: 1,
+            Ownership: "explicit",
+            Loaded: null);
+
+    private static string DescribeOwnership(WorkloadEntry entry)
+    {
+        List<string> owners = [];
+        if (entry.IsExplicitlyInstalled)
+        {
+            owners.Add("explicit");
+        }
+
+        if (entry.LogicalPackage is not null)
+        {
+            owners.Add($"logical:{entry.LogicalPackage.PackageId}");
+        }
+
+        int knownOwnerCount = (entry.IsExplicitlyInstalled ? 1 : 0) + (entry.LogicalPackage is null ? 0 : 1);
+        int metaOwnerCount = Math.Max(0, entry.InstallRefCount - knownOwnerCount);
+        if (metaOwnerCount > 0)
+        {
+            owners.Add($"meta:{metaOwnerCount}");
+        }
+
+        return string.Join(", ", owners);
     }
 
     private static string PrimaryAlias(ListRow row)
@@ -241,7 +309,7 @@ internal sealed class WorkloadListCommand : FuncCliCommand
         => string.IsNullOrWhiteSpace(row.DisplayName) ? row.PackageId : row.DisplayName;
 
     private static string GetDisplayName(WorkloadEntry entry)
-        => string.IsNullOrWhiteSpace(entry.DisplayName) ? entry.PackageId : entry.DisplayName;
+        => string.IsNullOrWhiteSpace(entry.DisplayName) ? entry.LogicalPackage?.PackageId ?? entry.PackageId : entry.DisplayName;
 
     private static string GroupDisplayName(IGrouping<string, ListRow> group)
     {
@@ -276,6 +344,12 @@ internal sealed class WorkloadListCommand : FuncCliCommand
         IReadOnlyList<string> Aliases,
         string DisplayName,
         string Description,
+        string PhysicalPackageId,
+        string PhysicalPackageVersion,
+        string? RuntimeIdentifier,
+        bool IsExplicitlyInstalled,
+        int InstallRefCount,
+        string Ownership,
         bool? Loaded);
 
     private sealed class PackageVersionKeyComparer : IEqualityComparer<(string PackageId, string Version)>

--- a/src/Func/Commands/Workload/WorkloadListCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadListCommand.cs
@@ -258,7 +258,7 @@ internal sealed class WorkloadListCommand : FuncCliCommand
             entry.PackageId,
             entry.PackageVersion,
             entry.RuntimeIdentifier,
-            entry.IsExplicitlyInstalled,
+            !entry.IsImplicitlyInstalled,
             entry.InstallRefCount,
             DescribeOwnership(entry),
             loaded);
@@ -282,7 +282,7 @@ internal sealed class WorkloadListCommand : FuncCliCommand
     private static string DescribeOwnership(WorkloadEntry entry)
     {
         List<string> owners = [];
-        if (entry.IsExplicitlyInstalled)
+        if (!entry.IsImplicitlyInstalled)
         {
             owners.Add("explicit");
         }
@@ -292,7 +292,7 @@ internal sealed class WorkloadListCommand : FuncCliCommand
             owners.Add($"logical:{entry.LogicalPackage.PackageId}");
         }
 
-        int knownOwnerCount = (entry.IsExplicitlyInstalled ? 1 : 0) + (entry.LogicalPackage is null ? 0 : 1);
+        int knownOwnerCount = (!entry.IsImplicitlyInstalled ? 1 : 0) + (entry.LogicalPackage is null ? 0 : 1);
         int metaOwnerCount = Math.Max(0, entry.InstallRefCount - knownOwnerCount);
         if (metaOwnerCount > 0)
         {

--- a/src/Func/Commands/Workload/WorkloadPruneCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadPruneCommand.cs
@@ -57,23 +57,20 @@ internal sealed class WorkloadPruneCommand : FuncCliCommand
             return 0;
         }
 
-        IReadOnlyList<WorkloadEntry> scoped = ScopeToTarget(installed, identifier, exact);
+        IReadOnlyList<PruneCandidate> scoped = ScopeToTarget(installed, identifier, exact);
         if (scoped.Count == 0)
         {
             _interaction.WriteWarning($"Workload '{identifier}' is not installed; nothing to prune.");
             return 0;
         }
 
-        // Group by canonical package id so an alias that maps to one
-        // package doesn't accidentally prune another. Within each group
-        // keep the highest installable semver and remove the rest.
-        IEnumerable<IGrouping<string, WorkloadEntry>> byPackageId = scoped
-            .GroupBy(e => e.PackageId, StringComparer.OrdinalIgnoreCase);
+        IEnumerable<IGrouping<string, PruneCandidate>> byPackageId = scoped
+            .GroupBy(e => $"{e.Ownership}:{e.PackageId}", StringComparer.OrdinalIgnoreCase);
 
         int removedCount = 0;
-        foreach (IGrouping<string, WorkloadEntry> group in byPackageId)
+        foreach (IGrouping<string, PruneCandidate> group in byPackageId)
         {
-            List<WorkloadEntry> ordered = [.. group.OrderByDescending(e => ParseVersion(e.PackageVersion))];
+            List<PruneCandidate> ordered = [.. group.OrderByDescending(e => ParseVersion(e.PackageVersion))];
             if (ordered.Count <= 1)
             {
                 continue;
@@ -82,9 +79,17 @@ internal sealed class WorkloadPruneCommand : FuncCliCommand
             // Skip ordered[0] (the highest version), uninstall the rest.
             for (int i = 1; i < ordered.Count; i++)
             {
-                WorkloadEntry candidate = ordered[i];
-                bool removed = await _installer.UninstallAsync(
-                    candidate.PackageId, candidate.PackageVersion, cancellationToken);
+                PruneCandidate candidate = ordered[i];
+                bool removed = candidate.Ownership == WorkloadOwnershipKind.Logical
+                    ? await _installer.UninstallAsync(
+                        candidate.PackageId,
+                        candidate.PackageVersion,
+                        WorkloadOwnershipKind.Logical,
+                        cancellationToken)
+                    : await _installer.UninstallAsync(
+                        candidate.PackageId,
+                        candidate.PackageVersion,
+                        cancellationToken);
                 if (removed)
                 {
                     removedCount++;
@@ -102,18 +107,52 @@ internal sealed class WorkloadPruneCommand : FuncCliCommand
         return 0;
     }
 
-    private static IReadOnlyList<WorkloadEntry> ScopeToTarget(IReadOnlyList<WorkloadEntry> installed, string? identifier, bool exact)
+    private static IReadOnlyList<PruneCandidate> ScopeToTarget(
+        IReadOnlyList<WorkloadEntry> installed,
+        string? identifier,
+        bool exact)
     {
+        IReadOnlyList<PruneCandidate> logical = [.. installed
+            .Where(e => e.LogicalPackage is not null)
+            .Select(e => new PruneCandidate(
+                e.LogicalPackage!.PackageId,
+                e.LogicalPackage.PackageVersion,
+                e.LogicalPackage.Aliases,
+                WorkloadOwnershipKind.Logical))];
+        IReadOnlyList<PruneCandidate> explicitPackages = [.. installed
+            .Where(e => e.IsExplicitlyInstalled)
+            .Select(e => new PruneCandidate(
+                e.PackageId,
+                e.PackageVersion,
+                e.Aliases,
+                WorkloadOwnershipKind.Explicit))];
+
         if (string.IsNullOrWhiteSpace(identifier))
         {
-            return installed;
+            return [.. logical, .. explicitPackages];
         }
 
-        return [.. installed.Where(e =>
+        IReadOnlyList<PruneCandidate> logicalMatches = [.. logical.Where(e =>
             string.Equals(e.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
-            || (!exact && (e.Aliases?.Any(a => string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)) ?? false)))];
+            || (!exact && e.Aliases.Any(a =>
+                string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase))))];
+        if (logicalMatches.Count > 0)
+        {
+            return logicalMatches;
+        }
+
+        return [.. explicitPackages.Where(e =>
+            string.Equals(e.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
+            || (!exact && e.Aliases.Any(a =>
+                string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase))))];
     }
 
     private static NuGetVersion ParseVersion(string raw) =>
         NuGetVersion.TryParse(raw, out NuGetVersion? v) ? v : new NuGetVersion(0, 0, 0);
+
+    private sealed record PruneCandidate(
+        string PackageId,
+        string PackageVersion,
+        IReadOnlyList<string> Aliases,
+        WorkloadOwnershipKind Ownership);
 }

--- a/src/Func/Commands/Workload/WorkloadPruneCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadPruneCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.CommandLine;
+using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Console;
 using Azure.Functions.Cli.Workloads.Install;
 using Azure.Functions.Cli.Workloads.Storage;
@@ -120,7 +121,7 @@ internal sealed class WorkloadPruneCommand : FuncCliCommand
                 e.LogicalPackage.Aliases,
                 WorkloadOwnershipKind.Logical))];
         IReadOnlyList<PruneCandidate> explicitPackages = [.. installed
-            .Where(e => e.IsExplicitlyInstalled)
+            .Where(e => !e.IsImplicitlyInstalled)
             .Select(e => new PruneCandidate(
                 e.PackageId,
                 e.PackageVersion,
@@ -138,13 +139,30 @@ internal sealed class WorkloadPruneCommand : FuncCliCommand
                 string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase))))];
         if (logicalMatches.Count > 0)
         {
-            return logicalMatches;
+            return EnsureUnambiguousTarget(identifier, logicalMatches);
         }
 
-        return [.. explicitPackages.Where(e =>
+        IReadOnlyList<PruneCandidate> explicitMatches = [.. explicitPackages.Where(e =>
             string.Equals(e.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
             || (!exact && e.Aliases.Any(a =>
                 string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase))))];
+        return EnsureUnambiguousTarget(identifier, explicitMatches);
+    }
+
+    private static IReadOnlyList<PruneCandidate> EnsureUnambiguousTarget(string identifier, IReadOnlyList<PruneCandidate> matches)
+    {
+        string[] packageIds = [.. matches
+            .Select(match => match.PackageId)
+            .Distinct(StringComparer.OrdinalIgnoreCase)];
+        if (packageIds.Length > 1)
+        {
+            throw new GracefulException(
+                $"Alias '{identifier}' matches multiple installed workloads ({string.Join(", ", packageIds)}). " +
+                "Pass the workload ID instead.",
+                isUserError: true);
+        }
+
+        return matches;
     }
 
     private static NuGetVersion ParseVersion(string raw) =>

--- a/src/Func/Commands/Workload/WorkloadUninstallCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadUninstallCommand.cs
@@ -141,7 +141,7 @@ internal sealed class WorkloadUninstallCommand : FuncCliCommand
         }
 
         return [.. installed
-            .Where(w => w.IsExplicitlyInstalled
+            .Where(w => !w.IsImplicitlyInstalled
                 && (string.Equals(w.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
                     || (!exact && w.Aliases.Any(a =>
                         string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)))))

--- a/src/Func/Commands/Workload/WorkloadUninstallCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadUninstallCommand.cs
@@ -76,9 +76,7 @@ internal sealed class WorkloadUninstallCommand : FuncCliCommand
         bool exact = parseResult.GetValue(ExactOption);
 
         IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
-        List<WorkloadEntry> matches = [.. installed
-            .Where(w => string.Equals(w.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
-                || (!exact && (w.Aliases?.Any(a => string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)) ?? false)))];
+        IReadOnlyList<UninstallCandidate> matches = ResolveCandidates(identifier, installed, exact);
 
         if (matches.Count == 0)
         {
@@ -87,7 +85,7 @@ internal sealed class WorkloadUninstallCommand : FuncCliCommand
         }
 
         string[] distinctPackageIds = [.. matches
-            .Select(m => m.PackageId)
+            .Select(m => m.OwnerPackageId)
             .Distinct(StringComparer.OrdinalIgnoreCase)];
 
         if (distinctPackageIds.Length > 1)
@@ -99,26 +97,65 @@ internal sealed class WorkloadUninstallCommand : FuncCliCommand
         }
 
         string packageId = distinctPackageIds[0];
-        IReadOnlyList<WorkloadEntry> toRemove = ResolveVersionsToRemove(packageId, version, all, matches);
+        IReadOnlyList<UninstallCandidate> toRemove = ResolveVersionsToRemove(packageId, version, all, matches);
 
-        foreach (WorkloadEntry candidate in toRemove)
+        foreach (UninstallCandidate candidate in toRemove)
         {
-            bool removed = await _installer.UninstallAsync(candidate.PackageId, candidate.PackageVersion, cancellationToken);
+            bool removed = candidate.Ownership == WorkloadOwnershipKind.Logical
+                ? await _installer.UninstallAsync(
+                    candidate.OwnerPackageId,
+                    candidate.OwnerPackageVersion,
+                    WorkloadOwnershipKind.Logical,
+                    cancellationToken: cancellationToken)
+                : await _installer.UninstallAsync(
+                    candidate.OwnerPackageId,
+                    candidate.OwnerPackageVersion,
+                    cancellationToken: cancellationToken);
             if (removed)
             {
                 _interaction.WriteSuccess(
-                    $"Uninstalled workload '{candidate.PackageId}' version '{candidate.PackageVersion}'.");
+                    $"Uninstalled workload '{candidate.OwnerPackageId}' version '{candidate.OwnerPackageVersion}'.");
             }
         }
 
         return 0;
     }
 
-    private static IReadOnlyList<WorkloadEntry> ResolveVersionsToRemove(
+    private static IReadOnlyList<UninstallCandidate> ResolveCandidates(
+        string identifier,
+        IReadOnlyList<WorkloadEntry> installed,
+        bool exact)
+    {
+        List<UninstallCandidate> logicalMatches = [.. installed
+            .Where(w => w.LogicalPackage is not null
+                && (string.Equals(w.LogicalPackage.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
+                    || (!exact && w.LogicalPackage.Aliases.Any(a =>
+                        string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)))))
+            .Select(w => new UninstallCandidate(
+                w.LogicalPackage!.PackageId,
+                w.LogicalPackage.PackageVersion,
+                WorkloadOwnershipKind.Logical))];
+        if (logicalMatches.Count > 0)
+        {
+            return logicalMatches;
+        }
+
+        return [.. installed
+            .Where(w => w.IsExplicitlyInstalled
+                && (string.Equals(w.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
+                    || (!exact && w.Aliases.Any(a =>
+                        string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)))))
+            .Select(w => new UninstallCandidate(
+                w.PackageId,
+                w.PackageVersion,
+                WorkloadOwnershipKind.Explicit))];
+    }
+
+    private static IReadOnlyList<UninstallCandidate> ResolveVersionsToRemove(
         string packageId,
         string? version,
         bool all,
-        IReadOnlyList<WorkloadEntry> matches)
+        IReadOnlyList<UninstallCandidate> matches)
     {
         if (all)
         {
@@ -127,12 +164,12 @@ internal sealed class WorkloadUninstallCommand : FuncCliCommand
 
         if (!string.IsNullOrEmpty(version))
         {
-            WorkloadEntry? match = matches.FirstOrDefault(
-                m => string.Equals(m.PackageVersion, version, StringComparison.Ordinal));
+            UninstallCandidate? match = matches.FirstOrDefault(
+                m => string.Equals(m.OwnerPackageVersion, version, StringComparison.Ordinal));
 
             if (match is null)
             {
-                string available = string.Join(", ", matches.Select(m => m.PackageVersion));
+                string available = string.Join(", ", matches.Select(m => m.OwnerPackageVersion));
                 throw new GracefulException(
                     $"Workload '{packageId}' version '{version}' is not installed. " +
                     $"Installed versions: {available}.",
@@ -144,7 +181,7 @@ internal sealed class WorkloadUninstallCommand : FuncCliCommand
 
         if (matches.Count > 1)
         {
-            string available = string.Join(", ", matches.Select(m => m.PackageVersion));
+            string available = string.Join(", ", matches.Select(m => m.OwnerPackageVersion));
             throw new GracefulException(
                 $"Multiple versions of '{packageId}' are installed ({available}). " +
                 "Pass --version <v> or --all-versions.",
@@ -153,4 +190,9 @@ internal sealed class WorkloadUninstallCommand : FuncCliCommand
 
         return matches;
     }
+
+    private sealed record UninstallCandidate(
+        string OwnerPackageId,
+        string OwnerPackageVersion,
+        WorkloadOwnershipKind Ownership);
 }

--- a/src/Func/Commands/Workload/WorkloadUpdateCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadUpdateCommand.cs
@@ -165,7 +165,7 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
         }
 
         string[] matchedIds = [.. installed
-            .Where(e => e.IsExplicitlyInstalled
+            .Where(e => !e.IsImplicitlyInstalled
                 && (string.Equals(e.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
                     || (!exact && e.Aliases.Any(a =>
                         string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)))))
@@ -359,13 +359,9 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
             }
         }
 
-        // A physical package owned by a pointer is updated through that pointer. Adding it again as an
-        // explicit target would re-resolve and replace the payload the logical update just staged.
-        HashSet<string> logicallyOwned = new(
-            installed.Where(e => e.LogicalPackage is not null).Select(e => e.PackageId),
-            StringComparer.OrdinalIgnoreCase);
+        // Logical and explicit ownership can coexist on one physical package and must move independently.
         HashSet<string> explicitIds = new(StringComparer.OrdinalIgnoreCase);
-        foreach (WorkloadEntry entry in installed.Where(e => e.IsExplicitlyInstalled && !logicallyOwned.Contains(e.PackageId)))
+        foreach (WorkloadEntry entry in installed.Where(e => !e.IsImplicitlyInstalled))
         {
             if (explicitIds.Add(entry.PackageId))
             {

--- a/src/Func/Commands/Workload/WorkloadUpdateCommand.cs
+++ b/src/Func/Commands/Workload/WorkloadUpdateCommand.cs
@@ -14,9 +14,9 @@ using NuGet.Versioning;
 namespace Azure.Functions.Cli.Commands.Workload;
 
 /// <summary>
-/// <c>func workload update [&lt;id&gt;]</c>. In-place atomic version
-/// swap per spec §6.4. Not side-by-side: use <c>install --force</c> for
-/// SxS. Pass <c>--all</c> to update every installed workload.
+/// <c>func workload update [&lt;id&gt;]</c>. Moves the selected explicit or
+/// logical ownership to the resolved package version. Pass <c>--all</c> to
+/// update every installed workload identity.
 /// </summary>
 internal sealed class WorkloadUpdateCommand : FuncCliCommand
 {
@@ -132,10 +132,10 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
             return await UpdateAllAsync(source, includePrerelease, allowMajor, cancellationToken);
         }
 
-        string packageId = await ResolveInstalledPackageIdAsync(identifier!, exact, cancellationToken);
+        UpdateTarget target = await ResolveInstalledTargetAsync(identifier!, exact, cancellationToken);
 
         return await UpdateOneAsync(
-            packageId,
+            target,
             string.IsNullOrEmpty(versionText) ? null : NuGetVersion.Parse(versionText),
             source,
             includePrerelease,
@@ -143,36 +143,47 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
             cancellationToken);
     }
 
-    private async Task<string> ResolveInstalledPackageIdAsync(string identifier, bool exact, CancellationToken cancellationToken)
+    private async Task<UpdateTarget> ResolveInstalledTargetAsync(string identifier, bool exact, CancellationToken cancellationToken)
     {
         IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
 
-        bool MatchesId(WorkloadEntry e) =>
-            string.Equals(e.PackageId, identifier, StringComparison.OrdinalIgnoreCase);
+        string[] logicalIds = [.. installed
+            .Where(e => e.LogicalPackage is not null
+                && (string.Equals(e.LogicalPackage.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
+                    || (!exact && e.LogicalPackage.Aliases.Any(a =>
+                        string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)))))
+            .Select(e => e.LogicalPackage!.PackageId)
+            .Distinct(StringComparer.OrdinalIgnoreCase)];
+        if (logicalIds.Length > 1)
+        {
+            throw CreateAmbiguousInstalledAlias(identifier, logicalIds);
+        }
 
-        bool MatchesAlias(WorkloadEntry e) =>
-            !exact && (e.Aliases?.Any(a => string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)) ?? false);
+        if (logicalIds.Length == 1)
+        {
+            return new UpdateTarget(logicalIds[0], WorkloadOwnershipKind.Logical);
+        }
 
         string[] matchedIds = [.. installed
-            .Where(e => MatchesId(e) || MatchesAlias(e))
+            .Where(e => e.IsExplicitlyInstalled
+                && (string.Equals(e.PackageId, identifier, StringComparison.OrdinalIgnoreCase)
+                    || (!exact && e.Aliases.Any(a =>
+                        string.Equals(a, identifier, StringComparison.OrdinalIgnoreCase)))))
             .Select(e => e.PackageId)
             .Distinct(StringComparer.OrdinalIgnoreCase)];
 
         if (matchedIds.Length > 1)
         {
-            throw new GracefulException(
-                $"Alias '{identifier}' matches multiple installed workloads ({string.Join(", ", matchedIds)}). " +
-                "Pass the workload ID instead.",
-                isUserError: true);
+            throw CreateAmbiguousInstalledAlias(identifier, matchedIds);
         }
 
-        // Defer the "not installed" error to UpdateAsync so messaging stays
-        // consistent with the --version path that's also resolved there.
-        return matchedIds.Length == 1 ? matchedIds[0] : identifier;
+        return new UpdateTarget(
+            matchedIds.Length == 1 ? matchedIds[0] : identifier,
+            WorkloadOwnershipKind.Explicit);
     }
 
     private async Task<int> UpdateOneAsync(
-        string packageId,
+        UpdateTarget target,
         NuGetVersion? targetVersion,
         string? source,
         bool? includePrerelease,
@@ -182,9 +193,13 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
         try
         {
             WorkloadUpdateResult result = await _interaction.RunWithProgressAsync(
-                $"Updating workload '{packageId}'",
-                async (ctx, ct) => await _installer.UpdateAsync(
-                    packageId, targetVersion, source, includePrerelease, allowMajor,
+                $"Updating workload '{target.PackageId}'",
+                async (ctx, ct) => await UpdateTargetAsync(
+                    target,
+                    targetVersion,
+                    source,
+                    includePrerelease,
+                    allowMajor,
                     new WorkloadInstallProgressAdapter(ctx),
                     ct),
                 cancellationToken);
@@ -213,25 +228,23 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
     private async Task<int> UpdateAllAsync(string? source, bool? includePrerelease, bool allowMajor, CancellationToken cancellationToken)
     {
         IReadOnlyList<WorkloadEntry> installed = await _store.GetWorkloadsAsync(cancellationToken);
-        IReadOnlyList<string> packageIds = [.. installed
-            .Select(e => e.PackageId)
-            .Distinct(StringComparer.OrdinalIgnoreCase)];
+        IReadOnlyList<UpdateTarget> targets = BuildUpdateAllTargets(installed);
 
-        if (packageIds.Count == 0)
+        if (targets.Count == 0)
         {
             _interaction.WriteHint("No workloads installed.");
             return 0;
         }
 
         bool anyFailed = false;
-        foreach (string packageId in packageIds)
+        foreach (UpdateTarget target in targets)
         {
             try
             {
                 WorkloadUpdateResult result = await _interaction.RunWithProgressAsync(
-                    $"Updating workload '{packageId}'",
-                    async (ctx, ct) => await _installer.UpdateAsync(
-                        packageId,
+                    $"Updating workload '{target.PackageId}'",
+                    async (ctx, ct) => await UpdateTargetAsync(
+                        target,
                         targetInstalledVersion: null,
                         source,
                         includePrerelease,
@@ -251,7 +264,7 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
                 // the message and keep going; the final exit code reflects
                 // whether any failed.
                 anyFailed = true;
-                _interaction.WriteError($"Update failed for '{packageId}': {ex.Message}");
+                _interaction.WriteError($"Update failed for '{target.PackageId}': {ex.Message}");
             }
         }
 
@@ -263,7 +276,12 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
         // Prefer the published alias for user-facing messages so the output
         // matches the token the user typed; fall back to the package id when
         // no alias is published.
-        string display = result.Entry.Aliases.Count > 0 ? result.Entry.Aliases[0] : result.Entry.PackageId;
+        LogicalPackage? logical = result.Entry.LogicalPackage;
+        IReadOnlyList<string> aliases = logical?.Aliases ?? result.Entry.Aliases;
+        string display = aliases.Count > 0
+            ? aliases[0]
+            : logical?.PackageId ?? result.Entry.PackageId;
+        string version = logical?.PackageVersion ?? result.Entry.PackageVersion;
 
         if (result.NoCandidateOnSource)
         {
@@ -277,14 +295,86 @@ internal sealed class WorkloadUpdateCommand : FuncCliCommand
         {
             _interaction.WriteWarning(
                 $"Workload '{display}' is already at the latest available version " +
-                $"({result.Entry.PackageVersion}).");
+                $"({version}).");
+            return;
+        }
+
+        // A RID pivot can land on the same version, where "from X to X" would read as a no-op.
+        if (string.Equals(result.PreviousVersion, version, StringComparison.Ordinal)
+            && !string.IsNullOrEmpty(result.Entry.RuntimeIdentifier))
+        {
+            _interaction.WriteSuccess(
+                $"Updated workload '{display}' to runtime identifier '{result.Entry.RuntimeIdentifier}' (version {version} unchanged).");
             return;
         }
 
         _interaction.WriteSuccess(
-            $"Updated workload '{display}' from {result.PreviousVersion} to {result.Entry.PackageVersion}.");
+            $"Updated workload '{display}' from {result.PreviousVersion} to {version}.");
     }
 
     private bool EffectivePrerelease(bool? userOverride) => userOverride ?? _catalogOptions.IncludePrerelease;
 
+    private Task<WorkloadUpdateResult> UpdateTargetAsync(
+        UpdateTarget target,
+        NuGetVersion? targetInstalledVersion,
+        string? source,
+        bool? includePrerelease,
+        bool allowMajor,
+        IProgress<WorkloadInstallProgress>? progress,
+        CancellationToken cancellationToken)
+        => target.Ownership == WorkloadOwnershipKind.Logical
+            ? _installer.UpdateAsync(
+                target.PackageId,
+                targetInstalledVersion,
+                source,
+                includePrerelease,
+                allowMajor,
+                WorkloadOwnershipKind.Logical,
+                progress,
+                cancellationToken)
+            : _installer.UpdateAsync(
+                target.PackageId,
+                targetInstalledVersion,
+                source,
+                includePrerelease,
+                allowMajor,
+                progress,
+                cancellationToken);
+
+    private static GracefulException CreateAmbiguousInstalledAlias(string identifier, IReadOnlyList<string> packageIds)
+        => new(
+            $"Alias '{identifier}' matches multiple installed workloads ({string.Join(", ", packageIds)}). " +
+            "Pass the workload ID instead.",
+            isUserError: true);
+
+    private static IReadOnlyList<UpdateTarget> BuildUpdateAllTargets(IReadOnlyList<WorkloadEntry> installed)
+    {
+        List<UpdateTarget> targets = [];
+        HashSet<string> logicalIds = new(StringComparer.OrdinalIgnoreCase);
+        foreach (WorkloadEntry entry in installed.Where(e => e.LogicalPackage is not null))
+        {
+            if (logicalIds.Add(entry.LogicalPackage!.PackageId))
+            {
+                targets.Add(new UpdateTarget(entry.LogicalPackage.PackageId, WorkloadOwnershipKind.Logical));
+            }
+        }
+
+        // A physical package owned by a pointer is updated through that pointer. Adding it again as an
+        // explicit target would re-resolve and replace the payload the logical update just staged.
+        HashSet<string> logicallyOwned = new(
+            installed.Where(e => e.LogicalPackage is not null).Select(e => e.PackageId),
+            StringComparer.OrdinalIgnoreCase);
+        HashSet<string> explicitIds = new(StringComparer.OrdinalIgnoreCase);
+        foreach (WorkloadEntry entry in installed.Where(e => e.IsExplicitlyInstalled && !logicallyOwned.Contains(e.PackageId)))
+        {
+            if (explicitIds.Add(entry.PackageId))
+            {
+                targets.Add(new UpdateTarget(entry.PackageId, WorkloadOwnershipKind.Explicit));
+            }
+        }
+
+        return targets;
+    }
+
+    private sealed record UpdateTarget(string PackageId, WorkloadOwnershipKind Ownership);
 }

--- a/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
@@ -252,7 +252,7 @@ public class WorkloadInstallCommandTests
     }
 
     [Fact]
-    public async Task Install_BrokenInstall_AppendsForceHint()
+    public async Task Install_BrokenInstall_SurfacesInstallerMessageAsUserError()
     {
         _installer.InstallFromCatalogAsync(
                 Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
@@ -263,7 +263,6 @@ public class WorkloadInstallCommandTests
         var cmd = NewInstall();
         GracefulException ex = (await FluentActions.Awaiting(() => InvokeAsync(cmd, "Test.Workload")).Should().ThrowAsync<GracefulException>()).Which;
         ex.Message.Should().Contain("missing from the registry");
-        ex.Message.Should().Contain("--force");
         ex.IsUserError.Should().BeTrue();
     }
 
@@ -379,6 +378,36 @@ public class WorkloadInstallCommandTests
     }
 
     [Fact]
+    public async Task Install_AlreadyInstalledLogicalAlias_HintsPointerIdentity()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            new WorkloadEntry
+            {
+                PackageId = "Test.Workload.win-x64",
+                PackageVersion = "1.2.3",
+                RuntimeIdentifier = "win-x64",
+                IsExplicitlyInstalled = false,
+                LogicalPackage = new LogicalPackage
+                {
+                    PackageId = "Test.Workload",
+                    PackageVersion = "1.2.3",
+                    Aliases = ["test"],
+                },
+            },
+        ]);
+
+        var cmd = NewInstall();
+        int exit = await InvokeAsync(cmd, "test");
+
+        exit.Should().Be(1);
+        _interaction.Lines.Should().Contain(line =>
+            line.StartsWith("HINT:", StringComparison.Ordinal)
+            && line.Contains("func workload update Test.Workload", StringComparison.Ordinal)
+            && line.Contains("1.2.3", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task Install_AlreadyInstalled_AliasMatch_NonInteractive_HintsCanonicalIdWhenNoAlias()
     {
         _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(new[]
@@ -419,6 +448,41 @@ public class WorkloadInstallCommandTests
         exit.Should().Be(0);
         await _installer.Received(1).InstallFromCatalogAsync(
             "alias1", null, null, (bool?)null, true, false, Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Install_PhysicalPackageWithOnlyLogicalOwnership_AddsExplicitOwnership()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            new WorkloadEntry
+            {
+                PackageId = "Test.Workload.win-x64",
+                PackageVersion = "1.0.0",
+                IsExplicitlyInstalled = false,
+                LogicalPackage = new LogicalPackage
+                {
+                    PackageId = "Test.Workload",
+                    PackageVersion = "1.0.0",
+                    Aliases = ["test"],
+                },
+            },
+        ]);
+        StubCatalogResult(packageId: "Test.Workload.win-x64");
+
+        var cmd = NewInstall();
+        int exit = await InvokeAsync(cmd, "Test.Workload.win-x64", "--exact");
+
+        exit.Should().Be(0);
+        await _installer.Received(1).InstallFromCatalogAsync(
+            "Test.Workload.win-x64",
+            null,
+            null,
+            (bool?)null,
+            true,
+            false,
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadInstallCommandTests.cs
@@ -83,6 +83,177 @@ public class WorkloadInstallCommandTests
     }
 
     [Fact]
+    public async Task Install_AlreadyInstalledExplicitDualOwnedPackage_UpdatesPhysicalIdentity()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            new WorkloadEntry
+            {
+                PackageId = "Test.Workload.win-x64",
+                PackageVersion = "1.0.0",
+                Aliases = ["implementation"],
+                RuntimeIdentifier = "win-x64",
+                IsImplicitlyInstalled = false,
+                LogicalPackage = new LogicalPackage
+                {
+                    PackageId = "Test.Workload",
+                    PackageVersion = "1.0.0",
+                    Aliases = ["test"],
+                },
+                InstallRefCount = 2,
+            },
+        ]);
+        _installer.UpdateAsync(
+                "Test.Workload.win-x64",
+                Arg.Any<NuGetVersion?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<bool>(),
+                Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new WorkloadUpdateResult(
+                new WorkloadEntry { PackageId = "Test.Workload.win-x64", PackageVersion = "1.1.0" },
+                "1.0.0",
+                NoUpdateAvailable: false));
+        _installer.UpdateAsync(
+                "Test.Workload",
+                Arg.Any<NuGetVersion?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<bool>(),
+                WorkloadOwnershipKind.Logical,
+                Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new WorkloadUpdateResult(
+                new WorkloadEntry
+                {
+                    PackageId = "Test.Workload.win-x64",
+                    PackageVersion = "1.1.0",
+                    IsImplicitlyInstalled = true,
+                    LogicalPackage = new LogicalPackage
+                    {
+                        PackageId = "Test.Workload",
+                        PackageVersion = "1.1.0",
+                        Aliases = ["test"],
+                    },
+                },
+                "1.0.0",
+                NoUpdateAvailable: false));
+        var interaction = new InteractiveTestInteractionService();
+        var update = new WorkloadUpdateCommand(interaction, _installer, _store, _testCatalogOptions);
+        var cmd = new WorkloadInstallCommand(interaction, _installer, _store, update, _testCatalogOptions);
+
+        int exit = await InvokeAsync(cmd, "Test.Workload.win-x64", "--exact");
+
+        exit.Should().Be(0);
+        await _installer.Received(1).UpdateAsync(
+            "Test.Workload.win-x64",
+            Arg.Any<NuGetVersion?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<bool>(),
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+        await _installer.DidNotReceive().UpdateAsync(
+            "Test.Workload",
+            Arg.Any<NuGetVersion?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<bool>(),
+            WorkloadOwnershipKind.Logical,
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Install_AmbiguousInstalledLogicalAlias_ThrowsBeforeInstalling()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            new WorkloadEntry
+            {
+                PackageId = "First.Workload.win-x64",
+                PackageVersion = "1.0.0",
+                IsImplicitlyInstalled = true,
+                LogicalPackage = new LogicalPackage
+                {
+                    PackageId = "First.Workload",
+                    PackageVersion = "1.0.0",
+                    Aliases = ["shared"],
+                },
+            },
+            new WorkloadEntry
+            {
+                PackageId = "Second.Workload.win-x64",
+                PackageVersion = "1.0.0",
+                IsImplicitlyInstalled = true,
+                LogicalPackage = new LogicalPackage
+                {
+                    PackageId = "Second.Workload",
+                    PackageVersion = "1.0.0",
+                    Aliases = ["shared"],
+                },
+            },
+        ]);
+        var cmd = NewInstall();
+
+        GracefulException ex = (await FluentActions.Awaiting(
+            () => InvokeAsync(cmd, "shared")).Should().ThrowExactlyAsync<GracefulException>()).Which;
+
+        ex.Message.Should().Contain("matches multiple installed workloads");
+        ex.Message.Should().Contain("First.Workload");
+        ex.Message.Should().Contain("Second.Workload");
+        await _installer.DidNotReceive().InstallFromCatalogAsync(
+            Arg.Any<string>(),
+            Arg.Any<NuGetVersion?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Install_AmbiguousInstalledExplicitAlias_ThrowsBeforeInstalling()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            new WorkloadEntry
+            {
+                PackageId = "First.Workload",
+                PackageVersion = "1.0.0",
+                Aliases = ["shared"],
+                IsImplicitlyInstalled = false,
+            },
+            new WorkloadEntry
+            {
+                PackageId = "Second.Workload",
+                PackageVersion = "1.0.0",
+                Aliases = ["shared"],
+                IsImplicitlyInstalled = false,
+            },
+        ]);
+        var cmd = NewInstall();
+
+        GracefulException ex = (await FluentActions.Awaiting(
+            () => InvokeAsync(cmd, "shared")).Should().ThrowExactlyAsync<GracefulException>()).Which;
+
+        ex.Message.Should().Contain("matches multiple installed workloads");
+        ex.Message.Should().Contain("First.Workload");
+        ex.Message.Should().Contain("Second.Workload");
+        await _installer.DidNotReceive().InstallFromCatalogAsync(
+            Arg.Any<string>(),
+            Arg.Any<NuGetVersion?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task Install_ShortAliases_VAndF_Forward()
     {
         StubCatalogResult();
@@ -353,7 +524,7 @@ public class WorkloadInstallCommandTests
             Arg.Any<string>(), Arg.Any<NuGetVersion?>(), Arg.Any<string?>(),
             Arg.Any<bool?>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<IProgress<WorkloadInstallProgress>?>(), Arg.Any<CancellationToken>());
         _interaction.Lines.Should().Contain(l =>
-            l.StartsWith("HINT:") && l.Contains("func workload update test"));
+            l.StartsWith("HINT:") && l.Contains("func workload update Test.Workload"));
     }
 
     [Fact]
@@ -374,7 +545,10 @@ public class WorkloadInstallCommandTests
 
         exit.Should().Be(1);
         _interaction.Lines.Should().Contain(l =>
-            l.StartsWith("HINT:") && l.Contains("alias1") && l.Contains("1.2.3"));
+            l.StartsWith("HINT:")
+            && l.Contains("alias1")
+            && l.Contains("1.2.3")
+            && l.Contains("func workload update Test.Workload"));
     }
 
     [Fact]
@@ -387,7 +561,7 @@ public class WorkloadInstallCommandTests
                 PackageId = "Test.Workload.win-x64",
                 PackageVersion = "1.2.3",
                 RuntimeIdentifier = "win-x64",
-                IsExplicitlyInstalled = false,
+                IsImplicitlyInstalled = true,
                 LogicalPackage = new LogicalPackage
                 {
                     PackageId = "Test.Workload",
@@ -459,7 +633,7 @@ public class WorkloadInstallCommandTests
             {
                 PackageId = "Test.Workload.win-x64",
                 PackageVersion = "1.0.0",
-                IsExplicitlyInstalled = false,
+                IsImplicitlyInstalled = true,
                 LogicalPackage = new LogicalPackage
                 {
                     PackageId = "Test.Workload",
@@ -567,6 +741,11 @@ public class WorkloadInstallCommandTests
         root.Subcommands.Add(cmd);
         var config = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
         return root.Parse(new[] { cmd.Name }.Concat(args).ToArray()).InvokeAsync(config);
+    }
+
+    private sealed class InteractiveTestInteractionService : TestInteractionService
+    {
+        public override bool IsInteractive => true;
     }
 }
 

--- a/test/Func.Tests/Commands/Workload/WorkloadListCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadListCommandTests.cs
@@ -303,7 +303,7 @@ public class WorkloadListCommandTests
             PackageVersion = "2.0.0",
             Aliases = ["pointer"],
             RuntimeIdentifier = "win-x64",
-            IsExplicitlyInstalled = false,
+            IsImplicitlyInstalled = true,
             LogicalPackage = new LogicalPackage
             {
                 PackageId = "Pkg.Pointer",

--- a/test/Func.Tests/Commands/Workload/WorkloadListCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadListCommandTests.cs
@@ -290,6 +290,45 @@ public class WorkloadListCommandTests
     }
 
     [Fact]
+    public async Task List_Json_ProjectsLogicalAndPhysicalPointerDetails()
+    {
+        RuntimeWorkloadInfo loaded = NewInfo(
+            new FakeWorkload(displayName: "Physical implementation"),
+            "Pkg.Pointer.win-x64",
+            "2.0.0",
+            ["pointer"]);
+        var entry = new WorkloadEntry
+        {
+            PackageId = "Pkg.Pointer.win-x64",
+            PackageVersion = "2.0.0",
+            Aliases = ["pointer"],
+            RuntimeIdentifier = "win-x64",
+            IsExplicitlyInstalled = false,
+            LogicalPackage = new LogicalPackage
+            {
+                PackageId = "Pkg.Pointer",
+                PackageVersion = "2.0.0",
+                Aliases = ["pointer"],
+                DisplayName = "Pointer workload",
+                Description = "RID-selected workload",
+            },
+            InstallRefCount = 1,
+        };
+        var store = Substitute.For<IWorkloadStore>();
+        store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns([entry]);
+
+        var cmd = new WorkloadListCommand(_interaction, Provider(loaded), store);
+        await InvokeAsync(cmd, "--json");
+
+        string jsonLine = _interaction.Lines.Single(line => line.StartsWith("JSON:", StringComparison.Ordinal));
+        jsonLine.Should().Contain("\"packageId\":\"Pkg.Pointer\"");
+        jsonLine.Should().Contain("\"physicalPackageId\":\"Pkg.Pointer.win-x64\"");
+        jsonLine.Should().Contain("\"runtimeIdentifier\":\"win-x64\"");
+        jsonLine.Should().Contain("\"ownership\":\"logical:Pkg.Pointer\"");
+        jsonLine.Should().Contain("\"isExplicitlyInstalled\":false");
+    }
+
+    [Fact]
     public async Task List_HasJsonAndAllVersionsOptions()
     {
         var cmd = new WorkloadListCommand(_interaction, Provider(), Substitute.For<IWorkloadStore>());

--- a/test/Func.Tests/Commands/Workload/WorkloadPruneCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadPruneCommandTests.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine;
 using Azure.Functions.Cli.Commands.Workload;
+using Azure.Functions.Cli.Common;
 using Azure.Functions.Cli.Workloads.Install;
 using Azure.Functions.Cli.Workloads.Storage;
 using NSubstitute;
@@ -116,6 +117,71 @@ public class WorkloadPruneCommandTests
     }
 
     [Fact]
+    public async Task Prune_AmbiguousExplicitAlias_ThrowsWithoutRemoving()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            new WorkloadEntry { PackageId = "Pkg.A", PackageVersion = "1.0.0", Aliases = ["shared"] },
+            new WorkloadEntry { PackageId = "Pkg.B", PackageVersion = "1.0.0", Aliases = ["shared"] },
+        ]);
+        var cmd = new WorkloadPruneCommand(_interaction, _installer, _store);
+
+        GracefulException ex = (await FluentActions.Awaiting(
+            () => InvokeAsync(cmd, "shared")).Should().ThrowExactlyAsync<GracefulException>()).Which;
+
+        ex.Message.Should().Contain("matches multiple installed workloads");
+        ex.Message.Should().Contain("Pkg.A");
+        ex.Message.Should().Contain("Pkg.B");
+        await _installer.DidNotReceive().UninstallAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Prune_AmbiguousLogicalAlias_ThrowsWithoutRemoving()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            new WorkloadEntry
+            {
+                PackageId = "Pkg.A.win-x64",
+                PackageVersion = "1.0.0",
+                IsImplicitlyInstalled = true,
+                LogicalPackage = new LogicalPackage
+                {
+                    PackageId = "Pkg.A",
+                    PackageVersion = "1.0.0",
+                    Aliases = ["shared"],
+                },
+            },
+            new WorkloadEntry
+            {
+                PackageId = "Pkg.B.win-x64",
+                PackageVersion = "1.0.0",
+                IsImplicitlyInstalled = true,
+                LogicalPackage = new LogicalPackage
+                {
+                    PackageId = "Pkg.B",
+                    PackageVersion = "1.0.0",
+                    Aliases = ["shared"],
+                },
+            },
+        ]);
+        var cmd = new WorkloadPruneCommand(_interaction, _installer, _store);
+
+        GracefulException ex = (await FluentActions.Awaiting(
+            () => InvokeAsync(cmd, "shared")).Should().ThrowExactlyAsync<GracefulException>()).Which;
+
+        ex.Message.Should().Contain("matches multiple installed workloads");
+        ex.Message.Should().Contain("Pkg.A");
+        ex.Message.Should().Contain("Pkg.B");
+        await _installer.DidNotReceive().UninstallAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            WorkloadOwnershipKind.Logical,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task Prune_Exact_DoesNotMatchAlias()
     {
         _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(new[]
@@ -167,7 +233,7 @@ public class WorkloadPruneCommandTests
         {
             PackageId = physicalPackageId,
             PackageVersion = version,
-            IsExplicitlyInstalled = false,
+            IsImplicitlyInstalled = true,
             LogicalPackage = new LogicalPackage
             {
                 PackageId = "Pkg.Pointer",

--- a/test/Func.Tests/Commands/Workload/WorkloadPruneCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadPruneCommandTests.cs
@@ -134,6 +134,50 @@ public class WorkloadPruneCommandTests
     }
 
     [Fact]
+    public async Task Prune_LogicalPointer_KeepsHighestPointerVersion()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            LogicalEntry("Pkg.Pointer.win-x64", "1.0.0"),
+            LogicalEntry("Pkg.Pointer.win-x64", "2.0.0"),
+        ]);
+        _installer.UninstallAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                WorkloadOwnershipKind.Logical,
+                Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var cmd = new WorkloadPruneCommand(_interaction, _installer, _store);
+        int exit = await InvokeAsync(cmd, "pointer");
+
+        exit.Should().Be(0);
+        await _installer.Received(1).UninstallAsync(
+            "Pkg.Pointer",
+            "1.0.0",
+            WorkloadOwnershipKind.Logical,
+            Arg.Any<CancellationToken>());
+        await _installer.DidNotReceive().UninstallAsync(
+            "Pkg.Pointer",
+            "2.0.0",
+            WorkloadOwnershipKind.Logical,
+            Arg.Any<CancellationToken>());
+
+        static WorkloadEntry LogicalEntry(string physicalPackageId, string version) => new()
+        {
+            PackageId = physicalPackageId,
+            PackageVersion = version,
+            IsExplicitlyInstalled = false,
+            LogicalPackage = new LogicalPackage
+            {
+                PackageId = "Pkg.Pointer",
+                PackageVersion = version,
+                Aliases = ["pointer"],
+            },
+        };
+    }
+
+    [Fact]
     public async Task Prune_WhitespaceArg_FailsValidation()
     {
         var cmd = new WorkloadPruneCommand(_interaction, _installer, _store);

--- a/test/Func.Tests/Commands/Workload/WorkloadUninstallCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadUninstallCommandTests.cs
@@ -254,7 +254,7 @@ public class WorkloadUninstallCommandTests
                 PackageId = "Test.Workload.win-x64",
                 PackageVersion = "1.0.0",
                 RuntimeIdentifier = "win-x64",
-                IsExplicitlyInstalled = true,
+                IsImplicitlyInstalled = false,
                 LogicalPackage = new LogicalPackage
                 {
                     PackageId = "Test.Workload",

--- a/test/Func.Tests/Commands/Workload/WorkloadUninstallCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadUninstallCommandTests.cs
@@ -244,6 +244,48 @@ public class WorkloadUninstallCommandTests
         await _installer.Received(1).UninstallAsync("First.Workload", "1.0.0", Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task Uninstall_LogicalPackageId_RemovesOnlyLogicalOwnership()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            new WorkloadEntry
+            {
+                PackageId = "Test.Workload.win-x64",
+                PackageVersion = "1.0.0",
+                RuntimeIdentifier = "win-x64",
+                IsExplicitlyInstalled = true,
+                LogicalPackage = new LogicalPackage
+                {
+                    PackageId = "Test.Workload",
+                    PackageVersion = "1.0.0",
+                    Aliases = ["test"],
+                },
+                InstallRefCount = 2,
+            },
+        ]);
+        _installer.UninstallAsync(
+                "Test.Workload",
+                "1.0.0",
+                WorkloadOwnershipKind.Logical,
+                Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var cmd = NewCommand();
+        int exit = await InvokeAsync(cmd, "Test.Workload", "--exact");
+
+        exit.Should().Be(0);
+        await _installer.Received(1).UninstallAsync(
+            "Test.Workload",
+            "1.0.0",
+            WorkloadOwnershipKind.Logical,
+            Arg.Any<CancellationToken>());
+        await _installer.DidNotReceive().UninstallAsync(
+            "Test.Workload.win-x64",
+            "1.0.0",
+            Arg.Any<CancellationToken>());
+    }
+
     private WorkloadUninstallCommand NewCommand() => new(_interaction, _installer, _store);
 
     private void StubInstalled(params (string PackageId, string Version)[] entries)

--- a/test/Func.Tests/Commands/Workload/WorkloadUpdateCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadUpdateCommandTests.cs
@@ -270,6 +270,86 @@ public class WorkloadUpdateCommandTests
     }
 
     [Fact]
+    public async Task Update_All_DualOwnedPackage_UpdatesLogicalAndExplicitOwnership()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            new WorkloadEntry
+            {
+                PackageId = "test.workload.win-x64",
+                PackageVersion = "1.0.0",
+                RuntimeIdentifier = "win-x64",
+                IsImplicitlyInstalled = false,
+                LogicalPackage = new LogicalPackage
+                {
+                    PackageId = "test.workload",
+                    PackageVersion = "1.0.0",
+                    Aliases = ["test"],
+                },
+                InstallRefCount = 2,
+            },
+        ]);
+        _installer.UpdateAsync(
+                "test.workload",
+                Arg.Any<NuGetVersion?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<bool>(),
+                WorkloadOwnershipKind.Logical,
+                Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new WorkloadUpdateResult(
+                new WorkloadEntry
+                {
+                    PackageId = "test.workload.win-x64",
+                    PackageVersion = "1.1.0",
+                    IsImplicitlyInstalled = true,
+                    LogicalPackage = new LogicalPackage
+                    {
+                        PackageId = "test.workload",
+                        PackageVersion = "1.1.0",
+                        Aliases = ["test"],
+                    },
+                },
+                "1.0.0",
+                NoUpdateAvailable: false));
+        _installer.UpdateAsync(
+                "test.workload.win-x64",
+                Arg.Any<NuGetVersion?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<bool>(),
+                Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new WorkloadUpdateResult(
+                new WorkloadEntry { PackageId = "test.workload.win-x64", PackageVersion = "1.1.0" },
+                "1.0.0",
+                NoUpdateAvailable: false));
+        var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store, _testCatalogOptions);
+
+        int exit = await InvokeAsync(cmd, "--all");
+
+        exit.Should().Be(0);
+        await _installer.Received(1).UpdateAsync(
+            "test.workload",
+            Arg.Any<NuGetVersion?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<bool>(),
+            WorkloadOwnershipKind.Logical,
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+        await _installer.Received(1).UpdateAsync(
+            "test.workload.win-x64",
+            Arg.Any<NuGetVersion?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<bool>(),
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task Update_All_PerIdFailureDoesNotStopOthers_ReturnsNonZero()
     {
         _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(new WorkloadEntry[]
@@ -362,7 +442,7 @@ public class WorkloadUpdateCommandTests
                 PackageId = "test.workload.win-x64",
                 PackageVersion = "1.0.0",
                 RuntimeIdentifier = "win-x64",
-                IsExplicitlyInstalled = false,
+                IsImplicitlyInstalled = true,
                 LogicalPackage = new LogicalPackage
                 {
                     PackageId = "test.workload",
@@ -386,7 +466,7 @@ public class WorkloadUpdateCommandTests
                     PackageId = "test.workload.win-x64",
                     PackageVersion = "1.1.0",
                     RuntimeIdentifier = "win-x64",
-                    IsExplicitlyInstalled = false,
+                    IsImplicitlyInstalled = true,
                     LogicalPackage = new LogicalPackage
                     {
                         PackageId = "test.workload",

--- a/test/Func.Tests/Commands/Workload/WorkloadUpdateCommandTests.cs
+++ b/test/Func.Tests/Commands/Workload/WorkloadUpdateCommandTests.cs
@@ -353,6 +353,66 @@ public class WorkloadUpdateCommandTests
     }
 
     [Fact]
+    public async Task Update_LogicalAlias_UpdatesPointerOwnership()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            new WorkloadEntry
+            {
+                PackageId = "test.workload.win-x64",
+                PackageVersion = "1.0.0",
+                RuntimeIdentifier = "win-x64",
+                IsExplicitlyInstalled = false,
+                LogicalPackage = new LogicalPackage
+                {
+                    PackageId = "test.workload",
+                    PackageVersion = "1.0.0",
+                    Aliases = ["demo"],
+                },
+            },
+        ]);
+        _installer.UpdateAsync(
+                "test.workload",
+                Arg.Any<NuGetVersion?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<bool>(),
+                WorkloadOwnershipKind.Logical,
+                Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new WorkloadUpdateResult(
+                new WorkloadEntry
+                {
+                    PackageId = "test.workload.win-x64",
+                    PackageVersion = "1.1.0",
+                    RuntimeIdentifier = "win-x64",
+                    IsExplicitlyInstalled = false,
+                    LogicalPackage = new LogicalPackage
+                    {
+                        PackageId = "test.workload",
+                        PackageVersion = "1.1.0",
+                        Aliases = ["demo"],
+                    },
+                },
+                "1.0.0",
+                NoUpdateAvailable: false));
+
+        var cmd = new WorkloadUpdateCommand(_interaction, _installer, _store, _testCatalogOptions);
+        int exit = await InvokeAsync(cmd, "demo");
+
+        exit.Should().Be(0);
+        await _installer.Received(1).UpdateAsync(
+            "test.workload",
+            Arg.Any<NuGetVersion?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<bool>(),
+            WorkloadOwnershipKind.Logical,
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task Update_ExactSkipsAliasLookup_PassesArgumentThrough()
     {
         _store.GetWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(new WorkloadEntry[]


### PR DESCRIPTION
Layer 5 of a 6-layer stack decomposing #5512 (RID-pointer workload support) into small, independently reviewable PRs.

**Targets `fabiocav/stack-4-installer-rid-resolution` (layer 4), not `vnext`.** Review the base first.

## What this layer does

Layer 4 added the ownership-aware `IWorkloadInstaller` overloads *additively*, deliberately preserving the pre-existing ones so the commands kept compiling unchanged. This layer is where the commands move onto the new overloads, so a RID pointer install is presented and managed as its **logical** identity rather than the physical RID-specific package that backs it.

- **`install`** — resolve an already-installed match through the logical package first, falling back to explicitly-installed physical packages. The non-interactive "already installed" hint now names the pointer id, so the suggested `func workload update <id>` is a command the user can actually run. Success/prompt text prefers the logical id, version, and aliases. The `--force to repair` suffix is dropped because the installer's own message now carries the actionable guidance.
- **`list`** — projects both logical and physical package identity, the resolved runtime identifier, and an ownership summary (`explicit`, `logical:<id>`, `meta:<n>`). Falls back to the loaded-workload projection when the registry is empty.
- **`uninstall`** / **`prune`** — release *logical* ownership through the logical overload, so a physical package still referenced by another owner isn't removed out from under it. Matching prefers logical candidates and only falls back to explicitly-installed physical ones.
- **`update`** — resolves the target to an explicit or logical identity and updates through the matching overload. `--all` skips physical packages already covered by a pointer, since updating them separately would re-resolve and replace the payload the logical update just staged. A RID pivot that lands on the same version now renders as a runtime-identifier change instead of a confusing "from X to X".

## Slice

Exactly 10 files, +612/-105:

**Production** (`src/Func/Commands/Workload/`): `WorkloadInstallCommand.cs`, `WorkloadListCommand.cs`, `WorkloadPruneCommand.cs`, `WorkloadUninstallCommand.cs`, `WorkloadUpdateCommand.cs`

**Tests** (`test/Func.Tests/Commands/Workload/`): the five matching `*CommandTests.cs`

No files outside this slice were touched.

## Deviations from the source PR

- **Assertion style.** The source wrote its 5 new tests with raw `Assert.Equal` / `Assert.Contains`. `.github/instructions/tests.instructions.md` requires AwesomeAssertions, and every prior layer in this stack converted them, so **11 assertions** were converted to `.Should()` form for consistency. Pre-existing assertions were left alone — no drive-by normalization.
- Fixed a stray-whitespace formatting defect in `WorkloadUpdateCommand.cs` (`WorkloadUpdateResult             result`) carried over from the source.

## Validation

- `CI=true dotnet build -c Release` — **0 Warning(s), 0 Error(s)**.
- Targeted: `--filter "FullyQualifiedName~WorkloadInstallCommand|...ListCommand|...PruneCommand|...UninstallCommand|...UpdateCommand"` — **87/87 passed**.
- Full `Func.Tests`: **1357 passed, 1 failed**. The only failure is `ProcessRunnerTests.RunAsync_Timeout_IsReported`, a machine-timing-dependent test that fails identically on `vnext` and on every layer of this stack, unrelated to this change.