### PR TITLE
Switch to prepack in package.json

### DIFF
--- a/eng/tools/publish-tools/npm/package.json
+++ b/eng/tools/publish-tools/npm/package.json
@@ -5,7 +5,7 @@
   "consolidatedBuildId": "226050",
   "scripts": {
     "postinstall": "node lib/install.js",
-    "prepublishOnly": "node lib/copy-metadata.js"
+    "prepack": "node lib/copy-metadata.js"
   },
   "author": "Microsoft",
   "license": "MIT",


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

`prepublishOnly` only runs before `npm publish`, not `npm pack`. Since we are moving to publishing with `npm pack` to produce a .tgz, `prepack` is required to ensure pre-pack hooks (like copying the README) actually execute.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

