### PR TITLE
Fix CFS pypi.org violations by moving PipAuthenticate before UsePythonVersion

### DIFF
--- a/eng/ci/templates/steps/install-tools.yml
+++ b/eng/ci/templates/steps/install-tools.yml
@@ -4,23 +4,20 @@ steps:
     versionSpec: '18.x'
   displayName: 'Install Node 18.x'
 
-# Set PIP_INDEX_URL before UsePythonVersion so that the pip upgrade inside
-# its setup.sh goes through the ADO upstream feed instead of pypi.org.
-- script: |
-    echo "##vso[task.setvariable variable=PIP_INDEX_URL]https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/"
-  displayName: 'Route pip through ADO feed'
+# PipAuthenticate must run before UsePythonVersion because UsePythonVersion's
+# setup.sh upgrades pip from pypi.org. PipAuthenticate sets PIP_INDEX_URL to
+# route through the ADO feed, preventing CFS violations. It only needs Node.
+- task: PipAuthenticate@1
+  displayName: 'Authenticate pip'
+  inputs:
+    artifactFeeds: 'public/upstream-public'
+    onlyAddExtraIndex: false
 
 - task: UsePythonVersion@0
   inputs:
     versionSpec: '3.10'
     addToPath: true
   displayName: 'Install Python 3.10'
-
-- task: PipAuthenticate@1
-  displayName: 'Authenticate pip'
-  inputs:
-    artifactFeeds: 'public/upstream-public'
-    onlyAddExtraIndex: false
 
 - task: NuGetToolInstaller@1
   inputs:

--- a/eng/ci/templates/steps/install-tools.yml
+++ b/eng/ci/templates/steps/install-tools.yml
@@ -4,6 +4,12 @@ steps:
     versionSpec: '18.x'
   displayName: 'Install Node 18.x'
 
+# Set PIP_INDEX_URL before UsePythonVersion so that the pip upgrade inside
+# its setup.sh goes through the ADO upstream feed instead of pypi.org.
+- script: |
+    echo "##vso[task.setvariable variable=PIP_INDEX_URL]https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/"
+  displayName: 'Route pip through ADO feed'
+
 - task: UsePythonVersion@0
   inputs:
     versionSpec: '3.10'

--- a/eng/ci/templates/steps/install-tools.yml
+++ b/eng/ci/templates/steps/install-tools.yml
@@ -10,6 +10,12 @@ steps:
     addToPath: true
   displayName: 'Install Python 3.10'
 
+- task: PipAuthenticate@1
+  displayName: 'Authenticate pip'
+  inputs:
+    artifactFeeds: 'public/upstream-public'
+    onlyAddExtraIndex: false
+
 - task: NuGetToolInstaller@1
   inputs:
     versionSpec:


### PR DESCRIPTION
## Problem

`UsePythonVersion@0` downloads Python and runs `setup.sh`, which upgrades pip from `pypi.org`:

```
Upgrading pip...
Collecting pip
Downloading pip-26.2.1-py3-none-any.whl (1.8 MB)
```

This causes 18 CFSClean violations from `./python` hitting `pypi.org`/`files.pythonhosted.org` in the Linux unit test job.

`PipAuthenticate@1` was placed **after** `UsePythonVersion@0`, so `PIP_INDEX_URL` wasn't set yet when the pip upgrade ran.

## Fix

Move `PipAuthenticate@1` **before** `UsePythonVersion@0` (but after `NodeTool@0`). `PipAuthenticate@1` is a [Node.js task](https://github.com/microsoft/azure-pipelines-tasks/blob/master/Tasks/PipAuthenticateV1/task.json) — it does not require Python to run. It sets `PIP_INDEX_URL` via `##vso[task.setvariable]`, which `UsePythonVersion@0`'s `setup.sh` then inherits, routing the pip upgrade through the ADO upstream feed.

## Changes

- `eng/ci/templates/steps/install-tools.yml`: Moved `PipAuthenticate@1` from after `UsePythonVersion@0` to before it