### PR TITLE
docs(templates): specify Azure Samples template pipeline

### DIFF
--- a/docs/azure-samples-template-pipeline/design.md
+++ b/docs/azure-samples-template-pipeline/design.md
@@ -1,0 +1,312 @@
+## Context
+
+See `proposal.md` for motivation and `specs/azure-samples-template-pipeline/spec.md` for the behavior contract.
+
+Azure-Samples repositories release independently through GitHub. The package builder must consume those repositories as untrusted content, produce packages accepted by the `FuncTemplate` contract, and preserve a traceable connection to an immutable Git release without requiring packaging infrastructure in each source repository.
+
+The control plane lives separately from both Azure-Samples and Azure Functions Core Tools:
+
+```text
+https://dev.azure.com/azfunc/internal/_git/func-templates
+|
++-- src/
+|   +-- Quickstarts/
+|   |   `-- *.yaml
+|   `-- Schema/
+|       `-- quickstart.schema.json
+`-- eng/
+    `-- ci/
+        +-- validate-onboarding.yaml
+        `-- publish-releases.yaml
+```
+
+The Azure Functions CLI, general template discovery, quickstart catalog generation, and package unlisting have separate owners and are not implemented by this repository.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make onboarding reviewable, deterministic, and safe to divide across files.
+- Convert eligible release snapshots into valid project template packages without executing source-controlled code.
+- Use package feeds as the durable publication checkpoint rather than maintaining a parallel release ledger.
+- Promote the exact validated artifact through a single approval gate.
+- Make independent release failures retryable without blocking successful packages.
+- Keep public package provenance useful without exposing pipeline implementation details.
+
+**Non-Goals:**
+
+- Generate or publish a dedicated quickstart catalog or general template discovery manifest.
+- Change `func init`, `func new`, or TemplateEngine package-install behavior.
+- Build, test, or execute source repository code during packaging.
+- Support repositories outside `Azure-Samples`.
+- Initialize Git submodules or Git LFS content.
+- Define SBOM generation, package size limits, unlisting, or incident response.
+- Own source-repository release conventions beyond the requirements needed for packaging.
+
+## Decisions
+
+### YAML files form one logical source manifest
+
+Onboarding sources use this shape:
+
+```yaml
+schemaVersion: 1
+
+quickstarts:
+  - id: python-openai-chat
+    repository: Azure-Samples/functions-python-openai-chat
+    packageId: Azure.Functions.Templates.PythonOpenAIChat
+    enabled: true
+
+    release:
+      minimumVersion: 1.0.0
+      includePrerelease: false
+
+    template:
+      identity: Azure.Functions.Templates.PythonOpenAIChat
+      shortName: functions-python-openai-chat
+      name: Azure Functions Python OpenAI Chat
+      description: Create an Azure Functions application using Azure OpenAI.
+      projects:
+        - root: .
+          stack: python
+          language: Python
+
+    licenseExpression: MIT
+```
+
+`schemaVersion`, `quickstarts`, `id`, `repository`, `packageId`, and `release.minimumVersion` are always required. The `template` section is optional at schema validation time because its presence is mutually exclusive with an authored root `.template.config/template.json` in the release snapshot. When `template` is present, `projects` is required and contains at least one Functions project.
+
+Defaults and optional synthesis values are resolved before source-aware validation:
+
+```text
+enabled                    -> true
+release.includePrerelease  -> false
+template.identity          -> packageId
+template.shortName         -> repository name
+template.name              -> title-cased repository name
+template.description       -> GitHub repository description
+licenseExpression          -> detection from release commit
+```
+
+Each synthesized project declares:
+
+```text
+root      repository-relative Functions project root
+stack     canonical func stack identifier
+language  canonical language recognized by that stack
+```
+
+The root project uses `.`. Other roots use normalized `/`-separated relative paths. Roots cannot be absolute, contain `..`, use excluded directories, collide case-insensitively, or overlap through ancestor/descendant nesting. The staged release must contain a regular `host.json` directly under every declared root.
+
+The JSON Schema owns structural validation and rejects unknown fields. A repository-wide validator owns cross-file uniqueness, effective-value collisions, GitHub slug restrictions, SemVer validation, package-prefix policy, project path safety, and canonical stack/language pairs.
+
+Files are scanned non-recursively in ordinal filename order. The order exists only for deterministic diagnostics; it does not establish precedence. Duplicate values are errors rather than last-write-wins behavior.
+
+**Alternative considered:** keep every repository in one YAML file. This creates a merge hotspot and makes ownership grouping difficult. It is rejected.
+
+**Alternative considered:** require one repository per file. The filename would become an accidental identity surface and would complicate grouping and migration. Files therefore contain zero or more entries.
+
+### Explicit operational and package identities remain stable
+
+The onboarding `id` is an internal operational key. `packageId` is explicitly reviewed and must use the reserved `Azure.Functions.Templates.` prefix. Neither is derived from mutable GitHub metadata.
+
+Repository, package ID, onboarding ID, effective template identity, and effective short names are unique case-insensitively. Synthesized identities and short names are resolved from YAML defaults. Authored identities and short names are resolved by loading the authored template during source-aware validation. Repository uniqueness intentionally limits one package to one repository in the initial design. A future need for multiple packaging scopes requires an explicit schema revision rather than duplicate entries.
+
+Template identity defaults to package ID, and short name defaults to the configured repository name. The display name transformation is mechanical: split on `-`, `_`, and `.`, capitalize the first character of each token, and join with spaces. YAML overrides preserve brand-specific casing.
+
+**Alternative considered:** derive package ID from repository name. Repository renames, normalization collisions, and NuGet namespace ownership would make package identity unstable. It is rejected.
+
+### The minimum version is the backfill boundary
+
+The daily pipeline enumerates all published releases rather than tracking only the newest release. `minimumVersion` establishes the first eligible version and makes onboarding backfill explicit and repeatable.
+
+Release eligibility is:
+
+```text
+published GitHub release
++ non-draft
++ tag matches v<SemVer 2.0>
++ no SemVer build metadata
++ version >= minimumVersion
++ prerelease enabled when GitHub marks it prerelease
+```
+
+Build metadata is rejected because NuGet normalization can map distinguishable SemVer tags to a conflicting package identity. GitHub release enumeration follows pagination and does not infer releases from tags alone.
+
+The tag is resolved to an exact commit independently of `target_commitish`. The package version removes the leading `v`; repository metadata records the resolved SHA.
+
+**Alternative considered:** process releases created after the onboarding merge timestamp. Timestamps do not express intentional backfill and behave poorly when releases are imported or republished. It is rejected.
+
+### Feed state replaces a separate processing ledger
+
+The staging feed and NuGet.org provide the durable state machine:
+
+```text
+absent from staging, absent from NuGet.org
+  -> build and stage
+
+present in staging, absent from NuGet.org
+  -> await or retry promotion using staged artifact
+
+present in staging, present in NuGet.org
+  -> complete
+```
+
+Every query includes package ID and version and verifies repository commit metadata. A package at the expected identity with another commit is a conflict. Immutable package versions are never overwritten.
+
+This design does not use Azure Pipeline artifacts as state because their lifetime follows run retention. It also avoids a separate database whose records could diverge from actual feed publication.
+
+**Alternative considered:** commit processed releases into the onboarding repository. That would generate operational commits, serialize pipeline activity with onboarding, and represent attempted rather than actual publication. It is rejected.
+
+### Packaging never executes repository code
+
+The pipeline acquires the exact release-tag snapshot into an isolated staging directory. Central packaging tooling performs copying, metadata generation, TemplateEngine validation, NuGet packing, and archive inspection. It does not invoke source build instructions or package managers.
+
+The content filter removes:
+
+- `.git`;
+- `.github`;
+- known build output and dependency-cache directories;
+- detected credential material;
+- links that resolve outside staging.
+
+Git submodules and Git LFS are outside the initial design and are not initialized. The final archive is inspected independently so an error in staging filters cannot publish excluded content.
+
+**Alternative considered:** run a repository-owned packaging script. That distributes infrastructure across sample repositories and executes untrusted code with publication credentials. It is rejected.
+
+### Authored and synthesized template modes are mutually exclusive
+
+The staged release snapshot selects exactly one template source:
+
+```text
+root .template.config/template.json exists
+  + onboarding template section absent
+  -> preserve and validate authored template
+
+root .template.config/template.json absent
+  + onboarding template.projects present
+  -> synthesize template configuration
+
+both present
+  -> fail: redundant and conflicting ownership
+
+both absent
+  -> fail: no template can be generated
+```
+
+The root location remains a convention; onboarding does not point to arbitrary template configuration paths. Supporting a list of paths would imply multiple templates per package and ambiguous content roots, which are outside the initial design.
+
+A root authored configuration is preserved byte-for-byte. The central validator loads and dry-runs it through Microsoft.TemplateEngine and requires:
+
+- valid identity and short-name metadata;
+- `tags.type` equal to `project`;
+- at least one trusted Functions project configuration finalization action;
+- every active configuration action to reference a resolved primary output and supply canonical stack and language;
+- no direct `.func/config.json` template content;
+- no behavior rejected by the centrally defined safety policy.
+
+The authored file owns project topology, parameters, conditions, primary outputs, and post-actions. YAML does not duplicate or assert those details. An invalid authored configuration fails packaging and is never rewritten or replaced with synthesis.
+
+When the authored file is absent, `template.projects` is the reviewed project topology. For each project, the packager:
+
+1. Requires `<root>/host.json` in the filtered release snapshot.
+2. Adds `<root>/host.json` as a primary output.
+3. Adds one mandatory trusted configuration finalization action referencing that primary output and carrying the declared canonical stack and language.
+
+The generated template uses effective identity, short name, name, and description metadata, sets `tags.type` to `project`, and treats the complete filtered snapshot as content. It defines no parameter symbols, replacements, or ordinary post-actions. It emits a singular language tag only when all declared projects have the same language; mixed-language topology is represented exclusively by the configuration actions.
+
+Both modes pass the same TemplateEngine load, dry-run, action, output-path, and package safety validation. `validate-onboarding.yaml` performs source-aware validation across enabled onboarding entries so authored template metadata and dry-run behavior are checked centrally; release generation repeats validation against the exact tagged commit.
+
+**Alternative considered:** inject generated actions into an authored file. This changes source-owned behavior without a source PR and cannot safely reproduce authored conditions or rename behavior. It is rejected.
+
+**Alternative considered:** require `projects` as an assertion for authored templates. That duplicates topology across repositories and the control plane. It is rejected.
+
+### License detection is pinned to release content
+
+The allowlist contains SPDX `MIT` and `Apache-2.0`. Detection order is:
+
+```text
+reviewed YAML licenseExpression
+  -> GitHub repository-license API with ref=<release commit>
+  -> inspect root license file in staged release snapshot
+  -> fail
+```
+
+An override handles recognized license text that GitHub cannot classify, but a root license file is still required. The package uses a NuGet license expression and retains the source license as template content.
+
+Default-branch license metadata is not authoritative because it may differ from the packaged release.
+
+**Alternative considered:** accept any SPDX expression returned by GitHub. Publication rights and review requirements differ by license; the initial supply chain intentionally admits only the two approved licenses.
+
+### NuGet metadata carries public provenance
+
+The central packager generates package metadata:
+
+| NuGet value | Source |
+|---|---|
+| ID | onboarding `packageId` |
+| Version | release tag without `v` |
+| Package type | `FuncTemplate` |
+| Description | effective YAML/GitHub description |
+| License | effective SPDX expression |
+| Project URL | canonical GitHub repository URL |
+| Repository type | `git` |
+| Repository URL | canonical GitHub repository URL |
+| Repository commit | resolved release-tag commit |
+| Release notes | corresponding GitHub release URL |
+
+GitHub release ID is unnecessary because the tag, commit, repository, and release URL identify the source release. Azure Pipeline definition and run IDs remain private implementation details and are not embedded. SBOM generation is deferred.
+
+### Staging and approval promote one immutable artifact
+
+The publication pipeline has distinct phases:
+
+```text
+discover
+  -> build and validate candidates independently
+  -> publish successful candidates to Azure Artifacts staging
+  -> summarize successful and failed candidates
+  -> one approval for the successful run set
+  -> download exact staged packages
+  -> verify again
+  -> push unchanged packages to NuGet.org
+```
+
+One failed release does not prevent unrelated releases from staging or promotion. The run ultimately reports failure when unresolved failures remain, but its successful set can pass through the shared approval.
+
+Promotion never rebuilds. Revalidation confirms staged identity, hash, provenance, and package safety before pushing the same bytes to NuGet.org.
+
+**Alternative considered:** require approval for each package. Daily batches would create unnecessary approval load without improving artifact isolation. It is rejected.
+
+**Alternative considered:** automatically promote after staging. A single human gate is required before public publication and is retained.
+
+### Recovery reuses normal pipeline behavior
+
+Transient GitHub and feed calls use bounded exponential backoff. Later daily runs discover incomplete work naturally from feed state. Manual runs can filter by onboarding ID and optional version but use the same validation, staging, approval, and promotion path.
+
+Only one publication run holds the feed mutation lock. A manual run never bypasses immutable identity checks and no force-overwrite option exists.
+
+Every run reports discovered, staged, promoted, already-complete, skipped, and failed releases. Exhausted failures notify one central `func-templates` operations team. Repository-specific routing is deferred until operational scale justifies additional onboarding metadata.
+
+## Risks / Trade-offs
+
+- **[Mutable GitHub repository descriptions can alter a not-yet-staged rebuild]** -> The first successfully staged package becomes authoritative; teams can pin wording in YAML when stability matters.
+- **[Moved tags undermine release immutability]** -> Compare the resolved commit with feed metadata and reject conflicts rather than repackaging.
+- **[A malicious repository can contain hostile files]** -> Never execute repository code, isolate staging, scan content, reject escaping links, and inspect the final archive.
+- **[GitHub license detection can be incomplete]** -> Inspect the release license file and allow a reviewed expression override while retaining the file requirement.
+- **[One approval can authorize many packages]** -> Present the complete successful set and failures before the gate, and promote only already validated staging artifacts.
+- **[Staging and NuGet.org can diverge]** -> Treat staging-only state as resumable promotion and verify provenance on both feeds.
+- **[Ignoring submodules or LFS can leave an incomplete sample]** -> Document the limitation and require source repositories to release self-contained content until support is designed.
+
+## Migration Plan
+
+1. Create the `func-templates` repository with source, schema, central tooling, tests, and both pipeline definitions.
+2. Reserve and configure the `Azure.Functions.Templates.` prefix and package ownership on NuGet.org.
+3. Provision the Azure Artifacts staging feed, GitHub read identity, feed publication identities, approval-gated NuGet.org environment, mutation lock, and central notifications.
+4. Add representative onboarding entries through PRs and validate package construction without publication.
+5. Publish representative packages to staging and verify installation through the existing `FuncTemplate` package path.
+6. Enable the shared approval gate and promote the exact staged packages to NuGet.org.
+7. Enable the daily schedule after end-to-end publication succeeds.
+
+Rollback disables the scheduled pipeline and promotion environment. Packages already published remain immutable; unlisting and incident response are owned outside this design.

