### PR TITLE
Rev CLI version to 5.0.0-preview.3

### DIFF
--- a/src/Directory.Version.props
+++ b/src/Directory.Version.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>5.0.0</VersionPrefix>
-    <VersionSuffix>preview.2</VersionSuffix>
+    <VersionSuffix>preview.3</VersionSuffix>
     <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>
 

--- a/src/Func/release_notes.md
+++ b/src/Func/release_notes.md
@@ -1,3 +1,5 @@
+## 5.0.0-preview.3
+
 # Azure Functions CLI 5.0.0
 
 #### Changes

--- a/src/Func/release_notes.md
+++ b/src/Func/release_notes.md
@@ -9,4 +9,9 @@
 - Clarified the `func new` "missing language" hint to mention both scaffolding and adopting an existing project. (#5300)
 - Fix `func start` failing to resolve installed prerelease worker workloads against built-in profile ranges (e.g. `node [3.13.0]` now accepts `3.13.0-preview.1`). (#5286)
 - Fix `func new` printing the "Cannot determine language" error three times when `stack.language` is missing from `.func/config.json`. (#5306)
+- When no installed stack workload matches the project, the error now includes specific `func workload install` guidance for the matching stack. (#5508)
+- Workload manifests now support a "rid-pointer" kind that maps runtime identifiers to platform-specific implementation packages, enabling per-OS/arch workload resolution. (#5516)
+- When managed Azurite is already running on the expected ports, `func start` now identifies the owning process and classifies it by data directory — reusing it if it matches, or failing with clear PID/directory guidance if it serves a different store. (#5264)
+- Managed Azurite now detects HTTP 500 responses paired with the Azurite-Blob header and surfaces a live warning with data-directory reset guidance, repeated in the end-of-run summary. (#5263)
+- `func workload install <path>.nupkg` now gives a clear "file does not exist" error when the package file is missing, instead of falling through to catalog resolution with a confusing failure. (#5497)
 


### PR DESCRIPTION
## Summary

Bumps the CLI version from **5.0.0-preview.2** to **5.0.0-preview.3**.

### Changes
- Updated `VersionSuffix` in `src/Directory.Version.props` from `preview.2` to `preview.3`
- Added `## 5.0.0-preview.3` section heading in `src/Func/release_notes.md`

### Post-merge steps
1. Tag with `v5.0.0-preview.3`
2. Wait for code mirror to complete
3. Run the `core-tools.cli.release` pipeline