### PR TITLE
Publish pipeline artifacts to CDN

### DIFF
--- a/eng/ci/release/official-release.cli.yml
+++ b/eng/ci/release/official-release.cli.yml
@@ -56,3 +56,11 @@ extends:
       - template: /eng/ci/templates/jobs/stage-cli-artifacts.yml@self
         parameters:
           sign: true
+
+    - stage: PublishCdn
+      displayName: Publish CLI to CDN
+      dependsOn: Release
+      jobs:
+      - template: /ci/release-cdn-artifacts.yml@eng
+        parameters:
+          version: $(Build.BuildNumber)

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -105,7 +105,7 @@ jobs:
           Contents: |
             install.ps1
             install.sh
-          TargetFolder: $(drop_cli)
+          TargetFolder: $(publish_dir)
 
     - ${{ if and(containsValue(parameters.artifacts, 'pack'), eq(parameters.sign, true)) }}:
       - template: ci/sign-files.yml@eng

--- a/install.ps1
+++ b/install.ps1
@@ -5,9 +5,9 @@
     Downloads and installs the Azure Functions CLI for the current platform.
 
 .DESCRIPTION
-    Downloads the func CLI from GitHub Releases, extracts it to the install dir,
-    drops a func5 wrapper for side-by-side use with Core Tools v4, and updates
-    PATH so 'func' / 'func5' are available in new terminals.
+    Downloads the func CLI, extracts it to the
+    install dir, drops a func5 wrapper for side-by-side use with Core Tools v4,
+    and updates PATH so 'func' / 'func5' are available in new terminals.
 
     Piped usage:
         irm https://aka.ms/func-cli/install.ps1 | iex
@@ -18,9 +18,6 @@
 
 .PARAMETER Version
     Specific version to install. Defaults to latest 5.x stable release.
-
-.PARAMETER Source
-    GitHub repo to fetch releases from. Defaults to Azure/azure-functions-core-tools.
 
 .PARAMETER Prerelease
     Include pre-release versions when resolving latest.