--- a/docs/azure-samples-template-pipeline/design.md
+++ b/docs/azure-samples-template-pipeline/design.md
@@ -13,7 +13,8 @@ https://dev.azure.com/azfunc/internal/_git/func-templates
 |   +-- Quickstarts/
 |   |   `-- *.yaml
 |   `-- Schema/
-|       `-- quickstart.schema.json
+|       +-- quickstart.schema.json
+|       `-- azure-functions-template.schema.json
 `-- eng/
     `-- ci/
         +-- validate-onboarding.yaml
@@ -62,34 +63,36 @@ quickstarts:
       minimumVersion: 1.0.0
       includePrerelease: false
 
-    template:
-      identity: Azure.Functions.Templates.PythonOpenAIChat
-      shortName: functions-python-openai-chat
-      name: Azure Functions Python OpenAI Chat
-      description: Create an Azure Functions application using Azure OpenAI.
-      projects:
-        - root: .
-          stack: python
-          language: Python
-
     licenseExpression: MIT
 ```
 
-`schemaVersion`, `quickstarts`, `id`, `repository`, `packageId`, and `release.minimumVersion` are always required. The `template` section is optional at schema validation time because its presence is mutually exclusive with an authored root `.template.config/template.json` in the release snapshot. When `template` is present, `projects` is required and contains at least one Functions project.
+`schemaVersion`, `quickstarts`, `id`, `repository`, `packageId`, and `release.minimumVersion` are always required. Onboarding contains no template metadata or project paths.
 
-Defaults and optional synthesis values are resolved before source-aware validation:
+Onboarding defaults are resolved before validation:
 
 ```text
 enabled                    -> true
 release.includePrerelease  -> false
-template.identity          -> packageId
-template.shortName         -> repository name
-template.name              -> title-cased repository name
-template.description       -> GitHub repository description
 licenseExpression          -> detection from release commit
 ```
 
-Each synthesized project declares:
+The exact release snapshot owns synthesis metadata in `.github/azure-functions-template.yaml`:
+
+```yaml
+schemaVersion: 1
+
+identity: Azure.Functions.Templates.PythonOpenAIChat
+shortName: functions-python-openai-chat
+name: Azure Functions Python OpenAI Chat
+description: Create an Azure Functions application using Azure OpenAI.
+
+projects:
+  - root: .
+    stack: python
+    language: Python
+```
+
+Every field other than `schemaVersion` belongs to the template definition rather than onboarding. The descriptor requires non-empty `identity`, `shortName`, `name`, `description`, and `projects`. Each project declares:
 
 ```text
 root      repository-relative Functions project root
@@ -99,7 +102,7 @@ language  canonical language recognized by that stack
 
 The root project uses `.`. Other roots use normalized `/`-separated relative paths. Roots cannot be absolute, contain `..`, use excluded directories, collide case-insensitively, or overlap through ancestor/descendant nesting. The staged release must contain a regular `host.json` directly under every declared root.
 
-The JSON Schema owns structural validation and rejects unknown fields. A repository-wide validator owns cross-file uniqueness, effective-value collisions, GitHub slug restrictions, SemVer validation, package-prefix policy, project path safety, and canonical stack/language pairs.
+The onboarding JSON Schema owns control-plane structure and rejects unknown fields. A separate centrally owned descriptor schema validates `.github/azure-functions-template.yaml`. Repository-wide onboarding validation owns central identity collisions, GitHub slug restrictions, SemVer validation, package-prefix policy, and license policy. Release packaging owns descriptor metadata, project path safety, canonical stack/language pairs, and TemplateEngine validation against the exact tagged content.
 
 Files are scanned non-recursively in ordinal filename order. The order exists only for deterministic diagnostics; it does not establish precedence. Duplicate values are errors rather than last-write-wins behavior.
 
@@ -111,11 +114,11 @@ Files are scanned non-recursively in ordinal filename order. The order exists on
 
 The onboarding `id` is an internal operational key. `packageId` is explicitly reviewed and must use the reserved `Azure.Functions.Templates.` prefix. Neither is derived from mutable GitHub metadata.
 
-Repository, package ID, onboarding ID, effective template identity, and effective short names are unique case-insensitively. Synthesized identities and short names are resolved from YAML defaults. Authored identities and short names are resolved by loading the authored template during source-aware validation. Repository uniqueness intentionally limits one package to one repository in the initial design. A future need for multiple packaging scopes requires an explicit schema revision rather than duplicate entries.
-
-Template identity defaults to package ID, and short name defaults to the configured repository name. The display name transformation is mechanical: split on `-`, `_`, and `.`, capitalize the first character of each token, and join with spaces. YAML overrides preserve brand-specific casing.
+Repository, package ID, and onboarding ID are unique case-insensitively. Repository uniqueness intentionally limits one package to one repository in the initial design. A future need for multiple packaging scopes requires an explicit schema revision rather than duplicate entries.
 
 **Alternative considered:** derive package ID from repository name. Repository renames, normalization collisions, and NuGet namespace ownership would make package identity unstable. It is rejected.
+
+**Alternative considered:** keep synthesized template metadata or project paths in onboarding. That makes repository structure and template presentation depend on a separately versioned control-plane file. It is rejected so the release commit atomically owns its content and synthesis descriptor.
 
 ### The minimum version is the backfill boundary
 
@@ -163,7 +166,7 @@ This design does not use Azure Pipeline artifacts as state because their lifetim
 
 The pipeline acquires the exact release-tag snapshot into an isolated staging directory. Central packaging tooling performs copying, metadata generation, TemplateEngine validation, NuGet packing, and archive inspection. It does not invoke source build instructions or package managers.
 
-The content filter removes:
+Before filtering, the pipeline reads at most the known `.github/azure-functions-template.yaml` descriptor needed to select and validate synthesis mode. The content filter then removes:
 
 - `.git`;
 - `.github`;
@@ -177,25 +180,23 @@ Git submodules and Git LFS are outside the initial design and are not initialize
 
 ### Authored and synthesized template modes are mutually exclusive
 
-The staged release snapshot selects exactly one template source:
+The exact release snapshot selects exactly one template source:
 
 ```text
 root .template.config/template.json exists
-  + onboarding template section absent
   -> preserve and validate authored template
 
-root .template.config/template.json absent
-  + onboarding template.projects present
+root .github/azure-functions-template.yaml exists
   -> synthesize template configuration
 
 both present
   -> fail: redundant and conflicting ownership
 
-both absent
+neither present
   -> fail: no template can be generated
 ```
 
