### PR TITLE
Onboard dependency restores to CFS (in-proc)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,11 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@azure:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@azure-rest:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@colors:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@dabh:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@js-joda:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@microsoft:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@opentelemetry:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@so-ric:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@types:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@typespec:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,13 +1,53 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <clear />
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
     <add key="Microsoft.Azure.Functions.PowerShellWorker" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/Microsoft.Azure.Functions.PowerShellWorker/nuget/v3/index.json" />
     <add key="AzureFunctions" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctions/nuget/v3/index.json" />
     <add key="AzureFunctionsRelease" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsRelease/nuget/v3/index.json" />
     <add key="AzureFunctionsPreRelease" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsPreRelease/nuget/v3/index.json" />
     <add key="AzureFunctionsTempStaging" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="upstream-public">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="Microsoft.Azure.Functions.PowerShellWorker">
+      <package pattern="Microsoft.Azure.Functions.PowerShellWorker.*" />
+    </packageSource>
+    <packageSource key="AzureFunctions">
+      <package pattern="Microsoft.Azure.AppService.Middleware" />
+      <package pattern="Microsoft.Azure.AppService.Middleware.Functions" />
+      <package pattern="Microsoft.Azure.AppService.Middleware.Modules" />
+      <package pattern="Microsoft.Azure.AppService.Middleware.NetCore" />
+    </packageSource>
+    <packageSource key="AzureFunctionsRelease">
+      <package pattern="Microsoft.Azure.Functions.JavaWorker" />
+      <package pattern="Microsoft.Azure.Functions.NodeJsWorker" />
+      <package pattern="Microsoft.Azure.Functions.PythonWorker" />
+      <package pattern="Microsoft.Azure.WebJobs.Script" />
+      <package pattern="Microsoft.Azure.WebJobs.Script.Grpc" />
+      <package pattern="Microsoft.Azure.WebJobs.Script.WebHost" />
+      <package pattern="Microsoft.Azure.WebJobs.Script.WebHost.InProc" />
+    </packageSource>
+    <packageSource key="AzureFunctionsPreRelease">
+      <package pattern="Microsoft.Azure.Functions.JavaWorker" />
+      <package pattern="Microsoft.Azure.Functions.NodeJsWorker" />
+      <package pattern="Microsoft.Azure.Functions.PythonWorker" />
+      <package pattern="Microsoft.Azure.WebJobs.Script" />
+      <package pattern="Microsoft.Azure.WebJobs.Script.Grpc" />
+      <package pattern="Microsoft.Azure.WebJobs.Script.WebHost" />
+      <package pattern="Microsoft.Azure.WebJobs.Script.WebHost.InProc" />
+    </packageSource>
+    <packageSource key="AzureFunctionsTempStaging">
+      <package pattern="Microsoft.Azure.AppService.Proxy.Client" />
+      <package pattern="Microsoft.Azure.AppService.Proxy.Common" />
+      <package pattern="Microsoft.Azure.AppService.Proxy.Runtime" />
+      <package pattern="Microsoft.Azure.DurableTask.AzureStorage.Internal" />
+      <package pattern="Microsoft.Azure.DurableTask.Core.Internal" />
+      <package pattern="Microsoft.Azure.Functions.Platform.Metrics.LinuxConsumption" />
+      <package pattern="Microsoft.Azure.WebSites.DataProtection" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>

--- a/eng/ci/templates/official/jobs/build-test.yml
+++ b/eng/ci/templates/official/jobs/build-test.yml
@@ -18,6 +18,8 @@ jobs:
   steps:
   - pwsh: . "tools/start-emulators.ps1" -NoWait
     displayName: "Start emulators (NoWait)"
+    env:
+      NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
 
   - pwsh: |
       $simulateReleaseBuild = $null
@@ -66,6 +68,14 @@ jobs:
     inputs:
       versionSpec:
     displayName: Install Nuget tool
+
+  - task: npmAuthenticate@0
+    displayName: 'Authenticate npm'
+    inputs:
+      workingFile: '$(Build.SourcesDirectory)/.npmrc'
+
+  - task: NuGetAuthenticate@1
+    displayName: 'Authenticate NuGet'
 
   - task: AzureCLI@2
     displayName: Login via Azure CLI to acquire access token

