### PR TITLE
Fix emulator steps hanging on Linux and macOS E2E pipelines

### DIFF
--- a/eng/ci/templates/jobs/test-e2e-linux.yml
+++ b/eng/ci/templates/jobs/test-e2e-linux.yml
@@ -29,25 +29,17 @@ jobs:
         languageWorker: 'Go'
         runtime: 'linux-x64'
 
+  variables:
+    NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
+
   steps:
   - template: /eng/ci/templates/steps/install-tools.yml@self
 
   - template: /eng/ci/templates/steps/authenticate-e2e-dependencies.yml@self
 
-  # The 1es-ubuntu-24.04-min image doesn't ship npm. NodeTool@0 in install-tools.yml
-  # installs Node into the agent user's tool cache, but start-emulators.ps1 runs
-  # `sudo npm install -g azurite` and sudo's PATH doesn't include the tool cache.
-  # Install npm system-wide via apt so azurite can be installed and launched as root.
-  - bash: |
-      sudo apt-get update
-      sudo apt-get install -y npm
-      npm --version
-    displayName: 'Install npm'
-
-  - pwsh: ./eng/scripts/start-emulators.ps1
-    displayName: 'Start emulators (NoWait)'
-    env:
-      NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
+  - script: |
+      npx --yes azurite --silent --inMemoryPersistence </dev/null >/dev/null 2>&1 &
+    displayName: 'Start azurite'
 
   - template: /eng/ci/templates/steps/restore-nuget.yml@self
 

--- a/eng/ci/templates/jobs/test-e2e-osx.yml
+++ b/eng/ci/templates/jobs/test-e2e-osx.yml
@@ -29,22 +29,22 @@ jobs:
         languageWorker: 'Go'
         runtime: 'osx-x64'
 
+  variables:
+    NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
+
   steps:
   - template: /eng/ci/templates/steps/authenticate-e2e-dependencies.yml@self
-
-  - pwsh: ./eng/scripts/start-emulators.ps1
-    displayName: 'Start emulators (NoWait)'
-    env:
-      NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
 
   - script: |
       sudo chown -R $(id -u):$(id -g) ~/.npm
       npm install -g @azure/functions --userconfig "$(Build.SourcesDirectory)/.npmrc"
     displayName: 'Install @azure/functions'
-    env:
-      NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
 
   - template: /eng/ci/templates/steps/install-tools.yml@self
+
+  - script: |
+      npx --yes azurite --silent --inMemoryPersistence </dev/null >/dev/null 2>&1 &
+    displayName: 'Start azurite'
 
   # On macOS, GoTool@0 (in install-tools.yml) is skipped because it only
   # ships an amd64 Go binary, which can't run on Apple Silicon agents.

--- a/eng/scripts/start-emulators.ps1
+++ b/eng/scripts/start-emulators.ps1
@@ -58,8 +58,8 @@ if (!$SkipStorageEmulator)
         else
         {
             sudo npm install -g azurite --userconfig $npmConfigPath
-            sudo mkdir azurite
-            sudo azurite --silent --skipApiVersionCheck --location azurite --debug azurite\debug.log &
+            sudo mkdir -p azurite
+            Start-Process -FilePath "sudo" -ArgumentList "azurite","--silent","--skipApiVersionCheck","--location","azurite","--debug","azurite/debug.log"
         }
 
         $startedStorage = $true
@@ -83,10 +83,18 @@ if ($NoWait -eq $true)
 if (!$SkipStorageEmulator -and $startedStorage -eq $true)
 {
     Write-Host "---Waiting for Storage emulator to be running---"
+    $maxRetries = 24  # 24 * 5s = 2 minutes
+    $retryCount = 0
     $storageEmulatorRunning = IsStorageEmulatorRunning
     while ($storageEmulatorRunning -eq $false)
     {
-        Write-Host "Storage emulator not ready."
+        $retryCount++
+        if ($retryCount -ge $maxRetries)
+        {
+            Write-Error "Storage emulator failed to start within 2 minutes."
+            exit 1
+        }
+        Write-Host "Storage emulator not ready. Attempt $retryCount/$maxRetries"
         Start-Sleep -Seconds 5
         $storageEmulatorRunning = IsStorageEmulatorRunning
     }


### PR DESCRIPTION
## Problem

The "Start emulators (NoWait)" step in Linux and macOS E2E pipelines hangs indefinitely, eventually timing out after 180 minutes.

**Root cause:** `start-emulators.ps1` launches azurite on Linux/macOS using `sudo azurite ... &` — this relies on PowerShell's background job operator under `sudo`, which doesn't reliably detach the process. Azurite either fails to start or gets cleaned up when the job ends, so the health-check polling loop spins forever.

Additionally, the Linux/macOS templates were missing the `-NoWait` flag (unlike Windows), meaning even if azurite failed silently, the script would poll indefinitely rather than proceeding.

## Fix

Adopt the same pattern used by [azure-functions-dotnet-worker](https://github.com/Azure/azure-functions-dotnet-worker/blob/main/eng/ci/templates/steps/setup-e2e-tests.yml#L33): launch azurite directly via a bash `script:` step with proper Unix daemonization:

```yaml
- script: |
    npx --yes azurite --silent --inMemoryPersistence </dev/null >/dev/null 2>&1 &
  displayName: 'Start azurite'
```

### Changes

| File | Change |
|------|--------|
| `eng/ci/templates/jobs/test-e2e-linux.yml` | Removed `sudo apt-get install npm` workaround and `start-emulators.ps1` call; replaced with `npx azurite` |
| `eng/ci/templates/jobs/test-e2e-osx.yml` | Removed `start-emulators.ps1` call; added `npx azurite` after `install-tools.yml` (so Node is available) |
| `eng/scripts/start-emulators.ps1` | Fixed `Start-Process` launch for non-Windows (still used locally), added 2-minute timeout to health-check loop, fixed backslash path |

### Why this works
- **No global install / no sudo** — `npx --yes` downloads and runs azurite on the fly
- **`--inMemoryPersistence`** — no filesystem directories or path separators to worry about
- **Bash `&` with redirects** — proper Unix daemonization, no PowerShell backgrounding issues
- **No wait loop needed** — azurite starts near-instantly; the build/publish steps give it time before tests run
- **Windows unchanged** — still uses `start-emulators.ps1 -NoWait` which works correctly with `Start-Process`