-The root location remains a convention; onboarding does not point to arbitrary template configuration paths. Supporting a list of paths would imply multiple templates per package and ambiguous content roots, which are outside the initial design.
+Both locations are fixed conventions; onboarding does not point to arbitrary template configuration or descriptor paths. Supporting lists of paths would imply multiple templates per package and ambiguous content roots, which are outside the initial design.
 
 A root authored configuration is preserved byte-for-byte. The central validator loads and dry-runs it through Microsoft.TemplateEngine and requires:
 
@@ -206,21 +207,21 @@ A root authored configuration is preserved byte-for-byte. The central validator 
 - no direct `.func/config.json` template content;
 - no behavior rejected by the centrally defined safety policy.
 
-The authored file owns project topology, parameters, conditions, primary outputs, and post-actions. YAML does not duplicate or assert those details. An invalid authored configuration fails packaging and is never rewritten or replaced with synthesis.
+The authored file owns template metadata, project topology, parameters, conditions, primary outputs, and post-actions. The synthesis descriptor MUST NOT coexist with it. An invalid authored configuration fails packaging and is never rewritten or replaced with synthesis.
 
-When the authored file is absent, `template.projects` is the reviewed project topology. For each project, the packager:
+When the authored file is absent, `.github/azure-functions-template.yaml` supplies the complete synthesized template metadata and project topology. For each project, the packager:
 
 1. Requires `<root>/host.json` in the filtered release snapshot.
 2. Adds `<root>/host.json` as a primary output.
 3. Adds one mandatory trusted configuration finalization action referencing that primary output and carrying the declared canonical stack and language.
 
-The generated template uses effective identity, short name, name, and description metadata, sets `tags.type` to `project`, and treats the complete filtered snapshot as content. It defines no parameter symbols, replacements, or ordinary post-actions. It emits a singular language tag only when all declared projects have the same language; mixed-language topology is represented exclusively by the configuration actions.
+The generated template uses the descriptor's identity, short name, name, and description, sets `tags.type` to `project`, and treats the complete filtered snapshot as content. It defines no parameter symbols, replacements, or ordinary post-actions. It emits a singular language tag only when all declared projects have the same language; mixed-language topology is represented exclusively by the configuration actions.
 
-Both modes pass the same TemplateEngine load, dry-run, action, output-path, and package safety validation. `validate-onboarding.yaml` performs source-aware validation across enabled onboarding entries so authored template metadata and dry-run behavior are checked centrally; release generation repeats validation against the exact tagged commit.
+Both modes pass the same TemplateEngine load, dry-run, action, output-path, and package safety validation during release packaging. Onboarding PR validation does not acquire source releases or validate repository-owned template definitions.
 
 **Alternative considered:** inject generated actions into an authored file. This changes source-owned behavior without a source PR and cannot safely reproduce authored conditions or rename behavior. It is rejected.
 
-**Alternative considered:** require `projects` as an assertion for authored templates. That duplicates topology across repositories and the control plane. It is rejected.
+**Alternative considered:** require the synthesis descriptor alongside authored templates as a topology assertion. That duplicates source-owned topology and creates conflicting authorities. It is rejected.
 
 ### License detection is pinned to release content
 
@@ -248,7 +249,7 @@ The central packager generates package metadata:
 | ID | onboarding `packageId` |
 | Version | release tag without `v` |
 | Package type | `FuncTemplate` |
-| Description | effective YAML/GitHub description |
+| Description | effective authored or synthesized template description |
 | License | effective SPDX expression |
 | Project URL | canonical GitHub repository URL |
 | Repository type | `git` |
@@ -291,7 +292,7 @@ Every run reports discovered, staged, promoted, already-complete, skipped, and f
 
 ## Risks / Trade-offs
 
-- **[Mutable GitHub repository descriptions can alter a not-yet-staged rebuild]** -> The first successfully staged package becomes authoritative; teams can pin wording in YAML when stability matters.
+- **[A release contains an invalid synthesis descriptor]** -> Fail that release before staging and report descriptor diagnostics; source-repository pre-release validation can be added later without changing package semantics.
 - **[Moved tags undermine release immutability]** -> Compare the resolved commit with feed metadata and reject conflicts rather than repackaging.
 - **[A malicious repository can contain hostile files]** -> Never execute repository code, isolate staging, scan content, reject escaping links, and inspect the final archive.
 - **[GitHub license detection can be incomplete]** -> Inspect the release license file and allow a reviewed expression override while retaining the file requirement.

--- a/docs/azure-samples-template-pipeline/proposal.md
+++ b/docs/azure-samples-template-pipeline/proposal.md
@@ -5,13 +5,13 @@ Azure-Samples quickstart repositories are independently released source reposito
 ## What Changes
 
 - Establish `https://dev.azure.com/azfunc/internal/_git/func-templates` as the control-plane repository for Azure-Samples template packaging.
-- Add PR-reviewed onboarding sources under `src/Quickstarts/*.yaml` and a shared JSON Schema at `src/Schema/quickstart.schema.json`.
-- Add `eng/ci/validate-onboarding.yaml` to validate every onboarding file and enforce repository-wide uniqueness.
+- Add PR-reviewed onboarding sources under `src/Quickstarts/*.yaml` plus centrally owned onboarding and synthesis-descriptor schemas under `src/Schema/`.
+- Add `eng/ci/validate-onboarding.yaml` to validate every onboarding file and enforce repository-wide onboarding uniqueness.
 - Add `eng/ci/publish-releases.yaml` to scan onboarded GitHub repositories daily for eligible releases.
 - Require published releases to use `v` followed by SemVer 2.0, support prereleases only through explicit opt-in, and use a required minimum version as the initial backfill boundary.
 - Build packages from the exact commit referenced by each eligible release tag without executing repository-controlled code.
-- Preserve and dry-run a valid authored root `.template.config/template.json` when onboarding omits `template`, or synthesize a project template with one required `.func/config.json` finalization action per declared `template.projects` entry.
-- Exclude `.git`, `.github`, generated build output, credentials, and unsafe links from package content.
+- Preserve and dry-run a valid authored root `.template.config/template.json`, or synthesize a project template from the release-owned `.github/azure-functions-template.yaml` descriptor with one required `.func/config.json` finalization action per declared project.
+- Read the synthesis descriptor before excluding `.git`, `.github`, generated build output, credentials, and unsafe links from package content.
 - Require an MIT or Apache-2.0 license detected from the release commit or declared through a reviewed override.
 - Create NuGet packages under the `Azure.Functions.Templates.` prefix with package type `FuncTemplate`, source repository metadata, commit provenance, and a release-notes link to the GitHub release.
 - Publish validated packages to an Azure Artifacts staging feed, request one approval for the successful packages in the pipeline run, and promote those exact package artifacts to NuGet.org.

--- a/docs/azure-samples-template-pipeline/proposal.md
+++ b/docs/azure-samples-template-pipeline/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+Azure-Samples quickstart repositories are independently released source repositories, but the Azure Functions CLI template system consumes versioned `FuncTemplate` NuGet packages. A centrally managed supply pipeline is needed to onboard eligible repositories, detect new releases, convert immutable release snapshots into safe template packages, and publish those packages without requiring each sample repository to own packaging infrastructure.
+
+## What Changes
+
+- Establish `https://dev.azure.com/azfunc/internal/_git/func-templates` as the control-plane repository for Azure-Samples template packaging.
+- Add PR-reviewed onboarding sources under `src/Quickstarts/*.yaml` and a shared JSON Schema at `src/Schema/quickstart.schema.json`.
+- Add `eng/ci/validate-onboarding.yaml` to validate every onboarding file and enforce repository-wide uniqueness.
+- Add `eng/ci/publish-releases.yaml` to scan onboarded GitHub repositories daily for eligible releases.
+- Require published releases to use `v` followed by SemVer 2.0, support prereleases only through explicit opt-in, and use a required minimum version as the initial backfill boundary.
+- Build packages from the exact commit referenced by each eligible release tag without executing repository-controlled code.
+- Preserve and dry-run a valid authored root `.template.config/template.json` when onboarding omits `template`, or synthesize a project template with one required `.func/config.json` finalization action per declared `template.projects` entry.
+- Exclude `.git`, `.github`, generated build output, credentials, and unsafe links from package content.
+- Require an MIT or Apache-2.0 license detected from the release commit or declared through a reviewed override.
+- Create NuGet packages under the `Azure.Functions.Templates.` prefix with package type `FuncTemplate`, source repository metadata, commit provenance, and a release-notes link to the GitHub release.
+- Publish validated packages to an Azure Artifacts staging feed, request one approval for the successful packages in the pipeline run, and promote those exact package artifacts to NuGet.org.
+- Process releases independently, retry transient failures, resume incomplete publication from feed state, and report partial success without blocking valid packages.
+
+## Capabilities
+
+### New Capabilities
+
+- `azure-samples-template-pipeline`: PR-based repository onboarding, GitHub release discovery, safe template synthesis and packaging, staged approval, and NuGet.org publication for Azure-Samples quickstarts.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Introduces the separate internal `func-templates` Azure DevOps repository and its source, schema, tooling, tests, and pipeline layout.
+- Requires read-only GitHub API access, an Azure Artifacts staging feed, and NuGet.org publication credentials protected by an approval-gated environment.
+- Produces packages compatible with the `FuncTemplate` ownership contract from `template-package-install`.
+- Does not change Azure Functions CLI commands, package installation behavior, quickstart catalogs, or template discovery manifests.

