### PR TITLE
Fix NuGet restore in consolidate artifacts pipeline

### DIFF
--- a/eng/ci/templates/official/jobs/consolidate-cli-artifacts.yml
+++ b/eng/ci/templates/official/jobs/consolidate-cli-artifacts.yml
@@ -53,11 +53,26 @@ jobs:
     displayName: 'Authenticate NuGet'
 
   - task: DotNetCoreCLI@2
+    displayName: "Restore ArtifactAssembler"
+    inputs:
+      command: 'restore'
+      projects: "$(Build.SourcesDirectory)/src/ArtifactAssembler/ArtifactAssembler.csproj"
+      feedsToUse: 'config'
+      nugetConfigPath: '$(Build.SourcesDirectory)/NuGet.Config'
+
+  - task: DotNetCoreCLI@2
+    displayName: "Build ArtifactAssembler"
+    inputs:
+      command: 'build'
+      projects: "$(Build.SourcesDirectory)/src/ArtifactAssembler/ArtifactAssembler.csproj"
+      arguments: '--no-restore -c release'
+
+  - task: DotNetCoreCLI@2
     displayName: "Run ArtifactAssembler"
     inputs:
       command: run
       projects: "$(Build.SourcesDirectory)/src/ArtifactAssembler/ArtifactAssembler.csproj"
-      arguments: '-c release -- "Azure.Functions.Cli.${{ parameters.arch }}"'
+      arguments: '--no-build -c release -- "Azure.Functions.Cli.${{ parameters.arch }}"'
       workingDirectory: '$(Pipeline.Workspace)'
     env:
       # Directory names containing the artifacts


### PR DESCRIPTION
## Summary

Splits the `dotnet run` step for ArtifactAssembler in the consolidate artifacts pipeline into three separate steps: **restore**, **build**, and **run**.

## Problem

The `DotNetCoreCLI@2` task with `command: run` performs an implicit NuGet restore. Because `feedsToUse` is only configurable for the `restore` command, the implicit restore defaults to `feedsToUse: 'select'`, which includes nuget.org as a package source. This causes network calls to nuget.org during the consolidation pipeline.

## Fix

Split the single step into three, following the established pattern used across other Azure Functions repos:

1. **Restore** — explicit `DotNetCoreCLI@2` with `command: restore`, `feedsToUse: 'config'`, and `nugetConfigPath` pointing to the repo's `NuGet.Config` (which uses `<clear />` and only lists ADO feeds).
2. **Build** — `DotNetCoreCLI@2` with `command: build` and `--no-restore`.
3. **Run** — `DotNetCoreCLI@2` with `command: run` and `--no-build` (implies `--no-restore`).

The second `dotnet run` invocation (zip step) already uses `--no-build` and is unaffected.