@@ -43,7 +40,6 @@ param(
     [Alias('InstallDir')]
     [string] $InstallPath = "",
     [string] $Version = "",
-    [string] $Source = "Azure/azure-functions-core-tools",
     [switch] $Prerelease,
     [switch] $Force,
     [switch] $SkipPath,
@@ -59,6 +55,8 @@ $Script:UserAgent = 'func-cli-install.ps1/1.0'
 $Script:ArchiveDownloadTimeoutSec = 600
 $Script:HeadRequestTimeoutSec = 60
 $Script:DefaultInstallDir = Join-Path $HOME '.azure-functions'
+$Script:DownloadBaseUrl = 'https://cdn.functions.azure.com'
+$Script:VersionManifestUrl = "$Script:DownloadBaseUrl/public/cli/v5/version.json"
 
 # True when invoked as a file (pwsh -File ... or .\install.ps1), false when piped
 # into iex. We use this so a piped 'exit' doesn't kill the user's pwsh session.
@@ -101,12 +99,11 @@ if ($Help) {
 Azure Functions CLI installer
 
 DESCRIPTION:
-    Downloads and installs the func CLI for the current platform from GitHub Releases.
+    Downloads and installs the func CLI for the current platform.
 
 PARAMETERS:
     -InstallPath <string>       Directory to install the CLI (default: `$HOME\.azure-functions)
     -Version <string>           Specific version to install (default: latest 5.x stable)
-    -Source <string>            GitHub repo to fetch releases from (default: Azure/azure-functions-core-tools)
     -Prerelease                 Include pre-release versions when resolving latest
     -Force                      Overwrite an existing installation
     -SkipPath                   Do not update PATH or shell profile
@@ -129,24 +126,6 @@ EXAMPLES:
 }
 
 if (-not $InstallPath) { $InstallPath = $Script:DefaultInstallDir }
-$repo = $Source
-$apiBase = "https://api.github.com/repos/$repo"
-
-# --- GitHub CLI detection ---
-
-# Prefer 'gh' when available and authenticated so API calls run against the user's
-# authenticated quota (5000/hr) instead of the anonymous 60/hr limit.
-$useGh = $false
-if (Get-Command gh -ErrorAction SilentlyContinue) {
-    & gh auth status *> $null
-    if ($LASTEXITCODE -eq 0) { $useGh = $true }
-}
-
-if ($useGh) {
-    Write-Message "Using GitHub CLI ('gh') for release metadata and asset download (authenticated, higher rate limit)."
-} else {
-    Write-Message "Using anonymous GitHub API requests. If you hit a rate limit, install and 'gh auth login' the GitHub CLI: https://cli.github.com"
-}
 
 # --- HTTP helpers ---
 
@@ -189,8 +168,15 @@ function Invoke-SecureWebRequest {
     return Invoke-WebRequest @params
 }
 
-function Test-ContentType {
-    param([string] $Uri)
+# HEAD-probe the asset before downloading: give a clear error when the
+# requested version/RID is not published (404), and guard against HTML error
+# pages served with a 200. Transient HEAD failures fall through to the download.
+function Test-DownloadAsset {
+    param(
+        [Parameter(Mandatory)] [string] $Uri,
+        [Parameter(Mandatory)] [string] $Version,
+        [Parameter(Mandatory)] [string] $Rid
+    )
     try {
         $response = Invoke-SecureWebRequest -Uri $Uri -Method 'Head' -TimeoutSec $Script:HeadRequestTimeoutSec
         $headers = $response.Headers
@@ -206,36 +192,78 @@ function Test-ContentType {
             }
         }
     } catch {
+        $statusCode = $null
+        if ($_.Exception.Response) {
+            try { $statusCode = [int]$_.Exception.Response.StatusCode } catch { $statusCode = $null }
+        }
+        if ($statusCode -eq 404) {
+            Write-Message "Azure Functions CLI $Version ($Rid) is not available for download." -Level Error
+            Write-Message "Verify the version number, or omit -Version to install the latest 5.x release." -Level Error
+            return $false
+        }
         Write-Message "HEAD request failed, proceeding with download: $($_.Exception.Message)" -Level Verbose
     }
     return $true
 }
 
-function Get-GitHubReleases {
-    if ($useGh) { return & gh api "/repos/$repo/releases?per_page=50" | ConvertFrom-Json }
-    return (Invoke-SecureWebRequest -Uri "$apiBase/releases?per_page=50").Content | ConvertFrom-Json
+function Get-VersionManifest {
+    $response = Invoke-SecureWebRequest -Uri $Script:VersionManifestUrl -TimeoutSec $Script:HeadRequestTimeoutSec
+    return $response.Content | ConvertFrom-Json
 }
 
-function Get-GitHubReleaseAsset {
-    param([string] $Tag, [string] $AssetName, [string] $OutFile)
-    if ($useGh) {
-        & gh release download $Tag --repo $repo --pattern $AssetName --output $OutFile --clobber
-        if ($LASTEXITCODE -ne 0) { throw "gh release download failed with exit code $LASTEXITCODE" }
-        return
+# Compares two SemVer strings by precedence (SemVer 2.0 §11). Returns -1, 0, or 1.
+function Compare-SemVer {
+    param([string] $Left, [string] $Right)
+
+    function Split-SemVer([string] $v) {
+        $v = ($v -replace '^[vV]', '') -replace '\+.*$', ''
+        $core, $pre = $v -split '-', 2
+        $nums = $core -split '\.'
+        return [pscustomobject]@{
+            Major      = [int]($nums[0]); Minor = [int]($nums[1]); Patch = [int]($nums[2])
+            Prerelease = $pre
+        }
     }
-    $downloadUrl = "https://github.com/$repo/releases/download/$Tag/$AssetName"
-    if (-not (Test-ContentType -Uri $downloadUrl)) { throw "Refusing to download $downloadUrl (HTML response)." }
-    Invoke-SecureWebRequest -Uri $downloadUrl -OutFile $OutFile -TimeoutSec $Script:ArchiveDownloadTimeoutSec | Out-Null
+
+    $l = Split-SemVer $Left
+    $r = Split-SemVer $Right
+
+    foreach ($part in 'Major', 'Minor', 'Patch') {
+        if ($l.$part -ne $r.$part) { return [Math]::Sign($l.$part - $r.$part) }
+    }
+
+    # A version without a prerelease outranks one that has it.
+    if (-not $l.Prerelease -and -not $r.Prerelease) { return 0 }
+    if (-not $l.Prerelease) { return 1 }
+    if (-not $r.Prerelease) { return -1 }
+
+    $li = $l.Prerelease -split '\.'
+    $ri = $r.Prerelease -split '\.'
+    for ($i = 0; $i -lt [Math]::Max($li.Count, $ri.Count); $i++) {
+        if ($i -ge $li.Count) { return -1 }
+        if ($i -ge $ri.Count) { return 1 }
+        $a = $li[$i]; $b = $ri[$i]
+        $aNum = $a -match '^\d+$'; $bNum = $b -match '^\d+$'
+        if ($aNum -and $bNum) {
+            if ([int]$a -ne [int]$b) { return [Math]::Sign([int]$a - [int]$b) }
+        } elseif ($aNum) { return -1 }
+        elseif ($bNum) { return 1 }
+        else {
+            $cmp = [string]::CompareOrdinal($a, $b)
+            if ($cmp -ne 0) { return [Math]::Sign($cmp) }
+        }
+    }
+    return 0
 }
 
 # --- Platform detection ---
 
 if ($IsWindows -or $env:OS -eq 'Windows_NT') {
-    $os = 'win'; $ext = 'zip'
+    $os = 'win'
 } elseif ($IsMacOS) {
-    $os = 'osx'; $ext = 'tar.gz'
+    $os = 'osx'
 } else {
-    $os = 'linux'; $ext = 'tar.gz'
+    $os = 'linux'
 }
 
 $archEnum = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
@@ -245,41 +273,49 @@ switch ($archEnum) {
     default { Write-Message "Unsupported architecture: $archEnum" -Level Error; Exit-Script 1; return }
 }
 
-$assetName = "func-$os-$archStr.$ext"
-Write-Verbose "Resolved platform: $os-$archStr, asset: $assetName"
+$rid = "$os-$archStr"
+Write-Verbose "Resolved platform RID: $rid"
 
 # --- Resolve version ---
 
-if (-not $Version) {
+if ($Version) {
+    # Release artifacts are named with a bare SemVer (no leading 'v').
+    $Version = $Version -replace '^[vV]', ''
+    if ($Version -notmatch '^5\.') {
+        Write-Message "Only Azure Functions CLI 5.x versions are supported by this installer. Requested: $Version" -Level Error
+        Exit-Script 1; return
+    }
+} else {
     $label = if ($Prerelease) { 'latest 5.x pre-release' } else { 'latest 5.x stable release' }
     Write-Message "Resolving $label..."
 
-    $releases = Get-GitHubReleases
-    $release = $releases |
-        Where-Object { $_.tag_name -match '^v?5\.' -and ($Prerelease -or -not $_.prerelease) } |
-        Select-Object -First 1
-
-    if (-not $release) {
-        if (-not $Prerelease) {
-            $prereleases = $releases | Where-Object { $_.tag_name -match '^v?5\.' -and $_.prerelease }
-            if ($prereleases) {
-                Write-Message 'No stable 5.x release found. Available pre-releases:' -Level Warning
-                $prereleases | Select-Object -First 5 | ForEach-Object { Write-Message "  $($_.tag_name)" }
-                Write-Message ''
-                Write-Message 'To install a pre-release, re-run with -Prerelease.'
-                Exit-Script 1; return
-            }
-        }
-        Write-Message 'Could not find a 5.x release.' -Level Error
-        Exit-Script 1; return
+    $manifest = Get-VersionManifest
+    if ($Prerelease -and $manifest.preview -and
+        (Compare-SemVer $manifest.preview $manifest.stable) -gt 0) {
+        $Version = $manifest.preview
+    } else {
+        $Version = $manifest.stable
     }
 
-    $Version = $release.tag_name
+    if (-not $Version) {
+        Write-Message 'Could not resolve a 5.x version from the version manifest.' -Level Error
+        Exit-Script 1; return
+    }
 }
 
-if ($Version -notlike 'v*') { $Version = "v$Version" }
+$assetExt = if ($os -eq 'win') { 'zip' } else { 'tar.gz' }
+$assetName = "Azure.Functions.Cli.$rid.$Version.$assetExt"
+$downloadUrl = "$Script:DownloadBaseUrl/public/cli/v5/$Version/$assetName"
 
-Write-Message "Installing func CLI $Version ($os-$archStr)..."
+# Probe availability up front so an unavailable version fails with a clear message
+# instead of a raw download error. Skipped under -WhatIf (no network side effect).
+if (-not $WhatIfPreference) {
+    if (-not (Test-DownloadAsset -Uri $downloadUrl -Version $Version -Rid $rid)) {
+        Exit-Script 1; return
+    }
+}
+
+Write-Message "Installing func CLI $Version ($rid)..."
 
 # --- Check existing install ---
 
@@ -299,18 +335,19 @@ New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
 try {
     $downloadPath = Join-Path $tempDir $assetName
 
-    if ($PSCmdlet.ShouldProcess($InstallPath, "Download $assetName from release $Version and install func CLI")) {
+    if ($PSCmdlet.ShouldProcess($InstallPath, "Download $assetName and install func CLI")) {
         Write-Message "Downloading $assetName..."
-        Get-GitHubReleaseAsset -Tag $Version -AssetName $assetName -OutFile $downloadPath
+        Invoke-SecureWebRequest -Uri $downloadUrl -OutFile $downloadPath -TimeoutSec $Script:ArchiveDownloadTimeoutSec | Out-Null
         New-Item -ItemType Directory -Path $InstallPath -Force | Out-Null
 
-        if ($ext -eq 'zip') {
+        if ($os -eq 'win') {
             Expand-Archive -Path $downloadPath -DestinationPath $InstallPath -Force
         } else {
             tar -xzf $downloadPath -C $InstallPath
-            if ($os -eq 'osx') {
-                xattr -d com.apple.quarantine (Join-Path $InstallPath 'func') 2>$null
-            }
+            if ($LASTEXITCODE -ne 0) { throw "Failed to extract $assetName (tar exit $LASTEXITCODE)." }
+        }
+        if ($os -eq 'osx') {
+            xattr -d com.apple.quarantine (Join-Path $InstallPath 'func') 2>$null
         }
 
         # Drop func5 wrappers so v5 can be invoked side-by-side with a v4 'func' on PATH.

--- a/install.sh
+++ b/install.sh
@@ -12,8 +12,9 @@ set -euo pipefail
 readonly USER_AGENT="func-cli-install.sh/1.0"
 readonly ARCHIVE_DOWNLOAD_TIMEOUT_SEC=600
 readonly HEAD_REQUEST_TIMEOUT_SEC=60
-readonly DEFAULT_REPO="Azure/azure-functions-core-tools"
 readonly DEFAULT_INSTALL_DIR="$HOME/.azure-functions"
+readonly DOWNLOAD_BASE_URL="https://cdn.functions.azure.com"
+readonly VERSION_MANIFEST_URL="${DOWNLOAD_BASE_URL}/public/cli/v5/version.json"
 readonly RED='\033[0;31m'
 readonly GREEN='\033[0;32m'
 readonly YELLOW='\033[1;33m'
@@ -23,7 +24,6 @@ readonly RESET='\033[0m'
 
 INSTALL_DIR="${INSTALL_DIR:-}"
 VERSION="${VERSION:-}"
-REPO="${SOURCE:-}"
 PRERELEASE="${PRERELEASE:-false}"
 FORCE="${FORCE:-false}"
 SKIP_PATH=false
@@ -63,7 +63,7 @@ show_help() {
 Azure Functions CLI installer
 
 DESCRIPTION:
-    Downloads and installs the func CLI for the current platform from GitHub Releases.
+    Downloads and installs the func CLI for the current platform.
     Automatically updates your shell profile so func is on PATH in new terminals.
 
 USAGE:
@@ -72,7 +72,6 @@ USAGE:
 OPTIONS:
     -i, --install-path PATH     Directory to install the CLI (default: $HOME/.azure-functions)
         --version VERSION       Specific version to install (default: latest 5.x stable)
-        --source REPO           GitHub repo to fetch releases from (default: Azure/azure-functions-core-tools)
         --prerelease            Include pre-release versions when resolving latest
     -f, --force                 Overwrite an existing installation
         --skip-path             Do not update PATH or shell profile
@@ -82,7 +81,7 @@ OPTIONS:
     -h, --help                  Show this help message
 
 ENVIRONMENT VARIABLES (back-compat, flags take precedence):
-    INSTALL_DIR, VERSION, SOURCE, PRERELEASE=true, FORCE=true
+    INSTALL_DIR, VERSION, PRERELEASE=true, FORCE=true
 
 GITHUB ACTIONS:
     When GITHUB_ACTIONS=true, the install dir is also appended to $GITHUB_PATH so
@@ -112,9 +111,6 @@ parse_args() {
             --version)
                 [[ $# -lt 2 || -z "$2" ]] && { say_error "Option '$1' requires a value"; exit 1; }
                 VERSION="$2"; shift 2 ;;
-            --source)
-                [[ $# -lt 2 || -z "$2" ]] && { say_error "Option '$1' requires a value"; exit 1; }
-                REPO="$2"; shift 2 ;;
             --prerelease) PRERELEASE=true; shift ;;
             -f|--force)   FORCE=true; shift ;;
             --skip-path)  SKIP_PATH=true; shift ;;
@@ -139,13 +135,14 @@ if [[ "$SHOW_HELP" == true ]]; then
 fi
 
 INSTALL_DIR="${INSTALL_DIR:-$DEFAULT_INSTALL_DIR}"
-REPO="${REPO:-$DEFAULT_REPO}"
-API_BASE="https://api.github.com/repos/${REPO}"
 
 # --- Platform detection ---
 
 detect_os() {
-    case "$(uname -s)" in
+    local os_name
+    os_name="$(uname -s)"
+
+    case "$os_name" in
         Linux*)
             if command -v ldd >/dev/null 2>&1 && ldd --version 2>&1 | grep -q musl; then
                 printf "linux-musl"
@@ -154,8 +151,14 @@ detect_os() {
             fi
             ;;
         Darwin*) printf "osx" ;;
-        CYGWIN*|MINGW*|MSYS*) printf "win" ;;
-        *) return 1 ;;
+        CYGWIN*|MINGW*|MSYS*|Windows_NT)
+            say_error "install.sh does not support Windows. Run the PowerShell installer instead: irm https://aka.ms/func-cli/install.ps1 | iex"
+            return 1
+            ;;
+        *)
+            say_error "Unsupported OS: $os_name"
+            return 1
+            ;;
     esac
 }
 
@@ -167,7 +170,7 @@ detect_arch() {
     esac
 }
 
-OS=$(detect_os) || { say_error "Unsupported OS: $(uname -s)"; exit 1; }
+OS=$(detect_os)
 ARCH=$(detect_arch) || { say_error "Unsupported architecture: $(uname -m)"; exit 1; }
 
 if [[ "$OS" == "linux-musl" ]]; then
@@ -175,24 +178,8 @@ if [[ "$OS" == "linux-musl" ]]; then
     OS="linux"
 fi
 
-ASSET_NAME="func-${OS}-${ARCH}.tar.gz"
-say_verbose "Resolved platform: ${OS}-${ARCH}, asset: ${ASSET_NAME}"
-
-# --- GitHub CLI detection ---
-
-# Prefer 'gh' when available and authenticated so API calls run against the user's
-# authenticated quota (5000/hr) instead of the anonymous 60/hr limit that customers
-# have been hitting from shared NAT egress.
-USE_GH=false
-if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
-    USE_GH=true
-fi
-
-if [[ "$USE_GH" == true ]]; then
-    say_info "Using GitHub CLI ('gh') for release metadata and asset download (authenticated, higher rate limit)."
-else
-    say_info "Using anonymous GitHub API requests. If you hit a rate limit, install and 'gh auth login' the GitHub CLI: https://cli.github.com"
-fi
+RID="${OS}-${ARCH}"
+say_verbose "Resolved platform RID: ${RID}"
 
 # --- HTTP helpers ---
 
@@ -204,7 +191,6 @@ secure_curl() {
     local method="${4:-GET}"
 
     local args=(
-        --fail
         --show-error
         --location
         --tlsv1.2
@@ -218,11 +204,16 @@ secure_curl() {
     )
 
     if [[ "$method" == "HEAD" ]]; then
+        # No --fail: the caller inspects the status code (e.g. 404) to report a
+        # clear "version not available" message rather than a raw curl error.
         args+=(--silent --head)
-    elif [[ "$VERBOSE" == true ]]; then
-        args+=(--progress-bar)
     else
-        args+=(--silent)
+        args+=(--fail)
+        if [[ "$VERBOSE" == true ]]; then
+            args+=(--progress-bar)
+        else
+            args+=(--silent)
+        fi
     fi
 
     if [[ "$method" == "GET" ]]; then
@@ -233,19 +224,30 @@ secure_curl() {
     curl "${args[@]}" "$url"
 }
 
-# HEAD-probe to make sure we're about to download a binary, not an HTML error page.
+# HEAD-probe the asset before downloading: fail clearly when the requested
+# version/RID is not published (404), and guard against HTML error pages.
 validate_content_type() {
     local url="$1"
     local headers
 
-    say_verbose "Validating content type for $url"
+    say_verbose "Validating asset availability for $url"
 
     if ! headers=$(secure_curl "$url" /dev/null "$HEAD_REQUEST_TIMEOUT_SEC" "HEAD" 2>&1); then
         say_verbose "HEAD request failed; proceeding with download anyway."
         return 0
     fi
 
-    # GitHub asset URLs return one or more 3xx redirects followed by a final 2xx.
+    # Take the status code from the final response (after any 3xx redirects).
+    local status
+    status=$(printf "%s\n" "$headers" | awk 'toupper($1) ~ /^HTTP/ { code = $2 } END { gsub(/\r/, "", code); print code }')
+
+    if [[ "$status" == "404" ]]; then
+        say_error "Azure Functions CLI ${VERSION} (${RID}) is not available for download."
+        say_error "Verify the version number, or omit --version to install the latest 5.x release."
+        return 1
+    fi
+
+    # Asset URLs may return one or more 3xx redirects followed by a final 2xx.
     # Look only at the final response block.
     local final_headers
     final_headers=$(printf "%s\n" "$headers" | awk '
@@ -262,9 +264,69 @@ validate_content_type() {
 
 # --- Resolve version ---
 
+# Extract a string field from a small flat JSON object without requiring jq.
+json_field() {
+    local json="$1" field="$2"
+    printf '%s' "$json" | tr -d '\n' \
+        | sed -nE "s/.*\"${field}\"[[:space:]]*:[[:space:]]*\"([^\"]*)\".*/\1/p"
+}
+
+# Returns 0 (true) if the first SemVer is strictly greater than the second by
+# precedence (SemVer 2.0 §11), 1 otherwise.
+semver_gt() {
+    local a="${1#[vV]}" b="${2#[vV]}"
+    a="${a%%+*}"; b="${b%%+*}"
+
+    local a_core="${a%%-*}" b_core="${b%%-*}"
+    local a_pre="" b_pre=""
+    [[ "$a" == *-* ]] && a_pre="${a#*-}"
+    [[ "$b" == *-* ]] && b_pre="${b#*-}"
+
+    local IFS=.
+    local -a an=($a_core) bn=($b_core)
+    local i
+    for i in 0 1 2; do
+        local av="${an[i]:-0}" bv="${bn[i]:-0}"
+        ((10#$av > 10#$bv)) && return 0
+        ((10#$av < 10#$bv)) && return 1
+    done
+
+    # Cores are equal: a build without a prerelease outranks one with it.
+    [[ -z "$a_pre" && -z "$b_pre" ]] && return 1
+    [[ -z "$a_pre" ]] && return 0
+    [[ -z "$b_pre" ]] && return 1
+
+    local -a ai=($a_pre) bi=($b_pre)
+    local n=${#ai[@]}
+    (( ${#bi[@]} > n )) && n=${#bi[@]}
+    for ((i = 0; i < n; i++)); do
+        (( i >= ${#ai[@]} )) && return 1
+        (( i >= ${#bi[@]} )) && return 0
+        local x="${ai[i]}" y="${bi[i]}"
+        if [[ "$x" =~ ^[0-9]+$ && "$y" =~ ^[0-9]+$ ]]; then
+            ((10#$x > 10#$y)) && return 0
+            ((10#$x < 10#$y)) && return 1
+        elif [[ "$x" =~ ^[0-9]+$ ]]; then
+            return 1
+        elif [[ "$y" =~ ^[0-9]+$ ]]; then
+            return 0
+        else
+            [[ "$x" > "$y" ]] && return 0
+            [[ "$x" < "$y" ]] && return 1
+        fi
+    done
+    return 1
+}
+
 resolve_version() {
     if [[ -n "$VERSION" ]]; then
-        case "$VERSION" in v*) ;; *) VERSION="v${VERSION}" ;; esac
+        # Release artifacts are named with a bare SemVer (no leading 'v').
+        VERSION="${VERSION#v}"
+        VERSION="${VERSION#V}"
+        if [[ "$VERSION" != 5.* ]]; then
+            say_error "Only Azure Functions CLI 5.x versions are supported by this installer. Requested: ${VERSION}"
+            exit 1
+        fi
         return 0
     fi
 
@@ -274,60 +336,34 @@ resolve_version() {
         say_info "Resolving latest stable 5.x release..."
     fi
 
-    local releases_json
-    if [[ "$USE_GH" == true ]]; then
-        releases_json=$(gh api "/repos/${REPO}/releases?per_page=50")
-    else
-        releases_json=$(curl -sSL --user-agent "$USER_AGENT" --max-time 60 "${API_BASE}/releases?per_page=50")
-    fi
+    local manifest_json
+    manifest_json=$(secure_curl "$VERSION_MANIFEST_URL" /dev/stdout "$HEAD_REQUEST_TIMEOUT_SEC") || {
+        say_error "Could not fetch version manifest from ${VERSION_MANIFEST_URL}"
+        exit 1
+    }
 
-    VERSION=$(echo "$releases_json" \
-        | tr ',' '\n' \
-        | grep -E '"tag_name"|"prerelease"' \
-        | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]*)".*/tag:\1/; s/.*"prerelease"[[:space:]]*:[[:space:]]*([^[:space:]]+).*/pre:\1/' \
-        | paste - - \
-        | awk -F'\t' -v include_pre="$PRERELEASE" '
-            {
-                sub(/^tag:/, "", $1); tag = $1
-                sub(/^pre:/, "", $2); pre = $2
-                if (tag ~ /^v?5\./ && (include_pre == "true" || pre == "false")) {
-                    print tag; exit
-                }
-            }')
+    local stable preview
+    stable=$(json_field "$manifest_json" "stable")
+    preview=$(json_field "$manifest_json" "preview")
+
+    if [[ "$PRERELEASE" == true && -n "$preview" ]] && semver_gt "$preview" "$stable"; then
+        VERSION="$preview"
+    else
+        VERSION="$stable"
+    fi
 
     if [[ -z "$VERSION" ]]; then
-        if [[ "$PRERELEASE" != true ]]; then
-            local pre_versions
-            pre_versions=$(echo "$releases_json" \
-                | tr ',' '\n' \
-                | grep -E '"tag_name"|"prerelease"' \
-                | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]*)".*/tag:\1/; s/.*"prerelease"[[:space:]]*:[[:space:]]*([^[:space:]]+).*/pre:\1/' \
-                | paste - - \
-                | awk -F'\t' '
-                    {
-                        sub(/^tag:/, "", $1); tag = $1
-                        sub(/^pre:/, "", $2); pre = $2
-                        if (tag ~ /^v?5\./ && pre == "true") { print tag; count++; if (count >= 5) exit }
-                    }')
-
-            if [[ -n "$pre_versions" ]]; then
-                say_warning "No stable 5.x release found. Available pre-releases:"
-                echo "$pre_versions" | sed 's/^/  /'
-                say_info ""
-                say_info "To install a pre-release, re-run with --prerelease."
-                exit 1
-            fi
-        fi
-        say_error "Could not find a 5.x release."
+        say_error "Could not resolve a 5.x version from the version manifest."
         exit 1
     fi
-
-    case "$VERSION" in v*) ;; *) VERSION="v${VERSION}" ;; esac
 }
 
 resolve_version
 
-say_info "Installing func CLI ${VERSION} (${OS}-${ARCH})..."
+ASSET_NAME="Azure.Functions.Cli.${RID}.${VERSION}.tar.gz"
+DOWNLOAD_URL="${DOWNLOAD_BASE_URL}/public/cli/v5/${VERSION}/${ASSET_NAME}"
+
+say_info "Installing func CLI ${VERSION} (${RID})..."
 
 # --- Check existing install ---
 
@@ -339,7 +375,6 @@ fi
 
 # --- Download and extract ---
 
-DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${ASSET_NAME}"
 TEMP_DIR=$(mktemp -d)
 if [[ "$KEEP_ARCHIVE" != true ]]; then
     trap 'rm -rf "$TEMP_DIR"' EXIT
@@ -351,15 +386,12 @@ if [[ "$DRY_RUN" == true ]]; then
     say_info "[DRY RUN] Would download ${DOWNLOAD_URL} to ${TEMP_DIR}/${ASSET_NAME}"
     say_info "[DRY RUN] Would extract to ${INSTALL_DIR}"
 else
-    if [[ "$USE_GH" == true ]]; then
-        gh release download "$VERSION" --repo "$REPO" --pattern "$ASSET_NAME" --output "${TEMP_DIR}/${ASSET_NAME}" --clobber
-    else
-        validate_content_type "$DOWNLOAD_URL" || exit 1
-        say_info "Downloading ${ASSET_NAME}..."
-        secure_curl "$DOWNLOAD_URL" "${TEMP_DIR}/${ASSET_NAME}"
-    fi
+    validate_content_type "$DOWNLOAD_URL" || exit 1
+    say_info "Downloading ${ASSET_NAME}..."
+    secure_curl "$DOWNLOAD_URL" "${TEMP_DIR}/${ASSET_NAME}"
     mkdir -p "$INSTALL_DIR"
     tar -xzf "${TEMP_DIR}/${ASSET_NAME}" -C "$INSTALL_DIR"
+    chmod +x "${INSTALL_DIR}/func" 2>/dev/null || true
 
     if [[ "$OS" == "osx" ]]; then
         xattr -d com.apple.quarantine "${INSTALL_DIR}/func" 2>/dev/null || true


### PR DESCRIPTION
This change updates the v5 release pipeline to publish artifacts and install scripts to the Azure Functions CDN.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