--- a/docs/azure-samples-template-pipeline/specs/azure-samples-template-pipeline/spec.md
+++ b/docs/azure-samples-template-pipeline/specs/azure-samples-template-pipeline/spec.md
@@ -1,0 +1,457 @@
+## Purpose
+
+Defines how Azure-Samples quickstart releases are onboarded, converted into safe `FuncTemplate` NuGet packages, staged, approved, and published to NuGet.org.
+
+## ADDED Requirements
+
+### Requirement: The func-templates repository owns the packaging control plane
+
+The system SHALL use the `func-templates` repository in the `internal` project of the `azfunc` Azure DevOps organization as the source of truth for quickstart onboarding and release automation. It SHALL keep onboarding YAML under `src/Quickstarts/`, the onboarding JSON Schema at `src/Schema/quickstart.schema.json`, and pipeline definitions under `eng/ci/`.
+
+#### Scenario: Repository layout is validated
+
+- **WHEN** the control-plane repository is validated
+- **THEN** onboarding sources are read from `src/Quickstarts/*.yaml`
+- **AND** the schema is read from `src/Schema/quickstart.schema.json`
+- **AND** `eng/ci/validate-onboarding.yaml` and `eng/ci/publish-releases.yaml` define the validation and publication pipelines
+
+### Requirement: Onboarding is PR-reviewed YAML
+
+Each file directly under `src/Quickstarts/` with the `.yaml` extension SHALL contain `schemaVersion: 1` and a `quickstarts` array containing zero or more onboarding entries. The scanner SHALL combine every matching file into one logical onboarding manifest. Filenames and the file containing an entry MUST NOT contribute to entry identity.
+
+#### Scenario: Multiple onboarding files are combined
+
+- **WHEN** multiple `.yaml` files contain valid quickstart entries
+- **THEN** the system validates and processes their entries as one logical manifest
+
+#### Scenario: Empty onboarding file is accepted
+
+- **WHEN** a valid onboarding file contains an empty `quickstarts` array
+- **THEN** validation succeeds for that file
+
+#### Scenario: Nested and alternate-extension files are not scanned
+
+- **WHEN** a YAML file is nested below `src/Quickstarts/` or uses an extension other than `.yaml`
+- **THEN** the onboarding scanner does not treat it as an onboarding source
+
+### Requirement: The onboarding schema is strict
+
+Every onboarding file SHALL validate against `src/Schema/quickstart.schema.json`. The schema SHALL reject unknown properties and SHALL define required values, types, formats, allowed values, and defaults for schema version 1.
+
+#### Scenario: Unknown field is rejected
+
+- **WHEN** an onboarding file or entry contains a property not defined by schema version 1
+- **THEN** PR validation fails with the file and property identified
+
+#### Scenario: Unsupported schema version is rejected
+
+- **WHEN** an onboarding file declares a schema version other than `1`
+- **THEN** PR validation fails
+
+### Requirement: Each onboarding entry has stable package and release identity
+
+Each entry SHALL require a stable `id`, an `Azure-Samples/<repository>` slug, a `packageId` beginning with `Azure.Functions.Templates.`, and `release.minimumVersion`. `enabled` SHALL default to `true`, and `release.includePrerelease` SHALL default to `false`. The `template` section SHALL be optional for structurally valid onboarding, but when present it SHALL require a non-empty `projects` array.
+
+#### Scenario: Minimal entry is accepted
+
+- **WHEN** an entry supplies all required fields and omits optional fields
+- **THEN** validation applies the documented defaults
+
+#### Scenario: Repository outside Azure-Samples is rejected
+
+- **WHEN** an entry identifies an owner other than `Azure-Samples`
+- **THEN** validation fails
+
+#### Scenario: Package ID has the wrong prefix
+
+- **WHEN** an entry's package ID does not begin with `Azure.Functions.Templates.`
+- **THEN** validation fails
+
+#### Scenario: Disabled entry is not scanned
+
+- **WHEN** an entry has `enabled: false`
+- **THEN** scheduled release discovery skips that entry without removing previously published packages
+
+#### Scenario: Synthesis section omits projects
+
+- **WHEN** an entry contains `template` without a non-empty `projects` array
+- **THEN** schema validation fails
+
+### Requirement: Effective identities are globally unique
+
+The system SHALL enforce case-insensitive uniqueness across all onboarding files for onboarding ID, repository slug, package ID, effective template identity, and every effective template short name. It SHALL resolve synthesized template values from YAML defaults and authored values by loading source template configuration. Moving an unchanged entry between files MUST NOT change its effective values.
+
+#### Scenario: Duplicate value exists in another file
+
+- **WHEN** two entries resolve to the same globally unique value ignoring case
+- **THEN** PR validation fails and identifies both entries
+
+#### Scenario: Derived value collides
+
+- **WHEN** an omitted template identity or short name resolves to a value used by another entry
+- **THEN** PR validation fails before publication
+
+#### Scenario: Authored identity collides
+
+- **WHEN** source-aware validation loads an authored template whose identity or short name collides with another onboarded template
+- **THEN** validation fails and identifies both entries
+
+### Requirement: Optional template metadata has deterministic defaults
+
+When `template` is present for synthesis, the system SHALL resolve `template.identity` from the explicit YAML value or the package ID, `template.shortName` from the explicit YAML value or repository name, `template.name` from the explicit YAML value or a deterministic title-casing of the repository name, and `template.description` from the explicit YAML value or the GitHub repository description. Name derivation SHALL split the repository name on hyphen, underscore, and period, uppercase the first character of each token, and join the tokens with spaces. The system SHALL fail synthesis when no non-empty description can be resolved.
+
+#### Scenario: Minimal metadata is derived
+
+- **WHEN** an entry omits optional template metadata
+- **THEN** identity, short name, name, and description are resolved using the documented defaults
+
+#### Scenario: Explicit metadata overrides a default
+
+- **WHEN** an entry supplies an optional template metadata value
+- **THEN** the supplied value is used instead of its derived default
+
+#### Scenario: Repository has no description
+
+- **WHEN** neither YAML nor GitHub provides a non-empty repository description
+- **THEN** package construction fails with guidance to add a YAML description
+
+### Requirement: PR validation is atomic
+
+`eng/ci/validate-onboarding.yaml` SHALL parse and validate every onboarding file, resolve effective values, and apply repository-wide invariants before accepting a PR. It SHALL perform source-aware TemplateEngine loading and dry-run validation for every enabled onboarding entry against its latest eligible published release. A malformed file, unavailable validation release, invalid entry, invalid template, or dry-run failure SHALL fail the complete validation run.
+
+#### Scenario: One file is malformed
+
+- **WHEN** any scanned onboarding file cannot be parsed
+- **THEN** PR validation fails without treating the remaining files as an accepted manifest
+
+#### Scenario: All files and global invariants are valid
+
+- **WHEN** every scanned file passes schema, repository-wide, source-aware, and TemplateEngine dry-run validation
+- **THEN** PR validation succeeds
+
+#### Scenario: Onboarded authored template fails dry-run
+
+- **WHEN** an enabled entry's latest eligible release contains an authored template that cannot complete TemplateEngine dry-run validation
+- **THEN** PR validation fails and identifies the onboarding entry and release
+
+#### Scenario: Entry has no eligible validation release
+
+- **WHEN** an enabled entry has no published release satisfying its release policy
+- **THEN** PR validation fails because its source template cannot be validated
+
+### Requirement: Scheduled discovery scans GitHub releases
+
+`eng/ci/publish-releases.yaml` SHALL run daily and enumerate all published GitHub releases for every enabled onboarding entry, following pagination. It SHALL ignore drafts and SHALL NOT treat a Git tag without a GitHub release as a release candidate.
+
+#### Scenario: Published release is discovered
+
+- **WHEN** an enabled repository has a published GitHub release
+- **THEN** the release is evaluated for packaging eligibility
+
+#### Scenario: Draft release exists
+
+- **WHEN** GitHub returns a draft release
+- **THEN** the pipeline does not package it
+
+#### Scenario: Tag has no GitHub release
+
+- **WHEN** a repository has a tag that is not associated with a GitHub release
+- **THEN** the pipeline does not package that tag
+
+### Requirement: Eligible releases use unambiguous SemVer tags
+
+An eligible release tag SHALL be `v` followed by a valid SemVer 2.0 version. The package version SHALL be the tag with the leading `v` removed. Build metadata SHALL be rejected. The version SHALL be greater than or equal to `release.minimumVersion`, and a GitHub prerelease SHALL be eligible only when `release.includePrerelease` is `true`.
+
+#### Scenario: Stable release is eligible
+
+- **WHEN** a published release tag is `v1.2.3`
+- **AND** version `1.2.3` meets the configured minimum
+- **THEN** package version `1.2.3` is eligible
+
+#### Scenario: Version predates onboarding boundary
+
+- **WHEN** a release version is lower than `release.minimumVersion`
+- **THEN** the release is skipped
+
+#### Scenario: Prerelease is not enabled
+
+- **WHEN** GitHub marks a release as a prerelease
+- **AND** `release.includePrerelease` is false
+- **THEN** the release is skipped
+
+#### Scenario: Build metadata is present
+
+- **WHEN** a release tag includes SemVer build metadata
+- **THEN** the release is rejected to prevent NuGet identity collisions
+
+### Requirement: Package input is pinned to the release tag commit
+
+The pipeline SHALL resolve the release tag to an exact commit SHA and package that commit. It SHALL record the resolved commit in NuGet repository metadata. An existing package version associated with a different commit SHALL be treated as a conflict and MUST NOT be overwritten or silently accepted.
+
+#### Scenario: Release tag resolves successfully
+
+- **WHEN** an eligible release tag resolves to a commit
+- **THEN** the pipeline checks out and packages that exact commit
+
+#### Scenario: Release tag cannot resolve
+
+- **WHEN** an eligible release tag cannot be resolved to a commit
+- **THEN** that release fails before staging
+
+#### Scenario: Tag moved after package publication
+
+- **WHEN** the release tag now resolves to a commit different from the commit recorded in an existing package
+- **THEN** the pipeline reports a version conflict
+- **AND** does not replace the existing package
+
+### Requirement: Source repositories are treated as untrusted content
+
+The packaging process SHALL NOT execute build scripts, package-manager scripts, repository pipeline definitions, or other code from the source repository. It SHALL stage a content snapshot and SHALL exclude `.git`, `.github`, generated build output, dependency caches, credentials detected by configured scanning, and links that escape the staged root.
+
+#### Scenario: Repository contains workflow definitions
+
+- **WHEN** a release snapshot contains `.github`
+- **THEN** `.github` is absent from the template package
+
+#### Scenario: Repository contains an escaping link
+
+- **WHEN** a symbolic or equivalent link resolves outside the staged source root
+- **THEN** package construction fails
+
+#### Scenario: Repository contains executable build instructions
+
+- **WHEN** a release snapshot contains build or package-manager configuration
+- **THEN** the files may be copied as template content
+- **BUT** the packaging process does not execute them
+
+### Requirement: Authored and synthesized template ownership is exclusive
+
+For each staged release snapshot, the pipeline SHALL accept exactly one template source. When a root `.template.config/template.json` exists, the onboarding entry MUST omit `template`. When the authored file is absent, the onboarding entry SHALL contain `template.projects`. The pipeline SHALL fail package generation when both sources are present or both sources are absent.
+
+#### Scenario: Authored configuration and YAML template section are present
+
+- **WHEN** the release snapshot contains root `.template.config/template.json`
+- **AND** onboarding contains `template`
+- **THEN** package generation fails with a redundant template ownership diagnostic
+
+#### Scenario: Neither template source is present
+
+- **WHEN** the release snapshot lacks root `.template.config/template.json`
+- **AND** onboarding omits `template`
+- **THEN** package generation fails without creating a template configuration
+
+#### Scenario: Exactly one template source is present
+
+- **WHEN** the release snapshot and onboarding select exactly one template source
+- **THEN** package generation continues with that source
+
+### Requirement: Authored template configuration is preserved and dry-run
+
+When the release snapshot contains root `.template.config/template.json` and onboarding omits `template`, the pipeline SHALL preserve the authored file byte-for-byte. It SHALL load and dry-run the template through Microsoft.TemplateEngine and require valid identity and short-name metadata, project template type, at least one trusted Functions project configuration finalization action, valid resolved primary-output references, canonical stack and language values, no direct `.func/config.json` content effect, and no behavior rejected by the central safety policy. Invalid authored configuration SHALL fail package construction rather than being rewritten.
+
+#### Scenario: Valid authored template exists
+
+- **WHEN** the root template configuration passes loading, dry-run, configuration-action, and safety validation
+- **THEN** the pipeline packages it without modification
+
+#### Scenario: Authored template omits configuration finalization
+
+- **WHEN** the authored template does not declare a valid configuration finalization action for an active Functions project
+- **THEN** package construction fails
+
+#### Scenario: Authored configuration is invalid
+
+- **WHEN** TemplateEngine cannot load or dry-run the authored template configuration
+- **THEN** package construction fails without synthesizing a replacement
+
+### Requirement: Synthesized project declarations are safe and complete
+
+Each `template.projects` entry SHALL require `root`, `stack`, and `language`. `root` SHALL be `.` or a normalized `/`-separated repository-relative path. Project roots MUST NOT be absolute, contain `..`, use excluded directories, collide case-insensitively, or overlap as ancestor and descendant roots. The declared stack and language SHALL be canonical and compatible. The filtered release snapshot SHALL contain a regular `host.json` directly under each declared root.
+
+#### Scenario: Root project is declared
+
+- **WHEN** a project uses `root: .`
+- **THEN** the pipeline resolves its primary-output anchor as root `host.json`
+
+#### Scenario: Nested project is declared
+
+- **WHEN** a project uses `root: src/api`
+- **THEN** the pipeline resolves its primary-output anchor as `src/api/host.json`
+
+#### Scenario: Project roots overlap
+
+- **WHEN** one declared project root is an ancestor of another declared project root
+- **THEN** validation fails before template synthesis
+
+#### Scenario: Project host file is missing
+
+- **WHEN** the filtered release snapshot has no regular `host.json` directly under a declared project root
+- **THEN** package generation fails and identifies the project
+
+#### Scenario: Stack and language are incompatible
+
+- **WHEN** a declared canonical stack does not recognize the declared canonical language
+- **THEN** validation fails before template synthesis
+
+### Requirement: Missing authored template configuration is synthesized
+
+When the release snapshot does not contain root `.template.config/template.json` and onboarding contains `template.projects`, the pipeline SHALL synthesize template configuration in staging using the effective onboarding metadata. The synthesized template SHALL have project type and SHALL treat the complete filtered release snapshot as template content. For each declared project, it SHALL add `<root>/host.json` as a primary output and add one mandatory trusted Functions project configuration finalization action referencing that output and supplying the declared canonical stack and language. It SHALL define no parameter symbols, content replacements, or ordinary post-actions.
+
+#### Scenario: Repository has no template configuration
+
+- **WHEN** the release snapshot lacks root `.template.config/template.json`
+- **AND** onboarding defines valid `template.projects`
+- **THEN** the pipeline adds a minimal synthesized project template to staging
+
+#### Scenario: Synthesized template is validated
+
+- **WHEN** template configuration has been synthesized
+- **THEN** the same TemplateEngine load, dry-run, action, output-path, and safety validation used for authored configuration succeeds before packing
+
+#### Scenario: Synthesized projects share one language
+
+- **WHEN** every declared project uses the same canonical language
+- **THEN** the synthesized template may expose that singular TemplateEngine language tag
+
+#### Scenario: Synthesized projects use mixed languages
+
+- **WHEN** declared projects use different canonical languages
+- **THEN** the synthesized template omits a singular language tag
+- **AND** preserves per-project languages in configuration actions
+
+### Requirement: Package licensing is release-specific and allowlisted
+
+The pipeline SHALL determine licensing from the exact release commit. It SHALL first use an explicit reviewed `licenseExpression` when present, otherwise use the GitHub repository-license API at the release commit, and otherwise inspect a root license file from the staged snapshot. Only SPDX expressions `MIT` and `Apache-2.0` SHALL be accepted. An explicit override SHALL NOT remove the requirement for a root license file.
+
+#### Scenario: GitHub detects an allowed license
+
+- **WHEN** GitHub identifies the release commit license as MIT or Apache-2.0
+- **THEN** the detected SPDX expression is used in package metadata
+
+#### Scenario: Detection fails but override is valid
+
+- **WHEN** automatic detection does not identify an allowed license
+- **AND** YAML supplies an allowed expression
+- **AND** the release snapshot contains a root license file
+- **THEN** the reviewed override is used
+
+#### Scenario: License is unsupported
+
+- **WHEN** the effective license is not MIT or Apache-2.0
+- **THEN** package construction fails
+
+### Requirement: NuGet packages have func template identity and provenance
+
+Each generated package SHALL use the explicit package ID, the release-derived package version, and package type `FuncTemplate`. NuGet metadata SHALL include the effective description and license, a project URL for the GitHub repository, repository type `git`, the canonical repository URL, the resolved commit SHA, and a release-notes link to the corresponding GitHub release. The root license file SHALL remain in template content.
+
+#### Scenario: Package metadata is inspected
+
+- **WHEN** a generated package is opened
+- **THEN** its ID, version, package type, description, license, project URL, repository URL, commit, and release-notes link match the resolved release
+
+#### Scenario: Pipeline implementation metadata is inspected
+
+- **WHEN** a generated package is opened
+- **THEN** it does not expose Azure Pipeline definition or run identifiers as package provenance
+
+### Requirement: Packages are validated before staging
+
+Before publication, the pipeline SHALL inspect the completed `.nupkg`, load and dry-run its templates through Microsoft.TemplateEngine, validate every required Functions project configuration finalization action and resolved primary output, and verify the expected identity, version, package type, metadata, content, and exclusions. A package that fails any check MUST NOT enter the staging feed.
+
+#### Scenario: Completed package is valid
+
+- **WHEN** package inspection and TemplateEngine loading succeed
+- **THEN** the package is eligible for staging
+
+#### Scenario: Excluded content is present
+
+- **WHEN** final package inspection finds excluded content
+- **THEN** publication fails before staging
+
+### Requirement: Azure Artifacts staging is the publication checkpoint
+
+Every validated package SHALL first be published to the Azure Artifacts staging feed. The staging feed and NuGet.org SHALL be queried by package ID and version to determine publication state. Pipeline-run artifacts SHALL NOT be the durable publication record.
+
+#### Scenario: Version is absent from both feeds
+
+- **WHEN** an eligible package version exists in neither feed
+- **THEN** the pipeline builds, validates, and publishes it to staging
+
+#### Scenario: Version exists only in staging
+
+- **WHEN** the expected package version exists in staging but not NuGet.org
+- **THEN** the pipeline reuses the staged package for promotion without rebuilding it
+
+#### Scenario: Version exists in both feeds
+
+- **WHEN** the expected package version exists in both feeds with matching provenance
+- **THEN** the release is complete and skipped
+
+### Requirement: One approval promotes the successful run set
+
+After all release candidates in a scheduled or manual run have been processed through staging, the pipeline SHALL present one summary and request one approval for all successfully staged packages in that run. Approval SHALL promote the exact staged `.nupkg` files to NuGet.org without rebuilding them. Releases that failed before staging SHALL be reported separately and SHALL NOT block approval or promotion of successful packages.
+
+#### Scenario: Run has multiple successful packages
+
+- **WHEN** several packages reach staging in one run
+- **THEN** one approval authorizes promotion of the complete successful set
+
+#### Scenario: Run has partial failure
+
+- **WHEN** some releases fail and others reach staging
+- **THEN** the approval includes the successfully staged packages
+- **AND** failures are reported separately
+
+#### Scenario: Approval is withheld
+
+- **WHEN** the run is not approved
+- **THEN** staged packages remain available for a later promotion attempt
+- **AND** nothing from that run is published to NuGet.org
+
+### Requirement: Publication is retryable and concurrency-safe
+
+The pipeline SHALL retry transient GitHub, network, and feed failures with bounded backoff. Subsequent daily or manual runs SHALL resume from feed state. Only one publication run SHALL mutate the staging and production feeds at a time, and no operation SHALL overwrite an existing package version.
+
+#### Scenario: Transient operation succeeds on retry
+
+- **WHEN** a transient external operation fails and then succeeds within the retry policy
+- **THEN** processing continues without producing a duplicate package
+
+#### Scenario: Previous promotion was interrupted
+
+- **WHEN** a package is present in staging but absent from NuGet.org
+- **THEN** a later run can promote the staged artifact
+
+#### Scenario: Publication run overlaps
+
+- **WHEN** another publication run already owns the feed mutation lock
+- **THEN** the new run waits or exits without concurrently publishing
+
+### Requirement: Operators can target manual recovery
+
+The publication pipeline SHALL support a manual run filtered by onboarding ID and optional package version. Manual execution SHALL use the same discovery, validation, staging, approval, and immutable publication behavior as scheduled execution and SHALL NOT provide a force-overwrite mode.
+
+#### Scenario: Operator targets one entry
+
+- **WHEN** an operator starts a manual run for one onboarding ID
+- **THEN** unrelated entries are not processed
+
+#### Scenario: Operator requests an existing conflicting version
+
+- **WHEN** a manual run targets a version whose feed provenance conflicts with the release commit
+- **THEN** the run reports the conflict rather than overwriting it
+
+### Requirement: Runs report partial and complete outcomes
+
+Each run SHALL produce a final summary of discovered, staged, promoted, already-complete, skipped, and failed releases. The pipeline SHALL continue processing independent releases after an item failure, SHALL fail its final status when any item remains failed, and SHALL notify the central `func-templates` operations team after configured retries are exhausted. Logs SHALL redact credentials and feed tokens.
+
+#### Scenario: One release fails
+
+- **WHEN** one release fails while another succeeds
+- **THEN** the successful release continues through staging and approval
+- **AND** the final run status reports the failure
+
+#### Scenario: Credentials are used
+
+- **WHEN** the pipeline authenticates to GitHub or a package feed
+- **THEN** credentials and tokens are not emitted in logs or summaries

