### PR TITLE
Workloads: activate RID pointer workloads and fix Python worker content root

### DIFF
--- a/src/Func/Commands/Setup/SetupRunner.cs
+++ b/src/Func/Commands/Setup/SetupRunner.cs
@@ -427,14 +427,6 @@ internal sealed class SetupRunner(
 
             if (runtimeFeature.InstallWorker)
             {
-                if (TryDetectUnsupportedWorkerRid(runtimeFeature.Name, out string unsupportedMessage))
-                {
-                    failures.Add(SetupDependencyResult.Failed(
-                        SetupDependency.Worker(runtimeFeature.Name, versionRange: null),
-                        unsupportedMessage));
-                    continue;
-                }
-
                 VersionRange? workerRange = null;
                 profileScope.Profile?.WorkerVersionRanges.TryGetValue(runtimeFeature.ProfileRuntime, out workerRange);
                 dependencies.Add(SetupDependency.Worker(runtimeFeature.Name, workerRange));
@@ -784,18 +776,18 @@ internal sealed class SetupRunner(
     private static bool MatchesDependency(WorkloadEntry entry, SetupDependency dependency)
     {
         if (dependency.ResolvedPackageId is { } resolvedPackageId
-            && string.Equals(entry.PackageId, resolvedPackageId, StringComparison.OrdinalIgnoreCase))
+            && MatchesPackageId(entry, resolvedPackageId))
         {
             return true;
         }
 
-        if (string.Equals(entry.PackageId, dependency.PackageId, StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-
-        return false;
+        return MatchesPackageId(entry, dependency.PackageId);
     }
+
+    private static bool MatchesPackageId(WorkloadEntry entry, string packageId)
+        => string.Equals(entry.PackageId, packageId, StringComparison.OrdinalIgnoreCase)
+            || (entry.LogicalPackage is { } logical
+                && string.Equals(logical.PackageId, packageId, StringComparison.OrdinalIgnoreCase));
 
     private static bool IsDeclaredProfile(ProjectProfileOptions projectOptions, string profile)
         => projectOptions.Profiles.Any(candidate => string.Equals(candidate, profile, StringComparison.OrdinalIgnoreCase));
@@ -838,26 +830,6 @@ internal sealed class SetupRunner(
         {
             runtimeFeatures.Add(new SetupRuntimeFeature(name, profileRuntime, installWorker));
         }
-    }
-
-    // Reject runtimes whose worker workload isn't published for the current RID
-    // before we hit the catalog, so users get a clear "no python worker for
-    // win-arm64" message instead of an opaque "package not found".
-    private static bool TryDetectUnsupportedWorkerRid(string runtimeName, out string message)
-    {
-        if (string.Equals(runtimeName, "python", StringComparison.OrdinalIgnoreCase)
-            && !PythonWorkerWorkloadPackage.IsCurrentRuntimeSupported())
-        {
-            string currentRid = WorkloadRuntimeIdentifier.Current;
-            string supported = string.Join(", ", PythonWorkerWorkloadPackage.SupportedRuntimeIdentifiers
-                .OrderBy(r => r, StringComparer.OrdinalIgnoreCase));
-            message = $"No python worker is published for runtime identifier '{currentRid}'. "
-                + $"Supported runtimes: {supported}.";
-            return true;
-        }
-
-        message = string.Empty;
-        return false;
     }
 
     private static string NormalizeFeature(string value)
@@ -945,7 +917,7 @@ internal sealed record SetupDependency(
             SetupDependencyKind.Host,
             "host",
             "host",
-            HostWorkloadPackage.CurrentPackageId,
+            HostWorkloadPackage.PackageId,
             versionRange,
             SetupRunnerRangeText(versionRange),
             ResolvedPackageId: null);
@@ -1033,7 +1005,7 @@ internal sealed record SetupDependency(
 
     private static string SetupRunnerWorkerPackageId(string runtime)
         => string.Equals(runtime, "python", StringComparison.OrdinalIgnoreCase)
-            ? PythonWorkerWorkloadPackage.CurrentPackageId
+            ? PythonWorkerWorkloadPackage.PackageId
             : WorkerPackagePrefix + runtime;
 
     private static string? SetupRunnerRangeText(VersionRange? range)

--- a/src/Func/Commands/Start/Initialization/HostWorkloads/DefaultHostWorkloadResolver.cs
+++ b/src/Func/Commands/Start/Initialization/HostWorkloads/DefaultHostWorkloadResolver.cs
@@ -89,7 +89,7 @@ internal sealed class DefaultHostWorkloadResolver(
         return new HostWorkloadResolution.InstallRequired(
             version,
             $"No installed host workload found for {version}",
-            HostWorkloadPackage.CurrentPackageId);
+            HostWorkloadPackage.PackageId);
     }
 
     private IReadOnlyList<InstalledHostCandidate> GetInstalledHostCandidates()
@@ -97,7 +97,7 @@ internal sealed class DefaultHostWorkloadResolver(
         List<InstalledHostCandidate> candidates = [];
         foreach (ContentWorkloadInfo workload in _workloadProvider.GetContentWorkloads())
         {
-            if (!string.Equals(workload.PackageId, HostWorkloadPackage.CurrentPackageId, StringComparison.OrdinalIgnoreCase)
+            if (!workload.PackageId.StartsWith(HostWorkloadPackage.PackageIdPrefix, StringComparison.OrdinalIgnoreCase)
                 || !NuGetVersion.TryParse(workload.PackageVersion, out NuGetVersion? version))
             {
                 continue;
@@ -116,7 +116,7 @@ internal sealed class DefaultHostWorkloadResolver(
 
     private async Task<ResolvedPackage> ResolveLatestInstallPackageAsync(VersionRange? range, CancellationToken cancellationToken)
     {
-        string packageId = HostWorkloadPackage.CurrentPackageId;
+        string packageId = HostWorkloadPackage.PackageId;
         ResolvedPackage? package = range is null
             ? await _workloadCatalog.ResolveLatestVersionAsync(
                 packageId, includePrerelease: null, currentVersion: null, allowMajor: true, source: null, cancellationToken)

--- a/src/Func/Commands/Start/Initialization/Steps/InstallHostWorkloadInitializationStep.cs
+++ b/src/Func/Commands/Start/Initialization/Steps/InstallHostWorkloadInitializationStep.cs
@@ -24,7 +24,7 @@ internal sealed class InstallHostWorkloadInitializationStep(
 
     private readonly IWorkloadInstaller _installer = installer ?? throw new ArgumentNullException(nameof(installer));
     private readonly IWorkloadPaths _workloadPaths = workloadPaths ?? throw new ArgumentNullException(nameof(workloadPaths));
-    private readonly string _packageId = string.IsNullOrWhiteSpace(packageId) ? HostWorkloadPackage.CurrentPackageId : packageId;
+    private readonly string _packageId = string.IsNullOrWhiteSpace(packageId) ? HostWorkloadPackage.PackageId : packageId;
 
     private readonly NuGetVersion _hostVersion = NuGetVersion.TryParse(hostVersion, out NuGetVersion? parsedHostVersion)
         ? parsedHostVersion
@@ -77,7 +77,7 @@ internal sealed class InstallHostWorkloadInitializationStep(
         }
         catch (InvalidOperationException ex)
         {
-            string message = $"{ex.Message} Run 'func workload install {HostWorkloadPackage.CurrentPackageId} --exact --force' to repair the install.";
+            string message = $"{ex.Message} Run 'func workload install {HostWorkloadPackage.PackageId} --exact --force' to repair the install.";
             throw new GracefulException(message, isUserError: true, verboseMessage: ex.ToString());
         }
 
@@ -105,7 +105,7 @@ internal sealed class InstallHostWorkloadInitializationStep(
             entry.PackageVersion,
             entry.Aliases,
             installDirectory,
-            Path.GetFullPath(Path.Combine(installDirectory, "tools", "any")),
+            WorkloadPackageLayout.GetContentRoot(installDirectory, entry.RuntimeIdentifier),
             string.IsNullOrWhiteSpace(entry.DisplayName) ? entry.PackageId : entry.DisplayName,
             entry.Description ?? string.Empty);
     }

--- a/src/Func/Hosting/WorkloadRegistration.cs
+++ b/src/Func/Hosting/WorkloadRegistration.cs
@@ -81,11 +81,16 @@ internal static class WorkloadRegistration
         CancellationToken cancellationToken)
     {
         var store = new WorkloadStore(paths);
-        var loader = new WorkloadLoader(paths);
+        var runtimeIdentifierProvider = new WorkloadRuntimeIdentifierProvider();
+        var loader = new WorkloadLoader(paths, runtimeIdentifierProvider);
 
         IReadOnlyList<WorkloadEntry> allEntries = await store.GetWorkloadsAsync(cancellationToken);
-        IReadOnlyList<WorkloadEntry> liveEntries = SelectLiveRuntimeEntries(allEntries);
-        IReadOnlyList<ContentWorkloadInfo> contentWorkloads = CreateContentWorkloads(allEntries, paths);
+        IReadOnlyList<WorkloadEntry> compatibleEntries = SelectRuntimeCompatibleEntries(
+            allEntries,
+            runtimeIdentifierProvider.Current,
+            interaction);
+        IReadOnlyList<WorkloadEntry> liveEntries = SelectLiveRuntimeEntries(compatibleEntries);
+        IReadOnlyList<ContentWorkloadInfo> contentWorkloads = CreateContentWorkloads(compatibleEntries, paths);
 
         var runtimeWorkloads = new List<RuntimeWorkloadInfo>(liveEntries.Count);
         foreach (WorkloadEntry entry in liveEntries)
@@ -141,6 +146,31 @@ internal static class WorkloadRegistration
         return runtimeWorkloads.Count;
     }
 
+    private static IReadOnlyList<WorkloadEntry> SelectRuntimeCompatibleEntries(
+        IReadOnlyList<WorkloadEntry> entries,
+        string currentRuntimeIdentifier,
+        IInteractionService interaction)
+    {
+        List<WorkloadEntry> compatible = [];
+        foreach (WorkloadEntry entry in entries)
+        {
+            if (entry.RuntimeIdentifier is null
+                || string.Equals(entry.RuntimeIdentifier, currentRuntimeIdentifier, StringComparison.OrdinalIgnoreCase))
+            {
+                compatible.Add(entry);
+                continue;
+            }
+
+            string logicalPackageId = entry.LogicalPackage?.PackageId ?? entry.PackageId;
+            interaction.WriteWarning(
+                $"Workload '{logicalPackageId}@{entry.LogicalPackage?.PackageVersion ?? entry.PackageVersion}' targets runtime identifier " +
+                $"'{entry.RuntimeIdentifier}', but this machine uses '{currentRuntimeIdentifier}'. " +
+                $"Run 'func workload update {logicalPackageId}' to install the matching implementation.");
+        }
+
+        return compatible;
+    }
+
     /// <summary>
     /// Skips non-runtime entries and keeps only the
     /// highest installed semver per <c>packageId</c>. Older versions stay on
@@ -173,7 +203,7 @@ internal static class WorkloadRegistration
                     e.PackageVersion,
                     e.Aliases,
                     installDirectory,
-                    Path.GetFullPath(Path.Combine(installDirectory, "tools", "any")),
+                    WorkloadPackageLayout.GetContentRoot(installDirectory, e.RuntimeIdentifier),
                     GetDisplayName(e),
                     e.Description ?? string.Empty);
             })];

--- a/src/Func/Workers/DefaultFunctionsWorkerInstaller.cs
+++ b/src/Func/Workers/DefaultFunctionsWorkerInstaller.cs
@@ -80,7 +80,8 @@ internal sealed class DefaultFunctionsWorkerInstaller(
         CancellationToken cancellationToken)
     {
         WorkloadEntry entry = result.Entry;
-        if (!string.Equals(entry.PackageId, expectedPackageId, StringComparison.OrdinalIgnoreCase))
+        string installedPackageId = entry.LogicalPackage?.PackageId ?? entry.PackageId;
+        if (!string.Equals(installedPackageId, expectedPackageId, StringComparison.OrdinalIgnoreCase))
         {
             throw new InvalidWorkloadException(
                 $"Expected worker workload package '{expectedPackageId}' but installed package '{entry.PackageId}'.");
@@ -107,7 +108,7 @@ internal sealed class DefaultFunctionsWorkerInstaller(
     private ContentWorkloadInfo CreateContentWorkloadInfo(WorkloadEntry entry)
     {
         string installDirectory = _workloadPaths.GetInstallDirectory(entry.PackageId, entry.PackageVersion);
-        string contentRoot = Path.GetFullPath(Path.Combine(installDirectory, "tools", "any"));
+        string contentRoot = WorkloadPackageLayout.GetContentRoot(installDirectory, entry.RuntimeIdentifier);
 
         return new ContentWorkloadInfo(
             entry.PackageId,

--- a/src/Func/Workloads/HostWorkloadPackage.cs
+++ b/src/Func/Workloads/HostWorkloadPackage.cs
@@ -5,6 +5,7 @@ namespace Azure.Functions.Cli.Workloads;
 
 internal static class HostWorkloadPackage
 {
+    internal const string PackageId = "Azure.Functions.Cli.Workloads.Host";
     internal const string PackageIdPrefix = "Azure.Functions.Cli.Workloads.Host.";
 
     public static string CurrentPackageId => FromRuntimeIdentifier(CurrentRuntimeIdentifier);

--- a/src/Func/Workloads/Loading/WorkloadLoader.cs
+++ b/src/Func/Workloads/Loading/WorkloadLoader.cs
@@ -12,10 +12,19 @@ namespace Azure.Functions.Cli.Workloads.Loading;
 /// collectible <see cref="WorkloadLoadContext"/> so dependency versions
 /// don't collide across workloads.
 /// </summary>
-internal sealed class WorkloadLoader(IWorkloadPaths paths) : IWorkloadLoader
+internal sealed class WorkloadLoader(
+    IWorkloadPaths paths,
+    IWorkloadRuntimeIdentifierProvider runtimeIdentifierProvider) : IWorkloadLoader
 {
     private readonly IWorkloadPaths _paths = paths
         ?? throw new ArgumentNullException(nameof(paths));
+    private readonly IWorkloadRuntimeIdentifierProvider _runtimeIdentifierProvider = runtimeIdentifierProvider
+        ?? throw new ArgumentNullException(nameof(runtimeIdentifierProvider));
+
+    public WorkloadLoader(IWorkloadPaths paths)
+        : this(paths, new WorkloadRuntimeIdentifierProvider())
+    {
+    }
 
     /// <inheritdoc />
     public IReadOnlyList<RuntimeWorkloadInfo> Load(IReadOnlyList<WorkloadEntry> entries)
@@ -25,11 +34,30 @@ internal sealed class WorkloadLoader(IWorkloadPaths paths) : IWorkloadLoader
         var results = new List<RuntimeWorkloadInfo>(entries.Count);
         foreach (WorkloadEntry entry in entries)
         {
-            results.Add(LoadEntry(entry));
+            try
+            {
+                results.Add(LoadEntry(entry));
+            }
+            catch (InvalidWorkloadException ex) when (HasRuntimeIdentifierMismatch(entry))
+            {
+                string logicalPackageId = entry.LogicalPackage?.PackageId ?? entry.PackageId;
+                throw new InvalidWorkloadException(
+                    $"{ex.Message} The installed implementation targets runtime identifier '{entry.RuntimeIdentifier}', " +
+                    $"but this machine uses '{_runtimeIdentifierProvider.Current}'. " +
+                    $"Run 'func workload update {logicalPackageId}' to install the matching implementation.",
+                    ex);
+            }
         }
 
         return results;
     }
+
+    private bool HasRuntimeIdentifierMismatch(WorkloadEntry entry)
+        => entry.RuntimeIdentifier is not null
+            && !string.Equals(
+                entry.RuntimeIdentifier,
+                _runtimeIdentifierProvider.Current,
+                StringComparison.OrdinalIgnoreCase);
 
     private RuntimeWorkloadInfo LoadEntry(WorkloadEntry entry)
     {

--- a/src/Func/Workloads/PythonWorkerWorkloadPackage.cs
+++ b/src/Func/Workloads/PythonWorkerWorkloadPackage.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Collections.Frozen;
-
 namespace Azure.Functions.Cli.Workloads;
 
 /// <summary>
@@ -13,29 +11,11 @@ namespace Azure.Functions.Cli.Workloads;
 /// </summary>
 internal static class PythonWorkerWorkloadPackage
 {
+    internal const string PackageId = "Azure.Functions.Cli.Workloads.Workers.Python";
     internal const string PackageIdPrefix = "Azure.Functions.Cli.Workloads.Workers.Python.";
 
-    /// <summary>
-    /// RIDs we publish a python worker pack for. Must match the
-    /// <c>_CliRuntimeIdentifiers</c> set in
-    /// <c>src/Workloads/Workers/Python/Workloads.Workers.Python.csproj</c>.
-    /// The upstream PythonWorker package has no <c>win-arm64</c> assets.
-    /// </summary>
-    public static readonly FrozenSet<string> SupportedRuntimeIdentifiers =
-        new[] { "win-x64", "linux-x64", "linux-arm64", "osx-x64", "osx-arm64" }
-            .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
-
     public static string CurrentPackageId => FromRuntimeIdentifier(WorkloadRuntimeIdentifier.Current);
-
-    public static bool IsSupported(string runtimeIdentifier)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(runtimeIdentifier);
-        return SupportedRuntimeIdentifiers.Contains(runtimeIdentifier.Trim());
-    }
-
-    public static bool IsCurrentRuntimeSupported() => IsSupported(WorkloadRuntimeIdentifier.Current);
 
     public static string FromRuntimeIdentifier(string runtimeIdentifier)
         => WorkloadRuntimeIdentifier.Qualify(PackageIdPrefix, runtimeIdentifier);
 }
-

--- a/src/Workloads/Workers/Python/Workloads.Workers.Python.csproj
+++ b/src/Workloads/Workers/Python/Workloads.Workers.Python.csproj
@@ -21,16 +21,16 @@
       TODO: Decouple from the upstream worker's precise package layout.
       The plan is to include the PythonWorker package's assets normally (let
       it wire up its content/None items via its build targets), then have a
-      target here transform those items and repack them under tools/any/. For
-      now we glob the restored package payload directly, which is brittle if
-      the upstream layout changes.is project.
+      target here transform those items and repack them under the workload
+      content root. For now we glob the restored package payload directly,
+      which is brittle if the upstream layout changes.is project.
     -->
     <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" VersionOverride="$(WorkerVersion)" PrivateAssets="all" />
   </ItemGroup>
 
-  <Target Name="IncludePythonWorkerContentInPack" DependsOnTargets="AssignTargetPaths">
+  <Target Name="IncludePythonWorkerContentInPack" DependsOnTargets="AssignTargetPaths;_SetWorkloadProperties">
     <ItemGroup>
-      <TfmSpecificPackageFile Include="@(None)" TargetPath="%(RecursiveDir)%(Filename)%(Extension)" Pack="true" PackagePath="tools/any/"
+      <TfmSpecificPackageFile Include="@(None)" TargetPath="%(RecursiveDir)%(Filename)%(Extension)" Pack="true" PackagePath="$(_WorkloadPackageContentRoot)"
          Condition="$([System.String]::new('%(None.TargetPath)').StartsWith('workers/python/'))" />
     </ItemGroup>
   </Target>

--- a/test/Func.Tests/Commands/HostWorkloadResolverTests.cs
+++ b/test/Func.Tests/Commands/HostWorkloadResolverTests.cs
@@ -18,6 +18,7 @@ namespace Azure.Functions.Cli.Tests.Commands;
 public class HostWorkloadResolverTests
 {
     private static readonly string _hostPackageId = HostWorkloadPackage.CurrentPackageId;
+    private static readonly string _hostPointerPackageId = HostWorkloadPackage.PackageId;
 
     private readonly IWorkloadProvider _workloadProvider = Substitute.For<IWorkloadProvider>();
     private readonly IWorkloadCatalog _workloadCatalog = Substitute.For<IWorkloadCatalog>();
@@ -122,15 +123,15 @@ public class HostWorkloadResolverTests
 
         HostWorkloadResolution.InstallRequired installRequired = result.Should().BeOfType<HostWorkloadResolution.InstallRequired>().Subject;
         installRequired.HostVersion.Should().Be("4.1000.0");
-        installRequired.PackageId.Should().Be(_hostPackageId);
+        installRequired.PackageId.Should().Be(_hostPointerPackageId);
     }
 
     [Fact]
     public async Task ResolveAsync_NoInstalledHost_ReturnsInstallRequired()
     {
-        ResolvedPackage resolved = CreateResolvedPackage(_hostPackageId, "4.1048.199");
+        ResolvedPackage resolved = CreateResolvedPackage(_hostPointerPackageId, "4.1048.199");
         _workloadCatalog.ResolveLatestVersionInRangeAsync(
-                _hostPackageId,
+                _hostPointerPackageId,
                 Arg.Any<VersionRange>(),
                 (bool?)null,
                 null,
@@ -146,7 +147,7 @@ public class HostWorkloadResolverTests
 
         HostWorkloadResolution.InstallRequired installRequired = result.Should().BeOfType<HostWorkloadResolution.InstallRequired>().Subject;
         installRequired.HostVersion.Should().Be("4.1048.199");
-        installRequired.PackageId.Should().Be(_hostPackageId);
+        installRequired.PackageId.Should().Be(_hostPointerPackageId);
     }
 
     [Fact]
@@ -178,7 +179,7 @@ public class HostWorkloadResolverTests
         HostWorkloadResolution resolution = new HostWorkloadResolution.InstallRequired(
             "4.1000.0",
             "No compatible host installed",
-            _hostPackageId);
+            _hostPointerPackageId);
         resolver.ResolveAsync(Arg.Any<HostWorkloadResolutionContext>(), Arg.Any<CancellationToken>())
             .Returns(resolution);
         var step = new ValidateHostWorkloadInitializationStep(
@@ -201,7 +202,7 @@ public class HostWorkloadResolverTests
         HostWorkloadResolution resolution = new HostWorkloadResolution.InstallRequired(
             "4.1000.0",
             "No compatible host installed",
-            _hostPackageId);
+            _hostPointerPackageId);
         resolver.ResolveAsync(Arg.Any<HostWorkloadResolutionContext>(), Arg.Any<CancellationToken>())
             .Returns(resolution);
         var step = new ValidateHostWorkloadInitializationStep(

--- a/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
+++ b/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
@@ -920,7 +920,7 @@ public sealed class SetupRunnerTests : IDisposable
             PackageId = $"{pointerPackageId}.{runtimeIdentifier}",
             PackageVersion = version,
             RuntimeIdentifier = runtimeIdentifier,
-            IsExplicitlyInstalled = false,
+            IsImplicitlyInstalled = true,
             LogicalPackage = new LogicalPackage
             {
                 PackageId = pointerPackageId,

--- a/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
+++ b/test/Func.Tests/Commands/Setup/SetupRunnerTests.cs
@@ -23,7 +23,7 @@ namespace Azure.Functions.Cli.Tests.Commands.Setup;
 
 public sealed class SetupRunnerTests : IDisposable
 {
-    private static readonly string _hostPackageId = HostWorkloadPackage.CurrentPackageId;
+    private static readonly string _hostPackageId = HostWorkloadPackage.PackageId;
     private static readonly string _dotNetStackPackageId = "Azure.Functions.Cli.Workloads.DotNet";
 
     private readonly string _tempDir;
@@ -375,6 +375,47 @@ public sealed class SetupRunnerTests : IDisposable
     }
 
     [Fact]
+    public async Task RunAsync_IfNeeded_RecognizesInstalledRidPointerWorkload()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>())
+            .Returns([LogicalEntry(_hostPackageId, "4.0.0", "win-x64")]);
+        FakeCatalog catalog = Catalog();
+        SetupRunner runner = CreateRunner(catalog);
+
+        SetupRunResult result = await runner.RunAsync(
+            Options(features: ["host"], installPolicy: SetupInstallPolicy.IfNeeded),
+            CancellationToken.None);
+
+        result.ExitCode.Should().Be(0);
+        catalog.ResolveLatestCallCount.Should().Be(0);
+        await _installer.DidNotReceive().InstallFromCatalogAsync(
+            Arg.Any<string>(),
+            Arg.Any<NuGetVersion?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunAsync_Check_RecognizesExactRidPointerWorkloadVersion()
+    {
+        _store.GetWorkloadsAsync(Arg.Any<CancellationToken>())
+            .Returns([LogicalEntry(_hostPackageId, "4.0.0", "win-x64")]);
+        FakeCatalog catalog = Catalog().WithLatest(_hostPackageId, "4.0.0");
+        SetupRunner runner = CreateRunner(catalog);
+
+        SetupRunResult result = await runner.RunAsync(
+            Options(features: ["host"], check: true),
+            CancellationToken.None);
+
+        result.ExitCode.Should().Be(0);
+        _interaction.Lines.Should().NotContain(line => line.Contains("not installed", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task RunAsync_LatestCompatibleCheck_FailsWhenLatestCompatibleIsMissing()
     {
         _store.GetWorkloadsAsync(Arg.Any<CancellationToken>())
@@ -664,7 +705,7 @@ public sealed class SetupRunnerTests : IDisposable
         await _installer.DidNotReceive().InstallFromCatalogAsync(
             Arg.Is<string>(id => id.StartsWith("Azure.Functions.Cli.Workloads.", StringComparison.OrdinalIgnoreCase)
                 && !id.StartsWith("Azure.Functions.Cli.Workloads.Workers.", StringComparison.OrdinalIgnoreCase)
-                && !id.StartsWith("Azure.Functions.Cli.Workloads.Host.", StringComparison.OrdinalIgnoreCase)
+                && !id.StartsWith(HostWorkloadPackage.PackageId, StringComparison.OrdinalIgnoreCase)
                 && !id.StartsWith("Azure.Functions.Cli.Workloads.ExtensionBundles", StringComparison.OrdinalIgnoreCase)),
             Arg.Any<NuGetVersion?>(),
             Arg.Any<string?>(),
@@ -871,6 +912,21 @@ public sealed class SetupRunnerTests : IDisposable
             PackageVersion = version,
             Aliases = aliases ?? [],
             Kind = kind,
+        };
+
+    private static WorkloadEntry LogicalEntry(string pointerPackageId, string version, string runtimeIdentifier)
+        => new()
+        {
+            PackageId = $"{pointerPackageId}.{runtimeIdentifier}",
+            PackageVersion = version,
+            RuntimeIdentifier = runtimeIdentifier,
+            IsExplicitlyInstalled = false,
+            LogicalPackage = new LogicalPackage
+            {
+                PackageId = pointerPackageId,
+                PackageVersion = version,
+            },
+            Kind = WorkloadKind.Content,
         };
 
     private sealed class FakeCatalog : IWorkloadCatalog

--- a/test/Func.Tests/Hosting/CliHostFactoryTests.cs
+++ b/test/Func.Tests/Hosting/CliHostFactoryTests.cs
@@ -88,6 +88,26 @@ public sealed class CliHostFactoryTests : IDisposable
     }
 
     [Fact]
+    public async Task CreateHostAsync_IncompatibleRidWorkload_IsSkippedWithUpdateGuidance()
+    {
+        StageFixtureWorkload("withcommand.fixture.incompatible-rid", "1.0.0", CommandWorkloadType);
+        WriteRegistryWithRuntimeIdentifier(
+            "withcommand.fixture.incompatible-rid",
+            "1.0.0",
+            CommandWorkloadType,
+            "incompatible-rid");
+
+        var interaction = new TestInteractionService();
+
+        using IHost host = await StartHostAsync(interaction);
+        var rootCommand = Parser.CreateCommand(host.Services);
+
+        rootCommand.Subcommands.Should().NotContain(c => string.Equals(c.Name, "hello-from-workload", StringComparison.Ordinal));
+        interaction.Lines.Should().Contain(line => line.StartsWith("WARNING:", StringComparison.Ordinal)
+            && line.Contains("func workload update", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task CreateHostAsync_WhenWorkloadConfigureThrows_WarnsAndContinues()
     {
         StageFixtureWorkload("throwing.fixture", "1.0.0", ThrowingWorkloadType);
@@ -253,6 +273,33 @@ public sealed class CliHostFactoryTests : IDisposable
                     Type = e.TypeName,
                 },
             })],
+        };
+
+        Directory.CreateDirectory(_home);
+        string json = JsonSerializer.Serialize(registry, WorkloadJsonContext.Default.WorkloadRegistry);
+        File.WriteAllText(Path.Combine(_home, WorkloadPathsOptions.WorkloadRegistryFileName), json);
+    }
+
+    private void WriteRegistryWithRuntimeIdentifier(string packageId, string version, string typeName, string runtimeIdentifier)
+    {
+        WorkloadRegistry registry = new()
+        {
+            Workloads =
+            [
+                new WorkloadEntry
+                {
+                    PackageId = packageId,
+                    PackageVersion = version,
+                    RuntimeIdentifier = runtimeIdentifier,
+                    Aliases = [],
+                    Kind = WorkloadKind.Workload,
+                    EntryPoint = new EntryPointSpec
+                    {
+                        AssemblyPath = FixtureAssembly,
+                        Type = typeName,
+                    },
+                },
+            ],
         };
 
         Directory.CreateDirectory(_home);

--- a/test/Func.Tests/Workers/DefaultFunctionsWorkerInstallerTests.cs
+++ b/test/Func.Tests/Workers/DefaultFunctionsWorkerInstallerTests.cs
@@ -112,6 +112,47 @@ public class DefaultFunctionsWorkerInstallerTests
     }
 
     [Fact]
+    public async Task InstallAsync_RidPointerImplementationReturnsWorker()
+    {
+        var workerId = new FunctionsWorkerId(WorkerRuntime);
+        WorkloadEntry entry = new()
+        {
+            PackageId = $"{WorkerPackageId}.win-x64",
+            PackageVersion = "3.14.0",
+            Kind = WorkloadKind.Content,
+            Aliases = ["node-worker"],
+            DisplayName = WorkerPackageId,
+            Description = string.Empty,
+            IsExplicitlyInstalled = false,
+            LogicalPackage = new LogicalPackage
+            {
+                PackageId = WorkerPackageId,
+                PackageVersion = "3.14.0",
+            },
+        };
+        _workloadInstaller.InstallFromCatalogAsync(
+                Arg.Any<string>(),
+                Arg.Any<NuGetVersion?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new WorkloadInstallResult(entry, AlreadyInstalled: false));
+        DefaultFunctionsWorkerInstaller installer = CreateInstaller();
+
+        FunctionsWorkerInstallResult result = await installer.InstallAsync(
+            workerId,
+            new Dictionary<string, VersionRange>(),
+            CancellationToken.None);
+
+        result.Worker.WorkerRuntime.Should().Be(WorkerRuntime);
+        result.Worker.WorkerConfigPath.Should()
+            .Be(Path.Combine(GetInstallDirectory("3.14.0", entry.PackageId), "tools", "any", "worker.config.json"));
+    }
+
+    [Fact]
     public async Task InstallAsync_NoPackageInProfileRange_ThrowsWorkloadPackageNotFound()
     {
         var workerId = new FunctionsWorkerId(WorkerRuntime);
@@ -190,10 +231,13 @@ public class DefaultFunctionsWorkerInstallerTests
         return new DefaultFunctionsWorkerInstaller(_workloadCatalog, _workloadInstaller, _workloadPaths, contentResolver);
     }
 
-    private static WorkloadEntry CreateWorkerEntry(string packageVersion, WorkloadKind kind = WorkloadKind.Content)
+    private static WorkloadEntry CreateWorkerEntry(
+        string packageVersion,
+        WorkloadKind kind = WorkloadKind.Content,
+        string packageId = WorkerPackageId)
         => new()
         {
-            PackageId = WorkerPackageId,
+            PackageId = packageId,
             PackageVersion = packageVersion,
             Kind = kind,
             Aliases = ["node-worker"],
@@ -201,5 +245,6 @@ public class DefaultFunctionsWorkerInstallerTests
             Description = string.Empty,
         };
 
-    private static string GetInstallDirectory(string packageVersion) => Path.Combine(Path.GetTempPath(), "workloads", WorkerPackageId, packageVersion);
+    private static string GetInstallDirectory(string packageVersion, string packageId = WorkerPackageId)
+        => Path.Combine(Path.GetTempPath(), "workloads", packageId, packageVersion);
 }

--- a/test/Func.Tests/Workers/DefaultFunctionsWorkerInstallerTests.cs
+++ b/test/Func.Tests/Workers/DefaultFunctionsWorkerInstallerTests.cs
@@ -111,6 +111,47 @@ public class DefaultFunctionsWorkerInstallerTests
     }
 
     [Fact]
+    public async Task InstallAsync_RidPointerImplementationReturnsWorker()
+    {
+        var workerId = new FunctionsWorkerId(WorkerRuntime);
+        WorkloadEntry entry = new()
+        {
+            PackageId = $"{WorkerPackageId}.win-x64",
+            PackageVersion = "3.14.0",
+            Kind = WorkloadKind.Content,
+            Aliases = ["node-worker"],
+            DisplayName = WorkerPackageId,
+            Description = string.Empty,
+            IsExplicitlyInstalled = false,
+            LogicalPackage = new LogicalPackage
+            {
+                PackageId = WorkerPackageId,
+                PackageVersion = "3.14.0",
+            },
+        };
+        _workloadInstaller.InstallFromCatalogAsync(
+                Arg.Any<string>(),
+                Arg.Any<NuGetVersion?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<IProgress<WorkloadInstallProgress>?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new WorkloadInstallResult(entry, AlreadyInstalled: false));
+        DefaultFunctionsWorkerInstaller installer = CreateInstaller();
+
+        FunctionsWorkerInstallResult result = await installer.InstallAsync(
+            workerId,
+            new Dictionary<string, VersionRange>(),
+            CancellationToken.None);
+
+        result.Worker.WorkerRuntime.Should().Be(WorkerRuntime);
+        result.Worker.WorkerConfigPath.Should()
+            .Be(Path.Combine(GetInstallDirectory("3.14.0", entry.PackageId), "tools", "any", "worker.config.json"));
+    }
+
+    [Fact]
     public async Task InstallAsync_NoPackageInProfileRange_ThrowsWorkloadPackageNotFound()
     {
         var workerId = new FunctionsWorkerId(WorkerRuntime);
@@ -189,10 +230,13 @@ public class DefaultFunctionsWorkerInstallerTests
         return new DefaultFunctionsWorkerInstaller(_workloadCatalog, _workloadInstaller, _workloadPaths, contentResolver);
     }
 
-    private static WorkloadEntry CreateWorkerEntry(string packageVersion, WorkloadKind kind = WorkloadKind.Content)
+    private static WorkloadEntry CreateWorkerEntry(
+        string packageVersion,
+        WorkloadKind kind = WorkloadKind.Content,
+        string packageId = WorkerPackageId)
         => new()
         {
-            PackageId = WorkerPackageId,
+            PackageId = packageId,
             PackageVersion = packageVersion,
             Kind = kind,
             Aliases = ["node-worker"],
@@ -200,5 +244,6 @@ public class DefaultFunctionsWorkerInstallerTests
             Description = string.Empty,
         };
 
-    private static string GetInstallDirectory(string packageVersion) => Path.Combine(Path.GetTempPath(), "workloads", WorkerPackageId, packageVersion);
+    private static string GetInstallDirectory(string packageVersion, string packageId = WorkerPackageId)
+        => Path.Combine(Path.GetTempPath(), "workloads", packageId, packageVersion);
 }

--- a/test/Func.Tests/Workers/DefaultFunctionsWorkerInstallerTests.cs
+++ b/test/Func.Tests/Workers/DefaultFunctionsWorkerInstallerTests.cs
@@ -123,7 +123,7 @@ public class DefaultFunctionsWorkerInstallerTests
             Aliases = ["node-worker"],
             DisplayName = WorkerPackageId,
             Description = string.Empty,
-            IsExplicitlyInstalled = false,
+            IsImplicitlyInstalled = true,
             LogicalPackage = new LogicalPackage
             {
                 PackageId = WorkerPackageId,

--- a/test/Func.Tests/Workloads/Loading/WorkloadLoaderTests.cs
+++ b/test/Func.Tests/Workloads/Loading/WorkloadLoaderTests.cs
@@ -56,6 +56,49 @@ public class WorkloadLoaderTests
     }
 
     [Fact]
+    public void Load_InvalidWorkloadForDifferentRid_IncludesUpdateGuidance()
+    {
+        var runtimeIdentifierProvider = Substitute.For<IWorkloadRuntimeIdentifierProvider>();
+        runtimeIdentifierProvider.Current.Returns("linux-x64");
+        var loader = new WorkloadLoader(StubPaths(), runtimeIdentifierProvider);
+        WorkloadEntry entry = FixtureEntry(
+            FixturePackageId,
+            assemblyFileOverride: "DoesNotExist.dll",
+            runtimeIdentifier: "win-x64",
+            logicalPackage: new LogicalPackage
+            {
+                PackageId = "Fixture.Pointer",
+                PackageVersion = "1.0.0",
+            });
+
+        InvalidWorkloadException ex = FluentActions.Invoking(() => loader.Load([entry]))
+            .Should().ThrowExactly<InvalidWorkloadException>().Which;
+
+        ex.Message.Should().Contain("targets runtime identifier 'win-x64'");
+        ex.Message.Should().Contain("this machine uses 'linux-x64'");
+        ex.Message.Should().Contain("func workload update Fixture.Pointer");
+        ex.InnerException.Should().BeOfType<InvalidWorkloadException>();
+    }
+
+    [Fact]
+    public void Load_InvalidWorkloadForCurrentRid_DoesNotIncludeUpdateGuidance()
+    {
+        var runtimeIdentifierProvider = Substitute.For<IWorkloadRuntimeIdentifierProvider>();
+        runtimeIdentifierProvider.Current.Returns("win-x64");
+        var loader = new WorkloadLoader(StubPaths(), runtimeIdentifierProvider);
+        WorkloadEntry entry = FixtureEntry(
+            FixturePackageId,
+            assemblyFileOverride: "DoesNotExist.dll",
+            runtimeIdentifier: "win-x64");
+
+        InvalidWorkloadException ex = FluentActions.Invoking(() => loader.Load([entry]))
+            .Should().ThrowExactly<InvalidWorkloadException>().Which;
+
+        ex.Message.Should().NotContain("func workload update");
+        ex.InnerException.Should().BeNull();
+    }
+
+    [Fact]
     public void Load_Throws_WhenTypeNotFoundInAssembly()
     {
         var loader = new WorkloadLoader(StubPaths());
@@ -334,10 +377,14 @@ public class WorkloadLoaderTests
     private static WorkloadEntry FixtureEntry(
         string packageId,
         string? assemblyFileOverride = null,
-        string? typeNameOverride = null) => new()
+        string? typeNameOverride = null,
+        string? runtimeIdentifier = null,
+        LogicalPackage? logicalPackage = null) => new()
         {
             PackageId = packageId,
             PackageVersion = "1.0.0",
+            RuntimeIdentifier = runtimeIdentifier,
+            LogicalPackage = logicalPackage,
             EntryPoint = new EntryPointSpec
             {
                 AssemblyPath = assemblyFileOverride ?? FixtureAssemblyFile,

--- a/test/Func.Tests/Workloads/PythonWorkerWorkloadPackageTests.cs
+++ b/test/Func.Tests/Workloads/PythonWorkerWorkloadPackageTests.cs
@@ -36,17 +36,9 @@ public sealed class PythonWorkerWorkloadPackageTests
         PythonWorkerWorkloadPackage.CurrentPackageId.Should().StartWith(PythonWorkerWorkloadPackage.PackageIdPrefix);
     }
 
-    [Theory]
-    [InlineData("win-x64", true)]
-    [InlineData("linux-x64", true)]
-    [InlineData("linux-arm64", true)]
-    [InlineData("osx-x64", true)]
-    [InlineData("osx-arm64", true)]
-    [InlineData("WIN-X64", true)]
-    [InlineData("win-arm64", false)]
-    [InlineData("freebsd-x64", false)]
-    public void IsSupported_MatchesPublishedRids(string runtimeIdentifier, bool expected)
+    [Fact]
+    public void PackageId_IsRidPointerPackageId()
     {
-        PythonWorkerWorkloadPackage.IsSupported(runtimeIdentifier).Should().Be(expected);
+        PythonWorkerWorkloadPackage.PackageId.Should().Be("Azure.Functions.Cli.Workloads.Workers.Python");
     }
 }


### PR DESCRIPTION
**Layer 6 of 6 (final)** in the stack decomposing #5512 (RID-pointer workload support). Targets layer 5's branch `fabiocav/workload-commands-rid-pointers`.

Stack: #5515 → #5516 → #5517 → #5518 → #5519 → **this PR**. With this layer merged, the stack reproduces all 45 files of #5512.

## What this layer does

Flips the **activation / consumption** surface over to RID pointer packages:

- **Pointer package IDs.** `HostWorkloadPackage.PackageId` and `PythonWorkerWorkloadPackage.PackageId` are the pointer IDs; setup, host resolution, and the install step now request the pointer instead of a RID-qualified ID. `DefaultHostWorkloadResolver` matches installed hosts by prefix so RID implementations are recognized.
- **Logical package matching.** `SetupRunner.MatchesPackageId` and `DefaultFunctionsWorkerInstaller` compare against `entry.LogicalPackage` so an installed `…Host.win-x64` satisfies a request for `…Host`.
- **RID-derived content roots.** `WorkloadRegistration`, `InstallHostWorkloadInitializationStep`, and `DefaultFunctionsWorkerInstaller` now call `WorkloadPackageLayout.GetContentRoot(installDir, entry.RuntimeIdentifier)` instead of hardcoding `tools/any`.
- **Incompatible-RID handling.** `WorkloadRegistration.SelectRuntimeCompatibleEntries` skips entries built for another RID and warns with `func workload update` guidance; `WorkloadLoader` enriches `InvalidWorkloadException` with the installed vs. current RID when the two disagree.
- **Dead code removal.** Drops the now-obsolete `PythonWorkerWorkloadPackage.SupportedRuntimeIdentifiers` / `IsSupported` pre-flight, superseded by catalog-driven RID resolution.

`test/Func.Tests/Hosting/CliHostFactoryTests.cs` lands here rather than in layer 3 because it asserts the skip/warning behavior of `SelectRuntimeCompatibleEntries`, which is introduced in this layer.

## ⚠️ Addition beyond #5512: Python worker content root

`src/Workloads/Workers/Python/Workloads.Workers.Python.csproj` is **not** part of #5512. It is included here because without it this PR is a hard regression.

The `IncludePythonWorkerContentInPack` target hardcoded `PackagePath="tools/any/"`, but the Python RID implementation packages do emit `runtimeIdentifier`, and the CLI change above derives the payload root from it. `DefaultFunctionsWorkerInstaller` has **no `tools/any` fallback** (unlike `WorkloadLoader`), so the CLI would look in `tools/win-x64/` while the payload sat in `tools/any/`. This escaped earlier validation because the target only runs at pack time; `workload`-kind packages go through `_IncludeWorkloadCopyLocal`, which already honors the content root correctly.

The target now uses `$(_WorkloadPackageContentRoot)` and adds `_SetWorkloadProperties` to `DependsOnTargets` — that target is what defines the property (`eng/build/Workloads/Workload.targets`).

### Pack evidence

`dotnet pack src/Workloads/Workers/Python/Workloads.Workers.Python.csproj -c Release`, then listing archive entries:

| Package | `tools/<rid>/*` | `tools/any/*` | root payload |
|---|---|---|---|
| `…Workers.Python.win-x64.4.43.0-preview.2.dev` | 1928 | 0 | 0 |
| `…Workers.Python.linux-x64.…` | 2044 | 0 | 0 |
| `…Workers.Python.linux-arm64.…` | 3689 | 0 | 0 |
| `…Workers.Python.osx-x64.…` | 2042 | 0 | 0 |
| `…Workers.Python.osx-arm64.…` | 2042 | 0 | 0 |

Sample entries, and the file the installer actually resolves:

```
tools/win-x64/worker.config.json
tools/win-x64/3.10/WINDOWS/X64/azure/functions/__init__.py
tools/linux-arm64/3.10/LINUX/Arm64/azure/functions/__init__.py
tools/osx-arm64/3.10/OSX/Arm64/azure/functions/__init__.py
```

The matching `workload.json` in the win-x64 implementation package declares `"runtimeIdentifier": "win-x64"` — which is exactly the value that feeds `GetContentRoot(installDir, rid)` → `tools/win-x64/`.

I also verified the `_SetWorkloadProperties` dependency is load-bearing rather than defensive. Packing with it removed puts the payload at the **package root** (`3.10/WINDOWS/X64/azure/functions/__init__.py`, with `tools/win-x64/*` = 0 and `tools/any/*` = 0), confirming the property expands to empty without it.

## Deviation from the source PR

The new tests in #5512 used raw `Assert.*`, which `.github/instructions/tests.instructions.md` forbids. **16 assertions** were converted to AwesomeAssertions (`Should().Be`, `Should().Contain` / `NotContain`, `Should().BeOfType`, `Should().BeNull`, and `FluentActions.Invoking(...).Should().ThrowExactly<T>().Which`). Pre-existing assertions were left untouched.

## Validation

- `CI=true dotnet build -c Release` → **0 Warning(s), 0 Error(s)**
- `dotnet test test/Func.Tests` → 1356 passed, 1 failed
- Full solution `dotnet test` → all 9 workload test projects green (359 tests); Func.Tests as above

The single failure is `ProcessRunnerTests.RunAsync_Timeout_IsReported`, a pre-existing machine-timing-dependent test that fails on `vnext` and on every layer of this stack, unrelated to these changes.