### PR TITLE
Fix CFS pypi.org violations by routing pip through ADO feed

### DIFF
--- a/eng/ci/templates/steps/install-tools.yml
+++ b/eng/ci/templates/steps/install-tools.yml
@@ -10,6 +10,12 @@ steps:
     addToPath: true
   displayName: 'Install Python 3.10'
 
+- task: PipAuthenticate@1
+  displayName: 'Authenticate pip'
+  inputs:
+    artifactFeeds: 'public/upstream-public'
+    onlyAddExtraIndex: false
+
 - task: NuGetToolInstaller@1
   inputs:
     versionSpec:


### PR DESCRIPTION
## Summary

Fixes the **18 CFSClean policy violations** from `pypi.org` / `files.pythonhosted.org` observed in the public-build Linux jobs.

## Problem

The `install-tools.yml` template installs Python via `UsePythonVersion@0` but doesn't configure pip authentication. When the PythonWorker NuGet package triggers Python processes during `dotnet build`/`test`, pip reaches out directly to `pypi.org` — violating the CFS network isolation policy.

## Fix

Added `PipAuthenticate@1` to `install-tools.yml` right after `UsePythonVersion@0`, routing all pip traffic through the internal `public/upstream-public` ADO upstream feed. This:

- Prevents the 18 CFSClean violations from `pypi.org`/`files.pythonhosted.org`
- Matches the existing pattern already used in E2E test (`authenticate-e2e-dependencies.yml`) and official build pipelines (`host-build-pack.yml`, `linux-deb-build-pack.yml`)
- Uses `onlyAddExtraIndex: false` to replace the default PyPI URL with the ADO feed proxy