--- a/docs/azure-samples-template-pipeline/specs/azure-samples-template-pipeline/spec.md
+++ b/docs/azure-samples-template-pipeline/specs/azure-samples-template-pipeline/spec.md
@@ -6,13 +6,13 @@ Defines how Azure-Samples quickstart releases are onboarded, converted into safe
 
 ### Requirement: The func-templates repository owns the packaging control plane
 
-The system SHALL use the `func-templates` repository in the `internal` project of the `azfunc` Azure DevOps organization as the source of truth for quickstart onboarding and release automation. It SHALL keep onboarding YAML under `src/Quickstarts/`, the onboarding JSON Schema at `src/Schema/quickstart.schema.json`, and pipeline definitions under `eng/ci/`.
+The system SHALL use the `func-templates` repository in the `internal` project of the `azfunc` Azure DevOps organization as the source of truth for quickstart onboarding and release automation. It SHALL keep onboarding YAML under `src/Quickstarts/`, the onboarding JSON Schema at `src/Schema/quickstart.schema.json`, the source synthesis-descriptor JSON Schema at `src/Schema/azure-functions-template.schema.json`, and pipeline definitions under `eng/ci/`.
 
 #### Scenario: Repository layout is validated
 
 - **WHEN** the control-plane repository is validated
 - **THEN** onboarding sources are read from `src/Quickstarts/*.yaml`
