### PR TITLE
fix: multi-function dotnet-isolated projects fail func kubernetes deploy

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -22,3 +22,8 @@
 - Added `durable-functions` dependency to `package.json` when creating Node.js durable function templates (#5495)
 - Changed `func start` to bind to the IPv4 loopback address (`127.0.0.1`) by default instead of `0.0.0.0`, and added an opt-in `--address` flag (and `Host.LocalHttpAddress` setting in `local.settings.json`) to override the bind address (#5484)
   - **Potential breaking change:** the host now binds to `127.0.0.1` by default, so it is only reachable from the local machine. Setups that relied on binding to `0.0.0.0` — for example reaching the host from outside a Docker container via a published port — will no longer connect. Workaround: start the host with `func start --address 0.0.0.0` (or set `"LocalHttpAddress": "0.0.0.0"` under `Host` in `local.settings.json`) to restore the previous behavior.
+# Azure Functions CLI (next release)
+
+#### Changes
+
+- Fixed `func kubernetes deploy` failing with `Invalid property identifier character: {` for dotnet-isolated projects with more than one function. The `print-functions.sh` script previously used a `sed` command that only captured the last function name and produced malformed JSON; replaced with `awk` to correctly key each function object by its `name` field. (#3585)

--- a/release_notes.md
+++ b/release_notes.md
@@ -10,3 +10,4 @@
 #### Changes
 - Fixed Python native dependency builds to inherit authenticated pip indexes in Docker containers (#5574)
 - Make host.json optional across func publish, and pack (#5488)
+- Fixed `func kubernetes deploy` failing with `Invalid property identifier character: {` for dotnet-isolated projects with more than one function. The `print-functions.sh` script previously used a `sed` command that only captured the last function name and produced malformed JSON; replaced with `awk` to correctly key each function object by its `name` field. (#3585)

--- a/src/Cli/func/StaticResources/print-functions.sh
+++ b/src/Cli/func/StaticResources/print-functions.sh
@@ -19,7 +19,23 @@ echo ','
 echo '"functionsJson": {'
 
 if [ -f "functions.metadata" ]; then
-    sed -nzE 's/^\[(.+\n {4}"name": "([^"]+)".+)\]$/"\2": \1/p' functions.metadata
+    awk '
+    BEGIN { in_obj=0; name=""; obj=""; first=1 }
+    !in_obj && /^  \{$/ { in_obj=1; obj=$0"\n"; next }
+    in_obj && /^  \}[,]?$/ {
+        obj=obj"  }"
+        if (!first) printf ",\n"
+        printf "\"%s\": %s\n", name, obj
+        first=0; in_obj=0; name=""; obj=""
+        next
+    }
+    in_obj {
+        if (name=="" && /^    "name":/) {
+            tmp=$0; sub(/^[[:space:]]*"name":[[:space:]]*"/,"",tmp); sub(/".*$/,"",tmp); name=tmp
+        }
+        obj=obj$0"\n"
+    }
+    ' functions.metadata
 else
     first=1
     for d in */; do


### PR DESCRIPTION
## Issue
Fixes #3585

## What changed
- Replaced fragile `sed -nzE` parsing in `print-functions.sh` with `awk`.
- Correctly emits keyed `functionsJson` entries for each function object in `functions.metadata`.
- Prevents `Invalid property identifier character: {` for multi-function dotnet-isolated projects.

## Notes
Root cause: print-functions.sh uses a sed -nzE command with a greedy .+ that backtracks to the last "name" field in functions.metadata, dumping the entire raw array body as that single key's value — producing malformed JSON for any dotnet-isolated project with more than one function. This causes Invalid property identifier character: {. Path 'functionsJson.<FuncName>' when DockerHelpers.cs deserialises the output.

Fix: Replace with an awk script that iterates over each top-level function object (2-space indented {/} boundaries), extracts the name field, and emits correctly keyed JSON pairs.

Why awk not perl: PR https://github.com/Azure/azure-functions-core-tools/pull/4228 was blocked for using perl. awk is POSIX.1-standard and confirmed present in mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0 and 4-dotnet-isolated10.0.

Tested by running both original and fixed scripts inside the actual Azure Functions Docker image against multi-function functions.metadata with inline and multi-line bindings, including route parameters containing {id}.

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #3585 

### Pull request checklist


* [x] My changes do not require documentation changes
* [x] My changes do not need to be backported to a previous version
* [ ] My changes should not be added to the release notes for the next release
* [ ] I have added all required tests (Unit tests, E2E tests)

