### PR TITLE
ci: wire telemetry key into vnext official build

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -68,3 +68,4 @@ extends:
           parameters:
             projects: Azure.Functions.Cli.slnx
             sign: ${{ variables.sign }}
+            build_args: -p:TelemetryInstrumentationKey="$(TELEMETRY_INSTRUMENTATION_KEY)"


### PR DESCRIPTION
## Summary

- pass `TELEMETRY_INSTRUMENTATION_KEY` to the vNext official build through the existing `build_args` parameter

## Validation

- `git diff --check origin/vnext...HEAD`