-- **AND** the schema is read from `src/Schema/quickstart.schema.json`
+- **AND** the schemas are read from `src/Schema/quickstart.schema.json` and `src/Schema/azure-functions-template.schema.json`
 - **AND** `eng/ci/validate-onboarding.yaml` and `eng/ci/publish-releases.yaml` define the validation and publication pipelines
 
 ### Requirement: Onboarding is PR-reviewed YAML
@@ -50,7 +50,7 @@ Every onboarding file SHALL validate against `src/Schema/quickstart.schema.json`
 
 ### Requirement: Each onboarding entry has stable package and release identity
 
-Each entry SHALL require a stable `id`, an `Azure-Samples/<repository>` slug, a `packageId` beginning with `Azure.Functions.Templates.`, and `release.minimumVersion`. `enabled` SHALL default to `true`, and `release.includePrerelease` SHALL default to `false`. The `template` section SHALL be optional for structurally valid onboarding, but when present it SHALL require a non-empty `projects` array.
+Each entry SHALL require a stable `id`, an `Azure-Samples/<repository>` slug, a `packageId` beginning with `Azure.Functions.Templates.`, and `release.minimumVersion`. `enabled` SHALL default to `true`, and `release.includePrerelease` SHALL default to `false`. Onboarding entries MUST NOT contain template metadata or project topology.
 
 #### Scenario: Minimal entry is accepted
 
@@ -72,52 +72,23 @@ Each entry SHALL require a stable `id`, an `Azure-Samples/<repository>` slug, a 
 - **WHEN** an entry has `enabled: false`
 - **THEN** scheduled release discovery skips that entry without removing previously published packages
 
-#### Scenario: Synthesis section omits projects
+#### Scenario: Onboarding contains template metadata
 
-- **WHEN** an entry contains `template` without a non-empty `projects` array
-- **THEN** schema validation fails
+- **WHEN** an onboarding entry contains a `template` property or project path
+- **THEN** schema validation fails because the release snapshot owns template definition
 
-### Requirement: Effective identities are globally unique
+### Requirement: Onboarding identities are globally unique
 
-The system SHALL enforce case-insensitive uniqueness across all onboarding files for onboarding ID, repository slug, package ID, effective template identity, and every effective template short name. It SHALL resolve synthesized template values from YAML defaults and authored values by loading source template configuration. Moving an unchanged entry between files MUST NOT change its effective values.
+The system SHALL enforce case-insensitive uniqueness across all onboarding files for onboarding ID, repository slug, and package ID. Moving an unchanged entry between files MUST NOT change its effective values.
 
 #### Scenario: Duplicate value exists in another file
 
 - **WHEN** two entries resolve to the same globally unique value ignoring case
 - **THEN** PR validation fails and identifies both entries
 
-#### Scenario: Derived value collides
-
-- **WHEN** an omitted template identity or short name resolves to a value used by another entry
-- **THEN** PR validation fails before publication
-
-#### Scenario: Authored identity collides
-
-- **WHEN** source-aware validation loads an authored template whose identity or short name collides with another onboarded template
-- **THEN** validation fails and identifies both entries
-
-### Requirement: Optional template metadata has deterministic defaults
-
-When `template` is present for synthesis, the system SHALL resolve `template.identity` from the explicit YAML value or the package ID, `template.shortName` from the explicit YAML value or repository name, `template.name` from the explicit YAML value or a deterministic title-casing of the repository name, and `template.description` from the explicit YAML value or the GitHub repository description. Name derivation SHALL split the repository name on hyphen, underscore, and period, uppercase the first character of each token, and join the tokens with spaces. The system SHALL fail synthesis when no non-empty description can be resolved.
-
-#### Scenario: Minimal metadata is derived
-
-- **WHEN** an entry omits optional template metadata
-- **THEN** identity, short name, name, and description are resolved using the documented defaults
-
-#### Scenario: Explicit metadata overrides a default
-
-- **WHEN** an entry supplies an optional template metadata value
-- **THEN** the supplied value is used instead of its derived default
-
-#### Scenario: Repository has no description
-
-- **WHEN** neither YAML nor GitHub provides a non-empty repository description
-- **THEN** package construction fails with guidance to add a YAML description
-
 ### Requirement: PR validation is atomic
 
-`eng/ci/validate-onboarding.yaml` SHALL parse and validate every onboarding file, resolve effective values, and apply repository-wide invariants before accepting a PR. It SHALL perform source-aware TemplateEngine loading and dry-run validation for every enabled onboarding entry against its latest eligible published release. A malformed file, unavailable validation release, invalid entry, invalid template, or dry-run failure SHALL fail the complete validation run.
+`eng/ci/validate-onboarding.yaml` SHALL parse and validate every onboarding file and apply repository-wide onboarding invariants before accepting a PR. A malformed file, invalid entry, or central identity collision SHALL fail the complete validation run. Onboarding validation SHALL NOT require acquiring a source release or validating repository-owned template definitions.
 
 #### Scenario: One file is malformed
 
@@ -126,18 +97,14 @@ When `template` is present for synthesis, the system SHALL resolve `template.ide
 
 #### Scenario: All files and global invariants are valid
 
-- **WHEN** every scanned file passes schema, repository-wide, source-aware, and TemplateEngine dry-run validation
+- **WHEN** every scanned file passes schema and repository-wide onboarding validation
 - **THEN** PR validation succeeds
 
-#### Scenario: Onboarded authored template fails dry-run
-
-- **WHEN** an enabled entry's latest eligible release contains an authored template that cannot complete TemplateEngine dry-run validation
-- **THEN** PR validation fails and identifies the onboarding entry and release
-
-#### Scenario: Entry has no eligible validation release
+#### Scenario: Source repository has no eligible release
 
 - **WHEN** an enabled entry has no published release satisfying its release policy
-- **THEN** PR validation fails because its source template cannot be validated
+- **THEN** onboarding validation can succeed
+- **AND** scheduled discovery finds no release candidate for that entry
 
 ### Requirement: Scheduled discovery scans GitHub releases
 
@@ -206,12 +173,13 @@ The pipeline SHALL resolve the release tag to an exact commit SHA and package th
 
 ### Requirement: Source repositories are treated as untrusted content
 
-The packaging process SHALL NOT execute build scripts, package-manager scripts, repository pipeline definitions, or other code from the source repository. It SHALL stage a content snapshot and SHALL exclude `.git`, `.github`, generated build output, dependency caches, credentials detected by configured scanning, and links that escape the staged root.
+The packaging process SHALL NOT execute build scripts, package-manager scripts, repository pipeline definitions, or other code from the source repository. It MAY parse the fixed `.github/azure-functions-template.yaml` synthesis descriptor before filtering. It SHALL exclude `.git`, `.github`, generated build output, dependency caches, credentials detected by configured scanning, and links that escape the staged root.
 
 #### Scenario: Repository contains workflow definitions
 
 - **WHEN** a release snapshot contains `.github`
-- **THEN** `.github` is absent from the template package
+- **THEN** the pipeline consumes any synthesis descriptor before filtering
+- **AND** `.github` is absent from the template package
 
 #### Scenario: Repository contains an escaping link
 
@@ -226,28 +194,28 @@ The packaging process SHALL NOT execute build scripts, package-manager scripts, 
 
 ### Requirement: Authored and synthesized template ownership is exclusive
 
-For each staged release snapshot, the pipeline SHALL accept exactly one template source. When a root `.template.config/template.json` exists, the onboarding entry MUST omit `template`. When the authored file is absent, the onboarding entry SHALL contain `template.projects`. The pipeline SHALL fail package generation when both sources are present or both sources are absent.
+For each release snapshot, the pipeline SHALL accept exactly one template source: root `.template.config/template.json` or `.github/azure-functions-template.yaml`. The pipeline SHALL fail package generation when both sources are present or both sources are absent. Onboarding MUST NOT select the mode or point to another path.
 
-#### Scenario: Authored configuration and YAML template section are present
+#### Scenario: Authored configuration and synthesis descriptor are present
 
 - **WHEN** the release snapshot contains root `.template.config/template.json`
-- **AND** onboarding contains `template`
+- **AND** the release snapshot contains `.github/azure-functions-template.yaml`
 - **THEN** package generation fails with a redundant template ownership diagnostic
 
 #### Scenario: Neither template source is present
 
 - **WHEN** the release snapshot lacks root `.template.config/template.json`
-- **AND** onboarding omits `template`
+- **AND** the release snapshot lacks `.github/azure-functions-template.yaml`
 - **THEN** package generation fails without creating a template configuration
 
 #### Scenario: Exactly one template source is present
 
-- **WHEN** the release snapshot and onboarding select exactly one template source
+- **WHEN** the release snapshot contains exactly one recognized template source
 - **THEN** package generation continues with that source
 
 ### Requirement: Authored template configuration is preserved and dry-run
 
-When the release snapshot contains root `.template.config/template.json` and onboarding omits `template`, the pipeline SHALL preserve the authored file byte-for-byte. It SHALL load and dry-run the template through Microsoft.TemplateEngine and require valid identity and short-name metadata, project template type, at least one trusted Functions project configuration finalization action, valid resolved primary-output references, canonical stack and language values, no direct `.func/config.json` content effect, and no behavior rejected by the central safety policy. Invalid authored configuration SHALL fail package construction rather than being rewritten.
+When the release snapshot contains root `.template.config/template.json` and no synthesis descriptor, the pipeline SHALL preserve the authored file byte-for-byte. It SHALL load and dry-run the template through Microsoft.TemplateEngine and require valid identity and short-name metadata, project template type, at least one trusted Functions project configuration finalization action, valid resolved primary-output references, canonical stack and language values, no direct `.func/config.json` content effect, and no behavior rejected by the central safety policy. Invalid authored configuration SHALL fail package construction rather than being rewritten.
 
 #### Scenario: Valid authored template exists
 
@@ -266,7 +234,12 @@ When the release snapshot contains root `.template.config/template.json` and onb
 
 ### Requirement: Synthesized project declarations are safe and complete
 
-Each `template.projects` entry SHALL require `root`, `stack`, and `language`. `root` SHALL be `.` or a normalized `/`-separated repository-relative path. Project roots MUST NOT be absolute, contain `..`, use excluded directories, collide case-insensitively, or overlap as ancestor and descendant roots. The declared stack and language SHALL be canonical and compatible. The filtered release snapshot SHALL contain a regular `host.json` directly under each declared root.
+The `.github/azure-functions-template.yaml` descriptor SHALL use `schemaVersion: 1`, reject unknown properties, and require non-empty `identity`, `shortName`, `name`, `description`, and `projects`. Each project SHALL require `root`, `stack`, and `language`. `root` SHALL be `.` or a normalized `/`-separated repository-relative path. Project roots MUST NOT be absolute, contain `..`, use excluded directories, collide case-insensitively, or overlap as ancestor and descendant roots. The declared stack and language SHALL be canonical and compatible. The filtered release snapshot SHALL contain a regular `host.json` directly under each declared root.
+
+#### Scenario: Descriptor metadata is incomplete
+
+- **WHEN** the synthesis descriptor omits required template metadata or contains an unknown property
+- **THEN** package generation fails and identifies the descriptor property
 
 #### Scenario: Root project is declared
 
@@ -293,14 +266,14 @@ Each `template.projects` entry SHALL require `root`, `stack`, and `language`. `r
 - **WHEN** a declared canonical stack does not recognize the declared canonical language
 - **THEN** validation fails before template synthesis
 
