### PR TITLE
Move NPM_CONFIG_USERCONFIG to job-level variables for E2E test coverage

### DIFF
--- a/eng/ci/templates/jobs/test-e2e-windows.yml
+++ b/eng/ci/templates/jobs/test-e2e-windows.yml
@@ -29,13 +29,14 @@ jobs:
         languageWorker: 'Go'
         runtime: 'win-x64'
 
+  variables:
+    NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
+
   steps:
   - template: /eng/ci/templates/steps/authenticate-e2e-dependencies.yml@self
 
   - pwsh: ./eng/scripts/start-emulators.ps1 -NoWait
     displayName: 'Start emulators (NoWait)'
-    env:
-      NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
 
   - template: /eng/ci/templates/steps/install-tools.yml@self
 


### PR DESCRIPTION
## Summary

The `NPM_CONFIG_USERCONFIG` environment variable was only set in the `env:` block of the `start-emulators.ps1` step in the Windows E2E test job. This meant subsequent steps (like the E2E test runner) that spawn Node (e.g., `func.exe` running `func init` with node template, or test apps doing `npm install`) could not find the `.npmrc`.

## Fix

- Added a `variables:` section to the job definition with `NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc`
- Removed the step-level `env:` block from the `start-emulators.ps1` step since the job-level variable now covers it

All steps—including the E2E test runner—now inherit the variable automatically.

## Related

- Companion fix for in-proc branch: #5547