### PR TITLE
Fix pip environment variable passthrough in linux-deb build

### DIFF
--- a/eng/ci/templates/official/jobs/linux-deb-build-pack.yml
+++ b/eng/ci/templates/official/jobs/linux-deb-build-pack.yml
@@ -89,6 +89,7 @@ jobs:
     env:
       linuxBuildNumber: $(DefaultArtifactVersion)
       consolidatedBuildId: $(ConsolidatedBuildId)
+      PIP_INDEX_URL: $(PIP_INDEX_URL)
 
   - task: Bash@3
     displayName: "Validate DEB architectures"


### PR DESCRIPTION
## Summary

Explicitly pass `PIP_INDEX_URL` through the `env:` block in the 'Build DEB package' Bash@3 task so it survives shell profile sourcing (`bashEnvValue: '~/.profile'`).

## Changes

- `eng/ci/templates/official/jobs/linux-deb-build-pack.yml`: Added `PIP_INDEX_URL: $(PIP_INDEX_URL)` to the existing `env:` block.

## Context

The `PipAuthenticate@1` task sets `PIP_INDEX_URL` as a pipeline variable, but the Bash task sources `~/.profile` which can reset environment variables. Mapping it explicitly in `env:` ensures it's available inside the script regardless of profile contents.