-### Requirement: Missing authored template configuration is synthesized
+### Requirement: Source descriptor is synthesized into template configuration
 
-When the release snapshot does not contain root `.template.config/template.json` and onboarding contains `template.projects`, the pipeline SHALL synthesize template configuration in staging using the effective onboarding metadata. The synthesized template SHALL have project type and SHALL treat the complete filtered release snapshot as template content. For each declared project, it SHALL add `<root>/host.json` as a primary output and add one mandatory trusted Functions project configuration finalization action referencing that output and supplying the declared canonical stack and language. It SHALL define no parameter symbols, content replacements, or ordinary post-actions.
+When the release snapshot contains `.github/azure-functions-template.yaml` and does not contain root `.template.config/template.json`, the pipeline SHALL synthesize template configuration in staging using the descriptor's identity, short name, name, description, and projects. The synthesized template SHALL have project type and SHALL treat the complete filtered release snapshot as template content. For each declared project, it SHALL add `<root>/host.json` as a primary output and add one mandatory trusted Functions project configuration finalization action referencing that output and supplying the declared canonical stack and language. It SHALL define no parameter symbols, content replacements, or ordinary post-actions.
 
 #### Scenario: Repository has no template configuration
 
 - **WHEN** the release snapshot lacks root `.template.config/template.json`
-- **AND** onboarding defines valid `template.projects`
+- **AND** the release snapshot contains a valid `.github/azure-functions-template.yaml`
 - **THEN** the pipeline adds a minimal synthesized project template to staging
 
 #### Scenario: Synthesized template is validated

--- a/docs/azure-samples-template-pipeline/tasks.md
+++ b/docs/azure-samples-template-pipeline/tasks.md
@@ -7,21 +7,21 @@
 
 ## 2. Onboarding Schema and Loading
 
-- [ ] 2.1 Author `src/Schema/quickstart.schema.json` for schema version 1 with strict properties, optional synthesis-only `template`, required non-empty `template.projects` when present, project fields, defaults, formats, package prefix, repository owner, and license allowlist.
+- [ ] 2.1 Author `src/Schema/quickstart.schema.json` for schema version 1 with strict onboarding properties, defaults, formats, package prefix, repository owner, and license allowlist, and reject template metadata or project topology.
 - [ ] 2.2 Implement non-recursive ordinal scanning of `src/Quickstarts/*.yaml` and combine zero-or-more entries from each file into one logical manifest.
 - [ ] 2.3 Implement schema validation with file, entry, property, and source-location diagnostics.
-- [ ] 2.4 Resolve defaults for enablement, prerelease policy, synthesis-only template identity, short name, display name, description, and license.
-- [ ] 2.5 Implement deterministic repository-name title casing and canonical GitHub repository URL construction.
-- [ ] 2.6 Enforce case-insensitive global uniqueness for onboarding ID, repository, package ID, synthesized effective template values, and authored identity and short names resolved during source-aware validation.
-- [ ] 2.7 Add unit tests for authored and synthesized entry shapes, valid project roots, missing or empty projects, malformed YAML, unknown fields, invalid formats, defaults, title casing, and every global collision.
+- [ ] 2.4 Resolve defaults for enablement, prerelease policy, and license.
+- [ ] 2.5 Implement canonical GitHub repository URL construction.
+- [ ] 2.6 Enforce case-insensitive global uniqueness for onboarding ID, repository, and package ID.
+- [ ] 2.7 Add unit tests for minimal entries, rejected template fields, malformed YAML, unknown fields, invalid formats, defaults, and every onboarding collision.
 
 ## 3. Pull Request Validation
 
 - [ ] 3.1 Add a validation command that parses every onboarding source and applies schema and repository-wide rules atomically.
-- [ ] 3.2 Add source-aware validation that acquires each enabled entry's latest eligible published release and resolves authored-versus-synthesized template ownership.
+- [ ] 3.2 Keep onboarding validation independent of source-release availability and repository-owned template definitions.
 - [ ] 3.3 Create `eng/ci/validate-onboarding.yaml` as the required PR pipeline.
-- [ ] 3.4 Load and dry-run every resolved project template, validate configuration actions and effective identities, and fail the complete PR result when any entry is unavailable or invalid.
-- [ ] 3.5 Add pipeline fixtures proving malformed YAML, no eligible validation release, conflicting identities, dual or missing template ownership, and one failed dry-run fail the complete validation result.
+- [ ] 3.4 Validate all onboarding files and central identities atomically without acquiring source repositories.
+- [ ] 3.5 Add pipeline fixtures proving malformed YAML, invalid entries, rejected template fields, and conflicting onboarding identities fail the complete validation result.
 
 ## 4. GitHub Release Discovery
 
@@ -50,15 +50,16 @@
 
 ## 7. Template Configuration
 
-- [ ] 7.1 Detect only the root `.template.config/template.json` as an authored template configuration.
-- [ ] 7.2 Reject onboarding `template` when authored configuration exists, and reject generation when neither authored configuration nor `template.projects` exists.
-- [ ] 7.3 Preserve authored configuration byte-for-byte and validate TemplateEngine loading, dry-run, identity, short names, project type, required configuration finalization actions, resolved primary outputs, and safety policy.
-- [ ] 7.4 Validate each synthesized project root for normalized relative syntax, case-insensitive uniqueness, non-overlap, excluded paths, and a regular direct-child `host.json`.
-- [ ] 7.5 Validate canonical stack and language compatibility for every synthesized project.
-- [ ] 7.6 Synthesize project `template.json` from effective metadata, adding each project `host.json` as a primary output and one mandatory trusted configuration finalization action per project.
-- [ ] 7.7 Omit parameter symbols, replacements, and ordinary post-actions from synthesized configuration; emit a singular language tag only for homogeneous project topology.
-- [ ] 7.8 Validate synthesized configuration through the same TemplateEngine load, dry-run, action, output-path, and safety path as authored configuration.
-- [ ] 7.9 Add tests for valid authored configuration, byte preservation, dual and missing ownership, invalid actions, unsafe authored behavior, root and nested synthesized projects, path attacks, overlapping roots, missing host files, mixed stacks and languages, metadata derivation, and dry-run failures.
+- [ ] 7.1 Detect only root `.template.config/template.json` and `.github/azure-functions-template.yaml` as template sources.
+- [ ] 7.2 Reject releases containing both recognized sources or neither source, without allowing onboarding to select a mode or alternate path.
+- [ ] 7.3 Author the strict centrally owned schema for `.github/azure-functions-template.yaml`, requiring schema version, identity, short name, name, description, and non-empty projects.
+- [ ] 7.4 Preserve authored configuration byte-for-byte and validate TemplateEngine loading, dry-run, identity, short names, project type, required configuration finalization actions, resolved primary outputs, and safety policy.
+- [ ] 7.5 Parse the synthesis descriptor before filtering `.github`, then validate each project root for normalized relative syntax, case-insensitive uniqueness, non-overlap, excluded paths, and a regular direct-child `host.json`.
+- [ ] 7.6 Validate canonical stack and language compatibility for every synthesized project.
+- [ ] 7.7 Synthesize project `template.json` from descriptor metadata, adding each project `host.json` as a primary output and one mandatory trusted configuration finalization action per project.
+- [ ] 7.8 Omit parameter symbols, replacements, and ordinary post-actions from synthesized configuration; emit a singular language tag only for homogeneous project topology.
+- [ ] 7.9 Validate synthesized configuration through the same TemplateEngine load, dry-run, action, output-path, and safety path as authored configuration.
+- [ ] 7.10 Add tests for valid authored configuration, byte preservation, dual and missing ownership, malformed descriptors, invalid actions, unsafe authored behavior, root and nested synthesized projects, path attacks, overlapping roots, missing host files, mixed stacks and languages, descriptor metadata, filtering, and dry-run failures.
 
 ## 8. NuGet Package Construction and Validation
 
@@ -98,7 +99,7 @@
 
 ## 12. Deployment and Documentation
 
-- [ ] 12.1 Document mutually exclusive authored and synthesized onboarding, `template.projects`, derived metadata and actions, release conventions, license policy, and source-aware PR validation diagnostics.
+- [ ] 12.1 Document mutually exclusive authored and synthesized source modes, `.github/azure-functions-template.yaml`, generated actions, release conventions, license policy, and publication diagnostics.
 - [ ] 12.2 Document publication states, the shared approval gate, manual recovery, immutable conflicts, and central operational ownership.
 - [ ] 12.3 Provision GitHub read access, Azure Artifacts staging, NuGet.org prefix ownership and credentials, concurrency controls, approval environment, and notifications with least privilege.
 - [ ] 12.4 Run a no-publication canary against representative authored and synthesized repositories and inspect the resulting packages.

