### PR TITLE
Fix CFS violations: route npm and NuGet through authenticated feeds in consolidated tests

### DIFF
--- a/eng/ci/templates/official/jobs/test-consolidated-cli-artifacts.yml
+++ b/eng/ci/templates/official/jobs/test-consolidated-cli-artifacts.yml
@@ -26,6 +26,9 @@ jobs:
       image: 1es-windows-2022
       os: windows
 
+  variables:
+    NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
+
   steps:
   - checkout: self
 
@@ -33,6 +36,8 @@ jobs:
 
   - task: NuGetAuthenticate@1
     displayName: 'Authenticate NuGet'
+
+  - template: /eng/ci/templates/steps/authenticate-e2e-dependencies.yml@self
 
   # For win-x86, we need to install x86 .NET 10 runtime. The install-tools.yml installs x64 versions.
   # The x86 func CLI spawns x86 worker processes that look for .NET in 'C:\Program Files (x86)\dotnet\'.


### PR DESCRIPTION
## Summary

Fixes CFS violations in the consolidated CLI artifact test template where:
1. `func.exe` npm calls during E2E tests hit `registry.npmjs.org` directly
2. `dotnet restore` in temp projects created by `func init` hit `api.nuget.org` directly

## Changes

In `eng/ci/templates/official/jobs/test-consolidated-cli-artifacts.yml`:
- Added job-level `NPM_CONFIG_USERCONFIG` variable pointing to repo `.npmrc`
- Added `authenticate-e2e-dependencies.yml` template reference (handles npm auth, NuGet user-config for temp projects, and pip auth)

This mirrors the approach used in `test-e2e-windows.yml`.

## Known remaining violation

The `win-x86` step still downloads `dotnet-install.ps1` from `https://dot.net`. This cannot be replaced with `UseDotNet@2` because that task doesn't support cross-architecture installs (x86 on an x64 agent). A separate solution is needed — similar to the known go.dev gap.