### PR TITLE
ci(dependabot): track vnext dotnet sdk

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,18 @@ updates:
           - "version-update:semver-major"
           - "version-update:semver-minor"
 
+  - package-ecosystem: "dotnet-sdk"
+    directory: "/"
+    target-branch: "vnext"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

- add a weekly Dependabot configuration for the .NET SDK on `vnext`
- limit automated SDK updates to patch releases
- keep the existing default-branch dependency configuration unchanged