--- a/docs/azure-samples-template-pipeline/tasks.md
+++ b/docs/azure-samples-template-pipeline/tasks.md
@@ -1,0 +1,106 @@
+## 1. Repository and Tooling Foundation
+
+- [ ] 1.1 Create the `func-templates` repository in `azfunc/internal` with `src/Quickstarts`, `src/Schema`, central tooling and test projects, and `eng/ci`.
+- [ ] 1.2 Add dependency restore, build, test, and code-quality configuration for the central packaging tooling.
+- [ ] 1.3 Add shared typed models for onboarding entries, effective metadata, GitHub releases, package provenance, feed state, and per-release outcomes.
+- [ ] 1.4 Add dependency-injected boundaries for filesystem, GitHub API, source acquisition, TemplateEngine validation, NuGet packing, feeds, time, retries, and reporting.
+
+## 2. Onboarding Schema and Loading
+
+- [ ] 2.1 Author `src/Schema/quickstart.schema.json` for schema version 1 with strict properties, optional synthesis-only `template`, required non-empty `template.projects` when present, project fields, defaults, formats, package prefix, repository owner, and license allowlist.
+- [ ] 2.2 Implement non-recursive ordinal scanning of `src/Quickstarts/*.yaml` and combine zero-or-more entries from each file into one logical manifest.
+- [ ] 2.3 Implement schema validation with file, entry, property, and source-location diagnostics.
+- [ ] 2.4 Resolve defaults for enablement, prerelease policy, synthesis-only template identity, short name, display name, description, and license.
+- [ ] 2.5 Implement deterministic repository-name title casing and canonical GitHub repository URL construction.
+- [ ] 2.6 Enforce case-insensitive global uniqueness for onboarding ID, repository, package ID, synthesized effective template values, and authored identity and short names resolved during source-aware validation.
+- [ ] 2.7 Add unit tests for authored and synthesized entry shapes, valid project roots, missing or empty projects, malformed YAML, unknown fields, invalid formats, defaults, title casing, and every global collision.
+
+## 3. Pull Request Validation
+
+- [ ] 3.1 Add a validation command that parses every onboarding source and applies schema and repository-wide rules atomically.
+- [ ] 3.2 Add source-aware validation that acquires each enabled entry's latest eligible published release and resolves authored-versus-synthesized template ownership.
+- [ ] 3.3 Create `eng/ci/validate-onboarding.yaml` as the required PR pipeline.
+- [ ] 3.4 Load and dry-run every resolved project template, validate configuration actions and effective identities, and fail the complete PR result when any entry is unavailable or invalid.
+- [ ] 3.5 Add pipeline fixtures proving malformed YAML, no eligible validation release, conflicting identities, dual or missing template ownership, and one failed dry-run fail the complete validation result.
+
+## 4. GitHub Release Discovery
+
+- [ ] 4.1 Implement authenticated, paginated release enumeration for enabled `Azure-Samples` repositories.
+- [ ] 4.2 Filter drafts, tag-only refs, versions below `minimumVersion`, and prereleases not explicitly enabled.
+- [ ] 4.3 Parse `v`-prefixed SemVer 2.0 tags, reject build metadata, and derive the NuGet version.
+- [ ] 4.4 Resolve each eligible release tag to an exact commit independently of `target_commitish`.
+- [ ] 4.5 Add bounded retry and cancellation behavior for GitHub API and tag-resolution operations.
+- [ ] 4.6 Add tests for pagination, drafts, tag-only refs, stable/prerelease policies, minimum versions, malformed versions, build metadata, missing tags, and moved tags.
+
+## 5. Safe Release Staging
+
+- [ ] 5.1 Implement isolated acquisition of the exact release-tag commit without initializing Git submodules or Git LFS.
+- [ ] 5.2 Implement filtered staging that excludes `.git`, `.github`, generated build output, dependency caches, and configured credential findings.
+- [ ] 5.3 Detect and reject symbolic or equivalent links that escape the staging root.
+- [ ] 5.4 Ensure source-controlled build, package-manager, and pipeline code is never executed by staging or packaging.
+- [ ] 5.5 Inspect the final staged content independently and fail when excluded content remains.
+- [ ] 5.6 Add adversarial tests for workflows, credentials, traversal, escaping links, build instructions, submodules, LFS pointers, and cleanup after failure or cancellation.
+
+## 6. License Resolution
+
+- [ ] 6.1 Implement license resolution from reviewed YAML override, GitHub repository-license API at the release commit, and root release license-file inspection.
+- [ ] 6.2 Allow only SPDX `MIT` and `Apache-2.0`, and require a root license file even when an override is supplied.
+- [ ] 6.3 Preserve the root license file as template content and project the effective expression into package metadata.
+- [ ] 6.4 Add tests for both allowed licenses, GitHub detection, file fallback, valid override, missing file, unknown detection, and unsupported expressions.
+
+## 7. Template Configuration
+
+- [ ] 7.1 Detect only the root `.template.config/template.json` as an authored template configuration.
+- [ ] 7.2 Reject onboarding `template` when authored configuration exists, and reject generation when neither authored configuration nor `template.projects` exists.
+- [ ] 7.3 Preserve authored configuration byte-for-byte and validate TemplateEngine loading, dry-run, identity, short names, project type, required configuration finalization actions, resolved primary outputs, and safety policy.
+- [ ] 7.4 Validate each synthesized project root for normalized relative syntax, case-insensitive uniqueness, non-overlap, excluded paths, and a regular direct-child `host.json`.
+- [ ] 7.5 Validate canonical stack and language compatibility for every synthesized project.
+- [ ] 7.6 Synthesize project `template.json` from effective metadata, adding each project `host.json` as a primary output and one mandatory trusted configuration finalization action per project.
+- [ ] 7.7 Omit parameter symbols, replacements, and ordinary post-actions from synthesized configuration; emit a singular language tag only for homogeneous project topology.
+- [ ] 7.8 Validate synthesized configuration through the same TemplateEngine load, dry-run, action, output-path, and safety path as authored configuration.
+- [ ] 7.9 Add tests for valid authored configuration, byte preservation, dual and missing ownership, invalid actions, unsafe authored behavior, root and nested synthesized projects, path attacks, overlapping roots, missing host files, mixed stacks and languages, metadata derivation, and dry-run failures.
+
+## 8. NuGet Package Construction and Validation
+
+- [ ] 8.1 Generate package metadata for explicit ID, release-derived version, `FuncTemplate` package type, description, license, project URL, Git repository URL, commit SHA, and GitHub release-notes link.
+- [ ] 8.2 Pack the filtered source and effective template configuration without adding Azure Pipeline definition or run metadata.
+- [ ] 8.3 Inspect the completed `.nupkg` and verify package identity, version, type, metadata, source commit, release URL, content, and exclusions.
+- [ ] 8.4 Load and dry-run templates from the completed package through Microsoft.TemplateEngine and require valid project type, configuration finalization actions, and resolved primary outputs.
+- [ ] 8.5 Produce deterministic package hashes for staging and promotion verification.
+- [ ] 8.6 Add package-level tests for authored and synthesized single- and multi-project templates, configuration actions, dry-run effects, metadata provenance, license inclusion, exclusions, invalid archives, and TemplateEngine discovery.
+
+## 9. Feed State and Staging
+
+- [ ] 9.1 Implement exact package ID/version lookup and package download for the Azure Artifacts staging feed and NuGet.org.
+- [ ] 9.2 Verify repository commit provenance for every package found in either feed and report immutable version conflicts.
+- [ ] 9.3 Model absent, staging-only, and complete feed states without a separate processing ledger.
+- [ ] 9.4 Publish newly validated packages to staging and treat the staged artifact as the durable promotion source.
+- [ ] 9.5 Prevent concurrent feed mutation by scheduled and manual publication runs.
+- [ ] 9.6 Add tests for all feed states, conflicting commits, idempotent reruns, concurrent runs, and interrupted staging.
+
+## 10. Approval and NuGet.org Promotion
+
+- [ ] 10.1 Build one run summary containing every successfully staged package and all separately failed releases.
+- [ ] 10.2 Configure one approval-gated environment for promoting the complete successful run set.
+- [ ] 10.3 Download each exact staged package after approval and revalidate identity, provenance, safety, and hash without rebuilding.
+- [ ] 10.4 Push unchanged approved packages to NuGet.org and verify resulting feed provenance.
+- [ ] 10.5 Preserve staging-only packages when approval is withheld or promotion is interrupted so a later run can resume.
+- [ ] 10.6 Add tests for multi-package approval, partial pre-staging failure, withheld approval, exact-artifact promotion, interrupted promotion, and immutable destination conflicts.
+
+## 11. Scheduled and Manual Publication Operations
+
+- [ ] 11.1 Create `eng/ci/publish-releases.yaml` with daily discovery, independent candidate processing, staging, summary, approval, promotion, and final outcome stages.
+- [ ] 11.2 Add manual onboarding-ID and optional version filters that reuse the complete scheduled pipeline path.
+- [ ] 11.3 Apply bounded exponential backoff to transient GitHub, network, staging-feed, and NuGet.org operations.
+- [ ] 11.4 Continue independent candidates after item failures, fail the final run when unresolved failures remain, and report discovered, staged, promoted, complete, skipped, and failed counts.
+- [ ] 11.5 Notify the central `func-templates` operations team after retries are exhausted and redact credentials and tokens from logs and summaries.
+- [ ] 11.6 Add end-to-end pipeline tests for scheduled discovery, filtered manual recovery, partial success, retries, cancellation, redaction, and notification.
+
+## 12. Deployment and Documentation
+
+- [ ] 12.1 Document mutually exclusive authored and synthesized onboarding, `template.projects`, derived metadata and actions, release conventions, license policy, and source-aware PR validation diagnostics.
+- [ ] 12.2 Document publication states, the shared approval gate, manual recovery, immutable conflicts, and central operational ownership.
+- [ ] 12.3 Provision GitHub read access, Azure Artifacts staging, NuGet.org prefix ownership and credentials, concurrency controls, approval environment, and notifications with least privilege.
+- [ ] 12.4 Run a no-publication canary against representative authored and synthesized repositories and inspect the resulting packages.
+- [ ] 12.5 Stage representative packages and verify installation through the Azure Functions CLI `FuncTemplate` package path.
+- [ ] 12.6 Approve and promote the exact canary artifacts, verify NuGet.org metadata and installation, then enable the daily schedule.

--- a/docs/templating-system/tasks.md
+++ b/docs/templating-system/tasks.md
@@ -11,7 +11,7 @@
 - [ ] 2.2 Create and strictly validate the `template-engine-post-actions` change covering supported actions, execution policy, dry-run behavior, cancellation, and diagnostics.
 - [ ] 2.3 Create and strictly validate the `template-engine-bind-sources` change covering MSBuild, npm, and other project-ecosystem value sources.
 - [ ] 2.4 Create and strictly validate the `func-new-search` change covering NuGet feed scanning, `FuncTemplate` discovery manifests, CDN publication, and CLI search.
-- [ ] 2.5 Create and strictly validate the `azure-samples-template-pipeline` change covering repository conventions, validation, package generation, and seamless release automation.
+- [x] 2.5 Create and strictly validate the `azure-samples-template-pipeline` change covering repository conventions, validation, package generation, and seamless release automation.
 - [ ] 2.6 Create and strictly validate the `func-init-quickstarts` change covering first-class Azure-Samples quickstart discovery, selection, acquisition, and invocation.
 
 ## 3. Cross-Change Coordination


### PR DESCRIPTION
## Summary

- add the completed Azure Samples template pipeline proposal, design, specification, and task artifacts
- mark umbrella templating task 2.5 complete while leaving task 2.6 open

## Validation

- `openspec validate azure-samples-template-pipeline --type change --strict --no-interactive`
- `git diff --check`