### PR TITLE
Switch to prepack

### DIFF
--- a/eng/tools/publish-tools/npm/package.json
+++ b/eng/tools/publish-tools/npm/package.json
@@ -5,7 +5,7 @@
   "consolidatedBuildId": "226050",
   "scripts": {
     "postinstall": "node lib/install.js",
-    "prepublishOnly": "node lib/copy-metadata.js"
+    "prepack": "node lib/copy-metadata.js"
   },
   "author": "Microsoft",
   "license": "MIT",

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,4 +1,4 @@
-# Azure Functions CLI 4.13.0
+# Azure Functions CLI 4.13.1
 
 #### Host Version
 

--- a/src/Cli/func/Directory.Version.props
+++ b/src/Cli/func/Directory.Version.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>4.13.0</VersionPrefix>
+    <VersionPrefix>4.13.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>


### PR DESCRIPTION
`copy-metadata.js` is wired up as `prepublishOnly`, which only runs before `npm publish` — not before `npm pack`. Since the new flow now uses `npm pack` to produce the `.tgz` package, the README never gets copied into the package before it's packed.

The fix is to change the script hook from `prepublishOnly` to `prepack`, which runs before both `npm pack` and `npm publish`.