--- a/eng/ci/templates/official/jobs/linux-package.yml
+++ b/eng/ci/templates/official/jobs/linux-package.yml
@@ -8,6 +8,15 @@ jobs:
     os: linux
   steps:
   - template: ../../steps/install-linux-tools.yml
+  - task: NuGetAuthenticate@1
+    displayName: 'Authenticate NuGet'
+
+  - task: PipAuthenticate@1
+    displayName: 'Authenticate pip'
+    inputs:
+      artifactFeeds: 'public/upstream-public'
+      onlyAddExtraIndex: false
+
   # Bash v3
   # Run a Bash script on macOS, Linux, or Windows.
   - task: Bash@3

--- a/eng/ci/templates/public/jobs/build-test-public.yml
+++ b/eng/ci/templates/public/jobs/build-test-public.yml
@@ -18,6 +18,8 @@ jobs:
   steps:
   - pwsh: . "tools/start-emulators.ps1" -NoWait
     displayName: "Start emulators (NoWait)"
+    env:
+      NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
   - pwsh: |
       $isIntegrationBuild = $false
       if ($env:INTEGRATIONBUILDNUMBER -like "PreRelease*-*")
@@ -41,6 +43,14 @@ jobs:
     inputs:
       versionSpec:
     displayName: Install Nuget tool
+
+  - task: npmAuthenticate@0
+    displayName: 'Authenticate npm'
+    inputs:
+      workingFile: '$(Build.SourcesDirectory)/.npmrc'
+
+  - task: NuGetAuthenticate@1
+    displayName: 'Authenticate NuGet'
   - pwsh: |
       .\validateWorkerVersions.ps1
     displayName: 'Validate worker versions'

--- a/tools/start-emulators.ps1
+++ b/tools/start-emulators.ps1
@@ -8,6 +8,7 @@ param(
 )
 
 $DebugPreference = 'Continue'
+$npmConfigPath = Join-Path $PSScriptRoot '..\.npmrc'
 
 Write-Host "Skip Storage Emulator: $SkipStorageEmulator"
 
@@ -51,12 +52,12 @@ if (!$SkipStorageEmulator)
     {
         if ($IsWindows)
         {
-            npm install -g azurite
+            npm install -g azurite --userconfig $npmConfigPath
             Start-Process azurite.cmd -ArgumentList "--silent --skipApiVersionCheck"
         }
         else
         {
-            sudo npm install -g azurite
+            sudo npm install -g azurite --userconfig $npmConfigPath
             sudo mkdir azurite
             sudo azurite --silent --skipApiVersionCheck --location azurite --debug azurite\debug.log &
         }


### PR DESCRIPTION
## Summary
Port of #5501 for the `in-proc` branch.

- Route public NuGet dependencies through `azfunc/public/upstream-public` instead of nuget.org
- Add `packageSourceMapping` to isolate Functions-owned packages to their Azure Artifacts feeds (including `Microsoft.Azure.WebJobs.Script.WebHost.InProc`)
- Authenticate NuGet, npm, and pip before every affected Azure Pipelines restore/install path
- Bind `NPM_CONFIG_USERCONFIG` to every global npm install step (`azurite`)
- Create root `.npmrc` mapping all consumed npm scopes to CFS

## Validation
- Cold-cache `dotnet restore --no-cache --configfile NuGet.Config --verbosity minimal` with an isolated `NUGET_PACKAGES` directory — NuGet correctly resolves all packages against CFS feeds (401 errors are expected without local auth; CI provides auth via `NuGetAuthenticate@1`)
- Authenticated global install of `azurite` using only `NPM_CONFIG_USERCONFIG` — HTTP traffic confirmed routed exclusively to `pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/` with no npmjs.org contact
- `.npmrc` routes npm registry to CFS (verified with `npm config get registry`)
- No `nuget.org` / `npmjs.org` / `pypi.org` direct references remain in pipeline-reachable paths (`eng/`, `tools/`)
- All changed Azure Pipelines YAML parsed successfully (pyyaml `safe_load`)