### PR TITLE
Fix NPM_CONFIG_USERCONFIG scope so E2E test npm calls use .npmrc

### DIFF
--- a/eng/ci/templates/official/jobs/build-test.yml
+++ b/eng/ci/templates/official/jobs/build-test.yml
@@ -15,11 +15,10 @@ jobs:
     devops_buildNumber: $[counter(format('1'), 6100)]
     DEVOPS_REPO_BRANCH: $[coalesce(variables['System.PullRequest.TargetBranch'], variables['Build.SourceBranchName'])]
     DEVOPS_REPO_COMMIT: $(Build.SourceVersion)
+    NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
   steps:
   - pwsh: . "tools/start-emulators.ps1" -NoWait
     displayName: "Start emulators (NoWait)"
-    env:
-      NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
 
   - pwsh: |
       $simulateReleaseBuild = $null

--- a/eng/ci/templates/public/jobs/build-test-public.yml
+++ b/eng/ci/templates/public/jobs/build-test-public.yml
@@ -15,11 +15,10 @@ jobs:
     devops_buildNumber: $[counter(format(''), 1500)]
     DEVOPS_REPO_BRANCH: $[coalesce(variables['System.PullRequest.TargetBranch'], variables['Build.SourceBranchName'])]
     DEVOPS_REPO_COMMIT: $(Build.SourceVersion)
+    NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
   steps:
   - pwsh: . "tools/start-emulators.ps1" -NoWait
     displayName: "Start emulators (NoWait)"
-    env:
-      NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
   - pwsh: |
       $isIntegrationBuild = $false
       if ($env:INTEGRATIONBUILDNUMBER -like "PreRelease*-*")


### PR DESCRIPTION
## Problem

The `.npmrc` configured by PR #5532 routes npm through the authenticated registry via `NPM_CONFIG_USERCONFIG`, but that env var was only set on the `start-emulators.ps1` step. During E2E tests, `func.exe` spawns Node (e.g., `func init` with a node template, or test function apps that run `npm install`) in different working directories — those 39 CFS-flagged calls from `C:\hostedtoolcache\windows\node\18.20.8\x64\node.exe` weren't picking up the `.npmrc`.

## Fix

Promote `NPM_CONFIG_USERCONFIG` from the step-level `env:` block to the job-level `variables` section in both pipeline templates. Azure DevOps automatically exposes job-level variables as environment variables to all steps, so every step (including the build script that runs E2E tests) now inherits it.

### Changes
- `eng/ci/templates/official/jobs/build-test.yml`
- `eng/ci/templates/public/jobs/build-test-public.yml`