### PR TITLE
Fix flaky TimerTrigger auth level test by using FuncInitWithRetryAsync

### DIFF
--- a/test/Cli/Func.E2ETests/Commands/FuncNew/InvalidInputsTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncNew/InvalidInputsTests.cs
@@ -15,14 +15,12 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncNew
     {
         [Fact]
         [Trait(WorkerRuntimeTraits.WorkerRuntime, WorkerRuntimeTraits.Node)]
-        public void FuncNew_TimerTrigger_WithAuthLevelFunction_NodeV3_CreatesSuccessfully()
+        public async Task FuncNew_TimerTrigger_WithAuthLevelFunction_NodeV3_CreatesSuccessfully()
         {
             var testName = nameof(FuncNew_TimerTrigger_WithAuthLevelFunction_NodeV3_CreatesSuccessfully);
 
             // Initialize function app with Node.js runtime and model version v3
-            new FuncInitCommand(FuncPath, testName, Log)
-                .WithWorkingDirectory(WorkingDirectory)
-                .Execute(["--worker-runtime", "node", "-m", "v3"]);
+            await FuncInitWithRetryAsync(testName, new[] { "--worker-runtime", "node", "-m", "v3" });
 
             // Create a new Timer Trigger function with authlevel = function
             var result = new FuncNewCommand(FuncPath, testName, Log)

--- a/test/Cli/Func.E2ETests/Commands/FuncStart/Core/BaseOfflineBundleTests.cs
+++ b/test/Cli/Func.E2ETests/Commands/FuncStart/Core/BaseOfflineBundleTests.cs
@@ -3,7 +3,6 @@
 
 using AwesomeAssertions;
 using Azure.Functions.Cli.E2ETests.Fixtures;
-using Azure.Functions.Cli.ExtensionBundle;
 using Azure.Functions.Cli.TestFramework.Assertions;
 using Azure.Functions.Cli.TestFramework.Commands;
 using Azure.Functions.Cli.TestFramework.Helpers;
@@ -17,8 +16,6 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncStart.Core
     /// </summary>
     public static class BaseOfflineBundleTests
     {
-        private const string DefaultBundleId = "Microsoft.Azure.Functions.ExtensionBundle";
-
         /// <summary>
         /// Runs func start with --offline when extension bundles have already been cached
         /// (from the fixture's initialization). The host should start successfully
@@ -44,36 +41,24 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncStart.Core
         }
 
         /// <summary>
-        /// Runs func start with --offline after temporarily moving the cached extension bundles.
+        /// Runs func start with --offline while pointing the bundle download path to an
+        /// empty directory so no cached bundles are found. This avoids moving the shared
+        /// global bundle cache, which causes race conditions with parallel tests that
+        /// also rely on the cache (e.g. tests using FUNCTIONS_CORE_TOOLS_OFFLINE).
         /// The host should fail to start and emit an error indicating that no cached
         /// version is available and bundles must be pre-cached for offline use.
-        /// The cached bundles are restored after the test completes to avoid long re-download times.
         /// </summary>
         public static void RunOfflineWithoutCachedBundlesTest(BaseFunctionAppFixture fixture, string language, string testName)
         {
             int port = ProcessHelper.GetAvailablePort();
 
-            // Temporarily move the cached bundles so they appear absent during the test
-            var defaultBundlePath = ExtensionBundleHelper.GetBundleDownloadPath(DefaultBundleId);
-            var backupPath = defaultBundlePath + "_backup";
-            bool movedCache = false;
-
-            if (Directory.Exists(defaultBundlePath))
-            {
-                try
-                {
-                    Directory.Move(defaultBundlePath, backupPath);
-                    movedCache = true;
-                }
-                catch
-                {
-                    // Best effort; test will still validate behavior
-                }
-            }
+            // Use an isolated empty directory so the process sees no cached bundles,
+            // without disturbing the shared cache used by other parallel tests.
+            var emptyBundlePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(emptyBundlePath);
 
             try
             {
-                // Start with --offline; bundles should NOT be available
                 var funcStartCommand = new FuncStartCommand(fixture.FuncPath, testName, fixture.Log);
 
                 funcStartCommand.ProcessStartedHandler = async (process) =>
@@ -86,28 +71,20 @@ namespace Azure.Functions.Cli.E2ETests.Commands.FuncStart.Core
                 var result = funcStartCommand
                     .WithWorkingDirectory(fixture.WorkingDirectory)
                     .WithEnvironmentVariable(Common.Constants.FunctionsWorkerRuntime, language)
+                    .WithEnvironmentVariable(Common.Constants.ExtensionBundleDownloadPath, emptyBundlePath)
                     .Execute(["--offline", "--verbose", "--port", port.ToString()]);
 
                 result.Should().HaveStdErrContaining("Running in offline mode but no cached version of extension bundle");
             }
             finally
             {
-                // Restore the cached bundles so subsequent tests don't need to re-download
-                if (movedCache && Directory.Exists(backupPath))
+                try
                 {
-                    try
-                    {
-                        if (Directory.Exists(defaultBundlePath))
-                        {
-                            Directory.Delete(defaultBundlePath, recursive: true);
-                        }
-
-                        Directory.Move(backupPath, defaultBundlePath);
-                    }
-                    catch
-                    {
-                        // Best effort restore
-                    }
+                    Directory.Delete(emptyBundlePath, recursive: true);
+                }
+                catch
+                {
+                    // Best effort cleanup
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fixes two flaky E2E test issues in the Node test suite.

### 1. `FuncNew_TimerTrigger_WithAuthLevelFunction_NodeV3_CreatesSuccessfully`

**Problem:** The test used `FuncInitCommand` directly, which doesn't retry template downloads. When the templates CDN was slow or the cache wasn't warm, `func new` would fail early with "Templates JSON is empty" instead of reaching the expected auth-level validation error.

**Fix:** Switched to `FuncInitWithRetryAsync`, matching the pattern used by other tests in the same class.

### 2. Offline bundle tests racing with parallel tests

**Problem:** `RunOfflineWithoutCachedBundlesTest` temporarily moved the **shared global** extension bundle cache directory to simulate missing bundles. When other tests ran in parallel (e.g., durable function tests with `FUNCTIONS_CORE_TOOLS_OFFLINE=true`), they'd fail because the cache was unexpectedly gone. Conversely, if the move failed silently (exception swallowed), the "without cached bundles" test itself would fail because the cache was still present.

**Fix:** Instead of moving the global cache, set `AzureFunctionsJobHost__extensionBundle__downloadPath` to point the `func` process at an empty temp directory. This isolates the test without affecting other parallel tests.